### PR TITLE
Handle deleted remote opfsCloud projects

### DIFF
--- a/e2e/playwright/opfs-cloud.spec.ts
+++ b/e2e/playwright/opfs-cloud.spec.ts
@@ -165,7 +165,11 @@ test(
         cleanSyncedProject,
         staleDirtyProject,
       ],
-      listedProjects: [remoteOnlyProject, cleanSyncedProject],
+      listedProjects: [
+        remoteOnlyProject,
+        cleanSyncedProject,
+        staleDirtyProject,
+      ],
       remoteListGate,
       createProject: () => ({
         id: 'created-local-only-project',

--- a/src/lib/fs-zds/opfsCloud.test.ts
+++ b/src/lib/fs-zds/opfsCloud.test.ts
@@ -10,6 +10,7 @@ import {
   filterOpfsCloudProjectFilesForSync,
   getOpfsCloudConflictCopyCleanupPlan,
   getOpfsCloudInitialLocalProjectSyncAction,
+  getOpfsCloudMissingRemoteProjectAction,
   getOpfsCloudProjectModifiedTime,
   getOpfsCloudProjectRoot,
   getOpfsCloudProjectSyncPreflightAction,
@@ -263,6 +264,57 @@ describe('opfsCloud sync helpers', () => {
         syncExcluded: false,
       })
     ).toBe('enqueue')
+  })
+
+  it('removes clean local mirrors when their remote project is missing', () => {
+    expect(
+      getOpfsCloudMissingRemoteProjectAction({
+        localProjectExists: true,
+        hasPendingLocalChanges: false,
+        hasBaseManifest: true,
+        localMatchesBase: true,
+      })
+    ).toBe('remove-clean-local')
+  })
+
+  it('detaches local projects when their missing remote cannot be safely removed', () => {
+    expect(
+      getOpfsCloudMissingRemoteProjectAction({
+        localProjectExists: true,
+        hasPendingLocalChanges: true,
+        hasBaseManifest: true,
+        localMatchesBase: true,
+      })
+    ).toBe('detach-dirty-local')
+
+    expect(
+      getOpfsCloudMissingRemoteProjectAction({
+        localProjectExists: true,
+        hasPendingLocalChanges: false,
+        hasBaseManifest: false,
+        localMatchesBase: false,
+      })
+    ).toBe('detach-dirty-local')
+
+    expect(
+      getOpfsCloudMissingRemoteProjectAction({
+        localProjectExists: true,
+        hasPendingLocalChanges: false,
+        hasBaseManifest: true,
+        localMatchesBase: false,
+      })
+    ).toBe('detach-dirty-local')
+  })
+
+  it('forgets metadata when a missing remote project is also missing locally', () => {
+    expect(
+      getOpfsCloudMissingRemoteProjectAction({
+        localProjectExists: false,
+        hasPendingLocalChanges: false,
+        hasBaseManifest: true,
+        localMatchesBase: false,
+      })
+    ).toBe('forget-missing-local')
   })
 
   it('detects conflict copy project folder names', () => {

--- a/src/lib/fs-zds/opfsCloud.ts
+++ b/src/lib/fs-zds/opfsCloud.ts
@@ -62,6 +62,7 @@ import { sanitizeProjectName } from '@src/lib/projectName'
 import {
   getCloudProjectIdFromProjectTomlContents,
   getProjectTitleFromProjectTomlContents,
+  removeCloudProjectIdFromProjectTomlContents,
   setCloudProjectIdInProjectTomlContents,
   setProjectTitleInProjectTomlContents,
 } from '@src/lib/projectTomlMetadata'
@@ -424,6 +425,32 @@ export function getOpfsCloudInitialLocalProjectSyncAction({
   return 'enqueue'
 }
 
+export type OpfsCloudMissingRemoteProjectAction =
+  | 'forget-missing-local'
+  | 'remove-clean-local'
+  | 'detach-dirty-local'
+
+export function getOpfsCloudMissingRemoteProjectAction({
+  localProjectExists,
+  hasPendingLocalChanges,
+  hasBaseManifest,
+  localMatchesBase,
+}: {
+  localProjectExists: boolean
+  hasPendingLocalChanges: boolean
+  hasBaseManifest: boolean
+  localMatchesBase: boolean
+}): OpfsCloudMissingRemoteProjectAction {
+  if (!localProjectExists) {
+    return 'forget-missing-local'
+  }
+  if (hasBaseManifest && localMatchesBase && !hasPendingLocalChanges) {
+    return 'remove-clean-local'
+  }
+
+  return 'detach-dirty-local'
+}
+
 async function writeLocalProjectTitle(projectPath: string, title: string) {
   return updateLocalProjectToml(projectPath, (projectToml) =>
     getProjectTitleFromProjectTomlContents(projectToml) === title
@@ -473,6 +500,17 @@ async function writeLocalProjectCloudProjectId(
           environmentName,
           projectId
         )
+  )
+}
+
+async function removeLocalProjectCloudProjectId(projectPath: string) {
+  const environmentName = getEnvironmentName()
+  if (!environmentName) {
+    return false
+  }
+
+  return updateLocalProjectToml(projectPath, (projectToml) =>
+    removeCloudProjectIdFromProjectTomlContents(projectToml, environmentName)
   )
 }
 
@@ -1361,6 +1399,69 @@ async function syncDeletedProject(metadata: ProjectMetadata) {
   await deleteProjectMetadata(metadata.localProjectPath)
 }
 
+async function reconcileMissingRemoteProject(
+  metadata: ProjectMetadata,
+  options: { hasPendingLocalChanges: boolean }
+) {
+  const localProjectExists = await exists(metadata.localProjectPath)
+  let localMatchesBase = false
+  if (
+    localProjectExists &&
+    metadata.baseManifest &&
+    !options.hasPendingLocalChanges
+  ) {
+    localMatchesBase = projectManifestsEqual(
+      await collectLocalProjectFiles(metadata.localProjectPath).then(
+        projectManifestFromFiles
+      ),
+      metadata.baseManifest
+    )
+  }
+
+  const action = getOpfsCloudMissingRemoteProjectAction({
+    localProjectExists,
+    hasPendingLocalChanges: options.hasPendingLocalChanges,
+    hasBaseManifest: Boolean(metadata.baseManifest),
+    localMatchesBase,
+  })
+
+  if (action === 'forget-missing-local') {
+    await clearOutboxEntriesForProject(metadata.localProjectPath)
+    await deleteProjectMetadata(metadata.localProjectPath)
+    return undefined
+  }
+
+  if (action === 'remove-clean-local') {
+    await clearOutboxEntriesForProject(metadata.localProjectPath)
+    await localFs.rm(metadata.localProjectPath, { recursive: true })
+    await deleteProjectMetadata(metadata.localProjectPath)
+    return undefined
+  }
+
+  await removeLocalProjectCloudProjectId(metadata.localProjectPath)
+  const nextMetadata = {
+    ...metadata,
+    remoteProjectId: undefined,
+    remoteRevision: undefined,
+    remoteUpdatedAt: undefined,
+    baseManifest: undefined,
+    conflict: undefined,
+    lastFailure: undefined,
+    lastSyncedAt: undefined,
+  }
+  await putProjectMetadata(nextMetadata)
+  if (!options.hasPendingLocalChanges) {
+    await appendOutboxEntry({
+      projectPath: metadata.localProjectPath,
+      kind: 'upsert',
+      targetPath: metadata.localProjectPath,
+      createdAt: nowIso(),
+    })
+  }
+
+  return nextMetadata
+}
+
 async function syncProject(projectPath: string, entries: OutboxEntry[]) {
   let metadata = await getOrCreateProjectMetadata(projectPath)
   if (isProjectSyncExcluded(metadata)) {
@@ -1409,7 +1510,19 @@ async function syncProject(projectPath: string, entries: OutboxEntry[]) {
     let remoteChanged = false
     let localChanged = true
     if (metadata.remoteProjectId) {
-      remoteProject = await getRemoteProject(config, metadata.remoteProjectId)
+      try {
+        remoteProject = await getRemoteProject(config, metadata.remoteProjectId)
+      } catch (error) {
+        if (error instanceof CloudApiError && error.status === 404) {
+          await reconcileMissingRemoteProject(metadata, {
+            hasPendingLocalChanges: entries.length > 0,
+          })
+          return
+        }
+
+        // eslint-disable-next-line suggest-no-throw/suggest-no-throw
+        throw error
+      }
       remoteRevision = getRevision(remoteProject)
     }
 
@@ -1574,6 +1687,9 @@ async function syncRemoteIndex() {
   await localFs.mkdir(projectDirectory, { recursive: true })
 
   const remoteProjects = await listRemoteProjects(config)
+  const remoteProjectIds = new Set(
+    remoteProjects.map((remoteProject) => remoteProject.id).filter(Boolean)
+  )
   let metadata = (await getAllProjectMetadata()).filter(
     (entry) => !isProjectSyncExcluded(entry)
   )
@@ -1598,6 +1714,38 @@ async function syncRemoteIndex() {
       ),
       nextMetadata,
     ]
+  }
+  const removeMetadata = (projectPath: string) => {
+    const normalizedProjectPath = normalizePathForSync(projectPath)
+    metadata = metadata.filter(
+      (entry) =>
+        normalizePathForSync(entry.localProjectPath) !== normalizedProjectPath
+    )
+  }
+
+  for (const localMetadata of [...metadata]) {
+    if (
+      !localMetadata.remoteProjectId ||
+      localMetadata.tombstone ||
+      remoteProjectIds.has(localMetadata.remoteProjectId)
+    ) {
+      continue
+    }
+
+    try {
+      const nextMetadata = await reconcileMissingRemoteProject(localMetadata, {
+        hasPendingLocalChanges: pendingProjectPaths.has(
+          normalizePathForSync(localMetadata.localProjectPath)
+        ),
+      })
+      if (nextMetadata) {
+        upsertMetadata(nextMetadata)
+      } else {
+        removeMetadata(localMetadata.localProjectPath)
+      }
+    } catch (error) {
+      failures.push(error)
+    }
   }
 
   for (const remoteProject of remoteProjects) {

--- a/src/lib/fs-zds/opfsCloud/README.md
+++ b/src/lib/fs-zds/opfsCloud/README.md
@@ -83,6 +83,7 @@ flowchart TD
 - Returning to a visible browser tab schedules an immediate remote-index check, bypassing the normal remote-index throttle.
 - Remote updates must send `expected_revision`; creates and deletes are the only unguarded remote writes.
 - A remote-only project discovered from the cloud index must be cloned into OPFS so later loads can hit local storage first.
+- A remotely deleted project may remove the local OPFS mirror only when that local mirror still matches the last synced base.
 - Remote hydration may replace OPFS only when local is clean relative to the last synced base.
 - If local and remote both changed differently, local remains primary and the remote archive is written as a conflict copy.
 - Sync failures must preserve outbox and dirty metadata.
@@ -114,6 +115,8 @@ Remote updates use optimistic concurrency by sending `expected_revision`. The up
 Remote creates do not have an expected revision because there is no remote base yet. After create succeeds, the returned remote id and revision become the local sync base.
 
 Remote deletes are intentionally not revision-guarded. A project-root `rm` records an explicit tombstone, then the sync worker deletes the remote project if it exists and ignores missing remote projects. Missing local directories are not treated as destructive cloud deletes unless there is a tombstone or queued delete.
+
+If a remote project disappears from the cloud index, the local mirror is removed only when its manifest still matches `ProjectMetadata.baseManifest` and it has no pending local outbox work. Dirty or unverifiable local projects are detached from the missing remote id and queued as local-first projects so user data is preserved and the stale id does not keep retrying a 404.
 
 Remote hydration is only allowed to replace OPFS when the local project is clean relative to `baseManifest`, or when an unknown remote project is being cloned into a new local path. If both local and remote changed since the base, the local project remains primary and the remote archive is written to a conflict project.
 

--- a/src/lib/projectTomlMetadata.test.ts
+++ b/src/lib/projectTomlMetadata.test.ts
@@ -1,6 +1,7 @@
 import {
   getCloudProjectIdFromProjectTomlContents,
   getProjectTitleFromProjectTomlContents,
+  removeCloudProjectIdFromProjectTomlContents,
   setCloudProjectIdInProjectTomlContents,
   setProjectTitleInProjectTomlContents,
 } from '@src/lib/projectTomlMetadata'
@@ -74,5 +75,29 @@ describe('projectTomlMetadata', () => {
       'new-project'
     )
     expect(toml).not.toContain('old-project')
+  })
+
+  it('removes one cloud project id without dropping other metadata', () => {
+    const toml = removeCloudProjectIdFromProjectTomlContents(
+      'title = "Some demo"\ndefault_file = "main.kcl"\n\n[cloud."zoo.dev"]\nproject_id = "project-123"\n\n[cloud."dev.zoo.dev"]\nproject_id = "project-456"\n',
+      'zoo.dev'
+    )
+
+    expect(getProjectTitleFromProjectTomlContents(toml)).toBe('Some demo')
+    expect(
+      getCloudProjectIdFromProjectTomlContents(toml, 'zoo.dev')
+    ).toBeUndefined()
+    expect(getCloudProjectIdFromProjectTomlContents(toml, 'dev.zoo.dev')).toBe(
+      'project-456'
+    )
+    expect(toml).toContain('default_file = "main.kcl"')
+  })
+
+  it('leaves invalid TOML unchanged when removing a cloud project id', () => {
+    const invalidToml = 'title = "Some demo"\n['
+
+    expect(
+      removeCloudProjectIdFromProjectTomlContents(invalidToml, 'zoo.dev')
+    ).toBe(invalidToml)
   })
 })

--- a/src/lib/projectTomlMetadata.ts
+++ b/src/lib/projectTomlMetadata.ts
@@ -27,6 +27,10 @@ function isTomlTable(value: TomlValue | undefined): value is TomlTable {
   )
 }
 
+function isEmptyTomlTable(value: TomlTable) {
+  return Object.keys(value).length === 0
+}
+
 export function getProjectTitleFromProjectTomlContents(contents: string) {
   const table = parseProjectToml(contents)
   if (!table) {
@@ -94,4 +98,29 @@ export function getCloudProjectIdFromProjectTomlContents(
   }
 
   return undefined
+}
+
+export function removeCloudProjectIdFromProjectTomlContents(
+  contents: string,
+  environmentName: string
+) {
+  const table = parseProjectToml(contents)
+  if (!table || !isTomlTable(table.cloud)) {
+    return contents
+  }
+
+  const environment = table.cloud[environmentName]
+  if (!isTomlTable(environment)) {
+    return contents
+  }
+
+  delete environment.project_id
+  if (isEmptyTomlTable(environment)) {
+    delete table.cloud[environmentName]
+  }
+  if (isEmptyTomlTable(table.cloud)) {
+    delete table.cloud
+  }
+
+  return stringifyToml(table)
 }


### PR DESCRIPTION
## Summary

Fixes #12212.

When a cloud project was deleted outside the current client, OPFSCloud could keep stale local sync metadata with the deleted `remoteProjectId`. A later sync would call `GET /user/projects/:id`, receive a 404, mark sync failed, and schedule another retry, leaving the status bar cycling through the same failure.

This PR makes missing remote projects an explicit sync policy:

1. If the local OPFS mirror is missing too, forget the stale metadata.
2. If the local OPFS mirror still matches `baseManifest` and has no pending local outbox work, remove the local mirror and its metadata.
3. If the local project is dirty or cannot be proven clean, preserve the local data by detaching it from the stale remote id, removing that id from `project.toml`, and queuing it as a local-first project.

The same reconciliation now runs both when the full remote index omits a known remote id and when scoped project sync receives a direct 404 from `getRemoteProject()`.

## Validation

- `npm run test:unit -- src/lib/fs-zds/opfsCloud.test.ts src/lib/projectTomlMetadata.test.ts`
- `npm run tsc`
- `npm run lint`
- `git diff --check`