### PR TITLE
Update code owner assignments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,18 @@
-* @KittyCAD/frontend
-/docs/ @KittyCAD/kcl
-/src/ @KittyCAD/frontend
-/rust/ @KittyCAD/kcl
-/public/kcl-samples/ @KittyCAD/kcl
-/e2e/playwright/benchmark/ @KittyCAD/mech
+*                                 @KittyCAD/frontend
+
+# ZDS
+/src/                             @KittyCAD/frontend
+
+# KCL
+/rust/                            @KittyCAD/kcl
+
+# ZDS-KCL bridge
+/rust/**/frontend.rs              @KittyCAD/frontend
+/rust/**/frontend/                @KittyCAD/frontend
+
+# Documentation
+/docs/                            @KittyCAD/frontend @KittyCAD/kcl
+/public/kcl-samples/              @KittyCAD/frontend @KittyCAD/kcl
+
+# Tests
+/e2e/playwright/benchmark/        @KittyCAD/mech


### PR DESCRIPTION
This is in preparation for requiring code owner approvals on PRs, an outcome of the 6/2 team retrospective.