### PR TITLE
Fix illegible text when hovering Zookeeper modes

### DIFF
--- a/src/components/MlEphantConversation.tsx
+++ b/src/components/MlEphantConversation.tsx
@@ -101,7 +101,7 @@ const MlCopilotModes = (props: MlCopilotModesProps) => {
                     close()
                     props.onClick(mode.id)
                   }}
-                  className={`flex flex-row items-start gap-2 cursor-pointer hover:bg-3 p-2 pr-4 rounded-md border ${props.current === mode.id ? 'border-primary' : ''}`}
+                  className={`flex flex-row items-start gap-2 cursor-pointer hover:bg-2 p-2 pr-4 rounded-md border ${props.current === mode.id ? 'border-primary' : ''}`}
                   data-testid={`ml-copilot-effort-button-${mode.id}`}
                 >
                   <CustomIcon


### PR DESCRIPTION
Before:

<img width="364" height="238" alt="Screenshot 2026-06-03 at 2 53 55 PM" src="https://github.com/user-attachments/assets/8d18da85-754d-4154-8299-a1a0792c64c7" /><br>

After:

<img width="363" height="291" alt="Screenshot 2026-06-03 at 2 53 24 PM" src="https://github.com/user-attachments/assets/584cee90-42d8-4754-a978-f87f58e5cf95" />

