### PR TITLE
Repair corrupt OPFS directory metadata

### DIFF
--- a/src/lib/fs-zds/opfs.test.ts
+++ b/src/lib/fs-zds/opfs.test.ts
@@ -1,0 +1,164 @@
+import path from 'path'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('@src/lib/fs-zds/opfsWriteWorker.ts?worker', () => ({
+  default: class MockOPFSWriteWorker {
+    onmessage: ((event: MessageEvent<unknown>) => void) | null = null
+
+    postMessage() {}
+
+    terminate() {}
+  },
+}))
+
+class MockFileSystemFileHandle {
+  data: Uint8Array<ArrayBuffer>
+  lastModified = Date.now()
+
+  constructor(
+    public name: string,
+    contents = ''
+  ) {
+    this.data = new TextEncoder().encode(contents)
+  }
+
+  async getFile() {
+    const data = this.data
+    const lastModified = this.lastModified
+    return {
+      size: data.byteLength,
+      lastModified,
+      text: async () => new TextDecoder().decode(data),
+      arrayBuffer: async () => data.slice().buffer,
+    } as File
+  }
+
+  async createWritable() {
+    return {
+      write: async (blob: Blob) => {
+        this.data = new Uint8Array(await blob.arrayBuffer())
+        this.lastModified = Date.now()
+      },
+      close: async () => {},
+    }
+  }
+}
+
+class MockFileSystemDirectoryHandle {
+  children = new Map<
+    string,
+    MockFileSystemDirectoryHandle | MockFileSystemFileHandle
+  >()
+
+  constructor(public name: string) {}
+
+  async *entries() {
+    for (const entry of this.children) {
+      yield entry
+    }
+  }
+
+  async getDirectoryHandle(name: string, options?: { create?: boolean }) {
+    const existing = this.children.get(name)
+    if (existing instanceof MockFileSystemDirectoryHandle) {
+      return existing
+    }
+    if (!options?.create) {
+      throw new Error('NotFoundError')
+    }
+
+    const next = new MockFileSystemDirectoryHandle(name)
+    this.children.set(name, next)
+    return next
+  }
+
+  async getFileHandle(name: string, options?: { create?: boolean }) {
+    const existing = this.children.get(name)
+    if (existing instanceof MockFileSystemFileHandle) {
+      return existing
+    }
+    if (!options?.create) {
+      throw new Error('NotFoundError')
+    }
+
+    const next = new MockFileSystemFileHandle(name)
+    this.children.set(name, next)
+    return next
+  }
+
+  async removeEntry(name: string) {
+    this.children.delete(name)
+  }
+
+  addDirectory(name: string) {
+    const next = new MockFileSystemDirectoryHandle(name)
+    this.children.set(name, next)
+    return next
+  }
+
+  addFile(name: string, contents = '') {
+    const next = new MockFileSystemFileHandle(name, contents)
+    this.children.set(name, next)
+    return next
+  }
+}
+
+describe('opfs', () => {
+  let root: MockFileSystemDirectoryHandle
+  const projectPath = path.resolve('projects', 'project')
+  const metaPath = path.resolve(projectPath, '._meta')
+
+  beforeEach(() => {
+    vi.resetModules()
+    root = new MockFileSystemDirectoryHandle('')
+    vi.stubGlobal('FileSystemDirectoryHandle', MockFileSystemDirectoryHandle)
+    vi.stubGlobal('FileSystemFileHandle', MockFileSystemFileHandle)
+    Object.defineProperty(globalThis.navigator, 'storage', {
+      configurable: true,
+      value: {
+        getDirectory: vi.fn(async () => root),
+      },
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  async function getOpfs() {
+    return (await import('@src/lib/fs-zds/opfs')).default
+  }
+
+  function addProjectWithMeta(contents: string) {
+    const projects = root.addDirectory('projects')
+    const project = projects.addDirectory('project')
+    project.addFile('._meta', contents)
+    return project
+  }
+
+  test('repairs empty directory metadata during stat', async () => {
+    addProjectWithMeta('')
+    const opfs = await getOpfs()
+
+    const stat = await opfs.impl.stat(projectPath)
+    const repaired = await opfs.impl.readFile(metaPath, {
+      encoding: 'utf-8',
+    })
+
+    expect(stat.mtimeMs).toEqual(expect.any(Number))
+    expect(JSON.parse(repaired)).toEqual({ mtimeMs: stat.mtimeMs })
+  })
+
+  test('repairs malformed directory metadata during stat', async () => {
+    addProjectWithMeta('{"mtimeMs":"not-a-number"}')
+    const opfs = await getOpfs()
+
+    const stat = await opfs.impl.stat(projectPath)
+    const repaired = await opfs.impl.readFile(metaPath, {
+      encoding: 'utf-8',
+    })
+
+    expect(stat.mtimeMs).toEqual(expect.any(Number))
+    expect(JSON.parse(repaired)).toEqual({ mtimeMs: stat.mtimeMs })
+  })
+})

--- a/src/lib/fs-zds/opfs.ts
+++ b/src/lib/fs-zds/opfs.ts
@@ -12,6 +12,22 @@ interface MetaFileDirectoryData {
   mtimeMs: number
 }
 
+function createDirectoryMetadata(): MetaFileDirectoryData {
+  return {
+    mtimeMs: new Date().getTime(),
+  }
+}
+
+async function writeDirectoryMetadata(
+  metaFilePath: string,
+  metadata: MetaFileDirectoryData
+) {
+  await writeFile(
+    path.resolve(metaFilePath),
+    new TextEncoder().encode(JSON.stringify(metadata))
+  )
+}
+
 const isMetaFileDirectoryData = (x: unknown): x is MetaFileDirectoryData => {
   return (
     typeof x === 'object' &&
@@ -213,35 +229,25 @@ const stat = async (targetPath: string): Promise<IStat> => {
   // update it as necessary. For now it will only store: creation and
   // modification time.
   const metaFilePath = path.resolve(targetPath, META_FILE)
-  let json
+  let obj
   try {
-    json = await readFile(metaFilePath, { encoding: 'utf-8' })
+    const json = await readFile(metaFilePath, { encoding: 'utf-8' })
+    try {
+      obj = JSON.parse(json)
+    } catch {
+      obj = undefined
+    }
   } catch (e: unknown) {
-    if (typeof e !== 'string') {
+    if (e !== 'ENOENT') {
       // eslint-disable-next-line suggest-no-throw/suggest-no-throw
       throw e
     }
-
-    // The metafile didn't exist in the first place. Let's create it.
-    if (e === 'ENOENT') {
-      await writeFile(
-        path.resolve(metaFilePath),
-        new TextEncoder().encode(
-          JSON.stringify({
-            mtimeMs: new Date().getTime(),
-          })
-        )
-      )
-    }
-
-    // This will work now.
-    json = await readFile(metaFilePath, { encoding: 'utf-8' })
   }
 
-  const obj = JSON.parse(json)
-  if (!isMetaFileDirectoryData(obj))
-    // eslint-disable-next-line suggest-no-throw/suggest-no-throw
-    throw new Error(`Corrupt ${META_FILE} file`)
+  if (!isMetaFileDirectoryData(obj)) {
+    obj = createDirectoryMetadata()
+    await writeDirectoryMetadata(metaFilePath, obj)
+  }
 
   return {
     dev: 0,
@@ -432,11 +438,7 @@ const writeFile = async (
 
   await writeFile(
     path.resolve(targetPath, '..', META_FILE),
-    new TextEncoder().encode(
-      JSON.stringify({
-        mtimeMs: new Date().getTime(),
-      })
-    )
+    new TextEncoder().encode(JSON.stringify(createDirectoryMetadata()))
   )
 
   return undefined


### PR DESCRIPTION
## Summary

- treat missing, empty, or malformed OPFS `._meta` directory metadata as repairable cache state
- rewrite invalid directory metadata during `stat()` instead of throwing JSON parse errors into callers like OPFSCloud sync
- keep non-ENOENT OPFS read/write failures visible instead of masking unrelated filesystem problems
- add unit coverage with an in-memory File System Access API mock for empty and malformed metadata repair

## Why

`._meta` only stores synthetic directory modified time because OPFS does not expose directory timestamps. If that file is empty or corrupt, failing the entire directory `stat()` can surface as status bar errors such as `Cloud sync failed: Unexpected end of JSON input`. Regenerating the metadata loses at most synthetic sort timing, while preserving project access and sync.

## Validation

- `npm run test -- src/lib/fs-zds/opfs.test.ts`
- `npm run tsc`
- `npm run lint -- src/lib/fs-zds/opfs.ts src/lib/fs-zds/opfs.test.ts`