### PR TITLE
Remove unneeded mirror2d-region workaround

### DIFF
--- a/rust/kcl-lib/src/std/sketch.rs
+++ b/rust/kcl-lib/src/std/sketch.rs
@@ -5,7 +5,6 @@ use std::f64;
 
 use anyhow::Result;
 use indexmap::IndexMap;
-use itertools::Itertools;
 use kcl_error::SourceRange;
 use kcmc::ModelingCmd;
 use kcmc::each_cmd as mcmd;
@@ -3153,32 +3152,6 @@ async fn inner_region(
                     new_path.set_id(*region_id);
                     new_paths.push(new_path);
                 }
-            }
-        }
-
-        // After mirror2d, sketch.paths still has the original (pre-mirror)
-        // segment IDs. The region_mapping values are mirrored entity edge
-        // IDs which don't match, so the remapping above produces no paths.
-        // Fall back to creating paths from the region_mapping keys directly.
-        if new_paths.is_empty() && !region_mapping.is_empty() {
-            // Sort because the input order is undefined. We need to be
-            // deterministic.
-            for region_edge_id in region_mapping.keys().sorted_unstable() {
-                // We don't know what the actual values are. We just need
-                // something so that `do_post_extrude()` has the correct segment
-                // IDs.
-                new_paths.push(Path::ToPoint {
-                    base: BasePath {
-                        from: [0.0, 0.0],
-                        to: [0.0, 0.0],
-                        units,
-                        tag: None,
-                        geo_meta: GeoMeta {
-                            id: *region_edge_id,
-                            metadata: args.source_range.into(),
-                        },
-                    },
-                });
             }
         }
 


### PR DESCRIPTION
Resolves #11937.

After the engine fix, this isn't needed anymore.