### PR TITLE
KCL: Add `version` flag to chamfer/fillet

### DIFF
--- a/docs/kcl-std/functions/std-solid-chamfer.md
+++ b/docs/kcl-std/functions/std-solid-chamfer.md
@@ -35,7 +35,7 @@ a sharp, straight transitional edge.
 | `angle` | [`number(Angle)`](/docs/kcl-std/types/std-types-number) | Chamfering cuts away two faces to create a third face. This argument determines the angle between the two cut edges. Requires `length`, incompatible with `secondLength`. The valid range is 0deg < angle < 90deg. | No |
 | `tag` | [`TagDecl`](/docs/kcl-std/types/std-types-TagDecl) | Create a new tag which refers to this chamfer | No |
 | `legacyMethod` | [`bool`](/docs/kcl-std/types/std-types-bool) | **Deprecated as of KCL 2.0.** You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
-| `version` | [`number(_)`](/docs/kcl-std/types/std-types-number) | **Experimental.** What version of the fillet algorithm to use. Defaults to 0. | No |
+| `version` | [`number(_)`](/docs/kcl-std/types/std-types-number) | **Experimental.** What version of the fillet algorithm to use. Defaults to 1. 0 means "let the Zoo engine choose whichever version is best", 1 is the original Zoo fillet algorithm, 2 is the newer algorithm (supports rolling ball fillets). | No |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-solid-chamfer.md
+++ b/docs/kcl-std/functions/std-solid-chamfer.md
@@ -16,6 +16,7 @@ chamfer(
   angle?: number(Angle),
   tag?: TagDecl,
   legacyMethod?: bool,
+  version?: number(_),
 ): Solid
 ```
 
@@ -34,6 +35,7 @@ a sharp, straight transitional edge.
 | `angle` | [`number(Angle)`](/docs/kcl-std/types/std-types-number) | Chamfering cuts away two faces to create a third face. This argument determines the angle between the two cut edges. Requires `length`, incompatible with `secondLength`. The valid range is 0deg < angle < 90deg. | No |
 | `tag` | [`TagDecl`](/docs/kcl-std/types/std-types-TagDecl) | Create a new tag which refers to this chamfer | No |
 | `legacyMethod` | [`bool`](/docs/kcl-std/types/std-types-bool) | **Deprecated as of KCL 2.0.** You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
+| `version` | [`number(_)`](/docs/kcl-std/types/std-types-number) | **Experimental.** What version of the fillet algorithm to use. Defaults to 0. | No |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-solid-fillet.md
+++ b/docs/kcl-std/functions/std-solid-fillet.md
@@ -33,7 +33,7 @@ will smoothly blend the transition.
 | `tolerance` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | Defines the smallest distance below which two entities are considered coincident, intersecting, coplanar, or similar. For most use cases, it should not be changed from its default value of 10^-7 millimeters. | No |
 | `tag` | [`TagDecl`](/docs/kcl-std/types/std-types-TagDecl) | Create a new tag which refers to this fillet | No |
 | `legacyMethod` | [`bool`](/docs/kcl-std/types/std-types-bool) | **Deprecated as of KCL 2.0.** You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
-| `version` | [`number(_)`](/docs/kcl-std/types/std-types-number) | **Experimental.** What version of the fillet algorithm to use. Defaults to 0. | No |
+| `version` | [`number(_)`](/docs/kcl-std/types/std-types-number) | **Experimental.** What version of the fillet algorithm to use. Defaults to 1. 0 means "let the Zoo engine choose whichever version is best", 1 is the original Zoo fillet algorithm, 2 is the newer algorithm (supports rolling ball fillets). | No |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-solid-fillet.md
+++ b/docs/kcl-std/functions/std-solid-fillet.md
@@ -15,6 +15,7 @@ fillet(
   tolerance?: number(Length),
   tag?: TagDecl,
   legacyMethod?: bool,
+  version?: number(_),
 ): Solid
 ```
 
@@ -32,6 +33,7 @@ will smoothly blend the transition.
 | `tolerance` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | Defines the smallest distance below which two entities are considered coincident, intersecting, coplanar, or similar. For most use cases, it should not be changed from its default value of 10^-7 millimeters. | No |
 | `tag` | [`TagDecl`](/docs/kcl-std/types/std-types-TagDecl) | Create a new tag which refers to this fillet | No |
 | `legacyMethod` | [`bool`](/docs/kcl-std/types/std-types-bool) | **Deprecated as of KCL 2.0.** You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
+| `version` | [`number(_)`](/docs/kcl-std/types/std-types-number) | **Experimental.** What version of the fillet algorithm to use. Defaults to 0. | No |
 
 ### Returns
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -110,7 +110,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -121,7 +121,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -318,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.8.2"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234655ec178edd82b891e262ea7cf71f6584bcd09eff94db786be23f1821825c"
+checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -328,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.8.2"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ec27229c38ed0eb3c0feee3d2c1d6a4379ae44f418a29a658890e062d8f365"
+checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
  "darling",
  "ident_case",
@@ -1116,7 +1116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2200,7 +2200,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2570,8 +2570,9 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.202"
-source = "git+https://github.com/KittyCAD/modeling-api.git?branch=achalmers%2Fedge-cut-version#c66ed78d8b52f5cefcc23d0ead2c1e0d17d7e2f6"
+version = "0.2.204"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9713868abfa0f81b664504b09b06c91100f24b95aaabf5fef60809f4d7d8549"
 dependencies = [
  "anyhow",
  "bon",
@@ -2599,7 +2600,8 @@ dependencies = [
 [[package]]
 name = "kittycad-modeling-cmds-macros"
 version = "0.1.13"
-source = "git+https://github.com/KittyCAD/modeling-api.git?branch=achalmers%2Fedge-cut-version#c66ed78d8b52f5cefcc23d0ead2c1e0d17d7e2f6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb4ba190f74f6d32f4607ecac4bdebd4a935d4943b8ca8369305e6e7a59b5976"
 dependencies = [
  "kittycad-modeling-cmds-macros-impl",
  "proc-macro2",
@@ -2610,7 +2612,8 @@ dependencies = [
 [[package]]
 name = "kittycad-modeling-cmds-macros-impl"
 version = "0.1.14"
-source = "git+https://github.com/KittyCAD/modeling-api.git?branch=achalmers%2Fedge-cut-version#c66ed78d8b52f5cefcc23d0ead2c1e0d17d7e2f6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743b6533d1848de67e3455a28614a2b7896807ab0d3358ccd3ea1863de3c4e6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3068,7 +3071,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4296,7 +4299,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4828,7 +4831,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5037,7 +5040,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5046,7 +5049,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6063,7 +6066,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -576,7 +576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1116,7 +1116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2200,7 +2200,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2571,7 +2571,7 @@ dependencies = [
 [[package]]
 name = "kittycad-modeling-cmds"
 version = "0.2.202"
-source = "git+https://github.com/KittyCAD/modeling-api.git?branch=achalmers%2Fedge-cut-version#f6886cbb22714df91d9642eed8a452245cff1074"
+source = "git+https://github.com/KittyCAD/modeling-api.git?branch=achalmers%2Fedge-cut-version#c66ed78d8b52f5cefcc23d0ead2c1e0d17d7e2f6"
 dependencies = [
  "anyhow",
  "bon",
@@ -2599,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "kittycad-modeling-cmds-macros"
 version = "0.1.13"
-source = "git+https://github.com/KittyCAD/modeling-api.git?branch=achalmers%2Fedge-cut-version#f6886cbb22714df91d9642eed8a452245cff1074"
+source = "git+https://github.com/KittyCAD/modeling-api.git?branch=achalmers%2Fedge-cut-version#c66ed78d8b52f5cefcc23d0ead2c1e0d17d7e2f6"
 dependencies = [
  "kittycad-modeling-cmds-macros-impl",
  "proc-macro2",
@@ -2610,7 +2610,7 @@ dependencies = [
 [[package]]
 name = "kittycad-modeling-cmds-macros-impl"
 version = "0.1.14"
-source = "git+https://github.com/KittyCAD/modeling-api.git?branch=achalmers%2Fedge-cut-version#f6886cbb22714df91d9642eed8a452245cff1074"
+source = "git+https://github.com/KittyCAD/modeling-api.git?branch=achalmers%2Fedge-cut-version#c66ed78d8b52f5cefcc23d0ead2c1e0d17d7e2f6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4283,7 +4283,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4296,7 +4296,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5037,7 +5037,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6063,7 +6063,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -110,7 +110,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -121,7 +121,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -576,7 +576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1116,7 +1116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2200,7 +2200,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2571,8 +2571,7 @@ dependencies = [
 [[package]]
 name = "kittycad-modeling-cmds"
 version = "0.2.202"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f427c17b09cea1a0d434bf28bf40b1a04f4f90753348f85cc8443f50c85981"
+source = "git+https://github.com/KittyCAD/modeling-api.git?branch=achalmers%2Fedge-cut-version#f6886cbb22714df91d9642eed8a452245cff1074"
 dependencies = [
  "anyhow",
  "bon",
@@ -2600,8 +2599,7 @@ dependencies = [
 [[package]]
 name = "kittycad-modeling-cmds-macros"
 version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb4ba190f74f6d32f4607ecac4bdebd4a935d4943b8ca8369305e6e7a59b5976"
+source = "git+https://github.com/KittyCAD/modeling-api.git?branch=achalmers%2Fedge-cut-version#f6886cbb22714df91d9642eed8a452245cff1074"
 dependencies = [
  "kittycad-modeling-cmds-macros-impl",
  "proc-macro2",
@@ -2612,8 +2610,7 @@ dependencies = [
 [[package]]
 name = "kittycad-modeling-cmds-macros-impl"
 version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743b6533d1848de67e3455a28614a2b7896807ab0d3358ccd3ea1863de3c4e6b"
+source = "git+https://github.com/KittyCAD/modeling-api.git?branch=achalmers%2Fedge-cut-version#f6886cbb22714df91d9642eed8a452245cff1074"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3071,7 +3068,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4286,7 +4283,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4299,7 +4296,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4831,7 +4828,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5040,7 +5037,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5049,7 +5046,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6066,7 +6063,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -29,7 +29,7 @@ kittycad = { version = "0.4.13", default-features = false, features = [
   "js",
   "requests",
 ] }
-kittycad-modeling-cmds = { version = "0.2.202", features = [
+kittycad-modeling-cmds = { version = "0.2.204", features = [
   "ts-rs",
   "websocket",
 ] }
@@ -91,7 +91,7 @@ insta = { opt-level = 3 }
 debug = "line-tables-only"
 
 #Example: how to point modeling-app at a different repo (e.g. a branch or a local clone)
-[patch.crates-io]
+# [patch.crates-io]
 # ezpz = { git = "https://github.com/KittyCAD/ezpz.git", branch = "david/circle-circle-tangent" }
-kittycad-modeling-cmds = { git = "https://github.com/KittyCAD/modeling-api.git", branch = "achalmers/edge-cut-version" }
+# kittycad-modeling-cmds = { git = "https://github.com/KittyCAD/modeling-api.git", branch = "main" }
 # kittycad-modeling-cmds = { path = "../../modeling-api/modeling-cmds" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -91,7 +91,7 @@ insta = { opt-level = 3 }
 debug = "line-tables-only"
 
 #Example: how to point modeling-app at a different repo (e.g. a branch or a local clone)
-# [patch.crates-io]
+[patch.crates-io]
 # ezpz = { git = "https://github.com/KittyCAD/ezpz.git", branch = "david/circle-circle-tangent" }
-# kittycad-modeling-cmds = { git = "https://github.com/KittyCAD/modeling-api.git", branch = "main" }
+kittycad-modeling-cmds = { git = "https://github.com/KittyCAD/modeling-api.git", branch = "achalmers/edge-cut-version" }
 # kittycad-modeling-cmds = { path = "../../modeling-api/modeling-cmds" }

--- a/rust/kcl-lib/src/std/chamfer.rs
+++ b/rust/kcl-lib/src/std/chamfer.rs
@@ -40,13 +40,17 @@ pub async fn chamfer(exec_state: &mut ExecState, args: Args) -> Result<KclValue,
     let legacy_csg: Option<bool> = args.get_kw_arg_opt("legacyMethod", &RuntimeType::bool(), exec_state)?;
     let csg_algorithm = CsgAlgorithm::legacy(legacy_csg.unwrap_or_default());
     let edge_cut_number: Option<u32> = args.get_kw_arg_opt("version", &RuntimeType::count(), exec_state)?;
-    let edge_cut_number = edge_cut_number.unwrap_or(0);
-    let edge_cut_version: EdgeCutVersion = edge_cut_number.try_into().map_err(|()| {
-        KclError::new_semantic(KclErrorDetails::new(
-            format!("{} is not a version of the Zoo edge cut algorithm", edge_cut_number),
-            vec![args.source_range],
-        ))
-    })?;
+    let edge_cut_version: EdgeCutVersion = edge_cut_number
+        .map(|num| {
+            num.try_into().map_err(|()| {
+                KclError::new_semantic(KclErrorDetails::new(
+                    format!("{} is not a version of the Zoo edge cut algorithm", num),
+                    vec![args.source_range],
+                ))
+            })
+        })
+        .transpose()?
+        .unwrap_or_default();
 
     let tag = args.get_kw_arg_opt("tag", &RuntimeType::tag_decl(), exec_state)?;
 

--- a/rust/kcl-lib/src/std/chamfer.rs
+++ b/rust/kcl-lib/src/std/chamfer.rs
@@ -4,9 +4,10 @@ use anyhow::Result;
 use kcmc::ModelingCmd;
 use kcmc::each_cmd as mcmd;
 use kcmc::length_unit::LengthUnit;
+use kcmc::shared::Angle;
 use kcmc::shared::CutStrategy;
 use kcmc::shared::CutTypeV2;
-use kittycad_modeling_cmds::shared::Angle;
+use kcmc::shared::EdgeCutVersion;
 use kittycad_modeling_cmds::{self as kcmc};
 
 use super::args::TyF64;
@@ -38,7 +39,14 @@ pub async fn chamfer(exec_state: &mut ExecState, args: Args) -> Result<KclValue,
     let angle = args.get_kw_arg_opt("angle", &RuntimeType::angle(), exec_state)?;
     let legacy_csg: Option<bool> = args.get_kw_arg_opt("legacyMethod", &RuntimeType::bool(), exec_state)?;
     let csg_algorithm = CsgAlgorithm::legacy(legacy_csg.unwrap_or_default());
-    // TODO: custom profiles not ready yet
+    let edge_cut_number: Option<u32> = args.get_kw_arg_opt("version", &RuntimeType::count(), exec_state)?;
+    let edge_cut_number = edge_cut_number.unwrap_or(0);
+    let edge_cut_version: EdgeCutVersion = edge_cut_number.try_into().map_err(|()| {
+        KclError::new_semantic(KclErrorDetails::new(
+            format!("{} is not a version of the Zoo edge cut algorithm", edge_cut_number),
+            vec![args.source_range],
+        ))
+    })?;
 
     let tag = args.get_kw_arg_opt("tag", &RuntimeType::tag_decl(), exec_state)?;
 
@@ -53,6 +61,7 @@ pub async fn chamfer(exec_state: &mut ExecState, args: Args) -> Result<KclValue,
         None,
         tag,
         csg_algorithm,
+        edge_cut_version,
         exec_state,
         args,
     )
@@ -70,6 +79,7 @@ async fn inner_chamfer(
     custom_profile: Option<Sketch>,
     tag: Option<TagNode>,
     csg_algorithm: CsgAlgorithm,
+    edge_cut_version: EdgeCutVersion,
     exec_state: &mut ExecState,
     args: Args,
 ) -> Result<Box<Solid>, KclError> {
@@ -146,8 +156,10 @@ async fn inner_chamfer(
                             .extra_face_ids(vec![])
                             .strategy(strategy)
                             .object_id(solid.id)
-                            .tolerance(LengthUnit(DEFAULT_TOLERANCE)) // We can let the user set this in the future.
+                            // We can let the user set this in the future.
+                            .tolerance(LengthUnit(DEFAULT_TOLERANCE))
                             .cut_type(cut_type)
+                            .version(edge_cut_version)
                             .build(),
                     ),
                 )

--- a/rust/kcl-lib/src/std/fillet.rs
+++ b/rust/kcl-lib/src/std/fillet.rs
@@ -6,6 +6,7 @@ use kcmc::ModelingCmd;
 use kcmc::each_cmd as mcmd;
 use kcmc::length_unit::LengthUnit;
 use kcmc::shared::CutTypeV2;
+use kcmc::shared::EdgeCutVersion;
 use kittycad_modeling_cmds as kcmc;
 use serde::Deserialize;
 use serde::Serialize;
@@ -96,11 +97,30 @@ pub async fn fillet(exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
     let tag = args.get_kw_arg_opt("tag", &RuntimeType::tag_decl(), exec_state)?;
     let legacy_csg: Option<bool> = args.get_kw_arg_opt("legacyMethod", &RuntimeType::bool(), exec_state)?;
     let csg_algorithm = CsgAlgorithm::legacy(legacy_csg.unwrap_or_default());
+    let edge_cut_number: Option<u32> = args.get_kw_arg_opt("version", &RuntimeType::count(), exec_state)?;
+    let edge_cut_number = edge_cut_number.unwrap_or(0);
+    let edge_cut_version: EdgeCutVersion = edge_cut_number.try_into().map_err(|()| {
+        KclError::new_semantic(KclErrorDetails::new(
+            format!("{} is not a version of the Zoo edge cut algorithm", edge_cut_number),
+            vec![args.source_range],
+        ))
+    })?;
 
     // Run the function.
     validate_unique(&tags)?;
     let tags: Vec<EdgeReference> = tags.into_iter().map(|item| item.0).collect();
-    let value = inner_fillet(solid, radius, tags, tolerance, csg_algorithm, tag, exec_state, args).await?;
+    let value = inner_fillet(
+        solid,
+        radius,
+        tags,
+        tolerance,
+        csg_algorithm,
+        tag,
+        edge_cut_version,
+        exec_state,
+        args,
+    )
+    .await?;
     Ok(KclValue::Solid { value })
 }
 
@@ -112,6 +132,7 @@ async fn inner_fillet(
     tolerance: Option<TyF64>,
     csg_algorithm: CsgAlgorithm,
     tag: Option<TagNode>,
+    edge_cut_version: EdgeCutVersion,
     exec_state: &mut ExecState,
     args: Args,
 ) -> Result<Box<Solid>, KclError> {
@@ -160,6 +181,7 @@ async fn inner_fillet(
                     .extra_face_ids(extra_face_ids)
                     .strategy(Default::default())
                     .object_id(solid.id)
+                    .version(edge_cut_version)
                     .tolerance(LengthUnit(
                         tolerance.as_ref().map(|t| t.to_mm()).unwrap_or(DEFAULT_TOLERANCE_MM),
                     ))

--- a/rust/kcl-lib/src/std/fillet.rs
+++ b/rust/kcl-lib/src/std/fillet.rs
@@ -98,13 +98,17 @@ pub async fn fillet(exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
     let legacy_csg: Option<bool> = args.get_kw_arg_opt("legacyMethod", &RuntimeType::bool(), exec_state)?;
     let csg_algorithm = CsgAlgorithm::legacy(legacy_csg.unwrap_or_default());
     let edge_cut_number: Option<u32> = args.get_kw_arg_opt("version", &RuntimeType::count(), exec_state)?;
-    let edge_cut_number = edge_cut_number.unwrap_or(0);
-    let edge_cut_version: EdgeCutVersion = edge_cut_number.try_into().map_err(|()| {
-        KclError::new_semantic(KclErrorDetails::new(
-            format!("{} is not a version of the Zoo edge cut algorithm", edge_cut_number),
-            vec![args.source_range],
-        ))
-    })?;
+    let edge_cut_version: EdgeCutVersion = edge_cut_number
+        .map(|num| {
+            num.try_into().map_err(|()| {
+                KclError::new_semantic(KclErrorDetails::new(
+                    format!("{} is not a version of the Zoo edge cut algorithm", num),
+                    vec![args.source_range],
+                ))
+            })
+        })
+        .transpose()?
+        .unwrap_or_default();
 
     // Run the function.
     validate_unique(&tags)?;

--- a/rust/kcl-lib/std/solid.kcl
+++ b/rust/kcl-lib/std/solid.kcl
@@ -108,8 +108,11 @@ export fn fillet(
   /// Defaults to false.
   @(deprecated_since = "2.0")
   legacyMethod?: bool,
-  /// What version of the fillet algorithm to use. Defaults to 0.
-  @(experimental = true) version?: number(Count) = 0,
+  /// What version of the fillet algorithm to use. Defaults to 1.
+  /// 0 means "let the Zoo engine choose whichever version is best",
+  /// 1 is the original Zoo fillet algorithm,
+  /// 2 is the newer algorithm (supports rolling ball fillets).
+  @(experimental = true) version?: number(Count) = 1,
 ): Solid {}
 
 /// Cut a straight transitional edge along a tagged path.
@@ -255,8 +258,11 @@ export fn chamfer(
   /// Defaults to false.
   @(deprecated_since = "2.0")
   legacyMethod?: bool,
-  /// What version of the fillet algorithm to use. Defaults to 0.
-  @(experimental = true) version?: number(Count) = 0,
+  /// What version of the fillet algorithm to use. Defaults to 1.
+  /// 0 means "let the Zoo engine choose whichever version is best",
+  /// 1 is the original Zoo fillet algorithm,
+  /// 2 is the newer algorithm (supports rolling ball fillets).
+  @(experimental = true) version?: number(Count) = 1,
 ): Solid {}
 
 /// Remove volume from a 3-dimensional shape such that a wall of the

--- a/rust/kcl-lib/std/solid.kcl
+++ b/rust/kcl-lib/std/solid.kcl
@@ -108,6 +108,8 @@ export fn fillet(
   /// Defaults to false.
   @(deprecated_since = "2.0")
   legacyMethod?: bool,
+  /// What version of the fillet algorithm to use. Defaults to 0.
+  @(experimental = true) version?: number(Count) = 0,
 ): Solid {}
 
 /// Cut a straight transitional edge along a tagged path.
@@ -253,6 +255,8 @@ export fn chamfer(
   /// Defaults to false.
   @(deprecated_since = "2.0")
   legacyMethod?: bool,
+  /// What version of the fillet algorithm to use. Defaults to 0.
+  @(experimental = true) version?: number(Count) = 0,
 ): Solid {}
 
 /// Remove volume from a 3-dimensional shape such that a wall of the


### PR DESCRIPTION
Requires https://github.com/KittyCAD/modeling-api/pull/1218

Enables upgrading to a new version of the fillet/chamfer algorithm that supports rolling ball fillets. Currently marked as experimental, so that we can test the new algorithm without worrying that ZK or customers will start using it and have their models change if we change the algorithm.