### PR TITLE
Fix cursor jump when editing autocomplete snippet arguments

### DIFF
--- a/packages/codemirror-lsp-client/src/plugin/autocomplete.test.ts
+++ b/packages/codemirror-lsp-client/src/plugin/autocomplete.test.ts
@@ -1,0 +1,109 @@
+import { hasNextSnippetField, snippet } from '@codemirror/autocomplete'
+import { EditorState } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
+import { afterEach, describe, expect, test } from 'vitest'
+
+import { clearSnippetBeforeEmptySelectionDelete } from './autocomplete'
+
+const snippetTemplate = 'mirror2d(axis = ${0:X})${}'
+
+function createView() {
+  const parent = document.createElement('div')
+  document.body.appendChild(parent)
+
+  return new EditorView({
+    parent,
+    state: EditorState.create({
+      doc: 'mirror2',
+    }),
+  })
+}
+
+function deleteSelection(view: EditorView) {
+  const selection = view.state.selection.main
+
+  view.dispatch({
+    changes: {
+      from: selection.from,
+      to: selection.to,
+      insert: '',
+    },
+    selection: {
+      anchor: selection.from,
+    },
+    userEvent: 'delete.selection',
+  })
+}
+
+function backspace(view: EditorView) {
+  clearSnippetBeforeEmptySelectionDelete(view)
+
+  const selection = view.state.selection.main
+
+  view.dispatch({
+    changes: {
+      from: selection.from - 1,
+      to: selection.from,
+      insert: '',
+    },
+    selection: {
+      anchor: selection.from - 1,
+    },
+    userEvent: 'delete.backward',
+  })
+}
+
+function typeText(view: EditorView, text: string) {
+  for (const character of text) {
+    const selection = view.state.selection.main
+
+    view.dispatch({
+      changes: {
+        from: selection.from,
+        to: selection.to,
+        insert: character,
+      },
+      selection: {
+        anchor: selection.from + character.length,
+      },
+      userEvent: 'input.type',
+    })
+  }
+}
+
+describe('LSP autocomplete snippets', () => {
+  let view: EditorView | undefined
+
+  afterEach(() => {
+    view?.destroy()
+    view = undefined
+    document.body.replaceChildren()
+  })
+
+  test('clears stale snippet state when editing through an emptied argument field', () => {
+    view = createView()
+
+    snippet(snippetTemplate)(view, { label: 'mirror2d' }, 0, 'mirror2'.length)
+    expect(view.state.doc.toString()).toBe('mirror2d(axis = X)')
+    expect(hasNextSnippetField(view.state)).toBe(true)
+
+    // Regression coverage for https://github.com/KittyCAD/modeling-app/issues/12133.
+    // After deleting the highlighted placeholder, the old snippet field is
+    // zero-width. Backspacing through `axis = ` should leave snippet mode,
+    // otherwise the field follows the cursor and later wraps typed `=`.
+    deleteSelection(view)
+    expect(view.state.doc.toString()).toBe('mirror2d(axis = )')
+    expect(hasNextSnippetField(view.state)).toBe(true)
+
+    backspace(view)
+    expect(hasNextSnippetField(view.state)).toBe(false)
+
+    while (view.state.doc.toString() !== 'mirror2d()') {
+      backspace(view)
+    }
+
+    typeText(view, 'foo = ')
+    expect(view.state.doc.toString()).toBe('mirror2d(foo = )')
+    expect(view.state.selection.main.from).toBe('mirror2d(foo = '.length)
+  })
+})

--- a/packages/codemirror-lsp-client/src/plugin/autocomplete.ts
+++ b/packages/codemirror-lsp-client/src/plugin/autocomplete.ts
@@ -5,6 +5,7 @@ import {
   closeCompletion,
   currentCompletions,
   hasNextSnippetField,
+  hasPrevSnippetField,
   moveCompletionSelection,
   nextSnippetField,
   prevSnippetField,
@@ -45,6 +46,8 @@ const lspAutocompleteKeymap: readonly KeyBinding[] = [
   { key: 'ArrowUp', run: moveCompletionSelectionOrExit(false) },
   { key: 'PageDown', run: moveCompletionSelection(true, 'page') },
   { key: 'PageUp', run: moveCompletionSelection(false, 'page') },
+  { key: 'Backspace', run: clearSnippetBeforeEmptySelectionDelete },
+  { key: 'Delete', run: clearSnippetBeforeEmptySelectionDelete },
   { key: 'Enter', run: acceptCompletion },
   {
     key: 'Tab',
@@ -61,6 +64,27 @@ const lspAutocompleteKeymap: readonly KeyBinding[] = [
 ]
 
 const lspAutocompleteKeymapExt = Prec.highest(keymap.of(lspAutocompleteKeymap))
+
+export function clearSnippetBeforeEmptySelectionDelete(
+  view: EditorView
+): boolean {
+  if (!view.state.selection.ranges.every((range) => range.empty)) {
+    return false
+  }
+
+  if (!hasNextSnippetField(view.state) && !hasPrevSnippetField(view.state)) {
+    return false
+  }
+
+  // Issue #12133: after a placeholder is emptied, Backspace/Delete can keep a
+  // zero-width snippet field alive while deleting the static argument text
+  // before it. That stale field then follows later input, so typing `foo =`
+  // reselects `=` and leaves the cursor before it.
+  clearSnippet(view)
+
+  // Let the regular delete command still handle the keypress.
+  return false
+}
 
 export function moveCompletionSelectionOrExit(forward: boolean) {
   const moveSelection = moveCompletionSelection(forward)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
           include: [
             'src/**/*.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
             'packages/registry/src/**/*.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
+            'packages/codemirror-lsp-client/src/**/*.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
           ],
         },
       },


### PR DESCRIPTION
Closes #12133. This is what it looked like:

https://github.com/user-attachments/assets/b9c0d8bc-ab2e-4ad0-b33a-29b45c213006

**Why?**
After accepting a snippet completion like `mirror2d(axis = ..)`, deleting the highlighted argument left a zero-width snippet field active. Backspacing through the generated `axis = ` text allowed that stale field to follow the cursor. When typing `foo =`, CodeMirror treated `=` as part of the stale snippet field, selected it, and left the cursor before the equal.

**So this PR:**
- Clears stale CodeMirror snippet state when Backspace/Delete edits through an emptied autocomplete placeholder
- Prevents typed `=` from being reselected with the cursor before it after accepting function autocomplete
- Adds regression coverage next to the LSP autocomplete plugin for #12133 / #12278

I also noticed old "LSP copilot" refs everywhere and I'm pretty certain we don't use that anymore. I thought it was related to the bug at first. Killing that will be in #12322.