### PR TITLE
Evict the Wasm cache after a week

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -109,6 +109,7 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           name: prepared-wasm
+          retention-days: 7
           path: |
             rust/kcl-wasm-lib/pkg/kcl_wasm_lib*
 


### PR DESCRIPTION
The default is 90 days but that is far longer than we'd ever expect to go without changes to the code.

In [this Slack thread](https://kittycadworkspace.slack.com/archives/C04KFV6NKL0/p1782827589267069?thread_ts=1782823792.384369&cid=C04KFV6NKL0), we were surprised to see a build use cached Wasm from more than a month ago. Presumably this was just a glitch, but setting a retention period should hopefully make that situation impossible.