### PR TITLE
KCL release 161

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2273,7 +2273,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-bumper"
-version = "0.1.160"
+version = "0.1.161"
 dependencies = [
  "anyhow",
  "clap",
@@ -2284,7 +2284,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-derive-docs"
-version = "0.2.160"
+version = "0.2.161"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2293,7 +2293,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-directory-test-macro"
-version = "0.1.160"
+version = "0.1.161"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -2303,7 +2303,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-error"
-version = "0.2.160"
+version = "0.2.161"
 dependencies = [
  "miette",
  "serde",
@@ -2313,7 +2313,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-language-server"
-version = "0.2.160"
+version = "0.2.161"
 dependencies = [
  "anyhow",
  "clap",
@@ -2334,7 +2334,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-language-server-release"
-version = "0.1.160"
+version = "0.1.161"
 dependencies = [
  "anyhow",
  "clap",
@@ -2354,7 +2354,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-lib"
-version = "0.2.160"
+version = "0.2.161"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2442,7 +2442,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-python-bindings"
-version = "0.3.161"
+version = "0.3.162"
 dependencies = [
  "anyhow",
  "kcl-lib",
@@ -2458,7 +2458,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-syntax"
-version = "0.2.160"
+version = "0.2.161"
 dependencies = [
  "logos",
  "proptest",
@@ -2466,7 +2466,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-test-server"
-version = "0.2.160"
+version = "0.2.161"
 dependencies = [
  "anyhow",
  "hyper 0.14.32",
@@ -2479,7 +2479,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-to-core"
-version = "0.1.160"
+version = "0.1.161"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2493,7 +2493,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-wasm-lib"
-version = "0.1.160"
+version = "0.1.161"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",

--- a/rust/kcl-bumper/Cargo.toml
+++ b/rust/kcl-bumper/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "kcl-bumper"
-version = "0.1.160"
+version = "0.1.161"
 edition = "2024"
 repository = "https://github.com/KittyCAD/modeling-api"
 description = "Bumps versions in Cargo.toml"

--- a/rust/kcl-derive-docs/Cargo.toml
+++ b/rust/kcl-derive-docs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-derive-docs"
 description = "A tool for generating documentation from Rust derive macros"
-version = "0.2.160"
+version = "0.2.161"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/rust/kcl-directory-test-macro/Cargo.toml
+++ b/rust/kcl-directory-test-macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-directory-test-macro"
 description = "A tool for generating tests from a directory of kcl files"
-version = "0.1.160"
+version = "0.1.161"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/rust/kcl-error/Cargo.toml
+++ b/rust/kcl-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-error"
-version = "0.2.160"
+version = "0.2.161"
 edition = "2024"
 description = "KCL error definitions"
 license = "MIT"

--- a/rust/kcl-language-server-release/Cargo.toml
+++ b/rust/kcl-language-server-release/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-language-server-release"
-version = "0.1.160"
+version = "0.1.161"
 edition = "2024"
 authors = ["KittyCAD Inc <kcl@kittycad.io>"]
 publish = false

--- a/rust/kcl-language-server/Cargo.toml
+++ b/rust/kcl-language-server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kcl-language-server"
 description = "A language server for KCL."
 authors = ["KittyCAD Inc <kcl@kittycad.io>"]
-version = "0.2.160"
+version = "0.2.161"
 edition = "2024"
 license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust/kcl-lib/Cargo.toml
+++ b/rust/kcl-lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-lib"
 description = "KittyCAD Language implementation and tools"
-version = "0.2.160"
+version = "0.2.161"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"
@@ -69,9 +69,9 @@ image = { version = "0.25.10", default-features = false, features = ["png"] }
 image-compare = "0.5.0"
 indexmap = { workspace = true, features = ["serde", "rayon"] }
 itertools = "0.14.0"
-kcl-derive-docs = { version = "0.2.160", path = "../kcl-derive-docs" }
-kcl-error = { version = "0.2.160", path = "../kcl-error" }
-kcl-syntax = { version = "0.2.160", path = "../kcl-syntax", optional = true }
+kcl-derive-docs = { version = "0.2.161", path = "../kcl-derive-docs" }
+kcl-error = { version = "0.2.161", path = "../kcl-error" }
+kcl-syntax = { version = "0.2.161", path = "../kcl-syntax", optional = true }
 ezpz = { workspace = true }
 kittycad = { workspace = true }
 kittycad-modeling-cmds = { workspace = true }

--- a/rust/kcl-syntax/Cargo.toml
+++ b/rust/kcl-syntax/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-syntax"
 description = "Lossless syntax trees for KCL"
-version = "0.2.160"
+version = "0.2.161"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/rust/kcl-test-server/Cargo.toml
+++ b/rust/kcl-test-server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-test-server"
 description = "A test server for KCL"
-version = "0.2.160"
+version = "0.2.161"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"
@@ -12,7 +12,7 @@ bench = false
 [dependencies]
 anyhow = "1.0.102"
 hyper = { version = "0.14.29", features = ["http1", "server", "tcp"] }
-kcl-lib = { version = "0.2.160", path = "../kcl-lib" }
+kcl-lib = { version = "0.2.161", path = "../kcl-lib" }
 pico-args = "0.5.0"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/rust/kcl-to-core/Cargo.toml
+++ b/rust/kcl-to-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-to-core"
 description = "Utility methods to convert kcl to engine core executable tests"
-version = "0.1.160"
+version = "0.1.161"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/rust/kcl-wasm-lib/Cargo.toml
+++ b/rust/kcl-wasm-lib/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kcl-wasm-lib"
 description = "KittyCAD Language wasm bindings"
 license = "MIT"
-version = "0.1.160"
+version = "0.1.161"
 edition = "2024"
 repository = "https://github.com/KittyCAD/modeling-app"
 publish = false


### PR DESCRIPTION
No changes since 160, it just brings Python bindings and the rest of KCL onto the same version number.

Python bindings got out of sync because we cut a special release for python previously. We released Python 160 early to get the commit "call maturin with --strip (#11882)" released.