### PR TITLE
Fix Zookeeper undo redo with file snapshots for long running tasks

### DIFF
--- a/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
+++ b/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
@@ -136,138 +136,192 @@ function MlEphantConversationPaneInner(props: AreaTypeComponentProps) {
 
   const {
     beginPendingZookeeperHistoryWrite,
+    cancelPendingZookeeperHistoryWrite,
     completePendingZookeeperHistoryWrite,
   } = useZookeeperEditPatchHistory({
     kclManager,
     mlEphantManagerActor,
   })
+  const zookeeperFileRequestQueue = useRef<Promise<void>>(Promise.resolve())
 
   useWatchForNewFileRequestsFromMlEphant(
     mlEphantManagerActor,
     kclManager.engineCommandManager,
     (requestProps) => {
-      void (async () => {
-        const activeFilePath =
-          requestProps.fileFocusedOnInEditor?.path ?? kclManager.path
-        const payload = prepareMlEphantNewFileRequest({
-          ...requestProps,
-          fallbackFilePath: activeFilePath,
-        })
+      zookeeperFileRequestQueue.current =
+        zookeeperFileRequestQueue.current.then(
+          () =>
+            new Promise<void>((resolve) => {
+              let pendingHistoryStarted = false
+              let requestSettled = false
+              const exchangeId = requestProps.exchangeId ?? 0
+              const settleRequest = () => {
+                if (requestSettled) return
+                requestSettled = true
+                resolve()
+              }
 
-        if (payload) {
-          let historyRecorded = false
-          const exchangeId = requestProps.exchangeId ?? 0
-          const activeRelativePath =
-            project?.path && activeFilePath
-              ? normalizeKCLFileDeletePath(
-                  fsZds.relative(project.path, activeFilePath)
+              void (async () => {
+                const activeFilePath =
+                  requestProps.fileFocusedOnInEditor?.path ?? kclManager.path
+                const payload = prepareMlEphantNewFileRequest({
+                  ...requestProps,
+                  fallbackFilePath: activeFilePath,
+                })
+
+                if (!payload) {
+                  settleRequest()
+                  return
+                }
+
+                let historyRecorded = false
+                const activeRelativePath =
+                  project?.path && activeFilePath
+                    ? normalizeKCLFileDeletePath(
+                        fsZds.relative(project.path, activeFilePath)
+                      )
+                    : ''
+                const activeFileDeleted =
+                  activeRelativePath.length > 0 &&
+                  payload.filesToDelete.some(
+                    (file) =>
+                      normalizeKCLFileDeletePath(file.requestedFileName) ===
+                      activeRelativePath
+                  )
+                const shouldRecordZookeeperHistory = Boolean(
+                  project?.path &&
+                    payload.zookeeperEditPatch?.changed_files?.length
                 )
-              : ''
-          const activeFileDeleted =
-            activeRelativePath.length > 0 &&
-            payload.filesToDelete.some(
-              (file) =>
-                normalizeKCLFileDeletePath(file.requestedFileName) ===
-                activeRelativePath
-            )
-          const shouldRecordZookeeperHistory = Boolean(
-            project?.path && payload.zookeeperEditPatch?.changed_files?.length
-          )
-          const activeFileOutput = payload.files.find(
-            (file) =>
-              normalizeKCLFileDeletePath(file.requestedFileName) ===
-              activeRelativePath
-          )
-          const shouldRefreshActiveEditorAfterPlainOutput = Boolean(
-            !shouldRecordZookeeperHistory &&
-              !activeFileDeleted &&
-              activeFileOutput &&
-              project?.name === payload.requestedProjectName &&
-              activeFilePath === kclManager.path
-          )
-          if (
-            shouldRecordZookeeperHistory &&
-            project?.path &&
-            payload.zookeeperEditPatch
-          ) {
-            await beginPendingZookeeperHistoryWrite({
-              activeFilePath,
-              exchangeId,
-              patch: payload.zookeeperEditPatch,
-              projectPath: project.path,
-            })
-          }
-          kclManager.mlEphantManagerMachineBulkManipulatingFileSystem = true
-          systemIOActor.send({
-            type: SystemIOMachineEvents.bulkCreateAndDeleteKCLFilesAndNavigateToFile,
-            data: {
-              files: payload.files,
-              filesToDelete: payload.filesToDelete,
-              override: true,
-              requestedProjectName: payload.requestedProjectName,
-              requestedFileNameWithExtension:
-                payload.requestedFileNameWithExtension ?? '',
-              onFileSystemSuccess: () => {
-                if (historyRecorded) return
-                historyRecorded = true
+                const activeFileOutput = payload.files.find(
+                  (file) =>
+                    normalizeKCLFileDeletePath(file.requestedFileName) ===
+                    activeRelativePath
+                )
+                const shouldRefreshActiveEditorAfterPlainOutput = Boolean(
+                  !shouldRecordZookeeperHistory &&
+                    !activeFileDeleted &&
+                    activeFileOutput &&
+                    project?.name === payload.requestedProjectName &&
+                    activeFilePath === kclManager.path
+                )
                 if (
                   shouldRecordZookeeperHistory &&
                   project?.path &&
                   payload.zookeeperEditPatch
                 ) {
-                  const currentFile = payload.files.find(
-                    (file) =>
-                      normalizeKCLFileDeletePath(file.requestedFileName) ===
-                      activeRelativePath
-                  )
-                  const currentEditorRelativePath =
-                    project.path && kclManager.path
-                      ? normalizeKCLFileDeletePath(
-                          fsZds.relative(project.path, kclManager.path)
-                        )
-                      : ''
-                  const currentEditorFile = payload.files.find(
-                    (file) =>
-                      normalizeKCLFileDeletePath(file.requestedFileName) ===
-                      currentEditorRelativePath
-                  )
-                  void completePendingZookeeperHistoryWrite({
-                    activeFileDeleted,
+                  pendingHistoryStarted = true
+                  await beginPendingZookeeperHistoryWrite({
                     activeFilePath,
-                    activeFileRequestedCode: currentFile?.requestedCode,
-                    currentFilePath: currentEditorFile
-                      ? kclManager.path
-                      : undefined,
-                    currentFileRequestedCode: currentEditorFile?.requestedCode,
                     exchangeId,
                     patch: payload.zookeeperEditPatch,
                     projectPath: project.path,
                   })
                 }
-              },
-              ...(shouldRefreshActiveEditorAfterPlainOutput && activeFileOutput
-                ? {
-                    onSuccess: () => {
-                      if (kclManager.path !== activeFilePath) return
-                      if (kclManager.code === activeFileOutput.requestedCode)
-                        return
-                      kclManager.updateCodeEditor(
-                        activeFileOutput.requestedCode,
-                        {
-                          shouldAddToHistory: false,
-                          shouldClearHistory: true,
-                          shouldExecute: true,
-                          shouldResetCamera: true,
-                          shouldWriteToDisk: true,
-                        }
-                      )
+                kclManager.mlEphantManagerMachineBulkManipulatingFileSystem = true
+                systemIOActor.send({
+                  type: SystemIOMachineEvents.bulkCreateAndDeleteKCLFilesAndNavigateToFile,
+                  data: {
+                    files: payload.files,
+                    filesToDelete: payload.filesToDelete,
+                    override: true,
+                    requestedProjectName: payload.requestedProjectName,
+                    requestedFileNameWithExtension:
+                      payload.requestedFileNameWithExtension ?? '',
+                    onFileSystemError: () => {
+                      if (pendingHistoryStarted) {
+                        cancelPendingZookeeperHistoryWrite({ exchangeId })
+                      }
+                      settleRequest()
                     },
-                  }
-                : {}),
-            },
-          })
-        }
-      })()
+                    onFileSystemSuccess: () => {
+                      if (historyRecorded) {
+                        settleRequest()
+                        return
+                      }
+                      historyRecorded = true
+                      if (
+                        shouldRecordZookeeperHistory &&
+                        project?.path &&
+                        payload.zookeeperEditPatch
+                      ) {
+                        const currentFile = payload.files.find(
+                          (file) =>
+                            normalizeKCLFileDeletePath(
+                              file.requestedFileName
+                            ) === activeRelativePath
+                        )
+                        const currentEditorRelativePath =
+                          project.path && kclManager.path
+                            ? normalizeKCLFileDeletePath(
+                                fsZds.relative(project.path, kclManager.path)
+                              )
+                            : ''
+                        const currentEditorFile = payload.files.find(
+                          (file) =>
+                            normalizeKCLFileDeletePath(
+                              file.requestedFileName
+                            ) === currentEditorRelativePath
+                        )
+                        void completePendingZookeeperHistoryWrite({
+                          activeFileDeleted,
+                          activeFilePath,
+                          activeFileRequestedCode: currentFile?.requestedCode,
+                          currentFilePath: currentEditorFile
+                            ? kclManager.path
+                            : undefined,
+                          currentFileRequestedCode:
+                            currentEditorFile?.requestedCode,
+                          exchangeId,
+                          patch: payload.zookeeperEditPatch,
+                          projectPath: project.path,
+                        })
+                          .catch((error: unknown) => {
+                            console.error(
+                              'Failed to complete Zookeeper history write.',
+                              error
+                            )
+                          })
+                          .finally(settleRequest)
+                        return
+                      }
+                      settleRequest()
+                    },
+                    ...(shouldRefreshActiveEditorAfterPlainOutput &&
+                    activeFileOutput
+                      ? {
+                          onSuccess: () => {
+                            if (kclManager.path !== activeFilePath) return
+                            if (
+                              kclManager.code === activeFileOutput.requestedCode
+                            )
+                              return
+                            kclManager.updateCodeEditor(
+                              activeFileOutput.requestedCode,
+                              {
+                                shouldAddToHistory: false,
+                                shouldClearHistory: true,
+                                shouldExecute: true,
+                                shouldResetCamera: true,
+                                shouldWriteToDisk: true,
+                              }
+                            )
+                          },
+                        }
+                      : {}),
+                  },
+                })
+              })().catch((error: unknown) => {
+                if (pendingHistoryStarted) {
+                  cancelPendingZookeeperHistoryWrite({ exchangeId })
+                }
+                console.error(
+                  'Failed to process Zookeeper file request.',
+                  error
+                )
+                settleRequest()
+              })
+            })
+        )
     }
   )
 
@@ -492,6 +546,35 @@ function useZookeeperEditPatchHistory({
     [kclManager]
   )
 
+  const cancelPendingZookeeperHistoryWrite = useCallback(
+    ({ exchangeId }: CancelPendingZookeeperHistoryWriteProps) => {
+      const pending = pendingZookeeperHistoryByExchange.current.get(exchangeId)
+      if (!pending) {
+        if (pendingZookeeperHistoryByExchange.current.size === 0) {
+          kclManager.zookeeperHistoryRecordingInProgress = false
+        }
+        return
+      }
+
+      pending.snapshotFilesByRelativePath.clear()
+      pending.outstandingWrites = Math.max(0, pending.outstandingWrites - 1)
+      if (
+        pending.outstandingWrites === 0 &&
+        !pending.patch?.changed_files?.length
+      ) {
+        pendingZookeeperHistoryByExchange.current.delete(exchangeId)
+      } else {
+        pendingZookeeperHistoryByExchange.current.set(exchangeId, pending)
+        tryFlushPendingZookeeperHistory(exchangeId)
+      }
+
+      if (pendingZookeeperHistoryByExchange.current.size === 0) {
+        kclManager.zookeeperHistoryRecordingInProgress = false
+      }
+    },
+    [kclManager, tryFlushPendingZookeeperHistory]
+  )
+
   const completePendingZookeeperHistoryWrite = useCallback(
     async ({
       activeFileDeleted,
@@ -542,6 +625,7 @@ function useZookeeperEditPatchHistory({
 
   return {
     beginPendingZookeeperHistoryWrite,
+    cancelPendingZookeeperHistoryWrite,
     completePendingZookeeperHistoryWrite,
   }
 }
@@ -759,6 +843,10 @@ type BeginPendingZookeeperHistoryWriteProps = {
   exchangeId: number
   patch: ZookeeperEditPatch
   projectPath: string
+}
+
+type CancelPendingZookeeperHistoryWriteProps = {
+  exchangeId: number
 }
 
 type CompletePendingZookeeperHistoryWriteProps = {

--- a/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
+++ b/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
@@ -4,18 +4,23 @@ import { useSignals } from '@preact/signals-react/runtime'
 import { LayoutPanel, LayoutPanelHeader } from '@src/components/layout/Panel'
 import { HeaderMenu } from '@src/components/layout/Panel/HeaderMenu'
 import { MlEphantConversationPane } from '@src/components/layout/areas/MlEphantConversationPane'
-import { zookeeperEditPatchHistoryEvent } from '@src/editor/plugins/zookeeper'
+import {
+  type ZookeeperSnapshotFileReplay,
+  zookeeperEditPatchHistoryEvent,
+} from '@src/editor/plugins/zookeeper'
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import type { KclManager } from '@src/lang/KclManager'
 import { useApp, useSingletons } from '@src/lib/boot'
 import { browserSaveFile } from '@src/lib/browserSaveFile'
 import { isCodeTheSame } from '@src/lib/codeEditor'
+import { isPathNotFoundError } from '@src/lib/desktop'
 import fsZds from '@src/lib/fs-zds'
 import type { AreaTypeComponentProps } from '@src/lib/layout'
 import {
   type ZookeeperEditPatch,
   type ZookeeperEditPatchFile,
   mergeZookeeperEditPatches,
+  normalizeZookeeperPatchPath,
 } from '@src/lib/zookeeperEditPatch'
 import { BillingTransition } from '@src/machines/billingMachine'
 import {
@@ -140,7 +145,7 @@ function MlEphantConversationPaneInner(props: AreaTypeComponentProps) {
   useWatchForNewFileRequestsFromMlEphant(
     mlEphantManagerActor,
     kclManager.engineCommandManager,
-    (requestProps) => {
+    async (requestProps) => {
       const activeFilePath =
         requestProps.fileFocusedOnInEditor?.path ?? kclManager.path
       const payload = prepareMlEphantNewFileRequest({
@@ -179,8 +184,17 @@ function MlEphantConversationPaneInner(props: AreaTypeComponentProps) {
             project?.name === payload.requestedProjectName &&
             activeFilePath === kclManager.path
         )
-        if (shouldRecordZookeeperHistory) {
-          beginPendingZookeeperHistoryWrite(exchangeId, activeFilePath)
+        if (
+          shouldRecordZookeeperHistory &&
+          project?.path &&
+          payload.zookeeperEditPatch
+        ) {
+          await beginPendingZookeeperHistoryWrite({
+            activeFilePath,
+            exchangeId,
+            patch: payload.zookeeperEditPatch,
+            projectPath: project.path,
+          })
         }
         kclManager.mlEphantManagerMachineBulkManipulatingFileSystem = true
         systemIOActor.send({
@@ -216,7 +230,7 @@ function MlEphantConversationPaneInner(props: AreaTypeComponentProps) {
                     normalizeKCLFileDeletePath(file.requestedFileName) ===
                     currentEditorRelativePath
                 )
-                completePendingZookeeperHistoryWrite({
+                void completePendingZookeeperHistoryWrite({
                   activeFileDeleted,
                   activeFilePath,
                   activeFileRequestedCode: currentFile?.requestedCode,
@@ -355,11 +369,16 @@ function useZookeeperEditPatchHistory({
         codeChangeRequestedCode !== undefined &&
         kclManager.path === codeChangeFilePath
       ) {
-        const codeChangePreviousCode = getZookeeperPatchPreviousCode(
-          pending.patch,
-          codeChangeRelativePath,
-          codeChangeRequestedCode
-        )
+        const codeChangePreviousCode =
+          getZookeeperSnapshotPreviousCode(
+            pending.snapshotFiles,
+            codeChangeRelativePath
+          ) ??
+          getZookeeperPatchPreviousCode(
+            pending.patch,
+            codeChangeRelativePath,
+            codeChangeRequestedCode
+          )
         // Project refreshes may reload the active editor before Zookeeper
         // history is recorded. Put the captured pre-write state back first so
         // the Zookeeper change lands on top of the user's local undo stack.
@@ -380,6 +399,7 @@ function useZookeeperEditPatchHistory({
             projectPath: pending.projectPath,
             patch: pending.patch,
             activeFilePath: pending.activeFilePath,
+            snapshotFiles: pending.snapshotFiles,
           }),
           codeChangeRequestedCode,
           codeChangePreviousCode
@@ -392,6 +412,7 @@ function useZookeeperEditPatchHistory({
           projectPath: pending.projectPath,
           patch: pending.patch,
           activeFilePath: pending.activeFilePath,
+          snapshotFiles: pending.snapshotFiles,
         })
       )
     },
@@ -422,6 +443,7 @@ function useZookeeperEditPatchHistory({
           currentFileRequestedCode: pending.currentFileRequestedCode,
           patch: pending.patch,
           projectPath: pending.projectPath,
+          snapshotFiles: getReadyZookeeperSnapshotFiles(pending),
         })
       } finally {
         if (pendingZookeeperHistoryByExchange.current.size === 0) {
@@ -433,11 +455,17 @@ function useZookeeperEditPatchHistory({
   )
 
   const beginPendingZookeeperHistoryWrite = useCallback(
-    (exchangeId: number, activeFilePath?: string) => {
+    async ({
+      activeFilePath,
+      exchangeId,
+      patch,
+      projectPath,
+    }: BeginPendingZookeeperHistoryWriteProps) => {
       const pending =
         pendingZookeeperHistoryByExchange.current.get(exchangeId) ??
         createPendingZookeeperHistory()
       pending.outstandingWrites += 1
+      pending.projectPath ??= projectPath
       if (
         !pending.activeEditorState &&
         activeFilePath &&
@@ -447,12 +475,23 @@ function useZookeeperEditPatchHistory({
       }
       pendingZookeeperHistoryByExchange.current.set(exchangeId, pending)
       kclManager.zookeeperHistoryRecordingInProgress = true
+      try {
+        await captureZookeeperSnapshotPreviousContents({
+          kclManager,
+          patch,
+          pending,
+          projectPath,
+        })
+      } catch (error: unknown) {
+        console.error('Failed to capture Zookeeper history snapshots.', error)
+        pending.snapshotFilesByRelativePath.clear()
+      }
     },
     [kclManager]
   )
 
   const completePendingZookeeperHistoryWrite = useCallback(
-    ({
+    async ({
       activeFileDeleted,
       activeFilePath,
       activeFileRequestedCode,
@@ -465,7 +504,6 @@ function useZookeeperEditPatchHistory({
       const pending =
         pendingZookeeperHistoryByExchange.current.get(exchangeId) ??
         createPendingZookeeperHistory()
-      pending.outstandingWrites = Math.max(0, pending.outstandingWrites - 1)
       pending.projectPath = projectPath
       pending.activeFilePath ??= activeFilePath
       pending.activeFileDeleted = pending.activeFileDeleted || activeFileDeleted
@@ -477,6 +515,17 @@ function useZookeeperEditPatchHistory({
       pending.patch = pending.patch
         ? mergeZookeeperEditPatches(pending.patch, patch)
         : patch
+      try {
+        await captureZookeeperSnapshotNextContents({
+          patch,
+          pending,
+          projectPath,
+        })
+      } catch (error: unknown) {
+        console.error('Failed to capture Zookeeper history snapshots.', error)
+        pending.snapshotFilesByRelativePath.clear()
+      }
+      pending.outstandingWrites = Math.max(0, pending.outstandingWrites - 1)
       pendingZookeeperHistoryByExchange.current.set(exchangeId, pending)
       tryFlushPendingZookeeperHistory(exchangeId)
     },
@@ -532,6 +581,144 @@ function getZookeeperCodeChangeTarget({
   }
 }
 
+function getZookeeperSnapshotPreviousCode(
+  snapshotFiles: readonly ZookeeperSnapshotFileReplay[],
+  relativePath: string | undefined
+) {
+  if (relativePath === undefined) {
+    return
+  }
+
+  const snapshotFile = snapshotFiles.find(
+    (file) => normalizeKCLFileDeletePath(file.relativePath) === relativePath
+  )
+  if (snapshotFile === undefined) {
+    return
+  }
+
+  return snapshotFile.previousContent ?? ''
+}
+
+async function captureZookeeperSnapshotPreviousContents({
+  kclManager,
+  patch,
+  pending,
+  projectPath,
+}: {
+  kclManager: KclManager
+  patch: ZookeeperEditPatch
+  pending: PendingZookeeperHistory
+  projectPath: string
+}) {
+  for (const changedFile of patch.changed_files ?? []) {
+    const snapshotPath = getZookeeperSnapshotPath(projectPath, changedFile.path)
+    if (pending.snapshotFilesByRelativePath.has(snapshotPath.relativePath)) {
+      continue
+    }
+
+    const previousContent =
+      snapshotPath.absolutePath === kclManager.path
+        ? kclManager.code
+        : await readZookeeperSnapshotFileIfExists(snapshotPath.absolutePath)
+    pending.snapshotFilesByRelativePath.set(snapshotPath.relativePath, {
+      ...snapshotPath,
+      previousContent,
+    })
+  }
+}
+
+async function captureZookeeperSnapshotNextContents({
+  patch,
+  pending,
+  projectPath,
+}: {
+  patch: ZookeeperEditPatch
+  pending: PendingZookeeperHistory
+  projectPath: string
+}) {
+  for (const changedFile of patch.changed_files ?? []) {
+    const snapshotPath = getZookeeperSnapshotPath(projectPath, changedFile.path)
+    const snapshotFile = pending.snapshotFilesByRelativePath.get(
+      snapshotPath.relativePath
+    ) ?? {
+      ...snapshotPath,
+      previousContent: null,
+    }
+
+    snapshotFile.nextContent = await readZookeeperSnapshotFileIfExists(
+      snapshotPath.absolutePath
+    )
+    pending.snapshotFilesByRelativePath.set(
+      snapshotPath.relativePath,
+      snapshotFile
+    )
+  }
+}
+
+function getReadyZookeeperSnapshotFiles(
+  pending: PendingZookeeperHistory
+): ZookeeperSnapshotFileReplay[] {
+  const snapshotFiles: ZookeeperSnapshotFileReplay[] = []
+
+  for (const snapshotFile of pending.snapshotFilesByRelativePath.values()) {
+    if (snapshotFile.nextContent === undefined) {
+      return []
+    }
+
+    snapshotFiles.push({
+      relativePath: snapshotFile.relativePath,
+      absolutePath: snapshotFile.absolutePath,
+      previousContent: snapshotFile.previousContent,
+      nextContent: snapshotFile.nextContent,
+    })
+  }
+
+  return snapshotFiles
+}
+
+function getZookeeperSnapshotPath(projectPath: string, relativePath: string) {
+  const normalizedPath = normalizeZookeeperPatchPath(relativePath)
+  const pathParts = normalizedPath.split('/')
+  const safePathParts = pathParts.filter(
+    (part) => part.length > 0 && part !== '.'
+  )
+
+  if (
+    pathParts.some((part) => part === '..') ||
+    safePathParts.length === 0 ||
+    normalizedPath.startsWith('/') ||
+    /^[A-Za-z]:/.test(normalizedPath)
+  ) {
+    throw new Error(
+      `Cannot record Zookeeper history for unsafe path "${relativePath}".`
+    )
+  }
+
+  return {
+    relativePath: normalizedPath,
+    absolutePath: fsZds.join(projectPath, ...safePathParts),
+  }
+}
+
+async function readZookeeperSnapshotFileIfExists(path: string) {
+  try {
+    return await fsZds.readFile(path, 'utf8')
+  } catch (error: unknown) {
+    if (isPathNotFoundError(error)) {
+      return null
+    }
+
+    return Promise.reject(error)
+  }
+}
+
+type PendingZookeeperSnapshotFile = {
+  relativePath: string
+  absolutePath: string
+  previousContent: string | null
+  nextContent?: string | null
+}
+
 type PendingZookeeperHistory = {
   activeFileDeleted: boolean
   activeEditorState?: EditorState
@@ -542,6 +729,7 @@ type PendingZookeeperHistory = {
   outstandingWrites: number
   patch?: ZookeeperEditPatch
   projectPath?: string
+  snapshotFilesByRelativePath: Map<string, PendingZookeeperSnapshotFile>
   streamEnded: boolean
 }
 
@@ -554,17 +742,32 @@ type ReadyPendingZookeeperHistory = {
   currentFileRequestedCode?: string
   patch: ZookeeperEditPatch
   projectPath: string
+  snapshotFiles: readonly ZookeeperSnapshotFileReplay[]
 }
 
-type CompletePendingZookeeperHistoryWriteProps =
-  ReadyPendingZookeeperHistory & {
-    exchangeId: number
-  }
+type BeginPendingZookeeperHistoryWriteProps = {
+  activeFilePath?: string
+  exchangeId: number
+  patch: ZookeeperEditPatch
+  projectPath: string
+}
+
+type CompletePendingZookeeperHistoryWriteProps = {
+  activeFileDeleted: boolean
+  activeFilePath?: string
+  activeFileRequestedCode?: string
+  currentFilePath?: string
+  currentFileRequestedCode?: string
+  exchangeId: number
+  patch: ZookeeperEditPatch
+  projectPath: string
+}
 
 function createPendingZookeeperHistory(): PendingZookeeperHistory {
   return {
     activeFileDeleted: false,
     outstandingWrites: 0,
+    snapshotFilesByRelativePath: new Map(),
     streamEnded: false,
   }
 }

--- a/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
+++ b/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
@@ -145,127 +145,129 @@ function MlEphantConversationPaneInner(props: AreaTypeComponentProps) {
   useWatchForNewFileRequestsFromMlEphant(
     mlEphantManagerActor,
     kclManager.engineCommandManager,
-    async (requestProps) => {
-      const activeFilePath =
-        requestProps.fileFocusedOnInEditor?.path ?? kclManager.path
-      const payload = prepareMlEphantNewFileRequest({
-        ...requestProps,
-        fallbackFilePath: activeFilePath,
-      })
+    (requestProps) => {
+      void (async () => {
+        const activeFilePath =
+          requestProps.fileFocusedOnInEditor?.path ?? kclManager.path
+        const payload = prepareMlEphantNewFileRequest({
+          ...requestProps,
+          fallbackFilePath: activeFilePath,
+        })
 
-      if (payload) {
-        let historyRecorded = false
-        const exchangeId = requestProps.exchangeId ?? 0
-        const activeRelativePath =
-          project?.path && activeFilePath
-            ? normalizeKCLFileDeletePath(
-                fsZds.relative(project.path, activeFilePath)
-              )
-            : ''
-        const activeFileDeleted =
-          activeRelativePath.length > 0 &&
-          payload.filesToDelete.some(
+        if (payload) {
+          let historyRecorded = false
+          const exchangeId = requestProps.exchangeId ?? 0
+          const activeRelativePath =
+            project?.path && activeFilePath
+              ? normalizeKCLFileDeletePath(
+                  fsZds.relative(project.path, activeFilePath)
+                )
+              : ''
+          const activeFileDeleted =
+            activeRelativePath.length > 0 &&
+            payload.filesToDelete.some(
+              (file) =>
+                normalizeKCLFileDeletePath(file.requestedFileName) ===
+                activeRelativePath
+            )
+          const shouldRecordZookeeperHistory = Boolean(
+            project?.path && payload.zookeeperEditPatch?.changed_files?.length
+          )
+          const activeFileOutput = payload.files.find(
             (file) =>
               normalizeKCLFileDeletePath(file.requestedFileName) ===
               activeRelativePath
           )
-        const shouldRecordZookeeperHistory = Boolean(
-          project?.path && payload.zookeeperEditPatch?.changed_files?.length
-        )
-        const activeFileOutput = payload.files.find(
-          (file) =>
-            normalizeKCLFileDeletePath(file.requestedFileName) ===
-            activeRelativePath
-        )
-        const shouldRefreshActiveEditorAfterPlainOutput = Boolean(
-          !shouldRecordZookeeperHistory &&
-            !activeFileDeleted &&
-            activeFileOutput &&
-            project?.name === payload.requestedProjectName &&
-            activeFilePath === kclManager.path
-        )
-        if (
-          shouldRecordZookeeperHistory &&
-          project?.path &&
-          payload.zookeeperEditPatch
-        ) {
-          await beginPendingZookeeperHistoryWrite({
-            activeFilePath,
-            exchangeId,
-            patch: payload.zookeeperEditPatch,
-            projectPath: project.path,
+          const shouldRefreshActiveEditorAfterPlainOutput = Boolean(
+            !shouldRecordZookeeperHistory &&
+              !activeFileDeleted &&
+              activeFileOutput &&
+              project?.name === payload.requestedProjectName &&
+              activeFilePath === kclManager.path
+          )
+          if (
+            shouldRecordZookeeperHistory &&
+            project?.path &&
+            payload.zookeeperEditPatch
+          ) {
+            await beginPendingZookeeperHistoryWrite({
+              activeFilePath,
+              exchangeId,
+              patch: payload.zookeeperEditPatch,
+              projectPath: project.path,
+            })
+          }
+          kclManager.mlEphantManagerMachineBulkManipulatingFileSystem = true
+          systemIOActor.send({
+            type: SystemIOMachineEvents.bulkCreateAndDeleteKCLFilesAndNavigateToFile,
+            data: {
+              files: payload.files,
+              filesToDelete: payload.filesToDelete,
+              override: true,
+              requestedProjectName: payload.requestedProjectName,
+              requestedFileNameWithExtension:
+                payload.requestedFileNameWithExtension ?? '',
+              onFileSystemSuccess: () => {
+                if (historyRecorded) return
+                historyRecorded = true
+                if (
+                  shouldRecordZookeeperHistory &&
+                  project?.path &&
+                  payload.zookeeperEditPatch
+                ) {
+                  const currentFile = payload.files.find(
+                    (file) =>
+                      normalizeKCLFileDeletePath(file.requestedFileName) ===
+                      activeRelativePath
+                  )
+                  const currentEditorRelativePath =
+                    project.path && kclManager.path
+                      ? normalizeKCLFileDeletePath(
+                          fsZds.relative(project.path, kclManager.path)
+                        )
+                      : ''
+                  const currentEditorFile = payload.files.find(
+                    (file) =>
+                      normalizeKCLFileDeletePath(file.requestedFileName) ===
+                      currentEditorRelativePath
+                  )
+                  void completePendingZookeeperHistoryWrite({
+                    activeFileDeleted,
+                    activeFilePath,
+                    activeFileRequestedCode: currentFile?.requestedCode,
+                    currentFilePath: currentEditorFile
+                      ? kclManager.path
+                      : undefined,
+                    currentFileRequestedCode: currentEditorFile?.requestedCode,
+                    exchangeId,
+                    patch: payload.zookeeperEditPatch,
+                    projectPath: project.path,
+                  })
+                }
+              },
+              ...(shouldRefreshActiveEditorAfterPlainOutput && activeFileOutput
+                ? {
+                    onSuccess: () => {
+                      if (kclManager.path !== activeFilePath) return
+                      if (kclManager.code === activeFileOutput.requestedCode)
+                        return
+                      kclManager.updateCodeEditor(
+                        activeFileOutput.requestedCode,
+                        {
+                          shouldAddToHistory: false,
+                          shouldClearHistory: true,
+                          shouldExecute: true,
+                          shouldResetCamera: true,
+                          shouldWriteToDisk: true,
+                        }
+                      )
+                    },
+                  }
+                : {}),
+            },
           })
         }
-        kclManager.mlEphantManagerMachineBulkManipulatingFileSystem = true
-        systemIOActor.send({
-          type: SystemIOMachineEvents.bulkCreateAndDeleteKCLFilesAndNavigateToFile,
-          data: {
-            files: payload.files,
-            filesToDelete: payload.filesToDelete,
-            override: true,
-            requestedProjectName: payload.requestedProjectName,
-            requestedFileNameWithExtension:
-              payload.requestedFileNameWithExtension ?? '',
-            onFileSystemSuccess: () => {
-              if (historyRecorded) return
-              historyRecorded = true
-              if (
-                shouldRecordZookeeperHistory &&
-                project?.path &&
-                payload.zookeeperEditPatch
-              ) {
-                const currentFile = payload.files.find(
-                  (file) =>
-                    normalizeKCLFileDeletePath(file.requestedFileName) ===
-                    activeRelativePath
-                )
-                const currentEditorRelativePath =
-                  project.path && kclManager.path
-                    ? normalizeKCLFileDeletePath(
-                        fsZds.relative(project.path, kclManager.path)
-                      )
-                    : ''
-                const currentEditorFile = payload.files.find(
-                  (file) =>
-                    normalizeKCLFileDeletePath(file.requestedFileName) ===
-                    currentEditorRelativePath
-                )
-                void completePendingZookeeperHistoryWrite({
-                  activeFileDeleted,
-                  activeFilePath,
-                  activeFileRequestedCode: currentFile?.requestedCode,
-                  currentFilePath: currentEditorFile
-                    ? kclManager.path
-                    : undefined,
-                  currentFileRequestedCode: currentEditorFile?.requestedCode,
-                  exchangeId,
-                  patch: payload.zookeeperEditPatch,
-                  projectPath: project.path,
-                })
-              }
-            },
-            ...(shouldRefreshActiveEditorAfterPlainOutput && activeFileOutput
-              ? {
-                  onSuccess: () => {
-                    if (kclManager.path !== activeFilePath) return
-                    if (kclManager.code === activeFileOutput.requestedCode)
-                      return
-                    kclManager.updateCodeEditor(
-                      activeFileOutput.requestedCode,
-                      {
-                        shouldAddToHistory: false,
-                        shouldClearHistory: true,
-                        shouldExecute: true,
-                        shouldResetCamera: true,
-                        shouldWriteToDisk: true,
-                      }
-                    )
-                  },
-                }
-              : {}),
-          },
-        })
-      }
+      })()
     }
   )
 
@@ -612,6 +614,9 @@ async function captureZookeeperSnapshotPreviousContents({
 }) {
   for (const changedFile of patch.changed_files ?? []) {
     const snapshotPath = getZookeeperSnapshotPath(projectPath, changedFile.path)
+    if (snapshotPath instanceof Error) {
+      return Promise.reject(snapshotPath)
+    }
     if (pending.snapshotFilesByRelativePath.has(snapshotPath.relativePath)) {
       continue
     }
@@ -638,6 +643,9 @@ async function captureZookeeperSnapshotNextContents({
 }) {
   for (const changedFile of patch.changed_files ?? []) {
     const snapshotPath = getZookeeperSnapshotPath(projectPath, changedFile.path)
+    if (snapshotPath instanceof Error) {
+      return Promise.reject(snapshotPath)
+    }
     const snapshotFile = pending.snapshotFilesByRelativePath.get(
       snapshotPath.relativePath
     ) ?? {
@@ -678,7 +686,8 @@ function getReadyZookeeperSnapshotFiles(
 
 function getZookeeperSnapshotPath(projectPath: string, relativePath: string) {
   const normalizedPath = normalizeZookeeperPatchPath(relativePath)
-  const pathParts = normalizedPath.split('/')
+  const pathSeparator = '/'
+  const pathParts = normalizedPath.split(pathSeparator)
   const safePathParts = pathParts.filter(
     (part) => part.length > 0 && part !== '.'
   )
@@ -689,7 +698,7 @@ function getZookeeperSnapshotPath(projectPath: string, relativePath: string) {
     normalizedPath.startsWith('/') ||
     /^[A-Za-z]:/.test(normalizedPath)
   ) {
-    throw new Error(
+    return new Error(
       `Cannot record Zookeeper history for unsafe path "${relativePath}".`
     )
   }

--- a/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
+++ b/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
@@ -36,6 +36,7 @@ import {
   SystemIOMachineEvents,
   normalizeKCLFileDeletePath,
   prepareMlEphantNewFileRequest,
+  waitForIdleState,
 } from '@src/machines/systemIO/utils'
 import { IS_STAGING_OR_DEBUG } from '@src/routes/utils'
 import { applyPatch, parsePatch, reversePatch } from 'diff'
@@ -138,6 +139,7 @@ function MlEphantConversationPaneInner(props: AreaTypeComponentProps) {
     beginPendingZookeeperHistoryWrite,
     cancelPendingZookeeperHistoryWrite,
     completePendingZookeeperHistoryWrite,
+    reservePendingZookeeperHistoryWrite,
   } = useZookeeperEditPatchHistory({
     kclManager,
     mlEphantManagerActor,
@@ -148,13 +150,69 @@ function MlEphantConversationPaneInner(props: AreaTypeComponentProps) {
     mlEphantManagerActor,
     kclManager.engineCommandManager,
     (requestProps) => {
+      const activeFilePath =
+        requestProps.fileFocusedOnInEditor?.path ?? kclManager.path
+      const payload = prepareMlEphantNewFileRequest({
+        ...requestProps,
+        fallbackFilePath: activeFilePath,
+      })
+
+      if (!payload) {
+        return
+      }
+
+      const exchangeId = requestProps.exchangeId ?? 0
+      const activeRelativePath =
+        project?.path && activeFilePath
+          ? normalizeKCLFileDeletePath(
+              fsZds.relative(project.path, activeFilePath)
+            )
+          : ''
+      const activeFileDeleted =
+        activeRelativePath.length > 0 &&
+        payload.filesToDelete.some(
+          (file) =>
+            normalizeKCLFileDeletePath(file.requestedFileName) ===
+            activeRelativePath
+        )
+      const shouldRecordZookeeperHistory = Boolean(
+        project?.path && payload.zookeeperEditPatch?.changed_files?.length
+      )
+      const activeFileOutput = payload.files.find(
+        (file) =>
+          normalizeKCLFileDeletePath(file.requestedFileName) ===
+          activeRelativePath
+      )
+      const shouldRefreshActiveEditorAfterPlainOutput = Boolean(
+        !shouldRecordZookeeperHistory &&
+          !activeFileDeleted &&
+          activeFileOutput &&
+          project?.name === payload.requestedProjectName &&
+          activeFilePath === kclManager.path
+      )
+      const pendingHistoryReserved = Boolean(
+        shouldRecordZookeeperHistory &&
+          project?.path &&
+          payload.zookeeperEditPatch
+      )
+      if (
+        pendingHistoryReserved &&
+        project?.path &&
+        payload.zookeeperEditPatch
+      ) {
+        reservePendingZookeeperHistoryWrite({
+          activeFilePath,
+          exchangeId,
+          projectPath: project.path,
+        })
+      }
+
       zookeeperFileRequestQueue.current =
         zookeeperFileRequestQueue.current.then(
           () =>
             new Promise<void>((resolve) => {
               let pendingHistoryStarted = false
               let requestSettled = false
-              const exchangeId = requestProps.exchangeId ?? 0
               const settleRequest = () => {
                 if (requestSettled) return
                 requestSettled = true
@@ -162,48 +220,9 @@ function MlEphantConversationPaneInner(props: AreaTypeComponentProps) {
               }
 
               void (async () => {
-                const activeFilePath =
-                  requestProps.fileFocusedOnInEditor?.path ?? kclManager.path
-                const payload = prepareMlEphantNewFileRequest({
-                  ...requestProps,
-                  fallbackFilePath: activeFilePath,
-                })
-
-                if (!payload) {
-                  settleRequest()
-                  return
-                }
-
                 let historyRecorded = false
-                const activeRelativePath =
-                  project?.path && activeFilePath
-                    ? normalizeKCLFileDeletePath(
-                        fsZds.relative(project.path, activeFilePath)
-                      )
-                    : ''
-                const activeFileDeleted =
-                  activeRelativePath.length > 0 &&
-                  payload.filesToDelete.some(
-                    (file) =>
-                      normalizeKCLFileDeletePath(file.requestedFileName) ===
-                      activeRelativePath
-                  )
-                const shouldRecordZookeeperHistory = Boolean(
-                  project?.path &&
-                    payload.zookeeperEditPatch?.changed_files?.length
-                )
-                const activeFileOutput = payload.files.find(
-                  (file) =>
-                    normalizeKCLFileDeletePath(file.requestedFileName) ===
-                    activeRelativePath
-                )
-                const shouldRefreshActiveEditorAfterPlainOutput = Boolean(
-                  !shouldRecordZookeeperHistory &&
-                    !activeFileDeleted &&
-                    activeFileOutput &&
-                    project?.name === payload.requestedProjectName &&
-                    activeFilePath === kclManager.path
-                )
+                await waitForIdleState({ systemIOActor })
+                kclManager.mlEphantManagerMachineBulkManipulatingFileSystem = true
                 if (
                   shouldRecordZookeeperHistory &&
                   project?.path &&
@@ -215,9 +234,9 @@ function MlEphantConversationPaneInner(props: AreaTypeComponentProps) {
                     exchangeId,
                     patch: payload.zookeeperEditPatch,
                     projectPath: project.path,
+                    reserved: pendingHistoryReserved,
                   })
                 }
-                kclManager.mlEphantManagerMachineBulkManipulatingFileSystem = true
                 systemIOActor.send({
                   type: SystemIOMachineEvents.bulkCreateAndDeleteKCLFilesAndNavigateToFile,
                   data: {
@@ -228,7 +247,7 @@ function MlEphantConversationPaneInner(props: AreaTypeComponentProps) {
                     requestedFileNameWithExtension:
                       payload.requestedFileNameWithExtension ?? '',
                     onFileSystemError: () => {
-                      if (pendingHistoryStarted) {
+                      if (pendingHistoryReserved || pendingHistoryStarted) {
                         cancelPendingZookeeperHistoryWrite({ exchangeId })
                       }
                       settleRequest()
@@ -311,7 +330,7 @@ function MlEphantConversationPaneInner(props: AreaTypeComponentProps) {
                   },
                 })
               })().catch((error: unknown) => {
-                if (pendingHistoryStarted) {
+                if (pendingHistoryReserved || pendingHistoryStarted) {
                   cancelPendingZookeeperHistoryWrite({ exchangeId })
                 }
                 console.error(
@@ -510,17 +529,44 @@ function useZookeeperEditPatchHistory({
     [kclManager, recordZookeeperHistory]
   )
 
+  const reservePendingZookeeperHistoryWrite = useCallback(
+    ({
+      activeFilePath,
+      exchangeId,
+      projectPath,
+    }: ReservePendingZookeeperHistoryWriteProps) => {
+      const pending =
+        pendingZookeeperHistoryByExchange.current.get(exchangeId) ??
+        createPendingZookeeperHistory()
+      pending.outstandingWrites += 1
+      pending.projectPath ??= projectPath
+      if (
+        !pending.activeEditorState &&
+        activeFilePath &&
+        activeFilePath === kclManager.path
+      ) {
+        pending.activeEditorState = kclManager.captureEditorHistoryState()
+      }
+      pendingZookeeperHistoryByExchange.current.set(exchangeId, pending)
+      kclManager.zookeeperHistoryRecordingInProgress = true
+    },
+    [kclManager]
+  )
+
   const beginPendingZookeeperHistoryWrite = useCallback(
     async ({
       activeFilePath,
       exchangeId,
       patch,
       projectPath,
+      reserved,
     }: BeginPendingZookeeperHistoryWriteProps) => {
       const pending =
         pendingZookeeperHistoryByExchange.current.get(exchangeId) ??
         createPendingZookeeperHistory()
-      pending.outstandingWrites += 1
+      if (!reserved) {
+        pending.outstandingWrites += 1
+      }
       pending.projectPath ??= projectPath
       if (
         !pending.activeEditorState &&
@@ -627,6 +673,7 @@ function useZookeeperEditPatchHistory({
     beginPendingZookeeperHistoryWrite,
     cancelPendingZookeeperHistoryWrite,
     completePendingZookeeperHistoryWrite,
+    reservePendingZookeeperHistoryWrite,
   }
 }
 
@@ -842,6 +889,13 @@ type BeginPendingZookeeperHistoryWriteProps = {
   activeFilePath?: string
   exchangeId: number
   patch: ZookeeperEditPatch
+  projectPath: string
+  reserved?: boolean
+}
+
+type ReservePendingZookeeperHistoryWriteProps = {
+  activeFilePath?: string
+  exchangeId: number
   projectPath: string
 }
 

--- a/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
+++ b/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
@@ -221,8 +221,6 @@ function MlEphantConversationPaneInner(props: AreaTypeComponentProps) {
 
               void (async () => {
                 let historyRecorded = false
-                await waitForIdleState({ systemIOActor })
-                kclManager.mlEphantManagerMachineBulkManipulatingFileSystem = true
                 if (
                   shouldRecordZookeeperHistory &&
                   project?.path &&
@@ -237,6 +235,8 @@ function MlEphantConversationPaneInner(props: AreaTypeComponentProps) {
                     reserved: pendingHistoryReserved,
                   })
                 }
+                await waitForIdleState({ systemIOActor })
+                kclManager.mlEphantManagerMachineBulkManipulatingFileSystem = true
                 systemIOActor.send({
                   type: SystemIOMachineEvents.bulkCreateAndDeleteKCLFilesAndNavigateToFile,
                   data: {

--- a/src/editor/plugins/zookeeper/history.integration.spec.ts
+++ b/src/editor/plugins/zookeeper/history.integration.spec.ts
@@ -560,6 +560,70 @@ describe('Zookeeper project history integration', () => {
     }
   })
 
+  it('uses snapshots to undo active-file Zookeeper edits when the streamed diff is stale', async () => {
+    const harness = await createProjectHarness({
+      'main.kcl': 'legCount = 4\nbraceLayout = "rectangle"\n',
+      'brace.kcl': 'braceCount = 4\n',
+    })
+    const mainPath = fsZds.join(harness.projectPath, 'main.kcl')
+    const bracePath = fsZds.join(harness.projectPath, 'brace.kcl')
+    const mainBefore = 'legCount = 4\nbraceLayout = "rectangle"\n'
+    const mainAfter = 'legCount = 3\nbraceLayout = "triangle"\n'
+    const braceBefore = 'braceCount = 4\n'
+    const braceAfter = 'braceCount = 3\n'
+    const patch: ZookeeperEditPatch = {
+      run_id: 'stale-diff-snapshot-replay',
+      changed_files: [
+        modifiedFile(
+          'main.kcl',
+          'this is not the table before\n',
+          'this is not the table after\n'
+        ),
+        modifiedFile(
+          'brace.kcl',
+          'this is not the brace before\n',
+          'this is not the brace after\n'
+        ),
+      ],
+    }
+
+    await writeText(mainPath, mainAfter)
+    await writeText(bracePath, braceAfter)
+    harness.kclManager.addGlobalHistoryEventWithCodeChange(
+      zookeeperEditPatchHistoryEvent({
+        projectPath: harness.projectPath,
+        activeFilePath: harness.kclManager.path,
+        patch,
+        snapshotFiles: [
+          {
+            relativePath: 'main.kcl',
+            absolutePath: mainPath,
+            previousContent: mainBefore,
+            nextContent: mainAfter,
+          },
+          {
+            relativePath: 'brace.kcl',
+            absolutePath: bracePath,
+            previousContent: braceBefore,
+            nextContent: braceAfter,
+          },
+        ],
+      }),
+      mainAfter,
+      mainBefore
+    )
+
+    harness.kclManager.undo()
+    await waitForHistoryIdle(harness.kclManager)
+    expect(harness.kclManager.code).toBe(mainBefore)
+    await expect(fsZds.readFile(bracePath, 'utf8')).resolves.toBe(braceBefore)
+
+    harness.kclManager.redo()
+    await waitForHistoryIdle(harness.kclManager)
+    expect(harness.kclManager.code).toBe(mainAfter)
+    await expect(fsZds.readFile(bracePath, 'utf8')).resolves.toBe(braceAfter)
+  })
+
   it('redoes the original active file after undoing a multi-file Zookeeper edit and switching files', async () => {
     const harness = await createProjectHarness({
       'main.kcl': 'main = 1\n',

--- a/src/editor/plugins/zookeeper/index.ts
+++ b/src/editor/plugins/zookeeper/index.ts
@@ -42,6 +42,7 @@ type ZookeeperPatchEffectProps = {
   patch: ZookeeperEditPatch
   direction: ZookeeperPatchReplayDirection
   activeFilePath?: string
+  snapshotFiles?: readonly ZookeeperSnapshotFileReplay[]
 }
 
 type ZookeeperPatchFileReplay = {
@@ -81,6 +82,8 @@ export type PreparedZookeeperPatchFileReplay = {
   nextContent: string | null
 }
 
+export type ZookeeperSnapshotFileReplay = PreparedZookeeperPatchFileReplay
+
 type ZookeeperPatchReplayOptions = {
   fileContentOverrides?: Map<string, string>
   alreadyReplayedFilePaths?: Set<string>
@@ -109,10 +112,12 @@ export function zookeeperEditPatchHistoryEvent({
   projectPath,
   patch,
   activeFilePath,
+  snapshotFiles,
 }: {
   projectPath: string
   patch: ZookeeperEditPatch
   activeFilePath?: string
+  snapshotFiles?: readonly ZookeeperSnapshotFileReplay[]
 }): TransactionSpecNoChanges {
   return {
     effects: zookeeperEditPatchEffect.of({
@@ -120,6 +125,7 @@ export function zookeeperEditPatchHistoryEvent({
       patch,
       direction: 'redo',
       activeFilePath,
+      snapshotFiles,
     }),
     annotations: [zookeeperPatchIgnoreAnnotationType.of(true)],
   }
@@ -251,18 +257,24 @@ async function replayZookeeperEditPatch({
     replayFiles: readonly PreparedZookeeperPatchFileReplay[]
   ) => void | Promise<void>
 }) {
-  const replayFiles = getZookeeperPatchFileReplays(effectProps)
-  if (isErr(replayFiles)) {
-    return Promise.reject(replayFiles)
-  }
   const alreadyReplayedFilePaths = new Set<string>()
   if (effectProps.activeFilePath === kclManager.path) {
     alreadyReplayedFilePaths.add(kclManager.path)
   }
-  const preparedReplayFiles = await prepareZookeeperPatchReplay(replayFiles, {
+  const replayOptions = {
     alreadyReplayedFilePaths,
     fileContentOverrides: new Map([[kclManager.path, kclManager.code]]),
-  })
+  }
+  const preparedReplayFiles = effectProps.snapshotFiles?.length
+    ? await prepareZookeeperSnapshotReplay(
+        effectProps.snapshotFiles,
+        effectProps.direction,
+        replayOptions
+      )
+    : await prepareZookeeperPatchReplay(
+        unwrapZookeeperPatchFileReplays(effectProps),
+        replayOptions
+      )
   const currentFileReplay = preparedReplayFiles.find(
     (replayFile) => replayFile.absolutePath === kclManager.path
   )
@@ -341,6 +353,17 @@ async function replayZookeeperEditPatch({
   })
 }
 
+function unwrapZookeeperPatchFileReplays(
+  effectProps: ZookeeperPatchEffectProps
+) {
+  const replayFiles = getZookeeperPatchFileReplays(effectProps)
+  if (isErr(replayFiles)) {
+    throw replayFiles
+  }
+
+  return replayFiles
+}
+
 function getZookeeperPatchFileReplays({
   projectPath,
   patch,
@@ -377,6 +400,73 @@ function getZookeeperPatchFileReplays({
   }
 
   return replays
+}
+
+async function prepareZookeeperSnapshotReplay(
+  snapshotFiles: readonly ZookeeperSnapshotFileReplay[],
+  direction: ZookeeperPatchReplayDirection,
+  {
+    alreadyReplayedFilePaths,
+    fileContentOverrides,
+  }: ZookeeperPatchReplayOptions = {}
+): Promise<PreparedZookeeperPatchFileReplay[]> {
+  const preparedReplayFiles: PreparedZookeeperPatchFileReplay[] = []
+
+  for (const snapshotFile of snapshotFiles) {
+    const previousContent =
+      direction === 'undo'
+        ? snapshotFile.nextContent
+        : snapshotFile.previousContent
+    const nextContent =
+      direction === 'undo'
+        ? snapshotFile.previousContent
+        : snapshotFile.nextContent
+    const diskContent = await readTextFileIfExists(snapshotFile.absolutePath)
+    const currentContent =
+      diskContent === null
+        ? null
+        : (fileContentOverrides?.get(snapshotFile.absolutePath) ?? diskContent)
+
+    if (isZookeeperReplayContentSame(currentContent, previousContent)) {
+      preparedReplayFiles.push({
+        relativePath: snapshotFile.relativePath,
+        absolutePath: snapshotFile.absolutePath,
+        previousContent,
+        nextContent,
+      })
+      continue
+    }
+
+    if (
+      alreadyReplayedFilePaths?.has(snapshotFile.absolutePath) &&
+      isZookeeperReplayContentSame(currentContent, nextContent)
+    ) {
+      preparedReplayFiles.push({
+        relativePath: snapshotFile.relativePath,
+        absolutePath: snapshotFile.absolutePath,
+        previousContent: currentContent,
+        nextContent: currentContent,
+      })
+      continue
+    }
+
+    return Promise.reject(
+      zookeeperPatchConflictError(snapshotFile.relativePath)
+    )
+  }
+
+  return preparedReplayFiles
+}
+
+function isZookeeperReplayContentSame(
+  currentContent: string | null,
+  expectedContent: string | null
+) {
+  if (currentContent === null || expectedContent === null) {
+    return currentContent === expectedContent
+  }
+
+  return isCodeTheSame(currentContent, expectedContent)
 }
 
 function getZookeeperPatchReplayContents(

--- a/src/editor/plugins/zookeeper/index.ts
+++ b/src/editor/plugins/zookeeper/index.ts
@@ -265,16 +265,23 @@ async function replayZookeeperEditPatch({
     alreadyReplayedFilePaths,
     fileContentOverrides: new Map([[kclManager.path, kclManager.code]]),
   }
-  const preparedReplayFiles = effectProps.snapshotFiles?.length
-    ? await prepareZookeeperSnapshotReplay(
-        effectProps.snapshotFiles,
-        effectProps.direction,
-        replayOptions
-      )
-    : await prepareZookeeperPatchReplay(
-        unwrapZookeeperPatchFileReplays(effectProps),
-        replayOptions
-      )
+  let preparedReplayFiles: PreparedZookeeperPatchFileReplay[]
+  if (effectProps.snapshotFiles?.length) {
+    preparedReplayFiles = await prepareZookeeperSnapshotReplay(
+      effectProps.snapshotFiles,
+      effectProps.direction,
+      replayOptions
+    )
+  } else {
+    const replayFiles = getZookeeperPatchFileReplays(effectProps)
+    if (isErr(replayFiles)) {
+      return Promise.reject(replayFiles)
+    }
+    preparedReplayFiles = await prepareZookeeperPatchReplay(
+      replayFiles,
+      replayOptions
+    )
+  }
   const currentFileReplay = preparedReplayFiles.find(
     (replayFile) => replayFile.absolutePath === kclManager.path
   )
@@ -351,17 +358,6 @@ async function replayZookeeperEditPatch({
       error
     )
   })
-}
-
-function unwrapZookeeperPatchFileReplays(
-  effectProps: ZookeeperPatchEffectProps
-) {
-  const replayFiles = getZookeeperPatchFileReplays(effectProps)
-  if (isErr(replayFiles)) {
-    throw replayFiles
-  }
-
-  return replayFiles
 }
 
 function getZookeeperPatchFileReplays({

--- a/src/editor/plugins/zookeeper/index.ts
+++ b/src/editor/plugins/zookeeper/index.ts
@@ -419,9 +419,7 @@ async function prepareZookeeperSnapshotReplay(
         : snapshotFile.nextContent
     const diskContent = await readTextFileIfExists(snapshotFile.absolutePath)
     const currentContent =
-      diskContent === null
-        ? null
-        : (fileContentOverrides?.get(snapshotFile.absolutePath) ?? diskContent)
+      fileContentOverrides?.get(snapshotFile.absolutePath) ?? diskContent
 
     if (isZookeeperReplayContentSame(currentContent, previousContent)) {
       preparedReplayFiles.push({

--- a/src/machines/systemIO/systemIOMachine.ts
+++ b/src/machines/systemIO/systemIOMachine.ts
@@ -143,6 +143,7 @@ export const systemIOMachine = setup({
             requestedFileNameWithExtension: string
             override?: boolean
             requestedSubRoute?: string
+            onFileSystemError?: () => void
             onFileSystemSuccess?: () => void
             onSuccess?: () => void
           }
@@ -668,6 +669,7 @@ export const systemIOMachine = setup({
             requestedFileNameWithExtension: string
             override?: boolean
             requestedSubRoute?: string
+            onFileSystemError?: () => void
             onFileSystemSuccess?: () => void
             onSuccess?: () => void
           }
@@ -1707,6 +1709,7 @@ export const systemIOMachine = setup({
             requestedFileNameWithExtension:
               event.data.requestedFileNameWithExtension,
             requestedSubRoute: event.data.requestedSubRoute,
+            onFileSystemError: event.data.onFileSystemError,
             onFileSystemSuccess: event.data.onFileSystemSuccess,
             onSuccess: event.data.onSuccess,
           }

--- a/src/machines/systemIO/systemIOMachineImpl.ts
+++ b/src/machines/systemIO/systemIOMachineImpl.ts
@@ -873,60 +873,66 @@ export const systemIOMachineImpl = systemIOMachine.provide({
             override?: boolean
             requestedFileNameWithExtension: string
             requestedSubRoute?: string
+            onFileSystemError?: () => void
             onFileSystemSuccess?: () => void
             onSuccess?: () => void
           }
         }) => {
-          const wasmInstance = await input.context.wasmInstancePromise
-          const message = await sharedBulkCreateWorkflow({
-            input: {
-              ...input,
-              wasmInstance,
-              override: input.override,
-            },
-          })
-          // We won't delete until everything's created / updated first.
-          const totalDeleted = await sharedBulkDeleteWorkflow({
-            input: {
-              ...input,
-              wasmInstance,
-            },
-          })
+          try {
+            const wasmInstance = await input.context.wasmInstancePromise
+            const message = await sharedBulkCreateWorkflow({
+              input: {
+                ...input,
+                wasmInstance,
+                override: input.override,
+              },
+            })
+            // We won't delete until everything's created / updated first.
+            const totalDeleted = await sharedBulkDeleteWorkflow({
+              input: {
+                ...input,
+                wasmInstance,
+              },
+            })
 
-          message.message += `, ${totalDeleted} deleted`
-          input.onFileSystemSuccess?.()
+            message.message += `, ${totalDeleted} deleted`
+            input.onFileSystemSuccess?.()
 
-          const project = input.context.app.project
-          const requestedRelativePath = normalizeKCLFileDeletePath(
-            input.requestedFileNameWithExtension
-          )
-          const deletesRequestedFile = (input.filesToDelete ?? []).some(
-            (file) =>
-              normalizeKCLFileDeletePath(file.requestedFileName) ===
-              requestedRelativePath
-          )
-          const requestedAbsolutePath = project
-            ? fsZds.join(project.path, input.requestedFileNameWithExtension)
-            : ''
-          const shouldNavigate =
-            !project ||
-            project.name !== input.requestedProjectName ||
-            project.executingPath !== requestedAbsolutePath ||
-            deletesRequestedFile
+            const project = input.context.app.project
+            const requestedRelativePath = normalizeKCLFileDeletePath(
+              input.requestedFileNameWithExtension
+            )
+            const deletesRequestedFile = (input.filesToDelete ?? []).some(
+              (file) =>
+                normalizeKCLFileDeletePath(file.requestedFileName) ===
+                requestedRelativePath
+            )
+            const requestedAbsolutePath = project
+              ? fsZds.join(project.path, input.requestedFileNameWithExtension)
+              : ''
+            const shouldNavigate =
+              !project ||
+              project.name !== input.requestedProjectName ||
+              project.executingPath !== requestedAbsolutePath ||
+              deletesRequestedFile
 
-          if (!shouldNavigate) {
-            input.onSuccess?.()
-          }
+            if (!shouldNavigate) {
+              input.onSuccess?.()
+            }
 
-          return {
-            ...message,
-            projectName: input.requestedProjectName,
-            fileName: input.requestedFileNameWithExtension || '',
-            subRoute: input.requestedSubRoute || '',
-            shouldNavigate,
-            ...(shouldNavigate && input.onSuccess
-              ? { onProjectLoaderComplete: input.onSuccess }
-              : {}),
+            return {
+              ...message,
+              projectName: input.requestedProjectName,
+              fileName: input.requestedFileNameWithExtension || '',
+              subRoute: input.requestedSubRoute || '',
+              shouldNavigate,
+              ...(shouldNavigate && input.onSuccess
+                ? { onProjectLoaderComplete: input.onSuccess }
+                : {}),
+            }
+          } catch (error: unknown) {
+            input.onFileSystemError?.()
+            return Promise.reject(error)
           }
         }
       ),


### PR DESCRIPTION
### Issue
- I missed this because the original fix validated the file create/delete failure path and simple ZK edit replay, but the broken case was more subtle: when ZK modifies the currently open file during a larger multi-file edit, undo/redo depends on both CodeMirror local history and the global ZK patch replay staying in sync. Our tests used clean patch diffs, so they didn’t catch the case where a long-running ZK response rewrites the same file multiple times and the final diff no longer applies cleanly. In that situation the active-file fallback could treat the file as already handled, so undo appeared to succeed while main.kcl stayed changed.
- I found it while doing manual end-to-end testing with a realistic multi-file design. I opened a follow-up PR that changes the approach from patch replay to exact before/after snapshots for touched files, which should make undo/redo deterministic for long ZK edits as well.

### Issue Demo
https://github.com/user-attachments/assets/91ecafa0-f470-4f94-a66f-ad70d5b8dcea


### Summary
- record exact before/after file snapshots for each pending Zookeeper history exchange
- replay snapshots for undo/redo when available, while keeping patch replay as the fallback
- use the captured active-file snapshot to seed local editor history instead of reconstructing previous code from a potentially stale streamed diff
- add a regression covering active main.kcl plus sibling-file undo/redo when the streamed diff is stale


### Demo using this PR's solution

https://github.com/user-attachments/assets/07e95b19-03fb-4ac8-b876-43ada01bf23c

