### PR TITLE
Add scoped keymap support for Markdown editor links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32063,6 +32063,7 @@
       "license": "MIT",
       "dependencies": {
         "@kittycad/lib": "^4.2.9",
+        "@tiptap/core": "^3.27.2",
         "@tiptap/extension-link": "^3.27.2",
         "@tiptap/markdown": "^3.27.2",
         "@tiptap/react": "^3.27.2",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@kittycad/lib": "^4.2.9",
+    "@tiptap/core": "^3.27.2",
     "@tiptap/extension-link": "^3.27.2",
     "@tiptap/markdown": "^3.27.2",
     "@tiptap/react": "^3.27.2",

--- a/packages/ui-components/src/components/MarkdownEditor/MarkdownEditor.test.tsx
+++ b/packages/ui-components/src/components/MarkdownEditor/MarkdownEditor.test.tsx
@@ -1,6 +1,7 @@
 import {
   defaultNormalizeMarkdownLinkHref,
   MarkdownEditor,
+  type MarkdownEditorActionName,
   type MarkdownEditorActions,
   normalizeMarkdownEditorValue,
 } from '@kittycad/ui-components'
@@ -96,7 +97,7 @@ describe('MarkdownEditor', () => {
     )
   })
 
-  it('exposes a link action for external keymap integrations', async () => {
+  it('exposes editor actions for external keymap integrations', async () => {
     const onChange = vi.fn()
     const actionsRef: { current: MarkdownEditorActions | null } = {
       current: null,
@@ -121,6 +122,20 @@ describe('MarkdownEditor', () => {
     const actions = actionsRef.current
     if (!actions) {
       throw new Error('Missing Markdown editor actions')
+    }
+
+    const actionNames = [
+      'toggleBold',
+      'toggleItalic',
+      'setLink',
+      'toggleBulletList',
+      'toggleOrderedList',
+      'undo',
+      'redo',
+    ] as const satisfies readonly MarkdownEditorActionName[]
+
+    for (const actionName of actionNames) {
+      expect(actions[actionName]).toEqual(expect.any(Function))
     }
 
     expect(actions.setLink()).toBe(true)

--- a/packages/ui-components/src/components/MarkdownEditor/MarkdownEditor.test.tsx
+++ b/packages/ui-components/src/components/MarkdownEditor/MarkdownEditor.test.tsx
@@ -1,6 +1,7 @@
 import {
   defaultNormalizeMarkdownLinkHref,
   MarkdownEditor,
+  type MarkdownEditorActions,
   normalizeMarkdownEditorValue,
 } from '@kittycad/ui-components'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
@@ -87,6 +88,42 @@ describe('MarkdownEditor', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Link' }))
 
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalled()
+    })
+    expect(onChange.mock.calls.at(-1)?.[0]).toContain(
+      '[https://zoo.dev/docs](https://zoo.dev/docs)'
+    )
+  })
+
+  it('exposes a link action for external keymap integrations', async () => {
+    const onChange = vi.fn()
+    const actionsRef: { current: MarkdownEditorActions | null } = {
+      current: null,
+    }
+
+    render(
+      <MarkdownEditor
+        id="description"
+        value=""
+        onChange={onChange}
+        onActionsChange={(nextActions) => {
+          actionsRef.current = nextActions
+        }}
+        promptForLink={() => 'zoo.dev/docs'}
+      />
+    )
+
+    await waitFor(() => {
+      expect(actionsRef.current).not.toBeNull()
+    })
+
+    const actions = actionsRef.current
+    if (!actions) {
+      throw new Error('Missing Markdown editor actions')
+    }
+
+    expect(actions.setLink()).toBe(true)
     await waitFor(() => {
       expect(onChange).toHaveBeenCalled()
     })

--- a/packages/ui-components/src/components/MarkdownEditor/MarkdownEditor.tsx
+++ b/packages/ui-components/src/components/MarkdownEditor/MarkdownEditor.tsx
@@ -109,9 +109,9 @@ export function MarkdownEditor({
   testId = 'markdown-editor',
 }: MarkdownEditorProps) {
   const featureKey = useMemo(() => [...features].sort().join('|'), [features])
-  // biome-ignore lint/correctness/useExhaustiveDependencies: featureKey intentionally keys by feature content, not array identity.
   const normalizedFeatures = useMemo(
     () => [...new Set(features)] as MarkdownEditorFeature[],
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- featureKey intentionally keys by feature content, not array identity.
     [featureKey]
   )
   const enabledFeatures = useMemo(

--- a/packages/ui-components/src/components/MarkdownEditor/MarkdownEditor.tsx
+++ b/packages/ui-components/src/components/MarkdownEditor/MarkdownEditor.tsx
@@ -1,3 +1,4 @@
+import { Extension } from '@tiptap/core'
 import { Link } from '@tiptap/extension-link'
 import { Markdown, MarkdownManager } from '@tiptap/markdown'
 import { EditorContent, useEditor } from '@tiptap/react'
@@ -17,8 +18,17 @@ export type MarkdownEditorNormalizeLinkHref = (
   value: string | undefined
 ) => string | null
 
+export type MarkdownEditorActionName =
+  | 'toggleBold'
+  | 'toggleItalic'
+  | 'setLink'
+  | 'toggleBulletList'
+  | 'toggleOrderedList'
+  | 'undo'
+  | 'redo'
+
 export type MarkdownEditorActions = {
-  setLink: () => boolean
+  [ActionName in MarkdownEditorActionName]: () => boolean
 }
 
 export interface MarkdownEditorProps {
@@ -34,9 +44,11 @@ export interface MarkdownEditorProps {
   labelledBy?: string
   normalizeLinkHref?: MarkdownEditorNormalizeLinkHref
   onActionsChange?: (actions: MarkdownEditorActions | null) => void
+  onFocusChange?: (isFocused: boolean) => void
   placeholder?: string
   promptForLink?: (currentHref: string) => string | null
   required?: boolean
+  suppressDefaultKeyboardShortcuts?: boolean
   testId?: string
 }
 
@@ -56,6 +68,25 @@ const MARKDOWN_OPTIONS = {
     gfm: true,
   },
 }
+const MarkdownEditorShortcutSuppressor = Extension.create({
+  name: 'markdownEditorShortcutSuppressor',
+  priority: 1000,
+  addKeyboardShortcuts() {
+    return {
+      'Mod-b': () => true,
+      'Mod-B': () => true,
+      'Mod-i': () => true,
+      'Mod-I': () => true,
+      'Mod-Shift-8': () => true,
+      'Mod-Shift-7': () => true,
+      'Mod-z': () => true,
+      'Mod-я': () => true,
+      'Shift-Mod-z': () => true,
+      'Mod-y': () => true,
+      'Shift-Mod-я': () => true,
+    }
+  },
+})
 
 export function MarkdownEditor({
   id,
@@ -70,15 +101,17 @@ export function MarkdownEditor({
   labelledBy,
   normalizeLinkHref = defaultNormalizeMarkdownLinkHref,
   onActionsChange,
+  onFocusChange,
   placeholder = '',
   promptForLink,
   required = false,
+  suppressDefaultKeyboardShortcuts = false,
   testId = 'markdown-editor',
 }: MarkdownEditorProps) {
   const featureKey = useMemo(() => [...features].sort().join('|'), [features])
+  // biome-ignore lint/correctness/useExhaustiveDependencies: featureKey intentionally keys by feature content, not array identity.
   const normalizedFeatures = useMemo(
     () => [...new Set(features)] as MarkdownEditorFeature[],
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- featureKey intentionally keys by feature content, not array identity.
     [featureKey]
   )
   const enabledFeatures = useMemo(
@@ -111,10 +144,11 @@ export function MarkdownEditor({
       ...createMarkdownEditorBaseExtensions({
         features: normalizedFeatures,
         normalizeLinkHref,
+        suppressDefaultKeyboardShortcuts,
       }),
       Markdown.configure(MARKDOWN_OPTIONS),
     ],
-    [normalizedFeatures, normalizeLinkHref]
+    [normalizedFeatures, normalizeLinkHref, suppressDefaultKeyboardShortcuts]
   )
 
   const editor = useEditor(
@@ -123,6 +157,16 @@ export function MarkdownEditor({
       contentType: 'markdown',
       editorProps: {
         attributes: editorAttributes,
+        handleDOMEvents: {
+          focus: () => {
+            onFocusChange?.(true)
+            return false
+          },
+          blur: () => {
+            onFocusChange?.(false)
+            return false
+          },
+        },
       },
       extensions,
       immediatelyRender: true,
@@ -152,6 +196,22 @@ export function MarkdownEditor({
       emitUpdate: false,
     })
   }, [editor, value])
+
+  const toggleBold = useCallback(() => {
+    if (!editor || !enabledFeatures.has('bold')) {
+      return false
+    }
+
+    return editor.chain().focus().toggleBold().run()
+  }, [editor, enabledFeatures])
+
+  const toggleItalic = useCallback(() => {
+    if (!editor || !enabledFeatures.has('italic')) {
+      return false
+    }
+
+    return editor.chain().focus().toggleItalic().run()
+  }, [editor, enabledFeatures])
 
   const setLink = useCallback(() => {
     if (!editor || !hasLink) {
@@ -200,11 +260,57 @@ export function MarkdownEditor({
     return true
   }, [editor, hasLink, normalizeLinkHref, promptForLink])
 
+  const toggleBulletList = useCallback(() => {
+    if (!editor || !enabledFeatures.has('bulletList')) {
+      return false
+    }
+
+    return editor.chain().focus().toggleBulletList().run()
+  }, [editor, enabledFeatures])
+
+  const toggleOrderedList = useCallback(() => {
+    if (!editor || !enabledFeatures.has('orderedList')) {
+      return false
+    }
+
+    return editor.chain().focus().toggleOrderedList().run()
+  }, [editor, enabledFeatures])
+
+  const undo = useCallback(() => {
+    if (!editor || !hasUndoRedo || !editor.can().undo()) {
+      return false
+    }
+
+    return editor.chain().focus().undo().run()
+  }, [editor, hasUndoRedo])
+
+  const redo = useCallback(() => {
+    if (!editor || !hasUndoRedo || !editor.can().redo()) {
+      return false
+    }
+
+    return editor.chain().focus().redo().run()
+  }, [editor, hasUndoRedo])
+
   const actions = useMemo<MarkdownEditorActions>(
     () => ({
+      toggleBold,
+      toggleItalic,
       setLink,
+      toggleBulletList,
+      toggleOrderedList,
+      undo,
+      redo,
     }),
-    [setLink]
+    [
+      toggleBold,
+      toggleItalic,
+      setLink,
+      toggleBulletList,
+      toggleOrderedList,
+      undo,
+      redo,
+    ]
   )
 
   useEffect(() => {
@@ -228,7 +334,7 @@ export function MarkdownEditor({
             label="Bold"
             pressed={editor?.isActive('bold') ?? false}
             disabled={!editor}
-            onClick={() => editor?.chain().focus().toggleBold().run()}
+            onClick={toggleBold}
           >
             <BoldIcon />
           </EditorToolbarButton>
@@ -238,7 +344,7 @@ export function MarkdownEditor({
             label="Italic"
             pressed={editor?.isActive('italic') ?? false}
             disabled={!editor}
-            onClick={() => editor?.chain().focus().toggleItalic().run()}
+            onClick={toggleItalic}
           >
             <ItalicIcon />
           </EditorToolbarButton>
@@ -261,7 +367,7 @@ export function MarkdownEditor({
             label="Bulleted list"
             pressed={editor?.isActive('bulletList') ?? false}
             disabled={!editor}
-            onClick={() => editor?.chain().focus().toggleBulletList().run()}
+            onClick={toggleBulletList}
           >
             <ListIcon ordered={false} />
           </EditorToolbarButton>
@@ -271,7 +377,7 @@ export function MarkdownEditor({
             label="Numbered list"
             pressed={editor?.isActive('orderedList') ?? false}
             disabled={!editor}
-            onClick={() => editor?.chain().focus().toggleOrderedList().run()}
+            onClick={toggleOrderedList}
           >
             <ListIcon ordered={true} />
           </EditorToolbarButton>
@@ -283,7 +389,7 @@ export function MarkdownEditor({
           <EditorToolbarButton
             label="Undo"
             disabled={!editor?.can().undo()}
-            onClick={() => editor?.chain().focus().undo().run()}
+            onClick={undo}
           >
             <UndoIcon />
           </EditorToolbarButton>
@@ -292,7 +398,7 @@ export function MarkdownEditor({
           <EditorToolbarButton
             label="Redo"
             disabled={!editor?.can().redo()}
-            onClick={() => editor?.chain().focus().redo().run()}
+            onClick={redo}
           >
             <RedoIcon />
           </EditorToolbarButton>
@@ -354,9 +460,11 @@ function serializeMarkdownOrFallback<T>(serialize: () => string, fallback: T) {
 function createMarkdownEditorBaseExtensions({
   features,
   normalizeLinkHref,
+  suppressDefaultKeyboardShortcuts = false,
 }: {
   features: readonly MarkdownEditorFeature[]
   normalizeLinkHref: MarkdownEditorNormalizeLinkHref
+  suppressDefaultKeyboardShortcuts?: boolean
 }) {
   const enabledFeatures = new Set(features)
   const hasLists =
@@ -382,6 +490,9 @@ function createMarkdownEditorBaseExtensions({
       underline: false,
       undoRedo: hasUndoRedo ? undefined : false,
     }),
+    ...(suppressDefaultKeyboardShortcuts
+      ? [MarkdownEditorShortcutSuppressor]
+      : []),
     ...(hasLink
       ? [
           createSafeLinkExtension(normalizeLinkHref).configure({

--- a/packages/ui-components/src/components/MarkdownEditor/MarkdownEditor.tsx
+++ b/packages/ui-components/src/components/MarkdownEditor/MarkdownEditor.tsx
@@ -2,7 +2,7 @@ import { Link } from '@tiptap/extension-link'
 import { Markdown, MarkdownManager } from '@tiptap/markdown'
 import { EditorContent, useEditor } from '@tiptap/react'
 import { StarterKit } from '@tiptap/starter-kit'
-import { type ReactNode, useEffect, useMemo } from 'react'
+import { type ReactNode, useCallback, useEffect, useMemo } from 'react'
 import './MarkdownEditor.css'
 
 export type MarkdownEditorFeature =
@@ -17,6 +17,10 @@ export type MarkdownEditorNormalizeLinkHref = (
   value: string | undefined
 ) => string | null
 
+export type MarkdownEditorActions = {
+  setLink: () => boolean
+}
+
 export interface MarkdownEditorProps {
   id: string
   value: string
@@ -29,6 +33,7 @@ export interface MarkdownEditorProps {
   invalid?: boolean
   labelledBy?: string
   normalizeLinkHref?: MarkdownEditorNormalizeLinkHref
+  onActionsChange?: (actions: MarkdownEditorActions | null) => void
   placeholder?: string
   promptForLink?: (currentHref: string) => string | null
   required?: boolean
@@ -64,6 +69,7 @@ export function MarkdownEditor({
   invalid = false,
   labelledBy,
   normalizeLinkHref = defaultNormalizeMarkdownLinkHref,
+  onActionsChange,
   placeholder = '',
   promptForLink,
   required = false,
@@ -147,9 +153,9 @@ export function MarkdownEditor({
     })
   }, [editor, value])
 
-  function setLink() {
-    if (!editor) {
-      return
+  const setLink = useCallback(() => {
+    if (!editor || !hasLink) {
+      return false
     }
 
     const currentHref = editor.getAttributes('link').href
@@ -161,17 +167,17 @@ export function MarkdownEditor({
         )
 
     if (rawHref === null) {
-      return
+      return true
     }
 
     if (!rawHref.trim()) {
       editor.chain().focus().extendMarkRange('link').unsetLink().run()
-      return
+      return true
     }
 
     const safeHref = normalizeLinkHref(rawHref)
     if (!safeHref) {
-      return
+      return true
     }
 
     if (editor.state.selection.empty && !editor.isActive('link')) {
@@ -182,7 +188,7 @@ export function MarkdownEditor({
           contentType: 'markdown',
         })
         .run()
-      return
+      return true
     }
 
     editor
@@ -191,7 +197,22 @@ export function MarkdownEditor({
       .extendMarkRange('link')
       .setLink({ href: safeHref })
       .run()
-  }
+    return true
+  }, [editor, hasLink, normalizeLinkHref, promptForLink])
+
+  const actions = useMemo<MarkdownEditorActions>(
+    () => ({
+      setLink,
+    }),
+    [setLink]
+  )
+
+  useEffect(() => {
+    onActionsChange?.(actions)
+    return () => {
+      onActionsChange?.(null)
+    }
+  }, [actions, onActionsChange])
 
   return (
     <div
@@ -424,8 +445,8 @@ function EditorToolbarButton({
       onClick={onClick}
       className={`m-0 flex h-7 w-7 items-center justify-center rounded border px-0 text-xs leading-none transition-colors focus-visible:outline-appForeground disabled:opacity-50 ${
         pressed
-          ? 'border-chalkboard-50 bg-chalkboard-20 text-chalkboard-100 dark:border-chalkboard-50 dark:bg-chalkboard-70 dark:text-chalkboard-10'
-          : 'border-transparent bg-transparent text-chalkboard-70 hover:border-chalkboard-20 hover:bg-chalkboard-20/60 hover:text-chalkboard-100 dark:text-chalkboard-30 dark:hover:border-chalkboard-70 dark:hover:bg-chalkboard-80/70 dark:hover:text-chalkboard-10'
+          ? 'border-chalkboard-50 bg-chalkboard-20 text-chalkboard-100 dark:border-transparent dark:bg-chalkboard-70 dark:text-chalkboard-10'
+          : 'border-transparent bg-transparent text-chalkboard-70 hover:border-chalkboard-20 hover:bg-chalkboard-20/60 hover:text-chalkboard-100 dark:border-transparent dark:text-chalkboard-30 dark:hover:border-transparent dark:hover:bg-chalkboard-80/70 dark:hover:text-chalkboard-10'
       }`}
     >
       {children}

--- a/packages/ui-components/src/components/MarkdownEditor/index.ts
+++ b/packages/ui-components/src/components/MarkdownEditor/index.ts
@@ -2,6 +2,7 @@ export {
   defaultMarkdownEditorFeatures,
   defaultNormalizeMarkdownLinkHref,
   MarkdownEditor,
+  type MarkdownEditorActions,
   type MarkdownEditorFeature,
   type MarkdownEditorNormalizeLinkHref,
   type MarkdownEditorProps,

--- a/packages/ui-components/src/components/MarkdownEditor/index.ts
+++ b/packages/ui-components/src/components/MarkdownEditor/index.ts
@@ -2,6 +2,7 @@ export {
   defaultMarkdownEditorFeatures,
   defaultNormalizeMarkdownLinkHref,
   MarkdownEditor,
+  type MarkdownEditorActionName,
   type MarkdownEditorActions,
   type MarkdownEditorFeature,
   type MarkdownEditorNormalizeLinkHref,

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -20,6 +20,7 @@ export {
   defaultMarkdownEditorFeatures,
   defaultNormalizeMarkdownLinkHref,
   MarkdownEditor,
+  type MarkdownEditorActions,
   type MarkdownEditorFeature,
   type MarkdownEditorNormalizeLinkHref,
   type MarkdownEditorProps,

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -20,6 +20,7 @@ export {
   defaultMarkdownEditorFeatures,
   defaultNormalizeMarkdownLinkHref,
   MarkdownEditor,
+  type MarkdownEditorActionName,
   type MarkdownEditorActions,
   type MarkdownEditorFeature,
   type MarkdownEditorNormalizeLinkHref,

--- a/src/components/PublishButton.tsx
+++ b/src/components/PublishButton.tsx
@@ -11,11 +11,17 @@ import {
 } from '@src/lib/share'
 import { err } from '@src/lib/trap'
 import { withSiteBaseURL } from '@src/lib/withBaseURL'
+import { keymapService } from '@src/registry/contracts/keymap'
+import {
+  MARKDOWN_EDITOR_FOCUSED_KEYMAP_SCOPE,
+  markdownEditorService,
+} from '@src/registry/contracts/markdownEditor'
 import {
   type ComponentProps,
   memo,
   useCallback,
   useEffect,
+  useMemo,
   useState,
 } from 'react'
 
@@ -69,6 +75,18 @@ function PublishPopoverContent({
   const publishRequiresUsername = !isCheckingUser && !!token && !username
   const accountUrl = withSiteBaseURL('/account')
   const buttonDisabled = kclEmpty || hasKclErrors
+  const keymap = app.registry.optional(keymapService)
+  const markdownEditor = app.registry.optional(markdownEditorService)
+  const markdownEditorKeymap = useMemo(
+    () =>
+      keymap && markdownEditor
+        ? {
+            focusScope: keymap.focusScope(MARKDOWN_EDITOR_FOCUSED_KEYMAP_SCOPE),
+            registerActions: markdownEditor.registerActiveEditor,
+          }
+        : undefined,
+    [keymap, markdownEditor]
+  )
 
   const fetchPublicationDetails = useCallback(async () => {
     if (!token || !project) {
@@ -161,6 +179,7 @@ function PublishPopoverContent({
           accountUrl={accountUrl}
           publicationDetails={publicationDetails}
           isLoadingPublicationDetails={isLoadingPublicationDetails}
+          markdownEditorKeymap={markdownEditorKeymap}
         />
       )}
     </>

--- a/src/components/PublishDialog.test.tsx
+++ b/src/components/PublishDialog.test.tsx
@@ -1,6 +1,6 @@
 import { Popover } from '@headlessui/react'
+import type { MarkdownEditorActions } from '@kittycad/ui-components'
 import { PublishDialog } from '@src/components/PublishDialog'
-import type { CurrentProjectPublicationDetails } from '@src/lib/share'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -26,39 +26,45 @@ describe('PublishDialog', () => {
     vi.unstubAllGlobals()
   })
 
-  it('submits normalized Markdown descriptions', async () => {
-    const onSubmit = vi.fn().mockResolvedValue(true)
-    const publicationDetails = {
-      projectId: 'project-1',
-      publicationStatus: 'draft',
-      title: 'Robot arm',
-      description:
-        'A [safe](zoo.dev/docs) link and an [unsafe](javascript:alert(1)) link.',
-      categoryIds: ['robotics'],
-      updatedAt: '2026-07-07T00:00:00.000Z',
-    } satisfies CurrentProjectPublicationDetails
+  it('registers the description editor with the Markdown keymap while focused', async () => {
+    const unregisterActions = vi.fn()
+    const registerActions = vi.fn((actions: MarkdownEditorActions) => {
+      void actions
+      return unregisterActions
+    })
+    const focusScope = {
+      onFocus: vi.fn(),
+      onBlur: vi.fn(),
+    }
 
     render(
       <Popover>
         <PublishDialog
-          onSubmit={onSubmit}
+          onSubmit={vi.fn()}
           accountUrl="https://zoo.dev/account"
-          publicationDetails={publicationDetails}
+          markdownEditorKeymap={{ focusScope, registerActions }}
         />
       </Popover>
     )
 
-    await waitFor(() => {
-      expect(screen.getByLabelText('Title*')).toHaveValue('Robot arm')
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Submit for review' }))
+    const editor = await screen.findByTestId(
+      'publish-project-description-editor'
+    )
+    fireEvent.focus(editor)
 
     await waitFor(() => {
-      expect(onSubmit).toHaveBeenCalledWith({
-        title: 'Robot arm',
-        description: 'A [safe](https://zoo.dev/docs) link and an unsafe link.',
-        categoryIds: ['robotics'],
-      })
+      expect(focusScope.onFocus).toHaveBeenCalledTimes(1)
+      expect(registerActions).toHaveBeenCalledTimes(1)
+    })
+    expect(registerActions.mock.calls[0][0]).toMatchObject({
+      setLink: expect.any(Function),
+    })
+
+    fireEvent.blur(editor)
+
+    await waitFor(() => {
+      expect(unregisterActions).toHaveBeenCalledTimes(1)
+      expect(focusScope.onBlur).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/components/PublishDialog.tsx
+++ b/src/components/PublishDialog.tsx
@@ -2,6 +2,7 @@ import { Popover, Transition } from '@headlessui/react'
 import type { ProjectCategoryResponse } from '@kittycad/lib'
 import {
   MarkdownEditor,
+  type MarkdownEditorActions,
   normalizeMarkdownEditorValue,
 } from '@kittycad/ui-components'
 import { ActionButton } from '@src/components/ActionButton'
@@ -12,7 +13,22 @@ import type {
   ProjectPublishSubmission,
 } from '@src/lib/share'
 import { withAPIBaseURL } from '@src/lib/withBaseURL'
-import { Fragment, useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  type FocusEvent,
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
+
+type PublishDialogMarkdownEditorKeymap = {
+  focusScope: {
+    onFocus: () => void
+    onBlur: () => void
+  }
+  registerActions: (actions: MarkdownEditorActions) => () => void
+}
 
 type PublishDialogProps = {
   onSubmit: (args: ProjectPublishSubmission) => Promise<boolean>
@@ -22,6 +38,7 @@ type PublishDialogProps = {
   accountUrl: string
   publicationDetails?: CurrentProjectPublicationDetails | null
   isLoadingPublicationDetails?: boolean
+  markdownEditorKeymap?: PublishDialogMarkdownEditorKeymap
 }
 
 const AQUARIUM_TERMS_URL = 'https://zoo.dev/aquarium-terms-of-use'
@@ -34,6 +51,7 @@ export function PublishDialog({
   accountUrl,
   publicationDetails = null,
   isLoadingPublicationDetails = false,
+  markdownEditorKeymap,
 }: PublishDialogProps) {
   const [title, setTitle] = useState(initialTitle)
   const [description, setDescription] = useState('')
@@ -46,6 +64,10 @@ export function PublishDialog({
   const [categories, setCategories] = useState<ProjectCategoryResponse[]>([])
   const [isLoadingCategories, setIsLoadingCategories] = useState(true)
   const [categoriesError, setCategoriesError] = useState<string | null>(null)
+  const [descriptionEditorActions, setDescriptionEditorActions] =
+    useState<MarkdownEditorActions | null>(null)
+  const [descriptionEditorFocused, setDescriptionEditorFocused] =
+    useState(false)
 
   useEffect(() => {
     if (!publicationDetails) {
@@ -116,6 +138,29 @@ export function PublishDialog({
     }
   }, [loadCategories])
 
+  useEffect(() => {
+    if (!markdownEditorKeymap || !descriptionEditorFocused) {
+      return
+    }
+
+    markdownEditorKeymap.focusScope.onFocus()
+    return () => {
+      markdownEditorKeymap.focusScope.onBlur()
+    }
+  }, [descriptionEditorFocused, markdownEditorKeymap])
+
+  useEffect(() => {
+    if (
+      !markdownEditorKeymap ||
+      !descriptionEditorFocused ||
+      !descriptionEditorActions
+    ) {
+      return
+    }
+
+    return markdownEditorKeymap.registerActions(descriptionEditorActions)
+  }, [descriptionEditorActions, descriptionEditorFocused, markdownEditorKeymap])
+
   const normalizedDescription = useMemo(
     () => normalizeMarkdownEditorValue(description),
     [description]
@@ -152,6 +197,28 @@ export function PublishDialog({
       setIsSubmitting(false)
     }
   }
+
+  const handleDescriptionEditorFocus = useCallback(
+    (event: FocusEvent<HTMLDivElement>) => {
+      if (eventTargetIsInside(event.currentTarget, event.relatedTarget)) {
+        return
+      }
+
+      setDescriptionEditorFocused(true)
+    },
+    []
+  )
+
+  const handleDescriptionEditorBlur = useCallback(
+    (event: FocusEvent<HTMLDivElement>) => {
+      if (eventTargetIsInside(event.currentTarget, event.relatedTarget)) {
+        return
+      }
+
+      setDescriptionEditorFocused(false)
+    },
+    []
+  )
 
   return (
     <Transition
@@ -225,26 +292,32 @@ export function PublishDialog({
               >
                 Description*
               </p>
-              <MarkdownEditor
-                id="publish-project-description"
-                value={description}
-                onChange={(value) => {
-                  setHasEditedDescription(true)
-                  setDescription(value)
-                }}
-                ariaLabel="Project description"
-                className="mt-2"
-                describedBy={
-                  hasTriedSubmit && !descriptionIsValid
-                    ? 'publish-project-description-error'
-                    : undefined
-                }
-                invalid={hasTriedSubmit && !descriptionIsValid}
-                labelledBy="publish-project-description-label"
-                placeholder="Tell people about what you made..."
-                required={true}
-                testId="publish-project-description-editor"
-              />
+              <div
+                onFocus={handleDescriptionEditorFocus}
+                onBlur={handleDescriptionEditorBlur}
+              >
+                <MarkdownEditor
+                  id="publish-project-description"
+                  value={description}
+                  onChange={(value) => {
+                    setHasEditedDescription(true)
+                    setDescription(value)
+                  }}
+                  ariaLabel="Project description"
+                  className="mt-2"
+                  describedBy={
+                    hasTriedSubmit && !descriptionIsValid
+                      ? 'publish-project-description-error'
+                      : undefined
+                  }
+                  invalid={hasTriedSubmit && !descriptionIsValid}
+                  labelledBy="publish-project-description-label"
+                  onActionsChange={setDescriptionEditorActions}
+                  placeholder="Tell people about what you made..."
+                  required={true}
+                  testId="publish-project-description-editor"
+                />
+              </div>
               {hasTriedSubmit && !descriptionIsValid && (
                 <p
                   id="publish-project-description-error"
@@ -427,6 +500,13 @@ function getSubmitButtonLabel(
     publicationDetails.publicationStatus !== undefined
     ? 'Update submission'
     : 'Submit for review'
+}
+
+function eventTargetIsInside(
+  currentTarget: HTMLElement,
+  nextTarget: EventTarget | null
+) {
+  return nextTarget instanceof Node && currentTarget.contains(nextTarget)
 }
 
 function getLastSubmittedText(

--- a/src/components/PublishDialog.tsx
+++ b/src/components/PublishDialog.tsx
@@ -13,14 +13,7 @@ import type {
   ProjectPublishSubmission,
 } from '@src/lib/share'
 import { withAPIBaseURL } from '@src/lib/withBaseURL'
-import {
-  type FocusEvent,
-  Fragment,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react'
+import { Fragment, useCallback, useEffect, useMemo, useState } from 'react'
 
 type PublishDialogMarkdownEditorKeymap = {
   focusScope: {
@@ -198,28 +191,6 @@ export function PublishDialog({
     }
   }
 
-  const handleDescriptionEditorFocus = useCallback(
-    (event: FocusEvent<HTMLDivElement>) => {
-      if (eventTargetIsInside(event.currentTarget, event.relatedTarget)) {
-        return
-      }
-
-      setDescriptionEditorFocused(true)
-    },
-    []
-  )
-
-  const handleDescriptionEditorBlur = useCallback(
-    (event: FocusEvent<HTMLDivElement>) => {
-      if (eventTargetIsInside(event.currentTarget, event.relatedTarget)) {
-        return
-      }
-
-      setDescriptionEditorFocused(false)
-    },
-    []
-  )
-
   return (
     <Transition
       appear
@@ -292,32 +263,29 @@ export function PublishDialog({
               >
                 Description*
               </p>
-              <div
-                onFocus={handleDescriptionEditorFocus}
-                onBlur={handleDescriptionEditorBlur}
-              >
-                <MarkdownEditor
-                  id="publish-project-description"
-                  value={description}
-                  onChange={(value) => {
-                    setHasEditedDescription(true)
-                    setDescription(value)
-                  }}
-                  ariaLabel="Project description"
-                  className="mt-2"
-                  describedBy={
-                    hasTriedSubmit && !descriptionIsValid
-                      ? 'publish-project-description-error'
-                      : undefined
-                  }
-                  invalid={hasTriedSubmit && !descriptionIsValid}
-                  labelledBy="publish-project-description-label"
-                  onActionsChange={setDescriptionEditorActions}
-                  placeholder="Tell people about what you made..."
-                  required={true}
-                  testId="publish-project-description-editor"
-                />
-              </div>
+              <MarkdownEditor
+                id="publish-project-description"
+                value={description}
+                onChange={(value) => {
+                  setHasEditedDescription(true)
+                  setDescription(value)
+                }}
+                ariaLabel="Project description"
+                className="mt-2"
+                describedBy={
+                  hasTriedSubmit && !descriptionIsValid
+                    ? 'publish-project-description-error'
+                    : undefined
+                }
+                invalid={hasTriedSubmit && !descriptionIsValid}
+                labelledBy="publish-project-description-label"
+                onActionsChange={setDescriptionEditorActions}
+                onFocusChange={setDescriptionEditorFocused}
+                placeholder="Tell people about what you made..."
+                required={true}
+                suppressDefaultKeyboardShortcuts={true}
+                testId="publish-project-description-editor"
+              />
               {hasTriedSubmit && !descriptionIsValid && (
                 <p
                   id="publish-project-description-error"
@@ -500,13 +468,6 @@ function getSubmitButtonLabel(
     publicationDetails.publicationStatus !== undefined
     ? 'Update submission'
     : 'Submit for review'
-}
-
-function eventTargetIsInside(
-  currentTarget: HTMLElement,
-  nextTarget: EventTarget | null
-) {
-  return nextTarget instanceof Node && currentTarget.contains(nextTarget)
 }
 
 function getLastSubmittedText(

--- a/src/registry/contracts/markdownEditor.ts
+++ b/src/registry/contracts/markdownEditor.ts
@@ -5,7 +5,6 @@ export const MARKDOWN_EDITOR_FOCUSED_KEYMAP_SCOPE = 'markdown-editor-focused'
 
 export type MarkdownEditorService = {
   registerActiveEditor: (actions: MarkdownEditorActions) => () => void
-  runLinkAction: () => boolean
 }
 
 export const markdownEditorContract = defineContract({

--- a/src/registry/contracts/markdownEditor.ts
+++ b/src/registry/contracts/markdownEditor.ts
@@ -1,0 +1,17 @@
+import { defineContract, defineService } from '@kittycad/registry'
+import type { MarkdownEditorActions } from '@kittycad/ui-components'
+
+export const MARKDOWN_EDITOR_FOCUSED_KEYMAP_SCOPE = 'markdown-editor-focused'
+
+export type MarkdownEditorService = {
+  registerActiveEditor: (actions: MarkdownEditorActions) => () => void
+  runLinkAction: () => boolean
+}
+
+export const markdownEditorContract = defineContract({
+  markdownEditorService: defineService<MarkdownEditorService>(
+    'markdown-editor.service'
+  ),
+})
+
+export const { markdownEditorService } = markdownEditorContract

--- a/src/registry/extensions/markdownEditor/index.spec.ts
+++ b/src/registry/extensions/markdownEditor/index.spec.ts
@@ -3,6 +3,7 @@ import {
   provideService,
   Registry,
 } from '@kittycad/registry'
+import type { MarkdownEditorActions } from '@kittycad/ui-components'
 import { MachineManager } from '@src/lib/MachineManager'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { commandsValueSpec } from '@src/registry/contracts/commands'
@@ -32,6 +33,30 @@ const persistenceMocks = vi.hoisted(() => ({
 
 vi.mock('@src/registry/extensions/keymap/persistence', () => persistenceMocks)
 
+function createMarkdownEditorActions(
+  overrides: Partial<MarkdownEditorActions> = {}
+): MarkdownEditorActions {
+  return {
+    toggleBold: vi.fn(() => true),
+    toggleItalic: vi.fn(() => true),
+    setLink: vi.fn(() => true),
+    toggleBulletList: vi.fn(() => true),
+    toggleOrderedList: vi.fn(() => true),
+    undo: vi.fn(() => true),
+    redo: vi.fn(() => true),
+    ...overrides,
+  }
+}
+
+function createModKeyboardEvent(key: string, { shift = false } = {}) {
+  return new KeyboardEvent('keydown', {
+    key,
+    ctrlKey: true,
+    metaKey: true,
+    shiftKey: shift,
+  })
+}
+
 describe('markdown editor extension', () => {
   beforeEach(() => {
     persistenceMocks.readUserKeymapFile.mockResolvedValue({
@@ -41,7 +66,7 @@ describe('markdown editor extension', () => {
     persistenceMocks.writeUserKeymapFile.mockResolvedValue(undefined)
   })
 
-  it('routes Mod+K to the focused Markdown editor link action', () => {
+  it('routes Markdown editor shortcuts only while the Markdown editor scope is focused', () => {
     const registry = new Registry()
     registry.configure([defaultKeymapItem, markdownEditorExtension])
 
@@ -51,21 +76,40 @@ describe('markdown editor extension', () => {
     const tree = registry.get(keymapValueSpec)
     const keymapScopes = registry.get(keymapScopesValueSpec)
     const baseMatch = matchKeymapKeystrokes(tree, [], ['mod+k'], keymapScopes)
-    const markdownEditorMatch = matchKeymapKeystrokes(
-      tree,
-      [MARKDOWN_EDITOR_FOCUSED_KEYMAP_SCOPE],
-      ['mod+k'],
-      keymapScopes
-    )
+    const expectedShortcuts = [
+      ['mod+b', MARKDOWN_EDITOR_COMMAND_IDS.toggleBold],
+      ['mod+shift+b', MARKDOWN_EDITOR_COMMAND_IDS.toggleBold],
+      ['mod+i', MARKDOWN_EDITOR_COMMAND_IDS.toggleItalic],
+      ['mod+shift+i', MARKDOWN_EDITOR_COMMAND_IDS.toggleItalic],
+      ['mod+k', MARKDOWN_EDITOR_COMMAND_IDS.setLink],
+      ['mod+shift+8', MARKDOWN_EDITOR_COMMAND_IDS.toggleBulletList],
+      ['mod+shift+*', MARKDOWN_EDITOR_COMMAND_IDS.toggleBulletList],
+      ['mod+shift+7', MARKDOWN_EDITOR_COMMAND_IDS.toggleOrderedList],
+      ['mod+shift+&', MARKDOWN_EDITOR_COMMAND_IDS.toggleOrderedList],
+      ['mod+z', MARKDOWN_EDITOR_COMMAND_IDS.undo],
+      ['mod+я', MARKDOWN_EDITOR_COMMAND_IDS.undo],
+      ['mod+shift+z', MARKDOWN_EDITOR_COMMAND_IDS.redo],
+      ['mod+y', MARKDOWN_EDITOR_COMMAND_IDS.redo],
+      ['mod+shift+я', MARKDOWN_EDITOR_COMMAND_IDS.redo],
+    ] as const
 
     expect(baseMatch).toMatchObject({
       type: 'full',
       item: { command: 'zds.commandPalette.open' },
     })
-    expect(markdownEditorMatch).toMatchObject({
-      type: 'full',
-      item: { command: MARKDOWN_EDITOR_COMMAND_IDS.setLink },
-    })
+    for (const [keystroke, command] of expectedShortcuts) {
+      expect(
+        matchKeymapKeystrokes(
+          tree,
+          [MARKDOWN_EDITOR_FOCUSED_KEYMAP_SCOPE],
+          [keystroke],
+          keymapScopes
+        )
+      ).toMatchObject({
+        type: 'full',
+        item: { command },
+      })
+    }
 
     if (!command) {
       throw new Error('Missing Markdown editor link command')
@@ -73,7 +117,9 @@ describe('markdown editor extension', () => {
 
     const service = registry.get(markdownEditorService)
     const setLink = vi.fn(() => true)
-    const unregister = service.registerActiveEditor({ setLink })
+    const unregister = service.registerActiveEditor(
+      createMarkdownEditorActions({ setLink })
+    )
 
     expect(command.onSubmit()).toBe(true)
     expect(setLink).toHaveBeenCalledTimes(1)
@@ -85,7 +131,7 @@ describe('markdown editor extension', () => {
     registry[Symbol.dispose]()
   })
 
-  it('executes the active editor link action through the keymap service', () => {
+  it('executes active editor actions through the keymap service', () => {
     const registry = new Registry()
     registry.configure([
       defineRegistryItem({
@@ -105,18 +151,34 @@ describe('markdown editor extension', () => {
 
     const keymap = registry.get(keymapService)
     const service = registry.get(markdownEditorService)
+    const toggleBold = vi.fn(() => true)
     const setLink = vi.fn(() => true)
-    const unregister = service.registerActiveEditor({ setLink })
-    const event = new KeyboardEvent('keydown', {
-      key: 'k',
-      ctrlKey: true,
-      metaKey: true,
-    })
+    const toggleBulletList = vi.fn(() => true)
+    const toggleOrderedList = vi.fn(() => true)
+    const redo = vi.fn(() => true)
+    const unregister = service.registerActiveEditor(
+      createMarkdownEditorActions({
+        toggleBold,
+        setLink,
+        toggleBulletList,
+        toggleOrderedList,
+        redo,
+      })
+    )
+    const expectedActions: [KeyboardEvent, () => void][] = [
+      [createModKeyboardEvent('b'), toggleBold],
+      [createModKeyboardEvent('k'), setLink],
+      [createModKeyboardEvent('*', { shift: true }), toggleBulletList],
+      [createModKeyboardEvent('&', { shift: true }), toggleOrderedList],
+      [createModKeyboardEvent('z', { shift: true }), redo],
+    ]
 
     keymap.applyScope(MARKDOWN_EDITOR_FOCUSED_KEYMAP_SCOPE)
 
-    expect(keymap.handleKeyDown(event, { source: 'global' })).toBe(true)
-    expect(setLink).toHaveBeenCalledTimes(1)
+    for (const [event, actionSpy] of expectedActions) {
+      expect(keymap.handleKeyDown(event, { source: 'global' })).toBe(true)
+      expect(actionSpy).toHaveBeenCalledTimes(1)
+    }
 
     unregister()
     registry[Symbol.dispose]()

--- a/src/registry/extensions/markdownEditor/index.spec.ts
+++ b/src/registry/extensions/markdownEditor/index.spec.ts
@@ -1,0 +1,60 @@
+import { Registry } from '@kittycad/registry'
+import { commandsValueSpec } from '@src/registry/contracts/commands'
+import {
+  keymapScopesValueSpec,
+  keymapValueSpec,
+  matchKeymapKeystrokes,
+} from '@src/registry/contracts/keymap'
+import {
+  MARKDOWN_EDITOR_FOCUSED_KEYMAP_SCOPE,
+  markdownEditorService,
+} from '@src/registry/contracts/markdownEditor'
+import { defaultKeymapItem } from '@src/registry/extensions/keymap/defaultKeymap'
+import { describe, expect, it, vi } from 'vitest'
+import markdownEditorExtension, { MARKDOWN_EDITOR_COMMAND_IDS } from '.'
+
+describe('markdown editor extension', () => {
+  it('routes Mod+K to the focused Markdown editor link action', () => {
+    const registry = new Registry()
+    registry.configure([defaultKeymapItem, markdownEditorExtension])
+
+    const command = registry
+      .get(commandsValueSpec)
+      .find((candidate) => candidate.id === MARKDOWN_EDITOR_COMMAND_IDS.setLink)
+    const tree = registry.get(keymapValueSpec)
+    const keymapScopes = registry.get(keymapScopesValueSpec)
+    const baseMatch = matchKeymapKeystrokes(tree, [], ['mod+k'], keymapScopes)
+    const markdownEditorMatch = matchKeymapKeystrokes(
+      tree,
+      [MARKDOWN_EDITOR_FOCUSED_KEYMAP_SCOPE],
+      ['mod+k'],
+      keymapScopes
+    )
+
+    expect(baseMatch).toMatchObject({
+      type: 'full',
+      item: { command: 'zds.commandPalette.open' },
+    })
+    expect(markdownEditorMatch).toMatchObject({
+      type: 'full',
+      item: { command: MARKDOWN_EDITOR_COMMAND_IDS.setLink },
+    })
+
+    if (!command) {
+      throw new Error('Missing Markdown editor link command')
+    }
+
+    const service = registry.get(markdownEditorService)
+    const setLink = vi.fn(() => true)
+    const unregister = service.registerActiveEditor({ setLink })
+
+    expect(command.onSubmit()).toBe(true)
+    expect(setLink).toHaveBeenCalledTimes(1)
+
+    unregister()
+
+    expect(command.onSubmit()).toBe(false)
+
+    registry[Symbol.dispose]()
+  })
+})

--- a/src/registry/extensions/markdownEditor/index.spec.ts
+++ b/src/registry/extensions/markdownEditor/index.spec.ts
@@ -1,19 +1,46 @@
-import { Registry } from '@kittycad/registry'
+import {
+  defineRegistryItem,
+  provideService,
+  Registry,
+} from '@kittycad/registry'
+import { MachineManager } from '@src/lib/MachineManager'
+import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { commandsValueSpec } from '@src/registry/contracts/commands'
 import {
+  KEYMAP_SCHEMA_VERSION,
   keymapScopesValueSpec,
+  keymapService,
   keymapValueSpec,
   matchKeymapKeystrokes,
 } from '@src/registry/contracts/keymap'
+import { machineManagerService } from '@src/registry/contracts/machineManager'
 import {
   MARKDOWN_EDITOR_FOCUSED_KEYMAP_SCOPE,
   markdownEditorService,
 } from '@src/registry/contracts/markdownEditor'
+import { provideWasmPromise } from '@src/registry/contracts/wasm'
+import { commandsExtension } from '@src/registry/extensions/commands'
+import keymapExtension from '@src/registry/extensions/keymap'
 import { defaultKeymapItem } from '@src/registry/extensions/keymap/defaultKeymap'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import markdownEditorExtension, { MARKDOWN_EDITOR_COMMAND_IDS } from '.'
 
+const persistenceMocks = vi.hoisted(() => ({
+  readUserKeymapFile: vi.fn(),
+  writeUserKeymapFile: vi.fn(),
+}))
+
+vi.mock('@src/registry/extensions/keymap/persistence', () => persistenceMocks)
+
 describe('markdown editor extension', () => {
+  beforeEach(() => {
+    persistenceMocks.readUserKeymapFile.mockResolvedValue({
+      version: KEYMAP_SCHEMA_VERSION,
+      bindings: [],
+    })
+    persistenceMocks.writeUserKeymapFile.mockResolvedValue(undefined)
+  })
+
   it('routes Mod+K to the focused Markdown editor link action', () => {
     const registry = new Registry()
     registry.configure([defaultKeymapItem, markdownEditorExtension])
@@ -55,6 +82,43 @@ describe('markdown editor extension', () => {
 
     expect(command.onSubmit()).toBe(false)
 
+    registry[Symbol.dispose]()
+  })
+
+  it('executes the active editor link action through the keymap service', () => {
+    const registry = new Registry()
+    registry.configure([
+      defineRegistryItem({
+        id: 'test-wasm-promise',
+        provides: [provideWasmPromise(Promise.resolve({} as ModuleType))],
+      }),
+      defineRegistryItem({
+        id: 'test-machine-manager',
+        providesServices: [
+          provideService(machineManagerService, new MachineManager()),
+        ],
+      }),
+      commandsExtension,
+      keymapExtension,
+      markdownEditorExtension,
+    ])
+
+    const keymap = registry.get(keymapService)
+    const service = registry.get(markdownEditorService)
+    const setLink = vi.fn(() => true)
+    const unregister = service.registerActiveEditor({ setLink })
+    const event = new KeyboardEvent('keydown', {
+      key: 'k',
+      ctrlKey: true,
+      metaKey: true,
+    })
+
+    keymap.applyScope(MARKDOWN_EDITOR_FOCUSED_KEYMAP_SCOPE)
+
+    expect(keymap.handleKeyDown(event, { source: 'global' })).toBe(true)
+    expect(setLink).toHaveBeenCalledTimes(1)
+
+    unregister()
     registry[Symbol.dispose]()
   })
 })

--- a/src/registry/extensions/markdownEditor/index.ts
+++ b/src/registry/extensions/markdownEditor/index.ts
@@ -1,0 +1,93 @@
+import {
+  defineRegistryItemFactory,
+  defineRuntimeRegistryItem,
+  provideService,
+} from '@kittycad/registry'
+import type { MarkdownEditorActions } from '@kittycad/ui-components'
+import type { Command } from '@src/lib/commandTypes'
+import { provideCommand } from '@src/registry/contracts/commands'
+import {
+  type KeymapItem,
+  provideKeymapItem,
+  provideKeymapScope,
+} from '@src/registry/contracts/keymap'
+import {
+  MARKDOWN_EDITOR_FOCUSED_KEYMAP_SCOPE,
+  type MarkdownEditorService,
+  markdownEditorService,
+} from '@src/registry/contracts/markdownEditor'
+
+const MARKDOWN_EDITOR_COMMAND_GROUP_ID = 'markdownEditor'
+const MARKDOWN_EDITOR_KEYMAP_SOURCE = 'Markdown editor'
+
+export const MARKDOWN_EDITOR_COMMAND_IDS = Object.freeze({
+  setLink: 'zds.markdownEditor.setLink',
+} as const)
+
+const setLinkKeymapItem: KeymapItem = {
+  id: 'markdown-editor.link',
+  title: 'Edit Markdown link',
+  source: MARKDOWN_EDITOR_KEYMAP_SOURCE,
+  scopes: [MARKDOWN_EDITOR_FOCUSED_KEYMAP_SCOPE],
+  keystrokes: ['mod+k'],
+  command: MARKDOWN_EDITOR_COMMAND_IDS.setLink,
+}
+
+const markdownEditorExtension = defineRegistryItemFactory(() => {
+  let nextRegistrationId = 0
+  const activeEditors: {
+    id: number
+    actions: MarkdownEditorActions
+  }[] = []
+
+  const serviceImpl: MarkdownEditorService = {
+    registerActiveEditor: (actions) => {
+      const registration = {
+        id: nextRegistrationId,
+        actions,
+      }
+      nextRegistrationId += 1
+      activeEditors.push(registration)
+
+      return () => {
+        const index = activeEditors.findIndex(
+          (candidate) => candidate.id === registration.id
+        )
+        if (index !== -1) {
+          activeEditors.splice(index, 1)
+        }
+      }
+    },
+    runLinkAction: () => activeEditors.at(-1)?.actions.setLink() ?? false,
+  }
+
+  const setLinkCommand: Command = {
+    id: MARKDOWN_EDITOR_COMMAND_IDS.setLink,
+    name: MARKDOWN_EDITOR_COMMAND_IDS.setLink,
+    groupId: MARKDOWN_EDITOR_COMMAND_GROUP_ID,
+    displayName: 'Edit Markdown link',
+    description: 'Add or edit a link in the focused Markdown editor.',
+    hideFromSearch: true,
+    needsReview: false,
+    onSubmit: () => serviceImpl.runLinkAction(),
+  }
+
+  return {
+    item: defineRuntimeRegistryItem({
+      id: 'markdown-editor-extension',
+      provides: [
+        provideCommand(setLinkCommand),
+        provideKeymapItem(setLinkKeymapItem),
+        provideKeymapScope({
+          id: MARKDOWN_EDITOR_FOCUSED_KEYMAP_SCOPE,
+          displayName: 'Markdown editor focused',
+          priority: 1200,
+          userEditable: false,
+        }),
+      ],
+      providesServices: [provideService(markdownEditorService, serviceImpl)],
+    }),
+  }
+}, 'markdown-editor-extension')
+
+export default markdownEditorExtension

--- a/src/registry/extensions/markdownEditor/index.ts
+++ b/src/registry/extensions/markdownEditor/index.ts
@@ -40,6 +40,8 @@ const markdownEditorExtension = defineRegistryItemFactory(() => {
     actions: MarkdownEditorActions
   }[] = []
 
+  const runLinkAction = () => activeEditors.at(-1)?.actions.setLink() ?? false
+
   const serviceImpl: MarkdownEditorService = {
     registerActiveEditor: (actions) => {
       const registration = {
@@ -58,7 +60,6 @@ const markdownEditorExtension = defineRegistryItemFactory(() => {
         }
       }
     },
-    runLinkAction: () => activeEditors.at(-1)?.actions.setLink() ?? false,
   }
 
   const setLinkCommand: Command = {
@@ -69,7 +70,7 @@ const markdownEditorExtension = defineRegistryItemFactory(() => {
     description: 'Add or edit a link in the focused Markdown editor.',
     hideFromSearch: true,
     needsReview: false,
-    onSubmit: () => serviceImpl.runLinkAction(),
+    onSubmit: runLinkAction,
   }
 
   return {

--- a/src/registry/extensions/markdownEditor/index.ts
+++ b/src/registry/extensions/markdownEditor/index.ts
@@ -43,7 +43,6 @@ type MarkdownEditorKeymapDefinition = {
   action: MarkdownEditorActionName
   keystrokes: readonly string[]
   hidden?: boolean
-  userBindingCommand?: MarkdownEditorCommandId
 }
 
 const markdownEditorKeymaps: readonly MarkdownEditorKeymapDefinition[] = [
@@ -61,7 +60,6 @@ const markdownEditorKeymaps: readonly MarkdownEditorKeymapDefinition[] = [
     action: 'toggleBold',
     keystrokes: ['mod+shift+b'],
     hidden: true,
-    userBindingCommand: MARKDOWN_EDITOR_COMMAND_IDS.toggleBold,
   },
   {
     id: 'markdown-editor.italic',
@@ -77,7 +75,6 @@ const markdownEditorKeymaps: readonly MarkdownEditorKeymapDefinition[] = [
     action: 'toggleItalic',
     keystrokes: ['mod+shift+i'],
     hidden: true,
-    userBindingCommand: MARKDOWN_EDITOR_COMMAND_IDS.toggleItalic,
   },
   {
     id: 'markdown-editor.link',
@@ -100,7 +97,6 @@ const markdownEditorKeymaps: readonly MarkdownEditorKeymapDefinition[] = [
     action: 'toggleBulletList',
     keystrokes: ['mod+shift+*'],
     hidden: true,
-    userBindingCommand: MARKDOWN_EDITOR_COMMAND_IDS.toggleBulletList,
   },
   {
     id: 'markdown-editor.ordered-list',
@@ -116,7 +112,6 @@ const markdownEditorKeymaps: readonly MarkdownEditorKeymapDefinition[] = [
     action: 'toggleOrderedList',
     keystrokes: ['mod+shift+&'],
     hidden: true,
-    userBindingCommand: MARKDOWN_EDITOR_COMMAND_IDS.toggleOrderedList,
   },
   {
     id: 'markdown-editor.undo',
@@ -132,7 +127,6 @@ const markdownEditorKeymaps: readonly MarkdownEditorKeymapDefinition[] = [
     action: 'undo',
     keystrokes: ['mod+я'],
     hidden: true,
-    userBindingCommand: MARKDOWN_EDITOR_COMMAND_IDS.undo,
   },
   {
     id: 'markdown-editor.redo',
@@ -148,7 +142,6 @@ const markdownEditorKeymaps: readonly MarkdownEditorKeymapDefinition[] = [
     action: 'redo',
     keystrokes: ['mod+y'],
     hidden: true,
-    userBindingCommand: MARKDOWN_EDITOR_COMMAND_IDS.redo,
   },
   {
     id: 'markdown-editor.redo-russian',
@@ -157,7 +150,6 @@ const markdownEditorKeymaps: readonly MarkdownEditorKeymapDefinition[] = [
     action: 'redo',
     keystrokes: ['mod+shift+я'],
     hidden: true,
-    userBindingCommand: MARKDOWN_EDITOR_COMMAND_IDS.redo,
   },
 ]
 
@@ -170,7 +162,6 @@ const markdownEditorKeymapItems: readonly KeymapItem[] =
     keystrokes: keymap.keystrokes,
     command: keymap.command,
     hidden: keymap.hidden,
-    userBindingCommand: keymap.userBindingCommand,
   }))
 
 const markdownEditorCommands: readonly Command[] = Object.values(

--- a/src/registry/extensions/markdownEditor/index.ts
+++ b/src/registry/extensions/markdownEditor/index.ts
@@ -3,7 +3,10 @@ import {
   defineRuntimeRegistryItem,
   provideService,
 } from '@kittycad/registry'
-import type { MarkdownEditorActions } from '@kittycad/ui-components'
+import type {
+  MarkdownEditorActionName,
+  MarkdownEditorActions,
+} from '@kittycad/ui-components'
 import type { Command } from '@src/lib/commandTypes'
 import { provideCommand } from '@src/registry/contracts/commands'
 import {
@@ -21,17 +24,173 @@ const MARKDOWN_EDITOR_COMMAND_GROUP_ID = 'markdownEditor'
 const MARKDOWN_EDITOR_KEYMAP_SOURCE = 'Markdown editor'
 
 export const MARKDOWN_EDITOR_COMMAND_IDS = Object.freeze({
+  toggleBold: 'zds.markdownEditor.toggleBold',
+  toggleItalic: 'zds.markdownEditor.toggleItalic',
   setLink: 'zds.markdownEditor.setLink',
+  toggleBulletList: 'zds.markdownEditor.toggleBulletList',
+  toggleOrderedList: 'zds.markdownEditor.toggleOrderedList',
+  undo: 'zds.markdownEditor.undo',
+  redo: 'zds.markdownEditor.redo',
 } as const)
 
-const setLinkKeymapItem: KeymapItem = {
-  id: 'markdown-editor.link',
-  title: 'Edit Markdown link',
-  source: MARKDOWN_EDITOR_KEYMAP_SOURCE,
-  scopes: [MARKDOWN_EDITOR_FOCUSED_KEYMAP_SCOPE],
-  keystrokes: ['mod+k'],
-  command: MARKDOWN_EDITOR_COMMAND_IDS.setLink,
+type MarkdownEditorCommandId =
+  (typeof MARKDOWN_EDITOR_COMMAND_IDS)[keyof typeof MARKDOWN_EDITOR_COMMAND_IDS]
+
+type MarkdownEditorKeymapDefinition = {
+  id: string
+  title: string
+  command: MarkdownEditorCommandId
+  action: MarkdownEditorActionName
+  keystrokes: readonly string[]
+  hidden?: boolean
+  userBindingCommand?: MarkdownEditorCommandId
 }
+
+const markdownEditorKeymaps: readonly MarkdownEditorKeymapDefinition[] = [
+  {
+    id: 'markdown-editor.bold',
+    title: 'Toggle Markdown bold',
+    command: MARKDOWN_EDITOR_COMMAND_IDS.toggleBold,
+    action: 'toggleBold',
+    keystrokes: ['mod+b'],
+  },
+  {
+    id: 'markdown-editor.bold-shift',
+    title: 'Toggle Markdown bold',
+    command: MARKDOWN_EDITOR_COMMAND_IDS.toggleBold,
+    action: 'toggleBold',
+    keystrokes: ['mod+shift+b'],
+    hidden: true,
+    userBindingCommand: MARKDOWN_EDITOR_COMMAND_IDS.toggleBold,
+  },
+  {
+    id: 'markdown-editor.italic',
+    title: 'Toggle Markdown italic',
+    command: MARKDOWN_EDITOR_COMMAND_IDS.toggleItalic,
+    action: 'toggleItalic',
+    keystrokes: ['mod+i'],
+  },
+  {
+    id: 'markdown-editor.italic-shift',
+    title: 'Toggle Markdown italic',
+    command: MARKDOWN_EDITOR_COMMAND_IDS.toggleItalic,
+    action: 'toggleItalic',
+    keystrokes: ['mod+shift+i'],
+    hidden: true,
+    userBindingCommand: MARKDOWN_EDITOR_COMMAND_IDS.toggleItalic,
+  },
+  {
+    id: 'markdown-editor.link',
+    title: 'Edit Markdown link',
+    command: MARKDOWN_EDITOR_COMMAND_IDS.setLink,
+    action: 'setLink',
+    keystrokes: ['mod+k'],
+  },
+  {
+    id: 'markdown-editor.bullet-list',
+    title: 'Toggle Markdown bullet list',
+    command: MARKDOWN_EDITOR_COMMAND_IDS.toggleBulletList,
+    action: 'toggleBulletList',
+    keystrokes: ['mod+shift+8'],
+  },
+  {
+    id: 'markdown-editor.bullet-list-asterisk',
+    title: 'Toggle Markdown bullet list',
+    command: MARKDOWN_EDITOR_COMMAND_IDS.toggleBulletList,
+    action: 'toggleBulletList',
+    keystrokes: ['mod+shift+*'],
+    hidden: true,
+    userBindingCommand: MARKDOWN_EDITOR_COMMAND_IDS.toggleBulletList,
+  },
+  {
+    id: 'markdown-editor.ordered-list',
+    title: 'Toggle Markdown numbered list',
+    command: MARKDOWN_EDITOR_COMMAND_IDS.toggleOrderedList,
+    action: 'toggleOrderedList',
+    keystrokes: ['mod+shift+7'],
+  },
+  {
+    id: 'markdown-editor.ordered-list-ampersand',
+    title: 'Toggle Markdown numbered list',
+    command: MARKDOWN_EDITOR_COMMAND_IDS.toggleOrderedList,
+    action: 'toggleOrderedList',
+    keystrokes: ['mod+shift+&'],
+    hidden: true,
+    userBindingCommand: MARKDOWN_EDITOR_COMMAND_IDS.toggleOrderedList,
+  },
+  {
+    id: 'markdown-editor.undo',
+    title: 'Undo Markdown edit',
+    command: MARKDOWN_EDITOR_COMMAND_IDS.undo,
+    action: 'undo',
+    keystrokes: ['mod+z'],
+  },
+  {
+    id: 'markdown-editor.undo-russian',
+    title: 'Undo Markdown edit',
+    command: MARKDOWN_EDITOR_COMMAND_IDS.undo,
+    action: 'undo',
+    keystrokes: ['mod+я'],
+    hidden: true,
+    userBindingCommand: MARKDOWN_EDITOR_COMMAND_IDS.undo,
+  },
+  {
+    id: 'markdown-editor.redo',
+    title: 'Redo Markdown edit',
+    command: MARKDOWN_EDITOR_COMMAND_IDS.redo,
+    action: 'redo',
+    keystrokes: ['mod+shift+z'],
+  },
+  {
+    id: 'markdown-editor.redo-y',
+    title: 'Redo Markdown edit',
+    command: MARKDOWN_EDITOR_COMMAND_IDS.redo,
+    action: 'redo',
+    keystrokes: ['mod+y'],
+    hidden: true,
+    userBindingCommand: MARKDOWN_EDITOR_COMMAND_IDS.redo,
+  },
+  {
+    id: 'markdown-editor.redo-russian',
+    title: 'Redo Markdown edit',
+    command: MARKDOWN_EDITOR_COMMAND_IDS.redo,
+    action: 'redo',
+    keystrokes: ['mod+shift+я'],
+    hidden: true,
+    userBindingCommand: MARKDOWN_EDITOR_COMMAND_IDS.redo,
+  },
+]
+
+const markdownEditorKeymapItems: readonly KeymapItem[] =
+  markdownEditorKeymaps.map((keymap) => ({
+    id: keymap.id,
+    title: keymap.title,
+    source: MARKDOWN_EDITOR_KEYMAP_SOURCE,
+    scopes: [MARKDOWN_EDITOR_FOCUSED_KEYMAP_SCOPE],
+    keystrokes: keymap.keystrokes,
+    command: keymap.command,
+    hidden: keymap.hidden,
+    userBindingCommand: keymap.userBindingCommand,
+  }))
+
+const markdownEditorCommands: readonly Command[] = Object.values(
+  MARKDOWN_EDITOR_COMMAND_IDS
+).map((commandId) => {
+  const keymap = markdownEditorKeymaps.find(
+    (candidate) => candidate.command === commandId
+  )
+
+  return {
+    id: commandId,
+    name: commandId,
+    groupId: MARKDOWN_EDITOR_COMMAND_GROUP_ID,
+    displayName: keymap?.title ?? commandId,
+    description: 'Run an action in the focused Markdown editor.',
+    hideFromSearch: true,
+    needsReview: false,
+    onSubmit: () => false,
+  }
+})
 
 const markdownEditorExtension = defineRegistryItemFactory(() => {
   let nextRegistrationId = 0
@@ -40,7 +199,8 @@ const markdownEditorExtension = defineRegistryItemFactory(() => {
     actions: MarkdownEditorActions
   }[] = []
 
-  const runLinkAction = () => activeEditors.at(-1)?.actions.setLink() ?? false
+  const runEditorAction = (action: MarkdownEditorActionName) =>
+    activeEditors.at(-1)?.actions[action]() ?? false
 
   const serviceImpl: MarkdownEditorService = {
     registerActiveEditor: (actions) => {
@@ -62,23 +222,23 @@ const markdownEditorExtension = defineRegistryItemFactory(() => {
     },
   }
 
-  const setLinkCommand: Command = {
-    id: MARKDOWN_EDITOR_COMMAND_IDS.setLink,
-    name: MARKDOWN_EDITOR_COMMAND_IDS.setLink,
-    groupId: MARKDOWN_EDITOR_COMMAND_GROUP_ID,
-    displayName: 'Edit Markdown link',
-    description: 'Add or edit a link in the focused Markdown editor.',
-    hideFromSearch: true,
-    needsReview: false,
-    onSubmit: runLinkAction,
-  }
+  const commands: readonly Command[] = markdownEditorCommands.map((command) => {
+    const keymap = markdownEditorKeymaps.find(
+      (candidate) => candidate.command === command.id
+    )
+
+    return {
+      ...command,
+      onSubmit: () => (keymap ? runEditorAction(keymap.action) : false),
+    }
+  })
 
   return {
     item: defineRuntimeRegistryItem({
       id: 'markdown-editor-extension',
       provides: [
-        provideCommand(setLinkCommand),
-        provideKeymapItem(setLinkKeymapItem),
+        ...commands.map(provideCommand),
+        ...markdownEditorKeymapItems.map(provideKeymapItem),
         provideKeymapScope({
           id: MARKDOWN_EDITOR_FOCUSED_KEYMAP_SCOPE,
           displayName: 'Markdown editor focused',


### PR DESCRIPTION
Follow-up from review feedback on PR #12353. This integrates the Markdown editor link shortcut with the app keymap system so Cmd+K / Ctrl+K triggers the Tiptap link action while the Publish dialog description editor is focused, without overriding the global command palette shortcut elsewhere.

Changes:
- Added a markdownEditor registry contract and extension with a focused Markdown editor scope.
- Registered a scoped mod+k keymap binding for zds.markdownEditor.setLink.
- Exposed MarkdownEditorActions from @kittycad/ui-components via onActionsChange.
- Wired PublishButton / PublishDialog to register the focused description editor with the markdown editor keymap service.
- Since we're here: two extras from the same feedback batch:
  - Cleaned up dark-mode Markdown toolbar button borders.
  - Removed duplicate PublishDialog markdown normalization coverage now handled by MarkdownEditor tests.