### PR TITLE
Prevent file-tree races during project folder refreshes

### DIFF
--- a/src/components/Explorer/FileExplorer.spec.tsx
+++ b/src/components/Explorer/FileExplorer.spec.tsx
@@ -13,6 +13,7 @@ describe('FileExplorer', () => {
           isRenaming={false}
           isCopying={false}
           isDeleting={false}
+          isInteractionDisabled={false}
           onDeleteEnd={() => {}}
         />
       )

--- a/src/components/Explorer/FileExplorer.tsx
+++ b/src/components/Explorer/FileExplorer.tsx
@@ -68,6 +68,7 @@ export const FileExplorer = ({
   isRenaming,
   isDeleting,
   isCopying,
+  isInteractionDisabled,
   isExternalDragOver,
   highlightedEntry,
   onDeleteEnd,
@@ -79,6 +80,7 @@ export const FileExplorer = ({
   isRenaming: boolean
   isDeleting: boolean
   isCopying: boolean
+  isInteractionDisabled: boolean
   isExternalDragOver?: boolean
   highlightedEntry?: FileExplorerEntry | null
   onDeleteEnd: () => void
@@ -108,6 +110,7 @@ export const FileExplorer = ({
             isRenaming={isRenaming}
             isDeleting={isDeleting}
             isCopying={isCopying}
+            isInteractionDisabled={isInteractionDisabled}
             isExternalDragHighlighted={isHighlighted}
             isExternalDragOver={isExternalDragOver}
             onDeleteEnd={onDeleteEnd}
@@ -260,6 +263,7 @@ export const FileExplorerRowElement = ({
   isRenaming,
   isDeleting,
   isCopying,
+  isInteractionDisabled,
   isExternalDragHighlighted,
   isExternalDragOver,
   onDeleteEnd,
@@ -271,6 +275,7 @@ export const FileExplorerRowElement = ({
   isRenaming: boolean
   isDeleting: boolean
   isCopying: boolean
+  isInteractionDisabled: boolean
   isExternalDragHighlighted?: boolean
   isExternalDragOver?: boolean
   onDeleteEnd: () => void
@@ -348,6 +353,9 @@ export const FileExplorerRowElement = ({
   const externalHighlightCSS = isExternalDragHighlighted
     ? 'ring-2 ring-inset ring-blue-500 bg-blue-500/10'
     : ''
+  const interactionCSS = isInteractionDisabled
+    ? 'cursor-wait opacity-70'
+    : 'cursor-pointer hover:outline hover:outline-1 hover:bg-gray-300/50'
   const handleDeleteDismiss = useCallback(() => {
     setIsConfirmingDelete(false)
     onDeleteEnd()
@@ -360,10 +368,11 @@ export const FileExplorerRowElement = ({
       ref={rowElementRef}
       role="treeitem"
       data-testid="file-tree-item"
-      className={`h-5 flex flex-row items-center text-xs cursor-pointer -outline-offset-1 ${outlineCSS} hover:outline hover:outline-1 hover:bg-gray-300/50 ${isSelected ? 'bg-primary/10' : ''} ${externalHighlightCSS} transition-all duration-100`}
+      className={`h-5 flex flex-row items-center text-xs -outline-offset-1 ${outlineCSS} ${interactionCSS} ${isSelected ? 'bg-primary/10' : ''} ${externalHighlightCSS} transition-all duration-100`}
       data-index={row.domIndex}
       data-last-element={row.domIndex === row.domLength - 1}
       data-parity={row.domIndex % 2 === 0}
+      aria-disabled={isInteractionDisabled}
       aria-setsize={row.setSize}
       aria-posinset={row.positionInSet}
       aria-label={row.name}
@@ -371,18 +380,27 @@ export const FileExplorerRowElement = ({
       aria-level={row.level + 1}
       aria-expanded={row.isFolder && row.isOpen}
       onClick={() => {
+        if (isInteractionDisabled) {
+          return
+        }
         row.onClick(row.domIndex)
       }}
       onDoubleClick={
         row.onDoubleClick
           ? (event) => {
+              if (isInteractionDisabled) {
+                return
+              }
               event.preventDefault()
               row.onDoubleClick?.(row.domIndex)
             }
           : undefined
       }
-      draggable="true"
+      draggable={!isInteractionDisabled}
       onDragOver={(event) => {
+        if (isInteractionDisabled) {
+          return
+        }
         event.preventDefault()
 
         if (isExternalFileDrag(event)) {
@@ -402,6 +420,9 @@ export const FileExplorerRowElement = ({
         }
       }}
       onDragLeave={(event) => {
+        if (isInteractionDisabled) {
+          return
+        }
         event.preventDefault()
 
         if (isExternalFileDrag(event)) {
@@ -416,6 +437,10 @@ export const FileExplorerRowElement = ({
         }
       }}
       onDragStart={(event) => {
+        if (isInteractionDisabled) {
+          event.preventDefault()
+          return
+        }
         event.dataTransfer.effectAllowed = 'move'
         event.dataTransfer.setData(
           'json',
@@ -435,6 +460,9 @@ export const FileExplorerRowElement = ({
         removeDragPreviewElem()
       }}
       onDrop={(event) => {
+        if (isInteractionDisabled) {
+          return
+        }
         event.preventDefault()
 
         if (isExternalFileDrag(event)) {
@@ -487,28 +515,30 @@ export const FileExplorerRowElement = ({
       {(isConfirmingDelete || isMyRowDeleting) && (
         <DeleteFileTreeItemDialog row={row} onDismiss={handleDeleteDismiss} />
       )}
-      <FileExplorerRowContextMenu
-        itemRef={rowElementRef}
-        onRename={() => {
-          row.onRenameStart()
-        }}
-        onDelete={() => {
-          setIsConfirmingDelete(true)
-        }}
-        onOpenInNewWindow={() => {
-          row.onOpenInNewWindow()
-        }}
-        onCopy={() => {
-          row.onCopy()
-        }}
-        callback={() => {
-          row.onContextMenuOpen(row.domIndex)
-        }}
-        onPaste={() => {
-          row.onPaste()
-        }}
-        isCopying={isCopying}
-      />
+      {!isInteractionDisabled && (
+        <FileExplorerRowContextMenu
+          itemRef={rowElementRef}
+          onRename={() => {
+            row.onRenameStart()
+          }}
+          onDelete={() => {
+            setIsConfirmingDelete(true)
+          }}
+          onOpenInNewWindow={() => {
+            row.onOpenInNewWindow()
+          }}
+          onCopy={() => {
+            row.onCopy()
+          }}
+          callback={() => {
+            row.onContextMenuOpen(row.domIndex)
+          }}
+          onPaste={() => {
+            row.onPaste()
+          }}
+          isCopying={isCopying}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/Explorer/ProjectExplorer.tsx
+++ b/src/components/Explorer/ProjectExplorer.tsx
@@ -36,13 +36,17 @@ import {
 import type { FileEntry, Project } from '@src/lib/project'
 import type { MaybePressOrBlur } from '@src/lib/types'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
-import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
+import {
+  SystemIOMachineEvents,
+  SystemIOMachineStates,
+} from '@src/machines/systemIO/utils'
 import {
   PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE,
   PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE,
   keymapService,
 } from '@src/registry/contracts/keymap'
 import { PROJECT_EXPLORER_COMMAND_IDS } from '@src/registry/extensions/keymap/defaultKeymap'
+import { useSelector } from '@xstate/react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { FocusEvent as ReactFocusEvent } from 'react'
 import toast from 'react-hot-toast'
@@ -53,6 +57,18 @@ const isFileExplorerEntryOpened = (
 ): boolean => {
   return rows[entry.key]
 }
+
+const FILE_TREE_MUTATION_STATES = [
+  SystemIOMachineStates.renamingFolder,
+  SystemIOMachineStates.renamingFile,
+  SystemIOMachineStates.deletingFileOrFolder,
+  SystemIOMachineStates.renamingFileAndNavigateToFile,
+  SystemIOMachineStates.renamingFolderAndNavigateToFile,
+  SystemIOMachineStates.deletingFileOrFolderAndNavigate,
+  SystemIOMachineStates.copyingRecursive,
+  SystemIOMachineStates.movingRecursive,
+  SystemIOMachineStates.movingRecursiveAndNavigate,
+] as const
 
 const handleExternalDragEvent = (e: React.DragEvent): boolean => {
   if (!isExternalFileDrag(e)) {
@@ -178,6 +194,14 @@ export const ProjectExplorer = ({
   const { commands, registry, settings, systemIOActor } = useApp()
   const keymap = registry.optional(keymapService)
   const { kclManager } = useSingletons()
+  const isSystemIOIdle = useSelector(systemIOActor, (state) =>
+    state.matches(SystemIOMachineStates.idle)
+  )
+  const isSystemIOFileTreeMutation = useSelector(systemIOActor, (state) =>
+    FILE_TREE_MUTATION_STATES.some((fileTreeMutationState) =>
+      state.matches(fileTreeMutationState)
+    )
+  )
   const errors = kclManager.errorsSignal.value
   const settingsValues = settings.useSettings()
   const applicationProjectDirectory =
@@ -213,6 +237,8 @@ export const ProjectExplorer = ({
   const [isRenaming, setIsRenaming] = useState<boolean>(false)
   const [isDeleting, setIsDeleting] = useState<boolean>(false)
   const [isCopying, setIsCopying] = useState<boolean>(false)
+  const [isFileTreeMutationPending, setIsFileTreeMutationPending] =
+    useState<boolean>(false)
   const lastIndexBeforeNothing = useRef<number>(-2)
 
   // Store a path to copy and paste! Works for folders and files
@@ -231,6 +257,7 @@ export const ProjectExplorer = ({
   const activeIndexRef = useRef(activeIndex)
   const selectedRowRef = useRef(selectedRow)
   const onRowEnterRef = useRef(onRowEnter)
+  const isFileTreeInteractionDisabledRef = useRef(false)
   const projectExplorerCommandHandlersRef = useRef({
     arrowLeft: () => {},
     arrowRight: () => {},
@@ -246,6 +273,28 @@ export const ProjectExplorer = ({
   const lastSyncedFilePathRef = useRef<string | undefined>(undefined)
 
   onRowEnterRef.current = onRowEnter
+  const isFileTreeInteractionDisabled =
+    isFileTreeMutationPending || isSystemIOFileTreeMutation
+  isFileTreeInteractionDisabledRef.current = isFileTreeInteractionDisabled
+
+  const setFileTreeMutationPending = useCallback((isPending: boolean) => {
+    isFileTreeInteractionDisabledRef.current = isPending
+    setIsFileTreeMutationPending(isPending)
+  }, [])
+
+  const sendFileTreeMutationEvent = useCallback(
+    (event: Parameters<typeof systemIOActor.send>[0]) => {
+      setFileTreeMutationPending(true)
+      systemIOActor.send(event)
+    },
+    [setFileTreeMutationPending, systemIOActor]
+  )
+
+  useEffect(() => {
+    if (isSystemIOIdle && isFileTreeMutationPending) {
+      setFileTreeMutationPending(false)
+    }
+  }, [isFileTreeMutationPending, isSystemIOIdle, setFileTreeMutationPending])
 
   // fake row is used for new files or folders, you should not be able to have multiple fake rows for creation
   const [fakeRow, setFakeRow] = useState<{
@@ -258,7 +307,11 @@ export const ProjectExplorer = ({
    * If code wants to externall trigger creating a file pass in a new timestamp.
    */
   useEffect(() => {
-    if (createFilePressed <= 0 || readOnly) {
+    if (
+      createFilePressed <= 0 ||
+      readOnly ||
+      isFileTreeInteractionDisabledRef.current
+    ) {
       return
     }
 
@@ -277,7 +330,11 @@ export const ProjectExplorer = ({
   }, [createFilePressed])
 
   useEffect(() => {
-    if (createFolderPressed <= 0 || readOnly) {
+    if (
+      createFolderPressed <= 0 ||
+      readOnly ||
+      isFileTreeInteractionDisabledRef.current
+    ) {
       return
     }
     const row =
@@ -359,7 +416,10 @@ export const ProjectExplorer = ({
   )
 
   const handleArrowLeftCommand = useCallback(() => {
-    if (activeIndexRef.current === CONTAINER_IS_SELECTED) {
+    if (
+      isFileTreeInteractionDisabledRef.current ||
+      activeIndexRef.current === CONTAINER_IS_SELECTED
+    ) {
       return
     }
 
@@ -392,7 +452,10 @@ export const ProjectExplorer = ({
   }, [onRowClickCallback, setOpenedRowsWrapper])
 
   const handleArrowRightCommand = useCallback(() => {
-    if (activeIndexRef.current === CONTAINER_IS_SELECTED) {
+    if (
+      isFileTreeInteractionDisabledRef.current ||
+      activeIndexRef.current === CONTAINER_IS_SELECTED
+    ) {
       return
     }
 
@@ -412,6 +475,10 @@ export const ProjectExplorer = ({
   }, [setOpenedRowsWrapper])
 
   const handleArrowUpCommand = useCallback(() => {
+    if (isFileTreeInteractionDisabledRef.current) {
+      return
+    }
+
     setActiveIndex((previous) => {
       const next =
         previous === NOTHING_IS_SELECTED
@@ -423,6 +490,10 @@ export const ProjectExplorer = ({
   }, [])
 
   const handleArrowDownCommand = useCallback(() => {
+    if (isFileTreeInteractionDisabledRef.current) {
+      return
+    }
+
     const lastRowIndex = rowsToRenderRef.current.length - 1
     if (lastRowIndex < STARTING_INDEX_TO_SELECT) {
       return
@@ -439,7 +510,10 @@ export const ProjectExplorer = ({
   }, [])
 
   const handleEnterCommand = useCallback(() => {
-    if (activeIndexRef.current < STARTING_INDEX_TO_SELECT) {
+    if (
+      isFileTreeInteractionDisabledRef.current ||
+      activeIndexRef.current < STARTING_INDEX_TO_SELECT
+    ) {
       return
     }
 
@@ -457,7 +531,11 @@ export const ProjectExplorer = ({
   }, [setOpenedRowsWrapper])
 
   const handleRenameCommand = useCallback(() => {
-    if (readOnly || activeIndexRef.current < STARTING_INDEX_TO_SELECT) {
+    if (
+      readOnly ||
+      isFileTreeInteractionDisabledRef.current ||
+      activeIndexRef.current < STARTING_INDEX_TO_SELECT
+    ) {
       return
     }
 
@@ -471,7 +549,11 @@ export const ProjectExplorer = ({
   }, [readOnly])
 
   const handleDeleteCommand = useCallback(() => {
-    if (readOnly || activeIndexRef.current < STARTING_INDEX_TO_SELECT) {
+    if (
+      readOnly ||
+      isFileTreeInteractionDisabledRef.current ||
+      activeIndexRef.current < STARTING_INDEX_TO_SELECT
+    ) {
       return
     }
 
@@ -485,7 +567,10 @@ export const ProjectExplorer = ({
   }, [readOnly])
 
   const handleCopyCommand = useCallback(() => {
-    if (activeIndexRef.current < STARTING_INDEX_TO_SELECT) {
+    if (
+      isFileTreeInteractionDisabledRef.current ||
+      activeIndexRef.current < STARTING_INDEX_TO_SELECT
+    ) {
       return
     }
 
@@ -498,7 +583,11 @@ export const ProjectExplorer = ({
   }, [])
 
   const handlePasteCommand = useCallback(() => {
-    if (readOnly || activeIndexRef.current < STARTING_INDEX_TO_SELECT) {
+    if (
+      readOnly ||
+      isFileTreeInteractionDisabledRef.current ||
+      activeIndexRef.current < STARTING_INDEX_TO_SELECT
+    ) {
       return
     }
 
@@ -630,7 +719,7 @@ export const ProjectExplorer = ({
 
   const handleExternalFileDrop = useCallback(
     async (dataTransfer: DataTransfer, target: FileExplorerEntry | null) => {
-      if (readOnly) {
+      if (readOnly || isFileTreeInteractionDisabledRef.current) {
         return
       }
 
@@ -686,6 +775,7 @@ export const ProjectExplorer = ({
 
       // Copy supported files to the target directory
       if (supportedFiles.length > 0) {
+        setFileTreeMutationPending(true)
         const targetPath = getDropTargetPath(target, project.path)
         const createdDirs = new Set<string>()
 
@@ -733,7 +823,13 @@ export const ProjectExplorer = ({
         )
       }
     },
-    [readOnly, project.path, wasmInstance, systemIOActor]
+    [
+      readOnly,
+      project.path,
+      wasmInstance,
+      systemIOActor,
+      setFileTreeMutationPending,
+    ]
   )
 
   const handleDragOverTarget = useCallback(
@@ -817,7 +913,7 @@ export const ProjectExplorer = ({
         '-copy-'
       )
       if (result && result.src && result.target) {
-        systemIOActor.send({
+        sendFileTreeMutationEvent({
           type: SystemIOMachineEvents.copyRecursive,
           data: {
             src: result.src,
@@ -904,7 +1000,7 @@ export const ProjectExplorer = ({
           isFake: false,
           activeIndex: activeIndex,
           onDelete: () => {
-            if (readOnly) {
+            if (readOnly || isFileTreeInteractionDisabledRef.current) {
               return
             }
 
@@ -913,9 +1009,10 @@ export const ProjectExplorer = ({
 
             if (shouldWeNavigate && file && file.path) {
               const src = child.path
+              setFileTreeMutationPending(true)
               toArchivePath(src)
                 .then((target) => {
-                  systemIOActor.send({
+                  sendFileTreeMutationEvent({
                     type: SystemIOMachineEvents.moveRecursiveAndNavigate,
                     data: {
                       src,
@@ -933,6 +1030,7 @@ export const ProjectExplorer = ({
                   )
                 })
                 .catch((e) => {
+                  setFileTreeMutationPending(false)
                   console.error(e)
                   console.warn(
                     `Error while archiving: the deletion of ${child.path} may have been unrecoverable.`
@@ -940,9 +1038,10 @@ export const ProjectExplorer = ({
                 })
             } else {
               const src = child.path
+              setFileTreeMutationPending(true)
               toArchivePath(src)
                 .then((target) => {
-                  systemIOActor.send({
+                  sendFileTreeMutationEvent({
                     type: SystemIOMachineEvents.moveRecursive,
                     data: {
                       src,
@@ -959,6 +1058,7 @@ export const ProjectExplorer = ({
                   )
                 })
                 .catch((e) => {
+                  setFileTreeMutationPending(false)
                   console.error(e)
                   console.warn(
                     `Error while archiving: the deletion of ${child.path} may have been unrecoverable.`
@@ -1020,7 +1120,7 @@ export const ProjectExplorer = ({
               )
               if (result && result.src && result.target) {
                 const { src, target } = result
-                systemIOActor.send({
+                sendFileTreeMutationEvent({
                   type: SystemIOMachineEvents.moveRecursive,
                   data: {
                     src,
@@ -1071,7 +1171,7 @@ export const ProjectExplorer = ({
               if (requestedName !== name) {
                 if (row.isFake) {
                   // create
-                  systemIOActor.send({
+                  sendFileTreeMutationEvent({
                     type: SystemIOMachineEvents.createBlankFolder,
                     data: {
                       requestedAbsolutePath: joinOSPaths(
@@ -1105,7 +1205,7 @@ export const ProjectExplorer = ({
                         overrideApplicationProjectDirectory ||
                           applicationProjectDirectory
                       )
-                    systemIOActor.send({
+                    sendFileTreeMutationEvent({
                       type: SystemIOMachineEvents.renameFolderAndNavigateToFile,
                       data: {
                         requestedFolderName: requestedName,
@@ -1116,7 +1216,7 @@ export const ProjectExplorer = ({
                       },
                     })
                   } else {
-                    systemIOActor.send({
+                    sendFileTreeMutationEvent({
                       type: SystemIOMachineEvents.renameFolder,
                       data: {
                         requestedFolderName: requestedName,
@@ -1163,7 +1263,7 @@ export const ProjectExplorer = ({
               if (row.isFake) {
                 // create a file if it is fake and navigate to that file!
                 if (file && canNavigate) {
-                  systemIOActor.send({
+                  sendFileTreeMutationEvent({
                     type: SystemIOMachineEvents.importFileFromURL,
                     data: {
                       requestedCode: '',
@@ -1176,7 +1276,7 @@ export const ProjectExplorer = ({
                     getParentAbsolutePath(row.path),
                     fileNameForcedWithOriginalExt
                   )
-                  systemIOActor.send({
+                  sendFileTreeMutationEvent({
                     type: SystemIOMachineEvents.createBlankFile,
                     data: {
                       requestedAbsolutePath,
@@ -1193,7 +1293,7 @@ export const ProjectExplorer = ({
                 const shouldWeNavigate =
                   requestedAbsoluteFilePathWithExtension === file?.path &&
                   canNavigate
-                systemIOActor.send({
+                sendFileTreeMutationEvent({
                   type: shouldWeNavigate
                     ? SystemIOMachineEvents.renameFileAndNavigateToFile
                     : SystemIOMachineEvents.renameFile,
@@ -1391,6 +1491,9 @@ export const ProjectExplorer = ({
         onFocus={handleExplorerFocus}
         onBlur={handleExplorerBlur}
         onClick={(event) => {
+          if (isFileTreeInteractionDisabled) {
+            return
+          }
           if (event.target === fileExplorerContainer.current) {
             focusProjectExplorer()
             setActiveIndexWrapper(CONTAINER_IS_SELECTED)
@@ -1398,17 +1501,26 @@ export const ProjectExplorer = ({
           }
         }}
         onDragEnter={(e) => {
+          if (isFileTreeInteractionDisabled) {
+            return
+          }
           if (handleExternalDragEvent(e)) {
             externalDragCounter.current++
             setIsExternalDragOver(true)
           }
         }}
         onDragOver={(e) => {
+          if (isFileTreeInteractionDisabled) {
+            return
+          }
           if (handleExternalDragEvent(e)) {
             e.dataTransfer.dropEffect = 'copy'
           }
         }}
         onDragLeave={(e) => {
+          if (isFileTreeInteractionDisabled) {
+            return
+          }
           if (handleExternalDragEvent(e)) {
             externalDragCounter.current--
             if (externalDragCounter.current <= 0) {
@@ -1419,6 +1531,9 @@ export const ProjectExplorer = ({
           }
         }}
         onDrop={(e) => {
+          if (isFileTreeInteractionDisabled) {
+            return
+          }
           if (handleExternalDragEvent(e)) {
             externalDragCounter.current = 0
             setIsExternalDragOver(false)
@@ -1437,6 +1552,7 @@ export const ProjectExplorer = ({
             isRenaming={isRenaming}
             isDeleting={isDeleting}
             isCopying={isCopying}
+            isInteractionDisabled={isFileTreeInteractionDisabled}
             isExternalDragOver={isExternalDragOver}
             highlightedEntry={highlightedEntry}
             onDeleteEnd={() => {

--- a/src/components/Explorer/ProjectExplorer.tsx
+++ b/src/components/Explorer/ProjectExplorer.tsx
@@ -202,6 +202,10 @@ export const ProjectExplorer = ({
       state.matches(fileTreeMutationState)
     )
   )
+  const lastRecursiveMoveTarget = useSelector(
+    systemIOActor,
+    (state) => state.context.lastRecursiveMoveTarget
+  )
   const errors = kclManager.errorsSignal.value
   const settingsValues = settings.useSettings()
   const applicationProjectDirectory =
@@ -271,6 +275,9 @@ export const ProjectExplorer = ({
   })
   const previousProject = useRef(project)
   const lastSyncedFilePathRef = useRef<string | undefined>(undefined)
+  const lastRevealedRecursiveMoveTargetRef = useRef<string | undefined>(
+    undefined
+  )
 
   onRowEnterRef.current = onRowEnter
   const isFileTreeInteractionDisabled =
@@ -897,6 +904,25 @@ export const ProjectExplorer = ({
         openedRowsForRender[key] = true
         pathIterator.pop()
       }
+    }
+    const shouldRevealRecursiveMoveTarget =
+      !!lastRecursiveMoveTarget &&
+      lastRecursiveMoveTarget !== lastRevealedRecursiveMoveTargetRef.current &&
+      (lastRecursiveMoveTarget === project.path ||
+        lastRecursiveMoveTarget.startsWith(`${project.path}${fsZds.sep}`))
+    if (shouldRevealRecursiveMoveTarget) {
+      const moveTargetKey = parentPathRelativeToApplicationDirectory(
+        lastRecursiveMoveTarget,
+        overrideApplicationProjectDirectory || applicationProjectDirectory
+      )
+      const pathIterator = desktopSafePathSplit(moveTargetKey)
+      while (pathIterator.length > 0) {
+        const key = desktopSafePathJoin(pathIterator)
+        openedRowsChanged = openedRowsChanged || !openedRowsForRender[key]
+        openedRowsForRender[key] = true
+        pathIterator.pop()
+      }
+      lastRevealedRecursiveMoveTargetRef.current = lastRecursiveMoveTarget
     }
 
     const copyEntryToTarget = (src: FileEntry, target: FileEntry) => {

--- a/src/components/Explorer/ProjectExplorer.tsx
+++ b/src/components/Explorer/ProjectExplorer.tsx
@@ -905,16 +905,21 @@ export const ProjectExplorer = ({
         pathIterator.pop()
       }
     }
+    const recursiveMoveTargetRow = lastRecursiveMoveTarget
+      ? flattenedData.find(
+          (child) =>
+            child.path === lastRecursiveMoveTarget &&
+            rowPathMatchesTreeParent(child, project)
+        )
+      : undefined
     const shouldRevealRecursiveMoveTarget =
-      !!lastRecursiveMoveTarget &&
-      lastRecursiveMoveTarget !== lastRevealedRecursiveMoveTargetRef.current &&
-      (lastRecursiveMoveTarget === project.path ||
-        lastRecursiveMoveTarget.startsWith(`${project.path}${fsZds.sep}`))
+      !!recursiveMoveTargetRow &&
+      lastRecursiveMoveTarget !== lastRevealedRecursiveMoveTargetRef.current
     if (shouldRevealRecursiveMoveTarget) {
-      const moveTargetKey = parentPathRelativeToApplicationDirectory(
-        lastRecursiveMoveTarget,
-        overrideApplicationProjectDirectory || applicationProjectDirectory
-      )
+      const moveTargetKey =
+        recursiveMoveTargetRow.children === null
+          ? recursiveMoveTargetRow.parentPath
+          : recursiveMoveTargetRow.key
       const pathIterator = desktopSafePathSplit(moveTargetKey)
       while (pathIterator.length > 0) {
         const key = desktopSafePathJoin(pathIterator)

--- a/src/machines/systemIO/systemIOMachine.spec.ts
+++ b/src/machines/systemIO/systemIOMachine.spec.ts
@@ -794,6 +794,53 @@ describe('systemIOMachine - XState', () => {
           actor.stop()
         }
       })
+      it('should accept file imports while checking read/write access', async () => {
+        const actor = createActor(
+          systemIOMachine.provide({
+            actors: {
+              [SystemIOMachineActors.checkReadWrite]: fromPromise(
+                async () => new Promise(() => {})
+              ),
+              [SystemIOMachineActors.createKCLFile]: fromPromise(
+                async () => new Promise(() => {})
+              ),
+            },
+          }),
+          {
+            input: {
+              wasmInstancePromise: Promise.resolve(instanceInThisFile),
+              app: appInstanceInThisFile,
+            },
+          }
+        ).start()
+
+        try {
+          actor.send({
+            type: SystemIOMachineEvents.setProjectDirectoryPath,
+            data: {
+              requestedProjectDirectoryPath: 'public/kcl-samples',
+            },
+          })
+          await waitFor(actor, (state) =>
+            state.matches(SystemIOMachineStates.checkingReadWrite)
+          )
+
+          actor.send({
+            type: SystemIOMachineEvents.importFileFromURL,
+            data: {
+              requestedProjectName: 'bracket',
+              requestedFileNameWithExtension: 'lego.kcl',
+              requestedCode: 'circle',
+            },
+          })
+
+          await waitFor(actor, (state) =>
+            state.matches(SystemIOMachineStates.importFileFromURL)
+          )
+        } finally {
+          actor.stop()
+        }
+      })
       it('should accept file navigation while checking read/write access', async () => {
         const actor = createActor(
           systemIOMachine.provide({

--- a/src/machines/systemIO/systemIOMachine.ts
+++ b/src/machines/systemIO/systemIOMachine.ts
@@ -302,7 +302,7 @@ export const systemIOMachine = setup({
         }
       | {
           type: SystemIOMachineEvents.done_moveRecursiveAndNavigate
-          output: { requestedProjectName: string }
+          output: { requestedProjectName: string; target: string }
         }
       | {
           type: SystemIOMachineEvents.getMlEphantConversations
@@ -768,6 +768,7 @@ export const systemIOMachine = setup({
           message: '',
           requestedAbsolutePath: '',
           requestedProjectName: '',
+          target: input.target,
         }
       }
     ),
@@ -837,6 +838,7 @@ export const systemIOMachine = setup({
       project: NO_PROJECT_DIRECTORY,
     },
     pendingRenamedProjectName: undefined,
+    lastRecursiveMoveTarget: undefined,
     lastOperation: SystemIOMachineStates.idle,
     mlEphantConversations: undefined,
   }),
@@ -1587,7 +1589,14 @@ export const systemIOMachine = setup({
         },
         onDone: {
           target: SystemIOMachineStates.readingFolders,
-          actions: [SystemIOMachineActions.toastSuccess],
+          actions: [
+            assign({
+              lastRecursiveMoveTarget: ({ event }) => {
+                return (event as { output: { target?: string } }).output.target
+              },
+            }),
+            SystemIOMachineActions.toastSuccess,
+          ],
         },
         onError: {
           target: SystemIOMachineStates.idle,
@@ -1896,6 +1905,9 @@ export const systemIOMachine = setup({
           target: SystemIOMachineStates.readingFolders,
           actions: [
             assign({
+              lastRecursiveMoveTarget: ({ event }) => {
+                return (event as { output: { target?: string } }).output.target
+              },
               requestedProjectName: ({ event }) => {
                 assertEvent(
                   event,

--- a/src/machines/systemIO/systemIOMachine.ts
+++ b/src/machines/systemIO/systemIOMachine.ts
@@ -1589,14 +1589,7 @@ export const systemIOMachine = setup({
         },
         onDone: {
           target: SystemIOMachineStates.readingFolders,
-          actions: [
-            assign({
-              lastRecursiveMoveTarget: ({ event }) => {
-                return (event as { output: { target?: string } }).output.target
-              },
-            }),
-            SystemIOMachineActions.toastSuccess,
-          ],
+          actions: [SystemIOMachineActions.toastSuccess],
         },
         onError: {
           target: SystemIOMachineStates.idle,
@@ -1879,7 +1872,14 @@ export const systemIOMachine = setup({
         },
         onDone: {
           target: SystemIOMachineStates.readingFolders,
-          actions: [SystemIOMachineActions.toastSuccess],
+          actions: [
+            assign({
+              lastRecursiveMoveTarget: ({ event }) => {
+                return (event as { output: { target?: string } }).output.target
+              },
+            }),
+            SystemIOMachineActions.toastSuccess,
+          ],
         },
         onError: {
           target: SystemIOMachineStates.idle,

--- a/src/machines/systemIO/systemIOMachine.ts
+++ b/src/machines/systemIO/systemIOMachine.ts
@@ -1279,6 +1279,9 @@ export const systemIOMachine = setup({
             actions: [SystemIOMachineActions.toastProjectNameTooLong],
           },
         ],
+        [SystemIOMachineEvents.importFileFromURL]: {
+          target: SystemIOMachineStates.importFileFromURL,
+        },
         [SystemIOMachineEvents.bulkImportProjectFilesAndNavigateToFile]: {
           target:
             SystemIOMachineStates.bulkImportingProjectFilesAndNavigateToFile,

--- a/src/machines/systemIO/systemIOMachineImpl.ts
+++ b/src/machines/systemIO/systemIOMachineImpl.ts
@@ -69,6 +69,58 @@ async function getProjectDirectoryEntryNames(projectDirectoryPath?: string) {
   }
 }
 
+function isPathNotFoundError(error: unknown) {
+  return (
+    error === 'ENOENT' ||
+    (typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      error.code === 'ENOENT')
+  )
+}
+
+async function pathExists(targetPath: string) {
+  try {
+    await fsZds.stat(targetPath)
+    return true
+  } catch (error) {
+    if (isPathNotFoundError(error)) {
+      return false
+    }
+    return Promise.reject(error)
+  }
+}
+
+async function moveRecursivePath({
+  src,
+  target,
+}: {
+  src: string
+  target: string
+}) {
+  const statRes = await fsZds.stat(src)
+  const isDirectory = Boolean(statRes.mode & fsZdsConstants.S_IFDIR)
+  const targetAlreadyExists = await pathExists(target)
+
+  if (!targetAlreadyExists) {
+    await fsZds.mkdir(fsZds.dirname(target), { recursive: true })
+    try {
+      await fsZds.rename(src, target)
+      return
+    } catch {
+      // Fall back to copy/remove for cases like cross-device moves.
+    }
+  }
+
+  if (isDirectory) {
+    await fsZds.mkdir(target, { recursive: true })
+  } else {
+    await fsZds.mkdir(fsZds.dirname(target), { recursive: true })
+  }
+  await fsZds.cp(src, target, { recursive: true })
+  await fsZds.rm(src, { recursive: true })
+}
+
 async function getUniqueProjectNameForCreate({
   context,
   requestedProjectName,
@@ -1131,32 +1183,19 @@ export const systemIOMachineImpl = systemIOMachine.provide({
           requestedProjectName?: string
         }
       }) => {
-        try {
-          // TODO: this force deletion behavior assumes this move is only
-          // really used in our archive/restore workflow. We should make
-          // dedicated archive/restore code paths for that if we need cases
-          // where we want to check with the user before going through with forcing.
-          const statRes = await fsZds.stat(input.src)
-          const isDirectory = Boolean(statRes.mode & fsZdsConstants.S_IFDIR)
-
-          if (isDirectory) {
-            await fsZds.mkdir(input.target, { recursive: true })
-            await fsZds.cp(input.src, input.target, { recursive: true })
-          } else {
-            const targetWithoutBasename = fsZds.dirname(input.target)
-            await fsZds.mkdir(targetWithoutBasename, { recursive: true })
-            await fsZds.cp(input.src, input.target, {
-              recursive: true,
-            })
-          }
-          await fsZds.rm(input.src, { recursive: true })
-        } catch (e: unknown) {
-          console.log(e)
-        }
+        // TODO: this force deletion behavior assumes this move is only
+        // really used in our archive/restore workflow. We should make
+        // dedicated archive/restore code paths for that if we need cases
+        // where we want to check with the user before going through with forcing.
+        await moveRecursivePath({
+          src: input.src,
+          target: input.target,
+        })
         return {
           message: input.successMessage || 'Moved successfully',
           requestedAbsolutePath: '',
           requestedProjectName: input.requestedProjectName || '',
+          target: input.target,
         }
       }
     ),

--- a/src/machines/systemIO/utils.ts
+++ b/src/machines/systemIO/utils.ts
@@ -145,6 +145,7 @@ export type SystemIOContext = SystemIOInput & {
 
   /** Temporary storage to return to project after renaming */
   pendingRenamedProjectName?: string
+  lastRecursiveMoveTarget?: string
   lastOperation: any
 
   // A mapping between project id and conversation ids.


### PR DESCRIPTION
## Summary

- gate file-tree row, keyboard, context-menu, and drag/drop interactions while file-tree mutations and their follow-up refresh are in flight
- allow `importFileFromURL` to interrupt an active `checkingReadWrite` state instead of being dropped
- make recursive file-tree moves use atomic rename when possible, surface move failures, and reveal the completed move target after refresh
- add a regression test for file imports during read/write checks

Closes #12090

## Root Cause

Some file-tree actions could be issued while the UI still showed rows from the previous folder snapshot or while the system IO machine was in a transient state. In particular, `checkingReadWrite` accepted project imports, project creation, and navigation, but not `importFileFromURL`, so a create-file action from visible stale folder data could be ignored.

The drag/undo flakes had a related runtime race: recursive moves created the destination folder before copying children, then removed the source, and errors were swallowed. That let the file tree observe or keep open-state around a moved row before the refreshed folder snapshot reliably contained the restored target. The fix moves atomically with `rename` when the destination does not exist, falls back to copy/remove only when needed, records the completed move target from `movingRecursive`, and waits until the refreshed explorer tree contains that target before revealing it.

## Validation

- `npm run tsc`
- `npx eslint --max-warnings 0 src/machines/systemIO/systemIOMachine.ts src/machines/systemIO/systemIOMachineImpl.ts src/machines/systemIO/systemIOMachine.spec.ts src/machines/systemIO/utils.ts src/components/Explorer/ProjectExplorer.tsx`
- `npx vitest run --mode=development --project=integration src/machines/systemIO/systemIOMachine.spec.ts`
- `npm run tronb:vite:dev`
- `npx playwright test --config=playwright.electron.config.ts e2e/playwright/file-tree.spec.ts --grep "dragging a file moves it and undo restores it" --repeat-each=20 --max-failures=20`
- `npx playwright test --config=playwright.electron.config.ts e2e/playwright/file-tree.spec.ts --grep "dragging a folder moves it and undo restores it" --repeat-each=20 --max-failures=20`

To repeat the three flaky desktop cases together through the Makefile:

```sh
make test-e2e-desktop E2E_GREP="dragging a file moves it and undo restores it|dragging a folder moves it and undo restores it|loading small file, then large, then back to small" E2E_FAILURES=20 PW_ARGS="--repeat-each=20"
```