### PR TITLE
Wait longer for the Vercel deployment to finish

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -472,7 +472,7 @@ jobs:
         continue-on-error: true
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          max_timeout: 1000 # average build times are <16 minutes
+          max_timeout: 1200 # average build times are 17-19 minutes
           check_interval: 10
           vercel_protection_bypass_header: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
@@ -484,7 +484,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           environment: staging
-          max_timeout: 1000 # average build times are <16 minutes
+          max_timeout: 1200 # average build times are 17-19 minutes
           check_interval: 10
           vercel_protection_bypass_header: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 


### PR DESCRIPTION
The cause it unknown, but something has caused build times to increase: https://kittycadworkspace.slack.com/archives/C07A80B83FS/p1783455833722579