### PR TITLE
docs: Change KCL language docs to use KCL 2.0

### DIFF
--- a/docs/kcl-lang/known-issues.md
+++ b/docs/kcl-lang/known-issues.md
@@ -4,6 +4,8 @@ excerpt: "Known issues with the KCL standard library for the Zoo Design Studio."
 layout: manual
 ---
 
+## Geometry Engine
+
 The following are bugs that are not in Zoo Design Studio or KCL itself. These bugs,
 once fixed in engine, will just start working here with no language changes.
 
@@ -11,3 +13,9 @@ once fixed in engine, will just start working here with no language changes.
     you cannot yet edit it, the engine will account for this later. 
 
 - **CSG Booleans**: Coplanar (bodies that share a plane) unions, subtractions, and intersections are not currently supported.
+
+## KCL Version 1.0
+
+The following are known issues with KCL 1.0. To opt-in to the fixes and new features, use the latest version of KCL with `@settings(kclVersion = 2.0)`.
+
+- **Region tags are shuffled**: When you name a segment in a sketch block, the tags in the region may not correspond to the original sketch segments.

--- a/docs/kcl-lang/known-issues.md
+++ b/docs/kcl-lang/known-issues.md
@@ -18,4 +18,4 @@ once fixed in engine, will just start working here with no language changes.
 
 The following are known issues with KCL 1.0. To opt-in to the fixes and new features, use the latest version of KCL with `@settings(kclVersion = 2.0)`.
 
-- **Region tags are shuffled**: When you name a segment in a sketch block, the tags in the region may not correspond to the original sketch segments.
+- **Region tags are shuffled**: When you name a segment in a sketch block, the tags in the region may not correspond to the original sketch segments. This is fixed in KCL 2.0.

--- a/docs/kcl-lang/settings.md
+++ b/docs/kcl-lang/settings.md
@@ -27,7 +27,7 @@ For example:
 
 ```kcl
 // The settings attribute.
-@settings(defaultLengthUnit = in)
+@settings(kclVersion = 2.0, defaultLengthUnit = in)
 
 // The rest of your KCL code goes below...
 
@@ -45,5 +45,6 @@ Valid properties are:
 - `experimentalFeatures`: how experimental features are handled within this file.
   - Accepted values: `allow` (experimental features can be used freely), `warn` (experimental features
   cause a warning), `deny` (the default, experimental features cause an error).
+- `kclVersion`: the version of the KCL language and standard libary to execute with.
 
 These settings override any project-wide settings (configured in project.toml or via the UI).

--- a/docs/kcl-lang/sketch-on-face.md
+++ b/docs/kcl-lang/sketch-on-face.md
@@ -40,7 +40,7 @@ squareSketch = sketch(on = XY) {
 region001 = region(segments = [squareSketch.line1, squareSketch.line2])
 cube = extrude(region001, length = 1)
 
-towerSketch = sketch(on = startSketchOn(cube, face = END)) {
+towerSketch = sketch(on = faceOf(cube, face = END)) {
   circle1 = circle(start = [var 0.6mm, var 0.5mm], center = [var 0.5mm, var 0.5mm])
 }
 region002 = region(segments = [towerSketch.circle1])
@@ -101,7 +101,7 @@ region001 = region(segments = [squareSketch.line1, squareSketch.line2])
 cube = extrude(region001, length = 1)
 
 // This tower is a separate solid from the cube.
-towerSketch = sketch(on = startSketchOn(cube, face = END)) {
+towerSketch = sketch(on = faceOf(cube, face = END)) {
   circle1 = circle(start = [var 0.6mm, var 0.5mm], center = [var 0.5mm, var 0.5mm])
 }
 region002 = region(segments = [towerSketch.circle1])

--- a/docs/kcl-lang/sketch-on-face.md
+++ b/docs/kcl-lang/sketch-on-face.md
@@ -7,6 +7,8 @@ layout: manual
 When you sketch on a plane and extrude, a new solid is created.
 
 ```kcl
+@settings(kclVersion = 2.0)
+
 squareSketch = sketch(on = XY) {
   line1 = line(start = [var 0mm, var 0mm], end = [var 1mm, var 0mm])
   line2 = line(start = [var 1mm, var 0mm], end = [var 1mm, var 1mm])
@@ -24,6 +26,8 @@ However, when you sketch on the face of an existing solid, extruding extends the
 existing solid.
 
 ```kcl
+@settings(kclVersion = 2.0)
+
 squareSketch = sketch(on = XY) {
   line1 = line(start = [var 0mm, var 0mm], end = [var 1mm, var 0mm])
   line2 = line(start = [var 1mm, var 0mm], end = [var 1mm, var 1mm])
@@ -55,6 +59,8 @@ the sketch on the same plane. Since it's not directly on the first solid's face,
 extrusions do not modify the solid. They create new solids instead.
 
 ```kcl
+@settings(kclVersion = 2.0)
+
 squareSketch = sketch(on = XY) {
   line1 = line(start = [var 0mm, var 0mm], end = [var 1mm, var 0mm])
   line2 = line(start = [var 1mm, var 0mm], end = [var 1mm, var 1mm])
@@ -80,6 +86,8 @@ The second way to create a separate solid is by using the `method` parameter of
 that the method should create a new solid using `method = NEW`.
 
 ```kcl
+@settings(kclVersion = 2.0)
+
 squareSketch = sketch(on = XY) {
   line1 = line(start = [var 0mm, var 0mm], end = [var 1mm, var 0mm])
   line2 = line(start = [var 1mm, var 0mm], end = [var 1mm, var 1mm])

--- a/docs/kcl-lang/types.md
+++ b/docs/kcl-lang/types.md
@@ -52,6 +52,8 @@ The syntax for declaring a tag is `$myTag`. Tags are used for bodies (such as ex
 **Example: Referencing sketch segments and tagging cap faces**
 
 ```kcl
+@settings(kclVersion = 2.0)
+
 sketch001 = sketch(on = XZ) {
   line1 = line(start = [var -2.17mm, var -0.91mm], end = [var 3.01mm, var -1.57mm])
   line2 = line(start = [var 3.01mm, var -1.57mm], end = [var 3.13mm, var 3.12mm])


### PR DESCRIPTION
This also documents the major known issue with KCL 1.0 to try to encourage people to upgrade.