### PR TITLE
Use CrLF line endings in linter

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -25,7 +25,8 @@
     "indentWidth": 2,
     "indentStyle": "space",
     "lineWidth": 80,
-    "formatWithErrors": true
+    "formatWithErrors": true,
+    "lineEnding": "crlf"
   },
   "javascript": {
     "formatter": {


### PR DESCRIPTION
Biome linter changes the line endings for the default in OS.
When the default is LF linter modifies lot of source files during every build.


This PR Fixes linting by force Biome to use CRLF.