### PR TITLE
KCL: the python bindings get KCL deps from path, not crates.io

### DIFF
--- a/rust/justfile
+++ b/rust/justfile
@@ -94,6 +94,7 @@ publish-kcl version:
     cargo publish -p kcl-derive-docs
     cargo publish -p kcl-directory-test-macro
     cargo publish -p kcl-error
+    cargo publish -p kcl-api
     cargo publish -p kcl-syntax
     cargo publish -p kcl-lib
     cargo publish -p kcl-test-server

--- a/rust/kcl-bumper/src/main.rs
+++ b/rust/kcl-bumper/src/main.rs
@@ -83,6 +83,7 @@ fn update_semver(bump: Option<SemverBump>, cargo_dot_toml: &mut DocumentMut) -> 
         println!("{current_version}");
         return Ok(None);
     };
+    let prev_version = current_version.clone();
     let mut next_version = current_version;
     match bump {
         SemverBump::Major => next_version.major += 1,
@@ -93,7 +94,7 @@ fn update_semver(bump: Option<SemverBump>, cargo_dot_toml: &mut DocumentMut) -> 
 
     // Update the Cargo.toml
     cargo_dot_toml["package"]["version"] = value(next_version.to_string());
-    println!("{next_version}");
+    println!("\tBumped {prev_version} => {next_version}");
     Ok(Some(next_version))
 }
 

--- a/rust/kcl-python-bindings/Cargo.toml
+++ b/rust/kcl-python-bindings/Cargo.toml
@@ -20,7 +20,7 @@ kcl-lib = { path = "../kcl-lib", features = [
 ] }
 #kcl-lib = { path = "../modeling-app/src/wasm-lib/kcl", default-features = false, features = ["pyo3", "engine", "disable-println"] }
 kittycad-modeling-cmds = { workspace = true, features = ["python"] }
-kcl-api = { version = "=0.2.166", path = "../kcl-api", features = ["pyo3"] }
+kcl-api = { path = "../kcl-api", features = ["pyo3"] }
 miette = { workspace = true, features = ["fancy"] }
 pyo3 = { workspace = true, features = ["serde", "experimental-async"] }
 pyo3-stub-gen = { workspace = true }


### PR DESCRIPTION
- kcl-api should be used as a `path` dep of `kcl-python-bindings`, not a crates.io dep. This is because kcl-python-bindings never gets published to crates.io. This makes kcl-api match how kcl-lib works (from the python bindings).
- add kcl-api to the list of crates to publish in `just publish-kcl`.

While debugging these issues, I made a small println change in the kcl-bumper which I found helpful.