### PR TITLE
[superseded] [codex] Move project route loading into the session service

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -9,7 +9,7 @@ import ModelingPageProvider from '@src/components/ModelingPageProvider'
 import { OpenedProject } from '@src/components/OpenedProject'
 import { NetworkContext } from '@src/hooks/useNetworkContext'
 import { useNetworkStatus } from '@src/hooks/useNetworkStatus'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp } from '@src/lib/boot'
 import { isDesktop } from '@src/lib/isDesktop'
 import { TestLayout } from '@src/lib/layout/TestLayout'
 import makeUrlPathRelative from '@src/lib/makeUrlPathRelative'
@@ -38,8 +38,7 @@ const createRouter = isDesktop() ? createHashRouter : createBrowserRouter
 export const Router = () => {
   useSignals()
   const app = useApp()
-  const { kclManager } = useSingletons()
-  const networkStatus = useNetworkStatus(kclManager.engineCommandManager)
+  const networkStatus = useNetworkStatus(app.engineCommandManager)
   const router = useMemo(
     () =>
       createRouter([

--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -18,7 +18,7 @@ import {
   getUnrenderedChangesDisabledReason,
   shouldDisableModelingForUnrenderedChanges,
 } from '@src/lib/automaticRendering'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { type HotkeySequence, hotkeyDisplay } from '@src/lib/hotkeys'
 import { isDesktop } from '@src/lib/isDesktop'
 import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
@@ -76,7 +76,7 @@ const Toolbar_ = memo(
     const app = useApp()
     const keymap = app.registry.get(keymapService)
     const keymapTree = keymap.keymap.value
-    const { kclManager } = useSingletons()
+    const kclManager = useExecutingEditor()
     const platform = usePlatform()
     const executionService = app.registry.signal(executingEditorService).value
     const unrenderedExecuteHotkeyLabel = hotkeyDisplay(
@@ -1017,7 +1017,7 @@ const ToolbarItemTooltipRichContent = memo(
 // Making this toplevel Toolbar memo'd is no-op, because we use context
 // inside that causes a render anyway. Instead we memo the inner.
 export function Toolbar() {
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const { settings } = useApp()
   const settingsValues = settings.useSettings()
   const { state, send, context, actor } = useModelingContext()

--- a/src/clientSideScene/ClientSideSceneComp.tsx
+++ b/src/clientSideScene/ClientSideSceneComp.tsx
@@ -42,7 +42,7 @@ import type { ConstrainInfo } from '@src/lang/std/stdTypes'
 import { topLevelRange } from '@src/lang/util'
 import type { CallExpressionKw, Expr, PathToNode } from '@src/lang/wasm'
 import { parse, recast, resultIsOk } from '@src/lang/wasm'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { cameraMouseDragGuards } from '@src/lib/cameraControls'
 import type { CameraSystem } from '@src/lib/cameraControls'
 import { getSketchSolveToolIconMap, useToolbarConfig } from '@src/lib/toolbar'
@@ -56,9 +56,7 @@ function useShouldHideScene(): { hideClient: boolean; hideServer: boolean } {
   const [isTween, setIsTween] = useState(false)
 
   const { state } = useModelingContext()
-  const {
-    kclManager: { sceneInfra },
-  } = useSingletons()
+  const { sceneInfra } = useExecutingEditor()
 
   useEffect(() => {
     sceneInfra.camControls.setIsCamMovingCallback(
@@ -90,9 +88,8 @@ export const ClientSideScene = ({
   enableTouchControls: boolean
   sketchSolveStreamDimming?: number
 }) => {
-  const {
-    kclManager: { sceneEntitiesManager, sceneInfra, engineCommandManager },
-  } = useSingletons()
+  const { sceneEntitiesManager, sceneInfra, engineCommandManager } =
+    useExecutingEditor()
   const { state, send, context } = useModelingContext()
   const { hideClient, hideServer } = useShouldHideScene()
 
@@ -338,7 +335,7 @@ const Overlay = ({
   overlayIndex: number
   pathToNodeString: string
 }) => {
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const wasmInstance = use(kclManager.wasmInstancePromise)
   const { context, send, state } = useModelingContext()
 
@@ -475,7 +472,7 @@ const SegmentMenu = ({
   pathToNode: PathToNode
   stdLibFnName: string
 }) => {
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const wasmInstance = use(kclManager.wasmInstancePromise)
   const { send } = useModelingContext()
   const dependentSourceRanges = findUsesOfTagInPipe(
@@ -541,7 +538,7 @@ const ConstraintSymbol = ({
   verticalPosition: 'top' | 'bottom'
 }) => {
   const { commands } = useApp()
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const wasmInstance = use(kclManager.wasmInstancePromise)
   const { context } = useModelingContext()
   const varNameMap: {
@@ -795,9 +792,7 @@ const throttled = (sceneInfra: SceneInfra) =>
 
 export const CamDebugSettings = () => {
   const { commands } = useApp()
-  const {
-    kclManager: { sceneInfra },
-  } = useSingletons()
+  const { sceneInfra } = useExecutingEditor()
   const [camSettings, setCamSettings] = useState<ReactCameraProperties>(
     sceneInfra.camControls.reactCameraProperties
   )

--- a/src/clientSideScene/EditingConstraintInput.tsx
+++ b/src/clientSideScene/EditingConstraintInput.tsx
@@ -1,6 +1,6 @@
 import { KclInput } from '@src/components/KclInput'
 import { useModelingContext } from '@src/hooks/useModelingContext'
-import { useSingletons } from '@src/lib/boot'
+import { useExecutingEditor } from '@src/lib/boot'
 import { SKETCH_FILE_VERSION } from '@src/lib/constants'
 import { jsAppSettings } from '@src/lib/settings/settingsUtils'
 import type { modelingMachine } from '@src/machines/modelingMachine'
@@ -15,9 +15,7 @@ import { useCallback, useEffect, useState } from 'react'
 import type { SnapshotFrom, StateFrom } from 'xstate'
 
 export const EditingConstraintInput = () => {
-  const {
-    kclManager: { sceneInfra, rustContext },
-  } = useSingletons()
+  const { sceneInfra, rustContext } = useExecutingEditor()
   const { state } = useModelingContext()
   const editingConstraintId = useSelector(
     state.children.sketchSolveMachine,

--- a/src/components/AstExplorer.tsx
+++ b/src/components/AstExplorer.tsx
@@ -6,13 +6,13 @@ import { getNodePathFromSourceRange } from '@src/lang/queryAstNodePathUtils'
 import { defaultSourceRange } from '@src/lang/sourceRange'
 import { codeRefFromRange } from '@src/lang/std/artifactGraph'
 import { topLevelRange } from '@src/lang/util'
-import { useSingletons } from '@src/lib/boot'
+import { useExecutingEditor } from '@src/lib/boot'
 import { codeToIdSelections } from '@src/lib/selections'
 import { trap } from '@src/lib/trap'
 import { isArray } from '@src/lib/utils'
 
 export function AstExplorer() {
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const wasmInstance = use(kclManager.wasmInstancePromise)
   const { context } = useModelingContext()
   const pathToNode = getNodePathFromSourceRange(
@@ -101,7 +101,7 @@ function DisplayObj({
   node: any
 }) {
   const { send } = useModelingContext()
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const ref = useRef<HTMLPreElement>(null)
   const [hasCursor, setHasCursor] = useState(false)
   const [isCollapsed, setIsCollapsed] = useState(false)

--- a/src/components/ConnectionStream.tsx
+++ b/src/components/ConnectionStream.tsx
@@ -21,7 +21,7 @@ import {
   getSketchBlockForArtifact,
 } from '@src/lang/std/artifactGraph'
 import { getAllOperations } from '@src/lang/wasm'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { btnName } from '@src/lib/cameraControls'
 import { EngineDebugger } from '@src/lib/debugger'
 import { prepareEditCommand } from '@src/lib/featureTree'
@@ -43,7 +43,7 @@ export const ConnectionStream = (props: {
 }) => {
   const { settings, project, wasmPromise, commands } = useApp()
   const wasmInstance = use(wasmPromise)
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const engineCommandManager = kclManager.engineCommandManager
   const sceneInfra = kclManager.sceneInfra
   const [showManualConnect, setShowManualConnect] = useState(false)

--- a/src/components/DebugArtifactGraph.tsx
+++ b/src/components/DebugArtifactGraph.tsx
@@ -5,10 +5,10 @@ import { DebugDisplayArray } from '@src/components/DebugDisplayObj'
 import type { PlaneArtifactRich } from '@src/lang/std/artifactGraph'
 import { expandPlane } from '@src/lang/std/artifactGraph'
 import type { ArtifactGraph } from '@src/lang/wasm'
-import { useSingletons } from '@src/lib/boot'
+import { useExecutingEditor } from '@src/lib/boot'
 
 export function DebugArtifactGraph() {
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const artifactGraphTree = useMemo(() => {
     return computeTree(kclManager.artifactGraph)
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!

--- a/src/components/DebugSelections.tsx
+++ b/src/components/DebugSelections.tsx
@@ -9,7 +9,7 @@ import {
   getOperationsForModule,
 } from '@src/lang/wasm'
 import type { ArtifactGraph, SourceRange } from '@src/lang/wasm'
-import { useSingletons } from '@src/lib/boot'
+import { useExecutingEditor } from '@src/lib/boot'
 import {
   filterOperations,
   groupOperationTypeStreaks,
@@ -22,7 +22,9 @@ import type { Selections } from '@src/machines/modelingSharedTypes'
 import { useMemo, useState } from 'react'
 import { use } from 'react'
 
-type SingletonDeps = Pick<ReturnType<typeof useSingletons>, 'kclManager'>
+type SingletonDeps = {
+  kclManager: ReturnType<typeof useExecutingEditor>
+}
 
 async function clearSceneSelection(deps: SingletonDeps) {
   await deps.kclManager.engineCommandManager.sendSceneCommand({
@@ -258,7 +260,7 @@ function computeOperationList(
 }
 
 export function DebugSelections() {
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const singletonDeps: SingletonDeps = useMemo(
     () => ({
       kclManager,

--- a/src/components/EngineCommands.tsx
+++ b/src/components/EngineCommands.tsx
@@ -2,11 +2,11 @@ import { useEffect, useState } from 'react'
 
 import type { CommandLog } from '@src/lang/std/commandLog'
 import { noAutofillInputProps } from '@src/lib/autofill'
-import { useSingletons } from '@src/lib/boot'
+import { useExecutingEditor } from '@src/lib/boot'
 import { reportRejection } from '@src/lib/trap'
 
 export function useEngineCommands(): [CommandLog[], () => void] {
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const engineCommandManager = kclManager.engineCommandManager
   const [engineCommands, setEngineCommands] = useState<CommandLog[]>(
     engineCommandManager.commandLogs
@@ -22,7 +22,7 @@ export function useEngineCommands(): [CommandLog[], () => void] {
 }
 
 export const EngineCommands = () => {
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const engineCommandManager = kclManager.engineCommandManager
   const [engineCommands, clearEngineCommands] = useEngineCommands()
   const [containsFilter, setContainsFilter] = useState('')

--- a/src/components/ExperimentalFeaturesMenu.tsx
+++ b/src/components/ExperimentalFeaturesMenu.tsx
@@ -7,7 +7,7 @@ import { defaultStatusBarItemClassNames } from '@src/components/StatusBar/Status
 import Tooltip from '@src/components/Tooltip'
 import { updateModelingState } from '@src/lang/modelingWorkflows'
 import { setExperimentalFeatures } from '@src/lang/modifyAst/settings'
-import { useSingletons } from '@src/lib/boot'
+import { useExecutingEditor } from '@src/lib/boot'
 import {
   DEFAULT_EXPERIMENTAL_FEATURES,
   EXECUTION_TYPE_REAL,
@@ -16,7 +16,7 @@ import { warningLevels } from '@src/lib/settings/settingsTypes'
 import { err, reportRejection } from '@src/lib/trap'
 
 export function ExperimentalFeaturesMenu() {
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const currentLevel: WarningLevel =
     kclManager.fileSettings.experimentalFeatures ??
     DEFAULT_EXPERIMENTAL_FEATURES

--- a/src/components/Explorer/ProjectExplorer.tsx
+++ b/src/components/Explorer/ProjectExplorer.tsx
@@ -17,7 +17,7 @@ import type {
 } from '@src/components/Explorer/utils'
 import { fsArchiveFile, fsMoveFile } from '@src/editor/plugins/fs'
 import { kclErrorsByFilename } from '@src/lang/errors'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import type { Command } from '@src/lib/commandTypes'
 import { FILE_EXT } from '@src/lib/constants'
 import { getNextFileName, sortFilesAndDirectories } from '@src/lib/desktopFS'
@@ -177,7 +177,7 @@ export const ProjectExplorer = ({
 }) => {
   const { commands, registry, settings, systemIOActor } = useApp()
   const keymap = registry.optional(keymapService)
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const errors = kclManager.errorsSignal.value
   const settingsValues = settings.useSettings()
   const applicationProjectDirectory =

--- a/src/components/HelpMenu.tsx
+++ b/src/components/HelpMenu.tsx
@@ -4,7 +4,7 @@ import { defaultStatusBarItemClassNames } from '@src/components/StatusBar/Status
 import Tooltip from '@src/components/Tooltip'
 import { useAbsoluteFilePath } from '@src/hooks/useAbsoluteFilePath'
 import { useMenuListener } from '@src/hooks/useMenu'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp } from '@src/lib/boot'
 import { isDesktop } from '@src/lib/isDesktop'
 import { onboardingStartPath } from '@src/lib/onboardingPaths'
 import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
@@ -21,7 +21,6 @@ const HelpMenuDivider = () => (
 
 export function HelpMenu() {
   const { settings, systemIOActor } = useApp()
-  const { kclManager } = useSingletons()
   const navigate = useNavigate()
   const filePath = useAbsoluteFilePath()
 
@@ -29,7 +28,6 @@ export function HelpMenu() {
     const props = {
       onboardingStatus: onboardingStartPath,
       navigate,
-      kclManager,
       systemIOActor,
       settingsActor: settings.actor,
       executingPath: filePath,

--- a/src/components/KclInput.tsx
+++ b/src/components/KclInput.tsx
@@ -7,7 +7,7 @@ import { Compartment, EditorState } from '@codemirror/state'
 import { EditorView, keymap } from '@codemirror/view'
 import { editorTheme } from '@src/editor/plugins/theme'
 import { parse, resultIsOk } from '@src/lang/wasm'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { DUMMY_VARIABLE_NAME } from '@src/lib/kclHelpers'
 import { getResolvedTheme } from '@src/lib/theme'
 import { err } from '@src/lib/trap'
@@ -24,7 +24,7 @@ export function KclInput(props: {
   style?: React.CSSProperties
 }) {
   const { settings: settingsSystem } = useApp()
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const settings = settingsSystem.useSettings()
   const wasmInstance = use(kclManager.rustContext.wasmInstancePromise)
 

--- a/src/components/LspProvider.tsx
+++ b/src/components/LspProvider.tsx
@@ -27,7 +27,7 @@ import type {
 import { LspWorker } from '@src/editor/plugins/lsp/types'
 import Worker from '@src/editor/plugins/lsp/worker.ts?worker'
 import { wasmUrl } from '@src/lang/wasmUtils'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useOptionalExecutingEditor } from '@src/lib/boot'
 import { PROJECT_ENTRYPOINT } from '@src/lib/constants'
 import { PATHS } from '@src/lib/paths'
 import type { FileEntry } from '@src/lib/project'
@@ -73,7 +73,7 @@ type LspContext = {
 export const LspStateContext = createContext({} as LspContext)
 export const LspProvider = ({ children }: { children: React.ReactNode }) => {
   const { auth } = useApp()
-  const { kclManager } = useSingletons()
+  const kclManager = useOptionalExecutingEditor()
   const [isKclLspReady, setIsKclLspReady] = useState(false)
   const [isCopilotLspReady, setIsCopilotLspReady] = useState(false)
 
@@ -124,7 +124,7 @@ export const LspProvider = ({ children }: { children: React.ReactNode }) => {
   ])
 
   useMemo(() => {
-    if (!window.electron && isKclLspReady && kclLspClient && kclManager.code) {
+    if (!window.electron && isKclLspReady && kclLspClient && kclManager?.code) {
       kclLspClient.textDocumentDidOpen({
         textDocument: {
           uri: `file:///${PROJECT_ENTRYPOINT}`,
@@ -134,7 +134,7 @@ export const LspProvider = ({ children }: { children: React.ReactNode }) => {
         },
       })
     }
-  }, [kclLspClient, isKclLspReady, kclManager.code])
+  }, [kclLspClient, isKclLspReady, kclManager?.code])
 
   // Here we initialize the plugin which will start the client.
   // Now that we have multi-file support the name of the file is a dep of
@@ -181,6 +181,9 @@ export const LspProvider = ({ children }: { children: React.ReactNode }) => {
     if (kclLSP === null) {
       return
     }
+    if (!kclManager) {
+      return
+    }
     kclManager.editorView.dispatch({
       effects: kclLspCompartment.reconfigure(Prec.highest(kclLSP)),
     })
@@ -188,7 +191,7 @@ export const LspProvider = ({ children }: { children: React.ReactNode }) => {
       kclManager.editorView.dispatch({
         effects: kclLspCompartment.reconfigure(Prec.highest([])),
       })
-  }, [kclLSP, kclManager.editorView])
+  }, [kclLSP, kclManager])
 
   const { lspClient: copilotLspClient } = useMemo(() => {
     if (!token || token === '') {
@@ -233,7 +236,7 @@ export const LspProvider = ({ children }: { children: React.ReactNode }) => {
   // We do not want to restart the server, its just wasteful.
   const copilotLSP = useMemo(() => {
     let plugin = null
-    if (isCopilotLspReady && copilotLspClient) {
+    if (isCopilotLspReady && copilotLspClient && kclManager) {
       // Set up the lsp plugin.
       const lsp = copilotPlugin(
         {
@@ -278,7 +281,7 @@ export const LspProvider = ({ children }: { children: React.ReactNode }) => {
         },
       })
     })
-    kclManager.clearGlobalHistory()
+    kclManager?.clearGlobalHistory()
 
     if (redirect) {
       void navigate(PATHS.HOME)

--- a/src/components/ModelingMachineProvider.tsx
+++ b/src/components/ModelingMachineProvider.tsx
@@ -15,7 +15,7 @@ import useHotkeyWrapper from '@src/lib/hotkeyWrapper'
 import { SNAP_TO_GRID_HOTKEY } from '@src/lib/hotkeys'
 
 import { useNetworkContext } from '@src/hooks/useNetworkContext'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { modelingMachineCommandConfig } from '@src/lib/commandBarConfigs/modelingCommandConfig'
 import type { Project } from '@src/lib/project'
 import { resetCameraPosition } from '@src/lib/resetCameraPosition'
@@ -57,7 +57,7 @@ export const ModelingMachineProvider = ({
   useSignals()
   const { machineManager, commands, settings, layout, project, registry } =
     useApp()
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const settingsActor = settings.actor
   const wasmInstance = use(kclManager.wasmInstancePromise)
   const settingsValues = settings.useSettings()

--- a/src/components/ModelingPageProvider.tsx
+++ b/src/components/ModelingPageProvider.tsx
@@ -11,7 +11,7 @@ import {
   updateOutsideEditorEvent,
 } from '@src/lang/KclManager'
 import { sourceRangeToUtf16 } from '@src/lang/errors'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { createNamedViewsCommand } from '@src/lib/commandBarConfigs/namedViewsConfig'
 import { createRouteCommands } from '@src/lib/commandBarConfigs/routeCommandConfig'
 import { createStandardViewsCommands } from '@src/lib/commandBarConfigs/standardViewsConfig'
@@ -62,7 +62,7 @@ export const ModelingPageProvider = ({
 }) => {
   useSignals()
   const { auth, commands, settings, project, systemIOActor } = useApp()
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const wasmInstance = use(kclManager.wasmInstancePromise)
   const navigate = useNavigate()
   const location = useLocation()

--- a/src/components/OpenedProject.tsx
+++ b/src/components/OpenedProject.tsx
@@ -22,7 +22,7 @@ import {
   autoUpdateDownloadProgressSignal,
   autoUpdateReadySignal,
 } from '@src/lib/autoUpdate'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import {
   ONBOARDING_TOAST_ID,
   WASM_INIT_FAILED_TOAST_ID,
@@ -75,12 +75,12 @@ export function OpenedProject() {
   useSignals()
   const { auth, billing, settings, layout, project, systemIOActor, registry } =
     useApp()
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const settingsActor = settings.actor
   const defaultAreaLibrary = useDefaultAreaLibrary()
   const defaultActionLibrary = useDefaultActionLibrary()
   const { state: modelingState, send: modelingSend } = useModelingContext()
-  useQueryParamEffects(kclManager)
+  useQueryParamEffects()
   const [nativeFileMenuCreated, setNativeFileMenuCreated] = useState(false)
   const location = useLocation()
   const navigate = useNavigate()
@@ -253,7 +253,6 @@ export function OpenedProject() {
           TutorialRequestToast({
             onboardingStatus: settingsValues.app.onboardingStatus.current,
             navigate,
-            kclManager,
             accountUrl: withSiteBaseURL('/account'),
             systemIOActor,
             settingsActor,

--- a/src/components/ProjectSidebarMenu.tsx
+++ b/src/components/ProjectSidebarMenu.tsx
@@ -19,7 +19,6 @@ import { hotkeyDisplay } from '@src/lib/hotkeys'
 import { isDesktop } from '@src/lib/isDesktop'
 import { PATHS, getProjectRelativeFilePath } from '@src/lib/paths'
 import type { FileEntry, Project } from '@src/lib/project'
-import type { IndexLoaderData } from '@src/lib/types'
 
 interface ProjectSidebarMenuProps extends React.PropsWithChildren {
   enableMenu?: boolean
@@ -62,8 +61,8 @@ function AppLogoLink({
   project,
   file,
 }: {
-  project?: IndexLoaderData['project']
-  file?: IndexLoaderData['file']
+  project?: Project
+  file?: FileEntry
 }) {
   const { kclManager } = useSingletons()
   const { onProjectClose } = useLspContext()
@@ -103,8 +102,8 @@ function ProjectMenuPopover({
   project,
   file,
 }: {
-  project?: IndexLoaderData['project']
-  file?: IndexLoaderData['file']
+  project?: Project
+  file?: FileEntry
 }) {
   const { machineManager, commands, settings } = useApp()
   const { kclManager } = useSingletons()

--- a/src/components/ProjectSidebarMenu.tsx
+++ b/src/components/ProjectSidebarMenu.tsx
@@ -12,7 +12,11 @@ import { useLspContext } from '@src/components/LspProvider'
 import Tooltip from '@src/components/Tooltip'
 import { useAbsoluteFilePath } from '@src/hooks/useAbsoluteFilePath'
 import usePlatform from '@src/hooks/usePlatform'
-import { useApp, useSingletons } from '@src/lib/boot'
+import {
+  useApp,
+  useExecutingEditor,
+  useOptionalExecutingEditor,
+} from '@src/lib/boot'
 import { sendAddFileToProjectCommandForCurrentProject } from '@src/lib/commandBarConfigs/applicationCommandConfig'
 import { APP_NAME } from '@src/lib/constants'
 import { hotkeyDisplay } from '@src/lib/hotkeys'
@@ -64,7 +68,7 @@ function AppLogoLink({
   project?: Project
   file?: FileEntry
 }) {
-  const { kclManager } = useSingletons()
+  const kclManager = useOptionalExecutingEditor()
   const { onProjectClose } = useLspContext()
   const wrapperClassName =
     "cursor-pointer relative group-hover/home:before:outline h-full grid flex-none place-content-center group p-1.5 before:block before:content-[''] before:absolute before:inset-0 before:bottom-1 before:z-[-1] before:bg-primary before:rounded-b-sm"
@@ -87,7 +91,9 @@ function AppLogoLink({
       data-testid="app-logo"
       onClick={() => {
         onProjectClose(file || null, project?.path || null, false)
-        kclManager.switchedFiles = true
+        if (kclManager) {
+          kclManager.switchedFiles = true
+        }
       }}
       to={PATHS.HOME}
       className={wrapperClassName + ' hover:before:brightness-110'}
@@ -106,7 +112,7 @@ function ProjectMenuPopover({
   file?: FileEntry
 }) {
   const { machineManager, commands, settings } = useApp()
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const machineApiEnabled = settings.useSettings().app.machineApi.current
   const platform = usePlatform()
   const navigate = useNavigate()

--- a/src/components/RouteProvider.tsx
+++ b/src/components/RouteProvider.tsx
@@ -1,7 +1,7 @@
 import { useSignals } from '@preact/signals-react/runtime'
 import { useAuthNavigation } from '@src/hooks/useAuthNavigation'
 import { useFileSystemWatcher } from '@src/hooks/useFileSystemWatcher'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useOptionalExecutingEditor } from '@src/lib/boot'
 import { getAppSettingsFilePath } from '@src/lib/desktop'
 import fsZds from '@src/lib/fs-zds'
 import { PATHS, getStringAfterLastSeparator } from '@src/lib/paths'
@@ -16,7 +16,7 @@ export const RouteProviderContext = createContext({})
 export function RouteProvider({ children }: { children: ReactNode }) {
   useSignals()
   const { settings, project } = useApp()
-  const { kclManager } = useSingletons()
+  const kclManager = useOptionalExecutingEditor()
   const settingsActor = settings.actor
   useAuthNavigation()
   const loadedProject = project?.projectIORefSignal.value
@@ -51,6 +51,10 @@ export function RouteProvider({ children }: { children: ReactNode }) {
 
   useFileSystemWatcher(
     async (eventType: string, path: string) => {
+      if (!kclManager) {
+        return
+      }
+
       // Only reload if there are changes. Ignore everything else.
       if (eventType !== 'change') {
         return
@@ -106,7 +110,7 @@ export function RouteProvider({ children }: { children: ReactNode }) {
       }
     },
     // This will build up for as many files you select and never remove until you exit the project to unmount the file watcher hook
-    kclManager.livePathsToWatch.value
+    kclManager?.livePathsToWatch.value ?? []
   )
 
   useFileSystemWatcher(

--- a/src/components/SetAngleLengthModal.tsx
+++ b/src/components/SetAngleLengthModal.tsx
@@ -10,7 +10,7 @@ import {
 } from '@src/components/AvailableVarsHelpers'
 import type { Expr } from '@src/lang/wasm'
 import { noAutofillInputProps } from '@src/lib/autofill'
-import { useSingletons } from '@src/lib/boot'
+import { useExecutingEditor } from '@src/lib/boot'
 import { useCalculateKclExpression } from '@src/lib/useCalculateKclExpression'
 import type { Selections } from '@src/machines/modelingSharedTypes'
 
@@ -46,7 +46,7 @@ export const SetAngleLengthModal = ({
   shouldCreateVariable: initialShouldCreateVariable = false,
   selectionRanges,
 }: SetAngleLengthModalProps) => {
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const [sign, setSign] = useState(initialValue.startsWith('-') ? -1 : 1)
   const [value, setValue] = useState(
     initialValue.startsWith('-') ? initialValue.substring(1) : initialValue

--- a/src/components/SetHorVertDistanceModal.tsx
+++ b/src/components/SetHorVertDistanceModal.tsx
@@ -10,7 +10,7 @@ import {
 } from '@src/components/AvailableVarsHelpers'
 import type { Expr } from '@src/lang/wasm'
 import { noAutofillInputProps } from '@src/lib/autofill'
-import { useSingletons } from '@src/lib/boot'
+import { useExecutingEditor } from '@src/lib/boot'
 import { useCalculateKclExpression } from '@src/lib/useCalculateKclExpression'
 import type { Selections } from '@src/machines/modelingSharedTypes'
 
@@ -49,7 +49,7 @@ export const GetInfoModal = ({
   initialVariableName,
   selectionRanges,
 }: GetInfoModalProps) => {
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const [sign, setSign] = useState(initialValue?.startsWith('-') ? -1 : 1)
   const [segName, setSegName] = useState(initialSegName)
   const [value, setValue] = useState(

--- a/src/components/SetVarNameModal.tsx
+++ b/src/components/SetVarNameModal.tsx
@@ -5,7 +5,7 @@ import { type InstanceProps, create } from 'react-modal-promise'
 
 import { ActionButton } from '@src/components/ActionButton'
 import { CreateNewVariable } from '@src/components/AvailableVarsHelpers'
-import { useSingletons } from '@src/lib/boot'
+import { useExecutingEditor } from '@src/lib/boot'
 import { useCalculateKclExpression } from '@src/lib/useCalculateKclExpression'
 import { platform } from '@src/lib/utils'
 import type { Selections } from '@src/machines/modelingSharedTypes'
@@ -30,7 +30,7 @@ export const SetVarNameModal = ({
   valueName,
   selectionRanges,
 }: SetVarNameModalProps) => {
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const { isNewVariableNameUnique, newVariableName, setNewVariableName } =
     useCalculateKclExpression({
       value: '',

--- a/src/components/Settings/AllSettingsFields.tsx
+++ b/src/components/Settings/AllSettingsFields.tsx
@@ -2,7 +2,7 @@ import { ActionButton } from '@src/components/ActionButton'
 import { SettingsFieldInput } from '@src/components/Settings/SettingsFieldInput'
 import { SettingsSection } from '@src/components/Settings/SettingsSection'
 import { useAbsoluteFilePath } from '@src/hooks/useAbsoluteFilePath'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp } from '@src/lib/boot'
 import { getSettingsFolderPaths } from '@src/lib/desktopFS'
 import { isDesktop } from '@src/lib/isDesktop'
 import { onboardingStartPath } from '@src/lib/onboardingPaths'
@@ -40,7 +40,6 @@ export const AllSettingsFields = forwardRef(
     scrollRef: ForwardedRef<HTMLDivElement>
   ) => {
     const { settings, layout, systemIOActor } = useApp()
-    const { kclManager } = useSingletons()
     const location = useLocation()
     const navigate = useNavigate()
     const context = settings.useSettings()
@@ -67,7 +66,6 @@ export const AllSettingsFields = forwardRef(
       const props = {
         onboardingStatus: onboardingStartPath,
         navigate,
-        kclManager,
         systemIOActor,
         settingsActor: settings.actor,
         executingPath,

--- a/src/components/SystemIOMachineLogicListener.tsx
+++ b/src/components/SystemIOMachineLogicListener.tsx
@@ -1,6 +1,6 @@
 import { useLspContext } from '@src/components/LspProvider'
 import { useFileSystemWatcher } from '@src/hooks/useFileSystemWatcher'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useOptionalExecutingEditor } from '@src/lib/boot'
 import {
   ASK_TO_OPEN_QUERY_PARAM,
   EXECUTE_AST_INTERRUPT_ERROR_MESSAGE,
@@ -34,7 +34,7 @@ import { useLocation } from 'react-router-dom'
 
 export function SystemIOMachineLogicListener() {
   const { settings, systemIOActor } = useApp()
-  const { kclManager } = useSingletons()
+  const kclManager = useOptionalExecutingEditor()
   // We gotta stop with this pattern. It doesn't scale. "Eager hook creation"
   const requestedProjectName = useRequestedProjectName()
   const requestedFileName = useRequestedFileName()
@@ -80,7 +80,7 @@ export function SystemIOMachineLogicListener() {
     // Open the requested file in the requested project
     onFileOpen(requestedFilePathWithExtension, requestedProjectDirectory)
 
-    kclManager.engineCommandManager.rejectAllModelingCommands(
+    kclManager?.engineCommandManager.rejectAllModelingCommands(
       EXECUTE_AST_INTERRUPT_ERROR_MESSAGE
     )
 
@@ -94,6 +94,7 @@ export function SystemIOMachineLogicListener() {
      * i.e. Only do switchedFiles check against two file paths, not null and a file path
      */
     if (
+      kclManager &&
       filePathWithExtension &&
       requestedFilePathWithExtension &&
       filePathWithExtension !== requestedFilePathWithExtension
@@ -101,7 +102,9 @@ export function SystemIOMachineLogicListener() {
       kclManager.switchedFiles = true
     }
 
-    kclManager.isExecuting = false
+    if (kclManager) {
+      kclManager.isExecuting = false
+    }
 
     const url = new URL(location.href)
     url.searchParams.delete(ASK_TO_OPEN_QUERY_PARAM)

--- a/src/components/UnitsMenu.tsx
+++ b/src/components/UnitsMenu.tsx
@@ -6,14 +6,14 @@ import { defaultStatusBarItemClassNames } from '@src/components/StatusBar/Status
 import Tooltip from '@src/components/Tooltip'
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import { changeDefaultUnits } from '@src/lang/wasm'
-import { useSingletons } from '@src/lib/boot'
+import { useExecutingEditor } from '@src/lib/boot'
 import { DEFAULT_DEFAULT_LENGTH_UNIT } from '@src/lib/constants'
 import { baseUnitLabels, baseUnitsUnion } from '@src/lib/settings/settingsTypes'
 import { err } from '@src/lib/trap'
 import { OrthographicCamera } from 'three'
 
 export function UnitsMenu() {
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const wasmInstance = use(kclManager.wasmInstancePromise)
   const [fileSettings, setFileSettings] = useState(kclManager.fileSettings)
   const { state: modelingState } = useModelingContext()

--- a/src/components/ViewControlMenu.tsx
+++ b/src/components/ViewControlMenu.tsx
@@ -9,7 +9,7 @@ import {
 } from '@src/components/ContextMenu'
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import { getSelectedSketchTarget } from '@src/lang/queryAst'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import type { AxisNames } from '@src/lib/constants'
 import { VIEW_NAMES_SEMANTIC } from '@src/lib/constants'
 import { SNAP_TO_GRID_HOTKEY } from '@src/lib/hotkeys'
@@ -26,7 +26,7 @@ import toast from 'react-hot-toast'
 export function useViewControlMenuItems() {
   useSignals()
   const { settings, layout } = useApp()
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const { state: modelingState, send: modelingSend } = useModelingContext()
   const planeOrFaceId = getSelectedSketchTarget(
     modelingState.context.selectionRanges

--- a/src/components/gizmo/AxisGizmo.tsx
+++ b/src/components/gizmo/AxisGizmo.tsx
@@ -1,4 +1,4 @@
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { useEffect, useRef } from 'react'
 import type { MutableRefObject } from 'react'
 
@@ -27,7 +27,7 @@ import {
 
 export default function AxisGizmo() {
   const { settings } = useApp()
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const { state: modelingState } = useModelingContext()
   const settingsValues = settings.useSettings()
   const wrapperRef = useRef<HTMLDivElement | null>(null)

--- a/src/components/gizmo/CubeGizmo.tsx
+++ b/src/components/gizmo/CubeGizmo.tsx
@@ -1,5 +1,5 @@
 import GizmoRenderer from '@src/components/gizmo/GizmoRenderer'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { useEffect, useRef, useState } from 'react'
 
 import { useModelingContext } from '@src/hooks/useModelingContext'
@@ -7,7 +7,7 @@ import { useResolvedTheme } from '@src/hooks/useResolvedTheme'
 
 export default function CubeGizmo() {
   const { settings } = useApp()
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const { state: modelingState } = useModelingContext()
   const settingsValues = settings.useSettings()
 

--- a/src/components/layout/areas/BodiesPane.tsx
+++ b/src/components/layout/areas/BodiesPane.tsx
@@ -13,7 +13,7 @@ import {
   getCodeRefsByArtifactId,
 } from '@src/lang/std/artifactGraph'
 import { type ArtifactGraph, getAllOperations } from '@src/lang/wasm'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { EXPERIMENTAL_POINT_AND_CLICK_FLAG } from '@src/lib/constants'
 import { sendSelectionEvent } from '@src/lib/featureTree'
 import type { AreaTypeComponentProps } from '@src/lib/layout'
@@ -32,7 +32,7 @@ type SolidArtifact = Artifact & { type: 'compositeSolid' | 'sweep' | 'pattern' }
 
 export function BodiesPane(props: AreaTypeComponentProps) {
   useSignals()
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const execState = kclManager.execStateSignal.value
   const artifactGraph = execState.artifactGraph
   const operations = getAllOperations(execState.operations)
@@ -120,7 +120,7 @@ function BodyItem({
   patternIndex?: number
   showExperimentalPointAndClick?: boolean
 }) {
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const {
     actor: modelingActor,
     context: modelingContext,

--- a/src/components/layout/areas/FeatureTreePane.tsx
+++ b/src/components/layout/areas/FeatureTreePane.tsx
@@ -16,7 +16,7 @@ import {
   emptyOperationsByModule,
   getAllOperations,
 } from '@src/lang/wasm'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import {
   type OperationTreeNode,
   buildOperationTree,
@@ -80,11 +80,12 @@ import type { ConnectionManager } from '@src/network/connectionManager'
 import { executingEditorService } from '@src/registry/contracts/executingEditor'
 import { useNavigate } from 'react-router-dom'
 
-type Singletons = ReturnType<typeof useSingletons>
+type ExecutingEditor = ReturnType<typeof useExecutingEditor>
 
 type ModuleInstanceOperation = Extract<Operation, { type: 'ModuleInstance' }>
 
-type SystemDeps = Pick<Singletons, 'kclManager'> & {
+type SystemDeps = {
+  kclManager: ExecutingEditor
   commandBarActor: CommandBarActorType
   sceneInfra: SceneInfra
   sceneEntitiesManager: SceneEntities
@@ -142,7 +143,7 @@ export const FeatureTreePaneContents = memo(() => {
     UNRENDERED_EXECUTE_HOTKEY,
     platform
   )
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const executionService = app.registry.signal(executingEditorService).value
   const { engineCommandManager, rustContext } = kclManager
   const {

--- a/src/components/layout/areas/KclEditorPane.tsx
+++ b/src/components/layout/areas/KclEditorPane.tsx
@@ -4,7 +4,7 @@ import { LayoutPanel, LayoutPanelHeader } from '@src/components/layout/Panel'
 import { HeaderMenu } from '@src/components/layout/Panel/HeaderMenu'
 import usePlatform from '@src/hooks/usePlatform'
 import { useConvertToVariable } from '@src/hooks/useToolbarGuards'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { hotkeyDisplay } from '@src/lib/hotkeys'
 import type { AreaTypeComponentProps } from '@src/lib/layout'
 import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
@@ -14,7 +14,7 @@ import { useEffect, useRef } from 'react'
 import toast from 'react-hot-toast'
 import styles from './KclEditorMenu.module.css'
 
-type Singletons = ReturnType<typeof useSingletons>
+type ExecutingEditor = ReturnType<typeof useExecutingEditor>
 
 export const editorShortcutMeta = {
   formatCode: {
@@ -45,7 +45,7 @@ export const KclEditorPane = (props: AreaTypeComponentProps) => {
 }
 
 export const KclEditorPaneContents = () => {
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const editorParent = useRef<HTMLDivElement>(null)
   useEffect(() => {
     editorParent.current?.appendChild(kclManager.editorView.dom)
@@ -62,7 +62,7 @@ export const KclEditorPaneContents = () => {
   )
 }
 
-function copyKclCodeToClipboard(kclManager: Singletons['kclManager']) {
+function copyKclCodeToClipboard(kclManager: ExecutingEditor) {
   if (!kclManager.codeSignal.value) {
     toast.error('No code available to copy.')
     return
@@ -83,7 +83,7 @@ function copyKclCodeToClipboard(kclManager: Singletons['kclManager']) {
 
 export const KclEditorMenu = () => {
   const { commands, settings } = useApp()
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const platform = usePlatform()
   const settingsActor = settings.actor
   const { enable: convertToVarEnabled, handleClick: handleConvertToVarClick } =

--- a/src/components/layout/areas/LoggingPanes.tsx
+++ b/src/components/layout/areas/LoggingPanes.tsx
@@ -2,7 +2,7 @@ import ReactJsonView from '@microlink/react-json-view'
 
 import { LayoutPanel, LayoutPanelHeader } from '@src/components/layout/Panel'
 import { useResolvedTheme } from '@src/hooks/useResolvedTheme'
-import { useSingletons } from '@src/lib/boot'
+import { useExecutingEditor } from '@src/lib/boot'
 import type { AreaTypeComponentProps } from '@src/lib/layout'
 
 export function LogsPane(props: AreaTypeComponentProps) {
@@ -24,7 +24,7 @@ export function LogsPane(props: AreaTypeComponentProps) {
   )
 }
 export const LogsPaneContent = () => {
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const theme = useResolvedTheme()
   const logs = kclManager.logsSignal.value
   return (

--- a/src/components/layout/areas/MemoryPane.tsx
+++ b/src/components/layout/areas/MemoryPane.tsx
@@ -12,14 +12,14 @@ import { useModelingContext } from '@src/hooks/useModelingContext'
 import { useResolvedTheme } from '@src/hooks/useResolvedTheme'
 import type { VariableMap } from '@src/lang/wasm'
 import { humanDisplayNumber, sketchFromKclValueOptional } from '@src/lang/wasm'
-import { useSingletons } from '@src/lib/boot'
+import { useExecutingEditor } from '@src/lib/boot'
 import type { AreaTypeComponentProps } from '@src/lib/layout'
 import { Reason, trap } from '@src/lib/trap'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { Suspense, use } from 'react'
 
 export const MemoryPaneMenu = () => {
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const variables = kclManager.variablesSignal.value
 
   function copyProgramMemoryToClipboard() {
@@ -73,7 +73,7 @@ export function MemoryPane(props: AreaTypeComponentProps) {
 }
 
 export const MemoryPaneContents = () => {
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const theme = useResolvedTheme()
   const variables = kclManager.variablesSignal.value
   const { state } = useModelingContext()

--- a/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
+++ b/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
@@ -4,7 +4,7 @@ import { LayoutPanel, LayoutPanelHeader } from '@src/components/layout/Panel'
 import { HeaderMenu } from '@src/components/layout/Panel/HeaderMenu'
 import { MlEphantConversationPane } from '@src/components/layout/areas/MlEphantConversationPane'
 import { useModelingContext } from '@src/hooks/useModelingContext'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { browserSaveFile } from '@src/lib/browserSaveFile'
 import type { AreaTypeComponentProps } from '@src/lib/layout'
 import { BillingTransition } from '@src/machines/billingMachine'
@@ -47,7 +47,7 @@ function MlEphantConversationPaneInner(props: AreaTypeComponentProps) {
   useSignals()
   const app = useApp()
   const { auth, billing, settings, project, systemIOActor } = app
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const settingsValues = settings.useSettings()
   const user = auth.useUser()
   const token = auth.useToken()

--- a/src/components/layout/areas/ProjectExplorerPane.tsx
+++ b/src/components/layout/areas/ProjectExplorerPane.tsx
@@ -6,7 +6,7 @@ import { ToastInsert } from '@src/components/ToastInsert'
 import { LayoutPanel, LayoutPanelHeader } from '@src/components/layout/Panel'
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import { relevantFileExtensions } from '@src/lang/wasmUtils'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { FILE_EXT, INSERT_FOREIGN_TOAST_ID } from '@src/lib/constants'
 import fsZds from '@src/lib/fs-zds'
 import {
@@ -32,7 +32,7 @@ import toast from 'react-hot-toast'
 
 export function ProjectExplorerPane(props: AreaTypeComponentProps) {
   const { commands, project, systemIOActor, layout } = useApp()
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const wasmInstance = use(kclManager.wasmInstancePromise)
   const projects = useFolders()
   const projectDirectoryPath = useProjectDirectoryPath()

--- a/src/hooks/network/useOnPageIdle.tsx
+++ b/src/hooks/network/useOnPageIdle.tsx
@@ -1,5 +1,5 @@
 import { useModelingContext } from '@src/hooks/useModelingContext'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { EngineDebugger } from '@src/lib/debugger'
 import { useEffect, useRef } from 'react'
 
@@ -11,7 +11,7 @@ export const useOnPageIdle = ({
   idleCallback: () => void
 }) => {
   const { settings } = useApp()
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const settingsValues = settings.useSettings()
   const streamIdleMode = settingsValues.app.streamIdleMode.current
   const { state: modelingMachineState } = useModelingContext()

--- a/src/hooks/network/useTryConnect.tsx
+++ b/src/hooks/network/useTryConnect.tsx
@@ -1,7 +1,7 @@
 import type { useAppState } from '@src/AppState'
 import type { SceneInfra } from '@src/clientSideScene/sceneInfra'
 import type { KclManager } from '@src/lang/KclManager'
-import { useSingletons } from '@src/lib/boot'
+import { useExecutingEditor } from '@src/lib/boot'
 import { NUMBER_OF_ENGINE_RETRIES } from '@src/lib/constants'
 import { EngineDebugger } from '@src/lib/debugger'
 import { resetCameraPosition } from '@src/lib/resetCameraPosition'
@@ -313,7 +313,7 @@ async function tryConnecting({
   return connection
 }
 export const useTryConnect = () => {
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const isConnecting = useRef(false)
   const numberOfConnectionAttempts = useRef(0)
   type TryConnectingArgs = Omit<

--- a/src/hooks/useProjectsLoader.tsx
+++ b/src/hooks/useProjectsLoader.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 
-import { useSingletons } from '@src/lib/boot'
+import { useApp } from '@src/lib/boot'
 import { ensureProjectDirectoryExists, listProjects } from '@src/lib/desktop'
 import type { Project } from '@src/lib/project'
 import { loadAndValidateSettings } from '@src/lib/settings/settingsUtils'
@@ -11,7 +11,7 @@ import { trap } from '@src/lib/trap'
 // Hook uses [number] to give users familiarity. It is meant to mimic a
 // dependency array, but is intended to only ever be used with 1 value.
 export const useProjectsLoader = (deps?: [number]) => {
-  const { kclManager } = useSingletons()
+  const { wasmPromise } = useApp()
   const [lastTs, setLastTs] = useState(-1)
   const [projectPaths, setProjectPaths] = useState<Project[]>([])
   const [projectsDir, setProjectsDir] = useState<string | undefined>(undefined)
@@ -23,17 +23,12 @@ export const useProjectsLoader = (deps?: [number]) => {
       setLastTs(deps[0])
     }
     ;(async () => {
-      const { configuration } = await loadAndValidateSettings(
-        kclManager.wasmInstancePromise
-      )
+      const { configuration } = await loadAndValidateSettings(wasmPromise)
       const _projectsDir = await ensureProjectDirectoryExists(configuration)
       setProjectsDir(_projectsDir)
 
       if (projectsDir) {
-        const _projectPaths = await listProjects(
-          kclManager.wasmInstancePromise,
-          configuration
-        )
+        const _projectPaths = await listProjects(wasmPromise, configuration)
         setProjectPaths(_projectPaths)
       }
     })().catch(trap)

--- a/src/hooks/useQueryParamEffects.ts
+++ b/src/hooks/useQueryParamEffects.ts
@@ -3,7 +3,6 @@ import toast from 'react-hot-toast'
 import { useSearchParams } from 'react-router-dom'
 import { waitFor } from 'xstate'
 
-import type { KclManager } from '@src/lang/KclManager'
 import { base64ToString } from '@src/lib/base64'
 import { useApp } from '@src/lib/boot'
 import type { ProjectsCommandSchema } from '@src/lib/commandBarConfigs/projectsCommandConfig'
@@ -50,7 +49,7 @@ export type CreateFileSchemaMethodOptional = Omit<
  * `?createFile`
  * "?cmd=<some-command-name>&groupId=<some-group-id>"
  */
-export function useQueryParamEffects(kclManager: KclManager) {
+export function useQueryParamEffects() {
   const app = useApp()
   const { auth, commands } = app
   const authState = auth.useAuthState()

--- a/src/hooks/useReliesOnEngine.tsx
+++ b/src/hooks/useReliesOnEngine.tsx
@@ -1,11 +1,11 @@
 import { useAppState } from '@src/AppState'
 import { useNetworkContext } from '@src/hooks/useNetworkContext'
 import { NetworkHealthState } from '@src/hooks/useNetworkStatus'
-import { useSingletons } from '@src/lib/boot'
+import { useExecutingEditor } from '@src/lib/boot'
 import { EngineConnectionStateType } from '@src/network/utils'
 
 export function useReliesOnEngine(isExecuting: boolean) {
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const { overallState, immediateState } = useNetworkContext()
   const { isStreamReady } = useAppState()
   const reliesOnEngine =

--- a/src/hooks/useStateMachineCommands.ts
+++ b/src/hooks/useStateMachineCommands.ts
@@ -6,7 +6,7 @@ import { useSignals } from '@preact/signals-react/runtime'
 import { useNetworkContext } from '@src/hooks/useNetworkContext'
 import { NetworkHealthState } from '@src/hooks/useNetworkStatus'
 import { shouldDisableModelingForUnrenderedChanges } from '@src/lib/automaticRendering'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import type {
   Command,
   StateMachineCommandSetConfig,
@@ -49,7 +49,7 @@ export default function useStateMachineCommands<
 }: UseStateMachineCommandsArgs<T, S>) {
   useSignals()
   const { commands, settings, userFeatures } = useApp()
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const showExperimentalCommands = userFeatures.useHas(
     EXPERIMENTAL_POINT_AND_CLICK_FLAG,
     false

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -407,7 +407,9 @@ export class ZDSProject {
     const foundEditor = this.findEditor(path)
     const found = foundEditor?.[1]
     if (found) {
-      console.warn(`Attempted to overwrite editor with path "${path}"`)
+      if (isExecuting) {
+        this.executingPath = path
+      }
       return found
     }
 

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -1914,6 +1914,7 @@ export class KclManager extends File {
 
   /** Clean up listeners, watchers, etc */
   public close() {
+    this.cancelAllExecutions()
     clearTimeout(this.timeoutWriter)
     clearTimeout(this.timeoutRewatch)
     this.settingsSubscription?.unsubscribe()

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -6,6 +6,7 @@ import type { Project } from '@src/lib/project'
 import { getChangedSettingsAtLevel } from '@src/lib/settings/settingsUtils'
 import { appHeaderItemsValueSpec } from '@src/registry/contracts/appHeader'
 import { executingEditorService } from '@src/registry/contracts/executingEditor'
+import { projectSessionService } from '@src/registry/contracts/projectSession'
 import { loadWasm } from '@src/unitTestUtils'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
@@ -86,8 +87,11 @@ describe('project system', () => {
         .get(pluginsValueSpec)
         .find((plugin) => plugin.id === pluginId)
       expect(plugin).toBeDefined()
+      if (!plugin) {
+        throw new Error(`Expected ${pluginId} plugin to be registered.`)
+      }
 
-      const pluginToggle = app.registry.get(plugin!.service)
+      const pluginToggle = app.registry.get(plugin.service)
       expect(pluginToggle.active.value).toBe(true)
 
       app.settings.actor.send({
@@ -182,13 +186,16 @@ describe('project system', () => {
         .get(pluginsValueSpec)
         .find((plugin) => plugin.id === pluginId)
       expect(plugin).toBeDefined()
+      if (!plugin) {
+        throw new Error(`Expected ${pluginId} plugin to be registered.`)
+      }
 
       app.settings.actor.send({ type: 'reload.settings' } as never)
 
       await waitForSettingsIdle(app)
 
       expect(app.settings.get().plugins[pluginId].current).toBe(true)
-      expect(app.registry.get(plugin!.service).active.value).toBe(true)
+      expect(app.registry.get(plugin.service).active.value).toBe(true)
     } finally {
       disposeApp(app)
     }
@@ -206,6 +213,9 @@ describe('project system', () => {
         .get(pluginsValueSpec)
         .find((plugin) => plugin.id === 'execution-indicator')
       expect(executionIndicatorPlugin).toBeDefined()
+      if (!executionIndicatorPlugin) {
+        throw new Error('Expected execution-indicator plugin to be registered.')
+      }
 
       app.settings.actor.send({ type: 'reload.settings' } as never)
 
@@ -218,7 +228,7 @@ describe('project system', () => {
       expect(modelingSettings.executionIndicator.current).toBe(false)
       expect(app.settings.get().plugins['execution-indicator']).toBeUndefined()
       expect(
-        app.registry.get(executionIndicatorPlugin!.service).active.value
+        app.registry.get(executionIndicatorPlugin.service).active.value
       ).toBe(false)
 
       app.settings.actor.send({
@@ -233,7 +243,7 @@ describe('project system', () => {
       await waitForSettingsIdle(app)
 
       expect(
-        app.registry.get(executionIndicatorPlugin!.service).active.value
+        app.registry.get(executionIndicatorPlugin.service).active.value
       ).toBe(true)
     } finally {
       disposeApp(app)
@@ -250,19 +260,37 @@ describe('project system', () => {
     })
 
     try {
-      const project = await app.openProject(mockProject)
+      const projectSession = app.registry.get(projectSessionService)
+      const project = await projectSession.openProject(mockProject)
 
       expect(app.project).toBeDefined()
+      expect(app.project).toBe(project)
+      expect(projectSession.openedProject.value).toBe(project)
+      expect(projectSession.openedProjectHandle.value).toEqual({
+        projectPath: mockProject.path,
+      })
       expect(app.project?.executingPath).toBeNull()
       expect(app.project?.executingFileEntry.value.name).toEqual('')
 
-      await project.openEditor(mockProject.children![0].path)
+      const mainFile = mockProject.children?.[0]
+      expect(mainFile).toBeDefined()
+      if (!mainFile) {
+        throw new Error('Expected mock project to include a main file.')
+      }
+
+      await projectSession.openEditor(mainFile.path)
       expect(app.project?.executingPath).toEqual('/some-dir/test/main.kcl')
       expect(app.project?.executingFileEntry.value.name).toEqual('main.kcl')
+      expect(projectSession.executingEditorHandle.value).toEqual({
+        projectPath: mockProject.path,
+        filePath: mainFile.path,
+      })
 
-      app.closeProject()
+      projectSession.closeProject()
 
       expect(app.project).toBeUndefined()
+      expect(projectSession.openedProjectHandle.value).toBeUndefined()
+      expect(projectSession.executingEditorHandle.value).toBeUndefined()
     } finally {
       disposeApp(app)
     }

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -286,6 +286,17 @@ describe('project system', () => {
         filePath: mainFile.path,
       })
 
+      await projectSession.openEditor('/some-dir/test/other.kcl')
+      expect(app.project?.executingPath).toEqual('/some-dir/test/other.kcl')
+
+      await projectSession.openEditor(mainFile.path)
+      expect(app.project?.executingPath).toEqual('/some-dir/test/main.kcl')
+      expect(app.project?.executingFileEntry.value.name).toEqual('main.kcl')
+      expect(projectSession.executingEditorHandle.value).toEqual({
+        projectPath: mockProject.path,
+        filePath: mainFile.path,
+      })
+
       projectSession.closeProject()
 
       expect(app.project).toBeUndefined()

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -1,7 +1,7 @@
 import { pluginsValueSpec } from '@kittycad/registry'
 import { File } from '@src/lang/KclManager'
 import { App } from '@src/lib/app'
-import { StorageName, moduleFsViaModuleImport } from '@src/lib/fs-zds'
+import fsZds, { StorageName, moduleFsViaModuleImport } from '@src/lib/fs-zds'
 import type { Project } from '@src/lib/project'
 import { getChangedSettingsAtLevel } from '@src/lib/settings/settingsUtils'
 import { appHeaderItemsValueSpec } from '@src/registry/contracts/appHeader'
@@ -10,9 +10,13 @@ import { projectSessionService } from '@src/registry/contracts/projectSession'
 import { loadWasm } from '@src/unitTestUtils'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
+const mockProjectPath = '/private/tmp/zds-app-spec-project-system/test'
+const mockProjectMainFilePath = `${mockProjectPath}/main.kcl`
+const mockProjectDirectoryPath = '/private/tmp/zds-app-spec-project-system'
+
 const mockProject: Project = {
   name: 'test',
-  default_file: 'main.kcl',
+  default_file: mockProjectMainFilePath,
   directory_count: 0,
   kcl_file_count: 1,
   metadata: {
@@ -23,12 +27,12 @@ const mockProject: Project = {
     size: 100,
     type: null,
   },
-  path: '/some-dir/test',
+  path: mockProjectPath,
   readWriteAccess: true,
   children: [
     {
       name: 'main.kcl',
-      path: '/some-dir/test/main.kcl',
+      path: mockProjectMainFilePath,
       children: [],
     },
   ],
@@ -40,9 +44,13 @@ beforeAll(async () => {
     type: StorageName.NodeFS,
     options: {},
   })
+  await fsZds.rm(mockProjectPath, { recursive: true, force: true })
+  await fsZds.mkdir(mockProjectPath, { recursive: true })
+  await fsZds.writeFile(mockProjectMainFilePath, new TextEncoder().encode(''))
 })
 
-afterAll(() => {
+afterAll(async () => {
+  await fsZds.rm(mockProjectPath, { recursive: true, force: true })
   vi.restoreAllMocks()
 })
 
@@ -63,8 +71,8 @@ async function waitForSettingsIdle(app: App) {
   })
 }
 
-function disposeApp(app: App) {
-  app.closeProject()
+async function disposeApp(app: App) {
+  await app.projectSession.setOpenedProjectHandle(undefined)
   app.systemIOActor.stop()
   app.settings.actor.stop()
   app.commands.actor.stop()
@@ -130,7 +138,7 @@ describe('project system', () => {
         ]
       ).toBeUndefined()
     } finally {
-      disposeApp(app)
+      await disposeApp(app)
     }
   })
 
@@ -169,7 +177,7 @@ describe('project system', () => {
       expect(textEditorSettings.automaticallyRender.current).toBe(true)
       expect(textEditorSettings.automaticallyRender.hideOnLevel).toBe('project')
     } finally {
-      disposeApp(app)
+      await disposeApp(app)
     }
   })
 
@@ -197,7 +205,7 @@ describe('project system', () => {
       expect(app.settings.get().plugins[pluginId].current).toBe(true)
       expect(app.registry.get(plugin.service).active.value).toBe(true)
     } finally {
-      disposeApp(app)
+      await disposeApp(app)
     }
   })
 
@@ -246,7 +254,7 @@ describe('project system', () => {
         app.registry.get(executionIndicatorPlugin.service).active.value
       ).toBe(true)
     } finally {
-      disposeApp(app)
+      await disposeApp(app)
     }
   })
 
@@ -261,7 +269,13 @@ describe('project system', () => {
 
     try {
       const projectSession = app.registry.get(projectSessionService)
-      const project = await projectSession.openProject(mockProject)
+      const project = await projectSession.setOpenedProjectHandle({
+        projectPath: mockProject.path,
+      })
+      expect(project).toBeDefined()
+      if (!project) {
+        throw new Error('Expected project session to open the mock project.')
+      }
 
       expect(app.project).toBeDefined()
       expect(app.project).toBe(project)
@@ -269,6 +283,9 @@ describe('project system', () => {
       expect(projectSession.openedProjectHandle.value).toEqual({
         projectPath: mockProject.path,
       })
+      expect(
+        app.systemIOActor.getSnapshot().context.projectDirectoryPath
+      ).toEqual(mockProjectDirectoryPath)
       expect(app.project?.executingPath).toBeNull()
       expect(app.project?.executingFileEntry.value.name).toEqual('')
 
@@ -278,32 +295,42 @@ describe('project system', () => {
         throw new Error('Expected mock project to include a main file.')
       }
 
-      await projectSession.openEditor(mainFile.path)
-      expect(app.project?.executingPath).toEqual('/some-dir/test/main.kcl')
+      await projectSession.setExecutingEditorHandle({
+        projectPath: mockProject.path,
+        filePath: mainFile.path,
+      })
+      expect(app.project?.executingPath).toEqual(mockProjectMainFilePath)
       expect(app.project?.executingFileEntry.value.name).toEqual('main.kcl')
       expect(projectSession.executingEditorHandle.value).toEqual({
         projectPath: mockProject.path,
         filePath: mainFile.path,
       })
 
-      await projectSession.openEditor('/some-dir/test/other.kcl')
-      expect(app.project?.executingPath).toEqual('/some-dir/test/other.kcl')
+      const otherFilePath = `${mockProjectPath}/other.kcl`
+      await projectSession.setExecutingEditorHandle({
+        projectPath: mockProject.path,
+        filePath: otherFilePath,
+      })
+      expect(app.project?.executingPath).toEqual(otherFilePath)
 
-      await projectSession.openEditor(mainFile.path)
-      expect(app.project?.executingPath).toEqual('/some-dir/test/main.kcl')
+      await projectSession.setExecutingEditorHandle({
+        projectPath: mockProject.path,
+        filePath: mainFile.path,
+      })
+      expect(app.project?.executingPath).toEqual(mockProjectMainFilePath)
       expect(app.project?.executingFileEntry.value.name).toEqual('main.kcl')
       expect(projectSession.executingEditorHandle.value).toEqual({
         projectPath: mockProject.path,
         filePath: mainFile.path,
       })
 
-      projectSession.closeProject()
+      await projectSession.setOpenedProjectHandle(undefined)
 
       expect(app.project).toBeUndefined()
       expect(projectSession.openedProjectHandle.value).toBeUndefined()
       expect(projectSession.executingEditorHandle.value).toBeUndefined()
     } finally {
-      disposeApp(app)
+      await disposeApp(app)
     }
   })
 })

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -724,20 +724,22 @@ export class App implements AppSubsystems {
     if (!this.project) {
       return // Everything in here only matters inside a project.
     }
+    const kclManager = this.project.executingEditor.value
+    if (!kclManager) {
+      return
+    }
     const { context } = snapshot
 
     // Update line wrapping
-    this.singletons.kclManager.setEditorLineWrapping(
-      context.textEditor.textWrapping.current
-    )
+    kclManager.setEditorLineWrapping(context.textEditor.textWrapping.current)
 
     // Update engine highlighting
     const newHighlighting = context.modeling.highlightEdges.current
     if (
       newHighlighting !== this.lastSettings.modeling.highlightEdges &&
-      this.singletons.kclManager.engineCommandManager.connection
+      kclManager.engineCommandManager.connection
     ) {
-      this.singletons.kclManager.engineCommandManager
+      kclManager.engineCommandManager
         .setHighlightEdges(newHighlighting)
         .catch(reportRejection)
     }
@@ -748,16 +750,16 @@ export class App implements AppSubsystems {
       '--cursor-color',
       newBlinking ? 'auto' : 'transparent'
     )
-    this.singletons.kclManager.setCursorBlinking(newBlinking)
+    kclManager.setCursorBlinking(newBlinking)
 
     // Update theme
     const newTheme = context.app.theme.current
     const newBackfaceColor = context.modeling.backfaceColor.current
     Promise.all([
-      this.singletons.kclManager.updateTheme(newTheme),
-      ...(this.singletons.kclManager.engineCommandManager.connection?.connected
+      kclManager.updateTheme(newTheme),
+      ...(kclManager.engineCommandManager.connection?.connected
         ? [
-            this.singletons.kclManager.engineCommandManager.setDefaultSystemProperties(
+            kclManager.engineCommandManager.setDefaultSystemProperties(
               newBackfaceColor
             ),
           ]
@@ -783,29 +785,29 @@ export class App implements AppSubsystems {
       // Relevant settings requiring a cleared scene and re-exec
       if (
         settingsIncludeNewRelevantValues &&
-        this.singletons.kclManager.engineCommandManager.connection
+        kclManager.engineCommandManager.connection
       ) {
-        this.singletons.kclManager.rustContext
+        kclManager.rustContext
           .clearSceneAndBustCache(
             jsAppSettings(this.settings.actor),
-            this.singletons.kclManager.path
+            kclManager.path
           )
-          .then(() => this.singletons.kclManager.executeCode())
+          .then(() => kclManager.executeCode())
           .catch(reportRejection)
       }
     } catch (e) {
       console.error('Error executing AST after settings change', e)
     }
 
-    this.singletons.kclManager.sceneInfra.camControls._setting_allowOrbitInSketchMode =
+    kclManager.sceneInfra.camControls._setting_allowOrbitInSketchMode =
       context.app.allowOrbitInSketchMode.current
 
     const newCurrentProjection = context.modeling.cameraProjection.current
     if (
-      this.singletons.kclManager.sceneInfra.camControls &&
-      !this.singletons.kclManager.modelingState?.matches('Sketch')
+      kclManager.sceneInfra.camControls &&
+      !kclManager.modelingState?.matches('Sketch')
     ) {
-      this.singletons.kclManager.sceneInfra.camControls.engineCameraProjection =
+      kclManager.sceneInfra.camControls.engineCameraProjection =
         newCurrentProjection
     }
 

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -8,8 +8,7 @@ import {
   provideService,
 } from '@kittycad/registry'
 import { type Signal, effect, signal } from '@preact/signals-core'
-import { buildFSHistoryExtension } from '@src/editor/plugins/fs'
-import { KclManager, ZDSProject } from '@src/lang/KclManager'
+import { KclManager, type ZDSProject } from '@src/lang/KclManager'
 import { initialiseWasm } from '@src/lang/wasmUtils'
 import { MachineManager } from '@src/lib/MachineManager'
 import { createAuthCommands } from '@src/lib/commandBarConfigs/authCommandConfig'
@@ -77,6 +76,10 @@ import { executingEditorService } from '@src/registry/contracts/executingEditor'
 import { keymapService } from '@src/registry/contracts/keymap'
 import { layoutContributionsValueSpec } from '@src/registry/contracts/layout'
 import { machineManagerService } from '@src/registry/contracts/machineManager'
+import {
+  type ProjectSessionService,
+  projectSessionService,
+} from '@src/registry/contracts/projectSession'
 import { settingsValueSpec } from '@src/registry/contracts/settings'
 import { userFeaturesService } from '@src/registry/contracts/userFeatures'
 import { provideWasmPromise } from '@src/registry/contracts/wasm'
@@ -248,6 +251,8 @@ export class App implements AppSubsystems {
   layout: AppLayoutSystem
   /** The registry system for the application */
   registry: AppRegistrySystem
+  /** The currently-opened project and editor lifecycle system */
+  projectSession: ProjectSessionService
   /**
    * The interface to reading/writing to IO.
    * TODO: We have agreed to move away from this XState approach, towards a class + signals approach.
@@ -276,6 +281,9 @@ export class App implements AppSubsystems {
         app: this,
       },
     }).start()
+    this.projectSession = this.registry.get(projectSessionService)
+    this.projectSignal = this.projectSession.openedProject
+    this.projectSession.bindApp(this)
 
     this.registry.reconfigure(appCommandsSlot, [
       defineRegistryItem({
@@ -551,43 +559,10 @@ export class App implements AppSubsystems {
   }
 
   async openProject(projectIORef: Project) {
-    const projectIORefSignal = signal(projectIORef)
-    this.project = await ZDSProject.open(projectIORefSignal, this)
-
-    // This extension makes it possible to mark FS operations as un/redoable
-    effect(() => {
-      if (this.project?.executingEditor.value) {
-        buildFSHistoryExtension(
-          this.systemIOActor,
-          this.project.executingEditor.value
-        )
-      }
-    })
-
-    // TODO: Rework the systemIOActor to fit into the system better,
-    // so that the project doesn't need to subscribe to it.
-    this.systemIOActor.subscribe(({ context }) => {
-      const foundProject = (context.folders ?? []).find(
-        (p) =>
-          p.name === projectIORefSignal.value.name &&
-          p.path === projectIORefSignal.value.path
-      )
-      if (foundProject && projectIORefSignal.value !== foundProject) {
-        projectIORefSignal.value = foundProject
-      }
-    })
-
-    this.unsubscribeFromSettings = this.settings.actor.subscribe(
-      this.onSettingsUpdate
-    )
-
-    return this.project
+    return this.projectSession.openProject(projectIORef)
   }
-  private unsubscribeFromSettings: Subscription | undefined = undefined
   closeProject() {
-    this.unsubscribeFromSettings?.unsubscribe()
-    this.project?.close()
-    this.project = undefined
+    this.projectSession.closeProject()
   }
 
   syncUserFeaturesFromAuth = (

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -30,7 +30,7 @@ import {
   setLayoutSaveHandler,
 } from '@src/lib/layout'
 import { playwrightLayoutConfig } from '@src/lib/layout/configs/playwright'
-import type { Project } from '@src/lib/project'
+import { getParentAbsolutePath } from '@src/lib/paths'
 import RustContext from '@src/lib/rustContext'
 import {
   type SettingsType,
@@ -57,7 +57,10 @@ import {
   settingsMachine,
 } from '@src/machines/settingsMachine'
 import { systemIOMachineImpl } from '@src/machines/systemIO/systemIOMachineImpl'
-import type { SystemIOActor } from '@src/machines/systemIO/utils'
+import {
+  type SystemIOActor,
+  SystemIOMachineEvents,
+} from '@src/machines/systemIO/utils'
 import {
   type UserFeaturesActorRef,
   type UserFeaturesContext,
@@ -262,6 +265,7 @@ export class App implements AppSubsystems {
   // TODO: refactor this to not require keeping around the last settings to compare to
   private lastSettings: SaveSettingsPayload
   private pluginSettingsSubscription: Subscription
+  private systemIOProjectDirectoryEffectUnsubscribe: ReturnType<typeof effect>
 
   constructor(subsystems: AppSubsystems) {
     this.wasmPromise = subsystems.wasmPromise
@@ -284,6 +288,9 @@ export class App implements AppSubsystems {
     this.projectSession = this.registry.get(projectSessionService)
     this.projectSignal = this.projectSession.openedProject
     this.projectSession.bindApp(this)
+    this.systemIOProjectDirectoryEffectUnsubscribe = effect(
+      this.syncSystemIOProjectDirectoryFromOpenedProjectHandle
+    )
 
     this.registry.reconfigure(appCommandsSlot, [
       defineRegistryItem({
@@ -558,13 +565,6 @@ export class App implements AppSubsystems {
     return new App(combined)
   }
 
-  async openProject(projectIORef: Project) {
-    return this.projectSession.openProject(projectIORef)
-  }
-  closeProject() {
-    this.projectSession.closeProject()
-  }
-
   syncUserFeaturesFromAuth = (
     snapshot: SnapshotFrom<typeof this.auth.actor>
   ) => {
@@ -624,6 +624,36 @@ export class App implements AppSubsystems {
 
       toggle.disable()
     }
+  }
+
+  syncSystemIOProjectDirectoryFromOpenedProjectHandle = () => {
+    const openedProjectHandle = this.projectSession.openedProjectHandle.value
+    const appProjectDir = this.settings.get().app.projectDirectory.current
+    const requestedProjectDirectoryPath =
+      openedProjectHandle?.projectPath.includes(appProjectDir)
+        ? appProjectDir
+        : openedProjectHandle
+          ? getParentAbsolutePath(openedProjectHandle.projectPath)
+          : appProjectDir
+
+    if (
+      this.systemIOActor.getSnapshot().context.projectDirectoryPath ===
+      requestedProjectDirectoryPath
+    ) {
+      if (!openedProjectHandle) {
+        this.systemIOActor.send({
+          type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
+        })
+      }
+      return
+    }
+
+    this.systemIOActor.send({
+      type: SystemIOMachineEvents.setProjectDirectoryPath,
+      data: {
+        requestedProjectDirectoryPath,
+      },
+    })
   }
 
   /**

--- a/src/lib/boot.ts
+++ b/src/lib/boot.ts
@@ -1,3 +1,4 @@
+import { useSignals } from '@preact/signals-react/runtime'
 import { App } from '@src/lib/app'
 import {
   StorageName,
@@ -51,6 +52,20 @@ window.app = app
  * `useSingletons` will eventually be deprecated.
  */
 export const useSingletons = () => React.useContext(AppContext).singletons
+
+export const useOptionalExecutingEditor = () => {
+  useSignals()
+  const app = React.useContext(AppContext)
+  return app.projectSession.openedProject.value?.executingEditor.value
+}
+
+export const useExecutingEditor = () => {
+  const executingEditor = useOptionalExecutingEditor()
+  if (!executingEditor) {
+    throw new Error('No executing editor is currently available.')
+  }
+  return executingEditor
+}
 
 /**
  * Hook to get access to the app instance.

--- a/src/lib/kclCommands.ts
+++ b/src/lib/kclCommands.ts
@@ -30,10 +30,9 @@ import {
 import { getPathFilenameInVariableCase } from '@src/lib/desktop'
 import fsZds from '@src/lib/fs-zds'
 import { copyFileShareLink } from '@src/lib/links'
-import type { Project } from '@src/lib/project'
+import type { FileEntry, Project } from '@src/lib/project'
 import { baseUnitsUnion, warningLevels } from '@src/lib/settings/settingsTypes'
 import { err, reportRejection } from '@src/lib/trap'
-import type { IndexLoaderData } from '@src/lib/types'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { CommandBarContext } from '@src/machines/commandBarMachine'
 import { listAllImportFilesWithinProject } from '@src/machines/systemIO/snapshotContext'
@@ -48,7 +47,11 @@ interface KclCommandConfig {
   kclManager: KclManager
   systemIOActor: SystemIOActor
   wasmInstance: ModuleType
-  projectData: IndexLoaderData
+  projectData: {
+    code: string | null
+    project?: Project
+    file?: FileEntry
+  }
   authToken: string
   settings: {
     defaultUnit: UnitLength

--- a/src/lib/layout/defaultActionLibrary.ts
+++ b/src/lib/layout/defaultActionLibrary.ts
@@ -1,6 +1,6 @@
 import { useSignals } from '@preact/signals-react/runtime'
 import { useReliesOnEngine } from '@src/hooks/useReliesOnEngine'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { sendAddFileToProjectCommandForCurrentProject } from '@src/lib/commandBarConfigs/applicationCommandConfig'
 import { isDesktop } from '@src/lib/isDesktop'
 import { isMobile } from '@src/lib/isMobile'
@@ -10,7 +10,7 @@ import { layoutActionLibraryValueSpec } from '@src/registry/contracts/layout'
 export const useDefaultActionLibrary = () => {
   useSignals()
   const { commands, settings, registry } = useApp()
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const machineApiEnabled = settings.useSettings().app.machineApi.current
   const registeredActionLibrary = registry.signal(
     layoutActionLibraryValueSpec

--- a/src/lib/layout/defaultAreaLibrary.tsx
+++ b/src/lib/layout/defaultAreaLibrary.tsx
@@ -14,7 +14,7 @@ import { MlEphantConversationPaneWrapper } from '@src/components/layout/areas/Ml
 import { ProjectExplorerPane } from '@src/components/layout/areas/ProjectExplorerPane'
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import { kclErrorsByFilename } from '@src/lang/errors'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
 import type { AreaLibrary, AreaTypeDefinition } from '@src/lib/layout/types'
 import { togglePaneLayoutNode } from '@src/lib/layout/utils'
@@ -90,7 +90,7 @@ function ModelingArea() {
 export const useDefaultAreaLibrary = () => {
   useSignals()
   const { settings, layout, registry } = useApp()
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const getSettings = settings.get
   const registeredAreaLibrary = registry.signal(
     layoutAreaLibraryValueSpec

--- a/src/lib/routeLoaders.ts
+++ b/src/lib/routeLoaders.ts
@@ -9,23 +9,19 @@ import { readAppSettingsFile } from '@src/lib/desktop'
 import fsZds from '@src/lib/fs-zds'
 import {
   PATHS,
-  getParentAbsolutePath,
   getProjectMetaByRouteId,
   getRouterSearchFromRequestUrl,
   safeEncodeForRouterPaths,
 } from '@src/lib/paths'
 import { loadAndValidateSettings } from '@src/lib/settings/settingsUtils'
-import type {
-  FileLoaderData,
-  HomeLoaderData,
-  IndexLoaderData,
-} from '@src/lib/types'
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
 import { projectSessionService } from '@src/registry/contracts/projectSession'
 import type { LoaderFunction } from 'react-router-dom'
 import { redirect } from 'react-router-dom'
 
 export const DEFAULT_WEB_PROJECT_NAME = 'demo-project'
+
+type EmptyLoaderData = Record<string, never>
 
 /**
  * The base loader is used to reroute `/` root path requests,
@@ -96,7 +92,7 @@ export const fileLoader =
   }: {
     app: App
   }): LoaderFunction =>
-  async (routerData): Promise<FileLoaderData | Response> => {
+  async (routerData): Promise<EmptyLoaderData | Response> => {
     const { kclManager } = app.singletons
     const projectSession = app.registry.get(projectSessionService)
     const { params } = routerData
@@ -174,78 +170,32 @@ export const fileLoader =
       }
     }
 
-    const defaultProjectData = {
-      name: projectName || 'unnamed',
-      path: projectPath,
-      children: [],
-      kcl_file_count: 0,
-      directory_count: 0,
-      metadata: null,
-      default_file: projectPath,
-      readWriteAccess: true,
-    }
-
-    const maybeProjectInfo = await getProjectInfo(projectPath, wasmInstance)
-
-    const project = maybeProjectInfo ?? defaultProjectData
-
-    const { editor } = await projectSession.openProjectEditor({
-      project,
+    await projectSession.setOpenedProjectHandle({ projectPath })
+    await projectSession.setExecutingEditorHandle({
+      projectPath,
       filePath: currentFilePath || PROJECT_ENTRYPOINT,
-      providedEditor: app.singletons.kclManager,
-      // If persistCode in localStorage is present, it'll persist that code
-      // through *anything*. INTENDED FOR TESTS.
-      providedCode:
-        window.electron?.process.env.NODE_ENV === 'test'
-          ? kclManager.localStoragePersistCode()
-          : undefined,
     })
 
-    const appProjectDir = settings.settings.app.projectDirectory.current
-    const requestedProjectDirectoryPath = project.path.includes(appProjectDir)
-      ? appProjectDir
-      : getParentAbsolutePath(project.path) // Fallback to parent directory if foreign to app project dir
-    app.systemIOActor.send({
-      type: SystemIOMachineEvents.setProjectDirectoryPath,
-      data: {
-        requestedProjectDirectoryPath,
-      },
-    })
-
-    const projectData: IndexLoaderData = {
-      code: editor.code,
-      project,
-      file: {
-        name: currentFileName || '',
-        path: currentFilePath || '',
-        children: [],
-      },
-    }
-
-    return {
-      ...projectData,
-    }
+    return {}
   }
 
 // Loads the settings and by extension the projects in the default directory
 // and returns them to the Home route, along with any errors that occurred
 
-// Should also clear currently loaded projects in SystemIO. They may be stale.
 export const homeLoader =
   ({
     app,
   }: {
     app: App
   }): LoaderFunction =>
-  async (): Promise<HomeLoaderData | Response> => {
+  async (): Promise<EmptyLoaderData | Response> => {
     // If on web, bump out to root, which will redirect to a project.
     if (!window.electron) {
       return redirect(PATHS.INDEX)
     }
 
-    app.systemIOActor.send({
-      type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
-    })
-    app.registry.get(projectSessionService).closeProject()
+    await app.registry
+      .get(projectSessionService)
+      .setOpenedProjectHandle(undefined)
     return {}
   }

--- a/src/lib/routeLoaders.ts
+++ b/src/lib/routeLoaders.ts
@@ -53,7 +53,7 @@ export const baseLoader =
     }
 
     // Web, make a default project and redirect to it.
-    const wasmInstance = await app.singletons.kclManager.wasmInstancePromise
+    const wasmInstance = await app.wasmPromise
 
     const settings = await loadAndValidateSettings(wasmInstance, undefined)
 

--- a/src/lib/routeLoaders.ts
+++ b/src/lib/routeLoaders.ts
@@ -1,18 +1,9 @@
 import { projectSkeletonCreate } from '@src/lang/project'
 import type { App } from '@src/lib/app'
-import {
-  DEFAULT_DEFAULT_LENGTH_UNIT,
-  PROJECT_ENTRYPOINT,
-} from '@src/lib/constants'
-import { getInitialDefaultDir, getProjectInfo } from '@src/lib/desktop'
-import { readAppSettingsFile } from '@src/lib/desktop'
+import { DEFAULT_DEFAULT_LENGTH_UNIT } from '@src/lib/constants'
+import { getInitialDefaultDir } from '@src/lib/desktop'
 import fsZds from '@src/lib/fs-zds'
-import {
-  PATHS,
-  getProjectMetaByRouteId,
-  getRouterSearchFromRequestUrl,
-  safeEncodeForRouterPaths,
-} from '@src/lib/paths'
+import { PATHS, getRouterSearchFromRequestUrl } from '@src/lib/paths'
 import { loadAndValidateSettings } from '@src/lib/settings/settingsUtils'
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
 import { projectSessionService } from '@src/registry/contracts/projectSession'
@@ -93,88 +84,16 @@ export const fileLoader =
     app: App
   }): LoaderFunction =>
   async (routerData): Promise<EmptyLoaderData | Response> => {
-    const { kclManager } = app.singletons
     const projectSession = app.registry.get(projectSessionService)
-    const { params } = routerData
-
-    // Must basically remain for all eternity, until the last person
-    // who's ever used ZDS on web before this point has died.
-    if (params.id?.startsWith('/browser')) {
-      // Pop us back home, which will cause a default project to be
-      // created.
-      return redirect(PATHS.HOME)
-    }
-
-    const heuristicProjectFilePath = params.id
-      ? params.id.split(fsZds.sep).slice(0, -1).join(fsZds.sep)
-      : undefined
-
-    const wasmInstance = await kclManager.wasmInstancePromise
-
-    const settings = await loadAndValidateSettings(
-      wasmInstance,
-      heuristicProjectFilePath
-    )
-
-    const projectPathData = await getProjectMetaByRouteId(
-      readAppSettingsFile,
-      wasmInstance,
-      params.id,
-      settings.configuration
-    )
-
-    if (!projectPathData) {
-      return Promise.reject(
-        new Error('bug: projectPathData undefined, early return')
-      )
-    }
-
-    const { projectName, projectPath, currentFileName, currentFilePath } =
-      projectPathData
-
-    const urlObj = new URL(routerData.request.url)
-
-    if (!urlObj.pathname.endsWith('/settings')) {
-      const fallbackFile = (await getProjectInfo(projectPath, wasmInstance))
-        .default_file
-      let fileExists = true
-      if (currentFilePath && fileExists) {
-        try {
-          await fsZds.stat(currentFilePath)
-        } catch (e) {
-          if (e === 'ENOENT') {
-            fileExists = false
-          }
-        }
-      }
-
-      // If we are navigating to the project and want to navigate to its
-      // default file, redirect to it keeping everything else in the URL the same.
-      if (projectPath && !currentFileName && fileExists && params.id) {
-        const encodedId = safeEncodeForRouterPaths(params.id)
-        const requestUrlWithDefaultFile = routerData.request.url.replace(
-          encodedId,
-          safeEncodeForRouterPaths(fallbackFile)
-        )
-        return redirect(requestUrlWithDefaultFile)
-      }
-
-      if (!fileExists || !currentFileName || !currentFilePath || !projectName) {
-        const routerSearch = getRouterSearchFromRequestUrl(
-          routerData.request.url,
-          Boolean(window.electron)
-        )
-        return redirect(
-          `${PATHS.FILE}/${encodeURIComponent(fallbackFile)}${routerSearch}`
-        )
-      }
-    }
-
-    await projectSession.setOpenedProjectHandle({ projectPath })
-    await projectSession.setExecutingEditorHandle({
-      projectPath,
-      filePath: currentFilePath || PROJECT_ENTRYPOINT,
+    const result = await projectSession.setProjectRouteHandles({
+      routeId: routerData.params.id,
+      requestUrl: routerData.request.url,
+      usesHashRouter: Boolean(window.electron),
     })
+
+    if (result.redirectTo) {
+      return redirect(result.redirectTo)
+    }
 
     return {}
   }

--- a/src/lib/routeLoaders.ts
+++ b/src/lib/routeLoaders.ts
@@ -1,5 +1,4 @@
 import { projectSkeletonCreate } from '@src/lang/project'
-import { projectFsManager } from '@src/lang/std/fileSystemManager'
 import type { App } from '@src/lib/app'
 import {
   DEFAULT_DEFAULT_LENGTH_UNIT,
@@ -22,9 +21,9 @@ import type {
   IndexLoaderData,
 } from '@src/lib/types'
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
+import { projectSessionService } from '@src/registry/contracts/projectSession'
 import type { LoaderFunction } from 'react-router-dom'
 import { redirect } from 'react-router-dom'
-import { waitFor } from 'xstate'
 
 export const DEFAULT_WEB_PROJECT_NAME = 'demo-project'
 
@@ -86,8 +85,7 @@ export const baseLoader =
         wasmInstance
       )
 
-      const fileURLPath =
-        PATHS.FILE + '/' + encodeURIComponent(requestedProjectName)
+      const fileURLPath = `${PATHS.FILE}/${encodeURIComponent(requestedProjectName)}`
       return redirect(fileURLPath + routerSearch)
     }
   }
@@ -99,10 +97,8 @@ export const fileLoader =
     app: App
   }): LoaderFunction =>
   async (routerData): Promise<FileLoaderData | Response> => {
-    const {
-      settings: { actor: settingsActor },
-    } = app
     const { kclManager } = app.singletons
+    const projectSession = app.registry.get(projectSessionService)
     const { params } = routerData
 
     // Must basically remain for all eternity, until the last person
@@ -119,7 +115,7 @@ export const fileLoader =
 
     const wasmInstance = await kclManager.wasmInstancePromise
 
-    let settings = await loadAndValidateSettings(
+    const settings = await loadAndValidateSettings(
       wasmInstance,
       heuristicProjectFilePath
     )
@@ -178,10 +174,6 @@ export const fileLoader =
       }
     }
 
-    // Set the file system manager to the project path
-    // So that WASM gets an updated path for operations
-    projectFsManager.dir = projectPath
-
     const defaultProjectData = {
       name: projectName || 'unnamed',
       path: projectPath,
@@ -197,25 +189,17 @@ export const fileLoader =
 
     const project = maybeProjectInfo ?? defaultProjectData
 
-    // Fire off the event to load the project settings
-    // once we know it's idle.
-    await waitFor(settingsActor, (state) => state.matches('idle'))
-    settingsActor.send({
-      type: 'load.project',
+    const { editor } = await projectSession.openProjectEditor({
       project,
-    })
-    await waitFor(settingsActor, (state) => state.matches('idle'))
-
-    const projectRef = await app.openProject(project)
-    const editor = await projectRef.openEditor(
-      currentFilePath || PROJECT_ENTRYPOINT,
-      app.singletons.kclManager,
+      filePath: currentFilePath || PROJECT_ENTRYPOINT,
+      providedEditor: app.singletons.kclManager,
       // If persistCode in localStorage is present, it'll persist that code
       // through *anything*. INTENDED FOR TESTS.
-      window.electron?.process.env.NODE_ENV === 'test'
-        ? kclManager.localStoragePersistCode()
-        : undefined
-    )
+      providedCode:
+        window.electron?.process.env.NODE_ENV === 'test'
+          ? kclManager.localStoragePersistCode()
+          : undefined,
+    })
 
     const appProjectDir = settings.settings.app.projectDirectory.current
     const requestedProjectDirectoryPath = project.path.includes(appProjectDir)
@@ -253,7 +237,7 @@ export const homeLoader =
   }: {
     app: App
   }): LoaderFunction =>
-  async ({ request }): Promise<HomeLoaderData | Response> => {
+  async (): Promise<HomeLoaderData | Response> => {
     // If on web, bump out to root, which will redirect to a project.
     if (!window.electron) {
       return redirect(PATHS.INDEX)
@@ -262,9 +246,6 @@ export const homeLoader =
     app.systemIOActor.send({
       type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
     })
-    app.closeProject()
-    app.settings.actor.send({
-      type: 'clear.project',
-    })
+    app.registry.get(projectSessionService).closeProject()
     return {}
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,19 +1,3 @@
-import type { FileEntry, Project } from '@src/lib/project'
-
-export type IndexLoaderData = {
-  code: string | null
-  project?: Project
-  file?: FileEntry
-}
-
-export type FileLoaderData = {
-  code: string | null
-  project?: FileEntry | Project
-  file?: FileEntry
-}
-
-export type HomeLoaderData = Record<string, never>
-
 // From the very helpful @jcalz on StackOverflow: https://stackoverflow.com/a/58436959/22753272
 type Join<K, P> = K extends string | number
   ? P extends string | number
@@ -97,17 +81,16 @@ export type DeepPartial<T> = {
 /**
  * Replace a function's return type with another type.
  */
-export type WithReturnType<F extends (...args: any[]) => any, NewReturn> = (
+type AnyFunction = (...args: never[]) => unknown
+
+export type WithReturnType<F extends AnyFunction, NewReturn> = (
   ...args: Parameters<F>
 ) => NewReturn
 
 /**
  * Assert that a function type is async, preserving its parameter types.
  */
-export type AsyncFn<F extends (...args: any[]) => any> = WithReturnType<
-  F,
-  Promise<unknown>
->
+export type AsyncFn<F extends AnyFunction> = WithReturnType<F, Promise<unknown>>
 
 export type FileMeta =
   | {
@@ -138,7 +121,5 @@ type PromisifyFn<F> = F extends (...args: infer A) => infer R
   : F
 /** Promisify only function properties, leave others unchanged */
 export type PromisifyProps<T> = {
-  [K in keyof T]: T[K] extends (...args: any[]) => any
-    ? PromisifyFn<T[K]>
-    : T[K]
+  [K in keyof T]: T[K] extends AnyFunction ? PromisifyFn<T[K]> : T[K]
 }

--- a/src/lib/usePreviousVarMentions.ts
+++ b/src/lib/usePreviousVarMentions.ts
@@ -1,7 +1,7 @@
 import type { CompletionContext } from '@codemirror/autocomplete'
 
 import type { Program, VariableMap } from '@src/lang/wasm'
-import { useSingletons } from '@src/lib/boot'
+import { useExecutingEditor } from '@src/lib/boot'
 import { usePreviousVariables } from '@src/lib/usePreviousVariables'
 import { use } from 'react'
 
@@ -12,7 +12,7 @@ export function usePreviousVarMentions(
   ast: Program,
   variables: VariableMap
 ) {
-  const { kclManager } = useSingletons()
+  const kclManager = useExecutingEditor()
   const wasmInstance = use(kclManager.wasmInstancePromise)
   const previousVariables = usePreviousVariables({
     code: context.view?.state.doc.toString() || '',

--- a/src/registry/contracts/projectSession.ts
+++ b/src/registry/contracts/projectSession.ts
@@ -22,6 +22,16 @@ export interface OpenEditorOptions {
   isExecuting?: boolean
 }
 
+export interface ProjectRouteHandlesOptions {
+  routeId?: string
+  requestUrl: string
+  usesHashRouter?: boolean
+}
+
+export interface ProjectRouteHandlesResult {
+  redirectTo?: string
+}
+
 export interface ProjectSessionService {
   readonly openedProjectHandle: Signal<OpenedProjectHandle | undefined>
   readonly executingEditorHandle: Signal<ExecutingEditorHandle | undefined>
@@ -34,6 +44,9 @@ export interface ProjectSessionService {
     handle: ExecutingEditorHandle | undefined,
     options?: OpenEditorOptions
   ): Promise<KclManager | undefined>
+  setProjectRouteHandles(
+    options: ProjectRouteHandlesOptions
+  ): Promise<ProjectRouteHandlesResult>
 }
 
 export const projectSessionContract = defineContract({

--- a/src/registry/contracts/projectSession.ts
+++ b/src/registry/contracts/projectSession.ts
@@ -6,7 +6,6 @@ import {
 import type { Signal } from '@preact/signals-core'
 import type { KclManager, ZDSProject } from '@src/lang/KclManager'
 import type { App } from '@src/lib/app'
-import type { Project } from '@src/lib/project'
 
 export interface OpenedProjectHandle {
   projectPath: string
@@ -23,23 +22,18 @@ export interface OpenEditorOptions {
   isExecuting?: boolean
 }
 
-export interface OpenProjectEditorInput extends OpenEditorOptions {
-  project: Project
-  filePath: string
-}
-
 export interface ProjectSessionService {
   readonly openedProjectHandle: Signal<OpenedProjectHandle | undefined>
   readonly executingEditorHandle: Signal<ExecutingEditorHandle | undefined>
   readonly openedProject: Signal<ZDSProject | undefined>
   bindApp(app: App): void
-  openProject(project: Project): Promise<ZDSProject>
-  openEditor(filePath: string, options?: OpenEditorOptions): Promise<KclManager>
-  openProjectEditor(input: OpenProjectEditorInput): Promise<{
-    project: ZDSProject
-    editor: KclManager
-  }>
-  closeProject(): void
+  setOpenedProjectHandle(
+    handle: OpenedProjectHandle | undefined
+  ): Promise<ZDSProject | undefined>
+  setExecutingEditorHandle(
+    handle: ExecutingEditorHandle | undefined,
+    options?: OpenEditorOptions
+  ): Promise<KclManager | undefined>
 }
 
 export const projectSessionContract = defineContract({

--- a/src/registry/contracts/projectSession.ts
+++ b/src/registry/contracts/projectSession.ts
@@ -1,0 +1,65 @@
+import {
+  defineContract,
+  defineService,
+  firstWinsValueSpec,
+} from '@kittycad/registry'
+import type { Signal } from '@preact/signals-core'
+import type { KclManager, ZDSProject } from '@src/lang/KclManager'
+import type { App } from '@src/lib/app'
+import type { Project } from '@src/lib/project'
+
+export interface OpenedProjectHandle {
+  projectPath: string
+}
+
+export interface ExecutingEditorHandle {
+  projectPath: string
+  filePath: string
+}
+
+export interface OpenEditorOptions {
+  providedEditor?: KclManager
+  providedCode?: string
+  isExecuting?: boolean
+}
+
+export interface OpenProjectEditorInput extends OpenEditorOptions {
+  project: Project
+  filePath: string
+}
+
+export interface ProjectSessionService {
+  readonly openedProjectHandle: Signal<OpenedProjectHandle | undefined>
+  readonly executingEditorHandle: Signal<ExecutingEditorHandle | undefined>
+  readonly openedProject: Signal<ZDSProject | undefined>
+  bindApp(app: App): void
+  openProject(project: Project): Promise<ZDSProject>
+  openEditor(filePath: string, options?: OpenEditorOptions): Promise<KclManager>
+  openProjectEditor(input: OpenProjectEditorInput): Promise<{
+    project: ZDSProject
+    editor: KclManager
+  }>
+  closeProject(): void
+}
+
+export const projectSessionContract = defineContract({
+  openedProjectHandleValueSpec: firstWinsValueSpec<
+    OpenedProjectHandle | undefined
+  >('opened-project-handle', undefined),
+  executingEditorHandleValueSpec: firstWinsValueSpec<
+    ExecutingEditorHandle | undefined
+  >('executing-editor-handle', undefined),
+  openedProjectValueSpec: firstWinsValueSpec<ZDSProject | undefined>(
+    'opened-project',
+    undefined
+  ),
+  projectSessionService:
+    defineService<ProjectSessionService>('project-session'),
+})
+
+export const {
+  openedProjectHandleValueSpec,
+  executingEditorHandleValueSpec,
+  openedProjectValueSpec,
+  projectSessionService,
+} = projectSessionContract

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -1,0 +1,218 @@
+import {
+  defineRegistryItemFactory,
+  defineRuntimeRegistryItem,
+  provide,
+  provideService,
+} from '@kittycad/registry'
+import { type Signal, effect, signal } from '@preact/signals-core'
+import { buildFSHistoryExtension } from '@src/editor/plugins/fs'
+import { ZDSProject } from '@src/lang/KclManager'
+import { projectFsManager } from '@src/lang/std/fileSystemManager'
+import type { App } from '@src/lib/app'
+import type { Project } from '@src/lib/project'
+import {
+  type OpenEditorOptions,
+  type OpenProjectEditorInput,
+  type ProjectSessionService,
+  executingEditorHandleValueSpec,
+  openedProjectHandleValueSpec,
+  openedProjectValueSpec,
+  projectSessionService,
+} from '@src/registry/contracts/projectSession'
+import type { Subscription } from 'xstate'
+import { waitFor } from 'xstate'
+
+interface CloseProjectOptions {
+  clearHandles?: boolean
+  clearProjectSettings?: boolean
+}
+
+const projectSessionExtension = defineRegistryItemFactory(() => {
+  let app: App | undefined
+  let unsubscribeFromSettings: Subscription | undefined
+  let unsubscribeFromSystemIO: Subscription | undefined
+  let stopFSHistoryEffect: (() => void) | undefined
+
+  const openedProjectHandle =
+    signal<ProjectSessionService['openedProjectHandle']['value']>(undefined)
+  const executingEditorHandle =
+    signal<ProjectSessionService['executingEditorHandle']['value']>(undefined)
+  const openedProject =
+    signal<ProjectSessionService['openedProject']['value']>(undefined)
+
+  const getApp = () => {
+    if (!app) {
+      throw new Error('Project session service has not been bound to App.')
+    }
+    return app
+  }
+
+  const stopProjectEffects = () => {
+    unsubscribeFromSettings?.unsubscribe()
+    unsubscribeFromSettings = undefined
+    unsubscribeFromSystemIO?.unsubscribe()
+    unsubscribeFromSystemIO = undefined
+    stopFSHistoryEffect?.()
+    stopFSHistoryEffect = undefined
+  }
+
+  const closeProject = ({
+    clearHandles = true,
+    clearProjectSettings = true,
+  }: CloseProjectOptions = {}) => {
+    const currentApp = app
+    const currentProject = openedProject.peek()
+
+    stopProjectEffects()
+    currentProject?.close()
+    openedProject.value = undefined
+
+    if (clearHandles) {
+      openedProjectHandle.value = undefined
+      executingEditorHandle.value = undefined
+    }
+
+    if (clearProjectSettings) {
+      currentApp?.settings.actor.send({
+        type: 'clear.project',
+      })
+    }
+  }
+
+  const syncProjectFromSystemIO = (projectIORefSignal: Signal<Project>) => {
+    const currentApp = getApp()
+
+    unsubscribeFromSystemIO = currentApp.systemIOActor.subscribe(
+      ({ context }) => {
+        const foundProject = (context.folders ?? []).find(
+          (project) =>
+            project.name === projectIORefSignal.value.name &&
+            project.path === projectIORefSignal.value.path
+        )
+        if (foundProject && projectIORefSignal.value !== foundProject) {
+          projectIORefSignal.value = foundProject
+        }
+      }
+    )
+  }
+
+  const startProjectEffects = (projectIORefSignal: Signal<Project>) => {
+    const currentApp = getApp()
+
+    stopProjectEffects()
+    stopFSHistoryEffect = effect(() => {
+      const editor = openedProject.value?.executingEditor.value
+      if (!editor) {
+        return
+      }
+
+      return buildFSHistoryExtension(currentApp.systemIOActor, editor)
+    })
+    syncProjectFromSystemIO(projectIORefSignal)
+    unsubscribeFromSettings = currentApp.settings.actor.subscribe(
+      currentApp.onSettingsUpdate
+    )
+  }
+
+  const openProject = async (project: Project) => {
+    const currentApp = getApp()
+    const currentProject = openedProject.peek()
+
+    openedProjectHandle.value = {
+      projectPath: project.path,
+    }
+    projectFsManager.dir = project.path
+
+    if (currentProject && currentProject.path !== project.path) {
+      closeProject({ clearHandles: false, clearProjectSettings: false })
+    }
+
+    await waitFor(currentApp.settings.actor, (state) => state.matches('idle'))
+    currentApp.settings.actor.send({
+      type: 'load.project',
+      project,
+    })
+    await waitFor(currentApp.settings.actor, (state) => state.matches('idle'))
+
+    if (currentProject?.path === project.path) {
+      currentProject.projectIORefSignal.value = project
+      return currentProject
+    }
+
+    const projectIORefSignal = signal(project)
+    const nextProject = await ZDSProject.open(projectIORefSignal, currentApp)
+    openedProject.value = nextProject
+    startProjectEffects(projectIORefSignal)
+    return nextProject
+  }
+
+  const openEditor = async (
+    filePath: string,
+    { providedEditor, providedCode, isExecuting = true }: OpenEditorOptions = {}
+  ) => {
+    const currentProject = openedProject.peek()
+    if (!currentProject) {
+      throw new Error('Cannot open an editor without an opened project.')
+    }
+
+    executingEditorHandle.value = {
+      projectPath: currentProject.path,
+      filePath,
+    }
+
+    return currentProject.openEditor(
+      filePath,
+      providedEditor,
+      providedCode,
+      isExecuting
+    )
+  }
+
+  const serviceImpl: ProjectSessionService = {
+    openedProjectHandle,
+    executingEditorHandle,
+    openedProject,
+    bindApp(boundApp) {
+      app = boundApp
+    },
+    openProject,
+    openEditor,
+    async openProjectEditor({
+      project,
+      filePath,
+      providedEditor,
+      providedCode,
+      isExecuting,
+    }: OpenProjectEditorInput) {
+      const opened = await openProject(project)
+      const editor = await openEditor(filePath, {
+        providedEditor,
+        providedCode,
+        isExecuting,
+      })
+      return { project: opened, editor }
+    },
+    closeProject: () => closeProject(),
+  }
+
+  return {
+    item: defineRuntimeRegistryItem({
+      id: 'project-session-extension',
+      provides: [
+        provide(openedProjectHandleValueSpec, openedProjectHandle, {
+          key: 'project-session',
+        }),
+        provide(executingEditorHandleValueSpec, executingEditorHandle, {
+          key: 'project-session',
+        }),
+        provide(openedProjectValueSpec, openedProject, {
+          key: 'project-session',
+        }),
+      ],
+      providesServices: [provideService(projectSessionService, serviceImpl)],
+      dispose: () => closeProject(),
+    }),
+  }
+}, 'project-session-extension')
+
+export default projectSessionExtension

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -9,13 +9,24 @@ import { buildFSHistoryExtension } from '@src/editor/plugins/fs'
 import { ZDSProject } from '@src/lang/KclManager'
 import { projectFsManager } from '@src/lang/std/fileSystemManager'
 import type { App } from '@src/lib/app'
-import { getProjectInfo } from '@src/lib/desktop'
-import { getStringAfterLastSeparator } from '@src/lib/paths'
+import { PROJECT_ENTRYPOINT } from '@src/lib/constants'
+import { getProjectInfo, readAppSettingsFile } from '@src/lib/desktop'
+import fsZds from '@src/lib/fs-zds'
+import {
+  PATHS,
+  getProjectMetaByRouteId,
+  getRouterSearchFromRequestUrl,
+  getStringAfterLastSeparator,
+  safeEncodeForRouterPaths,
+} from '@src/lib/paths'
 import type { Project } from '@src/lib/project'
+import { loadAndValidateSettings } from '@src/lib/settings/settingsUtils'
 import {
   type ExecutingEditorHandle,
   type OpenEditorOptions,
   type OpenedProjectHandle,
+  type ProjectRouteHandlesOptions,
+  type ProjectRouteHandlesResult,
   type ProjectSessionService,
   executingEditorHandleValueSpec,
   openedProjectHandleValueSpec,
@@ -243,6 +254,100 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     })
   }
 
+  const setProjectRouteHandles = async ({
+    routeId,
+    requestUrl,
+    usesHashRouter = Boolean(window.electron),
+  }: ProjectRouteHandlesOptions): Promise<ProjectRouteHandlesResult> => {
+    if (routeId?.startsWith('/browser')) {
+      return { redirectTo: PATHS.HOME }
+    }
+
+    if (!routeId) {
+      return Promise.reject(
+        new Error('bug: projectPathData undefined, early return')
+      )
+    }
+
+    const currentApp = app
+    if (!currentApp) {
+      return Promise.reject(projectSessionUnboundError())
+    }
+
+    const heuristicProjectFilePath = routeId
+      ? routeId.split(fsZds.sep).slice(0, -1).join(fsZds.sep)
+      : undefined
+
+    const wasmInstance = await currentApp.wasmPromise
+    const settings = await loadAndValidateSettings(
+      wasmInstance,
+      heuristicProjectFilePath
+    )
+
+    const projectPathData = await getProjectMetaByRouteId(
+      readAppSettingsFile,
+      wasmInstance,
+      routeId,
+      settings.configuration
+    )
+
+    if (!projectPathData) {
+      return Promise.reject(
+        new Error('bug: projectPathData undefined, early return')
+      )
+    }
+
+    const { projectName, projectPath, currentFileName, currentFilePath } =
+      projectPathData
+
+    const urlObj = new URL(requestUrl)
+
+    if (!urlObj.pathname.endsWith('/settings')) {
+      const fallbackFile = (await getProjectInfo(projectPath, wasmInstance))
+        .default_file
+      let fileExists = true
+      if (currentFilePath && fileExists) {
+        try {
+          await fsZds.stat(currentFilePath)
+        } catch (e) {
+          if (e === 'ENOENT') {
+            fileExists = false
+          }
+        }
+      }
+
+      if (projectPath && !currentFileName && fileExists && routeId) {
+        const encodedId = safeEncodeForRouterPaths(routeId)
+        return {
+          redirectTo: requestUrl.replace(
+            encodedId,
+            safeEncodeForRouterPaths(fallbackFile)
+          ),
+        }
+      }
+
+      if (!fileExists || !currentFileName || !currentFilePath || !projectName) {
+        const routerSearch = getRouterSearchFromRequestUrl(
+          requestUrl,
+          usesHashRouter
+        )
+        return {
+          redirectTo: `${PATHS.FILE}/${encodeURIComponent(
+            fallbackFile
+          )}${routerSearch}`,
+        }
+      }
+    }
+
+    await setOpenedProjectHandle({ projectPath })
+    await setExecutingEditorHandle({
+      projectPath,
+      filePath: currentFilePath || PROJECT_ENTRYPOINT,
+    })
+
+    return {}
+  }
+
   const serviceImpl: ProjectSessionService = {
     openedProjectHandle,
     executingEditorHandle,
@@ -252,6 +357,7 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     },
     setOpenedProjectHandle,
     setExecutingEditorHandle,
+    setProjectRouteHandles,
   }
 
   return {

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -9,10 +9,13 @@ import { buildFSHistoryExtension } from '@src/editor/plugins/fs'
 import { ZDSProject } from '@src/lang/KclManager'
 import { projectFsManager } from '@src/lang/std/fileSystemManager'
 import type { App } from '@src/lib/app'
+import { getProjectInfo } from '@src/lib/desktop'
+import { getStringAfterLastSeparator } from '@src/lib/paths'
 import type { Project } from '@src/lib/project'
 import {
+  type ExecutingEditorHandle,
   type OpenEditorOptions,
-  type OpenProjectEditorInput,
+  type OpenedProjectHandle,
   type ProjectSessionService,
   executingEditorHandleValueSpec,
   openedProjectHandleValueSpec,
@@ -22,7 +25,7 @@ import {
 import type { Subscription } from 'xstate'
 import { waitFor } from 'xstate'
 
-interface CloseProjectOptions {
+interface ClearProjectSessionOptions {
   clearHandles?: boolean
   clearProjectSettings?: boolean
 }
@@ -40,6 +43,30 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
   const openedProject =
     signal<ProjectSessionService['openedProject']['value']>(undefined)
 
+  const projectSessionUnboundError = () =>
+    new Error('Project session service has not been bound to App.')
+
+  const getProjectFromHandle = async (
+    currentApp: App,
+    { projectPath }: OpenedProjectHandle
+  ): Promise<Project> => {
+    const wasmInstance = await currentApp.wasmPromise
+    const maybeProjectInfo = await getProjectInfo(projectPath, wasmInstance)
+
+    return (
+      maybeProjectInfo ?? {
+        name: getStringAfterLastSeparator(projectPath) || 'unnamed',
+        path: projectPath,
+        children: [],
+        kcl_file_count: 0,
+        directory_count: 0,
+        metadata: null,
+        default_file: projectPath,
+        readWriteAccess: true,
+      }
+    )
+  }
+
   const stopProjectEffects = () => {
     unsubscribeFromSettings?.unsubscribe()
     unsubscribeFromSettings = undefined
@@ -49,10 +76,10 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     stopFSHistoryEffect = undefined
   }
 
-  const closeProject = ({
+  const clearProjectSession = ({
     clearHandles = true,
     clearProjectSettings = true,
-  }: CloseProjectOptions = {}) => {
+  }: ClearProjectSessionOptions = {}) => {
     const currentApp = app
     const currentProject = openedProject.peek()
 
@@ -109,13 +136,7 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     )
   }
 
-  const openProject = async (project: Project) => {
-    const currentApp = app
-    if (!currentApp) {
-      return Promise.reject(
-        new Error('Project session service has not been bound to App.')
-      )
-    }
+  const loadProjectFromInfo = async (currentApp: App, project: Project) => {
     const currentProject = openedProject.peek()
 
     openedProjectHandle.value = {
@@ -124,7 +145,10 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     projectFsManager.dir = project.path
 
     if (currentProject && currentProject.path !== project.path) {
-      closeProject({ clearHandles: false, clearProjectSettings: false })
+      clearProjectSession({
+        clearHandles: false,
+        clearProjectSettings: false,
+      })
     }
 
     await waitFor(currentApp.settings.actor, (state) => state.matches('idle'))
@@ -146,7 +170,26 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     return nextProject
   }
 
-  const openEditor = async (
+  const setOpenedProjectHandle = async (
+    handle: OpenedProjectHandle | undefined
+  ) => {
+    if (!handle) {
+      clearProjectSession()
+      return undefined
+    }
+
+    const currentApp = app
+    if (!currentApp) {
+      return Promise.reject(projectSessionUnboundError())
+    }
+
+    return loadProjectFromInfo(
+      currentApp,
+      await getProjectFromHandle(currentApp, handle)
+    )
+  }
+
+  const loadEditorFromHandle = async (
     filePath: string,
     { providedEditor, providedCode, isExecuting = true }: OpenEditorOptions = {}
   ) => {
@@ -170,6 +213,36 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     )
   }
 
+  const setExecutingEditorHandle = async (
+    handle: ExecutingEditorHandle | undefined,
+    options: OpenEditorOptions = {}
+  ) => {
+    if (!handle) {
+      executingEditorHandle.value = undefined
+      return undefined
+    }
+
+    const currentApp = app
+    if (!currentApp) {
+      return Promise.reject(projectSessionUnboundError())
+    }
+    const currentProject = openedProject.peek()
+    if (currentProject?.path !== handle.projectPath) {
+      await setOpenedProjectHandle({ projectPath: handle.projectPath })
+    }
+
+    return loadEditorFromHandle(handle.filePath, {
+      providedEditor:
+        options.providedEditor ?? currentApp.singletons.kclManager,
+      providedCode:
+        options.providedCode ??
+        (window.electron?.process.env.NODE_ENV === 'test'
+          ? currentApp.singletons.kclManager.localStoragePersistCode()
+          : undefined),
+      isExecuting: options.isExecuting,
+    })
+  }
+
   const serviceImpl: ProjectSessionService = {
     openedProjectHandle,
     executingEditorHandle,
@@ -177,24 +250,8 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     bindApp(boundApp) {
       app = boundApp
     },
-    openProject,
-    openEditor,
-    async openProjectEditor({
-      project,
-      filePath,
-      providedEditor,
-      providedCode,
-      isExecuting,
-    }: OpenProjectEditorInput) {
-      const opened = await openProject(project)
-      const editor = await openEditor(filePath, {
-        providedEditor,
-        providedCode,
-        isExecuting,
-      })
-      return { project: opened, editor }
-    },
-    closeProject: () => closeProject(),
+    setOpenedProjectHandle,
+    setExecutingEditorHandle,
   }
 
   return {
@@ -212,7 +269,7 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
         }),
       ],
       providesServices: [provideService(projectSessionService, serviceImpl)],
-      dispose: () => closeProject(),
+      dispose: () => clearProjectSession(),
     }),
   }
 }, 'project-session-extension')

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -40,13 +40,6 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
   const openedProject =
     signal<ProjectSessionService['openedProject']['value']>(undefined)
 
-  const getApp = () => {
-    if (!app) {
-      throw new Error('Project session service has not been bound to App.')
-    }
-    return app
-  }
-
   const stopProjectEffects = () => {
     unsubscribeFromSettings?.unsubscribe()
     unsubscribeFromSettings = undefined
@@ -79,9 +72,10 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     }
   }
 
-  const syncProjectFromSystemIO = (projectIORefSignal: Signal<Project>) => {
-    const currentApp = getApp()
-
+  const syncProjectFromSystemIO = (
+    currentApp: App,
+    projectIORefSignal: Signal<Project>
+  ) => {
     unsubscribeFromSystemIO = currentApp.systemIOActor.subscribe(
       ({ context }) => {
         const foundProject = (context.folders ?? []).find(
@@ -96,9 +90,10 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     )
   }
 
-  const startProjectEffects = (projectIORefSignal: Signal<Project>) => {
-    const currentApp = getApp()
-
+  const startProjectEffects = (
+    currentApp: App,
+    projectIORefSignal: Signal<Project>
+  ) => {
     stopProjectEffects()
     stopFSHistoryEffect = effect(() => {
       const editor = openedProject.value?.executingEditor.value
@@ -108,14 +103,19 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
 
       return buildFSHistoryExtension(currentApp.systemIOActor, editor)
     })
-    syncProjectFromSystemIO(projectIORefSignal)
+    syncProjectFromSystemIO(currentApp, projectIORefSignal)
     unsubscribeFromSettings = currentApp.settings.actor.subscribe(
       currentApp.onSettingsUpdate
     )
   }
 
   const openProject = async (project: Project) => {
-    const currentApp = getApp()
+    const currentApp = app
+    if (!currentApp) {
+      return Promise.reject(
+        new Error('Project session service has not been bound to App.')
+      )
+    }
     const currentProject = openedProject.peek()
 
     openedProjectHandle.value = {
@@ -142,7 +142,7 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     const projectIORefSignal = signal(project)
     const nextProject = await ZDSProject.open(projectIORefSignal, currentApp)
     openedProject.value = nextProject
-    startProjectEffects(projectIORefSignal)
+    startProjectEffects(currentApp, projectIORefSignal)
     return nextProject
   }
 
@@ -152,7 +152,9 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
   ) => {
     const currentProject = openedProject.peek()
     if (!currentProject) {
-      throw new Error('Cannot open an editor without an opened project.')
+      return Promise.reject(
+        new Error('Cannot open an editor without an opened project.')
+      )
     }
 
     executingEditorHandle.value = {

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -34,7 +34,7 @@ import {
   autoUpdateDownloadProgressSignal,
   autoUpdateReadySignal,
 } from '@src/lib/autoUpdate'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp } from '@src/lib/boot'
 import { createRouteCommands } from '@src/lib/commandBarConfigs/routeCommandConfig'
 import { isDesktop } from '@src/lib/isDesktop'
 import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
@@ -84,10 +84,9 @@ const Home = () => {
   useSignals()
   const { auth, billing, commands, settings, systemIOActor, registry } =
     useApp()
-  const { kclManager } = useSingletons()
   const executingPath = useAbsoluteFilePath()
   const settingsActor = settings.actor
-  useQueryParamEffects(kclManager)
+  useQueryParamEffects()
   const navigate = useNavigate()
   const location = useLocation()
   const readWriteProjectDir = useCanReadWriteProjectDirectory()
@@ -238,11 +237,9 @@ const Home = () => {
   }
   useMenuListener(cb)
 
-  // Cancel all KCL executions while on the home page
   useEffect(() => {
     markOnce('code/didLoadHome')
-    kclManager.cancelAllExecutions()
-  }, [kclManager])
+  }, [])
 
   useHotkeys('backspace', (e) => {
     e.preventDefault()
@@ -282,7 +279,6 @@ const Home = () => {
                     acceptOnboarding({
                       onboardingStatus,
                       navigate,
-                      kclManager,
                       systemIOActor,
                       settingsActor,
                       executingPath,

--- a/src/routes/Onboarding/utils.tsx
+++ b/src/routes/Onboarding/utils.tsx
@@ -13,7 +13,6 @@ import { CustomIcon, type CustomIconName } from '@src/components/CustomIcon'
 import { Logo } from '@src/components/Logo'
 import Tooltip from '@src/components/Tooltip'
 import { useAbsoluteFilePath } from '@src/hooks/useAbsoluteFilePath'
-import type { KclManager } from '@src/lang/KclManager'
 import { useApp } from '@src/lib/boot'
 import {
   ONBOARDING_DATA_ATTRIBUTE,
@@ -321,7 +320,6 @@ export function OnboardingButtons({
 
 export interface OnboardingUtilDeps {
   onboardingStatus: OnboardingStatus
-  kclManager: KclManager
   systemIOActor: SystemIOActor
   settingsActor: SettingsActorType
   navigate: NavigateFunction


### PR DESCRIPTION
Superseded by #12082. The project-session route-loading changes from this branch have been folded into `codex/route-loader-minimal-setters`, so the active stack no longer needs this separate PR layer.