### PR TITLE
Override tree highlighter update for performance tracking

### DIFF
--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -82,7 +82,6 @@ import {
   redoDepth,
   undoDepth,
 } from '@codemirror/commands'
-import { syntaxTree } from '@codemirror/language'
 import type { Diagnostic } from '@codemirror/lint'
 import { forEachDiagnostic, setDiagnosticsEffect } from '@codemirror/lint'
 import {
@@ -777,7 +776,6 @@ export class KclManager extends File {
 
   private readonly _editorView: EditorView
   private readonly _globalHistoryView: HistoryView
-  private readonly performanceTrackedTreeHighlighters = new WeakSet<object>()
   private readonly editorStatesByPath = new Map<string, EditorState>()
   private restoredEditorHistoryOnLastFileSwitch = false
   private disposeGlobalHistorySubscription: (() => boolean) | undefined
@@ -2745,49 +2743,6 @@ export class KclManager extends File {
     return this._copilotEnabled
   }
 
-  private overrideTreeHighlighterUpdateForPerformanceTracking() {
-    // @ts-ignore
-    this._editorView?.plugins.forEach((e) => {
-      let sawATreeDiff = false
-      // we cannot use <>.constructor.name since it will get destroyed
-      // when packaging the application.
-      const isTreeHighlightPlugin =
-        e?.value &&
-        e.value?.hasOwnProperty('tree') &&
-        e.value?.hasOwnProperty('decoratedTo') &&
-        e.value?.hasOwnProperty('decorations')
-      if (isTreeHighlightPlugin) {
-        if (this.performanceTrackedTreeHighlighters.has(e.value)) {
-          return
-        }
-        this.performanceTrackedTreeHighlighters.add(e.value)
-        let originalUpdate = e.value.update
-        // @ts-ignore
-        function performanceTrackingUpdate(args) {
-          /**
-           * TreeHighlighter.update will be called multiple times on start up.
-           * We do not want to track the highlight performance of an empty update.
-           * mark the syntax highlight one time when the new tree comes in with the
-           * initial code
-           */
-          const treeIsDifferent =
-            // @ts-ignore
-            !sawATreeDiff && this.tree !== syntaxTree(args.state)
-          if (treeIsDifferent && !sawATreeDiff) {
-            markOnce('code/willSyntaxHighlight')
-          }
-          // Call the original function
-          // @ts-ignore
-          originalUpdate.apply(this, [args])
-          if (treeIsDifferent && !sawATreeDiff) {
-            markOnce('code/didSyntaxHighlight')
-            sawATreeDiff = true
-          }
-        }
-        e.value.update = performanceTrackingUpdate
-      }
-    })
-  }
   get isAllTextSelected() {
     return this._isAllTextSelected
   }
@@ -2878,8 +2833,6 @@ export class KclManager extends File {
         Transaction.addToHistory.of(false),
       ],
     })
-    // themeCompartment.reconfigure above installs the syntax-highlighting extension
-    this.overrideTreeHighlighterUpdateForPerformanceTracking()
   }
   setEditorLineWrapping(shouldWrap: boolean) {
     this._editorView.dispatch({

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -777,6 +777,7 @@ export class KclManager extends File {
 
   private readonly _editorView: EditorView
   private readonly _globalHistoryView: HistoryView
+  private readonly performanceTrackedTreeHighlighters = new WeakSet<object>()
   private readonly editorStatesByPath = new Map<string, EditorState>()
   private restoredEditorHistoryOnLastFileSwitch = false
   private disposeGlobalHistorySubscription: (() => boolean) | undefined
@@ -2743,13 +2744,8 @@ export class KclManager extends File {
   get copilotEnabled(): boolean {
     return this._copilotEnabled
   }
-  // Invoked when editorView is created and each time when it is updated (eg. user is sketching)..
-  // setEditorView(editorView: EditorView) {
-  //   this.overrideTreeHighlighterUpdateForPerformanceTracking()
-  // }
 
-  /** TODO: Investigate if this is still needed in the new world */
-  overrideTreeHighlighterUpdateForPerformanceTracking() {
+  private overrideTreeHighlighterUpdateForPerformanceTracking() {
     // @ts-ignore
     this._editorView?.plugins.forEach((e) => {
       let sawATreeDiff = false
@@ -2761,6 +2757,10 @@ export class KclManager extends File {
         e.value?.hasOwnProperty('decoratedTo') &&
         e.value?.hasOwnProperty('decorations')
       if (isTreeHighlightPlugin) {
+        if (this.performanceTrackedTreeHighlighters.has(e.value)) {
+          return
+        }
+        this.performanceTrackedTreeHighlighters.add(e.value)
         let originalUpdate = e.value.update
         // @ts-ignore
         function performanceTrackingUpdate(args) {
@@ -2878,6 +2878,8 @@ export class KclManager extends File {
         Transaction.addToHistory.of(false),
       ],
     })
+    // themeCompartment.reconfigure above installs the syntax-highlighting extension
+    this.overrideTreeHighlighterUpdateForPerformanceTracking()
   }
   setEditorLineWrapping(shouldWrap: boolean) {
     this._editorView.dispatch({


### PR DESCRIPTION
Fixes #9184 

The way I see these 2 marks (`willSyntaxHighlight` and `didSyntaxHighlight`) are not really used/sent anywhere but they do appear in the telemetry window.

The first commit of this PR fixes the recursion issue reported in https://github.com/KittyCAD/modeling-app/issues/9184, the second commit deletes the override completely in case we don't need it.

I would lean towards deleting, we can always add it back if we want, but I want to offer both options as I don't have full context about what these were used for.