### PR TITLE
[superseded] [codex] Make executing editor session-owned

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -9,7 +9,7 @@ import ModelingPageProvider from '@src/components/ModelingPageProvider'
 import { OpenedProject } from '@src/components/OpenedProject'
 import { NetworkContext } from '@src/hooks/useNetworkContext'
 import { useNetworkStatus } from '@src/hooks/useNetworkStatus'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp } from '@src/lib/boot'
 import { isDesktop } from '@src/lib/isDesktop'
 import { TestLayout } from '@src/lib/layout/TestLayout'
 import makeUrlPathRelative from '@src/lib/makeUrlPathRelative'
@@ -38,8 +38,7 @@ const createRouter = isDesktop() ? createHashRouter : createBrowserRouter
 export const Router = () => {
   useSignals()
   const app = useApp()
-  const { kclManager } = useSingletons()
-  const networkStatus = useNetworkStatus(kclManager.engineCommandManager)
+  const networkStatus = useNetworkStatus(app.engineCommandManager)
   const router = useMemo(
     () =>
       createRouter([

--- a/src/components/HelpMenu.tsx
+++ b/src/components/HelpMenu.tsx
@@ -4,7 +4,7 @@ import { defaultStatusBarItemClassNames } from '@src/components/StatusBar/Status
 import Tooltip from '@src/components/Tooltip'
 import { useAbsoluteFilePath } from '@src/hooks/useAbsoluteFilePath'
 import { useMenuListener } from '@src/hooks/useMenu'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp } from '@src/lib/boot'
 import { isDesktop } from '@src/lib/isDesktop'
 import { onboardingStartPath } from '@src/lib/onboardingPaths'
 import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
@@ -21,7 +21,6 @@ const HelpMenuDivider = () => (
 
 export function HelpMenu() {
   const { settings, systemIOActor } = useApp()
-  const { kclManager } = useSingletons()
   const navigate = useNavigate()
   const filePath = useAbsoluteFilePath()
 
@@ -29,7 +28,6 @@ export function HelpMenu() {
     const props = {
       onboardingStatus: onboardingStartPath,
       navigate,
-      kclManager,
       systemIOActor,
       settingsActor: settings.actor,
       executingPath: filePath,

--- a/src/components/LspProvider.tsx
+++ b/src/components/LspProvider.tsx
@@ -27,7 +27,7 @@ import type {
 import { LspWorker } from '@src/editor/plugins/lsp/types'
 import Worker from '@src/editor/plugins/lsp/worker.ts?worker'
 import { wasmUrl } from '@src/lang/wasmUtils'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useOptionalExecutingEditor } from '@src/lib/boot'
 import { PROJECT_ENTRYPOINT } from '@src/lib/constants'
 import { PATHS } from '@src/lib/paths'
 import type { FileEntry } from '@src/lib/project'
@@ -73,7 +73,7 @@ type LspContext = {
 export const LspStateContext = createContext({} as LspContext)
 export const LspProvider = ({ children }: { children: React.ReactNode }) => {
   const { auth } = useApp()
-  const { kclManager } = useSingletons()
+  const kclManager = useOptionalExecutingEditor()
   const [isKclLspReady, setIsKclLspReady] = useState(false)
   const [isCopilotLspReady, setIsCopilotLspReady] = useState(false)
 
@@ -124,7 +124,7 @@ export const LspProvider = ({ children }: { children: React.ReactNode }) => {
   ])
 
   useMemo(() => {
-    if (!window.electron && isKclLspReady && kclLspClient && kclManager.code) {
+    if (!window.electron && isKclLspReady && kclLspClient && kclManager?.code) {
       kclLspClient.textDocumentDidOpen({
         textDocument: {
           uri: `file:///${PROJECT_ENTRYPOINT}`,
@@ -134,7 +134,7 @@ export const LspProvider = ({ children }: { children: React.ReactNode }) => {
         },
       })
     }
-  }, [kclLspClient, isKclLspReady, kclManager.code])
+  }, [kclLspClient, isKclLspReady, kclManager?.code])
 
   // Here we initialize the plugin which will start the client.
   // Now that we have multi-file support the name of the file is a dep of
@@ -178,7 +178,7 @@ export const LspProvider = ({ children }: { children: React.ReactNode }) => {
 
   useEffect(() => {
     // New code to just update the CodeMirror extensions directly.
-    if (kclLSP === null) {
+    if (kclLSP === null || !kclManager) {
       return
     }
     kclManager.editorView.dispatch({
@@ -188,7 +188,7 @@ export const LspProvider = ({ children }: { children: React.ReactNode }) => {
       kclManager.editorView.dispatch({
         effects: kclLspCompartment.reconfigure(Prec.highest([])),
       })
-  }, [kclLSP, kclManager.editorView])
+  }, [kclLSP, kclManager])
 
   const { lspClient: copilotLspClient } = useMemo(() => {
     if (!token || token === '') {
@@ -233,7 +233,7 @@ export const LspProvider = ({ children }: { children: React.ReactNode }) => {
   // We do not want to restart the server, its just wasteful.
   const copilotLSP = useMemo(() => {
     let plugin = null
-    if (isCopilotLspReady && copilotLspClient) {
+    if (isCopilotLspReady && copilotLspClient && kclManager) {
       // Set up the lsp plugin.
       const lsp = copilotPlugin(
         {
@@ -244,15 +244,24 @@ export const LspProvider = ({ children }: { children: React.ReactNode }) => {
         },
         kclManager
       )
-
-      // New code to just update the CodeMirror extensions directly.
-      kclManager.editorView.dispatch({
-        effects: kclAutocompleteCompartment.reconfigure(Prec.highest(lsp)),
-      })
       plugin = lsp
     }
     return plugin
   }, [copilotLspClient, isCopilotLspReady, kclManager])
+
+  useEffect(() => {
+    if (copilotLSP === null || !kclManager) {
+      return
+    }
+
+    kclManager.editorView.dispatch({
+      effects: kclAutocompleteCompartment.reconfigure(Prec.highest(copilotLSP)),
+    })
+    return () =>
+      kclManager.editorView.dispatch({
+        effects: kclAutocompleteCompartment.reconfigure(Prec.highest([])),
+      })
+  }, [copilotLSP, kclManager])
 
   let lspClients: LanguageServerClient[] = []
   if (kclLspClient) {
@@ -278,7 +287,7 @@ export const LspProvider = ({ children }: { children: React.ReactNode }) => {
         },
       })
     })
-    kclManager.clearGlobalHistory()
+    kclManager?.clearGlobalHistory()
 
     if (redirect) {
       void navigate(PATHS.HOME)

--- a/src/components/ModelingMachineProvider.tsx
+++ b/src/components/ModelingMachineProvider.tsx
@@ -15,7 +15,7 @@ import useHotkeyWrapper from '@src/lib/hotkeyWrapper'
 import { SNAP_TO_GRID_HOTKEY } from '@src/lib/hotkeys'
 
 import { useNetworkContext } from '@src/hooks/useNetworkContext'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useOptionalExecutingEditor } from '@src/lib/boot'
 import { modelingMachineCommandConfig } from '@src/lib/commandBarConfigs/modelingCommandConfig'
 import type { Project } from '@src/lib/project'
 import { resetCameraPosition } from '@src/lib/resetCameraPosition'
@@ -26,6 +26,8 @@ import { useFolders } from '@src/machines/systemIO/hooks'
 
 import { useSignals } from '@preact/signals-react/runtime'
 import type { CameraOrbitType } from '@rust/kcl-lib/bindings/CameraOrbitType'
+import Loading from '@src/components/Loading'
+import type { KclManager } from '@src/lang/KclManager'
 import { DefaultLayoutPaneID } from '@src/lib/layout'
 import { togglePaneLayoutNode } from '@src/lib/layout/utils'
 import {
@@ -55,9 +57,33 @@ export const ModelingMachineProvider = ({
   children: React.ReactNode
 }) => {
   useSignals()
+  const kclManager = useOptionalExecutingEditor()
+
+  if (!kclManager) {
+    return (
+      <div className="absolute inset-0 grid place-content-center">
+        <Loading>Loading Design Studio...</Loading>
+      </div>
+    )
+  }
+
+  return (
+    <ModelingMachineProviderWithEditor kclManager={kclManager}>
+      {children}
+    </ModelingMachineProviderWithEditor>
+  )
+}
+
+const ModelingMachineProviderWithEditor = ({
+  children,
+  kclManager,
+}: {
+  children: React.ReactNode
+  kclManager: KclManager
+}) => {
+  useSignals()
   const { machineManager, commands, settings, layout, project, registry } =
     useApp()
-  const { kclManager } = useSingletons()
   const settingsActor = settings.actor
   const wasmInstance = use(kclManager.wasmInstancePromise)
   const settingsValues = settings.useSettings()

--- a/src/components/ModelingPageProvider.tsx
+++ b/src/components/ModelingPageProvider.tsx
@@ -4,14 +4,16 @@ import React, { use, useEffect, useMemo } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
 import { useSignals } from '@preact/signals-react/runtime'
+import Loading from '@src/components/Loading'
 import { useAbsoluteFilePath } from '@src/hooks/useAbsoluteFilePath'
 import { useMenuListener } from '@src/hooks/useMenu'
 import {
+  type KclManager,
   type PendingFeatureTreeSourceSelection,
   updateOutsideEditorEvent,
 } from '@src/lang/KclManager'
 import { sourceRangeToUtf16 } from '@src/lang/errors'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useOptionalExecutingEditor } from '@src/lib/boot'
 import { createNamedViewsCommand } from '@src/lib/commandBarConfigs/namedViewsConfig'
 import { createRouteCommands } from '@src/lib/commandBarConfigs/routeCommandConfig'
 import { createStandardViewsCommands } from '@src/lib/commandBarConfigs/standardViewsConfig'
@@ -61,8 +63,32 @@ export const ModelingPageProvider = ({
   children: React.ReactNode
 }) => {
   useSignals()
+  const kclManager = useOptionalExecutingEditor()
+
+  if (!kclManager) {
+    return (
+      <div className="absolute inset-0 grid place-content-center">
+        <Loading>Loading Design Studio...</Loading>
+      </div>
+    )
+  }
+
+  return (
+    <ModelingPageProviderWithEditor kclManager={kclManager}>
+      {children}
+    </ModelingPageProviderWithEditor>
+  )
+}
+
+const ModelingPageProviderWithEditor = ({
+  children,
+  kclManager,
+}: {
+  children: React.ReactNode
+  kclManager: KclManager
+}) => {
+  useSignals()
   const { auth, commands, settings, project, systemIOActor } = useApp()
-  const { kclManager } = useSingletons()
   const wasmInstance = use(kclManager.wasmInstancePromise)
   const navigate = useNavigate()
   const location = useLocation()

--- a/src/components/OpenedProject.tsx
+++ b/src/components/OpenedProject.tsx
@@ -80,7 +80,7 @@ export function OpenedProject() {
   const defaultAreaLibrary = useDefaultAreaLibrary()
   const defaultActionLibrary = useDefaultActionLibrary()
   const { state: modelingState, send: modelingSend } = useModelingContext()
-  useQueryParamEffects(kclManager)
+  useQueryParamEffects()
   const [nativeFileMenuCreated, setNativeFileMenuCreated] = useState(false)
   const location = useLocation()
   const navigate = useNavigate()
@@ -253,7 +253,6 @@ export function OpenedProject() {
           TutorialRequestToast({
             onboardingStatus: settingsValues.app.onboardingStatus.current,
             navigate,
-            kclManager,
             accountUrl: withSiteBaseURL('/account'),
             systemIOActor,
             settingsActor,

--- a/src/components/ProjectSidebarMenu.tsx
+++ b/src/components/ProjectSidebarMenu.tsx
@@ -19,7 +19,6 @@ import { hotkeyDisplay } from '@src/lib/hotkeys'
 import { isDesktop } from '@src/lib/isDesktop'
 import { PATHS, getProjectRelativeFilePath } from '@src/lib/paths'
 import type { FileEntry, Project } from '@src/lib/project'
-import type { IndexLoaderData } from '@src/lib/types'
 
 interface ProjectSidebarMenuProps extends React.PropsWithChildren {
   enableMenu?: boolean
@@ -62,8 +61,8 @@ function AppLogoLink({
   project,
   file,
 }: {
-  project?: IndexLoaderData['project']
-  file?: IndexLoaderData['file']
+  project?: Project
+  file?: FileEntry
 }) {
   const { kclManager } = useSingletons()
   const { onProjectClose } = useLspContext()
@@ -103,8 +102,8 @@ function ProjectMenuPopover({
   project,
   file,
 }: {
-  project?: IndexLoaderData['project']
-  file?: IndexLoaderData['file']
+  project?: Project
+  file?: FileEntry
 }) {
   const { machineManager, commands, settings } = useApp()
   const { kclManager } = useSingletons()

--- a/src/components/ProjectSidebarMenu.tsx
+++ b/src/components/ProjectSidebarMenu.tsx
@@ -12,7 +12,11 @@ import { useLspContext } from '@src/components/LspProvider'
 import Tooltip from '@src/components/Tooltip'
 import { useAbsoluteFilePath } from '@src/hooks/useAbsoluteFilePath'
 import usePlatform from '@src/hooks/usePlatform'
-import { useApp, useSingletons } from '@src/lib/boot'
+import {
+  useApp,
+  useExecutingEditor,
+  useOptionalExecutingEditor,
+} from '@src/lib/boot'
 import { sendAddFileToProjectCommandForCurrentProject } from '@src/lib/commandBarConfigs/applicationCommandConfig'
 import { APP_NAME } from '@src/lib/constants'
 import { hotkeyDisplay } from '@src/lib/hotkeys'
@@ -64,7 +68,7 @@ function AppLogoLink({
   project?: Project
   file?: FileEntry
 }) {
-  const { kclManager } = useSingletons()
+  const kclManager = useOptionalExecutingEditor()
   const { onProjectClose } = useLspContext()
   const wrapperClassName =
     "cursor-pointer relative group-hover/home:before:outline h-full grid flex-none place-content-center group p-1.5 before:block before:content-[''] before:absolute before:inset-0 before:bottom-1 before:z-[-1] before:bg-primary before:rounded-b-sm"
@@ -87,7 +91,9 @@ function AppLogoLink({
       data-testid="app-logo"
       onClick={() => {
         onProjectClose(file || null, project?.path || null, false)
-        kclManager.switchedFiles = true
+        if (kclManager) {
+          kclManager.switchedFiles = true
+        }
       }}
       to={PATHS.HOME}
       className={wrapperClassName + ' hover:before:brightness-110'}
@@ -106,7 +112,7 @@ function ProjectMenuPopover({
   file?: FileEntry
 }) {
   const { machineManager, commands, settings } = useApp()
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const machineApiEnabled = settings.useSettings().app.machineApi.current
   const platform = usePlatform()
   const navigate = useNavigate()

--- a/src/components/PublishButton.tsx
+++ b/src/components/PublishButton.tsx
@@ -2,6 +2,7 @@ import { Popover } from '@headlessui/react'
 import { useSignals } from '@preact/signals-react/runtime'
 import { CustomIcon } from '@src/components/CustomIcon'
 import { PublishDialog } from '@src/components/PublishDialog'
+import type { KclManager } from '@src/lang/KclManager'
 import type { App } from '@src/lib/app'
 import type { Project } from '@src/lib/project'
 import {
@@ -28,12 +29,19 @@ export const PublishButton = memo(function PublishButton({
 }: PublishButtonProps) {
   useSignals()
   const project = app.projectSignal.value?.projectIORefSignal.value
+  const kclManager =
+    app.projectSession.openedProject.value?.executingEditor.value
+
+  if (!kclManager) {
+    return null
+  }
 
   return (
     <Popover className="relative hidden sm:flex">
       {(popover) => (
         <PublishPopoverContent
           app={app}
+          kclManager={kclManager}
           project={project}
           close={() => popover.close()}
           open={popover.open}
@@ -45,18 +53,19 @@ export const PublishButton = memo(function PublishButton({
 
 function PublishPopoverContent({
   app,
+  kclManager,
   project,
   close,
   open,
 }: {
   app: App
+  kclManager: KclManager
   project: Project | undefined
   close: () => void
   open: boolean
 }) {
   useSignals()
   const { auth } = app
-  const { kclManager } = app.singletons
   const ast = kclManager.astSignal.value
   const kclEmpty = kclManager.isAstBodyEmpty(ast)
   const hasKclErrors = kclManager.hasErrors()

--- a/src/components/RouteProvider.tsx
+++ b/src/components/RouteProvider.tsx
@@ -1,7 +1,7 @@
 import { useSignals } from '@preact/signals-react/runtime'
 import { useAuthNavigation } from '@src/hooks/useAuthNavigation'
 import { useFileSystemWatcher } from '@src/hooks/useFileSystemWatcher'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useOptionalExecutingEditor } from '@src/lib/boot'
 import { getAppSettingsFilePath } from '@src/lib/desktop'
 import fsZds from '@src/lib/fs-zds'
 import { PATHS, getStringAfterLastSeparator } from '@src/lib/paths'
@@ -16,7 +16,7 @@ export const RouteProviderContext = createContext({})
 export function RouteProvider({ children }: { children: ReactNode }) {
   useSignals()
   const { settings, project } = useApp()
-  const { kclManager } = useSingletons()
+  const kclManager = useOptionalExecutingEditor()
   const settingsActor = settings.actor
   useAuthNavigation()
   const loadedProject = project?.projectIORefSignal.value
@@ -53,6 +53,9 @@ export function RouteProvider({ children }: { children: ReactNode }) {
     async (eventType: string, path: string) => {
       // Only reload if there are changes. Ignore everything else.
       if (eventType !== 'change') {
+        return
+      }
+      if (!kclManager) {
         return
       }
 
@@ -106,7 +109,7 @@ export function RouteProvider({ children }: { children: ReactNode }) {
       }
     },
     // This will build up for as many files you select and never remove until you exit the project to unmount the file watcher hook
-    kclManager.livePathsToWatch.value
+    kclManager?.livePathsToWatch.value ?? []
   )
 
   useFileSystemWatcher(

--- a/src/components/Settings/AllSettingsFields.tsx
+++ b/src/components/Settings/AllSettingsFields.tsx
@@ -2,7 +2,7 @@ import { ActionButton } from '@src/components/ActionButton'
 import { SettingsFieldInput } from '@src/components/Settings/SettingsFieldInput'
 import { SettingsSection } from '@src/components/Settings/SettingsSection'
 import { useAbsoluteFilePath } from '@src/hooks/useAbsoluteFilePath'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp } from '@src/lib/boot'
 import { getSettingsFolderPaths } from '@src/lib/desktopFS'
 import { isDesktop } from '@src/lib/isDesktop'
 import { onboardingStartPath } from '@src/lib/onboardingPaths'
@@ -40,7 +40,6 @@ export const AllSettingsFields = forwardRef(
     scrollRef: ForwardedRef<HTMLDivElement>
   ) => {
     const { settings, layout, systemIOActor } = useApp()
-    const { kclManager } = useSingletons()
     const location = useLocation()
     const navigate = useNavigate()
     const context = settings.useSettings()
@@ -67,7 +66,6 @@ export const AllSettingsFields = forwardRef(
       const props = {
         onboardingStatus: onboardingStartPath,
         navigate,
-        kclManager,
         systemIOActor,
         settingsActor: settings.actor,
         executingPath,

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -4,6 +4,7 @@ import { CustomIcon } from '@src/components/CustomIcon'
 import { ShareDialog } from '@src/components/ShareDialog'
 import Tooltip from '@src/components/Tooltip'
 import usePlatform from '@src/hooks/usePlatform'
+import type { KclManager } from '@src/lang/KclManager'
 import type { App } from '@src/lib/app'
 import { hotkeyDisplay } from '@src/lib/hotkeys'
 import { copyFileShareLink } from '@src/lib/links'
@@ -20,9 +21,25 @@ type ShareButtonProps = {
 export const ShareButton = memo(function ShareButton({
   app,
 }: ShareButtonProps) {
+  useSignals()
+  const kclManager =
+    app.projectSession.openedProject.value?.executingEditor.value
+
+  if (!kclManager) {
+    return null
+  }
+
+  return <ShareButtonWithEditor app={app} kclManager={kclManager} />
+})
+
+function ShareButtonWithEditor({
+  app,
+  kclManager,
+}: ShareButtonProps & {
+  kclManager: KclManager
+}) {
   const { billing } = app
   const platform = usePlatform()
-
   const billingContext = billing.useContext()
   const billingLoading = billingContext.hasSubscription === undefined
   const shareButtonRef = useRef<HTMLButtonElement>(null)
@@ -42,6 +59,7 @@ export const ShareButton = memo(function ShareButton({
           <SharePopoverContent
             billingLoading={billingLoading}
             app={app}
+            kclManager={kclManager}
             shareButtonRef={shareButtonRef}
             close={() => popover.close()}
             open={popover.open}
@@ -51,10 +69,11 @@ export const ShareButton = memo(function ShareButton({
       }}
     </Popover>
   )
-})
+}
 
 function SharePopoverContent({
   app,
+  kclManager,
   billingLoading,
   shareButtonRef,
   close,
@@ -62,6 +81,7 @@ function SharePopoverContent({
   platform,
 }: {
   app: App
+  kclManager: KclManager
   billingLoading: boolean
   shareButtonRef: RefObject<HTMLButtonElement | null>
   close: () => void
@@ -70,7 +90,6 @@ function SharePopoverContent({
 }) {
   useSignals()
   const { auth, billing } = app
-  const { kclManager } = app.singletons
   const token = auth.useToken()
   const billingContext = billing.useContext()
   const currentProject = app.projectSignal.value?.projectIORefSignal.value

--- a/src/components/SystemIOMachineLogicListener.tsx
+++ b/src/components/SystemIOMachineLogicListener.tsx
@@ -1,6 +1,6 @@
 import { useLspContext } from '@src/components/LspProvider'
 import { useFileSystemWatcher } from '@src/hooks/useFileSystemWatcher'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useOptionalExecutingEditor } from '@src/lib/boot'
 import {
   ASK_TO_OPEN_QUERY_PARAM,
   EXECUTE_AST_INTERRUPT_ERROR_MESSAGE,
@@ -33,8 +33,8 @@ import { useNavigate } from 'react-router-dom'
 import { useLocation } from 'react-router-dom'
 
 export function SystemIOMachineLogicListener() {
-  const { settings, systemIOActor } = useApp()
-  const { kclManager } = useSingletons()
+  const { engineCommandManager, settings, systemIOActor } = useApp()
+  const kclManager = useOptionalExecutingEditor()
   // We gotta stop with this pattern. It doesn't scale. "Eager hook creation"
   const requestedProjectName = useRequestedProjectName()
   const requestedFileName = useRequestedFileName()
@@ -80,7 +80,7 @@ export function SystemIOMachineLogicListener() {
     // Open the requested file in the requested project
     onFileOpen(requestedFilePathWithExtension, requestedProjectDirectory)
 
-    kclManager.engineCommandManager.rejectAllModelingCommands(
+    engineCommandManager.rejectAllModelingCommands(
       EXECUTE_AST_INTERRUPT_ERROR_MESSAGE
     )
 
@@ -98,10 +98,14 @@ export function SystemIOMachineLogicListener() {
       requestedFilePathWithExtension &&
       filePathWithExtension !== requestedFilePathWithExtension
     ) {
-      kclManager.switchedFiles = true
+      if (kclManager) {
+        kclManager.switchedFiles = true
+      }
     }
 
-    kclManager.isExecuting = false
+    if (kclManager) {
+      kclManager.isExecuting = false
+    }
 
     const url = new URL(location.href)
     url.searchParams.delete(ASK_TO_OPEN_QUERY_PARAM)

--- a/src/hooks/network/useOnPageMounted.spec.tsx
+++ b/src/hooks/network/useOnPageMounted.spec.tsx
@@ -5,9 +5,9 @@ import { renderHook } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
 
 describe('useOnPageMounted', () => {
-  const singletons = App.fromProvided({
+  const app = App.fromProvided({
     wasmPromise: Promise.resolve({} as ModuleType),
-  }).singletons
+  })
 
   describe('on mounted', () => {
     test('should run once', () => {
@@ -21,9 +21,7 @@ describe('useOnPageMounted', () => {
       expect(callback).toHaveBeenCalledTimes(1)
 
       // clean up test!
-      result.current.resetGlobalEngineCommandManager(
-        singletons.kclManager.engineCommandManager
-      )
+      result.current.resetGlobalEngineCommandManager(app.engineCommandManager)
     })
     test('should reset with helper function', async () => {
       const callback_1 = vi.fn(() => 1)
@@ -35,17 +33,13 @@ describe('useOnPageMounted', () => {
           }),
         { initialProps: { callback: callback_1 } }
       )
-      result.current.resetGlobalEngineCommandManager(
-        singletons.kclManager.engineCommandManager
-      )
+      result.current.resetGlobalEngineCommandManager(app.engineCommandManager)
       rerender({ callback: callback_2 })
       unmount()
       expect(callback_1).toHaveBeenCalledTimes(1)
       expect(callback_2).toHaveBeenCalledTimes(1)
       // clean up test!
-      result.current.resetGlobalEngineCommandManager(
-        singletons.kclManager.engineCommandManager
-      )
+      result.current.resetGlobalEngineCommandManager(app.engineCommandManager)
     })
     test('should fail to call the callback again, did not reset', async () => {
       const callback_1 = vi.fn(() => 1)
@@ -62,9 +56,7 @@ describe('useOnPageMounted', () => {
       expect(callback_1).toHaveBeenCalledTimes(1)
       expect(callback_2).toHaveBeenCalledTimes(0)
       // clean up test!
-      result.current.resetGlobalEngineCommandManager(
-        singletons.kclManager.engineCommandManager
-      )
+      result.current.resetGlobalEngineCommandManager(app.engineCommandManager)
     })
   })
 })

--- a/src/hooks/useAbsoluteFilePath.ts
+++ b/src/hooks/useAbsoluteFilePath.ts
@@ -7,7 +7,6 @@ export function useAbsoluteFilePath() {
   const executingPath = app.project?.executingPathSignal.value?.value
 
   if (!executingPath) {
-    console.warn('bug: executingPath undefined, not navigating')
     return
   }
 

--- a/src/hooks/useProjectsLoader.tsx
+++ b/src/hooks/useProjectsLoader.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 
-import { useSingletons } from '@src/lib/boot'
+import { useApp } from '@src/lib/boot'
 import { ensureProjectDirectoryExists, listProjects } from '@src/lib/desktop'
 import type { Project } from '@src/lib/project'
 import { loadAndValidateSettings } from '@src/lib/settings/settingsUtils'
@@ -11,7 +11,7 @@ import { trap } from '@src/lib/trap'
 // Hook uses [number] to give users familiarity. It is meant to mimic a
 // dependency array, but is intended to only ever be used with 1 value.
 export const useProjectsLoader = (deps?: [number]) => {
-  const { kclManager } = useSingletons()
+  const app = useApp()
   const [lastTs, setLastTs] = useState(-1)
   const [projectPaths, setProjectPaths] = useState<Project[]>([])
   const [projectsDir, setProjectsDir] = useState<string | undefined>(undefined)
@@ -23,17 +23,12 @@ export const useProjectsLoader = (deps?: [number]) => {
       setLastTs(deps[0])
     }
     ;(async () => {
-      const { configuration } = await loadAndValidateSettings(
-        kclManager.wasmInstancePromise
-      )
+      const { configuration } = await loadAndValidateSettings(app.wasmPromise)
       const _projectsDir = await ensureProjectDirectoryExists(configuration)
       setProjectsDir(_projectsDir)
 
       if (projectsDir) {
-        const _projectPaths = await listProjects(
-          kclManager.wasmInstancePromise,
-          configuration
-        )
+        const _projectPaths = await listProjects(app.wasmPromise, configuration)
         setProjectPaths(_projectPaths)
       }
     })().catch(trap)

--- a/src/hooks/useQueryParamEffects.ts
+++ b/src/hooks/useQueryParamEffects.ts
@@ -3,7 +3,6 @@ import toast from 'react-hot-toast'
 import { useSearchParams } from 'react-router-dom'
 import { waitFor } from 'xstate'
 
-import type { KclManager } from '@src/lang/KclManager'
 import { base64ToString } from '@src/lib/base64'
 import { useApp } from '@src/lib/boot'
 import type { ProjectsCommandSchema } from '@src/lib/commandBarConfigs/projectsCommandConfig'
@@ -50,7 +49,7 @@ export type CreateFileSchemaMethodOptional = Omit<
  * `?createFile`
  * "?cmd=<some-command-name>&groupId=<some-group-id>"
  */
-export function useQueryParamEffects(kclManager: KclManager) {
+export function useQueryParamEffects() {
   const app = useApp()
   const { auth, commands } = app
   const authState = auth.useAuthState()

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -33,13 +33,13 @@ function launchApp(app: App) {
 
 /** initialize behaviors that rely on singletons */
 function initSingletonBehavior(app: App) {
-  const { singletons } = app
   markOnce('code/willAuth')
-  initializeWindowExceptionHandler(singletons.kclManager)
+  initializeWindowExceptionHandler(
+    () => app.projectSession.openedProject.value?.executingEditor.value
+  )
 
-  // Don't start the app machine until all these singletons
-  // are initialized, and the wasm module is loaded.
-  singletons.kclManager.wasmInstancePromise
+  // Application commands need WASM, so defer them until the module is loaded.
+  app.wasmPromise
     .then((wasmInstance) => {
       // Application commands must be created after the initPromise because
       // it calls WASM functions to file extensions, this dependency is not available during initialization, it is an async dependency

--- a/src/lang/KclManager.spec.ts
+++ b/src/lang/KclManager.spec.ts
@@ -503,7 +503,7 @@ describe('KclManager diagnostics', () => {
     expect(kclManager.code).toBe('external edit')
   })
 
-  it('arms disk watcher when reusing the singleton editor for an opened file', async () => {
+  it('creates a fresh editor and arms its disk watcher for an opened file', async () => {
     const { kclManager } = createKclManagerTestHarness('')
     const path = '/tmp/kcl-manager-watch-open-test.kcl'
     const readSpy = vi
@@ -515,12 +515,12 @@ describe('KclManager diagnostics', () => {
 
     const opened = await KclManager.fromFile(
       new File(path, 101),
-      (kclManager as any).systemDeps,
-      kclManager
+      (kclManager as any).systemDeps
     )
 
-    expect(opened).toBe(kclManager)
-    expect(kclManager.watching).toBe(true)
+    expect(opened).not.toBe(kclManager)
+    expect(opened.path).toBe(path)
+    expect(opened.watching).toBe(true)
     expect(watchSpy).toHaveBeenCalledWith(
       path,
       expect.any(String),

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -174,6 +174,7 @@ import {
   CODE_EDITOR_FOCUSED_KEYMAP_SCOPE,
   CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE,
   type KeymapService,
+  keymapService,
 } from '@src/registry/contracts/keymap'
 import toast from 'react-hot-toast'
 
@@ -323,7 +324,7 @@ export class ZDSProject {
   public executingEditor = computed(() =>
     this.#executingPath.value
       ? this.editors.get(this.#executingPath.value)
-      : null
+      : undefined
   )
   /** The currently-executing file's info as a FileEntry */
   executingFileEntry = computed<FileEntry>(() => ({
@@ -370,6 +371,7 @@ export class ZDSProject {
     // TODO: Clear current executing editor's execution status
 
     if (newPath === null) {
+      this.#executingPath.value = null
       return
     }
     const foundPathSignal = this.findEditor(newPath)
@@ -394,10 +396,6 @@ export class ZDSProject {
 
   async openEditor(
     path: string,
-    /** TODO: Remove providedEditor, replace with options about if the editor is the executing one
-     * once the app can handle not having a KclManager.
-     */
-    providedEditor?: KclManager,
     /** TODO: Remove `providedCode` once no tests rely on initializing
      * editor state through localstorage.
      */
@@ -418,10 +416,7 @@ export class ZDSProject {
       engineCommandManager: this.app.engineCommandManager,
       rustContext: this.app.rustContext,
       projectPath: computed(() => this.projectIORefSignal.value.path),
-    }
-
-    if (providedEditor) {
-      providedEditor.systemDeps.projectPath = systemDeps.projectPath
+      keymap: this.app.registry.get(keymapService),
     }
 
     const foundFileIndex = this.files.findIndex((f) => f.path === path)
@@ -430,7 +425,6 @@ export class ZDSProject {
         ? this.files[foundFileIndex]
         : new File(path, this.nextFileId++),
       systemDeps,
-      providedEditor,
       providedCode
     )
 
@@ -487,6 +481,9 @@ export class ZDSProject {
     }
     foundPathSignal[1].close()
     this.editors.delete(foundPathSignal[0])
+    if (this.#executingPath.value === foundPathSignal[0]) {
+      this.#executingPath.value = null
+    }
   }
 
   closeAllEditors() {
@@ -494,6 +491,7 @@ export class ZDSProject {
       editor.close()
     }
     this.editors.clear()
+    this.#executingPath.value = null
   }
 
   /** Handle updates from the disk representation of the project */
@@ -716,6 +714,7 @@ export class KclManager extends File {
    * The core state in KclManager are the code and the selection.
    * all other state should be derived from the code or selection in some way.
    */
+  private readonly _editor = signal<KclManager | undefined>(this)
   private _code = signal(bracket)
   private _hasEditsSinceLastExecution = signal(false)
   private _documentVersion = 0
@@ -755,6 +754,7 @@ export class KclManager extends File {
   }
   get executingEditorService(): ExecutingEditorService {
     return {
+      editor: this._editor,
       code: this._code,
       hasEditsSinceLastExecution: this._hasEditsSinceLastExecution,
       isExecuting: this._isExecuting,
@@ -1806,12 +1806,10 @@ export class KclManager extends File {
 
   /**
    * Upgrade a File to an Editor, reading its contents for the initial editor state.
-   * TODO: Remove providedEditor once the app can handle an undefined currently-executing editor.
    */
   static async fromFile(
     file: File,
     systemDeps: SystemDeps,
-    providedEditor?: KclManager,
     providedCode?: string
   ) {
     const diskCode = normalizeLineEndings(providedCode || (await file.read()))
@@ -1821,32 +1819,12 @@ export class KclManager extends File {
         ? normalizeLineEndings(recoverySnapshot.code)
         : diskCode
 
-    if (!providedEditor) {
-      const editor = new KclManager(file.path, initialCode, systemDeps, file.id)
-      if (!isCodeTheSame(initialCode, diskCode)) {
-        editor.markFileCodeAsSynced(diskCode)
-      }
-      editor.watch()
-      return editor
+    const editor = new KclManager(file.path, initialCode, systemDeps, file.id)
+    if (!isCodeTheSame(initialCode, diskCode)) {
+      editor.markFileCodeAsSynced(diskCode)
     }
-
-    // TODO: remove all this once the app can handle an undefined currently-executing editor
-    providedEditor.flushRecoverySnapshot()
-    providedEditor.path = file.path
-    providedEditor.id = file.id
-    providedEditor.codeSignal.value = initialCode
-    providedEditor.updateCodeEditor(initialCode, {
-      shouldExecute: providedEditor.engineCommandManager.connection?.connected,
-      // This way undo and redo are not super weird when opening new files.
-      shouldClearHistory: true,
-      shouldResetCamera: true,
-      // We explicitly do not write to the file here since we are loading from
-      // the file system and not the editor.
-      shouldWriteToDisk: false,
-    })
-    providedEditor.markFileCodeAsSynced(diskCode)
-    providedEditor.watch()
-    return providedEditor
+    editor.watch()
+    return editor
   }
 
   constructor(
@@ -1917,6 +1895,7 @@ export class KclManager extends File {
     this.settingsSubscription?.unsubscribe()
     this.flushRecoverySnapshot()
     this.unwatch()
+    this._editor.value = undefined
   }
 
   private markFileCodeAsSynced(code: string) {
@@ -3036,6 +3015,9 @@ export class KclManager extends File {
     })
   }
   localStoragePersistCode(): string {
+    return safeLSGetItem(PERSIST_CODE_KEY) || ''
+  }
+  static localStoragePersistCode(): string {
     return safeLSGetItem(PERSIST_CODE_KEY) || ''
   }
   /**

--- a/src/lang/testHelpers/kclManagerTestHarness.ts
+++ b/src/lang/testHelpers/kclManagerTestHarness.ts
@@ -1,7 +1,9 @@
 import { type Diagnostic, setDiagnosticsEffect } from '@codemirror/lint'
-import type { KclManager } from '@src/lang/KclManager'
+import { signal } from '@preact/signals-core'
+import { KclManager } from '@src/lang/KclManager'
 import { App } from '@src/lib/app'
 import { isArray } from '@src/lib/utils'
+import { keymapService } from '@src/registry/contracts/keymap'
 import { loadWasm } from '@src/unitTestUtils'
 
 const wasmPromise = loadWasm()
@@ -13,15 +15,15 @@ export function createKclManagerTestHarness(initialCode = ''): {
   const app = App.fromProvided({
     wasmPromise,
   })
-  const { kclManager } = app.singletons
-
-  if (kclManager.code !== initialCode) {
-    kclManager.updateCodeEditor(initialCode, {
-      shouldExecute: false,
-      shouldWriteToDisk: false,
-      shouldResetCamera: false,
-    })
-  }
+  const kclManager = new KclManager('', initialCode, {
+    settings: app.settings.actor,
+    wasmInstancePromise: app.wasmPromise,
+    commandBar: app.commands.actor,
+    projectPath: signal(''),
+    engineCommandManager: app.engineCommandManager,
+    rustContext: app.rustContext,
+    keymap: app.registry.get(keymapService),
+  })
 
   return { app, kclManager }
 }

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -6,6 +6,7 @@ import type { Project } from '@src/lib/project'
 import { getChangedSettingsAtLevel } from '@src/lib/settings/settingsUtils'
 import { appHeaderItemsValueSpec } from '@src/registry/contracts/appHeader'
 import { executingEditorService } from '@src/registry/contracts/executingEditor'
+import { projectSessionService } from '@src/registry/contracts/projectSession'
 import { loadWasm } from '@src/unitTestUtils'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
@@ -86,8 +87,11 @@ describe('project system', () => {
         .get(pluginsValueSpec)
         .find((plugin) => plugin.id === pluginId)
       expect(plugin).toBeDefined()
+      if (!plugin) {
+        throw new Error(`Expected ${pluginId} plugin to be registered.`)
+      }
 
-      const pluginToggle = app.registry.get(plugin!.service)
+      const pluginToggle = app.registry.get(plugin.service)
       expect(pluginToggle.active.value).toBe(true)
 
       app.settings.actor.send({
@@ -182,13 +186,16 @@ describe('project system', () => {
         .get(pluginsValueSpec)
         .find((plugin) => plugin.id === pluginId)
       expect(plugin).toBeDefined()
+      if (!plugin) {
+        throw new Error(`Expected ${pluginId} plugin to be registered.`)
+      }
 
       app.settings.actor.send({ type: 'reload.settings' } as never)
 
       await waitForSettingsIdle(app)
 
       expect(app.settings.get().plugins[pluginId].current).toBe(true)
-      expect(app.registry.get(plugin!.service).active.value).toBe(true)
+      expect(app.registry.get(plugin.service).active.value).toBe(true)
     } finally {
       disposeApp(app)
     }
@@ -206,6 +213,9 @@ describe('project system', () => {
         .get(pluginsValueSpec)
         .find((plugin) => plugin.id === 'execution-indicator')
       expect(executionIndicatorPlugin).toBeDefined()
+      if (!executionIndicatorPlugin) {
+        throw new Error('Expected execution-indicator plugin to be registered.')
+      }
 
       app.settings.actor.send({ type: 'reload.settings' } as never)
 
@@ -218,7 +228,7 @@ describe('project system', () => {
       expect(modelingSettings.executionIndicator.current).toBe(false)
       expect(app.settings.get().plugins['execution-indicator']).toBeUndefined()
       expect(
-        app.registry.get(executionIndicatorPlugin!.service).active.value
+        app.registry.get(executionIndicatorPlugin.service).active.value
       ).toBe(false)
 
       app.settings.actor.send({
@@ -233,7 +243,7 @@ describe('project system', () => {
       await waitForSettingsIdle(app)
 
       expect(
-        app.registry.get(executionIndicatorPlugin!.service).active.value
+        app.registry.get(executionIndicatorPlugin.service).active.value
       ).toBe(true)
     } finally {
       disposeApp(app)
@@ -250,19 +260,37 @@ describe('project system', () => {
     })
 
     try {
-      const project = await app.openProject(mockProject)
+      const projectSession = app.registry.get(projectSessionService)
+      const project = await projectSession.openProject(mockProject)
 
       expect(app.project).toBeDefined()
+      expect(app.project).toBe(project)
+      expect(projectSession.openedProject.value).toBe(project)
+      expect(projectSession.openedProjectHandle.value).toEqual({
+        projectPath: mockProject.path,
+      })
       expect(app.project?.executingPath).toBeNull()
       expect(app.project?.executingFileEntry.value.name).toEqual('')
 
-      await project.openEditor(mockProject.children![0].path)
+      const mainFile = mockProject.children?.[0]
+      expect(mainFile).toBeDefined()
+      if (!mainFile) {
+        throw new Error('Expected mock project to include a main file.')
+      }
+
+      await projectSession.openEditor(mainFile.path)
       expect(app.project?.executingPath).toEqual('/some-dir/test/main.kcl')
       expect(app.project?.executingFileEntry.value.name).toEqual('main.kcl')
+      expect(projectSession.executingEditorHandle.value).toEqual({
+        projectPath: mockProject.path,
+        filePath: mainFile.path,
+      })
 
-      app.closeProject()
+      projectSession.closeProject()
 
       expect(app.project).toBeUndefined()
+      expect(projectSession.openedProjectHandle.value).toBeUndefined()
+      expect(projectSession.executingEditorHandle.value).toBeUndefined()
     } finally {
       disposeApp(app)
     }

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -1,7 +1,7 @@
 import { pluginsValueSpec } from '@kittycad/registry'
 import { File } from '@src/lang/KclManager'
 import { App } from '@src/lib/app'
-import { StorageName, moduleFsViaModuleImport } from '@src/lib/fs-zds'
+import fsZds, { StorageName, moduleFsViaModuleImport } from '@src/lib/fs-zds'
 import type { Project } from '@src/lib/project'
 import { getChangedSettingsAtLevel } from '@src/lib/settings/settingsUtils'
 import { appHeaderItemsValueSpec } from '@src/registry/contracts/appHeader'
@@ -10,9 +10,13 @@ import { projectSessionService } from '@src/registry/contracts/projectSession'
 import { loadWasm } from '@src/unitTestUtils'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
+const mockProjectPath = '/private/tmp/zds-app-spec-project-system/test'
+const mockProjectMainFilePath = `${mockProjectPath}/main.kcl`
+const mockProjectDirectoryPath = '/private/tmp/zds-app-spec-project-system'
+
 const mockProject: Project = {
   name: 'test',
-  default_file: 'main.kcl',
+  default_file: mockProjectMainFilePath,
   directory_count: 0,
   kcl_file_count: 1,
   metadata: {
@@ -23,12 +27,12 @@ const mockProject: Project = {
     size: 100,
     type: null,
   },
-  path: '/some-dir/test',
+  path: mockProjectPath,
   readWriteAccess: true,
   children: [
     {
       name: 'main.kcl',
-      path: '/some-dir/test/main.kcl',
+      path: mockProjectMainFilePath,
       children: [],
     },
   ],
@@ -40,9 +44,13 @@ beforeAll(async () => {
     type: StorageName.NodeFS,
     options: {},
   })
+  await fsZds.rm(mockProjectPath, { recursive: true, force: true })
+  await fsZds.mkdir(mockProjectPath, { recursive: true })
+  await fsZds.writeFile(mockProjectMainFilePath, new TextEncoder().encode(''))
 })
 
-afterAll(() => {
+afterAll(async () => {
+  await fsZds.rm(mockProjectPath, { recursive: true, force: true })
   vi.restoreAllMocks()
 })
 
@@ -63,8 +71,8 @@ async function waitForSettingsIdle(app: App) {
   })
 }
 
-function disposeApp(app: App) {
-  app.closeProject()
+async function disposeApp(app: App) {
+  await app.projectSession.setOpenedProjectHandle(undefined)
   app.systemIOActor.stop()
   app.settings.actor.stop()
   app.commands.actor.stop()
@@ -130,7 +138,7 @@ describe('project system', () => {
         ]
       ).toBeUndefined()
     } finally {
-      disposeApp(app)
+      await disposeApp(app)
     }
   })
 
@@ -169,7 +177,7 @@ describe('project system', () => {
       expect(textEditorSettings.automaticallyRender.current).toBe(true)
       expect(textEditorSettings.automaticallyRender.hideOnLevel).toBe('project')
     } finally {
-      disposeApp(app)
+      await disposeApp(app)
     }
   })
 
@@ -197,7 +205,7 @@ describe('project system', () => {
       expect(app.settings.get().plugins[pluginId].current).toBe(true)
       expect(app.registry.get(plugin.service).active.value).toBe(true)
     } finally {
-      disposeApp(app)
+      await disposeApp(app)
     }
   })
 
@@ -246,7 +254,7 @@ describe('project system', () => {
         app.registry.get(executionIndicatorPlugin.service).active.value
       ).toBe(true)
     } finally {
-      disposeApp(app)
+      await disposeApp(app)
     }
   })
 
@@ -261,7 +269,13 @@ describe('project system', () => {
 
     try {
       const projectSession = app.registry.get(projectSessionService)
-      const project = await projectSession.openProject(mockProject)
+      const project = await projectSession.setOpenedProjectHandle({
+        projectPath: mockProject.path,
+      })
+      expect(project).toBeDefined()
+      if (!project) {
+        throw new Error('Expected project session to open the mock project.')
+      }
 
       expect(app.project).toBeDefined()
       expect(app.project).toBe(project)
@@ -269,6 +283,9 @@ describe('project system', () => {
       expect(projectSession.openedProjectHandle.value).toEqual({
         projectPath: mockProject.path,
       })
+      expect(
+        app.systemIOActor.getSnapshot().context.projectDirectoryPath
+      ).toEqual(mockProjectDirectoryPath)
       expect(app.project?.executingPath).toBeNull()
       expect(app.project?.executingFileEntry.value.name).toEqual('')
 
@@ -278,21 +295,24 @@ describe('project system', () => {
         throw new Error('Expected mock project to include a main file.')
       }
 
-      await projectSession.openEditor(mainFile.path)
-      expect(app.project?.executingPath).toEqual('/some-dir/test/main.kcl')
+      await projectSession.setExecutingEditorHandle({
+        projectPath: mockProject.path,
+        filePath: mainFile.path,
+      })
+      expect(app.project?.executingPath).toEqual(mockProjectMainFilePath)
       expect(app.project?.executingFileEntry.value.name).toEqual('main.kcl')
       expect(projectSession.executingEditorHandle.value).toEqual({
         projectPath: mockProject.path,
         filePath: mainFile.path,
       })
 
-      projectSession.closeProject()
+      await projectSession.setOpenedProjectHandle(undefined)
 
       expect(app.project).toBeUndefined()
       expect(projectSession.openedProjectHandle.value).toBeUndefined()
       expect(projectSession.executingEditorHandle.value).toBeUndefined()
     } finally {
-      disposeApp(app)
+      await disposeApp(app)
     }
   })
 })

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -8,8 +8,7 @@ import {
   provideService,
 } from '@kittycad/registry'
 import { type Signal, effect, signal } from '@preact/signals-core'
-import { buildFSHistoryExtension } from '@src/editor/plugins/fs'
-import { KclManager, ZDSProject } from '@src/lang/KclManager'
+import { KclManager, type ZDSProject } from '@src/lang/KclManager'
 import { initialiseWasm } from '@src/lang/wasmUtils'
 import { MachineManager } from '@src/lib/MachineManager'
 import { createAuthCommands } from '@src/lib/commandBarConfigs/authCommandConfig'
@@ -77,6 +76,10 @@ import { executingEditorService } from '@src/registry/contracts/executingEditor'
 import { keymapService } from '@src/registry/contracts/keymap'
 import { layoutContributionsValueSpec } from '@src/registry/contracts/layout'
 import { machineManagerService } from '@src/registry/contracts/machineManager'
+import {
+  type ProjectSessionService,
+  projectSessionService,
+} from '@src/registry/contracts/projectSession'
 import { settingsValueSpec } from '@src/registry/contracts/settings'
 import { userFeaturesService } from '@src/registry/contracts/userFeatures'
 import { provideWasmPromise } from '@src/registry/contracts/wasm'
@@ -248,6 +251,8 @@ export class App implements AppSubsystems {
   layout: AppLayoutSystem
   /** The registry system for the application */
   registry: AppRegistrySystem
+  /** The currently-opened project and editor lifecycle system */
+  projectSession: ProjectSessionService
   /**
    * The interface to reading/writing to IO.
    * TODO: We have agreed to move away from this XState approach, towards a class + signals approach.
@@ -276,6 +281,9 @@ export class App implements AppSubsystems {
         app: this,
       },
     }).start()
+    this.projectSession = this.registry.get(projectSessionService)
+    this.projectSignal = this.projectSession.openedProject
+    this.projectSession.bindApp(this)
 
     this.registry.reconfigure(appCommandsSlot, [
       defineRegistryItem({
@@ -551,43 +559,10 @@ export class App implements AppSubsystems {
   }
 
   async openProject(projectIORef: Project) {
-    const projectIORefSignal = signal(projectIORef)
-    this.project = await ZDSProject.open(projectIORefSignal, this)
-
-    // This extension makes it possible to mark FS operations as un/redoable
-    effect(() => {
-      if (this.project?.executingEditor.value) {
-        buildFSHistoryExtension(
-          this.systemIOActor,
-          this.project.executingEditor.value
-        )
-      }
-    })
-
-    // TODO: Rework the systemIOActor to fit into the system better,
-    // so that the project doesn't need to subscribe to it.
-    this.systemIOActor.subscribe(({ context }) => {
-      const foundProject = (context.folders ?? []).find(
-        (p) =>
-          p.name === projectIORefSignal.value.name &&
-          p.path === projectIORefSignal.value.path
-      )
-      if (foundProject && projectIORefSignal.value !== foundProject) {
-        projectIORefSignal.value = foundProject
-      }
-    })
-
-    this.unsubscribeFromSettings = this.settings.actor.subscribe(
-      this.onSettingsUpdate
-    )
-
-    return this.project
+    return this.projectSession.openProject(projectIORef)
   }
-  private unsubscribeFromSettings: Subscription | undefined = undefined
   closeProject() {
-    this.unsubscribeFromSettings?.unsubscribe()
-    this.project?.close()
-    this.project = undefined
+    this.projectSession.closeProject()
   }
 
   syncUserFeaturesFromAuth = (

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -30,7 +30,7 @@ import {
   setLayoutSaveHandler,
 } from '@src/lib/layout'
 import { playwrightLayoutConfig } from '@src/lib/layout/configs/playwright'
-import type { Project } from '@src/lib/project'
+import { getParentAbsolutePath } from '@src/lib/paths'
 import RustContext from '@src/lib/rustContext'
 import {
   type SettingsType,
@@ -57,7 +57,10 @@ import {
   settingsMachine,
 } from '@src/machines/settingsMachine'
 import { systemIOMachineImpl } from '@src/machines/systemIO/systemIOMachineImpl'
-import type { SystemIOActor } from '@src/machines/systemIO/utils'
+import {
+  type SystemIOActor,
+  SystemIOMachineEvents,
+} from '@src/machines/systemIO/utils'
 import {
   type UserFeaturesActorRef,
   type UserFeaturesContext,
@@ -262,6 +265,7 @@ export class App implements AppSubsystems {
   // TODO: refactor this to not require keeping around the last settings to compare to
   private lastSettings: SaveSettingsPayload
   private pluginSettingsSubscription: Subscription
+  private systemIOProjectDirectoryEffectUnsubscribe: ReturnType<typeof effect>
 
   constructor(subsystems: AppSubsystems) {
     this.wasmPromise = subsystems.wasmPromise
@@ -284,6 +288,9 @@ export class App implements AppSubsystems {
     this.projectSession = this.registry.get(projectSessionService)
     this.projectSignal = this.projectSession.openedProject
     this.projectSession.bindApp(this)
+    this.systemIOProjectDirectoryEffectUnsubscribe = effect(
+      this.syncSystemIOProjectDirectoryFromOpenedProjectHandle
+    )
 
     this.registry.reconfigure(appCommandsSlot, [
       defineRegistryItem({
@@ -558,13 +565,6 @@ export class App implements AppSubsystems {
     return new App(combined)
   }
 
-  async openProject(projectIORef: Project) {
-    return this.projectSession.openProject(projectIORef)
-  }
-  closeProject() {
-    this.projectSession.closeProject()
-  }
-
   syncUserFeaturesFromAuth = (
     snapshot: SnapshotFrom<typeof this.auth.actor>
   ) => {
@@ -624,6 +624,36 @@ export class App implements AppSubsystems {
 
       toggle.disable()
     }
+  }
+
+  syncSystemIOProjectDirectoryFromOpenedProjectHandle = () => {
+    const openedProjectHandle = this.projectSession.openedProjectHandle.value
+    const appProjectDir = this.settings.get().app.projectDirectory.current
+    const requestedProjectDirectoryPath =
+      openedProjectHandle?.projectPath.includes(appProjectDir)
+        ? appProjectDir
+        : openedProjectHandle
+          ? getParentAbsolutePath(openedProjectHandle.projectPath)
+          : appProjectDir
+
+    if (
+      this.systemIOActor.getSnapshot().context.projectDirectoryPath ===
+      requestedProjectDirectoryPath
+    ) {
+      if (!openedProjectHandle) {
+        this.systemIOActor.send({
+          type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
+        })
+      }
+      return
+    }
+
+    this.systemIOActor.send({
+      type: SystemIOMachineEvents.setProjectDirectoryPath,
+      data: {
+        requestedProjectDirectoryPath,
+      },
+    })
   }
 
   /**

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -8,7 +8,7 @@ import {
   provideService,
 } from '@kittycad/registry'
 import { type Signal, effect, signal } from '@preact/signals-core'
-import { KclManager, type ZDSProject } from '@src/lang/KclManager'
+import type { KclManager, ZDSProject } from '@src/lang/KclManager'
 import { initialiseWasm } from '@src/lang/wasmUtils'
 import { MachineManager } from '@src/lib/MachineManager'
 import { createAuthCommands } from '@src/lib/commandBarConfigs/authCommandConfig'
@@ -75,8 +75,6 @@ import {
   commandSystemService,
   provideCommand,
 } from '@src/registry/contracts/commands'
-import { executingEditorService } from '@src/registry/contracts/executingEditor'
-import { keymapService } from '@src/registry/contracts/keymap'
 import { layoutContributionsValueSpec } from '@src/registry/contracts/layout'
 import { machineManagerService } from '@src/registry/contracts/machineManager'
 import {
@@ -660,34 +658,10 @@ export class App implements AppSubsystems {
    * Build the world!
    */
   buildSingletons() {
-    // TODO: Remove this and make the app handle no executing editor,
-    // so we don't need to stub with empty strings
-    const kclManager = new KclManager('', '', {
-      settings: this.settings.actor,
-      wasmInstancePromise: this.wasmPromise,
-      commandBar: this.commands.actor,
-      projectPath: signal(''),
-      engineCommandManager: this.engineCommandManager,
-      rustContext: this.rustContext,
-      keymap: this.registry.get(keymapService),
-    })
-
-    this.registry.reconfigure(appRegistryServicesSlot, [
-      defineRegistryItem({
-        id: 'executing-editor-services',
-        providesServices: [
-          provideService(
-            executingEditorService,
-            kclManager.executingEditorService
-          ),
-        ],
-      }),
-    ])
-
     if (typeof window !== 'undefined') {
       // Accessible for tests mostly
-      window.engineCommandManager = kclManager.engineCommandManager
-      window.rustContext = kclManager.rustContext
+      window.engineCommandManager = this.engineCommandManager
+      window.rustContext = this.rustContext
       window.engineDebugger = EngineDebugger
       ;(window as any).enableMousePositionLogs = () =>
         document.addEventListener('mousemove', (e) =>
@@ -697,7 +671,7 @@ export class App implements AppSubsystems {
         ;(window as any)._enableFillet = true
       }
       ;(window as any).zoomToFit = () =>
-        kclManager.engineCommandManager.sendSceneCommand({
+        this.engineCommandManager.sendSceneCommand({
           type: 'modeling_cmd_req',
           cmd_id: uuidv4(),
           cmd: {
@@ -709,10 +683,18 @@ export class App implements AppSubsystems {
         })
     }
 
-    this.commands.actor.send({ type: 'Set kclManager', data: kclManager })
-
+    const getExecutingEditor = (): KclManager => {
+      const editor =
+        this.projectSession.openedProject.value?.executingEditor.value
+      if (!editor) {
+        throw new Error('No executing editor is currently available.')
+      }
+      return editor
+    }
     return {
-      kclManager,
+      get kclManager() {
+        return getExecutingEditor()
+      },
     }
   }
 
@@ -721,23 +703,22 @@ export class App implements AppSubsystems {
    * as a dependency input, we must subscribe to updates from the outside.
    */
   onSettingsUpdate = (snapshot: SnapshotFrom<typeof this.settings.actor>) => {
-    if (!this.project) {
+    const kclManager = this.project?.executingEditor.value
+    if (!kclManager) {
       return // Everything in here only matters inside a project.
     }
     const { context } = snapshot
 
     // Update line wrapping
-    this.singletons.kclManager.setEditorLineWrapping(
-      context.textEditor.textWrapping.current
-    )
+    kclManager.setEditorLineWrapping(context.textEditor.textWrapping.current)
 
     // Update engine highlighting
     const newHighlighting = context.modeling.highlightEdges.current
     if (
       newHighlighting !== this.lastSettings.modeling.highlightEdges &&
-      this.singletons.kclManager.engineCommandManager.connection
+      kclManager.engineCommandManager.connection
     ) {
-      this.singletons.kclManager.engineCommandManager
+      kclManager.engineCommandManager
         .setHighlightEdges(newHighlighting)
         .catch(reportRejection)
     }
@@ -748,16 +729,16 @@ export class App implements AppSubsystems {
       '--cursor-color',
       newBlinking ? 'auto' : 'transparent'
     )
-    this.singletons.kclManager.setCursorBlinking(newBlinking)
+    kclManager.setCursorBlinking(newBlinking)
 
     // Update theme
     const newTheme = context.app.theme.current
     const newBackfaceColor = context.modeling.backfaceColor.current
     Promise.all([
-      this.singletons.kclManager.updateTheme(newTheme),
-      ...(this.singletons.kclManager.engineCommandManager.connection?.connected
+      kclManager.updateTheme(newTheme),
+      ...(kclManager.engineCommandManager.connection?.connected
         ? [
-            this.singletons.kclManager.engineCommandManager.setDefaultSystemProperties(
+            kclManager.engineCommandManager.setDefaultSystemProperties(
               newBackfaceColor
             ),
           ]
@@ -783,29 +764,29 @@ export class App implements AppSubsystems {
       // Relevant settings requiring a cleared scene and re-exec
       if (
         settingsIncludeNewRelevantValues &&
-        this.singletons.kclManager.engineCommandManager.connection
+        kclManager.engineCommandManager.connection
       ) {
-        this.singletons.kclManager.rustContext
+        kclManager.rustContext
           .clearSceneAndBustCache(
             jsAppSettings(this.settings.actor),
-            this.singletons.kclManager.path
+            kclManager.path
           )
-          .then(() => this.singletons.kclManager.executeCode())
+          .then(() => kclManager.executeCode())
           .catch(reportRejection)
       }
     } catch (e) {
       console.error('Error executing AST after settings change', e)
     }
 
-    this.singletons.kclManager.sceneInfra.camControls._setting_allowOrbitInSketchMode =
+    kclManager.sceneInfra.camControls._setting_allowOrbitInSketchMode =
       context.app.allowOrbitInSketchMode.current
 
     const newCurrentProjection = context.modeling.cameraProjection.current
     if (
-      this.singletons.kclManager.sceneInfra.camControls &&
-      !this.singletons.kclManager.modelingState?.matches('Sketch')
+      kclManager.sceneInfra.camControls &&
+      !kclManager.modelingState?.matches('Sketch')
     ) {
-      this.singletons.kclManager.sceneInfra.camControls.engineCameraProjection =
+      kclManager.sceneInfra.camControls.engineCameraProjection =
         newCurrentProjection
     }
 

--- a/src/lib/boot.ts
+++ b/src/lib/boot.ts
@@ -1,3 +1,4 @@
+import { useSignals } from '@preact/signals-react/runtime'
 import { App } from '@src/lib/app'
 import {
   StorageName,
@@ -51,6 +52,20 @@ window.app = app
  * `useSingletons` will eventually be deprecated.
  */
 export const useSingletons = () => React.useContext(AppContext).singletons
+
+export const useOptionalExecutingEditor = () => {
+  useSignals()
+  const app = React.useContext(AppContext)
+  return app.projectSession.openedProject.value?.executingEditor.value
+}
+
+export const useExecutingEditor = () => {
+  const executingEditor = useOptionalExecutingEditor()
+  if (!executingEditor) {
+    throw new Error('No executing editor is currently available.')
+  }
+  return executingEditor
+}
 
 /**
  * Hook to get access to the app instance.

--- a/src/lib/exceptions.ts
+++ b/src/lib/exceptions.ts
@@ -13,7 +13,9 @@ let initialized = false
  * the global/DOM level. This will have to interface with whatever controlflow that needs to be picked up
  * within the error branch in the typescript to cover the application state.
  */
-export const initializeWindowExceptionHandler = (kclManager: KclManager) => {
+export const initializeWindowExceptionHandler = (
+  getExecutingEditor: () => KclManager | undefined
+) => {
   if (window && !initialized) {
     window.addEventListener('error', (event) => {
       void (async () => {
@@ -24,6 +26,10 @@ export const initializeWindowExceptionHandler = (kclManager: KclManager) => {
           matchMemoryAccessOutOfBoundsErrorCrash(event.message) ||
           matchGenericWasmRuntimeHeuristicErrorCrash(event)
         ) {
+          const kclManager = getExecutingEditor()
+          if (!kclManager) {
+            return
+          }
           // do global singleton cleanup
           kclManager.executeAstCleanUp()
           toast.error(

--- a/src/lib/kclCommands.ts
+++ b/src/lib/kclCommands.ts
@@ -30,10 +30,9 @@ import {
 import { getPathFilenameInVariableCase } from '@src/lib/desktop'
 import fsZds from '@src/lib/fs-zds'
 import { copyFileShareLink } from '@src/lib/links'
-import type { Project } from '@src/lib/project'
+import type { FileEntry, Project } from '@src/lib/project'
 import { baseUnitsUnion, warningLevels } from '@src/lib/settings/settingsTypes'
 import { err, reportRejection } from '@src/lib/trap'
-import type { IndexLoaderData } from '@src/lib/types'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { CommandBarContext } from '@src/machines/commandBarMachine'
 import { listAllImportFilesWithinProject } from '@src/machines/systemIO/snapshotContext'
@@ -48,7 +47,11 @@ interface KclCommandConfig {
   kclManager: KclManager
   systemIOActor: SystemIOActor
   wasmInstance: ModuleType
-  projectData: IndexLoaderData
+  projectData: {
+    code: string | null
+    project?: Project
+    file?: FileEntry
+  }
   authToken: string
   settings: {
     defaultUnit: UnitLength

--- a/src/lib/routeLoaders.ts
+++ b/src/lib/routeLoaders.ts
@@ -9,23 +9,19 @@ import { readAppSettingsFile } from '@src/lib/desktop'
 import fsZds from '@src/lib/fs-zds'
 import {
   PATHS,
-  getParentAbsolutePath,
   getProjectMetaByRouteId,
   getRouterSearchFromRequestUrl,
   safeEncodeForRouterPaths,
 } from '@src/lib/paths'
 import { loadAndValidateSettings } from '@src/lib/settings/settingsUtils'
-import type {
-  FileLoaderData,
-  HomeLoaderData,
-  IndexLoaderData,
-} from '@src/lib/types'
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
 import { projectSessionService } from '@src/registry/contracts/projectSession'
 import type { LoaderFunction } from 'react-router-dom'
 import { redirect } from 'react-router-dom'
 
 export const DEFAULT_WEB_PROJECT_NAME = 'demo-project'
+
+type EmptyLoaderData = Record<string, never>
 
 /**
  * The base loader is used to reroute `/` root path requests,
@@ -96,7 +92,7 @@ export const fileLoader =
   }: {
     app: App
   }): LoaderFunction =>
-  async (routerData): Promise<FileLoaderData | Response> => {
+  async (routerData): Promise<EmptyLoaderData | Response> => {
     const { kclManager } = app.singletons
     const projectSession = app.registry.get(projectSessionService)
     const { params } = routerData
@@ -174,78 +170,32 @@ export const fileLoader =
       }
     }
 
-    const defaultProjectData = {
-      name: projectName || 'unnamed',
-      path: projectPath,
-      children: [],
-      kcl_file_count: 0,
-      directory_count: 0,
-      metadata: null,
-      default_file: projectPath,
-      readWriteAccess: true,
-    }
-
-    const maybeProjectInfo = await getProjectInfo(projectPath, wasmInstance)
-
-    const project = maybeProjectInfo ?? defaultProjectData
-
-    const { editor } = await projectSession.openProjectEditor({
-      project,
+    await projectSession.setOpenedProjectHandle({ projectPath })
+    await projectSession.setExecutingEditorHandle({
+      projectPath,
       filePath: currentFilePath || PROJECT_ENTRYPOINT,
-      providedEditor: app.singletons.kclManager,
-      // If persistCode in localStorage is present, it'll persist that code
-      // through *anything*. INTENDED FOR TESTS.
-      providedCode:
-        window.electron?.process.env.NODE_ENV === 'test'
-          ? kclManager.localStoragePersistCode()
-          : undefined,
     })
 
-    const appProjectDir = settings.settings.app.projectDirectory.current
-    const requestedProjectDirectoryPath = project.path.includes(appProjectDir)
-      ? appProjectDir
-      : getParentAbsolutePath(project.path) // Fallback to parent directory if foreign to app project dir
-    app.systemIOActor.send({
-      type: SystemIOMachineEvents.setProjectDirectoryPath,
-      data: {
-        requestedProjectDirectoryPath,
-      },
-    })
-
-    const projectData: IndexLoaderData = {
-      code: editor.code,
-      project,
-      file: {
-        name: currentFileName || '',
-        path: currentFilePath || '',
-        children: [],
-      },
-    }
-
-    return {
-      ...projectData,
-    }
+    return {}
   }
 
 // Loads the settings and by extension the projects in the default directory
 // and returns them to the Home route, along with any errors that occurred
 
-// Should also clear currently loaded projects in SystemIO. They may be stale.
 export const homeLoader =
   ({
     app,
   }: {
     app: App
   }): LoaderFunction =>
-  async (): Promise<HomeLoaderData | Response> => {
+  async (): Promise<EmptyLoaderData | Response> => {
     // If on web, bump out to root, which will redirect to a project.
     if (!window.electron) {
       return redirect(PATHS.INDEX)
     }
 
-    app.systemIOActor.send({
-      type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
-    })
-    app.registry.get(projectSessionService).closeProject()
+    await app.registry
+      .get(projectSessionService)
+      .setOpenedProjectHandle(undefined)
     return {}
   }

--- a/src/lib/routeLoaders.ts
+++ b/src/lib/routeLoaders.ts
@@ -53,7 +53,7 @@ export const baseLoader =
     }
 
     // Web, make a default project and redirect to it.
-    const wasmInstance = await app.singletons.kclManager.wasmInstancePromise
+    const wasmInstance = await app.wasmPromise
 
     const settings = await loadAndValidateSettings(wasmInstance, undefined)
 
@@ -93,7 +93,6 @@ export const fileLoader =
     app: App
   }): LoaderFunction =>
   async (routerData): Promise<EmptyLoaderData | Response> => {
-    const { kclManager } = app.singletons
     const projectSession = app.registry.get(projectSessionService)
     const { params } = routerData
 
@@ -109,7 +108,7 @@ export const fileLoader =
       ? params.id.split(fsZds.sep).slice(0, -1).join(fsZds.sep)
       : undefined
 
-    const wasmInstance = await kclManager.wasmInstancePromise
+    const wasmInstance = await app.wasmPromise
 
     const settings = await loadAndValidateSettings(
       wasmInstance,
@@ -183,19 +182,12 @@ export const fileLoader =
 // and returns them to the Home route, along with any errors that occurred
 
 export const homeLoader =
-  ({
-    app,
-  }: {
-    app: App
-  }): LoaderFunction =>
+  (_input: { app: App }): LoaderFunction =>
   async (): Promise<EmptyLoaderData | Response> => {
     // If on web, bump out to root, which will redirect to a project.
     if (!window.electron) {
       return redirect(PATHS.INDEX)
     }
 
-    await app.registry
-      .get(projectSessionService)
-      .setOpenedProjectHandle(undefined)
     return {}
   }

--- a/src/lib/routeLoaders.ts
+++ b/src/lib/routeLoaders.ts
@@ -1,5 +1,4 @@
 import { projectSkeletonCreate } from '@src/lang/project'
-import { projectFsManager } from '@src/lang/std/fileSystemManager'
 import type { App } from '@src/lib/app'
 import {
   DEFAULT_DEFAULT_LENGTH_UNIT,
@@ -22,9 +21,9 @@ import type {
   IndexLoaderData,
 } from '@src/lib/types'
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
+import { projectSessionService } from '@src/registry/contracts/projectSession'
 import type { LoaderFunction } from 'react-router-dom'
 import { redirect } from 'react-router-dom'
-import { waitFor } from 'xstate'
 
 export const DEFAULT_WEB_PROJECT_NAME = 'demo-project'
 
@@ -86,8 +85,7 @@ export const baseLoader =
         wasmInstance
       )
 
-      const fileURLPath =
-        PATHS.FILE + '/' + encodeURIComponent(requestedProjectName)
+      const fileURLPath = `${PATHS.FILE}/${encodeURIComponent(requestedProjectName)}`
       return redirect(fileURLPath + routerSearch)
     }
   }
@@ -99,10 +97,8 @@ export const fileLoader =
     app: App
   }): LoaderFunction =>
   async (routerData): Promise<FileLoaderData | Response> => {
-    const {
-      settings: { actor: settingsActor },
-    } = app
     const { kclManager } = app.singletons
+    const projectSession = app.registry.get(projectSessionService)
     const { params } = routerData
 
     // Must basically remain for all eternity, until the last person
@@ -119,7 +115,7 @@ export const fileLoader =
 
     const wasmInstance = await kclManager.wasmInstancePromise
 
-    let settings = await loadAndValidateSettings(
+    const settings = await loadAndValidateSettings(
       wasmInstance,
       heuristicProjectFilePath
     )
@@ -178,10 +174,6 @@ export const fileLoader =
       }
     }
 
-    // Set the file system manager to the project path
-    // So that WASM gets an updated path for operations
-    projectFsManager.dir = projectPath
-
     const defaultProjectData = {
       name: projectName || 'unnamed',
       path: projectPath,
@@ -197,25 +189,17 @@ export const fileLoader =
 
     const project = maybeProjectInfo ?? defaultProjectData
 
-    // Fire off the event to load the project settings
-    // once we know it's idle.
-    await waitFor(settingsActor, (state) => state.matches('idle'))
-    settingsActor.send({
-      type: 'load.project',
+    const { editor } = await projectSession.openProjectEditor({
       project,
-    })
-    await waitFor(settingsActor, (state) => state.matches('idle'))
-
-    const projectRef = await app.openProject(project)
-    const editor = await projectRef.openEditor(
-      currentFilePath || PROJECT_ENTRYPOINT,
-      app.singletons.kclManager,
+      filePath: currentFilePath || PROJECT_ENTRYPOINT,
+      providedEditor: app.singletons.kclManager,
       // If persistCode in localStorage is present, it'll persist that code
       // through *anything*. INTENDED FOR TESTS.
-      window.electron?.process.env.NODE_ENV === 'test'
-        ? kclManager.localStoragePersistCode()
-        : undefined
-    )
+      providedCode:
+        window.electron?.process.env.NODE_ENV === 'test'
+          ? kclManager.localStoragePersistCode()
+          : undefined,
+    })
 
     const appProjectDir = settings.settings.app.projectDirectory.current
     const requestedProjectDirectoryPath = project.path.includes(appProjectDir)
@@ -253,7 +237,7 @@ export const homeLoader =
   }: {
     app: App
   }): LoaderFunction =>
-  async ({ request }): Promise<HomeLoaderData | Response> => {
+  async (): Promise<HomeLoaderData | Response> => {
     // If on web, bump out to root, which will redirect to a project.
     if (!window.electron) {
       return redirect(PATHS.INDEX)
@@ -262,9 +246,6 @@ export const homeLoader =
     app.systemIOActor.send({
       type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
     })
-    app.closeProject()
-    app.settings.actor.send({
-      type: 'clear.project',
-    })
+    app.registry.get(projectSessionService).closeProject()
     return {}
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,19 +1,3 @@
-import type { FileEntry, Project } from '@src/lib/project'
-
-export type IndexLoaderData = {
-  code: string | null
-  project?: Project
-  file?: FileEntry
-}
-
-export type FileLoaderData = {
-  code: string | null
-  project?: FileEntry | Project
-  file?: FileEntry
-}
-
-export type HomeLoaderData = Record<string, never>
-
 // From the very helpful @jcalz on StackOverflow: https://stackoverflow.com/a/58436959/22753272
 type Join<K, P> = K extends string | number
   ? P extends string | number
@@ -97,17 +81,16 @@ export type DeepPartial<T> = {
 /**
  * Replace a function's return type with another type.
  */
-export type WithReturnType<F extends (...args: any[]) => any, NewReturn> = (
+type AnyFunction = (...args: never[]) => unknown
+
+export type WithReturnType<F extends AnyFunction, NewReturn> = (
   ...args: Parameters<F>
 ) => NewReturn
 
 /**
  * Assert that a function type is async, preserving its parameter types.
  */
-export type AsyncFn<F extends (...args: any[]) => any> = WithReturnType<
-  F,
-  Promise<unknown>
->
+export type AsyncFn<F extends AnyFunction> = WithReturnType<F, Promise<unknown>>
 
 export type FileMeta =
   | {
@@ -138,7 +121,5 @@ type PromisifyFn<F> = F extends (...args: infer A) => infer R
   : F
 /** Promisify only function properties, leave others unchanged */
 export type PromisifyProps<T> = {
-  [K in keyof T]: T[K] extends (...args: any[]) => any
-    ? PromisifyFn<T[K]>
-    : T[K]
+  [K in keyof T]: T[K] extends AnyFunction ? PromisifyFn<T[K]> : T[K]
 }

--- a/src/machines/commandBarMachine.ts
+++ b/src/machines/commandBarMachine.ts
@@ -134,7 +134,7 @@ export type CommandBarMachineEvent =
       type: 'Change current argument'
       data: { [x: string]: CommandArgumentWithName<unknown> }
     }
-  | { type: 'Set kclManager'; data: KclManager }
+  | { type: 'Set kclManager'; data: KclManager | undefined }
 
 export const commandBarMachine = setup({
   types: {
@@ -210,7 +210,11 @@ export const commandBarMachine = setup({
         const { selectedCommand } = context
         if (!(selectedCommand && selectedCommand.args)) return undefined
         const rejectedArg =
-          'data' in event && 'arg' in event.data && event.data.arg
+          'data' in event &&
+          event.data &&
+          typeof event.data === 'object' &&
+          'arg' in event.data &&
+          event.data.arg
 
         // Find the first argument that is not to be skipped:
         // that is, the first argument that is not already in the argumentsToSubmit

--- a/src/registry/contracts/executingEditor.ts
+++ b/src/registry/contracts/executingEditor.ts
@@ -1,5 +1,6 @@
 import { defineContract, defineService } from '@kittycad/registry'
 import type { ReadonlySignal } from '@preact/signals-core'
+import type { KclManager } from '@src/lang/KclManager'
 
 export interface ExecutingEditorUpdateOptions {
   shouldExecute?: boolean
@@ -10,6 +11,7 @@ export interface ExecutingEditorUpdateOptions {
 }
 
 export interface ExecutingEditorService {
+  readonly editor: ReadonlySignal<KclManager | undefined>
   readonly code: ReadonlySignal<string>
   readonly hasEditsSinceLastExecution: ReadonlySignal<boolean>
   readonly isExecuting: ReadonlySignal<boolean>

--- a/src/registry/contracts/projectSession.ts
+++ b/src/registry/contracts/projectSession.ts
@@ -6,7 +6,6 @@ import {
 import type { Signal } from '@preact/signals-core'
 import type { KclManager, ZDSProject } from '@src/lang/KclManager'
 import type { App } from '@src/lib/app'
-import type { Project } from '@src/lib/project'
 
 export interface OpenedProjectHandle {
   projectPath: string
@@ -23,23 +22,18 @@ export interface OpenEditorOptions {
   isExecuting?: boolean
 }
 
-export interface OpenProjectEditorInput extends OpenEditorOptions {
-  project: Project
-  filePath: string
-}
-
 export interface ProjectSessionService {
   readonly openedProjectHandle: Signal<OpenedProjectHandle | undefined>
   readonly executingEditorHandle: Signal<ExecutingEditorHandle | undefined>
   readonly openedProject: Signal<ZDSProject | undefined>
   bindApp(app: App): void
-  openProject(project: Project): Promise<ZDSProject>
-  openEditor(filePath: string, options?: OpenEditorOptions): Promise<KclManager>
-  openProjectEditor(input: OpenProjectEditorInput): Promise<{
-    project: ZDSProject
-    editor: KclManager
-  }>
-  closeProject(): void
+  setOpenedProjectHandle(
+    handle: OpenedProjectHandle | undefined
+  ): Promise<ZDSProject | undefined>
+  setExecutingEditorHandle(
+    handle: ExecutingEditorHandle | undefined,
+    options?: OpenEditorOptions
+  ): Promise<KclManager | undefined>
 }
 
 export const projectSessionContract = defineContract({

--- a/src/registry/contracts/projectSession.ts
+++ b/src/registry/contracts/projectSession.ts
@@ -1,0 +1,65 @@
+import {
+  defineContract,
+  defineService,
+  firstWinsValueSpec,
+} from '@kittycad/registry'
+import type { Signal } from '@preact/signals-core'
+import type { KclManager, ZDSProject } from '@src/lang/KclManager'
+import type { App } from '@src/lib/app'
+import type { Project } from '@src/lib/project'
+
+export interface OpenedProjectHandle {
+  projectPath: string
+}
+
+export interface ExecutingEditorHandle {
+  projectPath: string
+  filePath: string
+}
+
+export interface OpenEditorOptions {
+  providedEditor?: KclManager
+  providedCode?: string
+  isExecuting?: boolean
+}
+
+export interface OpenProjectEditorInput extends OpenEditorOptions {
+  project: Project
+  filePath: string
+}
+
+export interface ProjectSessionService {
+  readonly openedProjectHandle: Signal<OpenedProjectHandle | undefined>
+  readonly executingEditorHandle: Signal<ExecutingEditorHandle | undefined>
+  readonly openedProject: Signal<ZDSProject | undefined>
+  bindApp(app: App): void
+  openProject(project: Project): Promise<ZDSProject>
+  openEditor(filePath: string, options?: OpenEditorOptions): Promise<KclManager>
+  openProjectEditor(input: OpenProjectEditorInput): Promise<{
+    project: ZDSProject
+    editor: KclManager
+  }>
+  closeProject(): void
+}
+
+export const projectSessionContract = defineContract({
+  openedProjectHandleValueSpec: firstWinsValueSpec<
+    OpenedProjectHandle | undefined
+  >('opened-project-handle', undefined),
+  executingEditorHandleValueSpec: firstWinsValueSpec<
+    ExecutingEditorHandle | undefined
+  >('executing-editor-handle', undefined),
+  openedProjectValueSpec: firstWinsValueSpec<ZDSProject | undefined>(
+    'opened-project',
+    undefined
+  ),
+  projectSessionService:
+    defineService<ProjectSessionService>('project-session'),
+})
+
+export const {
+  openedProjectHandleValueSpec,
+  executingEditorHandleValueSpec,
+  openedProjectValueSpec,
+  projectSessionService,
+} = projectSessionContract

--- a/src/registry/contracts/projectSession.ts
+++ b/src/registry/contracts/projectSession.ts
@@ -17,7 +17,6 @@ export interface ExecutingEditorHandle {
 }
 
 export interface OpenEditorOptions {
-  providedEditor?: KclManager
   providedCode?: string
   isExecuting?: boolean
 }

--- a/src/registry/extensions/engineScene/executionIndicator/index.test.ts
+++ b/src/registry/extensions/engineScene/executionIndicator/index.test.ts
@@ -5,6 +5,7 @@ import {
   provideService,
 } from '@kittycad/registry'
 import { signal } from '@preact/signals-core'
+import type { KclManager } from '@src/lang/KclManager'
 import type { ExecutingEditorService } from '@src/registry/contracts/executingEditor'
 import { executingEditorService } from '@src/registry/contracts/executingEditor'
 import { settingsValueSpec } from '@src/registry/contracts/settings'
@@ -17,6 +18,7 @@ function createExecutingEditorService(
   isExecuting = signal(false)
 ): ExecutingEditorService {
   return {
+    editor: signal({} as KclManager),
     code: signal(''),
     hasEditsSinceLastExecution: signal(false),
     isExecuting,

--- a/src/registry/extensions/engineScene/executionIndicator/index.ts
+++ b/src/registry/extensions/engineScene/executionIndicator/index.ts
@@ -21,7 +21,7 @@ const executionIndicatorStatusBarItem = defineRegistryItemFactory((ctx) => {
       (() => {
         const service = executionService.value
 
-        return service?.isExecuting.value
+        return service?.editor.value && service.isExecuting.value
           ? {
               id: EXECUTION_INDICATOR_STATUS_BAR_ITEM_ID,
               'data-testid': 'engine-executing-status',

--- a/src/registry/extensions/engineScene/index.spec.ts
+++ b/src/registry/extensions/engineScene/index.spec.ts
@@ -5,6 +5,7 @@ import {
   provideService,
 } from '@kittycad/registry'
 import { signal } from '@preact/signals-core'
+import type { KclManager } from '@src/lang/KclManager'
 import type { ExecutingEditorService } from '@src/registry/contracts/executingEditor'
 import { executingEditorService } from '@src/registry/contracts/executingEditor'
 import { settingsValueSpec } from '@src/registry/contracts/settings'
@@ -17,6 +18,7 @@ function createExecutingEditorService(
   showExperimentalFeaturesStatusBarItem = signal(true)
 ): ExecutingEditorService {
   return {
+    editor: signal({} as KclManager),
     code: signal(''),
     hasEditsSinceLastExecution: signal(false),
     isExecuting,

--- a/src/registry/extensions/engineScene/index.ts
+++ b/src/registry/extensions/engineScene/index.ts
@@ -61,7 +61,7 @@ const engineSceneExtension = defineRegistryItemFactory((ctx) => {
   const executionService = ctx.services.signal(executingEditorService)
   const selectionStatusBarItem = computed(() =>
     nullableStatusBarItem(
-      executionService.value
+      executionService.value?.editor.value
         ? {
             id: 'selection',
             'data-testid': 'selection-status',
@@ -78,7 +78,7 @@ const engineSceneExtension = defineRegistryItemFactory((ctx) => {
   )
   const selectionFilterStatusBarItem = computed(() =>
     nullableStatusBarItem(
-      executionService.value
+      executionService.value?.editor.value
         ? {
             id: 'selection-filter',
             component: EngineSceneSelectionFilterControls,
@@ -90,7 +90,8 @@ const engineSceneExtension = defineRegistryItemFactory((ctx) => {
   )
   const experimentalFeaturesStatusBarItem = computed(() =>
     nullableStatusBarItem(
-      executionService.value?.showExperimentalFeaturesStatusBarItem.value
+      executionService.value?.editor.value &&
+        executionService.value.showExperimentalFeaturesStatusBarItem.value
         ? {
             id: 'experimental-features',
             component: EngineSceneExperimentalFeaturesMenu,
@@ -102,7 +103,7 @@ const engineSceneExtension = defineRegistryItemFactory((ctx) => {
   )
   const unitsStatusBarItem = computed(() =>
     nullableStatusBarItem(
-      executionService.value
+      executionService.value?.editor.value
         ? {
             id: 'units',
             component: EngineSceneUnitsMenu,

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -1,0 +1,218 @@
+import {
+  defineRegistryItemFactory,
+  defineRuntimeRegistryItem,
+  provide,
+  provideService,
+} from '@kittycad/registry'
+import { type Signal, effect, signal } from '@preact/signals-core'
+import { buildFSHistoryExtension } from '@src/editor/plugins/fs'
+import { ZDSProject } from '@src/lang/KclManager'
+import { projectFsManager } from '@src/lang/std/fileSystemManager'
+import type { App } from '@src/lib/app'
+import type { Project } from '@src/lib/project'
+import {
+  type OpenEditorOptions,
+  type OpenProjectEditorInput,
+  type ProjectSessionService,
+  executingEditorHandleValueSpec,
+  openedProjectHandleValueSpec,
+  openedProjectValueSpec,
+  projectSessionService,
+} from '@src/registry/contracts/projectSession'
+import type { Subscription } from 'xstate'
+import { waitFor } from 'xstate'
+
+interface CloseProjectOptions {
+  clearHandles?: boolean
+  clearProjectSettings?: boolean
+}
+
+const projectSessionExtension = defineRegistryItemFactory(() => {
+  let app: App | undefined
+  let unsubscribeFromSettings: Subscription | undefined
+  let unsubscribeFromSystemIO: Subscription | undefined
+  let stopFSHistoryEffect: (() => void) | undefined
+
+  const openedProjectHandle =
+    signal<ProjectSessionService['openedProjectHandle']['value']>(undefined)
+  const executingEditorHandle =
+    signal<ProjectSessionService['executingEditorHandle']['value']>(undefined)
+  const openedProject =
+    signal<ProjectSessionService['openedProject']['value']>(undefined)
+
+  const getApp = () => {
+    if (!app) {
+      throw new Error('Project session service has not been bound to App.')
+    }
+    return app
+  }
+
+  const stopProjectEffects = () => {
+    unsubscribeFromSettings?.unsubscribe()
+    unsubscribeFromSettings = undefined
+    unsubscribeFromSystemIO?.unsubscribe()
+    unsubscribeFromSystemIO = undefined
+    stopFSHistoryEffect?.()
+    stopFSHistoryEffect = undefined
+  }
+
+  const closeProject = ({
+    clearHandles = true,
+    clearProjectSettings = true,
+  }: CloseProjectOptions = {}) => {
+    const currentApp = app
+    const currentProject = openedProject.peek()
+
+    stopProjectEffects()
+    currentProject?.close()
+    openedProject.value = undefined
+
+    if (clearHandles) {
+      openedProjectHandle.value = undefined
+      executingEditorHandle.value = undefined
+    }
+
+    if (clearProjectSettings) {
+      currentApp?.settings.actor.send({
+        type: 'clear.project',
+      })
+    }
+  }
+
+  const syncProjectFromSystemIO = (projectIORefSignal: Signal<Project>) => {
+    const currentApp = getApp()
+
+    unsubscribeFromSystemIO = currentApp.systemIOActor.subscribe(
+      ({ context }) => {
+        const foundProject = (context.folders ?? []).find(
+          (project) =>
+            project.name === projectIORefSignal.value.name &&
+            project.path === projectIORefSignal.value.path
+        )
+        if (foundProject && projectIORefSignal.value !== foundProject) {
+          projectIORefSignal.value = foundProject
+        }
+      }
+    )
+  }
+
+  const startProjectEffects = (projectIORefSignal: Signal<Project>) => {
+    const currentApp = getApp()
+
+    stopProjectEffects()
+    stopFSHistoryEffect = effect(() => {
+      const editor = openedProject.value?.executingEditor.value
+      if (!editor) {
+        return
+      }
+
+      return buildFSHistoryExtension(currentApp.systemIOActor, editor)
+    })
+    syncProjectFromSystemIO(projectIORefSignal)
+    unsubscribeFromSettings = currentApp.settings.actor.subscribe(
+      currentApp.onSettingsUpdate
+    )
+  }
+
+  const openProject = async (project: Project) => {
+    const currentApp = getApp()
+    const currentProject = openedProject.peek()
+
+    openedProjectHandle.value = {
+      projectPath: project.path,
+    }
+    projectFsManager.dir = project.path
+
+    if (currentProject && currentProject.path !== project.path) {
+      closeProject({ clearHandles: false, clearProjectSettings: false })
+    }
+
+    await waitFor(currentApp.settings.actor, (state) => state.matches('idle'))
+    currentApp.settings.actor.send({
+      type: 'load.project',
+      project,
+    })
+    await waitFor(currentApp.settings.actor, (state) => state.matches('idle'))
+
+    if (currentProject?.path === project.path) {
+      currentProject.projectIORefSignal.value = project
+      return currentProject
+    }
+
+    const projectIORefSignal = signal(project)
+    const nextProject = await ZDSProject.open(projectIORefSignal, currentApp)
+    openedProject.value = nextProject
+    startProjectEffects(projectIORefSignal)
+    return nextProject
+  }
+
+  const openEditor = async (
+    filePath: string,
+    { providedEditor, providedCode, isExecuting = true }: OpenEditorOptions = {}
+  ) => {
+    const currentProject = openedProject.peek()
+    if (!currentProject) {
+      throw new Error('Cannot open an editor without an opened project.')
+    }
+
+    executingEditorHandle.value = {
+      projectPath: currentProject.path,
+      filePath,
+    }
+
+    return currentProject.openEditor(
+      filePath,
+      providedEditor,
+      providedCode,
+      isExecuting
+    )
+  }
+
+  const serviceImpl: ProjectSessionService = {
+    openedProjectHandle,
+    executingEditorHandle,
+    openedProject,
+    bindApp(boundApp) {
+      app = boundApp
+    },
+    openProject,
+    openEditor,
+    async openProjectEditor({
+      project,
+      filePath,
+      providedEditor,
+      providedCode,
+      isExecuting,
+    }: OpenProjectEditorInput) {
+      const opened = await openProject(project)
+      const editor = await openEditor(filePath, {
+        providedEditor,
+        providedCode,
+        isExecuting,
+      })
+      return { project: opened, editor }
+    },
+    closeProject: () => closeProject(),
+  }
+
+  return {
+    item: defineRuntimeRegistryItem({
+      id: 'project-session-extension',
+      provides: [
+        provide(openedProjectHandleValueSpec, openedProjectHandle, {
+          key: 'project-session',
+        }),
+        provide(executingEditorHandleValueSpec, executingEditorHandle, {
+          key: 'project-session',
+        }),
+        provide(openedProjectValueSpec, openedProject, {
+          key: 'project-session',
+        }),
+      ],
+      providesServices: [provideService(projectSessionService, serviceImpl)],
+      dispose: () => closeProject(),
+    }),
+  }
+}, 'project-session-extension')
+
+export default projectSessionExtension

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -4,14 +4,16 @@ import {
   provide,
   provideService,
 } from '@kittycad/registry'
-import { type Signal, effect, signal } from '@preact/signals-core'
+import { type Signal, computed, effect, signal } from '@preact/signals-core'
 import { buildFSHistoryExtension } from '@src/editor/plugins/fs'
-import { ZDSProject } from '@src/lang/KclManager'
+import { KclManager, ZDSProject } from '@src/lang/KclManager'
 import { projectFsManager } from '@src/lang/std/fileSystemManager'
 import type { App } from '@src/lib/app'
 import { getProjectInfo } from '@src/lib/desktop'
 import { getStringAfterLastSeparator } from '@src/lib/paths'
 import type { Project } from '@src/lib/project'
+import type { ExecutingEditorService } from '@src/registry/contracts/executingEditor'
+import { executingEditorService } from '@src/registry/contracts/executingEditor'
 import {
   type ExecutingEditorHandle,
   type OpenEditorOptions,
@@ -42,6 +44,9 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     signal<ProjectSessionService['executingEditorHandle']['value']>(undefined)
   const openedProject =
     signal<ProjectSessionService['openedProject']['value']>(undefined)
+  const executingEditor = computed(
+    () => openedProject.value?.executingEditor.value ?? undefined
+  )
 
   const getApp = () => {
     if (!app) {
@@ -88,6 +93,7 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     const currentProject = openedProject.peek()
 
     stopProjectEffects()
+    currentProject?.executingEditor.value?.cancelAllExecutions()
     currentProject?.close()
     openedProject.value = undefined
 
@@ -101,6 +107,7 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
         type: 'clear.project',
       })
     }
+    currentApp?.commands.actor.send({ type: 'Set kclManager', data: undefined })
   }
 
   const syncProjectFromSystemIO = (projectIORefSignal: Signal<Project>) => {
@@ -186,7 +193,7 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
 
   const loadEditorFromHandle = async (
     filePath: string,
-    { providedEditor, providedCode, isExecuting = true }: OpenEditorOptions = {}
+    { providedCode, isExecuting = true }: OpenEditorOptions = {}
   ) => {
     const currentProject = openedProject.peek()
     if (!currentProject) {
@@ -198,12 +205,31 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
       filePath,
     }
 
-    return currentProject.openEditor(
+    const previousExecutingPath = currentProject.executingPath
+    const previousExecutingEditor = currentProject.executingEditor.value
+    if (previousExecutingPath !== filePath) {
+      const existingTargetEditor = currentProject.findEditor(filePath)?.[1]
+      if (existingTargetEditor) {
+        currentProject.closeEditor(filePath)
+      }
+    }
+
+    const editor = await currentProject.openEditor(
       filePath,
-      providedEditor,
       providedCode,
       isExecuting
     )
+    if (
+      previousExecutingPath &&
+      previousExecutingPath !== filePath &&
+      previousExecutingEditor &&
+      previousExecutingEditor !== editor
+    ) {
+      previousExecutingEditor.cancelAllExecutions()
+      currentProject.closeEditor(previousExecutingPath)
+    }
+    getApp().commands.actor.send({ type: 'Set kclManager', data: editor })
+    return editor
   }
 
   const setExecutingEditorHandle = async (
@@ -212,6 +238,12 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
   ) => {
     if (!handle) {
       executingEditorHandle.value = undefined
+      const currentProject = openedProject.peek()
+      currentProject?.executingEditor.value?.cancelAllExecutions()
+      if (currentProject) {
+        currentProject.executingPath = null
+      }
+      getApp().commands.actor.send({ type: 'Set kclManager', data: undefined })
       return undefined
     }
 
@@ -222,15 +254,59 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     }
 
     return loadEditorFromHandle(handle.filePath, {
-      providedEditor:
-        options.providedEditor ?? currentApp.singletons.kclManager,
       providedCode:
         options.providedCode ??
         (window.electron?.process.env.NODE_ENV === 'test'
-          ? currentApp.singletons.kclManager.localStoragePersistCode()
+          ? KclManager.localStoragePersistCode()
           : undefined),
       isExecuting: options.isExecuting,
     })
+  }
+
+  const emptyCode = signal('')
+  const hasNoEditsSinceLastExecution = signal(false)
+  const isNotExecuting = signal(false)
+  const emptyExecutionElapsedMs = signal(0)
+  const noSelectionStatusLabel = signal('No selection')
+  const hideExperimentalFeaturesStatusBarItem = signal(false)
+
+  const executingEditorServiceImpl: ExecutingEditorService = {
+    editor: executingEditor,
+    code: computed(() => executingEditor.value?.codeSignal.value ?? ''),
+    hasEditsSinceLastExecution: computed(
+      () =>
+        executingEditor.value?.hasEditsSinceLastExecutionSignal.value ??
+        hasNoEditsSinceLastExecution.value
+    ),
+    isExecuting: computed(
+      () =>
+        executingEditor.value?.isExecutingSignal.value ?? isNotExecuting.value
+    ),
+    executionElapsedMs: computed(
+      () =>
+        executingEditor.value?.executingEditorService.executionElapsedMs
+          .value ?? emptyExecutionElapsedMs.value
+    ),
+    selectionStatusLabel: computed(
+      () =>
+        executingEditor.value?.executingEditorService.selectionStatusLabel
+          .value ?? noSelectionStatusLabel.value
+    ),
+    showExperimentalFeaturesStatusBarItem: computed(
+      () =>
+        executingEditor.value?.executingEditorService
+          .showExperimentalFeaturesStatusBarItem.value ??
+        hideExperimentalFeaturesStatusBarItem.value
+    ),
+    getPendingCommandCount: () =>
+      executingEditor.value?.executingEditorService.getPendingCommandCount() ??
+      0,
+    executeCode: async (code) => {
+      await executingEditor.value?.executeCode(code)
+    },
+    updateCode: (code, options) => {
+      executingEditor.value?.updateCodeEditor(code, options)
+    },
   }
 
   const serviceImpl: ProjectSessionService = {
@@ -258,7 +334,10 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
           key: 'project-session',
         }),
       ],
-      providesServices: [provideService(projectSessionService, serviceImpl)],
+      providesServices: [
+        provideService(projectSessionService, serviceImpl),
+        provideService(executingEditorService, executingEditorServiceImpl),
+      ],
       dispose: () => clearProjectSession(),
     }),
   }

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -9,10 +9,13 @@ import { buildFSHistoryExtension } from '@src/editor/plugins/fs'
 import { ZDSProject } from '@src/lang/KclManager'
 import { projectFsManager } from '@src/lang/std/fileSystemManager'
 import type { App } from '@src/lib/app'
+import { getProjectInfo } from '@src/lib/desktop'
+import { getStringAfterLastSeparator } from '@src/lib/paths'
 import type { Project } from '@src/lib/project'
 import {
+  type ExecutingEditorHandle,
   type OpenEditorOptions,
-  type OpenProjectEditorInput,
+  type OpenedProjectHandle,
   type ProjectSessionService,
   executingEditorHandleValueSpec,
   openedProjectHandleValueSpec,
@@ -22,7 +25,7 @@ import {
 import type { Subscription } from 'xstate'
 import { waitFor } from 'xstate'
 
-interface CloseProjectOptions {
+interface ClearProjectSessionOptions {
   clearHandles?: boolean
   clearProjectSettings?: boolean
 }
@@ -47,6 +50,27 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     return app
   }
 
+  const getProjectFromHandle = async ({
+    projectPath,
+  }: OpenedProjectHandle): Promise<Project> => {
+    const currentApp = getApp()
+    const wasmInstance = await currentApp.wasmPromise
+    const maybeProjectInfo = await getProjectInfo(projectPath, wasmInstance)
+
+    return (
+      maybeProjectInfo ?? {
+        name: getStringAfterLastSeparator(projectPath) || 'unnamed',
+        path: projectPath,
+        children: [],
+        kcl_file_count: 0,
+        directory_count: 0,
+        metadata: null,
+        default_file: projectPath,
+        readWriteAccess: true,
+      }
+    )
+  }
+
   const stopProjectEffects = () => {
     unsubscribeFromSettings?.unsubscribe()
     unsubscribeFromSettings = undefined
@@ -56,10 +80,10 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     stopFSHistoryEffect = undefined
   }
 
-  const closeProject = ({
+  const clearProjectSession = ({
     clearHandles = true,
     clearProjectSettings = true,
-  }: CloseProjectOptions = {}) => {
+  }: ClearProjectSessionOptions = {}) => {
     const currentApp = app
     const currentProject = openedProject.peek()
 
@@ -114,7 +138,7 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     )
   }
 
-  const openProject = async (project: Project) => {
+  const loadProjectFromInfo = async (project: Project) => {
     const currentApp = getApp()
     const currentProject = openedProject.peek()
 
@@ -124,7 +148,10 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     projectFsManager.dir = project.path
 
     if (currentProject && currentProject.path !== project.path) {
-      closeProject({ clearHandles: false, clearProjectSettings: false })
+      clearProjectSession({
+        clearHandles: false,
+        clearProjectSettings: false,
+      })
     }
 
     await waitFor(currentApp.settings.actor, (state) => state.matches('idle'))
@@ -146,7 +173,18 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     return nextProject
   }
 
-  const openEditor = async (
+  const setOpenedProjectHandle = async (
+    handle: OpenedProjectHandle | undefined
+  ) => {
+    if (!handle) {
+      clearProjectSession()
+      return undefined
+    }
+
+    return loadProjectFromInfo(await getProjectFromHandle(handle))
+  }
+
+  const loadEditorFromHandle = async (
     filePath: string,
     { providedEditor, providedCode, isExecuting = true }: OpenEditorOptions = {}
   ) => {
@@ -168,6 +206,33 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     )
   }
 
+  const setExecutingEditorHandle = async (
+    handle: ExecutingEditorHandle | undefined,
+    options: OpenEditorOptions = {}
+  ) => {
+    if (!handle) {
+      executingEditorHandle.value = undefined
+      return undefined
+    }
+
+    const currentApp = getApp()
+    const currentProject = openedProject.peek()
+    if (currentProject?.path !== handle.projectPath) {
+      await setOpenedProjectHandle({ projectPath: handle.projectPath })
+    }
+
+    return loadEditorFromHandle(handle.filePath, {
+      providedEditor:
+        options.providedEditor ?? currentApp.singletons.kclManager,
+      providedCode:
+        options.providedCode ??
+        (window.electron?.process.env.NODE_ENV === 'test'
+          ? currentApp.singletons.kclManager.localStoragePersistCode()
+          : undefined),
+      isExecuting: options.isExecuting,
+    })
+  }
+
   const serviceImpl: ProjectSessionService = {
     openedProjectHandle,
     executingEditorHandle,
@@ -175,24 +240,8 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     bindApp(boundApp) {
       app = boundApp
     },
-    openProject,
-    openEditor,
-    async openProjectEditor({
-      project,
-      filePath,
-      providedEditor,
-      providedCode,
-      isExecuting,
-    }: OpenProjectEditorInput) {
-      const opened = await openProject(project)
-      const editor = await openEditor(filePath, {
-        providedEditor,
-        providedCode,
-        isExecuting,
-      })
-      return { project: opened, editor }
-    },
-    closeProject: () => closeProject(),
+    setOpenedProjectHandle,
+    setExecutingEditorHandle,
   }
 
   return {
@@ -210,7 +259,7 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
         }),
       ],
       providesServices: [provideService(projectSessionService, serviceImpl)],
-      dispose: () => closeProject(),
+      dispose: () => clearProjectSession(),
     }),
   }
 }, 'project-session-extension')

--- a/src/registry/plugins/codeEditor/index.ts
+++ b/src/registry/plugins/codeEditor/index.ts
@@ -27,6 +27,7 @@ function RenderHeaderItem({ app }: AppHeaderItemProps) {
     getAutomaticallyRenderEnabledFromSettings(state.context)
   )
   const executionService = app.registry.signal(executingEditorService).value
+  const executingEditor = executionService?.editor.value
   const hasEditsSinceLastExecution =
     executionService?.hasEditsSinceLastExecution.value ?? false
   const renderHotkeyLabel = hotkeyDisplay(RENDER_HOTKEY, platform)
@@ -45,14 +46,19 @@ function RenderHeaderItem({ app }: AppHeaderItemProps) {
 
       toast.success('Your work is auto-saved in real-time.')
     },
-    app.singletons.kclManager,
+    executingEditor,
     {
-      enabled: !!currentProject,
-      registerToCodeMirror: !!currentProject,
+      enabled: !!currentProject && !!executingEditor,
+      registerToCodeMirror: !!currentProject && !!executingEditor,
     }
   )
 
-  if (!currentProject || automaticallyRenderEnabled || !executionService) {
+  if (
+    !currentProject ||
+    !executingEditor ||
+    automaticallyRenderEnabled ||
+    !executionService
+  ) {
     return null
   }
 

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -34,7 +34,7 @@ import {
   autoUpdateDownloadProgressSignal,
   autoUpdateReadySignal,
 } from '@src/lib/autoUpdate'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp } from '@src/lib/boot'
 import { createRouteCommands } from '@src/lib/commandBarConfigs/routeCommandConfig'
 import { isDesktop } from '@src/lib/isDesktop'
 import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
@@ -82,12 +82,18 @@ type ReadWriteProjectState = {
 // as defined in Router.tsx, so we can use the desktop APIs and types.
 const Home = () => {
   useSignals()
-  const { auth, billing, commands, settings, systemIOActor, registry } =
-    useApp()
-  const { kclManager } = useSingletons()
+  const {
+    auth,
+    billing,
+    commands,
+    settings,
+    systemIOActor,
+    registry,
+    projectSession,
+  } = useApp()
   const executingPath = useAbsoluteFilePath()
   const settingsActor = settings.actor
-  useQueryParamEffects(kclManager)
+  useQueryParamEffects()
   const navigate = useNavigate()
   const location = useLocation()
   const readWriteProjectDir = useCanReadWriteProjectDirectory()
@@ -238,11 +244,10 @@ const Home = () => {
   }
   useMenuListener(cb)
 
-  // Cancel all KCL executions while on the home page
   useEffect(() => {
     markOnce('code/didLoadHome')
-    kclManager.cancelAllExecutions()
-  }, [kclManager])
+    projectSession.setOpenedProjectHandle(undefined).catch(reportRejection)
+  }, [projectSession])
 
   useHotkeys('backspace', (e) => {
     e.preventDefault()
@@ -282,7 +287,6 @@ const Home = () => {
                     acceptOnboarding({
                       onboardingStatus,
                       navigate,
-                      kclManager,
                       systemIOActor,
                       settingsActor,
                       executingPath,

--- a/src/routes/Onboarding/utils.tsx
+++ b/src/routes/Onboarding/utils.tsx
@@ -13,7 +13,6 @@ import { CustomIcon, type CustomIconName } from '@src/components/CustomIcon'
 import { Logo } from '@src/components/Logo'
 import Tooltip from '@src/components/Tooltip'
 import { useAbsoluteFilePath } from '@src/hooks/useAbsoluteFilePath'
-import type { KclManager } from '@src/lang/KclManager'
 import { useApp } from '@src/lib/boot'
 import {
   ONBOARDING_DATA_ATTRIBUTE,
@@ -321,7 +320,6 @@ export function OnboardingButtons({
 
 export interface OnboardingUtilDeps {
   onboardingStatus: OnboardingStatus
-  kclManager: KclManager
   systemIOActor: SystemIOActor
   settingsActor: SettingsActorType
   navigate: NavigateFunction


### PR DESCRIPTION
## Superseded

This draft is superseded by the newer stack:

- #12094: deprecates `useSingletons` at the UI boundary
- #12095: moves project route loading into `projectSession`
- #12096: supports projects without executing files

Those PRs represent the executing-file/session direction more completely and should be reviewed instead.