### PR TITLE
Fix wasm module to load in Safari

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3730,8 +3730,7 @@ dependencies = [
 [[package]]
 name = "pulp"
 version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e205bb30d5b916c55e584c22201771bcf2bad9aabd5d4127f38387140c38632"
+source = "git+https://github.com/KittyCAD/pulp.git?branch=modeling-app#305b28214e3d70de331deb53129f4193dd065cae"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -3747,8 +3746,7 @@ dependencies = [
 [[package]]
 name = "pulp-wasm-simd-flag"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40e24eee682d89fb193496edf918a7f407d30175b2e785fe057e4392dfd182e0"
+source = "git+https://github.com/KittyCAD/pulp.git?branch=modeling-app#305b28214e3d70de331deb53129f4193dd065cae"
 
 [[package]]
 name = "pxfm"
@@ -6628,8 +6626,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "kittycad-modeling-cmds"
-version = "0.2.205"
-source = "git+https://github.com/KittyCAD/modeling-api.git?branch=achalmers%2Fteleport#fa879728fc9d2911e19367af90ca17aeb84497cf"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -91,7 +91,8 @@ insta = { opt-level = 3 }
 debug = "line-tables-only"
 
 #Example: how to point modeling-app at a different repo (e.g. a branch or a local clone)
-# [patch.crates-io]
+[patch.crates-io]
+pulp = { git = "https://github.com/KittyCAD/pulp.git", branch = "modeling-app" }
 # ezpz = { git = "https://github.com/KittyCAD/ezpz.git", branch = "david/circle-circle-tangent" }
 # kittycad-modeling-cmds = { git = "https://github.com/KittyCAD/modeling-api.git", branch = "main" }
 # kittycad-modeling-cmds = { path = "../../modeling-api/modeling-cmds" }


### PR DESCRIPTION
Fixes #12055.

Safari doesn't support relaxed-simd out of the box. I made a PR upstream: https://github.com/sarah-quinones/pulp/pull/30. Until that's released, we can use our own fork. For that, I made a [`modeling-app`](https://github.com/KittyCAD/pulp/tree/modeling-app) branch so that if/when the PR merges, the commit won't disappear unexpectedly.

<img width="1436" height="998" alt="Screenshot 2026-06-11 at 5 06 50 PM" src="https://github.com/user-attachments/assets/a5ad9687-b3c3-4e23-be62-8e55c9b704f7" />
