### PR TITLE
Migrate app shortcuts to registry keymap

### DIFF
--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -50,8 +50,11 @@ import { EngineConnectionStateType } from '@src/network/utils'
 import { executingEditorService } from '@src/registry/contracts/executingEditor'
 import {
   findKeymapItemForCommand,
+  keymapKeystrokesDisplay,
+  keymapScopesValueSpec,
   keymapService,
 } from '@src/registry/contracts/keymap'
+import { APP_COMMAND_IDS } from '@src/registry/extensions/commands/appCommands'
 import { useSelector } from '@xstate/react'
 import type { SnapshotFrom } from 'xstate'
 
@@ -79,10 +82,7 @@ const Toolbar_ = memo(
     const { kclManager } = useSingletons()
     const platform = usePlatform()
     const executionService = app.registry.signal(executingEditorService).value
-    const unrenderedExecuteHotkeyLabel = hotkeyDisplay(
-      UNRENDERED_EXECUTE_HOTKEY,
-      platform
-    )
+    const keymapScopes = app.registry.signal(keymapScopesValueSpec).value
     const toolbarConfig = useToolbarConfig()
     const wasmInstance = use(kclManager.wasmInstancePromise)
     const iconClassName =
@@ -129,6 +129,15 @@ const Toolbar_ = memo(
     const currentToolbarKeymapScopes = [
       toolbarModeNameToKeymapScope[toolbarConfigurationName],
     ]
+    const unrenderedExecuteHotkeyLabel = keymapKeystrokesDisplay(
+      findKeymapItemForCommand(
+        keymapTree,
+        APP_COMMAND_IDS.editor.render,
+        currentToolbarKeymapScopes,
+        keymapScopes
+      )?.keystrokes ?? [UNRENDERED_EXECUTE_HOTKEY],
+      platform
+    )
     const disableSketchToolbar =
       isSketchToolbarTransitioning(props.state) &&
       (toolbarConfigurationName === 'sketching' ||
@@ -336,7 +345,8 @@ const Toolbar_ = memo(
         const item = findKeymapItemForCommand(
           keymapTree,
           command,
-          currentToolbarKeymapScopes
+          currentToolbarKeymapScopes,
+          keymapScopes
         )
         return item?.keystrokes.length ? [...item.keystrokes] : undefined
       }

--- a/src/components/CommandBar/CommandBarBasicInput.tsx
+++ b/src/components/CommandBar/CommandBarBasicInput.tsx
@@ -1,6 +1,5 @@
 import { useSelector } from '@xstate/react'
 import { use, useEffect, useMemo, useRef } from 'react'
-import { useHotkeys } from 'react-hotkeys-hook'
 
 import { MarkdownText } from '@src/components/MarkdownText'
 import { noAutofillFormProps, noAutofillInputProps } from '@src/lib/autofill'
@@ -30,7 +29,6 @@ function CommandBarBasicInput({
   const previouslySetValue = commandBarState.context.argumentsToSubmit[
     arg.name
   ] as string | undefined
-  useHotkeys('mod + /', () => commands.send({ type: 'Close' }))
   const inputRef = useRef<HTMLInputElement>(null)
   const argMachineContext = useSelector(
     arg.machineActor,

--- a/src/components/CommandBar/CommandBarPathInput.tsx
+++ b/src/components/CommandBar/CommandBarPathInput.tsx
@@ -1,5 +1,4 @@
 import { use, useEffect, useMemo, useRef } from 'react'
-import { useHotkeys } from 'react-hotkeys-hook'
 
 import { ActionButton } from '@src/components/ActionButton'
 import { noAutofillFormProps, noAutofillInputProps } from '@src/lib/autofill'
@@ -30,7 +29,6 @@ function CommandBarPathInput({
   const { wasmPromise, commands } = useApp()
   const wasmInstance = use(wasmPromise)
   const commandBarState = commands.useState()
-  useHotkeys('mod + /', () => commands.send({ type: 'Close' }))
   const inputRef = useRef<HTMLInputElement>(null)
   const argMachineContext = useSelector(
     arg.machineActor,

--- a/src/components/CommandBar/CommandBarTextareaInput.tsx
+++ b/src/components/CommandBar/CommandBarTextareaInput.tsx
@@ -1,6 +1,5 @@
 import type { RefObject } from 'react'
 import { useEffect, useRef } from 'react'
-import { useHotkeys } from 'react-hotkeys-hook'
 
 import { noAutofillFormProps, noAutofillInputProps } from '@src/lib/autofill'
 import { useApp } from '@src/lib/boot'
@@ -20,7 +19,6 @@ function CommandBarTextareaInput({
 }) {
   const { commands } = useApp()
   const commandBarState = commands.useState()
-  useHotkeys('mod + /', () => commands.send({ type: 'Close' }))
   const formRef = useRef<HTMLFormElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
   useTextareaAutoGrow(inputRef)

--- a/src/components/CommandBar/CommandBarVector2DInput.tsx
+++ b/src/components/CommandBar/CommandBarVector2DInput.tsx
@@ -11,7 +11,6 @@ import { roundOffWithUnits } from '@src/lib/utils'
 import { useSelector } from '@xstate/react'
 import { use, useEffect, useMemo, useRef, useState } from 'react'
 import toast from 'react-hot-toast'
-import { useHotkeys } from 'react-hotkeys-hook'
 import type { AnyStateMachine, SnapshotFrom } from 'xstate'
 
 // TODO: remove the need for this selector once we decouple all actors from React
@@ -178,9 +177,6 @@ function CommandBarVector2DInput({
   // DOM access for focus and keyboard navigation
   const xInputRef = useRef<HTMLInputElement>(null)
   const yInputRef = useRef<HTMLInputElement>(null)
-
-  // Close the command bar
-  useHotkeys('mod + /', () => commands.send({ type: 'Close' }))
 
   // Focus and select the first input on mount
   useEffect(() => {

--- a/src/components/CommandBar/CommandBarVector3DInput.tsx
+++ b/src/components/CommandBar/CommandBarVector3DInput.tsx
@@ -10,7 +10,6 @@ import { useCalculateKclExpression } from '@src/lib/useCalculateKclExpression'
 import { roundOffWithUnits } from '@src/lib/utils'
 import { use, useEffect, useMemo, useRef, useState } from 'react'
 import toast from 'react-hot-toast'
-import { useHotkeys } from 'react-hotkeys-hook'
 
 function CoordinateInput({
   label,
@@ -170,9 +169,6 @@ function CommandBarVector3DInput({
   const xInputRef = useRef<HTMLInputElement>(null)
   const yInputRef = useRef<HTMLInputElement>(null)
   const zInputRef = useRef<HTMLInputElement>(null)
-
-  // Close the command bar
-  useHotkeys('mod + /', () => commands.send({ type: 'Close' }))
 
   // Focus and select the first input on mount
   useEffect(() => {

--- a/src/components/CommandBar/constants.ts
+++ b/src/components/CommandBar/constants.ts
@@ -1,1 +1,2 @@
 export const COMMAND_PALETTE_HOTKEY = 'mod+k'
+export const COMMAND_PALETTE_OPEN_COMMAND_ID = 'zds.commandPalette.open'

--- a/src/components/CommandBarOpenButton.tsx
+++ b/src/components/CommandBarOpenButton.tsx
@@ -1,8 +1,17 @@
-import { COMMAND_PALETTE_HOTKEY } from '@src/components/CommandBar/constants'
+import { useSignals } from '@preact/signals-react/runtime'
+import {
+  COMMAND_PALETTE_HOTKEY,
+  COMMAND_PALETTE_OPEN_COMMAND_ID,
+} from '@src/components/CommandBar/constants'
 import { CustomIcon } from '@src/components/CustomIcon'
 import usePlatform from '@src/hooks/usePlatform'
 import type { App } from '@src/lib/app'
-import { hotkeyDisplay } from '@src/lib/hotkeys'
+import {
+  findKeymapItemForCommand,
+  keymapKeystrokesDisplay,
+  keymapScopesValueSpec,
+  keymapService,
+} from '@src/registry/contracts/keymap'
 import { memo } from 'react'
 
 type CommandBarOpenButtonProps = {
@@ -12,8 +21,21 @@ type CommandBarOpenButtonProps = {
 export const CommandBarOpenButton = memo(function CommandBarOpenButton({
   app,
 }: CommandBarOpenButtonProps) {
+  useSignals()
   const platform = usePlatform()
   const { commands } = app
+  const keymap = app.registry.optional(keymapService)
+  const commandPaletteKeybinding = keymapKeystrokesDisplay(
+    keymap
+      ? findKeymapItemForCommand(
+          keymap.keymap.value,
+          COMMAND_PALETTE_OPEN_COMMAND_ID,
+          keymap.getCurrentScopes(),
+          app.registry.signal(keymapScopesValueSpec).value
+        )?.keystrokes
+      : [COMMAND_PALETTE_HOTKEY],
+    platform
+  )
 
   return (
     <button
@@ -25,9 +47,11 @@ export const CommandBarOpenButton = memo(function CommandBarOpenButton({
     >
       <CustomIcon name="command" className="w-5 h-5" />
       <span>Commands</span>
-      <kbd className="hidden sm:block dark:bg-chalkboard-80 font-mono rounded-sm text-primary/70 dark:text-inherit inline-block px-1">
-        {hotkeyDisplay(COMMAND_PALETTE_HOTKEY, platform)}
-      </kbd>
+      {commandPaletteKeybinding && (
+        <kbd className="hidden sm:block dark:bg-chalkboard-80 font-mono rounded-sm text-primary/70 dark:text-inherit inline-block px-1">
+          {commandPaletteKeybinding}
+        </kbd>
+      )}
     </button>
   )
 })

--- a/src/components/ModelingMachineProvider.tsx
+++ b/src/components/ModelingMachineProvider.tsx
@@ -8,19 +8,12 @@ import { useMachine } from '@xstate/react'
 import type React from 'react'
 import { createContext, use, useEffect, useMemo, useRef } from 'react'
 import type { MutableRefObject } from 'react'
-import { useHotkeys } from 'react-hotkeys-hook'
 import type { Actor, ContextFrom, Prop, StateFrom } from 'xstate'
-
-import useHotkeyWrapper from '@src/lib/hotkeyWrapper'
-import { SNAP_TO_GRID_HOTKEY } from '@src/lib/hotkeys'
 
 import { useNetworkContext } from '@src/hooks/useNetworkContext'
 import { useApp, useSingletons } from '@src/lib/boot'
 import { modelingMachineCommandConfig } from '@src/lib/commandBarConfigs/modelingCommandConfig'
 import type { Project } from '@src/lib/project'
-import { resetCameraPosition } from '@src/lib/resetCameraPosition'
-import { selectAllInCurrentSketch } from '@src/lib/selections'
-import { getDeleteKeys } from '@src/lib/utils'
 import { modelingMachine } from '@src/machines/modelingMachine'
 import { useFolders } from '@src/machines/systemIO/hooks'
 
@@ -58,7 +51,6 @@ export const ModelingMachineProvider = ({
   const { machineManager, commands, settings, layout, project, registry } =
     useApp()
   const { kclManager } = useSingletons()
-  const settingsActor = settings.actor
   const wasmInstance = use(kclManager.wasmInstancePromise)
   const settingsValues = settings.useSettings()
   const {
@@ -68,7 +60,6 @@ export const ModelingMachineProvider = ({
       cameraProjection,
       cameraOrbit,
       useSketchSolveMode,
-      snapToGrid,
     },
   } = settingsValues
   const machineApiEnabled = settingsValues.app.machineApi.current
@@ -348,91 +339,6 @@ export const ModelingMachineProvider = ({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
   }, [allowOrbitInSketchMode.current])
-
-  // Allow using the delete key to delete solids. Backspace only on macOS as Windows and Linux have dedicated Delete
-  // `navigator.platform` is deprecated, but the alternative `navigator.userAgentData.platform` is not reliable
-  const deleteKeys = getDeleteKeys()
-
-  useHotkeys(deleteKeys, () => {
-    // Check if we're in sketch solve mode
-    const inSketchSolveMode = modelingState.matches('sketchSolveMode')
-    if (inSketchSolveMode) {
-      // Forward delete event to sketch solve mode
-      // it's probably save to send this regardless of inSketchSolveMode, but still
-      modelingSend({ type: 'delete selected' })
-      return
-    }
-
-    // When the current selection is a segment, delete that directly ('Delete selection' doesn't support it)
-    const segmentNodePaths = Object.keys(modelingState.context.segmentOverlays)
-    const selections =
-      modelingState.context.selectionRanges.graphSelections.filter((sel) =>
-        segmentNodePaths.includes(JSON.stringify(sel.codeRef.pathToNode))
-      )
-    // Order selections by how late they are used in the codebase, as later nodes are less likely to be referenced than
-    // earlier ones. This could be further refined as this is just a simple heuristic.
-    const orderedSelections = selections.slice().sort((a, b) => {
-      const aStart = a.codeRef.range?.[0] ?? 0
-      const bStart = b.codeRef.range?.[0] ?? 0
-      return bStart - aStart
-    })
-    modelingSend({
-      type: 'Delete segments',
-      data: orderedSelections.map((selection) => selection.codeRef.pathToNode),
-    })
-    if (
-      modelingState.context.selectionRanges.graphSelections.length >
-      selections.length
-    ) {
-      // Not all selection were segments -> keep the default delete behavior
-      modelingSend({ type: 'Delete selection' })
-    }
-  })
-
-  // Allow ctrl+alt+c to center to selection
-  useHotkeys(['mod + alt + c'], () => {
-    modelingSend({ type: 'Center camera on selection' })
-  })
-  useHotkeys(['mod + alt + x'], () => {
-    resetCameraPosition({
-      sceneInfra: kclManager.sceneInfra,
-      engineCommandManager: kclManager.engineCommandManager,
-      settingsActor,
-    }).catch(reportRejection)
-  })
-
-  // Toggle Snap to grid
-  useHotkeyWrapper(
-    [SNAP_TO_GRID_HOTKEY],
-    () => {
-      settingsActor.send({
-        type: 'set.modeling.snapToGrid',
-        data: { level: 'project', value: !snapToGrid.current },
-      })
-    },
-    kclManager
-  )
-
-  useHotkeys(
-    ['mod + a'],
-    (e) => {
-      const inSketchMode = modelingState.matches('Sketch')
-      if (!inSketchMode) return
-
-      e.preventDefault()
-      const selection = selectAllInCurrentSketch(
-        kclManager.artifactGraph,
-        kclManager.sceneEntitiesManager
-      )
-      modelingSend({
-        type: 'Set selection',
-        data: { selectionType: 'completeSelection', selection },
-      })
-    },
-    {
-      enableOnContentEditable: false,
-    }
-  )
 
   useModelingMachineCommands({
     machineId: 'modeling',

--- a/src/components/OpenedProject.tsx
+++ b/src/components/OpenedProject.tsx
@@ -30,7 +30,6 @@ import {
   WASM_INIT_FAILED_TOAST_ID,
 } from '@src/lib/constants'
 import { setOpfsCloudSyncProjectScope } from '@src/lib/fs-zds/opfsCloud'
-import useHotkeyWrapper from '@src/lib/hotkeyWrapper'
 import { isDesktop } from '@src/lib/isDesktop'
 import {
   DefaultLayoutPaneID,
@@ -64,7 +63,6 @@ import {
 import { useSelector } from '@xstate/react'
 import { useEffect, useMemo, useState } from 'react'
 import toast from 'react-hot-toast'
-import { useHotkeys } from 'react-hotkeys-hook'
 import ModalContainer from 'react-modal-promise'
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 
@@ -224,43 +222,6 @@ export function OpenedProject() {
     settingsValues.app.onboardingStatus.default
 
   useApplyRememberedOnboardingWorkflow(location.pathname, onboardingStatus)
-
-  useHotkeys('backspace', (e) => {
-    e.preventDefault()
-  })
-  // Since these already exist in the editor, we don't need to define them
-  // with the wrapper.
-  useHotkeys('mod+z', (e) => {
-    e.preventDefault()
-    kclManager.undo()
-  })
-  useHotkeys('mod+shift+z', (e) => {
-    e.preventDefault()
-    kclManager.redo()
-  })
-
-  useHotkeyWrapper(
-    ['alt + shift + f'],
-    () => {
-      void kclManager.format()
-    },
-    kclManager,
-    {
-      enabled: !isDesktop(),
-      enableOnContentEditable: true,
-      enableOnFormTags: true,
-      // Desktop uses the native Electron menu accelerator for this binding.
-      // Skip CodeMirror registration because this combo types a character there.
-      registerToCodeMirror: false,
-    }
-  )
-  useHotkeyWrapper(
-    ['ctrl + shift + c'],
-    () => {
-      void kclManager.convertToVariable()
-    },
-    kclManager
-  )
 
   useEngineConnectionSubscriptions()
 

--- a/src/components/ProjectSearchBar.tsx
+++ b/src/components/ProjectSearchBar.tsx
@@ -1,10 +1,11 @@
+import { useSignalEffect } from '@preact/signals-react'
 import Fuse from 'fuse.js'
 import { useEffect, useRef, useState } from 'react'
-import { useHotkeys } from 'react-hotkeys-hook'
 
 import { CustomIcon } from '@src/components/CustomIcon'
 import { noAutofillInputProps } from '@src/lib/autofill'
 import type { Project } from '@src/lib/project'
+import { projectSearchFocusRequest } from '@src/lib/searchFocusRequests'
 
 export function useProjectSearch(projects: Project[] | undefined) {
   const [query, setQuery] = useState('')
@@ -37,22 +38,15 @@ export function ProjectSearchBar({
   setQuery: (query: string) => void
 }) {
   const inputRef = useRef<HTMLInputElement>(null)
-  useHotkeys(
-    'Ctrl+.',
-    (event) => {
-      event.preventDefault()
-      inputRef.current?.focus()
-    },
-    { enableOnFormTags: true }
-  )
-  useHotkeys(
-    'mod+f',
-    (event) => {
-      event.preventDefault()
-      inputRef.current?.focus()
-    },
-    { enableOnFormTags: true }
-  )
+  const lastHandledFocusRequest = useRef(projectSearchFocusRequest.value)
+  useSignalEffect(() => {
+    const request = projectSearchFocusRequest.value
+    if (request === lastHandledFocusRequest.current) {
+      return
+    }
+    lastHandledFocusRequest.current = request
+    inputRef.current?.focus()
+  })
 
   return (
     <div className="relative group">

--- a/src/components/ProjectSearchBar.tsx
+++ b/src/components/ProjectSearchBar.tsx
@@ -34,8 +34,10 @@ export function useProjectSearch(projects: Project[] | undefined) {
 
 export function ProjectSearchBar({
   setQuery,
+  keybinding,
 }: {
   setQuery: (query: string) => void
+  keybinding?: string
 }) {
   const inputRef = useRef<HTMLInputElement>(null)
   const lastHandledFocusRequest = useRef(projectSearchFocusRequest.value)
@@ -60,7 +62,9 @@ export function ProjectSearchBar({
           ref={inputRef}
           onChange={(event) => setQuery(event.target.value)}
           className="w-full text-sm bg-transparent focus:outline-none selection:bg-primary/20 dark:selection:bg-primary/40 dark:focus:outline-none"
-          placeholder="Search projects (Ctrl+.)"
+          placeholder={
+            keybinding ? `Search projects (${keybinding})` : 'Search projects'
+          }
         />
       </div>
     </div>

--- a/src/components/ProjectSidebarMenu.tsx
+++ b/src/components/ProjectSidebarMenu.tsx
@@ -1,4 +1,5 @@
 import { Popover, Transition } from '@headlessui/react'
+import { useSignals } from '@preact/signals-react/runtime'
 import { useSelector } from '@xstate/react'
 import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
@@ -18,6 +19,12 @@ import { isDesktop } from '@src/lib/isDesktop'
 import { PATHS, getProjectRelativeFilePath } from '@src/lib/paths'
 import type { FileEntry, Project } from '@src/lib/project'
 import type { IndexLoaderData } from '@src/lib/types'
+import {
+  findKeymapItemForCommand,
+  keymapKeystrokesDisplay,
+  keymapScopesValueSpec,
+  keymapService,
+} from '@src/registry/contracts/keymap'
 
 interface ProjectSidebarMenuProps extends React.PropsWithChildren {
   enableMenu?: boolean
@@ -170,10 +177,23 @@ function ProjectMenuPopover({
   onProjectClose: ProjectCloseHandler
   onHomeNavigate: () => void
 }) {
+  useSignals()
   const { machineManager, commands, settings } = app
   const machineApiEnabled = settings.useSettings().app.machineApi.current
   const platform = usePlatform()
   const navigate = useNavigate()
+  const keymap = app.registry.optional(keymapService)
+  const projectSettingsKeybinding = keymapKeystrokesDisplay(
+    keymap
+      ? findKeymapItemForCommand(
+          keymap.keymap.value,
+          'zds.settings.open',
+          keymap.getCurrentScopes(),
+          app.registry.signal(keymapScopesValueSpec).value
+        )?.keystrokes
+      : [`mod+${isDesktop() ? '' : 'shift'}+,`],
+    platform
+  )
   const commandsSelector = (state: SnapshotFrom<typeof commands.actor>) =>
     state.context.commands
   const commandList = useSelector(commands.actor, commandsSelector)
@@ -202,9 +222,9 @@ function ProjectMenuPopover({
               <span className="flex-1" data-testid="project-settings">
                 Project settings
               </span>
-              <kbd className="hotkey">
-                {hotkeyDisplay(`mod+${isDesktop() ? '' : 'shift'}+,`, platform)}
-              </kbd>
+              {projectSettingsKeybinding && (
+                <kbd className="hotkey">{projectSettingsKeybinding}</kbd>
+              )}
             </>
           ),
           onClick: () => {

--- a/src/components/Settings/SettingsSearchBar.tsx
+++ b/src/components/Settings/SettingsSearchBar.tsx
@@ -1,15 +1,16 @@
 import { Combobox } from '@headlessui/react'
+import { useSignalEffect } from '@preact/signals-react'
 import { useSignals } from '@preact/signals-react/runtime'
 import { getKeybindingRows } from '@src/components/Settings/keybindingRows'
 import Fuse from 'fuse.js'
 import { useMemo, useRef, useState } from 'react'
-import { useHotkeys } from 'react-hotkeys-hook'
 import { useNavigate } from 'react-router-dom'
 
 import { CustomIcon } from '@src/components/CustomIcon'
 import { noAutofillInputProps } from '@src/lib/autofill'
 import { useApp } from '@src/lib/boot'
 import { isDesktop } from '@src/lib/isDesktop'
+import { settingsSearchFocusRequest } from '@src/lib/searchFocusRequests'
 import type { SettingsLevel } from '@src/lib/settings/settingsTypes'
 import {
   formatSettingsLabel,
@@ -28,6 +29,7 @@ type ExtendedSettingsLevel = SettingsLevel | 'keybindings'
 
 interface SettingsSearchBarProps {
   showPlugins: boolean
+  keybinding?: string
 }
 
 export type SettingsSearchItem = {
@@ -38,7 +40,10 @@ export type SettingsSearchItem = {
   level: ExtendedSettingsLevel
 }
 
-export function SettingsSearchBar({ showPlugins }: SettingsSearchBarProps) {
+export function SettingsSearchBar({
+  showPlugins,
+  keybinding,
+}: SettingsSearchBarProps) {
   useSignals()
   const { settings, registry } = useApp()
   const keymap = registry.optional(keymapService)
@@ -53,14 +58,15 @@ export function SettingsSearchBar({ showPlugins }: SettingsSearchBarProps) {
   )
   const keymapScopes = registry.signal(keymapScopesValueSpec).value
   const inputRef = useRef<HTMLInputElement>(null)
-  useHotkeys(
-    'Ctrl+.',
-    (e) => {
-      e.preventDefault()
-      inputRef.current?.focus()
-    },
-    { enableOnFormTags: true }
-  )
+  const lastHandledFocusRequest = useRef(settingsSearchFocusRequest.value)
+  useSignalEffect(() => {
+    const request = settingsSearchFocusRequest.value
+    if (request === lastHandledFocusRequest.current) {
+      return
+    }
+    lastHandledFocusRequest.current = request
+    inputRef.current?.focus()
+  })
   const navigate = useNavigate()
   const [query, setQuery] = useState('')
   const settingsValues = settings.useSettings()
@@ -129,7 +135,9 @@ export function SettingsSearchBar({ showPlugins }: SettingsSearchBarProps) {
             ref={inputRef}
             onChange={(event) => setQuery(event.target.value)}
             className="w-full bg-transparent focus:outline-none selection:bg-primary/20 dark:selection:bg-primary/40 dark:focus:outline-none"
-            placeholder="Search settings (Ctrl+.)"
+            placeholder={
+              keybinding ? `Search settings (${keybinding})` : 'Search settings'
+            }
             autoFocus
           />
           <CustomIcon

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -1,4 +1,6 @@
 import { Popover } from '@headlessui/react'
+import type { ReadonlySignal } from '@preact/signals-core'
+import { useSignalEffect } from '@preact/signals-react'
 import { useSignals } from '@preact/signals-react/runtime'
 import { CustomIcon } from '@src/components/CustomIcon'
 import { ShareDialog } from '@src/components/ShareDialog'
@@ -8,17 +10,18 @@ import type { App } from '@src/lib/app'
 import { hotkeyDisplay } from '@src/lib/hotkeys'
 import { copyFileShareLink } from '@src/lib/links'
 import { type RefObject, memo, useCallback, useRef } from 'react'
-import { useHotkeys } from 'react-hotkeys-hook'
 
 const shareHotkey = 'mod+alt+s'
 
 type ShareButtonProps = {
   app: App
+  openRequest?: ReadonlySignal<number>
 }
 
 /** Share Zoo link button shown in the upper-right of the modeling view */
 export const ShareButton = memo(function ShareButton({
   app,
+  openRequest,
 }: ShareButtonProps) {
   const { billing } = app
   const platform = usePlatform()
@@ -26,13 +29,15 @@ export const ShareButton = memo(function ShareButton({
   const billingContext = billing.useContext()
   const billingLoading = billingContext.hasSubscription === undefined
   const shareButtonRef = useRef<HTMLButtonElement>(null)
+  const lastHandledOpenRequest = useRef(openRequest?.value ?? 0)
 
-  const onShareClick = useCallback(() => {
+  useSignalEffect(() => {
+    const request = openRequest?.value
+    if (!request || request === lastHandledOpenRequest.current) {
+      return
+    }
+    lastHandledOpenRequest.current = request
     shareButtonRef.current?.click()
-  }, [])
-
-  useHotkeys(shareHotkey, onShareClick, {
-    scopes: ['modeling'],
   })
 
   return (

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -7,11 +7,18 @@ import { ShareDialog } from '@src/components/ShareDialog'
 import Tooltip from '@src/components/Tooltip'
 import usePlatform from '@src/hooks/usePlatform'
 import type { App } from '@src/lib/app'
-import { hotkeyDisplay } from '@src/lib/hotkeys'
 import { copyFileShareLink } from '@src/lib/links'
+import {
+  findKeymapItemForCommand,
+  keymapKeystrokesDisplay,
+  keymapScopesValueSpec,
+  keymapService,
+} from '@src/registry/contracts/keymap'
+import {
+  SHARE_COMMAND_ID,
+  SHARE_HOTKEY,
+} from '@src/registry/plugins/share/constants'
 import { type RefObject, memo, useCallback, useRef } from 'react'
-
-const shareHotkey = 'mod+alt+s'
 
 type ShareButtonProps = {
   app: App
@@ -83,6 +90,18 @@ function SharePopoverContent({
   const allowPassword = !!billingContext.hasSubscription
   const ast = kclManager.astSignal.value
   const shareDisabled = ast.body.some((n) => n.type === 'ImportStatement')
+  const keymap = app.registry.optional(keymapService)
+  const shareKeybinding = keymapKeystrokesDisplay(
+    keymap
+      ? findKeymapItemForCommand(
+          keymap.keymap.value,
+          SHARE_COMMAND_ID,
+          keymap.getCurrentScopes(),
+          app.registry.signal(keymapScopesValueSpec).value
+        )?.keystrokes
+      : [SHARE_HOTKEY],
+    platform
+  )
 
   const onCopyShareLink = useCallback(
     async ({
@@ -125,10 +144,8 @@ function SharePopoverContent({
                 ? `Share links are not currently supported for multi-file assemblies`
                 : `Share this project`}
           </span>
-          {!billingLoading && (
-            <kbd className="hotkey text-xs capitalize">
-              {hotkeyDisplay(shareHotkey, platform)}
-            </kbd>
+          {!billingLoading && shareKeybinding && (
+            <kbd className="hotkey text-xs capitalize">{shareKeybinding}</kbd>
           )}
         </Tooltip>
       </Popover.Button>

--- a/src/components/UndoRedoButtons.tsx
+++ b/src/components/UndoRedoButtons.tsx
@@ -3,9 +3,16 @@ import { CustomIcon } from '@src/components/CustomIcon'
 import Tooltip from '@src/components/Tooltip'
 import usePlatform from '@src/hooks/usePlatform'
 import type { KclManager } from '@src/lang/KclManager'
-import { hotkeyDisplay } from '@src/lib/hotkeys'
+import { useApp } from '@src/lib/boot'
 import { reportRejection } from '@src/lib/trap'
 import { refreshPage } from '@src/lib/utils'
+import {
+  findKeymapItemForCommand,
+  keymapKeystrokesDisplay,
+  keymapScopesValueSpec,
+  keymapService,
+} from '@src/registry/contracts/keymap'
+import { APP_COMMAND_IDS } from '@src/registry/extensions/commands/appCommands'
 import { type HTMLProps, type MouseEventHandler } from 'react'
 
 export function UndoRedoButtons({
@@ -13,11 +20,34 @@ export function UndoRedoButtons({
   ...props
 }: HTMLProps<HTMLDivElement> & { kclManager: KclManager }) {
   useSignals()
+  const app = useApp()
+  const platform = usePlatform()
+  const keymap = app.registry.optional(keymapService)
+  const keymapScopes = app.registry.signal(keymapScopesValueSpec).value
+  const currentScopes = keymap?.getCurrentScopes()
+  const keybindingDisplay = (
+    command: string,
+    fallbackKeystrokes: readonly string[]
+  ) =>
+    keymapKeystrokesDisplay(
+      keymap && currentScopes
+        ? findKeymapItemForCommand(
+            keymap.keymap.value,
+            command,
+            currentScopes,
+            keymapScopes
+          )?.keystrokes
+        : fallbackKeystrokes,
+      platform
+    )
+
   return (
     <div {...props}>
       <UndoOrRedoButton
         label="Undo"
-        keyboardShortcut="mod+z"
+        keyboardShortcut={keybindingDisplay(APP_COMMAND_IDS.editor.undo, [
+          'mod+z',
+        ])}
         iconName="arrowTurnLeft"
         onClick={() => kclManager.undo()}
         className="rounded-r-none"
@@ -25,7 +55,9 @@ export function UndoRedoButtons({
       />
       <UndoOrRedoButton
         label="Redo"
-        keyboardShortcut="mod+shift+z"
+        keyboardShortcut={keybindingDisplay(APP_COMMAND_IDS.editor.redo, [
+          'mod+shift+z',
+        ])}
         iconName="arrowTurnRight"
         onClick={() => kclManager.redo()}
         className="rounded-none"
@@ -62,7 +94,6 @@ function UndoOrRedoButton({
   className,
   ...rest
 }: UndoOrRedoButtonProps) {
-  const platform = usePlatform()
   return (
     <button
       {...rest}
@@ -79,9 +110,7 @@ function UndoOrRedoButton({
       >
         <span>{label}</span>
         {keyboardShortcut && (
-          <kbd className="hotkey capitalize">
-            {hotkeyDisplay(keyboardShortcut, platform)}
-          </kbd>
+          <kbd className="hotkey capitalize">{keyboardShortcut}</kbd>
         )}
       </Tooltip>
     </button>

--- a/src/components/layout/areas/FeatureTreePane.tsx
+++ b/src/components/layout/areas/FeatureTreePane.tsx
@@ -65,7 +65,6 @@ import {
   sendDeleteCommand,
   sendSelectionEvent,
 } from '@src/lib/featureTree'
-import { hotkeyDisplay } from '@src/lib/hotkeys'
 import {
   type AreaTypeComponentProps,
   DefaultLayoutPaneID,
@@ -78,6 +77,13 @@ import type RustContext from '@src/lib/rustContext'
 import type { CommandBarActorType } from '@src/machines/commandBarMachine'
 import type { ConnectionManager } from '@src/network/connectionManager'
 import { executingEditorService } from '@src/registry/contracts/executingEditor'
+import {
+  findKeymapItemForCommand,
+  keymapKeystrokesDisplay,
+  keymapScopesValueSpec,
+  keymapService,
+} from '@src/registry/contracts/keymap'
+import { APP_COMMAND_IDS } from '@src/registry/extensions/commands/appCommands'
 import { useNavigate } from 'react-router-dom'
 
 type Singletons = ReturnType<typeof useSingletons>
@@ -138,8 +144,16 @@ export const FeatureTreePaneContents = memo(() => {
   const { layout, commands, settings } = app
   const settingsValues = settings.useSettings()
   const platform = usePlatform()
-  const unrenderedExecuteHotkeyLabel = hotkeyDisplay(
-    UNRENDERED_EXECUTE_HOTKEY,
+  const keymap = app.registry.optional(keymapService)
+  const unrenderedExecuteHotkeyLabel = keymapKeystrokesDisplay(
+    keymap
+      ? findKeymapItemForCommand(
+          keymap.keymap.value,
+          APP_COMMAND_IDS.editor.render,
+          keymap.getCurrentScopes(),
+          app.registry.signal(keymapScopesValueSpec).value
+        )?.keystrokes
+      : [UNRENDERED_EXECUTE_HOTKEY],
     platform
   )
   const { kclManager } = useSingletons()

--- a/src/components/layout/areas/KclEditorPane.tsx
+++ b/src/components/layout/areas/KclEditorPane.tsx
@@ -1,15 +1,22 @@
 import { Menu } from '@headlessui/react'
+import { useSignals } from '@preact/signals-react/runtime'
 import { CustomIcon } from '@src/components/CustomIcon'
 import { LayoutPanel, LayoutPanelHeader } from '@src/components/layout/Panel'
 import { HeaderMenu } from '@src/components/layout/Panel/HeaderMenu'
 import usePlatform from '@src/hooks/usePlatform'
 import { useConvertToVariable } from '@src/hooks/useToolbarGuards'
 import { useApp, useSingletons } from '@src/lib/boot'
-import { hotkeyDisplay } from '@src/lib/hotkeys'
 import type { AreaTypeComponentProps } from '@src/lib/layout'
 import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
 import { reportRejection, trap } from '@src/lib/trap'
 import { withSiteBaseURL } from '@src/lib/withBaseURL'
+import {
+  findKeymapItemForCommand,
+  keymapKeystrokesDisplay,
+  keymapScopesValueSpec,
+  keymapService,
+} from '@src/registry/contracts/keymap'
+import { APP_COMMAND_IDS } from '@src/registry/extensions/commands/appCommands'
 import { useEffect, useRef } from 'react'
 import toast from 'react-hot-toast'
 import styles from './KclEditorMenu.module.css'
@@ -18,10 +25,10 @@ type Singletons = ReturnType<typeof useSingletons>
 
 export const editorShortcutMeta = {
   formatCode: {
-    display: 'Alt + Shift + F',
+    defaultKeys: ['alt+shift+f'],
   },
   convertToVariable: {
-    display: 'Ctrl + Shift + C',
+    defaultKeys: ['ctrl+shift+c'],
   },
 }
 
@@ -82,10 +89,38 @@ function copyKclCodeToClipboard(kclManager: Singletons['kclManager']) {
 }
 
 export const KclEditorMenu = () => {
-  const { commands, settings } = useApp()
+  useSignals()
+  const app = useApp()
+  const { commands, settings } = app
   const { kclManager } = useSingletons()
   const platform = usePlatform()
   const settingsActor = settings.actor
+  const keymap = app.registry.optional(keymapService)
+  const keymapScopes = app.registry.signal(keymapScopesValueSpec).value
+  const currentScopes = keymap?.getCurrentScopes()
+  const keybindingDisplay = (
+    command: string,
+    fallbackKeystrokes: readonly string[]
+  ) =>
+    keymapKeystrokesDisplay(
+      keymap && currentScopes
+        ? findKeymapItemForCommand(
+            keymap.keymap.value,
+            command,
+            currentScopes,
+            keymapScopes
+          )?.keystrokes
+        : fallbackKeystrokes,
+      platform
+    )
+  const formatCodeKeybinding = keybindingDisplay(
+    APP_COMMAND_IDS.editor.format,
+    editorShortcutMeta.formatCode.defaultKeys
+  )
+  const convertToVariableKeybinding = keybindingDisplay(
+    APP_COMMAND_IDS.editor.convertToVariable,
+    editorShortcutMeta.convertToVariable.defaultKeys
+  )
   const { enable: convertToVarEnabled, handleClick: handleConvertToVarClick } =
     useConvertToVariable(kclManager)
 
@@ -100,9 +135,7 @@ export const KclEditorMenu = () => {
           className={styles.button}
         >
           <span>Format code</span>
-          <small>
-            {hotkeyDisplay(editorShortcutMeta.formatCode.display, platform)}
-          </small>
+          {formatCodeKeybinding && <small>{formatCodeKeybinding}</small>}
         </button>
       </Menu.Item>
       <Menu.Item>
@@ -124,7 +157,9 @@ export const KclEditorMenu = () => {
             className={styles.button}
           >
             <span>Convert to Variable</span>
-            <small>{editorShortcutMeta.convertToVariable.display}</small>
+            {convertToVariableKeybinding && (
+              <small>{convertToVariableKeybinding}</small>
+            )}
           </button>
         </Menu.Item>
       )}

--- a/src/lib/hotkeys.ts
+++ b/src/lib/hotkeys.ts
@@ -1,13 +1,13 @@
 import { type Platform, isArray } from '@src/lib/utils'
+import {
+  keymapChordDisplay,
+  keymapKeystrokesDisplay,
+} from '@src/registry/contracts/keymap'
 
 /**
  * @deprecated Prefer registering shortcuts through `keymapValueSpec`.
  */
 export const SNAP_TO_GRID_HOTKEY = 'mod+g'
-
-const LOWER_CASE_LETTER = /[a-z]/
-const WHITESPACE = /\s+/g
-const HOTKEY_SEQUENCE_SEPARATOR = ' '
 
 export type HotkeySequence = string | readonly string[]
 
@@ -24,59 +24,8 @@ export function hotkeyDisplay(
   platform: Platform
 ): string | undefined {
   if (isArray(hotkey)) {
-    const display = hotkey
-      .map((chord) => hotkeyChordDisplay(chord, platform))
-      .filter((chordDisplay): chordDisplay is string => !!chordDisplay)
-      .join(HOTKEY_SEQUENCE_SEPARATOR)
-
-    return display || undefined
+    return keymapKeystrokesDisplay(hotkey, platform)
   }
 
-  return hotkeyChordDisplay(hotkey, platform)
-}
-
-function hotkeyChordDisplay(
-  hotkey: string | undefined,
-  platform: Platform
-): string | undefined {
-  if (!hotkey) {
-    return undefined
-  }
-  const isMac = platform === 'macos'
-  const isWindows = platform === 'windows'
-  // Browsers call it metaKey, but that's a misnomer.
-  const meta = isWindows ? 'Win' : 'Super'
-  const outputSeparator = isMac ? '' : '+'
-  const display = hotkey
-    // Capitalize letters.  We want Ctrl+K, not Ctrl+k, since Shift should be
-    // shown as a separate modifier.
-    .split('+')
-    .map((word) => word.trim().toLocaleLowerCase())
-    .map((word) => {
-      if (word === 'escape' || word === 'esc') {
-        return 'Esc'
-      }
-      if (word.length === 1 && LOWER_CASE_LETTER.test(word)) {
-        return word.toUpperCase()
-      }
-      return word
-    })
-    .join(outputSeparator)
-    // Collapse multiple spaces into one.
-    .replaceAll(WHITESPACE, ' ')
-    .replaceAll('mod', isMac ? '⌘' : 'Ctrl')
-    .replaceAll('meta', isMac ? '⌘' : meta)
-    // This is technically the wrong arrow for control, but it's more visible
-    // and recognizable.  May want to change this in the future.
-    //
-    // The correct arrow is ⌃ "UP ARROWHEAD" Unicode: U+2303
-    .replaceAll('ctrl', isMac ? '^' : 'Ctrl')
-    // This is technically the wrong arrow for shift, but it's more visible and
-    // recognizable.  May want to change this in the future.
-    //
-    // The correct arrow is ⇧ "UPWARDS WHITE ARROW" Unicode: U+21E7
-    .replaceAll('shift', isMac ? '⬆' : 'Shift')
-    .replaceAll('alt', isMac ? '⌥' : 'Alt')
-
-  return display
+  return keymapChordDisplay(hotkey, platform)
 }

--- a/src/lib/searchFocusRequests.ts
+++ b/src/lib/searchFocusRequests.ts
@@ -1,0 +1,4 @@
+import { signal } from '@preact/signals-core'
+
+export const projectSearchFocusRequest = signal(0)
+export const settingsSearchFocusRequest = signal(0)

--- a/src/registry/contracts/keymap.test.ts
+++ b/src/registry/contracts/keymap.test.ts
@@ -455,6 +455,71 @@ describe('keymap contract', () => {
     })
   })
 
+  it('keeps same-command linked hidden overrides in their original scopes', () => {
+    const hiddenEditorItem = createKeymapItem({
+      id: 'editor.undo.code-editor-focused',
+      command: 'zds.editor.undo',
+      keystrokes: ['mod+z'],
+      scopes: [CODE_EDITOR_FOCUSED_KEYMAP_SCOPE],
+      hidden: true,
+      userBindingCommand: 'zds.editor.undo',
+    })
+    const visibleItem = createKeymapItem({
+      id: 'editor.undo',
+      command: 'zds.editor.undo',
+      keystrokes: ['mod+z'],
+      scopes: [MODE_MODELING_KEYMAP_SCOPE],
+    })
+    const tree = createKeymapTree(
+      resolveKeymapItems([hiddenEditorItem, visibleItem], {
+        version: 1,
+        bindings: [
+          {
+            command: 'zds.editor.undo',
+            keystrokes: ['mod+alt+z'],
+            scopes: [MODE_MODELING_KEYMAP_SCOPE],
+          },
+        ],
+      })
+    )
+    const scopeMetadata = [
+      createContextScope(MODE_MODELING_KEYMAP_SCOPE, 100),
+      createContextScope(CODE_EDITOR_FOCUSED_KEYMAP_SCOPE, 1000),
+    ]
+
+    expect(
+      matchKeymapKeystrokes(
+        tree,
+        [CODE_EDITOR_FOCUSED_KEYMAP_SCOPE],
+        ['mod+alt+z'],
+        scopeMetadata
+      )
+    ).toEqual({
+      type: 'full',
+      item: {
+        ...hiddenEditorItem,
+        keystrokes: ['mod+alt+z'],
+        source: 'User',
+      },
+    })
+    expect(
+      matchKeymapKeystrokes(
+        tree,
+        [MODE_MODELING_KEYMAP_SCOPE],
+        ['mod+alt+z'],
+        scopeMetadata
+      )
+    ).toEqual({
+      type: 'full',
+      item: {
+        ...visibleItem,
+        keystrokes: ['mod+alt+z'],
+        scopes: [MODE_MODELING_KEYMAP_SCOPE],
+        source: 'User',
+      },
+    })
+  })
+
   it('resolves persisted unbind entries by command and keystrokes', () => {
     const item = createKeymapItem({
       id: 'open-command-palette',

--- a/src/registry/contracts/keymap.test.ts
+++ b/src/registry/contracts/keymap.test.ts
@@ -11,6 +11,7 @@ import {
   createKeymapTree,
   createKeymapTreeFromContributions,
   findKeymapItemForCommand,
+  keymapKeystrokesDisplay,
   matchKeymapKeystrokes,
   normalizeEventKey,
   normalizeKeymapChord,
@@ -32,6 +33,12 @@ describe('keymap contract', () => {
       type: 'full',
       item,
     })
+  })
+
+  it('formats keymap keystrokes for display', () => {
+    expect(keymapKeystrokesDisplay(['mod+k', 'p'], 'windows')).toBe('Ctrl+K P')
+    expect(keymapKeystrokesDisplay(['mod+k'], 'macos')).toBe('⌘K')
+    expect(keymapKeystrokesDisplay([], 'linux')).toBeUndefined()
   })
 
   it('normalizes modified alt-including keyboard events from their unmodified key code', () => {

--- a/src/registry/contracts/keymap.ts
+++ b/src/registry/contracts/keymap.ts
@@ -497,9 +497,9 @@ function getKeymapItemUserBindingCommand(item: KeymapItem) {
 
 function isKeymapLinkedUserBinding(item: KeymapItem, binding: KeymapBinding) {
   return (
+    item.hidden === true &&
     item.userBindingCommand !== undefined &&
-    item.userBindingCommand === binding.command &&
-    item.command !== binding.command
+    item.userBindingCommand === binding.command
   )
 }
 

--- a/src/registry/contracts/keymap.ts
+++ b/src/registry/contracts/keymap.ts
@@ -5,7 +5,7 @@ import {
   provide,
 } from '@kittycad/registry'
 import type { ReadonlySignal } from '@preact/signals-core'
-import { isArray } from '@src/lib/utils'
+import { type Platform, isArray } from '@src/lib/utils'
 
 export const BASE_KEYMAP_SCOPE = 'base'
 export const CODE_EDITOR_FOCUSED_KEYMAP_SCOPE = 'code-editor-focused'
@@ -14,6 +14,7 @@ export const MODE_MODELING_KEYMAP_SCOPE = 'mode-modeling'
 export const MODE_SKETCHING_KEYMAP_SCOPE = 'mode-sketching'
 export const MODE_SKETCH_NO_FACE_KEYMAP_SCOPE = 'mode-sketch-no-face'
 export const MODE_SKETCH_SOLVE_KEYMAP_SCOPE = 'mode-sketch-solve'
+export const HOME_KEYMAP_SCOPE = 'home'
 export const PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE = 'project-explorer.focused'
 export const PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE =
   'project-explorer.renaming'
@@ -115,6 +116,56 @@ const createKeymapTreeNode = (): KeymapTreeNode => ({
   items: [],
   scopes: new Set(),
 })
+
+const LOWER_CASE_LETTER = /[a-z]/
+const WHITESPACE = /\s+/g
+const KEYMAP_KEYSTROKE_SEPARATOR = ' '
+
+export function keymapKeystrokesDisplay(
+  keystrokes: readonly string[] | undefined,
+  platform: Platform
+): string | undefined {
+  const display = (keystrokes ?? [])
+    .map((chord) => keymapChordDisplay(chord, platform))
+    .filter((chordDisplay): chordDisplay is string => !!chordDisplay)
+    .join(KEYMAP_KEYSTROKE_SEPARATOR)
+
+  return display || undefined
+}
+
+export function keymapChordDisplay(
+  chord: string | undefined,
+  platform: Platform
+): string | undefined {
+  if (!chord) {
+    return undefined
+  }
+
+  const isMac = platform === 'macos'
+  const isWindows = platform === 'windows'
+  const meta = isWindows ? 'Win' : 'Super'
+  const outputSeparator = isMac ? '' : '+'
+
+  return chord
+    .split('+')
+    .map((word) => word.trim().toLocaleLowerCase())
+    .map((word) => {
+      if (word === 'escape' || word === 'esc') {
+        return 'Esc'
+      }
+      if (word.length === 1 && LOWER_CASE_LETTER.test(word)) {
+        return word.toUpperCase()
+      }
+      return word
+    })
+    .join(outputSeparator)
+    .replaceAll(WHITESPACE, ' ')
+    .replaceAll('mod', isMac ? '⌘' : 'Ctrl')
+    .replaceAll('meta', isMac ? '⌘' : meta)
+    .replaceAll('ctrl', isMac ? '^' : 'Ctrl')
+    .replaceAll('shift', isMac ? '⬆' : 'Shift')
+    .replaceAll('alt', isMac ? '⌥' : 'Alt')
+}
 
 export function normalizeKeymapChord(chord: string) {
   return chord

--- a/src/registry/extensions/commands/appCommands.ts
+++ b/src/registry/extensions/commands/appCommands.ts
@@ -1,0 +1,256 @@
+import { getAutomaticallyRenderEnabledFromSettings } from '@src/lib/automaticRendering'
+import type { Command } from '@src/lib/commandTypes'
+import { resetCameraPosition } from '@src/lib/resetCameraPosition'
+import {
+  projectSearchFocusRequest,
+  settingsSearchFocusRequest,
+} from '@src/lib/searchFocusRequests'
+import { selectAllInCurrentSketch } from '@src/lib/selections'
+import { reportRejection } from '@src/lib/trap'
+import type { CommandBarContext } from '@src/machines/commandBarMachine'
+import type { ModelingMachineEvent } from '@src/machines/modelingMachine'
+import toast from 'react-hot-toast'
+
+const APP_COMMAND_GROUP_ID = 'zds'
+
+export const APP_COMMAND_IDS = Object.freeze({
+  editor: {
+    undo: 'zds.editor.undo',
+    redo: 'zds.editor.redo',
+    format: 'zds.editor.format',
+    convertToVariable: 'zds.editor.convertToVariable',
+    render: 'zds.editor.render',
+  },
+  modeling: {
+    deleteSelection: 'zds.modeling.deleteSelection',
+    centerCameraOnSelection: 'zds.modeling.centerCameraOnSelection',
+    selectAllInCurrentSketch: 'zds.modeling.selectAllInCurrentSketch',
+    toggleSnapToGrid: 'zds.modeling.toggleSnapToGrid',
+  },
+  view: {
+    reset: 'zds.view.reset',
+  },
+  search: {
+    focusProjects: 'zds.search.focusProjects',
+    focusSettings: 'zds.search.focusSettings',
+  },
+} as const)
+
+type CommandSubmitInput = {
+  context?: CommandBarContext
+}
+
+function getCommandBarContext(input: unknown): CommandBarContext | undefined {
+  return input &&
+    typeof input === 'object' &&
+    'context' in input &&
+    input.context &&
+    typeof input.context === 'object'
+    ? (input as CommandSubmitInput).context
+    : undefined
+}
+
+function getKclManager(input: unknown) {
+  return getCommandBarContext(input)?.kclManager
+}
+
+function sendModelingEvent(
+  input: unknown,
+  event: ModelingMachineEvent
+): true | Error {
+  const kclManager = getKclManager(input)
+  if (!kclManager?.modelingState) {
+    return new Error('No active modeling context')
+  }
+
+  kclManager.sendModelingEvent(event)
+  return true
+}
+
+function createAppCommand({
+  id,
+  displayName,
+  onSubmit,
+}: {
+  id: string
+  displayName: string
+  onSubmit: Command['onSubmit']
+}): Command {
+  return {
+    id,
+    name: id,
+    groupId: APP_COMMAND_GROUP_ID,
+    displayName,
+    hideFromSearch: true,
+    needsReview: false,
+    onSubmit,
+  }
+}
+
+function deleteSelection(input: unknown) {
+  const kclManager = getKclManager(input)
+  const state = kclManager?.modelingState
+  if (!kclManager || !state) {
+    return new Error('No active modeling context')
+  }
+
+  if (state.matches('sketchSolveMode')) {
+    kclManager.sendModelingEvent({ type: 'delete selected' })
+    return
+  }
+
+  const segmentNodePaths = Object.keys(state.context.segmentOverlays)
+  const selections = state.context.selectionRanges.graphSelections.filter(
+    (selection) =>
+      segmentNodePaths.includes(JSON.stringify(selection.codeRef.pathToNode))
+  )
+  const orderedSelections = selections.slice().sort((a, b) => {
+    const aStart = a.codeRef.range?.[0] ?? 0
+    const bStart = b.codeRef.range?.[0] ?? 0
+    return bStart - aStart
+  })
+
+  kclManager.sendModelingEvent({
+    type: 'Delete segments',
+    data: orderedSelections.map((selection) => selection.codeRef.pathToNode),
+  })
+
+  if (
+    state.context.selectionRanges.graphSelections.length > selections.length
+  ) {
+    kclManager.sendModelingEvent({ type: 'Delete selection' })
+  }
+}
+
+function resetView(input: unknown) {
+  const kclManager = getKclManager(input)
+  if (!kclManager) {
+    return new Error('No active modeling context')
+  }
+
+  return resetCameraPosition({
+    sceneInfra: kclManager.sceneInfra,
+    engineCommandManager: kclManager.engineCommandManager,
+    settingsActor: kclManager.systemDeps.settings,
+  })
+}
+
+function toggleSnapToGrid(input: unknown) {
+  const kclManager = getKclManager(input)
+  const settingsActor = kclManager?.systemDeps.settings
+  if (!settingsActor) {
+    return new Error('No active settings context')
+  }
+
+  settingsActor.send({
+    type: 'set.modeling.snapToGrid',
+    data: {
+      level: 'project',
+      value: !settingsActor.getSnapshot().context.modeling.snapToGrid.current,
+    },
+  })
+}
+
+function selectAllInCurrentSketchCommand(input: unknown) {
+  const kclManager = getKclManager(input)
+  const state = kclManager?.modelingState
+  if (!kclManager || !state?.matches('Sketch')) {
+    return
+  }
+
+  const selection = selectAllInCurrentSketch(
+    kclManager.artifactGraph,
+    kclManager.sceneEntitiesManager
+  )
+  return sendModelingEvent(input, {
+    type: 'Set selection',
+    data: { selectionType: 'completeSelection', selection },
+  })
+}
+
+function reexecuteOrToastAutosaveBehavior(input: unknown) {
+  const kclManager = getKclManager(input)
+  if (!kclManager) {
+    return new Error('No active editor context')
+  }
+
+  const automaticallyRenderEnabled = getAutomaticallyRenderEnabledFromSettings(
+    kclManager.systemDeps.settings.getSnapshot().context
+  )
+  if (
+    !automaticallyRenderEnabled &&
+    kclManager.hasEditsSinceLastExecutionSignal.value
+  ) {
+    return kclManager.executeCode()
+  }
+
+  toast.success('Your work is auto-saved in real-time.')
+}
+
+export const appCommands: readonly Command[] = [
+  createAppCommand({
+    id: APP_COMMAND_IDS.editor.undo,
+    displayName: 'Undo',
+    onSubmit: (input) => getKclManager(input)?.undo(),
+  }),
+  createAppCommand({
+    id: APP_COMMAND_IDS.editor.redo,
+    displayName: 'Redo',
+    onSubmit: (input) => getKclManager(input)?.redo(),
+  }),
+  createAppCommand({
+    id: APP_COMMAND_IDS.editor.format,
+    displayName: 'Format code',
+    onSubmit: (input) => getKclManager(input)?.format().catch(reportRejection),
+  }),
+  createAppCommand({
+    id: APP_COMMAND_IDS.editor.convertToVariable,
+    displayName: 'Convert to variable',
+    onSubmit: (input) => getKclManager(input)?.convertToVariable(),
+  }),
+  createAppCommand({
+    id: APP_COMMAND_IDS.editor.render,
+    displayName: 'Render code',
+    onSubmit: reexecuteOrToastAutosaveBehavior,
+  }),
+  createAppCommand({
+    id: APP_COMMAND_IDS.modeling.deleteSelection,
+    displayName: 'Delete selection',
+    onSubmit: deleteSelection,
+  }),
+  createAppCommand({
+    id: APP_COMMAND_IDS.modeling.centerCameraOnSelection,
+    displayName: 'Center camera on selection',
+    onSubmit: (input) =>
+      sendModelingEvent(input, { type: 'Center camera on selection' }),
+  }),
+  createAppCommand({
+    id: APP_COMMAND_IDS.modeling.selectAllInCurrentSketch,
+    displayName: 'Select all in current sketch',
+    onSubmit: selectAllInCurrentSketchCommand,
+  }),
+  createAppCommand({
+    id: APP_COMMAND_IDS.modeling.toggleSnapToGrid,
+    displayName: 'Toggle snap to grid',
+    onSubmit: toggleSnapToGrid,
+  }),
+  createAppCommand({
+    id: APP_COMMAND_IDS.view.reset,
+    displayName: 'Reset view',
+    onSubmit: resetView,
+  }),
+  createAppCommand({
+    id: APP_COMMAND_IDS.search.focusProjects,
+    displayName: 'Focus project search',
+    onSubmit: () => {
+      projectSearchFocusRequest.value += 1
+    },
+  }),
+  createAppCommand({
+    id: APP_COMMAND_IDS.search.focusSettings,
+    displayName: 'Focus settings search',
+    onSubmit: () => {
+      settingsSearchFocusRequest.value += 1
+    },
+  }),
+]

--- a/src/registry/extensions/commands/appCommands.ts
+++ b/src/registry/extensions/commands/appCommands.ts
@@ -153,8 +153,7 @@ function toggleSnapToGrid(input: unknown) {
 
 function selectAllInCurrentSketchCommand(input: unknown) {
   const kclManager = getKclManager(input)
-  const state = kclManager?.modelingState
-  if (!kclManager || !state?.matches('Sketch')) {
+  if (!kclManager) {
     return
   }
 

--- a/src/registry/extensions/commands/index.spec.ts
+++ b/src/registry/extensions/commands/index.spec.ts
@@ -17,6 +17,7 @@ import { machineManagerService } from '@src/registry/contracts/machineManager'
 import { provideWasmPromise } from '@src/registry/contracts/wasm'
 import { describe, expect, it, vi } from 'vitest'
 import { commandsExtension } from '.'
+import { APP_COMMAND_IDS, appCommands } from './appCommands'
 import { TOOLBAR_COMMAND_IDS, toolbarCommands } from './toolbarCommands'
 
 function createCommandBarContext({
@@ -86,6 +87,16 @@ describe('commands extension', () => {
   it('provides toolbar commands for keymap-backed tool selection', () => {
     expect(toolbarCommands.map((command) => command.id)).toContain(
       TOOLBAR_COMMAND_IDS.sketchSolve.vertical
+    )
+  })
+
+  it('provides an app command for every app command id', () => {
+    const appCommandIds = Object.values(APP_COMMAND_IDS).flatMap((group) =>
+      Object.values(group)
+    )
+
+    expect(appCommands.map((command) => command.id).toSorted()).toEqual(
+      appCommandIds.toSorted()
     )
   })
 
@@ -254,5 +265,44 @@ describe('commands extension', () => {
     ])
 
     registry[Symbol.dispose]()
+  })
+
+  it('runs select all in current sketch from keymaps outside legacy sketch state', () => {
+    const sentEvents: unknown[] = []
+    const kclManager = {
+      modelingState: {
+        matches: () => false,
+      },
+      artifactGraph: new Map(),
+      sceneEntitiesManager: {
+        activeSegments: {},
+      },
+      sendModelingEvent: (event: unknown) => {
+        sentEvents.push(event)
+        return true
+      },
+    } as unknown as KclManager
+    const command = appCommands.find(
+      (candidate) =>
+        candidate.id === APP_COMMAND_IDS.modeling.selectAllInCurrentSketch
+    )
+
+    expect(command).toBeDefined()
+    command?.onSubmit({
+      context: { kclManager } as CommandBarContext,
+    })
+
+    expect(sentEvents).toEqual([
+      {
+        type: 'Set selection',
+        data: {
+          selectionType: 'completeSelection',
+          selection: {
+            graphSelections: [],
+            otherSelections: [],
+          },
+        },
+      },
+    ])
   })
 })

--- a/src/registry/extensions/commands/index.ts
+++ b/src/registry/extensions/commands/index.ts
@@ -17,6 +17,7 @@ import { machineManagerService } from '@src/registry/contracts/machineManager'
 import { wasmPromiseValueSpec } from '@src/registry/contracts/wasm'
 import { useSelector } from '@xstate/react'
 import { createActor } from 'xstate'
+import { appCommands } from './appCommands'
 import { toolbarCommands } from './toolbarCommands'
 
 export const commandsExtension = defineRegistryItemFactory((ctx) => {
@@ -90,7 +91,7 @@ export const commandsExtension = defineRegistryItemFactory((ctx) => {
 
 const toolbarCommandsItem = defineRegistryItem({
   id: 'toolbar-commands',
-  provides: toolbarCommands.map((command) =>
+  provides: [...toolbarCommands, ...appCommands].map((command) =>
     provide(commandsValueSpec, command, {
       key: command.id ?? `${command.groupId}:${String(command.name)}`,
     })

--- a/src/registry/extensions/keymap/defaultKeymap.ts
+++ b/src/registry/extensions/keymap/defaultKeymap.ts
@@ -2,6 +2,7 @@ import { defineRegistryItem, provide } from '@kittycad/registry'
 import { isDesktop } from '@src/lib/isDesktop'
 import { getDeleteKeys } from '@src/lib/utils'
 import {
+  CODE_EDITOR_FOCUSED_KEYMAP_SCOPE,
   CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE,
   HOME_KEYMAP_SCOPE,
   type KeymapDocument,
@@ -143,11 +144,29 @@ export const defaultKeymap: KeymapDocument = {
       command: APP_COMMAND_IDS.editor.undo,
     },
     {
+      id: 'editor.undo.code-editor-focused',
+      title: 'Undo',
+      scopes: [CODE_EDITOR_FOCUSED_KEYMAP_SCOPE],
+      keystrokes: ['mod+z'],
+      command: APP_COMMAND_IDS.editor.undo,
+      hidden: true,
+      userBindingCommand: APP_COMMAND_IDS.editor.undo,
+    },
+    {
       id: 'editor.redo',
       title: 'Redo',
       scopes: FILE_KEYMAP_SCOPES,
       keystrokes: ['mod+shift+z'],
       command: APP_COMMAND_IDS.editor.redo,
+    },
+    {
+      id: 'editor.redo.code-editor-focused',
+      title: 'Redo',
+      scopes: [CODE_EDITOR_FOCUSED_KEYMAP_SCOPE],
+      keystrokes: ['mod+shift+z'],
+      command: APP_COMMAND_IDS.editor.redo,
+      hidden: true,
+      userBindingCommand: APP_COMMAND_IDS.editor.redo,
     },
     ...(!isDesktop()
       ? [

--- a/src/registry/extensions/keymap/defaultKeymap.ts
+++ b/src/registry/extensions/keymap/defaultKeymap.ts
@@ -1,6 +1,9 @@
 import { defineRegistryItem, provide } from '@kittycad/registry'
 import { isDesktop } from '@src/lib/isDesktop'
+import { getDeleteKeys } from '@src/lib/utils'
 import {
+  CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE,
+  HOME_KEYMAP_SCOPE,
   type KeymapDocument,
   MODE_MODELING_KEYMAP_SCOPE,
   MODE_SKETCHING_KEYMAP_SCOPE,
@@ -9,9 +12,16 @@ import {
   PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE,
   keymapValueSpec,
 } from '@src/registry/contracts/keymap'
+import { APP_COMMAND_IDS } from '@src/registry/extensions/commands/appCommands'
 import { TOOLBAR_COMMAND_IDS } from '@src/registry/extensions/commands/toolbarCommands'
 
 const BASE_KEYMAP_SOURCE = 'Base'
+const FILE_KEYMAP_SCOPES = [
+  MODE_MODELING_KEYMAP_SCOPE,
+  MODE_SKETCHING_KEYMAP_SCOPE,
+  MODE_SKETCH_NO_FACE_KEYMAP_SCOPE,
+  MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
+]
 
 export const PROJECT_EXPLORER_COMMAND_IDS = {
   arrowLeft: 'project-explorer.arrow-left',
@@ -68,6 +78,15 @@ export const defaultKeymap: KeymapDocument = {
       command: 'zds.commandPalette.close',
     },
     {
+      id: 'command-palette.close-slash',
+      title: 'Close command palette',
+      scopes: ['cmd-palette-open'],
+      keystrokes: ['mod+/'],
+      command: 'zds.commandPalette.close',
+      hidden: true,
+      userBindingCommand: 'zds.commandPalette.close',
+    },
+    {
       id: 'settings.open',
       title: 'Open settings',
       keystrokes: [isDesktop() ? 'mod+,' : 'mod+shift+,'],
@@ -92,6 +111,93 @@ export const defaultKeymap: KeymapDocument = {
       arguments: {
         tab: 'user',
       },
+    },
+    {
+      id: 'settings.focus-search',
+      title: 'Focus settings search',
+      scopes: ['settings-open'],
+      keystrokes: ['ctrl+.'],
+      command: APP_COMMAND_IDS.search.focusSettings,
+    },
+    {
+      id: 'home.focus-project-search',
+      title: 'Focus project search',
+      scopes: [HOME_KEYMAP_SCOPE],
+      keystrokes: ['ctrl+.'],
+      command: APP_COMMAND_IDS.search.focusProjects,
+    },
+    {
+      id: 'home.find-projects',
+      title: 'Find projects',
+      scopes: [HOME_KEYMAP_SCOPE],
+      keystrokes: ['mod+f'],
+      command: APP_COMMAND_IDS.search.focusProjects,
+      hidden: true,
+      userBindingCommand: APP_COMMAND_IDS.search.focusProjects,
+    },
+    {
+      id: 'editor.undo',
+      title: 'Undo',
+      scopes: FILE_KEYMAP_SCOPES,
+      keystrokes: ['mod+z'],
+      command: APP_COMMAND_IDS.editor.undo,
+    },
+    {
+      id: 'editor.redo',
+      title: 'Redo',
+      scopes: FILE_KEYMAP_SCOPES,
+      keystrokes: ['mod+shift+z'],
+      command: APP_COMMAND_IDS.editor.redo,
+    },
+    ...(!isDesktop()
+      ? [
+          {
+            id: 'editor.format',
+            title: 'Format code',
+            scopes: [CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE],
+            keystrokes: ['alt+shift+f'],
+            command: APP_COMMAND_IDS.editor.format,
+          },
+        ]
+      : []),
+    {
+      id: 'editor.convert-to-variable',
+      title: 'Convert to variable',
+      scopes: FILE_KEYMAP_SCOPES,
+      keystrokes: ['ctrl+shift+c'],
+      command: APP_COMMAND_IDS.editor.convertToVariable,
+    },
+    ...getDeleteKeys().map((deleteKey) => ({
+      id: `modeling.delete-selection.${deleteKey}`,
+      title: 'Delete selection',
+      scopes: FILE_KEYMAP_SCOPES,
+      keystrokes: [deleteKey],
+      command: APP_COMMAND_IDS.modeling.deleteSelection,
+    })),
+    {
+      id: 'modeling.center-camera-on-selection',
+      title: 'Center camera on selection',
+      scopes: FILE_KEYMAP_SCOPES,
+      keystrokes: ['mod+alt+c'],
+      command: APP_COMMAND_IDS.modeling.centerCameraOnSelection,
+    },
+    {
+      id: 'modeling.select-all-in-current-sketch',
+      title: 'Select all in current sketch',
+      scopes: [
+        MODE_SKETCHING_KEYMAP_SCOPE,
+        MODE_SKETCH_NO_FACE_KEYMAP_SCOPE,
+        MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
+      ],
+      keystrokes: ['mod+a'],
+      command: APP_COMMAND_IDS.modeling.selectAllInCurrentSketch,
+    },
+    {
+      id: 'modeling.toggle-snap-to-grid',
+      title: 'Toggle snap to grid',
+      scopes: FILE_KEYMAP_SCOPES,
+      keystrokes: ['mod+g'],
+      command: APP_COMMAND_IDS.modeling.toggleSnapToGrid,
     },
     {
       id: 'project-explorer.arrow-left',
@@ -210,7 +316,14 @@ export const defaultKeymap: KeymapDocument = {
       title: 'Reset view',
       scopes: [MODE_MODELING_KEYMAP_SCOPE],
       keystrokes: ['v', 'r'],
-      command: 'zds.view.reset',
+      command: APP_COMMAND_IDS.view.reset,
+    },
+    {
+      id: 'view.reset-with-modifier',
+      title: 'Reset view',
+      scopes: FILE_KEYMAP_SCOPES,
+      keystrokes: ['mod+alt+x'],
+      command: APP_COMMAND_IDS.view.reset,
     },
     {
       id: 'toolbar.modeling.sketch',

--- a/src/registry/extensions/keymap/index.spec.ts
+++ b/src/registry/extensions/keymap/index.spec.ts
@@ -349,6 +349,38 @@ describe('keymap extension', () => {
     registry[Symbol.dispose]()
   })
 
+  it('handles default undo and redo keybindings from CodeMirror while the editor is focused', () => {
+    const registry = createRegistryWithKeymapItems([])
+    const keymap = registry.get(keymapService)
+
+    keymap.removeScope(CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE)
+    keymap.applyScope(CODE_EDITOR_FOCUSED_KEYMAP_SCOPE)
+
+    expect(
+      keymap.handleKeyDown(
+        new KeyboardEvent('keydown', {
+          key: 'z',
+          ctrlKey: true,
+          metaKey: true,
+        }),
+        { source: 'codeMirror' }
+      )
+    ).toBe(true)
+    expect(
+      keymap.handleKeyDown(
+        new KeyboardEvent('keydown', {
+          key: 'z',
+          ctrlKey: true,
+          metaKey: true,
+          shiftKey: true,
+        }),
+        { source: 'codeMirror' }
+      )
+    ).toBe(true)
+
+    registry[Symbol.dispose]()
+  })
+
   it('keeps editor focus priority until focus moves outside editable content', () => {
     const registry = createRegistryWithKeymapItems([
       {

--- a/src/registry/extensions/keymap/index.ts
+++ b/src/registry/extensions/keymap/index.ts
@@ -10,7 +10,6 @@ import { useSignals } from '@preact/signals-react/runtime'
 import type { StatusBarItemType } from '@src/components/StatusBar/statusBarTypes'
 import makeUrlPathRelative from '@src/lib/makeUrlPathRelative'
 import { PATHS, webSafeJoin } from '@src/lib/paths'
-import { resetCameraPosition } from '@src/lib/resetCameraPosition'
 import { reportRejection } from '@src/lib/trap'
 import { isArray } from '@src/lib/utils'
 import {
@@ -21,6 +20,7 @@ import {
   BASE_KEYMAP_SCOPE,
   CODE_EDITOR_FOCUSED_KEYMAP_SCOPE,
   CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE,
+  HOME_KEYMAP_SCOPE,
   type KeymapArguments,
   type KeymapItem,
   type KeymapScope,
@@ -72,6 +72,12 @@ const defaultKeymapScopes: readonly KeymapScope[] = [
     id: 'settings-open',
     displayName: 'Settings open',
     priority: 1900,
+    userEditable: false,
+  },
+  {
+    id: HOME_KEYMAP_SCOPE,
+    displayName: 'Home',
+    priority: 50,
     userEditable: false,
   },
   {
@@ -361,21 +367,6 @@ const keymapExtension = defineRegistryItemFactory((ctx) => {
     }),
   }
 
-  const resetView = () => {
-    const kclManager = ctx.services
-      .optional(commandSystemService)
-      ?.actor.getSnapshot().context.kclManager
-    if (!kclManager) {
-      return
-    }
-
-    resetCameraPosition({
-      sceneInfra: kclManager.sceneInfra,
-      engineCommandManager: kclManager.engineCommandManager,
-      settingsActor: kclManager.systemDeps.settings,
-    }).catch(reportRejection)
-  }
-
   function runKeymapItem(item: KeymapItem) {
     const result = runBuiltInKeymapCommand(item)
     if (result instanceof Promise) {
@@ -397,8 +388,6 @@ const keymapExtension = defineRegistryItemFactory((ctx) => {
         return openSettings()
       case 'zds.settings.tab':
         return updateSettingsTab(getSettingsTabArgument(item.arguments))
-      case 'zds.view.reset':
-        return resetView()
       default:
         return runCommandById(item)
     }

--- a/src/registry/plugins/codeEditor/index.ts
+++ b/src/registry/plugins/codeEditor/index.ts
@@ -4,7 +4,6 @@ import { CustomIcon } from '@src/components/CustomIcon'
 import Tooltip from '@src/components/Tooltip'
 import usePlatform from '@src/hooks/usePlatform'
 import { getAutomaticallyRenderEnabledFromSettings } from '@src/lib/automaticRendering'
-import { hotkeyDisplay } from '@src/lib/hotkeys'
 import { defineBooleanExtensionSetting } from '@src/lib/settings/extensionSettings'
 import { reportRejection } from '@src/lib/trap'
 import type { AppHeaderItemProps } from '@src/registry/contracts/appHeader'
@@ -16,6 +15,10 @@ import {
   MODE_SKETCHING_KEYMAP_SCOPE,
   MODE_SKETCH_NO_FACE_KEYMAP_SCOPE,
   MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
+  findKeymapItemForCommand,
+  keymapKeystrokesDisplay,
+  keymapScopesValueSpec,
+  keymapService,
   keymapValueSpec,
 } from '@src/registry/contracts/keymap'
 import { settingsValueSpec } from '@src/registry/contracts/settings'
@@ -55,7 +58,18 @@ function RenderHeaderItem({ app }: AppHeaderItemProps) {
   const executionService = app.registry.signal(executingEditorService).value
   const hasEditsSinceLastExecution =
     executionService?.hasEditsSinceLastExecution.value ?? false
-  const renderHotkeyLabel = hotkeyDisplay(RENDER_HOTKEY, platform)
+  const keymap = app.registry.optional(keymapService)
+  const renderHotkeyLabel = keymapKeystrokesDisplay(
+    keymap
+      ? findKeymapItemForCommand(
+          keymap.keymap.value,
+          APP_COMMAND_IDS.editor.render,
+          keymap.getCurrentScopes(),
+          app.registry.signal(keymapScopesValueSpec).value
+        )?.keystrokes
+      : [RENDER_HOTKEY],
+    platform
+  )
 
   if (!currentProject || automaticallyRenderEnabled || !executionService) {
     return null

--- a/src/registry/plugins/codeEditor/index.ts
+++ b/src/registry/plugins/codeEditor/index.ts
@@ -4,20 +4,46 @@ import { CustomIcon } from '@src/components/CustomIcon'
 import Tooltip from '@src/components/Tooltip'
 import usePlatform from '@src/hooks/usePlatform'
 import { getAutomaticallyRenderEnabledFromSettings } from '@src/lib/automaticRendering'
-import useHotkeyWrapper from '@src/lib/hotkeyWrapper'
 import { hotkeyDisplay } from '@src/lib/hotkeys'
 import { defineBooleanExtensionSetting } from '@src/lib/settings/extensionSettings'
 import { reportRejection } from '@src/lib/trap'
 import type { AppHeaderItemProps } from '@src/registry/contracts/appHeader'
 import { appHeaderItemsValueSpec } from '@src/registry/contracts/appHeader'
 import { executingEditorService } from '@src/registry/contracts/executingEditor'
+import {
+  type KeymapDocument,
+  MODE_MODELING_KEYMAP_SCOPE,
+  MODE_SKETCHING_KEYMAP_SCOPE,
+  MODE_SKETCH_NO_FACE_KEYMAP_SCOPE,
+  MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
+  keymapValueSpec,
+} from '@src/registry/contracts/keymap'
 import { settingsValueSpec } from '@src/registry/contracts/settings'
 import { createZdsPlugin } from '@src/registry/createZdsPlugin'
+import { APP_COMMAND_IDS } from '@src/registry/extensions/commands/appCommands'
 import { useSelector } from '@xstate/react'
 import { createElement } from 'react'
-import toast from 'react-hot-toast'
 
 const RENDER_HOTKEY = 'mod+s'
+const CODE_EDITOR_KEYMAP_SOURCE = 'code-editor'
+
+const codeEditorKeymap: KeymapDocument = {
+  source: CODE_EDITOR_KEYMAP_SOURCE,
+  bindings: [
+    {
+      id: 'code-editor.render',
+      title: 'Render code',
+      scopes: [
+        MODE_MODELING_KEYMAP_SCOPE,
+        MODE_SKETCHING_KEYMAP_SCOPE,
+        MODE_SKETCH_NO_FACE_KEYMAP_SCOPE,
+        MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
+      ],
+      keystrokes: [RENDER_HOTKEY],
+      command: APP_COMMAND_IDS.editor.render,
+    },
+  ],
+}
 
 function RenderHeaderItem({ app }: AppHeaderItemProps) {
   useSignals()
@@ -30,27 +56,6 @@ function RenderHeaderItem({ app }: AppHeaderItemProps) {
   const hasEditsSinceLastExecution =
     executionService?.hasEditsSinceLastExecution.value ?? false
   const renderHotkeyLabel = hotkeyDisplay(RENDER_HOTKEY, platform)
-
-  useHotkeyWrapper(
-    [RENDER_HOTKEY],
-    () => {
-      if (
-        !automaticallyRenderEnabled &&
-        hasEditsSinceLastExecution &&
-        executionService
-      ) {
-        executionService.executeCode().catch(reportRejection)
-        return
-      }
-
-      toast.success('Your work is auto-saved in real-time.')
-    },
-    app.singletons.kclManager,
-    {
-      enabled: !!currentProject,
-      registerToCodeMirror: !!currentProject,
-    }
-  )
 
   if (!currentProject || automaticallyRenderEnabled || !executionService) {
     return null
@@ -127,6 +132,9 @@ const codeEditorSettingsItem = defineRegistryItem({
 
 const renderHeaderItem = defineRegistryItem({
   provides: [
+    provide(keymapValueSpec, codeEditorKeymap, {
+      key: codeEditorKeymap.source,
+    }),
     provide(appHeaderItemsValueSpec, {
       id: 'code-editor.render',
       order: 5,

--- a/src/registry/plugins/share/constants.ts
+++ b/src/registry/plugins/share/constants.ts
@@ -1,0 +1,3 @@
+export const SHARE_COMMAND_ID = 'zds.share.open'
+export const SHARE_KEYMAP_SOURCE = 'share'
+export const SHARE_HOTKEY = 'mod+alt+s'

--- a/src/registry/plugins/share/index.ts
+++ b/src/registry/plugins/share/index.ts
@@ -14,11 +14,13 @@ import {
   keymapValueSpec,
 } from '@src/registry/contracts/keymap'
 import { createZdsPlugin } from '@src/registry/createZdsPlugin'
+import {
+  SHARE_COMMAND_ID,
+  SHARE_HOTKEY,
+  SHARE_KEYMAP_SOURCE,
+} from '@src/registry/plugins/share/constants'
 import { createElement } from 'react'
 
-const SHARE_COMMAND_ID = 'zds.share.open'
-const SHARE_KEYMAP_SOURCE = 'share'
-const SHARE_HOTKEY = 'mod+alt+s'
 const shareOpenRequest = signal(0)
 
 const shareKeymap: KeymapDocument = {

--- a/src/registry/plugins/share/index.ts
+++ b/src/registry/plugins/share/index.ts
@@ -1,10 +1,43 @@
 import { defineRegistryItem, provide } from '@kittycad/registry'
+import { signal } from '@preact/signals-core'
 import { useSignals } from '@preact/signals-react/runtime'
 import { ShareButton } from '@src/components/ShareButton'
 import type { AppHeaderItemProps } from '@src/registry/contracts/appHeader'
 import { appHeaderItemsValueSpec } from '@src/registry/contracts/appHeader'
+import { provideCommand } from '@src/registry/contracts/commands'
+import {
+  type KeymapDocument,
+  MODE_MODELING_KEYMAP_SCOPE,
+  MODE_SKETCHING_KEYMAP_SCOPE,
+  MODE_SKETCH_NO_FACE_KEYMAP_SCOPE,
+  MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
+  keymapValueSpec,
+} from '@src/registry/contracts/keymap'
 import { createZdsPlugin } from '@src/registry/createZdsPlugin'
 import { createElement } from 'react'
+
+const SHARE_COMMAND_ID = 'zds.share.open'
+const SHARE_KEYMAP_SOURCE = 'share'
+const SHARE_HOTKEY = 'mod+alt+s'
+const shareOpenRequest = signal(0)
+
+const shareKeymap: KeymapDocument = {
+  source: SHARE_KEYMAP_SOURCE,
+  bindings: [
+    {
+      id: 'share.open',
+      title: 'Open share dialog',
+      scopes: [
+        MODE_MODELING_KEYMAP_SCOPE,
+        MODE_SKETCHING_KEYMAP_SCOPE,
+        MODE_SKETCH_NO_FACE_KEYMAP_SCOPE,
+        MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
+      ],
+      keystrokes: [SHARE_HOTKEY],
+      command: SHARE_COMMAND_ID,
+    },
+  ],
+}
 
 function ShareHeaderItem({ app }: AppHeaderItemProps) {
   useSignals()
@@ -13,11 +46,23 @@ function ShareHeaderItem({ app }: AppHeaderItemProps) {
     return null
   }
 
-  return createElement(ShareButton, { app })
+  return createElement(ShareButton, { app, openRequest: shareOpenRequest })
 }
 
 const shareHeaderItem = defineRegistryItem({
   provides: [
+    provideCommand({
+      id: SHARE_COMMAND_ID,
+      name: SHARE_COMMAND_ID,
+      groupId: 'share',
+      displayName: 'Open share dialog',
+      hideFromSearch: true,
+      needsReview: false,
+      onSubmit: () => {
+        shareOpenRequest.value += 1
+      },
+    }),
+    provide(keymapValueSpec, shareKeymap, { key: shareKeymap.source }),
     provide(appHeaderItemsValueSpec, {
       id: 'share.open',
       order: 90,

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -63,6 +63,7 @@ import {
   getSortIcon,
 } from '@src/lib/sorting'
 import { reportRejection } from '@src/lib/trap'
+import { platform } from '@src/lib/utils'
 import { withSiteBaseURL } from '@src/lib/withBaseURL'
 import { BillingTransition } from '@src/machines/billingMachine'
 import {
@@ -78,6 +79,9 @@ import {
 import type { WebContentSendPayload } from '@src/menu/channels'
 import {
   HOME_KEYMAP_SCOPE,
+  findKeymapItemForCommand,
+  keymapKeystrokesDisplay,
+  keymapScopesValueSpec,
   keymapService,
 } from '@src/registry/contracts/keymap'
 import {
@@ -85,6 +89,7 @@ import {
   statusBarGlobalItemsValueSpec,
   statusBarLocalItemsValueSpec,
 } from '@src/registry/contracts/statusBar'
+import { APP_COMMAND_IDS } from '@src/registry/extensions/commands/appCommands'
 import {
   acceptOnboarding,
   needsToOnboard,
@@ -142,6 +147,17 @@ const Home = () => {
   const [searchParams, setSearchParams] = useSearchParams()
   const { searchResults, query, setQuery } =
     useProjectSearch(optimisticProjects)
+  const projectSearchKeybinding = keymapKeystrokesDisplay(
+    keymap
+      ? findKeymapItemForCommand(
+          keymap.keymap.value,
+          APP_COMMAND_IDS.search.focusProjects,
+          [HOME_KEYMAP_SCOPE],
+          registry.signal(keymapScopesValueSpec).value
+        )?.keystrokes
+      : undefined,
+    platform()
+  )
   const sort = searchParams.get('sort_by') ?? 'modified:desc'
   const sidebarButtonClasses =
     'flex items-center p-2 gap-2 leading-tight border-transparent dark:border-transparent enabled:dark:border-transparent enabled:hover:border-primary/50 enabled:dark:hover:border-inherit active:border-primary dark:bg-transparent hover:bg-transparent'
@@ -340,6 +356,7 @@ const Home = () => {
           setSearchParams={setSearchParams}
           settings={settingsValues}
           readWriteProjectDir={readWriteProjectDir}
+          projectSearchKeybinding={projectSearchKeybinding}
           className="col-start-2 -col-end-1"
         />
         <aside
@@ -532,6 +549,7 @@ interface HomeHeaderProps extends HTMLProps<HTMLDivElement> {
   setSearchParams: (params: Record<string, string>) => void
   settings: SettingsType
   readWriteProjectDir: ReadWriteProjectState
+  projectSearchKeybinding?: string
 }
 
 function HomeHeader({
@@ -540,6 +558,7 @@ function HomeHeader({
   setSearchParams,
   settings,
   readWriteProjectDir,
+  projectSearchKeybinding,
   ...rest
 }: HomeHeaderProps) {
   const isSortByModified = sort?.includes('modified') || !sort || sort === null
@@ -551,7 +570,10 @@ function HomeHeader({
           <h1 className="text-3xl font-bold">Projects</h1>
         </div>
         <div className="flex flex-col sm:flex-row gap-2 sm:items-center">
-          <ProjectSearchBar setQuery={setQuery} />
+          <ProjectSearchBar
+            setQuery={setQuery}
+            keybinding={projectSearchKeybinding}
+          />
           <div className="flex gap-2 items-center">
             <small>Sort by</small>
             <ActionButton

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -77,6 +77,10 @@ import {
 } from '@src/machines/systemIO/utils'
 import type { WebContentSendPayload } from '@src/menu/channels'
 import {
+  HOME_KEYMAP_SCOPE,
+  keymapService,
+} from '@src/registry/contracts/keymap'
+import {
   filterStatusBarItemsForScopes,
   statusBarGlobalItemsValueSpec,
   statusBarLocalItemsValueSpec,
@@ -99,10 +103,24 @@ const Home = () => {
   useSignals()
   const { auth, billing, commands, settings, systemIOActor, registry } =
     useApp()
+  const keymap = registry.optional(keymapService)
   const { kclManager } = useSingletons()
   const executingPath = useAbsoluteFilePath()
   const settingsActor = settings.actor
   useQueryParamEffects(kclManager)
+
+  useEffect(() => {
+    if (!keymap) {
+      return
+    }
+
+    keymap.applyScope(HOME_KEYMAP_SCOPE)
+
+    return () => {
+      keymap.removeScope(HOME_KEYMAP_SCOPE)
+    }
+  }, [keymap])
+
   const navigate = useNavigate()
   const location = useLocation()
   const readWriteProjectDir = useCanReadWriteProjectDirectory()
@@ -311,15 +329,6 @@ const Home = () => {
   useHotkeys('backspace', (e) => {
     e.preventDefault()
   })
-  useHotkeys(
-    isDesktop() ? 'mod+,' : 'shift+mod+,',
-    () => {
-      void navigate(PATHS.HOME + PATHS.SETTINGS)
-    },
-    {
-      splitKey: '|',
-    }
-  )
   return (
     <div className="relative flex flex-col items-stretch h-screen w-screen overflow-hidden">
       <AppHeader nativeFileMenuCreated={nativeFileMenuCreated} />

--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -1,4 +1,5 @@
 import { Dialog, Transition } from '@headlessui/react'
+import { useSignals } from '@preact/signals-react/runtime'
 import { Fragment, useEffect, useRef } from 'react'
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 
@@ -13,7 +14,14 @@ import { SettingsTabs } from '@src/components/Settings/SettingsTabs'
 import { useApp } from '@src/lib/boot'
 import { PATHS } from '@src/lib/paths'
 import type { SettingsLevel } from '@src/lib/settings/settingsTypes'
-import { keymapService } from '@src/registry/contracts/keymap'
+import { platform } from '@src/lib/utils'
+import {
+  findKeymapItemForCommand,
+  keymapKeystrokesDisplay,
+  keymapScopesValueSpec,
+  keymapService,
+} from '@src/registry/contracts/keymap'
+import { APP_COMMAND_IDS } from '@src/registry/extensions/commands/appCommands'
 
 const PLUGINS_FEATURE_FLAG = 'plugins'
 
@@ -29,6 +37,7 @@ function isSettingsTab(tab: string | null): tab is SettingsTab {
 }
 
 export const Settings = () => {
+  useSignals()
   const app = useApp()
   const keymap = app.registry.optional(keymapService)
   const navigate = useNavigate()
@@ -54,6 +63,17 @@ export const Settings = () => {
       : requestedSettingsTab
 
   const scrollRef = useRef<HTMLDivElement>(null)
+  const settingsSearchKeybinding = keymapKeystrokesDisplay(
+    keymap
+      ? findKeymapItemForCommand(
+          keymap.keymap.value,
+          APP_COMMAND_IDS.search.focusSettings,
+          ['settings-open'],
+          app.registry.signal(keymapScopesValueSpec).value
+        )?.keystrokes
+      : undefined,
+    platform()
+  )
 
   useEffect(() => {
     if (!keymap) {
@@ -121,7 +141,10 @@ export const Settings = () => {
             <div className="p-5 pb-0 flex justify-between items-center">
               <h1 className="text-2xl font-bold">Settings</h1>
               <div className="flex gap-4 items-start">
-                <SettingsSearchBar showPlugins={showPluginsTab} />
+                <SettingsSearchBar
+                  showPlugins={showPluginsTab}
+                  keybinding={settingsSearchKeybinding}
+                />
                 <button
                   type="button"
                   onClick={close}


### PR DESCRIPTION
## Summary

This PR continues moving app shortcuts into the registry keymap system so keybindings are registered, resolved, displayed, and overridden through the same path.

It adds keymap display helpers for formatting chords and keystroke sequences, migrates static shortcut displays to read the effective keymap binding, and wires several existing app shortcuts through hidden app commands so they can be edited from the keybindings UI.

## Demo

https://github.com/user-attachments/assets/1679f4ed-6789-4bf2-879f-a61de9aeefe4

## What changed

- Added `keymapKeystrokesDisplay` / `keymapChordDisplay` helpers and made deprecated `hotkeyDisplay` delegate to them.
- Added hidden app commands for shortcut-only actions that previously lived in component hooks or local handlers.
- Registered default keymap entries for those commands.
- Updated visible shortcut labels to show the current effective keybinding instead of hard-coded static text.
- Routed undo/redo through keymap handling while CodeMirror is focused, so overrides apply in the editor too.
- Fixed `Select all in current sketch` so the command path does not no-op outside the legacy sketch state.

## Newly Editable Keybindings

These shortcuts now have command-backed keymap entries and can be overridden:

- Focus settings search: `Ctrl+.`
- Focus project search: `Ctrl+.` and hidden `Mod+F`
- Undo: `Mod+Z`
- Redo: `Mod+Shift+Z`
- Format code: `Alt+Shift+F` on web
- Convert to variable: `Ctrl+Shift+C`
- Render code: `Mod+S`
- Delete selection: delete/backspace keys from `getDeleteKeys()`
- Center camera on selection: `Mod+Alt+C`
- Select all in current sketch: `Mod+A`
- Toggle snap to grid: `Mod+G`
- Reset view: `V R` and `Mod+Alt+X`
- Open share dialog: `Mod+Alt+S`

## Display Updates

The following UI now displays the effective keymap value instead of a hard-coded shortcut:

- Settings search
- Project search
- Command bar open button
- Share button
- Undo/redo buttons
- Render indicators
- KCL editor menu format / convert actions
- Project settings menu item

## Validation

- `npm run fmt:check`
- `npm run tsc`
- `npm run lint`
- `npm run test:unit -- src/registry/contracts/keymap.test.ts`
- `npm run test:integration -- src/registry/extensions/keymap/index.spec.ts`
- `npm run test:integration -- src/registry/extensions/commands/index.spec.ts`