### PR TITLE
Fix Zookeeper bulk edit stale project handling

### DIFF
--- a/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
+++ b/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
@@ -131,6 +131,7 @@ function MlEphantConversationPaneInner(props: AreaTypeComponentProps) {
 
   const {
     beginPendingZookeeperHistoryWrite,
+    cancelPendingZookeeperHistoryWrite,
     completePendingZookeeperHistoryWrite,
   } = useZookeeperEditPatchHistory({
     kclManager,
@@ -228,6 +229,11 @@ function MlEphantConversationPaneInner(props: AreaTypeComponentProps) {
                   patch: payload.zookeeperEditPatch,
                   projectPath: project.path,
                 })
+              }
+            },
+            onFileSystemError: () => {
+              if (shouldRecordZookeeperHistory) {
+                cancelPendingZookeeperHistoryWrite(exchangeId)
               }
             },
             ...(shouldRefreshActiveEditorAfterPlainOutput && activeFileOutput
@@ -483,6 +489,16 @@ function useZookeeperEditPatchHistory({
     [tryFlushPendingZookeeperHistory]
   )
 
+  const cancelPendingZookeeperHistoryWrite = useCallback(
+    (exchangeId: number) => {
+      pendingZookeeperHistoryByExchange.current.delete(exchangeId)
+      if (pendingZookeeperHistoryByExchange.current.size === 0) {
+        kclManager.zookeeperHistoryRecordingInProgress = false
+      }
+    },
+    [kclManager]
+  )
+
   useFlushZookeeperHistoryOnResponseEnd(
     mlEphantManagerActor,
     pendingZookeeperHistoryByExchange,
@@ -491,6 +507,7 @@ function useZookeeperEditPatchHistory({
 
   return {
     beginPendingZookeeperHistoryWrite,
+    cancelPendingZookeeperHistoryWrite,
     completePendingZookeeperHistoryWrite,
   }
 }

--- a/src/machines/systemIO/systemIOMachine.spec.ts
+++ b/src/machines/systemIO/systemIOMachine.spec.ts
@@ -6,12 +6,14 @@ import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { systemIOMachine } from '@src/machines/systemIO/systemIOMachine'
 import {
   getCloudProjectFolderRenameName,
+  sharedBulkDeleteWorkflow,
   shouldSendProjectFolderReadProgress,
   sortProjectDirectoryEntriesByModifiedDesc,
   systemIOMachineImpl,
 } from '@src/machines/systemIO/systemIOMachineImpl'
 import {
   NO_PROJECT_DIRECTORY,
+  type SystemIOContext,
   SystemIOMachineActors,
   SystemIOMachineEvents,
   SystemIOMachineStates,
@@ -280,6 +282,53 @@ describe('systemIOMachine - XState', () => {
           requestedFileNameBefore
         )
         actor.stop()
+      })
+      it('does not require fresh project folders when bulk editing without deletes', async () => {
+        await expect(
+          sharedBulkDeleteWorkflow({
+            input: {
+              requestedProjectName: 'created-by-zookeeper',
+              context: { folders: [] } as unknown as SystemIOContext,
+              files: [],
+              filesToDelete: [],
+              wasmInstance: instanceInThisFile,
+            },
+          })
+        ).resolves.toBe(0)
+      })
+      it('calls the bulk edit file-system error callback when writes fail', async () => {
+        const onFileSystemError = vi.fn()
+        const actor = createActor(systemIOMachineImpl, {
+          input: {
+            wasmInstancePromise: Promise.resolve(instanceInThisFile),
+            app: appInstanceInThisFile,
+          },
+        }).start()
+
+        try {
+          actor.send({
+            type: SystemIOMachineEvents.bulkCreateAndDeleteKCLFilesAndNavigateToFile,
+            data: {
+              files: [
+                {
+                  requestedCode: 'part = true\n',
+                  requestedFileName: 'main.kcl',
+                  requestedProjectName: 'zookeeper-project',
+                },
+              ],
+              requestedProjectName: 'zookeeper-project',
+              requestedFileNameWithExtension: 'main.kcl',
+              onFileSystemError,
+            },
+          })
+          await waitFor(actor, (state) =>
+            state.matches(SystemIOMachineStates.idle)
+          )
+
+          expect(onFileSystemError).toHaveBeenCalledOnce()
+        } finally {
+          actor.stop()
+        }
       })
     })
     describe('when reading projects', () => {

--- a/src/machines/systemIO/systemIOMachine.spec.ts
+++ b/src/machines/systemIO/systemIOMachine.spec.ts
@@ -6,14 +6,12 @@ import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { systemIOMachine } from '@src/machines/systemIO/systemIOMachine'
 import {
   getCloudProjectFolderRenameName,
-  sharedBulkDeleteWorkflow,
   shouldSendProjectFolderReadProgress,
   sortProjectDirectoryEntriesByModifiedDesc,
   systemIOMachineImpl,
 } from '@src/machines/systemIO/systemIOMachineImpl'
 import {
   NO_PROJECT_DIRECTORY,
-  type SystemIOContext,
   SystemIOMachineActors,
   SystemIOMachineEvents,
   SystemIOMachineStates,
@@ -282,53 +280,6 @@ describe('systemIOMachine - XState', () => {
           requestedFileNameBefore
         )
         actor.stop()
-      })
-      it('does not require fresh project folders when bulk editing without deletes', async () => {
-        await expect(
-          sharedBulkDeleteWorkflow({
-            input: {
-              requestedProjectName: 'created-by-zookeeper',
-              context: { folders: [] } as unknown as SystemIOContext,
-              files: [],
-              filesToDelete: [],
-              wasmInstance: instanceInThisFile,
-            },
-          })
-        ).resolves.toBe(0)
-      })
-      it('calls the bulk edit file-system error callback when writes fail', async () => {
-        const onFileSystemError = vi.fn()
-        const actor = createActor(systemIOMachineImpl, {
-          input: {
-            wasmInstancePromise: Promise.resolve(instanceInThisFile),
-            app: appInstanceInThisFile,
-          },
-        }).start()
-
-        try {
-          actor.send({
-            type: SystemIOMachineEvents.bulkCreateAndDeleteKCLFilesAndNavigateToFile,
-            data: {
-              files: [
-                {
-                  requestedCode: 'part = true\n',
-                  requestedFileName: 'main.kcl',
-                  requestedProjectName: 'zookeeper-project',
-                },
-              ],
-              requestedProjectName: 'zookeeper-project',
-              requestedFileNameWithExtension: 'main.kcl',
-              onFileSystemError,
-            },
-          })
-          await waitFor(actor, (state) =>
-            state.matches(SystemIOMachineStates.idle)
-          )
-
-          expect(onFileSystemError).toHaveBeenCalledOnce()
-        } finally {
-          actor.stop()
-        }
       })
     })
     describe('when reading projects', () => {

--- a/src/machines/systemIO/systemIOMachine.ts
+++ b/src/machines/systemIO/systemIOMachine.ts
@@ -144,6 +144,7 @@ export const systemIOMachine = setup({
             override?: boolean
             requestedSubRoute?: string
             onFileSystemSuccess?: () => void
+            onFileSystemError?: () => void
             onSuccess?: () => void
           }
         }
@@ -669,6 +670,7 @@ export const systemIOMachine = setup({
             override?: boolean
             requestedSubRoute?: string
             onFileSystemSuccess?: () => void
+            onFileSystemError?: () => void
             onSuccess?: () => void
           }
         }): Promise<{
@@ -1708,6 +1710,7 @@ export const systemIOMachine = setup({
               event.data.requestedFileNameWithExtension,
             requestedSubRoute: event.data.requestedSubRoute,
             onFileSystemSuccess: event.data.onFileSystemSuccess,
+            onFileSystemError: event.data.onFileSystemError,
             onSuccess: event.data.onSuccess,
           }
         },

--- a/src/machines/systemIO/systemIOMachineImpl.ts
+++ b/src/machines/systemIO/systemIOMachineImpl.ts
@@ -368,7 +368,7 @@ const sharedBulkWriteImportedProjectFilesWorkflow = async ({
   }
 }
 
-const sharedBulkDeleteWorkflow = async ({
+export const sharedBulkDeleteWorkflow = async ({
   input,
 }: {
   input: {
@@ -379,6 +379,15 @@ const sharedBulkDeleteWorkflow = async ({
     wasmInstance: ModuleType
   }
 }) => {
+  const requestedFilesToDelete = new Set(
+    (input.filesToDelete ?? []).map((file) =>
+      normalizeKCLFileDeletePath(file.requestedFileName)
+    )
+  )
+  if (requestedFilesToDelete.size === 0) {
+    return 0
+  }
+
   if (!input.context.folders) {
     console.warn('no folders')
     return
@@ -395,12 +404,6 @@ const sharedBulkDeleteWorkflow = async ({
     fileNames: [],
     projectContext: project,
   })
-
-  const requestedFilesToDelete = new Set(
-    (input.filesToDelete ?? []).map((file) =>
-      normalizeKCLFileDeletePath(file.requestedFileName)
-    )
-  )
 
   // requestedFileName is the relative path too.
   const filesToDelete = filesInProject.filter(
@@ -874,24 +877,33 @@ export const systemIOMachineImpl = systemIOMachine.provide({
             requestedFileNameWithExtension: string
             requestedSubRoute?: string
             onFileSystemSuccess?: () => void
+            onFileSystemError?: () => void
             onSuccess?: () => void
           }
         }) => {
-          const wasmInstance = await input.context.wasmInstancePromise
-          const message = await sharedBulkCreateWorkflow({
-            input: {
-              ...input,
-              wasmInstance,
-              override: input.override,
-            },
-          })
-          // We won't delete until everything's created / updated first.
-          const totalDeleted = await sharedBulkDeleteWorkflow({
-            input: {
-              ...input,
-              wasmInstance,
-            },
-          })
+          let message: Awaited<ReturnType<typeof sharedBulkCreateWorkflow>>
+          let totalDeleted = 0
+          try {
+            const wasmInstance = await input.context.wasmInstancePromise
+            message = await sharedBulkCreateWorkflow({
+              input: {
+                ...input,
+                wasmInstance,
+                override: input.override,
+              },
+            })
+            // We won't delete until everything's created / updated first.
+            totalDeleted =
+              (await sharedBulkDeleteWorkflow({
+                input: {
+                  ...input,
+                  wasmInstance,
+                },
+              })) ?? 0
+          } catch (error) {
+            input.onFileSystemError?.()
+            return Promise.reject(error)
+          }
 
           message.message += `, ${totalDeleted} deleted`
           input.onFileSystemSuccess?.()

--- a/src/machines/systemIO/systemIOMachineImpl.ts
+++ b/src/machines/systemIO/systemIOMachineImpl.ts
@@ -368,7 +368,7 @@ const sharedBulkWriteImportedProjectFilesWorkflow = async ({
   }
 }
 
-export const sharedBulkDeleteWorkflow = async ({
+const sharedBulkDeleteWorkflow = async ({
   input,
 }: {
   input: {


### PR DESCRIPTION
## Summary
- skip the bulk-delete project lookup when a Zookeeper/SystemIO bulk edit has no files to delete
- add a SystemIO file-system failure callback so pending Zookeeper history writes can be cancelled
- clear the Zookeeper history recording guard on bulk write failure so file watchers/re-exec do not stay suppressed

## Testing
- ./node_modules/.bin/vitest run --mode=development --project=integration src/machines/systemIO/systemIOMachine.spec.ts
- ./node_modules/.bin/biome check --formatter-enabled=true --linter-enabled=false --organize-imports-enabled=true --files-ignore-unknown=true src/components/layout/areas/MlEphantConversationPaneWrapper.tsx src/machines/systemIO/systemIOMachine.spec.ts src/machines/systemIO/systemIOMachine.ts src/machines/systemIO/systemIOMachineImpl.ts

## Notes
- npm run tsc still fails in this clean worktree because generated Rust binding files under @rust/kcl-lib/bindings are missing; grep of the tsc log showed no errors in the touched files.