### PR TITLE
Add project session registry service

### DIFF
--- a/src/components/SystemIOMachineLogicListener.tsx
+++ b/src/components/SystemIOMachineLogicListener.tsx
@@ -9,10 +9,10 @@ import {
 import fsZds from '@src/lib/fs-zds'
 import makeUrlPathRelative from '@src/lib/makeUrlPathRelative'
 import {
-  PATHS,
   getProjectDirectoryFromKCLFilePath,
   joinOSPaths,
   joinRouterPaths,
+  PATHS,
   safeEncodeForRouterPaths,
   webSafePathSplit,
 } from '@src/lib/paths'
@@ -29,8 +29,7 @@ import {
   SystemIOMachineStates,
 } from '@src/machines/systemIO/utils'
 import { useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
-import { useLocation } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 
 export function SystemIOMachineLogicListener() {
   const { settings, systemIOActor } = useApp()

--- a/src/components/SystemIOMachineLogicListener.tsx
+++ b/src/components/SystemIOMachineLogicListener.tsx
@@ -135,6 +135,8 @@ export function SystemIOMachineLogicListener() {
         SystemIOMachineStates.bulkCreateAndDeletingKCLFilesAndNavigateToFile,
         SystemIOMachineStates.renamingFileAndNavigateToFile,
         SystemIOMachineStates.renamingFolderAndNavigateToFile,
+        SystemIOMachineStates.deletingFileOrFolderAndNavigate,
+        SystemIOMachineStates.movingRecursiveAndNavigate,
       ]
       if (
         requestedFileName.project &&

--- a/src/lang/KclManager.spec.ts
+++ b/src/lang/KclManager.spec.ts
@@ -5,13 +5,12 @@ import type {
 } from '@rust/kcl-lib/bindings/FrontendApi'
 import { createEmptyAst } from '@src/editor/plugins/ast'
 import { File, KclManager } from '@src/lang/KclManager'
-import { afterEach, describe, expect, it, vi } from 'vitest'
-import { waitFor } from 'xstate'
-
 import {
   createKclManagerTestHarness,
   getLatestDispatchedDiagnostics,
 } from '@src/lang/testHelpers/kclManagerTestHarness'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { waitFor } from 'xstate'
 
 function createDeferred<T>() {
   let resolve!: (value: T) => void

--- a/src/lang/KclManager.spec.ts
+++ b/src/lang/KclManager.spec.ts
@@ -6,6 +6,7 @@ import type {
 import { createEmptyAst } from '@src/editor/plugins/ast'
 import { File, KclManager } from '@src/lang/KclManager'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { waitFor } from 'xstate'
 
 import {
   createKclManagerTestHarness,
@@ -638,6 +639,46 @@ describe('KclManager diagnostics', () => {
     await vi.advanceTimersByTimeAsync(1000)
 
     expect(executeCodeSpy).toHaveBeenCalledWith(mainCode)
+  })
+
+  it('reactivates settings subscriptions when reusing a closed singleton editor', async () => {
+    const { app, kclManager } = createKclManagerTestHarness('')
+    await waitFor(app.settings.actor, (state) => state.matches('idle'))
+
+    const path = '/tmp/kcl-manager-settings-reactivation-test.kcl'
+    const readSpy = vi
+      .spyOn(File.ioImplementations, 'read')
+      .mockResolvedValue('opened code')
+    const setAutomaticallyRenderSpy = vi.spyOn(
+      kclManager,
+      'setEditorAutomaticallyRender'
+    )
+
+    kclManager.close()
+
+    const opened = await KclManager.fromFile(
+      new File(path, 102),
+      (kclManager as any).systemDeps,
+      kclManager
+    )
+
+    expect(opened).toBe(kclManager)
+    setAutomaticallyRenderSpy.mockClear()
+
+    app.settings.actor.send({
+      type: 'set.textEditor.automaticallyRender',
+      data: {
+        level: 'user',
+        value: false,
+      },
+      doNotPersist: true,
+    } as never)
+    await waitFor(app.settings.actor, (state) => state.matches('idle'))
+
+    expect(setAutomaticallyRenderSpy).toHaveBeenCalledWith(false)
+
+    readSpy.mockRestore()
+    setAutomaticallyRenderSpy.mockRestore()
   })
 
   it('does not overwrite dirty editor state when an external reload resolves later', async () => {

--- a/src/lang/KclManager.spec.ts
+++ b/src/lang/KclManager.spec.ts
@@ -549,6 +549,29 @@ describe('KclManager diagnostics', () => {
     expect(kclManager.code).toBe('from disk')
   })
 
+  it('reloads clean editor state from explicit disk refreshes', async () => {
+    const { kclManager } = createKclManagerTestHarness('from disk')
+
+    kclManager.path = '/tmp/kcl-manager-explicit-reload-test.kcl'
+    ;(kclManager as any).markFileCodeAsSynced('from disk')
+
+    vi.spyOn(File.ioImplementations, 'read').mockResolvedValue('sketch = 1')
+    const updateSpy = vi.spyOn(kclManager, 'updateCodeEditor')
+
+    await kclManager.reloadFromDisk()
+
+    expect(updateSpy).toHaveBeenCalledWith(
+      'sketch = 1',
+      expect.objectContaining({
+        shouldExecute: true,
+        shouldClearHistory: true,
+        shouldResetCamera: true,
+        shouldWriteToDisk: false,
+      })
+    )
+    expect(kclManager.code).toBe('sketch = 1')
+  })
+
   it('arms disk watcher when reusing the singleton editor for an opened file', async () => {
     const { kclManager } = createKclManagerTestHarness('')
     const path = '/tmp/kcl-manager-watch-open-test.kcl'

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -2004,7 +2004,7 @@ export class KclManager extends File {
       })
     }
     providedEditor.markFileCodeAsSynced(diskCode)
-    providedEditor.watch()
+    providedEditor.reactivateFileLifecycle()
     return providedEditor
   }
 
@@ -2041,10 +2041,7 @@ export class KclManager extends File {
       zookeeperHistoryExtension(),
     ])
     this._editorView = this.createEditorView(initialCode)
-    this.settingsSubscription = this.systemDeps.settings.subscribe(() => {
-      this.setEditorAutomaticallyRender(this.getAutomaticallyRenderSetting())
-    })
-    this.setEditorAutomaticallyRender(this.getAutomaticallyRenderSetting())
+    this.subscribeToSettingsUpdates()
     // TODO: Delete this._code, only derive from the editorView's doc
     this._code.value = initialCode
     this.markFileCodeAsSynced(initialCode)
@@ -2081,9 +2078,23 @@ export class KclManager extends File {
     clearTimeout(this.timeoutWriter)
     clearTimeout(this.timeoutRewatch)
     this.settingsSubscription?.unsubscribe()
+    this.settingsSubscription = undefined
     this.disposeGlobalHistorySubscription?.()
     this.flushRecoverySnapshot()
     this.unwatch()
+  }
+
+  public reactivateFileLifecycle() {
+    this.subscribeToSettingsUpdates()
+    this.watch()
+  }
+
+  private subscribeToSettingsUpdates() {
+    this.settingsSubscription?.unsubscribe()
+    this.settingsSubscription = this.systemDeps.settings.subscribe(() => {
+      this.setEditorAutomaticallyRender(this.getAutomaticallyRenderSetting())
+    })
+    this.setEditorAutomaticallyRender(this.getAutomaticallyRenderSetting())
   }
 
   private markFileCodeAsSynced(code: string) {

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -1,81 +1,3 @@
-import type { EntityType } from '@kittycad/lib'
-import type { Node } from '@rust/kcl-lib/bindings/Node'
-import type { Operation } from '@rust/kcl-lib/bindings/Operation'
-import { SceneInfra } from '@src/clientSideScene/sceneInfra'
-import {
-  artifactAnnotationsEvent,
-  setArtifactGraphEffect,
-} from '@src/editor/plugins/artifacts'
-import type { KCLError } from '@src/lang/errors'
-import {
-  compilationIssuesToDiagnostics,
-  kclErrorsToDiagnostics,
-} from '@src/lang/errors'
-import { executeAst, executeAstMock, lintAst } from '@src/lang/langHelpers'
-import { getNodeFromPath, getSettingsAnnotation } from '@src/lang/queryAst'
-import { CommandLogType } from '@src/lang/std/commandLog'
-import { isTopLevelModule, topLevelRange } from '@src/lang/util'
-import type {
-  ArtifactGraph,
-  ExecCallbacks,
-  ExecState,
-  OperationCallbackArgs,
-  OperationsByModule,
-  PathToNode,
-  Program,
-  VariableMap,
-} from '@src/lang/wasm'
-import {
-  applyOperationCallbackToOperationsByModule,
-  emptyExecState,
-  emptyOperationsByModule,
-  execStateFromRust,
-  getKclVersion,
-  getOperationsForCurrentFile,
-  getSketchCheckpointLimit,
-  parse,
-  recast,
-} from '@src/lang/wasm'
-import type { ArtifactIndex } from '@src/lib/artifactIndex'
-import { buildArtifactIndex } from '@src/lib/artifactIndex'
-import {
-  DEFAULT_DEFAULT_LENGTH_UNIT,
-  DEFAULT_EXPERIMENTAL_FEATURES,
-  EXECUTE_AST_INTERRUPT_ERROR_MESSAGE,
-} from '@src/lib/constants'
-import { getOperationKey } from '@src/lib/featureTreeOperationTree'
-import fsZds from '@src/lib/fs-zds'
-import { markOnce } from '@src/lib/performance'
-import type RustContext from '@src/lib/rustContext'
-import type {
-  BaseUnit,
-  KclSettingsAnnotation,
-} from '@src/lib/settings/settingsTypes'
-import {
-  getSettingsFromActorContext,
-  jsAppSettings,
-} from '@src/lib/settings/settingsUtils'
-
-import {
-  FALLBACK_SKETCH_CHECKPOINT_LIMIT,
-  createHistoryExtension,
-} from '@src/editor/historyConfig'
-import { EngineDebugger } from '@src/lib/debugger'
-import {
-  type handleSelectionBatch as handleSelectionBatchFn,
-  processCodeMirrorRanges,
-  type processCodeMirrorRanges as processCodeMirrorRangesFn,
-} from '@src/lib/selections'
-import { err, reportRejection } from '@src/lib/trap'
-import { deferredCallback, uuidv4 } from '@src/lib/utils'
-import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
-import type {
-  PlaneVisibilityMap,
-  Selection,
-  Selections,
-} from '@src/machines/modelingSharedTypes'
-import type { ConnectionManager } from '@src/network/connectionManager'
-
 import {
   invertedEffects,
   isolateHistory,
@@ -97,37 +19,40 @@ import {
   type TransactionSpec,
 } from '@codemirror/state'
 import type { KeyBinding, ViewUpdate } from '@codemirror/view'
-import { EditorView, drawSelection, keymap } from '@codemirror/view'
-import {
-  clearSceneSelection,
-  defaultSelectionFilter,
-  setSelectionFilter,
-  setSelectionFilterToDefault,
-} from '@src/lib/selectionFilterUtils'
-import type { StateFrom, Subscription } from 'xstate'
-
-import {
-  addLineHighlight,
-  addLineHighlightEvent,
-} from '@src/editor/highlightextension'
-
-import { type Signal, computed, signal } from '@preact/signals-core'
+import { drawSelection, EditorView, keymap } from '@codemirror/view'
+import type { EntityType } from '@kittycad/lib'
+import { computed, type Signal, signal } from '@preact/signals-core'
 import type {
   ApiFile,
   SceneGraphDelta,
   SourceDelta,
 } from '@rust/kcl-lib/bindings/FrontendApi'
+import type { Node } from '@rust/kcl-lib/bindings/Node'
+import type { Operation } from '@rust/kcl-lib/bindings/Operation'
 import { SceneEntities } from '@src/clientSideScene/sceneEntities'
+import { SceneInfra } from '@src/clientSideScene/sceneInfra'
 import {
   baseEditorExtensions,
   cursorBlinkingCompartment,
   lineWrappingCompartment,
 } from '@src/editor'
+import { historyCompartment } from '@src/editor/compartments'
 import {
   HistoryView,
   type TransactionSpecNoChanges,
 } from '@src/editor/HistoryView'
-import { historyCompartment } from '@src/editor/compartments'
+import {
+  addLineHighlight,
+  addLineHighlightEvent,
+} from '@src/editor/highlightextension'
+import {
+  createHistoryExtension,
+  FALLBACK_SKETCH_CHECKPOINT_LIMIT,
+} from '@src/editor/historyConfig'
+import {
+  artifactAnnotationsEvent,
+  setArtifactGraphEffect,
+} from '@src/editor/plugins/artifacts'
 import {
   createEmptyAst,
   setAstEffect,
@@ -150,26 +75,96 @@ import {
   themeCompartment,
 } from '@src/editor/plugins/theme'
 import { requestWriteToFile } from '@src/editor/plugins/write'
-import { zookeeperHistoryExtension } from '@src/lib/zookeeper/editorPlugin'
+import type { KCLError } from '@src/lang/errors'
+import {
+  compilationIssuesToDiagnostics,
+  kclErrorsToDiagnostics,
+} from '@src/lang/errors'
+import { executeAst, executeAstMock, lintAst } from '@src/lang/langHelpers'
+import { getNodeFromPath, getSettingsAnnotation } from '@src/lang/queryAst'
+import { CommandLogType } from '@src/lang/std/commandLog'
 import { projectFsManager } from '@src/lang/std/fileSystemManager'
+import { isTopLevelModule, topLevelRange } from '@src/lang/util'
+import type {
+  ArtifactGraph,
+  ExecCallbacks,
+  ExecState,
+  OperationCallbackArgs,
+  OperationsByModule,
+  PathToNode,
+  Program,
+  VariableMap,
+} from '@src/lang/wasm'
+import {
+  applyOperationCallbackToOperationsByModule,
+  emptyExecState,
+  emptyOperationsByModule,
+  execStateFromRust,
+  getKclVersion,
+  getOperationsForCurrentFile,
+  getSketchCheckpointLimit,
+  parse,
+  recast,
+} from '@src/lang/wasm'
 import type { App } from '@src/lib/app'
+import type { ArtifactIndex } from '@src/lib/artifactIndex'
+import { buildArtifactIndex } from '@src/lib/artifactIndex'
 import { getAutomaticallyRenderEnabledFromSettings } from '@src/lib/automaticRendering'
 import { isCodeTheSame, normalizeLineEndings } from '@src/lib/codeEditor'
+import {
+  DEFAULT_DEFAULT_LENGTH_UNIT,
+  DEFAULT_EXPERIMENTAL_FEATURES,
+  EXECUTE_AST_INTERRUPT_ERROR_MESSAGE,
+} from '@src/lib/constants'
+import { EngineDebugger } from '@src/lib/debugger'
 import { isPathNotFoundError } from '@src/lib/desktop'
 import { bracket } from '@src/lib/exampleKcl'
+import { getOperationKey } from '@src/lib/featureTreeOperationTree'
+import fsZds from '@src/lib/fs-zds'
 import { setKclVersion } from '@src/lib/kclVersion'
 import { getStringAfterLastSeparator } from '@src/lib/paths'
+import { markOnce } from '@src/lib/performance'
 import type { FileEntry, Project } from '@src/lib/project'
 import { resetCameraPosition } from '@src/lib/resetCameraPosition'
+import type RustContext from '@src/lib/rustContext'
 import { createThumbnailPNGOnDesktop } from '@src/lib/screenshot'
-import { getSelectionTypeDisplayText } from '@src/lib/selections'
-import { type Themes, getOppositeTheme, getResolvedTheme } from '@src/lib/theme'
+import {
+  clearSceneSelection,
+  defaultSelectionFilter,
+  setSelectionFilter,
+  setSelectionFilterToDefault,
+} from '@src/lib/selectionFilterUtils'
+import {
+  getSelectionTypeDisplayText,
+  type handleSelectionBatch as handleSelectionBatchFn,
+  processCodeMirrorRanges,
+  type processCodeMirrorRanges as processCodeMirrorRangesFn,
+} from '@src/lib/selections'
+import type {
+  BaseUnit,
+  KclSettingsAnnotation,
+} from '@src/lib/settings/settingsTypes'
+import {
+  getSettingsFromActorContext,
+  jsAppSettings,
+} from '@src/lib/settings/settingsUtils'
+import { getOppositeTheme, getResolvedTheme, type Themes } from '@src/lib/theme'
+import { err, reportRejection } from '@src/lib/trap'
+import { deferredCallback, uuidv4 } from '@src/lib/utils'
+import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
+import { zookeeperHistoryExtension } from '@src/lib/zookeeper/editorPlugin'
 import type { CommandBarActorType } from '@src/machines/commandBarMachine'
 import type {
   ModelingMachineEvent,
   modelingMachine,
 } from '@src/machines/modelingMachine'
+import type {
+  PlaneVisibilityMap,
+  Selection,
+  Selections,
+} from '@src/machines/modelingSharedTypes'
 import type { SettingsActorType } from '@src/machines/settingsMachine'
+import type { ConnectionManager } from '@src/network/connectionManager'
 import type { ExecutingEditorService } from '@src/registry/contracts/executingEditor'
 import {
   CODE_EDITOR_FOCUSED_KEYMAP_SCOPE,
@@ -177,6 +172,7 @@ import {
   type KeymapService,
 } from '@src/registry/contracts/keymap'
 import toast from 'react-hot-toast'
+import type { StateFrom, Subscription } from 'xstate'
 
 interface ExecuteArgs {
   ast?: Node<Program>
@@ -390,6 +386,34 @@ export class ZDSProject {
       .find(([p]) => p.value === path)
   }
 
+  private pathContainsFile(targetPath: string, filePath: string) {
+    const targetPathPrefix = targetPath.endsWith(fsZds.sep)
+      ? targetPath
+      : `${targetPath}${fsZds.sep}`
+    return filePath === targetPath || filePath.startsWith(targetPathPrefix)
+  }
+
+  removePathFromFileRegistry(targetPath: string) {
+    const removedFiles = this.files.filter((file) =>
+      this.pathContainsFile(targetPath, file.path)
+    )
+    this.files = this.files.filter(
+      (file) => !this.pathContainsFile(targetPath, file.path)
+    )
+
+    for (const [pathSignal] of this.editors.entries()) {
+      if (!this.pathContainsFile(targetPath, pathSignal.value)) {
+        continue
+      }
+      if (this.#executingPath.value === pathSignal) {
+        this.#executingPath.value = null
+      }
+      this.editors.delete(pathSignal)
+    }
+
+    return removedFiles
+  }
+
   private deleteEditorReferences(editor: KclManager, exceptPath?: string) {
     for (const [pathSignal, foundEditor] of this.editors.entries()) {
       if (foundEditor === editor && pathSignal.value !== exceptPath) {
@@ -531,7 +555,7 @@ export class ZDSProject {
     // We ignore all currently-opened editors. The project watcher is meant
     // only to notify about the rest of the project's updates, and pass them
     // into the currently-executing editor.
-    if (foundEditorKey) {
+    if (foundEditorKey && eventType !== 'unlink') {
       return
     }
 
@@ -559,11 +583,10 @@ export class ZDSProject {
           }
           break
         case 'unlink':
-          const foundIndex = this.files.findIndex((f) => f.path === path)
-          if (foundIndex >= 0 && path !== this.executingPath && foundFile) {
-            this.files = this.files.filter((_, i) => i !== foundIndex)
+          const removedFiles = this.removePathFromFileRegistry(path)
+          for (const removedFile of removedFiles) {
             editor?.rustContext
-              .sendRemoveFile(foundFile.id)
+              .sendRemoveFile(removedFile.id)
               .catch(reportRejection)
           }
       }

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -390,6 +390,14 @@ export class ZDSProject {
       .find(([p]) => p.value === path)
   }
 
+  private deleteEditorReferences(editor: KclManager, exceptPath?: string) {
+    for (const [pathSignal, foundEditor] of this.editors.entries()) {
+      if (foundEditor === editor && pathSignal.value !== exceptPath) {
+        this.editors.delete(pathSignal)
+      }
+    }
+  }
+
   // Saving some keystrokes
   private set = this.editors.set.bind(this.editors)
 
@@ -407,15 +415,15 @@ export class ZDSProject {
   ) {
     const foundEditor = this.findEditor(path)
     const found = foundEditor?.[1]
-    if (
-      found &&
-      (!providedEditor || found !== providedEditor || found.path === path)
-    ) {
+    if (found && found.path === path) {
       if (isExecuting) {
         this.executingPath = path
       }
       console.warn(`Attempted to overwrite editor with path "${path}"`)
       return found
+    }
+    if (foundEditor) {
+      this.editors.delete(foundEditor[0])
     }
 
     const systemDeps: SystemDeps = {
@@ -463,6 +471,7 @@ export class ZDSProject {
     if (newEditor.path !== path) {
       newEditor.path = path
     }
+    this.deleteEditorReferences(newEditor, path)
 
     // Initialize the editor theme
     // Subsequent changes are listened for within app.onSettingsUpdate()

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -411,6 +411,9 @@ export class ZDSProject {
       found &&
       (!providedEditor || found !== providedEditor || found.path === path)
     ) {
+      if (isExecuting) {
+        this.executingPath = path
+      }
       console.warn(`Attempted to overwrite editor with path "${path}"`)
       return found
     }

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -3578,6 +3578,36 @@ export class KclManager extends File {
     this.updateLastCommittedSketchCheckpoint(resolvedOptions, additionalSpec)
     this.setDiagnosticsForCurrentErrors()
   }
+
+  async reloadFromDisk(
+    options: Partial<UpdateCodeEditorOptions> = {}
+  ): Promise<void> {
+    const code = normalizeLineEndings(await this.read())
+    if (isCodeTheSame(code, this.code)) {
+      this.markFileCodeAsSynced(code)
+      return
+    }
+
+    if (this.hasUnsavedLocalChanges()) {
+      console.warn(
+        'External file change detected while local edits are unsaved. Skipping automatic reload to avoid overwriting the editor buffer.'
+      )
+      toast.error(
+        'File changed on disk while this editor has unsaved changes. Reload was skipped to protect your work.'
+      )
+      return
+    }
+
+    this.updateCodeEditor(code, {
+      shouldExecute: true,
+      shouldClearHistory: true,
+      shouldResetCamera: true,
+      ...options,
+      shouldWriteToDisk: false,
+    })
+    this.markFileCodeAsSynced(code)
+  }
+
   async writeToFile(
     newCode = this.codeSignal.value,
     requestedDocumentVersion = this._documentVersion,

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -598,6 +598,25 @@ describe('project system', () => {
         filePath: mainFile.path,
       })
 
+      const otherProject: Project = {
+        ...mockProject,
+        name: 'other-test',
+        path: '/some-dir/other-test',
+        children: [
+          {
+            name: 'main.kcl',
+            path: '/some-dir/other-test/main.kcl',
+            children: [],
+          },
+        ],
+      }
+
+      await projectSession.openProject(otherProject)
+      expect(projectSession.openedProjectHandle.value).toEqual({
+        projectPath: otherProject.path,
+      })
+      expect(projectSession.executingEditorHandle.value).toBeUndefined()
+
       projectSession.closeProject()
 
       expect(app.project).toBeUndefined()

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -1,7 +1,6 @@
 import type { Feature } from '@kittycad/lib'
 import { pluginsValueSpec } from '@kittycad/registry'
 import { signal } from '@preact/signals-core'
-import { zookeeperEditPatchHistoryEvent } from '@src/lib/zookeeper/editorPlugin'
 import { File, type KclManager } from '@src/lang/KclManager'
 import { App } from '@src/lib/app'
 import {
@@ -13,6 +12,7 @@ import type { Project } from '@src/lib/project'
 import { getChangedSettingsAtLevel } from '@src/lib/settings/settingsUtils'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { notifyActiveWasmInstance } from '@src/lib/wasmLifecycle'
+import { zookeeperEditPatchHistoryEvent } from '@src/lib/zookeeper/editorPlugin'
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
 import type { UserFeaturesContext } from '@src/machines/userFeaturesMachine'
 import { UserFeaturesState } from '@src/machines/userFeaturesMachine'
@@ -622,6 +622,43 @@ describe('project system', () => {
       expect(app.project).toBeUndefined()
       expect(projectSession.openedProjectHandle.value).toBeUndefined()
       expect(projectSession.executingEditorHandle.value).toBeUndefined()
+    } finally {
+      app.dispose()
+    }
+  })
+
+  it('removes stale project file references when deleting an opened file tree', async () => {
+    File.ioImplementations.read = (path) =>
+      Promise.resolve(
+        new Map([
+          ['/some-dir/test/main.kcl', 'main = 1'],
+          ['/some-dir/test/parts/part.kcl', 'part = 2'],
+        ]).get(path) ?? ''
+      )
+    File.ioImplementations.write = () => Promise.resolve()
+
+    const app = createAppForTest()
+
+    try {
+      const projectSession = app.registry.get(projectSessionService)
+      const project = await projectSession.openProject(mockProject)
+      const partPath = '/some-dir/test/parts/part.kcl'
+
+      await projectSession.openEditor(partPath, {
+        providedEditor: app.singletons.kclManager,
+      })
+
+      expect(project.executingPath).toBe(partPath)
+      expect(project.files.some((file) => file.path === partPath)).toBe(true)
+
+      const removedFiles = project.removePathFromFileRegistry(
+        '/some-dir/test/parts'
+      )
+
+      expect(removedFiles.map((file) => file.path)).toContain(partPath)
+      expect(project.executingPath).toBeNull()
+      expect(project.findEditor(partPath)).toBeUndefined()
+      expect(project.files.some((file) => file.path === partPath)).toBe(false)
     } finally {
       app.dispose()
     }

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -20,6 +20,7 @@ import { appHeaderItemsValueSpec } from '@src/registry/contracts/appHeader'
 import { commandsValueSpec } from '@src/registry/contracts/commands'
 import { executingEditorService } from '@src/registry/contracts/executingEditor'
 import { machineManagerService } from '@src/registry/contracts/machineManager'
+import { projectSessionService } from '@src/registry/contracts/projectSession'
 import { userFeaturesService } from '@src/registry/contracts/userFeatures'
 import { wasmPromiseValueSpec } from '@src/registry/contracts/wasm'
 import { createTestWasmRegistryItem } from '@src/unitTestUtils'
@@ -297,8 +298,11 @@ describe('project system', () => {
         .get(pluginsValueSpec)
         .find((plugin) => plugin.id === pluginId)
       expect(plugin).toBeDefined()
+      if (!plugin) {
+        throw new Error(`Expected ${pluginId} plugin to be registered.`)
+      }
 
-      const pluginToggle = app.registry.get(plugin!.service)
+      const pluginToggle = app.registry.get(plugin.service)
       expect(pluginToggle.active.value).toBe(true)
       expect(syncActivePlugins).toHaveBeenCalledWith(
         expect.arrayContaining([pluginId])
@@ -450,13 +454,16 @@ describe('project system', () => {
         .get(pluginsValueSpec)
         .find((plugin) => plugin.id === pluginId)
       expect(plugin).toBeDefined()
+      if (!plugin) {
+        throw new Error(`Expected ${pluginId} plugin to be registered.`)
+      }
 
       app.settings.actor.send({ type: 'reload.settings' } as never)
 
       await waitForSettingsIdle(app)
 
       expect(app.settings.get().plugins[pluginId].current).toBe(true)
-      expect(app.registry.get(plugin!.service).active.value).toBe(true)
+      expect(app.registry.get(plugin.service).active.value).toBe(true)
     } finally {
       app.dispose()
     }
@@ -539,19 +546,37 @@ describe('project system', () => {
     const app = createAppForTest()
 
     try {
-      const project = await app.openProject(mockProject)
+      const projectSession = app.registry.get(projectSessionService)
+      const project = await projectSession.openProject(mockProject)
 
       expect(app.project).toBeDefined()
+      expect(app.project).toBe(project)
+      expect(projectSession.openedProject.value).toBe(project)
+      expect(projectSession.openedProjectHandle.value).toEqual({
+        projectPath: mockProject.path,
+      })
       expect(app.project?.executingPath).toBeNull()
       expect(app.project?.executingFileEntry.value.name).toEqual('')
 
-      await project.openEditor(mockProject.children![0].path)
+      const mainFile = mockProject.children?.[0]
+      expect(mainFile).toBeDefined()
+      if (!mainFile) {
+        throw new Error('Expected mock project to include a main file.')
+      }
+
+      await projectSession.openEditor(mainFile.path)
       expect(app.project?.executingPath).toEqual('/some-dir/test/main.kcl')
       expect(app.project?.executingFileEntry.value.name).toEqual('main.kcl')
+      expect(projectSession.executingEditorHandle.value).toEqual({
+        projectPath: mockProject.path,
+        filePath: mainFile.path,
+      })
 
-      app.closeProject()
+      projectSession.closeProject()
 
       expect(app.project).toBeUndefined()
+      expect(projectSession.openedProjectHandle.value).toBeUndefined()
+      expect(projectSession.executingEditorHandle.value).toBeUndefined()
     } finally {
       app.dispose()
     }

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -540,7 +540,13 @@ describe('project system', () => {
 
   it('can open, close project', async () => {
     // Stub out File read and write implementations
-    File.ioImplementations.read = () => Promise.resolve('')
+    File.ioImplementations.read = (path) =>
+      Promise.resolve(
+        new Map([
+          ['/some-dir/test/main.kcl', 'main = 1'],
+          ['/some-dir/test/other.kcl', 'other = 2'],
+        ]).get(path) ?? ''
+      )
     File.ioImplementations.write = () => Promise.resolve()
 
     const app = createAppForTest()
@@ -564,20 +570,29 @@ describe('project system', () => {
         throw new Error('Expected mock project to include a main file.')
       }
 
-      await projectSession.openEditor(mainFile.path)
+      await projectSession.openEditor(mainFile.path, {
+        providedEditor: app.singletons.kclManager,
+      })
       expect(app.project?.executingPath).toEqual('/some-dir/test/main.kcl')
       expect(app.project?.executingFileEntry.value.name).toEqual('main.kcl')
+      expect(app.singletons.kclManager.code).toBe('main = 1')
       expect(projectSession.executingEditorHandle.value).toEqual({
         projectPath: mockProject.path,
         filePath: mainFile.path,
       })
 
-      await projectSession.openEditor('/some-dir/test/other.kcl')
+      await projectSession.openEditor('/some-dir/test/other.kcl', {
+        providedEditor: app.singletons.kclManager,
+      })
       expect(app.project?.executingPath).toEqual('/some-dir/test/other.kcl')
+      expect(app.singletons.kclManager.code).toBe('other = 2')
 
-      await projectSession.openEditor(mainFile.path)
+      await projectSession.openEditor(mainFile.path, {
+        providedEditor: app.singletons.kclManager,
+      })
       expect(app.project?.executingPath).toEqual('/some-dir/test/main.kcl')
       expect(app.project?.executingFileEntry.value.name).toEqual('main.kcl')
+      expect(app.singletons.kclManager.code).toBe('main = 1')
       expect(projectSession.executingEditorHandle.value).toEqual({
         projectPath: mockProject.path,
         filePath: mainFile.path,

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -572,6 +572,17 @@ describe('project system', () => {
         filePath: mainFile.path,
       })
 
+      await projectSession.openEditor('/some-dir/test/other.kcl')
+      expect(app.project?.executingPath).toEqual('/some-dir/test/other.kcl')
+
+      await projectSession.openEditor(mainFile.path)
+      expect(app.project?.executingPath).toEqual('/some-dir/test/main.kcl')
+      expect(app.project?.executingFileEntry.value.name).toEqual('main.kcl')
+      expect(projectSession.executingEditorHandle.value).toEqual({
+        projectPath: mockProject.path,
+        filePath: mainFile.path,
+      })
+
       projectSession.closeProject()
 
       expect(app.project).toBeUndefined()

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -13,9 +13,9 @@ import { createProjectCommands } from '@src/lib/commandBarConfigs/projectsComman
 import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
 import type { Debugger } from '@src/lib/debugger'
 import { EngineDebugger } from '@src/lib/debugger'
+import { setKclRuntimeFlagsOnWasm } from '@src/lib/kclRuntimeFlags'
 import { layoutService } from '@src/lib/layout/registry/contract'
 import type { LayoutService } from '@src/lib/layout/types'
-import { setKclRuntimeFlagsOnWasm } from '@src/lib/kclRuntimeFlags'
 import type { MachineManager } from '@src/lib/MachineManager'
 import type { Project } from '@src/lib/project'
 import RustContext from '@src/lib/rustContext'
@@ -29,14 +29,14 @@ import { uuidv4 } from '@src/lib/utils'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { onActiveWasmInstance } from '@src/lib/wasmLifecycle'
 import { withAPIBaseURL } from '@src/lib/withBaseURL'
+import type { MlEphantManagerActor } from '@src/lib/zookeeper/mlEphantManagerMachine'
 import {
   BILLING_CONTEXT_DEFAULTS,
   billingMachine,
 } from '@src/machines/billingMachine'
-import type { MlEphantManagerActor } from '@src/lib/zookeeper/mlEphantManagerMachine'
 import { getOnlySettingsFromContext } from '@src/machines/settingsMachine'
 import { systemIOMachineImpl } from '@src/machines/systemIO/systemIOMachineImpl'
-import { type SystemIOActor } from '@src/machines/systemIO/utils'
+import type { SystemIOActor } from '@src/machines/systemIO/utils'
 import {
   UserFeaturesTransition,
   userFeaturesContextHas,

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -7,7 +7,7 @@ import {
   Slot,
 } from '@kittycad/registry'
 import { type Signal, signal } from '@preact/signals-core'
-import { KclManager, ZDSProject } from '@src/lang/KclManager'
+import { KclManager, type ZDSProject } from '@src/lang/KclManager'
 import { createAuthCommands } from '@src/lib/commandBarConfigs/authCommandConfig'
 import { createProjectCommands } from '@src/lib/commandBarConfigs/projectsCommandConfig'
 import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
@@ -77,11 +77,7 @@ import {
   coreRegistryItems,
 } from '@src/registry/registry'
 import { useSelector } from '@xstate/react'
-import type {
-  ActorRefFrom,
-  ContextFrom,
-  SnapshotFrom,
-} from 'xstate'
+import type { ActorRefFrom, ContextFrom, SnapshotFrom } from 'xstate'
 import { createActor } from 'xstate'
 
 const appCommandsSlot = new Slot()

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -6,12 +6,7 @@ import {
   type RegistryItem,
   Slot,
 } from '@kittycad/registry'
-import { effect, type Signal, signal } from '@preact/signals-core'
-import { buildFSHistoryExtension } from '@src/editor/plugins/fs'
-import {
-  buildZookeeperHistoryExtension,
-  type PreparedZookeeperPatchFileReplay,
-} from '@src/lib/zookeeper/editorPlugin'
+import { type Signal, signal } from '@preact/signals-core'
 import { KclManager, ZDSProject } from '@src/lang/KclManager'
 import { createAuthCommands } from '@src/lib/commandBarConfigs/authCommandConfig'
 import { createProjectCommands } from '@src/lib/commandBarConfigs/projectsCommandConfig'
@@ -41,10 +36,7 @@ import {
 import type { MlEphantManagerActor } from '@src/lib/zookeeper/mlEphantManagerMachine'
 import { getOnlySettingsFromContext } from '@src/machines/settingsMachine'
 import { systemIOMachineImpl } from '@src/machines/systemIO/systemIOMachineImpl'
-import {
-  type SystemIOActor,
-  SystemIOMachineEvents,
-} from '@src/machines/systemIO/utils'
+import { type SystemIOActor } from '@src/machines/systemIO/utils'
 import {
   UserFeaturesTransition,
   userFeaturesContextHas,
@@ -64,6 +56,10 @@ import { engineSceneRuntimeExtensionsSlot } from '@src/registry/contracts/engine
 import { executingEditorService } from '@src/registry/contracts/executingEditor'
 import { keymapService } from '@src/registry/contracts/keymap'
 import { machineManagerService } from '@src/registry/contracts/machineManager'
+import {
+  type ProjectSessionService,
+  projectSessionService,
+} from '@src/registry/contracts/projectSession'
 import {
   type SettingsRegistryService,
   settingsService,
@@ -85,7 +81,6 @@ import type {
   ActorRefFrom,
   ContextFrom,
   SnapshotFrom,
-  Subscription,
 } from 'xstate'
 import { createActor } from 'xstate'
 
@@ -93,28 +88,6 @@ const appCommandsSlot = new Slot()
 
 type AppRegistryOptions = {
   registryOverrides?: readonly RegistryItem[]
-}
-
-function zookeeperReplayChangesProjectFileSet(
-  replayFiles: readonly PreparedZookeeperPatchFileReplay[]
-) {
-  return replayFiles.some(
-    (replayFile) =>
-      replayFile.previousContent === null || replayFile.nextContent === null
-  )
-}
-
-function getZookeeperReplayFallbackFilePath(
-  project: ZDSProject,
-  deletedPaths: Set<string>
-) {
-  const defaultFile = project.projectIORefSignal.value.default_file
-  const candidates = [
-    defaultFile,
-    ...project.files.map((file) => file.path),
-  ].filter((path, index, paths) => paths.indexOf(path) === index)
-
-  return candidates.find((path) => path && !deletedPaths.has(path))
 }
 
 // We set some of our singletons on the window for debugging and E2E tests
@@ -208,6 +181,8 @@ export class App implements AppSubsystems {
   layout: AppLayoutSystem
   /** The registry system for the application */
   registry: AppRegistrySystem
+  /** The currently-opened project and editor lifecycle system */
+  projectSession: ProjectSessionService
   /**
    * The interface to reading/writing to IO.
    * TODO: We have agreed to move away from this XState approach, towards a class + signals approach.
@@ -237,6 +212,9 @@ export class App implements AppSubsystems {
         app: this,
       },
     }).start()
+    this.projectSession = this.registry.get(projectSessionService)
+    this.projectSignal = this.projectSession.openedProject
+    this.projectSession.bindApp(this)
 
     this.syncAppCommands()
     this.commands.actor.send({
@@ -348,83 +326,9 @@ export class App implements AppSubsystems {
   }
 
   async openProject(projectIORef: Project) {
-    this.disposeProjectHistoryExtensions?.()
-    const projectIORefSignal = signal(projectIORef)
-    this.project = await ZDSProject.open(projectIORefSignal, this)
-
-    // These extensions make global project operations un/redoable.
-    this.disposeProjectHistoryExtensions = effect(() => {
-      const project = this.project
-      const executingEditor = project?.executingEditor.value
-      if (!project || !executingEditor) {
-        return
-      }
-
-      const disposeFSHistory = buildFSHistoryExtension(
-        this.systemIOActor,
-        executingEditor
-      )
-      const disposeZookeeperHistory = buildZookeeperHistoryExtension({
-        kclManager: executingEditor,
-        onCurrentFileDelete: async (deletedPaths) => {
-          const fallbackPath = getZookeeperReplayFallbackFilePath(
-            project,
-            deletedPaths
-          )
-          if (!fallbackPath) {
-            return Promise.reject(
-              new Error(
-                'Cannot replay this Zookeeper edit because no fallback KCL file is available.'
-              )
-            )
-          }
-
-          await project.openEditor(fallbackPath, executingEditor)
-        },
-        onActiveFileRestore: async (restoredPath, restoredContents) => {
-          await project.openEditor(
-            restoredPath,
-            executingEditor,
-            restoredContents
-          )
-        },
-        onProjectFilesReplay: async (replayFiles) => {
-          await project.syncReplayedFilesToRust(replayFiles)
-          if (zookeeperReplayChangesProjectFileSet(replayFiles)) {
-            this.systemIOActor.send({
-              type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
-            })
-          }
-        },
-      })
-
-      return () => {
-        disposeFSHistory()
-        disposeZookeeperHistory()
-      }
-    })
-
-    // TODO: Rework the systemIOActor to fit into the system better,
-    // so that the project doesn't need to subscribe to it.
-    this.systemIOActor.subscribe(({ context }) => {
-      const foundProject = (context.folders ?? []).find(
-        (p) =>
-          p.name === projectIORefSignal.value.name &&
-          p.path === projectIORefSignal.value.path
-      )
-      if (foundProject && projectIORefSignal.value !== foundProject) {
-        projectIORefSignal.value = foundProject
-      }
-    })
-
-    this.unsubscribeFromSettings = this.settings.actor.subscribe(
-      this.onSettingsUpdate
-    )
-
-    return this.project
+    return this.projectSession.openProject(projectIORef)
   }
-  private unsubscribeFromSettings: Subscription | undefined = undefined
-  private disposeProjectHistoryExtensions: (() => void) | undefined = undefined
+
   dispose() {
     this.closeProject()
     this.unsubscribeFromActiveWasmInstance?.()
@@ -439,12 +343,7 @@ export class App implements AppSubsystems {
   }
 
   closeProject() {
-    this.disposeProjectHistoryExtensions?.()
-    this.disposeProjectHistoryExtensions = undefined
-    this.unsubscribeFromSettings?.unsubscribe()
-    this.unsubscribeFromSettings = undefined
-    this.project?.close()
-    this.project = undefined
+    this.projectSession.closeProject()
   }
 
   syncUserFeaturesFromAuth = (

--- a/src/lib/routeLoaderUtils.test.ts
+++ b/src/lib/routeLoaderUtils.test.ts
@@ -75,7 +75,6 @@ function createAppWithWebHomeFeature(enabled: boolean) {
     systemIOActor: {
       send: vi.fn(),
     },
-    closeProject,
     settings: {
       actor: {
         send: vi.fn(),
@@ -111,16 +110,13 @@ describe('route loaders', () => {
   it('loads Home project state without touching the demo-project flow', () => {
     const { app, closeProject } = createAppWithWebHomeFeature(true)
 
-    const result = loadHomeProjects(app)
+    const result = loadHomeProjects({ app, closeProject })
 
     expect(result).toEqual({})
     expect(app.systemIOActor.send).toHaveBeenCalledWith({
       type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
     })
     expect(closeProject).toHaveBeenCalled()
-    expect(app.settings.actor.send).toHaveBeenCalledWith({
-      type: 'clear.project',
-    })
   })
 
   it('waits for user features before deciding whether web Home is enabled', async () => {

--- a/src/lib/routeLoaderUtils.ts
+++ b/src/lib/routeLoaderUtils.ts
@@ -36,12 +36,6 @@ type HomeLoaderApp = {
       type: SystemIOMachineEvents.readFoldersFromProjectDirectory
     }) => void
   }
-  closeProject: () => void
-  settings: {
-    actor: {
-      send: (event: { type: 'clear.project' }) => void
-    }
-  }
 }
 
 async function waitForWebHomeFeatureGate(app: WebHomeApp) {
@@ -94,13 +88,16 @@ export async function webHomeRouteEnabled(app: WebHomeApp) {
   )
 }
 
-export function loadHomeProjects(app: HomeLoaderApp) {
+export function loadHomeProjects({
+  app,
+  closeProject,
+}: {
+  app: HomeLoaderApp
+  closeProject: () => void
+}) {
   app.systemIOActor.send({
     type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
   })
-  app.closeProject()
-  app.settings.actor.send({
-    type: 'clear.project',
-  })
+  closeProject()
   return {}
 }

--- a/src/lib/routeLoaders.ts
+++ b/src/lib/routeLoaders.ts
@@ -4,14 +4,18 @@ import {
   DEFAULT_DEFAULT_LENGTH_UNIT,
   PROJECT_ENTRYPOINT,
 } from '@src/lib/constants'
-import { getInitialDefaultDir, getProjectInfo } from '@src/lib/desktop'
-import { readAppSettingsFile } from '@src/lib/desktop'
+import {
+  getInitialDefaultDir,
+  getProjectInfo,
+  isPathNotFoundError,
+  readAppSettingsFile,
+} from '@src/lib/desktop'
 import fsZds from '@src/lib/fs-zds'
 import {
-  PATHS,
   getParentAbsolutePath,
   getProjectMetaByRouteId,
   getRouterSearchFromRequestUrl,
+  PATHS,
   safeEncodeForRouterPaths,
 } from '@src/lib/paths'
 import {
@@ -137,42 +141,7 @@ export const fileLoader =
       projectPathData
 
     const urlObj = new URL(routerData.request.url)
-
-    if (!urlObj.pathname.endsWith('/settings')) {
-      const fallbackFile = (await getProjectInfo(projectPath, wasmInstance))
-        .default_file
-      let fileExists = true
-      if (currentFilePath && fileExists) {
-        try {
-          await fsZds.stat(currentFilePath)
-        } catch (e) {
-          if (e === 'ENOENT') {
-            fileExists = false
-          }
-        }
-      }
-
-      // If we are navigating to the project and want to navigate to its
-      // default file, redirect to it keeping everything else in the URL the same.
-      if (projectPath && !currentFileName && fileExists && params.id) {
-        const encodedId = safeEncodeForRouterPaths(params.id)
-        const requestUrlWithDefaultFile = routerData.request.url.replace(
-          encodedId,
-          safeEncodeForRouterPaths(fallbackFile)
-        )
-        return redirect(requestUrlWithDefaultFile)
-      }
-
-      if (!fileExists || !currentFileName || !currentFilePath || !projectName) {
-        const routerSearch = getRouterSearchFromRequestUrl(
-          routerData.request.url,
-          Boolean(window.electron)
-        )
-        return redirect(
-          `${PATHS.FILE}/${encodeURIComponent(fallbackFile)}${routerSearch}`
-        )
-      }
-    }
+    const isSettingsRoute = urlObj.pathname.endsWith('/settings')
 
     const defaultProjectData = {
       name: projectName || 'unnamed',
@@ -186,20 +155,74 @@ export const fileLoader =
     }
 
     const maybeProjectInfo = await getProjectInfo(projectPath, wasmInstance)
-
     const project = maybeProjectInfo ?? defaultProjectData
 
-    const { editor } = await projectSession.openProjectEditor({
-      project,
-      filePath: currentFilePath || PROJECT_ENTRYPOINT,
-      providedEditor: app.singletons.kclManager,
-      // If persistCode in localStorage is present, it'll persist that code
-      // through *anything*. INTENDED FOR TESTS.
-      providedCode:
-        window.electron?.process.env.NODE_ENV === 'test'
-          ? kclManager.localStoragePersistCode()
-          : undefined,
-    })
+    const redirectToFallbackFile = () => {
+      const routerSearch = getRouterSearchFromRequestUrl(
+        routerData.request.url,
+        Boolean(window.electron)
+      )
+      return redirect(
+        `${PATHS.FILE}/${encodeURIComponent(project.default_file)}${routerSearch}`
+      )
+    }
+
+    if (!isSettingsRoute) {
+      let fileExists = true
+      if (currentFilePath && fileExists) {
+        try {
+          await fsZds.stat(currentFilePath)
+        } catch (error) {
+          if (isPathNotFoundError(error)) {
+            fileExists = false
+          }
+        }
+      }
+
+      // If we are navigating to the project and want to navigate to its
+      // default file, redirect to it keeping everything else in the URL the same.
+      if (projectPath && !currentFileName && fileExists && params.id) {
+        const encodedId = safeEncodeForRouterPaths(params.id)
+        const requestUrlWithDefaultFile = routerData.request.url.replace(
+          encodedId,
+          safeEncodeForRouterPaths(project.default_file)
+        )
+        return redirect(requestUrlWithDefaultFile)
+      }
+
+      if (!fileExists || !currentFileName || !currentFilePath || !projectName) {
+        return redirectToFallbackFile()
+      }
+    }
+
+    const editorFilePath = currentFilePath || PROJECT_ENTRYPOINT
+    let editor: Awaited<
+      ReturnType<typeof projectSession.openProjectEditor>
+    >['editor']
+    try {
+      const openedEditor = await projectSession.openProjectEditor({
+        project,
+        filePath: editorFilePath,
+        providedEditor: app.singletons.kclManager,
+        // If persistCode in localStorage is present, it'll persist that code
+        // through *anything*. INTENDED FOR TESTS.
+        providedCode:
+          window.electron?.process.env.NODE_ENV === 'test'
+            ? kclManager.localStoragePersistCode()
+            : undefined,
+      })
+      editor = openedEditor.editor
+    } catch (error) {
+      if (
+        !isSettingsRoute &&
+        isPathNotFoundError(error) &&
+        editorFilePath !== project.default_file
+      ) {
+        return redirectToFallbackFile()
+      }
+
+      return Promise.reject(error)
+    }
 
     const requestedFileName =
       app.systemIOActor.getSnapshot().context.requestedFileName

--- a/src/lib/routeLoaders.ts
+++ b/src/lib/routeLoaders.ts
@@ -1,5 +1,4 @@
 import { projectSkeletonCreate } from '@src/lang/project'
-import { projectFsManager } from '@src/lang/std/fileSystemManager'
 import type { App } from '@src/lib/app'
 import {
   DEFAULT_DEFAULT_LENGTH_UNIT,
@@ -26,9 +25,9 @@ import type {
   IndexLoaderData,
 } from '@src/lib/types'
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
+import { projectSessionService } from '@src/registry/contracts/projectSession'
 import type { LoaderFunction } from 'react-router-dom'
 import { redirect } from 'react-router-dom'
-import { waitFor } from 'xstate'
 
 export const DEFAULT_WEB_PROJECT_NAME = 'demo-project'
 
@@ -98,10 +97,8 @@ export const baseLoader =
 export const fileLoader =
   ({ app }: { app: App }): LoaderFunction =>
   async (routerData): Promise<FileLoaderData | Response> => {
-    const {
-      settings: { actor: settingsActor },
-    } = app
     const { kclManager } = app.singletons
+    const projectSession = app.registry.get(projectSessionService)
     const { params } = routerData
 
     // Must basically remain for all eternity, until the last person
@@ -177,10 +174,6 @@ export const fileLoader =
       }
     }
 
-    // Set the file system manager to the project path
-    // So that WASM gets an updated path for operations
-    projectFsManager.dir = projectPath
-
     const defaultProjectData = {
       name: projectName || 'unnamed',
       path: projectPath,
@@ -196,25 +189,17 @@ export const fileLoader =
 
     const project = maybeProjectInfo ?? defaultProjectData
 
-    // Fire off the event to load the project settings
-    // once we know it's idle.
-    await waitFor(settingsActor, (state) => state.matches('idle'))
-    settingsActor.send({
-      type: 'load.project',
+    const { editor } = await projectSession.openProjectEditor({
       project,
-    })
-    await waitFor(settingsActor, (state) => state.matches('idle'))
-
-    const projectRef = await app.openProject(project)
-    const editor = await projectRef.openEditor(
-      currentFilePath || PROJECT_ENTRYPOINT,
-      app.singletons.kclManager,
+      filePath: currentFilePath || PROJECT_ENTRYPOINT,
+      providedEditor: app.singletons.kclManager,
       // If persistCode in localStorage is present, it'll persist that code
       // through *anything*. INTENDED FOR TESTS.
-      window.electron?.process.env.NODE_ENV === 'test'
-        ? kclManager.localStoragePersistCode()
-        : undefined
-    )
+      providedCode:
+        window.electron?.process.env.NODE_ENV === 'test'
+          ? kclManager.localStoragePersistCode()
+          : undefined,
+    })
 
     const requestedFileName =
       app.systemIOActor.getSnapshot().context.requestedFileName
@@ -260,5 +245,9 @@ export const homeLoader =
       return redirect(PATHS.INDEX)
     }
 
-    return loadHomeProjects(app)
+    return loadHomeProjects({
+      app,
+      closeProject: () =>
+        app.registry.get(projectSessionService).closeProject(),
+    })
   }

--- a/src/machines/systemIO/systemIOMachine.spec.ts
+++ b/src/machines/systemIO/systemIOMachine.spec.ts
@@ -6,7 +6,6 @@ import type { Project } from '@src/lib/project'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { systemIOMachine } from '@src/machines/systemIO/systemIOMachine'
 import {
-  getCloudProjectFolderRenameName,
   reloadExecutingEditorAfterBulkWrite,
   shouldSendProjectFolderReadProgress,
   sortProjectDirectoryEntriesByModifiedDesc,

--- a/src/machines/systemIO/systemIOMachine.spec.ts
+++ b/src/machines/systemIO/systemIOMachine.spec.ts
@@ -263,6 +263,94 @@ describe('systemIOMachine - XState', () => {
         )
         actor.stop()
       })
+      it('requests default file navigation after archiving the active file', async () => {
+        const actor = createActor(
+          systemIOMachine.provide({
+            actors: {
+              [SystemIOMachineActors.moveRecursive]: fromPromise(
+                async ({ input }) => ({
+                  message: 'Archived successfully',
+                  requestedAbsolutePath: '',
+                  requestedProjectName: input.requestedProjectName || '',
+                  requestedFileName: 'main.kcl',
+                  target: input.target,
+                })
+              ),
+              [SystemIOMachineActors.readFoldersFromProjectDirectory]:
+                fromPromise(async () => [] as Project[]),
+            },
+          }),
+          {
+            input: {
+              wasmInstancePromise: Promise.resolve(instanceInThisFile),
+              app: appInstanceInThisFile,
+            },
+          }
+        ).start()
+
+        actor.send({
+          type: SystemIOMachineEvents.moveRecursiveAndNavigate,
+          data: {
+            src: '/projects/demo-project/fileToDelete.kcl',
+            target: '/projects/.archive/demo-project/fileToDelete.kcl',
+            requestedProjectName: 'demo-project',
+          },
+        })
+
+        await waitFor(
+          actor,
+          (state) => state.context.requestedFileName.file === 'main.kcl'
+        )
+
+        expect(actor.getSnapshot().context.requestedFileName).toStrictEqual({
+          project: 'demo-project',
+          file: 'main.kcl',
+        })
+        actor.stop()
+      })
+      it('requests default file navigation after deleting the active file', async () => {
+        const actor = createActor(
+          systemIOMachine.provide({
+            actors: {
+              [SystemIOMachineActors.deleteFileOrFolder]: fromPromise(
+                async ({ input }) => ({
+                  message: 'File deleted successfully',
+                  requestedPath: input.requestedPath,
+                  requestedProjectName: input.requestedProjectName || '',
+                  requestedFileName: 'main.kcl',
+                })
+              ),
+              [SystemIOMachineActors.readFoldersFromProjectDirectory]:
+                fromPromise(async () => [] as Project[]),
+            },
+          }),
+          {
+            input: {
+              wasmInstancePromise: Promise.resolve(instanceInThisFile),
+              app: appInstanceInThisFile,
+            },
+          }
+        ).start()
+
+        actor.send({
+          type: SystemIOMachineEvents.deleteFileOrFolderAndNavigate,
+          data: {
+            requestedPath: '/projects/demo-project/fileToDelete.kcl',
+            requestedProjectName: 'demo-project',
+          },
+        })
+
+        await waitFor(
+          actor,
+          (state) => state.context.requestedFileName.file === 'main.kcl'
+        )
+
+        expect(actor.getSnapshot().context.requestedFileName).toStrictEqual({
+          project: 'demo-project',
+          file: 'main.kcl',
+        })
+        actor.stop()
+      })
     })
     describe('when reading projects', () => {
       it('should exit early when project directory is empty string', async () => {

--- a/src/machines/systemIO/systemIOMachine.spec.ts
+++ b/src/machines/systemIO/systemIOMachine.spec.ts
@@ -6,12 +6,15 @@ import type { Project } from '@src/lib/project'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { systemIOMachine } from '@src/machines/systemIO/systemIOMachine'
 import {
+  getCloudProjectFolderRenameName,
+  reloadExecutingEditorAfterBulkWrite,
   shouldSendProjectFolderReadProgress,
   sortProjectDirectoryEntriesByModifiedDesc,
   systemIOMachineImpl,
 } from '@src/machines/systemIO/systemIOMachineImpl'
 import {
   NO_PROJECT_DIRECTORY,
+  type SystemIOContext,
   SystemIOMachineActors,
   SystemIOMachineEvents,
   SystemIOMachineStates,
@@ -1193,6 +1196,51 @@ describe('systemIOMachine - XState', () => {
         } finally {
           actor.stop()
         }
+      })
+    })
+    describe('when bulk writing the active file', () => {
+      it('should reload the executing editor after overwriting its file', async () => {
+        const reloadFromDisk = vi.fn().mockResolvedValue(undefined)
+
+        await reloadExecutingEditorAfterBulkWrite({
+          context: {
+            app: {
+              project: {
+                executingEditor: {
+                  value: {
+                    path: '/projects/demo/main.kcl',
+                    reloadFromDisk,
+                  },
+                },
+              },
+            },
+          } as unknown as SystemIOContext,
+          writtenFilePaths: ['/projects/demo/main.kcl'],
+        })
+
+        expect(reloadFromDisk).toHaveBeenCalledTimes(1)
+      })
+
+      it('should not reload the executing editor after writing another file', async () => {
+        const reloadFromDisk = vi.fn().mockResolvedValue(undefined)
+
+        await reloadExecutingEditorAfterBulkWrite({
+          context: {
+            app: {
+              project: {
+                executingEditor: {
+                  value: {
+                    path: '/projects/demo/main.kcl',
+                    reloadFromDisk,
+                  },
+                },
+              },
+            },
+          } as unknown as SystemIOContext,
+          writtenFilePaths: ['/projects/demo/other.kcl'],
+        })
+
+        expect(reloadFromDisk).not.toHaveBeenCalled()
       })
     })
     describe('when setting default project folder name', () => {

--- a/src/machines/systemIO/systemIOMachine.ts
+++ b/src/machines/systemIO/systemIOMachine.ts
@@ -293,7 +293,7 @@ export const systemIOMachine = setup({
         }
       | {
           type: SystemIOMachineEvents.done_deleteFileOrFolderAndNavigate
-          output: { requestedProjectName: string }
+          output: { requestedProjectName: string; requestedFileName: string }
         }
       | {
           type: SystemIOMachineEvents.copyRecursive
@@ -751,6 +751,7 @@ export const systemIOMachine = setup({
           message: '',
           requestedPath: '',
           requestedProjectName: '',
+          requestedFileName: '',
         }
       }
     ),
@@ -816,6 +817,7 @@ export const systemIOMachine = setup({
           message: '',
           requestedAbsolutePath: '',
           requestedProjectName: '',
+          requestedFileName: '',
           target: input.target,
         }
       }
@@ -1953,6 +1955,24 @@ export const systemIOMachine = setup({
                     .output.requestedProjectName,
                 }
               },
+              requestedFileName: ({ event }) => {
+                assertEvent(
+                  event,
+                  SystemIOMachineEvents.done_deleteFileOrFolderAndNavigate
+                )
+                const output = (
+                  event as {
+                    output: {
+                      requestedProjectName: string
+                      requestedFileName: string
+                    }
+                  }
+                ).output
+                return {
+                  project: output.requestedProjectName,
+                  file: output.requestedFileName,
+                }
+              },
             }),
             SystemIOMachineActions.toastSuccess,
           ],
@@ -2044,6 +2064,24 @@ export const systemIOMachine = setup({
                 return {
                   name: (event as { output: { requestedProjectName: string } })
                     .output.requestedProjectName,
+                }
+              },
+              requestedFileName: ({ event }) => {
+                assertEvent(
+                  event,
+                  SystemIOMachineEvents.done_moveRecursiveAndNavigate
+                )
+                const output = (
+                  event as {
+                    output: {
+                      requestedProjectName: string
+                      requestedFileName: string
+                    }
+                  }
+                ).output
+                return {
+                  project: output.requestedProjectName,
+                  file: output.requestedFileName,
                 }
               },
             }),

--- a/src/machines/systemIO/systemIOMachineImpl.ts
+++ b/src/machines/systemIO/systemIOMachineImpl.ts
@@ -355,11 +355,17 @@ const sharedBulkWriteImportedProjectFilesWorkflow = async ({
     }
 
     await fsZds.mkdir(projectRoot, { recursive: true })
+    const writtenFilePaths: string[] = []
     for (const file of input.files) {
       const targetPath = fsZds.join(projectRoot, file.requestedFileName)
       await fsZds.mkdir(fsZds.dirname(targetPath), { recursive: true })
       await fsZds.writeFile(targetPath, Uint8Array.from(file.requestedData))
+      writtenFilePaths.push(targetPath)
     }
+    await reloadExecutingEditorAfterBulkWrite({
+      context: input.context,
+      writtenFilePaths,
+    })
 
     if (requestedFileNameWithExtension) {
       const entrypointPath = fsZds.join(

--- a/src/machines/systemIO/systemIOMachineImpl.ts
+++ b/src/machines/systemIO/systemIOMachineImpl.ts
@@ -1128,6 +1128,9 @@ export const systemIOMachineImpl = systemIOMachine.provide({
         }
       }) => {
         await fsZds.rm(input.requestedPath, { recursive: true })
+        input.context.app.project?.removePathFromFileRegistry(
+          input.requestedPath
+        )
         const response = {
           message: 'File deleted successfully',
           requestedPath: input.requestedPath,
@@ -1265,6 +1268,7 @@ export const systemIOMachineImpl = systemIOMachine.provide({
           src: input.src,
           target: input.target,
         })
+        input.context.app.project?.removePathFromFileRegistry(input.src)
         return {
           message: input.successMessage || 'Moved successfully',
           requestedAbsolutePath: '',

--- a/src/machines/systemIO/systemIOMachineImpl.ts
+++ b/src/machines/systemIO/systemIOMachineImpl.ts
@@ -224,6 +224,25 @@ const prepareBulkProjectWrite = async ({
   }
 }
 
+export const reloadExecutingEditorAfterBulkWrite = async ({
+  context,
+  writtenFilePaths,
+}: {
+  context: SystemIOContext
+  writtenFilePaths: string[]
+}) => {
+  const executingEditor = context.app.project?.executingEditor.value
+  if (!executingEditor) {
+    return
+  }
+
+  if (!writtenFilePaths.includes(executingEditor.path)) {
+    return
+  }
+
+  await executingEditor.reloadFromDisk()
+}
+
 const sharedBulkCreateWorkflow = async ({
   input,
 }: {
@@ -245,6 +264,7 @@ const sharedBulkCreateWorkflow = async ({
     wasmInstance: input.wasmInstance,
   })
 
+  const writtenFilePaths: string[] = []
   for (let fileIndex = 0; fileIndex < input.files.length; fileIndex++) {
     const file = input.files[fileIndex]
     const requestedFileName = file.requestedFileName
@@ -261,6 +281,8 @@ const sharedBulkCreateWorkflow = async ({
           })
         ).name
 
+    writtenFilePaths.push(fsZds.join(projectRoot, fileName))
+
     // Create the project around the file if newProject
     await createNewProjectDirectory(
       newProjectName,
@@ -271,6 +293,11 @@ const sharedBulkCreateWorkflow = async ({
       projectDirectoryPath
     )
   }
+  await reloadExecutingEditorAfterBulkWrite({
+    context: input.context,
+    writtenFilePaths,
+  })
+
   const numberOfFiles = input.files.length
   const fileText = numberOfFiles > 1 ? 'files' : 'file'
   const message = input.override

--- a/src/machines/systemIO/systemIOMachineImpl.ts
+++ b/src/machines/systemIO/systemIOMachineImpl.ts
@@ -224,6 +224,34 @@ const prepareBulkProjectWrite = async ({
   }
 }
 
+function getDefaultRequestedFileName({
+  context,
+  requestedProjectName,
+}: {
+  context: SystemIOContext
+  requestedProjectName?: string
+}) {
+  const project = context.folders?.find(
+    (folder) => folder.name === requestedProjectName
+  )
+  const defaultFile = project?.default_file
+  if (!project || !defaultFile) {
+    return ''
+  }
+
+  const projectPathPrefix = project.path.endsWith(fsZds.sep)
+    ? project.path
+    : `${project.path}${fsZds.sep}`
+  if (defaultFile.startsWith(projectPathPrefix)) {
+    return fsZds.relative(project.path, defaultFile).replace(/^[\\/]+/, '')
+  }
+
+  return (
+    parentPathRelativeToProject(defaultFile, context.projectDirectoryPath) ||
+    defaultFile.replace(/^[\\/]+/, '')
+  )
+}
+
 export const reloadExecutingEditorAfterBulkWrite = async ({
   context,
   writtenFilePaths,
@@ -1104,6 +1132,10 @@ export const systemIOMachineImpl = systemIOMachine.provide({
           message: 'File deleted successfully',
           requestedPath: input.requestedPath,
           requestedProjectName: input.requestedProjectName || '',
+          requestedFileName: getDefaultRequestedFileName({
+            context: input.context,
+            requestedProjectName: input.requestedProjectName,
+          }),
         }
         return response
       }
@@ -1237,6 +1269,10 @@ export const systemIOMachineImpl = systemIOMachine.provide({
           message: input.successMessage || 'Moved successfully',
           requestedAbsolutePath: '',
           requestedProjectName: input.requestedProjectName || '',
+          requestedFileName: getDefaultRequestedFileName({
+            context: input.context,
+            requestedProjectName: input.requestedProjectName,
+          }),
           target: input.target,
         }
       }

--- a/src/registry/contracts/projectSession.ts
+++ b/src/registry/contracts/projectSession.ts
@@ -1,0 +1,65 @@
+import {
+  defineContract,
+  defineService,
+  firstWinsValueSpec,
+} from '@kittycad/registry'
+import type { Signal } from '@preact/signals-core'
+import type { KclManager, ZDSProject } from '@src/lang/KclManager'
+import type { App } from '@src/lib/app'
+import type { Project } from '@src/lib/project'
+
+export interface OpenedProjectHandle {
+  projectPath: string
+}
+
+export interface ExecutingEditorHandle {
+  projectPath: string
+  filePath: string
+}
+
+export interface OpenEditorOptions {
+  providedEditor?: KclManager
+  providedCode?: string
+  isExecuting?: boolean
+}
+
+export interface OpenProjectEditorInput extends OpenEditorOptions {
+  project: Project
+  filePath: string
+}
+
+export interface ProjectSessionService {
+  readonly openedProjectHandle: Signal<OpenedProjectHandle | undefined>
+  readonly executingEditorHandle: Signal<ExecutingEditorHandle | undefined>
+  readonly openedProject: Signal<ZDSProject | undefined>
+  bindApp(app: App): void
+  openProject(project: Project): Promise<ZDSProject>
+  openEditor(filePath: string, options?: OpenEditorOptions): Promise<KclManager>
+  openProjectEditor(input: OpenProjectEditorInput): Promise<{
+    project: ZDSProject
+    editor: KclManager
+  }>
+  closeProject(): void
+}
+
+export const projectSessionContract = defineContract({
+  openedProjectHandleValueSpec: firstWinsValueSpec<
+    OpenedProjectHandle | undefined
+  >('opened-project-handle', undefined),
+  executingEditorHandleValueSpec: firstWinsValueSpec<
+    ExecutingEditorHandle | undefined
+  >('executing-editor-handle', undefined),
+  openedProjectValueSpec: firstWinsValueSpec<ZDSProject | undefined>(
+    'opened-project',
+    undefined
+  ),
+  projectSessionService:
+    defineService<ProjectSessionService>('project-session'),
+})
+
+export const {
+  openedProjectHandleValueSpec,
+  executingEditorHandleValueSpec,
+  openedProjectValueSpec,
+  projectSessionService,
+} = projectSessionContract

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -1,0 +1,286 @@
+import {
+  defineRegistryItemFactory,
+  defineRuntimeRegistryItem,
+  provide,
+  provideService,
+} from '@kittycad/registry'
+import { type Signal, effect, signal } from '@preact/signals-core'
+import { buildFSHistoryExtension } from '@src/editor/plugins/fs'
+import {
+  type PreparedZookeeperPatchFileReplay,
+  buildZookeeperHistoryExtension,
+} from '@src/lib/zookeeper/editorPlugin'
+import { ZDSProject } from '@src/lang/KclManager'
+import { projectFsManager } from '@src/lang/std/fileSystemManager'
+import type { App } from '@src/lib/app'
+import type { Project } from '@src/lib/project'
+import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
+import {
+  type OpenEditorOptions,
+  type OpenProjectEditorInput,
+  type ProjectSessionService,
+  executingEditorHandleValueSpec,
+  openedProjectHandleValueSpec,
+  openedProjectValueSpec,
+  projectSessionService,
+} from '@src/registry/contracts/projectSession'
+import type { Subscription } from 'xstate'
+import { waitFor } from 'xstate'
+
+interface CloseProjectOptions {
+  clearHandles?: boolean
+  clearProjectSettings?: boolean
+}
+
+function zookeeperReplayChangesProjectFileSet(
+  replayFiles: readonly PreparedZookeeperPatchFileReplay[]
+) {
+  return replayFiles.some(
+    (replayFile) =>
+      replayFile.previousContent === null || replayFile.nextContent === null
+  )
+}
+
+function getZookeeperReplayFallbackFilePath(
+  project: ZDSProject,
+  deletedPaths: Set<string>
+) {
+  const defaultFile = project.projectIORefSignal.value.default_file
+  const candidates = [
+    defaultFile,
+    ...project.files.map((file) => file.path),
+  ].filter((path, index, paths) => paths.indexOf(path) === index)
+
+  return candidates.find((path) => path && !deletedPaths.has(path))
+}
+
+const projectSessionExtension = defineRegistryItemFactory(() => {
+  let app: App | undefined
+  let unsubscribeFromSettings: Subscription | undefined
+  let unsubscribeFromSystemIO: Subscription | undefined
+  let stopFSHistoryEffect: (() => void) | undefined
+
+  const openedProjectHandle =
+    signal<ProjectSessionService['openedProjectHandle']['value']>(undefined)
+  const executingEditorHandle =
+    signal<ProjectSessionService['executingEditorHandle']['value']>(undefined)
+  const openedProject =
+    signal<ProjectSessionService['openedProject']['value']>(undefined)
+
+  const getApp = () => {
+    if (!app) {
+      throw new Error('Project session service has not been bound to App.')
+    }
+    return app
+  }
+
+  const stopProjectEffects = () => {
+    unsubscribeFromSettings?.unsubscribe()
+    unsubscribeFromSettings = undefined
+    unsubscribeFromSystemIO?.unsubscribe()
+    unsubscribeFromSystemIO = undefined
+    stopFSHistoryEffect?.()
+    stopFSHistoryEffect = undefined
+  }
+
+  const closeProject = ({
+    clearHandles = true,
+    clearProjectSettings = true,
+  }: CloseProjectOptions = {}) => {
+    const currentApp = app
+    const currentProject = openedProject.peek()
+
+    stopProjectEffects()
+    currentProject?.close()
+    openedProject.value = undefined
+
+    if (clearHandles) {
+      openedProjectHandle.value = undefined
+      executingEditorHandle.value = undefined
+    }
+
+    if (clearProjectSettings) {
+      currentApp?.settings.actor.send({
+        type: 'clear.project',
+      })
+    }
+  }
+
+  const syncProjectFromSystemIO = (projectIORefSignal: Signal<Project>) => {
+    const currentApp = getApp()
+
+    unsubscribeFromSystemIO = currentApp.systemIOActor.subscribe(
+      ({ context }) => {
+        const foundProject = (context.folders ?? []).find(
+          (project) =>
+            project.name === projectIORefSignal.value.name &&
+            project.path === projectIORefSignal.value.path
+        )
+        if (foundProject && projectIORefSignal.value !== foundProject) {
+          projectIORefSignal.value = foundProject
+        }
+      }
+    )
+  }
+
+  const startProjectEffects = (projectIORefSignal: Signal<Project>) => {
+    const currentApp = getApp()
+
+    stopProjectEffects()
+    stopFSHistoryEffect = effect(() => {
+      const project = openedProject.value
+      const editor = project?.executingEditor.value
+      if (!project || !editor) {
+        return
+      }
+
+      const disposeFSHistory = buildFSHistoryExtension(
+        currentApp.systemIOActor,
+        editor
+      )
+      const disposeZookeeperHistory = buildZookeeperHistoryExtension({
+        kclManager: editor,
+        onCurrentFileDelete: async (deletedPaths) => {
+          const fallbackPath = getZookeeperReplayFallbackFilePath(
+            project,
+            deletedPaths
+          )
+          if (!fallbackPath) {
+            return Promise.reject(
+              new Error(
+                'Cannot replay this Zookeeper edit because no fallback KCL file is available.'
+              )
+            )
+          }
+
+          await openEditor(fallbackPath, { providedEditor: editor })
+        },
+        onActiveFileRestore: async (restoredPath, restoredContents) => {
+          await openEditor(restoredPath, {
+            providedEditor: editor,
+            providedCode: restoredContents,
+          })
+        },
+        onProjectFilesReplay: async (replayFiles) => {
+          await project.syncReplayedFilesToRust(replayFiles)
+          if (zookeeperReplayChangesProjectFileSet(replayFiles)) {
+            currentApp.systemIOActor.send({
+              type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
+            })
+          }
+        },
+      })
+
+      return () => {
+        disposeFSHistory()
+        disposeZookeeperHistory()
+      }
+    })
+    syncProjectFromSystemIO(projectIORefSignal)
+    unsubscribeFromSettings = currentApp.settings.actor.subscribe(
+      currentApp.onSettingsUpdate
+    )
+  }
+
+  const openProject = async (project: Project) => {
+    const currentApp = getApp()
+    const currentProject = openedProject.peek()
+
+    openedProjectHandle.value = {
+      projectPath: project.path,
+    }
+    projectFsManager.dir = project.path
+
+    if (currentProject && currentProject.path !== project.path) {
+      closeProject({ clearHandles: false, clearProjectSettings: false })
+    }
+
+    await waitFor(currentApp.settings.actor, (state) => state.matches('idle'))
+    currentApp.settings.actor.send({
+      type: 'load.project',
+      project,
+    })
+    await waitFor(currentApp.settings.actor, (state) => state.matches('idle'))
+
+    if (currentProject?.path === project.path) {
+      currentProject.projectIORefSignal.value = project
+      return currentProject
+    }
+
+    const projectIORefSignal = signal(project)
+    const nextProject = await ZDSProject.open(projectIORefSignal, currentApp)
+    openedProject.value = nextProject
+    startProjectEffects(projectIORefSignal)
+    return nextProject
+  }
+
+  const openEditor = async (
+    filePath: string,
+    { providedEditor, providedCode, isExecuting = true }: OpenEditorOptions = {}
+  ) => {
+    const currentProject = openedProject.peek()
+    if (!currentProject) {
+      throw new Error('Cannot open an editor without an opened project.')
+    }
+
+    executingEditorHandle.value = {
+      projectPath: currentProject.path,
+      filePath,
+    }
+
+    return currentProject.openEditor(
+      filePath,
+      providedEditor,
+      providedCode,
+      isExecuting
+    )
+  }
+
+  const serviceImpl: ProjectSessionService = {
+    openedProjectHandle,
+    executingEditorHandle,
+    openedProject,
+    bindApp(boundApp) {
+      app = boundApp
+    },
+    openProject,
+    openEditor,
+    async openProjectEditor({
+      project,
+      filePath,
+      providedEditor,
+      providedCode,
+      isExecuting,
+    }: OpenProjectEditorInput) {
+      const opened = await openProject(project)
+      const editor = await openEditor(filePath, {
+        providedEditor,
+        providedCode,
+        isExecuting,
+      })
+      return { project: opened, editor }
+    },
+    closeProject: () => closeProject(),
+  }
+
+  return {
+    item: defineRuntimeRegistryItem({
+      id: 'project-session-extension',
+      provides: [
+        provide(openedProjectHandleValueSpec, openedProjectHandle, {
+          key: 'project-session',
+        }),
+        provide(executingEditorHandleValueSpec, executingEditorHandle, {
+          key: 'project-session',
+        }),
+        provide(openedProjectValueSpec, openedProject, {
+          key: 'project-session',
+        }),
+      ],
+      providesServices: [provideService(projectSessionService, serviceImpl)],
+      dispose: () => closeProject(),
+    }),
+  }
+}, 'project-session-extension')
+
+export default projectSessionExtension

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -86,10 +86,10 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     stopProjectEffects()
     currentProject?.close()
     openedProject.value = undefined
+    executingEditorHandle.value = undefined
 
     if (clearHandles) {
       openedProjectHandle.value = undefined
-      executingEditorHandle.value = undefined
     }
 
     if (clearProjectSettings) {

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -67,13 +67,6 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
   const openedProject =
     signal<ProjectSessionService['openedProject']['value']>(undefined)
 
-  const getApp = () => {
-    if (!app) {
-      throw new Error('Project session service has not been bound to App.')
-    }
-    return app
-  }
-
   const stopProjectEffects = () => {
     unsubscribeFromSettings?.unsubscribe()
     unsubscribeFromSettings = undefined
@@ -106,9 +99,10 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     }
   }
 
-  const syncProjectFromSystemIO = (projectIORefSignal: Signal<Project>) => {
-    const currentApp = getApp()
-
+  const syncProjectFromSystemIO = (
+    currentApp: App,
+    projectIORefSignal: Signal<Project>
+  ) => {
     unsubscribeFromSystemIO = currentApp.systemIOActor.subscribe(
       ({ context }) => {
         const foundProject = (context.folders ?? []).find(
@@ -123,9 +117,10 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     )
   }
 
-  const startProjectEffects = (projectIORefSignal: Signal<Project>) => {
-    const currentApp = getApp()
-
+  const startProjectEffects = (
+    currentApp: App,
+    projectIORefSignal: Signal<Project>
+  ) => {
     stopProjectEffects()
     stopFSHistoryEffect = effect(() => {
       const project = openedProject.value
@@ -176,14 +171,19 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
         disposeZookeeperHistory()
       }
     })
-    syncProjectFromSystemIO(projectIORefSignal)
+    syncProjectFromSystemIO(currentApp, projectIORefSignal)
     unsubscribeFromSettings = currentApp.settings.actor.subscribe(
       currentApp.onSettingsUpdate
     )
   }
 
   const openProject = async (project: Project) => {
-    const currentApp = getApp()
+    const currentApp = app
+    if (!currentApp) {
+      return Promise.reject(
+        new Error('Project session service has not been bound to App.')
+      )
+    }
     const currentProject = openedProject.peek()
 
     openedProjectHandle.value = {
@@ -210,7 +210,7 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     const projectIORefSignal = signal(project)
     const nextProject = await ZDSProject.open(projectIORefSignal, currentApp)
     openedProject.value = nextProject
-    startProjectEffects(projectIORefSignal)
+    startProjectEffects(currentApp, projectIORefSignal)
     return nextProject
   }
 
@@ -220,7 +220,9 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
   ) => {
     const currentProject = openedProject.peek()
     if (!currentProject) {
-      throw new Error('Cannot open an editor without an opened project.')
+      return Promise.reject(
+        new Error('Cannot open an editor without an opened project.')
+      )
     }
 
     executingEditorHandle.value = {

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -4,24 +4,24 @@ import {
   provide,
   provideService,
 } from '@kittycad/registry'
-import { type Signal, effect, signal } from '@preact/signals-core'
+import { effect, type Signal, signal } from '@preact/signals-core'
 import { buildFSHistoryExtension } from '@src/editor/plugins/fs'
-import {
-  type PreparedZookeeperPatchFileReplay,
-  buildZookeeperHistoryExtension,
-} from '@src/lib/zookeeper/editorPlugin'
 import { ZDSProject } from '@src/lang/KclManager'
 import { projectFsManager } from '@src/lang/std/fileSystemManager'
 import type { App } from '@src/lib/app'
 import type { Project } from '@src/lib/project'
+import {
+  buildZookeeperHistoryExtension,
+  type PreparedZookeeperPatchFileReplay,
+} from '@src/lib/zookeeper/editorPlugin'
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
 import {
+  executingEditorHandleValueSpec,
   type OpenEditorOptions,
   type OpenProjectEditorInput,
-  type ProjectSessionService,
-  executingEditorHandleValueSpec,
   openedProjectHandleValueSpec,
   openedProjectValueSpec,
+  type ProjectSessionService,
   projectSessionService,
 } from '@src/registry/contracts/projectSession'
 import type { Subscription } from 'xstate'


### PR DESCRIPTION
## Summary

- add a core `projectSession` registry contract and runtime extension for opened project/editor state
- move project open/close/editor lifecycle ownership out of `App` methods and behind the service
- have `routeLoaders.ts` delegate project/editor setup and project clearing to the service while preserving existing loader data
- keep `app.project` and `app.projectSignal` as compatibility proxies over the service-owned opened project signal

## Motivation

This is the first step toward shrinking `routeLoaders.ts` so loaders publish route intent, while app state is scaffolded by services and derived signals. This PR moves lifecycle ownership to a registry extension without changing the current route data contract yet.

A follow-up can reduce loader return data once the app no longer relies on it and instead reads the project session service directly.

## Validation

- `npm run tsc -- --noEmit`
- `npm run test:integration -- src/lib/app.spec.ts`
- `npx biome check src/registry/contracts/projectSession.ts src/registry/extensions/projectSession/index.ts src/lib/routeLoaders.ts src/lib/app.ts src/lib/app.spec.ts`

Biome reports only the existing `app.ts` debug-window `any` warnings on touched files.