### PR TITLE
Silence a Google Cloud warning on release

### DIFF
--- a/.github/workflows/publish-apps.yml
+++ b/.github/workflows/publish-apps.yml
@@ -110,6 +110,7 @@ jobs:
           path: out
           glob: '*'
           parent: false
+          process_gcloudignore: false
           destination: 'dl.kittycad.io/releases/design-studio'
 
       - name: Invalidate bucket cache on latest*.yml and last_download.json files


### PR DESCRIPTION
Fixes this:

<img width="912" height="508" alt="Screenshot 2026-06-25 at 4 50 52 PM" src="https://github.com/user-attachments/assets/e49fe589-520c-4443-86a3-b1494cf2b06b" />
