### PR TITLE
Revert Zoodle rename

### DIFF
--- a/src/components/MlEphantConversation.spec.tsx
+++ b/src/components/MlEphantConversation.spec.tsx
@@ -855,12 +855,14 @@ describe('MlEphantConversation', () => {
       ).toBeInTheDocument()
     })
 
-    test('displays Zoodle button', () => {
+    test('displays screenshot annotation button', () => {
       renderConversation()
-      expect(screen.getByTestId('ml-ephant-zoodle-button')).toBeInTheDocument()
+      expect(
+        screen.getByTestId('ml-ephant-annotate-screenshot-button')
+      ).toBeInTheDocument()
     })
 
-    test('adds Zoodle as an attachment', async () => {
+    test('adds annotated viewport screenshot as an attachment', async () => {
       const OriginalImage = globalThis.Image
       class MockImage {
         onload: (() => void) | null = null
@@ -883,7 +885,9 @@ describe('MlEphantConversation', () => {
       try {
         renderConversation()
 
-        fireEvent.click(screen.getByTestId('ml-ephant-zoodle-button'))
+        fireEvent.click(
+          screen.getByTestId('ml-ephant-annotate-screenshot-button')
+        )
 
         expect(
           screen.getByTestId('viewport-annotation-overlay')
@@ -893,7 +897,9 @@ describe('MlEphantConversation', () => {
         await waitFor(() => expect(sendButton).not.toBeDisabled())
         fireEvent.click(sendButton)
 
-        expect(await screen.findByText('zoodle')).toBeInTheDocument()
+        expect(
+          await screen.findByText('annotated-viewport-screenshot.png')
+        ).toBeInTheDocument()
       } finally {
         drawImageSpy.mockRestore()
         globalThis.Image = OriginalImage

--- a/src/components/MlEphantConversation.tsx
+++ b/src/components/MlEphantConversation.tsx
@@ -178,15 +178,15 @@ export const MlEphantExtraInputs = (props: MlEphantExtraInputsProps) => {
         </button>
         <button
           type="button"
-          data-testid="ml-ephant-zoodle-button"
+          data-testid="ml-ephant-annotate-screenshot-button"
           onClick={props.onAnnotateScreenshot}
           disabled={props.attachmentsDisabled}
           className="h-7 w-7 bg-default flex items-center justify-center rounded-sm m-0 p-0 flex-none disabled:opacity-60"
-          aria-label="Zoodle"
+          aria-label="Annotate viewport screenshot"
         >
           <CustomIcon name="sketch" className="w-5 h-5" />
           <Tooltip position="top" hoverOnly={true}>
-            <span>Zoodle</span>
+            <span>Annotate viewport screenshot</span>
           </Tooltip>
         </button>
       </div>
@@ -557,7 +557,10 @@ export const MlEphantConversationInput = (
           imageDataUrl={annotationImageDataUrl}
           onCancel={() => setAnnotationImageDataUrl(null)}
           onSend={(annotatedDataUrl) => {
-            appendDataUrlAttachment(annotatedDataUrl, 'zoodle')
+            appendDataUrlAttachment(
+              annotatedDataUrl,
+              'annotated-viewport-screenshot.png'
+            )
             setAnnotationImageDataUrl(null)
           }}
         />


### PR DESCRIPTION
ai assisted

## Problem
PR #11887 renamed the annotated viewport screenshot flow to Zoodle, but the current behavior is confusing Zookeeper around which attached image to use. Users can end up with unclear attachment references instead of the direct annotated viewport screenshot workflow.

## Solution
Revert PR #11887 so the UI, test ids, and attached file name return to the explicit annotated viewport screenshot behavior while the Zoodle attachment flow is re-evaluated separately.