### PR TITLE
Dismiss onboarding in web tests to simplify debugging

### DIFF
--- a/e2e/playwright/share-link.spec.ts
+++ b/e2e/playwright/share-link.spec.ts
@@ -1,3 +1,4 @@
+import { closeOnboardingModalIfPresent } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
 import type { Page } from '@playwright/test'
 
@@ -24,6 +25,8 @@ test.describe('Share link tests', () => {
     { tag: ['@web', '@macos', '@linux'] },
     async ({ page }) => {
       test.skip(process.platform === 'win32')
+      await closeOnboardingModalIfPresent(page)
+
       const codeLength = 2000
       await navigateAndClickOpenInDesktopApp(page, codeLength)
       await expect(getToastError(page)).not.toBeVisible()
@@ -35,6 +38,8 @@ test.describe('Share link tests', () => {
     { tag: ['@web', '@windows'] },
     async ({ page }) => {
       test.skip(process.platform !== 'win32')
+      await closeOnboardingModalIfPresent(page)
+
       const codeLength = 1000
       await navigateAndClickOpenInDesktopApp(page, codeLength)
       await expect(getToastError(page)).not.toBeVisible()
@@ -46,6 +51,8 @@ test.describe('Share link tests', () => {
     { tag: ['@web', '@windows'] },
     async ({ page }) => {
       test.skip(process.platform !== 'win32')
+      await closeOnboardingModalIfPresent(page)
+
       const codeLength = 2000
       await navigateAndClickOpenInDesktopApp(page, codeLength)
       await expect(getToastError(page)).toBeVisible()
@@ -56,6 +63,8 @@ test.describe('Share link tests', () => {
     'should prefill demo project name on web',
     { tag: ['@web'] },
     async ({ page }) => {
+      await closeOnboardingModalIfPresent(page)
+
       const code = 'Zm9vYmFyID0gMQ==' // KCL: foobar = 1
       const next = new URL(page.url())
       next.searchParams.set('create-file', 'true')

--- a/e2e/playwright/testing-samples-loading.spec.ts
+++ b/e2e/playwright/testing-samples-loading.spec.ts
@@ -2,7 +2,10 @@ import { join } from 'node:path'
 import { bracket } from '@e2e/playwright/fixtures/bracket'
 import { FILE_EXT } from '@src/lib/constants'
 
-import { getUtils } from '@e2e/playwright/test-utils'
+import {
+  closeOnboardingModalIfPresent,
+  getUtils,
+} from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
 import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
 
@@ -137,6 +140,8 @@ test.describe('Query parameter command', { tag: '@web' }, () => {
     toolbar,
     editor,
   }) => {
+    await closeOnboardingModalIfPresent(page)
+
     const sampleTitle = 'Socket Head Cap Screw'
     const sampleSlug = 'socket-head-cap-screw'
     const queryString = `?cmd=add-kcl-file-to-project&groupId=application&projectName=browser&source=kcl-samples&sample=${sampleSlug}/main.kcl`


### PR DESCRIPTION
Clearing the onboarding modal will make it easier to debug tests that are unrelated to that functionality.