### PR TITLE
Move KclError into kcl_error crate

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2307,8 +2307,11 @@ name = "kcl-error"
 version = "0.2.165"
 dependencies = [
  "miette",
+ "pyo3",
+ "schemars",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "ts-rs",
 ]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -48,6 +48,7 @@ rayon = "1.12.0"
 rmp-serde = "1.3.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
+schemars = "0.8.22"
 slog = "2.8.2"
 slog-async = "2.8.0"
 slog-json = "2.6.1"

--- a/rust/kcl-error/Cargo.toml
+++ b/rust/kcl-error/Cargo.toml
@@ -18,6 +18,12 @@ ts-rs = { version = "12.0.1", features = [
   "no-serde-warnings",
   "serde-json-impl",
 ] }
+thiserror = "2.0.18"
+pyo3 = { workspace = true, optional = true }
+schemars = { workspace = true }
 
 [lints]
 workspace = true
+
+[features]
+pyo3 = ["dep:pyo3"]

--- a/rust/kcl-error/src/error.rs
+++ b/rust/kcl-error/src/error.rs
@@ -1,0 +1,417 @@
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+use thiserror::Error;
+
+use crate::CompilationIssue;
+use crate::SourceRange;
+
+const RETRYABLE_ENGINE_MESSAGE_MARKER_SETS: &[&[&str]] = &[
+    &["modeling connection", "interrupted", "please reconnect"],
+    &["modeling connection", "heartbeats", "please reconnect"],
+];
+
+pub trait IsRetryable {
+    /// Returns true if the error is transient and the operation that caused it
+    /// should be retried.
+    fn is_retryable(&self) -> bool;
+}
+
+#[derive(Error, Debug, Serialize, Deserialize, ts_rs::TS, Clone, PartialEq, Eq, JsonSchema)]
+#[ts(export)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum KclError {
+    #[error("lexical: {details:?}")]
+    Lexical { details: KclErrorDetails },
+    #[error("syntax: {details:?}")]
+    Syntax { details: KclErrorDetails },
+    #[error("semantic: {details:?}")]
+    Semantic { details: KclErrorDetails },
+    #[error("import cycle: {details:?}")]
+    ImportCycle { details: KclErrorDetails },
+    #[error("argument: {details:?}")]
+    Argument { details: KclErrorDetails },
+    #[error("type: {details:?}")]
+    Type { details: KclErrorDetails },
+    #[error("i/o: {details:?}")]
+    Io { details: KclErrorDetails },
+    #[error("unexpected: {details:?}")]
+    Unexpected { details: KclErrorDetails },
+    #[error("value already defined: {details:?}")]
+    ValueAlreadyDefined { details: KclErrorDetails },
+    #[error("undefined value: {details:?}")]
+    UndefinedValue {
+        details: KclErrorDetails,
+        name: Option<String>,
+    },
+    #[error("invalid expression: {details:?}")]
+    InvalidExpression { details: KclErrorDetails },
+    #[error("max call stack size exceeded: {details:?}")]
+    MaxCallStack { details: KclErrorDetails },
+    #[error("refactor: {details:?}")]
+    Refactor { details: KclErrorDetails },
+    #[error("engine: {details:?}")]
+    Engine { details: KclErrorDetails },
+    #[error("engine hangup: {details:?}")]
+    EngineHangup {
+        details: KclErrorDetails,
+        api_call_id: Option<String>,
+    },
+    #[error("engine internal: {details:?}")]
+    EngineInternal { details: KclErrorDetails },
+    #[error("internal error, please report to KittyCAD team: {details:?}")]
+    Internal { details: KclErrorDetails },
+}
+
+impl IsRetryable for KclError {
+    fn is_retryable(&self) -> bool {
+        matches!(self, KclError::EngineHangup { .. } | KclError::EngineInternal { .. })
+    }
+}
+#[derive(
+    Debug, Serialize, Deserialize, ts_rs::TS, Clone, PartialEq, Eq, thiserror::Error, miette::Diagnostic, JsonSchema,
+)]
+#[serde(rename_all = "camelCase")]
+#[error("{message}")]
+#[ts(export)]
+pub struct KclErrorDetails {
+    #[label(collection, "Errors")]
+    pub source_ranges: Vec<SourceRange>,
+    pub backtrace: Vec<BacktraceItem>,
+    #[serde(rename = "msg")]
+    pub message: String,
+}
+
+impl KclErrorDetails {
+    pub fn new(message: String, source_ranges: Vec<SourceRange>) -> KclErrorDetails {
+        let backtrace = source_ranges
+            .iter()
+            .map(|s| BacktraceItem {
+                source_range: *s,
+                fn_name: None,
+            })
+            .collect();
+        KclErrorDetails {
+            source_ranges,
+            backtrace,
+            message,
+        }
+    }
+}
+
+impl KclError {
+    pub fn internal(message: String) -> KclError {
+        KclError::Internal {
+            details: KclErrorDetails {
+                source_ranges: Default::default(),
+                backtrace: Default::default(),
+                message,
+            },
+        }
+    }
+
+    pub fn new_internal(details: KclErrorDetails) -> KclError {
+        KclError::Internal { details }
+    }
+
+    pub fn new_import_cycle(details: KclErrorDetails) -> KclError {
+        KclError::ImportCycle { details }
+    }
+
+    pub fn new_argument(details: KclErrorDetails) -> KclError {
+        KclError::Argument { details }
+    }
+
+    pub fn new_semantic(details: KclErrorDetails) -> KclError {
+        KclError::Semantic { details }
+    }
+
+    pub fn new_value_already_defined(details: KclErrorDetails) -> KclError {
+        KclError::ValueAlreadyDefined { details }
+    }
+
+    pub fn new_syntax(details: KclErrorDetails) -> KclError {
+        KclError::Syntax { details }
+    }
+
+    pub fn new_io(details: KclErrorDetails) -> KclError {
+        KclError::Io { details }
+    }
+
+    pub fn new_invalid_expression(details: KclErrorDetails) -> KclError {
+        KclError::InvalidExpression { details }
+    }
+
+    pub fn refactor(message: String) -> KclError {
+        KclError::Refactor {
+            details: KclErrorDetails {
+                source_ranges: Default::default(),
+                backtrace: Default::default(),
+                message,
+            },
+        }
+    }
+
+    pub fn new_engine(details: KclErrorDetails) -> KclError {
+        if details.message.eq_ignore_ascii_case("internal error") {
+            KclError::EngineInternal { details }
+        } else if is_retryable_engine_message(&details.message) {
+            KclError::EngineHangup {
+                details,
+                api_call_id: None,
+            }
+        } else {
+            KclError::Engine { details }
+        }
+    }
+
+    pub fn new_engine_hangup(details: KclErrorDetails, api_call_id: Option<String>) -> KclError {
+        KclError::EngineHangup { details, api_call_id }
+    }
+
+    pub fn new_lexical(details: KclErrorDetails) -> KclError {
+        KclError::Lexical { details }
+    }
+
+    pub fn new_undefined_value(details: KclErrorDetails, name: Option<String>) -> KclError {
+        KclError::UndefinedValue { details, name }
+    }
+
+    pub fn new_type(details: KclErrorDetails) -> KclError {
+        KclError::Type { details }
+    }
+
+    pub fn is_undefined_value(&self) -> bool {
+        matches!(self, KclError::UndefinedValue { .. })
+    }
+
+    /// Get the error message.
+    pub fn get_message(&self) -> String {
+        format!("{}: {}", self.error_type(), self.message())
+    }
+
+    pub fn error_type(&self) -> &'static str {
+        match self {
+            KclError::Lexical { .. } => "lexical",
+            KclError::Syntax { .. } => "syntax",
+            KclError::Semantic { .. } => "semantic",
+            KclError::ImportCycle { .. } => "import cycle",
+            KclError::Argument { .. } => "argument",
+            KclError::Type { .. } => "type",
+            KclError::Io { .. } => "i/o",
+            KclError::Unexpected { .. } => "unexpected",
+            KclError::ValueAlreadyDefined { .. } => "value already defined",
+            KclError::UndefinedValue { .. } => "undefined value",
+            KclError::InvalidExpression { .. } => "invalid expression",
+            KclError::MaxCallStack { .. } => "max call stack",
+            KclError::Refactor { .. } => "refactor",
+            KclError::Engine { .. } => "engine",
+            KclError::EngineHangup { .. } => "engine hangup",
+            KclError::EngineInternal { .. } => "engine internal",
+            KclError::Internal { .. } => "internal",
+        }
+    }
+
+    pub fn source_ranges(&self) -> Vec<SourceRange> {
+        match &self {
+            KclError::Lexical { details: e } => e.source_ranges.clone(),
+            KclError::Syntax { details: e } => e.source_ranges.clone(),
+            KclError::Semantic { details: e } => e.source_ranges.clone(),
+            KclError::ImportCycle { details: e } => e.source_ranges.clone(),
+            KclError::Argument { details: e } => e.source_ranges.clone(),
+            KclError::Type { details: e } => e.source_ranges.clone(),
+            KclError::Io { details: e } => e.source_ranges.clone(),
+            KclError::Unexpected { details: e } => e.source_ranges.clone(),
+            KclError::ValueAlreadyDefined { details: e } => e.source_ranges.clone(),
+            KclError::UndefinedValue { details: e, .. } => e.source_ranges.clone(),
+            KclError::InvalidExpression { details: e } => e.source_ranges.clone(),
+            KclError::MaxCallStack { details: e } => e.source_ranges.clone(),
+            KclError::Refactor { details: e } => e.source_ranges.clone(),
+            KclError::Engine { details: e } => e.source_ranges.clone(),
+            KclError::EngineHangup { details: e, .. } => e.source_ranges.clone(),
+            KclError::EngineInternal { details: e } => e.source_ranges.clone(),
+            KclError::Internal { details: e } => e.source_ranges.clone(),
+        }
+    }
+
+    /// Get the inner error message.
+    pub fn message(&self) -> &str {
+        match &self {
+            KclError::Lexical { details: e } => &e.message,
+            KclError::Syntax { details: e } => &e.message,
+            KclError::Semantic { details: e } => &e.message,
+            KclError::ImportCycle { details: e } => &e.message,
+            KclError::Argument { details: e } => &e.message,
+            KclError::Type { details: e } => &e.message,
+            KclError::Io { details: e } => &e.message,
+            KclError::Unexpected { details: e } => &e.message,
+            KclError::ValueAlreadyDefined { details: e } => &e.message,
+            KclError::UndefinedValue { details: e, .. } => &e.message,
+            KclError::InvalidExpression { details: e } => &e.message,
+            KclError::MaxCallStack { details: e } => &e.message,
+            KclError::Refactor { details: e } => &e.message,
+            KclError::Engine { details: e } => &e.message,
+            KclError::EngineHangup { details: e, .. } => &e.message,
+            KclError::EngineInternal { details: e } => &e.message,
+            KclError::Internal { details: e } => &e.message,
+        }
+    }
+
+    pub fn backtrace(&self) -> Vec<BacktraceItem> {
+        match self {
+            KclError::Lexical { details: e }
+            | KclError::Syntax { details: e }
+            | KclError::Semantic { details: e }
+            | KclError::ImportCycle { details: e }
+            | KclError::Argument { details: e }
+            | KclError::Type { details: e }
+            | KclError::Io { details: e }
+            | KclError::Unexpected { details: e }
+            | KclError::ValueAlreadyDefined { details: e }
+            | KclError::UndefinedValue { details: e, .. }
+            | KclError::InvalidExpression { details: e }
+            | KclError::MaxCallStack { details: e }
+            | KclError::Refactor { details: e }
+            | KclError::Engine { details: e }
+            | KclError::EngineHangup { details: e, .. }
+            | KclError::EngineInternal { details: e }
+            | KclError::Internal { details: e } => e.backtrace.clone(),
+        }
+    }
+
+    pub fn override_source_ranges(&self, source_ranges: Vec<SourceRange>) -> Self {
+        let mut new = self.clone();
+        match &mut new {
+            KclError::Lexical { details: e }
+            | KclError::Syntax { details: e }
+            | KclError::Semantic { details: e }
+            | KclError::ImportCycle { details: e }
+            | KclError::Argument { details: e }
+            | KclError::Type { details: e }
+            | KclError::Io { details: e }
+            | KclError::Unexpected { details: e }
+            | KclError::ValueAlreadyDefined { details: e }
+            | KclError::UndefinedValue { details: e, .. }
+            | KclError::InvalidExpression { details: e }
+            | KclError::MaxCallStack { details: e }
+            | KclError::Refactor { details: e }
+            | KclError::Engine { details: e }
+            | KclError::EngineHangup { details: e, .. }
+            | KclError::EngineInternal { details: e }
+            | KclError::Internal { details: e } => {
+                e.backtrace = source_ranges
+                    .iter()
+                    .map(|s| BacktraceItem {
+                        source_range: *s,
+                        fn_name: None,
+                    })
+                    .collect();
+                e.source_ranges = source_ranges;
+            }
+        }
+
+        new
+    }
+
+    pub fn add_unwind_location(&self, last_fn_name: Option<String>, source_range: SourceRange) -> Self {
+        let mut new = self.clone();
+        match &mut new {
+            KclError::Lexical { details: e }
+            | KclError::Syntax { details: e }
+            | KclError::Semantic { details: e }
+            | KclError::ImportCycle { details: e }
+            | KclError::Argument { details: e }
+            | KclError::Type { details: e }
+            | KclError::Io { details: e }
+            | KclError::Unexpected { details: e }
+            | KclError::ValueAlreadyDefined { details: e }
+            | KclError::UndefinedValue { details: e, .. }
+            | KclError::InvalidExpression { details: e }
+            | KclError::MaxCallStack { details: e }
+            | KclError::Refactor { details: e }
+            | KclError::Engine { details: e }
+            | KclError::EngineHangup { details: e, .. }
+            | KclError::EngineInternal { details: e }
+            | KclError::Internal { details: e } => {
+                if let Some(item) = e.backtrace.last_mut() {
+                    item.fn_name = last_fn_name;
+                }
+                e.backtrace.push(BacktraceItem {
+                    source_range,
+                    fn_name: None,
+                });
+                e.source_ranges.push(source_range);
+            }
+        }
+
+        new
+    }
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS, thiserror::Error, miette::Diagnostic, JsonSchema,
+)]
+#[serde(rename_all = "camelCase")]
+#[ts(export)]
+pub struct BacktraceItem {
+    pub source_range: SourceRange,
+    pub fn_name: Option<String>,
+}
+
+impl std::fmt::Display for BacktraceItem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(fn_name) = &self.fn_name {
+            write!(f, "{fn_name}: {:?}", self.source_range)
+        } else {
+            write!(f, "(fn): {:?}", self.source_range)
+        }
+    }
+}
+
+fn is_retryable_engine_message(message: &str) -> bool {
+    // TODO: Replace string matching with structured engine/API retry metadata once it is available.
+    let message = message.to_ascii_lowercase();
+    RETRYABLE_ENGINE_MESSAGE_MARKER_SETS
+        .iter()
+        .any(|markers| markers.iter().all(|marker| message.contains(marker)))
+}
+
+/// This is different than to_string() in that it will serialize the Error
+/// the struct as JSON so we can deserialize it on the js side.
+impl From<KclError> for String {
+    fn from(error: KclError) -> Self {
+        serde_json::to_string(&error).unwrap()
+    }
+}
+
+impl From<CompilationIssue> for KclErrorDetails {
+    fn from(err: CompilationIssue) -> Self {
+        let backtrace = vec![BacktraceItem {
+            source_range: err.source_range,
+            fn_name: None,
+        }];
+        KclErrorDetails {
+            source_ranges: vec![err.source_range],
+            backtrace,
+            message: err.message,
+        }
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl From<pyo3::PyErr> for KclError {
+    fn from(error: pyo3::PyErr) -> Self {
+        KclError::new_internal(KclErrorDetails {
+            source_ranges: vec![],
+            backtrace: Default::default(),
+            message: error.to_string(),
+        })
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl From<KclError> for pyo3::PyErr {
+    fn from(error: KclError) -> Self {
+        pyo3::exceptions::PyException::new_err(error.to_string())
+    }
+}

--- a/rust/kcl-error/src/lib.rs
+++ b/rust/kcl-error/src/lib.rs
@@ -1,13 +1,19 @@
+pub use error::BacktraceItem;
+pub use error::IsRetryable;
+pub use error::KclError;
+pub use error::KclErrorDetails;
+use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 pub use source_range::ModuleId;
 pub use source_range::SourceRange;
 
+mod error;
 mod source_range;
 
 /// An issue which occurred during parsing, etc. The severity determines whether
 /// it's an error, warning, or other kind of issue.
-#[derive(Debug, Clone, Serialize, Deserialize, ts_rs::TS, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, ts_rs::TS, PartialEq, Eq, JsonSchema)]
 #[ts(export)]
 pub struct CompilationIssue {
     #[serde(rename = "sourceRange")]
@@ -74,7 +80,7 @@ impl CompilationIssue {
     }
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, ts_rs::TS)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, ts_rs::TS, JsonSchema)]
 #[ts(export)]
 pub enum Severity {
     Warning,
@@ -107,7 +113,7 @@ impl Severity {
     }
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, ts_rs::TS)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, ts_rs::TS, JsonSchema)]
 #[ts(export)]
 pub enum Tag {
     Deprecated,
@@ -116,7 +122,7 @@ pub enum Tag {
     None,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ts_rs::TS, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, ts_rs::TS, PartialEq, Eq, JsonSchema)]
 #[ts(export)]
 pub struct Suggestion {
     pub title: String,

--- a/rust/kcl-error/src/source_range.rs
+++ b/rust/kcl-error/src/source_range.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -37,7 +38,7 @@ impl std::fmt::Display for ModuleId {
 // Don't use a doc comment for the below since the above goes in the website docs.
 // @see isTopLevelModule() in wasm.ts.
 // TODO we need to handle modules better in the frontend.
-#[derive(Debug, Default, Deserialize, Serialize, PartialEq, Copy, Clone, ts_rs::TS, Hash, Eq)]
+#[derive(Debug, Default, Deserialize, Serialize, PartialEq, Copy, Clone, ts_rs::TS, Hash, Eq, JsonSchema)]
 #[ts(export, type = "[number, number, number]")]
 pub struct SourceRange([usize; 3]);
 

--- a/rust/kcl-lib/src/errors.rs
+++ b/rust/kcl-lib/src/errors.rs
@@ -1,11 +1,14 @@
 use std::collections::BTreeMap;
 
 use indexmap::IndexMap;
+pub use kcl_error::BacktraceItem;
 pub use kcl_error::CompilationIssue;
+pub use kcl_error::IsRetryable;
+pub use kcl_error::KclError;
+pub use kcl_error::KclErrorDetails;
 pub use kcl_error::Severity;
 pub use kcl_error::Suggestion;
 pub use kcl_error::Tag;
-use serde::Deserialize;
 use serde::Serialize;
 use thiserror::Error;
 use tower_lsp::lsp_types::Diagnostic;
@@ -29,12 +32,6 @@ use crate::lsp::IntoDiagnostic;
 use crate::lsp::ToLspRange;
 use crate::modules::ModulePath;
 use crate::modules::ModuleSource;
-
-pub trait IsRetryable {
-    /// Returns true if the error is transient and the operation that caused it
-    /// should be retried.
-    fn is_retryable(&self) -> bool;
-}
 
 /// How did the KCL execution fail
 #[derive(thiserror::Error, Debug)]
@@ -135,75 +132,10 @@ pub enum ConnectionError {
     Establishing(anyhow::Error),
 }
 
-#[derive(Error, Debug, Serialize, Deserialize, ts_rs::TS, Clone, PartialEq, Eq)]
-#[ts(export)]
-#[serde(tag = "kind", rename_all = "snake_case")]
-pub enum KclError {
-    #[error("lexical: {details:?}")]
-    Lexical { details: KclErrorDetails },
-    #[error("syntax: {details:?}")]
-    Syntax { details: KclErrorDetails },
-    #[error("semantic: {details:?}")]
-    Semantic { details: KclErrorDetails },
-    #[error("import cycle: {details:?}")]
-    ImportCycle { details: KclErrorDetails },
-    #[error("argument: {details:?}")]
-    Argument { details: KclErrorDetails },
-    #[error("type: {details:?}")]
-    Type { details: KclErrorDetails },
-    #[error("i/o: {details:?}")]
-    Io { details: KclErrorDetails },
-    #[error("unexpected: {details:?}")]
-    Unexpected { details: KclErrorDetails },
-    #[error("value already defined: {details:?}")]
-    ValueAlreadyDefined { details: KclErrorDetails },
-    #[error("undefined value: {details:?}")]
-    UndefinedValue {
-        details: KclErrorDetails,
-        name: Option<String>,
-    },
-    #[error("invalid expression: {details:?}")]
-    InvalidExpression { details: KclErrorDetails },
-    #[error("max call stack size exceeded: {details:?}")]
-    MaxCallStack { details: KclErrorDetails },
-    #[error("refactor: {details:?}")]
-    Refactor { details: KclErrorDetails },
-    #[error("engine: {details:?}")]
-    Engine { details: KclErrorDetails },
-    #[error("engine hangup: {details:?}")]
-    EngineHangup {
-        details: KclErrorDetails,
-        api_call_id: Option<String>,
-    },
-    #[error("engine internal: {details:?}")]
-    EngineInternal { details: KclErrorDetails },
-    #[error("internal error, please report to KittyCAD team: {details:?}")]
-    Internal { details: KclErrorDetails },
-}
-
 impl From<KclErrorWithOutputs> for KclError {
     fn from(error: KclErrorWithOutputs) -> Self {
         error.error
     }
-}
-
-impl IsRetryable for KclError {
-    fn is_retryable(&self) -> bool {
-        matches!(self, KclError::EngineHangup { .. } | KclError::EngineInternal { .. })
-    }
-}
-
-const RETRYABLE_ENGINE_MESSAGE_MARKER_SETS: &[&[&str]] = &[
-    &["modeling connection", "interrupted", "please reconnect"],
-    &["modeling connection", "heartbeats", "please reconnect"],
-];
-
-fn is_retryable_engine_message(message: &str) -> bool {
-    // TODO: Replace string matching with structured engine/API retry metadata once it is available.
-    let message = message.to_ascii_lowercase();
-    RETRYABLE_ENGINE_MESSAGE_MARKER_SETS
-        .iter()
-        .any(|markers| markers.iter().all(|marker| message.contains(marker)))
 }
 
 #[derive(Error, Debug, Serialize, ts_rs::TS, Clone, PartialEq)]
@@ -580,302 +512,6 @@ pub fn render_compilation_issue_miette(filename: &str, source: &str, issue: Comp
     format!("{report:?}")
 }
 
-#[derive(Debug, Serialize, Deserialize, ts_rs::TS, Clone, PartialEq, Eq, thiserror::Error, miette::Diagnostic)]
-#[serde(rename_all = "camelCase")]
-#[error("{message}")]
-#[ts(export)]
-pub struct KclErrorDetails {
-    #[label(collection, "Errors")]
-    pub source_ranges: Vec<SourceRange>,
-    pub backtrace: Vec<super::BacktraceItem>,
-    #[serde(rename = "msg")]
-    pub message: String,
-}
-
-impl KclErrorDetails {
-    pub fn new(message: String, source_ranges: Vec<SourceRange>) -> KclErrorDetails {
-        let backtrace = source_ranges
-            .iter()
-            .map(|s| BacktraceItem {
-                source_range: *s,
-                fn_name: None,
-            })
-            .collect();
-        KclErrorDetails {
-            source_ranges,
-            backtrace,
-            message,
-        }
-    }
-}
-
-impl KclError {
-    pub fn internal(message: String) -> KclError {
-        KclError::Internal {
-            details: KclErrorDetails {
-                source_ranges: Default::default(),
-                backtrace: Default::default(),
-                message,
-            },
-        }
-    }
-
-    pub fn new_internal(details: KclErrorDetails) -> KclError {
-        KclError::Internal { details }
-    }
-
-    pub fn new_import_cycle(details: KclErrorDetails) -> KclError {
-        KclError::ImportCycle { details }
-    }
-
-    pub fn new_argument(details: KclErrorDetails) -> KclError {
-        KclError::Argument { details }
-    }
-
-    pub fn new_semantic(details: KclErrorDetails) -> KclError {
-        KclError::Semantic { details }
-    }
-
-    pub fn new_value_already_defined(details: KclErrorDetails) -> KclError {
-        KclError::ValueAlreadyDefined { details }
-    }
-
-    pub fn new_syntax(details: KclErrorDetails) -> KclError {
-        KclError::Syntax { details }
-    }
-
-    pub fn new_io(details: KclErrorDetails) -> KclError {
-        KclError::Io { details }
-    }
-
-    pub fn new_invalid_expression(details: KclErrorDetails) -> KclError {
-        KclError::InvalidExpression { details }
-    }
-
-    pub fn refactor(message: String) -> KclError {
-        KclError::Refactor {
-            details: KclErrorDetails {
-                source_ranges: Default::default(),
-                backtrace: Default::default(),
-                message,
-            },
-        }
-    }
-
-    pub fn new_engine(details: KclErrorDetails) -> KclError {
-        if details.message.eq_ignore_ascii_case("internal error") {
-            KclError::EngineInternal { details }
-        } else if is_retryable_engine_message(&details.message) {
-            KclError::EngineHangup {
-                details,
-                api_call_id: None,
-            }
-        } else {
-            KclError::Engine { details }
-        }
-    }
-
-    pub fn new_engine_hangup(details: KclErrorDetails, api_call_id: Option<String>) -> KclError {
-        KclError::EngineHangup { details, api_call_id }
-    }
-
-    pub fn new_lexical(details: KclErrorDetails) -> KclError {
-        KclError::Lexical { details }
-    }
-
-    pub fn new_undefined_value(details: KclErrorDetails, name: Option<String>) -> KclError {
-        KclError::UndefinedValue { details, name }
-    }
-
-    pub fn new_type(details: KclErrorDetails) -> KclError {
-        KclError::Type { details }
-    }
-
-    pub fn is_undefined_value(&self) -> bool {
-        matches!(self, KclError::UndefinedValue { .. })
-    }
-
-    /// Get the error message.
-    pub fn get_message(&self) -> String {
-        format!("{}: {}", self.error_type(), self.message())
-    }
-
-    pub fn error_type(&self) -> &'static str {
-        match self {
-            KclError::Lexical { .. } => "lexical",
-            KclError::Syntax { .. } => "syntax",
-            KclError::Semantic { .. } => "semantic",
-            KclError::ImportCycle { .. } => "import cycle",
-            KclError::Argument { .. } => "argument",
-            KclError::Type { .. } => "type",
-            KclError::Io { .. } => "i/o",
-            KclError::Unexpected { .. } => "unexpected",
-            KclError::ValueAlreadyDefined { .. } => "value already defined",
-            KclError::UndefinedValue { .. } => "undefined value",
-            KclError::InvalidExpression { .. } => "invalid expression",
-            KclError::MaxCallStack { .. } => "max call stack",
-            KclError::Refactor { .. } => "refactor",
-            KclError::Engine { .. } => "engine",
-            KclError::EngineHangup { .. } => "engine hangup",
-            KclError::EngineInternal { .. } => "engine internal",
-            KclError::Internal { .. } => "internal",
-        }
-    }
-
-    pub fn source_ranges(&self) -> Vec<SourceRange> {
-        match &self {
-            KclError::Lexical { details: e } => e.source_ranges.clone(),
-            KclError::Syntax { details: e } => e.source_ranges.clone(),
-            KclError::Semantic { details: e } => e.source_ranges.clone(),
-            KclError::ImportCycle { details: e } => e.source_ranges.clone(),
-            KclError::Argument { details: e } => e.source_ranges.clone(),
-            KclError::Type { details: e } => e.source_ranges.clone(),
-            KclError::Io { details: e } => e.source_ranges.clone(),
-            KclError::Unexpected { details: e } => e.source_ranges.clone(),
-            KclError::ValueAlreadyDefined { details: e } => e.source_ranges.clone(),
-            KclError::UndefinedValue { details: e, .. } => e.source_ranges.clone(),
-            KclError::InvalidExpression { details: e } => e.source_ranges.clone(),
-            KclError::MaxCallStack { details: e } => e.source_ranges.clone(),
-            KclError::Refactor { details: e } => e.source_ranges.clone(),
-            KclError::Engine { details: e } => e.source_ranges.clone(),
-            KclError::EngineHangup { details: e, .. } => e.source_ranges.clone(),
-            KclError::EngineInternal { details: e } => e.source_ranges.clone(),
-            KclError::Internal { details: e } => e.source_ranges.clone(),
-        }
-    }
-
-    /// Get the inner error message.
-    pub fn message(&self) -> &str {
-        match &self {
-            KclError::Lexical { details: e } => &e.message,
-            KclError::Syntax { details: e } => &e.message,
-            KclError::Semantic { details: e } => &e.message,
-            KclError::ImportCycle { details: e } => &e.message,
-            KclError::Argument { details: e } => &e.message,
-            KclError::Type { details: e } => &e.message,
-            KclError::Io { details: e } => &e.message,
-            KclError::Unexpected { details: e } => &e.message,
-            KclError::ValueAlreadyDefined { details: e } => &e.message,
-            KclError::UndefinedValue { details: e, .. } => &e.message,
-            KclError::InvalidExpression { details: e } => &e.message,
-            KclError::MaxCallStack { details: e } => &e.message,
-            KclError::Refactor { details: e } => &e.message,
-            KclError::Engine { details: e } => &e.message,
-            KclError::EngineHangup { details: e, .. } => &e.message,
-            KclError::EngineInternal { details: e } => &e.message,
-            KclError::Internal { details: e } => &e.message,
-        }
-    }
-
-    pub fn backtrace(&self) -> Vec<BacktraceItem> {
-        match self {
-            KclError::Lexical { details: e }
-            | KclError::Syntax { details: e }
-            | KclError::Semantic { details: e }
-            | KclError::ImportCycle { details: e }
-            | KclError::Argument { details: e }
-            | KclError::Type { details: e }
-            | KclError::Io { details: e }
-            | KclError::Unexpected { details: e }
-            | KclError::ValueAlreadyDefined { details: e }
-            | KclError::UndefinedValue { details: e, .. }
-            | KclError::InvalidExpression { details: e }
-            | KclError::MaxCallStack { details: e }
-            | KclError::Refactor { details: e }
-            | KclError::Engine { details: e }
-            | KclError::EngineHangup { details: e, .. }
-            | KclError::EngineInternal { details: e }
-            | KclError::Internal { details: e } => e.backtrace.clone(),
-        }
-    }
-
-    pub(crate) fn override_source_ranges(&self, source_ranges: Vec<SourceRange>) -> Self {
-        let mut new = self.clone();
-        match &mut new {
-            KclError::Lexical { details: e }
-            | KclError::Syntax { details: e }
-            | KclError::Semantic { details: e }
-            | KclError::ImportCycle { details: e }
-            | KclError::Argument { details: e }
-            | KclError::Type { details: e }
-            | KclError::Io { details: e }
-            | KclError::Unexpected { details: e }
-            | KclError::ValueAlreadyDefined { details: e }
-            | KclError::UndefinedValue { details: e, .. }
-            | KclError::InvalidExpression { details: e }
-            | KclError::MaxCallStack { details: e }
-            | KclError::Refactor { details: e }
-            | KclError::Engine { details: e }
-            | KclError::EngineHangup { details: e, .. }
-            | KclError::EngineInternal { details: e }
-            | KclError::Internal { details: e } => {
-                e.backtrace = source_ranges
-                    .iter()
-                    .map(|s| BacktraceItem {
-                        source_range: *s,
-                        fn_name: None,
-                    })
-                    .collect();
-                e.source_ranges = source_ranges;
-            }
-        }
-
-        new
-    }
-
-    pub(crate) fn add_unwind_location(&self, last_fn_name: Option<String>, source_range: SourceRange) -> Self {
-        let mut new = self.clone();
-        match &mut new {
-            KclError::Lexical { details: e }
-            | KclError::Syntax { details: e }
-            | KclError::Semantic { details: e }
-            | KclError::ImportCycle { details: e }
-            | KclError::Argument { details: e }
-            | KclError::Type { details: e }
-            | KclError::Io { details: e }
-            | KclError::Unexpected { details: e }
-            | KclError::ValueAlreadyDefined { details: e }
-            | KclError::UndefinedValue { details: e, .. }
-            | KclError::InvalidExpression { details: e }
-            | KclError::MaxCallStack { details: e }
-            | KclError::Refactor { details: e }
-            | KclError::Engine { details: e }
-            | KclError::EngineHangup { details: e, .. }
-            | KclError::EngineInternal { details: e }
-            | KclError::Internal { details: e } => {
-                if let Some(item) = e.backtrace.last_mut() {
-                    item.fn_name = last_fn_name;
-                }
-                e.backtrace.push(BacktraceItem {
-                    source_range,
-                    fn_name: None,
-                });
-                e.source_ranges.push(source_range);
-            }
-        }
-
-        new
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS, thiserror::Error, miette::Diagnostic)]
-#[serde(rename_all = "camelCase")]
-#[ts(export)]
-pub struct BacktraceItem {
-    pub source_range: SourceRange,
-    pub fn_name: Option<String>,
-}
-
-impl std::fmt::Display for BacktraceItem {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(fn_name) = &self.fn_name {
-            write!(f, "{fn_name}: {:?}", self.source_range)
-        } else {
-            write!(f, "(fn): {:?}", self.source_range)
-        }
-    }
-}
-
 impl IntoDiagnostic for KclError {
     fn to_lsp_diagnostics(&self, code: &str) -> Vec<Diagnostic> {
         let message = self.get_message();
@@ -909,52 +545,6 @@ impl IntoDiagnostic for KclError {
 
     fn severity(&self) -> DiagnosticSeverity {
         DiagnosticSeverity::ERROR
-    }
-}
-
-/// This is different than to_string() in that it will serialize the Error
-/// the struct as JSON so we can deserialize it on the js side.
-impl From<KclError> for String {
-    fn from(error: KclError) -> Self {
-        serde_json::to_string(&error).unwrap()
-    }
-}
-
-impl From<String> for KclError {
-    fn from(error: String) -> Self {
-        serde_json::from_str(&error).unwrap()
-    }
-}
-
-#[cfg(feature = "pyo3")]
-impl From<pyo3::PyErr> for KclError {
-    fn from(error: pyo3::PyErr) -> Self {
-        KclError::new_internal(KclErrorDetails {
-            source_ranges: vec![],
-            backtrace: Default::default(),
-            message: error.to_string(),
-        })
-    }
-}
-
-#[cfg(feature = "pyo3")]
-impl From<KclError> for pyo3::PyErr {
-    fn from(error: KclError) -> Self {
-        pyo3::exceptions::PyException::new_err(error.to_string())
-    }
-}
-
-impl From<CompilationIssue> for KclErrorDetails {
-    fn from(err: CompilationIssue) -> Self {
-        let backtrace = vec![BacktraceItem {
-            source_range: err.source_range,
-            fn_name: None,
-        }];
-        KclErrorDetails {
-            source_ranges: vec![err.source_range],
-            backtrace,
-            message: err.message,
-        }
     }
 }
 

--- a/rust/kcl-lib/src/parsing/token/mod.rs
+++ b/rust/kcl-lib/src/parsing/token/mod.rs
@@ -7,12 +7,11 @@ use std::num::NonZeroUsize;
 use std::str::FromStr;
 
 use anyhow::Result;
+use kcl_error::KclErrorDetails;
 use parse_display::Display;
 use serde::Deserialize;
 use serde::Serialize;
-use tokeniser::Input;
 use tower_lsp::lsp_types::SemanticTokenType;
-use winnow::error::ParseError;
 use winnow::stream::ContainsToken;
 use winnow::stream::Stream;
 use winnow::{self};
@@ -589,11 +588,7 @@ impl From<&Token> for SourceRange {
 }
 
 pub fn lex(s: &str, module_id: ModuleId) -> Result<TokenStream, KclError> {
-    tokeniser::lex(s, module_id).map_err(From::from)
-}
-
-impl From<ParseError<Input<'_>, winnow::error::ContextError>> for KclError {
-    fn from(err: ParseError<Input<'_>, winnow::error::ContextError>) -> Self {
+    tokeniser::lex(s, module_id).map_err(|err| {
         let (input, offset): (Vec<char>, usize) = (err.input().chars().collect(), err.offset());
         let module_id = err.input().state.module_id;
 
@@ -603,7 +598,7 @@ impl From<ParseError<Input<'_>, winnow::error::ContextError>> for KclError {
             // This is an offset, not an index, and may point to
             // the end of input (input.len()) on eof errors.
 
-            return KclError::new_lexical(crate::errors::KclErrorDetails::new(
+            return KclError::new_lexical(KclErrorDetails::new(
                 "unexpected EOF while parsing".to_owned(),
                 vec![SourceRange::new(offset, offset, module_id)],
             ));
@@ -614,9 +609,9 @@ impl From<ParseError<Input<'_>, winnow::error::ContextError>> for KclError {
         let bad_token = &input[offset];
         // TODO: Add the Winnow parser context to the error.
         // See https://github.com/KittyCAD/modeling-app/issues/784
-        KclError::new_lexical(crate::errors::KclErrorDetails::new(
+        KclError::new_lexical(KclErrorDetails::new(
             format!("found unknown token '{bad_token}'"),
             vec![SourceRange::new(offset, offset + 1, module_id)],
         ))
-    }
+    })
 }


### PR DESCRIPTION
This is part of the effort to run KCL on the engine (https://github.com/KittyCAD/modeling-app/issues/12236). If the engine executes KCL, and that KCL has an error, then the engine needs to serialize the KclError into JSON and send it back over the wire. That means the kittycad-modeling-cmds crate needs to know the KclError type, which means moving it out of kcl-lib to avoid an import cycle.

<img height="400" alt="Screenshot 2026-06-24 at 4 08 04 PM" src="https://github.com/user-attachments/assets/e9e1d7f9-227d-49e2-8276-fc565990861d" />

Used in https://github.com/KittyCAD/modeling-api/pull/1253