### PR TITLE
Fix default planes after canceling sketch start

### DIFF
--- a/src/machines/modelingMachine.spec.ts
+++ b/src/machines/modelingMachine.spec.ts
@@ -52,6 +52,8 @@ let machineManagerInThisFile: MachineManager = null!
 
 const TESTS_WITHOUT_ENGINE_WORLD = [
   'routes a cursor inside a sketch block segment to sketch solve edit',
+  'shows default planes again when canceling sketch plane selection on a blank scene',
+  'hides default planes when canceling sketch plane selection with geometry present',
 ]
 
 /**
@@ -1629,6 +1631,101 @@ sketch001 = sketch(on = YZ) {
             artifactId: sketchBlock.id,
           })
         )
+
+        actor.stop()
+      })
+
+      const createSketchPlaneSelectionContext = ({
+        artifactGraph = new Map(),
+      }: {
+        artifactGraph?: Map<unknown, unknown>
+      } = {}) =>
+        ({
+          ...modelingMachineInitialInternalContext,
+          kclManager: {
+            artifactGraph,
+            hasErrors: vi.fn(() => false),
+            hidePlanes: vi.fn(),
+            setCopilotEnabled: vi.fn(),
+            setSelectionFilter: vi.fn(),
+            setSelectionFilterToDefault: vi.fn(),
+            showPlanes: vi.fn(),
+            sceneInfra: {
+              animate: vi.fn(),
+              stop: vi.fn(),
+              resetMouseListeners: vi.fn(),
+              camControls: {
+                enablePan: true,
+                enableRotate: true,
+                syncDirection: 'engineToClient',
+              },
+            },
+          },
+          rustContext: {},
+          engineCommandManager: {},
+          wasmInstance: {},
+          commandBarActor: {},
+          machineManager: {},
+        }) as any
+
+      it('shows default planes again when canceling sketch plane selection on a blank scene', async () => {
+        const context = createSketchPlaneSelectionContext()
+
+        const actor = createActor(modelingMachine, { input: context }).start()
+
+        actor.send({
+          type: 'Enter sketch',
+          data: { forceNewSketch: true },
+        })
+
+        await waitForCondition(
+          () => actor.getSnapshot().value === 'Sketch no face'
+        )
+
+        actor.send({ type: 'Cancel' })
+
+        await waitForCondition(() => {
+          return (
+            JSON.stringify(actor.getSnapshot().value) ===
+            JSON.stringify({ idle: 'showPlanes' })
+          )
+        })
+
+        expect(context.kclManager.hidePlanes).toHaveBeenCalled()
+        expect(context.kclManager.showPlanes).toHaveBeenCalledTimes(2)
+
+        actor.stop()
+      })
+
+      it('hides default planes when canceling sketch plane selection with geometry present', async () => {
+        const context = {
+          ...createSketchPlaneSelectionContext({
+            artifactGraph: new Map([['artifact-id', {}]]),
+          }),
+        }
+
+        const actor = createActor(modelingMachine, { input: context }).start()
+
+        actor.send({
+          type: 'Enter sketch',
+          data: { forceNewSketch: true },
+        })
+
+        await waitForCondition(
+          () => actor.getSnapshot().value === 'Sketch no face'
+        )
+
+        actor.send({ type: 'Cancel' })
+
+        await waitForCondition(() => {
+          return (
+            JSON.stringify(actor.getSnapshot().value) ===
+            JSON.stringify({ idle: 'hidePlanes' })
+          )
+        })
+
+        expect(context.kclManager.hidePlanes).toHaveBeenCalled()
+        expect(context.kclManager.showPlanes).toHaveBeenCalledTimes(1)
 
         actor.stop()
       })

--- a/src/machines/modelingMachine.ts
+++ b/src/machines/modelingMachine.ts
@@ -784,6 +784,9 @@ export const modelingMachine = setup({
     'should use sketch solve mode': ({ context }) => {
       return context.store.useSketchSolveMode?.current === true
     },
+    'Artifact graph is empty': ({ context }) => {
+      return context.kclManager.artifactGraph.size === 0
+    },
     'Selection is sketchBlock': ({
       context: { selectionRanges, kclManager },
       event,
@@ -1151,6 +1154,9 @@ export const modelingMachine = setup({
           up: { x: 0, y: 0, z: 1 },
         },
       })
+    },
+    'stop scene infra': ({ context }) => {
+      context.kclManager.sceneInfra.stop()
     },
     'set new sketch metadata': assign(({ event }) => {
       if (
@@ -8271,6 +8277,26 @@ export const modelingMachine = setup({
 
       exit: ['hide default planes', 'set selection filter to defaults'],
       on: {
+        Cancel: [
+          {
+            guard: 'Artifact graph is empty',
+            target: '#Modeling.idle.showPlanes',
+            actions: [
+              'reset sketch metadata',
+              'enable copilot',
+              'stop scene infra',
+            ],
+          },
+          {
+            target: '#Modeling.idle.hidePlanes',
+            actions: [
+              'reset sketch metadata',
+              'enable copilot',
+              'stop scene infra',
+            ],
+          },
+        ],
+
         'Select sketch plane': {
           target: 'animating to plane',
           actions: ['reset sketch metadata'],


### PR DESCRIPTION
Fixes #12198.

This fixes the little void moment when you start a new sketch on a blank scene and then immediately cancel before picking a plane.

Before this, entering the “pick a sketch plane” state would show the default planes, but canceling out of that state would hide them again and land back in idle with no geometry around. So on a completely blank file you ended up staring into nothing, which is pretty disorienting.

This makes `Sketch no face` handle `Cancel` directly and return to `idle.showPlanes`, so we still do the normal cleanup but then show the default planes again.

Added a regression test for:

- start new sketch with no selected plane
- enter `Sketch no face`
- cancel
- land back in `idle.showPlanes`
- call `showPlanes` again

