### PR TITLE
Allow more pixels to differ in snapshots

### DIFF
--- a/e2e/playwright/snapshot-tests.spec.ts
+++ b/e2e/playwright/snapshot-tests.spec.ts
@@ -15,7 +15,7 @@ function screenshotName(step: number, name: string, mode: Themes) {
 }
 
 const screenshotOptions = (page: Page) => ({
-  maxDiffPixels: 300,
+  maxDiffPixelRatio: 0.001,
   mask: lowerRightMasks(page),
 })
 


### PR DESCRIPTION
A diff of 300 pixels seems to be right on the edge of timing flakiness based on the data here: https://test-analysis-bot.corp.zoo.dev/projects/KittyCAD/modeling-app/tests/17998

This PR increases the threshold and changes it to a ratio so it scales with the image size.