### PR TITLE
Use pulp from crates.io again

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3716,8 +3716,9 @@ dependencies = [
 
 [[package]]
 name = "pulp"
-version = "0.22.2"
-source = "git+https://github.com/KittyCAD/pulp.git?branch=modeling-app#305b28214e3d70de331deb53129f4193dd065cae"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -3732,8 +3733,9 @@ dependencies = [
 
 [[package]]
 name = "pulp-wasm-simd-flag"
-version = "0.1.0"
-source = "git+https://github.com/KittyCAD/pulp.git?branch=modeling-app#305b28214e3d70de331deb53129f4193dd065cae"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
 
 [[package]]
 name = "pxfm"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -90,8 +90,7 @@ insta = { opt-level = 3 }
 debug = "line-tables-only"
 
 #Example: how to point modeling-app at a different repo (e.g. a branch or a local clone)
-[patch.crates-io]
-pulp = { git = "https://github.com/KittyCAD/pulp.git", branch = "modeling-app" }
+# [patch.crates-io]
 # ezpz = { git = "https://github.com/KittyCAD/ezpz.git", branch = "david/circle-circle-tangent" }
 # kittycad-modeling-cmds = { git = "https://github.com/KittyCAD/modeling-api.git", branch = "main" }
 # kittycad-modeling-cmds = { path = "../../modeling-api/modeling-cmds" }


### PR DESCRIPTION
Jon's PR to pulp was merged, so we don't need our fork anymore.

See https://github.com/sarah-quinones/pulp/pull/30

Do we need to test this manually on safari?