### PR TITLE
More flaky test fixes after #11957

### DIFF
--- a/src/machines/systemIO/systemIOMachine.spec.ts
+++ b/src/machines/systemIO/systemIOMachine.spec.ts
@@ -36,6 +36,60 @@ function mockProject(name: string): Project {
   }
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+const fileTreeMutationCases = [
+  {
+    actorName: SystemIOMachineActors.renameFolder,
+    expectedState: SystemIOMachineStates.renamingFolder,
+    event: {
+      type: SystemIOMachineEvents.renameFolder,
+      data: {
+        requestedFolderName: 'renamed-folder',
+        folderName: 'folderToRename',
+        absolutePathToParentDirectory: '/Test Project',
+      },
+    },
+  },
+  {
+    actorName: SystemIOMachineActors.createBlankFile,
+    expectedState: SystemIOMachineStates.creatingBlankFile,
+    event: {
+      type: SystemIOMachineEvents.createBlankFile,
+      data: {
+        requestedAbsolutePath: '/Test Project/new-file.kcl',
+      },
+    },
+  },
+  {
+    actorName: SystemIOMachineActors.deleteFileOrFolder,
+    expectedState: SystemIOMachineStates.deletingFileOrFolder,
+    event: {
+      type: SystemIOMachineEvents.deleteFileOrFolder,
+      data: {
+        requestedPath: '/Test Project/delete-me.kcl',
+      },
+    },
+  },
+  {
+    actorName: SystemIOMachineActors.moveRecursive,
+    expectedState: SystemIOMachineStates.movingRecursive,
+    event: {
+      type: SystemIOMachineEvents.moveRecursive,
+      data: {
+        src: '/Test Project/source.kcl',
+        target: '/Test Project/target.kcl',
+      },
+    },
+  },
+] as const
+
 /**
  * Every it test could build the world and connect to the engine but this is too resource intensive and will
  * spam engine connections.
@@ -363,6 +417,44 @@ describe('systemIOMachine - XState', () => {
           )
         } finally {
           actor.stop()
+        }
+      })
+      it('should accept file-tree mutations while reading folders', async () => {
+        for (const testCase of fileTreeMutationCases) {
+          const actor = createActor(
+            systemIOMachine.provide({
+              actors: {
+                [SystemIOMachineActors.readFoldersFromProjectDirectory]:
+                  fromPromise(async () => new Promise(() => {})),
+                [testCase.actorName]: fromPromise(
+                  async () => new Promise(() => {})
+                ),
+              },
+            }),
+            {
+              input: {
+                wasmInstancePromise: Promise.resolve(instanceInThisFile),
+                app: appInstanceInThisFile,
+              },
+            }
+          ).start()
+
+          try {
+            actor.send({
+              type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
+            })
+            await waitFor(actor, (state) =>
+              state.matches(SystemIOMachineStates.readingFolders)
+            )
+
+            actor.send(testCase.event)
+
+            await waitFor(actor, (state) =>
+              state.matches(testCase.expectedState)
+            )
+          } finally {
+            actor.stop()
+          }
         }
       })
       it('should restart folder loading when project directory changes while reading folders', async () => {
@@ -702,13 +794,16 @@ describe('systemIOMachine - XState', () => {
         let context = actor.getSnapshot().context
         expect(context.projectDirectoryPath).toBe(kclSamplesPath)
       })
-      it('should accept project imports while checking read/write access', async () => {
+      it('should defer project imports while checking read/write access', async () => {
+        const checkReadWrite = deferred<{ value: boolean; error: unknown }>()
         const actor = createActor(
           systemIOMachine.provide({
             actors: {
               [SystemIOMachineActors.checkReadWrite]: fromPromise(
-                async () => new Promise(() => {})
+                async () => checkReadWrite.promise
               ),
+              [SystemIOMachineActors.readFoldersFromProjectDirectory]:
+                fromPromise(async () => new Promise(() => {})),
               [SystemIOMachineActors.bulkImportProjectFilesAndNavigateToFile]:
                 fromPromise(async () => new Promise(() => {})),
             },
@@ -740,6 +835,17 @@ describe('systemIOMachine - XState', () => {
             },
           })
 
+          expect(actor.getSnapshot()).toMatchObject({
+            value: SystemIOMachineStates.checkingReadWrite,
+          })
+          expect(
+            actor.getSnapshot().context.deferredSystemIOEvent
+          ).toMatchObject({
+            type: SystemIOMachineEvents.bulkImportProjectFilesAndNavigateToFile,
+          })
+
+          checkReadWrite.resolve({ value: true, error: undefined })
+
           await waitFor(actor, (state) =>
             state.matches(
               SystemIOMachineStates.bulkImportingProjectFilesAndNavigateToFile
@@ -749,13 +855,16 @@ describe('systemIOMachine - XState', () => {
           actor.stop()
         }
       })
-      it('should accept project creation while checking read/write access', async () => {
+      it('should defer project creation while checking read/write access', async () => {
+        const checkReadWrite = deferred<{ value: boolean; error: unknown }>()
         const actor = createActor(
           systemIOMachine.provide({
             actors: {
               [SystemIOMachineActors.checkReadWrite]: fromPromise(
-                async () => new Promise(() => {})
+                async () => checkReadWrite.promise
               ),
+              [SystemIOMachineActors.readFoldersFromProjectDirectory]:
+                fromPromise(async () => new Promise(() => {})),
               [SystemIOMachineActors.createProject]: fromPromise(
                 async () => new Promise(() => {})
               ),
@@ -787,6 +896,17 @@ describe('systemIOMachine - XState', () => {
             },
           })
 
+          expect(actor.getSnapshot()).toMatchObject({
+            value: SystemIOMachineStates.checkingReadWrite,
+          })
+          expect(
+            actor.getSnapshot().context.deferredSystemIOEvent
+          ).toMatchObject({
+            type: SystemIOMachineEvents.createProject,
+          })
+
+          checkReadWrite.resolve({ value: true, error: undefined })
+
           await waitFor(actor, (state) =>
             state.matches(SystemIOMachineStates.creatingProject)
           )
@@ -794,13 +914,16 @@ describe('systemIOMachine - XState', () => {
           actor.stop()
         }
       })
-      it('should accept file imports while checking read/write access', async () => {
+      it('should defer file imports while checking read/write access', async () => {
+        const checkReadWrite = deferred<{ value: boolean; error: unknown }>()
         const actor = createActor(
           systemIOMachine.provide({
             actors: {
               [SystemIOMachineActors.checkReadWrite]: fromPromise(
-                async () => new Promise(() => {})
+                async () => checkReadWrite.promise
               ),
+              [SystemIOMachineActors.readFoldersFromProjectDirectory]:
+                fromPromise(async () => new Promise(() => {})),
               [SystemIOMachineActors.createKCLFile]: fromPromise(
                 async () => new Promise(() => {})
               ),
@@ -834,11 +957,64 @@ describe('systemIOMachine - XState', () => {
             },
           })
 
+          expect(actor.getSnapshot()).toMatchObject({
+            value: SystemIOMachineStates.checkingReadWrite,
+          })
+          expect(
+            actor.getSnapshot().context.deferredSystemIOEvent
+          ).toMatchObject({
+            type: SystemIOMachineEvents.importFileFromURL,
+          })
+
+          checkReadWrite.resolve({ value: true, error: undefined })
+
           await waitFor(actor, (state) =>
             state.matches(SystemIOMachineStates.importFileFromURL)
           )
         } finally {
           actor.stop()
+        }
+      })
+      it('should accept absolute-path file-tree mutations while checking read/write access', async () => {
+        for (const testCase of fileTreeMutationCases) {
+          const actor = createActor(
+            systemIOMachine.provide({
+              actors: {
+                [SystemIOMachineActors.checkReadWrite]: fromPromise(
+                  async () => new Promise(() => {})
+                ),
+                [testCase.actorName]: fromPromise(
+                  async () => new Promise(() => {})
+                ),
+              },
+            }),
+            {
+              input: {
+                wasmInstancePromise: Promise.resolve(instanceInThisFile),
+                app: appInstanceInThisFile,
+              },
+            }
+          ).start()
+
+          try {
+            actor.send({
+              type: SystemIOMachineEvents.setProjectDirectoryPath,
+              data: {
+                requestedProjectDirectoryPath: 'public/kcl-samples',
+              },
+            })
+            await waitFor(actor, (state) =>
+              state.matches(SystemIOMachineStates.checkingReadWrite)
+            )
+
+            actor.send(testCase.event)
+
+            await waitFor(actor, (state) =>
+              state.matches(testCase.expectedState)
+            )
+          } finally {
+            actor.stop()
+          }
         }
       })
       it('should accept file navigation while checking read/write access', async () => {

--- a/src/machines/systemIO/systemIOMachine.ts
+++ b/src/machines/systemIO/systemIOMachine.ts
@@ -21,7 +21,7 @@ import {
   SystemIOMachineStates,
 } from '@src/machines/systemIO/utils'
 import toast from 'react-hot-toast'
-import { assertEvent, assign, fromPromise, setup } from 'xstate'
+import { assertEvent, assign, enqueueActions, fromPromise, setup } from 'xstate'
 
 /**
  * /some/dir            = directoryPath
@@ -451,6 +451,20 @@ export const systemIOMachine = setup({
         return event.output
       },
     }),
+    [SystemIOMachineActions.deferSystemIOEvent]: assign({
+      deferredSystemIOEvent: ({ event }) => event,
+    }),
+    [SystemIOMachineActions.flushDeferredSystemIOEvent]: enqueueActions(
+      ({ context, enqueue }) => {
+        if (!context.deferredSystemIOEvent) {
+          return
+        }
+
+        const deferredEvent = context.deferredSystemIOEvent
+        enqueue.assign({ deferredSystemIOEvent: undefined })
+        enqueue.raise(deferredEvent as any)
+      }
+    ),
   },
   actors: {
     [SystemIOMachineActors.readFoldersFromProjectDirectory]: fromPromise(
@@ -838,6 +852,7 @@ export const systemIOMachine = setup({
       project: NO_PROJECT_DIRECTORY,
     },
     pendingRenamedProjectName: undefined,
+    deferredSystemIOEvent: undefined,
     lastRecursiveMoveTarget: undefined,
     lastOperation: SystemIOMachineStates.idle,
     mlEphantConversations: undefined,
@@ -962,6 +977,10 @@ export const systemIOMachine = setup({
         [SystemIOMachineEvents.setFolders]: {
           actions: SystemIOMachineActions.setFolders,
         },
+        [SystemIOMachineEvents.readFoldersFromProjectDirectory]: {
+          target: SystemIOMachineStates.readingFolders,
+          reenter: true,
+        },
         [SystemIOMachineEvents.setProjectDirectoryPath]: {
           target: SystemIOMachineStates.checkingReadWrite,
           actions: [SystemIOMachineActions.setProjectDirectoryPath],
@@ -993,9 +1012,38 @@ export const systemIOMachine = setup({
         [SystemIOMachineEvents.deleteProject]: {
           target: SystemIOMachineStates.deletingProject,
         },
+        [SystemIOMachineEvents.createKCLFile]: {
+          target: SystemIOMachineStates.creatingKCLFile,
+        },
+        [SystemIOMachineEvents.setDefaultProjectFolderName]: {
+          actions: [SystemIOMachineActions.setDefaultProjectFolderName],
+        },
+        [SystemIOMachineEvents.importFileFromURL]: {
+          target: SystemIOMachineStates.importFileFromURL,
+        },
+        [SystemIOMachineEvents.generateTextToCAD]: {
+          actions: [SystemIOMachineActions.setRequestedTextToCadGeneration],
+        },
+        [SystemIOMachineEvents.deleteKCLFile]: {
+          target: SystemIOMachineStates.deletingKCLFile,
+        },
+        [SystemIOMachineEvents.bulkCreateKCLFiles]: {
+          target: SystemIOMachineStates.bulkCreatingKCLFiles,
+        },
+        [SystemIOMachineEvents.bulkCreateKCLFilesAndNavigateToProject]: {
+          target:
+            SystemIOMachineStates.bulkCreatingKCLFilesAndNavigateToProject,
+        },
         [SystemIOMachineEvents.bulkImportProjectFilesAndNavigateToFile]: {
           target:
             SystemIOMachineStates.bulkImportingProjectFilesAndNavigateToFile,
+        },
+        [SystemIOMachineEvents.bulkCreateAndDeleteKCLFilesAndNavigateToFile]: {
+          target:
+            SystemIOMachineStates.bulkCreateAndDeletingKCLFilesAndNavigateToFile,
+        },
+        [SystemIOMachineEvents.bulkCreateKCLFilesAndNavigateToFile]: {
+          target: SystemIOMachineStates.bulkCreatingKCLFilesAndNavigateToFile,
         },
         [SystemIOMachineEvents.renameFolder]: {
           target: SystemIOMachineStates.renamingFolder,
@@ -1029,6 +1077,15 @@ export const systemIOMachine = setup({
         },
         [SystemIOMachineEvents.moveRecursiveAndNavigate]: {
           target: SystemIOMachineStates.movingRecursiveAndNavigate,
+        },
+        [SystemIOMachineEvents.getMlEphantConversations]: {
+          target: SystemIOMachineStates.gettingMlEphantConversations,
+        },
+        [SystemIOMachineEvents.saveMlEphantConversations]: {
+          target: SystemIOMachineStates.savingMlEphantConversations,
+        },
+        [SystemIOMachineEvents.deleteMlEphantConversation]: {
+          target: SystemIOMachineStates.savingMlEphantConversations,
         },
       },
       invoke: {
@@ -1261,6 +1318,9 @@ export const systemIOMachine = setup({
     },
     [SystemIOMachineStates.checkingReadWrite]: {
       on: {
+        [SystemIOMachineEvents.readFoldersFromProjectDirectory]: {
+          actions: [SystemIOMachineActions.deferSystemIOEvent],
+        },
         [SystemIOMachineEvents.navigateToProject]: {
           actions: [SystemIOMachineActions.setRequestedProjectName],
         },
@@ -1275,18 +1335,95 @@ export const systemIOMachine = setup({
         [SystemIOMachineEvents.createProject]: [
           {
             guard: SystemIOMachineGuards.projectNameIsValidLength,
-            target: SystemIOMachineStates.creatingProject,
+            actions: [SystemIOMachineActions.deferSystemIOEvent],
           },
           {
             actions: [SystemIOMachineActions.toastProjectNameTooLong],
           },
         ],
+        [SystemIOMachineEvents.renameProject]: [
+          {
+            guard: SystemIOMachineGuards.projectNameIsValidLength,
+            actions: [SystemIOMachineActions.deferSystemIOEvent],
+          },
+          {
+            actions: [SystemIOMachineActions.toastProjectNameTooLong],
+          },
+        ],
+        [SystemIOMachineEvents.deleteProject]: {
+          actions: [SystemIOMachineActions.deferSystemIOEvent],
+        },
+        [SystemIOMachineEvents.createKCLFile]: {
+          actions: [SystemIOMachineActions.deferSystemIOEvent],
+        },
+        [SystemIOMachineEvents.setDefaultProjectFolderName]: {
+          actions: [SystemIOMachineActions.setDefaultProjectFolderName],
+        },
         [SystemIOMachineEvents.importFileFromURL]: {
-          target: SystemIOMachineStates.importFileFromURL,
+          actions: [SystemIOMachineActions.deferSystemIOEvent],
+        },
+        [SystemIOMachineEvents.generateTextToCAD]: {
+          actions: [SystemIOMachineActions.setRequestedTextToCadGeneration],
+        },
+        [SystemIOMachineEvents.deleteKCLFile]: {
+          actions: [SystemIOMachineActions.deferSystemIOEvent],
+        },
+        [SystemIOMachineEvents.bulkCreateKCLFiles]: {
+          actions: [SystemIOMachineActions.deferSystemIOEvent],
+        },
+        [SystemIOMachineEvents.bulkCreateKCLFilesAndNavigateToProject]: {
+          actions: [SystemIOMachineActions.deferSystemIOEvent],
         },
         [SystemIOMachineEvents.bulkImportProjectFilesAndNavigateToFile]: {
-          target:
-            SystemIOMachineStates.bulkImportingProjectFilesAndNavigateToFile,
+          actions: [SystemIOMachineActions.deferSystemIOEvent],
+        },
+        [SystemIOMachineEvents.bulkCreateAndDeleteKCLFilesAndNavigateToFile]: {
+          actions: [SystemIOMachineActions.deferSystemIOEvent],
+        },
+        [SystemIOMachineEvents.bulkCreateKCLFilesAndNavigateToFile]: {
+          actions: [SystemIOMachineActions.deferSystemIOEvent],
+        },
+        [SystemIOMachineEvents.renameFolder]: {
+          target: SystemIOMachineStates.renamingFolder,
+        },
+        [SystemIOMachineEvents.renameFile]: {
+          target: SystemIOMachineStates.renamingFile,
+        },
+        [SystemIOMachineEvents.deleteFileOrFolder]: {
+          target: SystemIOMachineStates.deletingFileOrFolder,
+        },
+        [SystemIOMachineEvents.createBlankFile]: {
+          target: SystemIOMachineStates.creatingBlankFile,
+        },
+        [SystemIOMachineEvents.createBlankFolder]: {
+          target: SystemIOMachineStates.creatingBlankFolder,
+        },
+        [SystemIOMachineEvents.renameFileAndNavigateToFile]: {
+          target: SystemIOMachineStates.renamingFileAndNavigateToFile,
+        },
+        [SystemIOMachineEvents.renameFolderAndNavigateToFile]: {
+          target: SystemIOMachineStates.renamingFolderAndNavigateToFile,
+        },
+        [SystemIOMachineEvents.deleteFileOrFolderAndNavigate]: {
+          target: SystemIOMachineStates.deletingFileOrFolderAndNavigate,
+        },
+        [SystemIOMachineEvents.copyRecursive]: {
+          target: SystemIOMachineStates.copyingRecursive,
+        },
+        [SystemIOMachineEvents.moveRecursive]: {
+          target: SystemIOMachineStates.movingRecursive,
+        },
+        [SystemIOMachineEvents.moveRecursiveAndNavigate]: {
+          target: SystemIOMachineStates.movingRecursiveAndNavigate,
+        },
+        [SystemIOMachineEvents.getMlEphantConversations]: {
+          target: SystemIOMachineStates.gettingMlEphantConversations,
+        },
+        [SystemIOMachineEvents.saveMlEphantConversations]: {
+          target: SystemIOMachineStates.savingMlEphantConversations,
+        },
+        [SystemIOMachineEvents.deleteMlEphantConversation]: {
+          target: SystemIOMachineStates.savingMlEphantConversations,
         },
       },
       invoke: {
@@ -1302,6 +1439,7 @@ export const systemIOMachine = setup({
         },
         onDone: {
           target: SystemIOMachineStates.readingFolders,
+          actions: [SystemIOMachineActions.flushDeferredSystemIOEvent],
         },
         onError: {
           target: SystemIOMachineStates.readingFolders,

--- a/src/machines/systemIO/utils.ts
+++ b/src/machines/systemIO/utils.ts
@@ -20,7 +20,7 @@ import type { MlEphantNewFileRequestProps } from '@src/machines/systemIO/hooks'
 import { getAllSubDirectoriesAtProjectRoot } from '@src/machines/systemIO/snapshotContext'
 import type { systemIOMachine } from '@src/machines/systemIO/systemIOMachine'
 import toast from 'react-hot-toast'
-import type { ActorRefFrom } from 'xstate'
+import type { ActorRefFrom, EventObject } from 'xstate'
 
 export { SystemIOMachineEvents } from '@src/machines/systemIO/events'
 
@@ -102,6 +102,8 @@ export enum SystemIOMachineActions {
   setLastProjectDeleteRequest = 'set last project delete request',
   toastProjectNameTooLong = 'toast project name too long',
   setMlEphantConversations = 'set ml-ephant conversations',
+  deferSystemIOEvent = 'defer system IO event',
+  flushDeferredSystemIOEvent = 'flush deferred system IO event',
 }
 
 export enum SystemIOMachineGuards {
@@ -145,6 +147,8 @@ export type SystemIOContext = SystemIOInput & {
 
   /** Temporary storage to return to project after renaming */
   pendingRenamedProjectName?: string
+  /** Event captured while checking project-directory access. */
+  deferredSystemIOEvent?: EventObject
   lastRecursiveMoveTarget?: string
   lastOperation: any
 


### PR DESCRIPTION
Trying a more systematic fix for the races/swallowed event cases found with the `systemIOActor` approach after merging #11957:
1. the `readingFolders` state now accepts basically all systemIOActor events, so none are swallowed.
2. `checkReadWrite` is trickier, but it now captures events while it's working and then fires them after it's done. This is what most the code changes and tests in here are.

An XState actor is just not the way we should model this system, which is made plain by all these swallowed events. But that will come in a few days; first we want the behavior stabilized before we improve it.

Closes #12090 for a second time.