### PR TITLE
Upgrade from aes 0.9.0 to 0.9.1

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aes"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bd29a732b644c0431c6140f370d097879203d79b80c94a6747ba0872adaef8"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
  "cipher",
  "cpubits",


### PR DESCRIPTION
aes 0.9.0 was yanked.

https://github.com/RustCrypto/block-ciphers/blob/master/aes/CHANGELOG.md