### PR TITLE
Use project titles instead of cloud UUIDs in project UI

### DIFF
--- a/src/components/ProjectSidebarMenu.spec.tsx
+++ b/src/components/ProjectSidebarMenu.spec.tsx
@@ -26,12 +26,13 @@ afterEach(() => {
 
 const now = Date.now()
 const projectWellFormed = {
-  name: 'Simple Box',
-  path: '/some/path/Simple Box',
+  name: '550e8400-e29b-41d4-a716-446655440000',
+  title: 'Simple Box',
+  path: '/some/path/550e8400-e29b-41d4-a716-446655440000',
   children: [
     {
       name: 'main.kcl',
-      path: '/some/path/Simple Box/main.kcl',
+      path: '/some/path/550e8400-e29b-41d4-a716-446655440000/main.kcl',
       children: [],
     },
   ],
@@ -46,12 +47,12 @@ const projectWellFormed = {
   },
   kcl_file_count: 1,
   directory_count: 0,
-  default_file: '/some/path/Simple Box/main.kcl',
+  default_file: '/some/path/550e8400-e29b-41d4-a716-446655440000/main.kcl',
 } satisfies Project
 
 const nestedFile = {
   name: 'nested-part.kcl',
-  path: '/some/path/Simple Box/parts/generated/nested-part.kcl',
+  path: '/some/path/550e8400-e29b-41d4-a716-446655440000/parts/generated/nested-part.kcl',
   children: null,
 } satisfies FileEntry
 
@@ -83,9 +84,7 @@ describe('ProjectSidebarMenu tests', () => {
   test('Disables popover menu by default', () => {
     renderWithRouter(<ProjectSidebarMenu project={projectWellFormed} />)
 
-    expect(screen.getByTestId('project-name')).toHaveTextContent(
-      projectWellFormed.name
-    )
+    expect(screen.getByTestId('project-name')).toHaveTextContent('Simple Box')
   })
 
   test('Links the logo to Home when home navigation is enabled', () => {

--- a/src/components/ProjectSidebarMenu.tsx
+++ b/src/components/ProjectSidebarMenu.tsx
@@ -17,6 +17,7 @@ import { hotkeyDisplay } from '@src/lib/hotkeys'
 import { isDesktop } from '@src/lib/isDesktop'
 import { PATHS, getProjectRelativeFilePath } from '@src/lib/paths'
 import type { FileEntry, Project } from '@src/lib/project'
+import { getProjectDisplayName } from '@src/lib/projectDisplayName'
 import type { IndexLoaderData } from '@src/lib/types'
 
 interface ProjectSidebarMenuProps extends React.PropsWithChildren {
@@ -68,6 +69,7 @@ const ProjectSidebarMenu = ({
     isDesktopApp: isDesktop(),
     hasOpfsCloudFeature,
   })
+  const projectDisplayName = project ? getProjectDisplayName(project) : APP_NAME
 
   return (
     <div className={'!no-underline flex min-w-0 gap-2 ' + trafficLightsOffset}>
@@ -100,7 +102,7 @@ const ProjectSidebarMenu = ({
           className="hidden self-center px-2 select-none cursor-default text-sm text-chalkboard-110 dark:text-chalkboard-20 whitespace-nowrap lg:block"
           data-testid="project-name"
         >
-          {project?.name ? project.name : APP_NAME}
+          {projectDisplayName}
         </span>
       )}
       {children}
@@ -400,8 +402,9 @@ export function ProjectBreadcrumbButton({
   // Breadcrumb for project and project-relative file path
   const relativeFilePath = getProjectRelativeFilePath(project, file)
   const formattedRelativeFilePath = relativeFilePath.replaceAll('/', ' / ')
+  const projectDisplayName = project ? getProjectDisplayName(project) : ''
   const breadCrumb = {
-    projectName: project?.name || '',
+    projectName: projectDisplayName,
     sep: ' / ',
     filePath: formattedRelativeFilePath,
   }
@@ -450,7 +453,7 @@ export function ProjectBreadcrumbButton({
       data-testid="project-sidebar-toggle"
     >
       <div className="flex min-w-0 items-baseline py-0.5 text-sm">
-        {project?.name && (
+        {project && (
           <>
             <span
               ref={projectNameRef}

--- a/src/lib/desktop.test.ts
+++ b/src/lib/desktop.test.ts
@@ -1,0 +1,56 @@
+import { PROJECT_SETTINGS_FILE_NAME } from '@src/lib/constants'
+import { createNewProjectDirectory } from '@src/lib/desktop'
+import fsZds, { StorageName, moduleFsViaModuleImport } from '@src/lib/fs-zds'
+import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
+import { buildTheWorldNode } from '@src/unitTestUtils'
+import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+
+const createdProjectDirectoryPaths: string[] = []
+let wasmInstance: ModuleType
+
+beforeAll(async () => {
+  await moduleFsViaModuleImport({
+    type: StorageName.NodeFS,
+    options: {},
+  })
+  const { instance } = await buildTheWorldNode()
+  wasmInstance = await instance
+})
+
+describe('createNewProjectDirectory', () => {
+  afterEach(async () => {
+    await Promise.all(
+      createdProjectDirectoryPaths.map((projectDirectoryPath) =>
+        fsZds.rm(projectDirectoryPath, { recursive: true, force: true })
+      )
+    )
+    createdProjectDirectoryPaths.length = 0
+  })
+
+  it('creates project.toml title metadata for new projects', async () => {
+    const projectDirectoryPath = `/tmp/create-project-${crypto.randomUUID()}`
+    createdProjectDirectoryPaths.push(projectDirectoryPath)
+
+    const project = await createNewProjectDirectory(
+      'Human Project',
+      wasmInstance,
+      undefined,
+      {
+        settings: {
+          project: {
+            directory: projectDirectoryPath,
+          },
+        },
+      }
+    )
+
+    const projectToml = await fsZds.readFile(
+      fsZds.join(project.path, PROJECT_SETTINGS_FILE_NAME),
+      { encoding: 'utf-8' }
+    )
+
+    expect(project.title).toBe('Human Project')
+    expect(projectToml).toContain('default_file = "main.kcl"')
+    expect(projectToml).toContain('title = "Human Project"')
+  })
+})

--- a/src/lib/desktop.test.ts
+++ b/src/lib/desktop.test.ts
@@ -59,4 +59,51 @@ describe('createNewProjectDirectory', () => {
     expect(projectToml).toContain('default_file = "main.kcl"')
     expect(projectToml).toContain('title = "Human Project"')
   })
+
+  it('treats serialized ENOENT strings as missing project.toml metadata', async () => {
+    const projectDirectoryPath = `/tmp/create-project-${crypto.randomUUID()}`
+    createdProjectDirectoryPaths.push(projectDirectoryPath)
+
+    const originalReadFile = fsZds.readFile
+    let hasThrownSerializedEnoent = false
+    fsZds.readFile = (async (filePath: string, options?: unknown) => {
+      if (
+        !hasThrownSerializedEnoent &&
+        filePath.endsWith(`/${PROJECT_SETTINGS_FILE_NAME}`)
+      ) {
+        hasThrownSerializedEnoent = true
+        return Promise.reject(
+          `ENOENT: no such file or directory, open '${filePath}'`
+        )
+      }
+
+      return originalReadFile(filePath, options as never)
+    }) as typeof fsZds.readFile
+
+    try {
+      const project = await createNewProjectDirectory(
+        'Serialized ENOENT',
+        wasmInstance,
+        undefined,
+        {
+          settings: {
+            project: {
+              directory: projectDirectoryPath,
+            },
+          },
+        }
+      )
+
+      const projectToml = await fsZds.readFile(
+        fsZds.join(project.path, PROJECT_SETTINGS_FILE_NAME),
+        { encoding: 'utf-8' }
+      )
+
+      expect(hasThrownSerializedEnoent).toBe(true)
+      expect(project.title).toBe('Serialized ENOENT')
+      expect(projectToml).toContain('title = "Serialized ENOENT"')
+    } finally {
+      fsZds.readFile = originalReadFile
+    }
+  })
 })

--- a/src/lib/desktop.test.ts
+++ b/src/lib/desktop.test.ts
@@ -106,4 +106,51 @@ describe('createNewProjectDirectory', () => {
       fsZds.readFile = originalReadFile
     }
   })
+
+  it('treats Electron ENOENT errors as missing project.toml metadata', async () => {
+    const projectDirectoryPath = `/tmp/create-project-${crypto.randomUUID()}`
+    createdProjectDirectoryPaths.push(projectDirectoryPath)
+
+    const originalReadFile = fsZds.readFile
+    let hasThrownElectronEnoent = false
+    fsZds.readFile = (async (filePath: string, options?: unknown) => {
+      if (
+        !hasThrownElectronEnoent &&
+        filePath.endsWith(`/${PROJECT_SETTINGS_FILE_NAME}`)
+      ) {
+        hasThrownElectronEnoent = true
+        return Promise.reject(
+          new Error(`ENOENT: no such file or directory, open '${filePath}'`)
+        )
+      }
+
+      return originalReadFile(filePath, options as never)
+    }) as typeof fsZds.readFile
+
+    try {
+      const project = await createNewProjectDirectory(
+        'Electron ENOENT',
+        wasmInstance,
+        undefined,
+        {
+          settings: {
+            project: {
+              directory: projectDirectoryPath,
+            },
+          },
+        }
+      )
+
+      const projectToml = await fsZds.readFile(
+        fsZds.join(project.path, PROJECT_SETTINGS_FILE_NAME),
+        { encoding: 'utf-8' }
+      )
+
+      expect(hasThrownElectronEnoent).toBe(true)
+      expect(project.title).toBe('Electron ENOENT')
+      expect(projectToml).toContain('title = "Electron ENOENT"')
+    } finally {
+      fsZds.readFile = originalReadFile
+    }
+  })
 })

--- a/src/lib/desktop.test.ts
+++ b/src/lib/desktop.test.ts
@@ -2,19 +2,25 @@ import { PROJECT_SETTINGS_FILE_NAME } from '@src/lib/constants'
 import { createNewProjectDirectory } from '@src/lib/desktop'
 import fsZds, { StorageName, moduleFsViaModuleImport } from '@src/lib/fs-zds'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
-import { buildTheWorldNode } from '@src/unitTestUtils'
-import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
 const createdProjectDirectoryPaths: string[] = []
-let wasmInstance: ModuleType
+const wasmInstance = {
+  change_default_units: vi.fn((kcl: string, len: string) => {
+    const defaultLengthUnit = JSON.parse(len)
+    return `@settings(defaultLengthUnit = ${defaultLengthUnit})\n\n${kcl}`
+  }),
+  change_kcl_version: vi.fn((kcl: string, versionString: string) => {
+    const version = JSON.parse(versionString)
+    return `@settings(kclVersion = ${version})\n\n${kcl}`
+  }),
+} as unknown as ModuleType
 
 beforeAll(async () => {
   await moduleFsViaModuleImport({
     type: StorageName.NodeFS,
     options: {},
   })
-  const { instance } = await buildTheWorldNode()
-  wasmInstance = await instance
 })
 
 describe('createNewProjectDirectory', () => {

--- a/src/lib/desktop.ts
+++ b/src/lib/desktop.ts
@@ -87,6 +87,7 @@ const convertIStatToFileMetadata = (
 function isPathNotFoundError(error: unknown) {
   return (
     error === 'ENOENT' ||
+    (typeof error === 'string' && error.startsWith('ENOENT')) ||
     (typeof error === 'object' &&
       error !== null &&
       'code' in error &&

--- a/src/lib/desktop.ts
+++ b/src/lib/desktop.ts
@@ -84,6 +84,16 @@ const convertIStatToFileMetadata = (
   }
 }
 
+function isPathNotFoundError(error: unknown) {
+  return (
+    error === 'ENOENT' ||
+    (typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      error.code === 'ENOENT')
+  )
+}
+
 async function readProjectTomlMetadata(projectPath: string) {
   const projectTomlPath = fsZds.join(projectPath, PROJECT_SETTINGS_FILE_NAME)
   try {
@@ -104,6 +114,46 @@ async function readProjectTomlMetadata(projectPath: string) {
       cloudProjectId: undefined,
     }
   }
+}
+
+async function ensureProjectTomlTitle({
+  projectPath,
+  title,
+  defaultFile,
+}: {
+  projectPath: string
+  title: string
+  defaultFile: string
+}) {
+  const projectTomlPath = fsZds.join(projectPath, PROJECT_SETTINGS_FILE_NAME)
+  let projectToml = ''
+  try {
+    projectToml = await fsZds.readFile(projectTomlPath, {
+      encoding: 'utf-8',
+    })
+  } catch (error) {
+    if (!isPathNotFoundError(error)) {
+      return Promise.reject(error)
+    }
+  }
+
+  if (getProjectTitleFromProjectTomlContents(projectToml)) {
+    return
+  }
+
+  const projectTomlWithDefaultFile = /^\s*default_file\s*=/m.test(projectToml)
+    ? projectToml
+    : `default_file = ${JSON.stringify(defaultFile.replaceAll('\\', '/'))}\n${
+        projectToml.trim() ? `\n${projectToml}` : ''
+      }`
+  const nextProjectToml = setProjectTitleInProjectTomlContents(
+    projectTomlWithDefaultFile,
+    title
+  )
+  await fsZds.writeFile(
+    projectTomlPath,
+    new TextEncoder().encode(nextProjectToml)
+  )
 }
 
 export async function renameProjectDirectory(
@@ -154,7 +204,7 @@ export async function ensureProjectDirectoryExists(
   try {
     await fsZds.stat(projectDir)
   } catch (e) {
-    if (e === 'ENOENT') {
+    if (isPathNotFoundError(e)) {
       await fsZds.mkdir(projectDir, { recursive: true })
     }
   }
@@ -203,7 +253,7 @@ export async function createNewProjectDirectory(
   try {
     await fsZds.stat(projectDir)
   } catch (e) {
-    if (e === 'ENOENT') {
+    if (isPathNotFoundError(e)) {
       await fsZds.mkdir(projectDir, { recursive: true })
     }
   }
@@ -225,6 +275,11 @@ export async function createNewProjectDirectory(
   )
   if (err(codeToWrite)) return Promise.reject(codeToWrite)
   await fsZds.writeFile(projectFile, new TextEncoder().encode(codeToWrite))
+  await ensureProjectTomlTitle({
+    projectPath: projectDir,
+    title: projectName,
+    defaultFile: kclFileName,
+  })
   let metadata: FileMetadata | null = null
   try {
     metadata = convertIStatToFileMetadata(await fsZds.stat(projectFile))
@@ -242,6 +297,7 @@ export async function createNewProjectDirectory(
   return {
     path: projectDir,
     name: projectName,
+    title: projectName,
     // We don't need to recursively get all files in the project directory.
     // Because we just created it and it's empty.
     children: null,
@@ -784,7 +840,7 @@ const getProjectSettingsFilePath = async (projectPath: string) => {
   try {
     await fsZds.stat(projectPath)
   } catch (e) {
-    if (e === 'ENOENT') {
+    if (isPathNotFoundError(e)) {
       await fsZds.mkdir(projectPath, { recursive: true })
     }
   }
@@ -817,7 +873,7 @@ export const readProjectSettingsFile = async (
   try {
     await fsZds.stat(settingsPath)
   } catch (e) {
-    if (e === 'ENOENT') {
+    if (isPathNotFoundError(e)) {
       return {}
     }
   }

--- a/src/lib/desktop.ts
+++ b/src/lib/desktop.ts
@@ -90,8 +90,10 @@ function isPathNotFoundError(error: unknown) {
     (typeof error === 'string' && error.startsWith('ENOENT')) ||
     (typeof error === 'object' &&
       error !== null &&
-      'code' in error &&
-      error.code === 'ENOENT')
+      (('code' in error && error.code === 'ENOENT') ||
+        ('message' in error &&
+          typeof error.message === 'string' &&
+          error.message.startsWith('ENOENT'))))
   )
 }
 
@@ -663,7 +665,7 @@ export async function writeProjectTitleToProjectToml(
       encoding: 'utf-8',
     })
   } catch (error) {
-    if (error !== 'ENOENT') {
+    if (!isPathNotFoundError(error)) {
       return Promise.reject(error)
     }
   }

--- a/src/lib/exportProjectZip.spec.ts
+++ b/src/lib/exportProjectZip.spec.ts
@@ -19,7 +19,10 @@ beforeAll(async () => {
   wasmInstance = await instance
 })
 
-function makeProject(projectPath: string): Project {
+function makeProject(
+  projectPath: string,
+  overrides: Partial<Project> = {}
+): Project {
   return {
     metadata: null,
     kcl_file_count: 2,
@@ -29,6 +32,7 @@ function makeProject(projectPath: string): Project {
     name: 'web-project',
     children: null,
     readWriteAccess: true,
+    ...overrides,
   }
 }
 
@@ -74,9 +78,8 @@ describe('createProjectZipArchive', () => {
       wasmInstance,
     })
 
-    expect(archive).not.toBeInstanceOf(Error)
     if (archive instanceof Error) {
-      return
+      throw archive
     }
 
     expect(archive.fileName).toBe('web-project.zip')
@@ -94,5 +97,35 @@ describe('createProjectZipArchive', () => {
     await expect(
       zip.file('web-project/project.toml')?.async('string')
     ).resolves.toBe('default_file = "main.kcl"')
+  })
+
+  it('uses the project title for the ZIP name and root when it differs from the folder name', async () => {
+    const projectPath = `/tmp/export-project-zip-${crypto.randomUUID()}`
+    createdProjectPaths.push(projectPath)
+
+    await fsZds.mkdir(projectPath, { recursive: true })
+    await fsZds.writeFile(
+      fsZds.join(projectPath, 'main.kcl'),
+      new TextEncoder().encode('disk = true')
+    )
+
+    const archive = await createProjectZipArchive({
+      project: makeProject(projectPath, {
+        name: '550e8400-e29b-41d4-a716-446655440000',
+        title: 'Human Project',
+      }),
+      wasmInstance,
+    })
+
+    if (archive instanceof Error) {
+      throw archive
+    }
+
+    expect(archive.fileName).toBe('Human Project.zip')
+    const zip = await JSZip.loadAsync(await archive.blob.arrayBuffer())
+
+    await expect(
+      zip.file('Human Project/main.kcl')?.async('string')
+    ).resolves.toBe('disk = true')
   })
 })

--- a/src/lib/exportProjectZip.ts
+++ b/src/lib/exportProjectZip.ts
@@ -9,6 +9,7 @@ import {
 import fsZds from '@src/lib/fs-zds'
 import { toProjectRelativePath, toWebSafePath } from '@src/lib/paths'
 import type { Project } from '@src/lib/project'
+import { getProjectDisplayName } from '@src/lib/projectDisplayName'
 import { sanitizeProjectName } from '@src/lib/projectName'
 import { getProjectTomlContents } from '@src/lib/projectToml'
 import { isErr } from '@src/lib/trap'
@@ -75,7 +76,10 @@ export async function createProjectZipArchive({
   }
 
   const zip = new JSZip()
-  const archiveRoot = sanitizeProjectName(project.name || 'project', 'project')
+  const archiveRoot = sanitizeProjectName(
+    getProjectDisplayName(project),
+    'project'
+  )
   for (const entry of entries) {
     const archivePath = `${archiveRoot}/${entry.relativePath}`
     zip.file(archivePath, entry.data, { binary: true })

--- a/src/lib/fs-zds/opfsCloud.test.ts
+++ b/src/lib/fs-zds/opfsCloud.test.ts
@@ -20,6 +20,7 @@ import {
   prepareProjectFilesForCloudUpload,
   projectManifestsEqual,
 } from '@src/lib/fs-zds/opfsCloud'
+import { withRemoteProjectMetadataInArchiveFiles } from '@src/lib/fs-zds/opfsCloud/projectArchive'
 import { describe, expect, it } from 'vitest'
 
 const encoder = new TextEncoder()
@@ -118,7 +119,46 @@ describe('opfsCloud sync helpers', () => {
           (file) => file.relativePath === PROJECT_SETTINGS_FILE_NAME
         )?.data
       )
-    ).toBe('default_file = "main.kcl"\n')
+    ).toContain('default_file = "main.kcl"')
+    expect(
+      new TextDecoder().decode(
+        payload.files.find(
+          (file) => file.relativePath === PROJECT_SETTINGS_FILE_NAME
+        )?.data
+      )
+    ).toContain('title = "bracket"')
+  })
+
+  it('adds the upload title to project.toml when local project settings have no title', () => {
+    const payload = prepareProjectFilesForCloudUpload('/projects/bracket', [
+      projectFile('main.kcl'),
+      projectFile(PROJECT_SETTINGS_FILE_NAME, 'default_file = "main.kcl"\n'),
+    ])
+    const projectToml = new TextDecoder().decode(
+      payload.files.find(
+        (file) => file.relativePath === PROJECT_SETTINGS_FILE_NAME
+      )?.data
+    )
+
+    expect(payload.body.title).toBe('bracket')
+    expect(projectToml).toContain('default_file = "main.kcl"')
+    expect(projectToml).toContain('title = "bracket"')
+  })
+
+  it('adds an Untitled project.toml title when remote project metadata has no title', () => {
+    const files = withRemoteProjectMetadataInArchiveFiles(
+      [projectFile('main.kcl')],
+      undefined,
+      'remote-project-123',
+      'dev.zoo.dev'
+    )
+    const projectToml = new TextDecoder().decode(
+      files.find((file) => file.relativePath === PROJECT_SETTINGS_FILE_NAME)
+        ?.data
+    )
+
+    expect(projectToml).toContain('title = "Untitled"')
+    expect(projectToml).toContain('project_id = "remote-project-123"')
   })
 
   it('excludes files ignored by project .gitignore from cloud sync manifests and uploads', () => {

--- a/src/lib/fs-zds/opfsCloud.ts
+++ b/src/lib/fs-zds/opfsCloud.ts
@@ -21,6 +21,7 @@ import {
   normalizeRelativePath,
 } from '@src/lib/fs-zds/opfsCloud/paths'
 import {
+  getRemoteProjectTitleForProjectToml,
   parseProjectArchive,
   projectManifestFromFiles,
   projectManifestsEqual,
@@ -429,6 +430,29 @@ async function writeLocalProjectTitle(projectPath: string, title: string) {
   )
 }
 
+async function ensureLocalProjectTitle(projectPath: string, title?: string) {
+  if (!title?.trim()) {
+    return false
+  }
+
+  return updateLocalProjectToml(projectPath, (projectToml) =>
+    getProjectTitleFromProjectTomlContents(projectToml)
+      ? projectToml
+      : setProjectTitleInProjectTomlContents(projectToml, title)
+  )
+}
+
+async function readLocalProjectTitle(projectPath: string) {
+  const projectTomlPath = localFs.join(projectPath, PROJECT_SETTINGS_FILE_NAME)
+  if (!(await exists(projectTomlPath))) {
+    return undefined
+  }
+
+  return getProjectTitleFromProjectTomlContents(
+    await localFs.readFile(projectTomlPath, { encoding: 'utf-8' })
+  )
+}
+
 async function writeLocalProjectCloudProjectId(
   projectPath: string,
   projectId: string
@@ -725,6 +749,17 @@ export async function ensureOpfsCloudProjectLocallySynced(
     knownLocalProjectPath &&
     (await exists(knownLocalProjectPath))
   ) {
+    if (!(await readLocalProjectTitle(knownLocalProjectPath))) {
+      const remoteProject = await getRemoteProject(config, projectId)
+      const nextMetadata = await hydrateCleanLocalProjectTitle(
+        knownLocalMetadata,
+        getRemoteProjectTitleForProjectToml(remoteProject.title)
+      )
+      if (nextMetadata !== knownLocalMetadata) {
+        scheduleSync(0)
+        return localProjectFromMetadata(nextMetadata)
+      }
+    }
     scheduleSync(0)
     return localProjectFromMetadata(knownLocalMetadata)
   }
@@ -747,6 +782,10 @@ export async function ensureOpfsCloudProjectLocallySynced(
       remoteProjectId: projectId,
       tombstone: false,
     }
+    await ensureLocalProjectTitle(
+      existingProjectPath,
+      getRemoteProjectTitleForProjectToml(remoteProject.title)
+    )
     await putProjectMetadata(nextMetadata)
     scheduleSync(0)
     return localProjectFromMetadata(nextMetadata)
@@ -1003,20 +1042,15 @@ async function hydrateCleanLocalProjectTitle(
   metadata: ProjectMetadata,
   remoteTitle?: string
 ) {
-  if (!remoteTitle?.trim() || !(await exists(metadata.localProjectPath))) {
+  if (!(await exists(metadata.localProjectPath))) {
     return metadata
   }
+  const projectTitle = getRemoteProjectTitleForProjectToml(remoteTitle)
 
-  const projectTomlPath = localFs.join(
-    metadata.localProjectPath,
-    PROJECT_SETTINGS_FILE_NAME
+  const existingProjectTitle = await readLocalProjectTitle(
+    metadata.localProjectPath
   )
-  const existingProjectToml = (await exists(projectTomlPath))
-    ? await localFs.readFile(projectTomlPath, { encoding: 'utf-8' })
-    : ''
-  if (
-    getProjectTitleFromProjectTomlContents(existingProjectToml) === remoteTitle
-  ) {
+  if (existingProjectTitle === projectTitle) {
     return metadata
   }
 
@@ -1031,7 +1065,7 @@ async function hydrateCleanLocalProjectTitle(
 
   const titleChanged = await writeLocalProjectTitle(
     metadata.localProjectPath,
-    remoteTitle
+    projectTitle
   )
   if (!titleChanged) {
     return metadata
@@ -1091,7 +1125,10 @@ async function markProjectConflict(
 
   await replaceLocalProjectWithFiles(
     conflictProjectPath,
-    withProjectTitleInArchiveFiles(remoteFiles, remoteTitle)
+    withProjectTitleInArchiveFiles(
+      remoteFiles,
+      getRemoteProjectTitleForProjectToml(remoteTitle)
+    )
   )
 
   await putProjectMetadata({
@@ -1288,8 +1325,6 @@ async function syncProject(projectPath: string, entries: OutboxEntry[]) {
         metadata.remoteProjectId
       )
     }
-    const localFiles = await collectLocalProjectFiles(metadata.localProjectPath)
-    const localManifest = await projectManifestFromFiles(localFiles)
 
     let remoteProject: RemoteProject | undefined
     let remoteRevision: Revision | undefined
@@ -1298,6 +1333,18 @@ async function syncProject(projectPath: string, entries: OutboxEntry[]) {
     if (metadata.remoteProjectId) {
       remoteProject = await getRemoteProject(config, metadata.remoteProjectId)
       remoteRevision = getRevision(remoteProject)
+    }
+
+    await ensureLocalProjectTitle(
+      metadata.localProjectPath,
+      remoteProject
+        ? getRemoteProjectTitleForProjectToml(remoteProject.title)
+        : metadata.projectName
+    )
+    const localFiles = await collectLocalProjectFiles(metadata.localProjectPath)
+    const localManifest = await projectManifestFromFiles(localFiles)
+
+    if (metadata.remoteProjectId) {
       remoteChanged =
         Boolean(metadata.remoteRevision && remoteRevision) &&
         metadata.remoteRevision !== remoteRevision

--- a/src/lib/fs-zds/opfsCloud/projectArchive.ts
+++ b/src/lib/fs-zds/opfsCloud/projectArchive.ts
@@ -20,6 +20,11 @@ import { isArray } from '@src/lib/utils'
 import JSZip from 'jszip'
 
 const localFs = opfs.impl
+export const OPFS_CLOUD_UNTITLED_PROJECT_TITLE = 'Untitled'
+
+export function getRemoteProjectTitleForProjectToml(title?: string) {
+  return title?.trim() || OPFS_CLOUD_UNTITLED_PROJECT_TITLE
+}
 
 export function prepareProjectFilesForCloudUpload(
   projectPath: string,
@@ -35,6 +40,7 @@ export function prepareProjectFilesForCloudUpload(
   const projectTitle =
     getProjectTomlTitle(normalizedFiles) ||
     localFs.basename(projectPath.replaceAll('\\', '/').replace(/\/+$/g, ''))
+  ensureProjectTomlUploadTitle(normalizedFiles, projectTitle || 'project')
   const body: ProjectUploadBody = {
     title: projectTitle || 'project',
     description: '',
@@ -77,6 +83,27 @@ function ensureProjectTomlUploadFile(
     ),
   })
   return PROJECT_SETTINGS_FILE_NAME
+}
+
+function ensureProjectTomlUploadTitle(
+  files: ProjectArchiveFile[],
+  title: string
+) {
+  const projectTomlFile = files.find(
+    (file) => file.relativePath === PROJECT_SETTINGS_FILE_NAME
+  )
+  if (!projectTomlFile) {
+    return
+  }
+
+  const existingProjectToml = new TextDecoder().decode(projectTomlFile.data)
+  if (getProjectTitleFromProjectTomlContents(existingProjectToml)) {
+    return
+  }
+
+  projectTomlFile.data = new TextEncoder().encode(
+    setProjectTitleInProjectTomlContents(existingProjectToml, title)
+  )
 }
 
 function getProjectTomlTitle(files: ProjectArchiveFile[]) {
@@ -208,7 +235,10 @@ export function withRemoteProjectMetadataInArchiveFiles(
   environmentName?: string
 ) {
   return withProjectCloudProjectIdInArchiveFiles(
-    withProjectTitleInArchiveFiles(files, title),
+    withProjectTitleInArchiveFiles(
+      files,
+      getRemoteProjectTitleForProjectToml(title)
+    ),
     projectId,
     environmentName
   )

--- a/src/lib/optimisticProjectRenames.test.ts
+++ b/src/lib/optimisticProjectRenames.test.ts
@@ -64,7 +64,7 @@ describe('optimistic project renames', () => {
     expect(projects?.[0].metadata?.modified).toBe(300)
   })
 
-  it('prunes overlays once the durable project modified time catches up', () => {
+  it('keeps overlays until the durable project title and modified time catch up', () => {
     expect(
       pruneSettledOptimisticProjectRenames([baseProject], {
         'project-123': {
@@ -84,6 +84,32 @@ describe('optimistic project renames', () => {
         [
           {
             ...baseProject,
+            metadata: {
+              ...baseProject.metadata,
+              modified: 200,
+            },
+          },
+        ],
+        {
+          'project-123': {
+            title: 'New cloud title',
+            modified: 200,
+          },
+        }
+      )
+    ).toEqual({
+      'project-123': {
+        title: 'New cloud title',
+        modified: 200,
+      },
+    })
+
+    expect(
+      pruneSettledOptimisticProjectRenames(
+        [
+          {
+            ...baseProject,
+            title: 'New cloud title',
             metadata: {
               ...baseProject.metadata,
               modified: 200,

--- a/src/lib/optimisticProjectRenames.ts
+++ b/src/lib/optimisticProjectRenames.ts
@@ -1,4 +1,5 @@
 import type { Project } from '@src/lib/project'
+import { getProjectDisplayName } from '@src/lib/projectDisplayName'
 
 export type OptimisticProjectRename = {
   title: string
@@ -59,6 +60,7 @@ export function pruneSettledOptimisticProjectRenames(
       optimisticProjectRenames[project.cloudProjectId]
     if (
       optimisticProjectRename &&
+      getProjectDisplayName(project) === optimisticProjectRename.title &&
       (project.metadata?.modified ?? Number.NEGATIVE_INFINITY) >=
         optimisticProjectRename.modified
     ) {


### PR DESCRIPTION
## Summary

- create and persist `project.toml` title metadata for new projects so projects have a human-readable title source
- use project titles in the project sidebar and downloaded project ZIP names instead of exposing implementation folder names or cloud UUIDs
- keep optimistic project title renames visible until the persisted project title catches up
- ensure OPFSCloud preserves, uploads, and hydrates project titles from cloud project metadata and archives

Closes #12161.

## Validation

- `npm run tsc`
- `npm run lint -- src/components/ProjectSidebarMenu.spec.tsx src/components/ProjectSidebarMenu.tsx src/lib/desktop.test.ts src/lib/desktop.ts src/lib/exportProjectZip.spec.ts src/lib/exportProjectZip.ts src/lib/fs-zds/opfsCloud.test.ts src/lib/fs-zds/opfsCloud.ts src/lib/fs-zds/opfsCloud/projectArchive.ts src/lib/optimisticProjectRenames.test.ts src/lib/optimisticProjectRenames.ts`
- `npm run test -- src/components/ProjectSidebarMenu.spec.tsx src/lib/desktop.test.ts src/lib/exportProjectZip.spec.ts src/lib/fs-zds/opfsCloud.test.ts src/lib/optimisticProjectRenames.test.ts`