### PR TITLE
Add new profile-transforming params for sweep

### DIFF
--- a/docs/kcl-std/functions/std-sketch-sweep.md
+++ b/docs/kcl-std/functions/std-sketch-sweep.md
@@ -14,6 +14,8 @@ sweep(
   sectional?: bool,
   tolerance?: number(Length),
   relativeTo?: string,
+  translateProfileToPath?: bool,
+  orientProfilePerpendicular?: bool,
   tagStart?: TagDecl,
   tagEnd?: TagDecl,
   bodyType?: string,
@@ -38,7 +40,9 @@ swept along the same path.
 | `path` | [`Sketch`](/docs/kcl-std/types/std-types-Sketch) or [`Helix`](/docs/kcl-std/types/std-types-Helix) or [[`Segment`](/docs/kcl-std/types/std-types-Segment); 1+] | The path to sweep the sketch along. | Yes |
 | `sectional` | [`bool`](/docs/kcl-std/types/std-types-bool) | If true, the sweep will be broken up into sub-sweeps (extrusions, revolves, sweeps) based on the trajectory path components. | No |
 | `tolerance` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | Defines the smallest distance below which two entities are considered coincident, intersecting, coplanar, or similar. For most use cases, it should not be changed from its default value of 10^-7 millimeters. | No |
-| `relativeTo` | [`string`](/docs/kcl-std/types/std-types-string) | What is the sweep relative to? Can be either 'sketchPlane' or 'trajectoryCurve'. | No |
+| `relativeTo` | [`string`](/docs/kcl-std/types/std-types-string) | Deprecated; please use 'translateProfileToPath' and 'orientProfilePerpendicular'. What is the sweep relative to? Can be either 'sketchPlane' or 'trajectoryCurve'. | No |
+| `translateProfileToPath` | [`bool`](/docs/kcl-std/types/std-types-bool) | If true, the profile being swept will be moved to the path being swept along, before the sweep starts. If false, the profile stays where it is, and the sweep starts from there. Defaults to false. | No |
+| `orientProfilePerpendicular` | [`bool`](/docs/kcl-std/types/std-types-bool) | If true, before the sweep starts, the profile will be re-oriented so that it is perpendicular to the path being swept along. If false, the profile is left in its current orientation. Defaults to false. | No |
 | `tagStart` | [`TagDecl`](/docs/kcl-std/types/std-types-TagDecl) | A named tag for the face at the start of the sweep, i.e. the original sketch. | No |
 | `tagEnd` | [`TagDecl`](/docs/kcl-std/types/std-types-TagDecl) | A named tag for the face at the end of the sweep. | No |
 | `bodyType` | [`string`](/docs/kcl-std/types/std-types-string) | What type of body to produce (solid or surface). Defaults to "solid". | No |

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -110,7 +110,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -121,7 +121,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1116,7 +1116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2200,7 +2200,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2570,8 +2570,9 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.205"
-source = "git+https://github.com/KittyCAD/modeling-api.git?branch=achalmers%2Fteleport#fa879728fc9d2911e19367af90ca17aeb84497cf"
+version = "0.2.206"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a35208abdee644c5a75a6becc4c95ab1590f994f9fb58ff97510c621bdf770b2"
 dependencies = [
  "anyhow",
  "bon",
@@ -2599,7 +2600,8 @@ dependencies = [
 [[package]]
 name = "kittycad-modeling-cmds-macros"
 version = "0.1.13"
-source = "git+https://github.com/KittyCAD/modeling-api.git?branch=achalmers%2Fteleport#fa879728fc9d2911e19367af90ca17aeb84497cf"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb4ba190f74f6d32f4607ecac4bdebd4a935d4943b8ca8369305e6e7a59b5976"
 dependencies = [
  "kittycad-modeling-cmds-macros-impl",
  "proc-macro2",
@@ -2610,7 +2612,8 @@ dependencies = [
 [[package]]
 name = "kittycad-modeling-cmds-macros-impl"
 version = "0.1.14"
-source = "git+https://github.com/KittyCAD/modeling-api.git?branch=achalmers%2Fteleport#fa879728fc9d2911e19367af90ca17aeb84497cf"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743b6533d1848de67e3455a28614a2b7896807ab0d3358ccd3ea1863de3c4e6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3068,7 +3071,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4296,7 +4299,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4828,7 +4831,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5037,7 +5040,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5046,7 +5049,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6063,7 +6066,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6625,3 +6628,8 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "kittycad-modeling-cmds"
+version = "0.2.205"
+source = "git+https://github.com/KittyCAD/modeling-api.git?branch=achalmers%2Fteleport#fa879728fc9d2911e19367af90ca17aeb84497cf"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -576,7 +576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1116,7 +1116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2200,7 +2200,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2571,8 +2571,7 @@ dependencies = [
 [[package]]
 name = "kittycad-modeling-cmds"
 version = "0.2.205"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612835dddacd987ad49e3a6c618dc295dded4cf1616885ecadc815892a5252ca"
+source = "git+https://github.com/KittyCAD/modeling-api.git?branch=achalmers%2Fteleport#fa879728fc9d2911e19367af90ca17aeb84497cf"
 dependencies = [
  "anyhow",
  "bon",
@@ -2585,8 +2584,8 @@ dependencies = [
  "kittycad-measurements",
  "kittycad-modeling-cmds-macros",
  "kittycad-unit-conversion-derive",
- "parse-display 0.10.0",
- "parse-display-derive 0.10.0",
+ "parse-display 0.11.0",
+ "parse-display-derive 0.11.0",
  "pyo3",
  "pyo3-stub-gen",
  "schemars",
@@ -2600,8 +2599,7 @@ dependencies = [
 [[package]]
 name = "kittycad-modeling-cmds-macros"
 version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb4ba190f74f6d32f4607ecac4bdebd4a935d4943b8ca8369305e6e7a59b5976"
+source = "git+https://github.com/KittyCAD/modeling-api.git?branch=achalmers%2Fteleport#fa879728fc9d2911e19367af90ca17aeb84497cf"
 dependencies = [
  "kittycad-modeling-cmds-macros-impl",
  "proc-macro2",
@@ -2612,8 +2610,7 @@ dependencies = [
 [[package]]
 name = "kittycad-modeling-cmds-macros-impl"
 version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743b6533d1848de67e3455a28614a2b7896807ab0d3358ccd3ea1863de3c4e6b"
+source = "git+https://github.com/KittyCAD/modeling-api.git?branch=achalmers%2Fteleport#fa879728fc9d2911e19367af90ca17aeb84497cf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4286,7 +4283,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4299,7 +4296,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5040,7 +5037,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6066,7 +6063,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -29,7 +29,7 @@ kittycad = { version = "0.4.13", default-features = false, features = [
   "js",
   "requests",
 ] }
-kittycad-modeling-cmds = { version = "0.2.205", features = [
+kittycad-modeling-cmds = { version = "0.2.206", features = [
   "ts-rs",
   "websocket",
 ] }
@@ -91,7 +91,7 @@ insta = { opt-level = 3 }
 debug = "line-tables-only"
 
 #Example: how to point modeling-app at a different repo (e.g. a branch or a local clone)
-[patch.crates-io]
+# [patch.crates-io]
 # ezpz = { git = "https://github.com/KittyCAD/ezpz.git", branch = "david/circle-circle-tangent" }
-kittycad-modeling-cmds = { git = "https://github.com/KittyCAD/modeling-api.git", branch = "achalmers/teleport" }
+# kittycad-modeling-cmds = { git = "https://github.com/KittyCAD/modeling-api.git", branch = "main" }
 # kittycad-modeling-cmds = { path = "../../modeling-api/modeling-cmds" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -91,7 +91,7 @@ insta = { opt-level = 3 }
 debug = "line-tables-only"
 
 #Example: how to point modeling-app at a different repo (e.g. a branch or a local clone)
-# [patch.crates-io]
+[patch.crates-io]
 # ezpz = { git = "https://github.com/KittyCAD/ezpz.git", branch = "david/circle-circle-tangent" }
-# kittycad-modeling-cmds = { git = "https://github.com/KittyCAD/modeling-api.git", branch = "main" }
+kittycad-modeling-cmds = { git = "https://github.com/KittyCAD/modeling-api.git", branch = "achalmers/teleport" }
 # kittycad-modeling-cmds = { path = "../../modeling-api/modeling-cmds" }

--- a/rust/kcl-lib/src/std/sweep.rs
+++ b/rust/kcl-lib/src/std/sweep.rs
@@ -206,7 +206,6 @@ async fn inner_sweep(
 
     let profile_transform = match (relative_to, translate_profile_to_path, orient_profile_perpendicular) {
         // Default case when the user doesn't give any flags at all.
-        //
         (None, None, None) => ProfileTransform::RelativeTo(match version {
             // We default to algorithm v1 if no choice was made.
             None | Some(1) => RelativeTo::TrajectoryCurve,
@@ -222,7 +221,8 @@ async fn inner_sweep(
                 )));
             }
         }),
-        // If the "new" profile transformation args are set,
+
+        // If the "new" profile transformation args are set.
         (None, translate, orient) => ProfileTransform::SeparateFlags {
             translate_profile_to_path: translate.unwrap_or_default(),
             orient_profile_perpendicular: orient.unwrap_or_default(),
@@ -239,7 +239,9 @@ async fn inner_sweep(
                 )));
             }
         }),
+
         // RelativeTo was set, but also one of its replacements was.
+        // This is an error.
         (Some(_relative_to), _, _) => {
             return Err(KclError::new_argument(crate::errors::KclErrorDetails::new(
                     "If you provide 'relativeTo', you cannot provide 'translateProfileToPath' or 'orientProfilePerpendicular'. Those arguments replace 'relativeTo', please use them instead.".to_owned(),

--- a/rust/kcl-lib/src/std/sweep.rs
+++ b/rust/kcl-lib/src/std/sweep.rs
@@ -155,15 +155,6 @@ impl ProfileTransform {
     }
 }
 
-impl Default for ProfileTransform {
-    fn default() -> Self {
-        Self::SeparateFlags {
-            translate_profile_to_path: false,
-            orient_profile_perpendicular: false,
-        }
-    }
-}
-
 #[allow(clippy::too_many_arguments)]
 async fn inner_sweep(
     sketches: Vec<Sketch>,

--- a/rust/kcl-lib/src/std/sweep.rs
+++ b/rust/kcl-lib/src/std/sweep.rs
@@ -69,11 +69,18 @@ pub async fn sweep(exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
     )?;
     let sectional = args.get_kw_arg_opt("sectional", &RuntimeType::bool(), exec_state)?;
     let tolerance: Option<TyF64> = args.get_kw_arg_opt("tolerance", &RuntimeType::length(), exec_state)?;
-    let relative_to: Option<String> = args.get_kw_arg_opt("relativeTo", &RuntimeType::string(), exec_state)?;
     let tag_start = args.get_kw_arg_opt("tagStart", &RuntimeType::tag_decl(), exec_state)?;
     let tag_end = args.get_kw_arg_opt("tagEnd", &RuntimeType::tag_decl(), exec_state)?;
     let body_type: Option<BodyType> = args.get_kw_arg_opt("bodyType", &RuntimeType::string(), exec_state)?;
     let version: Option<u32> = args.get_kw_arg_opt("version", &RuntimeType::count(), exec_state)?;
+    // Replaced by 2 args below.
+    let relative_to: Option<String> = args.get_kw_arg_opt("relativeTo", &RuntimeType::string(), exec_state)?;
+    // Replaces `relative_to`.
+    let translate_profile_to_path: Option<bool> =
+        args.get_kw_arg_opt("translateProfileToPath", &RuntimeType::bool(), exec_state)?;
+    let orient_profile_perpendicular: Option<bool> =
+        args.get_kw_arg_opt("orientProfilePerpendicular", &RuntimeType::bool(), exec_state)?;
+
     let path = match path {
         SweepPath::Segments(segments) => InnerSweepPath::Sketch(
             build_segment_surface_sketch(segments, exec_state, &args.ctx, args.source_range).await?,
@@ -99,6 +106,8 @@ pub async fn sweep(exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
         sectional,
         tolerance,
         relative_to,
+        translate_profile_to_path,
+        orient_profile_perpendicular,
         tag_start,
         tag_end,
         body_type,
@@ -110,6 +119,51 @@ pub async fn sweep(exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
     Ok(value.into())
 }
 
+enum ProfileTransform {
+    RelativeTo(RelativeTo),
+    SeparateFlags {
+        translate_profile_to_path: bool,
+        orient_profile_perpendicular: bool,
+    },
+}
+
+impl ProfileTransform {
+    fn relative_to(&self) -> Option<RelativeTo> {
+        match self {
+            ProfileTransform::RelativeTo(relative_to) => Some(*relative_to),
+            ProfileTransform::SeparateFlags { .. } => None,
+        }
+    }
+
+    fn translate_profile_to_path(&self) -> Option<bool> {
+        match self {
+            ProfileTransform::RelativeTo(..) => None,
+            ProfileTransform::SeparateFlags {
+                translate_profile_to_path,
+                ..
+            } => Some(*translate_profile_to_path),
+        }
+    }
+    fn orient_profile_perpendicular(&self) -> Option<bool> {
+        match self {
+            ProfileTransform::RelativeTo(..) => None,
+            ProfileTransform::SeparateFlags {
+                orient_profile_perpendicular,
+                ..
+            } => Some(*orient_profile_perpendicular),
+        }
+    }
+}
+
+impl Default for ProfileTransform {
+    fn default() -> Self {
+        Self::SeparateFlags {
+            translate_profile_to_path: false,
+            orient_profile_perpendicular: false,
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn inner_sweep(
     sketches: Vec<Sketch>,
@@ -117,6 +171,8 @@ async fn inner_sweep(
     sectional: Option<bool>,
     tolerance: Option<TyF64>,
     relative_to: Option<String>,
+    translate_profile_to_path: Option<bool>,
+    orient_profile_perpendicular: Option<bool>,
     tag_start: Option<TagNode>,
     tag_end: Option<TagNode>,
     body_type: Option<BodyType>,
@@ -136,14 +192,30 @@ async fn inner_sweep(
         InnerSweepPath::Sketch(sketch) => sketch.id,
         InnerSweepPath::Helix(helix) => helix.value,
     });
-    let relative_to = match relative_to.as_deref() {
-        Some("sketchPlane") => RelativeTo::SketchPlane,
-        Some("trajectoryCurve") | None => RelativeTo::TrajectoryCurve,
-        Some(_) => {
-            return Err(KclError::new_syntax(crate::errors::KclErrorDetails::new(
-                "If you provide relativeTo, it must either be 'sketchPlane' or 'trajectoryCurve'".to_owned(),
-                vec![args.source_range],
-            )));
+    let profile_transform = match (relative_to, translate_profile_to_path, orient_profile_perpendicular) {
+        // If the "new" profile transformation args are set,
+        (None, translate, orient) => ProfileTransform::SeparateFlags {
+            translate_profile_to_path: translate.unwrap_or_default(),
+            orient_profile_perpendicular: orient.unwrap_or_default(),
+        },
+
+        // RelativeTo was set, but none of its replacements were.
+        (Some(relative_to), None, None) => ProfileTransform::RelativeTo(match relative_to.as_str() {
+            "sketchPlane" => RelativeTo::SketchPlane,
+            "trajectoryCurve" => RelativeTo::TrajectoryCurve,
+            _ => {
+                return Err(KclError::new_syntax(crate::errors::KclErrorDetails::new(
+                    "If you provide relativeTo, it must either be 'sketchPlane' or 'trajectoryCurve'".to_owned(),
+                    vec![args.source_range],
+                )));
+            }
+        }),
+        // RelativeTo was set, but also one of its replacements was.
+        (Some(_relative_to), _, _) => {
+            return Err(KclError::new_argument(crate::errors::KclErrorDetails::new(
+                    "If you provide 'relativeTo', you cannot provide 'translateProfileToPath' or 'orientProfilePerpendicular'. Those arguments replace 'relativeTo', please use them instead.".to_owned(),
+                    vec![args.source_range],
+                )));
         }
     };
 
@@ -163,7 +235,9 @@ async fn inner_sweep(
                         .tolerance(LengthUnit(
                             tolerance.as_ref().map(|t| t.to_mm()).unwrap_or(DEFAULT_TOLERANCE_MM),
                         ))
-                        .relative_to(relative_to)
+                        .maybe_relative_to(profile_transform.relative_to())
+                        .maybe_orient_profile_perpendicular(profile_transform.orient_profile_perpendicular())
+                        .maybe_translate_profile_to_path(profile_transform.translate_profile_to_path())
                         .body_type(body_type)
                         .maybe_version(version)
                         .build(),

--- a/rust/kcl-lib/src/std/sweep.rs
+++ b/rust/kcl-lib/src/std/sweep.rs
@@ -188,11 +188,40 @@ async fn inner_sweep(
         )));
     }
 
+    let version = version
+        .map(|v| {
+            u8::try_from(v).map_err(|_e| {
+                KclError::new_argument(KclErrorDetails::new(
+                    format!("Invalid version {}", v),
+                    vec![args.source_range],
+                ))
+            })
+        })
+        .transpose()?;
+
     let trajectory = ModelingCmdId::from(match path {
         InnerSweepPath::Sketch(sketch) => sketch.id,
         InnerSweepPath::Helix(helix) => helix.value,
     });
+
     let profile_transform = match (relative_to, translate_profile_to_path, orient_profile_perpendicular) {
+        // Default case when the user doesn't give any flags at all.
+        //
+        (None, None, None) => ProfileTransform::RelativeTo(match version {
+            // We default to algorithm v1 if no choice was made.
+            None | Some(1) => RelativeTo::TrajectoryCurve,
+            // 0 means "let engine choose". Engine currently chooses version 1.
+            Some(0) => RelativeTo::TrajectoryCurve,
+            // Algorithm version 2 defaults to SketchPlane.
+            Some(2) => RelativeTo::SketchPlane,
+            // Error on unknown algorithm.
+            Some(other) => {
+                return Err(KclError::new_argument(KclErrorDetails::new(
+                    format!("Invalid version {}", other),
+                    vec![args.source_range],
+                )));
+            }
+        }),
         // If the "new" profile transformation args are set,
         (None, translate, orient) => ProfileTransform::SeparateFlags {
             translate_profile_to_path: translate.unwrap_or_default(),
@@ -218,8 +247,6 @@ async fn inner_sweep(
                 )));
         }
     };
-
-    let version = version.map(|v| u8::try_from(v).unwrap_or(u8::MAX));
 
     let mut solids = Vec::new();
     for sketch in &sketches {

--- a/rust/kcl-lib/std/sketch.kcl
+++ b/rust/kcl-lib/std/sketch.kcl
@@ -1754,8 +1754,19 @@ export fn sweep(
   sectional?: bool,
   /// Defines the smallest distance below which two entities are considered coincident, intersecting, coplanar, or similar. For most use cases, it should not be changed from its default value of 10^-7 millimeters.
   tolerance?: number(Length),
+  /// Deprecated; please use 'translateProfileToPath' and 'orientProfilePerpendicular'.
   /// What is the sweep relative to? Can be either 'sketchPlane' or 'trajectoryCurve'.
   relativeTo?: string = 'trajectoryCurve',
+  /// If true, the profile being swept will be moved to the path being swept along,
+  /// before the sweep starts.
+  /// If false, the profile stays where it is, and the sweep starts from there.
+  /// Defaults to false.
+  translateProfileToPath?: bool = false,
+  /// If true, before the sweep starts, the profile will be re-oriented
+  /// so that it is perpendicular to the path being swept along.
+  /// If false, the profile is left in its current orientation.
+  /// Defaults to false.
+  orientProfilePerpendicular?: bool = false,
   /// A named tag for the face at the start of the sweep, i.e. the original sketch.
   tagStart?: TagDecl,
   /// A named tag for the face at the end of the sweep.


### PR DESCRIPTION
Part of https://github.com/KittyCAD/modeling-app/issues/12059

Use with engine pool 4677.

Please note that it adds 2 new arguments without making them experimental, because we've got some time pressure to get this out and have Ryan use it when working with a customer. I've tested it manually against a local engine build. Once the engine has been deployed, I'll open a new PR with tests. Given that these are new flags without UI support I think that, if we discover a bug, we will fix forward rather than revert.

I talked this through with mechanical engineers (Nick, Max). Also spot checked against a couple of our automotive customer's files that use sweeps. Also reviewed on Huddle with Paul.