### PR TITLE
fix(kcl): allows multiline strings in new lexer

### DIFF
--- a/rust/kcl-syntax/src/lexer.rs
+++ b/rust/kcl-syntax/src/lexer.rs
@@ -101,8 +101,12 @@ impl<'a> Token<'a> {
 enum RawTokenKind {
     #[regex(r"[ \t\n\r]+")]
     Whitespace,
-    #[regex(r#""([^"\\\n\r]|\\[^\n\r])*""#)]
-    #[regex(r#"'([^'\\\n\r]|\\[^\n\r])*'"#)]
+    // A closed string may span newlines (KCL supports multiline strings), matching
+    // the legacy tokeniser: content is any char except the quote or backslash, or a
+    // backslash-escape of any char including a newline. Note the UnterminatedString
+    // patterns below deliberately still stop at a line boundary for recovery.
+    #[regex(r#""([^"\\]|\\[\s\S])*""#)]
+    #[regex(r#"'([^'\\]|\\[\s\S])*'"#)]
     String,
     #[regex(r#""([^"\\\n\r]|\\[^\n\r])*"#, unterminated_string)]
     #[regex(r#"'([^'\\\n\r]|\\[^\n\r])*"#, unterminated_string)]

--- a/rust/kcl-syntax/tests/lexer.rs
+++ b/rust/kcl-syntax/tests/lexer.rs
@@ -62,6 +62,19 @@ fn token_ranges_are_byte_ranges() {
 }
 
 #[test]
+fn lexes_multiline_strings() {
+    // A closed string may span raw newlines; the whole thing is one String token,
+    // matching the legacy lexer (KCL supports multiline strings).
+    assert_tokens(
+        "\"line one\nline two\"",
+        &[(SyntaxKind::String, "\"line one\nline two\"", 0..19)],
+    );
+    assert_tokens("'a\nb'", &[(SyntaxKind::String, "'a\nb'", 0..5)]);
+    // An escaped newline inside a closed string is part of the string.
+    assert_tokens("\"a\\\nb\"", &[(SyntaxKind::String, "\"a\\\nb\"", 0..6)]);
+}
+
+#[test]
 fn recovery_tokens_are_part_of_the_public_token_stream() {
     assert_tokens(
         "\"abc\n/*x",
@@ -525,12 +538,14 @@ fn lexes_unknown_string_escapes_as_string_text() {
 
 #[test]
 fn recovers_string_escape_newline_at_line_boundary() {
+    // An *unterminated* string with a trailing backslash still recovers at the
+    // line boundary. (An escaped newline only continues a *closed* string --
+    // matching the legacy tokeniser -- see `lexes_multiline_strings`.)
     assert_tokens(
-        concat!("\"a\\", "\n", "\""),
+        concat!("\"a\\", "\n"),
         &[
             (SyntaxKind::UnterminatedString, "\"a\\", 0..3),
             (SyntaxKind::Whitespace, "\n", 3..4),
-            (SyntaxKind::UnterminatedString, "\"", 4..5),
         ],
     );
 }


### PR DESCRIPTION
I missed this case and the work I am doing to hook up the new lexer uncovered the gap in behaviour.