### PR TITLE
Make "Show All Files" configurable per project

### DIFF
--- a/src/lib/desktop.ts
+++ b/src/lib/desktop.ts
@@ -594,8 +594,16 @@ export async function getProjectInfo(
   const { value: canReadWriteProjectPath } =
     await canReadWriteDirectory(projectPath)
 
-  const appSettings = await readAppSettingsFile(wasmInstance)
-  const showAllFiles = appSettings.settings?.app?.show_all_files === true
+  const [appSettings, projectSettings] = await Promise.all([
+    readAppSettingsFile(wasmInstance),
+    readProjectSettingsFile(projectPath, wasmInstance),
+  ])
+  const projectShowAllFiles = projectSettings.settings?.app?.show_all_files
+  const userShowAllFiles = appSettings.settings?.app?.show_all_files
+  const showAllFiles =
+    typeof projectShowAllFiles === 'boolean'
+      ? projectShowAllFiles
+      : userShowAllFiles === true
 
   const gitignoreStack = await createInitialGitignoreStack(projectPath)
 

--- a/src/lib/settings/initialSettings.tsx
+++ b/src/lib/settings/initialSettings.tsx
@@ -302,7 +302,6 @@ function createCoreSettings() {
       }),
       showAllFiles: new Setting<boolean>({
         defaultValue: false,
-        hideOnLevel: 'project',
         description:
           'Show all project files in the file pane, including dotfiles and configuration files.',
         validate: (v) => typeof v === 'boolean',

--- a/src/lib/settings/settingsUtils.ts
+++ b/src/lib/settings/settingsUtils.ts
@@ -540,6 +540,10 @@ const PROJECT_APP_ONLY_SETTINGS_SECTIONS = [
       { category: 'app', field: 'allowOrbitInSketchMode' },
       'allow_orbit_in_sketch_mode'
     ),
+    defineBooleanAppOnlyField(
+      { category: 'app', field: 'showAllFiles' },
+      'show_all_files'
+    ),
   ]),
   defineAppOnlySection('debug', [
     defineBooleanAppOnlyField(


### PR DESCRIPTION
I can see certain, complex projects wanting this. I've also been annoyed that there is an empty "App" settings section on the Projects tab.