### PR TITLE
Try to shrink stack space

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -70,7 +70,6 @@ zip = { version = "8.6.0", default-features = false }
 
 [workspace.lints.clippy]
 assertions_on_result_states = "warn"
-large_futures = "warn"
 dbg_macro = "warn"
 iter_over_hash_type = "warn"
 lossy_float_literal = "warn"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -70,6 +70,7 @@ zip = { version = "8.6.0", default-features = false }
 
 [workspace.lints.clippy]
 assertions_on_result_states = "warn"
+large_futures = "warn"
 dbg_macro = "warn"
 iter_over_hash_type = "warn"
 lossy_float_literal = "warn"

--- a/rust/kcl-lib/e2e/executor/cache.rs
+++ b/rust/kcl-lib/e2e/executor/cache.rs
@@ -86,7 +86,7 @@ async fn cache_test(
         // Save the snapshot.
         let path = crate::assert_out(&format!("cache_{test_name}_{index}"), &img);
 
-        img_results.push((path, img, outcome));
+        img_results.push((path, img, *outcome));
     }
 
     ctx.close().await;

--- a/rust/kcl-lib/src/bin/transpile.rs
+++ b/rust/kcl-lib/src/bin/transpile.rs
@@ -1003,7 +1003,7 @@ async fn execute(program: Program, settings: ExecutorSettings) -> Result<ExecOut
     // Always close the context.
     ctx.close().await;
 
-    result
+    result.map(|outcome| *outcome)
 }
 
 #[derive(Debug, Default)]

--- a/rust/kcl-lib/src/bin/transpile.rs
+++ b/rust/kcl-lib/src/bin/transpile.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::large_futures)]
 //! A binary to transpile KCL files with old sketch syntax (startProfile in pipe
 //! expressions) to the new sketch block syntax. This is only a temporary dev
 //! tool before we integrate it into the app.

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -1210,7 +1210,11 @@ impl ExecutorContext {
                 exec_state.add_id_to_source(id, source.clone());
                 // TODO handle parsing errors properly
                 let parsed = crate::parsing::parse_str(&source.source, id).parse_errs_as_err()?;
-                exec_state.add_module(id, resolved_path.clone(), ModuleRepr::Kcl(parsed, None));
+                exec_state.add_module(
+                    id,
+                    resolved_path.clone(),
+                    ModuleRepr::Kcl(Box::new(parsed), Box::new(None)),
+                );
 
                 Ok(id)
             }
@@ -1225,7 +1229,11 @@ impl ExecutorContext {
                 exec_state.add_path_to_source_id(resolved_path.clone(), id);
                 let format = super::import::format_from_annotations(attrs, path, source_range)?;
                 let geom = super::import::import_foreign(path, format, exec_state, self, source_range).await?;
-                exec_state.add_module(id, resolved_path.clone(), ModuleRepr::Foreign(geom, None));
+                exec_state.add_module(
+                    id,
+                    resolved_path.clone(),
+                    ModuleRepr::Foreign(Box::new(geom), Box::new(None)),
+                );
                 Ok(id)
             }
             ImportPath::Std { .. } => {
@@ -1248,7 +1256,11 @@ impl ExecutorContext {
                 let parsed = crate::parsing::parse_str(&source.source, id)
                     .parse_errs_as_err()
                     .unwrap();
-                exec_state.add_module(id, resolved_path.clone(), ModuleRepr::Kcl(parsed, None));
+                exec_state.add_module(
+                    id,
+                    resolved_path.clone(),
+                    ModuleRepr::Kcl(Box::new(parsed), Box::new(None)),
+                );
                 Ok(id)
             }
         }
@@ -1266,14 +1278,18 @@ impl ExecutorContext {
 
         let result = match &mut repr {
             ModuleRepr::Root => Err(exec_state.circular_import_error(&path, source_range)),
-            ModuleRepr::Kcl(_, Some(outcome)) => Ok((outcome.environment, outcome.exports.clone())),
-            ModuleRepr::Kcl(program, cache) => self
-                .exec_module_from_ast(program, module_id, &path, exec_state, source_range, PreserveMem::Normal)
-                .await
-                .map(|outcome| {
-                    *cache = Some(outcome.clone());
-                    (outcome.environment, outcome.exports)
-                }),
+            ModuleRepr::Kcl(program, cache) => {
+                if let Some(outcome) = cache.as_ref() {
+                    Ok((outcome.environment, outcome.exports.clone()))
+                } else {
+                    self.exec_module_from_ast(program, module_id, &path, exec_state, source_range, PreserveMem::Normal)
+                        .await
+                        .map(|outcome| {
+                            **cache = Some(outcome.clone());
+                            (outcome.environment, outcome.exports)
+                        })
+                }
+            }
             ModuleRepr::Foreign(geom, _) => Err(KclError::new_semantic(KclErrorDetails::new(
                 "Cannot import items from foreign modules".to_owned(),
                 vec![geom.source_range],
@@ -1297,32 +1313,38 @@ impl ExecutorContext {
 
         let result = match &mut repr {
             ModuleRepr::Root => Err(exec_state.circular_import_error(&path, source_range)),
-            ModuleRepr::Kcl(_, Some(outcome)) => Ok(outcome.last_expr.clone()),
             ModuleRepr::Kcl(program, cached_items) => {
-                let result = self
-                    .exec_module_from_ast(program, module_id, &path, exec_state, source_range, PreserveMem::Normal)
-                    .await;
-                match result {
-                    Ok(outcome) => {
-                        let value = outcome.last_expr.clone();
-                        *cached_items = Some(outcome);
-                        Ok(value)
+                if let Some(outcome) = cached_items.as_ref() {
+                    Ok(outcome.last_expr.clone())
+                } else {
+                    let result = self
+                        .exec_module_from_ast(program, module_id, &path, exec_state, source_range, PreserveMem::Normal)
+                        .await;
+                    match result {
+                        Ok(outcome) => {
+                            let value = outcome.last_expr.clone();
+                            **cached_items = Some(outcome);
+                            Ok(value)
+                        }
+                        Err(e) => Err(e),
                     }
-                    Err(e) => Err(e),
                 }
             }
-            ModuleRepr::Foreign(_, Some((imported, _))) => Ok(imported.clone()),
             ModuleRepr::Foreign(geom, cached) => {
-                let result = super::import::send_to_engine(geom.clone(), exec_state, self)
-                    .await
-                    .map(|geom| Some(KclValue::ImportedGeometry(geom)));
+                if let Some((imported, _)) = cached.as_ref() {
+                    Ok(imported.clone())
+                } else {
+                    let result = super::import::send_to_engine(geom.as_ref().clone(), exec_state, self)
+                        .await
+                        .map(|geom| Some(KclValue::ImportedGeometry(geom)));
 
-                match result {
-                    Ok(val) => {
-                        *cached = Some((val.clone(), exec_state.mod_local.artifacts.clone()));
-                        Ok(val)
+                    match result {
+                        Ok(val) => {
+                            **cached = Some((val.clone(), exec_state.mod_local.artifacts.clone()));
+                            Ok(val)
+                        }
+                        Err(e) => Err(e),
                     }
-                    Err(e) => Err(e),
                 }
             }
             ModuleRepr::Dummy => unreachable!(),

--- a/rust/kcl-lib/src/execution/import_graph.rs
+++ b/rust/kcl-lib/src/execution/import_graph.rs
@@ -180,7 +180,7 @@ fn import_dependencies(
         Ok(())
     }
 
-    walk(ret.clone(), prog.into(), path, ctx)?;
+    walk(ret.clone(), prog.as_ref().into(), path, ctx)?;
 
     let ret = ret.lock().map_err(|err| {
         KclError::new_internal(KclErrorDetails::new(
@@ -266,7 +266,7 @@ mod tests {
                 value: "".into(),
                 original_import_path: None,
             },
-            ModuleRepr::Kcl(program, None),
+            ModuleRepr::Kcl(Box::new(program), Box::new(None)),
         )
     }
 

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -1301,7 +1301,7 @@ impl ExecutorContext {
 
         let original_program = program.clone();
 
-        let (_program, exec_state, result) = match Box::pin(cache::read_old_ast()).await {
+        let (exec_state, result) = match Box::pin(cache::read_old_ast()).await {
             Some(mut cached_state) => {
                 let old = CacheInformation {
                     ast: &cached_state.main.ast,
@@ -1499,7 +1499,7 @@ impl ExecutorContext {
                     }
                 };
 
-                (program, exec_state, result)
+                (exec_state, result)
             }
             None => {
                 let mut exec_state = ExecState::new(self);
@@ -1509,7 +1509,7 @@ impl ExecutorContext {
 
                 let result = Box::pin(self.run_concurrent(&program, &mut exec_state, None, PreserveMem::Normal)).await;
 
-                (program, exec_state, result)
+                (exec_state, result)
             }
         };
 

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -89,7 +89,9 @@ use crate::modules::ModulePath;
 use crate::modules::ModuleRepr;
 use crate::parsing::ast::types::Expr;
 use crate::parsing::ast::types::ImportPath;
+use crate::parsing::ast::types::Node;
 use crate::parsing::ast::types::NodeRef;
+use crate::parsing::ast::types::Program as AstProgram;
 
 #[derive(Debug, Clone, Serialize, ts_rs::TS, PartialEq, Default)]
 #[ts(export)]
@@ -290,6 +292,16 @@ impl PreserveMem {
             PreserveMem::Always => false,
         }
     }
+}
+
+type ExecutionResult = std::result::Result<(EnvironmentRef, Option<ModelingSessionData>), KclErrorWithOutputs>;
+
+enum RunWithCachingResult {
+    Complete(ExecOutcome),
+    Executed {
+        exec_state: ExecState,
+        result: ExecutionResult,
+    },
 }
 
 /// Outcome of executing a program.  This is used in TS.
@@ -1299,210 +1311,202 @@ impl ExecutorContext {
             GridScaleBehavior::ScaleWithZoom
         };
 
-        let original_program = program.clone();
+        let original_ast = program.ast.clone();
 
-        let (exec_state, result) = match Box::pin(cache::read_old_ast()).await {
-            Some(mut cached_state) => {
-                let old = CacheInformation {
-                    ast: &cached_state.main.ast,
-                    settings: &cached_state.settings,
-                };
-                let new = CacheInformation {
-                    ast: &program.ast,
-                    settings: &self.settings,
-                };
+        let run_result = match Box::pin(cache::read_old_ast()).await {
+            Some(cached_state) => Box::pin(self.run_with_caching_hit(program, cached_state, grid_scale)).await?,
+            None => Box::pin(self.run_with_caching_miss(&program)).await?,
+        };
 
-                // Get the program that actually changed from the old and new information.
-                let (clear_scene, program, import_check_info) =
-                    match Box::pin(cache::get_changed_program(old, new)).await {
-                        CacheResult::ReExecute {
-                            clear_scene,
-                            reapply_settings,
-                            program: changed_program,
-                        } => {
-                            if reapply_settings
-                                && Box::pin(self.engine.reapply_settings(
-                                    &self.engine_batch,
-                                    &self.settings,
-                                    Default::default(),
-                                    &mut cached_state.main.exec_state.id_generator,
-                                    grid_scale,
-                                ))
-                                .await
-                                .is_err()
-                            {
-                                (true, program, None)
-                            } else {
-                                (
-                                    clear_scene,
-                                    crate::Program {
-                                        ast: changed_program,
-                                        original_file_contents: program.original_file_contents,
-                                    },
-                                    None,
-                                )
-                            }
-                        }
-                        CacheResult::CheckImportsOnly {
-                            reapply_settings,
+        match run_result {
+            RunWithCachingResult::Complete(outcome) => Ok(outcome),
+            RunWithCachingResult::Executed { exec_state, result } => {
+                Box::pin(self.run_with_caching_finalize(exec_state, result, original_ast)).await
+            }
+        }
+    }
+
+    async fn run_with_caching_hit(
+        &self,
+        program: crate::Program,
+        mut cached_state: GlobalState,
+        grid_scale: GridScaleBehavior,
+    ) -> Result<RunWithCachingResult, KclErrorWithOutputs> {
+        let old = CacheInformation {
+            ast: &cached_state.main.ast,
+            settings: &cached_state.settings,
+        };
+        let new = CacheInformation {
+            ast: &program.ast,
+            settings: &self.settings,
+        };
+
+        // Get the program that actually changed from the old and new information.
+        let (clear_scene, program, import_check_info) = match Box::pin(cache::get_changed_program(old, new)).await {
+            CacheResult::ReExecute {
+                clear_scene,
+                reapply_settings,
+                program: changed_program,
+            } => {
+                if reapply_settings
+                    && Box::pin(self.engine.reapply_settings(
+                        &self.engine_batch,
+                        &self.settings,
+                        Default::default(),
+                        &mut cached_state.main.exec_state.id_generator,
+                        grid_scale,
+                    ))
+                    .await
+                    .is_err()
+                {
+                    (true, program, None)
+                } else {
+                    (
+                        clear_scene,
+                        crate::Program {
                             ast: changed_program,
-                        } => {
-                            let mut reapply_failed = false;
-                            if reapply_settings {
-                                if Box::pin(self.engine.reapply_settings(
-                                    &self.engine_batch,
-                                    &self.settings,
-                                    Default::default(),
-                                    &mut cached_state.main.exec_state.id_generator,
-                                    grid_scale,
-                                ))
-                                .await
-                                .is_ok()
-                                {
-                                    Box::pin(cache::write_old_ast(GlobalState::with_settings(
-                                        cached_state.clone(),
-                                        self.settings.clone(),
-                                    )))
-                                    .await;
-                                } else {
-                                    reapply_failed = true;
-                                }
-                            }
+                            original_file_contents: program.original_file_contents,
+                        },
+                        None,
+                    )
+                }
+            }
+            CacheResult::CheckImportsOnly {
+                reapply_settings,
+                ast: changed_program,
+            } => {
+                let mut reapply_failed = false;
+                if reapply_settings {
+                    if Box::pin(self.engine.reapply_settings(
+                        &self.engine_batch,
+                        &self.settings,
+                        Default::default(),
+                        &mut cached_state.main.exec_state.id_generator,
+                        grid_scale,
+                    ))
+                    .await
+                    .is_ok()
+                    {
+                        Box::pin(cache::write_old_ast(GlobalState::with_settings(
+                            cached_state.clone(),
+                            self.settings.clone(),
+                        )))
+                        .await;
+                    } else {
+                        reapply_failed = true;
+                    }
+                }
 
-                            if reapply_failed {
-                                (true, program, None)
-                            } else {
-                                // We need to check our imports to see if they changed.
-                                let mut new_exec_state = ExecState::new(self);
-                                let (new_universe, new_universe_map) =
-                                    Box::pin(self.get_universe(&program, &mut new_exec_state)).await?;
+                if reapply_failed {
+                    (true, program, None)
+                } else {
+                    // We need to check our imports to see if they changed.
+                    let mut new_exec_state = ExecState::new(self);
+                    let (new_universe, new_universe_map) =
+                        Box::pin(self.get_universe(&program, &mut new_exec_state)).await?;
 
-                                let clear_scene = new_universe.values().any(|value| {
-                                    let id = value.1;
-                                    match (
-                                        cached_state.exec_state.get_source(id),
-                                        new_exec_state.global.get_source(id),
-                                    ) {
-                                        (Some(s0), Some(s1)) => s0.source != s1.source,
-                                        _ => false,
-                                    }
-                                });
-
-                                if !clear_scene {
-                                    // Return early we don't need to clear the scene.
-                                    Box::pin(cache::write_old_memory(
-                                        cached_state
-                                            .mock_memory_state()
-                                            .map_err(KclErrorWithOutputs::no_outputs)?,
-                                    ))
-                                    .await;
-                                    return Box::pin(cached_state.into_exec_outcome(self))
-                                        .await
-                                        .map_err(KclErrorWithOutputs::no_outputs);
-                                }
-
-                                (
-                                    true,
-                                    crate::Program {
-                                        ast: changed_program,
-                                        original_file_contents: program.original_file_contents,
-                                    },
-                                    Some((new_universe, new_universe_map, new_exec_state)),
-                                )
-                            }
+                    let clear_scene = new_universe.values().any(|value| {
+                        let id = value.1;
+                        match (
+                            cached_state.exec_state.get_source(id),
+                            new_exec_state.global.get_source(id),
+                        ) {
+                            (Some(s0), Some(s1)) => s0.source != s1.source,
+                            _ => false,
                         }
-                        CacheResult::NoAction(true) => {
-                            if Box::pin(self.engine.reapply_settings(
-                                &self.engine_batch,
-                                &self.settings,
-                                Default::default(),
-                                &mut cached_state.main.exec_state.id_generator,
-                                grid_scale,
-                            ))
-                            .await
-                            .is_ok()
-                            {
-                                // We need to update the old ast state with the new settings!!
-                                Box::pin(cache::write_old_ast(GlobalState::with_settings(
-                                    cached_state.clone(),
-                                    self.settings.clone(),
-                                )))
-                                .await;
+                    });
 
-                                Box::pin(cache::write_old_memory(
-                                    cached_state
-                                        .mock_memory_state()
-                                        .map_err(KclErrorWithOutputs::no_outputs)?,
-                                ))
-                                .await;
-                                return Box::pin(cached_state.into_exec_outcome(self))
-                                    .await
-                                    .map_err(KclErrorWithOutputs::no_outputs);
-                            }
-                            (true, program, None)
-                        }
-                        CacheResult::NoAction(false) => {
-                            Box::pin(cache::write_old_memory(
-                                cached_state
-                                    .mock_memory_state()
-                                    .map_err(KclErrorWithOutputs::no_outputs)?,
-                            ))
-                            .await;
-                            return Box::pin(cached_state.into_exec_outcome(self))
-                                .await
-                                .map_err(KclErrorWithOutputs::no_outputs);
-                        }
-                    };
-
-                let (exec_state, result) = match import_check_info {
-                    Some((new_universe, new_universe_map, mut new_exec_state)) => {
-                        // Clear the scene if the imports changed.
-                        Box::pin(self.send_clear_scene(&mut new_exec_state, Default::default()))
-                            .await
-                            .map_err(KclErrorWithOutputs::no_outputs)?;
-
-                        let result = Box::pin(self.run_concurrent(
-                            &program,
-                            &mut new_exec_state,
-                            Some((new_universe, new_universe_map)),
-                            PreserveMem::Normal,
+                    if !clear_scene {
+                        // Return early we don't need to clear the scene.
+                        Box::pin(cache::write_old_memory(
+                            cached_state
+                                .mock_memory_state()
+                                .map_err(KclErrorWithOutputs::no_outputs)?,
                         ))
                         .await;
-
-                        (new_exec_state, result)
-                    }
-                    None if clear_scene => {
-                        // Pop the execution state, since we are starting fresh.
-                        let mut exec_state = cached_state.reconstitute_exec_state(self);
-                        exec_state.reset(self);
-
-                        Box::pin(self.send_clear_scene(&mut exec_state, Default::default()))
+                        let outcome = Box::pin(cached_state.into_exec_outcome(self))
                             .await
                             .map_err(KclErrorWithOutputs::no_outputs)?;
-
-                        let result =
-                            Box::pin(self.run_concurrent(&program, &mut exec_state, None, PreserveMem::Normal)).await;
-
-                        (exec_state, result)
+                        return Ok(RunWithCachingResult::Complete(outcome));
                     }
-                    None => {
-                        let mut exec_state = cached_state.reconstitute_exec_state(self);
-                        exec_state
-                            .mut_stack()
-                            .restore_env(cached_state.main.result_env)
-                            .map_err(KclErrorWithOutputs::no_outputs)?;
 
-                        let result =
-                            Box::pin(self.run_concurrent(&program, &mut exec_state, None, PreserveMem::Always)).await;
-
-                        (exec_state, result)
-                    }
-                };
-
-                (exec_state, result)
+                    (
+                        true,
+                        crate::Program {
+                            ast: changed_program,
+                            original_file_contents: program.original_file_contents,
+                        },
+                        Some((new_universe, new_universe_map, new_exec_state)),
+                    )
+                }
             }
-            None => {
-                let mut exec_state = ExecState::new(self);
+            CacheResult::NoAction(true) => {
+                if Box::pin(self.engine.reapply_settings(
+                    &self.engine_batch,
+                    &self.settings,
+                    Default::default(),
+                    &mut cached_state.main.exec_state.id_generator,
+                    grid_scale,
+                ))
+                .await
+                .is_ok()
+                {
+                    // We need to update the old ast state with the new settings!!
+                    Box::pin(cache::write_old_ast(GlobalState::with_settings(
+                        cached_state.clone(),
+                        self.settings.clone(),
+                    )))
+                    .await;
+
+                    Box::pin(cache::write_old_memory(
+                        cached_state
+                            .mock_memory_state()
+                            .map_err(KclErrorWithOutputs::no_outputs)?,
+                    ))
+                    .await;
+                    let outcome = Box::pin(cached_state.into_exec_outcome(self))
+                        .await
+                        .map_err(KclErrorWithOutputs::no_outputs)?;
+                    return Ok(RunWithCachingResult::Complete(outcome));
+                }
+                (true, program, None)
+            }
+            CacheResult::NoAction(false) => {
+                Box::pin(cache::write_old_memory(
+                    cached_state
+                        .mock_memory_state()
+                        .map_err(KclErrorWithOutputs::no_outputs)?,
+                ))
+                .await;
+                let outcome = Box::pin(cached_state.into_exec_outcome(self))
+                    .await
+                    .map_err(KclErrorWithOutputs::no_outputs)?;
+                return Ok(RunWithCachingResult::Complete(outcome));
+            }
+        };
+
+        let (exec_state, result) = match import_check_info {
+            Some((new_universe, new_universe_map, mut new_exec_state)) => {
+                // Clear the scene if the imports changed.
+                Box::pin(self.send_clear_scene(&mut new_exec_state, Default::default()))
+                    .await
+                    .map_err(KclErrorWithOutputs::no_outputs)?;
+
+                let result = Box::pin(self.run_concurrent(
+                    &program,
+                    &mut new_exec_state,
+                    Some((new_universe, new_universe_map)),
+                    PreserveMem::Normal,
+                ))
+                .await;
+
+                (new_exec_state, result)
+            }
+            None if clear_scene => {
+                // Pop the execution state, since we are starting fresh.
+                let mut exec_state = cached_state.reconstitute_exec_state(self);
+                exec_state.reset(self);
+
                 Box::pin(self.send_clear_scene(&mut exec_state, Default::default()))
                     .await
                     .map_err(KclErrorWithOutputs::no_outputs)?;
@@ -1511,8 +1515,42 @@ impl ExecutorContext {
 
                 (exec_state, result)
             }
+            None => {
+                let mut exec_state = cached_state.reconstitute_exec_state(self);
+                exec_state
+                    .mut_stack()
+                    .restore_env(cached_state.main.result_env)
+                    .map_err(KclErrorWithOutputs::no_outputs)?;
+
+                let result = Box::pin(self.run_concurrent(&program, &mut exec_state, None, PreserveMem::Always)).await;
+
+                (exec_state, result)
+            }
         };
 
+        Ok(RunWithCachingResult::Executed { exec_state, result })
+    }
+
+    async fn run_with_caching_miss(
+        &self,
+        program: &crate::Program,
+    ) -> Result<RunWithCachingResult, KclErrorWithOutputs> {
+        let mut exec_state = ExecState::new(self);
+        Box::pin(self.send_clear_scene(&mut exec_state, Default::default()))
+            .await
+            .map_err(KclErrorWithOutputs::no_outputs)?;
+
+        let result = Box::pin(self.run_concurrent(program, &mut exec_state, None, PreserveMem::Normal)).await;
+
+        Ok(RunWithCachingResult::Executed { exec_state, result })
+    }
+
+    async fn run_with_caching_finalize(
+        &self,
+        exec_state: ExecState,
+        result: ExecutionResult,
+        original_ast: Node<AstProgram>,
+    ) -> Result<ExecOutcome, KclErrorWithOutputs> {
         if result.is_err() {
             cache::bust_cache().await;
         }
@@ -1526,7 +1564,7 @@ impl ExecutorContext {
         Box::pin(cache::write_old_ast(GlobalState::new(
             exec_state.clone(),
             self.settings.clone(),
-            original_program.ast,
+            original_ast,
             result.0,
         )))
         .await;

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -1301,7 +1301,7 @@ impl ExecutorContext {
 
         let original_program = program.clone();
 
-        let (_program, exec_state, result) = match cache::read_old_ast().await {
+        let (_program, exec_state, result) = match Box::pin(cache::read_old_ast()).await {
             Some(mut cached_state) => {
                 let old = CacheInformation {
                     ast: &cached_state.main.ast,
@@ -1313,170 +1313,161 @@ impl ExecutorContext {
                 };
 
                 // Get the program that actually changed from the old and new information.
-                let (clear_scene, program, import_check_info) = match cache::get_changed_program(old, new).await {
-                    CacheResult::ReExecute {
-                        clear_scene,
-                        reapply_settings,
-                        program: changed_program,
-                    } => {
-                        if reapply_settings
-                            && self
-                                .engine
-                                .reapply_settings(
+                let (clear_scene, program, import_check_info) =
+                    match Box::pin(cache::get_changed_program(old, new)).await {
+                        CacheResult::ReExecute {
+                            clear_scene,
+                            reapply_settings,
+                            program: changed_program,
+                        } => {
+                            if reapply_settings
+                                && Box::pin(self.engine.reapply_settings(
                                     &self.engine_batch,
                                     &self.settings,
                                     Default::default(),
                                     &mut cached_state.main.exec_state.id_generator,
                                     grid_scale,
-                                )
+                                ))
                                 .await
                                 .is_err()
-                        {
-                            (true, program, None)
-                        } else {
-                            (
-                                clear_scene,
-                                crate::Program {
-                                    ast: changed_program,
-                                    original_file_contents: program.original_file_contents,
-                                },
-                                None,
-                            )
+                            {
+                                (true, program, None)
+                            } else {
+                                (
+                                    clear_scene,
+                                    crate::Program {
+                                        ast: changed_program,
+                                        original_file_contents: program.original_file_contents,
+                                    },
+                                    None,
+                                )
+                            }
                         }
-                    }
-                    CacheResult::CheckImportsOnly {
-                        reapply_settings,
-                        ast: changed_program,
-                    } => {
-                        let mut reapply_failed = false;
-                        if reapply_settings {
-                            if self
-                                .engine
-                                .reapply_settings(
+                        CacheResult::CheckImportsOnly {
+                            reapply_settings,
+                            ast: changed_program,
+                        } => {
+                            let mut reapply_failed = false;
+                            if reapply_settings {
+                                if Box::pin(self.engine.reapply_settings(
                                     &self.engine_batch,
                                     &self.settings,
                                     Default::default(),
                                     &mut cached_state.main.exec_state.id_generator,
                                     grid_scale,
-                                )
+                                ))
                                 .await
                                 .is_ok()
-                            {
-                                cache::write_old_ast(GlobalState::with_settings(
-                                    cached_state.clone(),
-                                    self.settings.clone(),
-                                ))
-                                .await;
-                            } else {
-                                reapply_failed = true;
-                            }
-                        }
-
-                        if reapply_failed {
-                            (true, program, None)
-                        } else {
-                            // We need to check our imports to see if they changed.
-                            let mut new_exec_state = ExecState::new(self);
-                            let (new_universe, new_universe_map) =
-                                self.get_universe(&program, &mut new_exec_state).await?;
-
-                            let clear_scene = new_universe.values().any(|value| {
-                                let id = value.1;
-                                match (
-                                    cached_state.exec_state.get_source(id),
-                                    new_exec_state.global.get_source(id),
-                                ) {
-                                    (Some(s0), Some(s1)) => s0.source != s1.source,
-                                    _ => false,
+                                {
+                                    Box::pin(cache::write_old_ast(GlobalState::with_settings(
+                                        cached_state.clone(),
+                                        self.settings.clone(),
+                                    )))
+                                    .await;
+                                } else {
+                                    reapply_failed = true;
                                 }
-                            });
-
-                            if !clear_scene {
-                                // Return early we don't need to clear the scene.
-                                cache::write_old_memory(
-                                    cached_state
-                                        .mock_memory_state()
-                                        .map_err(KclErrorWithOutputs::no_outputs)?,
-                                )
-                                .await;
-                                return cached_state
-                                    .into_exec_outcome(self)
-                                    .await
-                                    .map_err(KclErrorWithOutputs::no_outputs);
                             }
 
-                            (
-                                true,
-                                crate::Program {
-                                    ast: changed_program,
-                                    original_file_contents: program.original_file_contents,
-                                },
-                                Some((new_universe, new_universe_map, new_exec_state)),
-                            )
+                            if reapply_failed {
+                                (true, program, None)
+                            } else {
+                                // We need to check our imports to see if they changed.
+                                let mut new_exec_state = ExecState::new(self);
+                                let (new_universe, new_universe_map) =
+                                    Box::pin(self.get_universe(&program, &mut new_exec_state)).await?;
+
+                                let clear_scene = new_universe.values().any(|value| {
+                                    let id = value.1;
+                                    match (
+                                        cached_state.exec_state.get_source(id),
+                                        new_exec_state.global.get_source(id),
+                                    ) {
+                                        (Some(s0), Some(s1)) => s0.source != s1.source,
+                                        _ => false,
+                                    }
+                                });
+
+                                if !clear_scene {
+                                    // Return early we don't need to clear the scene.
+                                    Box::pin(cache::write_old_memory(
+                                        cached_state
+                                            .mock_memory_state()
+                                            .map_err(KclErrorWithOutputs::no_outputs)?,
+                                    ))
+                                    .await;
+                                    return Box::pin(cached_state.into_exec_outcome(self))
+                                        .await
+                                        .map_err(KclErrorWithOutputs::no_outputs);
+                                }
+
+                                (
+                                    true,
+                                    crate::Program {
+                                        ast: changed_program,
+                                        original_file_contents: program.original_file_contents,
+                                    },
+                                    Some((new_universe, new_universe_map, new_exec_state)),
+                                )
+                            }
                         }
-                    }
-                    CacheResult::NoAction(true) => {
-                        if self
-                            .engine
-                            .reapply_settings(
+                        CacheResult::NoAction(true) => {
+                            if Box::pin(self.engine.reapply_settings(
                                 &self.engine_batch,
                                 &self.settings,
                                 Default::default(),
                                 &mut cached_state.main.exec_state.id_generator,
                                 grid_scale,
-                            )
+                            ))
                             .await
                             .is_ok()
-                        {
-                            // We need to update the old ast state with the new settings!!
-                            cache::write_old_ast(GlobalState::with_settings(
-                                cached_state.clone(),
-                                self.settings.clone(),
-                            ))
-                            .await;
+                            {
+                                // We need to update the old ast state with the new settings!!
+                                Box::pin(cache::write_old_ast(GlobalState::with_settings(
+                                    cached_state.clone(),
+                                    self.settings.clone(),
+                                )))
+                                .await;
 
-                            cache::write_old_memory(
+                                Box::pin(cache::write_old_memory(
+                                    cached_state
+                                        .mock_memory_state()
+                                        .map_err(KclErrorWithOutputs::no_outputs)?,
+                                ))
+                                .await;
+                                return Box::pin(cached_state.into_exec_outcome(self))
+                                    .await
+                                    .map_err(KclErrorWithOutputs::no_outputs);
+                            }
+                            (true, program, None)
+                        }
+                        CacheResult::NoAction(false) => {
+                            Box::pin(cache::write_old_memory(
                                 cached_state
                                     .mock_memory_state()
                                     .map_err(KclErrorWithOutputs::no_outputs)?,
-                            )
+                            ))
                             .await;
-                            return cached_state
-                                .into_exec_outcome(self)
+                            return Box::pin(cached_state.into_exec_outcome(self))
                                 .await
                                 .map_err(KclErrorWithOutputs::no_outputs);
                         }
-                        (true, program, None)
-                    }
-                    CacheResult::NoAction(false) => {
-                        cache::write_old_memory(
-                            cached_state
-                                .mock_memory_state()
-                                .map_err(KclErrorWithOutputs::no_outputs)?,
-                        )
-                        .await;
-                        return cached_state
-                            .into_exec_outcome(self)
-                            .await
-                            .map_err(KclErrorWithOutputs::no_outputs);
-                    }
-                };
+                    };
 
                 let (exec_state, result) = match import_check_info {
                     Some((new_universe, new_universe_map, mut new_exec_state)) => {
                         // Clear the scene if the imports changed.
-                        self.send_clear_scene(&mut new_exec_state, Default::default())
+                        Box::pin(self.send_clear_scene(&mut new_exec_state, Default::default()))
                             .await
                             .map_err(KclErrorWithOutputs::no_outputs)?;
 
-                        let result = self
-                            .run_concurrent(
-                                &program,
-                                &mut new_exec_state,
-                                Some((new_universe, new_universe_map)),
-                                PreserveMem::Normal,
-                            )
-                            .await;
+                        let result = Box::pin(self.run_concurrent(
+                            &program,
+                            &mut new_exec_state,
+                            Some((new_universe, new_universe_map)),
+                            PreserveMem::Normal,
+                        ))
+                        .await;
 
                         (new_exec_state, result)
                     }
@@ -1485,13 +1476,12 @@ impl ExecutorContext {
                         let mut exec_state = cached_state.reconstitute_exec_state(self);
                         exec_state.reset(self);
 
-                        self.send_clear_scene(&mut exec_state, Default::default())
+                        Box::pin(self.send_clear_scene(&mut exec_state, Default::default()))
                             .await
                             .map_err(KclErrorWithOutputs::no_outputs)?;
 
-                        let result = self
-                            .run_concurrent(&program, &mut exec_state, None, PreserveMem::Normal)
-                            .await;
+                        let result =
+                            Box::pin(self.run_concurrent(&program, &mut exec_state, None, PreserveMem::Normal)).await;
 
                         (exec_state, result)
                     }
@@ -1502,9 +1492,8 @@ impl ExecutorContext {
                             .restore_env(cached_state.main.result_env)
                             .map_err(KclErrorWithOutputs::no_outputs)?;
 
-                        let result = self
-                            .run_concurrent(&program, &mut exec_state, None, PreserveMem::Always)
-                            .await;
+                        let result =
+                            Box::pin(self.run_concurrent(&program, &mut exec_state, None, PreserveMem::Always)).await;
 
                         (exec_state, result)
                     }
@@ -1514,13 +1503,11 @@ impl ExecutorContext {
             }
             None => {
                 let mut exec_state = ExecState::new(self);
-                self.send_clear_scene(&mut exec_state, Default::default())
+                Box::pin(self.send_clear_scene(&mut exec_state, Default::default()))
                     .await
                     .map_err(KclErrorWithOutputs::no_outputs)?;
 
-                let result = self
-                    .run_concurrent(&program, &mut exec_state, None, PreserveMem::Normal)
-                    .await;
+                let result = Box::pin(self.run_concurrent(&program, &mut exec_state, None, PreserveMem::Normal)).await;
 
                 (program, exec_state, result)
             }
@@ -1536,16 +1523,15 @@ impl ExecutorContext {
         // Save this as the last successful execution to the cache.
         // Gotcha: `CacheResult::ReExecute.program` may be diff-based, do not save that AST
         // the last-successful AST. Instead, save in the full AST passed in.
-        cache::write_old_ast(GlobalState::new(
+        Box::pin(cache::write_old_ast(GlobalState::new(
             exec_state.clone(),
             self.settings.clone(),
             original_program.ast,
             result.0,
-        ))
+        )))
         .await;
 
-        let outcome = exec_state
-            .into_exec_outcome(result.0, self)
+        let outcome = Box::pin(exec_state.into_exec_outcome(result.0, self))
             .await
             .map_err(KclErrorWithOutputs::no_outputs)?;
         Ok(outcome)

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -1705,18 +1705,20 @@ impl ExecutorContext {
                                 )
                                 .await;
 
-                            result.map(|val| ModuleRepr::Kcl(program.clone(), Some(val)))
+                            result.map(|val| ModuleRepr::Kcl(program.clone(), Box::new(Some(val))))
                         }
                         ModuleRepr::Foreign(geom, _) => {
-                            let result = crate::execution::import::send_to_engine(geom.clone(), exec_state, exec_ctxt)
-                                .await
-                                .map(|geom| Some(KclValue::ImportedGeometry(geom)));
+                            let result =
+                                crate::execution::import::send_to_engine(geom.as_ref().clone(), exec_state, exec_ctxt)
+                                    .await
+                                    .map(|geom| Some(KclValue::ImportedGeometry(geom)));
 
                             // Foreign modules don't produce their own operations;
                             // use a fresh artifact state instead of capturing the
                             // cloned root module's artifacts (which may contain
                             // early-pushed ModuleInstance operations).
-                            result.map(|val| ModuleRepr::Foreign(geom.clone(), Some((val, Default::default()))))
+                            result
+                                .map(|val| ModuleRepr::Foreign(geom.clone(), Box::new(Some((val, Default::default())))))
                         }
                         ModuleRepr::Dummy | ModuleRepr::Root => Err(KclError::new_internal(KclErrorDetails::new(
                             format!("Module {module_path} not found in universe"),
@@ -1835,7 +1837,7 @@ impl ExecutorContext {
         let root_imports = import_graph::import_universe(
             self,
             &ModulePath::Main,
-            &ModuleRepr::Kcl(program.ast.clone(), None),
+            &ModuleRepr::Kcl(Box::new(program.ast.clone()), Box::new(None)),
             &mut universe,
             exec_state,
         )
@@ -1992,7 +1994,9 @@ impl ExecutorContext {
             op.fill_node_paths(programs, cached_body_items);
         }
         for module in exec_state.global.module_infos.values_mut() {
-            if let ModuleRepr::Kcl(_, Some(outcome)) = &mut module.repr {
+            if let ModuleRepr::Kcl(_, cache) = &mut module.repr
+                && let Some(outcome) = cache.as_mut()
+            {
                 for op in &mut outcome.artifacts.operations {
                     op.fill_node_paths(programs, cached_body_items);
                 }
@@ -2224,7 +2228,7 @@ impl ProgramLookup {
         let mut programs = IndexMap::with_capacity(module_infos.len());
         for (id, info) in module_infos {
             if let ModuleRepr::Kcl(program, _) = info.repr {
-                programs.insert(id, program);
+                programs.insert(id, *program);
             }
         }
         programs.insert(ModuleId::default(), current);

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -297,10 +297,10 @@ impl PreserveMem {
 type ExecutionResult = std::result::Result<(EnvironmentRef, Option<ModelingSessionData>), KclErrorWithOutputs>;
 
 enum RunWithCachingResult {
-    Complete(ExecOutcome),
+    Complete(Box<ExecOutcome>),
     Executed {
-        exec_state: ExecState,
-        result: ExecutionResult,
+        exec_state: Box<ExecState>,
+        result: Box<ExecutionResult>,
     },
 }
 
@@ -1196,7 +1196,7 @@ impl ExecutorContext {
         // after the cache is busted.
         let outcome = self.run_with_caching(crate::Program::empty()).await?;
 
-        Ok(outcome)
+        Ok(*outcome)
     }
 
     async fn prepare_mem(&self, exec_state: &mut ExecState) -> Result<(), KclErrorWithOutputs> {
@@ -1303,7 +1303,7 @@ impl ExecutorContext {
         Ok(outcome)
     }
 
-    pub async fn run_with_caching(&self, program: crate::Program) -> Result<ExecOutcome, KclErrorWithOutputs> {
+    pub async fn run_with_caching(&self, program: crate::Program) -> Result<Box<ExecOutcome>, KclErrorWithOutputs> {
         assert!(!self.is_mock());
         let grid_scale = if self.settings.fixed_size_grid {
             GridScaleBehavior::Fixed(program.meta_settings().ok().flatten().map(|s| s.default_length_units))
@@ -1427,7 +1427,7 @@ impl ExecutorContext {
                         let outcome = Box::pin(cached_state.into_exec_outcome(self))
                             .await
                             .map_err(KclErrorWithOutputs::no_outputs)?;
-                        return Ok(RunWithCachingResult::Complete(outcome));
+                        return Ok(RunWithCachingResult::Complete(Box::new(outcome)));
                     }
 
                     (
@@ -1467,7 +1467,7 @@ impl ExecutorContext {
                     let outcome = Box::pin(cached_state.into_exec_outcome(self))
                         .await
                         .map_err(KclErrorWithOutputs::no_outputs)?;
-                    return Ok(RunWithCachingResult::Complete(outcome));
+                    return Ok(RunWithCachingResult::Complete(Box::new(outcome)));
                 }
                 (true, program, None)
             }
@@ -1481,7 +1481,7 @@ impl ExecutorContext {
                 let outcome = Box::pin(cached_state.into_exec_outcome(self))
                     .await
                     .map_err(KclErrorWithOutputs::no_outputs)?;
-                return Ok(RunWithCachingResult::Complete(outcome));
+                return Ok(RunWithCachingResult::Complete(Box::new(outcome)));
             }
         };
 
@@ -1528,7 +1528,10 @@ impl ExecutorContext {
             }
         };
 
-        Ok(RunWithCachingResult::Executed { exec_state, result })
+        Ok(RunWithCachingResult::Executed {
+            exec_state: Box::new(exec_state),
+            result: Box::new(result),
+        })
     }
 
     async fn run_with_caching_miss(
@@ -1542,21 +1545,25 @@ impl ExecutorContext {
 
         let result = Box::pin(self.run_concurrent(program, &mut exec_state, None, PreserveMem::Normal)).await;
 
-        Ok(RunWithCachingResult::Executed { exec_state, result })
+        Ok(RunWithCachingResult::Executed {
+            exec_state: Box::new(exec_state),
+            result: Box::new(result),
+        })
     }
 
     async fn run_with_caching_finalize(
         &self,
-        exec_state: ExecState,
-        result: ExecutionResult,
+        exec_state: Box<ExecState>,
+        result: Box<ExecutionResult>,
         original_ast: Node<AstProgram>,
-    ) -> Result<ExecOutcome, KclErrorWithOutputs> {
+    ) -> Result<Box<ExecOutcome>, KclErrorWithOutputs> {
         if result.is_err() {
             cache::bust_cache().await;
         }
 
         // Throw the error.
-        let result = result?;
+        let result = (*result)?;
+        let exec_state = *exec_state;
 
         // Save this as the last successful execution to the cache.
         // Gotcha: `CacheResult::ReExecute.program` may be diff-based, do not save that AST
@@ -1572,7 +1579,7 @@ impl ExecutorContext {
         let outcome = Box::pin(exec_state.into_exec_outcome(result.0, self))
             .await
             .map_err(KclErrorWithOutputs::no_outputs)?;
-        Ok(outcome)
+        Ok(Box::new(outcome))
     }
 
     /// Perform the execution of a program.

--- a/rust/kcl-lib/src/execution/sketch_transpiler.rs
+++ b/rust/kcl-lib/src/execution/sketch_transpiler.rs
@@ -1,4 +1,4 @@
-//!
+#![allow(clippy::large_futures)]
 //! Transpiler for converting old sketch syntax to new sketch block syntax.
 
 use std::collections::HashMap;

--- a/rust/kcl-lib/src/execution/sketch_transpiler.rs
+++ b/rust/kcl-lib/src/execution/sketch_transpiler.rs
@@ -222,7 +222,7 @@ pub async fn transpile_old_sketch_to_new_with_execution(
                 ))
             })?
     } else {
-        ctx.run_with_caching(program.clone()).await.map_err(|e| {
+        *ctx.run_with_caching(program.clone()).await.map_err(|e| {
             KclError::new_internal(KclErrorDetails::new(
                 format!("Failed to execute program for transpilation: {:?}", e),
                 vec![],

--- a/rust/kcl-lib/src/execution/state.rs
+++ b/rust/kcl-lib/src/execution/state.rs
@@ -101,13 +101,17 @@ impl GlobalState {
         for (module_id, module_info) in &self.module_infos {
             match &module_info.repr {
                 ModuleRepr::Root => {}
-                ModuleRepr::Kcl(_, Some(outcome)) => {
-                    operations.insert(*module_id, outcome.artifacts.operations.clone());
+                ModuleRepr::Kcl(_, cache) => {
+                    if let Some(outcome) = cache.as_ref() {
+                        operations.insert(*module_id, outcome.artifacts.operations.clone());
+                    }
                 }
-                ModuleRepr::Foreign(_, Some((_, artifacts))) => {
-                    operations.insert(*module_id, artifacts.operations.clone());
+                ModuleRepr::Foreign(_, cache) => {
+                    if let Some((_, artifacts)) = cache.as_ref() {
+                        operations.insert(*module_id, artifacts.operations.clone());
+                    }
                 }
-                ModuleRepr::Kcl(_, None) | ModuleRepr::Foreign(_, None) | ModuleRepr::Dummy => {}
+                ModuleRepr::Dummy => {}
             }
         }
 
@@ -895,15 +899,19 @@ impl ExecState {
         let mut new_exec_artifacts = IndexMap::new();
         for module in self.global.module_infos.values_mut() {
             match &mut module.repr {
-                ModuleRepr::Kcl(_, Some(outcome)) => {
-                    new_commands.extend(outcome.artifacts.process_commands());
-                    new_exec_artifacts.extend(outcome.artifacts.artifacts.clone());
+                ModuleRepr::Kcl(_, cache) => {
+                    if let Some(outcome) = cache.as_mut() {
+                        new_commands.extend(outcome.artifacts.process_commands());
+                        new_exec_artifacts.extend(outcome.artifacts.artifacts.clone());
+                    }
                 }
-                ModuleRepr::Foreign(_, Some((_, module_artifacts))) => {
-                    new_commands.extend(module_artifacts.process_commands());
-                    new_exec_artifacts.extend(module_artifacts.artifacts.clone());
+                ModuleRepr::Foreign(_, cache) => {
+                    if let Some((_, module_artifacts)) = cache.as_mut() {
+                        new_commands.extend(module_artifacts.process_commands());
+                        new_exec_artifacts.extend(module_artifacts.artifacts.clone());
+                    }
                 }
-                ModuleRepr::Root | ModuleRepr::Kcl(_, None) | ModuleRepr::Foreign(_, None) | ModuleRepr::Dummy => {}
+                ModuleRepr::Root | ModuleRepr::Dummy => {}
             }
         }
         // Take from the module artifacts so that we don't try to process them

--- a/rust/kcl-lib/src/frontend.rs
+++ b/rust/kcl-lib/src/frontend.rs
@@ -3380,7 +3380,7 @@ impl FrontendState {
         // a real engine.
 
         // Execute.
-        let outcome = ctx.run_with_caching(new_program).await?;
+        let outcome = Box::pin(ctx.run_with_caching(new_program)).await?;
         let freedom_analysis_ran = true;
 
         let outcome = self.update_state_after_exec(outcome, freedom_analysis_ran);

--- a/rust/kcl-lib/src/frontend.rs
+++ b/rust/kcl-lib/src/frontend.rs
@@ -659,7 +659,7 @@ impl SketchApi for FrontendState {
         let outcome = ctx.run_with_caching(new_program.clone()).await?;
         let freedom_analysis_ran = true;
 
-        let outcome = self.update_state_after_exec(outcome, freedom_analysis_ran);
+        let outcome = self.update_state_after_exec(*outcome, freedom_analysis_ran);
 
         let Some(sketch_id) = self
             .scene_graph
@@ -761,7 +761,7 @@ impl SketchApi for FrontendState {
         let outcome = ctx.run_with_caching(self.program.clone()).await?;
 
         // exit_sketch doesn't run freedom analysis, just clears sketch_mode
-        self.update_state_after_exec(outcome, false);
+        self.update_state_after_exec(*outcome, false);
 
         Ok(self.scene_graph_for_ui())
     }
@@ -1851,7 +1851,7 @@ impl FrontendState {
         self.point_freedom_cache.clear();
         match ctx.run_with_caching(program).await {
             Ok(outcome) => {
-                let outcome = self.update_state_after_exec(outcome, true);
+                let outcome = self.update_state_after_exec(*outcome, true);
                 let checkpoint_id = self
                     .create_sketch_checkpoint(outcome.clone())
                     .await
@@ -1888,7 +1888,7 @@ impl FrontendState {
         self.point_freedom_cache.clear();
         match ctx.run_with_caching(program).await {
             Ok(outcome) => {
-                let outcome = self.update_state_after_exec(outcome, true);
+                let outcome = self.update_state_after_exec(*outcome, true);
                 Ok(SceneGraphDelta {
                     new_graph: self.scene_graph_for_ui(),
                     exec_outcome: outcome,
@@ -3380,10 +3380,10 @@ impl FrontendState {
         // a real engine.
 
         // Execute.
-        let outcome = Box::pin(ctx.run_with_caching(new_program)).await?;
+        let outcome = ctx.run_with_caching(new_program).await?;
         let freedom_analysis_ran = true;
 
-        let outcome = self.update_state_after_exec(outcome, freedom_analysis_ran);
+        let outcome = self.update_state_after_exec(*outcome, freedom_analysis_ran);
 
         let src_delta = SourceDelta { text: new_source };
         let scene_graph_delta = SceneGraphDelta {

--- a/rust/kcl-lib/src/frontend/trim.rs
+++ b/rust/kcl-lib/src/frontend/trim.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::large_futures)]
 use std::f64::consts::TAU;
 
 use indexmap::IndexSet;

--- a/rust/kcl-lib/src/lsp/kcl/mod.rs
+++ b/rust/kcl-lib/src/lsp/kcl/mod.rs
@@ -586,7 +586,7 @@ impl crate::lsp::backend::Backend for Backend {
         // Execute the code if we have an executor context.
         // This function automatically executes if we should & updates the diagnostics if we got
         // errors.
-        if self.execute(&params, &ast).await.is_err() {
+        if Box::pin(self.execute(&params, &ast)).await.is_err() {
             return;
         }
 
@@ -902,7 +902,7 @@ impl Backend {
                 .run_mock(ast, &crate::execution::MockConfig::default())
                 .await
         } else {
-            executor_ctx.run_with_caching(ast.clone()).await
+            Box::pin(executor_ctx.run_with_caching(ast.clone())).await
         };
 
         match result {

--- a/rust/kcl-lib/src/lsp/kcl/mod.rs
+++ b/rust/kcl-lib/src/lsp/kcl/mod.rs
@@ -902,7 +902,9 @@ impl Backend {
                 .run_mock(ast, &crate::execution::MockConfig::default())
                 .await
         } else {
-            Box::pin(executor_ctx.run_with_caching(ast.clone())).await
+            Box::pin(executor_ctx.run_with_caching(ast.clone()))
+                .await
+                .map(|outcome| *outcome)
         };
 
         match result {

--- a/rust/kcl-lib/src/modules.rs
+++ b/rust/kcl-lib/src/modules.rs
@@ -127,17 +127,19 @@ impl ModuleInfo {
     }
 }
 
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum ModuleRepr {
     Root,
     // AST, memory, exported names
     Kcl(
-        Node<Program>,
+        Box<Node<Program>>,
         /// Cached execution outcome.
-        Option<ModuleExecutionOutcome>,
+        Box<Option<ModuleExecutionOutcome>>,
     ),
-    Foreign(PreImportedGeometry, Option<(Option<KclValue>, ModuleArtifactState)>),
+    Foreign(
+        Box<PreImportedGeometry>,
+        Box<Option<(Option<KclValue>, ModuleArtifactState)>>,
+    ),
     Dummy,
 }
 
@@ -149,7 +151,6 @@ pub struct ModuleExecutionOutcome {
     pub artifacts: ModuleArtifactState,
 }
 
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, Hash, ts_rs::TS)]
 #[serde(tag = "type")]
 pub enum ModulePath {

--- a/rust/kcl-lib/src/parsing/ast/types/path.rs
+++ b/rust/kcl-lib/src/parsing/ast/types/path.rs
@@ -685,7 +685,7 @@ mod tests {
             crate::modules::ModuleInfo {
                 id: ModuleId::default(),
                 path: crate::modules::ModulePath::Main,
-                repr: crate::modules::ModuleRepr::Kcl(program.ast.clone(), None),
+                repr: crate::modules::ModuleRepr::Kcl(Box::new(program.ast.clone()), Box::new(None)),
             },
         )]);
         let programs = crate::execution::ProgramLookup::new(program.ast, module_infos);
@@ -916,7 +916,7 @@ mod tests {
             crate::modules::ModuleInfo {
                 id: ModuleId::default(),
                 path: crate::modules::ModulePath::Main,
-                repr: crate::modules::ModuleRepr::Kcl(program.ast.clone(), None),
+                repr: crate::modules::ModuleRepr::Kcl(Box::new(program.ast.clone()), Box::new(None)),
             },
         )]);
         let programs = crate::execution::ProgramLookup::new(program.ast, module_infos);
@@ -999,7 +999,7 @@ import "cylinder.kcl" as cylinder
             crate::modules::ModuleInfo {
                 id: ModuleId::default(),
                 path: crate::modules::ModulePath::Main,
-                repr: crate::modules::ModuleRepr::Kcl(program.ast.clone(), None),
+                repr: crate::modules::ModuleRepr::Kcl(Box::new(program.ast.clone()), Box::new(None)),
             },
         )]);
         let programs = crate::execution::ProgramLookup::new(program.ast, module_infos);

--- a/rust/kcl-lib/src/simulation_tests.rs
+++ b/rust/kcl-lib/src/simulation_tests.rs
@@ -121,16 +121,19 @@ impl ExecState {
                 ModuleRepr::Root => {
                     module_state.insert(relative_path, self.root_module_artifact_state().clone());
                 }
-                ModuleRepr::Kcl(_, None) => {
-                    module_state.insert(relative_path, Default::default());
+                ModuleRepr::Kcl(_, cache) => {
+                    if let Some(outcome) = cache.as_ref() {
+                        module_state.insert(relative_path, outcome.artifacts.clone());
+                    } else {
+                        module_state.insert(relative_path, Default::default());
+                    }
                 }
-                ModuleRepr::Kcl(_, Some(outcome)) => {
-                    module_state.insert(relative_path, outcome.artifacts.clone());
+                ModuleRepr::Foreign(_, cache) => {
+                    if let Some((_, module_artifacts)) = cache.as_ref() {
+                        module_state.insert(relative_path, module_artifacts.clone());
+                    }
                 }
-                ModuleRepr::Foreign(_, Some((_, module_artifacts))) => {
-                    module_state.insert(relative_path, module_artifacts.clone());
-                }
-                ModuleRepr::Foreign(_, None) | ModuleRepr::Dummy => {}
+                ModuleRepr::Dummy => {}
             }
         }
         module_state

--- a/rust/kcl-lib/src/util.rs
+++ b/rust/kcl-lib/src/util.rs
@@ -28,9 +28,10 @@ where
     E: IsRetryable + std::fmt::Display,
 {
     let mut retries_remaining = config.retries;
+    // TODO: Maybe change this to a for loop?
     loop {
         // Run the closure to execute.
-        let exec_result = execute().await;
+        let exec_result = Box::pin(execute()).await;
 
         if retries_remaining > 0
             && let Err(error) = &exec_result


### PR DESCRIPTION
Run this:
```sh
RUSTFLAGS=-Zprint-type-sizes cargo +nightly build -j1 > type-sizes.txt && top-type-sizes -ws -h33 -p 'run_with_caching\(\)' < type-sizes.txt | head -n 5
```

and replace `run_with_caching` with whatever function you want, to see its stack space.

This PR:

 - Boxes some Futures, moving them off the stack into the heap. In theory, worse performance, less stack overflows. I am very confident that the hit from following a pointer to the stack is going to be negligible.
 - Breaks some big functions with lots of `await`s into smaller functions, so that the state machine which the `async fn` creates has fewer and smaller states.