### PR TITLE
KCL bumper should reset hotfixes

### DIFF
--- a/rust/kcl-bumper/src/main.rs
+++ b/rust/kcl-bumper/src/main.rs
@@ -89,6 +89,7 @@ fn update_semver(bump: Option<SemverBump>, cargo_dot_toml: &mut DocumentMut) -> 
         SemverBump::Minor => next_version.minor += 1,
         SemverBump::Patch => next_version.patch += 1,
     };
+    next_version.pre = Default::default();
 
     // Update the Cargo.toml
     cargo_dot_toml["package"]["version"] = value(next_version.to_string());
@@ -219,6 +220,32 @@ anyhow = "1.0.81"
     #[test]
     fn test_bump_patch() {
         let mut cargo_dot_toml = EXAMPLE.parse::<DocumentMut>().unwrap();
+        update_semver(Some(SemverBump::Patch), &mut cargo_dot_toml).unwrap();
+        assert_eq!(
+            cargo_dot_toml.to_string(),
+            r#"
+[package]
+name = "bumper"
+version = "0.1.1"
+
+[dependencies]
+anyhow = "1.0.81"
+        "#
+        );
+    }
+
+    #[test]
+    fn test_bump_patch_dash_pre() {
+        let mut cargo_dot_toml = r#"
+[package]
+name = "bumper"
+version = "0.1.0-hotfix"
+
+[dependencies]
+anyhow = "1.0.81"
+        "#
+        .parse::<DocumentMut>()
+        .unwrap();
         update_semver(Some(SemverBump::Patch), &mut cargo_dot_toml).unwrap();
         assert_eq!(
             cargo_dot_toml.to_string(),


### PR DESCRIPTION
For example, bumping 0.1.87-beta should yield 0.1.88, no beta.

This is helpful so we can do one-off releases (e.g. hotfixes to the Python bindings and then ensure the bumper will bump them back to normal)