### PR TITLE
Wait for Zookeeper editor refresh before processing the next edit

### DIFF
--- a/src/components/layout/areas/MlEphantConversationPaneWrapper.spec.tsx
+++ b/src/components/layout/areas/MlEphantConversationPaneWrapper.spec.tsx
@@ -1,0 +1,231 @@
+import { render, waitFor } from '@testing-library/react'
+import { describe, expect, test, vi } from 'vitest'
+
+import { MlEphantConversationPaneWrapper } from '@src/components/layout/areas/MlEphantConversationPaneWrapper'
+import { AreaType, LayoutType } from '@src/lib/layout/types'
+import type * as SystemIOUtils from '@src/machines/systemIO/utils'
+
+const mocks = vi.hoisted(() => {
+  const systemIOSend = vi.fn()
+  const useWatchForNewFileRequestsFromMlEphant = vi.fn()
+  const mlEphantSubscribe = vi.fn(() => ({ unsubscribe: vi.fn() }))
+  const kclManager = {
+    captureEditorHistoryState: vi.fn(() => ({
+      doc: { toString: () => 'initial code' },
+    })),
+    code: 'initial code',
+    engineCommandManager: {},
+    path: '/workspace/demo/main.kcl',
+    zookeeperHistoryRecordingInProgress: false,
+    addGlobalHistoryEvent: vi.fn(),
+    addGlobalHistoryEventWithCodeChange: vi.fn(),
+  }
+
+  return {
+    kclManager,
+    mlEphantSubscribe,
+    systemIOSend,
+    useWatchForNewFileRequestsFromMlEphant,
+    watchCallback: undefined as
+      | ((props: {
+          toolOutput: unknown
+          projectNameCurrentlyOpened: string
+          fileFocusedOnInEditor: { name: string; path: string; children: null }
+          exchangeId: number
+        }) => void)
+      | undefined,
+  }
+})
+
+vi.mock('@src/components/layout/Panel', () => ({
+  LayoutPanel: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  LayoutPanelHeader: () => null,
+}))
+
+vi.mock('@src/components/layout/Panel/HeaderMenu', () => ({
+  HeaderMenu: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}))
+
+vi.mock('@src/components/layout/areas/MlEphantConversationPane', () => ({
+  MlEphantConversationPane: () => null,
+}))
+
+vi.mock('@src/hooks/useModelingContext', () => ({
+  useModelingContext: () => ({
+    context: {},
+    send: vi.fn(),
+    theProject: { current: undefined },
+  }),
+}))
+
+vi.mock('@src/lib/boot', () => ({
+  useApp: () => ({
+    auth: {
+      useToken: () => 'token',
+      useUser: () => undefined,
+    },
+    billing: { send: vi.fn() },
+    debug: {},
+    project: {
+      name: 'demo',
+      path: '/workspace/demo',
+      executingPath: '/workspace/demo/main.kcl',
+      executingFileEntry: { value: { name: 'main.kcl' } },
+    },
+    settings: {
+      actor: { send: vi.fn() },
+      useSettings: () => ({ meta: { id: { current: 'project-id' } } }),
+    },
+    systemIOActor: {
+      send: mocks.systemIOSend,
+    },
+  }),
+  useSingletons: () => ({
+    kclManager: mocks.kclManager,
+  }),
+}))
+
+vi.mock('@src/lib/fs-zds', () => ({
+  default: {
+    join: (...parts: string[]) =>
+      parts
+        .reduce((left, right) => (left ? `${left}/${right}` : right), '')
+        .replaceAll(/\/+/g, '/'),
+    readFile: vi.fn(async () => 'current disk code'),
+    relative: (from: string, to: string) =>
+      to.startsWith(`${from}/`) ? to.slice(from.length + 1) : to,
+    sep: '/',
+  },
+}))
+
+vi.mock('@src/machines/mlEphantManagerMachine', () => ({
+  MlEphantConversationToMarkdown: vi.fn(() => ''),
+  MlEphantManagerReactContext: {
+    Provider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    useActorRef: () => ({
+      getSnapshot: () => ({
+        context: {},
+      }),
+      send: vi.fn(),
+      subscribe: mocks.mlEphantSubscribe,
+    }),
+  },
+}))
+
+vi.mock('@src/machines/systemIO/hooks', () => ({
+  useProjectIdToConversationId: vi.fn(),
+  useWatchForNewFileRequestsFromMlEphant: (
+    ...args: [unknown, unknown, NonNullable<typeof mocks.watchCallback>]
+  ) => {
+    mocks.useWatchForNewFileRequestsFromMlEphant(...args)
+    mocks.watchCallback = args[2]
+  },
+}))
+
+vi.mock('@src/machines/systemIO/utils', async (importOriginal) => {
+  const original = await importOriginal<typeof SystemIOUtils>()
+
+  return {
+    ...original,
+    waitForIdleState: vi.fn(async () => undefined),
+  }
+})
+
+vi.mock('@src/routes/utils', () => ({
+  IS_STAGING_OR_DEBUG: false,
+}))
+
+function patchBackedZookeeperEdit(code: string) {
+  return {
+    type: 'edit_kcl_code',
+    status_code: 201,
+    project_name: 'demo',
+    outputs: {
+      'main.kcl': code,
+    },
+    zookeeper_edit_patch: {
+      run_id: 'run-1',
+      changed_files: [
+        {
+          path: 'main.kcl',
+          status: 'created',
+          contents: code,
+        },
+      ],
+    },
+  }
+}
+
+function emitZookeeperFileRequest(code: string) {
+  mocks.watchCallback?.({
+    toolOutput: patchBackedZookeeperEdit(code),
+    projectNameCurrentlyOpened: 'demo',
+    fileFocusedOnInEditor: {
+      name: 'main.kcl',
+      path: '/workspace/demo/main.kcl',
+      children: null,
+    },
+    exchangeId: 0,
+  })
+}
+
+async function flushQueuedWork() {
+  await Promise.resolve()
+  await Promise.resolve()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+describe('MlEphantConversationPaneWrapper', () => {
+  test('does not start the next patch-backed Zookeeper edit until the previous editor refresh completes', async () => {
+    mocks.systemIOSend.mockClear()
+    mocks.watchCallback = undefined
+
+    render(
+      <MlEphantConversationPaneWrapper
+        areaConfig={{ hide: () => false }}
+        layout={{
+          areaType: AreaType.TTC,
+          id: 'zookeeper',
+          label: 'Zookeeper',
+          type: LayoutType.Simple,
+        }}
+        onClose={vi.fn()}
+      />
+    )
+
+    expect(mocks.watchCallback).toBeDefined()
+
+    emitZookeeperFileRequest('intermediate code')
+
+    await waitFor(() => expect(mocks.systemIOSend).toHaveBeenCalledTimes(1))
+
+    const firstRequest = mocks.systemIOSend.mock.calls[0][0].data
+    expect(firstRequest.onSuccess).toEqual(expect.any(Function))
+
+    // The filesystem callback completes before the route/editor refresh callback.
+    // Starting the next edit here can let the older refresh win and leave stale
+    // intermediate KCL visible in the editor.
+    firstRequest.onFileSystemSuccess()
+    await flushQueuedWork()
+
+    emitZookeeperFileRequest('final code')
+    await flushQueuedWork()
+
+    expect(mocks.systemIOSend).toHaveBeenCalledTimes(1)
+
+    // Once the editor refresh has completed, the queued final edit can run.
+    firstRequest.onSuccess()
+
+    await waitFor(() => expect(mocks.systemIOSend).toHaveBeenCalledTimes(2))
+
+    const secondRequest = mocks.systemIOSend.mock.calls[1][0].data
+    expect(secondRequest.files[0]).toMatchObject({
+      requestedFileName: 'main.kcl',
+      requestedCode: 'final code',
+    })
+  })
+})

--- a/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
+++ b/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
@@ -213,8 +213,11 @@ function MlEphantConversationPaneInner(props: AreaTypeComponentProps) {
             new Promise<void>((resolve) => {
               let pendingHistoryStarted = false
               let requestSettled = false
+              let historyWriteCompleted = !shouldRecordZookeeperHistory
+              let postWriteCompleted = !shouldRecordZookeeperHistory
               const settleRequest = () => {
                 if (requestSettled) return
+                if (!historyWriteCompleted || !postWriteCompleted) return
                 requestSettled = true
                 resolve()
               }
@@ -250,10 +253,13 @@ function MlEphantConversationPaneInner(props: AreaTypeComponentProps) {
                       if (pendingHistoryReserved || pendingHistoryStarted) {
                         cancelPendingZookeeperHistoryWrite({ exchangeId })
                       }
+                      historyWriteCompleted = true
+                      postWriteCompleted = true
                       settleRequest()
                     },
                     onFileSystemSuccess: () => {
                       if (historyRecorded) {
+                        historyWriteCompleted = true
                         settleRequest()
                         return
                       }
@@ -300,30 +306,44 @@ function MlEphantConversationPaneInner(props: AreaTypeComponentProps) {
                               error
                             )
                           })
-                          .finally(settleRequest)
+                          .finally(() => {
+                            historyWriteCompleted = true
+                            settleRequest()
+                          })
                         return
                       }
+                      historyWriteCompleted = true
+                      postWriteCompleted = true
                       settleRequest()
                     },
-                    ...(shouldRefreshActiveEditorAfterPlainOutput &&
-                    activeFileOutput
+                    ...(shouldRecordZookeeperHistory ||
+                    (shouldRefreshActiveEditorAfterPlainOutput &&
+                      activeFileOutput)
                       ? {
                           onSuccess: () => {
+                            if (shouldRecordZookeeperHistory) {
+                              postWriteCompleted = true
+                              settleRequest()
+                              return
+                            }
+                            if (!activeFileOutput) return
                             if (kclManager.path !== activeFilePath) return
                             if (
-                              kclManager.code === activeFileOutput.requestedCode
-                            )
-                              return
-                            kclManager.updateCodeEditor(
-                              activeFileOutput.requestedCode,
-                              {
-                                shouldAddToHistory: false,
-                                shouldClearHistory: true,
-                                shouldExecute: true,
-                                shouldResetCamera: true,
-                                shouldWriteToDisk: true,
-                              }
-                            )
+                              kclManager.code !== activeFileOutput.requestedCode
+                            ) {
+                              kclManager.updateCodeEditor(
+                                activeFileOutput.requestedCode,
+                                {
+                                  shouldAddToHistory: false,
+                                  shouldClearHistory: true,
+                                  shouldExecute: true,
+                                  shouldResetCamera: true,
+                                  shouldWriteToDisk: true,
+                                }
+                              )
+                            }
+                            postWriteCompleted = true
+                            settleRequest()
                           },
                         }
                       : {}),
@@ -337,6 +357,8 @@ function MlEphantConversationPaneInner(props: AreaTypeComponentProps) {
                   'Failed to process Zookeeper file request.',
                   error
                 )
+                historyWriteCompleted = true
+                postWriteCompleted = true
                 settleRequest()
               })
             })


### PR DESCRIPTION
Fixes #12366.

Fixes a race where Zookeeper could apply multiple `edit_kcl_code` outputs in one exchange and leave the editor showing stale intermediate KCL.

`systemIO` reports filesystem success before the project loader/editor refresh has completed. Previously, the Zookeeper file request queue advanced on filesystem success, so a later final edit could start while an earlier intermediate edit was still finishing its editor refresh. If that older refresh completed last, it could win and put stale code back in the editor.

This PR updates the Zookeeper request queue to wait for both:

- the filesystem/history write work
- the post-write project/editor refresh callback

before allowing the next patch-backed Zookeeper edit to run.

It also adds a regression test that reproduces the ordering issue by emitting an intermediate edit, completing only its filesystem callback, then verifying the final edit stays queued until the first edit's refresh callback completes.

## Longer-term option

This is a focused fix for the Zookeeper race in #12366.

A better long-term home for this ordering is the broader `systemIO` queue refactor described in #12350. If `systemIO` becomes a queued service, it should treat a request as complete only after the disk write and any downstream navigation/project-loader/editor refresh work has completed. At that point, the bespoke Zookeeper-side queue could likely be simplified or removed.
