### PR TITLE
Restore DXF export for sketch blocks

### DIFF
--- a/src/components/layout/areas/FeatureTreePane.tsx
+++ b/src/components/layout/areas/FeatureTreePane.tsx
@@ -1057,6 +1057,30 @@ const OperationItem = ({
     }
   }
 
+  function canExportDxf(
+    item: Operation
+  ): item is Parameters<typeof exportSketchToDxf>[0] {
+    return (
+      (item.type === 'StdLibCall' &&
+        (item.name === 'startSketchOn' || item.name === 'subtract2d')) ||
+      (item.type === 'GroupBegin' && item.group.type === 'SketchBlock')
+    )
+  }
+
+  function exportDxf() {
+    if (!canExportDxf(item)) {
+      return
+    }
+    exportSketchToDxf(item, {
+      engineCommandManager,
+      kclManager,
+      toast,
+      uuidv4,
+      base64Decode,
+      browserSaveFile,
+    }).catch(reportRejection)
+  }
+
   const menuItems = useMemo(
     () => {
       const viewSourceMenuItem = (
@@ -1111,46 +1135,10 @@ const OperationItem = ({
               </ContextMenuItem>,
             ]
           : []),
-        ...(item.type === 'StdLibCall' && item.name === 'startSketchOn'
+        ...(canExportDxf(item)
           ? [
               <ContextMenuItem
-                onClick={() => {
-                  const exportDxf = async () => {
-                    if (item.type !== 'StdLibCall') return
-                    await exportSketchToDxf(item, {
-                      engineCommandManager,
-                      kclManager,
-                      toast,
-                      uuidv4,
-                      base64Decode,
-                      browserSaveFile,
-                    })
-                  }
-                  void exportDxf()
-                }}
-                data-testid="context-menu-export-dxf"
-              >
-                Export to DXF
-              </ContextMenuItem>,
-            ]
-          : []),
-        ...(item.type === 'StdLibCall' && item.name === 'subtract2d'
-          ? [
-              <ContextMenuItem
-                onClick={() => {
-                  const exportDxf = async () => {
-                    if (item.type !== 'StdLibCall') return
-                    await exportSketchToDxf(item, {
-                      engineCommandManager,
-                      kclManager,
-                      toast,
-                      uuidv4,
-                      base64Decode,
-                      browserSaveFile,
-                    })
-                  }
-                  void exportDxf()
-                }}
+                onClick={exportDxf}
                 data-testid="context-menu-export-dxf"
               >
                 Export to DXF

--- a/src/lib/exportDxf.spec.ts
+++ b/src/lib/exportDxf.spec.ts
@@ -113,6 +113,20 @@ const createMockOperation = (): StdLibCallOp => ({
   sourceRange: [0, 0, 0],
 })
 
+const createMockSketchBlockOperation = (): Parameters<
+  typeof exportSketchToDxf
+>[0] => ({
+  type: 'GroupBegin',
+  group: {
+    type: 'SketchBlock',
+    sketchId: 1,
+  },
+  nodePath: {
+    steps: [{ type: 'ProgramBodyItem', index: 0 }],
+  },
+  sourceRange: [10, 20, 0],
+})
+
 describe('DXF Export', () => {
   let mockDeps: Parameters<typeof exportSketchToDxf>[1]
   let mockOperation: StdLibCallOp
@@ -238,6 +252,89 @@ describe('DXF Export', () => {
           },
         ],
       })
+    })
+
+    it('should successfully export DXF for sketch block operations', async () => {
+      const sketchBlockOperation = createMockSketchBlockOperation()
+      const sketchBlockArtifact: Artifact = {
+        id: 'sketch-block-1',
+        type: 'sketchBlock',
+        pathId: 'path-1',
+        sketchId: 1,
+        codeRef: {
+          nodePath: sketchBlockOperation.nodePath,
+          range: sketchBlockOperation.sourceRange,
+          pathToNode: [],
+        },
+      }
+      const pathArtifact: Artifact = {
+        id: 'path-1',
+        type: 'path',
+        subType: 'sketch',
+        planeId: 'plane-id',
+        segIds: [],
+        codeRef: {
+          nodePath: sketchBlockOperation.nodePath,
+          range: sketchBlockOperation.sourceRange,
+          pathToNode: [],
+        },
+        trajectorySweepId: null,
+        consumed: false,
+        sketchBlockId: 'sketch-block-1',
+      }
+
+      mockDeps.kclManager.artifactGraph.set(
+        'sketch-block-1',
+        sketchBlockArtifact
+      )
+      mockDeps.kclManager.artifactGraph.set('path-1', pathArtifact)
+
+      const mockResponse: WebSocketResponse = {
+        success: true,
+        resp: {
+          type: 'modeling',
+          data: {
+            modeling_response: {
+              type: 'export2d',
+              data: {
+                files: [{ contents: 'base64-content', name: 'sketch.dxf' }],
+              },
+            },
+          },
+        },
+      }
+      vi.mocked(
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        mockDeps.engineCommandManager.sendSceneCommand
+      ).mockResolvedValue(mockResponse)
+
+      vi.mocked(mockDeps.base64Decode).mockReturnValue(new ArrayBuffer(8))
+      mockElectron.save.mockResolvedValue({
+        canceled: false,
+        filePath: '/path/to/sketch.dxf',
+      })
+
+      const result = await exportSketchToDxf(sketchBlockOperation, mockDeps)
+
+      expect(result).toBe(true)
+      expect(
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        mockDeps.engineCommandManager.sendSceneCommand
+      ).toHaveBeenCalledWith(
+        {
+          type: 'modeling_cmd_req',
+          cmd_id: 'test-uuid',
+          cmd: {
+            type: 'export2d',
+            entity_ids: ['path-1'],
+            format: {
+              type: 'dxf',
+              storage: 'ascii',
+            },
+          },
+        },
+        true
+      )
     })
 
     it('should successfully export DXF in desktop environment', async () => {

--- a/src/lib/exportDxf.ts
+++ b/src/lib/exportDxf.ts
@@ -1,11 +1,14 @@
 import type { WebSocketResponse } from '@kittycad/lib'
-import type { OpKclValue } from '@rust/kcl-lib/bindings/Operation'
+import type { OpKclValue, Operation } from '@rust/kcl-lib/bindings/Operation'
 import type { KclManager } from '@src/lang/KclManager'
 import {
   type StdLibCallOp,
   findOperationPlaneLikeArtifact,
 } from '@src/lang/queryAst'
-import { getPlaneFromArtifact } from '@src/lang/std/artifactGraph'
+import {
+  getArtifactFromRange,
+  getPlaneFromArtifact,
+} from '@src/lang/std/artifactGraph'
 import type { Artifact } from '@src/lang/std/artifactGraph'
 import fsZds from '@src/lib/fs-zds'
 import { isModelingResponse } from '@src/lib/kcSdkGuards'
@@ -14,6 +17,14 @@ import { isArray } from '@src/lib/utils'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { ConnectionManager } from '@src/network/connectionManager'
 import type { ToastOptions } from 'react-hot-toast'
+
+type GroupBeginOperation = Extract<Operation, { type: 'GroupBegin' }>
+
+type SketchBlockOperation = GroupBeginOperation & {
+  group: Extract<GroupBeginOperation['group'], { type: 'SketchBlock' }>
+}
+
+type DxfSketchOperation = StdLibCallOp | SketchBlockOperation
 
 function getSketchArtifactId(
   value: OpKclValue | null | undefined
@@ -44,9 +55,70 @@ function findPlaneArtifactForSubtract2d(
   return kclManager.artifactGraph.get(planeArtifact.id) ?? null
 }
 
+function getSketchBlockPathIds(
+  operation: SketchBlockOperation,
+  kclManager: KclManager
+): string[] | Error {
+  const artifact = getArtifactFromRange(
+    operation.sourceRange,
+    kclManager.artifactGraph
+  )
+
+  if (artifact?.type !== 'sketchBlock') {
+    return new Error('Could not find sketch block artifact')
+  }
+
+  if (!artifact.pathId) {
+    return new Error('Could not find sketch block path')
+  }
+
+  return [artifact.pathId]
+}
+
+function getLegacySketchPathIds(
+  operation: StdLibCallOp,
+  kclManager: KclManager
+): string[] | Error {
+  // For subtract2d operations, find the plane artifact from the same sketch.
+  let planeArtifact: Artifact | null | undefined
+  if (operation.name === 'subtract2d') {
+    planeArtifact = findPlaneArtifactForSubtract2d(operation, kclManager)
+    if (!planeArtifact) {
+      return new Error('Could not find plane artifact for subtract2d')
+    }
+  } else {
+    // Get the plane artifact associated with this sketch operation.
+    planeArtifact = findOperationPlaneLikeArtifact(
+      operation,
+      kclManager.artifactGraph
+    )
+  }
+
+  if (!planeArtifact) {
+    return new Error('Could not find plane artifact')
+  }
+
+  if (!('pathIds' in planeArtifact) || !planeArtifact.pathIds?.length) {
+    return new Error('Could not find path IDs')
+  }
+
+  return planeArtifact.pathIds
+}
+
+function getSketchPathIds(
+  operation: DxfSketchOperation,
+  kclManager: KclManager
+): string[] | Error {
+  if (operation.type === 'GroupBegin') {
+    return getSketchBlockPathIds(operation, kclManager)
+  }
+
+  return getLegacySketchPathIds(operation, kclManager)
+}
+
 // Exports a sketch operation to DXF format
 export async function exportSketchToDxf(
-  operation: StdLibCallOp,
+  operation: DxfSketchOperation,
   dependencies: {
     engineCommandManager: ConnectionManager
     kclManager: KclManager
@@ -80,38 +152,19 @@ export async function exportSketchToDxf(
   let toastId: string | undefined = undefined
 
   try {
-    // For subtract2d operations, find the plane artifact from the same sketch
-    let planeArtifact
-    if (operation.name === 'subtract2d') {
-      planeArtifact = findPlaneArtifactForSubtract2d(operation, kclManager)
-      if (!planeArtifact) {
-        toast.error(
-          'Could not find sketch to export from subtract2d operation.'
-        )
-        return new Error('Could not find plane artifact for subtract2d')
-      }
-    } else {
-      // Get the plane artifact associated with this sketch operation
-      planeArtifact = findOperationPlaneLikeArtifact(
-        operation,
-        kclManager.artifactGraph
+    const pathIds = getSketchPathIds(operation, kclManager)
+    if (pathIds instanceof Error) {
+      toast.error(
+        pathIds.message.includes('plane artifact')
+          ? 'Could not find sketch for DXF export.'
+          : 'Could not find sketch profiles for DXF export.'
       )
-    }
-
-    if (!planeArtifact) {
-      toast.error('Could not find sketch for DXF export.')
-      return new Error('Could not find plane artifact')
-    }
-
-    // Early exit if no path IDs to process
-    if (!('pathIds' in planeArtifact) || !planeArtifact.pathIds?.length) {
-      toast.error('Could not find sketch profiles for DXF export.')
-      return new Error('Could not find path IDs')
+      return pathIds
     }
 
     // Get all entity IDs from the plane's paths
     const entityIds: string[] = []
-    for (const pathId of planeArtifact.pathIds) {
+    for (const pathId of pathIds) {
       const pathArtifact = kclManager.artifactGraph.get(pathId)
       if (!pathArtifact) continue
       if ('compositeSolidId' in pathArtifact && pathArtifact.compositeSolidId) {


### PR DESCRIPTION
ai assisted

exported and double checked the file

<img width="203" height="140" alt="Screenshot 2026-07-03 at 22 26 01" src="https://github.com/user-attachments/assets/e27187d8-b535-41c2-8138-25cb55a746ff" />

## Problem

Users could export DXF from Sketch v1 feature-tree rows, but modern sketch-solve rows no longer showed the context-menu action because the menu predicate only recognized legacy `startSketchOn` and `subtract2d` operations.

## Solution

Recognize sketch-block feature-tree operations as DXF-exportable, resolve their generated path artifact, and keep the legacy sketch and `subtract2d` paths intact. Add coverage for sketch-block export so future operation-model changes do not silently drop the menu action.
