### PR TITLE
Fix missing kcl-api package fields for cargo crate publish

### DIFF
--- a/rust/kcl-api/Cargo.toml
+++ b/rust/kcl-api/Cargo.toml
@@ -2,6 +2,9 @@
 name = "kcl-api"
 version = "0.2.167"
 edition = "2024"
+description = "KCL API"
+license = "MIT"
+repository = "https://github.com/KittyCAD/modeling-app"
 
 [features]
 pyo3 = ["dep:pyo3", "dep:pyo3-stub-gen"]


### PR DESCRIPTION
Publishing the crate resulted in:

> error: failed to publish kcl-api v0.2.167 to registry at https://crates.io
>
> Caused by:
>   the remote server responded with an error (status 400 Bad Request): missing or empty metadata fields: description, license. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for more information on configuring these fields