### PR TITLE
Fix fixed theme system color changes

### DIFF
--- a/e2e/playwright/testing-settings.spec.ts
+++ b/e2e/playwright/testing-settings.spec.ts
@@ -5,6 +5,7 @@ import type { SettingsLevel } from '@src/lib/settings/settingsTypes'
 import * as fsp from 'fs/promises'
 
 import {
+  TEST_SETTINGS,
   TEST_SETTINGS_CORRUPTED,
   TEST_SETTINGS_DEFAULT_THEME,
   TEST_SETTINGS_KEY,
@@ -19,6 +20,7 @@ import {
 import { expect, test } from '@e2e/playwright/zoo-test'
 import type { UnitLength } from '@kittycad/lib/dist/types/src'
 import type { Page } from '@playwright/test'
+import { Themes } from '@src/lib/theme'
 import { isArray, uuidv4 } from '@src/lib/utils'
 
 const settingsSwitchTab = (page: Page) => async (tab: 'user' | 'proj') => {
@@ -696,6 +698,7 @@ test.describe(
         const lightBackgroundCss = 'oklch(0.9911 0 264.48)'
         const darkBackgroundColor: [number, number, number] = [50, 40, 51] // planes are on
         const lightBackgroundColor: [number, number, number] = [227, 222, 230] // planes are on
+        const streamBackgroundColorTolerance = 20
         const streamBackgroundPixelIsColor = async (
           color: [number, number, number]
         ) => {
@@ -719,7 +722,7 @@ test.describe(
           )
           await expect
             .poll(() => streamBackgroundPixelIsColor(lightBackgroundColor))
-            .toBeLessThan(15)
+            .toBeLessThanOrEqual(streamBackgroundColorTolerance)
         })
 
         await test.step(`Change media query preference to dark, emulating dusk with system theme`, async () => {
@@ -730,7 +733,68 @@ test.describe(
           await expect(toolbar).toHaveCSS('background-color', darkBackgroundCss)
           await expect
             .poll(() => streamBackgroundPixelIsColor(darkBackgroundColor))
-            .toBeLessThan(15)
+            .toBeLessThanOrEqual(streamBackgroundColorTolerance)
+        })
+      }
+    )
+
+    test(
+      `Changing system theme preferences should not override fixed light theme`,
+      { tag: ['@macos', '@windows'] },
+      async ({ page, homePage, tronApp }) => {
+        if (!tronApp) throw new Error('tronApp is missing.')
+
+        await tronApp.cleanProjectDir({
+          ...TEST_SETTINGS,
+          app: {
+            ...TEST_SETTINGS.app,
+            appearance: { theme: Themes.Light },
+          },
+        })
+
+        const u = await getUtils(page)
+
+        const lightBackgroundCss = 'oklch(0.9911 0 264.48)'
+        const lightBackgroundColor: [number, number, number] = [227, 222, 230]
+        const streamBackgroundColorTolerance = 20
+        const streamBackgroundPixelIsColor = async (
+          color: [number, number, number]
+        ) => {
+          return u.getGreatestPixDiff({ x: 1000, y: 200 }, color)
+        }
+        const toolbar = page.locator('menu').filter({ hasText: 'Start Sketch' })
+
+        await test.step(`Test setup`, async () => {
+          await page.emulateMedia({ colorScheme: 'light' })
+          await page.setBodyDimensions({ width: 1200, height: 500 })
+          await homePage.goToModelingScene()
+          await u.waitForPageLoad()
+          await page.waitForTimeout(1000)
+          await expect(toolbar).toBeVisible()
+        })
+
+        await test.step(`Check the fixed light theme before system change`, async () => {
+          await expect(toolbar).toHaveCSS(
+            'background-color',
+            lightBackgroundCss
+          )
+          await expect
+            .poll(() => streamBackgroundPixelIsColor(lightBackgroundColor))
+            .toBeLessThanOrEqual(streamBackgroundColorTolerance)
+        })
+
+        await test.step(`Change media query preference to dark, emulating dusk with fixed light theme`, async () => {
+          await page.emulateMedia({ colorScheme: 'dark' })
+        })
+
+        await test.step(`Check the fixed light theme after system change`, async () => {
+          await expect(toolbar).toHaveCSS(
+            'background-color',
+            lightBackgroundCss
+          )
+          await expect
+            .poll(() => streamBackgroundPixelIsColor(lightBackgroundColor))
+            .toBeLessThanOrEqual(streamBackgroundColorTolerance)
         })
       }
     )

--- a/e2e/playwright/testing-settings.spec.ts
+++ b/e2e/playwright/testing-settings.spec.ts
@@ -763,6 +763,24 @@ test.describe(
           return u.getGreatestPixDiff({ x: 1000, y: 200 }, color)
         }
         const toolbar = page.locator('menu').filter({ hasText: 'Start Sketch' })
+        const codeMirrorContent = page
+          .locator('.cm-content[data-language="kcl"]')
+          .first()
+        const getCodeMirrorThemeColors = async () =>
+          codeMirrorContent.evaluate((element) => {
+            const editor = element.closest('.cm-editor') ?? element
+            const editorStyle = getComputedStyle(editor)
+            const contentStyle = getComputedStyle(element)
+
+            return {
+              editorBackgroundColor: editorStyle.backgroundColor,
+              contentColor: contentStyle.color,
+              caretColor: contentStyle.caretColor,
+            }
+          })
+        let codeMirrorLightThemeColors:
+          | Awaited<ReturnType<typeof getCodeMirrorThemeColors>>
+          | undefined
 
         await test.step(`Test setup`, async () => {
           await page.emulateMedia({ colorScheme: 'light' })
@@ -778,6 +796,8 @@ test.describe(
             'background-color',
             lightBackgroundCss
           )
+          await expect(codeMirrorContent).toBeVisible()
+          codeMirrorLightThemeColors = await getCodeMirrorThemeColors()
           await expect
             .poll(() => streamBackgroundPixelIsColor(lightBackgroundColor))
             .toBeLessThanOrEqual(streamBackgroundColorTolerance)
@@ -792,6 +812,12 @@ test.describe(
             'background-color',
             lightBackgroundCss
           )
+          if (!codeMirrorLightThemeColors) {
+            throw new Error('CodeMirror light theme colors were not captured.')
+          }
+          await expect
+            .poll(() => getCodeMirrorThemeColors())
+            .toEqual(codeMirrorLightThemeColors)
           await expect
             .poll(() => streamBackgroundPixelIsColor(lightBackgroundColor))
             .toBeLessThanOrEqual(streamBackgroundColorTolerance)

--- a/src/components/OpenInDesktopAppHandler.tsx
+++ b/src/components/OpenInDesktopAppHandler.tsx
@@ -8,11 +8,9 @@ import {
   ZOO_STUDIO_PROTOCOL,
 } from '@src/lib/constants'
 import { isDesktop } from '@src/lib/isDesktop'
-import { Themes, darkModeMatcher, setThemeClass } from '@src/lib/theme'
 import { platform } from '@src/lib/utils'
 import { withSiteBaseURL } from '@src/lib/withBaseURL'
 import { APP_DOWNLOAD_PATH } from '@src/routes/utils'
-import { useEffect } from 'react'
 import toast from 'react-hot-toast'
 
 /**
@@ -27,16 +25,6 @@ export const OpenInDesktopAppHandler = (props: React.PropsWithChildren) => {
   // We also ignore this param on desktop, as it is redundant
   const hasAskToOpenParam =
     !isDesktop() && searchParams.has(ASK_TO_OPEN_QUERY_PARAM)
-
-  // Watch the system theme for changes
-  useEffect(() => {
-    const listener = (e: MediaQueryListEvent) => {
-      setThemeClass(e.matches ? Themes.Dark : Themes.Light)
-    }
-
-    darkModeMatcher?.addEventListener('change', listener)
-    return () => darkModeMatcher?.removeEventListener('change', listener)
-  }, [])
 
   /**
    * This function removes the query param to ask to open in desktop app

--- a/src/network/connectionManager.ts
+++ b/src/network/connectionManager.ts
@@ -453,6 +453,7 @@ export class ConnectionManager extends EventTarget {
 
   listenToDarkModeMatcher() {
     const onDarkThemeMediaQueryChange = createOnDarkThemeMediaQueryChange({
+      getTheme: () => this.settings.theme,
       setTheme: this.setTheme.bind(this),
     })
     this.trackListener('darkmodewatcher-change', {

--- a/src/network/connectionManagerEvents.test.ts
+++ b/src/network/connectionManagerEvents.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { Themes } from '@src/lib/theme'
+import { createOnDarkThemeMediaQueryChange } from '@src/network/connectionManagerEvents'
+
+describe('createOnDarkThemeMediaQueryChange', () => {
+  it('ignores system color changes when the app theme is fixed', () => {
+    const setTheme = vi
+      .fn<(theme: Themes) => Promise<void>>()
+      .mockResolvedValue(undefined)
+
+    createOnDarkThemeMediaQueryChange({
+      getTheme: () => Themes.Light,
+      setTheme,
+    })()
+    createOnDarkThemeMediaQueryChange({
+      getTheme: () => Themes.Dark,
+      setTheme,
+    })()
+
+    expect(setTheme).not.toHaveBeenCalled()
+  })
+
+  it('refreshes the engine theme when the app theme follows the system', () => {
+    const setTheme = vi
+      .fn<(theme: Themes) => Promise<void>>()
+      .mockResolvedValue(undefined)
+
+    createOnDarkThemeMediaQueryChange({
+      getTheme: () => Themes.System,
+      setTheme,
+    })()
+
+    expect(setTheme).toHaveBeenCalledTimes(1)
+    expect(setTheme).toHaveBeenCalledWith(Themes.System)
+  })
+})

--- a/src/network/connectionManagerEvents.ts
+++ b/src/network/connectionManagerEvents.ts
@@ -153,10 +153,18 @@ export const createOnEngineConnectionOpened = ({
 }
 
 export const createOnDarkThemeMediaQueryChange = ({
+  getTheme,
   setTheme,
-}: { setTheme: (theme: Themes) => Promise<void> }) => {
-  const onDarkThemeMediaQueryChange = (e: MediaQueryListEvent) => {
-    setTheme(e.matches ? Themes.Dark : Themes.Light).catch(reportRejection)
+}: {
+  getTheme: () => Themes
+  setTheme: (theme: Themes) => Promise<void>
+}) => {
+  const onDarkThemeMediaQueryChange = () => {
+    if (getTheme() !== Themes.System) {
+      return
+    }
+
+    setTheme(Themes.System).catch(reportRejection)
   }
   return onDarkThemeMediaQueryChange
 }


### PR DESCRIPTION
Closes #8820

ai assisted

https://github.com/user-attachments/assets/2b2c449c-0ffe-4260-aef9-116eaeded008

## Problem

Users who choose a fixed app theme expect Zoo Design Studio to stay in that theme when macOS switches between light and dark appearance. Instead, a system appearance change could partially override the app: surrounding UI, CodeMirror, and the engine stream could fall out of sync.

## Solution

Keep macOS appearance-change handling settings-aware. Fixed Light and Dark themes now ignore system color-scheme changes, while the System theme still refreshes the UI and engine stream when the OS changes. The regression coverage checks both the lightweight connection-manager handler and the desktop Electron path that would have caught issue #8820.