### PR TITLE
Rust: Run clippy with 8 cores

### DIFF
--- a/.github/workflows/cargo-clippy.yml
+++ b/.github/workflows/cargo-clippy.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   cargoclippy:
     name: cargo clippy
-    runs-on: namespace-profile-ubuntu-2-cores
+    runs-on: namespace-profile-ubuntu-8-cores
     steps:
       - uses: actions/checkout@v6.0.2
       - uses: taiki-e/install-action@just


### PR DESCRIPTION
Sometimes the CI runner seems to run out of memory or get cancelled. Other rust compiler jobs use 8 cores, let's match that.