### PR TITLE
Fix download fallback for disallowed File System API

### DIFF
--- a/src/lib/browserSaveFile.test.ts
+++ b/src/lib/browserSaveFile.test.ts
@@ -1,6 +1,131 @@
-import { describe, expect, it } from 'vitest'
+import {
+  type MockInstance,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
 
-import { getShowSaveFilePickerOptions } from '@src/lib/browserSaveFile'
+const { mockToast } = vi.hoisted(() => ({
+  mockToast: {
+    dismiss: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}))
+
+vi.mock('react-hot-toast', () => ({
+  default: mockToast,
+}))
+
+import {
+  browserSaveFile,
+  getShowSaveFilePickerOptions,
+} from '@src/lib/browserSaveFile'
+import { EXPORT_TOAST_MESSAGES } from '@src/lib/constants'
+
+type ShowSaveFilePicker = (options?: SaveFilePickerOptions) => Promise<unknown>
+
+const setShowSaveFilePicker = (showSaveFilePicker: ShowSaveFilePicker) => {
+  Object.defineProperty(window, 'showSaveFilePicker', {
+    configurable: true,
+    value: showSaveFilePicker,
+  })
+}
+
+const removeShowSaveFilePicker = () => {
+  Reflect.deleteProperty(window, 'showSaveFilePicker')
+}
+
+describe('browserSaveFile', () => {
+  let clickSpy: MockInstance<() => void>
+  let createObjectURL: ReturnType<typeof vi.fn>
+  let revokeObjectURL: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mockToast.dismiss.mockClear()
+    mockToast.error.mockClear()
+    mockToast.success.mockClear()
+    removeShowSaveFilePicker()
+
+    createObjectURL = vi.fn(() => 'blob:export')
+    revokeObjectURL = vi.fn()
+    vi.stubGlobal('URL', {
+      createObjectURL,
+      revokeObjectURL,
+    })
+    clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    document.body.innerHTML = ''
+    removeShowSaveFilePicker()
+  })
+
+  it('uses the download fallback when showSaveFilePicker is unavailable', async () => {
+    const blob = new Blob(['contents'])
+
+    await browserSaveFile(blob, 'main.step', 'toast-id')
+
+    expect(createObjectURL).toHaveBeenCalledWith(blob)
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+    expect(document.querySelector('a')?.download).toBe('main.step')
+    expect(mockToast.success).toHaveBeenCalledWith(
+      EXPORT_TOAST_MESSAGES.SUCCESS,
+      { id: 'toast-id' }
+    )
+
+    vi.runOnlyPendingTimers()
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:export')
+    expect(document.querySelector('a')).toBeNull()
+  })
+
+  it('falls back to download when the file picker is blocked', async () => {
+    const blob = new Blob(['contents'])
+    const showSaveFilePicker = vi
+      .fn()
+      .mockRejectedValue(
+        new DOMException('Denied by platform policy', 'NotAllowedError')
+      )
+    setShowSaveFilePicker(showSaveFilePicker)
+
+    await browserSaveFile(blob, 'main.step', 'toast-id')
+
+    expect(showSaveFilePicker).toHaveBeenCalledWith(
+      getShowSaveFilePickerOptions('main.step')
+    )
+    expect(createObjectURL).toHaveBeenCalledWith(blob)
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+    expect(mockToast.error).not.toHaveBeenCalled()
+    expect(mockToast.success).toHaveBeenCalledWith(
+      EXPORT_TOAST_MESSAGES.SUCCESS,
+      { id: 'toast-id' }
+    )
+  })
+
+  it('does not fall back to download when the user cancels the file picker', async () => {
+    const showSaveFilePicker = vi
+      .fn()
+      .mockRejectedValue(new DOMException('User canceled', 'AbortError'))
+    setShowSaveFilePicker(showSaveFilePicker)
+
+    await browserSaveFile(new Blob(['contents']), 'main.step', 'toast-id')
+
+    expect(createObjectURL).not.toHaveBeenCalled()
+    expect(clickSpy).not.toHaveBeenCalled()
+    expect(mockToast.dismiss).toHaveBeenCalledWith('toast-id')
+    expect(mockToast.success).not.toHaveBeenCalled()
+  })
+})
 
 describe('getShowSaveFilePickerOptions', () => {
   it('adds extension-constrained picker options when suggestedName has an extension', () => {

--- a/src/lib/browserSaveFile.ts
+++ b/src/lib/browserSaveFile.ts
@@ -1,6 +1,5 @@
-/// The method below uses the File System Access API when it's supported and
-// else falls back to the classic approach. In both cases the function saves
-// the file, but in case of where the File System Access API is supported, the
+// Saves a file through the File System Access API when possible, then falls
+// back to a normal browser download link.
 import toast from 'react-hot-toast'
 
 import { EXPORT_TOAST_MESSAGES } from '@src/lib/constants'
@@ -42,6 +41,35 @@ export const getShowSaveFilePickerOptions = (
   return options
 }
 
+const errorName = (err: unknown) => {
+  if (typeof err === 'object' && err && 'name' in err) {
+    return String(err.name)
+  }
+
+  return ''
+}
+
+const saveWithDownloadLink = (
+  blob: Blob,
+  suggestedName: string,
+  toastId: string
+) => {
+  const blobURL = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+
+  a.href = blobURL
+  a.download = suggestedName
+  a.style.display = 'none'
+  document.body.append(a)
+  a.click()
+
+  setTimeout(() => {
+    URL.revokeObjectURL(blobURL)
+    a.remove()
+  }, 1000)
+  toast.success(EXPORT_TOAST_MESSAGES.SUCCESS, { id: toastId })
+}
+
 // user will get a file save dialog where they can choose where the file should be saved.
 export const browserSaveFile = async (
   blob: Blob,
@@ -76,32 +104,21 @@ export const browserSaveFile = async (
       await writable.close()
       toast.success(EXPORT_TOAST_MESSAGES.SUCCESS, { id: toastId })
       return
-    } catch (err: any) {
+    } catch (err: unknown) {
+      const name = errorName(err)
+
       // Fail silently if the user has simply canceled the dialog.
-      if (err.name === 'AbortError') {
+      if (name === 'AbortError') {
         toast.dismiss(toastId)
+      } else if (name === 'NotAllowedError') {
+        saveWithDownloadLink(blob, suggestedName, toastId)
       } else {
-        console.error(err.name, err.message)
+        console.error(name, err)
         toast.error(EXPORT_TOAST_MESSAGES.FAILED, { id: toastId })
       }
       return
     }
   }
   // Fallback if the File System Access API is not supported…
-  // Create the blob URL.
-  const blobURL = URL.createObjectURL(blob)
-  // Create the `<a download>` element and append it invisibly.
-  const a = document.createElement('a')
-  a.href = blobURL
-  a.download = suggestedName
-  a.style.display = 'none'
-  document.body.append(a)
-  // Programmatically click the element.
-  a.click()
-  // Revoke the blob URL and remove the element.
-  setTimeout(() => {
-    URL.revokeObjectURL(blobURL)
-    a.remove()
-  }, 1000)
-  toast.success(EXPORT_TOAST_MESSAGES.SUCCESS, { id: toastId })
+  saveWithDownloadLink(blob, suggestedName, toastId)
 }


### PR DESCRIPTION
Fixes #12136. 

Codex written, the test file is a little mock-intensive but the fix is straighforward.

I was able to reproduce the issue at https://github.com/KittyCAD/modeling-app/issues/12136#issuecomment-4730680094 and confirm the fix with the Vercel preview at https://github.com/KittyCAD/modeling-app/issues/12136#issuecomment-4730716842.