### PR TITLE
Fix middle mouse button dragging in sketch mode

### DIFF
--- a/src/clientSideScene/sceneInfra.spec.ts
+++ b/src/clientSideScene/sceneInfra.spec.ts
@@ -30,3 +30,37 @@ describe('SceneInfra callback resets', () => {
     expect(sceneInfra.onMouseDownSelection).toBeUndefined()
   })
 })
+
+describe('SceneInfra non-primary mouse buttons', () => {
+  it('does not start sketch selection or area selection on middle mouse down', () => {
+    const sceneInfra = makeSceneInfraForCallbacksTest()
+    const solverMouseDownSelection = vi.fn(() => true)
+
+    sceneInfra.setCallbacks({
+      onMouseDownSelection: solverMouseDownSelection,
+    })
+
+    sceneInfra.onMouseDown(
+      new MouseEvent('mousedown', { button: 1, buttons: 4 })
+    )
+
+    expect(solverMouseDownSelection).not.toHaveBeenCalled()
+    expect(sceneInfra.selected).toBeNull()
+    expect(sceneInfra.areaSelect).toBeNull()
+  })
+
+  it('does not send a sketch click on middle mouse up', async () => {
+    const sceneInfra = makeSceneInfraForCallbacksTest()
+    const onClick = vi.fn()
+
+    sceneInfra.setCallbacks({
+      onClick,
+    })
+
+    await sceneInfra.onMouseUp(
+      new MouseEvent('mouseup', { button: 1, buttons: 0 })
+    )
+
+    expect(onClick).not.toHaveBeenCalled()
+  })
+})

--- a/src/clientSideScene/sceneInfra.ts
+++ b/src/clientSideScene/sceneInfra.ts
@@ -793,6 +793,10 @@ export class SceneInfra {
   }
 
   onMouseDown = (event: MouseEvent) => {
+    if (event.button !== 0) {
+      return
+    }
+
     this.updateCurrentMouseVector(event)
 
     const mouseDownVector = this.currentMouseVector.clone()
@@ -842,6 +846,10 @@ export class SceneInfra {
   }
 
   onMouseUp = async (mouseEvent: MouseEvent) => {
+    if (mouseEvent.button !== 0) {
+      return
+    }
+
     const wasmInstance = await this.wasmInstancePromise
     this.updateCurrentMouseVector(mouseEvent)
     const planeIntersectPoint = this.getPlaneIntersectPoint()


### PR DESCRIPTION
Realized during testing that you can drag segments with the middle mouse button in sketch mode, in which case both the camera pan + the drag is activated at the same time:

https://github.com/user-attachments/assets/7f34f420-4d49-489e-90b0-ad2b21d86d76

Very small fix to ignore middle mouse button events in sceneInfra / onMouseDown/onMouseUp