### PR TITLE
Better error message when using `=` op in sketch block

### DIFF
--- a/rust/kcl-lib/src/parsing/parser.rs
+++ b/rust/kcl-lib/src/parsing/parser.rs
@@ -3264,6 +3264,20 @@ fn expression_stmt(i: &mut TokenSlice) -> ModalResult<Node<ExpressionStatement>>
             "an expression (i.e. a value, or an algorithm for calculating one), e.g. 'x + y' or '3' or 'width * 2'",
         ))
         .parse_next(i)?;
+    if ParseContext::is_in_sketch_block() {
+        let checkpoint = i.checkpoint();
+        let _ = opt(whitespace).parse_next(i);
+        if let Ok(eq) = equals(i) {
+            return Err(ErrMode::Cut(
+                CompilationIssue::fatal(
+                    eq.as_source_range(),
+                    "The = operator doesn't work in sketch blocks, because there's no variable assignment. Did you mean == instead?",
+                )
+                .into(),
+            ));
+        }
+        i.reset(&checkpoint);
+    }
     let start = val.start();
     let end = val.end();
     let module_id = val.module_id();
@@ -6534,6 +6548,30 @@ bar = 1
             .expect("Found an error, but there was no cause. Add a cause.");
         assert_eq!(cause.message, "Missing comma between arguments, try adding a comma in",);
         assert_eq!(cause.source_range.start() - 1, expected_src_start);
+    }
+
+    #[test]
+    fn test_sensible_error_when_operation_undefined_in_sketch_block() {
+        let program_source = "sketch(on = XY) {
+  line001 = line(start = [var 0mm, var 0mm], end = [var 0mm, var 1mm])
+  distance([line001.start, line001.end]) = 5mm
+}";
+        let expected_src_start = program_source.find("= 5mm").unwrap();
+        let tokens = crate::parsing::token::lex(program_source, ModuleId::default()).unwrap();
+        ParseContext::init();
+        let err = program
+            .parse(tokens.as_slice())
+            .expect_err("Program succeeded, but it should have failed");
+        let cause = err
+            .inner()
+            .cause
+            .as_ref()
+            .expect("Found an error, but there was no cause. Add a cause.");
+        assert_eq!(cause.source_range.start(), expected_src_start);
+        assert_eq!(
+            cause.message,
+            "The = operator doesn't work in sketch blocks, because there's no variable assignment. Did you mean == instead?"
+        );
     }
 
     #[test]

--- a/rust/kcl-lib/src/parsing/parser.rs
+++ b/rust/kcl-lib/src/parsing/parser.rs
@@ -122,6 +122,8 @@ const MAX_NESTING_DEPTH: u16 = 512;
 /// space.
 const MAX_RECURSIVE_PARSER_DEPTH: u16 = 128;
 const MAX_NESTING_DEPTH_MESSAGE: &str = "Exceeded the maximum nesting limit while parsing this file. Try defining intermediate variables instead of deeply nesting expressions.";
+const ERR_INVALID_ASSIGNMENT_IN_SKETCH_BLOCK: &str =
+    "The left-hand side of the = cannot have a value assigned to it. Maybe you meant to use ==?";
 
 const KEYWORD_EXPECTING_IDENTIFIER: &str = "Expected an identifier, but found a reserved keyword.";
 
@@ -3269,11 +3271,7 @@ fn expression_stmt(i: &mut TokenSlice) -> ModalResult<Node<ExpressionStatement>>
         let _ = opt(whitespace).parse_next(i);
         if let Ok(eq) = equals(i) {
             return Err(ErrMode::Cut(
-                CompilationIssue::fatal(
-                    eq.as_source_range(),
-                    "The = operator doesn't work in sketch blocks, because there's no variable assignment. Did you mean == instead?",
-                )
-                .into(),
+                CompilationIssue::fatal(eq.as_source_range(), ERR_INVALID_ASSIGNMENT_IN_SKETCH_BLOCK).into(),
             ));
         }
         i.reset(&checkpoint);
@@ -6568,10 +6566,7 @@ bar = 1
             .as_ref()
             .expect("Found an error, but there was no cause. Add a cause.");
         assert_eq!(cause.source_range.start(), expected_src_start);
-        assert_eq!(
-            cause.message,
-            "The = operator doesn't work in sketch blocks, because there's no variable assignment. Did you mean == instead?"
-        );
+        assert_eq!(cause.message, ERR_INVALID_ASSIGNMENT_IN_SKETCH_BLOCK,);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #11626

The same problematic KCL now has the right source range, and a good error message.