### PR TITLE
Deprecate access of body tags through sketch or region

### DIFF
--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -3273,7 +3273,7 @@ impl Node<MemberExpression> {
                             CompilationIssue::err(
                                 SourceRange::from(self),
                                 format!(
-                                    "Accessing solid-created tag `{property}` through sketch tags is deprecated. Prefer the body's tags instead, e.g. `body.tags.{property}`."
+                                    "Accessing solid-created face `{property}` through sketch tags is deprecated. Use the body's faces instead, e.g. `body.faces.{property}`."
                                 ),
                             ),
                             annotations::WARN_DEPRECATED,

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -52,6 +52,7 @@ use crate::execution::fn_call::Arg;
 use crate::execution::fn_call::Args;
 use crate::execution::kcl_value::FunctionSource;
 use crate::execution::kcl_value::KclFunctionSourceParams;
+use crate::execution::kcl_value::KclObjectKind;
 use crate::execution::kcl_value::TypeDef;
 use crate::execution::memory::SKETCH_PREFIX;
 use crate::execution::memory::{self};
@@ -2029,6 +2030,7 @@ impl Node<SketchBlock> {
         let return_value = KclValue::Object {
             value: properties,
             constrainable: Default::default(),
+            object_kind: KclObjectKind::Default,
             meta: vec![metadata],
         };
         Ok(if self.is_being_edited {
@@ -2218,6 +2220,7 @@ impl Node<SketchBlock> {
         let meta_value = KclValue::Object {
             value: meta_map,
             constrainable: false,
+            object_kind: KclObjectKind::Default,
             meta: vec![Metadata {
                 source_range: SourceRange::from(self),
             }],
@@ -3251,8 +3254,31 @@ impl Node<MemberExpression> {
                     None,
                 )),
             },
-            (KclValue::Object { value: map, .. }, Property::String(property), false) => {
+            (
+                KclValue::Object {
+                    value: map,
+                    object_kind,
+                    ..
+                },
+                Property::String(property),
+                false,
+            ) => {
                 if let Some(value) = map.get(&property) {
+                    if object_kind
+                        .deprecated_solid_tag_names()
+                        .iter()
+                        .any(|tag_name| tag_name == &property)
+                    {
+                        exec_state.warn(
+                            CompilationIssue::err(
+                                SourceRange::from(self),
+                                format!(
+                                    "Accessing solid-created tag `{property}` through sketch tags is deprecated. Prefer the body's tags instead, e.g. `body.tags.{property}`."
+                                ),
+                            ),
+                            annotations::WARN_DEPRECATED,
+                        );
+                    }
                     Ok(value.to_owned().continue_())
                 } else {
                     Err(KclError::new_undefined_value(
@@ -3341,6 +3367,7 @@ impl Node<MemberExpression> {
                         .map(|(k, tag)| (k.to_owned(), KclValue::TagIdentifier(Box::new(tag.to_owned()))))
                         .collect(),
                     constrainable: false,
+                    object_kind: KclObjectKind::Default,
                 }
                 .continue_())
             }
@@ -3364,6 +3391,14 @@ impl Node<MemberExpression> {
                     .map(|(k, tag)| (k.to_owned(), KclValue::TagIdentifier(Box::new(tag.to_owned()))))
                     .collect(),
                 constrainable: false,
+                object_kind: KclObjectKind::SketchTags {
+                    deprecated_solid_tag_names: sk
+                        .tags
+                        .iter()
+                        .filter(|(_, tag)| tag.is_body_created_tag())
+                        .map(|(name, _)| name.to_owned())
+                        .collect(),
+                },
             }
             .continue_()),
             (geometry @ (KclValue::Sketch { .. } | KclValue::Solid { .. }), Property::String(property), false) => {
@@ -5321,6 +5356,7 @@ impl Node<UnaryExpression> {
                             value,
                             meta: meta.clone(),
                             constrainable: false,
+                            object_kind: KclObjectKind::Default,
                         }
                         .continue_())
                     }
@@ -5566,6 +5602,7 @@ impl Node<ObjectExpression> {
                 source_range: self.into(),
             }],
             constrainable: false,
+            object_kind: KclObjectKind::Default,
         }
         .continue_())
     }

--- a/rust/kcl-lib/src/execution/fn_call.rs
+++ b/rust/kcl-lib/src/execution/fn_call.rs
@@ -1238,7 +1238,7 @@ mod test {
             .exec_state
             .issues()
             .iter()
-            .filter(|issue| issue.message.contains("Accessing solid-created tag"))
+            .filter(|issue| issue.message.contains("Accessing solid-created face"))
             .collect()
     }
 
@@ -1746,7 +1746,7 @@ topFromBody = body.tags.top
         assert_eq!(warnings[0].severity, Severity::Warning);
         assert!(warnings[0].message.contains("`top`"), "found {}", warnings[0].message);
         assert!(
-            warnings[0].message.contains("Accessing solid-created tag `top` through sketch tags is deprecated. Prefer the body's tags instead, e.g. `body.tags.top`."),
+            warnings[0].message.contains("Accessing solid-created face `top` through sketch tags is deprecated. Use the body's faces instead, e.g. `body.faces.top`."),
             "found {}",
             warnings[0].message
         );

--- a/rust/kcl-lib/src/execution/fn_call.rs
+++ b/rust/kcl-lib/src/execution/fn_call.rs
@@ -1169,6 +1169,7 @@ mod test {
     use std::sync::Arc;
 
     use super::*;
+    use crate::errors::Severity;
     use crate::execution::ContextType;
     use crate::execution::EnvironmentRef;
     use crate::execution::ExecTestResults;
@@ -1230,6 +1231,15 @@ mod test {
                 "expected body.faces not to contain sketch tag `{tag}`"
             );
         }
+    }
+
+    fn deprecated_solid_tag_access_warnings(result: &ExecTestResults) -> Vec<&CompilationIssue> {
+        result
+            .exec_state
+            .issues()
+            .iter()
+            .filter(|issue| issue.message.contains("Accessing solid-created tag"))
+            .collect()
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1710,5 +1720,82 @@ legacyTop = top
             ],
         );
         assert_vars_are_missing(&result, &["edge1"]);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn accessing_body_tag_through_body_sketch_tags_warns() {
+        let program = r#"@settings(kclVersion = 2.0)
+profile = startSketchOn(XY)
+  |> startProfile(at = [0, 0])
+  |> line(end = [10, 0], tag = $line1)
+  |> line(end = [0, 10])
+  |> line(end = [-10, 0])
+  |> close()
+
+body = extrude(profile, length = 5, tagEnd = $top)
+topFromSketch = body.sketch.tags.top
+topFromBody = body.tags.top
+"#;
+
+        let result = parse_execute(program).await.unwrap();
+        assert!(matches!(get_var(&result, "topFromSketch"), KclValue::TagIdentifier(_)));
+        assert!(matches!(get_var(&result, "topFromBody"), KclValue::TagIdentifier(_)));
+
+        let warnings = deprecated_solid_tag_access_warnings(&result);
+        assert_eq!(warnings.len(), 1, "expected one deprecation warning, got {warnings:#?}");
+        assert_eq!(warnings[0].severity, Severity::Warning);
+        assert!(warnings[0].message.contains("`top`"), "found {}", warnings[0].message);
+        assert!(
+            warnings[0].message.contains("body.tags.top"),
+            "found {}",
+            warnings[0].message
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn accessing_sketch_path_tag_through_body_sketch_tags_does_not_warn() {
+        let program = r#"@settings(kclVersion = 2.0)
+profile = startSketchOn(XY)
+  |> startProfile(at = [0, 0])
+  |> line(end = [10, 0], tag = $line1)
+  |> line(end = [0, 10])
+  |> line(end = [-10, 0])
+  |> close()
+
+body = extrude(profile, length = 5, tagEnd = $top)
+lineFromSketch = body.sketch.tags.line1
+"#;
+
+        let result = parse_execute(program).await.unwrap();
+        assert!(matches!(get_var(&result, "lineFromSketch"), KclValue::TagIdentifier(_)));
+        let warnings = deprecated_solid_tag_access_warnings(&result);
+        assert!(
+            warnings.is_empty(),
+            "sketch path tags should not get body-tag deprecation warnings: {warnings:#?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn accessing_body_tag_through_sketch_block_region_tags_warns() {
+        let program = r#"@settings(kclVersion = 2.0)
+profile = sketch(on = XY) {
+  line1 = line(start = [0, 0], end = [10, 0])
+  line2 = line(start = [10, 0], end = [10, 10])
+  line3 = line(start = [10, 10], end = [0, 10])
+  line4 = line(start = [0, 10], end = [0, 0])
+}
+
+profileRegion = region(point = [1, 1], sketch = profile)
+body = extrude(profileRegion, length = 5, tagEnd = $top)
+topFromRegion = profileRegion.tags.top
+"#;
+
+        let result = parse_execute(program).await.unwrap();
+        assert!(matches!(get_var(&result, "topFromRegion"), KclValue::TagIdentifier(_)));
+
+        let warnings = deprecated_solid_tag_access_warnings(&result);
+        assert_eq!(warnings.len(), 1, "expected one deprecation warning, got {warnings:#?}");
+        assert_eq!(warnings[0].severity, Severity::Warning);
+        assert!(warnings[0].message.contains("`top`"), "found {}", warnings[0].message);
     }
 }

--- a/rust/kcl-lib/src/execution/fn_call.rs
+++ b/rust/kcl-lib/src/execution/fn_call.rs
@@ -1746,7 +1746,7 @@ topFromBody = body.tags.top
         assert_eq!(warnings[0].severity, Severity::Warning);
         assert!(warnings[0].message.contains("`top`"), "found {}", warnings[0].message);
         assert!(
-            warnings[0].message.contains("body.tags.top"),
+            warnings[0].message.contains("Accessing solid-created tag `top` through sketch tags is deprecated. Prefer the body's tags instead, e.g. `body.tags.top`."),
             "found {}",
             warnings[0].message
         );

--- a/rust/kcl-lib/src/execution/fn_call.rs
+++ b/rust/kcl-lib/src/execution/fn_call.rs
@@ -1734,7 +1734,7 @@ profile = startSketchOn(XY)
 
 body = extrude(profile, length = 5, tagEnd = $top)
 topFromSketch = body.sketch.tags.top
-topFromBody = body.tags.top
+topFromBody = body.faces.top
 "#;
 
         let result = parse_execute(program).await.unwrap();

--- a/rust/kcl-lib/src/execution/kcl_value.rs
+++ b/rust/kcl-lib/src/execution/kcl_value.rs
@@ -54,9 +54,28 @@ use crate::std::args::TyF64;
 
 pub type KclObjectFields = HashMap<String, KclValue>;
 
+#[derive(Debug, Clone, Default, PartialEq)]
+pub enum KclObjectKind {
+    #[default]
+    Default,
+    SketchTags {
+        deprecated_solid_tag_names: Vec<String>,
+    },
+}
+
+impl KclObjectKind {
+    pub(crate) fn deprecated_solid_tag_names(&self) -> &[String] {
+        match self {
+            Self::Default => &[],
+            Self::SketchTags {
+                deprecated_solid_tag_names,
+            } => deprecated_solid_tag_names,
+        }
+    }
+}
+
 /// Any KCL value.
 #[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
-#[expect(clippy::large_enum_variant)]
 #[ts(export)]
 #[serde(tag = "type")]
 pub enum KclValue {
@@ -102,6 +121,9 @@ pub enum KclValue {
     Object {
         value: KclObjectFields,
         constrainable: bool,
+        #[serde(skip)]
+        #[ts(skip)]
+        object_kind: KclObjectKind,
         #[serde(skip)]
         meta: Vec<Metadata>,
     },

--- a/rust/kcl-lib/src/execution/kcl_value.rs
+++ b/rust/kcl-lib/src/execution/kcl_value.rs
@@ -54,7 +54,7 @@ use crate::std::args::TyF64;
 
 pub type KclObjectFields = HashMap<String, KclValue>;
 
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
 pub enum KclObjectKind {
     #[default]
     Default,
@@ -64,6 +64,13 @@ pub enum KclObjectKind {
 }
 
 impl KclObjectKind {
+    fn is_default(&self) -> bool {
+        match self {
+            KclObjectKind::Default => true,
+            KclObjectKind::SketchTags { .. } => false,
+        }
+    }
+
     pub(crate) fn deprecated_solid_tag_names(&self) -> &[String] {
         match self {
             Self::Default => &[],
@@ -121,7 +128,7 @@ pub enum KclValue {
     Object {
         value: KclObjectFields,
         constrainable: bool,
-        #[serde(skip)]
+        #[serde(default, skip_serializing_if = "KclObjectKind::is_default")]
         #[ts(skip)]
         object_kind: KclObjectKind,
         #[serde(skip)]

--- a/rust/kcl-lib/src/execution/kcl_value.rs
+++ b/rust/kcl-lib/src/execution/kcl_value.rs
@@ -59,6 +59,7 @@ pub enum KclObjectKind {
     #[default]
     Default,
     SketchTags {
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
         deprecated_solid_tag_names: Vec<String>,
     },
 }

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -25,6 +25,7 @@ pub use id_generator::IdGenerator;
 pub(crate) use import::PreImportedGeometry;
 use indexmap::IndexMap;
 pub use kcl_value::KclObjectFields;
+pub use kcl_value::KclObjectKind;
 pub use kcl_value::KclValue;
 use kcmc::ImageFormat;
 use kcmc::ModelingCmd;
@@ -647,6 +648,12 @@ impl TagIdentifier {
 
     pub fn geometry(&self) -> Option<Geometry> {
         self.get_cur_info().map(|info| info.geometry.clone())
+    }
+
+    pub(crate) fn is_body_created_tag(&self) -> bool {
+        self.get_cur_info().is_some_and(|info| {
+            matches!(&info.geometry, Geometry::Solid(_)) && info.path.is_none() && info.surface.is_some()
+        })
     }
 }
 

--- a/rust/kcl-lib/src/execution/sketch_solve.rs
+++ b/rust/kcl-lib/src/execution/sketch_solve.rs
@@ -179,6 +179,7 @@ fn substitute_sketch_var(
         KclValue::Object {
             value,
             constrainable,
+            object_kind,
             meta,
         } => {
             let subbed = value
@@ -191,6 +192,7 @@ fn substitute_sketch_var(
             Ok(KclValue::Object {
                 value: subbed,
                 constrainable,
+                object_kind,
                 meta,
             })
         }

--- a/rust/kcl-lib/src/execution/types.rs
+++ b/rust/kcl-lib/src/execution/types.rs
@@ -1517,6 +1517,7 @@ impl KclValue {
                         value: [("origin".to_owned(), origin), ("direction".to_owned(), direction)].into(),
                         meta: meta.clone(),
                         constrainable: false,
+                        object_kind: Default::default(),
                     })
                 }
                 _ => Err(self.into()),
@@ -1560,6 +1561,7 @@ impl KclValue {
                         value: [("origin".to_owned(), origin), ("direction".to_owned(), direction)].into(),
                         meta: meta.clone(),
                         constrainable: false,
+                        object_kind: Default::default(),
                     })
                 }
                 _ => Err(self.into()),
@@ -1738,12 +1740,14 @@ impl KclValue {
                     // Note that we don't check for constrainability, coercing to a constrainable object
                     // adds that property.
                     constrainable,
+                    object_kind: Default::default(),
                 })
             }
             KclValue::KclNone { meta, .. } if tys.is_empty() => Ok(KclValue::Object {
                 value: HashMap::new(),
                 meta: meta.clone(),
                 constrainable,
+                object_kind: Default::default(),
             }),
             _ => Err(self.into()),
         }
@@ -1846,6 +1850,7 @@ mod test {
                 value: crate::execution::KclObjectFields::new(),
                 meta: Vec::new(),
                 constrainable: false,
+                object_kind: Default::default(),
             },
             KclValue::TagIdentifier(Box::new("foo".parse().unwrap())),
             KclValue::TagDeclarator(Box::new(crate::parsing::ast::types::TagDeclarator::new("foo"))),
@@ -2001,6 +2006,7 @@ mod test {
                 value: HashMap::new(),
                 meta: Vec::new(),
                 constrainable: false,
+                object_kind: Default::default(),
             },
             &mut exec_state,
         );
@@ -2015,6 +2021,7 @@ mod test {
             value: HashMap::new(),
             meta: Vec::new(),
             constrainable: false,
+            object_kind: Default::default(),
         };
         let obj1 = KclValue::Object {
             value: [(
@@ -2027,6 +2034,7 @@ mod test {
             .into(),
             meta: Vec::new(),
             constrainable: false,
+            object_kind: Default::default(),
         };
         let obj2 = KclValue::Object {
             value: [
@@ -2057,6 +2065,7 @@ mod test {
             .into(),
             meta: Vec::new(),
             constrainable: false,
+            object_kind: Default::default(),
         };
 
         let ty0 = RuntimeType::Object(vec![], false);
@@ -2376,6 +2385,7 @@ mod test {
             .into(),
             meta: Vec::new(),
             constrainable: false,
+            object_kind: Default::default(),
         };
         let a3d = KclValue::Object {
             value: [
@@ -2429,6 +2439,7 @@ mod test {
             .into(),
             meta: Vec::new(),
             constrainable: false,
+            object_kind: Default::default(),
         };
 
         let ty2d = RuntimeType::Primitive(PrimitiveType::Axis2d);

--- a/rust/kcl-lib/src/lib.rs
+++ b/rust/kcl-lib/src/lib.rs
@@ -148,6 +148,7 @@ pub mod exec {
     pub use crate::execution::ArtifactCommand;
     pub use crate::execution::DefaultPlanes;
     pub use crate::execution::IdGenerator;
+    pub use crate::execution::KclObjectKind;
     pub use crate::execution::KclValue;
     pub use crate::execution::Operation;
     pub use crate::execution::PlaneKind;

--- a/rust/kcl-lib/tests/get_common_edge_of_segment_edge_tag/program_memory.snap
+++ b/rust/kcl-lib/tests/get_common_edge_of_segment_edge_tag/program_memory.snap
@@ -233,7 +233,10 @@ description: Variables in memory after executing get_common_edge_of_segment_edge
         "value": "line4"
       }
     },
-    "constrainable": false
+    "constrainable": false,
+    "object_kind": {
+      "SketchTags": {}
+    }
   },
   "sketch001": {
     "type": "Object",


### PR DESCRIPTION
#12140
Stacked on #12150.

Users should access them through `body.faces` instead.

The implementation is admittedly a little weird. But the issue is that KCL code can grab the `region1.tags` record, and later access properties on it. So the fact that it came from the region or which properties should a trigger a warning needs to be stored at runtime.