### PR TITLE
Expose user feature state to registry extensions

### DIFF
--- a/src/components/ModelingMachineProvider.tsx
+++ b/src/components/ModelingMachineProvider.tsx
@@ -1,9 +1,7 @@
 import { useAppState } from '@src/AppState'
 import { letEngineAnimateAndSyncCamAfter } from '@src/clientSideScene/CameraControls'
-import {
-  useMenuListener,
-  useSketchModeMenuEnableDisable,
-} from '@src/hooks/useMenu'
+import { useMenuListener } from '@src/hooks/useMenu'
+import { useSketchModeMenuEnableDisable } from '@src/hooks/useSketchModeMenuEnableDisable'
 import useModelingMachineCommands from '@src/hooks/useStateMachineCommands'
 import { reportRejection } from '@src/lib/trap'
 import { useMachine } from '@xstate/react'

--- a/src/hooks/useMenu.test.tsx
+++ b/src/hooks/useMenu.test.tsx
@@ -1,0 +1,48 @@
+import { useMenuListener } from '@src/hooks/useMenu'
+import type { WebContentSendPayload } from '@src/menu/channels'
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+describe('useMenuListener', () => {
+  const originalElectron = window.electron
+
+  afterEach(() => {
+    window.electron = originalElectron
+    vi.restoreAllMocks()
+  })
+
+  test('handles menu actions with the latest callback after rerender', () => {
+    let registeredCallback:
+      | ((payload: WebContentSendPayload) => void)
+      | undefined
+    const removeListener = vi.fn()
+    const menuOn = vi.fn(
+      (callback: (payload: WebContentSendPayload) => void) => {
+        registeredCallback = callback
+        return removeListener
+      }
+    )
+    window.electron = { menuOn } as unknown as Window['electron']
+
+    const firstCallback = vi.fn()
+    const latestCallback = vi.fn()
+    const menuAction = {
+      menuLabel: 'File.Preferences.User settings',
+    } satisfies WebContentSendPayload
+
+    const { rerender, unmount } = renderHook(
+      ({ callback }) => useMenuListener(callback),
+      { initialProps: { callback: firstCallback } }
+    )
+
+    rerender({ callback: latestCallback })
+    act(() => registeredCallback?.(menuAction))
+
+    expect(menuOn).toHaveBeenCalledTimes(1)
+    expect(firstCallback).not.toHaveBeenCalled()
+    expect(latestCallback).toHaveBeenCalledWith(menuAction)
+
+    unmount()
+    expect(removeListener).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/hooks/useMenu.ts
+++ b/src/hooks/useMenu.ts
@@ -1,20 +1,21 @@
-import { NetworkHealthState } from '@src/hooks/useNetworkStatus'
-import { useApp } from '@src/lib/boot'
-import type { ToolbarModeName } from '@src/lib/toolbar'
-import { reportRejection } from '@src/lib/trap'
-import type { MenuLabels, WebContentSendPayload } from '@src/menu/channels'
-import { useEffect } from 'react'
+import type { WebContentSendPayload } from '@src/menu/channels'
+import { useEffect, useRef } from 'react'
 
 export function useMenuListener(
   callback: (data: WebContentSendPayload) => void
 ) {
+  const callbackRef = useRef(callback)
+  callbackRef.current = callback
+
   useEffect(() => {
     if (!window.electron) {
       // NO OP for web
       return
     }
 
-    const removeListener = window.electron.menuOn(callback)
+    const removeListener = window.electron.menuOn((data) => {
+      callbackRef.current(data)
+    })
     return () => {
       if (!window.electron) {
         // NO OP for web
@@ -22,75 +23,5 @@ export function useMenuListener(
       }
       removeListener()
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
   }, [])
-}
-
-// Enable disable menu actions specifically based on if you are in the modeling mode of sketching or modeling.
-// This is a similar behavior of the command bar which disables action if you are in sketch mode
-export function useSketchModeMenuEnableDisable(
-  currentMode: ToolbarModeName,
-  overallState: NetworkHealthState,
-  isExecuting: boolean,
-  isStreamReady: boolean,
-  menus: { menuLabel: MenuLabels; commandName?: string; groupId?: string }[]
-) {
-  const { commands } = useApp()
-  const commandBarState = commands.useState()
-  const commandList = commandBarState.context.commands
-
-  useEffect(() => {
-    if (!window.electron) {
-      // NO OP for web
-      return
-    }
-    const electron = window.electron
-
-    // Same exact logic as the command bar
-    const disableAllButtons =
-      (overallState !== NetworkHealthState.Ok &&
-        overallState !== NetworkHealthState.Weak) ||
-      isExecuting ||
-      !isStreamReady
-
-    // Enable or disable each menu based on the state of the application.
-    menus.forEach(({ menuLabel, commandName, groupId }) => {
-      // If someone goes wrong, disable all the buttons! Engine cannot take this request
-      if (disableAllButtons) {
-        electron.disableMenu(menuLabel).catch(reportRejection)
-        return
-      }
-
-      if (commandName && groupId) {
-        // If your menu is tied to a command bar action, see if the command exists in the command bar
-        const foundCommand = commandList.find((command) => {
-          return command.name === commandName && command.groupId === groupId
-        })
-        if (!foundCommand) {
-          electron.disableMenu(menuLabel).catch(reportRejection)
-        } else {
-          if (currentMode === 'sketching') {
-            electron.disableMenu(menuLabel).catch(reportRejection)
-          } else if (currentMode === 'modeling') {
-            electron.enableMenu(menuLabel).catch(reportRejection)
-          }
-        }
-      } else {
-        // menu is not tied to a command bar, do the sketch mode check
-        if (currentMode === 'sketching') {
-          electron.disableMenu(menuLabel).catch(reportRejection)
-        } else if (currentMode === 'modeling') {
-          electron.enableMenu(menuLabel).catch(reportRejection)
-        }
-      }
-    })
-
-    return () => {
-      if (!window.electron) {
-        // NO OP for web
-        return
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
-  }, [currentMode, commandList])
 }

--- a/src/hooks/useSketchModeMenuEnableDisable.ts
+++ b/src/hooks/useSketchModeMenuEnableDisable.ts
@@ -1,0 +1,75 @@
+import { NetworkHealthState } from '@src/hooks/useNetworkStatus'
+import { useApp } from '@src/lib/boot'
+import type { ToolbarModeName } from '@src/lib/toolbar'
+import { reportRejection } from '@src/lib/trap'
+import type { MenuLabels } from '@src/menu/channels'
+import { useEffect } from 'react'
+
+// Enable disable menu actions specifically based on if you are in the modeling mode of sketching or modeling.
+// This is a similar behavior of the command bar which disables action if you are in sketch mode
+export function useSketchModeMenuEnableDisable(
+  currentMode: ToolbarModeName,
+  overallState: NetworkHealthState,
+  isExecuting: boolean,
+  isStreamReady: boolean,
+  menus: { menuLabel: MenuLabels; commandName?: string; groupId?: string }[]
+) {
+  const { commands } = useApp()
+  const commandBarState = commands.useState()
+  const commandList = commandBarState.context.commands
+
+  useEffect(() => {
+    if (!window.electron) {
+      // NO OP for web
+      return
+    }
+    const electron = window.electron
+
+    // Same exact logic as the command bar
+    const disableAllButtons =
+      (overallState !== NetworkHealthState.Ok &&
+        overallState !== NetworkHealthState.Weak) ||
+      isExecuting ||
+      !isStreamReady
+
+    // Enable or disable each menu based on the state of the application.
+    menus.forEach(({ menuLabel, commandName, groupId }) => {
+      // If someone goes wrong, disable all the buttons! Engine cannot take this request
+      if (disableAllButtons) {
+        electron.disableMenu(menuLabel).catch(reportRejection)
+        return
+      }
+
+      if (commandName && groupId) {
+        // If your menu is tied to a command bar action, see if the command exists in the command bar
+        const foundCommand = commandList.find((command) => {
+          return command.name === commandName && command.groupId === groupId
+        })
+        if (!foundCommand) {
+          electron.disableMenu(menuLabel).catch(reportRejection)
+        } else {
+          if (currentMode === 'sketching') {
+            electron.disableMenu(menuLabel).catch(reportRejection)
+          } else if (currentMode === 'modeling') {
+            electron.enableMenu(menuLabel).catch(reportRejection)
+          }
+        }
+      } else {
+        // menu is not tied to a command bar, do the sketch mode check
+        if (currentMode === 'sketching') {
+          electron.disableMenu(menuLabel).catch(reportRejection)
+        } else if (currentMode === 'modeling') {
+          electron.enableMenu(menuLabel).catch(reportRejection)
+        }
+      }
+    })
+
+    return () => {
+      if (!window.electron) {
+        // NO OP for web
+        return
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
+  }, [currentMode, commandList])
+}

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -78,6 +78,7 @@ import { keymapService } from '@src/registry/contracts/keymap'
 import { layoutContributionsValueSpec } from '@src/registry/contracts/layout'
 import { machineManagerService } from '@src/registry/contracts/machineManager'
 import { settingsValueSpec } from '@src/registry/contracts/settings'
+import { userFeaturesService } from '@src/registry/contracts/userFeatures'
 import { provideWasmPromise } from '@src/registry/contracts/wasm'
 import { zdsPluginActivationSettingsValueSpec } from '@src/registry/createZdsPlugin'
 import {
@@ -104,9 +105,11 @@ function isPlaywrightRuntime() {
 function createAppRegistryItems({
   wasmPromise,
   machineManager,
+  userFeatures,
 }: {
   wasmPromise: Promise<ModuleType>
   machineManager: MachineManager
+  userFeatures?: AppUserFeaturesSystem
 }): RegistryItem[] {
   return [
     defineRegistryItem({
@@ -117,6 +120,19 @@ function createAppRegistryItems({
       id: 'app.machine-manager',
       providesServices: [provideService(machineManagerService, machineManager)],
     }),
+    ...(userFeatures
+      ? [
+          defineRegistryItem({
+            id: 'app.user-features',
+            providesServices: [
+              provideService(userFeaturesService, {
+                context: userFeatures.contextSignal,
+                has: userFeatures.has,
+              }),
+            ],
+          }),
+        ]
+      : []),
     appCommandsSlot.of(),
     appRegistryServicesSlot.of(),
     ...coreRegistryItems,
@@ -159,6 +175,7 @@ export type AppBillingSystem = {
 export type AppUserFeaturesSystem = UserFeaturesService & {
   actor: UserFeaturesActorRef
   send: UserFeaturesActorRef['send']
+  contextSignal: Signal<UserFeaturesContext>
   useContext: () => UserFeaturesContext
   useHas: (featureFlagId: UserFeature, defaultValue: boolean) => boolean
 }
@@ -360,9 +377,16 @@ export class App implements AppSubsystems {
     }
 
     const userFeaturesActor = createActor(userFeaturesMachine).start()
+    const userFeaturesContextSignal = signal<UserFeaturesContext>(
+      userFeaturesActor.getSnapshot().context
+    )
+    userFeaturesActor.subscribe((snapshot) => {
+      userFeaturesContextSignal.value = snapshot.context
+    })
     const userFeatures: AppUserFeaturesSystem = {
       actor: userFeaturesActor,
       send: userFeaturesActor.send.bind(App),
+      contextSignal: userFeaturesContextSignal,
       has: (featureFlagId, defaultValue) =>
         userFeaturesContextHas(
           userFeaturesActor.getSnapshot().context,
@@ -407,7 +431,7 @@ export class App implements AppSubsystems {
       ),
     }
     appRegistry.configure([
-      ...createAppRegistryItems({ wasmPromise, machineManager }),
+      ...createAppRegistryItems({ wasmPromise, machineManager, userFeatures }),
       createLayoutServiceRegistryItem(layoutService),
     ])
 

--- a/src/registry/contracts/userFeatures.ts
+++ b/src/registry/contracts/userFeatures.ts
@@ -1,0 +1,16 @@
+import type { UserFeature } from '@kittycad/lib'
+import { defineContract, defineService } from '@kittycad/registry'
+import type { ReadonlySignal } from '@preact/signals-core'
+import type { UserFeaturesContext } from '@src/machines/userFeaturesMachine'
+
+export type UserFeaturesRegistryService = {
+  context: ReadonlySignal<UserFeaturesContext>
+  has: (featureFlagId: UserFeature, defaultValue: boolean) => boolean
+}
+
+export const userFeaturesContract = defineContract({
+  userFeaturesService:
+    defineService<UserFeaturesRegistryService>('user-features'),
+})
+
+export const { userFeaturesService } = userFeaturesContract


### PR DESCRIPTION
## Summary

Third prep PR. This adds generic extension infrastructure needed by the final cloud status extension, and fixes the native menu listener shape without introducing OPFSCloud.

- Adds a `userFeaturesService` registry contract backed by the app user-features machine context signal.
- Provides user-feature state through the app registry for feature-aware extension factories.
- Splits `useMenuListener` from sketch-mode menu enable/disable behavior.
- Updates `useMenuListener` so native menu actions call the latest callback after React rerenders without re-registering the native listener.

## Review map

- `src/registry/contracts/userFeatures.ts` defines the registry service.
- `src/lib/app.ts` provides the service from the existing user-features machine.
- `src/hooks/useMenu.ts` is now the low-level native menu listener.
- `src/hooks/useSketchModeMenuEnableDisable.ts` keeps the modeling/sketching menu availability side effect.
- `src/hooks/useMenu.test.tsx` covers the stale-callback native-menu bug.

## Validation

- Stack head validation: `make all` passed on `cafd2f5ca2`.