### PR TITLE
Remove Home project directory retry

### DIFF
--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -56,7 +56,6 @@ import {
 } from '@src/machines/systemIO/hooks'
 import type { systemIOMachine } from '@src/machines/systemIO/systemIOMachine'
 import {
-  NO_PROJECT_DIRECTORY,
   SystemIOMachineEvents,
   SystemIOMachineStates,
 } from '@src/machines/systemIO/utils'
@@ -72,7 +71,6 @@ import {
   onDismissOnboardingInvite,
 } from '@src/routes/Onboarding/utils'
 import type { ActorRefFrom } from 'xstate'
-import { waitFor } from 'xstate'
 
 type ReadWriteProjectState = {
   value: boolean
@@ -125,43 +123,6 @@ const Home = () => {
   const settingsValues = settings.useSettings()
   const machineApiEnabled = settingsValues.app.machineApi.current
   const onboardingStatus = settingsValues.app.onboardingStatus.current
-
-  useEffect(() => {
-    let isCurrent = true
-    const requestedProjectDirectoryPath =
-      settingsValues.app?.projectDirectory?.current || NO_PROJECT_DIRECTORY
-
-    const setProjectDirectoryPath = () => {
-      if (!isCurrent) {
-        return
-      }
-
-      systemIOActor.send({
-        type: SystemIOMachineEvents.setProjectDirectoryPath,
-        data: {
-          requestedProjectDirectoryPath,
-        },
-      })
-    }
-
-    setProjectDirectoryPath()
-    void waitFor(systemIOActor, (state) =>
-      state.matches(SystemIOMachineStates.idle)
-    )
-      .then(() => {
-        setProjectDirectoryPath()
-      })
-      .catch((error) => {
-        if (isCurrent) {
-          reportRejection(error)
-        }
-      })
-
-    return () => {
-      isCurrent = false
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
-  }, [settingsValues.app?.projectDirectory?.current])
 
   // Menu listeners
   const cb = (data: WebContentSendPayload) => {


### PR DESCRIPTION
## Summary

Removes the Home route's duplicate `setProjectDirectoryPath` effect and its `waitFor(idle)` retry.

That retry appears to have been added during the fs-zds / OPFS migration, when `homeLoader` started kicking off project reads before Home had a chance to sync the settings project directory. At the time, `setProjectDirectoryPath` could be dropped while the system IO machine was reading/checking, so the second send after `idle` worked around that ordering issue.

After #12044, the system IO machine accepts `setProjectDirectoryPath` while `readingFolders` or `checkingReadWrite`, so this Home-level workaround is redundant. The app-level `SystemIOMachineLogicListener` already owns syncing the application project directory on Home/settings routes.

## Validation

- `npx biome check --formatter-enabled=true --linter-enabled=false --organize-imports-enabled=false src/routes/Home.tsx`
- `npm run test -- src/machines/systemIO/systemIOMachine.spec.ts`
- `npm run tsc -- --noEmit`

Note: after fetching current `main`, I ran `npm install --ignore-scripts` locally because the fetched lockfile includes `smol-toml` and this checkout's `node_modules` did not yet have it. No tracked dependency files changed.