### PR TITLE
Upgrade rust toolchain to 1.96.1

### DIFF
--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.96.0"
+channel = "1.96.1"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
https://blog.rust-lang.org/2026/06/30/Rust-1.96.1/