### PR TITLE
Don't run `getUnmodifiedKeyFromCode` if alt is not pressed

### DIFF
--- a/src/registry/contracts/keymap.test.ts
+++ b/src/registry/contracts/keymap.test.ts
@@ -33,7 +33,7 @@ describe('keymap contract', () => {
     })
   })
 
-  it('normalizes modified keyboard events from their unmodified key code', () => {
+  it('normalizes modified alt-including keyboard events from their unmodified key code', () => {
     expect(
       normalizeEventKey({
         key: '\u2202',
@@ -51,7 +51,7 @@ describe('keymap contract', () => {
         ctrlKey: true,
         metaKey: false,
       })
-    ).toBe('1')
+    ).toBe('!')
     expect(
       normalizeEventKey({
         key: '<',
@@ -60,7 +60,7 @@ describe('keymap contract', () => {
         ctrlKey: false,
         metaKey: true,
       })
-    ).toBe(',')
+    ).toBe('<')
   })
 
   it('returns prefix matches for keymap keystrokes', () => {

--- a/src/registry/contracts/keymap.ts
+++ b/src/registry/contracts/keymap.ts
@@ -141,7 +141,7 @@ function normalizeEventKeyValue(key: string) {
  * `event.key`, but `event.code` still identifies the D key as `KeyD`.
  */
 function getUnmodifiedKeyFromCode(event: KeyboardEventKeyInput) {
-  if (!event.altKey && !event.ctrlKey && !event.metaKey) {
+  if (!event.altKey) {
     return null
   }
 


### PR DESCRIPTION
Addressed some feedback on #11961 from @andrewvarga that I didn't see until it merged:
https://github.com/KittyCAD/modeling-app/pull/11961#discussion_r3357455572