### PR TITLE
Quick pass at burning down KCL-P&C drift

### DIFF
--- a/src/lang/modifyAst/boolean.ts
+++ b/src/lang/modifyAst/boolean.ts
@@ -7,11 +7,16 @@ import {
 } from '@src/lang/create'
 import {
   createVariableExpressionsArray,
+  insertVariableAndOffsetPathToNode,
   setCallInAst,
 } from '@src/lang/modifyAst'
-import { getVariableExprsFromSelection } from '@src/lang/queryAst'
+import {
+  getVariableExprsFromSelection,
+  valueOrVariable,
+} from '@src/lang/queryAst'
 import type { ArtifactGraph, PathToNode, Program } from '@src/lang/wasm'
 import { modelingStdLibCommandName } from '@src/lib/commandBarConfigs/modelingCommandStdLib'
+import type { KclCommandValue } from '@src/lib/commandTypes'
 import { KCL_DEFAULT_CONSTANT_PREFIXES } from '@src/lib/constants'
 import { err } from '@src/lib/trap'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
@@ -21,12 +26,14 @@ export function addUnion({
   ast,
   artifactGraph,
   solids,
+  tolerance,
   nodeToEdit,
   wasmInstance,
 }: {
   ast: Node<Program>
   artifactGraph: ArtifactGraph
   solids: Selections
+  tolerance?: KclCommandValue
   nodeToEdit?: PathToNode
   wasmInstance: ModuleType
 }): Error | { modifiedAst: Node<Program>; pathToNode: PathToNode } {
@@ -54,8 +61,11 @@ export function addUnion({
   const call = createCallExpressionStdLibKw(
     modelingStdLibCommandName('Boolean Union'),
     objectsExpr,
-    []
+    tolerance ? [createLabeledArg('tolerance', valueOrVariable(tolerance))] : []
   )
+  if (tolerance && 'variableName' in tolerance && tolerance.variableName) {
+    insertVariableAndOffsetPathToNode(tolerance, modifiedAst, mNodeToEdit)
+  }
 
   // 3. If edit, we assign the new function call declaration to the existing node,
   // otherwise just push to the end
@@ -81,12 +91,14 @@ export function addIntersect({
   ast,
   artifactGraph,
   solids,
+  tolerance,
   nodeToEdit,
   wasmInstance,
 }: {
   ast: Node<Program>
   artifactGraph: ArtifactGraph
   solids: Selections
+  tolerance?: KclCommandValue
   nodeToEdit?: PathToNode
   wasmInstance: ModuleType
 }): Error | { modifiedAst: Node<Program>; pathToNode: PathToNode } {
@@ -114,8 +126,11 @@ export function addIntersect({
   const call = createCallExpressionStdLibKw(
     modelingStdLibCommandName('Boolean Intersect'),
     objectsExpr,
-    []
+    tolerance ? [createLabeledArg('tolerance', valueOrVariable(tolerance))] : []
   )
+  if (tolerance && 'variableName' in tolerance && tolerance.variableName) {
+    insertVariableAndOffsetPathToNode(tolerance, modifiedAst, mNodeToEdit)
+  }
 
   // 3. If edit, we assign the new function call declaration to the existing node,
   // otherwise just push to the end
@@ -142,6 +157,7 @@ export function addSubtract({
   artifactGraph,
   solids,
   tools,
+  tolerance,
   nodeToEdit,
   wasmInstance,
 }: {
@@ -149,6 +165,7 @@ export function addSubtract({
   artifactGraph: ArtifactGraph
   solids: Selections
   tools: Selections
+  tolerance?: KclCommandValue
   nodeToEdit?: PathToNode
   wasmInstance: ModuleType
 }): Error | { modifiedAst: Node<Program>; pathToNode: PathToNode } {
@@ -196,8 +213,16 @@ export function addSubtract({
   const call = createCallExpressionStdLibKw(
     modelingStdLibCommandName('Boolean Subtract'),
     objectsExpr,
-    [createLabeledArg('tools', toolsExpr)]
+    [
+      createLabeledArg('tools', toolsExpr),
+      ...(tolerance
+        ? [createLabeledArg('tolerance', valueOrVariable(tolerance))]
+        : []),
+    ]
   )
+  if (tolerance && 'variableName' in tolerance && tolerance.variableName) {
+    insertVariableAndOffsetPathToNode(tolerance, modifiedAst, mNodeToEdit)
+  }
   if (vars.pathIfPipe && toolVars.pathIfPipe) {
     return new Error(
       'Cannot use both solids and tools in a subtraction operation with a pipe'

--- a/src/lang/modifyAst/edges.ts
+++ b/src/lang/modifyAst/edges.ts
@@ -63,6 +63,7 @@ export function addFillet({
   artifactGraph,
   selection,
   radius,
+  tolerance,
   tag,
   version,
   nodeToEdit,
@@ -72,6 +73,7 @@ export function addFillet({
   artifactGraph: ArtifactGraph
   selection: Selections
   radius: KclCommandValue
+  tolerance?: KclCommandValue
   tag?: string
   version?: KclCommandValue
   nodeToEdit?: PathToNode
@@ -126,12 +128,18 @@ export function addFillet({
   if (version && 'variableName' in version && version.variableName) {
     insertVariableAndOffsetPathToNode(version, modifiedAst, mNodeToEdit)
   }
+  if (tolerance && 'variableName' in tolerance && tolerance.variableName) {
+    insertVariableAndOffsetPathToNode(tolerance, modifiedAst, mNodeToEdit)
+  }
 
   // 3. Create fillet calls for each body
   const pathToNodes: PathToNode[] = []
   for (const data of bodies.values()) {
     const tagArgs = tag
       ? [createLabeledArg('tag', createTagDeclarator(tag))]
+      : []
+    const toleranceArgs = tolerance
+      ? [createLabeledArg('tolerance', valueOrVariable(tolerance))]
       : []
     const versionArgs = version
       ? [createLabeledArg('version', valueOrVariable(version))]
@@ -142,6 +150,7 @@ export function addFillet({
       [
         createLabeledArg('tags', data.tagsExpr),
         createLabeledArg('radius', valueOrVariable(radius)),
+        ...toleranceArgs,
         ...tagArgs,
         ...versionArgs,
       ]

--- a/src/lang/modifyAst/surfaces.ts
+++ b/src/lang/modifyAst/surfaces.ts
@@ -1,12 +1,20 @@
 import type { Node } from '@rust/kcl-lib/bindings/Node'
-import { createCallExpressionStdLibKw } from '@src/lang/create'
+import {
+  createCallExpressionStdLibKw,
+  createLabeledArg,
+} from '@src/lang/create'
 import {
   createVariableExpressionsArray,
+  insertVariableAndOffsetPathToNode,
   setCallInAst,
 } from '@src/lang/modifyAst'
-import { getVariableExprsFromSelection } from '@src/lang/queryAst'
+import {
+  getVariableExprsFromSelection,
+  valueOrVariable,
+} from '@src/lang/queryAst'
 import type { ArtifactGraph, PathToNode, Program } from '@src/lang/wasm'
 import { modelingStdLibCommandName } from '@src/lib/commandBarConfigs/modelingCommandStdLib'
+import type { KclCommandValue } from '@src/lib/commandTypes'
 import { KCL_DEFAULT_CONSTANT_PREFIXES } from '@src/lib/constants'
 import { err } from '@src/lib/trap'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
@@ -97,12 +105,14 @@ export function addJoinSurfaces({
   ast,
   artifactGraph,
   selection,
+  tolerance,
   wasmInstance,
   nodeToEdit,
 }: {
   ast: Node<Program>
   artifactGraph: ArtifactGraph
   selection: Selections
+  tolerance?: KclCommandValue
   wasmInstance: ModuleType
   nodeToEdit?: PathToNode
 }): Error | { modifiedAst: Node<Program>; pathToNode: PathToNode } {
@@ -134,8 +144,11 @@ export function addJoinSurfaces({
   const call = createCallExpressionStdLibKw(
     modelingStdLibCommandName('Join Surfaces'),
     objectsExpr,
-    []
+    tolerance ? [createLabeledArg('tolerance', valueOrVariable(tolerance))] : []
   )
+  if (tolerance && 'variableName' in tolerance && tolerance.variableName) {
+    insertVariableAndOffsetPathToNode(tolerance, modifiedAst, mNodeToEdit)
+  }
 
   // 3. If edit, we assign the new function call declaration to the existing node,
   // otherwise just push to the end

--- a/src/lang/modifyAst/sweeps.ts
+++ b/src/lang/modifyAst/sweeps.ts
@@ -67,6 +67,7 @@ export function addExtrude({
   length,
   to,
   symmetric,
+  direction,
   bidirectionalLength,
   tagStart,
   tagEnd,
@@ -86,6 +87,7 @@ export function addExtrude({
   length?: KclCommandValue
   to?: Selections
   symmetric?: boolean
+  direction?: KclCommandValue
   bidirectionalLength?: KclCommandValue
   tagStart?: string
   tagEnd?: string
@@ -189,6 +191,9 @@ export function addExtrude({
     symmetric !== undefined
       ? [createLabeledArg('symmetric', createLiteral(symmetric, wasmInstance))]
       : []
+  const directionExpr = direction
+    ? [createLabeledArg('direction', valueOrVariable(direction))]
+    : []
   const bidirectionalLengthExpr = bidirectionalLength
     ? [
         createLabeledArg(
@@ -240,6 +245,7 @@ export function addExtrude({
       ...lengthExpr,
       ...toExpr,
       ...symmetricExpr,
+      ...directionExpr,
       ...bidirectionalLengthExpr,
       ...tagStartExpr,
       ...tagEndExpr,
@@ -256,6 +262,9 @@ export function addExtrude({
   // Insert variables for labeled arguments if provided
   if (length && 'variableName' in length && length.variableName) {
     insertVariableAndOffsetPathToNode(length, modifiedAst, mNodeToEdit)
+  }
+  if (direction && 'variableName' in direction && direction.variableName) {
+    insertVariableAndOffsetPathToNode(direction, modifiedAst, mNodeToEdit)
   }
   if (
     bidirectionalLength &&
@@ -324,6 +333,7 @@ export function addSweep({
   path,
   wasmInstance,
   sectional,
+  tolerance,
   relativeTo,
   translateProfileToPath,
   orientProfilePerpendicular,
@@ -339,6 +349,7 @@ export function addSweep({
   path: Selections
   wasmInstance: ModuleType
   sectional?: boolean
+  tolerance?: KclCommandValue
   relativeTo?: SweepRelativeTo
   translateProfileToPath?: boolean
   orientProfilePerpendicular?: boolean
@@ -438,6 +449,9 @@ export function addSweep({
     sectional !== undefined
       ? [createLabeledArg('sectional', createLiteral(sectional, wasmInstance))]
       : []
+  const toleranceExpr = tolerance
+    ? [createLabeledArg('tolerance', valueOrVariable(tolerance))]
+    : []
   // `relativeTo` is legacy for new sweep calls; only preserve or update it when
   // editing existing code that already depends on that argument.
   const relativeToExpr =
@@ -501,6 +515,7 @@ export function addSweep({
     [
       createLabeledArg('path', pathExpr),
       ...sectionalExpr,
+      ...toleranceExpr,
       ...relativeToExpr,
       ...tagStartExpr,
       ...tagEndExpr,
@@ -513,6 +528,9 @@ export function addSweep({
 
   if (version && 'variableName' in version && version.variableName) {
     insertVariableAndOffsetPathToNode(version, modifiedAst, mNodeToEdit)
+  }
+  if (tolerance && 'variableName' in tolerance && tolerance.variableName) {
+    insertVariableAndOffsetPathToNode(tolerance, modifiedAst, mNodeToEdit)
   }
 
   // 3. If edit, we assign the new function call declaration to the existing node,
@@ -543,6 +561,7 @@ export function addLoft({
   vDegree,
   bezApproximateRational,
   baseCurveIndex,
+  tolerance,
   tagStart,
   tagEnd,
   bodyType,
@@ -555,6 +574,7 @@ export function addLoft({
   vDegree?: KclCommandValue
   bezApproximateRational?: boolean
   baseCurveIndex?: KclCommandValue
+  tolerance?: KclCommandValue
   tagStart?: string
   tagEnd?: string
   bodyType?: KclPreludeBodyType
@@ -619,6 +639,9 @@ export function addLoft({
   const baseCurveIndexExpr = baseCurveIndex
     ? [createLabeledArg('baseCurveIndex', valueOrVariable(baseCurveIndex))]
     : []
+  const toleranceExpr = tolerance
+    ? [createLabeledArg('tolerance', valueOrVariable(tolerance))]
+    : []
   const tagStartExpr = tagStart
     ? [createLabeledArg('tagStart', createTagDeclarator(tagStart))]
     : []
@@ -637,6 +660,7 @@ export function addLoft({
       ...vDegreeExpr,
       ...bezApproximateRationalExpr,
       ...baseCurveIndexExpr,
+      ...toleranceExpr,
       ...tagStartExpr,
       ...tagEndExpr,
       ...bodyTypeExpr,
@@ -653,6 +677,9 @@ export function addLoft({
     baseCurveIndex.variableName
   ) {
     insertVariableAndOffsetPathToNode(baseCurveIndex, modifiedAst, mNodeToEdit)
+  }
+  if (tolerance && 'variableName' in tolerance && tolerance.variableName) {
+    insertVariableAndOffsetPathToNode(tolerance, modifiedAst, mNodeToEdit)
   }
 
   // 3. If edit, we assign the new function call declaration to the existing node,
@@ -683,6 +710,7 @@ export function addRevolve({
   wasmInstance,
   axis,
   edge,
+  tolerance,
   symmetric,
   bidirectionalAngle,
   tagStart,
@@ -697,6 +725,7 @@ export function addRevolve({
   wasmInstance: ModuleType
   axis?: string
   edge?: Selections
+  tolerance?: KclCommandValue
   symmetric?: boolean
   bidirectionalAngle?: KclCommandValue
   tagStart?: string
@@ -764,6 +793,9 @@ export function addRevolve({
     symmetric !== undefined
       ? [createLabeledArg('symmetric', createLiteral(symmetric, wasmInstance))]
       : []
+  const toleranceExpr = tolerance
+    ? [createLabeledArg('tolerance', valueOrVariable(tolerance))]
+    : []
   const bidirectionalAngleExpr = bidirectionalAngle
     ? [
         createLabeledArg(
@@ -789,6 +821,7 @@ export function addRevolve({
     [
       createLabeledArg('angle', valueOrVariable(angle)),
       createLabeledArg('axis', getAxisResult.generatedAxis),
+      ...toleranceExpr,
       ...symmetricExpr,
       ...bidirectionalAngleExpr,
       ...tagStartExpr,
@@ -800,6 +833,9 @@ export function addRevolve({
   // Insert variables for labeled arguments if provided
   if ('variableName' in angle && angle.variableName) {
     insertVariableAndOffsetPathToNode(angle, modifiedAst, mNodeToEdit)
+  }
+  if (tolerance && 'variableName' in tolerance && tolerance.variableName) {
+    insertVariableAndOffsetPathToNode(tolerance, modifiedAst, mNodeToEdit)
   }
 
   if (

--- a/src/lang/modifyAst/sweeps.ts
+++ b/src/lang/modifyAst/sweeps.ts
@@ -67,7 +67,6 @@ export function addExtrude({
   length,
   to,
   symmetric,
-  direction,
   bidirectionalLength,
   tagStart,
   tagEnd,
@@ -87,7 +86,6 @@ export function addExtrude({
   length?: KclCommandValue
   to?: Selections
   symmetric?: boolean
-  direction?: KclCommandValue
   bidirectionalLength?: KclCommandValue
   tagStart?: string
   tagEnd?: string
@@ -191,9 +189,6 @@ export function addExtrude({
     symmetric !== undefined
       ? [createLabeledArg('symmetric', createLiteral(symmetric, wasmInstance))]
       : []
-  const directionExpr = direction
-    ? [createLabeledArg('direction', valueOrVariable(direction))]
-    : []
   const bidirectionalLengthExpr = bidirectionalLength
     ? [
         createLabeledArg(
@@ -245,7 +240,6 @@ export function addExtrude({
       ...lengthExpr,
       ...toExpr,
       ...symmetricExpr,
-      ...directionExpr,
       ...bidirectionalLengthExpr,
       ...tagStartExpr,
       ...tagEndExpr,
@@ -262,9 +256,6 @@ export function addExtrude({
   // Insert variables for labeled arguments if provided
   if (length && 'variableName' in length && length.variableName) {
     insertVariableAndOffsetPathToNode(length, modifiedAst, mNodeToEdit)
-  }
-  if (direction && 'variableName' in direction && direction.variableName) {
-    insertVariableAndOffsetPathToNode(direction, modifiedAst, mNodeToEdit)
   }
   if (
     bidirectionalLength &&

--- a/src/lang/modifyAst/transforms.spec.ts
+++ b/src/lang/modifyAst/transforms.spec.ts
@@ -781,6 +781,31 @@ scale(
       return recast(result.modifiedAst, instance)
     }
 
+    async function runAddAxisRotateTest(
+      code: string,
+      instance: ModuleType,
+      kclManager: KclManager,
+      rustContext: RustContext
+    ) {
+      const {
+        artifactGraph,
+        ast,
+        sketches: objects,
+      } = await getAstAndSketchSelections(code, instance, kclManager)
+      const result = addRotate({
+        ast,
+        artifactGraph,
+        objects,
+        axis: 'Z',
+        angle: await getKclCommandValue('90deg', instance, rustContext),
+        global: true,
+        wasmInstance: instanceInThisFile,
+      })
+      if (err(result)) throw result
+      await runNewAstAndCheckForSweep(result.modifiedAst, rustContext)
+      return recast(result.modifiedAst, instance)
+    }
+
     it('should add a standalone call on sweep selection', async () => {
       const code = `sketch001 = startSketchOn(XY)
 profile001 = circle(sketch001, center = [0, 0], radius = 1)
@@ -793,6 +818,25 @@ extrude001 = extrude(profile001, length = 1)`
   global = true,
 )`
       const newCode = await runAddRotateTest(
+        code,
+        instanceInThisFile,
+        kclManagerInThisFile,
+        rustContextInThisFile
+      )
+      expect(newCode).toContain(code + '\n' + expectedNewLine)
+    })
+
+    it('should add a named axis as a bare identifier', async () => {
+      const code = `sketch001 = startSketchOn(XY)
+profile001 = circle(sketch001, center = [0, 0], radius = 1)
+extrude001 = extrude(profile001, length = 1)`
+      const expectedNewLine = `rotate(
+  extrude001,
+  axis = Z,
+  angle = 90deg,
+  global = true,
+)`
+      const newCode = await runAddAxisRotateTest(
         code,
         instanceInThisFile,
         kclManagerInThisFile,

--- a/src/lang/modifyAst/transforms.ts
+++ b/src/lang/modifyAst/transforms.ts
@@ -41,6 +41,7 @@ export function addTranslate({
   y,
   z,
   global,
+  xyz,
   nodeToEdit,
 }: {
   ast: Node<Program>
@@ -51,6 +52,7 @@ export function addTranslate({
   y?: KclCommandValue
   z?: KclCommandValue
   global?: boolean
+  xyz?: KclCommandValue
   nodeToEdit?: PathToNode
 }): Error | { modifiedAst: Node<Program>; pathToNode: PathToNode } {
   // 1. Clone the ast and nodeToEdit so we can freely edit them
@@ -80,12 +82,13 @@ export function addTranslate({
     global !== undefined
       ? [createLabeledArg('global', createLiteral(global, wasmInstance))]
       : []
+  const xyzExpr = xyz ? [createLabeledArg('xyz', valueOrVariable(xyz))] : []
 
   const objectsExpr = createVariableExpressionsArray(vars.exprs)
   const call = createCallExpressionStdLibKw(
     modelingStdLibCommandName('Translate'),
     objectsExpr,
-    [...xExpr, ...yExpr, ...zExpr, ...globalExpr]
+    [...xExpr, ...yExpr, ...zExpr, ...globalExpr, ...xyzExpr]
   )
 
   // Insert variables for labeled arguments if provided
@@ -97,6 +100,9 @@ export function addTranslate({
   }
   if (z && 'variableName' in z && z.variableName) {
     insertVariableAndOffsetPathToNode(z, modifiedAst, mNodeToEdit)
+  }
+  if (xyz && 'variableName' in xyz && xyz.variableName) {
+    insertVariableAndOffsetPathToNode(xyz, modifiedAst, mNodeToEdit)
   }
 
   // 3. If edit, we assign the new function call declaration to the existing node,
@@ -127,6 +133,8 @@ export function addRotate({
   roll,
   pitch,
   yaw,
+  axis,
+  angle,
   global,
   nodeToEdit,
 }: {
@@ -137,6 +145,8 @@ export function addRotate({
   roll?: KclCommandValue
   pitch?: KclCommandValue
   yaw?: KclCommandValue
+  axis?: KclCommandValue
+  angle?: KclCommandValue
   global?: boolean
   nodeToEdit?: PathToNode
 }): Error | { modifiedAst: Node<Program>; pathToNode: PathToNode } {
@@ -165,6 +175,10 @@ export function addRotate({
     ? [createLabeledArg('pitch', valueOrVariable(pitch))]
     : []
   const yawExpr = yaw ? [createLabeledArg('yaw', valueOrVariable(yaw))] : []
+  const axisExpr = axis ? [createLabeledArg('axis', valueOrVariable(axis))] : []
+  const angleExpr = angle
+    ? [createLabeledArg('angle', valueOrVariable(angle))]
+    : []
   const globalExpr =
     global !== undefined
       ? [createLabeledArg('global', createLiteral(global, wasmInstance))]
@@ -174,7 +188,14 @@ export function addRotate({
   const call = createCallExpressionStdLibKw(
     modelingStdLibCommandName('Rotate'),
     objectsExpr,
-    [...rollExpr, ...pitchExpr, ...yawExpr, ...globalExpr]
+    [
+      ...rollExpr,
+      ...pitchExpr,
+      ...yawExpr,
+      ...axisExpr,
+      ...angleExpr,
+      ...globalExpr,
+    ]
   )
 
   // Insert variables for labeled arguments if provided
@@ -186,6 +207,12 @@ export function addRotate({
   }
   if (yaw && 'variableName' in yaw && yaw.variableName) {
     insertVariableAndOffsetPathToNode(yaw, modifiedAst, mNodeToEdit)
+  }
+  if (axis && 'variableName' in axis && axis.variableName) {
+    insertVariableAndOffsetPathToNode(axis, modifiedAst, mNodeToEdit)
+  }
+  if (angle && 'variableName' in angle && angle.variableName) {
+    insertVariableAndOffsetPathToNode(angle, modifiedAst, mNodeToEdit)
   }
 
   // 3. If edit, we assign the new function call declaration to the existing node,

--- a/src/lang/modifyAst/transforms.ts
+++ b/src/lang/modifyAst/transforms.ts
@@ -4,6 +4,7 @@ import {
   createCallExpressionStdLibKw,
   createLabeledArg,
   createLiteral,
+  createLocalName,
   createVariableDeclaration,
 } from '@src/lang/create'
 import {
@@ -145,7 +146,7 @@ export function addRotate({
   roll?: KclCommandValue
   pitch?: KclCommandValue
   yaw?: KclCommandValue
-  axis?: KclCommandValue
+  axis?: string
   angle?: KclCommandValue
   global?: boolean
   nodeToEdit?: PathToNode
@@ -175,7 +176,7 @@ export function addRotate({
     ? [createLabeledArg('pitch', valueOrVariable(pitch))]
     : []
   const yawExpr = yaw ? [createLabeledArg('yaw', valueOrVariable(yaw))] : []
-  const axisExpr = axis ? [createLabeledArg('axis', valueOrVariable(axis))] : []
+  const axisExpr = axis ? [createLabeledArg('axis', createLocalName(axis))] : []
   const angleExpr = angle
     ? [createLabeledArg('angle', valueOrVariable(angle))]
     : []
@@ -207,9 +208,6 @@ export function addRotate({
   }
   if (yaw && 'variableName' in yaw && yaw.variableName) {
     insertVariableAndOffsetPathToNode(yaw, modifiedAst, mNodeToEdit)
-  }
-  if (axis && 'variableName' in axis && axis.variableName) {
-    insertVariableAndOffsetPathToNode(axis, modifiedAst, mNodeToEdit)
   }
   if (angle && 'variableName' in angle && angle.variableName) {
     insertVariableAndOffsetPathToNode(angle, modifiedAst, mNodeToEdit)

--- a/src/lib/commandBarConfigs/modelingCommandConfig.integration.spec.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.integration.spec.ts
@@ -304,11 +304,7 @@ describe('stdlib command arg derivation', () => {
       inputType: 'vector2d',
       required: false,
     })
-    expect(args.direction).toMatchObject({
-      inputType: 'kcl',
-      required: false,
-      status: 'experimental',
-    })
+    expect('direction' in args).toBe(false)
   })
 
   it('derives command status from KCL stdlib metadata', () => {
@@ -325,7 +321,7 @@ describe('stdlib command arg derivation', () => {
     ][] = [
       ['Extrude', {}, false],
       ['Extrude', { draftAngle: parsedLength('45deg') }, true],
-      ['Extrude', { direction: selectionsForArtifact() }, true],
+      ['Extrude', { direction: selectionsForArtifact() }, false],
       ['Fillet', { edges: selectionsForArtifact() }, false],
       ['Fillet', { version: parsedLength('2') }, true],
       ['Helical Gear', {}, true],

--- a/src/lib/commandBarConfigs/modelingCommandConfig.integration.spec.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.integration.spec.ts
@@ -304,7 +304,11 @@ describe('stdlib command arg derivation', () => {
       inputType: 'vector2d',
       required: false,
     })
-    expect('direction' in args).toBe(false)
+    expect(args.direction).toMatchObject({
+      inputType: 'kcl',
+      required: false,
+      status: 'experimental',
+    })
   })
 
   it('derives command status from KCL stdlib metadata', () => {
@@ -321,7 +325,7 @@ describe('stdlib command arg derivation', () => {
     ][] = [
       ['Extrude', {}, false],
       ['Extrude', { draftAngle: parsedLength('45deg') }, true],
-      ['Extrude', { direction: selectionsForArtifact() }, false],
+      ['Extrude', { direction: selectionsForArtifact() }, true],
       ['Fillet', { edges: selectionsForArtifact() }, false],
       ['Fillet', { version: parsedLength('2') }, true],
       ['Helical Gear', {}, true],

--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -613,9 +613,6 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
           tagStart: {
             // TODO: add validation like for Clone command
           },
-          direction: {
-            allowArrays: true,
-          },
           twistCenter: {
             defaultValue: KCL_DEFAULT_ORIGIN_2D,
           },

--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -1530,7 +1530,13 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
           defaultValue: KCL_DEFAULT_TRANSFORM,
         },
         axis: {
+          inputType: 'options',
           defaultValue: KCL_AXIS_Z,
+          options: [
+            { name: 'X-axis', value: KCL_AXIS_X },
+            { name: 'Y-axis', value: KCL_AXIS_Y },
+            { name: 'Z-axis', isCurrent: true, value: KCL_AXIS_Z },
+          ],
         },
         angle: {
           defaultValue: KCL_DEFAULT_DEGREE,

--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -613,6 +613,9 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
           tagStart: {
             // TODO: add validation like for Clone command
           },
+          direction: {
+            allowArrays: true,
+          },
           twistCenter: {
             defaultValue: KCL_DEFAULT_ORIGIN_2D,
           },
@@ -1497,6 +1500,10 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
           z: {
             defaultValue: KCL_DEFAULT_TRANSFORM,
           },
+          xyz: {
+            inputType: 'vector3d',
+            defaultValue: KCL_DEFAULT_ORIGIN,
+          },
         },
       }
     ),
@@ -1524,6 +1531,12 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         },
         yaw: {
           defaultValue: KCL_DEFAULT_TRANSFORM,
+        },
+        axis: {
+          defaultValue: KCL_AXIS_Z,
+        },
+        angle: {
+          defaultValue: KCL_DEFAULT_DEGREE,
         },
       },
     }),

--- a/src/lib/commandBarConfigs/modelingCommandStdLib.ts
+++ b/src/lib/commandBarConfigs/modelingCommandStdLib.ts
@@ -204,6 +204,7 @@ export const modelingCommandStdLibDriftConfig = {
     stdLibName: 'extrude',
     editFlow: true,
     flowArgOrder: ['sketches', 'length', 'bodyType'],
+    omittedStdLibArgs: ['direction'],
   },
   Sweep: {
     stdLibName: 'sweep',

--- a/src/lib/commandBarConfigs/modelingCommandStdLib.ts
+++ b/src/lib/commandBarConfigs/modelingCommandStdLib.ts
@@ -204,20 +204,17 @@ export const modelingCommandStdLibDriftConfig = {
     stdLibName: 'extrude',
     editFlow: true,
     flowArgOrder: ['sketches', 'length', 'bodyType'],
-    omittedStdLibArgs: ['direction'],
   },
   Sweep: {
     stdLibName: 'sweep',
     editFlow: true,
     flowArgOrder: ['sketches', 'path', 'bodyType'],
     deprecatedStdLibArgs: ['relativeTo'],
-    omittedStdLibArgs: ['tolerance'],
   },
   Loft: {
     stdLibName: 'loft',
     editFlow: true,
     flowArgOrder: ['sketches', 'bodyType'],
-    omittedStdLibArgs: ['tolerance'],
   },
   Revolve: {
     stdLibName: 'revolve',
@@ -231,7 +228,6 @@ export const modelingCommandStdLibDriftConfig = {
       'bodyType',
     ],
     uiOnlyArgs: ['axisOrEdge', 'edge'],
-    omittedStdLibArgs: ['tolerance'],
   },
   Shell: {
     stdLibName: 'shell',
@@ -272,7 +268,7 @@ export const modelingCommandStdLibDriftConfig = {
     stdLibName: 'fillet',
     editFlow: true,
     flowArgOrder: ['selection', 'radius'],
-    omittedStdLibArgs: ['solid', 'edges', 'tolerance'],
+    omittedStdLibArgs: ['solid', 'edges'],
     argAliases: {
       tags: 'selection',
     },
@@ -356,13 +352,11 @@ export const modelingCommandStdLibDriftConfig = {
     stdLibName: 'translate',
     editFlow: true,
     flowArgOrder: ['objects'],
-    omittedStdLibArgs: ['xyz'],
   },
   Rotate: {
     stdLibName: 'rotate',
     editFlow: true,
     flowArgOrder: ['objects'],
-    omittedStdLibArgs: ['axis', 'angle'],
   },
   Scale: {
     stdLibName: 'scale',
@@ -534,17 +528,14 @@ export const modelingCommandStdLibDriftConfig = {
   'Boolean Subtract': {
     stdLibName: 'subtract',
     flowArgOrder: ['solids', 'tools'],
-    omittedStdLibArgs: ['tolerance'],
   },
   'Boolean Union': {
     stdLibName: 'union',
     flowArgOrder: ['solids'],
-    omittedStdLibArgs: ['tolerance'],
   },
   'Boolean Intersect': {
     stdLibName: 'intersect',
     flowArgOrder: ['solids'],
-    omittedStdLibArgs: ['tolerance'],
   },
   'Boolean Split': {
     stdLibName: 'split',
@@ -567,7 +558,6 @@ export const modelingCommandStdLibDriftConfig = {
   'Join Surfaces': {
     stdLibName: 'joinSurfaces',
     flowArgOrder: ['selection'],
-    omittedStdLibArgs: ['tolerance'],
   },
 } as const satisfies Partial<
   Record<ModelingCommandName, StdLibCommandDriftConfig>

--- a/src/lib/commandBarConfigs/modelingCommandStdLibTypes.ts
+++ b/src/lib/commandBarConfigs/modelingCommandStdLibTypes.ts
@@ -165,7 +165,7 @@ export type TranslateCommandArgs = StdLibCommandArgs<'translate'>
 export type RotateCommandArgs = Override<
   StdLibCommandArgs<'rotate'>,
   {
-    axis: string
+    axis?: string
   }
 >
 

--- a/src/lib/commandBarConfigs/modelingCommandStdLibTypes.ts
+++ b/src/lib/commandBarConfigs/modelingCommandStdLibTypes.ts
@@ -165,7 +165,7 @@ export type TranslateCommandArgs = StdLibCommandArgs<'translate'>
 export type RotateCommandArgs = Override<
   StdLibCommandArgs<'rotate'>,
   {
-    axis?: KclCommandValue
+    axis: string
   }
 >
 

--- a/src/lib/commandBarConfigs/modelingCommandStdLibTypes.ts
+++ b/src/lib/commandBarConfigs/modelingCommandStdLibTypes.ts
@@ -60,9 +60,8 @@ type GdtObjectsCommandArgs<Name extends StdLibCommandName> = GdtObjectsArgs<
 export type HelixModes = 'Axis' | 'Edge' | 'Cylinder'
 
 export type ExtrudeCommandArgs = Override<
-  StdLibCommandArgs<'extrude'>,
+  Omit<StdLibCommandArgs<'extrude'>, 'direction'>,
   {
-    direction?: KclCommandValue
     method?: KclPreludeExtrudeMethod
     bodyType?: KclPreludeBodyType
   }

--- a/src/lib/commandBarConfigs/modelingCommandStdLibTypes.ts
+++ b/src/lib/commandBarConfigs/modelingCommandStdLibTypes.ts
@@ -60,15 +60,16 @@ type GdtObjectsCommandArgs<Name extends StdLibCommandName> = GdtObjectsArgs<
 export type HelixModes = 'Axis' | 'Edge' | 'Cylinder'
 
 export type ExtrudeCommandArgs = Override<
-  Omit<StdLibCommandArgs<'extrude'>, 'direction'>,
+  StdLibCommandArgs<'extrude'>,
   {
+    direction?: KclCommandValue
     method?: KclPreludeExtrudeMethod
     bodyType?: KclPreludeBodyType
   }
 >
 
 export type SweepCommandArgs = Override<
-  Omit<StdLibCommandArgs<'sweep'>, 'tolerance'>,
+  StdLibCommandArgs<'sweep'>,
   {
     relativeTo?: SweepRelativeTo
     bodyType?: KclPreludeBodyType
@@ -76,14 +77,14 @@ export type SweepCommandArgs = Override<
 >
 
 export type LoftCommandArgs = Override<
-  Omit<StdLibCommandArgs<'loft'>, 'tolerance'>,
+  StdLibCommandArgs<'loft'>,
   {
     bodyType?: KclPreludeBodyType
   }
 >
 
 export type RevolveCommandArgs = Override<
-  Omit<StdLibCommandArgs<'revolve'>, 'axis' | 'tolerance'>,
+  Omit<StdLibCommandArgs<'revolve'>, 'axis'>,
   {
     axisOrEdge: 'Axis' | 'Edge'
     axis: string | undefined
@@ -115,7 +116,7 @@ export type HoleCommandArgs = Override<
 >
 
 export type FilletCommandArgs = Override<
-  Omit<StdLibCommandArgs<'fillet'>, 'solid' | 'tags' | 'edges' | 'tolerance'>,
+  Omit<StdLibCommandArgs<'fillet'>, 'solid' | 'tags' | 'edges'>,
   {
     selection: Selections
     radius: KclCommandValue
@@ -160,11 +161,13 @@ export type AppearanceCommandArgs = Override<
 
 export type DeleteCommandArgs = StdLibCommandArgs<'delete'>
 
-export type TranslateCommandArgs = Omit<StdLibCommandArgs<'translate'>, 'xyz'>
+export type TranslateCommandArgs = StdLibCommandArgs<'translate'>
 
-export type RotateCommandArgs = Omit<
+export type RotateCommandArgs = Override<
   StdLibCommandArgs<'rotate'>,
-  'axis' | 'angle'
+  {
+    axis?: KclCommandValue
+  }
 >
 
 export type ScaleCommandArgs = StdLibCommandArgs<'scale'>
@@ -235,15 +238,15 @@ export type GdtDatumCommandArgs = Override<
 
 export type BooleanSubtractCommandArgs = Omit<
   StdLibCommandArgs<'subtract'>,
-  'tolerance' | 'legacyMethod'
+  'legacyMethod'
 >
 export type BooleanUnionCommandArgs = Omit<
   StdLibCommandArgs<'union'>,
-  'tolerance' | 'legacyMethod'
+  'legacyMethod'
 >
 export type BooleanIntersectCommandArgs = Omit<
   StdLibCommandArgs<'intersect'>,
-  'tolerance' | 'legacyMethod'
+  'legacyMethod'
 >
 export type BooleanSplitCommandArgs = Omit<
   StdLibCommandArgs<'split'>,
@@ -255,10 +258,7 @@ export type DeleteFaceCommandArgs = Override<
   { faces: Selections }
 >
 export type BlendCommandArgs = StdLibCommandArgs<'blend'>
-export type JoinSurfacesCommandArgs = Omit<
-  StdLibCommandArgs<'joinSurfaces'>,
-  'tolerance'
->
+export type JoinSurfacesCommandArgs = StdLibCommandArgs<'joinSurfaces'>
 
 export type StdLibModelingCommandSchema = {
   Extrude: ExtrudeCommandArgs

--- a/src/lib/operations.spec.ts
+++ b/src/lib/operations.spec.ts
@@ -401,10 +401,10 @@ describe('operations.test.ts', () => {
   }
 
   describe('Extrude edit flow', () => {
-    it('preserves experimental KCL args in the command defaults', async () => {
+    it('preserves draftAngle in the command defaults', async () => {
       const { rustContext } = await buildTheWorldAndNoEngineConnection()
       const code =
-        'extrude001 = extrude(profile001, length = 10, direction = [0, 0, 1], draftAngle = 45deg)'
+        'extrude001 = extrude(profile001, length = 10, draftAngle = 45deg)'
       const operation = stdlib('extrude')
       if (operation.type !== 'StdLibCall') {
         throw new Error('Expected operation to be a StdLibCall')
@@ -425,17 +425,6 @@ describe('operations.test.ts', () => {
           value: { type: 'Number', value: 45, ty: { type: 'Any' } },
           sourceRange: rangeOfText(code, '45deg'),
         },
-        direction: {
-          value: {
-            type: 'Array',
-            value: [
-              { type: 'Number', value: 0, ty: { type: 'Any' } },
-              { type: 'Number', value: 0, ty: { type: 'Any' } },
-              { type: 'Number', value: 1, ty: { type: 'Any' } },
-            ],
-          },
-          sourceRange: rangeOfText(code, '[0, 0, 1]'),
-        },
       }
 
       const result = await enterEditFlow({
@@ -453,11 +442,9 @@ describe('operations.test.ts', () => {
 
       const argDefaultValues = result.data.argDefaultValues as {
         draftAngle?: { valueText: string }
-        direction?: { valueText: string }
       }
       expect(result.data.name).toBe('Extrude')
       expect(argDefaultValues.draftAngle?.valueText).toBe('45deg')
-      expect(argDefaultValues.direction?.valueText).toBe('[0, 0, 1]')
     })
   })
 

--- a/src/lib/operations.spec.ts
+++ b/src/lib/operations.spec.ts
@@ -401,10 +401,10 @@ describe('operations.test.ts', () => {
   }
 
   describe('Extrude edit flow', () => {
-    it('preserves draftAngle in the command defaults', async () => {
+    it('preserves experimental KCL args in the command defaults', async () => {
       const { rustContext } = await buildTheWorldAndNoEngineConnection()
       const code =
-        'extrude001 = extrude(profile001, length = 10, draftAngle = 45deg)'
+        'extrude001 = extrude(profile001, length = 10, direction = [0, 0, 1], draftAngle = 45deg)'
       const operation = stdlib('extrude')
       if (operation.type !== 'StdLibCall') {
         throw new Error('Expected operation to be a StdLibCall')
@@ -425,6 +425,17 @@ describe('operations.test.ts', () => {
           value: { type: 'Number', value: 45, ty: { type: 'Any' } },
           sourceRange: rangeOfText(code, '45deg'),
         },
+        direction: {
+          value: {
+            type: 'Array',
+            value: [
+              { type: 'Number', value: 0, ty: { type: 'Any' } },
+              { type: 'Number', value: 0, ty: { type: 'Any' } },
+              { type: 'Number', value: 1, ty: { type: 'Any' } },
+            ],
+          },
+          sourceRange: rangeOfText(code, '[0, 0, 1]'),
+        },
       }
 
       const result = await enterEditFlow({
@@ -442,9 +453,11 @@ describe('operations.test.ts', () => {
 
       const argDefaultValues = result.data.argDefaultValues as {
         draftAngle?: { valueText: string }
+        direction?: { valueText: string }
       }
       expect(result.data.name).toBe('Extrude')
       expect(argDefaultValues.draftAngle?.valueText).toBe('45deg')
+      expect(argDefaultValues.direction?.valueText).toBe('[0, 0, 1]')
     })
   })
 
@@ -452,7 +465,7 @@ describe('operations.test.ts', () => {
     it('retrieves tagged cap profiles in the command defaults', async () => {
       const { rustContext } = await buildTheWorldAndNoEngineConnection()
       const code =
-        'sweep001 = sweep(capEnd001, path = profile002, version = 2, translateProfileToPath = false, orientProfilePerpendicular = true)'
+        'sweep001 = sweep(capEnd001, path = profile002, tolerance = 0.01mm, version = 2, translateProfileToPath = false, orientProfilePerpendicular = true)'
       const operation = stdlib('sweep')
       if (operation.type !== 'StdLibCall') {
         throw new Error('Expected operation to be a StdLibCall')
@@ -480,6 +493,14 @@ describe('operations.test.ts', () => {
             ty: { type: 'Any' },
           },
           sourceRange: rangeOfText(code, '2'),
+        },
+        tolerance: {
+          value: {
+            type: 'Number',
+            value: 0.01,
+            ty: { type: 'Any' },
+          },
+          sourceRange: rangeOfText(code, '0.01mm'),
         },
         translateProfileToPath: {
           value: {
@@ -518,6 +539,7 @@ describe('operations.test.ts', () => {
       const argDefaultValues = result.data.argDefaultValues as {
         sketches?: { graphSelections: Array<{ artifact?: Artifact }> }
         path?: { graphSelections: Array<{ artifact?: Artifact }> }
+        tolerance?: { valueText: string }
         version?: { valueText: string }
         translateProfileToPath?: boolean
         orientProfilePerpendicular?: boolean
@@ -529,6 +551,7 @@ describe('operations.test.ts', () => {
       expect(argDefaultValues.path?.graphSelections[0].artifact?.type).toBe(
         'path'
       )
+      expect(argDefaultValues.tolerance?.valueText).toBe('0.01mm')
       expect(argDefaultValues.version?.valueText).toBe('2')
       expect(argDefaultValues.translateProfileToPath).toBe(false)
       expect(argDefaultValues.orientProfilePerpendicular).toBe(true)

--- a/src/lib/operations.spec.ts
+++ b/src/lib/operations.spec.ts
@@ -545,6 +545,64 @@ describe('operations.test.ts', () => {
     })
   })
 
+  describe('Rotate edit flow', () => {
+    it('enters edit flow for roll/pitch/yaw rotate without an axis', async () => {
+      const { rustContext } = await buildTheWorldAndNoEngineConnection()
+      const code =
+        'rotate001 = rotate(extrude001, roll = 10deg, pitch = 20deg, yaw = 30deg)'
+      const operation = stdlib('rotate')
+      if (operation.type !== 'StdLibCall') {
+        throw new Error('Expected operation to be a StdLibCall')
+      }
+      operation.unlabeledArg = {
+        value: {
+          type: 'Solid',
+          value: { artifactId: 'sweep-id' },
+        },
+        sourceRange: rangeOfText(code, 'extrude001'),
+      }
+      operation.labeledArgs = {
+        roll: {
+          value: { type: 'Number', value: 10, ty: { type: 'Any' } },
+          sourceRange: rangeOfText(code, '10deg'),
+        },
+        pitch: {
+          value: { type: 'Number', value: 20, ty: { type: 'Any' } },
+          sourceRange: rangeOfText(code, '20deg'),
+        },
+        yaw: {
+          value: { type: 'Number', value: 30, ty: { type: 'Any' } },
+          sourceRange: rangeOfText(code, '30deg'),
+        },
+      }
+
+      const result = await enterEditFlow({
+        operation,
+        code,
+        artifactGraph: toArtifactGraph([sweepArtifact('sweep-id', 'path-id')]),
+        rustContext,
+      })
+      if (result instanceof Error) {
+        throw result
+      }
+      if (result.type !== 'Find and select command') {
+        throw new Error(`Expected edit flow event, got ${result.type}`)
+      }
+
+      const argDefaultValues = result.data.argDefaultValues as {
+        axis?: string
+        roll?: { valueText: string }
+        pitch?: { valueText: string }
+        yaw?: { valueText: string }
+      }
+      expect(result.data.name).toBe('Rotate')
+      expect(argDefaultValues.axis).toBe('Z')
+      expect(argDefaultValues.roll?.valueText).toBe('10deg')
+      expect(argDefaultValues.pitch?.valueText).toBe('20deg')
+      expect(argDefaultValues.yaw?.valueText).toBe('30deg')
+    })
+  })
+
   describe('GDT edit flow', () => {
     it.each([
       {

--- a/src/lib/operations.spec.ts
+++ b/src/lib/operations.spec.ts
@@ -596,7 +596,7 @@ describe('operations.test.ts', () => {
         yaw?: { valueText: string }
       }
       expect(result.data.name).toBe('Rotate')
-      expect(argDefaultValues.axis).toBe('Z')
+      expect(argDefaultValues.axis).toBeUndefined()
       expect(argDefaultValues.roll?.valueText).toBe('10deg')
       expect(argDefaultValues.pitch?.valueText).toBe('20deg')
       expect(argDefaultValues.yaw?.valueText).toBe('30deg')

--- a/src/lib/operations.ts
+++ b/src/lib/operations.ts
@@ -268,11 +268,36 @@ async function extractOptionalKclArrayArgument(
   argName: string,
   rustContext: RustContext
 ): Promise<KclCommandValue | undefined | { error: string }> {
+  return extractOptionalKclArgument(
+    code,
+    operation,
+    argName,
+    rustContext,
+    true,
+    true
+  )
+}
+
+async function extractOptionalKclArgument(
+  code: string,
+  operation: StdLibCallOp,
+  argName: string,
+  rustContext: RustContext,
+  isArray?: boolean,
+  allowStringArrays?: boolean
+): Promise<KclCommandValue | undefined | { error: string }> {
   if (!operation.labeledArgs?.[argName]?.sourceRange) {
     return undefined
   }
 
-  return extractKclArgument(code, operation, argName, rustContext, true, true)
+  return extractKclArgument(
+    code,
+    operation,
+    argName,
+    rustContext,
+    isArray,
+    allowStringArrays
+  )
 }
 
 /**
@@ -384,6 +409,18 @@ const prepareToEditExtrude: PrepareToEditCallback = async ({
         ...operation.labeledArgs.symmetric.sourceRange.map(boundToUtf16)
       ) === 'true'
   }
+
+  const directionResult = await extractOptionalKclArgument(
+    code,
+    operation,
+    'direction',
+    rustContext,
+    true
+  )
+  if (directionResult && 'error' in directionResult) {
+    return { reason: directionResult.error }
+  }
+  const direction = directionResult
 
   // bidirectionalLength argument from a string to a KCL expression
   let bidirectionalLength: KclCommandValue | undefined
@@ -527,6 +564,7 @@ const prepareToEditExtrude: PrepareToEditCallback = async ({
     length,
     to,
     symmetric,
+    direction,
     bidirectionalLength,
     tagStart,
     tagEnd,
@@ -629,6 +667,17 @@ const prepareToEditLoft: PrepareToEditCallback = async ({
     baseCurveIndex = result
   }
 
+  const toleranceResult = await extractOptionalKclArgument(
+    code,
+    operation,
+    'tolerance',
+    rustContext
+  )
+  if (toleranceResult && 'error' in toleranceResult) {
+    return { reason: toleranceResult.error }
+  }
+  const tolerance = toleranceResult
+
   // tagStart and tagEnd arguments
   let tagStart: string | undefined
   let tagEnd: string | undefined
@@ -658,6 +707,7 @@ const prepareToEditLoft: PrepareToEditCallback = async ({
     vDegree,
     bezApproximateRational,
     baseCurveIndex,
+    tolerance,
     tagStart,
     tagEnd,
     bodyType,
@@ -708,6 +758,16 @@ const prepareToEditFillet: PrepareToEditCallback = async ({
   if ('error' in radius) return { reason: radius.error }
 
   const tag = extractStringArgument(code, operation, 'tag')
+  const toleranceResult = await extractOptionalKclArgument(
+    code,
+    operation,
+    'tolerance',
+    rustContext
+  )
+  if (toleranceResult && 'error' in toleranceResult) {
+    return { reason: toleranceResult.error }
+  }
+  const tolerance = toleranceResult
   const versionResult = await extractKclArgument(
     code,
     operation,
@@ -722,6 +782,7 @@ const prepareToEditFillet: PrepareToEditCallback = async ({
   const argDefaultValues: ModelingCommandSchema['Fillet'] = {
     selection,
     radius,
+    tolerance,
     tag,
     version,
     nodeToEdit: pathToNodeFromRustNodePath(operation.nodePath),
@@ -1324,6 +1385,17 @@ const prepareToEditSweep: PrepareToEditCallback = async ({
       ) === 'true'
   }
 
+  const toleranceResult = await extractOptionalKclArgument(
+    code,
+    operation,
+    'tolerance',
+    rustContext
+  )
+  if (toleranceResult && 'error' in toleranceResult) {
+    return { reason: toleranceResult.error }
+  }
+  const tolerance = toleranceResult
+
   let translateProfileToPath: boolean | undefined
   if (
     'translateProfileToPath' in operation.labeledArgs &&
@@ -1409,6 +1481,7 @@ const prepareToEditSweep: PrepareToEditCallback = async ({
     sketches,
     path,
     sectional,
+    tolerance,
     relativeTo,
     translateProfileToPath,
     orientProfilePerpendicular,
@@ -1623,6 +1696,17 @@ const prepareToEditRevolve: PrepareToEditCallback = async ({
     return { reason: 'Error in angle argument retrieval' }
   }
 
+  const toleranceResult = await extractOptionalKclArgument(
+    code,
+    operation,
+    'tolerance',
+    rustContext
+  )
+  if (toleranceResult && 'error' in toleranceResult) {
+    return { reason: toleranceResult.error }
+  }
+  const tolerance = toleranceResult
+
   // symmetric argument from a string to boolean
   let symmetric: boolean | undefined
   if ('symmetric' in operation.labeledArgs && operation.labeledArgs.symmetric) {
@@ -1683,6 +1767,7 @@ const prepareToEditRevolve: PrepareToEditCallback = async ({
     axis,
     edge,
     angle,
+    tolerance,
     symmetric,
     bidirectionalAngle,
     tagStart,
@@ -4042,6 +4127,18 @@ async function prepareToEditTranslate({
     z = result
   }
 
+  const xyzResult = await extractOptionalKclArgument(
+    code,
+    operation,
+    'xyz',
+    rustContext,
+    true
+  )
+  if (xyzResult && 'error' in xyzResult) {
+    return { reason: xyzResult.error }
+  }
+  const xyz = xyzResult
+
   if (operation.labeledArgs.global) {
     global =
       code.slice(
@@ -4058,6 +4155,7 @@ async function prepareToEditTranslate({
     y,
     z,
     global,
+    xyz,
     nodeToEdit: pathToNodeFromRustNodePath(operation.nodePath),
   }
   return {
@@ -4225,6 +4323,29 @@ async function prepareToEditRotate({
     yaw = result
   }
 
+  const axisResult = await extractOptionalKclArgument(
+    code,
+    operation,
+    'axis',
+    rustContext,
+    true
+  )
+  if (axisResult && 'error' in axisResult) {
+    return { reason: axisResult.error }
+  }
+  const axis = axisResult
+
+  const angleResult = await extractOptionalKclArgument(
+    code,
+    operation,
+    'angle',
+    rustContext
+  )
+  if (angleResult && 'error' in angleResult) {
+    return { reason: angleResult.error }
+  }
+  const angle = angleResult
+
   if (operation.labeledArgs.global) {
     global =
       code.slice(
@@ -4240,6 +4361,8 @@ async function prepareToEditRotate({
     roll,
     pitch,
     yaw,
+    axis,
+    angle,
     global,
     nodeToEdit: pathToNodeFromRustNodePath(operation.nodePath),
   }

--- a/src/lib/operations.ts
+++ b/src/lib/operations.ts
@@ -410,18 +410,6 @@ const prepareToEditExtrude: PrepareToEditCallback = async ({
       ) === 'true'
   }
 
-  const directionResult = await extractOptionalKclArgument(
-    code,
-    operation,
-    'direction',
-    rustContext,
-    true
-  )
-  if (directionResult && 'error' in directionResult) {
-    return { reason: directionResult.error }
-  }
-  const direction = directionResult
-
   // bidirectionalLength argument from a string to a KCL expression
   let bidirectionalLength: KclCommandValue | undefined
   if (
@@ -564,7 +552,6 @@ const prepareToEditExtrude: PrepareToEditCallback = async ({
     length,
     to,
     symmetric,
-    direction,
     bidirectionalLength,
     tagStart,
     tagEnd,

--- a/src/lib/operations.ts
+++ b/src/lib/operations.ts
@@ -262,6 +262,24 @@ function extractStringArgument(
     : undefined
 }
 
+function extractRequiredStringArgument(
+  code: string,
+  operation: StdLibCallOp,
+  argName: string
+): string | { error: string } {
+  const arg = operation.labeledArgs?.[argName]
+  if (!arg?.sourceRange) {
+    return { error: `Missing or invalid ${argName} argument` }
+  }
+
+  const value = code.slice(...arg.sourceRange.map((r) => toUtf16(r, code)))
+  if (!value) {
+    return { error: `Couldn't retrieve ${argName} argument` }
+  }
+
+  return value
+}
+
 async function extractOptionalKclArrayArgument(
   code: string,
   operation: StdLibCallOp,
@@ -1818,15 +1836,11 @@ const prepareToEditPatternCircular3d: PrepareToEditCallback = async ({
 
   // 3. Convert the axis argument from a string to a string value
   // Axis is configured as 'options' inputType, so it should be a string, not a KCL expression
-  const axisArg = operation.labeledArgs?.['axis']
-  if (!axisArg || !axisArg.sourceRange) {
-    return { reason: 'Missing or invalid axis argument' }
+  const axisResult = extractRequiredStringArgument(code, operation, 'axis')
+  if (typeof axisResult !== 'string') {
+    return { reason: axisResult.error }
   }
-
-  const axisString = code.slice(...axisArg.sourceRange.map(boundToUtf16))
-  if (!axisString) {
-    return { reason: "Couldn't retrieve axis argument" }
-  }
+  const axisString = axisResult
 
   // 4. Convert the center argument from a string to a KCL expression
   const centerArg = operation.labeledArgs?.['center']
@@ -1966,17 +1980,11 @@ const prepareToEditPatternLinear3d: PrepareToEditCallback = async ({
 
   // 4. Convert the axis argument from a string to a string value
   // Axis is configured as 'options' inputType, so it should be a string, not a KCL expression
-  const axisArg = operation.labeledArgs?.['axis']
-  if (!axisArg || !axisArg.sourceRange) {
-    return { reason: 'Missing or invalid axis argument' }
+  const axisResult = extractRequiredStringArgument(code, operation, 'axis')
+  if (typeof axisResult !== 'string') {
+    return { reason: axisResult.error }
   }
-
-  const axisString = code.slice(
-    ...axisArg.sourceRange.map((r) => toUtf16(r, code))
-  )
-  if (!axisString) {
-    return { reason: "Couldn't retrieve axis argument" }
-  }
+  const axisString = axisResult
 
   // 5. Convert the useOriginal argument from a string to a boolean
   const useOriginalArg = operation.labeledArgs?.['useOriginal']
@@ -4310,14 +4318,8 @@ async function prepareToEditRotate({
     yaw = result
   }
 
-  const axisResult = await extractOptionalKclArgument(
-    code,
-    operation,
-    'axis',
-    rustContext,
-    true
-  )
-  if (axisResult && 'error' in axisResult) {
+  const axisResult = extractRequiredStringArgument(code, operation, 'axis')
+  if (typeof axisResult !== 'string') {
     return { reason: axisResult.error }
   }
   const axis = axisResult

--- a/src/lib/operations.ts
+++ b/src/lib/operations.ts
@@ -53,7 +53,6 @@ import type {
 import type { KclCommandValue, KclExpression } from '@src/lib/commandTypes'
 import {
   EXECUTION_TYPE_REAL,
-  KCL_AXIS_Z,
   KCL_PRELUDE_EXTRUDE_METHOD_MERGE,
   KCL_PRELUDE_EXTRUDE_METHOD_NEW,
   type KclPreludeBodyType,

--- a/src/lib/operations.ts
+++ b/src/lib/operations.ts
@@ -4319,7 +4319,7 @@ async function prepareToEditRotate({
     yaw = result
   }
 
-  const axis = extractStringArgument(code, operation, 'axis') ?? KCL_AXIS_Z
+  const axis = extractStringArgument(code, operation, 'axis')
 
   const angleResult = await extractOptionalKclArgument(
     code,

--- a/src/lib/operations.ts
+++ b/src/lib/operations.ts
@@ -53,6 +53,7 @@ import type {
 import type { KclCommandValue, KclExpression } from '@src/lib/commandTypes'
 import {
   EXECUTION_TYPE_REAL,
+  KCL_AXIS_Z,
   KCL_PRELUDE_EXTRUDE_METHOD_MERGE,
   KCL_PRELUDE_EXTRUDE_METHOD_NEW,
   type KclPreludeBodyType,
@@ -4318,11 +4319,7 @@ async function prepareToEditRotate({
     yaw = result
   }
 
-  const axisResult = extractRequiredStringArgument(code, operation, 'axis')
-  if (typeof axisResult !== 'string') {
-    return { reason: axisResult.error }
-  }
-  const axis = axisResult
+  const axis = extractStringArgument(code, operation, 'axis') ?? KCL_AXIS_Z
 
   const angleResult = await extractOptionalKclArgument(
     code,


### PR DESCRIPTION
Implemented a pass that removes the low-risk `omittedStdLibArgs` and threads them through P&C submit/edit paths.

Burned down:
- ~`Extrude.direction`~ will be done in #12218 
- `Sweep/Loft/Revolve/Fillet` `tolerance`
- `Translate.xyz`
- `Rotate.axis` / `Rotate.angle`
- Boolean `Subtract/Union/Intersect` `tolerance`
- `Join Surfaces.tolerance`

Left intentionally omitted because they’re structural selection-derived args, not simple KCL fields:
- `Shell.solids`
- `Hole.solid`
- `Fillet/Chamfer.solid` and raw `edges`
- `Delete Face.body` / `faceIndices`

Also updated edit-flow extraction so existing KCL with these args preserves them, and added targeted edit-flow coverage for ~`Extrude.direction` and~ `Sweep.tolerance`.