### PR TITLE
Scope OPFSCloud sync to the opened project

### DIFF
--- a/src/components/OpenedProject.tsx
+++ b/src/components/OpenedProject.tsx
@@ -27,6 +27,7 @@ import {
   ONBOARDING_TOAST_ID,
   WASM_INIT_FAILED_TOAST_ID,
 } from '@src/lib/constants'
+import { setOpfsCloudSyncProjectScope } from '@src/lib/fs-zds/opfsCloud'
 import useHotkeyWrapper from '@src/lib/hotkeyWrapper'
 import { isDesktop } from '@src/lib/isDesktop'
 import {
@@ -99,6 +100,14 @@ export function OpenedProject() {
   const projectPath = project?.path || null
 
   const systemIOState = useSelector(systemIOActor, (actor) => actor.value)
+
+  useEffect(() => {
+    setOpfsCloudSyncProjectScope(projectPath ?? undefined)
+
+    return () => {
+      setOpfsCloudSyncProjectScope(undefined)
+    }
+  }, [projectPath])
 
   // Handle our project folder disappearing (Go back to Projects listing)
   useEffect(() => {

--- a/src/lib/fs-zds/opfsCloud.test.ts
+++ b/src/lib/fs-zds/opfsCloud.test.ts
@@ -1,5 +1,6 @@
 import { PROJECT_FOLDER, PROJECT_SETTINGS_FILE_NAME } from '@src/lib/constants'
 import {
+  type OutboxEntry,
   type ProjectArchiveFile,
   type ProjectManifest,
   getOpfsCloudProjectModifiedTime,
@@ -7,6 +8,7 @@ import {
   getOpfsCloudProjectSyncPreflightAction,
   getOpfsCloudRemoteArchiveReconciliationAction,
   getOpfsCloudRemoteIndexAction,
+  getOpfsCloudSyncScopePlan,
   prepareProjectFilesForCloudUpload,
   projectManifestsEqual,
 } from '@src/lib/fs-zds/opfsCloud'
@@ -243,5 +245,42 @@ describe('opfsCloud sync helpers', () => {
         100
       )
     ).toBe(100)
+  })
+
+  it('plans full cloud sync on Home and scoped sync on file routes', () => {
+    const entries: OutboxEntry[] = [
+      {
+        projectPath: '/projects/current',
+        kind: 'upsert',
+        targetPath: '/projects/current/main.kcl',
+        createdAt: '2026-06-12T00:00:00.000Z',
+      },
+      {
+        projectPath: '/projects/conflicted',
+        kind: 'upsert',
+        targetPath: '/projects/conflicted/main.kcl',
+        createdAt: '2026-06-12T00:00:01.000Z',
+      },
+    ]
+
+    expect(getOpfsCloudSyncScopePlan(entries)).toEqual({
+      shouldSyncRemoteIndex: true,
+      projectPaths: ['/projects/current', '/projects/conflicted'],
+      pendingCount: 2,
+    })
+
+    expect(getOpfsCloudSyncScopePlan(entries, '/projects/current')).toEqual({
+      shouldSyncRemoteIndex: false,
+      projectPaths: ['/projects/current'],
+      pendingCount: 1,
+    })
+  })
+
+  it('keeps syncing the open project even when it has no queued local edits', () => {
+    expect(getOpfsCloudSyncScopePlan([], '/projects/current')).toEqual({
+      shouldSyncRemoteIndex: false,
+      projectPaths: ['/projects/current'],
+      pendingCount: 0,
+    })
   })
 })

--- a/src/lib/fs-zds/opfsCloud.ts
+++ b/src/lib/fs-zds/opfsCloud.ts
@@ -64,6 +64,7 @@ export type {
   OPFSCloudSyncStatus,
   OpfsCloudLocalProject,
   OpfsCloudProjectMetadataIndexEntry,
+  OutboxEntry,
   ProjectArchiveFile,
   ProjectManifest,
   ProjectMetadata,
@@ -93,6 +94,7 @@ let lastRemoteIndexSyncAt = 0
 let initialLocalScanComplete = false
 let pendingStatusSyncedAt: string | undefined
 let detachVisibilityChangeListener: (() => void) | undefined
+let syncScopeProjectPath: string | undefined
 
 export const opfsCloudSyncStatus = signal<OPFSCloudSyncStatus>({
   enabled: false,
@@ -153,6 +155,65 @@ function isInternalOpfsPath(targetPath: string) {
 
 function isConfiguredForCloud() {
   return config.enabled === true
+}
+
+function getSyncScopeProjectPath(projectPath: string | undefined) {
+  if (!projectPath) {
+    return undefined
+  }
+
+  const normalizedProjectPath = normalizePathForSync(projectPath)
+  return isProjectPathInDirectory(
+    normalizedProjectPath,
+    getConfiguredProjectDirectoryPath()
+  )
+    ? normalizedProjectPath
+    : undefined
+}
+
+function projectPathMatchesSyncScope(projectPath: string) {
+  return (
+    !syncScopeProjectPath ||
+    normalizePathForSync(projectPath) === syncScopeProjectPath
+  )
+}
+
+function outboxEntriesForProject(entries: OutboxEntry[], projectPath: string) {
+  const normalizedProjectPath = normalizePathForSync(projectPath)
+  return entries.filter(
+    (entry) => normalizePathForSync(entry.projectPath) === normalizedProjectPath
+  )
+}
+
+export type OpfsCloudSyncScopePlan = {
+  shouldSyncRemoteIndex: boolean
+  projectPaths: string[]
+  pendingCount: number
+}
+
+export function getOpfsCloudSyncScopePlan(
+  entries: OutboxEntry[],
+  scopeProjectPath?: string
+): OpfsCloudSyncScopePlan {
+  const normalizedScopeProjectPath = scopeProjectPath
+    ? normalizePathForSync(scopeProjectPath)
+    : undefined
+  if (normalizedScopeProjectPath) {
+    return {
+      shouldSyncRemoteIndex: false,
+      projectPaths: [normalizedScopeProjectPath],
+      pendingCount: outboxEntriesForProject(entries, normalizedScopeProjectPath)
+        .length,
+    }
+  }
+
+  return {
+    shouldSyncRemoteIndex: true,
+    projectPaths: Array.from(
+      new Set(entries.map((entry) => normalizePathForSync(entry.projectPath)))
+    ),
+    pendingCount: entries.length,
+  }
 }
 
 function getEnvironmentName() {
@@ -284,7 +345,10 @@ async function clearOutboxEntriesForProject(projectPath: string) {
 async function refreshPendingCount() {
   try {
     const entries = await getAllOutboxEntries()
-    updateStatus({ pendingCount: entries.length })
+    updateStatus({
+      pendingCount: getOpfsCloudSyncScopePlan(entries, syncScopeProjectPath)
+        .pendingCount,
+    })
   } catch {
     updateStatus({ pendingCount: 0 })
   }
@@ -618,11 +682,14 @@ async function markProjectFailure(
     },
   }
   await putProjectMetadata(next)
-  updateStatus({
-    state: 'failed',
-    lastFailure: message,
-    lastFailureAt: next.lastFailure.at,
-  })
+  if (projectPathMatchesSyncScope(metadata.localProjectPath)) {
+    updateStatus({
+      state: 'failed',
+      activeProjectPath: metadata.localProjectPath,
+      lastFailure: message,
+      lastFailureAt: next.lastFailure.at,
+    })
+  }
 }
 
 function markCloudMetadataFailure(error: unknown) {
@@ -659,6 +726,10 @@ async function markProjectSynced(
     lastFailure: undefined,
     lastSyncedAt: syncedAt,
   })
+  if (!projectPathMatchesSyncScope(metadata.localProjectPath)) {
+    return
+  }
+
   if (syncInProgress) {
     pendingStatusSyncedAt = syncedAt
     updateStatus({
@@ -756,12 +827,14 @@ async function markProjectConflict(
       at: nowIso(),
     },
   })
-  updateStatus({
-    state: 'conflict',
-    activeProjectPath: metadata.localProjectPath,
-    lastFailure: 'Cloud sync conflict: local and remote both changed.',
-    lastFailureAt: nowIso(),
-  })
+  if (projectPathMatchesSyncScope(metadata.localProjectPath)) {
+    updateStatus({
+      state: 'conflict',
+      activeProjectPath: metadata.localProjectPath,
+      lastFailure: 'Cloud sync conflict: local and remote both changed.',
+      lastFailureAt: nowIso(),
+    })
+  }
 }
 
 function latestOutboxKind(entries: OutboxEntry[]) {
@@ -884,10 +957,12 @@ async function syncDeletedProject(metadata: ProjectMetadata) {
 
 async function syncProject(projectPath: string, entries: OutboxEntry[]) {
   let metadata = await getOrCreateProjectMetadata(projectPath)
-  updateStatus({
-    state: 'syncing',
-    activeProjectPath: metadata.localProjectPath,
-  })
+  if (projectPathMatchesSyncScope(metadata.localProjectPath)) {
+    updateStatus({
+      state: 'syncing',
+      activeProjectPath: metadata.localProjectPath,
+    })
+  }
 
   try {
     const latestKind = latestOutboxKind(entries)
@@ -1305,31 +1380,34 @@ async function runCloudSync() {
   syncInProgress = true
   pendingStatusSyncedAt = undefined
   updateStatus({ enabled: true, state: 'syncing' })
+  const scopedProjectPath = syncScopeProjectPath
   let remoteIndexFailed = false
   let remoteIndexFailureMessage: string | undefined
 
   try {
-    await enqueueExistingLocalProjectsForInitialSync()
-    await syncRemoteIndex().catch((error) => {
-      remoteIndexFailed = true
-      remoteIndexFailureMessage = errorMessage(error)
-      updateStatus({
-        state: 'failed',
-        lastFailure: remoteIndexFailureMessage,
-        lastFailureAt: nowIso(),
+    let entries = await getAllOutboxEntries()
+    let syncScopePlan = getOpfsCloudSyncScopePlan(entries, scopedProjectPath)
+    if (syncScopePlan.shouldSyncRemoteIndex) {
+      await enqueueExistingLocalProjectsForInitialSync()
+      await syncRemoteIndex().catch((error) => {
+        remoteIndexFailed = true
+        remoteIndexFailureMessage = errorMessage(error)
+        updateStatus({
+          state: 'failed',
+          lastFailure: remoteIndexFailureMessage,
+          lastFailureAt: nowIso(),
+        })
       })
-    })
 
-    const entries = await getAllOutboxEntries()
-    const projectPaths = Array.from(
-      new Set(entries.map((entry) => normalizePathForSync(entry.projectPath)))
-    )
+      entries = await getAllOutboxEntries()
+      syncScopePlan = getOpfsCloudSyncScopePlan(entries, scopedProjectPath)
+    }
 
-    for (const projectPath of projectPaths) {
-      const projectEntries = entries.filter(
-        (entry) => normalizePathForSync(entry.projectPath) === projectPath
+    for (const projectPath of syncScopePlan.projectPaths) {
+      await syncProject(
+        projectPath,
+        outboxEntriesForProject(entries, projectPath)
       )
-      await syncProject(projectPath, projectEntries)
     }
 
     await refreshPendingCount()
@@ -1368,7 +1446,7 @@ async function runCloudSync() {
       state: 'failed',
       lastFailure: errorMessage(error),
       lastFailureAt: nowIso(),
-      activeProjectPath: undefined,
+      activeProjectPath: scopedProjectPath,
       ...(syncedAt ? { lastSyncedAt: syncedAt } : {}),
     })
     scheduleSync(SYNC_RETRY_MS)
@@ -1401,6 +1479,36 @@ function scheduleSync(delay = SYNC_DEBOUNCE_MS) {
 function scheduleRemoteIndexSync(delay = 0) {
   lastRemoteIndexSyncAt = 0
   scheduleSync(delay)
+}
+
+// Home syncs the full cloud index; file routes narrow status and retries to
+// the open project so unrelated project conflicts do not pollute the editor UI.
+export function setOpfsCloudSyncProjectScope(projectPath?: string) {
+  const nextSyncScopeProjectPath = getSyncScopeProjectPath(projectPath)
+  if (syncScopeProjectPath === nextSyncScopeProjectPath) {
+    return
+  }
+
+  syncScopeProjectPath = nextSyncScopeProjectPath
+  void refreshPendingCount()
+
+  const statusProjectPath = opfsCloudSyncStatus.value.activeProjectPath
+    ? normalizePathForSync(opfsCloudSyncStatus.value.activeProjectPath)
+    : undefined
+  if (
+    nextSyncScopeProjectPath &&
+    opfsCloudSyncStatus.value.state !== 'disabled' &&
+    statusProjectPath !== nextSyncScopeProjectPath
+  ) {
+    updateStatus({
+      state: 'idle',
+      activeProjectPath: undefined,
+      lastFailure: undefined,
+      lastFailureAt: undefined,
+    })
+  }
+
+  scheduleSync(0)
 }
 
 function attachVisibilityChangeListener() {
@@ -1564,6 +1672,11 @@ export function configureOpfsCloudSync(nextConfig: OPFSCloudConfig) {
 }
 
 export function retryOpfsCloudSync() {
+  if (syncScopeProjectPath) {
+    scheduleSync(0)
+    return
+  }
+
   scheduleRemoteIndexSync()
 }
 

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -37,7 +37,10 @@ import {
 } from '@src/lib/autoUpdate'
 import { useApp, useSingletons } from '@src/lib/boot'
 import { createRouteCommands } from '@src/lib/commandBarConfigs/routeCommandConfig'
-import { opfsCloudSyncStatus } from '@src/lib/fs-zds/opfsCloud'
+import {
+  opfsCloudSyncStatus,
+  setOpfsCloudSyncProjectScope,
+} from '@src/lib/fs-zds/opfsCloud'
 import { isDesktop } from '@src/lib/isDesktop'
 import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
 import {
@@ -119,6 +122,10 @@ const Home = () => {
   const sort = searchParams.get('sort_by') ?? 'modified:desc'
   const sidebarButtonClasses =
     'flex items-center p-2 gap-2 leading-tight border-transparent dark:border-transparent enabled:dark:border-transparent enabled:hover:border-primary/50 enabled:dark:hover:border-inherit active:border-primary dark:bg-transparent hover:bg-transparent'
+
+  useEffect(() => {
+    setOpfsCloudSyncProjectScope(undefined)
+  }, [])
 
   useEffect(() => {
     setOptimisticProjectRenames((renames) =>


### PR DESCRIPTION
## Summary

- scope OPFSCloud sync while the modeling `/file/` route is mounted so the status bar reflects the currently opened project
- keep Home behavior unchanged by clearing the scope there, so Home still performs full remote index hydration and all-project sync
- filter pending count and failure/conflict status to the scoped project while still retrying only that project
- add unit coverage for the sync-scope planning policy

## Motivation

When a user has an unrelated project with a cloud conflict, the modeling view should not show the cloud sync status as failed/conflicted for a different project. The file route now narrows sync work and status reporting to the open project, while Home remains the place where full project-list hydration and broader sync happen.

## Validation

- `npm run tsc`
- `npx eslint --max-warnings 0 src/lib/fs-zds/opfsCloud.ts src/lib/fs-zds/opfsCloud.test.ts src/components/OpenedProject.tsx src/routes/Home.tsx`
- `npx vitest run --mode=development --project=unit src/lib/fs-zds/opfsCloud.test.ts`