### PR TITLE
Migrate ProjectExplorer shortcuts to keymap

### DIFF
--- a/src/components/Explorer/FileExplorer.spec.tsx
+++ b/src/components/Explorer/FileExplorer.spec.tsx
@@ -12,6 +12,8 @@ describe('FileExplorer', () => {
           contextMenuRow={null}
           isRenaming={false}
           isCopying={false}
+          isDeleting={false}
+          onDeleteEnd={() => {}}
         />
       )
       const container = screen.getByTestId('file-explorer')

--- a/src/components/Explorer/FileExplorer.tsx
+++ b/src/components/Explorer/FileExplorer.tsx
@@ -15,7 +15,6 @@ import { noAutofillFormProps, noAutofillInputProps } from '@src/lib/autofill'
 import fsZds from '@src/lib/fs-zds'
 import type { MaybePressOrBlur, SubmitByPressOrBlur } from '@src/lib/types'
 import { uuidv4 } from '@src/lib/utils'
-import type { Dispatch } from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 export const StatusDot = () => {
@@ -67,18 +66,22 @@ export const FileExplorer = ({
   selectedRow,
   contextMenuRow,
   isRenaming,
+  isDeleting,
   isCopying,
   isExternalDragOver,
   highlightedEntry,
+  onDeleteEnd,
   onExternalDragOverRow,
 }: {
   rowsToRender: FileExplorerRow[]
   selectedRow: FileExplorerEntry | null
   contextMenuRow: FileExplorerEntry | null
   isRenaming: boolean
+  isDeleting: boolean
   isCopying: boolean
   isExternalDragOver?: boolean
   highlightedEntry?: FileExplorerEntry | null
+  onDeleteEnd: () => void
   onExternalDragOverRow?: (entry: FileExplorerEntry | null) => void
 }) => {
   return (
@@ -103,9 +106,11 @@ export const FileExplorer = ({
             selectedRow={selectedRow}
             contextMenuRow={contextMenuRow}
             isRenaming={isRenaming}
+            isDeleting={isDeleting}
             isCopying={isCopying}
             isExternalDragHighlighted={isHighlighted}
             isExternalDragOver={isExternalDragOver}
+            onDeleteEnd={onDeleteEnd}
             onExternalDragOverRow={onExternalDragOverRow}
           />
         )
@@ -218,18 +223,18 @@ function RenameForm({
 
 function DeleteFileTreeItemDialog({
   row,
-  setIsOpen,
+  onDismiss,
 }: {
   row: FileExplorerRender
-  setIsOpen: Dispatch<React.SetStateAction<boolean>>
+  onDismiss: () => void
 }) {
   return (
     <DeleteConfirmationDialog
       title={`Delete ${row.isFolder ? 'folder' : 'file'}`}
-      onDismiss={() => setIsOpen(false)}
+      onDismiss={onDismiss}
       onConfirm={() => {
         row.onDelete()
-        setIsOpen(false)
+        onDismiss()
       }}
     >
       <p className="my-4">
@@ -253,18 +258,22 @@ export const FileExplorerRowElement = ({
   selectedRow,
   contextMenuRow,
   isRenaming,
+  isDeleting,
   isCopying,
   isExternalDragHighlighted,
   isExternalDragOver,
+  onDeleteEnd,
   onExternalDragOverRow,
 }: {
   row: FileExplorerRender
   selectedRow: FileExplorerEntry | null
   contextMenuRow: FileExplorerEntry | null
   isRenaming: boolean
+  isDeleting: boolean
   isCopying: boolean
   isExternalDragHighlighted?: boolean
   isExternalDragOver?: boolean
+  onDeleteEnd: () => void
   onExternalDragOverRow?: (entry: FileExplorerEntry | null) => void
 }) => {
   const dragPreviewId = `drag-preview-${row.name}`
@@ -327,6 +336,7 @@ export const FileExplorerRowElement = ({
   const isIndexActive = row.domIndex === row.activeIndex
   const isContextMenuRow = contextMenuRow?.key === row.key
   const isMyRowRenaming = isContextMenuRow && isRenaming
+  const isMyRowDeleting = isContextMenuRow && isDeleting
   const [isConfirmingDelete, setIsConfirmingDelete] = useState<boolean>(false)
 
   const outlineCSS =
@@ -338,6 +348,10 @@ export const FileExplorerRowElement = ({
   const externalHighlightCSS = isExternalDragHighlighted
     ? 'ring-2 ring-inset ring-blue-500 bg-blue-500/10'
     : ''
+  const handleDeleteDismiss = useCallback(() => {
+    setIsConfirmingDelete(false)
+    onDeleteEnd()
+  }, [onDeleteEnd])
 
   // Complaining about role="treeitem" focus but it is reimplemented aria labels
   /* eslint-disable */
@@ -470,8 +484,8 @@ export const FileExplorerRowElement = ({
       )}
       <div className="ml-auto">{row.status}</div>
       <div style={{ width: '0.25rem' }}></div>
-      {isConfirmingDelete && (
-        <DeleteFileTreeItemDialog row={row} setIsOpen={setIsConfirmingDelete} />
+      {(isConfirmingDelete || isMyRowDeleting) && (
+        <DeleteFileTreeItemDialog row={row} onDismiss={handleDeleteDismiss} />
       )}
       <FileExplorerRowContextMenu
         itemRef={rowElementRef}

--- a/src/components/Explorer/ProjectExplorer.spec.tsx
+++ b/src/components/Explorer/ProjectExplorer.spec.tsx
@@ -7,6 +7,10 @@ import { StorageName, moduleFsViaModuleImport } from '@src/lib/fs-zds'
 import type { FileEntry, Project } from '@src/lib/project'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import {
+  PROJECT_EXPLORER_COMMAND_IDS,
+  defaultKeymap,
+} from '@src/registry/extensions/keymap/defaultKeymap'
+import {
   cleanup,
   fireEvent,
   render,
@@ -51,6 +55,14 @@ const createFolder = (name: string, children?: FileEntry[]): FileEntry => {
     path: `/${applicationDirectory}/${projectName}/${name}`,
     children: children || [],
   }
+}
+const fireModKeyDown = (key: string, code: string) => {
+  fireEvent.keyDown(window, {
+    key,
+    code,
+    ctrlKey: true,
+    metaKey: true,
+  })
 }
 const oneFile: FileEntry = createFile('main.kcl')
 const PROJECT_TEMPLATE: Project = {
@@ -367,6 +379,93 @@ describe('ProjectExplorer', () => {
         'main.kcl'
       )
     })
+  })
+  it('should enable paste after copying the active row with the keymap shortcut', async () => {
+    project.children = [oneFile]
+
+    render(
+      <ProjectExplorer
+        wasmInstance={wasmInstance}
+        project={project}
+        file={oneFile}
+        createFilePressed={-1}
+        createFolderPressed={-1}
+        refreshExplorerPressed={-1}
+        collapsePressed={-1}
+        onRowClicked={(row: FileExplorerEntry, index: number) => {}}
+        onRowEnter={(row: FileExplorerEntry, index: number) => {}}
+        readOnly={false}
+        canNavigate={true}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('file-tree-item')).toHaveAttribute(
+        'aria-selected',
+        'true'
+      )
+    })
+
+    fireEvent.click(screen.getByText('main.kcl'))
+    fireModKeyDown('c', 'KeyC')
+    fireEvent.contextMenu(screen.getByText('main.kcl'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('context-menu-paste')).not.toHaveAttribute(
+        'disabled'
+      )
+    })
+  })
+  it('should open delete confirmation with the delete keymap shortcut', async () => {
+    project.children = [oneFile]
+
+    render(
+      <ProjectExplorer
+        wasmInstance={wasmInstance}
+        project={project}
+        file={oneFile}
+        createFilePressed={-1}
+        createFolderPressed={-1}
+        refreshExplorerPressed={-1}
+        collapsePressed={-1}
+        onRowClicked={(row: FileExplorerEntry, index: number) => {}}
+        onRowEnter={(row: FileExplorerEntry, index: number) => {}}
+        readOnly={false}
+        canNavigate={true}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('file-tree-item')).toHaveAttribute(
+        'aria-selected',
+        'true'
+      )
+    })
+
+    fireEvent.click(screen.getByText('main.kcl'))
+    fireModKeyDown('Backspace', 'Backspace')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('delete-confirmation')).toBeInTheDocument()
+    })
+  })
+  it('should define default keymap bindings for project explorer file operations', () => {
+    expect(defaultKeymap.bindings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: PROJECT_EXPLORER_COMMAND_IDS.delete,
+          keystrokes: ['mod+backspace'],
+        }),
+        expect.objectContaining({
+          id: PROJECT_EXPLORER_COMMAND_IDS.copy,
+          keystrokes: ['mod+c'],
+        }),
+        expect.objectContaining({
+          id: PROJECT_EXPLORER_COMMAND_IDS.paste,
+          keystrokes: ['mod+v'],
+        }),
+      ])
+    )
   })
   it('should move the active row with keymap arrow navigation without resetting to the current file', async () => {
     const mainFile = createFile('main.kcl')

--- a/src/components/Explorer/ProjectExplorer.spec.tsx
+++ b/src/components/Explorer/ProjectExplorer.spec.tsx
@@ -13,7 +13,15 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react'
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
 
 beforeAll(async () => {
   await moduleFsViaModuleImport({
@@ -257,6 +265,72 @@ describe('ProjectExplorer', () => {
       expect(items[0].innerText).toBe('shared-project')
       expect(selectedRows[0]).toBe(items[1])
     })
+  })
+  it('should not handle Enter outside of the explorer when the current file is selected', async () => {
+    project.children = [oneFile]
+    const onRowEnter = vi.fn()
+
+    render(
+      <ProjectExplorer
+        wasmInstance={wasmInstance}
+        project={project}
+        file={oneFile}
+        createFilePressed={-1}
+        createFolderPressed={-1}
+        refreshExplorerPressed={-1}
+        collapsePressed={-1}
+        onRowClicked={(row: FileExplorerEntry, index: number) => {}}
+        onRowEnter={onRowEnter}
+        readOnly={false}
+        canNavigate={true}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('file-tree-item')).toHaveAttribute(
+        'aria-selected',
+        'true'
+      )
+    })
+
+    fireEvent.keyDown(window, { key: 'Enter' })
+
+    expect(onRowEnter).not.toHaveBeenCalled()
+  })
+  it('should handle Enter through the keymap after the explorer row is clicked', async () => {
+    project.children = [oneFile]
+    const onRowEnter = vi.fn()
+
+    render(
+      <ProjectExplorer
+        wasmInstance={wasmInstance}
+        project={project}
+        file={oneFile}
+        createFilePressed={-1}
+        createFolderPressed={-1}
+        refreshExplorerPressed={-1}
+        collapsePressed={-1}
+        onRowClicked={(row: FileExplorerEntry, index: number) => {}}
+        onRowEnter={onRowEnter}
+        readOnly={false}
+        canNavigate={true}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('file-tree-item')).toHaveAttribute(
+        'aria-selected',
+        'true'
+      )
+    })
+
+    fireEvent.click(screen.getByText('main.kcl'))
+    fireEvent.keyDown(window, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(onRowEnter).toHaveBeenCalledTimes(1)
+    })
+    expect(onRowEnter.mock.calls[0][0].path).toBe(oneFile.path)
   })
   it('should render main.kcl on initialization within 3 nested folders', () => {
     const mainFile = createFile('main.kcl', 'parts/very/cool/')

--- a/src/components/Explorer/ProjectExplorer.spec.tsx
+++ b/src/components/Explorer/ProjectExplorer.spec.tsx
@@ -332,6 +332,138 @@ describe('ProjectExplorer', () => {
     })
     expect(onRowEnter.mock.calls[0][0].path).toBe(oneFile.path)
   })
+  it('should start renaming the active row with the F2 keymap shortcut', async () => {
+    project.children = [oneFile]
+
+    render(
+      <ProjectExplorer
+        wasmInstance={wasmInstance}
+        project={project}
+        file={oneFile}
+        createFilePressed={-1}
+        createFolderPressed={-1}
+        refreshExplorerPressed={-1}
+        collapsePressed={-1}
+        onRowClicked={(row: FileExplorerEntry, index: number) => {}}
+        onRowEnter={(row: FileExplorerEntry, index: number) => {}}
+        readOnly={false}
+        canNavigate={true}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('file-tree-item')).toHaveAttribute(
+        'aria-selected',
+        'true'
+      )
+    })
+
+    fireEvent.click(screen.getByText('main.kcl'))
+    fireEvent.keyDown(window, { key: 'F2' })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('file-rename-field')).toHaveAttribute(
+        'placeholder',
+        'main.kcl'
+      )
+    })
+  })
+  it('should move the active row with keymap arrow navigation without resetting to the current file', async () => {
+    const mainFile = createFile('main.kcl')
+    const dogFile = createFile('dog.kcl')
+    project.children = [mainFile, dogFile]
+
+    render(
+      <ProjectExplorer
+        wasmInstance={wasmInstance}
+        project={project}
+        file={mainFile}
+        createFilePressed={-1}
+        createFolderPressed={-1}
+        refreshExplorerPressed={-1}
+        collapsePressed={-1}
+        onRowClicked={(row: FileExplorerEntry, index: number) => {}}
+        onRowEnter={(row: FileExplorerEntry, index: number) => {}}
+        readOnly={false}
+        canNavigate={true}
+      />
+    )
+
+    await waitFor(() => {
+      const rows = screen.getAllByTestId('file-tree-item')
+      expect(rows[1]).toHaveAttribute('aria-selected', 'true')
+    })
+
+    const [dogRow, mainRow] = screen.getAllByTestId('file-tree-item')
+    expect(dogRow.innerText).toBe('dog.kcl')
+    expect(mainRow.innerText).toBe('main.kcl')
+
+    fireEvent.click(mainRow)
+    expect(mainRow.className).toContain('outline-primary')
+
+    fireEvent.keyDown(window, { key: 'ArrowUp' })
+
+    await waitFor(() => {
+      expect(dogRow.className).toContain('outline-primary')
+    })
+    expect(mainRow).toHaveAttribute('aria-selected', 'true')
+  })
+  it('should collapse and reopen the current file parent folder with keymap arrow navigation', async () => {
+    const mainFile = createFile('main.kcl', 'parts/')
+    project.children = [createFolder('parts', [mainFile])]
+    addPlaceHoldersForNewFileAndFolder(project.children, project.path)
+
+    render(
+      <ProjectExplorer
+        wasmInstance={wasmInstance}
+        project={project}
+        file={mainFile}
+        createFilePressed={-1}
+        createFolderPressed={-1}
+        refreshExplorerPressed={-1}
+        collapsePressed={-1}
+        onRowClicked={(row: FileExplorerEntry, index: number) => {}}
+        onRowEnter={(row: FileExplorerEntry, index: number) => {}}
+        readOnly={false}
+        canNavigate={true}
+        overrideApplicationProjectDirectory="applicationDirectory/"
+      />
+    )
+
+    await waitFor(() => {
+      const rows = screen.getAllByTestId('file-tree-item')
+      expect(rows).toHaveLength(2)
+      expect(rows[1]).toHaveAttribute('aria-selected', 'true')
+    })
+
+    fireEvent.click(screen.getByText('main.kcl'))
+    fireEvent.keyDown(window, { key: 'ArrowUp' })
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('file-tree-item')[0].className).toContain(
+        'outline-primary'
+      )
+    })
+
+    fireEvent.keyDown(window, { key: 'ArrowLeft' })
+
+    await waitFor(() => {
+      const rows = screen.getAllByTestId('file-tree-item')
+      expect(rows).toHaveLength(1)
+      expect(rows[0].innerText).toBe('parts')
+      expect(rows[0]).toHaveAttribute('aria-expanded', 'false')
+    })
+
+    fireEvent.keyDown(window, { key: 'ArrowRight' })
+
+    await waitFor(() => {
+      const rows = screen.getAllByTestId('file-tree-item')
+      expect(rows).toHaveLength(2)
+      expect(rows[0].innerText).toBe('parts')
+      expect(rows[0]).toHaveAttribute('aria-expanded', 'true')
+      expect(rows[1].innerText).toBe('main.kcl')
+    })
+  })
   it('should render main.kcl on initialization within 3 nested folders', () => {
     const mainFile = createFile('main.kcl', 'parts/very/cool/')
     project.children = [

--- a/src/components/Explorer/ProjectExplorer.tsx
+++ b/src/components/Explorer/ProjectExplorer.tsx
@@ -236,8 +236,10 @@ export const ProjectExplorer = ({
     arrowUp: () => {},
     arrowDown: () => {},
     enter: () => {},
+    rename: () => {},
   })
   const previousProject = useRef(project)
+  const lastSyncedFilePathRef = useRef<string | undefined>(undefined)
 
   onRowEnterRef.current = onRowEnter
 
@@ -450,11 +452,26 @@ export const ProjectExplorer = ({
     onRowEnterRef.current(focusedEntry, activeIndexRef.current)
   }, [setOpenedRowsWrapper])
 
+  const handleRenameCommand = useCallback(() => {
+    if (readOnly || activeIndexRef.current < STARTING_INDEX_TO_SELECT) {
+      return
+    }
+
+    const focusedEntry = rowsToRenderRef.current[activeIndexRef.current]
+    if (!focusedEntry || focusedEntry.isFake) {
+      return
+    }
+
+    setContextMenuRow(focusedEntry)
+    setIsRenaming(true)
+  }, [readOnly])
+
   projectExplorerCommandHandlersRef.current.arrowLeft = handleArrowLeftCommand
   projectExplorerCommandHandlersRef.current.arrowRight = handleArrowRightCommand
   projectExplorerCommandHandlersRef.current.arrowUp = handleArrowUpCommand
   projectExplorerCommandHandlersRef.current.arrowDown = handleArrowDownCommand
   projectExplorerCommandHandlersRef.current.enter = handleEnterCommand
+  projectExplorerCommandHandlersRef.current.rename = handleRenameCommand
 
   const projectExplorerCommands = useMemo<Command[]>(
     () => [
@@ -502,6 +519,15 @@ export const ProjectExplorer = ({
         needsReview: false,
         hideFromSearch: true,
         onSubmit: () => projectExplorerCommandHandlersRef.current.enter(),
+      },
+      {
+        id: PROJECT_EXPLORER_COMMAND_IDS.rename,
+        name: 'rename',
+        groupId: 'project-explorer',
+        displayName: 'Rename selected project explorer row',
+        needsReview: false,
+        hideFromSearch: true,
+        onSubmit: () => projectExplorerCommandHandlersRef.current.rename(),
       },
     ],
     []
@@ -647,13 +673,15 @@ export const ProjectExplorer = ({
     /**
      * You are loading a new project, clear the internal state!
      */
-    if (previousProject.current.name !== project.name) {
+    const didProjectChange = previousProject.current.name !== project.name
+    if (didProjectChange) {
       setOpenedRows({})
       setSelectedRow(null)
       setActiveIndexWrapper(NOTHING_IS_SELECTED)
       setRowsToRender([])
       setContextMenuRow(null)
       setIsRenaming(false)
+      lastSyncedFilePathRef.current = undefined
       keymap?.removeScope(PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE)
       keymap?.removeScope(PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE)
     }
@@ -677,14 +705,20 @@ export const ProjectExplorer = ({
     }
 
     const openedRowsForRender = { ...openedRows }
+    if (!file?.path) {
+      lastSyncedFilePathRef.current = undefined
+    }
     const currentFileRow = file?.path
       ? flattenedData.find(
           (child) =>
             child.path === file.path && rowPathMatchesTreeParent(child, project)
         )
       : undefined
+    const shouldRevealCurrentFile =
+      !!currentFileRow &&
+      (didProjectChange || lastSyncedFilePathRef.current !== file?.path)
     let openedRowsChanged = false
-    if (currentFileRow) {
+    if (shouldRevealCurrentFile) {
       const pathIterator = desktopSafePathSplit(currentFileRow.parentPath)
       while (pathIterator.length > 0) {
         const key = desktopSafePathJoin(pathIterator)
@@ -1154,9 +1188,13 @@ export const ProjectExplorer = ({
     const currentFileRowIndex = requestedRowsToRender.findIndex(
       (row) => row.path === file?.path
     )
-    if (currentFileRowIndex >= 0) {
+    const shouldSyncCurrentFileSelection =
+      currentFileRowIndex >= 0 && !!shouldRevealCurrentFile
+
+    if (shouldSyncCurrentFileSelection) {
       setSelectedRowWrapper(requestedRowsToRender[currentFileRowIndex])
       setActiveIndexWrapper(currentFileRowIndex)
+      lastSyncedFilePathRef.current = file?.path
     }
     if (openedRowsChanged) {
       setOpenedRowsWrapper(openedRowsForRender)

--- a/src/components/Explorer/ProjectExplorer.tsx
+++ b/src/components/Explorer/ProjectExplorer.tsx
@@ -18,6 +18,7 @@ import type {
 import { fsArchiveFile, fsMoveFile } from '@src/editor/plugins/fs'
 import { kclErrorsByFilename } from '@src/lang/errors'
 import { useApp, useSingletons } from '@src/lib/boot'
+import type { Command } from '@src/lib/commandTypes'
 import { FILE_EXT } from '@src/lib/constants'
 import { getNextFileName, sortFilesAndDirectories } from '@src/lib/desktopFS'
 import fsZds from '@src/lib/fs-zds'
@@ -36,7 +37,14 @@ import type { FileEntry, Project } from '@src/lib/project'
 import type { MaybePressOrBlur } from '@src/lib/types'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE,
+  PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE,
+  keymapService,
+} from '@src/registry/contracts/keymap'
+import { PROJECT_EXPLORER_COMMAND_IDS } from '@src/registry/extensions/keymap/defaultKeymap'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { FocusEvent as ReactFocusEvent } from 'react'
 import toast from 'react-hot-toast'
 
 const isFileExplorerEntryOpened = (
@@ -167,7 +175,8 @@ export const ProjectExplorer = ({
   canNavigate: boolean
   overrideApplicationProjectDirectory?: string
 }) => {
-  const { settings, systemIOActor } = useApp()
+  const { commands, registry, settings, systemIOActor } = useApp()
+  const keymap = registry.optional(keymapService)
   const { kclManager } = useSingletons()
   const errors = kclManager.errorsSignal.value
   const settingsValues = settings.useSettings()
@@ -220,7 +229,6 @@ export const ProjectExplorer = ({
   const rowsToRenderRef = useRef(rowsToRender)
   const activeIndexRef = useRef(activeIndex)
   const selectedRowRef = useRef(selectedRow)
-  const isRenamingRef = useRef(isRenaming)
   const previousProject = useRef(project)
 
   // fake row is used for new files or folders, you should not be able to have multiple fake rows for creation
@@ -288,24 +296,227 @@ export const ProjectExplorer = ({
     setOpenedRows({})
   }, [collapsePressed])
 
-  const setSelectedRowWrapper = (row: FileExplorerEntry | null) => {
+  const setSelectedRowWrapper = useCallback((row: FileExplorerEntry | null) => {
     setSelectedRow(row)
     selectedRowRef.current = row
-  }
+  }, [])
+
+  const setActiveIndexWrapper = useCallback((index: number) => {
+    setActiveIndex(index)
+    activeIndexRef.current = index
+  }, [])
+
+  const setOpenedRowsWrapper = useCallback(
+    (rows: { [key: string]: boolean }) => {
+      setOpenedRows(rows)
+      openedRowsRef.current = rows
+    },
+    []
+  )
+
+  const focusProjectExplorer = useCallback(() => {
+    keymap?.applyScope(PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE)
+    fileExplorerContainer.current?.focus()
+  }, [keymap])
 
   /**
    * Gotcha: closure
    * Needs a reference to openedRows since it is a callback
    */
-  const onRowClickCallback = (file: FileExplorerEntry, domIndex: number) => {
+  const onRowClickCallback = useCallback(
+    (file: FileExplorerEntry, domIndex: number) => {
+      focusProjectExplorer()
+      const newOpenedRows = { ...openedRowsRef.current }
+      const key = file.key
+      const value = openedRowsRef.current[key]
+      newOpenedRows[key] = !value
+      setOpenedRowsWrapper(newOpenedRows)
+      setSelectedRowWrapper(file)
+      setActiveIndexWrapper(domIndex)
+    },
+    [
+      focusProjectExplorer,
+      setActiveIndexWrapper,
+      setOpenedRowsWrapper,
+      setSelectedRowWrapper,
+    ]
+  )
+
+  const handleArrowLeftCommand = useCallback(() => {
+    if (activeIndexRef.current === CONTAINER_IS_SELECTED) {
+      return
+    }
+
+    const focusedEntry = rowsToRenderRef.current[activeIndexRef.current]
+    const isEntryOpened =
+      focusedEntry &&
+      isFileExplorerEntryOpened(openedRowsRef.current, focusedEntry)
+    if (!(focusedEntry && isEntryOpened)) {
+      return
+    }
+
     const newOpenedRows = { ...openedRowsRef.current }
-    const key = file.key
+    const key = focusedEntry.key
     const value = openedRowsRef.current[key]
     newOpenedRows[key] = !value
-    setOpenedRows(newOpenedRows)
-    setSelectedRowWrapper(file)
-    setActiveIndex(domIndex)
-  }
+    setOpenedRowsWrapper(newOpenedRows)
+
+    // If you press the left arrow and you are at the first child in a folder,
+    // move to the parent and close it.
+    if (
+      focusedEntry.positionInSet === 1 &&
+      focusedEntry.level !== 0 &&
+      activeIndexRef.current > 0
+    ) {
+      onRowClickCallback(
+        rowsToRenderRef.current[activeIndexRef.current - 1],
+        activeIndexRef.current - 1
+      )
+    }
+  }, [onRowClickCallback, setOpenedRowsWrapper])
+
+  const handleArrowRightCommand = useCallback(() => {
+    if (activeIndexRef.current === CONTAINER_IS_SELECTED) {
+      return
+    }
+
+    const focusedEntry = rowsToRenderRef.current[activeIndexRef.current]
+    const isEntryOpened =
+      focusedEntry &&
+      isFileExplorerEntryOpened(openedRowsRef.current, focusedEntry)
+    if (!(focusedEntry && !isEntryOpened)) {
+      return
+    }
+
+    const newOpenedRows = { ...openedRowsRef.current }
+    const key = focusedEntry.key
+    const value = openedRowsRef.current[key]
+    newOpenedRows[key] = !value
+    setOpenedRowsWrapper(newOpenedRows)
+  }, [setOpenedRowsWrapper])
+
+  const handleArrowUpCommand = useCallback(() => {
+    setActiveIndex((previous) => {
+      const next =
+        previous === NOTHING_IS_SELECTED
+          ? STARTING_INDEX_TO_SELECT
+          : Math.max(STARTING_INDEX_TO_SELECT, previous - 1)
+      activeIndexRef.current = next
+      return next
+    })
+  }, [])
+
+  const handleArrowDownCommand = useCallback(() => {
+    const lastRowIndex = rowsToRenderRef.current.length - 1
+    if (lastRowIndex < STARTING_INDEX_TO_SELECT) {
+      return
+    }
+
+    setActiveIndex((previous) => {
+      const next =
+        previous === NOTHING_IS_SELECTED
+          ? STARTING_INDEX_TO_SELECT
+          : Math.min(lastRowIndex, previous + 1)
+      activeIndexRef.current = next
+      return next
+    })
+  }, [])
+
+  const handleEnterCommand = useCallback(() => {
+    if (activeIndexRef.current < STARTING_INDEX_TO_SELECT) {
+      return
+    }
+
+    const focusedEntry = rowsToRenderRef.current[activeIndexRef.current]
+    if (!focusedEntry) {
+      return
+    }
+
+    const newOpenedRows = { ...openedRowsRef.current }
+    const key = focusedEntry.key
+    const value = openedRowsRef.current[key]
+    newOpenedRows[key] = !value
+    setOpenedRowsWrapper(newOpenedRows)
+    onRowEnter(focusedEntry, activeIndexRef.current)
+  }, [onRowEnter, setOpenedRowsWrapper])
+
+  const projectExplorerCommands = useMemo<Command[]>(
+    () => [
+      {
+        id: PROJECT_EXPLORER_COMMAND_IDS.arrowLeft,
+        name: 'arrow-left',
+        groupId: 'project-explorer',
+        displayName: 'Close selected project explorer row',
+        needsReview: false,
+        hideFromSearch: true,
+        onSubmit: handleArrowLeftCommand,
+      },
+      {
+        id: PROJECT_EXPLORER_COMMAND_IDS.arrowRight,
+        name: 'arrow-right',
+        groupId: 'project-explorer',
+        displayName: 'Open selected project explorer row',
+        needsReview: false,
+        hideFromSearch: true,
+        onSubmit: handleArrowRightCommand,
+      },
+      {
+        id: PROJECT_EXPLORER_COMMAND_IDS.arrowUp,
+        name: 'arrow-up',
+        groupId: 'project-explorer',
+        displayName: 'Move project explorer selection up',
+        needsReview: false,
+        hideFromSearch: true,
+        onSubmit: handleArrowUpCommand,
+      },
+      {
+        id: PROJECT_EXPLORER_COMMAND_IDS.arrowDown,
+        name: 'arrow-down',
+        groupId: 'project-explorer',
+        displayName: 'Move project explorer selection down',
+        needsReview: false,
+        hideFromSearch: true,
+        onSubmit: handleArrowDownCommand,
+      },
+      {
+        id: PROJECT_EXPLORER_COMMAND_IDS.enter,
+        name: 'enter',
+        groupId: 'project-explorer',
+        displayName: 'Open selected project explorer file',
+        needsReview: false,
+        hideFromSearch: true,
+        onSubmit: handleEnterCommand,
+      },
+    ],
+    [
+      handleArrowDownCommand,
+      handleArrowLeftCommand,
+      handleArrowRightCommand,
+      handleArrowUpCommand,
+      handleEnterCommand,
+    ]
+  )
+
+  useEffect(() => {
+    commands.send({
+      type: 'Add commands',
+      data: { commands: projectExplorerCommands },
+    })
+
+    return () => {
+      commands.send({
+        type: 'Remove commands',
+        data: { commands: projectExplorerCommands },
+      })
+    }
+  }, [commands, projectExplorerCommands])
+
+  useEffect(() => {
+    return () => {
+      keymap?.removeScope(PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE)
+      keymap?.removeScope(PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE)
+    }
+  }, [keymap])
 
   const handleExternalFileDrop = useCallback(
     async (dataTransfer: DataTransfer, target: FileExplorerEntry | null) => {
@@ -429,10 +640,12 @@ export const ProjectExplorer = ({
     if (previousProject.current.name !== project.name) {
       setOpenedRows({})
       setSelectedRow(null)
-      setActiveIndex(NOTHING_IS_SELECTED)
+      setActiveIndexWrapper(NOTHING_IS_SELECTED)
       setRowsToRender([])
       setContextMenuRow(null)
       setIsRenaming(false)
+      keymap?.removeScope(PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE)
+      keymap?.removeScope(PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE)
     }
 
     // gotcha: sync state
@@ -539,7 +752,8 @@ export const ProjectExplorer = ({
             setOpenedRows(newOpenedRows)
           },
           onContextMenuOpen: (domIndex: number) => {
-            setActiveIndex(domIndex)
+            focusProjectExplorer()
+            setActiveIndexWrapper(domIndex)
             setContextMenuRow(child)
           },
           isFake: false,
@@ -709,12 +923,10 @@ export const ProjectExplorer = ({
             }
 
             setIsRenaming(true)
-            isRenamingRef.current = true
           },
           onRenameEnd: (event: MaybePressOrBlur) => {
             // TODO: Implement renameFolder and renameFile to navigate
             setIsRenaming(false)
-            isRenamingRef.current = false
             setFakeRow(null)
 
             if (!event) {
@@ -934,11 +1146,10 @@ export const ProjectExplorer = ({
     )
     if (currentFileRowIndex >= 0) {
       setSelectedRowWrapper(requestedRowsToRender[currentFileRowIndex])
-      setActiveIndex(currentFileRowIndex)
+      setActiveIndexWrapper(currentFileRowIndex)
     }
     if (openedRowsChanged) {
-      setOpenedRows(openedRowsForRender)
-      openedRowsRef.current = openedRowsForRender
+      setOpenedRowsWrapper(openedRowsForRender)
     }
     setRowsToRender(requestedRowsToRender)
     rowsToRenderRef.current = requestedRowsToRender
@@ -946,7 +1157,18 @@ export const ProjectExplorer = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
   }, [project, openedRows, fakeRow, activeIndex, errors, file?.path])
 
-  // Handle clicks and keyboard presses within the global DOM level
+  useEffect(() => {
+    if (isRenaming) {
+      keymap?.applyScope(PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE)
+      return () => {
+        keymap?.removeScope(PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE)
+      }
+    }
+
+    keymap?.removeScope(PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE)
+  }, [isRenaming, keymap])
+
+  // Handle clicks outside of the explorer at the global DOM level.
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       const path = event.composedPath ? event.composedPath() : []
@@ -958,125 +1180,17 @@ export const ProjectExplorer = ({
         if (activeIndexRef.current > 0) {
           lastIndexBeforeNothing.current = activeIndexRef.current
         }
-        setActiveIndex(NOTHING_IS_SELECTED)
+        keymap?.removeScope(PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE)
+        keymap?.removeScope(PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE)
+        setActiveIndexWrapper(NOTHING_IS_SELECTED)
       }
     }
 
-    const keyDownHandler = (event: KeyboardEvent) => {
-      if (
-        activeIndexRef.current === NOTHING_IS_SELECTED ||
-        isRenamingRef.current
-      ) {
-        // NO OP you are not focused in this DOM element
-        return
-      }
-
-      const key = event.key
-      const focusedEntry = rowsToRenderRef.current[activeIndexRef.current]
-      const shouldCheckOpened = focusedEntry
-      const isEntryOpened =
-        shouldCheckOpened &&
-        isFileExplorerEntryOpened(openedRowsRef.current, focusedEntry)
-      switch (key) {
-        case 'ArrowLeft':
-          if (activeIndexRef.current === CONTAINER_IS_SELECTED) {
-            // NO OP
-          } else if (shouldCheckOpened && isEntryOpened) {
-            // close
-            const newOpenedRows = { ...openedRowsRef.current }
-            const key = focusedEntry.key
-            const value = openedRowsRef.current[key]
-            newOpenedRows[key] = !value
-            setOpenedRows(newOpenedRows)
-
-            // If you press the left arrow and you are at the first child in a folder, run the callback on the parent
-            // folder which would move your cursor up a level and close the folder
-            if (
-              focusedEntry.positionInSet === 1 &&
-              focusedEntry.level !== 0 &&
-              activeIndexRef.current > 0
-            ) {
-              onRowClickCallback(
-                rowsToRenderRef.current[activeIndexRef.current - 1],
-                activeIndexRef.current - 1
-              )
-            }
-          }
-          break
-        case 'ArrowRight':
-          if (activeIndexRef.current === CONTAINER_IS_SELECTED) {
-            // NO OP
-          } else if (shouldCheckOpened && !isEntryOpened) {
-            // open!
-            const newOpenedRows = { ...openedRowsRef.current }
-            const key = focusedEntry.key
-            const value = openedRowsRef.current[key]
-            newOpenedRows[key] = !value
-            setOpenedRows(newOpenedRows)
-          }
-          break
-        case 'ArrowUp':
-          setActiveIndex((previous) => {
-            if (previous === NOTHING_IS_SELECTED) {
-              return STARTING_INDEX_TO_SELECT
-            }
-            return Math.max(STARTING_INDEX_TO_SELECT, previous - 1)
-          })
-          break
-        case 'ArrowDown':
-          if (fileExplorerContainer.current) {
-            const numberOfDOMRows =
-              fileExplorerContainer.current.children[0].children.length - 1
-            setActiveIndex((previous) => {
-              if (previous === NOTHING_IS_SELECTED) {
-                return STARTING_INDEX_TO_SELECT
-              }
-              return Math.min(numberOfDOMRows, previous + 1)
-            })
-          }
-          break
-        case 'Enter':
-          if (activeIndexRef.current >= STARTING_INDEX_TO_SELECT) {
-            // open close folder
-            const newOpenedRows = { ...openedRowsRef.current }
-            const key = focusedEntry.key
-            const value = openedRowsRef.current[key]
-            newOpenedRows[key] = !value
-            setOpenedRows(newOpenedRows)
-            onRowEnter(focusedEntry, activeIndexRef.current)
-          }
-          break
-      }
-    }
-
-    const handleFocus = () => {
-      setActiveIndex(CONTAINER_IS_SELECTED)
-    }
-
-    const handleBlur = (event: FocusEvent) => {
-      const path = event.composedPath ? event.composedPath() : []
-      if (
-        projectExplorerRef.current instanceof HTMLDivElement &&
-        fileExplorerContainer.current &&
-        !path.includes(projectExplorerRef.current)
-      ) {
-        setActiveIndex(NOTHING_IS_SELECTED)
-      }
-    }
-
-    document.addEventListener('keydown', keyDownHandler)
     document.addEventListener('click', handleClickOutside)
-    fileExplorerContainer.current?.addEventListener('focus', handleFocus)
-    fileExplorerContainer.current?.addEventListener('blur', handleBlur)
     return () => {
       document.removeEventListener('click', handleClickOutside)
-      document.removeEventListener('keydown', keyDownHandler)
-      fileExplorerContainer.current?.removeEventListener('focus', handleFocus)
-      // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
-      fileExplorerContainer.current?.removeEventListener('blur', handleBlur)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
-  }, [])
+  }, [keymap, setActiveIndexWrapper])
 
   // Compute which entry should be highlighted for external drag
   const getHighlightedEntry = useCallback((): FileExplorerEntry | null => {
@@ -1094,6 +1208,36 @@ export const ProjectExplorer = ({
   }, [isExternalDragOver, dragOverTarget, rowsToRender])
 
   const highlightedEntry = getHighlightedEntry()
+
+  const handleExplorerFocus = useCallback(
+    (event: ReactFocusEvent<HTMLDivElement>) => {
+      keymap?.applyScope(PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE)
+      if (
+        event.target === fileExplorerContainer.current &&
+        activeIndexRef.current === NOTHING_IS_SELECTED
+      ) {
+        setActiveIndexWrapper(CONTAINER_IS_SELECTED)
+      }
+    },
+    [keymap, setActiveIndexWrapper]
+  )
+
+  const handleExplorerBlur = useCallback(
+    (event: ReactFocusEvent<HTMLDivElement>) => {
+      const nextTarget = event.relatedTarget
+      if (
+        nextTarget instanceof Node &&
+        projectExplorerRef.current?.contains(nextTarget)
+      ) {
+        return
+      }
+
+      keymap?.removeScope(PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE)
+      keymap?.removeScope(PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE)
+      setActiveIndexWrapper(NOTHING_IS_SELECTED)
+    },
+    [keymap, setActiveIndexWrapper]
+  )
 
   return (
     <div
@@ -1113,9 +1257,12 @@ export const ProjectExplorer = ({
         role="tree"
         aria-label="Files Explorer"
         ref={fileExplorerContainer}
+        onFocus={handleExplorerFocus}
+        onBlur={handleExplorerBlur}
         onClick={(event) => {
           if (event.target === fileExplorerContainer.current) {
-            setActiveIndex(CONTAINER_IS_SELECTED)
+            focusProjectExplorer()
+            setActiveIndexWrapper(CONTAINER_IS_SELECTED)
             setSelectedRowWrapper(null)
           }
         }}

--- a/src/components/Explorer/ProjectExplorer.tsx
+++ b/src/components/Explorer/ProjectExplorer.tsx
@@ -211,6 +211,7 @@ export const ProjectExplorer = ({
   const [contextMenuRow, setContextMenuRow] =
     useState<FileExplorerEntry | null>(null)
   const [isRenaming, setIsRenaming] = useState<boolean>(false)
+  const [isDeleting, setIsDeleting] = useState<boolean>(false)
   const [isCopying, setIsCopying] = useState<boolean>(false)
   const lastIndexBeforeNothing = useRef<number>(-2)
 
@@ -237,6 +238,9 @@ export const ProjectExplorer = ({
     arrowDown: () => {},
     enter: () => {},
     rename: () => {},
+    delete: () => {},
+    copy: () => {},
+    paste: () => {},
   })
   const previousProject = useRef(project)
   const lastSyncedFilePathRef = useRef<string | undefined>(undefined)
@@ -466,12 +470,55 @@ export const ProjectExplorer = ({
     setIsRenaming(true)
   }, [readOnly])
 
+  const handleDeleteCommand = useCallback(() => {
+    if (readOnly || activeIndexRef.current < STARTING_INDEX_TO_SELECT) {
+      return
+    }
+
+    const focusedEntry = rowsToRenderRef.current[activeIndexRef.current]
+    if (!focusedEntry || focusedEntry.isFake) {
+      return
+    }
+
+    setContextMenuRow(focusedEntry)
+    setIsDeleting(true)
+  }, [readOnly])
+
+  const handleCopyCommand = useCallback(() => {
+    if (activeIndexRef.current < STARTING_INDEX_TO_SELECT) {
+      return
+    }
+
+    const focusedEntry = rowsToRenderRef.current[activeIndexRef.current]
+    if (!focusedEntry || focusedEntry.isFake) {
+      return
+    }
+
+    focusedEntry.onCopy()
+  }, [])
+
+  const handlePasteCommand = useCallback(() => {
+    if (readOnly || activeIndexRef.current < STARTING_INDEX_TO_SELECT) {
+      return
+    }
+
+    const focusedEntry = rowsToRenderRef.current[activeIndexRef.current]
+    if (!focusedEntry || focusedEntry.isFake) {
+      return
+    }
+
+    focusedEntry.onPaste()
+  }, [readOnly])
+
   projectExplorerCommandHandlersRef.current.arrowLeft = handleArrowLeftCommand
   projectExplorerCommandHandlersRef.current.arrowRight = handleArrowRightCommand
   projectExplorerCommandHandlersRef.current.arrowUp = handleArrowUpCommand
   projectExplorerCommandHandlersRef.current.arrowDown = handleArrowDownCommand
   projectExplorerCommandHandlersRef.current.enter = handleEnterCommand
   projectExplorerCommandHandlersRef.current.rename = handleRenameCommand
+  projectExplorerCommandHandlersRef.current.delete = handleDeleteCommand
+  projectExplorerCommandHandlersRef.current.copy = handleCopyCommand
+  projectExplorerCommandHandlersRef.current.paste = handlePasteCommand
 
   const projectExplorerCommands = useMemo<Command[]>(
     () => [
@@ -528,6 +575,33 @@ export const ProjectExplorer = ({
         needsReview: false,
         hideFromSearch: true,
         onSubmit: () => projectExplorerCommandHandlersRef.current.rename(),
+      },
+      {
+        id: PROJECT_EXPLORER_COMMAND_IDS.delete,
+        name: 'delete',
+        groupId: 'project-explorer',
+        displayName: 'Delete selected project explorer row',
+        needsReview: false,
+        hideFromSearch: true,
+        onSubmit: () => projectExplorerCommandHandlersRef.current.delete(),
+      },
+      {
+        id: PROJECT_EXPLORER_COMMAND_IDS.copy,
+        name: 'copy',
+        groupId: 'project-explorer',
+        displayName: 'Copy selected project explorer row',
+        needsReview: false,
+        hideFromSearch: true,
+        onSubmit: () => projectExplorerCommandHandlersRef.current.copy(),
+      },
+      {
+        id: PROJECT_EXPLORER_COMMAND_IDS.paste,
+        name: 'paste',
+        groupId: 'project-explorer',
+        displayName: 'Paste into selected project explorer row',
+        needsReview: false,
+        hideFromSearch: true,
+        onSubmit: () => projectExplorerCommandHandlersRef.current.paste(),
       },
     ],
     []
@@ -681,6 +755,7 @@ export const ProjectExplorer = ({
       setRowsToRender([])
       setContextMenuRow(null)
       setIsRenaming(false)
+      setIsDeleting(false)
       lastSyncedFilePathRef.current = undefined
       keymap?.removeScope(PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE)
       keymap?.removeScope(PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE)
@@ -725,6 +800,32 @@ export const ProjectExplorer = ({
         openedRowsChanged = openedRowsChanged || !openedRowsForRender[key]
         openedRowsForRender[key] = true
         pathIterator.pop()
+      }
+    }
+
+    const copyEntryToTarget = (src: FileEntry, target: FileEntry) => {
+      const absoluteParentPath = getParentAbsolutePath(target.path)
+      const parentIndex = flattenedData.findIndex((entry) => {
+        return entry.path === absoluteParentPath
+      })
+      const parent = parentIndex >= 0 ? flattenedData[parentIndex] : project
+      const result = copyPasteSourceAndTarget(
+        target.children?.map((child) => child.path) || [],
+        parent.children?.map((child) => child.path) || [],
+        src,
+        target,
+        '-copy-'
+      )
+      if (result && result.src && result.target) {
+        systemIOActor.send({
+          type: SystemIOMachineEvents.copyRecursive,
+          data: {
+            src: result.src,
+            target: result.target,
+          },
+        })
+      } else {
+        toast.error('Failed to copy and paste the result is null.')
       }
     }
 
@@ -878,34 +979,11 @@ export const ProjectExplorer = ({
           },
           onPaste: () => {
             if (copyToClipBoard.current) {
-              const absoluteParentPath = getParentAbsolutePath(row.path)
-              const parentIndex = flattenedData.findIndex((entry) => {
-                return entry.path === absoluteParentPath
+              copyEntryToTarget(copyToClipBoard.current, {
+                path: row.path,
+                name: row.name,
+                children: row.children,
               })
-              const parent =
-                parentIndex >= 0 ? flattenedData[parentIndex] : project
-              const result = copyPasteSourceAndTarget(
-                row.children?.map((child) => child.path) || [],
-                parent.children?.map((child) => child.path) || [],
-                copyToClipBoard.current,
-                {
-                  path: row.path,
-                  name: row.name,
-                  children: row.children,
-                },
-                '-copy-'
-              )
-              if (result && result.src && result.target) {
-                systemIOActor.send({
-                  type: SystemIOMachineEvents.copyRecursive,
-                  data: {
-                    src: result.src,
-                    target: result.target,
-                  },
-                })
-              } else {
-                toast.error('Failed to copy and paste the result is null.')
-              }
             }
 
             // clear the path
@@ -1207,9 +1285,14 @@ export const ProjectExplorer = ({
 
   useEffect(() => {
     if (isRenaming) {
+      const fileExplorerContainerElement = fileExplorerContainer.current
+      keymap?.removeScope(PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE)
       keymap?.applyScope(PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE)
       return () => {
         keymap?.removeScope(PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE)
+        if (fileExplorerContainerElement?.contains(document.activeElement)) {
+          keymap?.applyScope(PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE)
+        }
       }
     }
 
@@ -1352,9 +1435,13 @@ export const ProjectExplorer = ({
             selectedRow={selectedRow}
             contextMenuRow={contextMenuRow}
             isRenaming={isRenaming}
+            isDeleting={isDeleting}
             isCopying={isCopying}
             isExternalDragOver={isExternalDragOver}
             highlightedEntry={highlightedEntry}
+            onDeleteEnd={() => {
+              setIsDeleting(false)
+            }}
             onExternalDragOverRow={handleDragOverTarget}
           />
         )}

--- a/src/components/Explorer/ProjectExplorer.tsx
+++ b/src/components/Explorer/ProjectExplorer.tsx
@@ -229,7 +229,17 @@ export const ProjectExplorer = ({
   const rowsToRenderRef = useRef(rowsToRender)
   const activeIndexRef = useRef(activeIndex)
   const selectedRowRef = useRef(selectedRow)
+  const onRowEnterRef = useRef(onRowEnter)
+  const projectExplorerCommandHandlersRef = useRef({
+    arrowLeft: () => {},
+    arrowRight: () => {},
+    arrowUp: () => {},
+    arrowDown: () => {},
+    enter: () => {},
+  })
   const previousProject = useRef(project)
+
+  onRowEnterRef.current = onRowEnter
 
   // fake row is used for new files or folders, you should not be able to have multiple fake rows for creation
   const [fakeRow, setFakeRow] = useState<{
@@ -437,8 +447,14 @@ export const ProjectExplorer = ({
     const value = openedRowsRef.current[key]
     newOpenedRows[key] = !value
     setOpenedRowsWrapper(newOpenedRows)
-    onRowEnter(focusedEntry, activeIndexRef.current)
-  }, [onRowEnter, setOpenedRowsWrapper])
+    onRowEnterRef.current(focusedEntry, activeIndexRef.current)
+  }, [setOpenedRowsWrapper])
+
+  projectExplorerCommandHandlersRef.current.arrowLeft = handleArrowLeftCommand
+  projectExplorerCommandHandlersRef.current.arrowRight = handleArrowRightCommand
+  projectExplorerCommandHandlersRef.current.arrowUp = handleArrowUpCommand
+  projectExplorerCommandHandlersRef.current.arrowDown = handleArrowDownCommand
+  projectExplorerCommandHandlersRef.current.enter = handleEnterCommand
 
   const projectExplorerCommands = useMemo<Command[]>(
     () => [
@@ -449,7 +465,7 @@ export const ProjectExplorer = ({
         displayName: 'Close selected project explorer row',
         needsReview: false,
         hideFromSearch: true,
-        onSubmit: handleArrowLeftCommand,
+        onSubmit: () => projectExplorerCommandHandlersRef.current.arrowLeft(),
       },
       {
         id: PROJECT_EXPLORER_COMMAND_IDS.arrowRight,
@@ -458,7 +474,7 @@ export const ProjectExplorer = ({
         displayName: 'Open selected project explorer row',
         needsReview: false,
         hideFromSearch: true,
-        onSubmit: handleArrowRightCommand,
+        onSubmit: () => projectExplorerCommandHandlersRef.current.arrowRight(),
       },
       {
         id: PROJECT_EXPLORER_COMMAND_IDS.arrowUp,
@@ -467,7 +483,7 @@ export const ProjectExplorer = ({
         displayName: 'Move project explorer selection up',
         needsReview: false,
         hideFromSearch: true,
-        onSubmit: handleArrowUpCommand,
+        onSubmit: () => projectExplorerCommandHandlersRef.current.arrowUp(),
       },
       {
         id: PROJECT_EXPLORER_COMMAND_IDS.arrowDown,
@@ -476,7 +492,7 @@ export const ProjectExplorer = ({
         displayName: 'Move project explorer selection down',
         needsReview: false,
         hideFromSearch: true,
-        onSubmit: handleArrowDownCommand,
+        onSubmit: () => projectExplorerCommandHandlersRef.current.arrowDown(),
       },
       {
         id: PROJECT_EXPLORER_COMMAND_IDS.enter,
@@ -485,16 +501,10 @@ export const ProjectExplorer = ({
         displayName: 'Open selected project explorer file',
         needsReview: false,
         hideFromSearch: true,
-        onSubmit: handleEnterCommand,
+        onSubmit: () => projectExplorerCommandHandlersRef.current.enter(),
       },
     ],
-    [
-      handleArrowDownCommand,
-      handleArrowLeftCommand,
-      handleArrowRightCommand,
-      handleArrowUpCommand,
-      handleEnterCommand,
-    ]
+    []
   )
 
   useEffect(() => {

--- a/src/components/layout/areas/ProjectExplorerPane.tsx
+++ b/src/components/layout/areas/ProjectExplorerPane.tsx
@@ -117,80 +117,94 @@ export function ProjectExplorerPane(props: AreaTypeComponentProps) {
     [openCodeEditorPaneIfClosed]
   )
 
-  const onRowClicked = (entry: FileExplorerEntry) => {
-    const requestedFileName = parentPathRelativeToProject(
-      entry.path,
-      projectDirectoryPath
-    )
-
-    const RELEVANT_FILE_EXTENSIONS = relevantFileExtensions(wasmInstance)
-    const isRelevantFile = (filename: string): boolean => {
-      const extension = getEXTNoPeriod(filename)
-      if (!extension) {
-        return false
-      }
-      return isExtensionARelevantExtension(extension, RELEVANT_FILE_EXTENSIONS)
-    }
-
-    // Only open the file if it is a kcl file.
-    if (
-      projectRef.current?.value.name &&
-      entry.children == null &&
-      entry.path.endsWith(FILE_EXT)
-    ) {
-      const name = projectRef.current.value.name.slice()
-
-      const navigateHelper = () => {
-        systemIOActor.send({
-          type: SystemIOMachineEvents.navigateToFile,
-          data: {
-            requestedProjectName: name,
-            requestedFileName: requestedFileName,
-          },
-        })
-      }
-
-      if (modelingMachineState.matches('Sketch')) {
-        modelingSend({ type: 'Cancel' })
-        const waitForIdlePromise = new Promise((resolve) => {
-          const subscription = modelingActor.subscribe((state) => {
-            if (state.matches('idle')) {
-              subscription.unsubscribe()
-              resolve(undefined)
-            }
-          })
-        })
-        waitForIdlePromise.catch(reportRejection).finally(() => {
-          navigateHelper()
-        })
-      } else {
-        // immediately navigate
-        navigateHelper()
-      }
-    } else if (isRelevantFile(entry.path) && projectRef.current?.value.path) {
-      // Allow insert if it is a importable file
-      toast.custom(
-        ToastInsert({
-          onInsert: () => {
-            const relativeFilePath = entry.path.replace(
-              projectRef.current?.value.path + fsZds.sep,
-              ''
-            )
-            commands.send({
-              type: 'Find and select command',
-              data: {
-                name: 'Insert',
-                groupId: 'code',
-                argDefaultValues: { path: relativeFilePath },
-              },
-            })
-            toast.dismiss(INSERT_FOREIGN_TOAST_ID)
-          },
-        }),
-        { duration: 30000, id: INSERT_FOREIGN_TOAST_ID }
+  const onRowClicked = useCallback(
+    (entry: FileExplorerEntry) => {
+      const requestedFileName = parentPathRelativeToProject(
+        entry.path,
+        projectDirectoryPath
       )
-    }
-  }
+
+      const RELEVANT_FILE_EXTENSIONS = relevantFileExtensions(wasmInstance)
+      const isRelevantFile = (filename: string): boolean => {
+        const extension = getEXTNoPeriod(filename)
+        if (!extension) {
+          return false
+        }
+        return isExtensionARelevantExtension(
+          extension,
+          RELEVANT_FILE_EXTENSIONS
+        )
+      }
+
+      // Only open the file if it is a kcl file.
+      if (
+        projectRef.current?.value.name &&
+        entry.children == null &&
+        entry.path.endsWith(FILE_EXT)
+      ) {
+        const name = projectRef.current.value.name.slice()
+
+        const navigateHelper = () => {
+          systemIOActor.send({
+            type: SystemIOMachineEvents.navigateToFile,
+            data: {
+              requestedProjectName: name,
+              requestedFileName: requestedFileName,
+            },
+          })
+        }
+
+        if (modelingMachineState.matches('Sketch')) {
+          modelingSend({ type: 'Cancel' })
+          const waitForIdlePromise = new Promise((resolve) => {
+            const subscription = modelingActor.subscribe((state) => {
+              if (state.matches('idle')) {
+                subscription.unsubscribe()
+                resolve(undefined)
+              }
+            })
+          })
+          waitForIdlePromise.catch(reportRejection).finally(() => {
+            navigateHelper()
+          })
+        } else {
+          // immediately navigate
+          navigateHelper()
+        }
+      } else if (isRelevantFile(entry.path) && projectRef.current?.value.path) {
+        // Allow insert if it is a importable file
+        toast.custom(
+          ToastInsert({
+            onInsert: () => {
+              const relativeFilePath = entry.path.replace(
+                projectRef.current?.value.path + fsZds.sep,
+                ''
+              )
+              commands.send({
+                type: 'Find and select command',
+                data: {
+                  name: 'Insert',
+                  groupId: 'code',
+                  argDefaultValues: { path: relativeFilePath },
+                },
+              })
+              toast.dismiss(INSERT_FOREIGN_TOAST_ID)
+            },
+          }),
+          { duration: 30000, id: INSERT_FOREIGN_TOAST_ID }
+        )
+      }
+    },
+    [
+      commands,
+      modelingActor,
+      modelingMachineState,
+      modelingSend,
+      projectDirectoryPath,
+      systemIOActor,
+      wasmInstance,
+    ]
+  )
 
   return (
     <LayoutPanel

--- a/src/registry/contracts/keymap.ts
+++ b/src/registry/contracts/keymap.ts
@@ -13,6 +13,9 @@ export const MODE_MODELING_KEYMAP_SCOPE = 'mode-modeling'
 export const MODE_SKETCHING_KEYMAP_SCOPE = 'mode-sketching'
 export const MODE_SKETCH_NO_FACE_KEYMAP_SCOPE = 'mode-sketch-no-face'
 export const MODE_SKETCH_SOLVE_KEYMAP_SCOPE = 'mode-sketch-solve'
+export const PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE = 'project-explorer.focused'
+export const PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE =
+  'project-explorer.renaming'
 
 export type KeymapArguments =
   | null

--- a/src/registry/extensions/keymap/defaultKeymap.ts
+++ b/src/registry/extensions/keymap/defaultKeymap.ts
@@ -20,6 +20,9 @@ export const PROJECT_EXPLORER_COMMAND_IDS = {
   arrowDown: 'project-explorer.arrow-down',
   enter: 'project-explorer.enter',
   rename: 'project-explorer.rename',
+  delete: 'project-explorer.delete',
+  copy: 'project-explorer.copy',
+  paste: 'project-explorer.paste',
 } as const
 
 function createExitSketchBindings({
@@ -125,6 +128,27 @@ export const defaultKeymap: KeymapDocument = {
       scopes: [PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE],
       keystrokes: ['f2'],
       command: PROJECT_EXPLORER_COMMAND_IDS.rename,
+    },
+    {
+      id: 'project-explorer.delete',
+      title: 'Delete selected project explorer row',
+      scopes: [PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE],
+      keystrokes: ['mod+backspace'],
+      command: PROJECT_EXPLORER_COMMAND_IDS.delete,
+    },
+    {
+      id: 'project-explorer.copy',
+      title: 'Copy selected project explorer row',
+      scopes: [PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE],
+      keystrokes: ['mod+c'],
+      command: PROJECT_EXPLORER_COMMAND_IDS.copy,
+    },
+    {
+      id: 'project-explorer.paste',
+      title: 'Paste into selected project explorer row',
+      scopes: [PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE],
+      keystrokes: ['mod+v'],
+      command: PROJECT_EXPLORER_COMMAND_IDS.paste,
     },
     {
       id: 'view.top',

--- a/src/registry/extensions/keymap/defaultKeymap.ts
+++ b/src/registry/extensions/keymap/defaultKeymap.ts
@@ -19,6 +19,7 @@ export const PROJECT_EXPLORER_COMMAND_IDS = {
   arrowUp: 'project-explorer.arrow-up',
   arrowDown: 'project-explorer.arrow-down',
   enter: 'project-explorer.enter',
+  rename: 'project-explorer.rename',
 } as const
 
 function createExitSketchBindings({
@@ -117,6 +118,13 @@ export const defaultKeymap: KeymapDocument = {
       scopes: [PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE],
       keystrokes: ['enter'],
       command: PROJECT_EXPLORER_COMMAND_IDS.enter,
+    },
+    {
+      id: 'project-explorer.rename',
+      title: 'Rename selected project explorer row',
+      scopes: [PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE],
+      keystrokes: ['f2'],
+      command: PROJECT_EXPLORER_COMMAND_IDS.rename,
     },
     {
       id: 'view.top',

--- a/src/registry/extensions/keymap/defaultKeymap.ts
+++ b/src/registry/extensions/keymap/defaultKeymap.ts
@@ -6,11 +6,20 @@ import {
   MODE_SKETCHING_KEYMAP_SCOPE,
   MODE_SKETCH_NO_FACE_KEYMAP_SCOPE,
   MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
+  PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE,
   keymapValueSpec,
 } from '@src/registry/contracts/keymap'
 import { TOOLBAR_COMMAND_IDS } from '@src/registry/extensions/commands/toolbarCommands'
 
 const BASE_KEYMAP_SOURCE = 'Base'
+
+export const PROJECT_EXPLORER_COMMAND_IDS = {
+  arrowLeft: 'project-explorer.arrow-left',
+  arrowRight: 'project-explorer.arrow-right',
+  arrowUp: 'project-explorer.arrow-up',
+  arrowDown: 'project-explorer.arrow-down',
+  enter: 'project-explorer.enter',
+} as const
 
 function createExitSketchBindings({
   id,
@@ -73,6 +82,41 @@ export const defaultKeymap: KeymapDocument = {
       arguments: {
         tab: 'user',
       },
+    },
+    {
+      id: 'project-explorer.arrow-left',
+      title: 'Close selected project explorer row',
+      scopes: [PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE],
+      keystrokes: ['arrowleft'],
+      command: PROJECT_EXPLORER_COMMAND_IDS.arrowLeft,
+    },
+    {
+      id: 'project-explorer.arrow-right',
+      title: 'Open selected project explorer row',
+      scopes: [PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE],
+      keystrokes: ['arrowright'],
+      command: PROJECT_EXPLORER_COMMAND_IDS.arrowRight,
+    },
+    {
+      id: 'project-explorer.arrow-up',
+      title: 'Move project explorer selection up',
+      scopes: [PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE],
+      keystrokes: ['arrowup'],
+      command: PROJECT_EXPLORER_COMMAND_IDS.arrowUp,
+    },
+    {
+      id: 'project-explorer.arrow-down',
+      title: 'Move project explorer selection down',
+      scopes: [PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE],
+      keystrokes: ['arrowdown'],
+      command: PROJECT_EXPLORER_COMMAND_IDS.arrowDown,
+    },
+    {
+      id: 'project-explorer.enter',
+      title: 'Open selected project explorer file',
+      scopes: [PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE],
+      keystrokes: ['enter'],
+      command: PROJECT_EXPLORER_COMMAND_IDS.enter,
     },
     {
       id: 'view.top',

--- a/src/registry/extensions/keymap/index.ts
+++ b/src/registry/extensions/keymap/index.ts
@@ -30,6 +30,8 @@ import {
   MODE_SKETCHING_KEYMAP_SCOPE,
   MODE_SKETCH_NO_FACE_KEYMAP_SCOPE,
   MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
+  PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE,
+  PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE,
   keymapScopesValueSpec,
   keymapService,
   keymapValueSpec,
@@ -42,6 +44,7 @@ import { createElement } from 'react'
 
 const PARTIAL_MATCH_TIMEOUT_MS = 1500
 const KEYMAP_CONTEXT_SCOPE_GROUP = 'context'
+const KEYMAP_PROJECT_EXPLORER_SCOPE_GROUP = 'project-explorer'
 type SettingsKeymapTab = 'project' | 'user' | 'keybindings' | 'plugins'
 
 const defaultKeymapScopes: readonly KeymapScope[] = [
@@ -103,6 +106,20 @@ const defaultKeymapScopes: readonly KeymapScope[] = [
     displayName: 'Code editor focused',
     group: KEYMAP_CONTEXT_SCOPE_GROUP,
     priority: 1000,
+    userEditable: false,
+  },
+  {
+    id: PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE,
+    displayName: 'Project explorer focused',
+    group: KEYMAP_PROJECT_EXPLORER_SCOPE_GROUP,
+    priority: 100,
+    userEditable: false,
+  },
+  {
+    id: PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE,
+    displayName: 'Project explorer renaming',
+    group: KEYMAP_PROJECT_EXPLORER_SCOPE_GROUP,
+    priority: 200,
     userEditable: false,
   },
 ]


### PR DESCRIPTION
Closes #11918 by forward fixing the regressions found in #11865. Through a bit of untested second-order effects, the rogue `Enter` listener in the ProjectExplorer pane would preempt users' attempts to type newline characters, navigating them to the same page they were on and effectively cancelling their typing. The forward fix is to register the ProjectExplorer's several keyboard shortcuts to be proper keymap items that use two new scopes to not collide with other actions in the app. I also had Codex write a set of regression tests so this behavior is tests a bit more; these shortcuts were untested from what I can see.

## Demo

https://github.com/user-attachments/assets/4e610f64-0efb-43dd-b15e-7ae8abd96f31

## Summary
- Move ProjectExplorer arrow and Enter shortcuts into default keymap entries scoped to `project-explorer.focused`.
- Register ProjectExplorer local command handlers while the pane is mounted.
- Add `project-explorer.renaming` scope to suppress focused navigation while rename UI is active.
- Add regression coverage for Enter outside the focused explorer versus after an explorer row click.

## Testing
- `npx eslint src/components/Explorer/ProjectExplorer.tsx src/components/Explorer/ProjectExplorer.spec.tsx src/registry/contracts/keymap.ts src/registry/extensions/keymap/defaultKeymap.ts src/registry/extensions/keymap/index.ts`
- `npx vitest run --mode=development src/components/Explorer/ProjectExplorer.spec.tsx`
- `npx vitest run --mode=development src/registry/extensions/keymap/index.spec.ts src/registry/contracts/keymap.test.ts`