### PR TITLE
fix: `code/env` was reported at the wrong time

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,6 @@ import toast, { Toaster } from 'react-hot-toast'
 import { HotkeysProvider } from 'react-hotkeys-hook'
 import ModalContainer from 'react-modal-promise'
 import '@src/index.css'
-import env from '@src/env'
 import type { App } from '@src/lib/app'
 import {
   clearAutoUpdateDownloadProgress,
@@ -35,20 +34,6 @@ function launchApp(app: App) {
 /** initialize behaviors that rely on singletons */
 function initSingletonBehavior(app: App) {
   const { singletons } = app
-  markOnce('code/env', {
-    name: 'code/env',
-    startTime: performance.now(),
-    entryType: 'mark',
-    detail: {
-      env: {
-        NODE_ENV: env().NODE_ENV,
-        VITE_ZOO_BASE_DOMAIN: env().VITE_ZOO_BASE_DOMAIN,
-        VITE_ZOO_API_BASE_URL: env().VITE_ZOO_API_BASE_URL,
-        VITE_KITTYCAD_WEBSOCKET_URL: env().VITE_KITTYCAD_WEBSOCKET_URL,
-        VITE_MLEPHANT_WEBSOCKET_URL: env().VITE_MLEPHANT_WEBSOCKET_URL,
-      },
-    },
-  })
   markOnce('code/willAuth')
   initializeWindowExceptionHandler(singletons.kclManager)
 

--- a/src/machines/authMachine.ts
+++ b/src/machines/authMachine.ts
@@ -27,7 +27,7 @@ import {
 } from '@src/lib/desktop'
 import { isDesktop } from '@src/lib/isDesktop'
 import { createKCClient, kcCall } from '@src/lib/kcClient'
-import { markOnce } from '@src/lib/performance'
+import { mark, markOnce } from '@src/lib/performance'
 import { withAPIBaseURL } from '@src/lib/withBaseURL'
 import { assign, fromPromise, setup } from 'xstate'
 
@@ -165,6 +165,20 @@ async function getUser(input: { token?: string }) {
   const environment =
     (await readEnvironmentFile()) || env().VITE_ZOO_BASE_DOMAIN || ''
   updateEnvironment(environment)
+  mark('config/env', {
+    name: 'config/env',
+    startTime: performance.now(),
+    entryType: 'mark',
+    detail: {
+      env: {
+        NODE_ENV: env().NODE_ENV,
+        VITE_ZOO_BASE_DOMAIN: env().VITE_ZOO_BASE_DOMAIN,
+        VITE_ZOO_API_BASE_URL: env().VITE_ZOO_API_BASE_URL,
+        VITE_KITTYCAD_WEBSOCKET_URL: env().VITE_KITTYCAD_WEBSOCKET_URL,
+        VITE_MLEPHANT_WEBSOCKET_URL: env().VITE_MLEPHANT_WEBSOCKET_URL,
+      },
+    },
+  })
 
   // Update the Engine WebSocket URL override
   const cachedKittycadWebSocketUrl =

--- a/src/network/connection.ts
+++ b/src/network/connection.ts
@@ -3,7 +3,6 @@ import type {
   WebSocketRequest,
   WebSocketResponse,
 } from '@kittycad/lib/dist/types/src'
-import env from '@src/env'
 import { EngineDebugger } from '@src/lib/debugger'
 import { markOnce } from '@src/lib/performance'
 import { promiseFactory, uuidv4 } from '@src/lib/utils'

--- a/src/network/connection.ts
+++ b/src/network/connection.ts
@@ -3,6 +3,7 @@ import type {
   WebSocketRequest,
   WebSocketResponse,
 } from '@kittycad/lib/dist/types/src'
+import env from '@src/env'
 import { EngineDebugger } from '@src/lib/debugger'
 import { markOnce } from '@src/lib/performance'
 import { promiseFactory, uuidv4 } from '@src/lib/utils'

--- a/src/routes/SignIn.tsx
+++ b/src/routes/SignIn.tsx
@@ -15,6 +15,7 @@ import { APP_NAME } from '@src/lib/constants'
 import { readEnvironmentFile, writeEnvironmentFile } from '@src/lib/desktop'
 import { isDesktop } from '@src/lib/isDesktop'
 import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
+import { mark } from '@src/lib/performance'
 import { Themes, getSystemTheme } from '@src/lib/theme'
 import { reportRejection } from '@src/lib/trap'
 import { returnSelfOrGetHostNameFromURL, toSync } from '@src/lib/utils'
@@ -121,6 +122,20 @@ const SignIn = () => {
     signInAttemptRef.current = signInAttempt
     const requestedEnvironment = selectedEnvironment.trim()
     updateEnvironment(requestedEnvironment)
+    mark('config/env', {
+      name: 'config/env',
+      startTime: performance.now(),
+      entryType: 'mark',
+      detail: {
+        env: {
+          NODE_ENV: env().NODE_ENV,
+          VITE_ZOO_BASE_DOMAIN: env().VITE_ZOO_BASE_DOMAIN,
+          VITE_ZOO_API_BASE_URL: env().VITE_ZOO_API_BASE_URL,
+          VITE_KITTYCAD_WEBSOCKET_URL: env().VITE_KITTYCAD_WEBSOCKET_URL,
+          VITE_MLEPHANT_WEBSOCKET_URL: env().VITE_MLEPHANT_WEBSOCKET_URL,
+        },
+      },
+    })
     setUserCode('')
     setVerificationUri('')
 


### PR DESCRIPTION
# Issue

When the application boots if you call `env()` too early it can be the default values of the binary build. When you use the production binary it should default to `zoo.dev` but you could have your last local environment file be `dev.zoo.dev`. When the application boots it needs to read this cached file on your disk to say "what was the last logged in environment"

The issue was, I used `markOnce` at the start of the app boot so it was always the wrong configuration.

# Fix

- renamed it to `config/env` from `code/env` 
- I changed `markOnce` to `mark`
- I added multiple `mark` locations whenever the environment was updated dynamically when the application boots and reads the last logged in environment

# Screenshots

Bug, you can see I am in `zoo.dev` but the `env()` on the staging build ran too early and defaulted to the development environment.
<img width="1169" height="815" alt="Screenshot from 2026-06-25 11-14-14" src="https://github.com/user-attachments/assets/74ad2bde-9a88-43c9-8c03-63008b4f28e5" />

I debugged the staging binary and put a breakpoint to confirm the function `Jr()` which is the `env()` function was asking for the value too quickly. 
<img width="1169" height="815" alt="Screenshot from 2026-06-25 11-18-56" src="https://github.com/user-attachments/assets/ad23bd66-126e-4b2a-9417-a770ad2da03a" />

Now we have multiple `config/env`
<img width="817" height="689" alt="Screenshot from 2026-06-25 11-35-14" src="https://github.com/user-attachments/assets/f3afb72c-e101-4de6-a5cc-b809fc42fd53" />
