### PR TITLE
Fix Home project loading retry

### DIFF
--- a/src/machines/systemIO/systemIOMachine.spec.ts
+++ b/src/machines/systemIO/systemIOMachine.spec.ts
@@ -213,6 +213,174 @@ describe('systemIOMachine - XState', () => {
           actor.stop()
         }
       })
+      it('should restart folder loading when project directory changes while reading folders', async () => {
+        const readProjectDirectoryPaths: string[] = []
+        const readSignals: AbortSignal[] = []
+        const actor = createActor(
+          systemIOMachine.provide({
+            actors: {
+              [SystemIOMachineActors.readFoldersFromProjectDirectory]:
+                fromPromise(async ({ input, signal }) => {
+                  readProjectDirectoryPaths.push(input.projectDirectoryPath)
+                  readSignals.push(signal)
+                  return new Promise<Project[]>(() => {})
+                }),
+              [SystemIOMachineActors.checkReadWrite]: fromPromise(
+                async (): Promise<{ value: boolean; error: unknown }> => ({
+                  value: true,
+                  error: undefined,
+                })
+              ),
+            },
+          }),
+          {
+            input: {
+              wasmInstancePromise: Promise.resolve(instanceInThisFile),
+              app: appInstanceInThisFile,
+            },
+          }
+        ).start()
+
+        try {
+          actor.send({
+            type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
+          })
+          await waitFor(actor, (state) =>
+            state.matches(SystemIOMachineStates.readingFolders)
+          )
+
+          actor.send({
+            type: SystemIOMachineEvents.setProjectDirectoryPath,
+            data: {
+              requestedProjectDirectoryPath: '/projects',
+            },
+          })
+
+          await waitFor(
+            actor,
+            (state) =>
+              state.matches(SystemIOMachineStates.readingFolders) &&
+              state.context.projectDirectoryPath === '/projects' &&
+              readProjectDirectoryPaths.length === 2
+          )
+
+          expect(readProjectDirectoryPaths).toStrictEqual([
+            NO_PROJECT_DIRECTORY,
+            '/projects',
+          ])
+          expect(readSignals[0].aborted).toBe(true)
+        } finally {
+          actor.stop()
+        }
+      })
+      it('should restart read/write checks when project directory changes while checking read/write access', async () => {
+        const checkProjectDirectoryPaths: string[] = []
+        const checkSignals: AbortSignal[] = []
+        const readProjectDirectoryPaths: string[] = []
+        const actor = createActor(
+          systemIOMachine.provide({
+            actors: {
+              [SystemIOMachineActors.checkReadWrite]: fromPromise(
+                async ({ input, signal }) => {
+                  checkProjectDirectoryPaths.push(
+                    input.requestedProjectDirectoryPath
+                  )
+                  checkSignals.push(signal)
+                  if (checkProjectDirectoryPaths.length === 1) {
+                    return new Promise<{ value: boolean; error: unknown }>(
+                      () => {}
+                    )
+                  }
+
+                  return { value: true, error: undefined }
+                }
+              ),
+              [SystemIOMachineActors.readFoldersFromProjectDirectory]:
+                fromPromise(async ({ input }) => {
+                  readProjectDirectoryPaths.push(input.projectDirectoryPath)
+                  return new Promise<Project[]>(() => {})
+                }),
+            },
+          }),
+          {
+            input: {
+              wasmInstancePromise: Promise.resolve(instanceInThisFile),
+              app: appInstanceInThisFile,
+            },
+          }
+        ).start()
+
+        try {
+          actor.send({
+            type: SystemIOMachineEvents.setProjectDirectoryPath,
+            data: {
+              requestedProjectDirectoryPath: '/stale-projects',
+            },
+          })
+          await waitFor(actor, (state) =>
+            state.matches(SystemIOMachineStates.checkingReadWrite)
+          )
+
+          actor.send({
+            type: SystemIOMachineEvents.setProjectDirectoryPath,
+            data: {
+              requestedProjectDirectoryPath: '/projects',
+            },
+          })
+
+          await waitFor(
+            actor,
+            (state) =>
+              state.matches(SystemIOMachineStates.readingFolders) &&
+              state.context.projectDirectoryPath === '/projects' &&
+              readProjectDirectoryPaths.includes('/projects')
+          )
+
+          expect(checkProjectDirectoryPaths).toStrictEqual([
+            '/stale-projects',
+            '/projects',
+          ])
+          expect(checkSignals[0].aborted).toBe(true)
+        } finally {
+          actor.stop()
+        }
+      })
+      it('should leave a terminal folders value when reading folders fails', async () => {
+        const actor = createActor(
+          systemIOMachine.provide({
+            actors: {
+              [SystemIOMachineActors.readFoldersFromProjectDirectory]:
+                fromPromise(async (): Promise<Project[]> => {
+                  throw new Error('Failed to read projects')
+                }),
+            },
+          }),
+          {
+            input: {
+              wasmInstancePromise: Promise.resolve(instanceInThisFile),
+              app: appInstanceInThisFile,
+            },
+          }
+        ).start()
+
+        try {
+          actor.send({
+            type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
+          })
+
+          await waitFor(
+            actor,
+            (state) =>
+              state.matches(SystemIOMachineStates.idle) &&
+              state.context.folders !== undefined
+          )
+
+          expect(actor.getSnapshot().context.folders).toStrictEqual([])
+          expect(actor.getSnapshot().context.hasListedProjects).toBe(true)
+        } finally {
+          actor.stop()
+        }
+      })
       it('should update folders incrementally while reading folders', async () => {
         const actor = createActor(
           systemIOMachine.provide({

--- a/src/machines/systemIO/systemIOMachine.ts
+++ b/src/machines/systemIO/systemIOMachine.ts
@@ -960,6 +960,10 @@ export const systemIOMachine = setup({
         [SystemIOMachineEvents.setFolders]: {
           actions: SystemIOMachineActions.setFolders,
         },
+        [SystemIOMachineEvents.setProjectDirectoryPath]: {
+          target: SystemIOMachineStates.checkingReadWrite,
+          actions: [SystemIOMachineActions.setProjectDirectoryPath],
+        },
         [SystemIOMachineEvents.navigateToProject]: {
           actions: [SystemIOMachineActions.setRequestedProjectName],
         },
@@ -1006,6 +1010,12 @@ export const systemIOMachine = setup({
         },
         onError: {
           target: SystemIOMachineStates.idle,
+          actions: [
+            assign({
+              folders: ({ context }) => context.folders ?? [],
+              hasListedProjects: true,
+            }),
+          ],
         },
       },
     },
@@ -1209,6 +1219,11 @@ export const systemIOMachine = setup({
         },
         [SystemIOMachineEvents.navigateToFile]: {
           actions: [SystemIOMachineActions.setRequestedFileName],
+        },
+        [SystemIOMachineEvents.setProjectDirectoryPath]: {
+          target: SystemIOMachineStates.checkingReadWrite,
+          reenter: true,
+          actions: [SystemIOMachineActions.setProjectDirectoryPath],
         },
         [SystemIOMachineEvents.createProject]: [
           {

--- a/src/machines/systemIO/systemIOMachineImpl.ts
+++ b/src/machines/systemIO/systemIOMachineImpl.ts
@@ -388,7 +388,12 @@ export const systemIOMachineImpl = systemIOMachine.provide({
           }
 
           const projectPath = fsZds.join(projectDirectoryPath, entry)
-          const stat = await fsZds.stat(projectPath)
+          let stat: Awaited<ReturnType<typeof fsZds.stat>>
+          try {
+            stat = await fsZds.stat(projectPath)
+          } catch {
+            continue
+          }
           if (!(stat.mode & fsZdsConstants.S_IFDIR)) {
             continue
           }

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -56,6 +56,7 @@ import {
 } from '@src/machines/systemIO/hooks'
 import type { systemIOMachine } from '@src/machines/systemIO/systemIOMachine'
 import {
+  NO_PROJECT_DIRECTORY,
   SystemIOMachineEvents,
   SystemIOMachineStates,
 } from '@src/machines/systemIO/utils'
@@ -126,24 +127,39 @@ const Home = () => {
   const onboardingStatus = settingsValues.app.onboardingStatus.current
 
   useEffect(() => {
-    systemIOActor.send({
-      type: SystemIOMachineEvents.setProjectDirectoryPath,
-      data: {
-        requestedProjectDirectoryPath:
-          settingsValues.app?.projectDirectory?.current,
-      },
-    })
-    void waitFor(systemIOActor, (state) =>
-      state.matches(SystemIOMachineStates.idle)
-    ).then(() => {
+    let isCurrent = true
+    const requestedProjectDirectoryPath =
+      settingsValues.app?.projectDirectory?.current || NO_PROJECT_DIRECTORY
+
+    const setProjectDirectoryPath = () => {
+      if (!isCurrent) {
+        return
+      }
+
       systemIOActor.send({
         type: SystemIOMachineEvents.setProjectDirectoryPath,
         data: {
-          requestedProjectDirectoryPath:
-            settingsValues.app?.projectDirectory?.current,
+          requestedProjectDirectoryPath,
         },
       })
-    })
+    }
+
+    setProjectDirectoryPath()
+    void waitFor(systemIOActor, (state) =>
+      state.matches(SystemIOMachineStates.idle)
+    )
+      .then(() => {
+        setProjectDirectoryPath()
+      })
+      .catch((error) => {
+        if (isCurrent) {
+          reportRejection(error)
+        }
+      })
+
+    return () => {
+      isCurrent = false
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
   }, [settingsValues.app?.projectDirectory?.current])
 


### PR DESCRIPTION
## Summary

Fixes a Home loading hang where the route could wait forever for `idle` after `homeLoader` started a stale project-folder read.

The system IO machine now accepts `setProjectDirectoryPath` while it is already reading folders or checking read/write access, so Home can cancel and restart stale in-flight work instead of waiting for it to finish. Home also guards its deferred retry so old path values cannot fire after the effect has been cleaned up.

I also made the folder reader tolerate per-entry `stat` failures and ensured a failed folder read leaves `folders` with a terminal value instead of `undefined`, which prevents the full-page loading spinner from persisting after an error.

## Validation

- `npm run test -- src/machines/systemIO/systemIOMachine.spec.ts`
- `npm run tsc -- --noEmit`
- `npx biome check --formatter-enabled=true --linter-enabled=false --organize-imports-enabled=false src/routes/Home.tsx src/machines/systemIO/systemIOMachine.ts src/machines/systemIO/systemIOMachineImpl.ts src/machines/systemIO/systemIOMachine.spec.ts`