### PR TITLE
Standardize on aHash for hashing

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2372,7 +2372,6 @@ dependencies = [
  "dhat",
  "expectorate",
  "ezpz",
- "fnv",
  "form_urlencoded",
  "futures",
  "futures-lite",

--- a/rust/kcl-lib/Cargo.toml
+++ b/rust/kcl-lib/Cargo.toml
@@ -60,7 +60,6 @@ convert_case = "0.11.0"
 csscolorparser = "0.8.3"
 dashmap = { workspace = true }
 dhat = { version = "0.3", optional = true }
-fnv = "1.0.7"
 form_urlencoded = "1.2.2"
 futures = { version = "0.3.32" }
 git_rev = "0.1.0"

--- a/rust/kcl-lib/src/execution/artifact.rs
+++ b/rust/kcl-lib/src/execution/artifact.rs
@@ -1,5 +1,5 @@
-use fnv::FnvHashMap;
-use fnv::FnvHashSet;
+use ahash::AHashMap;
+use ahash::AHashSet;
 use indexmap::IndexMap;
 use kittycad_modeling_cmds::EnableSketchMode;
 use kittycad_modeling_cmds::FaceIsPlanar;
@@ -892,8 +892,8 @@ fn import_statement_code_refs(
     module_infos: &ModuleInfoMap,
     programs: &crate::execution::ProgramLookup,
     cached_body_items: usize,
-) -> FnvHashMap<ModuleId, ImportCodeRef> {
-    let mut code_refs = FnvHashMap::default();
+) -> AHashMap<ModuleId, ImportCodeRef> {
+    let mut code_refs = AHashMap::default();
     for body_item in &ast.body {
         let BodyItem::ImportStatement(import_stmt) = body_item else {
             continue;
@@ -935,7 +935,7 @@ fn code_ref_for_range(
     programs: &crate::execution::ProgramLookup,
     cached_body_items: usize,
     range: SourceRange,
-    import_code_refs: &FnvHashMap<ModuleId, ImportCodeRef>,
+    import_code_refs: &AHashMap<ModuleId, ImportCodeRef>,
 ) -> (SourceRange, NodePath) {
     if let Some(code_ref) = import_code_refs.get(&range.module_id()) {
         return (code_ref.range, code_ref.node_path.clone());
@@ -962,7 +962,7 @@ pub(super) fn build_artifact_graph(
     let item_count = initial_graph.item_count;
     let mut map = initial_graph.into_map();
 
-    let mut path_to_plane_id_map = FnvHashMap::default();
+    let mut path_to_plane_id_map = AHashMap::default();
     let mut current_plane_id = None;
     let import_code_refs = import_statement_code_refs(ast, module_infos, programs, item_count);
     let flattened_responses = flatten_modeling_command_responses(responses);
@@ -1026,7 +1026,7 @@ fn fill_in_node_paths(
     artifact: &mut Artifact,
     programs: &crate::execution::ProgramLookup,
     cached_body_items: usize,
-    import_code_refs: &FnvHashMap<ModuleId, ImportCodeRef>,
+    import_code_refs: &AHashMap<ModuleId, ImportCodeRef>,
 ) {
     match artifact {
         Artifact::StartSketchOnFace(face) if face.code_ref.node_path.is_empty() => {
@@ -1065,8 +1065,8 @@ fn fill_in_node_paths(
 /// responses.  The raw responses from the engine contain batches.
 fn flatten_modeling_command_responses(
     responses: &IndexMap<Uuid, WebSocketResponse>,
-) -> FnvHashMap<Uuid, OkModelingCmdResponse> {
-    let mut map = FnvHashMap::default();
+) -> AHashMap<Uuid, OkModelingCmdResponse> {
+    let mut map = AHashMap::default();
     for (cmd_id, ws_response) in responses {
         let WebSocketResponse::Success(response) = ws_response else {
             // Response not successful.
@@ -1117,9 +1117,9 @@ struct PendingEntityCloneMapping {
 /// `EntityGetAllChildUuids` queries emitted by `std::clone`.
 fn build_entity_clone_id_maps(
     artifact_commands: &[ArtifactCommand],
-    responses: &FnvHashMap<Uuid, OkModelingCmdResponse>,
-) -> FnvHashMap<Uuid, FnvHashMap<ArtifactId, ArtifactId>> {
-    let mut clone_id_maps = FnvHashMap::default();
+    responses: &AHashMap<Uuid, OkModelingCmdResponse>,
+) -> AHashMap<Uuid, AHashMap<ArtifactId, ArtifactId>> {
+    let mut clone_id_maps = AHashMap::default();
     let mut pending = Vec::new();
 
     for artifact_command in artifact_commands {
@@ -1149,7 +1149,7 @@ fn build_entity_clone_id_maps(
                     if let Some(old_child_ids) = &pending_map.old_child_ids
                         && *entity_id == pending_map.clone_cmd_id
                     {
-                        let mut id_map = FnvHashMap::default();
+                        let mut id_map = AHashMap::default();
                         id_map.insert(
                             ArtifactId::new(pending_map.old_entity_id),
                             ArtifactId::new(pending_map.clone_cmd_id),
@@ -1218,34 +1218,31 @@ fn merge_opt_id(base: &mut Option<ArtifactId>, new: Option<ArtifactId>) {
     *base = new;
 }
 
-fn remap_id_for_clone(id: ArtifactId, entity_id_map: &FnvHashMap<ArtifactId, ArtifactId>) -> ArtifactId {
+fn remap_id_for_clone(id: ArtifactId, entity_id_map: &AHashMap<ArtifactId, ArtifactId>) -> ArtifactId {
     entity_id_map.get(&id).copied().unwrap_or(id)
 }
 
 fn remap_opt_id_for_clone(
     id: Option<ArtifactId>,
-    entity_id_map: &FnvHashMap<ArtifactId, ArtifactId>,
+    entity_id_map: &AHashMap<ArtifactId, ArtifactId>,
 ) -> Option<ArtifactId> {
     id.map(|id| remap_id_for_clone(id, entity_id_map))
 }
 
-fn remap_ids_for_clone(ids: &[ArtifactId], entity_id_map: &FnvHashMap<ArtifactId, ArtifactId>) -> Vec<ArtifactId> {
+fn remap_ids_for_clone(ids: &[ArtifactId], entity_id_map: &AHashMap<ArtifactId, ArtifactId>) -> Vec<ArtifactId> {
     ids.iter()
         .copied()
         .map(|id| remap_id_for_clone(id, entity_id_map))
         .collect()
 }
 
-fn remap_mapped_ids_for_clone(
-    ids: &[ArtifactId],
-    entity_id_map: &FnvHashMap<ArtifactId, ArtifactId>,
-) -> Vec<ArtifactId> {
+fn remap_mapped_ids_for_clone(ids: &[ArtifactId], entity_id_map: &AHashMap<ArtifactId, ArtifactId>) -> Vec<ArtifactId> {
     ids.iter().filter_map(|id| entity_id_map.get(id).copied()).collect()
 }
 
 fn remap_artifact_for_clone(
     artifact: &Artifact,
-    entity_id_map: &FnvHashMap<ArtifactId, ArtifactId>,
+    entity_id_map: &AHashMap<ArtifactId, ArtifactId>,
     clone_code_ref: &CodeRef,
     clone_cmd_id: Uuid,
     source_root_id: ArtifactId,
@@ -1552,7 +1549,7 @@ fn update_consumed_csg_sweep(
     return_arr: &mut Vec<Artifact>,
     artifacts: &IndexMap<ArtifactId, Artifact>,
     sweep_id: ArtifactId,
-    consumed_sweep_ids: &mut FnvHashSet<ArtifactId>,
+    consumed_sweep_ids: &mut AHashSet<ArtifactId>,
 ) {
     if consumed_sweep_ids.insert(sweep_id)
         && let Some(Artifact::Sweep(sweep)) = artifacts.get(&sweep_id)
@@ -1567,7 +1564,7 @@ fn mark_artifact_consumed_by_id(
     return_arr: &mut Vec<Artifact>,
     artifacts: &IndexMap<ArtifactId, Artifact>,
     artifact_id: ArtifactId,
-    consumed_ids: &mut FnvHashSet<ArtifactId>,
+    consumed_ids: &mut AHashSet<ArtifactId>,
 ) {
     let already_marked_as_consumed = !consumed_ids.insert(artifact_id);
     if already_marked_as_consumed {
@@ -1615,7 +1612,7 @@ fn mark_deleted_artifacts_consumed(
     object_ids: &std::collections::HashSet<Uuid>,
 ) -> Vec<Artifact> {
     let mut return_arr = Vec::new();
-    let mut consumed_ids = FnvHashSet::default();
+    let mut consumed_ids = AHashSet::default();
 
     // The order of iteration doesn't matter here, as all artifacts get marked as consumed.
     // Also the set comes from the API crate which uses HashSet.
@@ -1633,7 +1630,7 @@ fn update_csg_input_artifacts(
     artifacts: &IndexMap<ArtifactId, Artifact>,
     input_ids: &[ArtifactId],
     composite_solid_id: Option<ArtifactId>,
-    consumed_sweep_ids: &mut FnvHashSet<ArtifactId>,
+    consumed_sweep_ids: &mut AHashSet<ArtifactId>,
 ) {
     for input_id in input_ids {
         if let Some(artifact) = artifacts.get(input_id) {
@@ -1722,13 +1719,13 @@ fn mirror_3d_artifact_updates(
 fn artifacts_to_update(
     artifacts: &IndexMap<ArtifactId, Artifact>,
     artifact_command: &ArtifactCommand,
-    responses: &FnvHashMap<Uuid, OkModelingCmdResponse>,
-    entity_clone_id_maps: &FnvHashMap<Uuid, FnvHashMap<ArtifactId, ArtifactId>>,
-    path_to_plane_id_map: &FnvHashMap<Uuid, Uuid>,
+    responses: &AHashMap<Uuid, OkModelingCmdResponse>,
+    entity_clone_id_maps: &AHashMap<Uuid, AHashMap<ArtifactId, ArtifactId>>,
+    path_to_plane_id_map: &AHashMap<Uuid, Uuid>,
     programs: &crate::execution::ProgramLookup,
     cached_body_items: usize,
     exec_artifacts: &IndexMap<ArtifactId, Artifact>,
-    import_code_refs: &FnvHashMap<ModuleId, ImportCodeRef>,
+    import_code_refs: &AHashMap<ModuleId, ImportCodeRef>,
 ) -> Result<Vec<Artifact>, KclError> {
     let uuid = artifact_command.cmd_id;
     let response = responses.get(&uuid);
@@ -2801,7 +2798,7 @@ fn artifacts_to_update(
             }
 
             let mut return_arr = Vec::new();
-            let mut consumed_sweep_ids = FnvHashSet::default();
+            let mut consumed_sweep_ids = AHashSet::default();
             let mut input_ids = solid_ids.clone();
             merge_ids(&mut input_ids, tool_ids.clone());
 
@@ -2861,7 +2858,7 @@ fn artifacts_to_update(
             }
 
             let mut return_arr = Vec::new();
-            let mut consumed_sweep_ids = FnvHashSet::default();
+            let mut consumed_sweep_ids = AHashSet::default();
 
             for input_id in solid_ids.iter().chain(tool_ids.iter()) {
                 let sweep_id = match artifacts.get(input_id) {

--- a/rust/kcl-lib/src/execution/artifact/mermaid_tests.rs
+++ b/rust/kcl-lib/src/execution/artifact/mermaid_tests.rs
@@ -279,7 +279,7 @@ impl ArtifactGraph {
         output.push_str("flowchart LR\n");
 
         let mut next_id = 1_u32;
-        let mut stable_id_map = FnvHashMap::default();
+        let mut stable_id_map = AHashMap::default();
 
         for id in self.map.keys() {
             stable_id_map.insert(*id, next_id);
@@ -301,7 +301,7 @@ impl ArtifactGraph {
     fn flowchart_nodes<W: Write>(
         &self,
         output: &mut W,
-        stable_id_map: &FnvHashMap<ArtifactId, NodeId>,
+        stable_id_map: &AHashMap<ArtifactId, NodeId>,
         prefix: &str,
     ) -> std::fmt::Result {
         // Artifact ID of the path is the key.  The value is a list of
@@ -568,7 +568,7 @@ impl ArtifactGraph {
     fn flowchart_edges<W: Write>(
         &self,
         output: &mut W,
-        stable_id_map: &FnvHashMap<ArtifactId, NodeId>,
+        stable_id_map: &AHashMap<ArtifactId, NodeId>,
         prefix: &str,
     ) -> Result<(), std::fmt::Error> {
         // Mermaid will display two edges in either direction, even using

--- a/rust/kcl-lib/src/execution/artifact/tests.rs
+++ b/rust/kcl-lib/src/execution/artifact/tests.rs
@@ -13,7 +13,7 @@ fn gdt_annotation_artifacts_get_node_paths() {
         code_ref: CodeRef::placeholder(source_range),
     });
 
-    fill_in_node_paths(&mut artifact, &programs, 0, &FnvHashMap::default());
+    fill_in_node_paths(&mut artifact, &programs, 0, &AHashMap::default());
 
     let Artifact::GdtAnnotation(annotation) = artifact else {
         panic!("Expected GD&T annotation artifact");
@@ -50,12 +50,12 @@ fn entity_clone_remaps_sweep_ids() {
             pattern_ids: Vec::new(),
         }),
     );
-    let mut clone_id_map = FnvHashMap::default();
+    let mut clone_id_map = AHashMap::default();
     clone_id_map.insert(source_path_id, cloned_path_id);
     clone_id_map.insert(source_surface_id, cloned_surface_id);
     clone_id_map.insert(source_edge_id, cloned_edge_id);
     clone_id_map.insert(source_trajectory_id, cloned_trajectory_id);
-    let mut entity_clone_id_maps = FnvHashMap::default();
+    let mut entity_clone_id_maps = AHashMap::default();
     entity_clone_id_maps.insert(cmd_id, clone_id_map);
 
     let command = ModelingCmd::from(
@@ -74,13 +74,13 @@ fn entity_clone_remaps_sweep_ids() {
     let updated = artifacts_to_update(
         &artifacts,
         &artifact_command,
-        &FnvHashMap::default(),
+        &AHashMap::default(),
         &entity_clone_id_maps,
-        &FnvHashMap::default(),
+        &AHashMap::default(),
         &programs,
         0,
         &IndexMap::default(),
-        &FnvHashMap::default(),
+        &AHashMap::default(),
     )
     .unwrap();
 
@@ -141,7 +141,7 @@ fn entity_clone_remaps_path_ids() {
             outer_path_id: Some(source_outer_path_id),
         }),
     );
-    let mut clone_id_map = FnvHashMap::default();
+    let mut clone_id_map = AHashMap::default();
     clone_id_map.insert(source_seg_id, cloned_seg_id);
     clone_id_map.insert(source_sweep_id, cloned_sweep_id);
     clone_id_map.insert(source_trajectory_sweep_id, cloned_trajectory_sweep_id);
@@ -150,7 +150,7 @@ fn entity_clone_remaps_path_ids() {
     clone_id_map.insert(source_origin_path_id, cloned_origin_path_id);
     clone_id_map.insert(source_inner_path_id, cloned_inner_path_id);
     clone_id_map.insert(source_outer_path_id, cloned_outer_path_id);
-    let mut entity_clone_id_maps = FnvHashMap::default();
+    let mut entity_clone_id_maps = AHashMap::default();
     entity_clone_id_maps.insert(cmd_id, clone_id_map);
 
     let command = ModelingCmd::from(
@@ -169,13 +169,13 @@ fn entity_clone_remaps_path_ids() {
     let updated = artifacts_to_update(
         &artifacts,
         &artifact_command,
-        &FnvHashMap::default(),
+        &AHashMap::default(),
         &entity_clone_id_maps,
-        &FnvHashMap::default(),
+        &AHashMap::default(),
         &programs,
         0,
         &IndexMap::default(),
-        &FnvHashMap::default(),
+        &AHashMap::default(),
     )
     .unwrap();
 
@@ -223,11 +223,11 @@ fn entity_clone_remaps_composite_solid_ids() {
             pattern_ids: Vec::new(),
         }),
     );
-    let mut clone_id_map = FnvHashMap::default();
+    let mut clone_id_map = AHashMap::default();
     clone_id_map.insert(source_solid_id, cloned_solid_id);
     clone_id_map.insert(source_tool_id, cloned_tool_id);
     clone_id_map.insert(source_parent_composite_id, cloned_parent_composite_id);
-    let mut entity_clone_id_maps = FnvHashMap::default();
+    let mut entity_clone_id_maps = AHashMap::default();
     entity_clone_id_maps.insert(cmd_id, clone_id_map);
 
     let command = ModelingCmd::from(
@@ -246,13 +246,13 @@ fn entity_clone_remaps_composite_solid_ids() {
     let updated = artifacts_to_update(
         &artifacts,
         &artifact_command,
-        &FnvHashMap::default(),
+        &AHashMap::default(),
         &entity_clone_id_maps,
-        &FnvHashMap::default(),
+        &AHashMap::default(),
         &programs,
         0,
         &IndexMap::default(),
-        &FnvHashMap::default(),
+        &AHashMap::default(),
     )
     .unwrap();
 
@@ -312,13 +312,13 @@ fn entity_clone_does_not_preserve_unmapped_pattern_links() {
     let updated = artifacts_to_update(
         &artifacts,
         &artifact_command,
-        &FnvHashMap::default(),
-        &FnvHashMap::default(),
-        &FnvHashMap::default(),
+        &AHashMap::default(),
+        &AHashMap::default(),
+        &AHashMap::default(),
         &programs,
         0,
         &IndexMap::default(),
-        &FnvHashMap::default(),
+        &AHashMap::default(),
     )
     .unwrap();
 
@@ -404,12 +404,12 @@ fn entity_clone_clones_mapped_child_artifacts() {
         }),
     );
 
-    let mut clone_id_map = FnvHashMap::default();
+    let mut clone_id_map = AHashMap::default();
     clone_id_map.insert(source_path_id, cloned_path_id);
     clone_id_map.insert(source_seg_id, cloned_seg_id);
     clone_id_map.insert(source_sweep_id, cloned_sweep_id);
     clone_id_map.insert(source_wall_id, cloned_wall_id);
-    let mut entity_clone_id_maps = FnvHashMap::default();
+    let mut entity_clone_id_maps = AHashMap::default();
     entity_clone_id_maps.insert(cmd_id, clone_id_map);
 
     let command = ModelingCmd::from(
@@ -428,13 +428,13 @@ fn entity_clone_clones_mapped_child_artifacts() {
     let updated = artifacts_to_update(
         &artifacts,
         &artifact_command,
-        &FnvHashMap::default(),
+        &AHashMap::default(),
         &entity_clone_id_maps,
-        &FnvHashMap::default(),
+        &AHashMap::default(),
         &programs,
         0,
         &IndexMap::default(),
-        &FnvHashMap::default(),
+        &AHashMap::default(),
     )
     .unwrap();
 
@@ -512,7 +512,7 @@ fn build_entity_clone_id_maps_from_child_queries() {
         },
     ];
 
-    let mut responses = FnvHashMap::default();
+    let mut responses = AHashMap::default();
     let old_children_response: kcmc::output::EntityGetAllChildUuids =
         serde_json::from_value(serde_json::json!({ "entity_ids": [old_child_a, old_child_b] })).unwrap();
     let new_children_response: kcmc::output::EntityGetAllChildUuids =
@@ -623,13 +623,13 @@ fn surface_blend_creates_blend_sweep_artifact() {
     let updated = artifacts_to_update(
         &artifacts,
         &artifact_command,
-        &FnvHashMap::default(),
-        &FnvHashMap::default(),
-        &FnvHashMap::default(),
+        &AHashMap::default(),
+        &AHashMap::default(),
+        &AHashMap::default(),
         &programs,
         0,
         &IndexMap::default(),
-        &FnvHashMap::default(),
+        &AHashMap::default(),
     )
     .unwrap();
 
@@ -695,13 +695,13 @@ fn create_region_creates_region_path_sub_type() {
     let updated = artifacts_to_update(
         &artifacts,
         &artifact_command,
-        &FnvHashMap::default(),
-        &FnvHashMap::default(),
-        &FnvHashMap::default(),
+        &AHashMap::default(),
+        &AHashMap::default(),
+        &AHashMap::default(),
         &programs,
         0,
         &IndexMap::default(),
-        &FnvHashMap::default(),
+        &AHashMap::default(),
     )
     .unwrap();
 
@@ -941,7 +941,7 @@ fn mirror_3d_artifacts_include_mirrored_body_with_face_and_edge_ids() {
         ]
     }))
     .expect("valid mirror response");
-    let mut responses = FnvHashMap::default();
+    let mut responses = AHashMap::default();
     responses.insert(cmd_id, OkModelingCmdResponse::EntityMirrorAcross(mirror_response));
     let ast = crate::parsing::parse_str("", ModuleId::default()).unwrap();
     let programs = crate::execution::ProgramLookup::new(ast, Default::default());
@@ -950,12 +950,12 @@ fn mirror_3d_artifacts_include_mirrored_body_with_face_and_edge_ids() {
         &artifacts,
         &artifact_command,
         &responses,
-        &FnvHashMap::default(),
-        &FnvHashMap::default(),
+        &AHashMap::default(),
+        &AHashMap::default(),
         &programs,
         0,
         &IndexMap::default(),
-        &FnvHashMap::default(),
+        &AHashMap::default(),
     )
     .unwrap();
 

--- a/rust/kcl-lib/src/parsing/token/tokeniser.rs
+++ b/rust/kcl-lib/src/parsing/token/tokeniser.rs
@@ -1,5 +1,5 @@
-use fnv::FnvHashMap;
-use fnv::FnvHashSet;
+use ahash::AHashMap;
+use ahash::AHashSet;
 use lazy_static::lazy_static;
 use winnow::LocatingSlice;
 use winnow::Stateful;
@@ -27,8 +27,8 @@ use crate::parsing::token::Token;
 use crate::parsing::token::TokenType;
 
 lazy_static! {
-    pub(crate) static ref RESERVED_WORDS: FnvHashMap<&'static str, TokenType> = {
-        let mut set = FnvHashMap::default();
+    pub(crate) static ref RESERVED_WORDS: AHashMap<&'static str, TokenType> = {
+        let mut set = AHashMap::default();
         set.insert("if", TokenType::Keyword);
         set.insert("else", TokenType::Keyword);
         set.insert("for", TokenType::Keyword);
@@ -62,8 +62,8 @@ lazy_static! {
         set
     };
     /// These names are reserved only in sketch blocks.
-    pub(crate) static ref RESERVED_SKETCH_BLOCK_WORDS: FnvHashSet<&'static str> = {
-        let mut set = FnvHashSet::default();
+    pub(crate) static ref RESERVED_SKETCH_BLOCK_WORDS: AHashSet<&'static str> = {
+        let mut set = AHashSet::default();
         set.insert("construction");
         set.insert("dependencies");
         set.insert("exports");

--- a/rust/kcl-lib/src/simulation_tests/kcl_samples.rs
+++ b/rust/kcl-lib/src/simulation_tests/kcl_samples.rs
@@ -5,8 +5,8 @@ use std::panic::catch_unwind;
 use std::path::Path;
 use std::path::PathBuf;
 
+use ahash::AHashSet;
 use anyhow::Result;
-use fnv::FnvHashSet;
 use serde::Deserialize;
 use serde::Serialize;
 use walkdir::WalkDir;
@@ -85,7 +85,7 @@ fn test_after_engine_ensure_kcl_samples_manifest_etc() {
     let expected_outputs = kcl_samples_outputs();
 
     // Ensure that inputs aren't missing.
-    let input_names = FnvHashSet::from_iter(tests.iter().map(|t| t.name.clone()));
+    let input_names = AHashSet::from_iter(tests.iter().map(|t| t.name.clone()));
     let missing = expected_outputs
         .into_iter()
         .filter(|name| !input_names.contains(name))


### PR DESCRIPTION
We already use aHash, and it's generally a better default. FNV has the foot-gun of being bad for user input, so care has to be taken to avoid DoS. By using aHash, we avoid that completely.

See https://github.com/tkaitchuck/aHash/blob/master/compare/readme.md.