### PR TITLE
Use short VS Code test profile dirs

### DIFF
--- a/rust/kcl-language-server/client/src/test/runTest.ts
+++ b/rust/kcl-language-server/client/src/test/runTest.ts
@@ -1,6 +1,6 @@
-import * as path from 'path'
 import * as fs from 'fs'
 import * as os from 'os'
+import * as path from 'path'
 import { runTests } from '@vscode/test-electron'
 
 function createShortVSCodeProfileDir() {

--- a/rust/kcl-language-server/client/src/test/runTest.ts
+++ b/rust/kcl-language-server/client/src/test/runTest.ts
@@ -1,7 +1,16 @@
 import * as path from 'path'
+import * as fs from 'fs'
+import * as os from 'os'
 import { runTests } from '@vscode/test-electron'
 
+function createShortVSCodeProfileDir() {
+  const tempRoot = process.platform === 'win32' ? os.tmpdir() : '/tmp'
+  return fs.mkdtempSync(path.join(tempRoot, 'kcl-ls-'))
+}
+
 async function main() {
+  const vscodeProfileDir = createShortVSCodeProfileDir()
+
   try {
     // The folder containing the Extension Manifest package.json
     // Passed to `--extensionDevelopmentPath`
@@ -12,11 +21,20 @@ async function main() {
     const extensionTestsPath = path.resolve(__dirname, './suite/index')
 
     // Download VS Code, unzip it and run the integration test
-    await runTests({ extensionDevelopmentPath, extensionTestsPath })
+    await runTests({
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: [
+        `--user-data-dir=${path.join(vscodeProfileDir, 'user-data')}`,
+        `--extensions-dir=${path.join(vscodeProfileDir, 'extensions')}`,
+      ],
+    })
   } catch (err) {
     console.error(err)
     console.error('Failed to run tests')
-    process.exit(1)
+    process.exitCode = 1
+  } finally {
+    fs.rmSync(vscodeProfileDir, { force: true, recursive: true })
   }
 }
 


### PR DESCRIPTION
## Summary

Use a short per-run VS Code profile directory for the KCL language server VS Code Electron tests.

## Why

The macOS test job can fail before the extension tests start because VS Code creates its IPC socket under the default `.vscode-test/user-data` directory inside the deep Actions checkout path. That socket path can exceed macOS' Unix socket path limit, producing `listen EINVAL`.

Failing job log: https://github.com/KittyCAD/modeling-app/actions/runs/26980588446/job/79618555372?pr=11957#step:6:46

## Changes

- Create a temporary profile root under `/tmp/kcl-ls-*` on Unix-like systems.
- Pass explicit `--user-data-dir` and `--extensions-dir` launch args to `@vscode/test-electron`.
- Clean up the temporary profile directory after the test run.

## Validation

- `npm --prefix rust/kcl-language-server run test-compile`
- `npx eslint --max-warnings 0 rust/kcl-language-server/client/src/test/runTest.ts`
- `git diff --check`
