### PR TITLE
e2e click location helper

### DIFF
--- a/e2e/playwright/fixtures/sceneFixture.ts
+++ b/e2e/playwright/fixtures/sceneFixture.ts
@@ -43,6 +43,73 @@ type DragFromHandler = (
   dragParams: MouseDragFromParams
 ) => Promise<undefined | boolean>
 
+async function markAndPauseAtPoint(
+  page: Page,
+  point: { x: number; y: number },
+  label?: string
+) {
+  await page.evaluate(
+    ({ point, label }) => {
+      const markerId = 'playwright-click-debug-marker'
+      const existing = document.getElementById(markerId)
+      if (existing) existing.remove()
+
+      const marker = document.createElement('div')
+      marker.id = markerId
+      marker.style.position = 'fixed'
+      marker.style.left = `${point.x}px`
+      marker.style.top = `${point.y}px`
+      marker.style.width = '16px'
+      marker.style.height = '16px'
+      marker.style.transform = 'translate(-50%, -50%)'
+      marker.style.border = '2px solid red'
+      marker.style.borderRadius = '9999px'
+      marker.style.background = 'rgba(255, 0, 0, 0.25)'
+      marker.style.boxShadow = '0 0 0 9999px rgba(0, 0, 0, 0.01)'
+      marker.style.pointerEvents = 'none'
+      marker.style.zIndex = '2147483647'
+
+      const horizontal = document.createElement('div')
+      horizontal.style.position = 'absolute'
+      horizontal.style.left = '-8px'
+      horizontal.style.top = '50%'
+      horizontal.style.width = '32px'
+      horizontal.style.height = '2px'
+      horizontal.style.background = 'red'
+      horizontal.style.transform = 'translateY(-50%)'
+
+      const vertical = document.createElement('div')
+      vertical.style.position = 'absolute'
+      vertical.style.left = '50%'
+      vertical.style.top = '-8px'
+      vertical.style.width = '2px'
+      vertical.style.height = '32px'
+      vertical.style.background = 'red'
+      vertical.style.transform = 'translateX(-50%)'
+
+      marker.append(horizontal, vertical)
+
+      if (label) {
+        const markerLabel = document.createElement('div')
+        markerLabel.textContent = label
+        markerLabel.style.position = 'absolute'
+        markerLabel.style.left = '20px'
+        markerLabel.style.top = '-4px'
+        markerLabel.style.padding = '2px 4px'
+        markerLabel.style.background = 'red'
+        markerLabel.style.color = 'white'
+        markerLabel.style.font = '12px sans-serif'
+        markerLabel.style.whiteSpace = 'nowrap'
+        marker.append(markerLabel)
+      }
+
+      document.body.append(marker)
+    },
+    { point, label }
+  )
+  await page.pause()
+}
+
 export class SceneFixture {
   public page: Page
   public streamWrapper!: Locator
@@ -120,7 +187,17 @@ export class SceneFixture {
   makeMouseHelpers = (
     x: number,
     y: number,
-    { steps, format }: { steps?: number; format?: 'pixels' | 'ratio' } = {
+    {
+      steps,
+      format,
+      debug,
+      debugLabel,
+    }: {
+      steps?: number
+      format?: 'pixels' | 'ratio'
+      debug?: boolean
+      debugLabel?: string
+    } = {
       steps: 20,
       format: 'pixels',
     }
@@ -132,6 +209,9 @@ export class SceneFixture {
           y,
           format
         )
+        if (debug) {
+          await markAndPauseAtPoint(this.page, resolvedPoint, debugLabel)
+        }
         if (clickParams?.pixelDiff) {
           return doAndWaitForImageDiff(
             this.page,
@@ -172,6 +252,9 @@ export class SceneFixture {
           y,
           format
         )
+        if (debug) {
+          await markAndPauseAtPoint(this.page, resolvedPoint, debugLabel)
+        }
         if (moveParams?.pixelDiff) {
           return doAndWaitForImageDiff(
             this.page,
@@ -188,6 +271,9 @@ export class SceneFixture {
           y,
           format
         )
+        if (debug) {
+          await markAndPauseAtPoint(this.page, resolvedPoint, debugLabel)
+        }
         if (clickParams?.pixelDiff) {
           return doAndWaitForImageDiff(
             this.page,


### PR DESCRIPTION
This adds an optional click-debug helper for Playwright scene tests.
The main use case is debugging point-and-click tests where the click coordinate might be slightly wrong, or where the test may be clicking before the scene has finished rendering. Instead of guessing from logs, the helper can draw a red marker at the exact resolved click point and then pause the test.

<img width="1160" height="543" alt="image" src="https://github.com/user-attachments/assets/919e6fe2-d080-4655-b919-98337b9e6842" />


Example usage:
```ts
const [clickProfile] = scene.makeMouseHelpers(0.49, 0.79, {
  format: 'ratio',
  debug: true,
  debugLabel: 'profile click',
})

await clickProfile()
```