### PR TITLE
Add systemIO registry project state, make systemIOActor subscribe to that

### DIFF
--- a/packages/registry/src/helpers.ts
+++ b/packages/registry/src/helpers.ts
@@ -44,7 +44,7 @@ export function unwrapMaybeSignal<T>(value: MaybeSignal<T>): T {
 
 /** Normalize function-based and Symbol.dispose-based cleanup into one shape. */
 export function normalizeDisposer(
-  dispose?: { [Symbol.dispose](): void } | (() => void) | void
+  dispose?: { [Symbol.dispose](): void } | (() => void)
 ): (() => void) | undefined {
   if (!dispose) return undefined
   if (typeof dispose === 'function') return dispose

--- a/packages/registry/src/helpers.ts
+++ b/packages/registry/src/helpers.ts
@@ -44,7 +44,7 @@ export function unwrapMaybeSignal<T>(value: MaybeSignal<T>): T {
 
 /** Normalize function-based and Symbol.dispose-based cleanup into one shape. */
 export function normalizeDisposer(
-  dispose?: { [Symbol.dispose](): void } | (() => void)
+  dispose?: { [Symbol.dispose](): void } | (() => void) | void
 ): (() => void) | undefined {
   if (!dispose) return undefined
   if (typeof dispose === 'function') return dispose

--- a/packages/registry/src/registry.test.ts
+++ b/packages/registry/src/registry.test.ts
@@ -4,6 +4,7 @@ import {
   defineContract,
   defineRegistryItem,
   defineRegistryItemFactory,
+  defineRuntimeRegistryItem,
   provide,
   provideService,
 } from './helpers'
@@ -69,6 +70,41 @@ describe('Registry', () => {
 
     expect(container.get(registrySignal)).toEqual(['stable', 'b'])
     expect(calls).toHaveBeenCalledTimes(1)
+  })
+
+  it('activates runtime items after graph construction', async () => {
+    const service = defineService<{ readonly id: string }>('workspace')
+    const activate = vi.fn()
+    const cleanup = vi.fn()
+    const runtime = defineRegistryItemFactory(
+      ({ services }) => ({
+        item: defineRuntimeRegistryItem({
+          activate: () => {
+            activate(services.get(service).id)
+            return cleanup
+          },
+        }),
+      }),
+      'runtime-with-activate'
+    )
+    const container = new Registry()
+
+    container.configure([
+      defineRegistryItem({
+        providesServices: [provideService(service, { id: 'project' })],
+      }),
+      runtime,
+    ])
+
+    container.inspect()
+    expect(activate).not.toHaveBeenCalled()
+
+    await Promise.resolve()
+
+    expect(activate).toHaveBeenCalledWith('project')
+
+    container[Symbol.dispose]()
+    expect(cleanup).toHaveBeenCalled()
   })
 
   it('merges object value specs', () => {

--- a/packages/registry/src/registry.ts
+++ b/packages/registry/src/registry.ts
@@ -26,6 +26,7 @@ import type {
   RegistryItemContext,
   RegistryItemFactory,
   RegistryItemKey,
+  RegistryItemLifecycleHook,
   RuntimeRegistryItemHandle,
   Service,
   ServiceReader,
@@ -53,6 +54,10 @@ interface FlattenedServiceContribution {
 interface RuntimeInstance {
   readonly key: RegistryItemKey
   readonly handle: RuntimeRegistryItemHandle<unknown>
+  readonly activate?: RegistryItemLifecycleHook
+  activated: boolean
+  activationQueued: boolean
+  activationDispose?: () => void
   readonly dispose?: () => void
 }
 
@@ -438,11 +443,54 @@ export class Registry implements ValueSpecReader, ServiceReader {
     const instance: RuntimeInstance = {
       key,
       handle,
+      activate: handle.item.activate,
+      activated: false,
+      activationQueued: false,
       dispose: normalizeDisposer(handle.item.dispose),
     }
 
     this.runtimeInstances.set(key, instance)
+    this.queueRuntimeActivation(instance)
     return instance
+  }
+
+  /** Run runtime activation after graph construction, when services are safe to read. */
+  private queueRuntimeActivation(instance: RuntimeInstance): void {
+    const activate = instance.activate
+    if (!activate || instance.activationQueued || instance.activated) {
+      return
+    }
+
+    instance.activationQueued = true
+    queueMicrotask(() => {
+      // Force reconciliation against the latest roots before activating.
+      void this.flat.value
+
+      instance.activationQueued = false
+      if (
+        this.runtimeInstances.get(instance.key) !== instance ||
+        instance.activated
+      ) {
+        return
+      }
+
+      instance.activated = true
+      instance.activationDispose = normalizeDisposer(activate())
+    })
+  }
+
+  private disposeRuntimeInstance(instance: RuntimeInstance): void {
+    try {
+      instance.activationDispose?.()
+    } catch {
+      // cleanup failures are intentionally swallowed during reconciliation
+    }
+
+    try {
+      instance.dispose?.()
+    } catch {
+      // cleanup failures are intentionally swallowed during reconciliation
+    }
   }
 
   /** Dispose runtime instances that are no longer reachable from the registry graph. */
@@ -452,12 +500,7 @@ export class Registry implements ValueSpecReader, ServiceReader {
     for (const [key, instance] of this.runtimeInstances) {
       if (activeKeys.has(key)) continue
 
-      try {
-        instance.dispose?.()
-      } catch {
-        // cleanup failures are intentionally swallowed during reconciliation
-      }
-
+      this.disposeRuntimeInstance(instance)
       this.runtimeInstances.delete(key)
     }
   }
@@ -465,11 +508,7 @@ export class Registry implements ValueSpecReader, ServiceReader {
   /** Dispose the container and all active runtime instances. */
   [Symbol.dispose](): void {
     for (const [, instance] of this.runtimeInstances) {
-      try {
-        instance.dispose?.()
-      } catch {
-        // ignore cleanup failures during shutdown
-      }
+      this.disposeRuntimeInstance(instance)
     }
 
     this.runtimeInstances.clear()

--- a/packages/registry/src/registry.ts
+++ b/packages/registry/src/registry.ts
@@ -475,7 +475,10 @@ export class Registry implements ValueSpecReader, ServiceReader {
       }
 
       instance.activated = true
-      instance.activationDispose = normalizeDisposer(activate())
+      const cleanup = activate()
+      instance.activationDispose = cleanup
+        ? normalizeDisposer(cleanup)
+        : undefined
     })
   }
 

--- a/packages/registry/src/types.ts
+++ b/packages/registry/src/types.ts
@@ -16,8 +16,9 @@ export interface DisposableLike {
 
 export type RegistryItemLifecycleCleanup = DisposableLike | (() => void)
 
-export type RegistryItemLifecycleHook =
-  () => void | RegistryItemLifecycleCleanup
+export type RegistryItemLifecycleHook = () =>
+  | RegistryItemLifecycleCleanup
+  | undefined
 
 /**
  * Value-spec contributions may be static values or live reactive values.

--- a/packages/registry/src/types.ts
+++ b/packages/registry/src/types.ts
@@ -14,6 +14,11 @@ export interface DisposableLike {
   [Symbol.dispose](): void
 }
 
+export type RegistryItemLifecycleCleanup = DisposableLike | (() => void)
+
+export type RegistryItemLifecycleHook =
+  () => void | RegistryItemLifecycleCleanup
+
 /**
  * Value-spec contributions may be static values or live reactive values.
  *
@@ -92,7 +97,8 @@ export interface RegistryItemDefinition {
  * contributions.
  */
 export interface RuntimeRegistryItemDefinition extends RegistryItemDefinition {
-  readonly dispose?: DisposableLike | (() => void)
+  readonly activate?: RegistryItemLifecycleHook
+  readonly dispose?: RegistryItemLifecycleCleanup
 }
 
 /**

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -84,6 +84,7 @@ import {
   type SettingsRegistryService,
   settingsService,
 } from '@src/registry/contracts/settings'
+import { projectsValueSpec } from '@src/registry/contracts/systemIO'
 import { userFeaturesService } from '@src/registry/contracts/userFeatures'
 import { provideWasmPromise } from '@src/registry/contracts/wasm'
 import { zdsPluginActivationSettingsValueSpec } from '@src/registry/createZdsPlugin'
@@ -327,6 +328,19 @@ export class App implements AppSubsystems {
       this.syncPluginSettings
     )
     this.syncPluginSettings(this.settings.actor.getSnapshot())
+
+    const projectsSignal = this.registry.signal(projectsValueSpec)
+    effect(() => {
+      const projects = projectsSignal.value
+      if (projects === undefined) {
+        return
+      }
+
+      this.systemIOActor.send({
+        type: SystemIOMachineEvents.setFolders,
+        data: { folders: projects },
+      })
+    })
   }
 
   /**

--- a/src/machines/systemIO/systemIOMachine.spec.ts
+++ b/src/machines/systemIO/systemIOMachine.spec.ts
@@ -281,6 +281,34 @@ describe('systemIOMachine - XState', () => {
         )
         actor.stop()
       })
+      it('should accept externally synced folders while idle', async () => {
+        const actor = createActor(systemIOMachineImpl, {
+          input: {
+            wasmInstancePromise: Promise.resolve(instanceInThisFile),
+            app: appInstanceInThisFile,
+          },
+        }).start()
+
+        try {
+          const folders = [mockProject('from-registry')]
+          actor.send({
+            type: SystemIOMachineEvents.setFolders,
+            data: { folders },
+          })
+
+          await waitFor(actor, (state) => state.context.folders === folders)
+
+          expect(actor.getSnapshot()).toMatchObject({
+            value: SystemIOMachineStates.idle,
+            context: {
+              folders,
+              hasListedProjects: true,
+            },
+          })
+        } finally {
+          actor.stop()
+        }
+      })
     })
     describe('when reading projects', () => {
       it('should exit early when project directory is empty string', async () => {

--- a/src/machines/systemIO/systemIOMachine.ts
+++ b/src/machines/systemIO/systemIOMachine.ts
@@ -886,6 +886,16 @@ export const systemIOMachine = setup({
     lastOperation: SystemIOMachineStates.idle,
     mlEphantConversations: undefined,
   }),
+  on: {
+    [SystemIOMachineEvents.setFolders]: {
+      actions: [
+        SystemIOMachineActions.setFolders,
+        assign({
+          hasListedProjects: true,
+        }),
+      ],
+    },
+  },
   states: {
     [SystemIOMachineStates.idle]: {
       on: {

--- a/src/registry/contracts/systemIO.ts
+++ b/src/registry/contracts/systemIO.ts
@@ -1,0 +1,17 @@
+import { defineContract, defineService } from '@kittycad/registry'
+import type { ReadonlySignal } from '@preact/signals-core'
+
+export type ProjectHandle = {
+  readonly path: string
+}
+
+export type SystemIOService = {
+  projectHandles: ReadonlySignal<readonly ProjectHandle[]>
+  refreshProjectHandles: () => Promise<readonly ProjectHandle[]>
+}
+
+export const systemIOContract = defineContract({
+  systemIOService: defineService<SystemIOService>('system-io.service'),
+})
+
+export const { systemIOService } = systemIOContract

--- a/src/registry/contracts/systemIO.ts
+++ b/src/registry/contracts/systemIO.ts
@@ -10,21 +10,29 @@ export type ProjectHandle = {
   readonly path: string
 }
 
+export type ProjectHandles = readonly ProjectHandle[] | undefined
+
 export type Projects = Project[] | undefined
 
 export type SystemIOService = {
-  projectHandles: ReadonlySignal<readonly ProjectHandle[]>
+  projectHandles: ReadonlySignal<ProjectHandles>
   projects: ReadonlySignal<Projects>
   refreshProjectHandles: () => Promise<readonly ProjectHandle[]>
 }
 
 export function combineProjectHandles(
-  inputs: readonly (readonly ProjectHandle[])[]
-): readonly ProjectHandle[] {
+  inputs: readonly ProjectHandles[]
+): ProjectHandles {
+  let hasHandles = false
   const seenPaths = new Set<string>()
   const handles: ProjectHandle[] = []
 
   for (const input of inputs) {
+    if (input === undefined) {
+      continue
+    }
+
+    hasHandles = true
     for (const handle of input) {
       if (seenPaths.has(handle.path)) {
         continue
@@ -35,7 +43,7 @@ export function combineProjectHandles(
     }
   }
 
-  return handles
+  return hasHandles ? handles : undefined
 }
 
 export function combineProjects(inputs: readonly Projects[]): Projects {
@@ -64,12 +72,9 @@ export function combineProjects(inputs: readonly Projects[]): Projects {
 
 export const systemIOContract = defineContract({
   systemIOService: defineService<SystemIOService>('system-io.service'),
-  projectHandlesValueSpec: defineValueSpec<
-    readonly ProjectHandle[],
-    readonly ProjectHandle[]
-  >({
+  projectHandlesValueSpec: defineValueSpec<ProjectHandles, ProjectHandles>({
     name: 'system-io.project-handles',
-    defaultValue: [],
+    defaultValue: undefined,
     combine: combineProjectHandles,
   }),
   projectsValueSpec: defineValueSpec<Projects, Projects>({

--- a/src/registry/contracts/systemIO.ts
+++ b/src/registry/contracts/systemIO.ts
@@ -1,17 +1,83 @@
-import { defineContract, defineService } from '@kittycad/registry'
+import {
+  defineContract,
+  defineService,
+  defineValueSpec,
+} from '@kittycad/registry'
 import type { ReadonlySignal } from '@preact/signals-core'
+import type { Project } from '@src/lib/project'
 
 export type ProjectHandle = {
   readonly path: string
 }
 
+export type Projects = Project[] | undefined
+
 export type SystemIOService = {
   projectHandles: ReadonlySignal<readonly ProjectHandle[]>
+  projects: ReadonlySignal<Projects>
   refreshProjectHandles: () => Promise<readonly ProjectHandle[]>
+}
+
+export function combineProjectHandles(
+  inputs: readonly (readonly ProjectHandle[])[]
+): readonly ProjectHandle[] {
+  const seenPaths = new Set<string>()
+  const handles: ProjectHandle[] = []
+
+  for (const input of inputs) {
+    for (const handle of input) {
+      if (seenPaths.has(handle.path)) {
+        continue
+      }
+
+      seenPaths.add(handle.path)
+      handles.push(handle)
+    }
+  }
+
+  return handles
+}
+
+export function combineProjects(inputs: readonly Projects[]): Projects {
+  let hasProjects = false
+  const seenPaths = new Set<string>()
+  const projects: Project[] = []
+
+  for (const input of inputs) {
+    if (input === undefined) {
+      continue
+    }
+
+    hasProjects = true
+    for (const project of input) {
+      if (seenPaths.has(project.path)) {
+        continue
+      }
+
+      seenPaths.add(project.path)
+      projects.push(project)
+    }
+  }
+
+  return hasProjects ? projects : undefined
 }
 
 export const systemIOContract = defineContract({
   systemIOService: defineService<SystemIOService>('system-io.service'),
+  projectHandlesValueSpec: defineValueSpec<
+    readonly ProjectHandle[],
+    readonly ProjectHandle[]
+  >({
+    name: 'system-io.project-handles',
+    defaultValue: [],
+    combine: combineProjectHandles,
+  }),
+  projectsValueSpec: defineValueSpec<Projects, Projects>({
+    name: 'system-io.projects',
+    defaultValue: undefined,
+    combine: combineProjects,
+  }),
 })
 
-export const { systemIOService } = systemIOContract
+export const { projectHandlesValueSpec, projectsValueSpec, systemIOService } =
+  systemIOContract

--- a/src/registry/extensions/systemIO/index.test.ts
+++ b/src/registry/extensions/systemIO/index.test.ts
@@ -1,0 +1,110 @@
+import { tmpdir } from 'node:os'
+import {
+  Registry,
+  defineRegistryItem,
+  provideService,
+} from '@kittycad/registry'
+import { signal } from '@preact/signals-core'
+import fsZds, { StorageName, moduleFsViaModuleImport } from '@src/lib/fs-zds'
+import type { SettingsType } from '@src/lib/settings/initialSettings'
+import {
+  type SettingsRegistryService,
+  settingsService,
+} from '@src/registry/contracts/settings'
+import { systemIOService } from '@src/registry/contracts/systemIO'
+import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { listProjectHandlesFromProjectDirectory, systemIOExtension } from '.'
+
+const cleanup: Array<() => Promise<void> | void> = []
+
+function createSettings(projectDirectory: string) {
+  return {
+    app: {
+      projectDirectory: {
+        current: projectDirectory,
+      },
+    },
+  } as SettingsType
+}
+
+describe('systemIO extension', () => {
+  beforeAll(async () => {
+    await moduleFsViaModuleImport({
+      type: StorageName.NodeFS,
+      options: {},
+    })
+  })
+
+  afterEach(async () => {
+    while (cleanup.length > 0) {
+      await cleanup.pop()?.()
+    }
+  })
+
+  it('provides empty project handles without a settings service', async () => {
+    const registry = new Registry()
+    cleanup.push(() => registry[Symbol.dispose]())
+    registry.configure([systemIOExtension])
+
+    const systemIO = registry.get(systemIOService)
+
+    expect(systemIO.projectHandles.value).toEqual([])
+    await expect(systemIO.refreshProjectHandles()).resolves.toEqual([])
+  })
+
+  it('lists immediate child directories from settings.app.projectDirectory', async () => {
+    const projectDirectory = fsZds.join(
+      tmpdir(),
+      `system-io-extension-${Date.now()}`
+    )
+    const alphaProject = fsZds.join(projectDirectory, 'alpha')
+    const betaProject = fsZds.join(projectDirectory, 'beta')
+    const hiddenProject = fsZds.join(projectDirectory, '.hidden')
+    const notesFile = fsZds.join(projectDirectory, 'notes.txt')
+
+    await fsZds.mkdir(alphaProject, { recursive: true })
+    await fsZds.mkdir(betaProject, { recursive: true })
+    await fsZds.mkdir(hiddenProject, { recursive: true })
+    await fsZds.writeFile(notesFile, new TextEncoder().encode('not a project'))
+    cleanup.push(() =>
+      fsZds.rm(projectDirectory, { recursive: true, force: true })
+    )
+
+    expect(
+      (await listProjectHandlesFromProjectDirectory(projectDirectory))
+        .map((handle) => handle.path)
+        .sort()
+    ).toEqual([alphaProject, betaProject])
+
+    const settings = signal(createSettings(projectDirectory))
+    const registry = new Registry()
+    cleanup.push(() => registry[Symbol.dispose]())
+    registry.configure([
+      defineRegistryItem({
+        id: 'test-settings-service',
+        providesServices: [
+          provideService(settingsService, {
+            current: settings,
+            get: () => settings.value,
+          } as SettingsRegistryService),
+        ],
+      }),
+      systemIOExtension,
+    ])
+
+    expect(
+      registry.get(settingsService).current.value.app.projectDirectory.current
+    ).toBe(projectDirectory)
+
+    const systemIO = registry.get(systemIOService)
+    const handles = await systemIO.refreshProjectHandles()
+
+    expect(handles.map((handle) => handle.path).sort()).toEqual([
+      alphaProject,
+      betaProject,
+    ])
+    expect(
+      systemIO.projectHandles.value.map((handle) => handle.path).sort()
+    ).toEqual([alphaProject, betaProject])
+  })
+})

--- a/src/registry/extensions/systemIO/index.test.ts
+++ b/src/registry/extensions/systemIO/index.test.ts
@@ -62,23 +62,26 @@ describe('systemIO extension', () => {
     }
   })
 
-  it('provides empty project handles without a settings service', async () => {
+  it('provides unloaded project handles until refreshed without a settings service', async () => {
     const registry = new Registry()
     cleanup.push(() => registry[Symbol.dispose]())
     registry.configure([systemIOExtension])
 
     const systemIO = registry.get(systemIOService)
 
-    expect(systemIO.projectHandles.value).toEqual([])
+    expect(systemIO.projectHandles.value).toBeUndefined()
     expect(systemIO.projects.value).toBeUndefined()
-    expect(registry.get(projectHandlesValueSpec)).toEqual([])
+    expect(registry.get(projectHandlesValueSpec)).toBeUndefined()
     expect(registry.get(projectsValueSpec)).toBeUndefined()
     await expect(systemIO.refreshProjectHandles()).resolves.toEqual([])
+    expect(systemIO.projectHandles.value).toEqual([])
+    expect(registry.get(projectHandlesValueSpec)).toEqual([])
   })
 
   it('combines project handle contributions by path', () => {
     expect(
       combineProjectHandles([
+        undefined,
         [{ path: '/projects/alpha' }, { path: '/projects/beta' }],
         [{ path: '/projects/beta' }, { path: '/projects/gamma' }],
       ])
@@ -87,6 +90,10 @@ describe('systemIO extension', () => {
       { path: '/projects/beta' },
       { path: '/projects/gamma' },
     ])
+  })
+
+  it('combines missing project handles as not loaded', () => {
+    expect(combineProjectHandles([undefined])).toBeUndefined()
   })
 
   it('combines project contributions by path', () => {
@@ -164,13 +171,62 @@ describe('systemIO extension', () => {
       betaProject,
     ])
     expect(
-      systemIO.projectHandles.value.map((handle) => handle.path).sort()
+      systemIO.projectHandles.value?.map((handle) => handle.path).sort()
     ).toEqual([alphaProject, betaProject])
     expect(
       registry
         .get(projectHandlesValueSpec)
-        .map((handle) => handle.path)
+        ?.map((handle) => handle.path)
         .sort()
     ).toEqual([alphaProject, betaProject])
+  })
+
+  it('clears project handles while a changed project directory refreshes', async () => {
+    const firstProjectDirectory = fsZds.join(
+      tmpdir(),
+      `system-io-extension-first-${Date.now()}`
+    )
+    const secondProjectDirectory = fsZds.join(
+      tmpdir(),
+      `system-io-extension-second-${Date.now()}`
+    )
+    const firstProject = fsZds.join(firstProjectDirectory, 'first')
+    const secondProject = fsZds.join(secondProjectDirectory, 'second')
+
+    await fsZds.mkdir(firstProject, { recursive: true })
+    await fsZds.mkdir(secondProject, { recursive: true })
+    cleanup.push(() =>
+      fsZds.rm(firstProjectDirectory, { recursive: true, force: true })
+    )
+    cleanup.push(() =>
+      fsZds.rm(secondProjectDirectory, { recursive: true, force: true })
+    )
+
+    const settings = signal(createSettings(firstProjectDirectory))
+    const registry = new Registry()
+    cleanup.push(() => registry[Symbol.dispose]())
+    registry.configure([
+      defineRegistryItem({
+        id: 'test-settings-service',
+        providesServices: [
+          provideService(settingsService, {
+            current: settings,
+            get: () => settings.value,
+          } as SettingsRegistryService),
+        ],
+      }),
+      systemIOExtension,
+    ])
+
+    const systemIO = registry.get(systemIOService)
+    await Promise.resolve()
+    await systemIO.refreshProjectHandles()
+    expect(systemIO.projectHandles.value?.map((handle) => handle.path)).toEqual(
+      [firstProject]
+    )
+
+    settings.value = createSettings(secondProjectDirectory)
+
+    expect(systemIO.projectHandles.value).toBeUndefined()
   })
 })

--- a/src/registry/extensions/systemIO/index.test.ts
+++ b/src/registry/extensions/systemIO/index.test.ts
@@ -6,12 +6,19 @@ import {
 } from '@kittycad/registry'
 import { signal } from '@preact/signals-core'
 import fsZds, { StorageName, moduleFsViaModuleImport } from '@src/lib/fs-zds'
+import type { Project } from '@src/lib/project'
 import type { SettingsType } from '@src/lib/settings/initialSettings'
 import {
   type SettingsRegistryService,
   settingsService,
 } from '@src/registry/contracts/settings'
-import { systemIOService } from '@src/registry/contracts/systemIO'
+import {
+  combineProjectHandles,
+  combineProjects,
+  projectHandlesValueSpec,
+  projectsValueSpec,
+  systemIOService,
+} from '@src/registry/contracts/systemIO'
 import { afterEach, beforeAll, describe, expect, it } from 'vitest'
 import { listProjectHandlesFromProjectDirectory, systemIOExtension } from '.'
 
@@ -25,6 +32,20 @@ function createSettings(projectDirectory: string) {
       },
     },
   } as SettingsType
+}
+
+function createProject(path: string, name: string): Project {
+  return {
+    path,
+    name,
+    title: name,
+    metadata: null,
+    kcl_file_count: 1,
+    directory_count: 0,
+    default_file: fsZds.join(path, 'main.kcl'),
+    children: [],
+    readWriteAccess: true,
+  }
 }
 
 describe('systemIO extension', () => {
@@ -49,7 +70,46 @@ describe('systemIO extension', () => {
     const systemIO = registry.get(systemIOService)
 
     expect(systemIO.projectHandles.value).toEqual([])
+    expect(systemIO.projects.value).toBeUndefined()
+    expect(registry.get(projectHandlesValueSpec)).toEqual([])
+    expect(registry.get(projectsValueSpec)).toBeUndefined()
     await expect(systemIO.refreshProjectHandles()).resolves.toEqual([])
+  })
+
+  it('combines project handle contributions by path', () => {
+    expect(
+      combineProjectHandles([
+        [{ path: '/projects/alpha' }, { path: '/projects/beta' }],
+        [{ path: '/projects/beta' }, { path: '/projects/gamma' }],
+      ])
+    ).toEqual([
+      { path: '/projects/alpha' },
+      { path: '/projects/beta' },
+      { path: '/projects/gamma' },
+    ])
+  })
+
+  it('combines project contributions by path', () => {
+    expect(
+      combineProjects([
+        undefined,
+        [
+          createProject('/projects/alpha', 'alpha'),
+          createProject('/projects/beta', 'beta'),
+        ],
+        [
+          createProject('/projects/beta', 'beta duplicate'),
+          createProject('/projects/gamma', 'gamma'),
+        ],
+      ])?.map((project) => ({
+        path: project.path,
+        name: project.name,
+      }))
+    ).toEqual([
+      { path: '/projects/alpha', name: 'alpha' },
+      { path: '/projects/beta', name: 'beta' },
+      { path: '/projects/gamma', name: 'gamma' },
+    ])
   })
 
   it('lists immediate child directories from settings.app.projectDirectory', async () => {
@@ -105,6 +165,12 @@ describe('systemIO extension', () => {
     ])
     expect(
       systemIO.projectHandles.value.map((handle) => handle.path).sort()
+    ).toEqual([alphaProject, betaProject])
+    expect(
+      registry
+        .get(projectHandlesValueSpec)
+        .map((handle) => handle.path)
+        .sort()
     ).toEqual([alphaProject, betaProject])
   })
 })

--- a/src/registry/extensions/systemIO/index.ts
+++ b/src/registry/extensions/systemIO/index.ts
@@ -12,6 +12,7 @@ import { fsZdsConstants } from '@src/lib/fs-zds/constants'
 import { settingsService } from '@src/registry/contracts/settings'
 import {
   type ProjectHandle,
+  type ProjectHandles,
   type Projects,
   type SystemIOService,
   projectHandlesValueSpec,
@@ -70,7 +71,7 @@ export async function listProjectHandlesFromProjectDirectory(
 }
 
 export const systemIOExtension = defineRegistryItemFactory((ctx) => {
-  const projectDirectoryProjectHandles = signal<readonly ProjectHandle[]>([])
+  const projectDirectoryProjectHandles = signal<ProjectHandles>(undefined)
   const projectHandles = ctx.valueSpecs.signal(projectHandlesValueSpec)
   const projects = ctx.valueSpecs.signal(projectsValueSpec)
   let latestProjectDirectoryPath = ''
@@ -85,11 +86,16 @@ export const systemIOExtension = defineRegistryItemFactory((ctx) => {
   const refreshProjectHandlesFromDirectory = async (
     projectDirectoryPath: string
   ) => {
+    const directoryChanged = projectDirectoryPath !== latestProjectDirectoryPath
     latestProjectDirectoryPath = projectDirectoryPath
+    if (directoryChanged) {
+      projectDirectoryProjectHandles.value = undefined
+    }
+
     const nextProjectHandles =
       await listProjectHandlesFromProjectDirectory(projectDirectoryPath)
 
-    if (projectDirectoryPath === latestProjectDirectoryPath) {
+    if (!disposed && projectDirectoryPath === latestProjectDirectoryPath) {
       projectDirectoryProjectHandles.value = nextProjectHandles
     }
 
@@ -141,17 +147,13 @@ export const systemIOExtension = defineRegistryItemFactory((ctx) => {
     watchedProjectDirectoryPath = projectDirectoryPath
   }
 
-  queueMicrotask(() => {
-    if (disposed) {
-      return
-    }
-
+  const activate = () => {
     disposeSettingsEffect = effect(() => {
       const projectDirectoryPath = getProjectDirectoryPath()
       watchProjectDirectory(projectDirectoryPath)
       void refreshProjectHandlesFromDirectory(projectDirectoryPath)
     })
-  })
+  }
 
   const serviceImpl: SystemIOService = {
     projectHandles,
@@ -168,6 +170,7 @@ export const systemIOExtension = defineRegistryItemFactory((ctx) => {
         }),
       ],
       providesServices: [provideService(systemIOService, serviceImpl)],
+      activate,
       dispose: () => {
         disposed = true
         disposeSettingsEffect?.()
@@ -180,17 +183,19 @@ export const systemIOExtension = defineRegistryItemFactory((ctx) => {
 export const systemIOProjectsExtension = defineRegistryItemFactory((ctx) => {
   const projectHandles = ctx.valueSpecs.signal(projectHandlesValueSpec)
   const projects = signal<Projects>(undefined)
-  let hasSkippedInitialEmptyProjectHandles = false
   let latestRefreshId = 0
   let disposed = false
   let disposeProjectHandlesEffect: (() => void) | undefined
 
   const getWasmPromise = () => ctx.valueSpecs.get(wasmPromiseValueSpec)
 
-  const refreshProjectsFromHandles = async (
-    handles: readonly ProjectHandle[]
-  ) => {
+  const refreshProjectsFromHandles = async (handles: ProjectHandles) => {
     const refreshId = ++latestRefreshId
+
+    if (handles === undefined) {
+      projects.value = undefined
+      return
+    }
 
     if (handles.length === 0) {
       projects.value = []
@@ -224,23 +229,11 @@ export const systemIOProjectsExtension = defineRegistryItemFactory((ctx) => {
     }
   }
 
-  queueMicrotask(() => {
-    if (disposed) {
-      return
-    }
-
+  const activate = () => {
     disposeProjectHandlesEffect = effect(() => {
-      if (
-        !hasSkippedInitialEmptyProjectHandles &&
-        projectHandles.value.length === 0
-      ) {
-        hasSkippedInitialEmptyProjectHandles = true
-        return
-      }
-
       void refreshProjectsFromHandles(projectHandles.value)
     })
-  })
+  }
 
   return {
     item: defineRuntimeRegistryItem({
@@ -250,6 +243,7 @@ export const systemIOProjectsExtension = defineRegistryItemFactory((ctx) => {
           key: 'system-io.project-handles',
         }),
       ],
+      activate,
       dispose: () => {
         disposed = true
         disposeProjectHandlesEffect?.()

--- a/src/registry/extensions/systemIO/index.ts
+++ b/src/registry/extensions/systemIO/index.ts
@@ -1,0 +1,122 @@
+import {
+  defineRegistryItem,
+  defineRegistryItemFactory,
+  defineRuntimeRegistryItem,
+  provideService,
+} from '@kittycad/registry'
+import { effect, signal } from '@preact/signals-core'
+import fsZds from '@src/lib/fs-zds'
+import { fsZdsConstants } from '@src/lib/fs-zds/constants'
+import { settingsService } from '@src/registry/contracts/settings'
+import {
+  type ProjectHandle,
+  type SystemIOService,
+  systemIOService,
+} from '@src/registry/contracts/systemIO'
+
+type ProjectHandleWithModified = ProjectHandle & {
+  modified: number
+}
+
+export async function listProjectHandlesFromProjectDirectory(
+  projectDirectoryPath: string
+): Promise<readonly ProjectHandle[]> {
+  if (!projectDirectoryPath) {
+    return []
+  }
+
+  let entries: string[]
+  try {
+    entries = await fsZds.readdir(projectDirectoryPath)
+  } catch {
+    return []
+  }
+
+  const handles: ProjectHandleWithModified[] = []
+
+  for (const entry of entries) {
+    if (entry.startsWith('.')) {
+      continue
+    }
+
+    const path = fsZds.join(projectDirectoryPath, entry)
+
+    try {
+      const stat = await fsZds.stat(path)
+      if (!(stat.mode & fsZdsConstants.S_IFDIR)) {
+        continue
+      }
+
+      handles.push({ path, modified: stat.mtimeMs })
+    } catch {
+      continue
+    }
+  }
+
+  return handles
+    .sort((a, b) => b.modified - a.modified)
+    .map(({ path }) => ({ path }))
+}
+
+export const systemIOExtension = defineRegistryItemFactory((ctx) => {
+  const projectHandles = signal<readonly ProjectHandle[]>([])
+  let latestProjectDirectoryPath = ''
+  let disposed = false
+  let disposeSettingsEffect: (() => void) | undefined
+
+  const getProjectDirectoryPath = () =>
+    ctx.services.optional(settingsService)?.current.value.app.projectDirectory
+      .current ?? ''
+
+  const refreshProjectHandlesFromDirectory = async (
+    projectDirectoryPath: string
+  ) => {
+    latestProjectDirectoryPath = projectDirectoryPath
+    const nextProjectHandles =
+      await listProjectHandlesFromProjectDirectory(projectDirectoryPath)
+
+    if (projectDirectoryPath === latestProjectDirectoryPath) {
+      projectHandles.value = nextProjectHandles
+    }
+
+    return nextProjectHandles
+  }
+
+  const refreshProjectHandles: SystemIOService['refreshProjectHandles'] =
+    () => {
+      return refreshProjectHandlesFromDirectory(getProjectDirectoryPath())
+    }
+
+  queueMicrotask(() => {
+    if (disposed) {
+      return
+    }
+
+    disposeSettingsEffect = effect(() => {
+      void refreshProjectHandlesFromDirectory(getProjectDirectoryPath())
+    })
+  })
+
+  const serviceImpl: SystemIOService = {
+    projectHandles,
+    refreshProjectHandles,
+  }
+
+  return {
+    item: defineRuntimeRegistryItem({
+      id: 'system-io-extension',
+      providesServices: [provideService(systemIOService, serviceImpl)],
+      dispose: () => {
+        disposed = true
+        disposeSettingsEffect?.()
+      },
+    }),
+  }
+}, 'system-io-extension')
+
+const systemIORegistryItem = defineRegistryItem({
+  id: 'systemIO',
+  uses: [systemIOExtension],
+})
+
+export default systemIORegistryItem

--- a/src/registry/extensions/systemIO/index.ts
+++ b/src/registry/extensions/systemIO/index.ts
@@ -9,6 +9,11 @@ import { effect, signal } from '@preact/signals-core'
 import { getProjectInfo } from '@src/lib/desktop'
 import fsZds from '@src/lib/fs-zds'
 import { fsZdsConstants } from '@src/lib/fs-zds/constants'
+import {
+  getOpfsCloudProjectMetadataIndex,
+  getOpfsCloudProjectModifiedTime,
+  opfsCloudSyncStatus,
+} from '@src/lib/fs-zds/opfsCloud'
 import { settingsService } from '@src/registry/contracts/settings'
 import {
   type ProjectHandle,
@@ -30,6 +35,10 @@ type ProjectHandleWithModified = ProjectHandle & {
 const getElectron = () =>
   typeof window === 'undefined' ? undefined : window.electron
 
+function normalizeProjectPathForCloudMetadata(projectPath: string) {
+  return projectPath.replaceAll('\\', '/').replace(/\/+$/g, '')
+}
+
 export async function listProjectHandlesFromProjectDirectory(
   projectDirectoryPath: string
 ): Promise<readonly ProjectHandle[]> {
@@ -45,6 +54,9 @@ export async function listProjectHandlesFromProjectDirectory(
   }
 
   const handles: ProjectHandleWithModified[] = []
+  const cloudProjectMetadataByPath = opfsCloudSyncStatus.value.enabled
+    ? await getOpfsCloudProjectMetadataIndex().catch(() => new Map())
+    : new Map()
 
   for (const entry of entries) {
     if (entry.startsWith('.')) {
@@ -59,7 +71,16 @@ export async function listProjectHandlesFromProjectDirectory(
         continue
       }
 
-      handles.push({ path, modified: stat.mtimeMs })
+      handles.push({
+        path,
+        modified:
+          getOpfsCloudProjectModifiedTime(
+            cloudProjectMetadataByPath.get(
+              normalizeProjectPathForCloudMetadata(path)
+            ),
+            stat.mtimeMs
+          ) ?? stat.mtimeMs,
+      })
     } catch {
       // Ignore entries that disappear or cannot be statted.
     }
@@ -82,6 +103,11 @@ export const systemIOExtension = defineRegistryItemFactory((ctx) => {
   const getProjectDirectoryPath = () =>
     ctx.services.optional(settingsService)?.current.value.app.projectDirectory
       .current ?? ''
+
+  const getProjectDirectoryRefreshState = () => ({
+    projectDirectoryPath: getProjectDirectoryPath(),
+    cloudSyncedAt: opfsCloudSyncStatus.value.lastSyncedAt,
+  })
 
   const refreshProjectHandlesFromDirectory = async (
     projectDirectoryPath: string
@@ -149,10 +175,11 @@ export const systemIOExtension = defineRegistryItemFactory((ctx) => {
 
   const activate = () => {
     disposeSettingsEffect = effect(() => {
-      const projectDirectoryPath = getProjectDirectoryPath()
+      const { projectDirectoryPath } = getProjectDirectoryRefreshState()
       watchProjectDirectory(projectDirectoryPath)
       void refreshProjectHandlesFromDirectory(projectDirectoryPath)
     })
+    return undefined
   }
 
   const serviceImpl: SystemIOService = {
@@ -209,11 +236,25 @@ export const systemIOProjectsExtension = defineRegistryItemFactory((ctx) => {
     }
 
     const wasmInstance = await wasmPromise
+    const cloudProjectMetadataByPath = opfsCloudSyncStatus.value.enabled
+      ? await getOpfsCloudProjectMetadataIndex().catch(() => new Map())
+      : new Map()
     const nextProjects: NonNullable<Projects> = []
 
     for (const handle of handles) {
       try {
         const project = await getProjectInfo(handle.path, wasmInstance)
+        const cloudMetadata = cloudProjectMetadataByPath.get(
+          normalizeProjectPathForCloudMetadata(handle.path)
+        )
+        project.cloudProjectId ??= cloudMetadata?.remoteProjectId
+        if (project.metadata) {
+          project.metadata.modified = getOpfsCloudProjectModifiedTime(
+            cloudMetadata,
+            project.metadata.modified
+          )
+        }
+
         if (project.kcl_file_count === 0 && project.readWriteAccess) {
           continue
         }
@@ -233,6 +274,7 @@ export const systemIOProjectsExtension = defineRegistryItemFactory((ctx) => {
     disposeProjectHandlesEffect = effect(() => {
       void refreshProjectsFromHandles(projectHandles.value)
     })
+    return undefined
   }
 
   return {

--- a/src/registry/extensions/systemIO/index.ts
+++ b/src/registry/extensions/systemIO/index.ts
@@ -2,21 +2,32 @@ import {
   defineRegistryItem,
   defineRegistryItemFactory,
   defineRuntimeRegistryItem,
+  provide,
   provideService,
 } from '@kittycad/registry'
 import { effect, signal } from '@preact/signals-core'
+import { getProjectInfo } from '@src/lib/desktop'
 import fsZds from '@src/lib/fs-zds'
 import { fsZdsConstants } from '@src/lib/fs-zds/constants'
 import { settingsService } from '@src/registry/contracts/settings'
 import {
   type ProjectHandle,
+  type Projects,
   type SystemIOService,
+  projectHandlesValueSpec,
+  projectsValueSpec,
   systemIOService,
 } from '@src/registry/contracts/systemIO'
+import { wasmPromiseValueSpec } from '@src/registry/contracts/wasm'
+
+const PROJECT_HANDLES_WATCHER_KEY = 'system-io.project-handles'
 
 type ProjectHandleWithModified = ProjectHandle & {
   modified: number
 }
+
+const getElectron = () =>
+  typeof window === 'undefined' ? undefined : window.electron
 
 export async function listProjectHandlesFromProjectDirectory(
   projectDirectoryPath: string
@@ -49,7 +60,7 @@ export async function listProjectHandlesFromProjectDirectory(
 
       handles.push({ path, modified: stat.mtimeMs })
     } catch {
-      continue
+      // Ignore entries that disappear or cannot be statted.
     }
   }
 
@@ -59,10 +70,13 @@ export async function listProjectHandlesFromProjectDirectory(
 }
 
 export const systemIOExtension = defineRegistryItemFactory((ctx) => {
-  const projectHandles = signal<readonly ProjectHandle[]>([])
+  const projectDirectoryProjectHandles = signal<readonly ProjectHandle[]>([])
+  const projectHandles = ctx.valueSpecs.signal(projectHandlesValueSpec)
+  const projects = ctx.valueSpecs.signal(projectsValueSpec)
   let latestProjectDirectoryPath = ''
   let disposed = false
   let disposeSettingsEffect: (() => void) | undefined
+  let watchedProjectDirectoryPath = ''
 
   const getProjectDirectoryPath = () =>
     ctx.services.optional(settingsService)?.current.value.app.projectDirectory
@@ -76,7 +90,7 @@ export const systemIOExtension = defineRegistryItemFactory((ctx) => {
       await listProjectHandlesFromProjectDirectory(projectDirectoryPath)
 
     if (projectDirectoryPath === latestProjectDirectoryPath) {
-      projectHandles.value = nextProjectHandles
+      projectDirectoryProjectHandles.value = nextProjectHandles
     }
 
     return nextProjectHandles
@@ -87,36 +101,166 @@ export const systemIOExtension = defineRegistryItemFactory((ctx) => {
       return refreshProjectHandlesFromDirectory(getProjectDirectoryPath())
     }
 
+  const unwatchProjectDirectory = () => {
+    const electron = getElectron()
+    if (!watchedProjectDirectoryPath || !electron) {
+      watchedProjectDirectoryPath = ''
+      return
+    }
+
+    electron.watchFileOff(
+      watchedProjectDirectoryPath,
+      PROJECT_HANDLES_WATCHER_KEY
+    )
+    watchedProjectDirectoryPath = ''
+  }
+
+  const watchProjectDirectory = (projectDirectoryPath: string) => {
+    if (watchedProjectDirectoryPath === projectDirectoryPath) {
+      return
+    }
+
+    unwatchProjectDirectory()
+
+    const electron = getElectron()
+    if (!projectDirectoryPath || !electron) {
+      return
+    }
+
+    electron.watchFileOn(
+      projectDirectoryPath,
+      PROJECT_HANDLES_WATCHER_KEY,
+      () => {
+        if (projectDirectoryPath !== getProjectDirectoryPath()) {
+          return
+        }
+
+        void refreshProjectHandlesFromDirectory(projectDirectoryPath)
+      }
+    )
+    watchedProjectDirectoryPath = projectDirectoryPath
+  }
+
   queueMicrotask(() => {
     if (disposed) {
       return
     }
 
     disposeSettingsEffect = effect(() => {
-      void refreshProjectHandlesFromDirectory(getProjectDirectoryPath())
+      const projectDirectoryPath = getProjectDirectoryPath()
+      watchProjectDirectory(projectDirectoryPath)
+      void refreshProjectHandlesFromDirectory(projectDirectoryPath)
     })
   })
 
   const serviceImpl: SystemIOService = {
     projectHandles,
+    projects,
     refreshProjectHandles,
   }
 
   return {
     item: defineRuntimeRegistryItem({
       id: 'system-io-extension',
+      provides: [
+        provide(projectHandlesValueSpec, projectDirectoryProjectHandles, {
+          key: 'system-io.project-directory',
+        }),
+      ],
       providesServices: [provideService(systemIOService, serviceImpl)],
       dispose: () => {
         disposed = true
         disposeSettingsEffect?.()
+        unwatchProjectDirectory()
       },
     }),
   }
 }, 'system-io-extension')
 
+export const systemIOProjectsExtension = defineRegistryItemFactory((ctx) => {
+  const projectHandles = ctx.valueSpecs.signal(projectHandlesValueSpec)
+  const projects = signal<Projects>(undefined)
+  let hasSkippedInitialEmptyProjectHandles = false
+  let latestRefreshId = 0
+  let disposed = false
+  let disposeProjectHandlesEffect: (() => void) | undefined
+
+  const getWasmPromise = () => ctx.valueSpecs.get(wasmPromiseValueSpec)
+
+  const refreshProjectsFromHandles = async (
+    handles: readonly ProjectHandle[]
+  ) => {
+    const refreshId = ++latestRefreshId
+
+    if (handles.length === 0) {
+      projects.value = []
+      return
+    }
+
+    const wasmPromise = getWasmPromise()
+    if (!wasmPromise) {
+      projects.value = []
+      return
+    }
+
+    const wasmInstance = await wasmPromise
+    const nextProjects: NonNullable<Projects> = []
+
+    for (const handle of handles) {
+      try {
+        const project = await getProjectInfo(handle.path, wasmInstance)
+        if (project.kcl_file_count === 0 && project.readWriteAccess) {
+          continue
+        }
+
+        nextProjects.push(project)
+      } catch {
+        // Ignore handles that no longer point at readable projects.
+      }
+    }
+
+    if (!disposed && refreshId === latestRefreshId) {
+      projects.value = nextProjects
+    }
+  }
+
+  queueMicrotask(() => {
+    if (disposed) {
+      return
+    }
+
+    disposeProjectHandlesEffect = effect(() => {
+      if (
+        !hasSkippedInitialEmptyProjectHandles &&
+        projectHandles.value.length === 0
+      ) {
+        hasSkippedInitialEmptyProjectHandles = true
+        return
+      }
+
+      void refreshProjectsFromHandles(projectHandles.value)
+    })
+  })
+
+  return {
+    item: defineRuntimeRegistryItem({
+      id: 'system-io-projects-extension',
+      provides: [
+        provide(projectsValueSpec, projects, {
+          key: 'system-io.project-handles',
+        }),
+      ],
+      dispose: () => {
+        disposed = true
+        disposeProjectHandlesEffect?.()
+      },
+    }),
+  }
+}, 'system-io-projects-extension')
+
 const systemIORegistryItem = defineRegistryItem({
   id: 'systemIO',
-  uses: [systemIOExtension],
+  uses: [systemIOExtension, systemIOProjectsExtension],
 })
 
 export default systemIORegistryItem

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -68,7 +68,10 @@ import { withSiteBaseURL } from '@src/lib/withBaseURL'
 import { BillingTransition } from '@src/machines/billingMachine'
 import { useCanReadWriteProjectDirectory } from '@src/machines/systemIO/hooks'
 import type { systemIOMachine } from '@src/machines/systemIO/systemIOMachine'
-import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
+import {
+  SystemIOMachineEvents,
+  SystemIOMachineStates,
+} from '@src/machines/systemIO/utils'
 import type { WebContentSendPayload } from '@src/menu/channels'
 import {
   HOME_KEYMAP_SCOPE,

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -1,4 +1,3 @@
-import { effect as createSignalEffect } from '@preact/signals-core'
 import { useSignals } from '@preact/signals-react/runtime'
 import type { Dispatch, FormEvent, HTMLProps, SetStateAction } from 'react'
 import { useEffect, useMemo, useState } from 'react'
@@ -41,10 +40,7 @@ import {
 } from '@src/lib/autoUpdate'
 import { useApp, useSingletons } from '@src/lib/boot'
 import { createRouteCommands } from '@src/lib/commandBarConfigs/routeCommandConfig'
-import {
-  opfsCloudSyncStatus,
-  setOpfsCloudSyncProjectScope,
-} from '@src/lib/fs-zds/opfsCloud'
+import { setOpfsCloudSyncProjectScope } from '@src/lib/fs-zds/opfsCloud'
 import { isDesktop } from '@src/lib/isDesktop'
 import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
 import {
@@ -68,10 +64,7 @@ import { withSiteBaseURL } from '@src/lib/withBaseURL'
 import { BillingTransition } from '@src/machines/billingMachine'
 import { useCanReadWriteProjectDirectory } from '@src/machines/systemIO/hooks'
 import type { systemIOMachine } from '@src/machines/systemIO/systemIOMachine'
-import {
-  SystemIOMachineEvents,
-  SystemIOMachineStates,
-} from '@src/machines/systemIO/utils'
+import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
 import type { WebContentSendPayload } from '@src/menu/channels'
 import {
   HOME_KEYMAP_SCOPE,
@@ -92,7 +85,7 @@ import {
   needsToOnboard,
   onDismissOnboardingInvite,
 } from '@src/routes/Onboarding/utils'
-import { type ActorRefFrom, waitFor } from 'xstate'
+import type { ActorRefFrom } from 'xstate'
 
 type ReadWriteProjectState = {
   value: boolean
@@ -214,37 +207,6 @@ const Home = () => {
   const settingsValues = settings.useSettings()
   const machineApiEnabled = settingsValues.app.machineApi.current
   const onboardingStatus = settingsValues.app.onboardingStatus.current
-
-  useEffect(() => {
-    let disposed = false
-    let lastHandledSyncedAt: string | undefined
-
-    const disposeCloudSyncRefreshEffect = createSignalEffect(() => {
-      const syncedAt = opfsCloudSyncStatus.value.lastSyncedAt
-      if (!syncedAt || syncedAt === lastHandledSyncedAt) {
-        return
-      }
-
-      lastHandledSyncedAt = syncedAt
-      void waitFor(systemIOActor, (state) =>
-        state.matches(SystemIOMachineStates.idle)
-      )
-        .then(() => {
-          if (disposed || lastHandledSyncedAt !== syncedAt) {
-            return
-          }
-          systemIOActor.send({
-            type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
-          })
-        })
-        .catch(reportRejection)
-    })
-
-    return () => {
-      disposed = true
-      disposeCloudSyncRefreshEffect()
-    }
-  }, [systemIOActor])
 
   // Menu listeners
   const cb = (data: WebContentSendPayload) => {

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -66,16 +66,9 @@ import { reportRejection } from '@src/lib/trap'
 import { platform } from '@src/lib/utils'
 import { withSiteBaseURL } from '@src/lib/withBaseURL'
 import { BillingTransition } from '@src/machines/billingMachine'
-import {
-  useCanReadWriteProjectDirectory,
-  useFolders,
-  useState as useSystemIOState,
-} from '@src/machines/systemIO/hooks'
+import { useCanReadWriteProjectDirectory } from '@src/machines/systemIO/hooks'
 import type { systemIOMachine } from '@src/machines/systemIO/systemIOMachine'
-import {
-  SystemIOMachineEvents,
-  SystemIOMachineStates,
-} from '@src/machines/systemIO/utils'
+import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
 import type { WebContentSendPayload } from '@src/menu/channels'
 import {
   HOME_KEYMAP_SCOPE,
@@ -89,6 +82,7 @@ import {
   statusBarGlobalItemsValueSpec,
   statusBarLocalItemsValueSpec,
 } from '@src/registry/contracts/statusBar'
+import { projectsValueSpec } from '@src/registry/contracts/systemIO'
 import { APP_COMMAND_IDS } from '@src/registry/extensions/commands/appCommands'
 import {
   acceptOnboarding,
@@ -133,10 +127,11 @@ const Home = () => {
   const apiToken = auth.useToken()
   const networkMachineStatus = useNetworkMachineStatus()
   const billingContext = billing.useContext()
-  const hasUnlimitedCredits = billingContext.balance === Infinity
+  const hasUnlimitedCredits =
+    billingContext.balance === Number.POSITIVE_INFINITY
   const openBillingLinkExternally = openExternalBrowserIfDesktop()
 
-  const projects = useFolders()
+  const projects = registry.signal(projectsValueSpec).value
   const projectStatuses = useProjectStatuses(projects, apiToken)
   const [optimisticProjectRenames, setOptimisticProjectRenames] =
     useState<OptimisticProjectRenames>({})
@@ -197,6 +192,7 @@ const Home = () => {
   }, [navigate, location, commands])
 
   // Only create the native file menus on desktop
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Existing mount-only setup effect.
   useEffect(() => {
     if (window.electron) {
       window.electron
@@ -672,18 +668,12 @@ function ProjectGrid({
   ...rest
 }: ProjectGridProps) {
   const { systemIOActor } = useApp()
-  const state = useSystemIOState()
-  const isReadingFolders = state.matches(SystemIOMachineStates.readingFolders)
+  const isReadingProjects = projects === undefined
   const sortedSearchResults = searchResults.toSorted(getSortFunction(sort))
-  const loadingMore = isReadingFolders ? (
-    <div className="py-4">
-      <Loading isDummy={true}>Loading more projects...</Loading>
-    </div>
-  ) : null
 
   return (
     <section data-testid="home-section" {...rest}>
-      {projects === undefined || (isReadingFolders && projects.length === 0) ? (
+      {isReadingProjects ? (
         <Loading isDummy={true}>Loading your Projects...</Loading>
       ) : (
         <>
@@ -714,7 +704,6 @@ function ProjectGrid({
                 : ` with the search term "${query}"`}
             </p>
           )}
-          {loadingMore}
         </>
       )}
     </section>
@@ -741,7 +730,7 @@ function handleRenameProject(
     SetStateAction<OptimisticProjectRenames>
   >
 ) {
-  return async function (e: FormEvent<HTMLFormElement>, project: Project) {
+  return async (e: FormEvent<HTMLFormElement>, project: Project) => {
     const { newProjectName } = Object.fromEntries(
       new FormData(e.target as HTMLFormElement)
     )
@@ -781,7 +770,7 @@ function handleRenameProject(
 function handleDeleteProject(
   systemIOActor: ActorRefFrom<typeof systemIOMachine>
 ) {
-  return async function (project: Project) {
+  return async (project: Project) => {
     systemIOActor.send({
       type: SystemIOMachineEvents.deleteProject,
       data: {


### PR DESCRIPTION
## Summary

- add a systemIO registry contract and extension that provides `projectHandles` and derived `projects`
- switch Home project listings to consume the registry `projects` value while leaving existing project actions on `systemIOActor`
- add an incremental compatibility bridge that syncs registry-derived projects into `systemIOActor.context.folders`

## Motivation

This starts dismantling the systemIO machine incrementally by moving stable project-listing state into registry values and services first. The existing actor remains in place for workflows that still depend on it, but its folder state can now be derived from the registry surface.

This PR is stacked on `franknoirot/system-io-audit`, which contains the settings service migration.

## Validation

- `npm run test:unit -- src/registry/extensions/systemIO/index.test.ts`
- `npm run test:integration -- src/machines/systemIO/systemIOMachine.spec.ts`
- `npm run tsc -- --noEmit`