### PR TITLE
Support projects without executing files

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -9,7 +9,7 @@ import ModelingPageProvider from '@src/components/ModelingPageProvider'
 import { OpenedProject } from '@src/components/OpenedProject'
 import { NetworkContext } from '@src/hooks/useNetworkContext'
 import { useNetworkStatus } from '@src/hooks/useNetworkStatus'
-import { useApp } from '@src/lib/boot'
+import { useApp, useOptionalExecutingEditor } from '@src/lib/boot'
 import { isDesktop } from '@src/lib/isDesktop'
 import { TestLayout } from '@src/lib/layout/TestLayout'
 import makeUrlPathRelative from '@src/lib/makeUrlPathRelative'
@@ -60,23 +60,7 @@ export const Router = () => {
               id: PATHS.FILE,
               path: PATHS.FILE + '/:id',
               errorElement: <ErrorPage />,
-              element: (
-                <ModelingPageProvider>
-                  <Suspense
-                    fallback={
-                      <div className="absolute inset-0 grid place-content-center">
-                        <Loading>Loading Design Studio...</Loading>
-                      </div>
-                    }
-                  >
-                    <ModelingMachineProvider>
-                      <Outlet />
-                      <OpenedProject />
-                      <CommandBar />
-                    </ModelingMachineProvider>
-                  </Suspense>
-                </ModelingPageProvider>
-              ),
+              element: <ProjectRouteElement />,
               children: [
                 {
                   id: PATHS.FILE + 'SETTINGS',
@@ -170,5 +154,46 @@ export const Router = () => {
       <MachineApiController />
       <RouterProvider router={router} />
     </NetworkContext.Provider>
+  )
+}
+
+function ProjectRouteElement() {
+  useSignals()
+  const app = useApp()
+  const executingEditor = useOptionalExecutingEditor()
+  const pendingExecutingEditorHandle =
+    app.projectSession.executingEditorHandle.value
+  const isLoadingExecutingEditor =
+    !executingEditor && Boolean(pendingExecutingEditorHandle)
+  const content = (
+    <Suspense
+      fallback={
+        <div className="absolute inset-0 grid place-content-center">
+          <Loading>Loading Design Studio...</Loading>
+        </div>
+      }
+    >
+      {isLoadingExecutingEditor ? (
+        <div className="absolute inset-0 grid place-content-center">
+          <Loading>Loading executing file...</Loading>
+        </div>
+      ) : (
+        <>
+          <Outlet />
+          <OpenedProject />
+          <CommandBar />
+        </>
+      )}
+    </Suspense>
+  )
+
+  if (!executingEditor) {
+    return content
+  }
+
+  return (
+    <ModelingPageProvider>
+      <ModelingMachineProvider>{content}</ModelingMachineProvider>
+    </ModelingPageProvider>
   )
 }

--- a/src/components/ConnectionStream.tsx
+++ b/src/components/ConnectionStream.tsx
@@ -1,6 +1,7 @@
 import { useAppState } from '@src/AppState'
 import { ClientSideScene } from '@src/clientSideScene/ClientSideSceneComp'
 import Loading from '@src/components/Loading'
+import { NoExecutingFileEmptyState } from '@src/components/NoExecutingFileEmptyState'
 import { ViewControlContextMenu } from '@src/components/ViewControlMenu'
 import { useOnOfflineToExitSketchMode } from '@src/hooks/network/useOnOfflineToExitSketchMode'
 import { useOnPageExit } from '@src/hooks/network/useOnPageExit'
@@ -15,13 +16,14 @@ import { useTryConnect } from '@src/hooks/network/useTryConnect'
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import { useNetworkContext } from '@src/hooks/useNetworkContext'
 import { NetworkHealthState } from '@src/hooks/useNetworkStatus'
+import type { KclManager } from '@src/lang/KclManager'
 import { findOperationForArtifact } from '@src/lang/queryAst'
 import {
   getArtifactOfTypes,
   getSketchBlockForArtifact,
 } from '@src/lang/std/artifactGraph'
 import { getAllOperations } from '@src/lang/wasm'
-import { useApp, useExecutingEditor } from '@src/lib/boot'
+import { useApp, useOptionalExecutingEditor } from '@src/lib/boot'
 import { btnName } from '@src/lib/cameraControls'
 import { EngineDebugger } from '@src/lib/debugger'
 import { prepareEditCommand } from '@src/lib/featureTree'
@@ -41,9 +43,32 @@ export const ConnectionStream = (props: {
   authToken: string | undefined
   sketchSolveStreamDimming?: number
 }) => {
+  const kclManager = useOptionalExecutingEditor()
+  if (!kclManager) {
+    return (
+      <div
+        className="absolute inset-[-4px] z-0"
+        id="stream"
+        data-testid="stream"
+      >
+        <NoExecutingFileEmptyState />
+      </div>
+    )
+  }
+
+  return (
+    <ConnectionStreamWithExecutingFile {...props} kclManager={kclManager} />
+  )
+}
+
+const ConnectionStreamWithExecutingFile = (props: {
+  authToken: string | undefined
+  sketchSolveStreamDimming?: number
+  kclManager: KclManager
+}) => {
   const { settings, project, wasmPromise, commands } = useApp()
   const wasmInstance = use(wasmPromise)
-  const kclManager = useExecutingEditor()
+  const { kclManager } = props
   const engineCommandManager = kclManager.engineCommandManager
   const sceneInfra = kclManager.sceneInfra
   const [showManualConnect, setShowManualConnect] = useState(false)

--- a/src/components/Explorer/ProjectExplorer.spec.tsx
+++ b/src/components/Explorer/ProjectExplorer.spec.tsx
@@ -248,6 +248,29 @@ describe('ProjectExplorer', () => {
     expect(container.childNodes.length).toBe(1)
     expect(file.innerText).toBe('main.kcl')
   })
+  it('should render project files without an executing file', () => {
+    project.children = [oneFile]
+    render(
+      <ProjectExplorer
+        wasmInstance={wasmInstance}
+        project={project}
+        file={undefined}
+        executingFilePath={undefined}
+        createFilePressed={-1}
+        createFolderPressed={-1}
+        refreshExplorerPressed={-1}
+        collapsePressed={-1}
+        onRowClicked={(row: FileExplorerEntry, index: number) => {}}
+        onRowEnter={(row: FileExplorerEntry, index: number) => {}}
+        readOnly={false}
+        canNavigate={true}
+      />
+    )
+    const container = screen.getByTestId('file-explorer')
+    const file = screen.getByTestId('file-tree-item')
+    expect(container.childNodes.length).toBe(1)
+    expect(file.innerText).toBe('main.kcl')
+  })
   it('should render two files A-Z', () => {
     project.children = [createFile('main.kcl'), createFile('dog.kcl')]
     render(

--- a/src/components/Explorer/ProjectExplorer.tsx
+++ b/src/components/Explorer/ProjectExplorer.tsx
@@ -81,6 +81,18 @@ const handleExternalDragEvent = (e: React.DragEvent): boolean => {
   return true
 }
 
+const ExecutingFileStatus = () => {
+  return (
+    <span
+      aria-label="Executing file"
+      title="Executing file"
+      className="text-primary"
+    >
+      ●
+    </span>
+  )
+}
+
 const getDropTargetPath = (
   target: FileExplorerEntry | null,
   projectPath: string
@@ -168,6 +180,7 @@ export const ProjectExplorer = ({
   wasmInstance,
   project,
   file,
+  executingFilePath,
   createFilePressed,
   createFolderPressed,
   refreshExplorerPressed,
@@ -182,6 +195,7 @@ export const ProjectExplorer = ({
   wasmInstance: ModuleType
   project: Project
   file: FileEntry | undefined
+  executingFilePath?: string
   createFilePressed: number
   createFolderPressed: number
   refreshExplorerPressed: number
@@ -1001,13 +1015,23 @@ export const ProjectExplorer = ({
         )
         const hasRuntimeError =
           runtimeErrors.has(child.path) || anyParentFolderHasError
+        const isExecutingFile = child.path === executingFilePath
+        const status =
+          hasRuntimeError || isExecutingFile ? (
+            <span className="flex items-center gap-1">
+              {hasRuntimeError ? StatusDot() : null}
+              {isExecutingFile ? <ExecutingFileStatus /> : null}
+            </span>
+          ) : (
+            <></>
+          )
 
         const row: FileExplorerRow = {
           // copy over all the other data that was built up to the DOM render row
           ...child,
           icon: icon,
           isFolder: !isFile,
-          status: hasRuntimeError ? StatusDot() : <></>,
+          status,
           isOpen,
           render: render,
           onClick: (domIndex: number) => {

--- a/src/components/Explorer/ProjectExplorer.tsx
+++ b/src/components/Explorer/ProjectExplorer.tsx
@@ -1078,7 +1078,7 @@ export const ProjectExplorer = ({
                       requestedProjectName: project.name,
                     },
                   })
-                  kclManager?.addGlobalHistoryEvent(
+                  kclManager?.addProjectHistoryEvent(
                     fsArchiveFile({
                       src,
                       target,
@@ -1106,7 +1106,7 @@ export const ProjectExplorer = ({
                       successMessage: 'Archived successfully',
                     },
                   })
-                  kclManager?.addGlobalHistoryEvent(
+                  kclManager?.addProjectHistoryEvent(
                     fsArchiveFile({
                       src,
                       target,
@@ -1184,7 +1184,7 @@ export const ProjectExplorer = ({
                     target,
                   },
                 })
-                kclManager?.addGlobalHistoryEvent(
+                kclManager?.addProjectHistoryEvent(
                   fsMoveFile({
                     src,
                     target,

--- a/src/components/LspProvider.tsx
+++ b/src/components/LspProvider.tsx
@@ -46,8 +46,8 @@ export function projectBasename(filePath: string, projectPath: string): string {
   return trimmedStr
 }
 
-function getDocumentUri(currentFilePath: string) {
-  return `file:///${currentFilePath}`
+function fileUri(filePath: string, projectPath: string | null): string {
+  return `file:///${projectBasename(filePath, projectPath || '')}`
 }
 
 type LspContext = {
@@ -143,7 +143,10 @@ export const LspProvider = ({ children }: { children: React.ReactNode }) => {
 
     return {
       currentFilePath,
-      documentUri: getDocumentUri(currentFilePath),
+      documentUri: fileUri(
+        activePath || PROJECT_ENTRYPOINT,
+        activeProjectPath || null
+      ),
       text: activeCode ?? kclManager.code,
     }
   }, [activeCode, activePath, activeProjectPath, kclManager])
@@ -159,7 +162,7 @@ export const LspProvider = ({ children }: { children: React.ReactNode }) => {
       // Set up the lsp plugin.
       const lsp = kcl({
         documentUri:
-          activeDocument?.documentUri ?? getDocumentUri(PROJECT_ENTRYPOINT),
+          activeDocument?.documentUri ?? fileUri(PROJECT_ENTRYPOINT, null),
         workspaceFolders: getWorkspaceFolders(),
         client: kclLspClient,
         processLspNotification: (
@@ -254,7 +257,7 @@ export const LspProvider = ({ children }: { children: React.ReactNode }) => {
       const lsp = copilotPlugin(
         {
           documentUri:
-            activeDocument?.documentUri ?? getDocumentUri(PROJECT_ENTRYPOINT),
+            activeDocument?.documentUri ?? fileUri(PROJECT_ENTRYPOINT, null),
           workspaceFolders: getWorkspaceFolders(),
           client: copilotLspClient,
           allowHTMLContent: true,
@@ -296,7 +299,7 @@ export const LspProvider = ({ children }: { children: React.ReactNode }) => {
     lspClients.forEach((lspClient) => {
       lspClient.textDocumentDidClose({
         textDocument: {
-          uri: `file:///${currentFilePath}`,
+          uri: fileUri(currentFilePath, null),
         },
       })
     })
@@ -330,7 +333,7 @@ export const LspProvider = ({ children }: { children: React.ReactNode }) => {
       lspClients.forEach((lspClient) => {
         lspClient.textDocumentDidOpen({
           textDocument: {
-            uri: getDocumentUri(filename),
+            uri: fileUri(file?.path || PROJECT_ENTRYPOINT, project?.path || ''),
             languageId: 'kcl',
             version: 1,
             text,
@@ -352,7 +355,7 @@ export const LspProvider = ({ children }: { children: React.ReactNode }) => {
     lspClients.forEach((lspClient) => {
       lspClient.textDocumentDidOpen({
         textDocument: {
-          uri: getDocumentUri(currentFilePath),
+          uri: fileUri(filePath || PROJECT_ENTRYPOINT, projectPath),
           languageId: 'kcl',
           version: 1,
           text,
@@ -369,7 +372,7 @@ export const LspProvider = ({ children }: { children: React.ReactNode }) => {
     lspClients.forEach((lspClient) => {
       lspClient.textDocumentDidClose({
         textDocument: {
-          uri: `file:///${currentFilePath}`,
+          uri: fileUri(currentFilePath, null),
         },
       })
     })

--- a/src/components/LspProvider.tsx
+++ b/src/components/LspProvider.tsx
@@ -303,7 +303,7 @@ export const LspProvider = ({ children }: { children: React.ReactNode }) => {
         },
       })
     })
-    kclManager?.clearGlobalHistory()
+    kclManager?.clearProjectHistory()
 
     if (redirect) {
       void navigate(PATHS.HOME)

--- a/src/components/ModelingMachineProvider.tsx
+++ b/src/components/ModelingMachineProvider.tsx
@@ -6,7 +6,14 @@ import useModelingMachineCommands from '@src/hooks/useStateMachineCommands'
 import { reportRejection } from '@src/lib/trap'
 import { useMachine } from '@xstate/react'
 import type React from 'react'
-import { createContext, use, useEffect, useMemo, useRef } from 'react'
+import {
+  createContext,
+  use,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from 'react'
 import type { MutableRefObject } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 import type { Actor, ContextFrom, Prop, StateFrom } from 'xstate'
@@ -263,15 +270,19 @@ export const ModelingMachineProvider = ({
   }, [modelingActor])
 
   // Give the state back to the kclManager.
-  useEffect(() => {
+  useLayoutEffect(() => {
+    commands.actor.send({ type: 'Set kclManager', data: kclManager })
+  }, [commands.actor, kclManager])
+
+  useLayoutEffect(() => {
     kclManager.modelingSend = modelingSend
   }, [modelingSend, kclManager])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     kclManager.modelingState = modelingState
   }, [modelingState, kclManager])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     kclManager.selectionRanges = modelingState.context.selectionRanges
   }, [modelingState.context.selectionRanges, kclManager])
 

--- a/src/components/ModelingPageProvider.tsx
+++ b/src/components/ModelingPageProvider.tsx
@@ -1,7 +1,7 @@
 import { EditorSelection } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
 import React, { use, useEffect, useMemo } from 'react'
-import { useLocation, useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 
 import { useSignals } from '@preact/signals-react/runtime'
 import { useAbsoluteFilePath } from '@src/hooks/useAbsoluteFilePath'
@@ -63,7 +63,6 @@ export const ModelingPageProvider = ({
   const kclManager = useExecutingEditor()
   const wasmInstance = use(kclManager.wasmInstancePromise)
   const navigate = useNavigate()
-  const location = useLocation()
   const token = auth.useToken()
   const settingsValues = settings.useSettings()
   const settingsActor = settings.actor

--- a/src/components/ModelingPageProvider.tsx
+++ b/src/components/ModelingPageProvider.tsx
@@ -13,12 +13,10 @@ import {
 import { sourceRangeToUtf16 } from '@src/lang/errors'
 import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { createNamedViewsCommand } from '@src/lib/commandBarConfigs/namedViewsConfig'
-import { createRouteCommands } from '@src/lib/commandBarConfigs/routeCommandConfig'
 import { createStandardViewsCommands } from '@src/lib/commandBarConfigs/standardViewsConfig'
 import { DEFAULT_DEFAULT_LENGTH_UNIT } from '@src/lib/constants'
 import fsZds from '@src/lib/fs-zds'
 import { kclCommands } from '@src/lib/kclCommands'
-import { PATHS } from '@src/lib/paths'
 import { markOnce } from '@src/lib/performance'
 import { isArray } from '@src/lib/utils'
 import { modelingMenuCallbackMostActions } from '@src/menu/register'
@@ -159,43 +157,6 @@ export const ModelingPageProvider = ({
     kclManager.code,
     kclManager.pendingFeatureTreeSourceSelection,
   ])
-
-  // Due to the route provider, i've moved this to the ModelingPageProvider instead of CommandBarProvider
-  // This will register the commands to route to Telemetry, Home, and Settings.
-  useEffect(() => {
-    if (file?.path === undefined) {
-      return
-    }
-
-    const filePath = PATHS.FILE + '/' + encodeURIComponent(file?.path)
-
-    const { RouteTelemetryCommand, RouteHomeCommand, RouteSettingsCommand } =
-      createRouteCommands(navigate, location, filePath)
-    commands.send({
-      type: 'Add commands',
-      data: {
-        commands: [
-          RouteTelemetryCommand,
-          RouteSettingsCommand,
-          RouteHomeCommand,
-        ],
-      },
-    })
-    return () => {
-      commands.send({
-        type: 'Remove commands',
-        data: {
-          commands: [
-            RouteTelemetryCommand,
-            RouteHomeCommand,
-            RouteSettingsCommand,
-          ],
-        },
-      })
-    }
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
-  }, [location])
 
   const cb = modelingMenuCallbackMostActions({
     authActor: auth.actor,

--- a/src/components/NoExecutingFileEmptyState.spec.tsx
+++ b/src/components/NoExecutingFileEmptyState.spec.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { NoExecutingFileEmptyState } from '@src/components/NoExecutingFileEmptyState'
+
+describe('NoExecutingFileEmptyState', () => {
+  it('shows a set executing file action', () => {
+    render(<NoExecutingFileEmptyState />)
+
+    expect(screen.getByText('No executing file')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Set executing file' })
+    ).toBeInTheDocument()
+  })
+})

--- a/src/components/NoExecutingFileEmptyState.tsx
+++ b/src/components/NoExecutingFileEmptyState.tsx
@@ -1,0 +1,47 @@
+import { ActionButton } from '@src/components/ActionButton'
+import { CustomIcon } from '@src/components/CustomIcon'
+import { useApp } from '@src/lib/boot'
+
+type NoExecutingFileEmptyStateProps = {
+  className?: string
+}
+
+export function NoExecutingFileEmptyState({
+  className = '',
+}: NoExecutingFileEmptyStateProps) {
+  const { commands } = useApp()
+
+  return (
+    <div
+      className={`flex h-full w-full flex-col items-center justify-center gap-3 p-4 text-center ${className}`}
+    >
+      <CustomIcon
+        name="file"
+        className="h-6 w-6 text-chalkboard-70 dark:text-chalkboard-40"
+      />
+      <div className="space-y-1">
+        <h2 className="text-sm font-medium text-chalkboard-100 dark:text-chalkboard-10">
+          No executing file
+        </h2>
+        <p className="max-w-72 text-xs text-chalkboard-70 dark:text-chalkboard-40">
+          Select a KCL file to edit and run.
+        </p>
+      </div>
+      <ActionButton
+        Element="button"
+        className="h-7"
+        onClick={() => {
+          commands.send({
+            type: 'Find and select command',
+            data: {
+              name: 'set-executing-file',
+              groupId: 'projects',
+            },
+          })
+        }}
+      >
+        Set executing file
+      </ActionButton>
+    </div>
+  )
+}

--- a/src/components/OpenedProject.tsx
+++ b/src/components/OpenedProject.tsx
@@ -182,9 +182,9 @@ function OpenedProjectWithoutExecutingFile() {
     ['file']
   )
   const authToken = auth.useToken()
+  const onboardingStatusSetting = settingsValues.app.onboardingStatus
   const onboardingStatus =
-    settingsValues.app.onboardingStatus.current ||
-    settingsValues.app.onboardingStatus.default
+    onboardingStatusSetting.current || onboardingStatusSetting.default
 
   useApplyRememberedOnboardingWorkflow(location.pathname, onboardingStatus)
 
@@ -220,7 +220,7 @@ function OpenedProjectWithoutExecutingFile() {
       toast.success(
         () =>
           TutorialRequestToast({
-            onboardingStatus: settingsValues.app.onboardingStatus.current,
+            onboardingStatus: onboardingStatusSetting.current,
             navigate,
             accountUrl: withSiteBaseURL('/account'),
             systemIOActor,
@@ -235,8 +235,7 @@ function OpenedProjectWithoutExecutingFile() {
       )
     }
   }, [
-    settingsValues.app.onboardingStatus.current,
-    settingsValues.app.theme.current,
+    onboardingStatusSetting,
     href,
     navigate,
     searchParams.size,

--- a/src/components/OpenedProject.tsx
+++ b/src/components/OpenedProject.tsx
@@ -14,16 +14,20 @@ import { UndoRedoButtons } from '@src/components/UndoRedoButtons'
 import { WasmErrToast } from '@src/components/WasmErrToast'
 import { ZookeeperCreditsMenu } from '@src/components/ZookeeperCreditsMenu'
 import { getMlEphantProjectReloadBehavior } from '@src/components/openedProjectUtils'
+import { useAbsoluteFilePath } from '@src/hooks/useAbsoluteFilePath'
 import { useEngineConnectionSubscriptions } from '@src/hooks/useEngineConnectionSubscriptions'
+import { useExecutingFileCommands } from '@src/hooks/useExecutingFileCommands'
 import { useHotKeyListener } from '@src/hooks/useHotKeyListener'
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import { useProjectStatus } from '@src/hooks/useProjectStatus'
 import { useQueryParamEffects } from '@src/hooks/useQueryParamEffects'
+import type { KclManager } from '@src/lang/KclManager'
 import {
   autoUpdateDownloadProgressSignal,
   autoUpdateReadySignal,
 } from '@src/lib/autoUpdate'
-import { useApp, useExecutingEditor } from '@src/lib/boot'
+import { useApp, useOptionalExecutingEditor } from '@src/lib/boot'
+import { createRouteCommands } from '@src/lib/commandBarConfigs/routeCommandConfig'
 import {
   CHANGES_REQUESTED_TOAST_ID,
   ONBOARDING_TOAST_ID,
@@ -75,10 +79,256 @@ if (window.electron) {
 }
 
 export function OpenedProject() {
+  const kclManager = useOptionalExecutingEditor()
+  useExecutingFileCommands()
+  useProjectRouteCommands()
+
+  if (!kclManager) {
+    return <OpenedProjectWithoutExecutingFile />
+  }
+
+  return <OpenedProjectWithExecutingFile kclManager={kclManager} />
+}
+
+function useProjectRouteCommands() {
+  const { commands } = useApp()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const filePath = useAbsoluteFilePath()
+
+  useEffect(() => {
+    if (!filePath) {
+      return
+    }
+
+    const { RouteTelemetryCommand, RouteHomeCommand, RouteSettingsCommand } =
+      createRouteCommands(navigate, location, filePath)
+
+    const routeCommands = [
+      RouteTelemetryCommand,
+      RouteHomeCommand,
+      RouteSettingsCommand,
+    ]
+    commands.send({
+      type: 'Add commands',
+      data: {
+        commands: routeCommands,
+      },
+    })
+
+    return () => {
+      commands.send({
+        type: 'Remove commands',
+        data: {
+          commands: routeCommands,
+        },
+      })
+    }
+  }, [commands, filePath, location, navigate])
+}
+
+function OpenedProjectWithoutExecutingFile() {
   useSignals()
   const { auth, billing, settings, layout, project, systemIOActor, registry } =
     useApp()
-  const kclManager = useExecutingEditor()
+  const defaultAreaLibrary = useDefaultAreaLibrary()
+  const defaultActionLibrary = useDefaultActionLibrary()
+  const settingsActor = settings.actor
+  const [nativeFileMenuCreated, setNativeFileMenuCreated] = useState(false)
+  const location = useLocation()
+  const navigate = useNavigate()
+  const autoUpdateDownloadProgress = autoUpdateDownloadProgressSignal.value
+  const autoUpdateReady = autoUpdateReadySignal.value
+  const lastOperation = useLastOperation()
+  const projects = useFolders()
+  const { onProjectOpen } = useLspContext()
+  const networkHealthStatus = useNetworkHealthStatus()
+  const networkMachineStatus = useNetworkMachineStatus()
+  const [searchParams] = useSearchParams()
+  const projectName = project?.name || null
+  const projectPath = project?.path || null
+
+  useEffect(() => {
+    if (
+      projects &&
+      projects.length > 0 &&
+      projects.every((p: Project) => p.name !== projectName) &&
+      [
+        SystemIOMachineStates.creatingProject,
+        SystemIOMachineStates.renamingProject,
+        SystemIOMachineStates.importFileFromURL,
+      ].includes(lastOperation) === false
+    ) {
+      void navigate(PATHS.HOME)
+    }
+
+    if (projects && projects.length === 0) {
+      void navigate(PATHS.HOME)
+    }
+  }, [projects, lastOperation, navigate, projectName])
+
+  useEffect(() => {
+    onProjectOpen({ name: projectName, path: projectPath }, null)
+  }, [onProjectOpen, projectName, projectPath])
+
+  const settingsValues = settings.useSettings()
+  const machineApiEnabled = settingsValues.app.machineApi.current
+  const registryGlobalStatusBarItems = filterStatusBarItemsForScopes(
+    registry.signal(statusBarGlobalItemsValueSpec).value,
+    ['file']
+  )
+  const registryLocalStatusBarItems = filterStatusBarItemsForScopes(
+    registry.signal(statusBarLocalItemsValueSpec).value,
+    ['file']
+  )
+  const authToken = auth.useToken()
+  const onboardingStatus =
+    settingsValues.app.onboardingStatus.current ||
+    settingsValues.app.onboardingStatus.default
+
+  useApplyRememberedOnboardingWorkflow(location.pathname, onboardingStatus)
+
+  useHotkeys('backspace', (e) => {
+    e.preventDefault()
+  })
+
+  useEffect(() => {
+    if (window.electron) {
+      window.electron
+        .createModelingPageMenu()
+        .then(() => {
+          setNativeFileMenuCreated(true)
+        })
+        .catch(reportRejection)
+    }
+  }, [])
+
+  useEffect(() => {
+    billing.send({ type: BillingTransition.Update, apiToken: authToken })
+  }, [authToken, billing])
+
+  const href = 'href' in location ? location.href : ''
+
+  useEffect(() => {
+    const needsOnboarded =
+      !window.electron &&
+      authToken &&
+      searchParams.size === 0 &&
+      needsToOnboard(location, onboardingStatus)
+
+    if (needsOnboarded) {
+      toast.success(
+        () =>
+          TutorialRequestToast({
+            onboardingStatus: settingsValues.app.onboardingStatus.current,
+            navigate,
+            accountUrl: withSiteBaseURL('/account'),
+            systemIOActor,
+            settingsActor,
+          }),
+        {
+          id: ONBOARDING_TOAST_ID,
+          duration: Number.POSITIVE_INFINITY,
+          icon: null,
+          style: { maxInlineSize: 'min(900px, 100%)' },
+        }
+      )
+    }
+  }, [
+    settingsValues.app.onboardingStatus.current,
+    settingsValues.app.theme.current,
+    href,
+    navigate,
+    searchParams.size,
+    authToken,
+    systemIOActor,
+    settingsActor,
+    location,
+    onboardingStatus,
+  ])
+
+  const zookeeperLocalStatusBarItems: StatusBarItemType[] = useMemo(
+    () =>
+      getOpenPanes({ rootLayout: layout.signal.value }).includes(
+        DefaultLayoutPaneID.TTC
+      )
+        ? [
+            {
+              id: 'zookeeper-credits',
+              component: ZookeeperCreditsMenu,
+            },
+          ]
+        : [],
+    [layout.signal.value]
+  )
+
+  const notifications: boolean[] = Object.values(defaultAreaLibrary).map(
+    (x) => {
+      if ('useNotifications' in x) {
+        const obj = x.useNotifications?.()
+        return obj !== undefined && Boolean(obj.value)
+      }
+      return false
+    }
+  )
+
+  return (
+    <div className="h-screen flex flex-col overflow-hidden select-none">
+      <div className="relative flex flex-1 flex-col">
+        <div className="relative flex items-center flex-col">
+          <AppHeader
+            className="transition-opacity transition-duration-75"
+            project={project?.projectIORefSignal.value}
+            file={undefined}
+            enableMenu={true}
+            nativeFileMenuCreated={nativeFileMenuCreated}
+          />
+        </div>
+        <ModalContainer />
+        <section className="pointer-events-auto flex-1">
+          <LayoutRootNode
+            layout={layout.signal.value || defaultLayout}
+            getLayout={layout.get}
+            setLayout={layout.set}
+            areaLibrary={defaultAreaLibrary}
+            actionLibrary={defaultActionLibrary}
+            showDebugPanel={settingsValues.debug.showPanel.current}
+            notifications={notifications}
+            artifactGraph={new Map()}
+          />
+        </section>
+        <StatusBar
+          globalItems={[
+            networkHealthStatus,
+            ...(isDesktop() && machineApiEnabled ? [networkMachineStatus] : []),
+            ...defaultGlobalStatusBarItems({
+              autoUpdateDownloadProgress,
+              autoUpdateReady,
+              onRestartToUpdate: () => {
+                window.electron?.appRestart()
+              },
+            }),
+            ...registryGlobalStatusBarItems,
+          ]}
+          localItems={[
+            ...registryLocalStatusBarItems,
+            ...zookeeperLocalStatusBarItems,
+            ...defaultLocalStatusBarItems,
+          ]}
+        />
+      </div>
+    </div>
+  )
+}
+
+function OpenedProjectWithExecutingFile({
+  kclManager,
+}: {
+  kclManager: KclManager
+}) {
+  useSignals()
+  const { auth, billing, settings, layout, project, systemIOActor, registry } =
+    useApp()
   const settingsActor = settings.actor
   const defaultAreaLibrary = useDefaultAreaLibrary()
   const defaultActionLibrary = useDefaultActionLibrary()
@@ -100,6 +350,8 @@ export function OpenedProject() {
 
   const projectName = project?.name || null
   const projectPath = project?.path || null
+  const executingPath = project?.executingPath ?? null
+  const executingFile = executingPath ? project?.executingFileEntry.value : null
 
   const systemIOState = useSelector(systemIOActor, (actor) => actor.value)
 
@@ -174,9 +426,9 @@ export function OpenedProject() {
   useEffect(() => {
     onProjectOpen(
       { name: projectName, path: projectPath },
-      project?.executingPath ? project.executingFileEntry.value : null
+      executingFile ?? null
     )
-  }, [onProjectOpen, projectName, projectPath, project])
+  }, [onProjectOpen, projectName, projectPath, executingPath, executingFile])
 
   useHotKeyListener(kclManager)
 

--- a/src/components/ProjectSidebarMenu.spec.tsx
+++ b/src/components/ProjectSidebarMenu.spec.tsx
@@ -1,5 +1,5 @@
 import { Popover } from '@headlessui/react'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { BrowserRouter } from 'react-router-dom'
 import { afterEach, beforeAll, describe, expect, test, vi } from 'vitest'
@@ -105,6 +105,31 @@ describe('ProjectSidebarMenu tests', () => {
     expect(screen.getByTestId('app-header-file-name')).toHaveTextContent(
       'parts / generated / nested-part.kcl'
     )
+  })
+
+  test('Shows no executing file breadcrumb and menu options without a file', () => {
+    render(
+      <BrowserRouter>
+        <ProjectSidebarMenu
+          app={window.app}
+          enableMenu
+          project={projectWellFormed}
+        />
+      </BrowserRouter>
+    )
+
+    expect(screen.getByTestId('app-header-file-name')).toHaveTextContent(
+      'No executing file'
+    )
+
+    fireEvent.click(screen.getByTestId('project-sidebar-toggle'))
+
+    expect(
+      screen.getByRole('button', { name: 'Set executing file' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Clear executing file' })
+    ).toBeDisabled()
   })
 
   test('Shows the full breadcrumb tooltip when the path is truncated', async () => {

--- a/src/components/ProjectSidebarMenu.tsx
+++ b/src/components/ProjectSidebarMenu.tsx
@@ -9,8 +9,13 @@ import { ActionButton } from '@src/components/ActionButton'
 import { CustomIcon } from '@src/components/CustomIcon'
 import { Logo } from '@src/components/Logo'
 import Tooltip from '@src/components/Tooltip'
+import {
+  findClearExecutingFileCommand,
+  findSetExecutingFileCommand,
+} from '@src/hooks/useExecutingFileCommands'
 import usePlatform from '@src/hooks/usePlatform'
 import type { App } from '@src/lib/app'
+import { useOptionalExecutingEditor } from '@src/lib/boot'
 import { sendAddFileToProjectCommandForCurrentProject } from '@src/lib/commandBarConfigs/applicationCommandConfig'
 import { APP_NAME } from '@src/lib/constants'
 import { hotkeyDisplay } from '@src/lib/hotkeys'
@@ -170,6 +175,7 @@ function ProjectMenuPopover({
   onHomeNavigate: () => void
 }) {
   const { machineManager, commands, settings } = app
+  const kclManager = useOptionalExecutingEditor()
   const machineApiEnabled = settings.useSettings().app.machineApi.current
   const platform = usePlatform()
   const navigate = useNavigate()
@@ -183,10 +189,14 @@ function ProjectMenuPopover({
     groupId: 'application',
   }
   const makeCommandInfo = { name: 'Make', groupId: 'modeling' }
+  const getCommand = (obj: { name: string; groupId: string }) =>
+    commandList.find((c) => c.name === obj.name && c.groupId === obj.groupId)
   const findCommand = (obj: { name: string; groupId: string }) =>
-    Boolean(
-      commandList.find((c) => c.name === obj.name && c.groupId === obj.groupId)
-    )
+    Boolean(getCommand(obj))
+  const isCommandEnabled = (obj: { name: string; groupId: string }) => {
+    const command = getCommand(obj)
+    return Boolean(command && !command.disabled)
+  }
   const machineCount = machineManager.machines.length
 
   // We filter this memoized list so that no orphan "break" elements are rendered.
@@ -213,6 +223,29 @@ function ProjectMenuPopover({
                 : PATHS.HOME + PATHS.SETTINGS_PROJECT
             void navigate(targetPath)
           },
+        },
+        'break',
+        {
+          id: 'set-executing-file',
+          Element: 'button',
+          children: 'Set executing file',
+          disabled: !isCommandEnabled(findSetExecutingFileCommand),
+          onClick: () =>
+            commands.send({
+              type: 'Find and select command',
+              data: findSetExecutingFileCommand,
+            }),
+        },
+        {
+          id: 'clear-executing-file',
+          Element: 'button',
+          children: 'Clear executing file',
+          disabled: !isCommandEnabled(findClearExecutingFileCommand),
+          onClick: () =>
+            commands.send({
+              type: 'Find and select command',
+              data: findClearExecutingFileCommand,
+            }),
         },
         'break',
         {
@@ -246,12 +279,14 @@ function ProjectMenuPopover({
                   position="right"
                   wrapperClassName="!max-w-none min-w-fit"
                 >
-                  Awaiting engine connection
+                  {kclManager
+                    ? 'Awaiting engine connection'
+                    : 'Select an executing file first'}
                 </Tooltip>
               )}
             </>
           ),
-          disabled: !findCommand(exportCommandInfo),
+          disabled: !kclManager || !findCommand(exportCommandInfo),
           onClick: () =>
             commands.send({
               type: 'Find and select command',
@@ -294,12 +329,15 @@ function ProjectMenuPopover({
                   position="right"
                   wrapperClassName="!max-w-none min-w-fit"
                 >
-                  Awaiting engine connection
+                  {kclManager
+                    ? 'Awaiting engine connection'
+                    : 'Select an executing file first'}
                 </Tooltip>
               )}
             </>
           ),
-          disabled: !findCommand(makeCommandInfo) || machineCount === 0,
+          disabled:
+            !kclManager || !findCommand(makeCommandInfo) || machineCount === 0,
           onClick: () => {
             commands.send({
               type: 'Find and select command',
@@ -331,6 +369,7 @@ function ProjectMenuPopover({
       // eslint-disable-next-line @typescript-eslint/unbound-method
       commands.send,
       onHomeNavigate,
+      kclManager,
       onProjectClose,
       isDesktop,
       homeNavigationEnabled,
@@ -397,7 +436,11 @@ export function ProjectBreadcrumbButton({
   file?: FileEntry
 }) {
   // Breadcrumb for project and project-relative file path
-  const relativeFilePath = getProjectRelativeFilePath(project, file)
+  const relativeFilePath = file
+    ? getProjectRelativeFilePath(project, file)
+    : project
+      ? 'No executing file'
+      : APP_NAME
   const formattedRelativeFilePath = relativeFilePath.replaceAll('/', ' / ')
   const breadCrumb = {
     projectName: project?.name || '',

--- a/src/components/PublishButton.tsx
+++ b/src/components/PublishButton.tsx
@@ -2,6 +2,7 @@ import { Popover } from '@headlessui/react'
 import { useSignals } from '@preact/signals-react/runtime'
 import { CustomIcon } from '@src/components/CustomIcon'
 import { PublishDialog } from '@src/components/PublishDialog'
+import type { KclManager } from '@src/lang/KclManager'
 import type { App } from '@src/lib/app'
 import type { Project } from '@src/lib/project'
 import {
@@ -28,12 +29,18 @@ export const PublishButton = memo(function PublishButton({
 }: PublishButtonProps) {
   useSignals()
   const project = app.projectSignal.value?.projectIORefSignal.value
+  const kclManager = app.projectSignal.value?.executingEditor.value
+
+  if (!kclManager) {
+    return null
+  }
 
   return (
     <Popover className="relative hidden sm:flex">
       {(popover) => (
         <PublishPopoverContent
           app={app}
+          kclManager={kclManager}
           project={project}
           close={() => popover.close()}
           open={popover.open}
@@ -45,18 +52,19 @@ export const PublishButton = memo(function PublishButton({
 
 function PublishPopoverContent({
   app,
+  kclManager,
   project,
   close,
   open,
 }: {
   app: App
+  kclManager: KclManager
   project: Project | undefined
   close: () => void
   open: boolean
 }) {
   useSignals()
   const { auth } = app
-  const { kclManager } = app.singletons
   const ast = kclManager.astSignal.value
   const kclEmpty = kclManager.isAstBodyEmpty(ast)
   const hasKclErrors = kclManager.hasErrors()

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -4,6 +4,7 @@ import { CustomIcon } from '@src/components/CustomIcon'
 import { ShareDialog } from '@src/components/ShareDialog'
 import Tooltip from '@src/components/Tooltip'
 import usePlatform from '@src/hooks/usePlatform'
+import type { KclManager } from '@src/lang/KclManager'
 import type { App } from '@src/lib/app'
 import { hotkeyDisplay } from '@src/lib/hotkeys'
 import { copyFileShareLink } from '@src/lib/links'
@@ -20,12 +21,14 @@ type ShareButtonProps = {
 export const ShareButton = memo(function ShareButton({
   app,
 }: ShareButtonProps) {
+  useSignals()
   const { billing } = app
   const platform = usePlatform()
 
   const billingContext = billing.useContext()
   const billingLoading = billingContext.hasSubscription === undefined
   const shareButtonRef = useRef<HTMLButtonElement>(null)
+  const kclManager = app.projectSignal.value?.executingEditor.value
 
   const onShareClick = useCallback(() => {
     shareButtonRef.current?.click()
@@ -33,7 +36,12 @@ export const ShareButton = memo(function ShareButton({
 
   useHotkeys(shareHotkey, onShareClick, {
     scopes: ['modeling'],
+    enabled: !!kclManager,
   })
+
+  if (!kclManager) {
+    return null
+  }
 
   return (
     <Popover className="relative hidden sm:flex">
@@ -42,6 +50,7 @@ export const ShareButton = memo(function ShareButton({
           <SharePopoverContent
             billingLoading={billingLoading}
             app={app}
+            kclManager={kclManager}
             shareButtonRef={shareButtonRef}
             close={() => popover.close()}
             open={popover.open}
@@ -55,6 +64,7 @@ export const ShareButton = memo(function ShareButton({
 
 function SharePopoverContent({
   app,
+  kclManager,
   billingLoading,
   shareButtonRef,
   close,
@@ -62,6 +72,7 @@ function SharePopoverContent({
   platform,
 }: {
   app: App
+  kclManager: KclManager
   billingLoading: boolean
   shareButtonRef: RefObject<HTMLButtonElement | null>
   close: () => void
@@ -70,7 +81,6 @@ function SharePopoverContent({
 }) {
   useSignals()
   const { auth, billing } = app
-  const { kclManager } = app.singletons
   const token = auth.useToken()
   const billingContext = billing.useContext()
   const currentProject = app.projectSignal.value?.projectIORefSignal.value

--- a/src/components/SystemIOMachineLogicListener.tsx
+++ b/src/components/SystemIOMachineLogicListener.tsx
@@ -4,6 +4,7 @@ import { useApp, useOptionalExecutingEditor } from '@src/lib/boot'
 import {
   ASK_TO_OPEN_QUERY_PARAM,
   EXECUTE_AST_INTERRUPT_ERROR_MESSAGE,
+  PROJECT_ENTRYPOINT,
   PROJECT_ID_QUERY_PARAM,
 } from '@src/lib/constants'
 import fsZds from '@src/lib/fs-zds'
@@ -163,14 +164,21 @@ export function SystemIOMachineLogicListener() {
         projectDirectoryPath,
         requestedProjectName.name
       )
+      const shouldNavigateToDefaultFile =
+        lastOperation === SystemIOMachineStates.creatingProject
+      const requestedFilePath = shouldNavigateToDefaultFile
+        ? joinOSPaths(projectPathWithoutSpecificKCLFile, PROJECT_ENTRYPOINT)
+        : projectPathWithoutSpecificKCLFile
       const requestedPath = joinRouterPaths(
         PATHS.FILE,
-        safeEncodeForRouterPaths(projectPathWithoutSpecificKCLFile),
+        safeEncodeForRouterPaths(requestedFilePath),
         requestedProjectName.subRoute || ''
       )
       safestNavigateToFile({
         requestedPath,
-        requestedFilePathWithExtension: null,
+        requestedFilePathWithExtension: shouldNavigateToDefaultFile
+          ? requestedFilePath
+          : null,
         requestedProjectDirectory: projectPathWithoutSpecificKCLFile,
       })
       // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!

--- a/src/components/gizmo/AxisGizmo.tsx
+++ b/src/components/gizmo/AxisGizmo.tsx
@@ -185,7 +185,6 @@ export default function AxisGizmo() {
       isDisposed = true
       isPointerOverRef.current = false
       isHoverRefreshPausedRef.current = false
-      renderer.forceContextLoss()
       renderer.dispose()
       disposeMouseEvents()
       kclManager.sceneInfra.camControls.cameraChange.remove(animate)

--- a/src/components/gizmo/CubeGizmo.tsx
+++ b/src/components/gizmo/CubeGizmo.tsx
@@ -5,6 +5,8 @@ import { useEffect, useRef, useState } from 'react'
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import { useResolvedTheme } from '@src/hooks/useResolvedTheme'
 
+const MAX_RENDERER_CREATE_ATTEMPTS = 3
+
 export default function CubeGizmo() {
   const { settings } = useApp()
   const kclManager = useExecutingEditor()
@@ -27,15 +29,39 @@ export default function CubeGizmo() {
 
   // onMount
   useEffect(() => {
-    if (canvasRef.current) {
-      renderer.current = new GizmoRenderer(
-        canvasRef.current,
-        initialIsPerspectiveRef.current,
-        initialResolvedThemeRef.current,
-        kclManager.sceneInfra
-      )
+    let isDisposed = false
+    let raf = -1
+    let attempts = 0
+
+    const createRenderer = () => {
+      if (isDisposed || renderer.current || !canvasRef.current) {
+        return
+      }
+
+      try {
+        renderer.current = new GizmoRenderer(
+          canvasRef.current,
+          initialIsPerspectiveRef.current,
+          initialResolvedThemeRef.current,
+          kclManager.sceneInfra
+        )
+      } catch (error) {
+        attempts += 1
+        if (attempts < MAX_RENDERER_CREATE_ATTEMPTS) {
+          raf = requestAnimationFrame(createRenderer)
+          return
+        }
+        console.warn('Unable to initialize cube gizmo renderer.', error)
+      }
     }
+
+    raf = requestAnimationFrame(createRenderer)
+
     return () => {
+      isDisposed = true
+      if (raf > -1) {
+        cancelAnimationFrame(raf)
+      }
       renderer.current?.dispose()
       renderer.current = null
     }

--- a/src/components/gizmo/GizmoRenderer.ts
+++ b/src/components/gizmo/GizmoRenderer.ts
@@ -332,7 +332,6 @@ export default class GizmoRenderer {
       cancelAnimationFrame(this.raf)
     }
     this.dprDetector.dispose()
-    this.renderer.forceContextLoss()
     this.renderer.dispose()
   }
 

--- a/src/components/layout/areas/BodiesPane.tsx
+++ b/src/components/layout/areas/BodiesPane.tsx
@@ -1,6 +1,7 @@
 import type { PropsOf } from '@headlessui/react/dist/types'
 import { useSignals } from '@preact/signals-react/runtime'
 import { ContextMenuItem } from '@src/components/ContextMenu'
+import { NoExecutingFileEmptyState } from '@src/components/NoExecutingFileEmptyState'
 import { RowItemWithIconMenuAndToggle } from '@src/components/RowItemWithIconMenuAndToggle'
 import { VisibilityToggle } from '@src/components/VisibilityToggle'
 import { LayoutPanel, LayoutPanelHeader } from '@src/components/layout/Panel'
@@ -13,7 +14,11 @@ import {
   getCodeRefsByArtifactId,
 } from '@src/lang/std/artifactGraph'
 import { type ArtifactGraph, getAllOperations } from '@src/lang/wasm'
-import { useApp, useExecutingEditor } from '@src/lib/boot'
+import {
+  useApp,
+  useExecutingEditor,
+  useOptionalExecutingEditor,
+} from '@src/lib/boot'
 import { EXPERIMENTAL_POINT_AND_CLICK_FLAG } from '@src/lib/constants'
 import { sendSelectionEvent } from '@src/lib/featureTree'
 import type { AreaTypeComponentProps } from '@src/lib/layout'
@@ -32,7 +37,24 @@ type SolidArtifact = Artifact & { type: 'compositeSolid' | 'sweep' | 'pattern' }
 
 export function BodiesPane(props: AreaTypeComponentProps) {
   useSignals()
-  const kclManager = useExecutingEditor()
+  const kclManager = useOptionalExecutingEditor()
+  if (!kclManager) {
+    return (
+      <LayoutPanel
+        title={props.layout.label}
+        id={`${props.layout.id}-pane`}
+        className="border-none"
+      >
+        <LayoutPanelHeader
+          id={props.layout.id}
+          icon="model"
+          title={props.layout.label}
+        />
+        <NoExecutingFileEmptyState />
+      </LayoutPanel>
+    )
+  }
+
   const execState = kclManager.execStateSignal.value
   const artifactGraph = execState.artifactGraph
   const operations = getAllOperations(execState.operations)

--- a/src/components/layout/areas/DebugPane.tsx
+++ b/src/components/layout/areas/DebugPane.tsx
@@ -3,7 +3,9 @@ import { AstExplorer } from '@src/components/AstExplorer'
 import { DebugArtifactGraph } from '@src/components/DebugArtifactGraph'
 import { DebugSelections } from '@src/components/DebugSelections'
 import { EngineCommands } from '@src/components/EngineCommands'
+import { NoExecutingFileEmptyState } from '@src/components/NoExecutingFileEmptyState'
 import { LayoutPanel, LayoutPanelHeader } from '@src/components/layout/Panel'
+import { useOptionalExecutingEditor } from '@src/lib/boot'
 import type { AreaTypeComponentProps } from '@src/lib/layout'
 
 export function DebugPane(props: AreaTypeComponentProps) {
@@ -26,6 +28,11 @@ export function DebugPane(props: AreaTypeComponentProps) {
 }
 
 export const DebugPaneContent = () => {
+  const kclManager = useOptionalExecutingEditor()
+  if (!kclManager) {
+    return <NoExecutingFileEmptyState />
+  }
+
   return (
     <div className="relative">
       <section

--- a/src/components/layout/areas/FeatureTreePane.tsx
+++ b/src/components/layout/areas/FeatureTreePane.tsx
@@ -16,7 +16,11 @@ import {
   emptyOperationsByModule,
   getAllOperations,
 } from '@src/lang/wasm'
-import { useApp, useExecutingEditor } from '@src/lib/boot'
+import {
+  useApp,
+  useExecutingEditor,
+  useOptionalExecutingEditor,
+} from '@src/lib/boot'
 import {
   type OperationTreeNode,
   buildOperationTree,
@@ -46,6 +50,7 @@ import { Disclosure } from '@headlessui/react'
 import { useSignals } from '@preact/signals-react/runtime'
 import type { SceneEntities } from '@src/clientSideScene/sceneEntities'
 import type { SceneInfra } from '@src/clientSideScene/sceneInfra'
+import { NoExecutingFileEmptyState } from '@src/components/NoExecutingFileEmptyState'
 import { RowItemWithIconMenuAndToggle } from '@src/components/RowItemWithIconMenuAndToggle'
 import Tooltip from '@src/components/Tooltip'
 import { VisibilityToggle } from '@src/components/VisibilityToggle'
@@ -95,6 +100,8 @@ type SystemDeps = {
 const UNRENDERED_EXECUTE_HOTKEY = 'mod+s'
 
 export function FeatureTreePane(props: AreaTypeComponentProps) {
+  const kclManager = useOptionalExecutingEditor()
+
   return (
     <LayoutPanel
       title={props.layout.label}
@@ -114,7 +121,7 @@ export function FeatureTreePane(props: AreaTypeComponentProps) {
           props.onClose?.('feature-tree')
         }}
       />
-      <FeatureTreePaneContents />
+      {kclManager ? <FeatureTreePaneContents /> : <NoExecutingFileEmptyState />}
     </LayoutPanel>
   )
 }

--- a/src/components/layout/areas/KclEditorPane.spec.tsx
+++ b/src/components/layout/areas/KclEditorPane.spec.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const editorState = vi.hoisted(() => ({
+  current: undefined as { editorView: { dom: HTMLElement } } | undefined,
+  send: vi.fn(),
+}))
+
+vi.mock('@src/lib/boot', () => ({
+  useOptionalExecutingEditor: () => editorState.current,
+  useApp: () => ({
+    commands: {
+      send: editorState.send,
+    },
+  }),
+}))
+
+import { KclEditorPaneContents } from '@src/components/layout/areas/KclEditorPane'
+
+function fakeEditor(testId: string, code: string) {
+  const dom = document.createElement('div')
+  dom.dataset.testid = testId
+  dom.textContent = code
+  return { editorView: { dom } }
+}
+
+describe('KclEditorPaneContents', () => {
+  afterEach(() => {
+    editorState.current = undefined
+    editorState.send.mockClear()
+  })
+
+  it('replaces the mounted editor DOM when the executing file changes', () => {
+    const firstEditor = fakeEditor('first-editor', 'first file')
+    const secondEditor = fakeEditor('second-editor', 'second file')
+
+    editorState.current = firstEditor
+    const { rerender } = render(<KclEditorPaneContents />)
+
+    expect(screen.getByTestId('first-editor')).toHaveTextContent('first file')
+
+    editorState.current = secondEditor
+    rerender(<KclEditorPaneContents />)
+
+    expect(screen.queryByTestId('first-editor')).not.toBeInTheDocument()
+    expect(firstEditor.editorView.dom.parentElement).toBeNull()
+    expect(screen.getByTestId('second-editor')).toHaveTextContent('second file')
+  })
+})

--- a/src/components/layout/areas/KclEditorPane.tsx
+++ b/src/components/layout/areas/KclEditorPane.tsx
@@ -1,20 +1,22 @@
 import { Menu } from '@headlessui/react'
 import { CustomIcon } from '@src/components/CustomIcon'
+import { NoExecutingFileEmptyState } from '@src/components/NoExecutingFileEmptyState'
 import { LayoutPanel, LayoutPanelHeader } from '@src/components/layout/Panel'
 import { HeaderMenu } from '@src/components/layout/Panel/HeaderMenu'
 import usePlatform from '@src/hooks/usePlatform'
 import { useConvertToVariable } from '@src/hooks/useToolbarGuards'
-import { useApp, useExecutingEditor } from '@src/lib/boot'
+import type { KclManager } from '@src/lang/KclManager'
+import { useApp, useOptionalExecutingEditor } from '@src/lib/boot'
 import { hotkeyDisplay } from '@src/lib/hotkeys'
 import type { AreaTypeComponentProps } from '@src/lib/layout'
 import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
 import { reportRejection, trap } from '@src/lib/trap'
 import { withSiteBaseURL } from '@src/lib/withBaseURL'
-import { useEffect, useRef } from 'react'
+import { useLayoutEffect, useRef } from 'react'
 import toast from 'react-hot-toast'
 import styles from './KclEditorMenu.module.css'
 
-type ExecutingEditor = ReturnType<typeof useExecutingEditor>
+type ExecutingEditor = KclManager
 
 export const editorShortcutMeta = {
   formatCode: {
@@ -45,11 +47,27 @@ export const KclEditorPane = (props: AreaTypeComponentProps) => {
 }
 
 export const KclEditorPaneContents = () => {
-  const kclManager = useExecutingEditor()
+  const kclManager = useOptionalExecutingEditor()
   const editorParent = useRef<HTMLDivElement>(null)
-  useEffect(() => {
-    editorParent.current?.appendChild(kclManager.editorView.dom)
-  }, [kclManager.editorView.dom])
+  useLayoutEffect(() => {
+    const parent = editorParent.current
+    if (!kclManager || !parent) {
+      return
+    }
+
+    const editorDom = kclManager.editorView.dom
+    parent.replaceChildren(editorDom)
+
+    return () => {
+      if (editorDom.parentElement === parent) {
+        parent.removeChild(editorDom)
+      }
+    }
+  }, [kclManager])
+
+  if (!kclManager) {
+    return <NoExecutingFileEmptyState />
+  }
 
   return (
     <div className="relative">
@@ -83,9 +101,39 @@ function copyKclCodeToClipboard(kclManager: ExecutingEditor) {
 
 export const KclEditorMenu = () => {
   const { commands, settings } = useApp()
-  const kclManager = useExecutingEditor()
-  const platform = usePlatform()
+  const kclManager = useOptionalExecutingEditor()
   const settingsActor = settings.actor
+
+  if (kclManager) {
+    return (
+      <KclEditorMenuWithExecutingFile
+        kclManager={kclManager}
+        commands={commands}
+        settingsActor={settingsActor}
+      />
+    )
+  }
+
+  return (
+    <HeaderMenu>
+      <KclEditorMenuSharedItems
+        commands={commands}
+        settingsActor={settingsActor}
+      />
+    </HeaderMenu>
+  )
+}
+
+function KclEditorMenuWithExecutingFile({
+  kclManager,
+  commands,
+  settingsActor,
+}: {
+  kclManager: ExecutingEditor
+  commands: ReturnType<typeof useApp>['commands']
+  settingsActor: ReturnType<typeof useApp>['settings']['actor']
+}) {
+  const platform = usePlatform()
   const { enable: convertToVarEnabled, handleClick: handleConvertToVarClick } =
     useConvertToVariable(kclManager)
 
@@ -128,6 +176,23 @@ export const KclEditorMenu = () => {
           </button>
         </Menu.Item>
       )}
+      <KclEditorMenuSharedItems
+        commands={commands}
+        settingsActor={settingsActor}
+      />
+    </HeaderMenu>
+  )
+}
+
+function KclEditorMenuSharedItems({
+  commands,
+  settingsActor,
+}: {
+  commands: ReturnType<typeof useApp>['commands']
+  settingsActor: ReturnType<typeof useApp>['settings']['actor']
+}) {
+  return (
+    <>
       <Menu.Item>
         <a
           className={styles.button}
@@ -187,6 +252,6 @@ export const KclEditorMenu = () => {
           </small>
         </a>
       </Menu.Item>
-    </HeaderMenu>
+    </>
   )
 }

--- a/src/components/layout/areas/LoggingPanes.tsx
+++ b/src/components/layout/areas/LoggingPanes.tsx
@@ -1,8 +1,9 @@
 import ReactJsonView from '@microlink/react-json-view'
 
+import { NoExecutingFileEmptyState } from '@src/components/NoExecutingFileEmptyState'
 import { LayoutPanel, LayoutPanelHeader } from '@src/components/layout/Panel'
 import { useResolvedTheme } from '@src/hooks/useResolvedTheme'
-import { useExecutingEditor } from '@src/lib/boot'
+import { useOptionalExecutingEditor } from '@src/lib/boot'
 import type { AreaTypeComponentProps } from '@src/lib/layout'
 
 export function LogsPane(props: AreaTypeComponentProps) {
@@ -24,8 +25,11 @@ export function LogsPane(props: AreaTypeComponentProps) {
   )
 }
 export const LogsPaneContent = () => {
-  const kclManager = useExecutingEditor()
+  const kclManager = useOptionalExecutingEditor()
   const theme = useResolvedTheme()
+  if (!kclManager) {
+    return <NoExecutingFileEmptyState />
+  }
   const logs = kclManager.logsSignal.value
   return (
     <div className="overflow-hidden">

--- a/src/components/layout/areas/MemoryPane.tsx
+++ b/src/components/layout/areas/MemoryPane.tsx
@@ -6,20 +6,24 @@ import type { Path } from '@rust/kcl-lib/bindings/Path'
 
 import { ActionButton } from '@src/components/ActionButton'
 import Loading from '@src/components/Loading'
+import { NoExecutingFileEmptyState } from '@src/components/NoExecutingFileEmptyState'
 import Tooltip from '@src/components/Tooltip'
 import { LayoutPanel, LayoutPanelHeader } from '@src/components/layout/Panel'
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import { useResolvedTheme } from '@src/hooks/useResolvedTheme'
 import type { VariableMap } from '@src/lang/wasm'
 import { humanDisplayNumber, sketchFromKclValueOptional } from '@src/lang/wasm'
-import { useExecutingEditor } from '@src/lib/boot'
+import { useOptionalExecutingEditor } from '@src/lib/boot'
 import type { AreaTypeComponentProps } from '@src/lib/layout'
 import { Reason, trap } from '@src/lib/trap'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { Suspense, use } from 'react'
 
 export const MemoryPaneMenu = () => {
-  const kclManager = useExecutingEditor()
+  const kclManager = useOptionalExecutingEditor()
+  if (!kclManager) {
+    return null
+  }
   const variables = kclManager.variablesSignal.value
 
   function copyProgramMemoryToClipboard() {
@@ -73,8 +77,27 @@ export function MemoryPane(props: AreaTypeComponentProps) {
 }
 
 export const MemoryPaneContents = () => {
-  const kclManager = useExecutingEditor()
+  const kclManager = useOptionalExecutingEditor()
   const theme = useResolvedTheme()
+  if (!kclManager) {
+    return <NoExecutingFileEmptyState />
+  }
+
+  return (
+    <MemoryPaneContentsWithExecutingFile
+      kclManager={kclManager}
+      theme={theme}
+    />
+  )
+}
+
+function MemoryPaneContentsWithExecutingFile({
+  kclManager,
+  theme,
+}: {
+  kclManager: NonNullable<ReturnType<typeof useOptionalExecutingEditor>>
+  theme: ReturnType<typeof useResolvedTheme>
+}) {
   const variables = kclManager.variablesSignal.value
   const { state } = useModelingContext()
   const wasmInstance = use(kclManager.wasmInstancePromise)

--- a/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
+++ b/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
@@ -1,10 +1,12 @@
 import { Menu } from '@headlessui/react'
 import { useSignals } from '@preact/signals-react/runtime'
+import { NoExecutingFileEmptyState } from '@src/components/NoExecutingFileEmptyState'
 import { LayoutPanel, LayoutPanelHeader } from '@src/components/layout/Panel'
 import { HeaderMenu } from '@src/components/layout/Panel/HeaderMenu'
 import { MlEphantConversationPane } from '@src/components/layout/areas/MlEphantConversationPane'
 import { useModelingContext } from '@src/hooks/useModelingContext'
-import { useApp, useExecutingEditor } from '@src/lib/boot'
+import type { KclManager } from '@src/lang/KclManager'
+import { useApp, useOptionalExecutingEditor } from '@src/lib/boot'
 import { browserSaveFile } from '@src/lib/browserSaveFile'
 import type { AreaTypeComponentProps } from '@src/lib/layout'
 import { BillingTransition } from '@src/machines/billingMachine'
@@ -46,17 +48,7 @@ export function MlEphantConversationPaneWrapper(props: AreaTypeComponentProps) {
 function MlEphantConversationPaneInner(props: AreaTypeComponentProps) {
   useSignals()
   const app = useApp()
-  const { auth, billing, settings, project, systemIOActor } = app
-  const kclManager = useExecutingEditor()
-  const settingsValues = settings.useSettings()
-  const user = auth.useUser()
-  const token = auth.useToken()
-  const {
-    context: contextModeling,
-    send: sendModeling,
-    theProject,
-  } = useModelingContext()
-  const loaderFile = project?.executingFileEntry.value
+  const kclManager = useOptionalExecutingEditor()
   const mlEphantManagerActor = MlEphantManagerReactContext.useActorRef()
 
   useEffect(() => {
@@ -71,6 +63,62 @@ function MlEphantConversationPaneInner(props: AreaTypeComponentProps) {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- Only run on mount
   }, [])
+
+  if (!kclManager) {
+    return <MlEphantConversationPaneWithoutExecutingFile {...props} />
+  }
+
+  return (
+    <MlEphantConversationPaneWithExecutingFile
+      {...props}
+      kclManager={kclManager}
+      mlEphantManagerActor={mlEphantManagerActor}
+    />
+  )
+}
+
+function MlEphantConversationPaneWithoutExecutingFile(
+  props: AreaTypeComponentProps
+) {
+  return (
+    <LayoutPanel
+      title={props.layout.label}
+      id={`${props.layout.id}-pane`}
+      className="border-none"
+    >
+      <LayoutPanelHeader
+        id={props.layout.id}
+        icon="sparkles"
+        title="Zookeeper"
+        onClose={props.onClose}
+        Menu={MlEphantConversationMenu}
+      />
+      <NoExecutingFileEmptyState />
+    </LayoutPanel>
+  )
+}
+
+function MlEphantConversationPaneWithExecutingFile({
+  kclManager,
+  mlEphantManagerActor,
+  ...props
+}: AreaTypeComponentProps & {
+  kclManager: KclManager
+  mlEphantManagerActor: ReturnType<
+    typeof MlEphantManagerReactContext.useActorRef
+  >
+}) {
+  const app = useApp()
+  const { auth, billing, settings, project, systemIOActor } = app
+  const settingsValues = settings.useSettings()
+  const user = auth.useUser()
+  const token = auth.useToken()
+  const {
+    context: contextModeling,
+    send: sendModeling,
+    theProject,
+  } = useModelingContext()
+  const loaderFile = project?.executingFileEntry.value
 
   useWatchForNewFileRequestsFromMlEphant(
     mlEphantManagerActor,

--- a/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
+++ b/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
@@ -9,6 +9,8 @@ import type { KclManager } from '@src/lang/KclManager'
 import { useApp, useOptionalExecutingEditor } from '@src/lib/boot'
 import { browserSaveFile } from '@src/lib/browserSaveFile'
 import type { AreaTypeComponentProps } from '@src/lib/layout'
+import { PATHS, toProjectRelativePath } from '@src/lib/paths'
+import { reportRejection } from '@src/lib/trap'
 import { BillingTransition } from '@src/machines/billingMachine'
 import {
   MlEphantConversationToMarkdown,
@@ -20,10 +22,13 @@ import {
 } from '@src/machines/systemIO/hooks'
 import {
   SystemIOMachineEvents,
+  normalizeKCLFileDeletePath,
   prepareMlEphantNewFileRequest,
+  waitForIdleState,
 } from '@src/machines/systemIO/utils'
 import { IS_STAGING_OR_DEBUG } from '@src/routes/utils'
 import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
 // Yea, feels bad, but literally every other pane is doing this.
 // TODO: Don't use CSS module for this? More generic module?
 import styles from './KclEditorMenu.module.css'
@@ -110,6 +115,7 @@ function MlEphantConversationPaneWithExecutingFile({
 }) {
   const app = useApp()
   const { auth, billing, settings, project, systemIOActor } = app
+  const navigate = useNavigate()
   const settingsValues = settings.useSettings()
   const user = auth.useUser()
   const token = auth.useToken()
@@ -127,18 +133,45 @@ function MlEphantConversationPaneWithExecutingFile({
       const payload = prepareMlEphantNewFileRequest(requestProps)
 
       if (payload) {
-        kclManager.mlEphantManagerMachineBulkManipulatingFileSystem = true
+        const executingRelativePath =
+          project?.executingPath && project.path
+            ? normalizeKCLFileDeletePath(
+                toProjectRelativePath(project.path, project.executingPath)
+              )
+            : undefined
+        const deletesExecutingFile =
+          executingRelativePath !== undefined &&
+          payload.filesToDelete.some(
+            (file) =>
+              normalizeKCLFileDeletePath(file.requestedFileName) ===
+              executingRelativePath
+          )
+
+        kclManager.mlEphantManagerMachineBulkManipulatingFileSystem =
+          !deletesExecutingFile
         systemIOActor.send({
           type: SystemIOMachineEvents.bulkCreateAndDeleteKCLFilesAndNavigateToFile,
           data: {
             files: payload.files,
             filesToDelete: payload.filesToDelete,
             override: true,
+            navigateToFile: false,
             requestedProjectName: payload.requestedProjectName,
             requestedFileNameWithExtension:
               payload.requestedFileNameWithExtension ?? '',
           },
         })
+
+        if (!deletesExecutingFile || !project) {
+          return
+        }
+
+        waitForIdleState({ systemIOActor })
+          .then(async () => {
+            await app.projectSession.setExecutingEditorHandle(undefined)
+            void navigate(`${PATHS.FILE}/${encodeURIComponent(project.path)}`)
+          })
+          .catch(reportRejection)
       }
     }
   )

--- a/src/components/layout/areas/ProjectExplorerPane.tsx
+++ b/src/components/layout/areas/ProjectExplorerPane.tsx
@@ -6,7 +6,7 @@ import { ToastInsert } from '@src/components/ToastInsert'
 import { LayoutPanel, LayoutPanelHeader } from '@src/components/layout/Panel'
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import { relevantFileExtensions } from '@src/lang/wasmUtils'
-import { useApp, useExecutingEditor } from '@src/lib/boot'
+import { useApp, useOptionalExecutingEditor } from '@src/lib/boot'
 import { FILE_EXT, INSERT_FOREIGN_TOAST_ID } from '@src/lib/constants'
 import fsZds from '@src/lib/fs-zds'
 import {
@@ -16,9 +16,9 @@ import {
   togglePaneLayoutNode,
 } from '@src/lib/layout'
 import {
+  PATHS,
   getEXTNoPeriod,
   isExtensionARelevantExtension,
-  parentPathRelativeToProject,
 } from '@src/lib/paths'
 import type { Project } from '@src/lib/project'
 import { reportRejection } from '@src/lib/trap'
@@ -29,26 +29,36 @@ import {
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
 import { use, useCallback, useEffect, useRef, useState } from 'react'
 import toast from 'react-hot-toast'
+import { useNavigate } from 'react-router-dom'
 
 export function ProjectExplorerPane(props: AreaTypeComponentProps) {
-  const { commands, project, systemIOActor, layout } = useApp()
-  const kclManager = useExecutingEditor()
-  const wasmInstance = use(kclManager.wasmInstancePromise)
+  const {
+    commands,
+    project,
+    projectSession,
+    systemIOActor,
+    layout,
+    wasmPromise,
+  } = useApp()
+  const kclManager = useOptionalExecutingEditor()
+  const navigate = useNavigate()
+  const wasmInstance = use(wasmPromise)
   const projects = useFolders()
   const projectDirectoryPath = useProjectDirectoryPath()
   const projectRef = useRef(project?.projectIORefSignal)
   const [theProject, setTheProject] = useState<Project | null>(null)
-  const file = project?.executingFileEntry.value
-  const {
-    state: modelingMachineState,
-    send: modelingSend,
-    actor: modelingActor,
-  } = useModelingContext()
+  const file = project?.executingPath
+    ? project.executingFileEntry.value
+    : undefined
+  const modelingContext = useModelingContext()
+  const modelingMachineState = modelingContext.state
+  const modelingSend = modelingContext.send
+  const modelingActor = modelingContext.actor
 
   useEffect(() => {
     // Have no idea why the project loader data doesn't have the children from the ls on disk
     // That means it is a different object or cached incorrectly?
-    if (!project || !file || !projects) {
+    if (!project || !projects) {
       return
     }
 
@@ -72,7 +82,7 @@ export function ProjectExplorerPane(props: AreaTypeComponentProps) {
     const duplicated = structuredClone(foundProject)
     addPlaceHoldersForNewFileAndFolder(duplicated.children, foundProject.path)
     setTheProject(duplicated)
-  }, [file, projects, project, systemIOActor])
+  }, [projects, project, systemIOActor])
 
   const [createFilePressed, setCreateFilePressed] = useState<number>(0)
   const [createFolderPressed, setCreateFolderPressed] = useState<number>(0)
@@ -119,11 +129,6 @@ export function ProjectExplorerPane(props: AreaTypeComponentProps) {
 
   const onRowClicked = useCallback(
     (entry: FileExplorerEntry) => {
-      const requestedFileName = parentPathRelativeToProject(
-        entry.path,
-        projectDirectoryPath
-      )
-
       const RELEVANT_FILE_EXTENSIONS = relevantFileExtensions(wasmInstance)
       const isRelevantFile = (filename: string): boolean => {
         const extension = getEXTNoPeriod(filename)
@@ -139,22 +144,28 @@ export function ProjectExplorerPane(props: AreaTypeComponentProps) {
       // Only open the file if it is a kcl file.
       if (
         projectRef.current?.value.name &&
+        projectRef.current.value.path &&
         entry.children == null &&
         entry.path.endsWith(FILE_EXT)
       ) {
-        const name = projectRef.current.value.name.slice()
-
         const navigateHelper = () => {
-          systemIOActor.send({
-            type: SystemIOMachineEvents.navigateToFile,
-            data: {
-              requestedProjectName: name,
-              requestedFileName: requestedFileName,
-            },
-          })
+          const projectPath = projectRef.current?.value.path
+          if (!projectPath) {
+            return
+          }
+
+          projectSession
+            .setExecutingEditorHandle({
+              projectPath,
+              filePath: entry.path,
+            })
+            .then(() => {
+              void navigate(`${PATHS.FILE}/${encodeURIComponent(entry.path)}`)
+            })
+            .catch(reportRejection)
         }
 
-        if (modelingMachineState.matches('Sketch')) {
+        if (modelingMachineState?.matches('Sketch') && modelingActor) {
           modelingSend({ type: 'Cancel' })
           const waitForIdlePromise = new Promise((resolve) => {
             const subscription = modelingActor.subscribe((state) => {
@@ -171,7 +182,11 @@ export function ProjectExplorerPane(props: AreaTypeComponentProps) {
           // immediately navigate
           navigateHelper()
         }
-      } else if (isRelevantFile(entry.path) && projectRef.current?.value.path) {
+      } else if (
+        kclManager &&
+        isRelevantFile(entry.path) &&
+        projectRef.current?.value.path
+      ) {
         // Allow insert if it is a importable file
         toast.custom(
           ToastInsert({
@@ -197,11 +212,12 @@ export function ProjectExplorerPane(props: AreaTypeComponentProps) {
     },
     [
       commands,
+      kclManager,
       modelingActor,
       modelingMachineState,
       modelingSend,
-      projectDirectoryPath,
-      systemIOActor,
+      navigate,
+      projectSession,
       wasmInstance,
     ]
   )
@@ -238,12 +254,13 @@ export function ProjectExplorerPane(props: AreaTypeComponentProps) {
         }
         onClose={props.onClose}
       />
-      {theProject && file ? (
+      {theProject ? (
         <div className={'w-full h-full flex flex-col'}>
           <ProjectExplorer
             wasmInstance={wasmInstance}
             project={theProject}
             file={file}
+            executingFilePath={project?.executingPath ?? undefined}
             createFilePressed={createFilePressed}
             createFolderPressed={createFolderPressed}
             refreshExplorerPressed={refreshExplorerPressed}

--- a/src/editor/HistoryView.ts
+++ b/src/editor/HistoryView.ts
@@ -78,11 +78,24 @@ export class HistoryView {
       effects: [
         globalHistory.reconfigure([this.buildForwardingExtension(target)]),
       ],
-      annotations: [HistoryView.doNotForward.of(true)],
+      annotations: [
+        HistoryView.doNotForward.of(true),
+        Transaction.addToHistory.of(false),
+      ],
     })
     target.dispatch({
       effects: [localHistoryTarget.reconfigure(this.localHistoryExtension())],
       annotations: [Transaction.addToHistory.of(false)],
+    })
+  }
+
+  clearLocalHistoryTarget() {
+    this.editorView.dispatch({
+      effects: [globalHistory.reconfigure([])],
+      annotations: [
+        HistoryView.doNotForward.of(true),
+        Transaction.addToHistory.of(false),
+      ],
     })
   }
 

--- a/src/editor/plugins/fs/index.ts
+++ b/src/editor/plugins/fs/index.ts
@@ -82,8 +82,8 @@ export function buildFSHistoryExtension(
   })
 
   // Note that the FS history extension is not on the EditorView for the code editor itself,
-  // but rather the globalHistoryView.
-  kclManager.globalHistoryView.dispatch(
+  // but rather the project history view.
+  kclManager.projectHistory.dispatch(
     {
       effects: [fsEffectCompartment.reconfigure(fsWiredListener)],
     },
@@ -92,7 +92,7 @@ export function buildFSHistoryExtension(
   )
   // Teardown
   return () => {
-    kclManager.globalHistoryView.dispatch(
+    kclManager.projectHistory.dispatch(
       {
         effects: [fsEffectCompartment.reconfigure([])],
       },

--- a/src/hooks/useAbsoluteFilePath.ts
+++ b/src/hooks/useAbsoluteFilePath.ts
@@ -5,11 +5,12 @@ export function useAbsoluteFilePath() {
   const app = useApp()
 
   const executingPath = app.project?.executingPathSignal.value?.value
+  const projectPath = app.project?.path
+  const targetPath = executingPath ?? projectPath
 
-  if (!executingPath) {
-    console.warn('bug: executingPath undefined, not navigating')
+  if (!targetPath) {
     return
   }
 
-  return PATHS.FILE + '/' + encodeURIComponent(executingPath)
+  return PATHS.FILE + '/' + encodeURIComponent(targetPath)
 }

--- a/src/hooks/useExecutingFileCommands.ts
+++ b/src/hooks/useExecutingFileCommands.ts
@@ -1,0 +1,135 @@
+import { useSignals } from '@preact/signals-react/runtime'
+import { useApp } from '@src/lib/boot'
+import type { Command, CommandArgumentOption } from '@src/lib/commandTypes'
+import { FILE_EXT } from '@src/lib/constants'
+import { PATHS, toProjectRelativePath } from '@src/lib/paths'
+import type { FileEntry } from '@src/lib/project'
+import { reportRejection } from '@src/lib/trap'
+import { useEffect, useMemo } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+const setExecutingFileCommandInfo = {
+  name: 'set-executing-file',
+  groupId: 'projects',
+} as const
+
+const clearExecutingFileCommandInfo = {
+  name: 'clear-executing-file',
+  groupId: 'projects',
+} as const
+
+function collectKclFiles(entry: FileEntry | undefined): FileEntry[] {
+  if (!entry) {
+    return []
+  }
+
+  if (entry.children === null) {
+    return entry.path.endsWith(FILE_EXT) ? [entry] : []
+  }
+
+  return entry.children.flatMap(collectKclFiles)
+}
+
+export function useExecutingFileCommands() {
+  useSignals()
+  const { commands, projectSession } = useApp()
+  const navigate = useNavigate()
+  const project = projectSession.openedProject.value
+  const projectInfo = project?.projectIORefSignal.value
+  const executingPath = project?.executingPathSignal.value?.value
+
+  const projectCommands = useMemo<Command[]>(() => {
+    const kclFiles = projectInfo?.children?.flatMap(collectKclFiles) ?? []
+    const fileOptions: CommandArgumentOption<string>[] = kclFiles.map(
+      (file) => {
+        const relativePath = projectInfo
+          ? toProjectRelativePath(projectInfo.path, file.path)
+          : file.name
+        return {
+          name: relativePath || file.name,
+          value: file.path,
+          isCurrent: file.path === executingPath,
+        }
+      }
+    )
+
+    return [
+      {
+        icon: 'file',
+        name: setExecutingFileCommandInfo.name,
+        displayName: 'Set executing file',
+        description: 'Select the KCL file to edit and run',
+        groupId: setExecutingFileCommandInfo.groupId,
+        needsReview: false,
+        disabled: !projectInfo || fileOptions.length === 0,
+        onSubmit: (record) => {
+          const filePath =
+            record && typeof record.filePath === 'string'
+              ? record.filePath
+              : undefined
+          if (!filePath || !projectInfo) {
+            return
+          }
+
+          projectSession
+            .setExecutingEditorHandle({
+              projectPath: projectInfo.path,
+              filePath,
+            })
+            .then(() => {
+              void navigate(`${PATHS.FILE}/${encodeURIComponent(filePath)}`)
+            })
+            .catch(reportRejection)
+        },
+        args: {
+          filePath: {
+            displayName: 'Executing file',
+            inputType: 'options',
+            required: true,
+            options: fileOptions,
+          },
+        },
+      },
+      {
+        icon: 'file',
+        name: clearExecutingFileCommandInfo.name,
+        displayName: 'Clear executing file',
+        description: 'Clear the current executing file',
+        groupId: clearExecutingFileCommandInfo.groupId,
+        needsReview: false,
+        disabled: !projectInfo || !executingPath,
+        onSubmit: () => {
+          if (!projectInfo) {
+            return
+          }
+
+          projectSession
+            .setExecutingEditorHandle(undefined)
+            .then(() => {
+              void navigate(
+                `${PATHS.FILE}/${encodeURIComponent(projectInfo.path)}`
+              )
+            })
+            .catch(reportRejection)
+        },
+      },
+    ]
+  }, [executingPath, navigate, projectInfo, projectSession])
+
+  useEffect(() => {
+    commands.send({
+      type: 'Add commands',
+      data: { commands: projectCommands },
+    })
+
+    return () => {
+      commands.send({
+        type: 'Remove commands',
+        data: { commands: projectCommands },
+      })
+    }
+  }, [commands, projectCommands])
+}
+
+export const findSetExecutingFileCommand = setExecutingFileCommandInfo
+export const findClearExecutingFileCommand = clearExecutingFileCommandInfo

--- a/src/hooks/useReliesOnEngine.tsx
+++ b/src/hooks/useReliesOnEngine.tsx
@@ -1,17 +1,17 @@
 import { useAppState } from '@src/AppState'
 import { useNetworkContext } from '@src/hooks/useNetworkContext'
 import { NetworkHealthState } from '@src/hooks/useNetworkStatus'
-import { useExecutingEditor } from '@src/lib/boot'
+import { useOptionalExecutingEditor } from '@src/lib/boot'
 import { EngineConnectionStateType } from '@src/network/utils'
 
 export function useReliesOnEngine(isExecuting: boolean) {
-  const kclManager = useExecutingEditor()
+  const kclManager = useOptionalExecutingEditor()
   const { overallState, immediateState } = useNetworkContext()
   const { isStreamReady } = useAppState()
   const reliesOnEngine =
     (overallState !== NetworkHealthState.Ok &&
       overallState !== NetworkHealthState.Weak) ||
-    kclManager.isExecutingSignal.value ||
+    (kclManager?.isExecutingSignal.value ?? isExecuting) ||
     immediateState.type !== EngineConnectionStateType.ConnectionEstablished ||
     !isStreamReady
 

--- a/src/lang/KclManager.spec.ts
+++ b/src/lang/KclManager.spec.ts
@@ -485,6 +485,43 @@ describe('KclManager diagnostics', () => {
     expect(writeSpy).toHaveBeenCalledWith('second')
   })
 
+  it('ignores delayed disk watcher events from its own app writes', async () => {
+    vi.useFakeTimers()
+
+    const { kclManager } = createKclManagerTestHarness('base')
+    const path = '/tmp/kcl-manager-own-write-watch-test.kcl'
+    const writeSpy = vi.spyOn(kclManager, 'write').mockResolvedValue(undefined)
+    const updateCodeEditorSpy = vi.spyOn(kclManager, 'updateCodeEditor')
+
+    kclManager.path = path
+    ;(kclManager as any).systemDeps.projectPath.value = '/tmp/project'
+    ;(kclManager as any).markFileCodeAsSynced('base')
+    vi.spyOn(File.ioImplementations, 'read')
+      .mockResolvedValueOnce('base')
+      .mockResolvedValueOnce('base')
+
+    kclManager.updateCodeEditor('saved by app', {
+      shouldExecute: false,
+      shouldWriteToDisk: true,
+      shouldResetCamera: false,
+    })
+
+    await vi.advanceTimersByTimeAsync(1000)
+    await flushPromises()
+
+    expect(writeSpy).toHaveBeenCalledWith('saved by app')
+    expect(kclManager.code).toBe('saved by app')
+
+    const watchHandler = kclManager.onWatchEvent.at(-1)
+    expect(watchHandler).toBeDefined()
+
+    watchHandler?.('change', path)
+    await flushPromises()
+
+    expect(kclManager.code).toBe('saved by app')
+    expect(updateCodeEditorSpy).toHaveBeenCalledTimes(1)
+  })
+
   it('reloads clean editor state from disk watcher updates', async () => {
     const { kclManager } = createKclManagerTestHarness('from disk')
 

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -933,6 +933,9 @@ export class KclManager extends File {
     if (this.writingPromise.value) {
       return
     }
+    if (_eventType === 'unlink') {
+      return
+    }
 
     // Your current file is changed, read it from disk and write it into the code manager and execute the AST,
     // unless the change was initiated by us (the currently running instance).

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -285,6 +285,7 @@ interface SystemDeps {
   settings: SettingsActorType
   commandBar: CommandBarActorType
   projectPath: Signal<string>
+  projectHistory?: HistoryView
   engineCommandManager: ConnectionManager
   rustContext: RustContext
   keymap?: KeymapService
@@ -313,6 +314,7 @@ window.EditorView = EditorView
 export class ZDSProject {
   private nextFileId = 0
   files: File[] = []
+  public readonly projectHistory = new HistoryView([fsHistoryExtension()])
   get path() {
     return this.projectIORefSignal.value.path
   }
@@ -373,6 +375,7 @@ export class ZDSProject {
 
     if (newPath === null) {
       this.#executingPath.value = null
+      this.projectHistory.clearLocalHistoryTarget()
       return
     }
     const foundPathSignal = this.findEditor(newPath)
@@ -384,6 +387,7 @@ export class ZDSProject {
       // TODO: Reconfigure the editor to be an executing one
     }
     this.#executingPath.value = foundPathSignal[0]
+    this.projectHistory.registerLocalHistoryTarget(found.editorView)
   }
   findEditor(path: string) {
     return this.editors
@@ -434,6 +438,7 @@ export class ZDSProject {
       engineCommandManager: this.app.engineCommandManager,
       rustContext: this.app.rustContext,
       projectPath: computed(() => this.projectIORefSignal.value.path),
+      projectHistory: this.projectHistory,
     }
 
     if (providedEditor) {
@@ -502,14 +507,16 @@ export class ZDSProject {
       console.warn(`Attempted to close nonexistent editor with path "${path}"`)
       return
     }
-    foundPathSignal[1].close()
-    this.editors.delete(foundPathSignal[0])
     if (this.#executingPath.value === foundPathSignal[0]) {
       this.#executingPath.value = null
+      this.projectHistory.clearLocalHistoryTarget()
     }
+    foundPathSignal[1].close()
+    this.editors.delete(foundPathSignal[0])
   }
 
   closeAllEditors() {
+    this.projectHistory.clearLocalHistoryTarget()
     for (const editor of this.editors.values()) {
       editor.close()
     }
@@ -731,7 +738,7 @@ export class KclManager extends File {
   // CORE STATE
 
   private readonly _editorView: EditorView
-  private readonly _globalHistoryView: HistoryView
+  private readonly _projectHistory: HistoryView
 
   /**
    * The core state in KclManager are the code and the selection.
@@ -870,8 +877,8 @@ export class KclManager extends File {
   undoListenerEffect = EditorView.updateListener.of((vu) => {
     const localUndo = undoDepth(vu.state)
     const localRedo = redoDepth(vu.state)
-    const globalUndo = undoDepth(this._globalHistoryView.state)
-    const globalRedo = redoDepth(this._globalHistoryView.state)
+    const globalUndo = undoDepth(this._projectHistory.state)
+    const globalRedo = redoDepth(this._projectHistory.state)
 
     this.undoDepth.value = localUndo + globalUndo
     this.redoDepth.value = localRedo + globalRedo
@@ -1908,7 +1915,8 @@ export class KclManager extends File {
       getSettings
     )
 
-    this._globalHistoryView = new HistoryView([fsHistoryExtension()])
+    this._projectHistory =
+      this.systemDeps.projectHistory ?? new HistoryView([fsHistoryExtension()])
     this._editorView = this.createEditorView(initialCode)
     this.settingsSubscription = this.systemDeps.settings.subscribe(() => {
       this.setEditorAutomaticallyRender(this.getAutomaticallyRenderSetting())
@@ -1917,7 +1925,9 @@ export class KclManager extends File {
     // TODO: Delete this._code, only derive from the editorView's doc
     this._code.value = initialCode
     this.markFileCodeAsSynced(initialCode)
-    this._globalHistoryView.registerLocalHistoryTarget(this._editorView)
+    if (!this.systemDeps.projectHistory) {
+      this._projectHistory.registerLocalHistoryTarget(this._editorView)
+    }
 
     this.systemDeps.wasmInstancePromise
       .then(async (wasmInstance) => {
@@ -2625,8 +2635,11 @@ export class KclManager extends File {
   get state() {
     return this.editorState
   }
+  get projectHistory() {
+    return this._projectHistory
+  }
   get globalHistoryView() {
-    return this._globalHistoryView
+    return this.projectHistory
   }
   setCopilotEnabled(enabled: boolean) {
     this._copilotEnabled = enabled
@@ -2882,14 +2895,17 @@ export class KclManager extends File {
       ],
     })
   }
+  addProjectHistoryEvent(spec: TransactionSpecNoChanges) {
+    this._projectHistory.dispatch(spec)
+  }
   addGlobalHistoryEvent(spec: TransactionSpecNoChanges) {
-    this._globalHistoryView.dispatch(spec)
+    this.addProjectHistoryEvent(spec)
   }
   undo() {
-    this._globalHistoryView.undo(this._editorView)
+    this._projectHistory.undo(this._editorView)
   }
   redo() {
-    this._globalHistoryView.redo(this._editorView)
+    this._projectHistory.redo(this._editorView)
   }
   clearLocalHistory() {
     this.directSketchHistoryCheckpointsByEntryId.clear()
@@ -2908,25 +2924,28 @@ export class KclManager extends File {
       ],
     })
   }
-  clearGlobalHistory() {
-    this._globalHistoryView.dispatch(
+  clearProjectHistory() {
+    this._projectHistory.dispatch(
       {
-        effects: [this._globalHistoryView.historyCompartment.reconfigure([])],
+        effects: [this._projectHistory.historyCompartment.reconfigure([])],
       },
       { shouldForwardToLocalHistory: false }
     )
 
     // Add history back
-    this._globalHistoryView.dispatch(
+    this._projectHistory.dispatch(
       {
         effects: [
-          this._globalHistoryView.historyCompartment.reconfigure([
+          this._projectHistory.historyCompartment.reconfigure([
             createHistoryExtension(this.sketchCheckpointLimit),
           ]),
         ],
       },
       { shouldForwardToLocalHistory: false }
     )
+  }
+  clearGlobalHistory() {
+    this.clearProjectHistory()
   }
 
   private reconfigureHistoryLimit(checkpointLimit: number) {
@@ -2943,10 +2962,10 @@ export class KclManager extends File {
       annotations: [Transaction.addToHistory.of(false)],
     })
 
-    this._globalHistoryView.dispatch(
+    this._projectHistory.dispatch(
       {
         effects: [
-          this._globalHistoryView.historyCompartment.reconfigure([
+          this._projectHistory.historyCompartment.reconfigure([
             createHistoryExtension(this.sketchCheckpointLimit),
           ]),
         ],

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -216,6 +216,8 @@ type DirectSketchHistoryMarker = {
   entryId: number
 }
 
+const APP_WRITE_WATCH_SUPPRESS_MS = 2_000
+
 type MinimalDocumentChange = {
   from: number
   to: number
@@ -370,6 +372,7 @@ export class ZDSProject {
     // TODO: Clear current executing editor's execution status
 
     if (newPath === null) {
+      this.#executingPath.value = null
       return
     }
     const foundPathSignal = this.findEditor(newPath)
@@ -501,6 +504,9 @@ export class ZDSProject {
     }
     foundPathSignal[1].close()
     this.editors.delete(foundPathSignal[0])
+    if (this.#executingPath.value === foundPathSignal[0]) {
+      this.#executingPath.value = null
+    }
   }
 
   closeAllEditors() {
@@ -508,6 +514,7 @@ export class ZDSProject {
       editor.close()
     }
     this.editors.clear()
+    this.#executingPath.value = null
   }
 
   /** Handle updates from the disk representation of the project */
@@ -916,15 +923,24 @@ export class KclManager extends File {
     ) {
       return
     }
+    if (this.writingPromise.value) {
+      return
+    }
+
     // Your current file is changed, read it from disk and write it into the code manager and execute the AST,
     // unless the change was initiated by us (the currently running instance).
     const requestedDocumentVersion = this._documentVersion
     File.ioImplementations
       .read(path)
       .then((code) => {
+        const diskCode = normalizeLineEndings(code)
         if (requestedDocumentVersion !== this._documentVersion) {
           return
         }
+        if (this.shouldIgnoreRecentAppWriteWatchEvent(diskCode)) {
+          return
+        }
+
         const isInSketchMode =
           this.modelingState?.matches('Sketch') ||
           this.modelingState?.matches('sketchSolveMode')
@@ -998,6 +1014,7 @@ export class KclManager extends File {
     undefined
   private executionTimeoutId: ReturnType<typeof setTimeout> | undefined =
     undefined
+  private suppressDiskReloadUntil = 0
   private settingsSubscription: Subscription | undefined = undefined
   private _automaticallyRenderEnabled = true
   private _lastKnownFileCode = ''
@@ -1941,6 +1958,20 @@ export class KclManager extends File {
 
   private hasUnsavedLocalChanges() {
     return !isCodeTheSame(this.code, this._lastKnownFileCode)
+  }
+
+  private shouldIgnoreRecentAppWriteWatchEvent(diskCode: string) {
+    if (this.writingPromise.value) {
+      return true
+    }
+    if (Date.now() >= this.suppressDiskReloadUntil) {
+      return false
+    }
+
+    return (
+      isCodeTheSame(diskCode, this._lastKnownFileCode) ||
+      !this.hasUnsavedLocalChanges()
+    )
   }
 
   private persistRecoverySnapshot() {
@@ -3457,10 +3488,14 @@ export class KclManager extends File {
 
     this.writeCausedByAppCheckedInFileTreeFileSystemWatcher = true
     this.unwatch()
+    this.suppressDiskReloadUntil = Date.now() + APP_WRITE_WATCH_SUPPRESS_MS
 
+    const writePromise = this.write(newCode)
+    this.writingPromise.value = writePromise
     try {
-      await this.write(newCode)
+      await writePromise
       this.markFileCodeAsSynced(newCode)
+      this.suppressDiskReloadUntil = Date.now() + APP_WRITE_WATCH_SUPPRESS_MS
 
       // After a cooldown, start watching this file again on disk.
       this.timeoutRewatch = setTimeout(() => {
@@ -3472,6 +3507,10 @@ export class KclManager extends File {
       console.warn('error saving file', err)
       toast.error('Error saving file, please check file permissions.')
       return Promise.reject(err)
+    } finally {
+      if (this.writingPromise.value === writePromise) {
+        this.writingPromise.value = null
+      }
     }
   }
 

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -1,7 +1,9 @@
 import path from 'node:path'
+import { undoDepth } from '@codemirror/commands'
 import type { UserFeature } from '@kittycad/lib'
 import { pluginsValueSpec } from '@kittycad/registry'
 import { signal } from '@preact/signals-core'
+import { fsArchiveFile } from '@src/editor/plugins/fs'
 import { File, KclManager } from '@src/lang/KclManager'
 import { App } from '@src/lib/app'
 import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
@@ -587,6 +589,68 @@ describe('project system', () => {
       readSpy.mockRestore()
       resetCameraPositionSpy.mockClear()
       executeCodeSpy.mockRestore()
+      await disposeApp(app)
+    }
+  })
+
+  it('keeps project history when replacing executing editor instances', async () => {
+    const app = App.fromProvided({
+      wasmPromise: loadWasm(),
+    })
+    const otherFilePath = `${mockProjectPath}/other.kcl`
+    const readSpy = vi
+      .spyOn(File.ioImplementations, 'read')
+      .mockImplementation((path) =>
+        Promise.resolve(path === otherFilePath ? 'other code' : 'main code')
+      )
+
+    try {
+      const projectSession = app.registry.get(projectSessionService)
+      await projectSession.setOpenedProjectHandle({
+        projectPath: mockProject.path,
+      })
+
+      await projectSession.setExecutingEditorHandle({
+        projectPath: mockProject.path,
+        filePath: mockProjectMainFilePath,
+      })
+
+      const project = app.project
+      const firstEditor = project?.executingEditor.value
+      expect(project).toBeDefined()
+      expect(firstEditor).toBeDefined()
+      if (!project || !firstEditor) {
+        throw new Error(
+          'Expected project and executing editor to be available.'
+        )
+      }
+
+      const projectHistory = project.projectHistory
+      const closeFirstEditor = vi.spyOn(firstEditor, 'close')
+      firstEditor.addProjectHistoryEvent(
+        fsArchiveFile({
+          src: `${mockProjectPath}/old.kcl`,
+          target: `${mockProjectPath}/.trash/old.kcl`,
+          requestedProjectName: mockProject.name,
+        })
+      )
+
+      expect(firstEditor.projectHistory).toBe(projectHistory)
+      expect(undoDepth(projectHistory.state)).toBe(1)
+
+      await projectSession.setExecutingEditorHandle({
+        projectPath: mockProject.path,
+        filePath: otherFilePath,
+      })
+
+      const secondEditor = project.executingEditor.value
+      expect(closeFirstEditor).toHaveBeenCalled()
+      expect(secondEditor).toBeDefined()
+      expect(secondEditor).not.toBe(firstEditor)
+      expect(secondEditor?.projectHistory).toBe(projectHistory)
+      expect(undoDepth(projectHistory.state)).toBe(1)
+    } finally {
+      readSpy.mockRestore()
       await disposeApp(app)
     }
   })

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -2,11 +2,12 @@ import path from 'node:path'
 import type { UserFeature } from '@kittycad/lib'
 import { pluginsValueSpec } from '@kittycad/registry'
 import { signal } from '@preact/signals-core'
-import { File } from '@src/lang/KclManager'
+import { File, KclManager } from '@src/lang/KclManager'
 import { App } from '@src/lib/app'
 import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
 import fsZds, { StorageName, moduleFsViaModuleImport } from '@src/lib/fs-zds'
 import type { Project } from '@src/lib/project'
+import { resetCameraPosition } from '@src/lib/resetCameraPosition'
 import { getChangedSettingsAtLevel } from '@src/lib/settings/settingsUtils'
 import type { UserFeaturesContext } from '@src/machines/userFeaturesMachine'
 import { UserFeaturesState } from '@src/machines/userFeaturesMachine'
@@ -16,6 +17,10 @@ import { executingEditorService } from '@src/registry/contracts/executingEditor'
 import { projectSessionService } from '@src/registry/contracts/projectSession'
 import { loadWasm } from '@src/unitTestUtils'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@src/lib/resetCameraPosition', () => ({
+  resetCameraPosition: vi.fn().mockResolvedValue(undefined),
+}))
 
 const mockProjectDirectoryPath = path.join(
   process.cwd(),
@@ -58,6 +63,10 @@ beforeAll(async () => {
   await fsZds.rm(mockProjectDirectoryPath, { recursive: true, force: true })
   await fsZds.mkdir(mockProjectPath, { recursive: true })
   await fsZds.writeFile(mockProjectMainFilePath, new TextEncoder().encode(''))
+  await fsZds.writeFile(
+    `${mockProjectPath}/project.toml`,
+    new TextEncoder().encode('')
+  )
 })
 
 afterAll(async () => {
@@ -97,6 +106,28 @@ async function waitForAuthSettled(app: App) {
       resolve()
     })
   })
+}
+
+async function flushPromises(count = 2) {
+  for (let i = 0; i < count; i += 1) {
+    await Promise.resolve()
+  }
+}
+
+function setEngineConnectionReady(app: App) {
+  app.engineCommandManager.started = true
+  app.engineCommandManager.connection = {
+    deferredConnection: {
+      promise: Promise.resolve(),
+      resolve: vi.fn(),
+      reject: vi.fn(),
+    },
+    isUsingUnitTestingConnection: false,
+    connected: true,
+    websocket: {
+      readyState: WebSocket.OPEN,
+    },
+  } as never
 }
 
 async function disposeApp(app: App) {
@@ -300,11 +331,7 @@ describe('project system', () => {
           'publish.open',
         ])
       )
-      expect(
-        app.registry.get(executingEditorService).hasEditsSinceLastExecution
-          .value
-      ).toBe(false)
-      expect(app.registry.get(executingEditorService).code.value).toBe('')
+      expect(app.registry.optional(executingEditorService)).toBeUndefined()
 
       const textEditorSettings = app.settings.get().textEditor as Record<
         string,
@@ -430,6 +457,7 @@ describe('project system', () => {
       ).toEqual(mockProjectDirectoryPath)
       expect(app.project?.executingPath).toBeNull()
       expect(app.project?.executingFileEntry.value.name).toEqual('')
+      expect(app.registry.optional(executingEditorService)).toBeUndefined()
 
       const mainFile = mockProject.children?.[0]
       expect(mainFile).toBeDefined()
@@ -443,10 +471,21 @@ describe('project system', () => {
       })
       expect(app.project?.executingPath).toEqual(mockProjectMainFilePath)
       expect(app.project?.executingFileEntry.value.name).toEqual('main.kcl')
+      expect(app.registry.optional(executingEditorService)?.code.value).toBe('')
       expect(projectSession.executingEditorHandle.value).toEqual({
         projectPath: mockProject.path,
         filePath: mainFile.path,
       })
+
+      const mainEditor = app.project?.executingEditor.value
+      expect(mainEditor).toBeDefined()
+      if (!mainEditor) {
+        throw new Error('Expected main executing editor to be available.')
+      }
+      expect(app.commands.actor.getSnapshot().context.kclManager).toBe(
+        mainEditor
+      )
+      const closeMainEditor = vi.spyOn(mainEditor, 'close')
 
       const otherFilePath = `${mockProjectPath}/other.kcl`
       await projectSession.setExecutingEditorHandle({
@@ -454,6 +493,7 @@ describe('project system', () => {
         filePath: otherFilePath,
       })
       expect(app.project?.executingPath).toEqual(otherFilePath)
+      expect(closeMainEditor).toHaveBeenCalled()
 
       await projectSession.setExecutingEditorHandle({
         projectPath: mockProject.path,
@@ -466,11 +506,162 @@ describe('project system', () => {
         filePath: mainFile.path,
       })
 
+      const finalEditor = app.project?.executingEditor.value
+      expect(finalEditor).toBeDefined()
+      if (!finalEditor) {
+        throw new Error('Expected final executing editor to be available.')
+      }
+      const closeFinalEditor = vi.spyOn(finalEditor, 'close')
+
+      await projectSession.setExecutingEditorHandle(undefined)
+
+      expect(closeFinalEditor).toHaveBeenCalled()
+      expect(app.project?.executingPath).toBeNull()
+      expect(projectSession.executingEditorHandle.value).toBeUndefined()
+      expect(app.registry.optional(executingEditorService)).toBeUndefined()
+      expect(
+        app.commands.actor.getSnapshot().context.kclManager
+      ).toBeUndefined()
+
       await projectSession.setOpenedProjectHandle(undefined)
 
       expect(app.project).toBeUndefined()
       expect(projectSession.openedProjectHandle.value).toBeUndefined()
       expect(projectSession.executingEditorHandle.value).toBeUndefined()
+    } finally {
+      await disposeApp(app)
+    }
+  })
+
+  it('executes the selected editor when the executing file changes while the engine is started', async () => {
+    const app = App.fromProvided({
+      wasmPromise: loadWasm(),
+    })
+    const otherFilePath = `${mockProjectPath}/other.kcl`
+    const readSpy = vi
+      .spyOn(File.ioImplementations, 'read')
+      .mockImplementation((path) =>
+        Promise.resolve(path === otherFilePath ? 'other code' : 'main code')
+      )
+    const resetCameraPositionSpy = vi.mocked(resetCameraPosition)
+    resetCameraPositionSpy.mockClear()
+    const executeCodeSpy = vi
+      .spyOn(KclManager.prototype, 'executeCode')
+      .mockResolvedValue(undefined)
+
+    try {
+      setEngineConnectionReady(app)
+      const projectSession = app.registry.get(projectSessionService)
+      await projectSession.setOpenedProjectHandle({
+        projectPath: mockProject.path,
+      })
+
+      await projectSession.setExecutingEditorHandle({
+        projectPath: mockProject.path,
+        filePath: mockProjectMainFilePath,
+      })
+      await flushPromises()
+
+      expect(executeCodeSpy).toHaveBeenCalledTimes(1)
+      expect(resetCameraPositionSpy).toHaveBeenCalledTimes(1)
+      expect(resetCameraPositionSpy).toHaveBeenLastCalledWith({
+        sceneInfra: expect.any(Object),
+        engineCommandManager: app.engineCommandManager,
+        settingsActor: app.settings.actor,
+      })
+
+      await projectSession.setExecutingEditorHandle({
+        projectPath: mockProject.path,
+        filePath: otherFilePath,
+      })
+      await flushPromises()
+
+      expect(executeCodeSpy).toHaveBeenCalledTimes(2)
+      expect(resetCameraPositionSpy).toHaveBeenCalledTimes(2)
+      expect(resetCameraPositionSpy).toHaveBeenLastCalledWith({
+        sceneInfra: expect.any(Object),
+        engineCommandManager: app.engineCommandManager,
+        settingsActor: app.settings.actor,
+      })
+    } finally {
+      readSpy.mockRestore()
+      resetCameraPositionSpy.mockClear()
+      executeCodeSpy.mockRestore()
+      await disposeApp(app)
+    }
+  })
+
+  it('leaves initial connection execution to the engine connection setup path', async () => {
+    const app = App.fromProvided({
+      wasmPromise: loadWasm(),
+    })
+    const readSpy = vi
+      .spyOn(File.ioImplementations, 'read')
+      .mockResolvedValue('main code')
+    const resetCameraPositionSpy = vi.mocked(resetCameraPosition)
+    resetCameraPositionSpy.mockClear()
+    const executeCodeSpy = vi
+      .spyOn(KclManager.prototype, 'executeCode')
+      .mockResolvedValue(undefined)
+    const websocket: { readyState: number } = {
+      readyState: WebSocket.CONNECTING,
+    }
+
+    try {
+      app.engineCommandManager.started = true
+      app.engineCommandManager.connection = {
+        deferredConnection: {
+          promise: new Promise(() => {}),
+          resolve: vi.fn(),
+          reject: vi.fn(),
+        },
+        isUsingUnitTestingConnection: false,
+        connected: false,
+        websocket,
+      } as never
+      const projectSession = app.registry.get(projectSessionService)
+      await projectSession.setOpenedProjectHandle({
+        projectPath: mockProject.path,
+      })
+
+      await projectSession.setExecutingEditorHandle({
+        projectPath: mockProject.path,
+        filePath: mockProjectMainFilePath,
+      })
+      await flushPromises()
+
+      expect(executeCodeSpy).not.toHaveBeenCalled()
+      expect(resetCameraPositionSpy).not.toHaveBeenCalled()
+    } finally {
+      readSpy.mockRestore()
+      resetCameraPositionSpy.mockClear()
+      executeCodeSpy.mockRestore()
+      await disposeApp(app)
+    }
+  })
+
+  it('accepts project-only route handles without opening a default file', async () => {
+    const app = App.fromProvided({
+      wasmPromise: loadWasm(),
+    })
+
+    try {
+      const projectSession = app.registry.get(projectSessionService)
+      const result = await projectSession.setProjectRouteHandles({
+        routeId: mockProject.path,
+        requestUrl: `http://localhost/file/${encodeURIComponent(
+          mockProject.path
+        )}`,
+        usesHashRouter: false,
+      })
+
+      expect(result).toEqual({})
+      expect(projectSession.openedProjectHandle.value).toEqual({
+        projectPath: mockProject.path,
+      })
+      expect(projectSession.executingEditorHandle.value).toBeUndefined()
+      expect(app.project?.executingPath).toBeNull()
+      expect(app.registry.optional(executingEditorService)).toBeUndefined()
     } finally {
       await disposeApp(app)
     }

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -69,7 +69,6 @@ import {
   commandSystemService,
   provideCommand,
 } from '@src/registry/contracts/commands'
-import { executingEditorService } from '@src/registry/contracts/executingEditor'
 import { keymapService } from '@src/registry/contracts/keymap'
 import { layoutContributionsValueSpec } from '@src/registry/contracts/layout'
 import { machineManagerService } from '@src/registry/contracts/machineManager'
@@ -688,18 +687,6 @@ export class App implements AppSubsystems {
       rustContext: this.rustContext,
       keymap: this.registry.get(keymapService),
     })
-
-    this.registry.reconfigure(appRegistryServicesSlot, [
-      defineRegistryItem({
-        id: 'app.runtime-services',
-        providesServices: [
-          provideService(
-            executingEditorService,
-            kclManager.executingEditorService
-          ),
-        ],
-      }),
-    ])
 
     if (typeof window !== 'undefined') {
       // Accessible for tests mostly

--- a/src/lib/layout/defaultActionLibrary.ts
+++ b/src/lib/layout/defaultActionLibrary.ts
@@ -1,6 +1,6 @@
 import { useSignals } from '@preact/signals-react/runtime'
 import { useReliesOnEngine } from '@src/hooks/useReliesOnEngine'
-import { useApp, useExecutingEditor } from '@src/lib/boot'
+import { useApp, useOptionalExecutingEditor } from '@src/lib/boot'
 import { sendAddFileToProjectCommandForCurrentProject } from '@src/lib/commandBarConfigs/applicationCommandConfig'
 import { isDesktop } from '@src/lib/isDesktop'
 import { isMobile } from '@src/lib/isMobile'
@@ -10,7 +10,7 @@ import { layoutActionLibraryValueSpec } from '@src/registry/contracts/layout'
 export const useDefaultActionLibrary = () => {
   useSignals()
   const { commands, settings, registry } = useApp()
-  const kclManager = useExecutingEditor()
+  const kclManager = useOptionalExecutingEditor()
   const machineApiEnabled = settings.useSettings().app.machineApi.current
   const registeredActionLibrary = registry.signal(
     layoutActionLibraryValueSpec
@@ -21,8 +21,11 @@ export const useDefaultActionLibrary = () => {
       useHidden: () => false,
       useDisabled: () => {
         const engineIsReady = useReliesOnEngine(
-          kclManager.isExecutingSignal.value ?? false
+          kclManager?.isExecutingSignal.value ?? false
         )
+        if (!kclManager) {
+          return 'Select an executing file first'
+        }
         return engineIsReady ? 'Need engine connection to export' : undefined
       },
       shortcut: 'Ctrl + Shift + E',
@@ -44,7 +47,8 @@ export const useDefaultActionLibrary = () => {
     },
     share: {
       useHidden: () => !isMobile(),
-      useDisabled: () => undefined,
+      useDisabled: () =>
+        kclManager ? undefined : 'Select an executing file first',
       shortcut: 'Mod + Alt + S',
       execute: () =>
         commands.actor.send({
@@ -65,6 +69,9 @@ export const useDefaultActionLibrary = () => {
     make: {
       useDisabled: () => {
         const { machineManager } = useApp()
+        if (!kclManager) {
+          return 'Select an executing file first'
+        }
         return machineManager.noMachinesReason()
       },
       shortcut: 'Ctrl + Shift + M',

--- a/src/lib/layout/defaultAreaLibrary.tsx
+++ b/src/lib/layout/defaultAreaLibrary.tsx
@@ -158,19 +158,19 @@ export const useDefaultAreaLibrary = () => {
           shortcut: 'Shift + C',
           Component: KclEditorPane,
           useNotifications() {
+            const value =
+              kclManager?.diagnosticsSignal.value.filter(
+                (diagnostic) => diagnostic.severity === 'error'
+              ).length ?? 0
             if (!kclManager) {
               return undefined
             }
-            const value = kclManager.diagnosticsSignal.value.filter(
-              (diagnostic) => diagnostic.severity === 'error'
-            ).length
-            return useMemo(() => {
-              return {
-                value,
-                onClick: onCodeNotificationClick,
-                title: undefined,
-              }
-            }, [value])
+
+            return {
+              value,
+              onClick: onCodeNotificationClick,
+              title: undefined,
+            }
           },
         },
         files: {
@@ -178,13 +178,12 @@ export const useDefaultAreaLibrary = () => {
           shortcut: 'Shift + F',
           Component: ProjectExplorerPane,
           useNotifications() {
-            if (!kclManager) {
-              return undefined
-            }
             const title = 'Project files have runtime errors'
             // Only compute runtime errors! Compilation errors are not tracked here.
-            const errors = kclErrorsByFilename(kclManager.errorsSignal.value)
-            const value = errors.size > 0 ? 'x' : ''
+            const errors = kclManager
+              ? kclErrorsByFilename(kclManager.errorsSignal.value)
+              : undefined
+            const value = errors && errors.size > 0 ? 'x' : ''
             const onClick: MouseEventHandler = useCallback((e) => {
               e.preventDefault()
               // TODO: When we have generic file open
@@ -194,7 +193,11 @@ export const useDefaultAreaLibrary = () => {
               // Do you automatically open the project files
               // kclManager.scrollToFirstErrorDiagnosticIfExists()
             }, [])
-            return useMemo(() => ({ value, onClick, title }), [value, onClick])
+            if (!kclManager) {
+              return undefined
+            }
+
+            return { value, onClick, title }
           },
         },
         variables: {

--- a/src/lib/layout/defaultAreaLibrary.tsx
+++ b/src/lib/layout/defaultAreaLibrary.tsx
@@ -3,6 +3,7 @@ import { Toolbar } from '@src/Toolbar'
 import { DEFAULT_SKETCH_SOLVE_STREAM_DIMMING } from '@src/clientSideScene/ClientSideSceneComp'
 import { ConnectionStream } from '@src/components/ConnectionStream'
 import { CustomIcon } from '@src/components/CustomIcon'
+import { NoExecutingFileEmptyState } from '@src/components/NoExecutingFileEmptyState'
 import Gizmo from '@src/components/gizmo/Gizmo'
 import { BodiesPane } from '@src/components/layout/areas/BodiesPane'
 import { DebugPane } from '@src/components/layout/areas/DebugPane'
@@ -14,7 +15,7 @@ import { MlEphantConversationPaneWrapper } from '@src/components/layout/areas/Ml
 import { ProjectExplorerPane } from '@src/components/layout/areas/ProjectExplorerPane'
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import { kclErrorsByFilename } from '@src/lang/errors'
-import { useApp, useExecutingEditor } from '@src/lib/boot'
+import { useApp, useOptionalExecutingEditor } from '@src/lib/boot'
 import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
 import type { AreaLibrary, AreaTypeDefinition } from '@src/lib/layout/types'
 import { togglePaneLayoutNode } from '@src/lib/layout/utils'
@@ -23,6 +24,19 @@ import type { MouseEventHandler } from 'react'
 import { useCallback, useMemo, useState } from 'react'
 
 function ModelingArea() {
+  const kclManager = useOptionalExecutingEditor()
+  if (!kclManager) {
+    return (
+      <div className="relative z-0 min-w-64 flex flex-col flex-1 overflow-hidden">
+        <NoExecutingFileEmptyState />
+      </div>
+    )
+  }
+
+  return <ModelingAreaWithExecutingFile />
+}
+
+function ModelingAreaWithExecutingFile() {
   const { auth } = useApp()
   const { state, send } = useModelingContext()
   const authToken = auth.useToken()
@@ -90,7 +104,7 @@ function ModelingArea() {
 export const useDefaultAreaLibrary = () => {
   useSignals()
   const { settings, layout, registry } = useApp()
-  const kclManager = useExecutingEditor()
+  const kclManager = useOptionalExecutingEditor()
   const getSettings = settings.get
   const registeredAreaLibrary = registry.signal(
     layoutAreaLibraryValueSpec
@@ -98,6 +112,9 @@ export const useDefaultAreaLibrary = () => {
   const onCodeNotificationClick: MouseEventHandler = useCallback(
     (e) => {
       e.preventDefault()
+      if (!kclManager) {
+        return
+      }
       const rootLayout = structuredClone(layout.signal.value)
       layout.set(
         togglePaneLayoutNode({
@@ -141,6 +158,9 @@ export const useDefaultAreaLibrary = () => {
           shortcut: 'Shift + C',
           Component: KclEditorPane,
           useNotifications() {
+            if (!kclManager) {
+              return undefined
+            }
             const value = kclManager.diagnosticsSignal.value.filter(
               (diagnostic) => diagnostic.severity === 'error'
             ).length
@@ -158,6 +178,9 @@ export const useDefaultAreaLibrary = () => {
           shortcut: 'Shift + F',
           Component: ProjectExplorerPane,
           useNotifications() {
+            if (!kclManager) {
+              return undefined
+            }
             const title = 'Project files have runtime errors'
             // Only compute runtime errors! Compilation errors are not tracked here.
             const errors = kclErrorsByFilename(kclManager.errorsSignal.value)

--- a/src/lib/routeLoaders.ts
+++ b/src/lib/routeLoaders.ts
@@ -1,7 +1,9 @@
 import { projectSkeletonCreate } from '@src/lang/project'
 import type { App } from '@src/lib/app'
-import { DEFAULT_DEFAULT_LENGTH_UNIT } from '@src/lib/constants'
-import { getInitialDefaultDir } from '@src/lib/desktop'
+import {
+  DEFAULT_DEFAULT_LENGTH_UNIT,
+  PROJECT_ENTRYPOINT,
+} from '@src/lib/constants'
 import fsZds from '@src/lib/fs-zds'
 import { PATHS, getRouterSearchFromRequestUrl } from '@src/lib/paths'
 import { webHomeRouteEnabled } from '@src/lib/routeLoaderUtils'
@@ -13,6 +15,10 @@ import { redirect } from 'react-router-dom'
 export const DEFAULT_WEB_PROJECT_NAME = 'demo-project'
 
 type EmptyLoaderData = Record<string, never>
+
+function projectFileRedirectPath(projectPath: string, fileName: string) {
+  return `${PATHS.FILE}/${encodeURIComponent(fsZds.join(projectPath, fileName))}`
+}
 
 /**
  * The base loader is used to reroute `/` root path requests,
@@ -60,25 +66,33 @@ export const baseLoader =
     // We have to create and/or navigate to a project on web.
     try {
       await fsZds.stat(requestedProjectPath)
-      const fileURLPath = `${PATHS.FILE}/${encodeURIComponent(
+      let fileURLPath = `${PATHS.FILE}/${encodeURIComponent(
         requestedProjectPath
       )}`
+      try {
+        await fsZds.stat(fsZds.join(requestedProjectPath, PROJECT_ENTRYPOINT))
+        fileURLPath = projectFileRedirectPath(
+          requestedProjectPath,
+          PROJECT_ENTRYPOINT
+        )
+      } catch (e) {
+        if (e !== 'ENOENT') {
+          return Promise.reject(e)
+        }
+      }
       return redirect(fileURLPath + routerSearch)
     } catch {
       await projectSkeletonCreate(
-        fsZds.resolve(
-          await getInitialDefaultDir(),
-          DEFAULT_WEB_PROJECT_NAME,
-          'main.kcl'
-        ),
+        fsZds.join(requestedProjectPath, PROJECT_ENTRYPOINT),
         settings.settings.modeling.defaultUnit.current ??
           DEFAULT_DEFAULT_LENGTH_UNIT,
         wasmInstance
       )
 
-      const fileURLPath = `${PATHS.FILE}/${encodeURIComponent(
-        requestedProjectPath
-      )}`
+      const fileURLPath = projectFileRedirectPath(
+        requestedProjectPath,
+        PROJECT_ENTRYPOINT
+      )
       return redirect(fileURLPath + routerSearch)
     }
   }

--- a/src/machines/commandBarMachine.ts
+++ b/src/machines/commandBarMachine.ts
@@ -134,7 +134,7 @@ export type CommandBarMachineEvent =
       type: 'Change current argument'
       data: { [x: string]: CommandArgumentWithName<unknown> }
     }
-  | { type: 'Set kclManager'; data: KclManager }
+  | { type: 'Set kclManager'; data: KclManager | undefined }
 
 export const commandBarMachine = setup({
   types: {
@@ -210,7 +210,7 @@ export const commandBarMachine = setup({
         const { selectedCommand } = context
         if (!(selectedCommand && selectedCommand.args)) return undefined
         const rejectedArg =
-          'data' in event && 'arg' in event.data && event.data.arg
+          'data' in event && event.data && 'arg' in event.data && event.data.arg
 
         // Find the first argument that is not to be skipped:
         // that is, the first argument that is not already in the argumentsToSubmit

--- a/src/machines/systemIO/systemIOMachine.spec.ts
+++ b/src/machines/systemIO/systemIOMachine.spec.ts
@@ -777,6 +777,66 @@ describe('systemIOMachine - XState', () => {
           actor.stop()
         }
       })
+      it('should preserve the requested file when bulk editing without navigation', async () => {
+        const actor = createActor(
+          systemIOMachine.provide({
+            actors: {
+              [SystemIOMachineActors.readFoldersFromProjectDirectory]:
+                fromPromise(async () => [] as Project[]),
+              [SystemIOMachineActors.bulkCreateAndDeleteKCLFilesAndNavigateToFile]:
+                fromPromise(async ({ input }) => ({
+                  message: 'Updated',
+                  projectName: input.requestedProjectName,
+                  fileName: input.requestedFileNameWithExtension,
+                  subRoute: '',
+                  navigateToFile: input.navigateToFile ?? true,
+                })),
+            },
+          }),
+          {
+            input: {
+              wasmInstancePromise: Promise.resolve(instanceInThisFile),
+              app: appInstanceInThisFile,
+            },
+          }
+        ).start()
+
+        try {
+          actor.send({
+            type: SystemIOMachineEvents.navigateToFile,
+            data: {
+              requestedProjectName: 'demo-project',
+              requestedFileName: 'current.kcl',
+            },
+          })
+
+          actor.send({
+            type: SystemIOMachineEvents.bulkCreateAndDeleteKCLFilesAndNavigateToFile,
+            data: {
+              files: [],
+              filesToDelete: [{ requestedFileName: 'other.kcl' }],
+              requestedProjectName: 'demo-project',
+              requestedFileNameWithExtension: 'other.kcl',
+              navigateToFile: false,
+            },
+          })
+
+          await waitFor(actor, (state) =>
+            state.matches(SystemIOMachineStates.idle)
+          )
+
+          expect(actor.getSnapshot().context.requestedFileName).toStrictEqual({
+            project: 'demo-project',
+            file: 'current.kcl',
+            subRoute: undefined,
+          })
+          expect(actor.getSnapshot().context.lastOperation).toBe(
+            SystemIOMachineStates.bulkCreateAndDeletingKCLFilesAndNavigateToFile
+          )
+        } finally {
+          actor.stop()
+        }
+      })
     })
     describe('when setting project directory path', () => {
       it('should set new project directory path', async () => {

--- a/src/machines/systemIO/systemIOMachine.ts
+++ b/src/machines/systemIO/systemIOMachine.ts
@@ -140,6 +140,7 @@ export const systemIOMachine = setup({
             filesToDelete?: RequestedKCLFileDelete[]
             requestedProjectName: string
             requestedFileNameWithExtension: string
+            navigateToFile?: boolean
             override?: boolean
             requestedSubRoute?: string
           }
@@ -160,7 +161,11 @@ export const systemIOMachine = setup({
         }
       | {
           type: SystemIOMachineEvents.done_bulkCreateAndDeleteKCLFilesAndNavigateToFile
-          output: { projectName: string; fileName: string }
+          output: {
+            projectName: string
+            fileName: string
+            navigateToFile: boolean
+          }
         }
       | {
           type: SystemIOMachineEvents.importFileFromURL
@@ -650,6 +655,7 @@ export const systemIOMachine = setup({
             filesToDelete?: RequestedKCLFileDelete[]
             requestedProjectName: string
             requestedFileNameWithExtension: string
+            navigateToFile?: boolean
             requestedSubRoute?: string
           }
         }): Promise<{
@@ -657,8 +663,15 @@ export const systemIOMachine = setup({
           fileName: string
           projectName: string
           subRoute: string
+          navigateToFile: boolean
         }> => {
-          return { message: '', fileName: '', projectName: '', subRoute: '' }
+          return {
+            message: '',
+            fileName: '',
+            projectName: '',
+            subRoute: '',
+            navigateToFile: true,
+          }
         }
       ),
     [SystemIOMachineActors.renameFolder]: fromPromise(
@@ -1679,6 +1692,7 @@ export const systemIOMachine = setup({
             override: event.data.override,
             requestedFileNameWithExtension:
               event.data.requestedFileNameWithExtension,
+            navigateToFile: event.data.navigateToFile ?? true,
             requestedSubRoute: event.data.requestedSubRoute,
           }
         },
@@ -1686,14 +1700,25 @@ export const systemIOMachine = setup({
           target: SystemIOMachineStates.readingFolders,
           actions: [
             assign({
-              requestedFileName: ({ event }) => {
+              lastOperation:
+                SystemIOMachineStates.bulkCreateAndDeletingKCLFilesAndNavigateToFile,
+              requestedFileName: ({ context, event }) => {
                 assertEvent(
                   event,
                   SystemIOMachineEvents.done_bulkCreateAndDeleteKCLFilesAndNavigateToFile
                 )
                 const output = (
-                  event as { output: { projectName: string; fileName: string } }
+                  event as {
+                    output: {
+                      projectName: string
+                      fileName: string
+                      navigateToFile: boolean
+                    }
+                  }
                 ).output
+                if (!output.navigateToFile) {
+                  return context.requestedFileName
+                }
                 // Gotcha: file could have an ending of .kcl...
                 const file = output.fileName.endsWith('.kcl')
                   ? output.fileName

--- a/src/machines/systemIO/systemIOMachineImpl.ts
+++ b/src/machines/systemIO/systemIOMachineImpl.ts
@@ -898,6 +898,7 @@ export const systemIOMachineImpl = systemIOMachine.provide({
             requestedProjectName: string
             override?: boolean
             requestedFileNameWithExtension: string
+            navigateToFile?: boolean
             requestedSubRoute?: string
           }
         }) => {
@@ -923,6 +924,7 @@ export const systemIOMachineImpl = systemIOMachine.provide({
             ...message,
             projectName: input.requestedProjectName,
             fileName: input.requestedFileNameWithExtension || '',
+            navigateToFile: input.navigateToFile ?? true,
             subRoute: input.requestedSubRoute || '',
           }
         }

--- a/src/machines/systemIO/utils.spec.ts
+++ b/src/machines/systemIO/utils.spec.ts
@@ -256,6 +256,29 @@ describe('System IO Utils', () => {
     expect(preparedPayload?.filesToDelete).toEqual([
       { requestedFileName: 'old.kcl' },
     ])
+    expect(preparedPayload?.deletesFocusedFile).toBe(false)
+  })
+
+  it('marks Zookeeper edit requests that delete the focused file', () => {
+    const preparedPayload = prepareMlEphantNewFileRequest({
+      projectNameCurrentlyOpened: 'some-project',
+      fileFocusedOnInEditor: {
+        name: 'main.kcl',
+        path: '/some-project/main.kcl',
+        children: null,
+      },
+      filesToDelete: [{ requestedFileName: 'main.kcl' }],
+      toolOutput: {
+        status_code: 200,
+        type: 'edit_kcl_code',
+        project_name: 'some-project',
+        outputs: {
+          'other.kcl': 'cube = 1',
+        },
+      },
+    })
+
+    expect(preparedPayload?.deletesFocusedFile).toBe(true)
   })
 
   it('matches explicit Zookeeper delete signals across path separators', () => {

--- a/src/machines/systemIO/utils.ts
+++ b/src/machines/systemIO/utils.ts
@@ -414,10 +414,21 @@ export const prepareMlEphantNewFileRequest = ({
   const requestedFileNameWithExtension = rawRelativePath.startsWith(fsZds.sep)
     ? rawRelativePath.slice(fsZds.sep.length)
     : rawRelativePath
+  const normalizedRequestedFileName = normalizeKCLFileDeletePath(
+    requestedFileNameWithExtension
+  )
+  const deletesFocusedFile =
+    normalizedRequestedFileName.length > 0 &&
+    filesToDelete.some(
+      (file) =>
+        normalizeKCLFileDeletePath(file.requestedFileName) ===
+        normalizedRequestedFileName
+    )
 
   return {
     files: requestedFiles,
     filesToDelete,
+    deletesFocusedFile,
     requestedProjectName: projectNameCurrentlyOpened,
     requestedFileNameWithExtension,
   }

--- a/src/registry/extensions/engineScene/index.spec.ts
+++ b/src/registry/extensions/engineScene/index.spec.ts
@@ -2,6 +2,7 @@ import {
   Registry,
   defineRegistryItem,
   pluginsValueSpec,
+  provide,
   provideService,
 } from '@kittycad/registry'
 import { signal } from '@preact/signals-core'
@@ -81,6 +82,27 @@ describe('engineScene extension', () => {
     expect(
       registry.get(statusBarLocalItemsValueSpec).map((item) => item.scopes)
     ).toEqual([['file'], ['file'], ['file'], ['file']])
+  })
+
+  it('omits executing-file status bar items without clearing unrelated local items', () => {
+    const registry = new Registry()
+    registry.configure([
+      defineRegistryItem({
+        id: 'unrelated-local-status-bar-item',
+        provides: [
+          provide(statusBarLocalItemsValueSpec, {
+            id: 'unrelated',
+            element: 'text',
+            label: 'Unrelated',
+          }),
+        ],
+      }),
+      engineSceneExtension,
+    ])
+
+    expect(
+      registry.get(statusBarLocalItemsValueSpec).map((item) => item.id)
+    ).toEqual(['unrelated'])
   })
 
   it('hides the experimental features item when file settings deny it', () => {

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -1,4 +1,5 @@
 import {
+  defineRegistryItem,
   defineRegistryItemFactory,
   defineRuntimeRegistryItem,
   provide,
@@ -6,10 +7,9 @@ import {
 } from '@kittycad/registry'
 import { type Signal, effect, signal } from '@preact/signals-core'
 import { buildFSHistoryExtension } from '@src/editor/plugins/fs'
-import { ZDSProject } from '@src/lang/KclManager'
+import { type KclManager, ZDSProject } from '@src/lang/KclManager'
 import { projectFsManager } from '@src/lang/std/fileSystemManager'
 import type { App } from '@src/lib/app'
-import { PROJECT_ENTRYPOINT } from '@src/lib/constants'
 import { getProjectInfo, readAppSettingsFile } from '@src/lib/desktop'
 import fsZds from '@src/lib/fs-zds'
 import {
@@ -20,7 +20,10 @@ import {
   safeEncodeForRouterPaths,
 } from '@src/lib/paths'
 import type { Project } from '@src/lib/project'
+import { resetCameraPosition } from '@src/lib/resetCameraPosition'
 import { loadAndValidateSettings } from '@src/lib/settings/settingsUtils'
+import { reportRejection } from '@src/lib/trap'
+import { executingEditorService } from '@src/registry/contracts/executingEditor'
 import {
   type ExecutingEditorHandle,
   type OpenEditorOptions,
@@ -33,6 +36,7 @@ import {
   openedProjectValueSpec,
   projectSessionService,
 } from '@src/registry/contracts/projectSession'
+import { appRegistryServicesSlot } from '@src/registry/registry'
 import type { Subscription } from 'xstate'
 import { waitFor } from 'xstate'
 
@@ -46,6 +50,7 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
   let unsubscribeFromSettings: Subscription | undefined
   let unsubscribeFromSystemIO: Subscription | undefined
   let stopFSHistoryEffect: (() => void) | undefined
+  let stopExecutingEditorServiceEffect: (() => void) | undefined
 
   const openedProjectHandle =
     signal<ProjectSessionService['openedProjectHandle']['value']>(undefined)
@@ -56,6 +61,72 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
 
   const projectSessionUnboundError = () =>
     new Error('Project session service has not been bound to App.')
+
+  const isCurrentExecutingEditor = (
+    editor: KclManager,
+    handle: ExecutingEditorHandle
+  ) => {
+    const currentHandle = executingEditorHandle.peek()
+    return (
+      currentHandle?.projectPath === handle.projectPath &&
+      currentHandle.filePath === handle.filePath &&
+      openedProject.peek()?.executingEditor.value === editor
+    )
+  }
+
+  const executeSelectedEditor = async (
+    currentApp: App,
+    editor: KclManager,
+    handle: ExecutingEditorHandle
+  ) => {
+    if (!editor.engineCommandManager.started) {
+      return
+    }
+    if (!isCurrentExecutingEditor(editor, handle)) {
+      return
+    }
+    if (!editor.engineCommandManager.connection?.connected) {
+      return
+    }
+
+    await editor.executeCode()
+    if (!isCurrentExecutingEditor(editor, handle)) {
+      return
+    }
+
+    await resetCameraPosition({
+      sceneInfra: editor.sceneInfra,
+      engineCommandManager: editor.engineCommandManager,
+      settingsActor: currentApp.settings.actor,
+    })
+  }
+
+  const syncExecutingEditorService = (currentApp: App) => {
+    const editor = openedProject.value?.executingEditor.value
+    currentApp.registry.reconfigure(
+      appRegistryServicesSlot,
+      editor
+        ? [
+            defineRegistryItem({
+              id: 'executing-editor-services',
+              providesServices: [
+                provideService(
+                  executingEditorService,
+                  editor.executingEditorService
+                ),
+              ],
+            }),
+          ]
+        : []
+    )
+  }
+
+  const startExecutingEditorServiceEffect = (currentApp: App) => {
+    stopExecutingEditorServiceEffect?.()
+    stopExecutingEditorServiceEffect = effect(() => {
+      syncExecutingEditorService(currentApp)
+    })
+  }
 
   const getProjectFromHandle = async (
     currentApp: App,
@@ -101,6 +172,10 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     if (clearHandles) {
       openedProjectHandle.value = undefined
       executingEditorHandle.value = undefined
+      currentApp?.commands.actor.send({
+        type: 'Set kclManager',
+        data: undefined,
+      })
     }
 
     if (clearProjectSettings) {
@@ -216,12 +291,15 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
       filePath,
     }
 
-    return currentProject.openEditor(
+    const editor = await currentProject.openEditor(
       filePath,
       providedEditor,
       providedCode,
       isExecuting
     )
+
+    app?.commands.actor.send({ type: 'Set kclManager', data: editor })
+    return editor
   }
 
   const setExecutingEditorHandle = async (
@@ -229,7 +307,15 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     options: OpenEditorOptions = {}
   ) => {
     if (!handle) {
+      const currentProject = openedProject.peek()
+      if (currentProject?.executingPath) {
+        currentProject.closeEditor(currentProject.executingPath)
+      }
+      if (currentProject) {
+        currentProject.executingPath = null
+      }
       executingEditorHandle.value = undefined
+      app?.commands.actor.send({ type: 'Set kclManager', data: undefined })
       return undefined
     }
 
@@ -241,10 +327,16 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     if (currentProject?.path !== handle.projectPath) {
       await setOpenedProjectHandle({ projectPath: handle.projectPath })
     }
+    const targetProject = openedProject.peek()
+    const previousExecutingPath = targetProject?.executingPath ?? undefined
+    const shouldClosePreviousExecutingEditor =
+      previousExecutingPath !== undefined &&
+      previousExecutingPath !== handle.filePath
+    const shouldExecuteSelectedEditor =
+      options.isExecuting !== false && previousExecutingPath !== handle.filePath
 
-    return loadEditorFromHandle(handle.filePath, {
-      providedEditor:
-        options.providedEditor ?? currentApp.singletons.kclManager,
+    const nextEditor = await loadEditorFromHandle(handle.filePath, {
+      providedEditor: options.providedEditor,
       providedCode:
         options.providedCode ??
         (window.electron?.process.env.NODE_ENV === 'test'
@@ -252,6 +344,17 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
           : undefined),
       isExecuting: options.isExecuting,
     })
+
+    if (shouldClosePreviousExecutingEditor) {
+      targetProject?.closeEditor(previousExecutingPath)
+    }
+    if (shouldExecuteSelectedEditor) {
+      executeSelectedEditor(currentApp, nextEditor, handle).catch(
+        reportRejection
+      )
+    }
+
+    return nextEditor
   }
 
   const setProjectRouteHandles = async ({
@@ -275,7 +378,9 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     }
 
     const heuristicProjectFilePath = routeId
-      ? routeId.split(fsZds.sep).slice(0, -1).join(fsZds.sep)
+      ? fsZds.extname(routeId) === '.kcl'
+        ? routeId.split(fsZds.sep).slice(0, -1).join(fsZds.sep)
+        : routeId
       : undefined
 
     const wasmInstance = await currentApp.wasmPromise
@@ -297,52 +402,44 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
       )
     }
 
-    const { projectName, projectPath, currentFileName, currentFilePath } =
-      projectPathData
+    const { projectPath, currentFileName, currentFilePath } = projectPathData
 
     const urlObj = new URL(requestUrl)
+    const isSettingsRoute = urlObj.pathname.endsWith('/settings')
 
-    if (!urlObj.pathname.endsWith('/settings')) {
-      const fallbackFile = (await getProjectInfo(projectPath, wasmInstance))
-        .default_file
+    await setOpenedProjectHandle({ projectPath })
+
+    if (!currentFileName || !currentFilePath) {
+      await setExecutingEditorHandle(undefined)
+      return {}
+    }
+
+    if (!isSettingsRoute) {
       let fileExists = true
-      if (currentFilePath && fileExists) {
-        try {
-          await fsZds.stat(currentFilePath)
-        } catch (e) {
-          if (e === 'ENOENT') {
-            fileExists = false
-          }
+      try {
+        await fsZds.stat(currentFilePath)
+      } catch (e) {
+        if (e === 'ENOENT') {
+          fileExists = false
         }
       }
 
-      if (projectPath && !currentFileName && fileExists && routeId) {
-        const encodedId = safeEncodeForRouterPaths(routeId)
-        return {
-          redirectTo: requestUrl.replace(
-            encodedId,
-            safeEncodeForRouterPaths(fallbackFile)
-          ),
-        }
-      }
-
-      if (!fileExists || !currentFileName || !currentFilePath || !projectName) {
+      if (!fileExists) {
         const routerSearch = getRouterSearchFromRequestUrl(
           requestUrl,
           usesHashRouter
         )
         return {
           redirectTo: `${PATHS.FILE}/${encodeURIComponent(
-            fallbackFile
+            projectPath
           )}${routerSearch}`,
         }
       }
     }
 
-    await setOpenedProjectHandle({ projectPath })
     await setExecutingEditorHandle({
       projectPath,
-      filePath: currentFilePath || PROJECT_ENTRYPOINT,
+      filePath: currentFilePath,
     })
 
     return {}
@@ -354,6 +451,7 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
     openedProject,
     bindApp(boundApp) {
       app = boundApp
+      startExecutingEditorServiceEffect(boundApp)
     },
     setOpenedProjectHandle,
     setExecutingEditorHandle,
@@ -375,7 +473,11 @@ const projectSessionExtension = defineRegistryItemFactory(() => {
         }),
       ],
       providesServices: [provideService(projectSessionService, serviceImpl)],
-      dispose: () => clearProjectSession(),
+      dispose: () => {
+        stopExecutingEditorServiceEffect?.()
+        stopExecutingEditorServiceEffect = undefined
+        clearProjectSession()
+      },
     }),
   }
 }, 'project-session-extension')

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -17,7 +17,6 @@ import {
   getProjectMetaByRouteId,
   getRouterSearchFromRequestUrl,
   getStringAfterLastSeparator,
-  safeEncodeForRouterPaths,
 } from '@src/lib/paths'
 import type { Project } from '@src/lib/project'
 import { resetCameraPosition } from '@src/lib/resetCameraPosition'

--- a/src/registry/plugins/codeEditor/index.ts
+++ b/src/registry/plugins/codeEditor/index.ts
@@ -47,8 +47,8 @@ function RenderHeaderItem({ app }: AppHeaderItemProps) {
     },
     app.singletons.kclManager,
     {
-      enabled: !!currentProject,
-      registerToCodeMirror: !!currentProject,
+      enabled: !!currentProject && !!executionService,
+      registerToCodeMirror: !!currentProject && !!executionService,
     }
   )
 


### PR DESCRIPTION
## Summary

- Allow project-only routes to open a project without auto-selecting or creating an executing file.
- Add user-facing `Set executing file` / `Clear executing file` flows, no-executing-file empty states, and command/menu support.
- Make editor/modeling-dependent UI paths tolerate `openedProject && !executingEditor`.
- Hoist project history onto `ZDSProject` so history survives executing editor replacement.
- Update Zookeeper/file deletion behavior so deleting the executing file clears the executing file and navigates to the project-only route, while unrelated edits stay on the current route.

## Demo

https://github.com/user-attachments/assets/7a32fe53-35f1-475f-82ca-46939b0def95

## Motivation

This is the semantic branch that makes “project open, no executing file” a valid state. It lets route/session state own the executing file instead of recreating editor state implicitly from route loaders, and it gives the UI explicit affordances for selecting or clearing the executing file.

This PR is now stacked directly on `codex/deprecate-use-singletons-boundary` / #12094. The former intermediate route-loader shrinking PR (#12095) has been folded into #12082 and closed.

## Validation

- `npm run lint`
- `npm run test:integration -- src/lib/app.spec.ts src/lang/KclManager.spec.ts src/registry/extensions/engineScene/index.spec.ts`
- `npm run test:integration -- src/components/ProjectSidebarMenu.spec.tsx src/components/Explorer/ProjectExplorer.spec.tsx src/components/layout/areas/KclEditorPane.spec.tsx src/components/NoExecutingFileEmptyState.spec.tsx`
- `npm run tsc` is blocked locally by stale `node_modules`: package-lock has `@kittycad/lib@4.2.13`, but the installed copy is `4.2.9`, so newer API types such as announcements/project-status feedback are missing.