### PR TITLE
Add OPFSCloud conflict resolution UI

### DIFF
--- a/src/components/CloudConflictDialog.tsx
+++ b/src/components/CloudConflictDialog.tsx
@@ -1,0 +1,200 @@
+import { Dialog } from '@headlessui/react'
+import { useSignals } from '@preact/signals-react/runtime'
+import { useEffect, useState } from 'react'
+import toast from 'react-hot-toast'
+
+import { ActionButton } from '@src/components/ActionButton'
+import {
+  type OpfsCloudConflictResolution,
+  type ProjectMetadata,
+  getOpfsCloudProjectMetadata,
+  getOpfsCloudProjectMetadataIndex,
+  opfsCloudSyncStatus,
+  resolveOpfsCloudProjectConflict,
+} from '@src/lib/fs-zds/opfsCloud'
+import { reportRejection } from '@src/lib/trap'
+
+type CloudConflictDialogProps = {
+  projectPath: string
+  projectName: string
+  onDismiss: () => void
+  onResolved?: () => void
+}
+
+function messageFromError(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export function useOpfsCloudProjectConflict(projectPath?: string) {
+  useSignals()
+  const status = opfsCloudSyncStatus.value
+  const [metadata, setMetadata] = useState<ProjectMetadata | undefined>()
+
+  useEffect(() => {
+    let cancelled = false
+
+    if (!status.enabled || !projectPath) {
+      setMetadata(undefined)
+      return
+    }
+
+    getOpfsCloudProjectMetadata(projectPath)
+      .then((nextMetadata) => {
+        if (!cancelled) {
+          setMetadata(nextMetadata?.conflict ? nextMetadata : undefined)
+        }
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) {
+          setMetadata(undefined)
+        }
+        reportRejection(error)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [
+    projectPath,
+    status.enabled,
+    status.state,
+    status.pendingCount,
+    status.lastFailureAt,
+    status.lastSyncedAt,
+  ])
+
+  return metadata
+}
+
+export function useOpfsCloudProjectConflicts() {
+  useSignals()
+  const status = opfsCloudSyncStatus.value
+  const [metadata, setMetadata] = useState<ProjectMetadata[] | undefined>()
+
+  useEffect(() => {
+    let cancelled = false
+
+    if (!status.enabled) {
+      setMetadata([])
+      return
+    }
+
+    setMetadata(undefined)
+    getOpfsCloudProjectMetadataIndex()
+      .then((metadataIndex) => {
+        if (cancelled) {
+          return
+        }
+
+        setMetadata(
+          Array.from(metadataIndex.values())
+            .filter((entry) => entry.conflict)
+            .toSorted((left, right) =>
+              left.projectName.localeCompare(right.projectName)
+            )
+        )
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) {
+          setMetadata([])
+        }
+        reportRejection(error)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [
+    status.enabled,
+    status.state,
+    status.pendingCount,
+    status.lastFailureAt,
+    status.lastSyncedAt,
+  ])
+
+  return metadata
+}
+
+export function CloudConflictDialog({
+  projectPath,
+  projectName,
+  onDismiss,
+  onResolved,
+}: CloudConflictDialogProps) {
+  const [resolving, setResolving] =
+    useState<OpfsCloudConflictResolution | null>(null)
+
+  async function resolveConflict(resolution: OpfsCloudConflictResolution) {
+    setResolving(resolution)
+    try {
+      await resolveOpfsCloudProjectConflict(projectPath, resolution)
+      toast.success('Cloud conflict resolved.')
+      onResolved?.()
+      onDismiss()
+    } catch (error) {
+      toast.error(messageFromError(error))
+      reportRejection(error)
+    } finally {
+      setResolving(null)
+    }
+  }
+
+  return (
+    <Dialog open={true} onClose={onDismiss} className="relative z-50">
+      <div className="fixed inset-0 grid bg-chalkboard-110/80 place-content-center p-4">
+        <Dialog.Panel
+          className="w-full max-w-xl rounded border border-warn-80 bg-chalkboard-10 p-4 shadow-lg dark:bg-chalkboard-100"
+          data-testid="cloud-conflict-dialog"
+        >
+          <Dialog.Title as="h2" className="mb-1 text-2xl font-bold">
+            Cloud conflict
+          </Dialog.Title>
+          <p className="mb-4 break-words text-sm font-medium text-chalkboard-80 dark:text-chalkboard-30">
+            {projectName}
+          </p>
+          <Dialog.Description as="div" className="space-y-3 text-sm">
+            <p className="break-words">
+              Local and cloud data both changed for "{projectName}". Choose
+              which version should become the project source of truth.
+            </p>
+            <p>
+              Using local data uploads your current local project to the cloud.
+              Using cloud data replaces the local project with the conflicted
+              cloud version that was saved locally.
+            </p>
+          </Dialog.Description>
+
+          <div className="mt-6 flex flex-wrap justify-end gap-2">
+            <ActionButton
+              Element="button"
+              onClick={onDismiss}
+              disabled={resolving !== null}
+              tabIndex={0}
+            >
+              Cancel
+            </ActionButton>
+            <ActionButton
+              Element="button"
+              data-testid="use-cloud-data"
+              disabled={resolving !== null}
+              tabIndex={0}
+              onClick={() => void resolveConflict('cloud')}
+            >
+              {resolving === 'cloud' ? 'Using cloud data...' : 'Use cloud data'}
+            </ActionButton>
+            <ActionButton
+              Element="button"
+              data-testid="use-local-data"
+              disabled={resolving !== null}
+              tabIndex={0}
+              onClick={() => void resolveConflict('local')}
+              className="border-warn-70 bg-warn-10/30 dark:bg-warn-80/20"
+            >
+              {resolving === 'local' ? 'Using local data...' : 'Use local data'}
+            </ActionButton>
+          </div>
+        </Dialog.Panel>
+      </div>
+    </Dialog>
+  )
+}

--- a/src/components/ProjectCard/ProjectCard.spec.tsx
+++ b/src/components/ProjectCard/ProjectCard.spec.tsx
@@ -117,4 +117,27 @@ describe('ProjectCard', () => {
       )
     )
   })
+
+  test('opens the cloud conflict dialog from conflicted project cards', () => {
+    renderProjectCard({
+      project: {
+        ...cloudProject,
+        cloudConflict: {
+          conflictProjectPath: '/projects/old-cloud-title conflict',
+          createdAt: new Date(now).toISOString(),
+          remoteRevision: 'revision-123',
+        },
+      },
+    })
+
+    expect(screen.getByTestId('cloud-conflict-badge')).toHaveTextContent(
+      'Inspect Conflicts'
+    )
+
+    fireEvent.click(screen.getByTestId('project-link'))
+
+    expect(screen.getByTestId('cloud-conflict-dialog')).toBeInTheDocument()
+    expect(screen.getByText('Use local data')).toBeInTheDocument()
+    expect(screen.getByText('Use cloud data')).toBeInTheDocument()
+  })
 })

--- a/src/components/ProjectCard/ProjectCard.tsx
+++ b/src/components/ProjectCard/ProjectCard.tsx
@@ -4,6 +4,7 @@ import { useHotkeys } from 'react-hotkeys-hook'
 import { Link } from 'react-router-dom'
 
 import { ActionButton } from '@src/components/ActionButton'
+import { CloudConflictDialog } from '@src/components/CloudConflictDialog'
 import { DeleteConfirmationDialog } from '@src/components/ProjectCard/DeleteProjectDialog'
 import { ProjectCardRenameForm } from '@src/components/ProjectCard/ProjectCardRenameForm'
 import Tooltip from '@src/components/Tooltip'
@@ -34,8 +35,10 @@ function ProjectCard({
   useHotkeys('esc', () => setIsEditing(false))
   const [isEditing, setIsEditing] = useState(false)
   const [isConfirmingDelete, setIsConfirmingDelete] = useState(false)
+  const [isInspectingConflict, setIsInspectingConflict] = useState(false)
   const hasChangesRequested =
     projectStatus?.publicationStatus === 'changes_requested'
+  const hasCloudConflict = Boolean(project.cloudConflict)
   const [numberOfFiles, setNumberOfFiles] = useState(1)
   const [numberOfFolders, setNumberOfFolders] = useState(0)
   const [imageUrl, setImageUrl] = useState('')
@@ -167,6 +170,13 @@ function ProjectCard({
     >
       <Link
         data-testid="project-link"
+        onClick={(e) => {
+          if (!hasCloudConflict) {
+            return
+          }
+          e.preventDefault()
+          setIsInspectingConflict(true)
+        }}
         to={
           project.readWriteAccess
             ? `${PATHS.FILE}/${encodeURIComponent(project.default_file)}`
@@ -179,6 +189,14 @@ function ProjectCard({
         }`}
       >
         <div className="h-36 relative overflow-hidden bg-gradient-to-b from-transparent to-primary/10 rounded-t-sm">
+          {hasCloudConflict && (
+            <span
+              className="absolute top-2 left-2 z-10 rounded bg-warn-20 px-1.5 py-0.5 text-[10px] font-medium text-warn-90 dark:bg-warn-80 dark:text-warn-10 pointer-events-none"
+              data-testid="cloud-conflict-badge"
+            >
+              Inspect Conflicts
+            </span>
+          )}
           {imageUrl && (
             <img
               src={imageUrl}
@@ -188,7 +206,9 @@ function ProjectCard({
           )}
           {hasChangesRequested && (
             <span
-              className="absolute top-2 left-2 z-10 rounded bg-warn-20 px-1.5 py-0.5 text-[10px] font-medium text-warn-80 dark:bg-warn-80 dark:text-warn-10 pointer-events-none"
+              className={`absolute ${
+                hasCloudConflict ? 'top-8' : 'top-2'
+              } left-2 z-10 rounded bg-warn-20 px-1.5 py-0.5 text-[10px] font-medium text-warn-80 dark:bg-warn-80 dark:text-warn-10 pointer-events-none`}
               data-testid="changes-requested-badge"
             >
               Changes requested
@@ -298,6 +318,14 @@ function ProjectCard({
             "? This action cannot be undone.
           </p>
         </DeleteConfirmationDialog>
+      )}
+      {isInspectingConflict && (
+        <CloudConflictDialog
+          projectPath={project.path}
+          projectName={projectName}
+          onDismiss={() => setIsInspectingConflict(false)}
+          onResolved={() => setIsInspectingConflict(false)}
+        />
       )}
     </li>
   )

--- a/src/components/ProjectSidebarMenu.tsx
+++ b/src/components/ProjectSidebarMenu.tsx
@@ -7,6 +7,10 @@ import type { SnapshotFrom } from 'xstate'
 
 import type { ActionButtonProps } from '@src/components/ActionButton'
 import { ActionButton } from '@src/components/ActionButton'
+import {
+  CloudConflictDialog,
+  useOpfsCloudProjectConflict,
+} from '@src/components/CloudConflictDialog'
 import { CustomIcon } from '@src/components/CustomIcon'
 import { Logo } from '@src/components/Logo'
 import Tooltip from '@src/components/Tooltip'
@@ -18,6 +22,7 @@ import { hotkeyDisplay } from '@src/lib/hotkeys'
 import { isDesktop } from '@src/lib/isDesktop'
 import { PATHS, getProjectRelativeFilePath } from '@src/lib/paths'
 import type { FileEntry, Project } from '@src/lib/project'
+import { getProjectDisplayName } from '@src/lib/projectDisplayName'
 import type { IndexLoaderData } from '@src/lib/types'
 import {
   findKeymapItemForCommand,
@@ -42,6 +47,7 @@ type ProjectCloseHandler = (
   projectPath: string | null,
   redirect: boolean
 ) => void
+type ProjectMenuItem = ActionButtonProps | 'break' | null
 
 const noopProjectClose: ProjectCloseHandler = () => undefined
 const noopHomeNavigate = () => undefined
@@ -194,6 +200,8 @@ function ProjectMenuPopover({
       : [`mod+${isDesktop() ? '' : 'shift'}+,`],
     platform
   )
+  const cloudConflictMetadata = useOpfsCloudProjectConflict(project?.path)
+  const [isInspectingConflict, setIsInspectingConflict] = useState(false)
   const commandsSelector = (state: SnapshotFrom<typeof commands.actor>) =>
     state.context.commands
   const commandList = useSelector(commands.actor, commandsSelector)
@@ -212,8 +220,28 @@ function ProjectMenuPopover({
 
   // We filter this memoized list so that no orphan "break" elements are rendered.
   const projectMenuItems = useMemo<(ActionButtonProps | 'break')[]>(
-    () =>
-      [
+    () => {
+      const items: ProjectMenuItem[] = [
+        cloudConflictMetadata
+          ? {
+              id: 'inspect-cloud-conflicts',
+              Element: 'button',
+              iconStart: {
+                icon: 'triangleExclamation',
+                bgClassName: '!bg-transparent dark:!bg-transparent',
+                iconClassName: '!text-warn-80 dark:!text-warn-10',
+              },
+              className:
+                'bg-warn-10/50 text-warn-90 hover:!bg-warn-20 focus:!bg-warn-20 dark:bg-warn-80/20 dark:text-warn-10 dark:hover:!bg-warn-80/30 dark:focus:!bg-warn-80/30',
+              children: (
+                <span className="flex-1" data-testid="inspect-cloud-conflicts">
+                  Inspect Conflicts
+                </span>
+              ),
+              onClick: () => setIsInspectingConflict(true),
+            }
+          : null,
+        cloudConflictMetadata ? 'break' : null,
         {
           id: 'settings',
           Element: 'button',
@@ -339,11 +367,17 @@ function ProjectMenuPopover({
             onHomeNavigate()
           },
         },
-      ].filter(
-        (props) =>
-          props === 'break' ||
-          (typeof props !== 'string' && !props.className?.includes('hidden'))
-      ) as (ActionButtonProps | 'break')[],
+      ]
+      return items.filter((props): props is ActionButtonProps | 'break' => {
+        if (!props) {
+          return false
+        }
+        if (props === 'break') {
+          return true
+        }
+        return !props.className?.includes('hidden')
+      })
+    },
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
     [
       platform,
@@ -355,67 +389,84 @@ function ProjectMenuPopover({
       onProjectClose,
       isDesktop,
       homeNavigationEnabled,
+      cloudConflictMetadata,
     ]
   )
 
   return (
-    <Popover className="relative min-w-0">
-      <ProjectBreadcrumbButton project={project} file={file} />
+    <>
+      <Popover className="relative min-w-0">
+        <ProjectBreadcrumbButton
+          project={project}
+          file={file}
+          hasCloudConflict={Boolean(cloudConflictMetadata)}
+        />
 
-      <Transition
-        enter="duration-100 ease-out"
-        enterFrom="opacity-0 -translate-y-2"
-        enterTo="opacity-100 translate-y-0"
-        as={Fragment}
-      >
-        <Popover.Panel
-          className={`z-10 absolute top-full left-0 mt-1 pb-1 w-52 bg-chalkboard-10 dark:bg-chalkboard-90
+        <Transition
+          enter="duration-100 ease-out"
+          enterFrom="opacity-0 -translate-y-2"
+          enterTo="opacity-100 translate-y-0"
+          as={Fragment}
+        >
+          <Popover.Panel
+            className={`z-10 absolute top-full left-0 mt-1 pb-1 w-52 bg-chalkboard-10 dark:bg-chalkboard-90
           border border-solid border-chalkboard-20 dark:border-chalkboard-90 rounded
           shadow-lg`}
-        >
-          {({ close }) => (
-            <ul className="relative flex flex-col items-stretch content-stretch p-0.5">
-              {projectMenuItems.map((props, index) => {
-                if (props === 'break') {
-                  return index !== projectMenuItems.length - 1 ? (
-                    <li key={`break-${index}`} className="contents">
-                      <hr className="border-chalkboard-20 dark:border-chalkboard-80" />
-                    </li>
-                  ) : null
-                }
+          >
+            {({ close }) => (
+              <ul className="relative flex flex-col items-stretch content-stretch p-0.5">
+                {projectMenuItems.map((props, index) => {
+                  if (props === 'break') {
+                    return index !== projectMenuItems.length - 1 ? (
+                      <li key={`break-${index}`} className="contents">
+                        <hr className="border-chalkboard-20 dark:border-chalkboard-80" />
+                      </li>
+                    ) : null
+                  }
 
-                const { id, className, children, ...rest } = props
-                return (
-                  <li key={id} className="contents">
-                    <ActionButton
-                      {...rest}
-                      className={
-                        'relative !font-sans flex items-center gap-2 rounded-sm py-1.5 px-2 cursor-pointer hover:bg-chalkboard-20 dark:hover:bg-chalkboard-80 border-none text-left ' +
-                        className
-                      }
-                      onMouseUp={() => {
-                        close()
-                      }}
-                    >
-                      {children}
-                    </ActionButton>
-                  </li>
-                )
-              })}
-            </ul>
-          )}
-        </Popover.Panel>
-      </Transition>
-    </Popover>
+                  const { id, className, children, ...rest } = props
+                  return (
+                    <li key={id} className="contents">
+                      <ActionButton
+                        {...rest}
+                        className={
+                          'relative !font-sans flex items-center gap-2 rounded-sm py-1.5 px-2 cursor-pointer hover:bg-chalkboard-20 dark:hover:bg-chalkboard-80 border-none text-left ' +
+                          className
+                        }
+                        onMouseUp={() => {
+                          close()
+                        }}
+                      >
+                        {children}
+                      </ActionButton>
+                    </li>
+                  )
+                })}
+              </ul>
+            )}
+          </Popover.Panel>
+        </Transition>
+      </Popover>
+      {isInspectingConflict && project && (
+        <CloudConflictDialog
+          projectPath={project.path}
+          projectName={getProjectDisplayName(project)}
+          onDismiss={() => setIsInspectingConflict(false)}
+          onResolved={() => setIsInspectingConflict(false)}
+        />
+      )}
+    </>
   )
 }
 
 export function ProjectBreadcrumbButton({
   project,
   file,
+  hasCloudConflict = false,
 }: {
   project?: IndexLoaderData['project']
   file?: IndexLoaderData['file']
+  hasCloudConflict?: boolean
 }) {
   // Breadcrumb for project and project-relative file path
   const relativeFilePath = getProjectRelativeFilePath(project, file)
@@ -492,6 +543,14 @@ export function ProjectBreadcrumbButton({
           {breadCrumb.filePath}
         </span>
       </div>
+      {hasCloudConflict && (
+        <span
+          className="hidden shrink-0 rounded bg-warn-20 px-1.5 py-0.5 text-[10px] font-medium leading-none text-warn-90 dark:bg-warn-80 dark:text-warn-10 sm:inline-flex"
+          data-testid="project-sidebar-cloud-conflict-badge"
+        >
+          Cloud conflict
+        </span>
+      )}
       <CustomIcon
         name="caretDown"
         className="w-4 h-4 shrink-0 text-chalkboard-70 dark:text-chalkboard-40 ui-open:rotate-180"

--- a/src/lib/fs-zds/opfsCloud.ts
+++ b/src/lib/fs-zds/opfsCloud.ts
@@ -86,6 +86,8 @@ export {
   projectManifestsEqual,
 } from '@src/lib/fs-zds/opfsCloud/projectArchive'
 
+export type OpfsCloudConflictResolution = 'local' | 'cloud'
+
 const SYNC_DEBOUNCE_MS = 2500
 const SYNC_RETRY_MS = 30_000
 const REMOTE_INDEX_INTERVAL_MS = 5 * 60 * 1000
@@ -997,6 +999,82 @@ async function markProjectSynced(
     lastFailure: undefined,
     lastFailureAt: undefined,
   })
+}
+
+async function deleteConflictCopy(conflictProjectPath: string) {
+  await clearOutboxEntriesForProject(conflictProjectPath)
+  await deleteProjectMetadata(conflictProjectPath)
+  if (await exists(conflictProjectPath)) {
+    await localFs.rm(conflictProjectPath, { recursive: true })
+  }
+}
+
+async function applyCloudDataForConflict(metadata: ProjectMetadata) {
+  const conflict = metadata.conflict
+  if (!conflict) {
+    return
+  }
+
+  const remoteFiles = await collectLocalProjectFiles(
+    conflict.conflictProjectPath
+  )
+  const remoteManifest = await projectManifestFromFiles(remoteFiles)
+  await replaceLocalProjectWithFiles(metadata.localProjectPath, remoteFiles)
+  await clearOutboxEntriesForProject(metadata.localProjectPath)
+  await deleteConflictCopy(conflict.conflictProjectPath)
+  await markProjectSynced(metadata, remoteManifest, {
+    revision: conflict.remoteRevision,
+  })
+}
+
+async function applyLocalDataForConflict(metadata: ProjectMetadata) {
+  const conflict = metadata.conflict
+  if (!metadata.remoteProjectId || !conflict) {
+    return Promise.reject(
+      new Error('Cloud conflict cannot be resolved without a remote project.')
+    )
+  }
+
+  const localFiles = await collectLocalProjectFiles(metadata.localProjectPath)
+  const localManifest = await projectManifestFromFiles(localFiles)
+  const updated = await updateRemoteProject({
+    config,
+    projectPath: metadata.localProjectPath,
+    projectId: metadata.remoteProjectId,
+    files: localFiles,
+    expectedRevision: conflict.remoteRevision ?? metadata.remoteRevision,
+  })
+  await clearOutboxEntriesForProject(metadata.localProjectPath)
+  await deleteConflictCopy(conflict.conflictProjectPath)
+  await markProjectSynced(
+    metadata,
+    localManifest,
+    remoteSyncMetadata(updated, { useNowAsUpdatedAtFallback: true })
+  )
+}
+
+export async function resolveOpfsCloudProjectConflict(
+  projectPath: string,
+  resolution: OpfsCloudConflictResolution
+) {
+  const metadata = await getProjectMetadata(projectPath)
+  if (!metadata?.conflict) {
+    return
+  }
+
+  try {
+    if (resolution === 'cloud') {
+      await applyCloudDataForConflict(metadata)
+    } else {
+      await applyLocalDataForConflict(metadata)
+    }
+    await refreshPendingCount()
+    scheduleSync(0)
+  } catch (error) {
+    await markProjectFailure(metadata, error)
+    // eslint-disable-next-line suggest-no-throw/suggest-no-throw
+    throw error
+  }
 }
 
 async function hydrateCleanLocalProjectTitle(

--- a/src/lib/project.d.ts
+++ b/src/lib/project.d.ts
@@ -1,3 +1,5 @@
+import type { ProjectMetadata } from '@src/lib/fs-zds/opfsCloud'
+
 /**
  * The permissions of a file.
  */
@@ -59,6 +61,11 @@ export type Project = {
    * Cloud project id when this local project is bound to a remote project.
    */
   cloudProjectId?: string
+  /**
+   * Cloud sync conflict metadata when this local project needs manual
+   * resolution against a remote version.
+   */
+  cloudConflict?: ProjectMetadata['conflict']
   /**
    * Absolute path most likely to main.kcl within the project
    */

--- a/src/machines/systemIO/systemIOMachineImpl.ts
+++ b/src/machines/systemIO/systemIOMachineImpl.ts
@@ -523,6 +523,7 @@ export const systemIOMachineImpl = systemIOMachine.provide({
             normalizeProjectPathForCloudMetadata(entry.path)
           )
           project.cloudProjectId ??= cloudMetadata?.remoteProjectId
+          project.cloudConflict = cloudMetadata?.conflict
           if (project.metadata) {
             project.metadata.modified = getOpfsCloudProjectModifiedTime(
               cloudMetadata,

--- a/src/registry/extensions/cloudSync/index.ts
+++ b/src/registry/extensions/cloudSync/index.ts
@@ -1,3 +1,4 @@
+import { Popover } from '@headlessui/react'
 import {
   defineRegistryItem,
   defineRegistryItemFactory,
@@ -7,6 +8,11 @@ import {
 import { computed } from '@preact/signals-core'
 import { useSignals } from '@preact/signals-react/runtime'
 import { ActionIcon } from '@src/components/ActionIcon'
+import {
+  CloudConflictDialog,
+  useOpfsCloudProjectConflict,
+  useOpfsCloudProjectConflicts,
+} from '@src/components/CloudConflictDialog'
 import type { CustomIconName } from '@src/components/CustomIcon'
 import { defaultStatusBarItemClassNames } from '@src/components/StatusBar/StatusBar'
 import Tooltip from '@src/components/Tooltip'
@@ -16,13 +22,16 @@ import {
   opfsCloudSyncStatus,
   retryOpfsCloudSync,
 } from '@src/lib/fs-zds/opfsCloud'
+import type { ProjectMetadata } from '@src/lib/fs-zds/opfsCloud'
+import { PATHS } from '@src/lib/paths'
 import { userFeaturesContextHas } from '@src/machines/userFeaturesMachine'
 import {
   nullableStatusBarItem,
   statusBarGlobalItemsValueSpec,
 } from '@src/registry/contracts/statusBar'
 import { userFeaturesService } from '@src/registry/contracts/userFeatures'
-import { createElement } from 'react'
+import { Fragment, createElement, useState } from 'react'
+import { useLocation } from 'react-router-dom'
 
 type CloudSyncStatusBarPresentation = {
   label: string
@@ -72,31 +81,162 @@ export function getCloudSyncStatusBarPresentation(
 
 function CloudSyncStatusBarItem() {
   useSignals()
+  const location = useLocation()
   const status = opfsCloudSyncStatus.value
+  const conflictMetadata = useOpfsCloudProjectConflict(status.activeProjectPath)
+  const conflictMetadataList = useOpfsCloudProjectConflicts()
+  const [isInspectingConflict, setIsInspectingConflict] = useState(false)
+  const [selectedConflict, setSelectedConflict] = useState<
+    ProjectMetadata | undefined
+  >()
   if (!status.enabled) {
     return null
   }
 
   const presentation = getCloudSyncStatusBarPresentation(status)
+  const isHomeRoute = location.pathname.startsWith(PATHS.HOME)
+  const isFileRoute = location.pathname.startsWith(PATHS.FILE)
+  const canInspectConflict =
+    status.state === 'conflict' &&
+    isFileRoute &&
+    status.activeProjectPath &&
+    conflictMetadata?.conflict
+  const projectName = status.activeProjectPath
+    ?.split(/[\\/]/)
+    .filter(Boolean)
+    .at(-1)
+  const selectedConflictProjectName = selectedConflict?.projectName
+  const selectedConflictProjectPath = selectedConflict?.localProjectPath
+  const shouldListConflicts = status.state === 'conflict' && isHomeRoute
 
-  return createElement(
-    'button',
-    {
-      type: 'button',
-      className: `${defaultStatusBarItemClassNames} ${
-        presentation.isBlocked ? 'text-destroy-80 dark:text-destroy-40' : ''
-      }`,
-      'data-testid': 'cloud-sync-status',
-      onClick: retryOpfsCloudSync,
-    },
+  const statusBarButtonChildren = [
     createElement(ActionIcon, {
+      key: 'icon',
       icon: presentation.icon,
       iconClassName: presentation.iconClassName,
       bgClassName: 'bg-transparent dark:bg-transparent',
       size: 'sm',
     }),
-    createElement('span', null, presentation.label),
-    createElement(Tooltip, null, presentation.tooltip)
+    createElement('span', { key: 'label' }, presentation.label),
+    createElement(Tooltip, { key: 'tooltip' }, presentation.tooltip),
+  ]
+
+  const blockedClassName =
+    status.state === 'conflict'
+      ? 'text-warn-80 dark:text-warn-40'
+      : presentation.isBlocked
+        ? 'text-destroy-80 dark:text-destroy-40'
+        : ''
+  const statusBarClassName = `${defaultStatusBarItemClassNames} ${blockedClassName}`
+
+  return createElement(
+    Fragment,
+    null,
+    shouldListConflicts
+      ? createElement(
+          Popover,
+          { className: 'relative flex items-stretch' },
+          createElement(
+            Popover.Button,
+            {
+              as: Fragment,
+            },
+            createElement(
+              'button',
+              {
+                className: statusBarClassName,
+                'data-testid': 'cloud-sync-status',
+                type: 'button',
+              },
+              ...statusBarButtonChildren
+            )
+          ),
+          createElement(
+            Popover.Panel,
+            {
+              as: Fragment,
+            },
+            createElement(
+              'div',
+              {
+                className:
+                  'absolute left-0 bottom-full z-20 mb-1 flex w-72 max-w-[calc(100vw-1rem)] flex-col gap-1 rounded border border-chalkboard-30 bg-chalkboard-10 p-2 text-xs shadow-lg dark:border-chalkboard-80 dark:bg-chalkboard-90',
+                'data-testid': 'cloud-conflict-list',
+              },
+              createElement(
+                'div',
+                {
+                  className:
+                    'px-2 py-1 font-bold text-chalkboard-100 dark:text-chalkboard-10',
+                },
+                'Projects with cloud conflicts'
+              ),
+              conflictMetadataList === undefined
+                ? createElement(
+                    'p',
+                    {
+                      className:
+                        'px-2 py-1 text-chalkboard-70 dark:text-chalkboard-40',
+                    },
+                    'Loading conflicted projects...'
+                  )
+                : conflictMetadataList.length > 0
+                  ? conflictMetadataList.map((metadata) =>
+                      createElement(
+                        'button',
+                        {
+                          key: metadata.localProjectPath,
+                          type: 'button',
+                          className:
+                            'rounded px-2 py-1 text-left text-chalkboard-100 hover:bg-chalkboard-20 focus:bg-chalkboard-20 focus:outline-none dark:text-chalkboard-10 dark:hover:bg-chalkboard-80 dark:focus:bg-chalkboard-80',
+                          onClick: () => setSelectedConflict(metadata),
+                        },
+                        metadata.projectName
+                      )
+                    )
+                  : createElement(
+                      'p',
+                      {
+                        className:
+                          'px-2 py-1 text-chalkboard-70 dark:text-chalkboard-40',
+                      },
+                      'No conflicted projects found.'
+                    )
+            )
+          )
+        )
+      : createElement(
+          'button',
+          {
+            type: 'button',
+            className: statusBarClassName,
+            'data-testid': 'cloud-sync-status',
+            onClick: () => {
+              if (canInspectConflict) {
+                setIsInspectingConflict(true)
+                return
+              }
+              retryOpfsCloudSync()
+            },
+          },
+          ...statusBarButtonChildren
+        ),
+    isInspectingConflict &&
+      status.activeProjectPath &&
+      createElement(CloudConflictDialog, {
+        projectPath: status.activeProjectPath,
+        projectName: projectName || 'this project',
+        onDismiss: () => setIsInspectingConflict(false),
+        onResolved: () => setIsInspectingConflict(false),
+      }),
+    selectedConflictProjectPath &&
+      selectedConflictProjectName &&
+      createElement(CloudConflictDialog, {
+        projectPath: selectedConflictProjectPath,
+        projectName: selectedConflictProjectName,
+        onDismiss: () => setSelectedConflict(undefined),
+        onResolved: () => setSelectedConflict(undefined),
+      })
   )
 }
 


### PR DESCRIPTION
## Summary

- add an OPFSCloud conflict resolution API that can choose either the local project or the saved cloud conflict copy as the source of truth
- surface cloud conflict metadata on loaded projects so Home/project UI can show conflict state
- add a shared conflict resolution dialog with explicit `Use local data` and `Use cloud data` actions
- show warning-colored conflict affordances on ProjectCards, the project sidebar menu/breadcrumbs, and the cloud sync status bar
- make the Home status bar conflict click open a project picker instead of guessing which project to inspect

Closes #12159.

## Demo

https://github.com/user-attachments/assets/8bc08273-0fa2-4943-896c-3ed16d8b2da5

## Validation

- `npm run tsc`
- `npm run lint -- src/components/CloudConflictDialog.tsx src/components/ProjectCard/ProjectCard.tsx src/components/ProjectCard/ProjectCard.spec.tsx src/components/ProjectSidebarMenu.tsx src/lib/fs-zds/opfsCloud.ts src/lib/project.d.ts src/machines/systemIO/systemIOMachineImpl.ts src/registry/extensions/cloudSync/index.ts`
- `npm run test -- src/components/ProjectCard/ProjectCard.spec.tsx`