### PR TITLE
Move project route loading into projectSession

### DIFF
--- a/src/components/ProjectSidebarMenu.tsx
+++ b/src/components/ProjectSidebarMenu.tsx
@@ -23,7 +23,6 @@ import { isDesktop } from '@src/lib/isDesktop'
 import { PATHS, getProjectRelativeFilePath } from '@src/lib/paths'
 import type { FileEntry, Project } from '@src/lib/project'
 import { getProjectDisplayName } from '@src/lib/projectDisplayName'
-import type { IndexLoaderData } from '@src/lib/types'
 import {
   findKeymapItemForCommand,
   keymapKeystrokesDisplay,
@@ -130,8 +129,8 @@ function AppLogoLink({
   onProjectClose,
   onHomeNavigate,
 }: {
-  project?: IndexLoaderData['project']
-  file?: IndexLoaderData['file']
+  project?: Project
+  file?: FileEntry
   enabled: boolean
   onProjectClose: ProjectCloseHandler
   onHomeNavigate: () => void
@@ -178,8 +177,8 @@ function ProjectMenuPopover({
   onHomeNavigate,
 }: {
   app: App
-  project?: IndexLoaderData['project']
-  file?: IndexLoaderData['file']
+  project?: Project
+  file?: FileEntry
   filePath?: string
   homeNavigationEnabled: boolean
   onProjectClose: ProjectCloseHandler
@@ -501,8 +500,8 @@ export function ProjectBreadcrumbButton({
   file,
   hasCloudConflict = false,
 }: {
-  project?: IndexLoaderData['project']
-  file?: IndexLoaderData['file']
+  project?: Project
+  file?: FileEntry
   hasCloudConflict?: boolean
 }) {
   // Breadcrumb for project and project-relative file path

--- a/src/components/SystemIOMachineLogicListener.tsx
+++ b/src/components/SystemIOMachineLogicListener.tsx
@@ -135,6 +135,8 @@ export function SystemIOMachineLogicListener() {
         SystemIOMachineStates.bulkCreateAndDeletingKCLFilesAndNavigateToFile,
         SystemIOMachineStates.renamingFileAndNavigateToFile,
         SystemIOMachineStates.renamingFolderAndNavigateToFile,
+        SystemIOMachineStates.deletingFileOrFolderAndNavigate,
+        SystemIOMachineStates.movingRecursiveAndNavigate,
       ]
       if (
         requestedFileName.project &&

--- a/src/editor/plugins/zookeeper/history.integration.spec.ts
+++ b/src/editor/plugins/zookeeper/history.integration.spec.ts
@@ -13,7 +13,6 @@ import { File, KclManager, type ZDSProject } from '@src/lang/KclManager'
 import { App } from '@src/lib/app'
 import { StorageName, moduleFsViaModuleImport } from '@src/lib/fs-zds'
 import fsZds from '@src/lib/fs-zds'
-import type { Project } from '@src/lib/project'
 import { loadWasm } from '@src/unitTestUtils'
 
 const apps: App[] = []
@@ -1364,26 +1363,21 @@ async function createProjectHarness(files: Record<string, string>) {
     await writeText(fsZds.join(projectPath, relativePath), contents)
   }
 
-  const project: Project = {
-    name: fsZds.basename(projectPath),
-    path: projectPath,
-    default_file: fsZds.join(projectPath, 'main.kcl'),
-    directory_count: 0,
-    kcl_file_count: Object.keys(files).length,
-    metadata: null,
-    readWriteAccess: true,
-    children: Object.keys(files).map((relativePath) => ({
-      name: relativePath,
-      path: fsZds.join(projectPath, relativePath),
-      children: null,
-    })),
-  }
   const app = App.fromProvided({ wasmPromise: loadWasm() })
   apps.push(app)
-  const openedProject = await app.openProject(project)
-  const kclManager = await openedProject.openEditor(
-    fsZds.join(projectPath, 'main.kcl')
-  )
+  const openedProject = await app.projectSession.setOpenedProjectHandle({
+    projectPath,
+  })
+  if (!openedProject) {
+    throw new Error('Expected project session to open a project.')
+  }
+  const kclManager = await app.projectSession.setExecutingEditorHandle({
+    projectPath,
+    filePath: fsZds.join(projectPath, 'main.kcl'),
+  })
+  if (!kclManager) {
+    throw new Error('Expected project session to open an executing editor.')
+  }
   historyDisposers.push(
     buildZookeeperHistoryExtension({
       kclManager,
@@ -1600,7 +1594,7 @@ async function waitForHistoryIdle(kclManager: KclManager) {
 
 async function disposeApp(app: App) {
   const projectPath = app.project?.path
-  app.closeProject()
+  await app.projectSession.setOpenedProjectHandle(undefined)
   app.systemIOActor.stop()
   app.settings.actor.stop()
   app.commands.actor.stop()

--- a/src/lang/KclManager.spec.ts
+++ b/src/lang/KclManager.spec.ts
@@ -6,6 +6,7 @@ import type {
 import { createEmptyAst } from '@src/editor/plugins/ast'
 import { File, KclManager } from '@src/lang/KclManager'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { waitFor } from 'xstate'
 
 import {
   createKclManagerTestHarness,
@@ -638,6 +639,46 @@ describe('KclManager diagnostics', () => {
     await vi.advanceTimersByTimeAsync(1000)
 
     expect(executeCodeSpy).toHaveBeenCalledWith(mainCode)
+  })
+
+  it('reactivates settings subscriptions when reusing a closed singleton editor', async () => {
+    const { app, kclManager } = createKclManagerTestHarness('')
+    await waitFor(app.settings.actor, (state) => state.matches('idle'))
+
+    const path = '/tmp/kcl-manager-settings-reactivation-test.kcl'
+    const readSpy = vi
+      .spyOn(File.ioImplementations, 'read')
+      .mockResolvedValue('opened code')
+    const setAutomaticallyRenderSpy = vi.spyOn(
+      kclManager,
+      'setEditorAutomaticallyRender'
+    )
+
+    kclManager.close()
+
+    const opened = await KclManager.fromFile(
+      new File(path, 102),
+      (kclManager as any).systemDeps,
+      kclManager
+    )
+
+    expect(opened).toBe(kclManager)
+    setAutomaticallyRenderSpy.mockClear()
+
+    app.settings.actor.send({
+      type: 'set.textEditor.automaticallyRender',
+      data: {
+        level: 'user',
+        value: false,
+      },
+      doNotPersist: true,
+    } as never)
+    await waitFor(app.settings.actor, (state) => state.matches('idle'))
+
+    expect(setAutomaticallyRenderSpy).toHaveBeenCalledWith(false)
+
+    readSpy.mockRestore()
+    setAutomaticallyRenderSpy.mockRestore()
   })
 
   it('does not overwrite dirty editor state when an external reload resolves later', async () => {

--- a/src/lang/KclManager.spec.ts
+++ b/src/lang/KclManager.spec.ts
@@ -549,6 +549,29 @@ describe('KclManager diagnostics', () => {
     expect(kclManager.code).toBe('from disk')
   })
 
+  it('reloads clean editor state from explicit disk refreshes', async () => {
+    const { kclManager } = createKclManagerTestHarness('from disk')
+
+    kclManager.path = '/tmp/kcl-manager-explicit-reload-test.kcl'
+    ;(kclManager as any).markFileCodeAsSynced('from disk')
+
+    vi.spyOn(File.ioImplementations, 'read').mockResolvedValue('sketch = 1')
+    const updateSpy = vi.spyOn(kclManager, 'updateCodeEditor')
+
+    await kclManager.reloadFromDisk()
+
+    expect(updateSpy).toHaveBeenCalledWith(
+      'sketch = 1',
+      expect.objectContaining({
+        shouldExecute: true,
+        shouldClearHistory: true,
+        shouldResetCamera: true,
+        shouldWriteToDisk: false,
+      })
+    )
+    expect(kclManager.code).toBe('sketch = 1')
+  })
+
   it('arms disk watcher when reusing the singleton editor for an opened file', async () => {
     const { kclManager } = createKclManagerTestHarness('')
     const path = '/tmp/kcl-manager-watch-open-test.kcl'

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -3586,6 +3586,36 @@ export class KclManager extends File {
     this.updateLastCommittedSketchCheckpoint(resolvedOptions, additionalSpec)
     this.setDiagnosticsForCurrentErrors()
   }
+
+  async reloadFromDisk(
+    options: Partial<UpdateCodeEditorOptions> = {}
+  ): Promise<void> {
+    const code = normalizeLineEndings(await this.read())
+    if (isCodeTheSame(code, this.code)) {
+      this.markFileCodeAsSynced(code)
+      return
+    }
+
+    if (this.hasUnsavedLocalChanges()) {
+      console.warn(
+        'External file change detected while local edits are unsaved. Skipping automatic reload to avoid overwriting the editor buffer.'
+      )
+      toast.error(
+        'File changed on disk while this editor has unsaved changes. Reload was skipped to protect your work.'
+      )
+      return
+    }
+
+    this.updateCodeEditor(code, {
+      shouldExecute: true,
+      shouldClearHistory: true,
+      shouldResetCamera: true,
+      ...options,
+      shouldWriteToDisk: false,
+    })
+    this.markFileCodeAsSynced(code)
+  }
+
   async writeToFile(
     newCode = this.codeSignal.value,
     requestedDocumentVersion = this._documentVersion,

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -2005,7 +2005,7 @@ export class KclManager extends File {
       })
     }
     providedEditor.markFileCodeAsSynced(diskCode)
-    providedEditor.watch()
+    providedEditor.reactivateFileLifecycle()
     return providedEditor
   }
 
@@ -2042,10 +2042,7 @@ export class KclManager extends File {
       zookeeperHistoryExtension(),
     ])
     this._editorView = this.createEditorView(initialCode)
-    this.settingsSubscription = this.systemDeps.settings.subscribe(() => {
-      this.setEditorAutomaticallyRender(this.getAutomaticallyRenderSetting())
-    })
-    this.setEditorAutomaticallyRender(this.getAutomaticallyRenderSetting())
+    this.subscribeToSettingsUpdates()
     // TODO: Delete this._code, only derive from the editorView's doc
     this._code.value = initialCode
     this.markFileCodeAsSynced(initialCode)
@@ -2082,9 +2079,23 @@ export class KclManager extends File {
     clearTimeout(this.timeoutWriter)
     clearTimeout(this.timeoutRewatch)
     this.settingsSubscription?.unsubscribe()
+    this.settingsSubscription = undefined
     this.disposeGlobalHistorySubscription?.()
     this.flushRecoverySnapshot()
     this.unwatch()
+  }
+
+  public reactivateFileLifecycle() {
+    this.subscribeToSettingsUpdates()
+    this.watch()
+  }
+
+  private subscribeToSettingsUpdates() {
+    this.settingsSubscription?.unsubscribe()
+    this.settingsSubscription = this.systemDeps.settings.subscribe(() => {
+      this.setEditorAutomaticallyRender(this.getAutomaticallyRenderSetting())
+    })
+    this.setEditorAutomaticallyRender(this.getAutomaticallyRenderSetting())
   }
 
   private markFileCodeAsSynced(code: string) {

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -390,6 +390,14 @@ export class ZDSProject {
       .find(([p]) => p.value === path)
   }
 
+  private deleteEditorReferences(editor: KclManager, exceptPath?: string) {
+    for (const [pathSignal, foundEditor] of this.editors.entries()) {
+      if (foundEditor === editor && pathSignal.value !== exceptPath) {
+        this.editors.delete(pathSignal)
+      }
+    }
+  }
+
   // Saving some keystrokes
   private set = this.editors.set.bind(this.editors)
 
@@ -407,15 +415,15 @@ export class ZDSProject {
   ) {
     const foundEditor = this.findEditor(path)
     const found = foundEditor?.[1]
-    if (
-      found &&
-      (!providedEditor || found !== providedEditor || found.path === path)
-    ) {
+    if (found && found.path === path) {
       if (isExecuting) {
         this.executingPath = path
       }
       console.warn(`Attempted to overwrite editor with path "${path}"`)
       return found
+    }
+    if (foundEditor) {
+      this.editors.delete(foundEditor[0])
     }
 
     const systemDeps: SystemDeps = {
@@ -463,6 +471,7 @@ export class ZDSProject {
     if (newEditor.path !== path) {
       newEditor.path = path
     }
+    this.deleteEditorReferences(newEditor, path)
 
     // Initialize the editor theme
     // Subsequent changes are listened for within app.onSettingsUpdate()

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -411,6 +411,9 @@ export class ZDSProject {
       found &&
       (!providedEditor || found !== providedEditor || found.path === path)
     ) {
+      if (isExecuting) {
+        this.executingPath = path
+      }
       console.warn(`Attempted to overwrite editor with path "${path}"`)
       return found
     }

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -502,6 +502,17 @@ describe('project system', () => {
         filePath: mainFile.path,
       })
 
+      await projectSession.openEditor('/some-dir/test/other.kcl')
+      expect(app.project?.executingPath).toEqual('/some-dir/test/other.kcl')
+
+      await projectSession.openEditor(mainFile.path)
+      expect(app.project?.executingPath).toEqual('/some-dir/test/main.kcl')
+      expect(app.project?.executingFileEntry.value.name).toEqual('main.kcl')
+      expect(projectSession.executingEditorHandle.value).toEqual({
+        projectPath: mockProject.path,
+        filePath: mainFile.path,
+      })
+
       projectSession.closeProject()
 
       expect(app.project).toBeUndefined()

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -500,29 +500,9 @@ describe('project system', () => {
         throw new Error('Expected mock project to include a main file.')
       }
 
-      await projectSession.openEditor(mainFile.path, {
-        providedEditor: app.singletons.kclManager,
-      })
+      await projectSession.openEditor(mainFile.path)
       expect(app.project?.executingPath).toEqual('/some-dir/test/main.kcl')
       expect(app.project?.executingFileEntry.value.name).toEqual('main.kcl')
-      expect(app.singletons.kclManager.code).toBe('main = 1')
-      expect(projectSession.executingEditorHandle.value).toEqual({
-        projectPath: mockProject.path,
-        filePath: mainFile.path,
-      })
-
-      await projectSession.openEditor('/some-dir/test/other.kcl', {
-        providedEditor: app.singletons.kclManager,
-      })
-      expect(app.project?.executingPath).toEqual('/some-dir/test/other.kcl')
-      expect(app.singletons.kclManager.code).toBe('other = 2')
-
-      await projectSession.openEditor(mainFile.path, {
-        providedEditor: app.singletons.kclManager,
-      })
-      expect(app.project?.executingPath).toEqual('/some-dir/test/main.kcl')
-      expect(app.project?.executingFileEntry.value.name).toEqual('main.kcl')
-      expect(app.singletons.kclManager.code).toBe('main = 1')
       expect(projectSession.executingEditorHandle.value).toEqual({
         projectPath: mockProject.path,
         filePath: mainFile.path,

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -426,24 +426,14 @@ describe('project system', () => {
 
     try {
       await writeText(mainPath, 'main = true\n')
-      const project: Project = {
-        name: fsZds.basename(projectPath),
-        default_file: mainPath,
-        directory_count: 0,
-        kcl_file_count: 1,
-        metadata: null,
-        path: projectPath,
-        readWriteAccess: true,
-        children: [
-          {
-            name: 'main.kcl',
-            path: mainPath,
-            children: null,
-          },
-        ],
+      await app.projectSession.setOpenedProjectHandle({ projectPath })
+      const kclManager = await app.projectSession.setExecutingEditorHandle({
+        projectPath,
+        filePath: mainPath,
+      })
+      if (!kclManager) {
+        throw new Error('Expected project session to open an executing editor.')
       }
-      const openedProject = await app.openProject(project)
-      const kclManager = await openedProject.openEditor(mainPath)
       await Promise.resolve()
 
       await writeText(createdPath, 'created = true\n')
@@ -482,7 +472,7 @@ describe('project system', () => {
         'created = true\n'
       )
     } finally {
-      disposeApp(app)
+      await disposeApp(app)
       await fsZds.rm(projectPath, { recursive: true, force: true })
     }
   })

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import type { UserFeature } from '@kittycad/lib'
 import { pluginsValueSpec } from '@kittycad/registry'
 import { signal } from '@preact/signals-core'
@@ -18,12 +19,15 @@ import { projectSessionService } from '@src/registry/contracts/projectSession'
 import { loadWasm } from '@src/unitTestUtils'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
-const mockProjectPath = '/private/tmp/zds-app-spec-project-system/test'
+const mockProjectDirectoryPath = path.join(
+  process.cwd(),
+  '.tmp',
+  'zds-app-spec-project-system'
+)
+const mockProjectPath = path.join(mockProjectDirectoryPath, 'test')
 const mockProjectMainFilePath = `${mockProjectPath}/main.kcl`
-const mockOtherProjectPath =
-  '/private/tmp/zds-app-spec-project-system/other-test'
+const mockOtherProjectPath = path.join(mockProjectDirectoryPath, 'other-test')
 const mockOtherProjectMainFilePath = `${mockOtherProjectPath}/main.kcl`
-const mockProjectDirectoryPath = '/private/tmp/zds-app-spec-project-system'
 
 const mockProject: Project = {
   name: 'test',
@@ -55,7 +59,7 @@ beforeAll(async () => {
     type: StorageName.NodeFS,
     options: {},
   })
-  await fsZds.rm(mockProjectPath, { recursive: true, force: true })
+  await fsZds.rm(mockProjectDirectoryPath, { recursive: true, force: true })
   await fsZds.mkdir(mockProjectPath, { recursive: true })
   await fsZds.writeFile(mockProjectMainFilePath, new TextEncoder().encode(''))
   await fsZds.rm(mockOtherProjectPath, { recursive: true, force: true })
@@ -67,8 +71,7 @@ beforeAll(async () => {
 })
 
 afterAll(async () => {
-  await fsZds.rm(mockProjectPath, { recursive: true, force: true })
-  await fsZds.rm(mockOtherProjectPath, { recursive: true, force: true })
+  await fsZds.rm(mockProjectDirectoryPath, { recursive: true, force: true })
   vi.restoreAllMocks()
 })
 

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -14,6 +14,7 @@ import { UserFeaturesState } from '@src/machines/userFeaturesMachine'
 import { appHeaderItemsValueSpec } from '@src/registry/contracts/appHeader'
 import { commandsValueSpec } from '@src/registry/contracts/commands'
 import { executingEditorService } from '@src/registry/contracts/executingEditor'
+import { projectSessionService } from '@src/registry/contracts/projectSession'
 import { loadWasm } from '@src/unitTestUtils'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
@@ -175,8 +176,11 @@ describe('project system', () => {
         .get(pluginsValueSpec)
         .find((plugin) => plugin.id === pluginId)
       expect(plugin).toBeDefined()
+      if (!plugin) {
+        throw new Error(`Expected ${pluginId} plugin to be registered.`)
+      }
 
-      const pluginToggle = app.registry.get(plugin!.service)
+      const pluginToggle = app.registry.get(plugin.service)
       expect(pluginToggle.active.value).toBe(true)
 
       app.settings.actor.send({
@@ -327,13 +331,16 @@ describe('project system', () => {
         .get(pluginsValueSpec)
         .find((plugin) => plugin.id === pluginId)
       expect(plugin).toBeDefined()
+      if (!plugin) {
+        throw new Error(`Expected ${pluginId} plugin to be registered.`)
+      }
 
       app.settings.actor.send({ type: 'reload.settings' } as never)
 
       await waitForSettingsIdle(app)
 
       expect(app.settings.get().plugins[pluginId].current).toBe(true)
-      expect(app.registry.get(plugin!.service).active.value).toBe(true)
+      expect(app.registry.get(plugin.service).active.value).toBe(true)
     } finally {
       disposeApp(app)
     }
@@ -351,6 +358,9 @@ describe('project system', () => {
         .get(pluginsValueSpec)
         .find((plugin) => plugin.id === 'execution-indicator')
       expect(executionIndicatorPlugin).toBeDefined()
+      if (!executionIndicatorPlugin) {
+        throw new Error('Expected execution-indicator plugin to be registered.')
+      }
 
       app.settings.actor.send({ type: 'reload.settings' } as never)
 
@@ -363,7 +373,7 @@ describe('project system', () => {
       expect(modelingSettings.executionIndicator.current).toBe(false)
       expect(app.settings.get().plugins['execution-indicator']).toBeUndefined()
       expect(
-        app.registry.get(executionIndicatorPlugin!.service).active.value
+        app.registry.get(executionIndicatorPlugin.service).active.value
       ).toBe(false)
 
       app.settings.actor.send({
@@ -378,7 +388,7 @@ describe('project system', () => {
       await waitForSettingsIdle(app)
 
       expect(
-        app.registry.get(executionIndicatorPlugin!.service).active.value
+        app.registry.get(executionIndicatorPlugin.service).active.value
       ).toBe(true)
     } finally {
       disposeApp(app)
@@ -466,19 +476,37 @@ describe('project system', () => {
     })
 
     try {
-      const project = await app.openProject(mockProject)
+      const projectSession = app.registry.get(projectSessionService)
+      const project = await projectSession.openProject(mockProject)
 
       expect(app.project).toBeDefined()
+      expect(app.project).toBe(project)
+      expect(projectSession.openedProject.value).toBe(project)
+      expect(projectSession.openedProjectHandle.value).toEqual({
+        projectPath: mockProject.path,
+      })
       expect(app.project?.executingPath).toBeNull()
       expect(app.project?.executingFileEntry.value.name).toEqual('')
 
-      await project.openEditor(mockProject.children![0].path)
+      const mainFile = mockProject.children?.[0]
+      expect(mainFile).toBeDefined()
+      if (!mainFile) {
+        throw new Error('Expected mock project to include a main file.')
+      }
+
+      await projectSession.openEditor(mainFile.path)
       expect(app.project?.executingPath).toEqual('/some-dir/test/main.kcl')
       expect(app.project?.executingFileEntry.value.name).toEqual('main.kcl')
+      expect(projectSession.executingEditorHandle.value).toEqual({
+        projectPath: mockProject.path,
+        filePath: mainFile.path,
+      })
 
-      app.closeProject()
+      projectSession.closeProject()
 
       expect(app.project).toBeUndefined()
+      expect(projectSession.openedProjectHandle.value).toBeUndefined()
+      expect(projectSession.executingEditorHandle.value).toBeUndefined()
     } finally {
       disposeApp(app)
     }

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -18,9 +18,16 @@ import { projectSessionService } from '@src/registry/contracts/projectSession'
 import { loadWasm } from '@src/unitTestUtils'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
+const mockProjectPath = '/private/tmp/zds-app-spec-project-system/test'
+const mockProjectMainFilePath = `${mockProjectPath}/main.kcl`
+const mockOtherProjectPath =
+  '/private/tmp/zds-app-spec-project-system/other-test'
+const mockOtherProjectMainFilePath = `${mockOtherProjectPath}/main.kcl`
+const mockProjectDirectoryPath = '/private/tmp/zds-app-spec-project-system'
+
 const mockProject: Project = {
   name: 'test',
-  default_file: 'main.kcl',
+  default_file: mockProjectMainFilePath,
   directory_count: 0,
   kcl_file_count: 1,
   metadata: {
@@ -31,12 +38,12 @@ const mockProject: Project = {
     size: 100,
     type: null,
   },
-  path: '/some-dir/test',
+  path: mockProjectPath,
   readWriteAccess: true,
   children: [
     {
       name: 'main.kcl',
-      path: '/some-dir/test/main.kcl',
+      path: mockProjectMainFilePath,
       children: [],
     },
   ],
@@ -48,9 +55,20 @@ beforeAll(async () => {
     type: StorageName.NodeFS,
     options: {},
   })
+  await fsZds.rm(mockProjectPath, { recursive: true, force: true })
+  await fsZds.mkdir(mockProjectPath, { recursive: true })
+  await fsZds.writeFile(mockProjectMainFilePath, new TextEncoder().encode(''))
+  await fsZds.rm(mockOtherProjectPath, { recursive: true, force: true })
+  await fsZds.mkdir(mockOtherProjectPath, { recursive: true })
+  await fsZds.writeFile(
+    mockOtherProjectMainFilePath,
+    new TextEncoder().encode('')
+  )
 })
 
-afterAll(() => {
+afterAll(async () => {
+  await fsZds.rm(mockProjectPath, { recursive: true, force: true })
+  await fsZds.rm(mockOtherProjectPath, { recursive: true, force: true })
   vi.restoreAllMocks()
 })
 
@@ -88,8 +106,8 @@ async function waitForAuthSettled(app: App) {
   })
 }
 
-function disposeApp(app: App) {
-  app.closeProject()
+async function disposeApp(app: App) {
+  await app.projectSession.setOpenedProjectHandle(undefined)
   app.systemIOActor.stop()
   app.settings.actor.stop()
   app.commands.actor.stop()
@@ -219,7 +237,7 @@ describe('project system', () => {
         ]
       ).toBeUndefined()
     } finally {
-      disposeApp(app)
+      await disposeApp(app)
     }
   })
 
@@ -314,7 +332,7 @@ describe('project system', () => {
       expect(textEditorSettings.automaticallyRender.current).toBe(true)
       expect(textEditorSettings.automaticallyRender.hideOnLevel).toBe('project')
     } finally {
-      disposeApp(app)
+      await disposeApp(app)
     }
   })
 
@@ -342,7 +360,7 @@ describe('project system', () => {
       expect(app.settings.get().plugins[pluginId].current).toBe(true)
       expect(app.registry.get(plugin.service).active.value).toBe(true)
     } finally {
-      disposeApp(app)
+      await disposeApp(app)
     }
   })
 
@@ -391,7 +409,7 @@ describe('project system', () => {
         app.registry.get(executionIndicatorPlugin.service).active.value
       ).toBe(true)
     } finally {
-      disposeApp(app)
+      await disposeApp(app)
     }
   })
 
@@ -483,7 +501,13 @@ describe('project system', () => {
 
     try {
       const projectSession = app.registry.get(projectSessionService)
-      const project = await projectSession.openProject(mockProject)
+      const project = await projectSession.setOpenedProjectHandle({
+        projectPath: mockProject.path,
+      })
+      expect(project).toBeDefined()
+      if (!project) {
+        throw new Error('Expected project session to open the mock project.')
+      }
 
       expect(app.project).toBeDefined()
       expect(app.project).toBe(project)
@@ -491,6 +515,9 @@ describe('project system', () => {
       expect(projectSession.openedProjectHandle.value).toEqual({
         projectPath: mockProject.path,
       })
+      expect(
+        app.systemIOActor.getSnapshot().context.projectDirectoryPath
+      ).toEqual(mockProjectDirectoryPath)
       expect(app.project?.executingPath).toBeNull()
       expect(app.project?.executingFileEntry.value.name).toEqual('')
 
@@ -500,40 +527,50 @@ describe('project system', () => {
         throw new Error('Expected mock project to include a main file.')
       }
 
-      await projectSession.openEditor(mainFile.path)
-      expect(app.project?.executingPath).toEqual('/some-dir/test/main.kcl')
+      await projectSession.setExecutingEditorHandle({
+        projectPath: mockProject.path,
+        filePath: mainFile.path,
+      })
+      expect(app.project?.executingPath).toEqual(mockProjectMainFilePath)
       expect(app.project?.executingFileEntry.value.name).toEqual('main.kcl')
       expect(projectSession.executingEditorHandle.value).toEqual({
         projectPath: mockProject.path,
         filePath: mainFile.path,
       })
 
-      const otherProject: Project = {
-        ...mockProject,
-        name: 'other-test',
-        path: '/some-dir/other-test',
-        children: [
-          {
-            name: 'main.kcl',
-            path: '/some-dir/other-test/main.kcl',
-            children: [],
-          },
-        ],
-      }
+      const otherFilePath = `${mockProjectPath}/other.kcl`
+      await projectSession.setExecutingEditorHandle({
+        projectPath: mockProject.path,
+        filePath: otherFilePath,
+      })
+      expect(app.project?.executingPath).toEqual(otherFilePath)
 
-      await projectSession.openProject(otherProject)
+      await projectSession.setExecutingEditorHandle({
+        projectPath: mockProject.path,
+        filePath: mainFile.path,
+      })
+      expect(app.project?.executingPath).toEqual(mockProjectMainFilePath)
+      expect(app.project?.executingFileEntry.value.name).toEqual('main.kcl')
+      expect(projectSession.executingEditorHandle.value).toEqual({
+        projectPath: mockProject.path,
+        filePath: mainFile.path,
+      })
+
+      await projectSession.setOpenedProjectHandle({
+        projectPath: mockOtherProjectPath,
+      })
       expect(projectSession.openedProjectHandle.value).toEqual({
-        projectPath: otherProject.path,
+        projectPath: mockOtherProjectPath,
       })
       expect(projectSession.executingEditorHandle.value).toBeUndefined()
 
-      projectSession.closeProject()
+      await projectSession.setOpenedProjectHandle(undefined)
 
       expect(app.project).toBeUndefined()
       expect(projectSession.openedProjectHandle.value).toBeUndefined()
       expect(projectSession.executingEditorHandle.value).toBeUndefined()
     } finally {
-      disposeApp(app)
+      await disposeApp(app)
     }
   })
 })

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -528,6 +528,25 @@ describe('project system', () => {
         filePath: mainFile.path,
       })
 
+      const otherProject: Project = {
+        ...mockProject,
+        name: 'other-test',
+        path: '/some-dir/other-test',
+        children: [
+          {
+            name: 'main.kcl',
+            path: '/some-dir/other-test/main.kcl',
+            children: [],
+          },
+        ],
+      }
+
+      await projectSession.openProject(otherProject)
+      expect(projectSession.openedProjectHandle.value).toEqual({
+        projectPath: otherProject.path,
+      })
+      expect(projectSession.executingEditorHandle.value).toBeUndefined()
+
       projectSession.closeProject()
 
       expect(app.project).toBeUndefined()

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -294,7 +294,7 @@ describe('project system', () => {
       expect(snapshot.context.currentArgument?.name).toBe('name')
     } finally {
       await waitForAuthSettled(app)
-      disposeApp(app)
+      await disposeApp(app)
     }
   })
 

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -468,7 +468,13 @@ describe('project system', () => {
 
   it('can open, close project', async () => {
     // Stub out File read and write implementations
-    File.ioImplementations.read = () => Promise.resolve('')
+    File.ioImplementations.read = (path) =>
+      Promise.resolve(
+        new Map([
+          ['/some-dir/test/main.kcl', 'main = 1'],
+          ['/some-dir/test/other.kcl', 'other = 2'],
+        ]).get(path) ?? ''
+      )
     File.ioImplementations.write = () => Promise.resolve()
 
     const app = App.fromProvided({
@@ -494,20 +500,29 @@ describe('project system', () => {
         throw new Error('Expected mock project to include a main file.')
       }
 
-      await projectSession.openEditor(mainFile.path)
+      await projectSession.openEditor(mainFile.path, {
+        providedEditor: app.singletons.kclManager,
+      })
       expect(app.project?.executingPath).toEqual('/some-dir/test/main.kcl')
       expect(app.project?.executingFileEntry.value.name).toEqual('main.kcl')
+      expect(app.singletons.kclManager.code).toBe('main = 1')
       expect(projectSession.executingEditorHandle.value).toEqual({
         projectPath: mockProject.path,
         filePath: mainFile.path,
       })
 
-      await projectSession.openEditor('/some-dir/test/other.kcl')
+      await projectSession.openEditor('/some-dir/test/other.kcl', {
+        providedEditor: app.singletons.kclManager,
+      })
       expect(app.project?.executingPath).toEqual('/some-dir/test/other.kcl')
+      expect(app.singletons.kclManager.code).toBe('other = 2')
 
-      await projectSession.openEditor(mainFile.path)
+      await projectSession.openEditor(mainFile.path, {
+        providedEditor: app.singletons.kclManager,
+      })
       expect(app.project?.executingPath).toEqual('/some-dir/test/main.kcl')
       expect(app.project?.executingFileEntry.value.name).toEqual('main.kcl')
+      expect(app.singletons.kclManager.code).toBe('main = 1')
       expect(projectSession.executingEditorHandle.value).toEqual({
         projectPath: mockProject.path,
         filePath: mainFile.path,

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -34,7 +34,7 @@ import {
   setLayoutSaveHandler,
 } from '@src/lib/layout'
 import { playwrightLayoutConfig } from '@src/lib/layout/configs/playwright'
-import type { Project } from '@src/lib/project'
+import { getParentAbsolutePath } from '@src/lib/paths'
 import RustContext from '@src/lib/rustContext'
 import type { SaveSettingsPayload } from '@src/lib/settings/settingsTypes'
 import {
@@ -266,6 +266,7 @@ export class App implements AppSubsystems {
   // TODO: refactor this to not require keeping around the last settings to compare to
   private lastSettings: SaveSettingsPayload
   private pluginSettingsSubscription: Subscription
+  private systemIOProjectDirectoryEffectUnsubscribe: ReturnType<typeof effect>
 
   constructor(subsystems: AppSubsystems) {
     this.wasmPromise = subsystems.wasmPromise
@@ -288,6 +289,9 @@ export class App implements AppSubsystems {
     this.projectSession = this.registry.get(projectSessionService)
     this.projectSignal = this.projectSession.openedProject
     this.projectSession.bindApp(this)
+    this.systemIOProjectDirectoryEffectUnsubscribe = effect(
+      this.syncSystemIOProjectDirectoryFromOpenedProjectHandle
+    )
 
     this.syncAppCommands()
     this.commands.actor.send({
@@ -549,13 +553,6 @@ export class App implements AppSubsystems {
     return new App(combined)
   }
 
-  async openProject(projectIORef: Project) {
-    return this.projectSession.openProject(projectIORef)
-  }
-  closeProject() {
-    this.projectSession.closeProject()
-  }
-
   syncUserFeaturesFromAuth = (
     snapshot: SnapshotFrom<typeof this.auth.actor>
   ) => {
@@ -666,6 +663,36 @@ export class App implements AppSubsystems {
 
       toggle.disable()
     }
+  }
+
+  syncSystemIOProjectDirectoryFromOpenedProjectHandle = () => {
+    const openedProjectHandle = this.projectSession.openedProjectHandle.value
+    const appProjectDir = this.settings.get().app.projectDirectory.current
+    const requestedProjectDirectoryPath =
+      openedProjectHandle?.projectPath.includes(appProjectDir)
+        ? appProjectDir
+        : openedProjectHandle
+          ? getParentAbsolutePath(openedProjectHandle.projectPath)
+          : appProjectDir
+
+    if (
+      this.systemIOActor.getSnapshot().context.projectDirectoryPath ===
+      requestedProjectDirectoryPath
+    ) {
+      if (!openedProjectHandle) {
+        this.systemIOActor.send({
+          type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
+        })
+      }
+      return
+    }
+
+    this.systemIOActor.send({
+      type: SystemIOMachineEvents.setProjectDirectoryPath,
+      data: {
+        requestedProjectDirectoryPath,
+      },
+    })
   }
 
   /**

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -8,12 +8,7 @@ import {
   provideService,
 } from '@kittycad/registry'
 import { type Signal, effect, signal } from '@preact/signals-core'
-import { buildFSHistoryExtension } from '@src/editor/plugins/fs'
-import {
-  type PreparedZookeeperPatchFileReplay,
-  buildZookeeperHistoryExtension,
-} from '@src/editor/plugins/zookeeper'
-import { KclManager, ZDSProject } from '@src/lang/KclManager'
+import { KclManager, type ZDSProject } from '@src/lang/KclManager'
 import { initialiseWasm } from '@src/lang/wasmUtils'
 import { MachineManager } from '@src/lib/MachineManager'
 import { createAuthCommands } from '@src/lib/commandBarConfigs/authCommandConfig'
@@ -81,6 +76,10 @@ import { keymapService } from '@src/registry/contracts/keymap'
 import { layoutContributionsValueSpec } from '@src/registry/contracts/layout'
 import { machineManagerService } from '@src/registry/contracts/machineManager'
 import {
+  type ProjectSessionService,
+  projectSessionService,
+} from '@src/registry/contracts/projectSession'
+import {
   type SettingsRegistryService,
   settingsService,
 } from '@src/registry/contracts/settings'
@@ -104,28 +103,6 @@ import { createActor } from 'xstate'
 const DEFAULT_LAYOUT_CONFIG_NAME = 'default'
 const PLAYWRIGHT_LAYOUT_CONFIG_NAME = 'test'
 const appCommandsSlot = new Slot()
-
-function zookeeperReplayChangesProjectFileSet(
-  replayFiles: readonly PreparedZookeeperPatchFileReplay[]
-) {
-  return replayFiles.some(
-    (replayFile) =>
-      replayFile.previousContent === null || replayFile.nextContent === null
-  )
-}
-
-function getZookeeperReplayFallbackFilePath(
-  project: ZDSProject,
-  deletedPaths: Set<string>
-) {
-  const defaultFile = project.projectIORefSignal.value.default_file
-  const candidates = [
-    defaultFile,
-    ...project.files.map((file) => file.path),
-  ].filter((path, index, paths) => paths.indexOf(path) === index)
-
-  return candidates.find((path) => path && !deletedPaths.has(path))
-}
 
 function isPlaywrightRuntime() {
   return typeof window !== 'undefined' && isPlaywright()
@@ -278,6 +255,8 @@ export class App implements AppSubsystems {
   layout: AppLayoutSystem
   /** The registry system for the application */
   registry: AppRegistrySystem
+  /** The currently-opened project and editor lifecycle system */
+  projectSession: ProjectSessionService
   /**
    * The interface to reading/writing to IO.
    * TODO: We have agreed to move away from this XState approach, towards a class + signals approach.
@@ -306,6 +285,9 @@ export class App implements AppSubsystems {
         app: this,
       },
     }).start()
+    this.projectSession = this.registry.get(projectSessionService)
+    this.projectSignal = this.projectSession.openedProject
+    this.projectSession.bindApp(this)
 
     this.syncAppCommands()
     this.commands.actor.send({
@@ -568,90 +550,10 @@ export class App implements AppSubsystems {
   }
 
   async openProject(projectIORef: Project) {
-    this.disposeProjectHistoryExtensions?.()
-    const projectIORefSignal = signal(projectIORef)
-    this.project = await ZDSProject.open(projectIORefSignal, this)
-
-    // These extensions make global project operations un/redoable.
-    this.disposeProjectHistoryExtensions = effect(() => {
-      const project = this.project
-      const executingEditor = project?.executingEditor.value
-      if (!project || !executingEditor) {
-        return
-      }
-
-      const disposeFSHistory = buildFSHistoryExtension(
-        this.systemIOActor,
-        executingEditor
-      )
-      const disposeZookeeperHistory = buildZookeeperHistoryExtension({
-        kclManager: executingEditor,
-        onCurrentFileDelete: async (deletedPaths) => {
-          const fallbackPath = getZookeeperReplayFallbackFilePath(
-            project,
-            deletedPaths
-          )
-          if (!fallbackPath) {
-            return Promise.reject(
-              new Error(
-                'Cannot replay this Zookeeper edit because no fallback KCL file is available.'
-              )
-            )
-          }
-
-          await project.openEditor(fallbackPath, executingEditor)
-        },
-        onActiveFileRestore: async (restoredPath, restoredContents) => {
-          await project.openEditor(
-            restoredPath,
-            executingEditor,
-            restoredContents
-          )
-        },
-        onProjectFilesReplay: async (replayFiles) => {
-          await project.syncReplayedFilesToRust(replayFiles)
-          if (zookeeperReplayChangesProjectFileSet(replayFiles)) {
-            this.systemIOActor.send({
-              type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
-            })
-          }
-        },
-      })
-
-      return () => {
-        disposeFSHistory()
-        disposeZookeeperHistory()
-      }
-    })
-
-    // TODO: Rework the systemIOActor to fit into the system better,
-    // so that the project doesn't need to subscribe to it.
-    this.systemIOActor.subscribe(({ context }) => {
-      const foundProject = (context.folders ?? []).find(
-        (p) =>
-          p.name === projectIORefSignal.value.name &&
-          p.path === projectIORefSignal.value.path
-      )
-      if (foundProject && projectIORefSignal.value !== foundProject) {
-        projectIORefSignal.value = foundProject
-      }
-    })
-
-    this.unsubscribeFromSettings = this.settings.actor.subscribe(
-      this.onSettingsUpdate
-    )
-
-    return this.project
+    return this.projectSession.openProject(projectIORef)
   }
-  private unsubscribeFromSettings: Subscription | undefined = undefined
-  private disposeProjectHistoryExtensions: (() => void) | undefined = undefined
   closeProject() {
-    this.disposeProjectHistoryExtensions?.()
-    this.disposeProjectHistoryExtensions = undefined
-    this.unsubscribeFromSettings?.unsubscribe()
-    this.unsubscribeFromSettings = undefined
-    this.project?.close()
-    this.project = undefined
+    this.projectSession.closeProject()
   }
 
   syncUserFeaturesFromAuth = (

--- a/src/lib/kclCommands.ts
+++ b/src/lib/kclCommands.ts
@@ -29,10 +29,9 @@ import {
 } from '@src/lib/constants'
 import { getPathFilenameInVariableCase } from '@src/lib/desktop'
 import fsZds from '@src/lib/fs-zds'
-import type { Project } from '@src/lib/project'
+import type { FileEntry, Project } from '@src/lib/project'
 import { baseUnitsUnion, warningLevels } from '@src/lib/settings/settingsTypes'
 import { err, reportRejection } from '@src/lib/trap'
-import type { IndexLoaderData } from '@src/lib/types'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { CommandBarContext } from '@src/machines/commandBarMachine'
 import { listAllImportFilesWithinProject } from '@src/machines/systemIO/snapshotContext'
@@ -47,7 +46,11 @@ interface KclCommandConfig {
   kclManager: KclManager
   systemIOActor: SystemIOActor
   wasmInstance: ModuleType
-  projectData: IndexLoaderData
+  projectData: {
+    code: string | null
+    project?: Project
+    file?: FileEntry
+  }
   settings: {
     defaultUnit: UnitLength
   }

--- a/src/lib/routeLoaderUtils.test.ts
+++ b/src/lib/routeLoaderUtils.test.ts
@@ -75,7 +75,6 @@ function createAppWithWebHomeFeature(enabled: boolean) {
     systemIOActor: {
       send: vi.fn(),
     },
-    closeProject,
     settings: {
       actor: {
         send: vi.fn(),
@@ -111,16 +110,13 @@ describe('route loaders', () => {
   it('loads Home project state without touching the demo-project flow', () => {
     const { app, closeProject } = createAppWithWebHomeFeature(true)
 
-    const result = loadHomeProjects(app)
+    const result = loadHomeProjects({ app, closeProject })
 
     expect(result).toEqual({})
     expect(app.systemIOActor.send).toHaveBeenCalledWith({
       type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
     })
     expect(closeProject).toHaveBeenCalled()
-    expect(app.settings.actor.send).toHaveBeenCalledWith({
-      type: 'clear.project',
-    })
   })
 
   it('waits for user features before deciding whether web Home is enabled', async () => {

--- a/src/lib/routeLoaderUtils.ts
+++ b/src/lib/routeLoaderUtils.ts
@@ -36,12 +36,6 @@ type HomeLoaderApp = {
       type: SystemIOMachineEvents.readFoldersFromProjectDirectory
     }) => void
   }
-  closeProject: () => void
-  settings: {
-    actor: {
-      send: (event: { type: 'clear.project' }) => void
-    }
-  }
 }
 
 async function waitForWebHomeFeatureGate(app: WebHomeApp) {
@@ -94,13 +88,16 @@ export async function webHomeRouteEnabled(app: WebHomeApp) {
   )
 }
 
-export function loadHomeProjects(app: HomeLoaderApp) {
+export function loadHomeProjects({
+  app,
+  closeProject,
+}: {
+  app: HomeLoaderApp
+  closeProject: () => void
+}) {
   app.systemIOActor.send({
     type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
   })
-  app.closeProject()
-  app.settings.actor.send({
-    type: 'clear.project',
-  })
+  closeProject()
   return {}
 }

--- a/src/lib/routeLoaders.ts
+++ b/src/lib/routeLoaders.ts
@@ -1,18 +1,9 @@
 import { projectSkeletonCreate } from '@src/lang/project'
 import type { App } from '@src/lib/app'
-import {
-  DEFAULT_DEFAULT_LENGTH_UNIT,
-  PROJECT_ENTRYPOINT,
-} from '@src/lib/constants'
-import { getInitialDefaultDir, getProjectInfo } from '@src/lib/desktop'
-import { readAppSettingsFile } from '@src/lib/desktop'
+import { DEFAULT_DEFAULT_LENGTH_UNIT } from '@src/lib/constants'
+import { getInitialDefaultDir } from '@src/lib/desktop'
 import fsZds from '@src/lib/fs-zds'
-import {
-  PATHS,
-  getProjectMetaByRouteId,
-  getRouterSearchFromRequestUrl,
-  safeEncodeForRouterPaths,
-} from '@src/lib/paths'
+import { PATHS, getRouterSearchFromRequestUrl } from '@src/lib/paths'
 import { webHomeRouteEnabled } from '@src/lib/routeLoaderUtils'
 import { loadAndValidateSettings } from '@src/lib/settings/settingsUtils'
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
@@ -98,88 +89,16 @@ export const fileLoader =
     app: App
   }): LoaderFunction =>
   async (routerData): Promise<EmptyLoaderData | Response> => {
-    const { kclManager } = app.singletons
     const projectSession = app.registry.get(projectSessionService)
-    const { params } = routerData
-
-    // Must basically remain for all eternity, until the last person
-    // who's ever used ZDS on web before this point has died.
-    if (params.id?.startsWith('/browser')) {
-      // Pop us back home, which will cause a default project to be
-      // created.
-      return redirect(PATHS.HOME)
-    }
-
-    const heuristicProjectFilePath = params.id
-      ? params.id.split(fsZds.sep).slice(0, -1).join(fsZds.sep)
-      : undefined
-
-    const wasmInstance = await kclManager.wasmInstancePromise
-
-    const settings = await loadAndValidateSettings(
-      wasmInstance,
-      heuristicProjectFilePath
-    )
-
-    const projectPathData = await getProjectMetaByRouteId(
-      readAppSettingsFile,
-      wasmInstance,
-      params.id,
-      settings.configuration
-    )
-
-    if (!projectPathData) {
-      return Promise.reject(
-        new Error('bug: projectPathData undefined, early return')
-      )
-    }
-
-    const { projectName, projectPath, currentFileName, currentFilePath } =
-      projectPathData
-
-    const urlObj = new URL(routerData.request.url)
-
-    if (!urlObj.pathname.endsWith('/settings')) {
-      const fallbackFile = (await getProjectInfo(projectPath, wasmInstance))
-        .default_file
-      let fileExists = true
-      if (currentFilePath && fileExists) {
-        try {
-          await fsZds.stat(currentFilePath)
-        } catch (e) {
-          if (e === 'ENOENT') {
-            fileExists = false
-          }
-        }
-      }
-
-      // If we are navigating to the project and want to navigate to its
-      // default file, redirect to it keeping everything else in the URL the same.
-      if (projectPath && !currentFileName && fileExists && params.id) {
-        const encodedId = safeEncodeForRouterPaths(params.id)
-        const requestUrlWithDefaultFile = routerData.request.url.replace(
-          encodedId,
-          safeEncodeForRouterPaths(fallbackFile)
-        )
-        return redirect(requestUrlWithDefaultFile)
-      }
-
-      if (!fileExists || !currentFileName || !currentFilePath || !projectName) {
-        const routerSearch = getRouterSearchFromRequestUrl(
-          routerData.request.url,
-          Boolean(window.electron)
-        )
-        return redirect(
-          `${PATHS.FILE}/${encodeURIComponent(fallbackFile)}${routerSearch}`
-        )
-      }
-    }
-
-    await projectSession.setOpenedProjectHandle({ projectPath })
-    await projectSession.setExecutingEditorHandle({
-      projectPath,
-      filePath: currentFilePath || PROJECT_ENTRYPOINT,
+    const result = await projectSession.setProjectRouteHandles({
+      routeId: routerData.params.id,
+      requestUrl: routerData.request.url,
+      usesHashRouter: Boolean(window.electron),
     })
+
+    if (result.redirectTo) {
+      return redirect(result.redirectTo)
+    }
 
     return {}
   }

--- a/src/lib/routeLoaders.ts
+++ b/src/lib/routeLoaders.ts
@@ -6,7 +6,6 @@ import fsZds from '@src/lib/fs-zds'
 import { PATHS, getRouterSearchFromRequestUrl } from '@src/lib/paths'
 import { webHomeRouteEnabled } from '@src/lib/routeLoaderUtils'
 import { loadAndValidateSettings } from '@src/lib/settings/settingsUtils'
-import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
 import { projectSessionService } from '@src/registry/contracts/projectSession'
 import type { LoaderFunction } from 'react-router-dom'
 import { redirect } from 'react-router-dom'
@@ -53,18 +52,18 @@ export const baseLoader =
 
     const settings = await loadAndValidateSettings(wasmInstance, undefined)
 
-    const requestedProjectName = fsZds.resolve(
+    const requestedProjectPath = fsZds.resolve(
       settings.settings.app.projectDirectory.current,
       DEFAULT_WEB_PROJECT_NAME
     )
 
     // We have to create and/or navigate to a project on web.
     try {
-      await fsZds.stat(requestedProjectName)
-      app.systemIOActor.send({
-        type: SystemIOMachineEvents.navigateToProject,
-        data: { requestedProjectName },
-      })
+      await fsZds.stat(requestedProjectPath)
+      const fileURLPath = `${PATHS.FILE}/${encodeURIComponent(
+        requestedProjectPath
+      )}`
+      return redirect(fileURLPath + routerSearch)
     } catch {
       await projectSkeletonCreate(
         fsZds.resolve(
@@ -77,7 +76,9 @@ export const baseLoader =
         wasmInstance
       )
 
-      const fileURLPath = `${PATHS.FILE}/${encodeURIComponent(requestedProjectName)}`
+      const fileURLPath = `${PATHS.FILE}/${encodeURIComponent(
+        requestedProjectPath
+      )}`
       return redirect(fileURLPath + routerSearch)
     }
   }

--- a/src/lib/routeLoaders.ts
+++ b/src/lib/routeLoaders.ts
@@ -1,5 +1,4 @@
 import { projectSkeletonCreate } from '@src/lang/project'
-import { projectFsManager } from '@src/lang/std/fileSystemManager'
 import type { App } from '@src/lib/app'
 import {
   DEFAULT_DEFAULT_LENGTH_UNIT,
@@ -26,9 +25,9 @@ import type {
   IndexLoaderData,
 } from '@src/lib/types'
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
+import { projectSessionService } from '@src/registry/contracts/projectSession'
 import type { LoaderFunction } from 'react-router-dom'
 import { redirect } from 'react-router-dom'
-import { waitFor } from 'xstate'
 
 export const DEFAULT_WEB_PROJECT_NAME = 'demo-project'
 
@@ -106,10 +105,8 @@ export const fileLoader =
     app: App
   }): LoaderFunction =>
   async (routerData): Promise<FileLoaderData | Response> => {
-    const {
-      settings: { actor: settingsActor },
-    } = app
     const { kclManager } = app.singletons
+    const projectSession = app.registry.get(projectSessionService)
     const { params } = routerData
 
     // Must basically remain for all eternity, until the last person
@@ -185,10 +182,6 @@ export const fileLoader =
       }
     }
 
-    // Set the file system manager to the project path
-    // So that WASM gets an updated path for operations
-    projectFsManager.dir = projectPath
-
     const defaultProjectData = {
       name: projectName || 'unnamed',
       path: projectPath,
@@ -204,25 +197,17 @@ export const fileLoader =
 
     const project = maybeProjectInfo ?? defaultProjectData
 
-    // Fire off the event to load the project settings
-    // once we know it's idle.
-    await waitFor(settingsActor, (state) => state.matches('idle'))
-    settingsActor.send({
-      type: 'load.project',
+    const { editor } = await projectSession.openProjectEditor({
       project,
-    })
-    await waitFor(settingsActor, (state) => state.matches('idle'))
-
-    const projectRef = await app.openProject(project)
-    const editor = await projectRef.openEditor(
-      currentFilePath || PROJECT_ENTRYPOINT,
-      app.singletons.kclManager,
+      filePath: currentFilePath || PROJECT_ENTRYPOINT,
+      providedEditor: app.singletons.kclManager,
       // If persistCode in localStorage is present, it'll persist that code
       // through *anything*. INTENDED FOR TESTS.
-      window.electron?.process.env.NODE_ENV === 'test'
-        ? kclManager.localStoragePersistCode()
-        : undefined
-    )
+      providedCode:
+        window.electron?.process.env.NODE_ENV === 'test'
+          ? kclManager.localStoragePersistCode()
+          : undefined,
+    })
 
     const requestedFileName =
       app.systemIOActor.getSnapshot().context.requestedFileName
@@ -272,5 +257,9 @@ export const homeLoader =
       return redirect(PATHS.INDEX)
     }
 
-    return loadHomeProjects(app)
+    return loadHomeProjects({
+      app,
+      closeProject: () =>
+        app.registry.get(projectSessionService).closeProject(),
+    })
   }

--- a/src/lib/routeLoaders.ts
+++ b/src/lib/routeLoaders.ts
@@ -9,27 +9,20 @@ import { readAppSettingsFile } from '@src/lib/desktop'
 import fsZds from '@src/lib/fs-zds'
 import {
   PATHS,
-  getParentAbsolutePath,
   getProjectMetaByRouteId,
   getRouterSearchFromRequestUrl,
   safeEncodeForRouterPaths,
 } from '@src/lib/paths'
-import {
-  loadHomeProjects,
-  webHomeRouteEnabled,
-} from '@src/lib/routeLoaderUtils'
+import { webHomeRouteEnabled } from '@src/lib/routeLoaderUtils'
 import { loadAndValidateSettings } from '@src/lib/settings/settingsUtils'
-import type {
-  FileLoaderData,
-  HomeLoaderData,
-  IndexLoaderData,
-} from '@src/lib/types'
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
 import { projectSessionService } from '@src/registry/contracts/projectSession'
 import type { LoaderFunction } from 'react-router-dom'
 import { redirect } from 'react-router-dom'
 
 export const DEFAULT_WEB_PROJECT_NAME = 'demo-project'
+
+type EmptyLoaderData = Record<string, never>
 
 /**
  * The base loader is used to reroute `/` root path requests,
@@ -104,7 +97,7 @@ export const fileLoader =
   }: {
     app: App
   }): LoaderFunction =>
-  async (routerData): Promise<FileLoaderData | Response> => {
+  async (routerData): Promise<EmptyLoaderData | Response> => {
     const { kclManager } = app.singletons
     const projectSession = app.registry.get(projectSessionService)
     const { params } = routerData
@@ -182,84 +175,32 @@ export const fileLoader =
       }
     }
 
-    const defaultProjectData = {
-      name: projectName || 'unnamed',
-      path: projectPath,
-      children: [],
-      kcl_file_count: 0,
-      directory_count: 0,
-      metadata: null,
-      default_file: projectPath,
-      readWriteAccess: true,
-    }
-
-    const maybeProjectInfo = await getProjectInfo(projectPath, wasmInstance)
-
-    const project = maybeProjectInfo ?? defaultProjectData
-
-    const { editor } = await projectSession.openProjectEditor({
-      project,
+    await projectSession.setOpenedProjectHandle({ projectPath })
+    await projectSession.setExecutingEditorHandle({
+      projectPath,
       filePath: currentFilePath || PROJECT_ENTRYPOINT,
-      providedEditor: app.singletons.kclManager,
-      // If persistCode in localStorage is present, it'll persist that code
-      // through *anything*. INTENDED FOR TESTS.
-      providedCode:
-        window.electron?.process.env.NODE_ENV === 'test'
-          ? kclManager.localStoragePersistCode()
-          : undefined,
     })
 
-    const requestedFileName =
-      app.systemIOActor.getSnapshot().context.requestedFileName
-    if (requestedFileName.project === projectName) {
-      requestedFileName.onProjectLoaderComplete?.()
-    }
-
-    const appProjectDir = settings.settings.app.projectDirectory.current
-    const requestedProjectDirectoryPath = project.path.includes(appProjectDir)
-      ? appProjectDir
-      : getParentAbsolutePath(project.path) // Fallback to parent directory if foreign to app project dir
-    app.systemIOActor.send({
-      type: SystemIOMachineEvents.setProjectDirectoryPath,
-      data: {
-        requestedProjectDirectoryPath,
-      },
-    })
-
-    const projectData: IndexLoaderData = {
-      code: editor.code,
-      project,
-      file: {
-        name: currentFileName || '',
-        path: currentFilePath || '',
-        children: [],
-      },
-    }
-
-    return {
-      ...projectData,
-    }
+    return {}
   }
 
 // Loads the settings and by extension the projects in the default directory
 // and returns them to the Home route, along with any errors that occurred
 
-// Should also clear currently loaded projects in SystemIO. They may be stale.
 export const homeLoader =
   ({
     app,
   }: {
     app: App
   }): LoaderFunction =>
-  async (): Promise<HomeLoaderData | Response> => {
+  async (): Promise<EmptyLoaderData | Response> => {
     // If on unflagged web, bump out to root, which will redirect to a project.
     if (!window.electron && !(await webHomeRouteEnabled(app))) {
       return redirect(PATHS.INDEX)
     }
 
-    return loadHomeProjects({
-      app,
-      closeProject: () =>
-        app.registry.get(projectSessionService).closeProject(),
-    })
+    await app.registry
+      .get(projectSessionService)
+      .setOpenedProjectHandle(undefined)
+    return {}
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,19 +1,3 @@
-import type { FileEntry, Project } from '@src/lib/project'
-
-export type IndexLoaderData = {
-  code: string | null
-  project?: Project
-  file?: FileEntry
-}
-
-export type FileLoaderData = {
-  code: string | null
-  project?: FileEntry | Project
-  file?: FileEntry
-}
-
-export type HomeLoaderData = Record<string, never>
-
 // From the very helpful @jcalz on StackOverflow: https://stackoverflow.com/a/58436959/22753272
 type Join<K, P> = K extends string | number
   ? P extends string | number
@@ -97,17 +81,16 @@ export type DeepPartial<T> = {
 /**
  * Replace a function's return type with another type.
  */
-export type WithReturnType<F extends (...args: any[]) => any, NewReturn> = (
+type AnyFunction = (...args: never[]) => unknown
+
+export type WithReturnType<F extends AnyFunction, NewReturn> = (
   ...args: Parameters<F>
 ) => NewReturn
 
 /**
  * Assert that a function type is async, preserving its parameter types.
  */
-export type AsyncFn<F extends (...args: any[]) => any> = WithReturnType<
-  F,
-  Promise<unknown>
->
+export type AsyncFn<F extends AnyFunction> = WithReturnType<F, Promise<unknown>>
 
 export type FileMeta =
   | {
@@ -138,7 +121,5 @@ type PromisifyFn<F> = F extends (...args: infer A) => infer R
   : F
 /** Promisify only function properties, leave others unchanged */
 export type PromisifyProps<T> = {
-  [K in keyof T]: T[K] extends (...args: any[]) => any
-    ? PromisifyFn<T[K]>
-    : T[K]
+  [K in keyof T]: T[K] extends AnyFunction ? PromisifyFn<T[K]> : T[K]
 }

--- a/src/machines/systemIO/systemIOMachine.spec.ts
+++ b/src/machines/systemIO/systemIOMachine.spec.ts
@@ -6,12 +6,14 @@ import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { systemIOMachine } from '@src/machines/systemIO/systemIOMachine'
 import {
   getCloudProjectFolderRenameName,
+  reloadExecutingEditorAfterBulkWrite,
   shouldSendProjectFolderReadProgress,
   sortProjectDirectoryEntriesByModifiedDesc,
   systemIOMachineImpl,
 } from '@src/machines/systemIO/systemIOMachineImpl'
 import {
   NO_PROJECT_DIRECTORY,
+  type SystemIOContext,
   SystemIOMachineActors,
   SystemIOMachineEvents,
   SystemIOMachineStates,
@@ -1191,6 +1193,51 @@ describe('systemIOMachine - XState', () => {
         } finally {
           actor.stop()
         }
+      })
+    })
+    describe('when bulk writing the active file', () => {
+      it('should reload the executing editor after overwriting its file', async () => {
+        const reloadFromDisk = vi.fn().mockResolvedValue(undefined)
+
+        await reloadExecutingEditorAfterBulkWrite({
+          context: {
+            app: {
+              project: {
+                executingEditor: {
+                  value: {
+                    path: '/projects/demo/main.kcl',
+                    reloadFromDisk,
+                  },
+                },
+              },
+            },
+          } as unknown as SystemIOContext,
+          writtenFilePaths: ['/projects/demo/main.kcl'],
+        })
+
+        expect(reloadFromDisk).toHaveBeenCalledTimes(1)
+      })
+
+      it('should not reload the executing editor after writing another file', async () => {
+        const reloadFromDisk = vi.fn().mockResolvedValue(undefined)
+
+        await reloadExecutingEditorAfterBulkWrite({
+          context: {
+            app: {
+              project: {
+                executingEditor: {
+                  value: {
+                    path: '/projects/demo/main.kcl',
+                    reloadFromDisk,
+                  },
+                },
+              },
+            },
+          } as unknown as SystemIOContext,
+          writtenFilePaths: ['/projects/demo/other.kcl'],
+        })
+
+        expect(reloadFromDisk).not.toHaveBeenCalled()
       })
     })
     describe('when setting default project folder name', () => {

--- a/src/machines/systemIO/systemIOMachine.spec.ts
+++ b/src/machines/systemIO/systemIOMachine.spec.ts
@@ -283,6 +283,94 @@ describe('systemIOMachine - XState', () => {
         )
         actor.stop()
       })
+      it('requests default file navigation after archiving the active file', async () => {
+        const actor = createActor(
+          systemIOMachine.provide({
+            actors: {
+              [SystemIOMachineActors.moveRecursive]: fromPromise(
+                async ({ input }) => ({
+                  message: 'Archived successfully',
+                  requestedAbsolutePath: '',
+                  requestedProjectName: input.requestedProjectName || '',
+                  requestedFileName: 'main.kcl',
+                  target: input.target,
+                })
+              ),
+              [SystemIOMachineActors.readFoldersFromProjectDirectory]:
+                fromPromise(async () => [] as Project[]),
+            },
+          }),
+          {
+            input: {
+              wasmInstancePromise: Promise.resolve(instanceInThisFile),
+              app: appInstanceInThisFile,
+            },
+          }
+        ).start()
+
+        actor.send({
+          type: SystemIOMachineEvents.moveRecursiveAndNavigate,
+          data: {
+            src: '/projects/demo-project/fileToDelete.kcl',
+            target: '/projects/.archive/demo-project/fileToDelete.kcl',
+            requestedProjectName: 'demo-project',
+          },
+        })
+
+        await waitFor(
+          actor,
+          (state) => state.context.requestedFileName.file === 'main.kcl'
+        )
+
+        expect(actor.getSnapshot().context.requestedFileName).toStrictEqual({
+          project: 'demo-project',
+          file: 'main.kcl',
+        })
+        actor.stop()
+      })
+      it('requests default file navigation after deleting the active file', async () => {
+        const actor = createActor(
+          systemIOMachine.provide({
+            actors: {
+              [SystemIOMachineActors.deleteFileOrFolder]: fromPromise(
+                async ({ input }) => ({
+                  message: 'File deleted successfully',
+                  requestedPath: input.requestedPath,
+                  requestedProjectName: input.requestedProjectName || '',
+                  requestedFileName: 'main.kcl',
+                })
+              ),
+              [SystemIOMachineActors.readFoldersFromProjectDirectory]:
+                fromPromise(async () => [] as Project[]),
+            },
+          }),
+          {
+            input: {
+              wasmInstancePromise: Promise.resolve(instanceInThisFile),
+              app: appInstanceInThisFile,
+            },
+          }
+        ).start()
+
+        actor.send({
+          type: SystemIOMachineEvents.deleteFileOrFolderAndNavigate,
+          data: {
+            requestedPath: '/projects/demo-project/fileToDelete.kcl',
+            requestedProjectName: 'demo-project',
+          },
+        })
+
+        await waitFor(
+          actor,
+          (state) => state.context.requestedFileName.file === 'main.kcl'
+        )
+
+        expect(actor.getSnapshot().context.requestedFileName).toStrictEqual({
+          project: 'demo-project',
+          file: 'main.kcl',
+        })
+        actor.stop()
+      })
       it('should accept externally synced folders while idle', async () => {
         const actor = createActor(systemIOMachineImpl, {
           input: {

--- a/src/machines/systemIO/systemIOMachine.ts
+++ b/src/machines/systemIO/systemIOMachine.ts
@@ -283,7 +283,7 @@ export const systemIOMachine = setup({
         }
       | {
           type: SystemIOMachineEvents.done_deleteFileOrFolderAndNavigate
-          output: { requestedProjectName: string }
+          output: { requestedProjectName: string; requestedFileName: string }
         }
       | {
           type: SystemIOMachineEvents.copyRecursive
@@ -311,7 +311,11 @@ export const systemIOMachine = setup({
         }
       | {
           type: SystemIOMachineEvents.done_moveRecursiveAndNavigate
-          output: { requestedProjectName: string; target: string }
+          output: {
+            requestedProjectName: string
+            requestedFileName: string
+            target: string
+          }
         }
       | {
           type: SystemIOMachineEvents.getMlEphantConversations
@@ -746,6 +750,7 @@ export const systemIOMachine = setup({
           message: '',
           requestedPath: '',
           requestedProjectName: '',
+          requestedFileName: '',
         }
       }
     ),
@@ -811,6 +816,7 @@ export const systemIOMachine = setup({
           message: '',
           requestedAbsolutePath: '',
           requestedProjectName: '',
+          requestedFileName: '',
           target: input.target,
         }
       }
@@ -2023,6 +2029,24 @@ export const systemIOMachine = setup({
                     .output.requestedProjectName,
                 }
               },
+              requestedFileName: ({ event }) => {
+                assertEvent(
+                  event,
+                  SystemIOMachineEvents.done_deleteFileOrFolderAndNavigate
+                )
+                const output = (
+                  event as {
+                    output: {
+                      requestedProjectName: string
+                      requestedFileName: string
+                    }
+                  }
+                ).output
+                return {
+                  project: output.requestedProjectName,
+                  file: output.requestedFileName,
+                }
+              },
             }),
             SystemIOMachineActions.toastSuccess,
           ],
@@ -2114,6 +2138,24 @@ export const systemIOMachine = setup({
                 return {
                   name: (event as { output: { requestedProjectName: string } })
                     .output.requestedProjectName,
+                }
+              },
+              requestedFileName: ({ event }) => {
+                assertEvent(
+                  event,
+                  SystemIOMachineEvents.done_moveRecursiveAndNavigate
+                )
+                const output = (
+                  event as {
+                    output: {
+                      requestedProjectName: string
+                      requestedFileName: string
+                    }
+                  }
+                ).output
+                return {
+                  project: output.requestedProjectName,
+                  file: output.requestedFileName,
                 }
               },
             }),

--- a/src/machines/systemIO/systemIOMachineImpl.ts
+++ b/src/machines/systemIO/systemIOMachineImpl.ts
@@ -357,11 +357,17 @@ const sharedBulkWriteImportedProjectFilesWorkflow = async ({
     }
 
     await fsZds.mkdir(projectRoot, { recursive: true })
+    const writtenFilePaths: string[] = []
     for (const file of input.files) {
       const targetPath = fsZds.join(projectRoot, file.requestedFileName)
       await fsZds.mkdir(fsZds.dirname(targetPath), { recursive: true })
       await fsZds.writeFile(targetPath, Uint8Array.from(file.requestedData))
+      writtenFilePaths.push(targetPath)
     }
+    await reloadExecutingEditorAfterBulkWrite({
+      context: input.context,
+      writtenFilePaths,
+    })
 
     if (requestedFileNameWithExtension) {
       const entrypointPath = fsZds.join(

--- a/src/machines/systemIO/systemIOMachineImpl.ts
+++ b/src/machines/systemIO/systemIOMachineImpl.ts
@@ -226,6 +226,34 @@ const prepareBulkProjectWrite = async ({
   }
 }
 
+function getDefaultRequestedFileName({
+  context,
+  requestedProjectName,
+}: {
+  context: SystemIOContext
+  requestedProjectName?: string
+}) {
+  const project = context.folders?.find(
+    (folder) => folder.name === requestedProjectName
+  )
+  const defaultFile = project?.default_file
+  if (!project || !defaultFile) {
+    return ''
+  }
+
+  const projectPathPrefix = project.path.endsWith(fsZds.sep)
+    ? project.path
+    : `${project.path}${fsZds.sep}`
+  if (defaultFile.startsWith(projectPathPrefix)) {
+    return fsZds.relative(project.path, defaultFile).replace(/^[\\/]+/, '')
+  }
+
+  return (
+    parentPathRelativeToProject(defaultFile, context.projectDirectoryPath) ||
+    defaultFile.replace(/^[\\/]+/, '')
+  )
+}
+
 export const reloadExecutingEditorAfterBulkWrite = async ({
   context,
   writtenFilePaths,
@@ -1133,6 +1161,10 @@ export const systemIOMachineImpl = systemIOMachine.provide({
           message: 'File deleted successfully',
           requestedPath: input.requestedPath,
           requestedProjectName: input.requestedProjectName || '',
+          requestedFileName: getDefaultRequestedFileName({
+            context: input.context,
+            requestedProjectName: input.requestedProjectName,
+          }),
         }
         return response
       }
@@ -1266,6 +1298,10 @@ export const systemIOMachineImpl = systemIOMachine.provide({
           message: input.successMessage || 'Moved successfully',
           requestedAbsolutePath: '',
           requestedProjectName: input.requestedProjectName || '',
+          requestedFileName: getDefaultRequestedFileName({
+            context: input.context,
+            requestedProjectName: input.requestedProjectName,
+          }),
           target: input.target,
         }
       }

--- a/src/machines/systemIO/systemIOMachineImpl.ts
+++ b/src/machines/systemIO/systemIOMachineImpl.ts
@@ -226,6 +226,25 @@ const prepareBulkProjectWrite = async ({
   }
 }
 
+export const reloadExecutingEditorAfterBulkWrite = async ({
+  context,
+  writtenFilePaths,
+}: {
+  context: SystemIOContext
+  writtenFilePaths: string[]
+}) => {
+  const executingEditor = context.app.project?.executingEditor.value
+  if (!executingEditor) {
+    return
+  }
+
+  if (!writtenFilePaths.includes(executingEditor.path)) {
+    return
+  }
+
+  await executingEditor.reloadFromDisk()
+}
+
 const sharedBulkCreateWorkflow = async ({
   input,
 }: {
@@ -247,6 +266,7 @@ const sharedBulkCreateWorkflow = async ({
     wasmInstance: input.wasmInstance,
   })
 
+  const writtenFilePaths: string[] = []
   for (let fileIndex = 0; fileIndex < input.files.length; fileIndex++) {
     const file = input.files[fileIndex]
     const requestedFileName = file.requestedFileName
@@ -263,6 +283,8 @@ const sharedBulkCreateWorkflow = async ({
           })
         ).name
 
+    writtenFilePaths.push(fsZds.join(projectRoot, fileName))
+
     // Create the project around the file if newProject
     await createNewProjectDirectory(
       newProjectName,
@@ -273,6 +295,11 @@ const sharedBulkCreateWorkflow = async ({
       projectDirectoryPath
     )
   }
+  await reloadExecutingEditorAfterBulkWrite({
+    context: input.context,
+    writtenFilePaths,
+  })
+
   const numberOfFiles = input.files.length
   const fileText = numberOfFiles > 1 ? 'files' : 'file'
   const message = input.override

--- a/src/registry/contracts/projectSession.ts
+++ b/src/registry/contracts/projectSession.ts
@@ -22,6 +22,16 @@ export interface OpenEditorOptions {
   isExecuting?: boolean
 }
 
+export interface ProjectRouteHandlesOptions {
+  routeId?: string
+  requestUrl: string
+  usesHashRouter?: boolean
+}
+
+export interface ProjectRouteHandlesResult {
+  redirectTo?: string
+}
+
 export interface ProjectSessionService {
   readonly openedProjectHandle: Signal<OpenedProjectHandle | undefined>
   readonly executingEditorHandle: Signal<ExecutingEditorHandle | undefined>
@@ -34,6 +44,9 @@ export interface ProjectSessionService {
     handle: ExecutingEditorHandle | undefined,
     options?: OpenEditorOptions
   ): Promise<KclManager | undefined>
+  setProjectRouteHandles(
+    options: ProjectRouteHandlesOptions
+  ): Promise<ProjectRouteHandlesResult>
 }
 
 export const projectSessionContract = defineContract({

--- a/src/registry/contracts/projectSession.ts
+++ b/src/registry/contracts/projectSession.ts
@@ -6,7 +6,6 @@ import {
 import type { Signal } from '@preact/signals-core'
 import type { KclManager, ZDSProject } from '@src/lang/KclManager'
 import type { App } from '@src/lib/app'
-import type { Project } from '@src/lib/project'
 
 export interface OpenedProjectHandle {
   projectPath: string
@@ -23,23 +22,18 @@ export interface OpenEditorOptions {
   isExecuting?: boolean
 }
 
-export interface OpenProjectEditorInput extends OpenEditorOptions {
-  project: Project
-  filePath: string
-}
-
 export interface ProjectSessionService {
   readonly openedProjectHandle: Signal<OpenedProjectHandle | undefined>
   readonly executingEditorHandle: Signal<ExecutingEditorHandle | undefined>
   readonly openedProject: Signal<ZDSProject | undefined>
   bindApp(app: App): void
-  openProject(project: Project): Promise<ZDSProject>
-  openEditor(filePath: string, options?: OpenEditorOptions): Promise<KclManager>
-  openProjectEditor(input: OpenProjectEditorInput): Promise<{
-    project: ZDSProject
-    editor: KclManager
-  }>
-  closeProject(): void
+  setOpenedProjectHandle(
+    handle: OpenedProjectHandle | undefined
+  ): Promise<ZDSProject | undefined>
+  setExecutingEditorHandle(
+    handle: ExecutingEditorHandle | undefined,
+    options?: OpenEditorOptions
+  ): Promise<KclManager | undefined>
 }
 
 export const projectSessionContract = defineContract({

--- a/src/registry/contracts/projectSession.ts
+++ b/src/registry/contracts/projectSession.ts
@@ -1,0 +1,65 @@
+import {
+  defineContract,
+  defineService,
+  firstWinsValueSpec,
+} from '@kittycad/registry'
+import type { Signal } from '@preact/signals-core'
+import type { KclManager, ZDSProject } from '@src/lang/KclManager'
+import type { App } from '@src/lib/app'
+import type { Project } from '@src/lib/project'
+
+export interface OpenedProjectHandle {
+  projectPath: string
+}
+
+export interface ExecutingEditorHandle {
+  projectPath: string
+  filePath: string
+}
+
+export interface OpenEditorOptions {
+  providedEditor?: KclManager
+  providedCode?: string
+  isExecuting?: boolean
+}
+
+export interface OpenProjectEditorInput extends OpenEditorOptions {
+  project: Project
+  filePath: string
+}
+
+export interface ProjectSessionService {
+  readonly openedProjectHandle: Signal<OpenedProjectHandle | undefined>
+  readonly executingEditorHandle: Signal<ExecutingEditorHandle | undefined>
+  readonly openedProject: Signal<ZDSProject | undefined>
+  bindApp(app: App): void
+  openProject(project: Project): Promise<ZDSProject>
+  openEditor(filePath: string, options?: OpenEditorOptions): Promise<KclManager>
+  openProjectEditor(input: OpenProjectEditorInput): Promise<{
+    project: ZDSProject
+    editor: KclManager
+  }>
+  closeProject(): void
+}
+
+export const projectSessionContract = defineContract({
+  openedProjectHandleValueSpec: firstWinsValueSpec<
+    OpenedProjectHandle | undefined
+  >('opened-project-handle', undefined),
+  executingEditorHandleValueSpec: firstWinsValueSpec<
+    ExecutingEditorHandle | undefined
+  >('executing-editor-handle', undefined),
+  openedProjectValueSpec: firstWinsValueSpec<ZDSProject | undefined>(
+    'opened-project',
+    undefined
+  ),
+  projectSessionService:
+    defineService<ProjectSessionService>('project-session'),
+})
+
+export const {
+  openedProjectHandleValueSpec,
+  executingEditorHandleValueSpec,
+  openedProjectValueSpec,
+  projectSessionService,
+} = projectSessionContract

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -86,10 +86,10 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     stopProjectEffects()
     currentProject?.close()
     openedProject.value = undefined
+    executingEditorHandle.value = undefined
 
     if (clearHandles) {
       openedProjectHandle.value = undefined
-      executingEditorHandle.value = undefined
     }
 
     if (clearProjectSettings) {

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -13,14 +13,25 @@ import {
 import { ZDSProject } from '@src/lang/KclManager'
 import { projectFsManager } from '@src/lang/std/fileSystemManager'
 import type { App } from '@src/lib/app'
-import { getProjectInfo } from '@src/lib/desktop'
-import { getStringAfterLastSeparator } from '@src/lib/paths'
+import { PROJECT_ENTRYPOINT } from '@src/lib/constants'
+import { getProjectInfo, readAppSettingsFile } from '@src/lib/desktop'
+import fsZds from '@src/lib/fs-zds'
+import {
+  PATHS,
+  getProjectMetaByRouteId,
+  getRouterSearchFromRequestUrl,
+  getStringAfterLastSeparator,
+  safeEncodeForRouterPaths,
+} from '@src/lib/paths'
 import type { Project } from '@src/lib/project'
+import { loadAndValidateSettings } from '@src/lib/settings/settingsUtils'
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
 import {
   type ExecutingEditorHandle,
   type OpenEditorOptions,
   type OpenedProjectHandle,
+  type ProjectRouteHandlesOptions,
+  type ProjectRouteHandlesResult,
   type ProjectSessionService,
   executingEditorHandleValueSpec,
   openedProjectHandleValueSpec,
@@ -311,6 +322,100 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     })
   }
 
+  const setProjectRouteHandles = async ({
+    routeId,
+    requestUrl,
+    usesHashRouter = Boolean(window.electron),
+  }: ProjectRouteHandlesOptions): Promise<ProjectRouteHandlesResult> => {
+    if (routeId?.startsWith('/browser')) {
+      return { redirectTo: PATHS.HOME }
+    }
+
+    if (!routeId) {
+      return Promise.reject(
+        new Error('bug: projectPathData undefined, early return')
+      )
+    }
+
+    const currentApp = app
+    if (!currentApp) {
+      return Promise.reject(projectSessionUnboundError())
+    }
+
+    const heuristicProjectFilePath = routeId
+      ? routeId.split(fsZds.sep).slice(0, -1).join(fsZds.sep)
+      : undefined
+
+    const wasmInstance = await currentApp.wasmPromise
+    const settings = await loadAndValidateSettings(
+      wasmInstance,
+      heuristicProjectFilePath
+    )
+
+    const projectPathData = await getProjectMetaByRouteId(
+      readAppSettingsFile,
+      wasmInstance,
+      routeId,
+      settings.configuration
+    )
+
+    if (!projectPathData) {
+      return Promise.reject(
+        new Error('bug: projectPathData undefined, early return')
+      )
+    }
+
+    const { projectName, projectPath, currentFileName, currentFilePath } =
+      projectPathData
+
+    const urlObj = new URL(requestUrl)
+
+    if (!urlObj.pathname.endsWith('/settings')) {
+      const fallbackFile = (await getProjectInfo(projectPath, wasmInstance))
+        .default_file
+      let fileExists = true
+      if (currentFilePath && fileExists) {
+        try {
+          await fsZds.stat(currentFilePath)
+        } catch (e) {
+          if (e === 'ENOENT') {
+            fileExists = false
+          }
+        }
+      }
+
+      if (projectPath && !currentFileName && fileExists && routeId) {
+        const encodedId = safeEncodeForRouterPaths(routeId)
+        return {
+          redirectTo: requestUrl.replace(
+            encodedId,
+            safeEncodeForRouterPaths(fallbackFile)
+          ),
+        }
+      }
+
+      if (!fileExists || !currentFileName || !currentFilePath || !projectName) {
+        const routerSearch = getRouterSearchFromRequestUrl(
+          requestUrl,
+          usesHashRouter
+        )
+        return {
+          redirectTo: `${PATHS.FILE}/${encodeURIComponent(
+            fallbackFile
+          )}${routerSearch}`,
+        }
+      }
+    }
+
+    await setOpenedProjectHandle({ projectPath })
+    await setExecutingEditorHandle({
+      projectPath,
+      filePath: currentFilePath || PROJECT_ENTRYPOINT,
+    })
+
+    return {}
+  }
+
   const serviceImpl: ProjectSessionService = {
     openedProjectHandle,
     executingEditorHandle,
@@ -320,6 +425,7 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     },
     setOpenedProjectHandle,
     setExecutingEditorHandle,
+    setProjectRouteHandles,
   }
 
   return {

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -67,13 +67,6 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
   const openedProject =
     signal<ProjectSessionService['openedProject']['value']>(undefined)
 
-  const getApp = () => {
-    if (!app) {
-      throw new Error('Project session service has not been bound to App.')
-    }
-    return app
-  }
-
   const stopProjectEffects = () => {
     unsubscribeFromSettings?.unsubscribe()
     unsubscribeFromSettings = undefined
@@ -106,9 +99,10 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     }
   }
 
-  const syncProjectFromSystemIO = (projectIORefSignal: Signal<Project>) => {
-    const currentApp = getApp()
-
+  const syncProjectFromSystemIO = (
+    currentApp: App,
+    projectIORefSignal: Signal<Project>
+  ) => {
     unsubscribeFromSystemIO = currentApp.systemIOActor.subscribe(
       ({ context }) => {
         const foundProject = (context.folders ?? []).find(
@@ -123,9 +117,10 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     )
   }
 
-  const startProjectEffects = (projectIORefSignal: Signal<Project>) => {
-    const currentApp = getApp()
-
+  const startProjectEffects = (
+    currentApp: App,
+    projectIORefSignal: Signal<Project>
+  ) => {
     stopProjectEffects()
     stopFSHistoryEffect = effect(() => {
       const project = openedProject.value
@@ -176,14 +171,19 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
         disposeZookeeperHistory()
       }
     })
-    syncProjectFromSystemIO(projectIORefSignal)
+    syncProjectFromSystemIO(currentApp, projectIORefSignal)
     unsubscribeFromSettings = currentApp.settings.actor.subscribe(
       currentApp.onSettingsUpdate
     )
   }
 
   const openProject = async (project: Project) => {
-    const currentApp = getApp()
+    const currentApp = app
+    if (!currentApp) {
+      return Promise.reject(
+        new Error('Project session service has not been bound to App.')
+      )
+    }
     const currentProject = openedProject.peek()
 
     openedProjectHandle.value = {
@@ -210,7 +210,7 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     const projectIORefSignal = signal(project)
     const nextProject = await ZDSProject.open(projectIORefSignal, currentApp)
     openedProject.value = nextProject
-    startProjectEffects(projectIORefSignal)
+    startProjectEffects(currentApp, projectIORefSignal)
     return nextProject
   }
 
@@ -220,7 +220,9 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
   ) => {
     const currentProject = openedProject.peek()
     if (!currentProject) {
-      throw new Error('Cannot open an editor without an opened project.')
+      return Promise.reject(
+        new Error('Cannot open an editor without an opened project.')
+      )
     }
 
     executingEditorHandle.value = {

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -13,11 +13,14 @@ import {
 import { ZDSProject } from '@src/lang/KclManager'
 import { projectFsManager } from '@src/lang/std/fileSystemManager'
 import type { App } from '@src/lib/app'
+import { getProjectInfo } from '@src/lib/desktop'
+import { getStringAfterLastSeparator } from '@src/lib/paths'
 import type { Project } from '@src/lib/project'
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
 import {
+  type ExecutingEditorHandle,
   type OpenEditorOptions,
-  type OpenProjectEditorInput,
+  type OpenedProjectHandle,
   type ProjectSessionService,
   executingEditorHandleValueSpec,
   openedProjectHandleValueSpec,
@@ -27,7 +30,7 @@ import {
 import type { Subscription } from 'xstate'
 import { waitFor } from 'xstate'
 
-interface CloseProjectOptions {
+interface ClearProjectSessionOptions {
   clearHandles?: boolean
   clearProjectSettings?: boolean
 }
@@ -67,6 +70,30 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
   const openedProject =
     signal<ProjectSessionService['openedProject']['value']>(undefined)
 
+  const projectSessionUnboundError = () =>
+    new Error('Project session service has not been bound to App.')
+
+  const getProjectFromHandle = async (
+    currentApp: App,
+    { projectPath }: OpenedProjectHandle
+  ): Promise<Project> => {
+    const wasmInstance = await currentApp.wasmPromise
+    const maybeProjectInfo = await getProjectInfo(projectPath, wasmInstance)
+
+    return (
+      maybeProjectInfo ?? {
+        name: getStringAfterLastSeparator(projectPath) || 'unnamed',
+        path: projectPath,
+        children: [],
+        kcl_file_count: 0,
+        directory_count: 0,
+        metadata: null,
+        default_file: projectPath,
+        readWriteAccess: true,
+      }
+    )
+  }
+
   const stopProjectEffects = () => {
     unsubscribeFromSettings?.unsubscribe()
     unsubscribeFromSettings = undefined
@@ -76,10 +103,10 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     stopFSHistoryEffect = undefined
   }
 
-  const closeProject = ({
+  const clearProjectSession = ({
     clearHandles = true,
     clearProjectSettings = true,
-  }: CloseProjectOptions = {}) => {
+  }: ClearProjectSessionOptions = {}) => {
     const currentApp = app
     const currentProject = openedProject.peek()
 
@@ -177,13 +204,7 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     )
   }
 
-  const openProject = async (project: Project) => {
-    const currentApp = app
-    if (!currentApp) {
-      return Promise.reject(
-        new Error('Project session service has not been bound to App.')
-      )
-    }
+  const loadProjectFromInfo = async (currentApp: App, project: Project) => {
     const currentProject = openedProject.peek()
 
     openedProjectHandle.value = {
@@ -192,7 +213,10 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     projectFsManager.dir = project.path
 
     if (currentProject && currentProject.path !== project.path) {
-      closeProject({ clearHandles: false, clearProjectSettings: false })
+      clearProjectSession({
+        clearHandles: false,
+        clearProjectSettings: false,
+      })
     }
 
     await waitFor(currentApp.settings.actor, (state) => state.matches('idle'))
@@ -214,7 +238,26 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     return nextProject
   }
 
-  const openEditor = async (
+  const setOpenedProjectHandle = async (
+    handle: OpenedProjectHandle | undefined
+  ) => {
+    if (!handle) {
+      clearProjectSession()
+      return undefined
+    }
+
+    const currentApp = app
+    if (!currentApp) {
+      return Promise.reject(projectSessionUnboundError())
+    }
+
+    return loadProjectFromInfo(
+      currentApp,
+      await getProjectFromHandle(currentApp, handle)
+    )
+  }
+
+  const loadEditorFromHandle = async (
     filePath: string,
     { providedEditor, providedCode, isExecuting = true }: OpenEditorOptions = {}
   ) => {
@@ -238,6 +281,36 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     )
   }
 
+  const setExecutingEditorHandle = async (
+    handle: ExecutingEditorHandle | undefined,
+    options: OpenEditorOptions = {}
+  ) => {
+    if (!handle) {
+      executingEditorHandle.value = undefined
+      return undefined
+    }
+
+    const currentApp = app
+    if (!currentApp) {
+      return Promise.reject(projectSessionUnboundError())
+    }
+    const currentProject = openedProject.peek()
+    if (currentProject?.path !== handle.projectPath) {
+      await setOpenedProjectHandle({ projectPath: handle.projectPath })
+    }
+
+    return loadEditorFromHandle(handle.filePath, {
+      providedEditor:
+        options.providedEditor ?? currentApp.singletons.kclManager,
+      providedCode:
+        options.providedCode ??
+        (window.electron?.process.env.NODE_ENV === 'test'
+          ? currentApp.singletons.kclManager.localStoragePersistCode()
+          : undefined),
+      isExecuting: options.isExecuting,
+    })
+  }
+
   const serviceImpl: ProjectSessionService = {
     openedProjectHandle,
     executingEditorHandle,
@@ -245,24 +318,8 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     bindApp(boundApp) {
       app = boundApp
     },
-    openProject,
-    openEditor,
-    async openProjectEditor({
-      project,
-      filePath,
-      providedEditor,
-      providedCode,
-      isExecuting,
-    }: OpenProjectEditorInput) {
-      const opened = await openProject(project)
-      const editor = await openEditor(filePath, {
-        providedEditor,
-        providedCode,
-        isExecuting,
-      })
-      return { project: opened, editor }
-    },
-    closeProject: () => closeProject(),
+    setOpenedProjectHandle,
+    setExecutingEditorHandle,
   }
 
   return {
@@ -280,7 +337,7 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
         }),
       ],
       providesServices: [provideService(projectSessionService, serviceImpl)],
-      dispose: () => closeProject(),
+      dispose: () => clearProjectSession(),
     }),
   }
 }, 'project-session-extension')

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -186,10 +186,10 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
             )
           }
 
-          await openEditor(fallbackPath, { providedEditor: editor })
+          await loadEditorFromHandle(fallbackPath, { providedEditor: editor })
         },
         onActiveFileRestore: async (restoredPath, restoredContents) => {
-          await openEditor(restoredPath, {
+          await loadEditorFromHandle(restoredPath, {
             providedEditor: editor,
             providedCode: restoredContents,
           })

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -1,0 +1,286 @@
+import {
+  defineRegistryItemFactory,
+  defineRuntimeRegistryItem,
+  provide,
+  provideService,
+} from '@kittycad/registry'
+import { type Signal, effect, signal } from '@preact/signals-core'
+import { buildFSHistoryExtension } from '@src/editor/plugins/fs'
+import {
+  type PreparedZookeeperPatchFileReplay,
+  buildZookeeperHistoryExtension,
+} from '@src/editor/plugins/zookeeper'
+import { ZDSProject } from '@src/lang/KclManager'
+import { projectFsManager } from '@src/lang/std/fileSystemManager'
+import type { App } from '@src/lib/app'
+import type { Project } from '@src/lib/project'
+import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
+import {
+  type OpenEditorOptions,
+  type OpenProjectEditorInput,
+  type ProjectSessionService,
+  executingEditorHandleValueSpec,
+  openedProjectHandleValueSpec,
+  openedProjectValueSpec,
+  projectSessionService,
+} from '@src/registry/contracts/projectSession'
+import type { Subscription } from 'xstate'
+import { waitFor } from 'xstate'
+
+interface CloseProjectOptions {
+  clearHandles?: boolean
+  clearProjectSettings?: boolean
+}
+
+function zookeeperReplayChangesProjectFileSet(
+  replayFiles: readonly PreparedZookeeperPatchFileReplay[]
+) {
+  return replayFiles.some(
+    (replayFile) =>
+      replayFile.previousContent === null || replayFile.nextContent === null
+  )
+}
+
+function getZookeeperReplayFallbackFilePath(
+  project: ZDSProject,
+  deletedPaths: Set<string>
+) {
+  const defaultFile = project.projectIORefSignal.value.default_file
+  const candidates = [
+    defaultFile,
+    ...project.files.map((file) => file.path),
+  ].filter((path, index, paths) => paths.indexOf(path) === index)
+
+  return candidates.find((path) => path && !deletedPaths.has(path))
+}
+
+const projectSessionExtension = defineRegistryItemFactory(() => {
+  let app: App | undefined
+  let unsubscribeFromSettings: Subscription | undefined
+  let unsubscribeFromSystemIO: Subscription | undefined
+  let stopFSHistoryEffect: (() => void) | undefined
+
+  const openedProjectHandle =
+    signal<ProjectSessionService['openedProjectHandle']['value']>(undefined)
+  const executingEditorHandle =
+    signal<ProjectSessionService['executingEditorHandle']['value']>(undefined)
+  const openedProject =
+    signal<ProjectSessionService['openedProject']['value']>(undefined)
+
+  const getApp = () => {
+    if (!app) {
+      throw new Error('Project session service has not been bound to App.')
+    }
+    return app
+  }
+
+  const stopProjectEffects = () => {
+    unsubscribeFromSettings?.unsubscribe()
+    unsubscribeFromSettings = undefined
+    unsubscribeFromSystemIO?.unsubscribe()
+    unsubscribeFromSystemIO = undefined
+    stopFSHistoryEffect?.()
+    stopFSHistoryEffect = undefined
+  }
+
+  const closeProject = ({
+    clearHandles = true,
+    clearProjectSettings = true,
+  }: CloseProjectOptions = {}) => {
+    const currentApp = app
+    const currentProject = openedProject.peek()
+
+    stopProjectEffects()
+    currentProject?.close()
+    openedProject.value = undefined
+
+    if (clearHandles) {
+      openedProjectHandle.value = undefined
+      executingEditorHandle.value = undefined
+    }
+
+    if (clearProjectSettings) {
+      currentApp?.settings.actor.send({
+        type: 'clear.project',
+      })
+    }
+  }
+
+  const syncProjectFromSystemIO = (projectIORefSignal: Signal<Project>) => {
+    const currentApp = getApp()
+
+    unsubscribeFromSystemIO = currentApp.systemIOActor.subscribe(
+      ({ context }) => {
+        const foundProject = (context.folders ?? []).find(
+          (project) =>
+            project.name === projectIORefSignal.value.name &&
+            project.path === projectIORefSignal.value.path
+        )
+        if (foundProject && projectIORefSignal.value !== foundProject) {
+          projectIORefSignal.value = foundProject
+        }
+      }
+    )
+  }
+
+  const startProjectEffects = (projectIORefSignal: Signal<Project>) => {
+    const currentApp = getApp()
+
+    stopProjectEffects()
+    stopFSHistoryEffect = effect(() => {
+      const project = openedProject.value
+      const editor = project?.executingEditor.value
+      if (!project || !editor) {
+        return
+      }
+
+      const disposeFSHistory = buildFSHistoryExtension(
+        currentApp.systemIOActor,
+        editor
+      )
+      const disposeZookeeperHistory = buildZookeeperHistoryExtension({
+        kclManager: editor,
+        onCurrentFileDelete: async (deletedPaths) => {
+          const fallbackPath = getZookeeperReplayFallbackFilePath(
+            project,
+            deletedPaths
+          )
+          if (!fallbackPath) {
+            return Promise.reject(
+              new Error(
+                'Cannot replay this Zookeeper edit because no fallback KCL file is available.'
+              )
+            )
+          }
+
+          await openEditor(fallbackPath, { providedEditor: editor })
+        },
+        onActiveFileRestore: async (restoredPath, restoredContents) => {
+          await openEditor(restoredPath, {
+            providedEditor: editor,
+            providedCode: restoredContents,
+          })
+        },
+        onProjectFilesReplay: async (replayFiles) => {
+          await project.syncReplayedFilesToRust(replayFiles)
+          if (zookeeperReplayChangesProjectFileSet(replayFiles)) {
+            currentApp.systemIOActor.send({
+              type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
+            })
+          }
+        },
+      })
+
+      return () => {
+        disposeFSHistory()
+        disposeZookeeperHistory()
+      }
+    })
+    syncProjectFromSystemIO(projectIORefSignal)
+    unsubscribeFromSettings = currentApp.settings.actor.subscribe(
+      currentApp.onSettingsUpdate
+    )
+  }
+
+  const openProject = async (project: Project) => {
+    const currentApp = getApp()
+    const currentProject = openedProject.peek()
+
+    openedProjectHandle.value = {
+      projectPath: project.path,
+    }
+    projectFsManager.dir = project.path
+
+    if (currentProject && currentProject.path !== project.path) {
+      closeProject({ clearHandles: false, clearProjectSettings: false })
+    }
+
+    await waitFor(currentApp.settings.actor, (state) => state.matches('idle'))
+    currentApp.settings.actor.send({
+      type: 'load.project',
+      project,
+    })
+    await waitFor(currentApp.settings.actor, (state) => state.matches('idle'))
+
+    if (currentProject?.path === project.path) {
+      currentProject.projectIORefSignal.value = project
+      return currentProject
+    }
+
+    const projectIORefSignal = signal(project)
+    const nextProject = await ZDSProject.open(projectIORefSignal, currentApp)
+    openedProject.value = nextProject
+    startProjectEffects(projectIORefSignal)
+    return nextProject
+  }
+
+  const openEditor = async (
+    filePath: string,
+    { providedEditor, providedCode, isExecuting = true }: OpenEditorOptions = {}
+  ) => {
+    const currentProject = openedProject.peek()
+    if (!currentProject) {
+      throw new Error('Cannot open an editor without an opened project.')
+    }
+
+    executingEditorHandle.value = {
+      projectPath: currentProject.path,
+      filePath,
+    }
+
+    return currentProject.openEditor(
+      filePath,
+      providedEditor,
+      providedCode,
+      isExecuting
+    )
+  }
+
+  const serviceImpl: ProjectSessionService = {
+    openedProjectHandle,
+    executingEditorHandle,
+    openedProject,
+    bindApp(boundApp) {
+      app = boundApp
+    },
+    openProject,
+    openEditor,
+    async openProjectEditor({
+      project,
+      filePath,
+      providedEditor,
+      providedCode,
+      isExecuting,
+    }: OpenProjectEditorInput) {
+      const opened = await openProject(project)
+      const editor = await openEditor(filePath, {
+        providedEditor,
+        providedCode,
+        isExecuting,
+      })
+      return { project: opened, editor }
+    },
+    closeProject: () => closeProject(),
+  }
+
+  return {
+    item: defineRuntimeRegistryItem({
+      id: 'project-session-extension',
+      provides: [
+        provide(openedProjectHandleValueSpec, openedProjectHandle, {
+          key: 'project-session',
+        }),
+        provide(executingEditorHandleValueSpec, executingEditorHandle, {
+          key: 'project-session',
+        }),
+        provide(openedProjectValueSpec, openedProject, {
+          key: 'project-session',
+        }),
+      ],
+      providesServices: [provideService(projectSessionService, serviceImpl)],
+      dispose: () => closeProject(),
+    }),
+  }
+}, 'project-session-extension')
+
+export default projectSessionExtension


### PR DESCRIPTION
## Summary

- Folds the former route-loader-minimal-setters and project-session route-loading work into one PR.
- Keeps route loaders thin by delegating project/file setup to `projectSession.setProjectRouteHandles`.
- Preserves the rebased Home/web loader behavior while removing the extra stacked PR layer.

## Validation

- `npm run lint`
- `npm run test:integration -- src/lib/app.spec.ts src/lang/KclManager.spec.ts src/registry/extensions/engineScene/index.spec.ts`
- `npm run test:integration -- src/components/ProjectSidebarMenu.spec.tsx src/components/Explorer/ProjectExplorer.spec.tsx src/components/layout/areas/KclEditorPane.spec.tsx src/components/NoExecutingFileEmptyState.spec.tsx`
- `npm run tsc` is blocked locally by stale `node_modules`: package-lock has `@kittycad/lib@4.2.13`, but the installed copy is `4.2.9`, so newer API types such as announcements/project-status feedback are missing.