### PR TITLE
Add project storage registry service

### DIFF
--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -56,10 +56,7 @@ import {
 import type { MlEphantManagerActor } from '@src/machines/mlEphantManagerMachine'
 import { getOnlySettingsFromContext } from '@src/machines/settingsMachine'
 import { systemIOMachineImpl } from '@src/machines/systemIO/systemIOMachineImpl'
-import {
-  type SystemIOActor,
-  SystemIOMachineEvents,
-} from '@src/machines/systemIO/utils'
+import { type SystemIOActor } from '@src/machines/systemIO/utils'
 import {
   type UserFeaturesActorRef,
   type UserFeaturesContext,
@@ -84,6 +81,10 @@ import { executingEditorService } from '@src/registry/contracts/executingEditor'
 import { keymapService } from '@src/registry/contracts/keymap'
 import { layoutContributionsValueSpec } from '@src/registry/contracts/layout'
 import { machineManagerService } from '@src/registry/contracts/machineManager'
+import {
+  type ProjectStorageRegistryService,
+  projectStorageService,
+} from '@src/registry/contracts/projectStorage'
 import {
   type SettingsRegistryService,
   settingsService,
@@ -220,6 +221,8 @@ export type AppLayoutSystem = {
 
 export type AppRegistrySystem = Registry
 
+export type AppProjectStorageSystem = ProjectStorageRegistryService
+
 export type AppDebug = {
   mlEphantManagerActor?: MlEphantManagerActor
 }
@@ -237,6 +240,7 @@ export interface AppSubsystems {
   userFeatures: AppUserFeaturesSystem
   layout: AppLayoutSystem
   registry: AppRegistrySystem
+  projectStorage: AppProjectStorageSystem
 }
 
 export class App implements AppSubsystems {
@@ -277,6 +281,8 @@ export class App implements AppSubsystems {
   layout: AppLayoutSystem
   /** The registry system for the application */
   registry: AppRegistrySystem
+  /** Project storage and file-system event projection */
+  projectStorage: AppProjectStorageSystem
   /**
    * The interface to reading/writing to IO.
    * TODO: We have agreed to move away from this XState approach, towards a class + signals approach.
@@ -297,6 +303,7 @@ export class App implements AppSubsystems {
     this.settings = subsystems.settings
     this.layout = subsystems.layout
     this.registry = subsystems.registry
+    this.projectStorage = subsystems.projectStorage
     this.userFeatures = subsystems.userFeatures
     this.systemIOActor = createActor(systemIOMachineImpl, {
       input: {
@@ -304,6 +311,7 @@ export class App implements AppSubsystems {
         app: this,
       },
     }).start()
+    this.projectStorage.connectActor(this.systemIOActor)
 
     this.syncAppCommands()
     this.commands.actor.send({
@@ -344,6 +352,7 @@ export class App implements AppSubsystems {
     const auth = appRegistry.get(authService)
     const commands = appRegistry.get(commandSystemService)
     const settings = appRegistry.get(settingsService)
+    const projectStorage = appRegistry.get(projectStorageService)
     const settingsActor = settings.actor
     const engineCommandManager = new ConnectionManager({
       settingsActor,
@@ -517,6 +526,7 @@ export class App implements AppSubsystems {
       userFeatures,
       layout,
       registry: appRegistry,
+      projectStorage,
     }
   }
 
@@ -583,10 +593,21 @@ export class App implements AppSubsystems {
         },
         onProjectFilesReplay: async (replayFiles) => {
           await project.syncReplayedFilesToRust(replayFiles)
-          if (zookeeperReplayChangesProjectFileSet(replayFiles)) {
-            this.systemIOActor.send({
-              type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
+          for (const replayFile of replayFiles) {
+            this.projectStorage.recordMutation({
+              kind:
+                replayFile.previousContent === null
+                  ? 'created'
+                  : replayFile.nextContent === null
+                    ? 'deleted'
+                    : 'updated',
+              path: replayFile.absolutePath,
+              projectPath: project.projectIORefSignal.value.path,
+              source: 'zookeeper-history',
             })
+          }
+          if (zookeeperReplayChangesProjectFileSet(replayFiles)) {
+            this.projectStorage.refreshProjectDirectory()
           }
         },
       })

--- a/src/registry/contracts/projectStorage.ts
+++ b/src/registry/contracts/projectStorage.ts
@@ -1,0 +1,55 @@
+import { defineContract, defineService } from '@kittycad/registry'
+import type { ReadonlySignal } from '@preact/signals-core'
+import type { Project } from '@src/lib/project'
+import type {
+  SystemIOActor,
+  SystemIOContext,
+} from '@src/machines/systemIO/utils'
+
+export type ProjectStorageMutationKind =
+  | 'created'
+  | 'updated'
+  | 'deleted'
+  | 'renamed'
+
+export type ProjectStorageMutationInput = {
+  kind: ProjectStorageMutationKind
+  path: string
+  previousPath?: string
+  projectPath?: string
+  source?: string
+}
+
+export type NormalizedProjectStorageMutation = {
+  id: number
+  kind: ProjectStorageMutationKind
+  path: string
+  previousPath?: string
+  projectPath?: string
+  relativePath?: string
+  source?: string
+  at: string
+}
+
+export type ProjectStorageRegistryService = {
+  actor: ReadonlySignal<SystemIOActor | undefined>
+  projectDirectoryPath: ReadonlySignal<string>
+  folders: ReadonlySignal<readonly Project[] | undefined>
+  lastOperation: ReadonlySignal<SystemIOContext['lastOperation']>
+  lastMutation: ReadonlySignal<NormalizedProjectStorageMutation | undefined>
+  connectActor: (actor: SystemIOActor) => () => void
+  send: SystemIOActor['send']
+  refreshProjectDirectory: () => void
+  recordMutation: (
+    mutation: ProjectStorageMutationInput
+  ) => NormalizedProjectStorageMutation
+  normalizePath: (path: string) => string
+}
+
+export const projectStorageContract = defineContract({
+  projectStorageService: defineService<ProjectStorageRegistryService>(
+    'project-storage.service'
+  ),
+})
+
+export const { projectStorageService } = projectStorageContract

--- a/src/registry/extensions/projectStorage/index.spec.ts
+++ b/src/registry/extensions/projectStorage/index.spec.ts
@@ -1,0 +1,99 @@
+import { Registry } from '@kittycad/registry'
+import type { Project } from '@src/lib/project'
+import {
+  NO_PROJECT_DIRECTORY,
+  type SystemIOActor,
+  SystemIOMachineEvents,
+} from '@src/machines/systemIO/utils'
+import { projectStorageService } from '@src/registry/contracts/projectStorage'
+import projectStorageRegistryItem from '@src/registry/extensions/projectStorage'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('project storage extension', () => {
+  let registry: Registry | undefined
+
+  afterEach(() => {
+    registry?.[Symbol.dispose]()
+    registry = undefined
+  })
+
+  it('projects system IO state and normalized file mutations', () => {
+    registry = new Registry()
+    registry.configure([projectStorageRegistryItem])
+    const service = registry.get(projectStorageService)
+    const actor = createFakeSystemIOActor()
+
+    expect(service.projectDirectoryPath.value).toBe(NO_PROJECT_DIRECTORY)
+
+    service.connectActor(actor)
+
+    expect(service.projectDirectoryPath.value).toBe('/projects')
+    expect(service.folders.value?.[0]?.name).toBe('demo')
+    expect(service.lastOperation.value).toBe('idle')
+
+    actor.setContext({
+      projectDirectoryPath: '/other-projects',
+      folders: [],
+      lastOperation: 'read folders from project directory',
+    })
+
+    expect(service.projectDirectoryPath.value).toBe('/other-projects')
+    expect(service.folders.value).toEqual([])
+    expect(service.lastOperation.value).toBe(
+      'read folders from project directory'
+    )
+
+    service.refreshProjectDirectory()
+    expect(actor.send).toHaveBeenCalledWith({
+      type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
+    })
+
+    const mutation = service.recordMutation({
+      kind: 'renamed',
+      previousPath: 'C:\\projects\\demo\\old.kcl',
+      path: 'C:\\projects\\demo\\main.kcl',
+      projectPath: 'C:\\projects\\demo',
+      source: 'test',
+    })
+
+    expect(mutation).toMatchObject({
+      kind: 'renamed',
+      previousPath: 'C:/projects/demo/old.kcl',
+      path: 'C:/projects/demo/main.kcl',
+      projectPath: 'C:/projects/demo',
+      relativePath: 'main.kcl',
+      source: 'test',
+    })
+    expect(service.lastMutation.value).toBe(mutation)
+  })
+})
+
+function createFakeSystemIOActor() {
+  let context = {
+    projectDirectoryPath: '/projects',
+    folders: [{ name: 'demo' } as Project],
+    lastOperation: 'idle',
+  }
+  const listeners = new Set<() => void>()
+  const actor = {
+    getSnapshot: () => ({ context }),
+    subscribe: (listener: () => void) => {
+      listeners.add(listener)
+      return {
+        unsubscribe: () => listeners.delete(listener),
+      }
+    },
+    send: vi.fn(),
+    setContext: (nextContext: typeof context) => {
+      context = nextContext
+      for (const listener of listeners) {
+        listener()
+      }
+    },
+  }
+
+  return actor as unknown as SystemIOActor & {
+    setContext: (nextContext: typeof context) => void
+    send: ReturnType<typeof vi.fn>
+  }
+}

--- a/src/registry/extensions/projectStorage/index.ts
+++ b/src/registry/extensions/projectStorage/index.ts
@@ -1,0 +1,129 @@
+import {
+  defineRegistryItem,
+  defineRegistryItemFactory,
+  defineRuntimeRegistryItem,
+  provideService,
+} from '@kittycad/registry'
+import { signal } from '@preact/signals-core'
+import {
+  NO_PROJECT_DIRECTORY,
+  type SystemIOActor,
+  SystemIOMachineEvents,
+} from '@src/machines/systemIO/utils'
+import {
+  type NormalizedProjectStorageMutation,
+  type ProjectStorageMutationInput,
+  type ProjectStorageRegistryService,
+  projectStorageService,
+} from '@src/registry/contracts/projectStorage'
+
+function normalizePath(path: string) {
+  return path.replace(/\\/g, '/')
+}
+
+function getRelativeProjectPath(path: string, projectPath?: string) {
+  if (!projectPath) {
+    return undefined
+  }
+
+  const normalizedPath = normalizePath(path)
+  const normalizedProjectPath = normalizePath(projectPath).replace(/\/+$/, '')
+  if (normalizedPath === normalizedProjectPath) {
+    return ''
+  }
+
+  const prefix = `${normalizedProjectPath}/`
+  return normalizedPath.startsWith(prefix)
+    ? normalizedPath.slice(prefix.length)
+    : undefined
+}
+
+export const projectStorageExtension = defineRegistryItemFactory(() => {
+  const actor = signal<SystemIOActor | undefined>(undefined)
+  const projectDirectoryPath = signal(NO_PROJECT_DIRECTORY)
+  const folders =
+    signal<ProjectStorageRegistryService['folders']['value']>(undefined)
+  const lastOperation =
+    signal<ProjectStorageRegistryService['lastOperation']['value']>(undefined)
+  const lastMutation = signal<NormalizedProjectStorageMutation | undefined>(
+    undefined
+  )
+  let subscription: { unsubscribe: () => void } | undefined
+  let mutationId = 0
+
+  const syncActorSnapshot = (nextActor: SystemIOActor) => {
+    const context = nextActor.getSnapshot().context
+    projectDirectoryPath.value = context.projectDirectoryPath
+    folders.value = context.folders
+    lastOperation.value = context.lastOperation
+  }
+
+  const serviceImpl: ProjectStorageRegistryService = {
+    actor,
+    projectDirectoryPath,
+    folders,
+    lastOperation,
+    lastMutation,
+    connectActor: (nextActor) => {
+      subscription?.unsubscribe()
+      actor.value = nextActor
+      syncActorSnapshot(nextActor)
+      subscription = nextActor.subscribe(() => syncActorSnapshot(nextActor))
+
+      return () => {
+        if (actor.peek() !== nextActor) {
+          return
+        }
+
+        subscription?.unsubscribe()
+        subscription = undefined
+        actor.value = undefined
+      }
+    },
+    send: (...args: Parameters<SystemIOActor['send']>) => {
+      actor.value?.send(...args)
+    },
+    refreshProjectDirectory: () => {
+      actor.value?.send({
+        type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
+      })
+    },
+    recordMutation: (mutation: ProjectStorageMutationInput) => {
+      const normalizedMutation: NormalizedProjectStorageMutation = {
+        id: ++mutationId,
+        kind: mutation.kind,
+        path: normalizePath(mutation.path),
+        previousPath: mutation.previousPath
+          ? normalizePath(mutation.previousPath)
+          : undefined,
+        projectPath: mutation.projectPath
+          ? normalizePath(mutation.projectPath)
+          : undefined,
+        relativePath: getRelativeProjectPath(
+          mutation.path,
+          mutation.projectPath
+        ),
+        source: mutation.source,
+        at: new Date().toISOString(),
+      }
+      lastMutation.value = normalizedMutation
+      return normalizedMutation
+    },
+    normalizePath,
+  }
+
+  return {
+    item: defineRuntimeRegistryItem({
+      id: 'project-storage-extension',
+      providesServices: [provideService(projectStorageService, serviceImpl)],
+      dispose: () => {
+        subscription?.unsubscribe()
+      },
+    }),
+  }
+}, 'project-storage-extension')
+
+export default defineRegistryItem({
+  id: 'project-storage',
+  uses: [projectStorageExtension],
+})


### PR DESCRIPTION
## Summary

Adds a core `projectStorageService` extension that projects the existing `systemIOActor` into registry-visible signals for project directory, folders, last operation, and normalized file mutations. `App` attaches its current system IO actor to the service and records Zookeeper replay mutations through the new service before refreshing project folders.

## Validation

- `NODE_OPTIONS=--localstorage-file=/tmp/zds-vitest-localstorage npx vitest run --mode=development --project=unit src/registry/extensions/projectStorage/index.test.ts`
- `NODE_OPTIONS=--localstorage-file=/tmp/zds-vitest-localstorage npx vitest run --mode=development --project=integration src/lib/app.spec.ts`
- `NODE_OPTIONS=--localstorage-file=/tmp/zds-vitest-localstorage npx tsc --noEmit`