### PR TITLE
Fix Zoodle snapshot clipping

### DIFF
--- a/src/components/Thinking.tsx
+++ b/src/components/Thinking.tsx
@@ -407,19 +407,19 @@ const ImageFileItem = (props: {
   }
 
   return (
-    <div className="flex flex-col gap-1">
-      <span className="text-xs text-chalkboard-70 dark:text-chalkboard-40">
+    <div className="flex max-w-full min-w-0 flex-col gap-1">
+      <span className="max-w-full truncate text-xs text-chalkboard-70 dark:text-chalkboard-40">
         {props.file.name}
       </span>
       <button
         onClick={() => props.onDownload(props.url!, props.file.name)}
-        className="cursor-pointer hover:opacity-80 transition-opacity text-left"
+        className="m-0 w-fit max-w-full cursor-pointer overflow-hidden rounded border border-chalkboard-30 bg-transparent p-0 text-left transition-opacity hover:opacity-80 dark:border-chalkboard-80"
         title={`Click to download ${props.file.name}`}
       >
         <img
           src={props.url}
           alt={props.file.name}
-          className="max-w-full h-auto rounded border border-chalkboard-30 dark:border-chalkboard-80"
+          className="block h-auto max-w-full"
           onError={() => setImageError(true)}
         />
       </button>
@@ -472,8 +472,8 @@ export const FilesSnapshot = (props: {
       }
     >
       {/* Using a custom content wrapper without height restriction for images */}
-      <div className="pt-4 pb-4 border-l pl-5 ml-3 b-3">
-        <div className="flex flex-col gap-3">
+      <div className="min-w-0 max-w-full pt-4 pb-4 border-l pl-5 ml-3 b-3">
+        <div className="flex max-w-full min-w-0 flex-col gap-3">
           {imageFiles.map((file, index) => {
             const fileIndex = props.files.indexOf(file)
             const url = objectUrls[fileIndex]

--- a/src/components/ViewportAnnotationOverlay.tsx
+++ b/src/components/ViewportAnnotationOverlay.tsx
@@ -5,35 +5,7 @@ import {
   getTrimPreviewLineWidth,
   TRIM_PREVIEW_LINE_COLOR,
 } from '@src/lib/freehandLineDrawing'
-
-type ViewportAnnotationRect = {
-  left: number
-  top: number
-  width: number
-  height: number
-}
-
-const getViewportAnnotationRect = (): ViewportAnnotationRect => {
-  const viewport = document.querySelector('[data-engine]')
-  if (viewport instanceof HTMLElement) {
-    const rect = viewport.getBoundingClientRect()
-    if (rect.width > 0 && rect.height > 0) {
-      return {
-        left: rect.left,
-        top: rect.top,
-        width: rect.width,
-        height: rect.height,
-      }
-    }
-  }
-
-  return {
-    left: 0,
-    top: 0,
-    width: window.innerWidth,
-    height: window.innerHeight,
-  }
-}
+import { getVisibleViewportRect } from '@src/lib/viewportElement'
 
 const loadImage = (src: string): Promise<HTMLImageElement> =>
   new Promise((resolve, reject) => {
@@ -84,7 +56,7 @@ export const ViewportAnnotationOverlay = (
 ) => {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const lastPoint = useRef<{ x: number; y: number } | null>(null)
-  const [viewportRect, setViewportRect] = useState(getViewportAnnotationRect)
+  const [viewportRect, setViewportRect] = useState(getVisibleViewportRect)
   const [imageSize, setImageSize] = useState<{
     width: number
     height: number
@@ -121,8 +93,7 @@ export const ViewportAnnotationOverlay = (
   }, [props.imageDataUrl])
 
   useEffect(() => {
-    const updateViewportRect = () =>
-      setViewportRect(getViewportAnnotationRect())
+    const updateViewportRect = () => setViewportRect(getVisibleViewportRect())
     const viewport = document.querySelector('[data-engine]')
     const resizeObserver =
       typeof ResizeObserver === 'undefined'

--- a/src/lib/screenshot.ts
+++ b/src/lib/screenshot.ts
@@ -1,4 +1,85 @@
 import { writeProjectThumbnailFile } from '@src/lib/desktop'
+import { getVisibleElementRect } from '@src/lib/viewportElement'
+
+const getVisibleCanvasCrop = (canvas: HTMLCanvasElement) => {
+  const canvasRect = canvas.getBoundingClientRect()
+  const visibleRect = getVisibleElementRect(canvas)
+
+  if (!visibleRect || canvasRect.width <= 0 || canvasRect.height <= 0) {
+    return null
+  }
+
+  const scaleX = canvas.width / canvasRect.width
+  const scaleY = canvas.height / canvasRect.height
+  const sourceX = Math.max(
+    0,
+    Math.round((visibleRect.left - canvasRect.left) * scaleX)
+  )
+  const sourceY = Math.max(
+    0,
+    Math.round((visibleRect.top - canvasRect.top) * scaleY)
+  )
+  const sourceWidth = Math.min(
+    canvas.width - sourceX,
+    Math.max(1, Math.round(visibleRect.width * scaleX))
+  )
+  const sourceHeight = Math.min(
+    canvas.height - sourceY,
+    Math.max(1, Math.round(visibleRect.height * scaleY))
+  )
+
+  if (sourceWidth <= 0 || sourceHeight <= 0) {
+    return null
+  }
+
+  return {
+    visibleRect,
+    sourceX,
+    sourceY,
+    sourceWidth,
+    sourceHeight,
+  }
+}
+
+const drawVisibleVideoStream = (
+  video: HTMLVideoElement,
+  canvas: HTMLCanvasElement,
+  targetCanvas: HTMLCanvasElement
+) => {
+  const crop = getVisibleCanvasCrop(canvas)
+  if (!crop) {
+    return null
+  }
+
+  const fullCanvas = document.createElement('canvas')
+  fullCanvas.width = canvas.width
+  fullCanvas.height = canvas.height
+  const fullContext = fullCanvas.getContext('2d')
+  if (!fullContext) {
+    return null
+  }
+
+  fullContext.drawImage(video, 0, 0, fullCanvas.width, fullCanvas.height)
+  targetCanvas.width = crop.sourceWidth
+  targetCanvas.height = crop.sourceHeight
+  const targetContext = targetCanvas.getContext('2d')
+  if (!targetContext) {
+    return null
+  }
+  targetContext.drawImage(
+    fullCanvas,
+    crop.sourceX,
+    crop.sourceY,
+    crop.sourceWidth,
+    crop.sourceHeight,
+    0,
+    0,
+    targetCanvas.width,
+    targetCanvas.height
+  )
+
+  return crop
+}
 
 export function takeScreenshotOfVideoStreamCanvas() {
   const canvas = document.querySelector('[data-engine]')
@@ -10,10 +91,10 @@ export function takeScreenshotOfVideoStreamCanvas() {
     video instanceof HTMLVideoElement
   ) {
     const videoCanvas = document.createElement('canvas')
-    videoCanvas.width = canvas.width
-    videoCanvas.height = canvas.height
-    const context = videoCanvas.getContext('2d')
-    context?.drawImage(video, 0, 0, videoCanvas.width, videoCanvas.height)
+    const crop = drawVisibleVideoStream(video, canvas, videoCanvas)
+    if (!crop) {
+      return ''
+    }
     const url = videoCanvas.toDataURL('image/png')
     return url
   } else {
@@ -38,13 +119,10 @@ export function takeViewportScreenshot(): string {
   }
 
   const compositeCanvas = document.createElement('canvas')
-  compositeCanvas.width = canvas.width
-  compositeCanvas.height = canvas.height
+  const crop = drawVisibleVideoStream(video, canvas, compositeCanvas)
   const ctx = compositeCanvas.getContext('2d')
+  if (!crop) return ''
   if (!ctx) return ''
-
-  // Draw the video stream (the 3D model)
-  ctx.drawImage(video, 0, 0, compositeCanvas.width, compositeCanvas.height)
 
   // Draw the gizmo overlay if present
   const gizmoWrapper = document.querySelector(
@@ -52,17 +130,13 @@ export function takeViewportScreenshot(): string {
   )
   const gizmoCanvas = gizmoWrapper?.querySelector('canvas')
   if (gizmoCanvas instanceof HTMLCanvasElement) {
-    // The gizmo container is positioned absolute bottom-2 right-2 (8px)
-    // relative to the modeling area. We need to map that to the canvas
-    // coordinate space since the canvas may be a different size than the
-    // on-screen element.
-    const scaleX = compositeCanvas.width / canvas.clientWidth
-    const scaleY = compositeCanvas.height / canvas.clientHeight
-    const margin = 8
-    const gizmoW = gizmoCanvas.clientWidth * scaleX
-    const gizmoH = gizmoCanvas.clientHeight * scaleY
-    const x = compositeCanvas.width - gizmoW - margin * scaleX
-    const y = compositeCanvas.height - gizmoH - margin * scaleY
+    const gizmoRect = gizmoCanvas.getBoundingClientRect()
+    const scaleX = compositeCanvas.width / crop.visibleRect.width
+    const scaleY = compositeCanvas.height / crop.visibleRect.height
+    const gizmoW = gizmoRect.width * scaleX
+    const gizmoH = gizmoRect.height * scaleY
+    const x = (gizmoRect.left - crop.visibleRect.left) * scaleX
+    const y = (gizmoRect.top - crop.visibleRect.top) * scaleY
     ctx.drawImage(gizmoCanvas, x, y, gizmoW, gizmoH)
   }
 

--- a/src/lib/viewportElement.test.ts
+++ b/src/lib/viewportElement.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import {
+  getVisibleElementRect,
+  getVisibleViewportRect,
+} from '@src/lib/viewportElement'
+
+const rect = ({
+  left,
+  top,
+  width,
+  height,
+}: {
+  left: number
+  top: number
+  width: number
+  height: number
+}): DOMRect =>
+  ({
+    left,
+    top,
+    right: left + width,
+    bottom: top + height,
+    width,
+    height,
+    x: left,
+    y: top,
+    toJSON: () => ({}),
+  }) as DOMRect
+
+const setWindowSize = (width: number, height: number) => {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    value: width,
+  })
+  Object.defineProperty(window, 'innerHeight', {
+    configurable: true,
+    value: height,
+  })
+}
+
+describe('viewportElement', () => {
+  beforeEach(() => {
+    setWindowSize(100, 80)
+  })
+
+  afterEach(() => {
+    document.body.replaceChildren()
+    vi.restoreAllMocks()
+  })
+
+  test('clips an overgrown engine element to the browser viewport', () => {
+    const element = document.createElement('canvas')
+    vi.spyOn(element, 'getBoundingClientRect').mockReturnValue(
+      rect({ left: -4, top: 8, width: 112, height: 40 })
+    )
+
+    expect(getVisibleElementRect(element)).toEqual({
+      left: 0,
+      top: 8,
+      width: 100,
+      height: 40,
+    })
+  })
+
+  test('clips an overgrown engine element to overflow-hidden ancestors', () => {
+    const parent = document.createElement('div')
+    const element = document.createElement('canvas')
+    parent.style.overflow = 'hidden'
+    parent.append(element)
+    document.body.append(parent)
+
+    vi.spyOn(parent, 'getBoundingClientRect').mockReturnValue(
+      rect({ left: 20, top: 10, width: 60, height: 50 })
+    )
+    vi.spyOn(element, 'getBoundingClientRect').mockReturnValue(
+      rect({ left: 16, top: 6, width: 68, height: 58 })
+    )
+
+    expect(getVisibleElementRect(element)).toEqual({
+      left: 20,
+      top: 10,
+      width: 60,
+      height: 50,
+    })
+  })
+
+  test('returns the visible rect for the data-engine element', () => {
+    const element = document.createElement('canvas')
+    element.setAttribute('data-engine', '')
+    document.body.append(element)
+    vi.spyOn(element, 'getBoundingClientRect').mockReturnValue(
+      rect({ left: 10, top: 12, width: 30, height: 40 })
+    )
+
+    expect(getVisibleViewportRect()).toEqual({
+      left: 10,
+      top: 12,
+      width: 30,
+      height: 40,
+    })
+  })
+
+  test('falls back to the window when no data-engine element exists', () => {
+    expect(getVisibleViewportRect()).toEqual({
+      left: 0,
+      top: 0,
+      width: 100,
+      height: 80,
+    })
+  })
+})

--- a/src/lib/viewportElement.ts
+++ b/src/lib/viewportElement.ts
@@ -1,0 +1,102 @@
+export type ViewportElementRect = {
+  left: number
+  top: number
+  width: number
+  height: number
+}
+
+type RectBounds = ViewportElementRect & {
+  right: number
+  bottom: number
+}
+
+const clipsOverflow = (value: string) =>
+  value === 'auto' ||
+  value === 'clip' ||
+  value === 'hidden' ||
+  value === 'scroll'
+
+const boundsFromRect = (rect: DOMRect): RectBounds => ({
+  left: rect.left,
+  top: rect.top,
+  right: rect.right,
+  bottom: rect.bottom,
+  width: rect.width,
+  height: rect.height,
+})
+
+const rectFromBounds = (bounds: RectBounds): ViewportElementRect | null => {
+  const width = Math.max(0, bounds.right - bounds.left)
+  const height = Math.max(0, bounds.bottom - bounds.top)
+
+  if (width <= 0 || height <= 0) {
+    return null
+  }
+
+  return {
+    left: bounds.left,
+    top: bounds.top,
+    width,
+    height,
+  }
+}
+
+export const getVisibleElementRect = (
+  element: HTMLElement
+): ViewportElementRect | null => {
+  const elementRect = element.getBoundingClientRect()
+  let bounds = boundsFromRect(elementRect)
+
+  bounds = {
+    left: Math.max(bounds.left, 0),
+    top: Math.max(bounds.top, 0),
+    right: Math.min(bounds.right, window.innerWidth),
+    bottom: Math.min(bounds.bottom, window.innerHeight),
+    width: 0,
+    height: 0,
+  }
+
+  let parent = element.parentElement
+  while (parent && parent !== document.body) {
+    const style = window.getComputedStyle(parent)
+    const overflowX = style.overflowX || style.overflow
+    const overflowY = style.overflowY || style.overflow
+    const clipsX = clipsOverflow(overflowX)
+    const clipsY = clipsOverflow(overflowY)
+
+    if (clipsX || clipsY) {
+      const parentRect = parent.getBoundingClientRect()
+      if (clipsX) {
+        bounds.left = Math.max(bounds.left, parentRect.left)
+        bounds.right = Math.min(bounds.right, parentRect.right)
+      }
+      if (clipsY) {
+        bounds.top = Math.max(bounds.top, parentRect.top)
+        bounds.bottom = Math.min(bounds.bottom, parentRect.bottom)
+      }
+    }
+
+    parent = parent.parentElement
+  }
+
+  return rectFromBounds(bounds)
+}
+
+export const getViewportElement = (): HTMLElement | null => {
+  const viewport = document.querySelector('[data-engine]')
+  return viewport instanceof HTMLElement ? viewport : null
+}
+
+export const getVisibleViewportRect = (): ViewportElementRect => {
+  const viewport = getViewportElement()
+  const visibleRect = viewport ? getVisibleElementRect(viewport) : null
+
+  return (
+    visibleRect ?? {
+      left: 0,
+      top: 0,
+      width: window.innerWidth,
+      height: window.innerHeight,
+    }
+  )
+}


### PR DESCRIPTION
ai assisted

## Problem
People using Zoodle can see snapshot previews and the drawing surface clipped at the sides because the capture and overlay can inherit the oversized engine stream bounds instead of the visible viewport.

## Solution
Clamp Zoodle capture and overlay sizing to the visible engine rectangle, crop viewport screenshots to those visible bounds, and constrain Zookeeper image snapshot previews so their rounded borders stay inside the chat pane.