### PR TITLE
Load Home projects incrementally

### DIFF
--- a/src/lib/pathUtils.ts
+++ b/src/lib/pathUtils.ts
@@ -1,0 +1,15 @@
+/**
+ * Use this for only web related paths not paths in OS or on disk
+ * e.g. document.location.pathname
+ * WARNING (lee): THIS IS TRULY FOR ALL WEB USES, EVEN IN ELECTRON RENDERER!
+ * I got bit hard by this.
+ */
+export function webSafePathSplit(targetPath: string): string[] {
+  // eslint-disable-next-line no-restricted-syntax
+  return targetPath.split('/')
+}
+
+export function webSafeJoin(paths: string[]): string {
+  // eslint-disable-next-line no-restricted-syntax
+  return paths.join('/')
+}

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -1,6 +1,7 @@
 import type { Configuration } from '@rust/kcl-lib/bindings/Configuration'
 import { APP_NAME, ARCHIVE_DIR, IS_PLAYWRIGHT_KEY } from '@src/lib/constants'
 import fsZds from '@src/lib/fs-zds'
+import { webSafeJoin } from '@src/lib/pathUtils'
 
 import type { FileEntry, Project } from '@src/lib/project'
 import { err } from '@src/lib/trap'
@@ -234,21 +235,7 @@ export function parentPathRelativeToApplicationDirectory(
   return ''
 }
 
-/**
- * Use this for only web related paths not paths in OS or on disk
- * e.g. document.location.pathname
- * WARNING (lee): THIS IS TRULY FOR ALL WEB USES, EVEN IN ELECTRON RENDERER!
- * I got bit hard by this.
- */
-export function webSafePathSplit(targetPath: string): string[] {
-  // eslint-disable-next-line no-restricted-syntax
-  return targetPath.split('/')
-}
-
-export function webSafeJoin(paths: string[]): string {
-  // eslint-disable-next-line no-restricted-syntax
-  return paths.join('/')
-}
+export { webSafeJoin, webSafePathSplit } from '@src/lib/pathUtils'
 
 export function toWebSafePath(targetPath: string, sep = fsZds.sep): string {
   return sep && sep !== '/' ? targetPath.replaceAll(sep, '/') : targetPath

--- a/src/lib/sorting.test.ts
+++ b/src/lib/sorting.test.ts
@@ -1,0 +1,41 @@
+import type { Project } from '@src/lib/project'
+import { getSortFunction } from '@src/lib/sorting'
+import { describe, expect, it } from 'vitest'
+
+function project(name: string, modified?: number): Project {
+  return {
+    name,
+    path: `/projects/${name}`,
+    children: [],
+    default_file: `/projects/${name}/main.kcl`,
+    directory_count: 0,
+    kcl_file_count: 1,
+    metadata:
+      modified === undefined
+        ? null
+        : {
+            accessed: null,
+            created: null,
+            modified,
+            permission: null,
+            size: 0,
+            type: 'directory',
+          },
+    readWriteAccess: true,
+  }
+}
+
+describe('project sorting', () => {
+  it('sorts modified-desc projects before unknown dates and falls back to name', () => {
+    expect(
+      [
+        project('unknown-z'),
+        project('older', 10),
+        project('newest', 30),
+        project('unknown-a'),
+      ]
+        .toSorted(getSortFunction('modified:desc'))
+        .map((entry) => entry.name)
+    ).toEqual(['newest', 'older', 'unknown-a', 'unknown-z'])
+  })
+})

--- a/src/lib/sorting.ts
+++ b/src/lib/sorting.ts
@@ -36,14 +36,17 @@ export function getSortFunction(sortBy: string) {
   }
 
   const sortByModified = (a: Project, b: Project) => {
-    if (a.metadata?.modified && b.metadata?.modified) {
-      const aDate = new Date(a.metadata.modified)
-      const bDate = new Date(b.metadata.modified)
-      return !sortBy || sortBy.includes('desc')
-        ? bDate.getTime() - aDate.getTime()
-        : aDate.getTime() - bDate.getTime()
+    const aModified = a.metadata?.modified ?? Number.NEGATIVE_INFINITY
+    const bModified = b.metadata?.modified ?? Number.NEGATIVE_INFINITY
+    const modifiedComparison =
+      !sortBy || sortBy.includes('desc')
+        ? bModified - aModified
+        : aModified - bModified
+    if (!Number.isNaN(modifiedComparison) && modifiedComparison !== 0) {
+      return modifiedComparison
     }
-    return 0
+
+    return (a.name ?? '').localeCompare(b.name ?? '')
   }
 
   if (sortBy?.includes('name')) {

--- a/src/machines/systemIO/systemIOMachine.spec.ts
+++ b/src/machines/systemIO/systemIOMachine.spec.ts
@@ -4,7 +4,11 @@ import { DEFAULT_PROJECT_NAME } from '@src/lib/constants'
 import type { Project } from '@src/lib/project'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { systemIOMachine } from '@src/machines/systemIO/systemIOMachine'
-import { systemIOMachineImpl } from '@src/machines/systemIO/systemIOMachineImpl'
+import {
+  shouldSendProjectFolderReadProgress,
+  sortProjectDirectoryEntriesByModifiedDesc,
+  systemIOMachineImpl,
+} from '@src/machines/systemIO/systemIOMachineImpl'
 import {
   NO_PROJECT_DIRECTORY,
   SystemIOMachineActors,
@@ -17,6 +21,19 @@ import { createActor, fromPromise, waitFor } from 'xstate'
 
 let appInstanceInThisFile: App = null!
 let instanceInThisFile: ModuleType = null!
+
+function mockProject(name: string): Project {
+  return {
+    metadata: null,
+    kcl_file_count: 0,
+    directory_count: 0,
+    default_file: `/${name}/main.kcl`,
+    path: `/${name}`,
+    name,
+    children: [],
+    readWriteAccess: true,
+  }
+}
 
 /**
  * Every it test could build the world and connect to the engine but this is too resource intensive and will
@@ -37,6 +54,26 @@ beforeEach(async () => {
 })
 
 describe('systemIOMachine - XState', () => {
+  describe('project folder loading', () => {
+    it('only emits folder read progress for initial loads', () => {
+      expect(shouldSendProjectFolderReadProgress(undefined)).toBe(true)
+      expect(shouldSendProjectFolderReadProgress([])).toBe(true)
+      expect(
+        shouldSendProjectFolderReadProgress([mockProject('local-project')])
+      ).toBe(false)
+    })
+
+    it('orders folder read progress by newest project directory first', () => {
+      expect(
+        sortProjectDirectoryEntriesByModifiedDesc([
+          { name: 'alpha', path: '/projects/alpha', modified: 10 },
+          { name: 'charlie', path: '/projects/charlie', modified: 30 },
+          { name: 'bravo', path: '/projects/bravo', modified: 30 },
+        ]).map((entry) => entry.name)
+      ).toEqual(['bravo', 'charlie', 'alpha'])
+    })
+  })
+
   describe('desktop', () => {
     describe('when initialized', () => {
       it('should contain the default context values', () => {
@@ -131,6 +168,139 @@ describe('systemIOMachine - XState', () => {
               SystemIOMachineStates.bulkImportingProjectFilesAndNavigateToFile
             )
           )
+        } finally {
+          actor.stop()
+        }
+      })
+      it('should accept project creation while reading folders', async () => {
+        const actor = createActor(
+          systemIOMachine.provide({
+            actors: {
+              [SystemIOMachineActors.readFoldersFromProjectDirectory]:
+                fromPromise(async () => new Promise(() => {})),
+              [SystemIOMachineActors.createProject]: fromPromise(
+                async () => new Promise(() => {})
+              ),
+            },
+          }),
+          {
+            input: {
+              wasmInstancePromise: Promise.resolve(instanceInThisFile),
+              app: appInstanceInThisFile,
+            },
+          }
+        ).start()
+
+        try {
+          actor.send({
+            type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
+          })
+          await waitFor(actor, (state) =>
+            state.matches(SystemIOMachineStates.readingFolders)
+          )
+
+          actor.send({
+            type: SystemIOMachineEvents.createProject,
+            data: {
+              requestedProjectName: 'local-first-project',
+            },
+          })
+
+          await waitFor(actor, (state) =>
+            state.matches(SystemIOMachineStates.creatingProject)
+          )
+        } finally {
+          actor.stop()
+        }
+      })
+      it('should update folders incrementally while reading folders', async () => {
+        const actor = createActor(
+          systemIOMachine.provide({
+            actors: {
+              [SystemIOMachineActors.readFoldersFromProjectDirectory]:
+                fromPromise(async () => new Promise(() => {})),
+            },
+          }),
+          {
+            input: {
+              wasmInstancePromise: Promise.resolve(instanceInThisFile),
+              app: appInstanceInThisFile,
+            },
+          }
+        ).start()
+
+        try {
+          actor.send({
+            type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
+          })
+          await waitFor(actor, (state) =>
+            state.matches(SystemIOMachineStates.readingFolders)
+          )
+
+          const folders = [mockProject('bravo'), mockProject('alpha')]
+          actor.send({
+            type: SystemIOMachineEvents.setFolders,
+            data: { folders },
+          })
+
+          await waitFor(
+            actor,
+            (state) => state.context.folders?.length === folders.length
+          )
+
+          expect(actor.getSnapshot().context.folders).toStrictEqual(folders)
+          expect(actor.getSnapshot()).toMatchObject({
+            value: SystemIOMachineStates.readingFolders,
+          })
+        } finally {
+          actor.stop()
+        }
+      })
+      it('should accept file navigation while reading folders', async () => {
+        const actor = createActor(
+          systemIOMachine.provide({
+            actors: {
+              [SystemIOMachineActors.readFoldersFromProjectDirectory]:
+                fromPromise(async () => new Promise(() => {})),
+            },
+          }),
+          {
+            input: {
+              wasmInstancePromise: Promise.resolve(instanceInThisFile),
+              app: appInstanceInThisFile,
+            },
+          }
+        ).start()
+
+        try {
+          actor.send({
+            type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
+          })
+          await waitFor(actor, (state) =>
+            state.matches(SystemIOMachineStates.readingFolders)
+          )
+
+          actor.send({
+            type: SystemIOMachineEvents.navigateToFile,
+            data: {
+              requestedProjectName: 'bracket',
+              requestedFileName: 'empty.kcl',
+            },
+          })
+
+          await waitFor(
+            actor,
+            (state) => state.context.requestedFileName.file === 'empty.kcl'
+          )
+
+          expect(actor.getSnapshot().context.requestedFileName).toStrictEqual({
+            project: 'bracket',
+            file: 'empty.kcl',
+            subRoute: undefined,
+          })
+          expect(actor.getSnapshot()).toMatchObject({
+            value: SystemIOMachineStates.readingFolders,
+          })
         } finally {
           actor.stop()
         }
@@ -255,6 +425,104 @@ describe('systemIOMachine - XState', () => {
               SystemIOMachineStates.bulkImportingProjectFilesAndNavigateToFile
             )
           )
+        } finally {
+          actor.stop()
+        }
+      })
+      it('should accept project creation while checking read/write access', async () => {
+        const actor = createActor(
+          systemIOMachine.provide({
+            actors: {
+              [SystemIOMachineActors.checkReadWrite]: fromPromise(
+                async () => new Promise(() => {})
+              ),
+              [SystemIOMachineActors.createProject]: fromPromise(
+                async () => new Promise(() => {})
+              ),
+            },
+          }),
+          {
+            input: {
+              wasmInstancePromise: Promise.resolve(instanceInThisFile),
+              app: appInstanceInThisFile,
+            },
+          }
+        ).start()
+
+        try {
+          actor.send({
+            type: SystemIOMachineEvents.setProjectDirectoryPath,
+            data: {
+              requestedProjectDirectoryPath: 'public/kcl-samples',
+            },
+          })
+          await waitFor(actor, (state) =>
+            state.matches(SystemIOMachineStates.checkingReadWrite)
+          )
+
+          actor.send({
+            type: SystemIOMachineEvents.createProject,
+            data: {
+              requestedProjectName: 'local-first-project',
+            },
+          })
+
+          await waitFor(actor, (state) =>
+            state.matches(SystemIOMachineStates.creatingProject)
+          )
+        } finally {
+          actor.stop()
+        }
+      })
+      it('should accept file navigation while checking read/write access', async () => {
+        const actor = createActor(
+          systemIOMachine.provide({
+            actors: {
+              [SystemIOMachineActors.checkReadWrite]: fromPromise(
+                async () => new Promise(() => {})
+              ),
+            },
+          }),
+          {
+            input: {
+              wasmInstancePromise: Promise.resolve(instanceInThisFile),
+              app: appInstanceInThisFile,
+            },
+          }
+        ).start()
+
+        try {
+          actor.send({
+            type: SystemIOMachineEvents.setProjectDirectoryPath,
+            data: {
+              requestedProjectDirectoryPath: 'public/kcl-samples',
+            },
+          })
+          await waitFor(actor, (state) =>
+            state.matches(SystemIOMachineStates.checkingReadWrite)
+          )
+
+          actor.send({
+            type: SystemIOMachineEvents.navigateToFile,
+            data: {
+              requestedProjectName: 'bracket',
+              requestedFileName: 'empty.kcl',
+            },
+          })
+
+          await waitFor(
+            actor,
+            (state) => state.context.requestedFileName.file === 'empty.kcl'
+          )
+
+          expect(actor.getSnapshot().context.requestedFileName).toStrictEqual({
+            project: 'bracket',
+            file: 'empty.kcl',
+            subRoute: undefined,
+          })
+          expect(actor.getSnapshot()).toMatchObject({
+            value: SystemIOMachineStates.checkingReadWrite,
+          })
         } finally {
           actor.stop()
         }

--- a/src/machines/systemIO/systemIOMachine.ts
+++ b/src/machines/systemIO/systemIOMachine.ts
@@ -53,6 +53,10 @@ export const systemIOMachine = setup({
           output: Project[]
         }
       | {
+          type: SystemIOMachineEvents.setFolders
+          data: { folders: Project[] }
+        }
+      | {
           type: SystemIOMachineEvents.done_checkReadWrite
           output: { value: boolean; error: unknown }
         }
@@ -341,17 +345,31 @@ export const systemIOMachine = setup({
   actions: {
     [SystemIOMachineActions.setFolders]: assign({
       folders: ({ event }) => {
-        assertEvent(
-          event,
-          SystemIOMachineEvents.done_readFoldersFromProjectDirectory
-        )
-        return event.output
+        assertEvent(event, [
+          SystemIOMachineEvents.done_readFoldersFromProjectDirectory,
+          SystemIOMachineEvents.setFolders,
+        ])
+        return 'output' in event ? event.output : event.data.folders
       },
     }),
     [SystemIOMachineActions.setProjectDirectoryPath]: assign({
       projectDirectoryPath: ({ event }) => {
         assertEvent(event, SystemIOMachineEvents.setProjectDirectoryPath)
         return event.data.requestedProjectDirectoryPath
+      },
+      folders: ({ context, event }) => {
+        assertEvent(event, SystemIOMachineEvents.setProjectDirectoryPath)
+        return context.projectDirectoryPath ===
+          event.data.requestedProjectDirectoryPath
+          ? context.folders
+          : undefined
+      },
+      hasListedProjects: ({ context, event }) => {
+        assertEvent(event, SystemIOMachineEvents.setProjectDirectoryPath)
+        return context.projectDirectoryPath ===
+          event.data.requestedProjectDirectoryPath
+          ? context.hasListedProjects
+          : false
       },
     }),
     [SystemIOMachineActions.setRequestedProjectName]: assign({
@@ -939,6 +957,24 @@ export const systemIOMachine = setup({
     },
     [SystemIOMachineStates.readingFolders]: {
       on: {
+        [SystemIOMachineEvents.setFolders]: {
+          actions: SystemIOMachineActions.setFolders,
+        },
+        [SystemIOMachineEvents.navigateToProject]: {
+          actions: [SystemIOMachineActions.setRequestedProjectName],
+        },
+        [SystemIOMachineEvents.navigateToFile]: {
+          actions: [SystemIOMachineActions.setRequestedFileName],
+        },
+        [SystemIOMachineEvents.createProject]: [
+          {
+            guard: SystemIOMachineGuards.projectNameIsValidLength,
+            target: SystemIOMachineStates.creatingProject,
+          },
+          {
+            actions: [SystemIOMachineActions.toastProjectNameTooLong],
+          },
+        ],
         [SystemIOMachineEvents.bulkImportProjectFilesAndNavigateToFile]: {
           target:
             SystemIOMachineStates.bulkImportingProjectFilesAndNavigateToFile,
@@ -1168,6 +1204,21 @@ export const systemIOMachine = setup({
     },
     [SystemIOMachineStates.checkingReadWrite]: {
       on: {
+        [SystemIOMachineEvents.navigateToProject]: {
+          actions: [SystemIOMachineActions.setRequestedProjectName],
+        },
+        [SystemIOMachineEvents.navigateToFile]: {
+          actions: [SystemIOMachineActions.setRequestedFileName],
+        },
+        [SystemIOMachineEvents.createProject]: [
+          {
+            guard: SystemIOMachineGuards.projectNameIsValidLength,
+            target: SystemIOMachineStates.creatingProject,
+          },
+          {
+            actions: [SystemIOMachineActions.toastProjectNameTooLong],
+          },
+        ],
         [SystemIOMachineEvents.bulkImportProjectFilesAndNavigateToFile]: {
           target:
             SystemIOMachineStates.bulkImportingProjectFilesAndNavigateToFile,

--- a/src/machines/systemIO/systemIOMachineImpl.ts
+++ b/src/machines/systemIO/systemIOMachineImpl.ts
@@ -9,7 +9,6 @@ import {
   mkdirOrNOOP,
   readAppSettingsFile,
   renameProjectDirectory,
-  statIsDirectory,
 } from '@src/lib/desktop'
 import {
   doesProjectNameNeedInterpolated,
@@ -25,7 +24,7 @@ import {
   getStringAfterLastSeparator,
   parentPathRelativeToProject,
 } from '@src/lib/paths'
-import type { Project } from '@src/lib/project'
+import type { FileEntry, Project } from '@src/lib/project'
 import { err, isErr } from '@src/lib/trap'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { systemIOMachine } from '@src/machines/systemIO/systemIOMachine'
@@ -47,6 +46,73 @@ import {
 import { fromPromise } from 'xstate'
 
 const ML_CONVERSATIONS_FILE_NAME = 'ml-conversations.json'
+
+async function getProjectDirectoryEntryNames(projectDirectoryPath?: string) {
+  if (!projectDirectoryPath) {
+    return []
+  }
+
+  try {
+    return await fsZds.readdir(projectDirectoryPath)
+  } catch (error) {
+    if (error === 'ENOENT') {
+      return []
+    }
+    return Promise.reject(error)
+  }
+}
+
+async function getUniqueProjectNameForCreate({
+  context,
+  requestedProjectName,
+  projectDirectoryPath,
+}: {
+  context: SystemIOContext
+  requestedProjectName: string
+  projectDirectoryPath?: string
+}) {
+  const knownProjectNames = new Set<string>()
+  for (const folder of context.folders ?? []) {
+    knownProjectNames.add(folder.name)
+  }
+  for (const entryName of await getProjectDirectoryEntryNames(
+    projectDirectoryPath
+  )) {
+    knownProjectNames.add(entryName)
+  }
+
+  const existingEntries: FileEntry[] = Array.from(
+    knownProjectNames,
+    (name) => ({
+      name,
+      path: projectDirectoryPath
+        ? fsZds.join(projectDirectoryPath, name)
+        : name,
+      children: [],
+    })
+  )
+  return getUniqueProjectName(requestedProjectName, existingEntries)
+}
+
+export function shouldSendProjectFolderReadProgress(
+  folders: SystemIOContext['folders']
+) {
+  return !folders?.length
+}
+
+type ProjectDirectoryEntry = {
+  name: string
+  path: string
+  modified: number
+}
+
+export function sortProjectDirectoryEntriesByModifiedDesc(
+  entries: ProjectDirectoryEntry[]
+) {
+  return entries.toSorted(
+    (a, b) => b.modified - a.modified || a.name.localeCompare(b.name)
+  )
+}
 
 const prepareBulkProjectWrite = async ({
   context,
@@ -293,33 +359,57 @@ const sharedBulkDeleteWorkflow = async ({
 export const systemIOMachineImpl = systemIOMachine.provide({
   actors: {
     [SystemIOMachineActors.readFoldersFromProjectDirectory]: fromPromise(
-      async ({ input: context }: { input: SystemIOContext }) => {
-        const projects = []
+      async ({ input: context, signal }) => {
+        const PROJECT_FOLDER_PROGRESS_CHUNK_SIZE = 12
+        const projects: Project[] = []
         const projectDirectoryPath = context.projectDirectoryPath
+        const canSendProgress = shouldSendProjectFolderReadProgress(
+          context.folders
+        )
         if (projectDirectoryPath === NO_PROJECT_DIRECTORY) {
           return []
         }
+        const sendFoldersProgress = (folders: Project[]) => {
+          if (signal.aborted) {
+            return
+          }
+          context.app.systemIOActor.send({
+            type: SystemIOMachineEvents.setFolders,
+            data: { folders },
+          })
+        }
+
         await mkdirOrNOOP(projectDirectoryPath)
         // Gotcha: readdir will list all folders at this project directory even if you do not have readwrite access on the directory path
-        const entries = await fsZds.readdir(projectDirectoryPath)
-        const { value: canReadWriteProjectDirectory } =
-          await canReadWriteDirectory(projectDirectoryPath)
-
-        for (let entry of entries) {
-          // Skip directories that start with a dot
+        const entries: ProjectDirectoryEntry[] = []
+        for (const entry of await fsZds.readdir(projectDirectoryPath)) {
           if (entry.startsWith('.')) {
             continue
           }
-          const projectPath = fsZds.join(projectDirectoryPath, entry)
 
-          // if it's not a directory ignore.
-          // Gotcha: statIsDirectory will work even if you do not have read write permissions on the project path
-          const isDirectory = await statIsDirectory(projectPath)
-          if (!isDirectory) {
+          const projectPath = fsZds.join(projectDirectoryPath, entry)
+          const stat = await fsZds.stat(projectPath)
+          if (!(stat.mode & fsZdsConstants.S_IFDIR)) {
             continue
           }
+
+          entries.push({
+            name: entry,
+            path: projectPath,
+            modified: stat.mtimeMs,
+          })
+        }
+        const { value: canReadWriteProjectDirectory } =
+          await canReadWriteDirectory(projectDirectoryPath)
+
+        for (const entry of sortProjectDirectoryEntriesByModifiedDesc(
+          entries
+        )) {
+          if (signal.aborted) {
+            return projects
+          }
           const project: Project = await getProjectInfo(
-            projectPath,
+            entry.path,
             await context.wasmInstancePromise
           )
           if (
@@ -330,7 +420,14 @@ export const systemIOMachineImpl = systemIOMachine.provide({
             continue
           }
           projects.push(project)
+          if (
+            canSendProgress &&
+            projects.length % PROJECT_FOLDER_PROGRESS_CHUNK_SIZE === 0
+          ) {
+            sendFoldersProgress([...projects])
+          }
         }
+        sendFoldersProgress(projects)
         return projects
       }
     ),
@@ -340,16 +437,24 @@ export const systemIOMachineImpl = systemIOMachine.provide({
       }: {
         input: { context: SystemIOContext; requestedProjectName: string }
       }) => {
-        const folders = input.context.folders
-        if (!folders) {
-          return Promise.reject(new Error('no folders'))
-        }
-
         const requestedProjectName = input.requestedProjectName
-        const uniqueName = getUniqueProjectName(requestedProjectName, folders)
+        const projectDirectoryPath =
+          input.context.projectDirectoryPath &&
+          input.context.projectDirectoryPath !== NO_PROJECT_DIRECTORY
+            ? input.context.projectDirectoryPath
+            : undefined
+        const uniqueName = await getUniqueProjectNameForCreate({
+          context: input.context,
+          requestedProjectName,
+          projectDirectoryPath,
+        })
         await createNewProjectDirectory(
           uniqueName,
-          await input.context.wasmInstancePromise
+          await input.context.wasmInstancePromise,
+          undefined,
+          undefined,
+          undefined,
+          projectDirectoryPath
         )
         return {
           message: `Successfully created "${uniqueName}"`,

--- a/src/machines/systemIO/utils.ts
+++ b/src/machines/systemIO/utils.ts
@@ -93,6 +93,7 @@ export enum SystemIOMachineEvents {
   readFoldersFromProjectDirectory = 'read folders from project directory',
   done_readFoldersFromProjectDirectory = donePrefix +
     'read folders from project directory',
+  setFolders = 'set folders',
   setProjectDirectoryPath = 'set project directory path',
   navigateToProject = 'navigate to project',
   navigateToFile = 'navigate to file',

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -572,35 +572,50 @@ function ProjectGrid({
 }: ProjectGridProps) {
   const { systemIOActor } = useApp()
   const state = useSystemIOState()
+  const isReadingFolders = state.matches(SystemIOMachineStates.readingFolders)
+  const sortedSearchResults = searchResults.toSorted(getSortFunction(sort))
 
   return (
     <section data-testid="home-section" {...rest}>
-      {state.matches(SystemIOMachineStates.readingFolders) ||
-      projects === undefined ? (
+      {projects === undefined || (isReadingFolders && projects.length === 0) ? (
         <Loading isDummy={true}>Loading your Projects...</Loading>
       ) : (
         <>
           {searchResults.length > 0 ? (
-            <ul className="grid w-full sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-              {searchResults.sort(getSortFunction(sort)).map((project) => (
-                <ProjectCard
-                  key={project.name}
-                  project={project}
-                  handleRenameProject={handleRenameProject}
-                  handleDeleteProject={handleDeleteProject(systemIOActor)}
-                />
-              ))}
-            </ul>
+            <>
+              <ul className="grid w-full sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+                {sortedSearchResults.map((project) => (
+                  <ProjectCard
+                    key={project.name}
+                    project={project}
+                    handleRenameProject={handleRenameProject}
+                    handleDeleteProject={handleDeleteProject(systemIOActor)}
+                  />
+                ))}
+              </ul>
+              {isReadingFolders && (
+                <div className="py-4">
+                  <Loading isDummy={true}>Loading more projects...</Loading>
+                </div>
+              )}
+            </>
           ) : (
-            <p
-              data-testid="projects-none"
-              className="p-4 my-8 border border-dashed rounded border-chalkboard-30 dark:border-chalkboard-70"
-            >
-              No projects found
-              {projects !== undefined && projects.length === 0
-                ? ', ready to make your first one?'
-                : ` with the search term "${query}"`}
-            </p>
+            <>
+              <p
+                data-testid="projects-none"
+                className="p-4 my-8 border border-dashed rounded border-chalkboard-30 dark:border-chalkboard-70"
+              >
+                No projects found
+                {projects !== undefined && projects.length === 0
+                  ? ', ready to make your first one?'
+                  : ` with the search term "${query}"`}
+              </p>
+              {isReadingFolders && (
+                <div className="py-4">
+                  <Loading isDummy={true}>Loading more projects...</Loading>
+                </div>
+              )}
+            </>
           )}
         </>
       )}


### PR DESCRIPTION
This reverts commit 74864c58b8085baca7434157bfcdf8431e4fc4a4. It is a re-issuance of #11954, which was merged without proper review.

## Summary

This is the first prep PR for OPFSCloud, but it intentionally ships as a general Home/project-loading improvement with no cloud behavior.

- Streams project directory results into Home in stable modified-time batches instead of waiting for the full directory walk.
- Allows create/open project events to proceed while project folder loading or read/write checks are in flight.
- Adds deterministic modified-date sorting fallback and shared web-safe slash helpers.

## Review map

- `src/machines/systemIO/systemIOMachine.ts` accepts incremental `setFolders` updates and handles project actions during loading states.
- `src/machines/systemIO/systemIOMachineImpl.ts` sorts directory entries by modified time before emitting local batches.
- `src/routes/Home.tsx` renders the partial list and a loading-more state without replacing the whole grid.
- `src/lib/sorting.ts`, `src/lib/pathUtils.ts`, and `src/lib/paths.ts` contain the reusable sort/path helpers.