### PR TITLE
Use mock context in frontend benchmark

### DIFF
--- a/rust/kcl-lib/benches/frontend.rs
+++ b/rust/kcl-lib/benches/frontend.rs
@@ -4,6 +4,7 @@ use criterion::Criterion;
 use criterion::criterion_group;
 use criterion::criterion_main;
 use kcl_lib::ExecutorContext;
+use kcl_lib::MockConfig;
 use kcl_lib::Program;
 use kcl_lib::front::ExistingSegmentCtor;
 use kcl_lib::front::Expr;
@@ -21,12 +22,14 @@ fn bench_edit_segments(c: &mut Criterion) {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let (mut frontend, mock_ctx, version, sketch_id, segments) = rt.block_on(async {
             let mut frontend = FrontendState::new();
-            let ctx = ExecutorContext::new_with_default_client().await.unwrap();
             let mock_ctx = ExecutorContext::new_mock(None).await;
             let version = Version(0);
             let source = include_str!("../tests/inputs/lots_of_segments.kcl");
             let program = Program::parse(source).unwrap().0.unwrap();
-            let outcome = frontend.hack_set_program(&ctx, program).await.unwrap();
+            let outcome = frontend
+                .hack_set_program_mock(&mock_ctx, program, &MockConfig::default())
+                .await
+                .unwrap();
             match outcome {
                 kcl_lib::front::SetProgramOutcome::Success { .. } => {}
                 kcl_lib::front::SetProgramOutcome::ExecFailure { error } => panic!("{}", error.to_string()),
@@ -57,7 +60,6 @@ fn bench_edit_segments(c: &mut Criterion) {
                 id: point_id,
                 ctor: SegmentCtor::Point(point_ctor),
             }];
-            ctx.close().await;
             (frontend, mock_ctx, version, sketch_id, segments)
         });
         b.iter(|| {
@@ -68,7 +70,6 @@ fn bench_edit_segments(c: &mut Criterion) {
                         .await
                         .unwrap(),
                 );
-                mock_ctx.close().await;
                 Ok::<(), anyhow::Error>(())
             }) {
                 panic!("Failed to execute program: {err}");

--- a/rust/kcl-lib/src/frontend.rs
+++ b/rust/kcl-lib/src/frontend.rs
@@ -1870,6 +1870,37 @@ impl FrontendState {
         }
     }
 
+    pub async fn hack_set_program_mock(
+        &mut self,
+        ctx: &ExecutorContext,
+        program: Program,
+        mock_config: &MockConfig,
+    ) -> ExecResult<SetProgramOutcome> {
+        self.program = program.clone();
+        self.point_freedom_cache.clear();
+
+        match ctx.run_mock(&program, mock_config).await {
+            Ok(outcome) => {
+                let outcome = self.update_state_after_exec(outcome, true);
+                let checkpoint_id = self
+                    .create_sketch_checkpoint(outcome.clone())
+                    .await
+                    .map_err(|err| KclErrorWithOutputs::no_outputs(KclError::refactor(err.msg)))?;
+                Ok(SetProgramOutcome::Success {
+                    scene_graph: Box::new(self.scene_graph_for_ui()),
+                    exec_outcome: Box::new(outcome),
+                    checkpoint_id: Some(checkpoint_id),
+                })
+            }
+            Err(mut err) => {
+                let outcome = self.exec_outcome_from_exec_error(err.clone())?;
+                self.update_state_after_exec(outcome, true);
+                err.scene_graph = Some(self.scene_graph_for_ui());
+                Ok(SetProgramOutcome::ExecFailure { error: Box::new(err) })
+            }
+        }
+    }
+
     /// Decorate engine execution such that our state is updated and the scene
     /// graph is added to the return.
     pub async fn engine_execute(


### PR DESCRIPTION
## Summary

This splits out the cargo bench fix from the OPFS cloud PR because the failing benchmark path already exists on `main`.

The frontend benchmark was seeding `FrontendState` with `ExecutorContext::new_with_default_client()`, then performing the benchmarked edit operations with a mock context. In CI, the real engine-backed setup can hang up before the benchmark runs, producing websocket errors like `Sending after closing is not allowed`.

## Changes

- Add `FrontendState::hack_set_program_mock` for callers that need to seed frontend state from mock execution instead of a live engine.
- Update `rust/kcl-lib/benches/frontend.rs` to seed and edit through the mock context.
- Stop closing the mock context inside `b.iter`, since that can leave later benchmark iterations using a closed context.

## Validation

- `cargo fmt --manifest-path rust/kcl-lib/Cargo.toml`
- `cargo bench --manifest-path rust/kcl-lib/Cargo.toml --bench frontend -- --test`
- `git diff --check`