### PR TITLE
Route edge extrudes through body type input

### DIFF
--- a/e2e/playwright/command-bar-tests.spec.ts
+++ b/e2e/playwright/command-bar-tests.spec.ts
@@ -819,16 +819,6 @@ export exported = 2`,
 
     await cmdBar.progressCmdBar()
     await cmdBar.expectState({
-      stage: 'review',
-      commandName: 'Extrude',
-      headerArguments: {
-        Profiles: '1 edge',
-        Length: '5',
-      },
-    })
-
-    await cmdBar.clickOptionalArgument('bodyType')
-    await cmdBar.expectState({
       stage: 'arguments',
       commandName: 'Extrude',
       currentArgKey: 'bodyType',
@@ -840,14 +830,15 @@ export exported = 2`,
       },
       highlightedHeaderArg: 'bodyType',
     })
-    await cmdBar.selectOption({ name: 'Solid' }).click()
+
+    await cmdBar.selectOption({ name: 'Surface' }).click()
     await cmdBar.expectState({
       stage: 'review',
       commandName: 'Extrude',
       headerArguments: {
         Profiles: '1 edge',
         Length: '5',
-        BodyType: 'SOLID',
+        BodyType: 'SURFACE',
       },
     })
 
@@ -860,7 +851,7 @@ export exported = 2`,
       headerArguments: {
         Profiles: '1 edge',
         Length: '5',
-        BodyType: 'SOLID',
+        BodyType: 'SURFACE',
         Method: '',
       },
       highlightedHeaderArg: 'method',
@@ -876,7 +867,7 @@ export exported = 2`,
       headerArguments: {
         Profiles: '1 edge',
         Length: '5',
-        BodyType: 'SOLID',
+        BodyType: 'SURFACE',
       },
       highlightedHeaderArg: 'bodyType',
     })
@@ -890,7 +881,7 @@ export exported = 2`,
       headerArguments: {
         Profiles: '1 edge',
         Length: '5',
-        BodyType: 'SOLID',
+        BodyType: 'SURFACE',
       },
       highlightedHeaderArg: 'length',
     })
@@ -904,7 +895,7 @@ export exported = 2`,
       headerArguments: {
         Profiles: '1 edge',
         Length: '5',
-        BodyType: 'SOLID',
+        BodyType: 'SURFACE',
       },
       highlightedHeaderArg: 'Profiles',
     })

--- a/e2e/playwright/point-click-sketch-v1.spec.ts
+++ b/e2e/playwright/point-click-sketch-v1.spec.ts
@@ -164,10 +164,24 @@ profile001 = circle(sketch001, center = [0, 0], radius = 5)`
         await page.keyboard.insertText('4')
         await cmdBar.progressCmdBar()
         await cmdBar.expectState({
+          stage: 'arguments',
+          currentArgKey: 'bodyType',
+          currentArgValue: '',
+          headerArguments: {
+            Length: '4',
+            Profiles: '1 edge',
+            BodyType: '',
+          },
+          highlightedHeaderArg: 'bodyType',
+          commandName: 'Extrude',
+        })
+        await cmdBar.selectOption({ name: 'Surface' }).click()
+        await cmdBar.expectState({
           stage: 'review',
           headerArguments: {
             Length: '4',
             Profiles: '1 edge',
+            BodyType: 'SURFACE',
           },
           commandName: 'Extrude',
         })
@@ -181,6 +195,7 @@ profile001 = circle(sketch001, center = [0, 0], radius = 5)`
           headerArguments: {
             Length: '4',
             Profiles: '1 edge',
+            BodyType: 'SURFACE',
             TagEnd: '',
           },
           highlightedHeaderArg: 'tagEnd',
@@ -193,6 +208,7 @@ profile001 = circle(sketch001, center = [0, 0], radius = 5)`
           headerArguments: {
             Length: '4',
             Profiles: '1 edge',
+            BodyType: 'SURFACE',
             TagEnd: 'myEndTag',
           },
           commandName: 'Extrude',
@@ -200,9 +216,11 @@ profile001 = circle(sketch001, center = [0, 0], radius = 5)`
       })
       await test.step('Submit and verify', async () => {
         await cmdBar.submit()
-        await editor.expectEditor.toContain(
-          'extrude(profile001, length = 4, tagEnd = $myEndTag)'
-        )
+        await editor.expectEditor.toContain('extrude(')
+        await editor.expectEditor.toContain('profile001')
+        await editor.expectEditor.toContain('length = 4')
+        await editor.expectEditor.toContain('tagEnd = $myEndTag')
+        await editor.expectEditor.toContain('bodyType = SURFACE')
       })
     })
 
@@ -218,6 +236,7 @@ profile001 = circle(sketch001, center = [0, 0], radius = 5)`
           currentArgValue: '4',
           headerArguments: {
             Length: '4',
+            BodyType: 'SURFACE',
             TagEnd: 'myEndTag',
           },
           highlightedHeaderArg: 'length',
@@ -229,6 +248,7 @@ profile001 = circle(sketch001, center = [0, 0], radius = 5)`
           stage: 'review',
           headerArguments: {
             Length: '3',
+            BodyType: 'SURFACE',
             TagEnd: 'myEndTag',
           },
           commandName: 'Extrude',
@@ -236,9 +256,11 @@ profile001 = circle(sketch001, center = [0, 0], radius = 5)`
       })
       await test.step('Submit and verify', async () => {
         await cmdBar.submit()
-        await editor.expectEditor.toContain(
-          'extrude(profile001, length = 3, tagEnd = $myEndTag)'
-        )
+        await editor.expectEditor.toContain('extrude(')
+        await editor.expectEditor.toContain('profile001')
+        await editor.expectEditor.toContain('length = 3')
+        await editor.expectEditor.toContain('tagEnd = $myEndTag')
+        await editor.expectEditor.toContain('bodyType = SURFACE')
       })
     })
   })

--- a/src/lib/commandBarConfigs/modelingCommandConfig.integration.spec.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.integration.spec.ts
@@ -1,14 +1,37 @@
 import { getNextAvailableDatumName } from '@src/lang/modifyAst/gdt'
 import { assertParse } from '@src/lang/wasm'
+import type { Artifact } from '@src/lang/wasm'
 import {
+  extrudeSelectionRequiresBodyType,
   getDefaultGdtTolerance,
   modelingMachineCommandConfig,
 } from '@src/lib/commandBarConfigs/modelingCommandConfig'
 import type { KclCommandValue } from '@src/lib/commandTypes'
 import { isArray } from '@src/lib/utils'
 import type { ModelingMachineContext } from '@src/machines/modelingSharedTypes'
+import type { Selections } from '@src/machines/modelingSharedTypes'
 import { buildTheWorldAndNoEngineConnection } from '@src/unitTestUtils'
 import { describe, expect, it } from 'vitest'
+
+function selectionsForArtifact(artifact?: Artifact): Selections {
+  return {
+    graphSelections: [
+      {
+        artifact,
+        codeRef: { range: [0, 1], pathToNode: [] },
+      },
+    ],
+    otherSelections: [],
+  }
+}
+
+function parsedLength(value = '5'): KclCommandValue {
+  return {
+    valueAst: {},
+    valueText: value,
+    valueCalculated: value,
+  } as KclCommandValue
+}
 
 describe('GDT Datum Default Name', () => {
   it('should work with command bar when datum A already exists', async () => {
@@ -91,5 +114,74 @@ describe('GDT tolerance defaults', () => {
         required: true,
       })
     }
+  })
+})
+
+describe('Extrude bodyType argument', () => {
+  it('requires bodyType when extruding sketch segments after length is confirmed', () => {
+    const commandConfig = modelingMachineCommandConfig.Extrude
+    if (!commandConfig || isArray(commandConfig)) {
+      throw new Error('Extrude should have a single command config')
+    }
+
+    const bodyTypeArg = commandConfig.args?.bodyType
+    if (!bodyTypeArg) throw new Error('Extrude should expose bodyType')
+
+    const required =
+      typeof bodyTypeArg.required === 'function'
+        ? bodyTypeArg.required({
+            argumentsToSubmit: {
+              sketches: selectionsForArtifact({ type: 'segment' } as Artifact),
+              length: parsedLength(),
+            },
+          })
+        : bodyTypeArg.required
+
+    expect(required).toBe(true)
+  })
+
+  it('keeps bodyType optional for sketch segments before length is confirmed', () => {
+    expect(
+      extrudeSelectionRequiresBodyType({
+        argumentsToSubmit: {
+          sketches: selectionsForArtifact({ type: 'segment' } as Artifact),
+          length: '5',
+        },
+      })
+    ).toBe(false)
+  })
+
+  it('keeps bodyType optional for closed extrude profiles and regions', () => {
+    expect(
+      extrudeSelectionRequiresBodyType({
+        argumentsToSubmit: {
+          sketches: selectionsForArtifact({ type: 'solid2d' } as Artifact),
+          length: parsedLength(),
+        },
+      })
+    ).toBe(false)
+
+    expect(
+      extrudeSelectionRequiresBodyType({
+        argumentsToSubmit: {
+          sketches: selectionsForArtifact({
+            type: 'path',
+            subType: 'region',
+          } as Artifact),
+          length: parsedLength(),
+        },
+      })
+    ).toBe(false)
+  })
+
+  it('requires bodyType for valid segment selections before artifact data is available', () => {
+    expect(
+      extrudeSelectionRequiresBodyType({
+        argumentsToSubmit: {
+          sketches: selectionsForArtifact(),
+          length: parsedLength(),
+        },
+      })
+    ).toBe(true)
   })
 })

--- a/src/lib/commandBarConfigs/modelingCommandConfig.integration.spec.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.integration.spec.ts
@@ -18,7 +18,7 @@ function selectionsForArtifact(artifact?: Artifact): Selections {
     graphSelections: [
       {
         artifact,
-        codeRef: { range: [0, 1], pathToNode: [] },
+        codeRef: { range: [0, 1, 0], pathToNode: [] },
       },
     ],
     otherSelections: [],

--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -112,7 +112,7 @@ import {
   addScale,
   addTranslate,
 } from '@src/lang/modifyAst/transforms'
-import { capitaliseFC } from '@src/lib/utils'
+import { capitaliseFC, isArray } from '@src/lib/utils'
 import type { ConnectionManager } from '@src/network/connectionManager'
 
 type OutputFormat = OutputFormat3d
@@ -181,6 +181,41 @@ const kclBodyTypeOptions = KCL_PRELUDE_BODY_TYPE_VALUES.map((value) => ({
   name: capitaliseFC(value.toLowerCase()),
   value,
 }))
+
+function isSelections(value: unknown): value is Selections {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'graphSelections' in value &&
+    isArray(value.graphSelections) &&
+    'otherSelections' in value &&
+    isArray(value.otherSelections)
+  )
+}
+
+function isKclCommandValue(value: unknown): value is KclCommandValue {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'valueAst' in value &&
+    'valueText' in value &&
+    'valueCalculated' in value
+  )
+}
+
+export function extrudeSelectionRequiresBodyType({
+  argumentsToSubmit,
+}: {
+  argumentsToSubmit: Record<string, unknown>
+}): boolean {
+  const sketches = argumentsToSubmit.sketches
+  if (!isSelections(sketches)) return false
+  if (!isKclCommandValue(argumentsToSubmit.length)) return false
+
+  return sketches.graphSelections.some(
+    (selection) => !selection.artifact || selection.artifact.type === 'segment'
+  )
+}
 
 const hasEngineConnection = (
   engineCommandManager: ConnectionManager
@@ -1080,7 +1115,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       },
       bodyType: {
         inputType: 'options',
-        required: false,
+        required: extrudeSelectionRequiresBodyType,
         options: kclBodyTypeOptions,
       },
     },


### PR DESCRIPTION
ai assisted

https://github.com/user-attachments/assets/41a3e523-1f08-4a66-aff1-126b84c960af

## Problem
When a user extrudes sketch edges, the command bar could collect length and go straight to review with the implicit solid body type. That let the backend error explain that edges require a surface extrude, which felt like the UI asked for the wrong thing.

## Solution
The extrude command now asks for body type after length only when the selected profiles are sketch edges. Closed profiles and regions keep the faster optional body type flow, while edge selections guide users to choose surface before review.