### PR TITLE
Disable autofill in all inputs on web

### DIFF
--- a/src/components/AvailableVarsHelpers.tsx
+++ b/src/components/AvailableVarsHelpers.tsx
@@ -5,6 +5,7 @@ import {
 } from '@src/lang/create'
 import type { PrevVariable } from '@src/lang/queryAst'
 import type { BinaryPart } from '@src/lang/wasm'
+import { noAutofillInputProps } from '@src/lib/autofill'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 
 export const AvailableVars = ({
@@ -121,13 +122,12 @@ export const CreateNewVariable = ({
           />
         )}
         <input
+          {...noAutofillInputProps}
           type="text"
           disabled={!shouldCreateVariable}
           name="create-new-variable"
           id="create-new-variable"
           autoFocus={true}
-          autoCapitalize="off"
-          autoCorrect="off"
           className={`flex-1 sm:text-sm px-2 py-1 rounded-sm bg-chalkboard-10 dark:bg-chalkboard-90 text-chalkboard-90 dark:text-chalkboard-10 ${
             !shouldCreateVariable ? 'opacity-50' : ''
           }`}

--- a/src/components/CommandBar/CommandArgOptionInput.tsx
+++ b/src/components/CommandBar/CommandArgOptionInput.tsx
@@ -4,6 +4,7 @@ import Fuse from 'fuse.js'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type { AnyStateMachine, StateFrom } from 'xstate'
 
+import { noAutofillFormProps, noAutofillInputProps } from '@src/lib/autofill'
 import { useApp } from '@src/lib/boot'
 import type {
   CommandArgument,
@@ -119,6 +120,7 @@ function CommandArgOptionInput({
 
   return (
     <form
+      {...noAutofillFormProps}
       id="arg-form"
       onSubmit={handleSubmit}
       ref={formRef}
@@ -144,6 +146,7 @@ function CommandArgOptionInput({
             {argName}
           </label>
           <Combobox.Input
+            {...noAutofillInputProps}
             id="option-input"
             data-testid="cmd-bar-arg-value"
             ref={inputRef}
@@ -171,10 +174,6 @@ function CommandArgOptionInput({
               argName ||
               'Select an option'
             }
-            autoCapitalize="off"
-            autoComplete="off"
-            autoCorrect="off"
-            spellCheck="false"
             autoFocus
           />
         </div>

--- a/src/components/CommandBar/CommandBarBasicInput.tsx
+++ b/src/components/CommandBar/CommandBarBasicInput.tsx
@@ -3,6 +3,7 @@ import { use, useEffect, useMemo, useRef } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 
 import { MarkdownText } from '@src/components/MarkdownText'
+import { noAutofillFormProps, noAutofillInputProps } from '@src/lib/autofill'
 import { useApp } from '@src/lib/boot'
 import type { CommandArgument } from '@src/lib/commandTypes'
 import type { AnyStateMachine, SnapshotFrom } from 'xstate'
@@ -70,7 +71,12 @@ function CommandBarBasicInput({
   }
 
   return (
-    <form id="arg-form" onSubmit={handleSubmit} className="flex flex-col">
+    <form
+      {...noAutofillFormProps}
+      id="arg-form"
+      onSubmit={handleSubmit}
+      className="flex flex-col"
+    >
       <label
         data-testid="cmd-bar-arg-name"
         className="flex items-center mx-4 my-4"
@@ -84,6 +90,7 @@ function CommandBarBasicInput({
           </span>
         )}
         <input
+          {...noAutofillInputProps}
           data-testid="cmd-bar-arg-value"
           id="arg-form"
           name={arg.inputType}
@@ -93,10 +100,6 @@ function CommandBarBasicInput({
           className={`flex-grow ${arg.inputType === 'color' ? 'h-[41px]' : 'px-2 py-1 border-b border-b-chalkboard-100 dark:border-b-chalkboard-80'} !bg-transparent focus:outline-none`}
           placeholder="Enter a value"
           defaultValue={defaultValue}
-          data-1p-ignore
-          data-lpignore="true"
-          data-form-type="other"
-          data-bwignore
           onKeyDown={(event) => {
             if (event.key === 'Backspace' && event.metaKey) {
               stepBack()

--- a/src/components/CommandBar/CommandBarKclInput.tsx
+++ b/src/components/CommandBar/CommandBarKclInput.tsx
@@ -33,6 +33,11 @@ import { Compartment, EditorState } from '@codemirror/state'
 import { editorTheme, themeCompartment } from '@src/editor/plugins/theme'
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import type { KclManager } from '@src/lang/KclManager'
+import {
+  noAutofillFormProps,
+  noAutofillInputProps,
+  setNoAutofillAttributes,
+} from '@src/lib/autofill'
 import styles from './CommandBarKclInput.module.css'
 
 // TODO: remove the need for this selector once we decouple all actors from React
@@ -256,6 +261,9 @@ function CommandBarKclInput({
 
   useEffect(() => {
     if (editorRef.current) {
+      setNoAutofillAttributes(editorRef.current)
+      setNoAutofillAttributes(miniEditor.dom)
+      setNoAutofillAttributes(miniEditor.contentDOM)
       miniEditor.dispatch({
         changes: {
           from: 0,
@@ -334,6 +342,7 @@ function CommandBarKclInput({
 
   return (
     <form
+      {...noAutofillFormProps}
       id="arg-form"
       className="mb-2"
       onSubmit={handleSubmit}
@@ -398,16 +407,13 @@ function CommandBarKclInput({
           {createNewVariable && (
             <>
               <input
+                {...noAutofillInputProps}
                 type="text"
                 id="variable-name"
                 name="variable-name"
                 className="flex-1  border-solid border-0 border-b border-chalkboard-50 bg-transparent focus:outline-none"
                 placeholder="Variable name"
                 value={newVariableName}
-                autoCapitalize="off"
-                autoCorrect="off"
-                autoComplete="off"
-                spellCheck="false"
                 autoFocus
                 onChange={(e) => setNewVariableName(e.target.value)}
                 onKeyDown={(e) => {

--- a/src/components/CommandBar/CommandBarPathInput.tsx
+++ b/src/components/CommandBar/CommandBarPathInput.tsx
@@ -2,6 +2,7 @@ import { use, useEffect, useMemo, useRef } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 
 import { ActionButton } from '@src/components/ActionButton'
+import { noAutofillFormProps, noAutofillInputProps } from '@src/lib/autofill'
 import { useApp } from '@src/lib/boot'
 import type { CommandArgument } from '@src/lib/commandTypes'
 import { reportRejection } from '@src/lib/trap'
@@ -91,7 +92,7 @@ function CommandBarPathInput({
   }, [])
 
   return (
-    <form id="arg-form" onSubmit={handleSubmit}>
+    <form {...noAutofillFormProps} id="arg-form" onSubmit={handleSubmit}>
       <label
         data-testid="cmd-bar-arg-name"
         className="flex items-center mx-4 my-4 border-b border-b-chalkboard-100 dark:border-b-chalkboard-80"
@@ -100,6 +101,7 @@ function CommandBarPathInput({
           {arg.displayName || arg.name}
         </span>
         <input
+          {...noAutofillInputProps}
           type="text"
           data-testid="cmd-bar-arg-value"
           id="arg-form"

--- a/src/components/CommandBar/CommandBarReview.tsx
+++ b/src/components/CommandBar/CommandBarReview.tsx
@@ -4,6 +4,7 @@ import CommandBarDivider from '@src/components/CommandBar/CommandBarDivider'
 import CommandBarHeaderFooter from '@src/components/CommandBar/CommandBarHeaderFooter'
 import { evaluateCommandBarArg } from '@src/components/CommandBar/utils'
 import { CustomIcon } from '@src/components/CustomIcon'
+import { noAutofillFormProps, noAutofillInputProps } from '@src/lib/autofill'
 import { useApp } from '@src/lib/boot'
 import type { CommandArgument } from '@src/lib/commandTypes'
 import { useMemo } from 'react'
@@ -38,10 +39,10 @@ function CommandBarReview({ stepBack }: { stepBack: () => void }) {
       'alt+0',
     ],
     (_, b) => {
-      if (b.keys && !Number.isNaN(parseInt(b.keys[0], 10))) {
+      if (b.keys && !Number.isNaN(Number.parseInt(b.keys[0], 10))) {
         if (!selectedCommand?.args) return
         const argName = Object.keys(selectedCommand.args)[
-          parseInt(b.keys[0], 10) - 1
+          Number.parseInt(b.keys[0], 10) - 1
         ]
         const arg = selectedCommand?.args[argName]
         if (!arg) return
@@ -158,6 +159,7 @@ function CommandBarReview({ stepBack }: { stepBack: () => void }) {
         </>
       )}
       <form
+        {...noAutofillFormProps}
         id="review-form"
         className="absolute opacity-0 inset-0 pointer-events-none"
         onSubmit={submitCommand}
@@ -170,6 +172,7 @@ function CommandBarReview({ stepBack }: { stepBack: () => void }) {
 
           return (
             <input
+              {...noAutofillInputProps}
               id={key}
               name={key}
               key={key}

--- a/src/components/CommandBar/CommandBarSelectionInput.tsx
+++ b/src/components/CommandBar/CommandBarSelectionInput.tsx
@@ -3,6 +3,7 @@ import { use, useEffect, useMemo, useRef, useState } from 'react'
 import type { StateFrom } from 'xstate'
 
 import type { KclManager } from '@src/lang/KclManager'
+import { noAutofillFormProps, noAutofillInputProps } from '@src/lib/autofill'
 import { useApp } from '@src/lib/boot'
 import type { CommandArgument } from '@src/lib/commandTypes'
 import {
@@ -155,7 +156,7 @@ function CommandBarSelectionInput({
   }, [arg.selectionFilter, wasmInstance])
 
   return (
-    <form id="arg-form" onSubmit={handleSubmit}>
+    <form {...noAutofillFormProps} id="arg-form" onSubmit={handleSubmit}>
       <label
         className={
           'relative flex flex-col mx-4 my-4 ' +
@@ -172,6 +173,7 @@ function CommandBarSelectionInput({
           {arg.name}
         </span>
         <input
+          {...noAutofillInputProps}
           id="selection"
           name="selection"
           ref={inputRef}

--- a/src/components/CommandBar/CommandBarSelectionMixedInput.tsx
+++ b/src/components/CommandBar/CommandBarSelectionMixedInput.tsx
@@ -3,6 +3,7 @@ import { use, useEffect, useMemo, useRef, useState } from 'react'
 
 import type { KclManager } from '@src/lang/KclManager'
 import { coerceSelectionsToBody } from '@src/lang/std/artifactGraph'
+import { noAutofillFormProps, noAutofillInputProps } from '@src/lib/autofill'
 import { useApp } from '@src/lib/boot'
 import type { CommandArgument } from '@src/lib/commandTypes'
 import {
@@ -226,7 +227,7 @@ export default function CommandBarSelectionMixedInput({
     isMixedSelection && arg.selectionSource?.allowSceneSelection
 
   return (
-    <form id="arg-form" onSubmit={handleSubmit}>
+    <form {...noAutofillFormProps} id="arg-form" onSubmit={handleSubmit}>
       <label
         className={
           'relative flex flex-col mx-4 my-4 ' +
@@ -261,6 +262,7 @@ export default function CommandBarSelectionMixedInput({
           {arg.name}
         </span>
         <input
+          {...noAutofillInputProps}
           id="selection"
           name="selection"
           ref={inputRef}

--- a/src/components/CommandBar/CommandBarTextareaInput.tsx
+++ b/src/components/CommandBar/CommandBarTextareaInput.tsx
@@ -2,6 +2,7 @@ import type { RefObject } from 'react'
 import { useEffect, useRef } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 
+import { noAutofillFormProps, noAutofillInputProps } from '@src/lib/autofill'
 import { useApp } from '@src/lib/boot'
 import type { CommandArgument } from '@src/lib/commandTypes'
 
@@ -38,6 +39,7 @@ function CommandBarTextareaInput({
 
   return (
     <form
+      {...noAutofillFormProps}
       id="arg-form"
       className="flex flex-col items-stretch gap-2 mx-4 my-4 "
       onSubmit={handleSubmit}
@@ -51,6 +53,7 @@ function CommandBarTextareaInput({
           {arg.displayName || arg.name}
         </span>
         <textarea
+          {...noAutofillInputProps}
           data-testid="cmd-bar-arg-value"
           id="arg-form"
           name={arg.inputType}

--- a/src/components/CommandBar/CommandBarVector2DInput.tsx
+++ b/src/components/CommandBar/CommandBarVector2DInput.tsx
@@ -1,6 +1,7 @@
 import { CustomIcon } from '@src/components/CustomIcon'
 import { Spinner } from '@src/components/Spinner'
 import type { KclManager } from '@src/lang/KclManager'
+import { noAutofillFormProps, noAutofillInputProps } from '@src/lib/autofill'
 import { useApp } from '@src/lib/boot'
 import type { CommandArgument, KclCommandValue } from '@src/lib/commandTypes'
 import { isKclCommandValue } from '@src/lib/commandUtils'
@@ -40,6 +41,7 @@ function CoordinateInput({
         {label}
       </span>
       <input
+        {...noAutofillInputProps}
         ref={inputRef}
         data-testid={testId}
         type="text"
@@ -272,6 +274,7 @@ function CommandBarVector2DInput({
 
   return (
     <form
+      {...noAutofillFormProps}
       id="arg-form"
       className="mb-2"
       onSubmit={handleSubmit}

--- a/src/components/CommandBar/CommandBarVector3DInput.tsx
+++ b/src/components/CommandBar/CommandBarVector3DInput.tsx
@@ -1,6 +1,7 @@
 import { CustomIcon } from '@src/components/CustomIcon'
 import { Spinner } from '@src/components/Spinner'
 import type { KclManager } from '@src/lang/KclManager'
+import { noAutofillFormProps, noAutofillInputProps } from '@src/lib/autofill'
 import { useApp } from '@src/lib/boot'
 import type { CommandArgument, KclCommandValue } from '@src/lib/commandTypes'
 import { isKclCommandValue } from '@src/lib/commandUtils'
@@ -34,6 +35,7 @@ function CoordinateInput({
         {label}
       </span>
       <input
+        {...noAutofillInputProps}
         ref={inputRef}
         data-testid={testId}
         type="text"
@@ -279,6 +281,7 @@ function CommandBarVector3DInput({
 
   return (
     <form
+      {...noAutofillFormProps}
       id="arg-form"
       className="mb-2"
       onSubmit={handleSubmit}

--- a/src/components/CommandComboBox.tsx
+++ b/src/components/CommandComboBox.tsx
@@ -3,6 +3,7 @@ import Fuse from 'fuse.js'
 import { useEffect, useMemo, useState } from 'react'
 
 import { CustomIcon } from '@src/components/CustomIcon'
+import { noAutofillInputProps } from '@src/lib/autofill'
 import { useApp } from '@src/lib/boot'
 import type { Command } from '@src/lib/commandTypes'
 import { sortCommands } from '@src/lib/commandUtils'
@@ -58,6 +59,7 @@ function CommandComboBox({
           className="w-5 h-5 bg-primary/10 dark:bg-primary text-primary dark:text-inherit"
         />
         <Combobox.Input
+          {...noAutofillInputProps}
           data-testid="cmd-bar-search"
           onChange={(event) => setQuery(event.target.value)}
           className="w-full bg-transparent focus:outline-none selection:bg-primary/20 dark:selection:bg-primary/40 dark:focus:outline-none"
@@ -75,10 +77,6 @@ function CommandComboBox({
             placeholder ||
             'Search commands'
           }
-          autoCapitalize="off"
-          autoComplete="off"
-          autoCorrect="off"
-          spellCheck="false"
           autoFocus
         />
       </div>

--- a/src/components/EngineCommands.tsx
+++ b/src/components/EngineCommands.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 
 import type { CommandLog } from '@src/lang/std/commandLog'
+import { noAutofillInputProps } from '@src/lib/autofill'
 import { useSingletons } from '@src/lib/boot'
 import { reportRejection } from '@src/lib/trap'
 
@@ -29,6 +30,7 @@ export const EngineCommands = () => {
   return (
     <div>
       <input
+        {...noAutofillInputProps}
         className="text-gray-800 bg-slate-300 px-2"
         data-testid="filter-input"
         type="text"
@@ -77,6 +79,7 @@ export const EngineCommands = () => {
       </button>
       <br />
       <input
+        {...noAutofillInputProps}
         className="text-gray-800 bg-slate-300 px-2"
         type="text"
         value={customCmd}

--- a/src/components/Explorer/FileExplorer.tsx
+++ b/src/components/Explorer/FileExplorer.tsx
@@ -11,6 +11,7 @@ import {
   shouldDroppedEntryBeMoved,
 } from '@src/components/Explorer/utils'
 import { DeleteConfirmationDialog } from '@src/components/ProjectCard/DeleteProjectDialog'
+import { noAutofillFormProps, noAutofillInputProps } from '@src/lib/autofill'
 import fsZds from '@src/lib/fs-zds'
 import type { MaybePressOrBlur, SubmitByPressOrBlur } from '@src/lib/types'
 import { uuidv4 } from '@src/lib/utils'
@@ -193,16 +194,15 @@ function RenameForm({
   }
   const formattedPlaceHolder = isRowFake(row) ? '' : row.name
   return (
-    <form onKeyUp={handleRenameSubmit}>
+    <form {...noAutofillFormProps} onKeyUp={handleRenameSubmit}>
       <label>
         <span className="sr-only">Rename file</span>
         <input
+          {...noAutofillInputProps}
           data-testid="file-rename-field"
           ref={inputRef}
           type="text"
           autoFocus
-          autoCapitalize="off"
-          autoCorrect="off"
           placeholder={formattedPlaceHolder}
           className="p-1 overflow-hidden whitespace-nowrap text-ellipsis py-1 bg-transparent outline outline-primary -outline-offset-4 text-chalkboard-100 placeholder:text-chalkboard-70 dark:text-chalkboard-10 dark:placeholder:text-chalkboard-50 focus:ring-0"
           onKeyDown={handleKeyDown}

--- a/src/components/MlEphantConversation.tsx
+++ b/src/components/MlEphantConversation.tsx
@@ -6,6 +6,7 @@ import Loading from '@src/components/Loading'
 import { MakeathonAnnouncement } from '@src/components/MakeathonAnnouncement'
 import Tooltip from '@src/components/Tooltip'
 import { ViewportAnnotationOverlay } from '@src/components/ViewportAnnotationOverlay'
+import { noAutofillInputProps } from '@src/lib/autofill'
 import { dataUrlToFile, takeViewportScreenshot } from '@src/lib/screenshot'
 import { err } from '@src/lib/trap'
 import { isNonNullable } from '@src/lib/utils'
@@ -15,7 +16,7 @@ import type {
   MlCopilotModeId,
   MlCopilotModeOption,
 } from '@src/machines/mlEphantManagerMachine'
-import { type Selections } from '@src/machines/modelingSharedTypes'
+import type { Selections } from '@src/machines/modelingSharedTypes'
 import type { ChangeEvent, ReactNode } from 'react'
 import { useEffect, useRef, useState } from 'react'
 
@@ -450,9 +451,7 @@ export const MlEphantConversationInput = (
           className="hidden"
         />
         <textarea
-          autoCapitalize="off"
-          autoCorrect="off"
-          spellCheck="false"
+          {...noAutofillInputProps}
           data-testid="ml-ephant-conversation-input"
           onChange={(e) => setValue(e.target.value)}
           value={value}

--- a/src/components/ProjectCard/ProjectCardRenameForm.tsx
+++ b/src/components/ProjectCard/ProjectCardRenameForm.tsx
@@ -3,6 +3,7 @@ import { forwardRef } from 'react'
 
 import { ActionButton } from '@src/components/ActionButton'
 import Tooltip from '@src/components/Tooltip'
+import { noAutofillFormProps, noAutofillInputProps } from '@src/lib/autofill'
 import type { Project } from '@src/lib/project'
 
 interface ProjectCardRenameFormProps extends HTMLProps<HTMLFormElement> {
@@ -16,8 +17,9 @@ export const ProjectCardRenameForm = forwardRef(
     ref: React.Ref<HTMLInputElement>
   ) => {
     return (
-      <form {...props}>
+      <form {...props} {...noAutofillFormProps}>
         <input
+          {...noAutofillInputProps}
           className="min-w-0 dark:bg-chalkboard-80 dark:border-chalkboard-40 focus:outline-none"
           type="text"
           data-testid="project-rename-input"
@@ -25,8 +27,6 @@ export const ProjectCardRenameForm = forwardRef(
           onClickCapture={(e) => e.preventDefault()}
           name="newProjectName"
           required
-          autoCorrect="off"
-          autoCapitalize="off"
           defaultValue={project.name}
           ref={ref}
           onKeyDown={(e) => {

--- a/src/components/ProjectSearchBar.tsx
+++ b/src/components/ProjectSearchBar.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 
 import { CustomIcon } from '@src/components/CustomIcon'
+import { noAutofillInputProps } from '@src/lib/autofill'
 import type { Project } from '@src/lib/project'
 
 export function useProjectSearch(projects: Project[] | undefined) {
@@ -58,14 +59,11 @@ export function ProjectSearchBar({
           className="w-5 h-5 rounded-sm bg-primary/10 dark:bg-transparent text-primary dark:text-chalkboard-10 group-focus-within:bg-primary group-focus-within:text-chalkboard-10"
         />
         <input
+          {...noAutofillInputProps}
           ref={inputRef}
           onChange={(event) => setQuery(event.target.value)}
           className="w-full text-sm bg-transparent focus:outline-none selection:bg-primary/20 dark:selection:bg-primary/40 dark:focus:outline-none"
           placeholder="Search projects (Ctrl+.)"
-          autoCapitalize="off"
-          autoComplete="off"
-          autoCorrect="off"
-          spellCheck="false"
         />
       </div>
     </div>

--- a/src/components/PublishDialog.tsx
+++ b/src/components/PublishDialog.tsx
@@ -1,6 +1,7 @@
 import { Popover, Transition } from '@headlessui/react'
 import type { ProjectCategoryResponse } from '@kittycad/lib'
 import { ActionButton } from '@src/components/ActionButton'
+import { noAutofillFormProps, noAutofillInputProps } from '@src/lib/autofill'
 import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
 import type {
   CurrentProjectPublicationDetails,
@@ -171,6 +172,7 @@ export function PublishDialog({
         </div>
 
         <form
+          {...noAutofillFormProps}
           className="flex flex-col gap-4 px-4 py-4"
           onSubmit={(event) => {
             event.preventDefault()
@@ -186,6 +188,7 @@ export function PublishDialog({
                 Title*
               </label>
               <input
+                {...noAutofillInputProps}
                 id="publish-project-title"
                 type="text"
                 required
@@ -217,6 +220,7 @@ export function PublishDialog({
                 Description*
               </label>
               <textarea
+                {...noAutofillInputProps}
                 id="publish-project-description"
                 required
                 rows={4}

--- a/src/components/SetAngleLengthModal.tsx
+++ b/src/components/SetAngleLengthModal.tsx
@@ -9,6 +9,7 @@ import {
   addToInputHelper,
 } from '@src/components/AvailableVarsHelpers'
 import type { Expr } from '@src/lang/wasm'
+import { noAutofillInputProps } from '@src/lib/autofill'
 import { useSingletons } from '@src/lib/boot'
 import { useCalculateKclExpression } from '@src/lib/useCalculateKclExpression'
 import type { Selections } from '@src/machines/modelingSharedTypes'
@@ -129,6 +130,7 @@ export const SetAngleLengthModal = ({
                     {sign > 0 ? '+' : '-'}
                   </button>
                   <input
+                    {...noAutofillInputProps}
                     ref={inputRef}
                     type="text"
                     name="val"

--- a/src/components/SetHorVertDistanceModal.tsx
+++ b/src/components/SetHorVertDistanceModal.tsx
@@ -9,6 +9,7 @@ import {
   addToInputHelper,
 } from '@src/components/AvailableVarsHelpers'
 import type { Expr } from '@src/lang/wasm'
+import { noAutofillInputProps } from '@src/lib/autofill'
 import { useSingletons } from '@src/lib/boot'
 import { useCalculateKclExpression } from '@src/lib/useCalculateKclExpression'
 import type { Selections } from '@src/machines/modelingSharedTypes'
@@ -131,6 +132,7 @@ export const GetInfoModal = ({
                     {sign > 0 ? '+' : '-'}
                   </button>
                   <input
+                    {...noAutofillInputProps}
                     type="text"
                     name="val"
                     id="val"
@@ -151,6 +153,7 @@ export const GetInfoModal = ({
                 </label>
                 <div className="mt-1">
                   <input
+                    {...noAutofillInputProps}
                     type="text"
                     name="segName"
                     id="segName"

--- a/src/components/Settings/SettingsFieldInput.tsx
+++ b/src/components/Settings/SettingsFieldInput.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import type { EventFrom } from 'xstate'
 
 import { Toggle } from '@src/components/Toggle/Toggle'
+import { noAutofillInputProps } from '@src/lib/autofill'
 import { useApp } from '@src/lib/boot'
 import type { Setting } from '@src/lib/settings/initialSettings'
 import type {
@@ -126,6 +127,7 @@ export function SettingsFieldInput({
           : setting.getFallback(settingsLevel)
       return (
         <input
+          {...noAutofillInputProps}
           // When reverting to default value then the input doesn't update without a key change.
           // Another fix for this would be to make this a controlled component.
           key={`${category}-${settingName}-${settingsLevel}-${String(
@@ -179,7 +181,7 @@ export function SettingsFieldInput({
           min={min}
           disabled={!setting.isEnabled(context)}
           onBlur={(e) => {
-            let numValue = parseFloat(e.target.value)
+            const numValue = Number.parseFloat(e.target.value)
             let updatedValue = numValue
             // "integer" option
             if (setting.commandConfig && 'integer' in setting.commandConfig) {

--- a/src/components/Settings/SettingsSearchBar.tsx
+++ b/src/components/Settings/SettingsSearchBar.tsx
@@ -5,6 +5,7 @@ import { useHotkeys } from 'react-hotkeys-hook'
 import { useNavigate } from 'react-router-dom'
 
 import { CustomIcon } from '@src/components/CustomIcon'
+import { noAutofillInputProps } from '@src/lib/autofill'
 import { useApp } from '@src/lib/boot'
 import { isDesktop } from '@src/lib/isDesktop'
 import { interactionMap } from '@src/lib/settings/initialKeybindings'
@@ -102,14 +103,11 @@ export function SettingsSearchBar({ showPlugins }: SettingsSearchBarProps) {
       <div className="relative group">
         <div className="flex items-center gap-2 py-0.5 pr-1 pl-2 rounded border-solid border border-primary/10 dark:border-chalkboard-80 focus-within:border-primary dark:focus-within:border-chalkboard-30">
           <Combobox.Input
+            {...noAutofillInputProps}
             ref={inputRef}
             onChange={(event) => setQuery(event.target.value)}
             className="w-full bg-transparent focus:outline-none selection:bg-primary/20 dark:selection:bg-primary/40 dark:focus:outline-none"
             placeholder="Search settings (Ctrl+.)"
-            autoCapitalize="off"
-            autoComplete="off"
-            autoCorrect="off"
-            spellCheck="false"
             autoFocus
           />
           <CustomIcon

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -1,6 +1,7 @@
 import { Popover, Transition } from '@headlessui/react'
 import { ActionButton } from '@src/components/ActionButton'
 import { CustomIcon } from '@src/components/CustomIcon'
+import { noAutofillFormProps, noAutofillInputProps } from '@src/lib/autofill'
 import { Fragment, useEffect, useState } from 'react'
 
 export interface ShareDialogSubmitArgs {
@@ -101,6 +102,7 @@ export function ShareDialog({
         </div>
 
         <form
+          {...noAutofillFormProps}
           className="flex flex-col gap-4 px-4 py-4"
           onSubmit={(event) => {
             event.preventDefault()
@@ -180,15 +182,12 @@ export function ShareDialog({
                 Password
               </label>
               <input
+                {...noAutofillInputProps}
                 id="share-link-password"
                 type="text"
                 value={password}
                 disabled={!allowPassword}
                 onChange={(event) => setPassword(event.target.value)}
-                autoCapitalize="off"
-                autoComplete="off"
-                autoCorrect="off"
-                spellCheck="false"
                 placeholder="Set a password"
                 className={`mt-2 w-full rounded border border-chalkboard-20/80 bg-chalkboard-10/90 px-2.5 py-2 text-sm text-chalkboard-100 placeholder:text-chalkboard-60 focus:outline-none focus-visible:outline-appForeground dark:border-chalkboard-80/70 dark:bg-chalkboard-90/80 dark:text-chalkboard-10 dark:placeholder:text-chalkboard-40 ${
                   allowPassword ? '' : 'cursor-not-allowed'

--- a/src/lib/autofill.ts
+++ b/src/lib/autofill.ts
@@ -1,0 +1,40 @@
+export const noAutofillFormProps = {
+  autoComplete: 'off',
+  'data-form-type': 'other',
+} as const
+
+export const noAutofillInputProps = {
+  autoCapitalize: 'off',
+  autoComplete: 'off',
+  autoCorrect: 'off',
+  spellCheck: false,
+  'data-1p-ignore': 'true',
+  'data-op-ignore': 'true',
+  'data-lpignore': 'true',
+  'data-form-type': 'other',
+  'data-bwignore': 'true',
+  'data-protonpass-ignore': 'true',
+} as const
+
+const noAutofillAttributes = {
+  autocapitalize: noAutofillInputProps.autoCapitalize,
+  autocomplete: noAutofillInputProps.autoComplete,
+  autocorrect: noAutofillInputProps.autoCorrect,
+  spellcheck: String(noAutofillInputProps.spellCheck),
+  'data-1p-ignore': noAutofillInputProps['data-1p-ignore'],
+  'data-op-ignore': noAutofillInputProps['data-op-ignore'],
+  'data-lpignore': noAutofillInputProps['data-lpignore'],
+  'data-form-type': noAutofillInputProps['data-form-type'],
+  'data-bwignore': noAutofillInputProps['data-bwignore'],
+  'data-protonpass-ignore': noAutofillInputProps['data-protonpass-ignore'],
+} as const
+
+export function setNoAutofillAttributes(element?: HTMLElement | null) {
+  if (!element) {
+    return
+  }
+
+  for (const [attribute, value] of Object.entries(noAutofillAttributes)) {
+    element.setAttribute(attribute, value)
+  }
+}

--- a/src/routes/AdvancedSignInOptions.tsx
+++ b/src/routes/AdvancedSignInOptions.tsx
@@ -1,6 +1,7 @@
 import { Combobox, Popover, RadioGroup, Transition } from '@headlessui/react'
 import { ActionButton } from '@src/components/ActionButton'
 import { CustomIcon } from '@src/components/CustomIcon'
+import { noAutofillInputProps } from '@src/lib/autofill'
 import { isDesktop } from '@src/lib/isDesktop'
 import { Fragment, useState } from 'react'
 
@@ -171,6 +172,7 @@ export const AdvancedSignInOptions = ({
                 >
                   {showCustomInput && (
                     <Combobox.Input
+                      {...noAutofillInputProps}
                       className="gap-1 rounded h-6 border px-2 flex items-center dark:hover:bg-chalkboard-80 text-xs text-chalkboard-70 dark:text-chalkboard-30 dark:bg-chalkboard-90"
                       placeholder="auto"
                       onChange={(event) =>

--- a/src/routes/SignIn.tsx
+++ b/src/routes/SignIn.tsx
@@ -9,6 +9,7 @@ import { CustomIcon } from '@src/components/CustomIcon'
 import { Logo } from '@src/components/Logo'
 import { updateEnvironment } from '@src/env'
 import env from '@src/env'
+import { noAutofillInputProps } from '@src/lib/autofill'
 import { useApp } from '@src/lib/boot'
 import { APP_NAME } from '@src/lib/constants'
 import { readEnvironmentFile, writeEnvironmentFile } from '@src/lib/desktop'
@@ -273,6 +274,7 @@ const SignIn = () => {
                         </p>
                         <div className="flex flex-col gap-2 sm:flex-row">
                           <input
+                            {...noAutofillInputProps}
                             readOnly
                             aria-label="Sign-in URL"
                             value={verificationUri}


### PR DESCRIPTION
Fixes #11901

Codex written. Sets common input props to disable autofill from password managers in all fields in the app.