### PR TITLE
#12133 Fix cursor jumping issues during autocomplete typing

### DIFF
--- a/packages/codemirror-lsp-client/src/plugin/autocomplete.ts
+++ b/packages/codemirror-lsp-client/src/plugin/autocomplete.ts
@@ -14,9 +14,9 @@ import {
 import type { CompletionContext } from '@codemirror/autocomplete'
 import { syntaxTree } from '@codemirror/language'
 import type { Extension } from '@codemirror/state'
-import { Prec } from '@codemirror/state'
-import type { EditorView, KeyBinding, ViewPlugin } from '@codemirror/view'
-import { keymap } from '@codemirror/view'
+import { Prec, Transaction } from '@codemirror/state'
+import type { KeyBinding, ViewPlugin } from '@codemirror/view'
+import { EditorView, keymap } from '@codemirror/view'
 import {
   CompletionItemKind,
   CompletionTriggerKind,
@@ -62,6 +62,31 @@ const lspAutocompleteKeymap: readonly KeyBinding[] = [
 
 const lspAutocompleteKeymapExt = Prec.highest(keymap.of(lspAutocompleteKeymap))
 
+// When autocomplete has been active, spaces and equals signs can be inserted at
+// the wrong DOM position because CodeMirror selection state and the browser
+// selection can get out of sync. Route those inputs through CodeMirror state so
+// they are inserted at the editor's cursor.
+const lspAutocompleteBoundaryInputExt = Prec.highest(
+  EditorView.domEventHandlers({
+    beforeinput(event, view) {
+      const shouldRoute =
+        event.inputType === 'insertText' &&
+        (event.data === ' ' || event.data === '=')
+
+      if (!shouldRoute) {
+        return false
+      }
+
+      const transactionSpec = view.state.replaceSelection(event.data)
+      view.dispatch({
+        ...transactionSpec,
+        annotations: Transaction.userEvent.of('input.type'),
+      })
+      return true
+    },
+  })
+)
+
 export function moveCompletionSelectionOrExit(forward: boolean) {
   const moveSelection = moveCompletionSelection(forward)
 
@@ -87,6 +112,7 @@ export default function lspAutocompleteExt(
 ): Extension {
   return [
     lspAutocompleteKeymapExt,
+    lspAutocompleteBoundaryInputExt,
     autocompletion({
       defaultKeymap: false,
       override: [


### PR DESCRIPTION
Fixes #12133 

Concretely these 2 scenarios:

1. Typing while autocomplete pops up, pressing space, =
- Have this in your KCL:
```
a = polar(angle = 5, angle = 9, leng)
```
- Place the cursor after "leng" to continue typing out "length"
- After the last character "h" is typed, wait at least a second (the "length" autocomplete appear during typing, just ignore it)
- Then type these keys: space, =, space

-> Result (two spaces before `=` and the cursor is blinking between them):
```
a = polar(angle = 5, angle = 9, length  =)
```

Expected (space, =, space, cursor blinking before the closing parenthesis):
```
a = polar(angle = 5, angle = 9, length = )
```

https://github.com/user-attachments/assets/0afbcb3b-d1b9-4e46-aa4e-7850ac6e78c4

2. Select autocomplete option, than delete and type again
- type "mirror2d"
- accept autocomplete: mirror2d(axis = X)
- wait for execution (1 sec)
- delete the param "axis = X"
- type "foo = "
-> result will be "foo =" (two spaces before =) and the cursor will be between the two spaces


https://github.com/user-attachments/assets/7184c024-e4c9-43c6-9bea-5dc791d90ce8



The root cause seems to be that CodeMirror has its own editor selection in `view.state.selection`, the browser also has a native selection but these don't match sometimes during typing while autocomplete is on.
Maybe this could also be fixed within CodeMirror, but it's also possible that the issue is how our LSP autocomplete interacts with CodeMirror.
More time could be spent on finding the exact cause for a cleaner fix.

The current fix in this PR dispatches `view.state.replaceSelection` as a transaction, which inserts `event.data` at CodeMirror's current selection, not at the browser DOM selection, which helps when they are out of sync.
I restricted this to the problematic characters only, applying to all characters would include some risk: foreign language characters arriving through composite events.