### PR TITLE
Keep Zookeeper reasoning expanded on stream retries

### DIFF
--- a/src/components/ExchangeCard.tsx
+++ b/src/components/ExchangeCard.tsx
@@ -34,8 +34,10 @@ type MlCopilotServerMessageEndOfStream = Extract<
   { end_of_stream: unknown }
 >
 
-const MANUAL_EDIT_INFO_TEXT =
-  'Manual edits detected since the last Zookeeper state.'
+const NON_TERMINAL_INFO_TEXTS = [
+  'Manual edits detected since the last Zookeeper state.',
+  'Transient model streaming error; retrying.',
+]
 
 const getEndOfStreamResponse = (
   responses?: MlCopilotServerMessage[]
@@ -45,15 +47,18 @@ const getEndOfStreamResponse = (
       'end_of_stream' in response
   )
 
-const isManualEditInfoResponse = (response: MlCopilotServerMessage): boolean =>
-  'info' in response && response.info.text.startsWith(MANUAL_EDIT_INFO_TEXT)
+const isNonTerminalInfoResponse = (response: MlCopilotServerMessage): boolean =>
+  'info' in response &&
+  NON_TERMINAL_INFO_TEXTS.some((infoText) =>
+    response.info.text.startsWith(infoText)
+  )
 
 const isExchangeComplete = (responses?: MlCopilotServerMessage[]): boolean =>
   responses?.some(
     (response) =>
       'end_of_stream' in response ||
       'error' in response ||
-      ('info' in response && !isManualEditInfoResponse(response))
+      ('info' in response && !isNonTerminalInfoResponse(response))
   ) ?? false
 
 export interface IButtonCopyProps {

--- a/src/components/MlEphantConversation.spec.tsx
+++ b/src/components/MlEphantConversation.spec.tsx
@@ -369,6 +369,73 @@ describe('MlEphantConversation', () => {
     ).toBeInTheDocument()
   })
 
+  test.each([
+    'Manual edits detected since the last Zookeeper state.',
+    'Transient model streaming error; retrying.',
+  ])(
+    'keeps reasoning expanded for non-terminal info notices: %s',
+    async (infoText) => {
+      const conversation: Conversation = {
+        exchanges: [
+          {
+            request: {
+              type: 'user',
+              content: 'Render a bracket',
+            },
+            responses: [
+              {
+                reasoning: {
+                  type: 'text',
+                  content: 'Checking the model stream...',
+                },
+              },
+              {
+                info: {
+                  text: infoText,
+                },
+              },
+            ],
+            deltasAggregated: '',
+          },
+        ],
+      }
+
+      render(
+        <MlEphantConversation
+          isLoading={false}
+          conversation={conversation}
+          onProcess={vi.fn()}
+          onClickClearChat={() => {}}
+          onReconnect={() => {}}
+          onCancel={() => {}}
+          needsReconnect={false}
+          disabled={false}
+          hasPromptCompleted={false}
+          contexts={[]}
+          isProcessing={true}
+          queue={[]}
+          onRemoveFromQueue={() => {}}
+          onSteer={() => {}}
+        />
+      )
+
+      expect(
+        screen.getByTestId('ml-response-info-chat-bubble')
+      ).toHaveTextContent(infoText)
+      expect(
+        screen.getByTestId('ml-response-chat-bubble-thinking')
+      ).toBeInTheDocument()
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('ml-response-thinking-view')
+        ).toBeInTheDocument()
+      })
+      expect(screen.getByText('Collapse')).toBeInTheDocument()
+      expect(screen.queryByText('See reasoning')).not.toBeInTheDocument()
+    }
+  )
+
   test('hides the immediate thought when end_of_stream is followed by another response', () => {
     const finalResponse = 'Rendered.'
 


### PR DESCRIPTION
## Summary
- Treat the transient model streaming retry notice as a non-terminal info response.
- Keep the response bubble in the loading state and the reasoning pane expanded while retries continue.
- Add regression coverage for manual-edit and transient retry info notices.
