### PR TITLE
Fix Zookeeper composer controls overlapping at narrow widths

### DIFF
--- a/src/components/MlEphantConversation.tsx
+++ b/src/components/MlEphantConversation.tsx
@@ -93,13 +93,16 @@ export interface MlCopilotModesProps {
 const MlCopilotModes = (props: MlCopilotModesProps) => {
   return (
     <>
-      <Popover className="relative">
+      <Popover className="relative min-w-0 max-w-full">
         <Popover.Button
           data-testid="ml-copilot-efforts-button"
-          className="h-7 bg-default flex flex-row items-center gap-1 m-0 pl-1 pr-2 rounded-sm"
+          className="h-7 max-w-full min-w-0 bg-default flex flex-row items-center gap-1 m-0 pl-1 pr-1.5 rounded-sm"
         >
           {props.children}
-          <CustomIcon name="caretUp" className="w-5 h-5 ui-open:rotate-180" />
+          <CustomIcon
+            name="caretUp"
+            className="w-5 h-5 flex-none ui-open:rotate-180"
+          />
         </Popover.Button>
 
         <Popover.Panel className="absolute bottom-full left-0 z-20 flex flex-col gap-2 bg-default mb-1 p-2 border border-chalkboard-70 text-xs rounded-md min-w-[240px]">
@@ -164,16 +167,19 @@ export const MlEphantExtraInputs = (props: MlEphantExtraInputsProps) => {
   const modeOptions = props.modeOptions ?? []
 
   return (
-    <div className="flex-1 flex min-w-0 items-end">
-      <div className="flex flex-row w-fit-content items-end gap-1">
+    <div
+      className="flex min-w-0 flex-1 items-end"
+      data-testid="ml-ephant-extra-inputs"
+    >
+      <div className="flex w-full min-w-0 flex-wrap items-end gap-1">
         {SHOW_ZOOKEEPER_REASONING_MODE_DROPDOWN && currentMode && (
           <MlCopilotModes
             onClick={props.onSetMode}
             current={props.mode}
             modeOptions={modeOptions}
           >
-            <CustomIcon name={currentMode.icon} className="w-5 h-5" />
-            {currentMode.label}
+            <CustomIcon name={currentMode.icon} className="w-5 h-5 flex-none" />
+            <span className="min-w-0 truncate">{currentMode.label}</span>
           </MlCopilotModes>
         )}
         <button
@@ -527,7 +533,10 @@ export const MlEphantConversationInput = (
             ))}
           </div>
         )}
-        <div className="flex items-end">
+        <div
+          className="grid grid-cols-[minmax(0,1fr)_auto] items-end gap-1"
+          data-testid="ml-ephant-composer-actions"
+        >
           <MlEphantExtraInputs
             mode={mode}
             onSetMode={(m) => {
@@ -541,7 +550,7 @@ export const MlEphantConversationInput = (
             attachmentsDisabled={props.disabled}
             modeOptions={props.modeOptions}
           />
-          <div className="flex flex-row gap-1">
+          <div className="flex flex-none flex-row gap-1">
             {!props.disabled && props.needsReconnect && (
               <div className="flex flex-col w-fit items-end">
                 <div className="pr-1 text-xs text-red-500 flex flex-row items-center h-5">


### PR DESCRIPTION
- Constrain the Zookeeper composer action row so tool controls cannot overlap the send button.
- Allow extra input controls to wrap at narrow panel widths.
- Truncate long reasoning mode labels like “Thoughtful” inside the mode button.

Fixes #12137