### PR TITLE
Fix Project Explorer startup race with Zookeeper

### DIFF
--- a/src/components/Explorer/placeholders.ts
+++ b/src/components/Explorer/placeholders.ts
@@ -1,0 +1,44 @@
+import type { FileEntry } from '@src/lib/project'
+
+export const FOLDER_PLACEHOLDER_NAME = '.zoo-placeholder-folder'
+export const FILE_PLACEHOLDER_NAME = '.zoo-placeholder-file.kcl'
+
+function joinProjectPath(parentPath: string, childName: string) {
+  const separator = parentPath.includes('\\') ? '\\' : '/'
+  const trimPattern = separator === '\\' ? /^\\+|\\+$/g : /^\/+|\/+$/g
+  const parts = [parentPath, childName]
+    .map((part) => part.replace(trimPattern, ''))
+    .filter((part) => part.length > 0)
+
+  return `${separator === '\\' ? '' : separator}${parts.join(separator)}`
+}
+
+export const addPlaceHoldersForNewFileAndFolder = (
+  children: FileEntry[] | null,
+  parentPath: string
+) => {
+  if (children === null) {
+    return
+  }
+
+  for (let i = 0; i < children.length; i++) {
+    addPlaceHoldersForNewFileAndFolder(
+      children[i].children,
+      joinProjectPath(parentPath, children[i].name)
+    )
+  }
+
+  const placeHolderFolderEntry: FileEntry = {
+    path: joinProjectPath(parentPath, FOLDER_PLACEHOLDER_NAME),
+    name: FOLDER_PLACEHOLDER_NAME,
+    children: [],
+  }
+  children.unshift(placeHolderFolderEntry)
+
+  const placeHolderFileEntry: FileEntry = {
+    path: joinProjectPath(parentPath, FILE_PLACEHOLDER_NAME),
+    name: FILE_PLACEHOLDER_NAME,
+    children: null,
+  }
+  children.push(placeHolderFileEntry)
+}

--- a/src/components/Explorer/utils.ts
+++ b/src/components/Explorer/utils.ts
@@ -1,4 +1,8 @@
 import type { CustomIconName } from '@src/components/CustomIcon'
+import {
+  FILE_PLACEHOLDER_NAME,
+  FOLDER_PLACEHOLDER_NAME,
+} from '@src/components/Explorer/placeholders'
 import { sortFilesAndDirectories } from '@src/lib/desktopFS'
 import {
   desktopSafePathJoin,
@@ -10,6 +14,11 @@ import {
 import type { FileEntry } from '@src/lib/project'
 import type { SubmitByPressOrBlur } from '@src/lib/types'
 import type { ReactNode } from 'react'
+export {
+  addPlaceHoldersForNewFileAndFolder,
+  FILE_PLACEHOLDER_NAME,
+  FOLDER_PLACEHOLDER_NAME,
+} from '@src/components/Explorer/placeholders'
 
 /**
  * Remap FileEntry data into another data structure for the Project Explorer
@@ -170,42 +179,6 @@ export const flattenProject = (
     )
   }
   return flattenTreeInOrder
-}
-
-/**
- * In memory add fake placeholders for folder and files.
- * @param children
- * @param parentPath absolute path
- * @returns
- */
-export const addPlaceHoldersForNewFileAndFolder = (
-  children: FileEntry[] | null,
-  parentPath: string
-) => {
-  if (children === null) {
-    return
-  }
-
-  for (let i = 0; i < children.length; i++) {
-    addPlaceHoldersForNewFileAndFolder(
-      children[i].children,
-      joinOSPaths(parentPath, children[i].name)
-    )
-  }
-
-  const placeHolderFolderEntry: FileEntry = {
-    path: joinOSPaths(parentPath, FOLDER_PLACEHOLDER_NAME),
-    name: FOLDER_PLACEHOLDER_NAME,
-    children: [],
-  }
-  children.unshift(placeHolderFolderEntry)
-
-  const placeHolderFileEntry: FileEntry = {
-    path: joinOSPaths(parentPath, FILE_PLACEHOLDER_NAME),
-    name: FILE_PLACEHOLDER_NAME,
-    children: null,
-  }
-  children.push(placeHolderFileEntry)
 }
 
 export const isRowFake = (
@@ -409,8 +382,6 @@ export function shouldDroppedEntryBeMoved(
 export const NOTHING_IS_SELECTED: number = -2
 export const CONTAINER_IS_SELECTED: number = -1
 export const STARTING_INDEX_TO_SELECT: number = 0
-export const FOLDER_PLACEHOLDER_NAME = '.zoo-placeholder-folder'
-export const FILE_PLACEHOLDER_NAME = '.zoo-placeholder-file.kcl'
 
 /**
  * Check if a drag event contains external files (not internal drag)

--- a/src/components/layout/areas/MlEphantConversationPane.spec.tsx
+++ b/src/components/layout/areas/MlEphantConversationPane.spec.tsx
@@ -116,16 +116,24 @@ const createFakeActor = ({
 const createFakeSystemIOActor = ({
   mlEphantConversations = undefined,
   completeSavesAutomatically = true,
+  value = SystemIOMachineStates.idle,
 }: {
   mlEphantConversations?: Map<string, string>
   completeSavesAutomatically?: boolean
+  value?: SystemIOMachineStates
 } = {}) => {
   type SaveConversationEvent = {
     type: SystemIOMachineEvents
     data?: { projectId?: string; conversationId?: string }
   }
-  let snapshot = {
-    value: SystemIOMachineStates.idle,
+  type FakeSystemIOSnapshot = {
+    value: SystemIOMachineStates
+    context: {
+      mlEphantConversations?: Map<string, string>
+    }
+  }
+  let snapshot: FakeSystemIOSnapshot = {
+    value,
     context: {
       mlEphantConversations,
     },
@@ -179,6 +187,17 @@ const createFakeSystemIOActor = ({
       }
     },
     completeSave,
+    setSnapshot: (nextSnapshot: Partial<FakeSystemIOSnapshot>) => {
+      snapshot = {
+        ...snapshot,
+        ...nextSnapshot,
+        context: {
+          ...snapshot.context,
+          ...nextSnapshot.context,
+        },
+      }
+      notify()
+    },
     send: vi.fn((event: SaveConversationEvent) => {
       if (
         event.type !== SystemIOMachineEvents.saveMlEphantConversations &&
@@ -293,7 +312,9 @@ const createStatefulPromptActor = (awaitingResponse = false) => {
           awaitingResponse: nextAwaitingResponse,
         },
       }
-      listeners.forEach((listener) => listener(snapshot))
+      for (const listener of listeners) {
+        listener(snapshot)
+      }
     },
   }
 
@@ -669,6 +690,29 @@ describe('MlEphantConversationPane', () => {
         conversationId: 'conversation-id',
       })
     )
+  })
+
+  test('waits for SystemIO idle before loading saved project conversations', () => {
+    const systemIOActor = createFakeSystemIOActor({
+      value: SystemIOMachineStates.readingFolders,
+    })
+
+    renderPane({
+      systemIOActor,
+      settingsMetaId: 'project-id',
+    })
+
+    expect(systemIOActor.send).not.toHaveBeenCalledWith({
+      type: SystemIOMachineEvents.getMlEphantConversations,
+    })
+
+    systemIOActor.setSnapshot({
+      value: SystemIOMachineStates.idle,
+    })
+
+    expect(systemIOActor.send).toHaveBeenCalledWith({
+      type: SystemIOMachineEvents.getMlEphantConversations,
+    })
   })
 
   test('clearing chat forgets the saved project conversation before starting a fresh one', () => {

--- a/src/components/layout/areas/MlEphantConversationPane.tsx
+++ b/src/components/layout/areas/MlEphantConversationPane.tsx
@@ -214,6 +214,7 @@ export const MlEphantConversationPane = (props: {
 
   // Auto-submit the next queued message when current processing completes.
   // If a message was steered, it takes priority over the default FIFO order.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: queue processing intentionally uses the queued prompt state captured by this effect.
   useEffect(() => {
     if (
       !isPromptRunning &&
@@ -261,6 +262,7 @@ export const MlEphantConversationPane = (props: {
     let clearedConversationMapping = true
     let sentDeleteConversationMapping = false
     let startedFreshConversation = false
+    // biome-ignore lint/style/useConst: cleanup can run through actor callbacks before subscription assignment completes.
     let sub: ReturnType<typeof props.mlEphantManagerActor.subscribe> | undefined
     let systemIOSub:
       | ReturnType<typeof props.systemIOActor.subscribe>
@@ -386,6 +388,7 @@ export const MlEphantConversationPane = (props: {
     }
   }
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: this actor coordination effect intentionally tracks project identity, matching the existing eslint suppression below.
   useEffect(() => {
     const subscriptionSystemIOActor = props.systemIOActor.subscribe(
       (systemIOActorSnapshot) => {
@@ -437,7 +440,7 @@ export const MlEphantConversationPane = (props: {
           ) &&
           props.theProject !== undefined
         ) {
-          let project: Project = props.theProject
+          const project: Project = props.theProject
 
           const currentLoaderFile = loaderFileRef.current
           void collectProjectFiles({
@@ -473,9 +476,16 @@ export const MlEphantConversationPane = (props: {
         tryToGetExchanges()
       })
 
-    props.systemIOActor.send({
-      type: SystemIOMachineEvents.getMlEphantConversations,
-    })
+    const systemIOSnapshot = props.systemIOActor.getSnapshot()
+    if (
+      systemIOSnapshot.value === 'idle' &&
+      props.settings.meta.id.current !== uuidNIL &&
+      systemIOSnapshot.context.mlEphantConversations === undefined
+    ) {
+      props.systemIOActor.send({
+        type: SystemIOMachineEvents.getMlEphantConversations,
+      })
+    }
 
     tryToGetExchanges()
 

--- a/src/components/layout/areas/ProjectExplorerPane.test.ts
+++ b/src/components/layout/areas/ProjectExplorerPane.test.ts
@@ -1,0 +1,72 @@
+import {
+  FILE_PLACEHOLDER_NAME,
+  FOLDER_PLACEHOLDER_NAME,
+} from '@src/components/Explorer/utils'
+import { getProjectExplorerProjectForRender } from '@src/components/layout/areas/ProjectExplorerPane.utils'
+import type { Project } from '@src/lib/project'
+import { describe, expect, it } from 'vitest'
+
+const project = (name: string, children: Project['children']): Project => ({
+  metadata: null,
+  kcl_file_count: 1,
+  directory_count: 0,
+  default_file: `/projects/${name}/main.kcl`,
+  path: `/projects/${name}`,
+  name,
+  children,
+  readWriteAccess: true,
+})
+
+describe('getProjectExplorerProjectForRender', () => {
+  it('uses the loaded project while folder hydration is pending', () => {
+    const loadedProject = project('demo', [
+      {
+        name: 'main.kcl',
+        path: '/projects/demo/main.kcl',
+        children: null,
+      },
+    ])
+
+    const projectForRender = getProjectExplorerProjectForRender({
+      loadedProject,
+      projects: undefined,
+    })
+
+    expect(projectForRender?.children?.map((child) => child.name)).toEqual([
+      FOLDER_PLACEHOLDER_NAME,
+      'main.kcl',
+      FILE_PLACEHOLDER_NAME,
+    ])
+    expect(loadedProject.children?.map((child) => child.name)).toEqual([
+      'main.kcl',
+    ])
+  })
+
+  it('prefers the hydrated project from the folder list', () => {
+    const loadedProject = project('demo', [
+      {
+        name: 'stale.kcl',
+        path: '/projects/demo/stale.kcl',
+        children: null,
+      },
+    ])
+    const hydratedProject = project('demo', [
+      {
+        name: 'fresh.kcl',
+        path: '/projects/demo/fresh.kcl',
+        children: null,
+      },
+    ])
+
+    const projectForRender = getProjectExplorerProjectForRender({
+      loadedProject,
+      projects: [hydratedProject],
+    })
+
+    expect(projectForRender?.children?.map((child) => child.name)).toEqual([
+      FOLDER_PLACEHOLDER_NAME,
+      'fresh.kcl',
+      FILE_PLACEHOLDER_NAME,
+    ])
+  })
+})

--- a/src/components/layout/areas/ProjectExplorerPane.test.ts
+++ b/src/components/layout/areas/ProjectExplorerPane.test.ts
@@ -1,8 +1,8 @@
 import {
   FILE_PLACEHOLDER_NAME,
   FOLDER_PLACEHOLDER_NAME,
-} from '@src/components/Explorer/utils'
-import { getProjectExplorerProjectForRender } from '@src/components/layout/areas/ProjectExplorerPane.utils'
+} from '@src/components/Explorer/placeholders'
+import { getProjectExplorerProjectWithPlaceholders } from '@src/components/layout/areas/ProjectExplorerPane.utils'
 import type { Project } from '@src/lib/project'
 import { describe, expect, it } from 'vitest'
 
@@ -17,7 +17,7 @@ const project = (name: string, children: Project['children']): Project => ({
   readWriteAccess: true,
 })
 
-describe('getProjectExplorerProjectForRender', () => {
+describe('getProjectExplorerProjectWithPlaceholders', () => {
   it('uses the loaded project while folder hydration is pending', () => {
     const loadedProject = project('demo', [
       {
@@ -27,12 +27,12 @@ describe('getProjectExplorerProjectForRender', () => {
       },
     ])
 
-    const projectForRender = getProjectExplorerProjectForRender({
+    const explorerProject = getProjectExplorerProjectWithPlaceholders({
       loadedProject,
       projects: undefined,
     })
 
-    expect(projectForRender?.children?.map((child) => child.name)).toEqual([
+    expect(explorerProject?.children?.map((child) => child.name)).toEqual([
       FOLDER_PLACEHOLDER_NAME,
       'main.kcl',
       FILE_PLACEHOLDER_NAME,
@@ -58,12 +58,12 @@ describe('getProjectExplorerProjectForRender', () => {
       },
     ])
 
-    const projectForRender = getProjectExplorerProjectForRender({
+    const explorerProject = getProjectExplorerProjectWithPlaceholders({
       loadedProject,
       projects: [hydratedProject],
     })
 
-    expect(projectForRender?.children?.map((child) => child.name)).toEqual([
+    expect(explorerProject?.children?.map((child) => child.name)).toEqual([
       FOLDER_PLACEHOLDER_NAME,
       'fresh.kcl',
       FILE_PLACEHOLDER_NAME,

--- a/src/components/layout/areas/ProjectExplorerPane.tsx
+++ b/src/components/layout/areas/ProjectExplorerPane.tsx
@@ -1,7 +1,6 @@
 import { FileExplorerHeaderActions } from '@src/components/Explorer/FileExplorerHeaderActions'
 import { ProjectExplorer } from '@src/components/Explorer/ProjectExplorer'
 import type { FileExplorerEntry } from '@src/components/Explorer/utils'
-import { addPlaceHoldersForNewFileAndFolder } from '@src/components/Explorer/utils'
 import { ToastInsert } from '@src/components/ToastInsert'
 import { LayoutPanel, LayoutPanelHeader } from '@src/components/layout/Panel'
 import { useModelingContext } from '@src/hooks/useModelingContext'
@@ -29,6 +28,7 @@ import {
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
 import { use, useCallback, useEffect, useRef, useState } from 'react'
 import toast from 'react-hot-toast'
+import { getProjectExplorerProjectForRender } from './ProjectExplorerPane.utils'
 
 export function ProjectExplorerPane(props: AreaTypeComponentProps) {
   const { commands, project, systemIOActor, layout } = useApp()
@@ -48,29 +48,25 @@ export function ProjectExplorerPane(props: AreaTypeComponentProps) {
   useEffect(() => {
     // Have no idea why the project loader data doesn't have the children from the ls on disk
     // That means it is a different object or cached incorrectly?
-    if (!project || !file || !projects) {
+    if (!project || !file) {
       return
     }
 
+    const loadedProject = project.projectIORefSignal.value
     if (projects === undefined) {
       systemIOActor.send({
         type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
       })
-      return
     }
 
-    // You need to find the real project in the storage from the loader information since the loader Project is not hydrated
-    const foundProject = projects.find((p) => {
-      return p.name === project?.name
+    const duplicated = getProjectExplorerProjectForRender({
+      loadedProject,
+      projects,
     })
 
-    if (!foundProject) {
+    if (!duplicated) {
       return
     }
-
-    // Duplicate the state to not edit the raw data
-    const duplicated = structuredClone(foundProject)
-    addPlaceHoldersForNewFileAndFolder(duplicated.children, foundProject.path)
     setTheProject(duplicated)
   }, [file, projects, project, systemIOActor])
 

--- a/src/components/layout/areas/ProjectExplorerPane.tsx
+++ b/src/components/layout/areas/ProjectExplorerPane.tsx
@@ -3,6 +3,7 @@ import { ProjectExplorer } from '@src/components/Explorer/ProjectExplorer'
 import type { FileExplorerEntry } from '@src/components/Explorer/utils'
 import { ToastInsert } from '@src/components/ToastInsert'
 import { LayoutPanel, LayoutPanelHeader } from '@src/components/layout/Panel'
+import { getProjectExplorerProjectWithPlaceholders } from '@src/components/layout/areas/ProjectExplorerPane.utils'
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import { relevantFileExtensions } from '@src/lang/wasmUtils'
 import { useApp, useSingletons } from '@src/lib/boot'
@@ -28,7 +29,6 @@ import {
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
 import { use, useCallback, useEffect, useRef, useState } from 'react'
 import toast from 'react-hot-toast'
-import { getProjectExplorerProjectForRender } from './ProjectExplorerPane.utils'
 
 export function ProjectExplorerPane(props: AreaTypeComponentProps) {
   const { commands, project, systemIOActor, layout } = useApp()
@@ -59,7 +59,7 @@ export function ProjectExplorerPane(props: AreaTypeComponentProps) {
       })
     }
 
-    const duplicated = getProjectExplorerProjectForRender({
+    const duplicated = getProjectExplorerProjectWithPlaceholders({
       loadedProject,
       projects,
     })

--- a/src/components/layout/areas/ProjectExplorerPane.utils.ts
+++ b/src/components/layout/areas/ProjectExplorerPane.utils.ts
@@ -1,0 +1,22 @@
+import { addPlaceHoldersForNewFileAndFolder } from '@src/components/Explorer/utils'
+import type { Project } from '@src/lib/project'
+
+export function getProjectExplorerProjectForRender({
+  loadedProject,
+  projects,
+}: {
+  loadedProject: Project
+  projects: Project[] | undefined
+}) {
+  const sourceProject =
+    projects?.find((p) => p.name === loadedProject.name) ??
+    (projects === undefined ? loadedProject : null)
+
+  if (!sourceProject) {
+    return null
+  }
+
+  const duplicated = structuredClone(sourceProject)
+  addPlaceHoldersForNewFileAndFolder(duplicated.children, duplicated.path)
+  return duplicated
+}

--- a/src/components/layout/areas/ProjectExplorerPane.utils.ts
+++ b/src/components/layout/areas/ProjectExplorerPane.utils.ts
@@ -1,7 +1,7 @@
-import { addPlaceHoldersForNewFileAndFolder } from '@src/components/Explorer/utils'
+import { addPlaceHoldersForNewFileAndFolder } from '@src/components/Explorer/placeholders'
 import type { Project } from '@src/lib/project'
 
-export function getProjectExplorerProjectForRender({
+export function getProjectExplorerProjectWithPlaceholders({
   loadedProject,
   projects,
 }: {


### PR DESCRIPTION
## Summary
- gate Zookeeper's saved-conversation load until SystemIO is idle, so it does not interrupt project folder hydration during startup
- let Project Explorer render from the router-loaded project while folder hydration is pending, then prefer hydrated folder data once available
- add focused regression coverage for both behaviors

Fixes #12270.

## Tests
- `./node_modules/.bin/vitest run --mode=development --project=unit src/components/layout/areas/ProjectExplorerPane.test.ts`
- `./node_modules/.bin/vitest run --mode=development --project=integration src/components/layout/areas/MlEphantConversationPane.spec.tsx`
- `./node_modules/.bin/biome check src/components/layout/areas/MlEphantConversationPane.tsx src/components/layout/areas/MlEphantConversationPane.spec.tsx src/components/layout/areas/ProjectExplorerPane.tsx src/components/layout/areas/ProjectExplorerPane.utils.ts src/components/layout/areas/ProjectExplorerPane.test.ts`
- `git diff --check`