### PR TITLE
Infer mock CSG output sizes from indexed uses

### DIFF
--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -60,6 +60,7 @@ pub(crate) use state::KclVersion;
 pub use state::MetaSettings;
 pub(crate) use state::ModuleArtifactState;
 pub(crate) use state::TangencyMode;
+use state::infer_mock_csg_output_minimums;
 
 use crate::CompilationIssue;
 use crate::ExecError;
@@ -1244,6 +1245,7 @@ impl ExecutorContext {
 
         let use_prev_memory = mock_config.use_prev_memory;
         let mut exec_state = ExecState::new_mock(self, mock_config);
+        exec_state.set_mock_csg_output_minimums(infer_mock_csg_output_minimums(&program.ast));
         if use_prev_memory {
             match cache::read_old_memory().await {
                 Some(mem) => Self::restore_mock_memory(&mut exec_state, mem, mock_config)?,

--- a/rust/kcl-lib/src/execution/state.rs
+++ b/rust/kcl-lib/src/execution/state.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use ahash::AHashMap;
+use ahash::AHashSet;
 use anyhow::Result;
 use indexmap::IndexMap;
 use kcl_api::UnitAngle;
@@ -59,8 +60,17 @@ use crate::modules::ModulePath;
 use crate::modules::ModuleRepr;
 use crate::modules::ModuleSource;
 use crate::parsing::ast::types::Annotation;
+use crate::parsing::ast::types::BinaryPart;
+use crate::parsing::ast::types::BodyItem;
+use crate::parsing::ast::types::Expr;
+use crate::parsing::ast::types::IfExpression;
+use crate::parsing::ast::types::LiteralValue;
+use crate::parsing::ast::types::MemberExpression;
+use crate::parsing::ast::types::Node;
 use crate::parsing::ast::types::NodeRef;
+use crate::parsing::ast::types::Program as AstProgram;
 use crate::parsing::ast::types::TagNode;
+use crate::parsing::token::NumericSuffix;
 
 /// State for executing a program.
 #[derive(Debug, Clone)]
@@ -231,6 +241,232 @@ pub(super) struct ModuleState {
     /// the exact key lookup misses, this map lets us reject that solid by
     /// `engine_id`, unless the key is a recorded operation output.
     pub(super) consumed_solid_ids: AHashMap<Uuid, ConsumedSolidInfo>,
+    /// Mock-only lower bounds for top-level CSG operation output arrays,
+    /// inferred from direct indexed uses elsewhere in the same module.
+    pub(super) mock_csg_output_minimums: AHashMap<String, usize>,
+}
+
+pub(crate) fn infer_mock_csg_output_minimums(program: &Node<AstProgram>) -> AHashMap<String, usize> {
+    let mut csg_declarations = AHashSet::default();
+    for item in &program.body {
+        if let BodyItem::VariableDeclaration(declaration) = item
+            && is_direct_csg_output_expr(&declaration.declaration.init)
+        {
+            csg_declarations.insert(declaration.declaration.id.name.to_string());
+        }
+    }
+
+    let mut minimums = AHashMap::default();
+    for item in &program.body {
+        collect_mock_csg_index_requirements_from_body_item(item, &csg_declarations, &mut minimums);
+    }
+
+    minimums
+}
+
+fn is_direct_csg_output_expr(expr: &Expr) -> bool {
+    match expr {
+        Expr::CallExpressionKw(call) => is_mock_sized_csg_call(call.callee.name.name.as_str()),
+        Expr::PipeExpression(pipe) => pipe.body.last().is_some_and(is_direct_csg_output_expr),
+        Expr::AscribedExpression(expr) => is_direct_csg_output_expr(&expr.expr),
+        Expr::LabelledExpression(expr) => is_direct_csg_output_expr(&expr.expr),
+        _ => false,
+    }
+}
+
+fn is_mock_sized_csg_call(name: &str) -> bool {
+    matches!(name, "union" | "subtract" | "intersect" | "split")
+}
+
+fn collect_mock_csg_index_requirements_from_body_item(
+    item: &BodyItem,
+    csg_declarations: &AHashSet<String>,
+    minimums: &mut AHashMap<String, usize>,
+) {
+    match item {
+        BodyItem::ExpressionStatement(statement) => {
+            collect_mock_csg_index_requirements_from_expr(&statement.expression, csg_declarations, minimums);
+        }
+        BodyItem::VariableDeclaration(declaration) => {
+            collect_mock_csg_index_requirements_from_expr(&declaration.declaration.init, csg_declarations, minimums);
+        }
+        BodyItem::ReturnStatement(statement) => {
+            collect_mock_csg_index_requirements_from_expr(&statement.argument, csg_declarations, minimums);
+        }
+        BodyItem::ImportStatement(_) | BodyItem::TypeDeclaration(_) => {}
+    }
+}
+
+fn collect_mock_csg_index_requirements_from_program(
+    program: &AstProgram,
+    csg_declarations: &AHashSet<String>,
+    minimums: &mut AHashMap<String, usize>,
+) {
+    for item in &program.body {
+        collect_mock_csg_index_requirements_from_body_item(item, csg_declarations, minimums);
+    }
+}
+
+fn collect_mock_csg_index_requirements_from_expr(
+    expr: &Expr,
+    csg_declarations: &AHashSet<String>,
+    minimums: &mut AHashMap<String, usize>,
+) {
+    match expr {
+        Expr::BinaryExpression(expr) => {
+            collect_mock_csg_index_requirements_from_binary_part(&expr.left, csg_declarations, minimums);
+            collect_mock_csg_index_requirements_from_binary_part(&expr.right, csg_declarations, minimums);
+        }
+        Expr::CallExpressionKw(call) => {
+            if let Some(unlabeled) = &call.unlabeled {
+                collect_mock_csg_index_requirements_from_expr(unlabeled, csg_declarations, minimums);
+            }
+            for arg in &call.arguments {
+                collect_mock_csg_index_requirements_from_expr(&arg.arg, csg_declarations, minimums);
+            }
+        }
+        Expr::PipeExpression(pipe) => {
+            for expr in &pipe.body {
+                collect_mock_csg_index_requirements_from_expr(expr, csg_declarations, minimums);
+            }
+        }
+        Expr::ArrayExpression(expr) => {
+            for element in &expr.elements {
+                collect_mock_csg_index_requirements_from_expr(element, csg_declarations, minimums);
+            }
+        }
+        Expr::ArrayRangeExpression(expr) => {
+            collect_mock_csg_index_requirements_from_expr(&expr.start_element, csg_declarations, minimums);
+            collect_mock_csg_index_requirements_from_expr(&expr.end_element, csg_declarations, minimums);
+        }
+        Expr::ObjectExpression(expr) => {
+            for property in &expr.properties {
+                collect_mock_csg_index_requirements_from_expr(&property.value, csg_declarations, minimums);
+            }
+        }
+        Expr::MemberExpression(expr) => {
+            collect_mock_csg_index_requirements_from_member_expression(expr, csg_declarations, minimums)
+        }
+        Expr::UnaryExpression(expr) => {
+            collect_mock_csg_index_requirements_from_binary_part(&expr.argument, csg_declarations, minimums);
+        }
+        Expr::IfExpression(expr) => {
+            collect_mock_csg_index_requirements_from_if_expression(expr, csg_declarations, minimums)
+        }
+        Expr::LabelledExpression(expr) => {
+            collect_mock_csg_index_requirements_from_expr(&expr.expr, csg_declarations, minimums);
+        }
+        Expr::AscribedExpression(expr) => {
+            collect_mock_csg_index_requirements_from_expr(&expr.expr, csg_declarations, minimums);
+        }
+        Expr::SketchBlock(expr) => {
+            for arg in &expr.arguments {
+                collect_mock_csg_index_requirements_from_expr(&arg.arg, csg_declarations, minimums);
+            }
+        }
+        // Function bodies have their own local scope. Leave them to the fallback behavior for now.
+        Expr::FunctionExpression(_) => {}
+        Expr::Literal(_)
+        | Expr::Name(_)
+        | Expr::TagDeclarator(_)
+        | Expr::PipeSubstitution(_)
+        | Expr::SketchVar(_)
+        | Expr::None(_) => {}
+    }
+}
+
+fn collect_mock_csg_index_requirements_from_member_expression(
+    expr: &MemberExpression,
+    csg_declarations: &AHashSet<String>,
+    minimums: &mut AHashMap<String, usize>,
+) {
+    if expr.computed
+        && let Expr::Name(name) = &expr.object
+        && csg_declarations.contains(name.name.name.as_str())
+        && let Some(index) = literal_array_index(&expr.property)
+    {
+        minimums
+            .entry(name.name.name.to_string())
+            .and_modify(|minimum| *minimum = (*minimum).max(index + 1))
+            .or_insert(index + 1);
+    }
+    collect_mock_csg_index_requirements_from_expr(&expr.object, csg_declarations, minimums);
+    collect_mock_csg_index_requirements_from_expr(&expr.property, csg_declarations, minimums);
+}
+
+fn collect_mock_csg_index_requirements_from_if_expression(
+    expr: &IfExpression,
+    csg_declarations: &AHashSet<String>,
+    minimums: &mut AHashMap<String, usize>,
+) {
+    collect_mock_csg_index_requirements_from_expr(&expr.cond, csg_declarations, minimums);
+    collect_mock_csg_index_requirements_from_program(&expr.then_val, csg_declarations, minimums);
+    for else_if in &expr.else_ifs {
+        collect_mock_csg_index_requirements_from_expr(&else_if.cond, csg_declarations, minimums);
+        collect_mock_csg_index_requirements_from_program(&else_if.then_val, csg_declarations, minimums);
+    }
+    collect_mock_csg_index_requirements_from_program(&expr.final_else, csg_declarations, minimums);
+}
+
+fn collect_mock_csg_index_requirements_from_binary_part(
+    part: &BinaryPart,
+    csg_declarations: &AHashSet<String>,
+    minimums: &mut AHashMap<String, usize>,
+) {
+    match part {
+        BinaryPart::BinaryExpression(expr) => {
+            collect_mock_csg_index_requirements_from_binary_part(&expr.left, csg_declarations, minimums);
+            collect_mock_csg_index_requirements_from_binary_part(&expr.right, csg_declarations, minimums);
+        }
+        BinaryPart::CallExpressionKw(call) => {
+            if let Some(unlabeled) = &call.unlabeled {
+                collect_mock_csg_index_requirements_from_expr(unlabeled, csg_declarations, minimums);
+            }
+            for arg in &call.arguments {
+                collect_mock_csg_index_requirements_from_expr(&arg.arg, csg_declarations, minimums);
+            }
+        }
+        BinaryPart::UnaryExpression(expr) => {
+            collect_mock_csg_index_requirements_from_binary_part(&expr.argument, csg_declarations, minimums);
+        }
+        BinaryPart::MemberExpression(expr) => {
+            collect_mock_csg_index_requirements_from_member_expression(expr, csg_declarations, minimums);
+        }
+        BinaryPart::ArrayExpression(expr) => {
+            for element in &expr.elements {
+                collect_mock_csg_index_requirements_from_expr(element, csg_declarations, minimums);
+            }
+        }
+        BinaryPart::ArrayRangeExpression(expr) => {
+            collect_mock_csg_index_requirements_from_expr(&expr.start_element, csg_declarations, minimums);
+            collect_mock_csg_index_requirements_from_expr(&expr.end_element, csg_declarations, minimums);
+        }
+        BinaryPart::ObjectExpression(expr) => {
+            for property in &expr.properties {
+                collect_mock_csg_index_requirements_from_expr(&property.value, csg_declarations, minimums);
+            }
+        }
+        BinaryPart::IfExpression(expr) => {
+            collect_mock_csg_index_requirements_from_if_expression(expr, csg_declarations, minimums)
+        }
+        BinaryPart::AscribedExpression(expr) => {
+            collect_mock_csg_index_requirements_from_expr(&expr.expr, csg_declarations, minimums);
+        }
+        BinaryPart::Literal(_) | BinaryPart::Name(_) | BinaryPart::SketchVar(_) => {}
+    }
+}
+
+fn literal_array_index(expr: &Expr) -> Option<usize> {
+    let Expr::Literal(literal) = expr else {
+        return None;
+    };
+    let LiteralValue::Number { value, suffix } = &literal.value else {
+        return None;
+    };
+    if *suffix != NumericSuffix::None || *value < 0.0 || value.fract() != 0.0 {
+        return None;
+    }
+    Some(*value as usize)
 }
 
 /// Internal identity for one runtime KCL solid value.
@@ -685,6 +921,27 @@ impl ExecState {
     /// boolean operation.
     pub(crate) fn check_solid_id_consumed(&self, id: &Uuid) -> Option<&ConsumedSolidInfo> {
         self.mod_local.consumed_solid_ids.get(id)
+    }
+
+    pub(crate) fn set_mock_csg_output_minimums(&mut self, minimums: AHashMap<String, usize>) {
+        self.mod_local.mock_csg_output_minimums = minimums;
+    }
+
+    pub(crate) fn mock_csg_output_count_for_current_top_level_declaration(&self, default_count: usize) -> usize {
+        // Stdlib calls increment the user-level call stack. A direct top-level
+        // CSG call is at depth 1; calls inside user functions or nested calls
+        // are intentionally left to the existing fallback behavior.
+        if self.mod_local.call_stack_size != 1 {
+            return default_count;
+        }
+        let Some(declaration_name) = self.mod_local.being_declared.as_ref() else {
+            return default_count;
+        };
+        self.mod_local
+            .mock_csg_output_minimums
+            .get(declaration_name)
+            .copied()
+            .map_or(default_count, |minimum| default_count.max(minimum))
     }
 
     /// Follow direct replacement links until we find the latest known output.
@@ -1161,6 +1418,7 @@ impl ModuleState {
             denied_warnings: Vec::new(),
             consumed_solids: AHashMap::default(),
             consumed_solid_ids: AHashMap::default(),
+            mock_csg_output_minimums: AHashMap::default(),
             inside_stdlib: false,
         }
     }

--- a/rust/kcl-lib/src/std/csg.rs
+++ b/rust/kcl-lib/src/std/csg.rs
@@ -90,6 +90,29 @@ fn subtract_output_ids(
     output_ids
 }
 
+fn mock_csg_output_solids(
+    template: &Solid,
+    first_output_id: uuid::Uuid,
+    output_count: usize,
+    exec_state: &mut ExecState,
+) -> Vec<Solid> {
+    let mut first_solid = template.clone();
+    first_solid.set_id(first_output_id);
+    first_solid.artifact_id = first_output_id.into();
+    let mut solids = vec![first_solid.clone()];
+
+    for _ in 1..output_count {
+        let extra_solid_id = exec_state.next_uuid();
+        let mut new_solid = first_solid.clone();
+        new_solid.set_id(extra_solid_id);
+        new_solid.value_id = first_output_id;
+        new_solid.artifact_id = extra_solid_id.into();
+        solids.push(new_solid);
+    }
+
+    solids
+}
+
 pub(crate) async fn inner_union(
     solids: Vec<Solid>,
     tolerance: Option<TyF64>,
@@ -107,6 +130,12 @@ pub(crate) async fn inner_union(
     let mut new_solids = vec![solid.clone()];
 
     if args.ctx.no_engine_commands().await {
+        new_solids = mock_csg_output_solids(
+            &solids[0],
+            solid_out_id,
+            exec_state.mock_csg_output_count_for_current_top_level_declaration(1),
+            exec_state,
+        );
         record_consumed_solids(exec_state, &solids, ConsumedSolidOperation::Union, &new_solids);
         return Ok(new_solids);
     }
@@ -202,6 +231,12 @@ pub(crate) async fn inner_intersect(
     let mut new_solids = vec![solid.clone()];
 
     if args.ctx.no_engine_commands().await {
+        new_solids = mock_csg_output_solids(
+            &solids[0],
+            solid_out_id,
+            exec_state.mock_csg_output_count_for_current_top_level_declaration(1),
+            exec_state,
+        );
         record_consumed_solids(exec_state, &solids, ConsumedSolidOperation::Intersect, &new_solids);
         return Ok(new_solids);
     }
@@ -289,10 +324,12 @@ pub(crate) async fn inner_subtract(
     let tool_ids = tools.iter().map(|s| s.id).collect::<Vec<_>>();
 
     if args.ctx.no_engine_commands().await {
-        let mut solid = solids[0].clone();
-        solid.set_id(solid_out_id);
-        solid.artifact_id = solid_out_id.into();
-        let new_solids = vec![solid];
+        let new_solids = mock_csg_output_solids(
+            &solids[0],
+            solid_out_id,
+            exec_state.mock_csg_output_count_for_current_top_level_declaration(1),
+            exec_state,
+        );
         record_consumed_solids(exec_state, &solids, ConsumedSolidOperation::Subtract, &new_solids);
         record_consumed_solids(exec_state, &tools, ConsumedSolidOperation::Subtract, &[]);
         return Ok(new_solids);
@@ -416,12 +453,12 @@ pub(crate) async fn inner_imprint(
 
     if args.ctx.no_engine_commands().await {
         if separate_bodies {
-            let extra_solid_id = exec_state.next_uuid();
-            let mut new_solid = body.clone();
-            new_solid.set_id(extra_solid_id);
-            new_solid.value_id = body_out_id;
-            new_solid.artifact_id = extra_solid_id.into();
-            new_solids.push(new_solid);
+            new_solids = mock_csg_output_solids(
+                &targets[0],
+                body_out_id,
+                exec_state.mock_csg_output_count_for_current_top_level_declaration(2),
+                exec_state,
+            );
         }
         record_consumed_solids(exec_state, &targets, ConsumedSolidOperation::Split, &new_solids);
         if !keep_tools && let Some(tools) = tools.as_ref() {
@@ -506,6 +543,27 @@ mod tests {
 
     fn test_uuid(id: u128) -> Uuid {
         Uuid::from_u128(id)
+    }
+
+    fn rectangular_solid_code(name: &str, min_x: i32, min_y: i32, max_x: i32, max_y: i32) -> String {
+        let point_x = (min_x + max_x) / 2;
+        let point_y = (min_y + max_y) / 2;
+        format!(
+            r#"
+{name}Sketch = sketch(on = XY) {{
+  line1 = line(start = [var {min_x}, var {min_y}], end = [var {max_x}, var {min_y}])
+  line2 = line(start = [var {max_x}, var {min_y}], end = [var {max_x}, var {max_y}])
+  line3 = line(start = [var {max_x}, var {max_y}], end = [var {min_x}, var {max_y}])
+  line4 = line(start = [var {min_x}, var {max_y}], end = [var {min_x}, var {min_y}])
+  coincident([line1.end, line2.start])
+  coincident([line2.end, line3.start])
+  coincident([line3.end, line4.start])
+  coincident([line4.end, line1.start])
+}}
+
+{name} = extrude(region(point = [{point_x}, {point_y}], sketch = {name}Sketch), length = 10)
+"#
+        )
     }
 
     #[test]
@@ -830,6 +888,93 @@ second = subtract(first, tools = [tool])
         ctx.close().await;
 
         assert!(outcome.variables.contains_key("second"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn split_mock_with_multiple_tools_supports_indexed_outputs() {
+        let code = r#"
+targetSketch = sketch(on = XY) {
+  line1 = line(start = [var -10, var -10], end = [var 10, var -10])
+  line2 = line(start = [var 10, var -10], end = [var 10, var 10])
+  line3 = line(start = [var 10, var 10], end = [var -10, var 10])
+  line4 = line(start = [var -10, var 10], end = [var -10, var -10])
+  coincident([line1.end, line2.start])
+  coincident([line2.end, line3.start])
+  coincident([line3.end, line4.start])
+  coincident([line4.end, line1.start])
+}
+
+target = extrude(region(point = [0, 0], sketch = targetSketch), length = 20)
+
+tool1Sketch = sketch(on = XY) {
+  line1 = line(start = [var -8, var -10], end = [var -6, var -10])
+  line2 = line(start = [var -6, var -10], end = [var -6, var 10])
+  line3 = line(start = [var -6, var 10], end = [var -8, var 10])
+  line4 = line(start = [var -8, var 10], end = [var -8, var -10])
+  coincident([line1.end, line2.start])
+  coincident([line2.end, line3.start])
+  coincident([line3.end, line4.start])
+  coincident([line4.end, line1.start])
+}
+
+tool1 = extrude(region(point = [-7, 0], sketch = tool1Sketch), length = 20)
+
+tool2Sketch = sketch(on = XY) {
+  line1 = line(start = [var 6, var -10], end = [var 8, var -10])
+  line2 = line(start = [var 8, var -10], end = [var 8, var 10])
+  line3 = line(start = [var 8, var 10], end = [var 6, var 10])
+  line4 = line(start = [var 6, var 10], end = [var 6, var -10])
+  coincident([line1.end, line2.start])
+  coincident([line2.end, line3.start])
+  coincident([line3.end, line4.start])
+  coincident([line4.end, line1.start])
+}
+
+tool2 = extrude(region(point = [7, 0], sketch = tool2Sketch), length = 20)
+
+splitResult = split(target, tools = [tool1, tool2])
+hide([splitResult[1], splitResult[2], splitResult[3], splitResult[4]])
+pieceFromHiddenSplit = splitResult[4]
+"#;
+
+        let ctx = crate::ExecutorContext::new_mock(None).await;
+        let program = crate::Program::parse_no_errs(code).unwrap();
+        let outcome = ctx.run_mock(&program, &MockConfig::default()).await.unwrap();
+        ctx.close().await;
+
+        assert!(outcome.variables.contains_key("pieceFromHiddenSplit"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn boolean_mocks_support_indexed_outputs_required_by_program() {
+        let mut code = String::new();
+        code.push_str(&rectangular_solid_code("unionLeft", -30, 0, -24, 6));
+        code.push_str(&rectangular_solid_code("unionRight", -26, 2, -20, 8));
+        code.push_str(&rectangular_solid_code("intersectLeft", -8, 0, -2, 6));
+        code.push_str(&rectangular_solid_code("intersectRight", -6, 2, 0, 8));
+        code.push_str(&rectangular_solid_code("subtractTarget", 10, 0, 18, 8));
+        code.push_str(&rectangular_solid_code("subtractTool", 13, 2, 15, 6));
+        code.push_str(
+            r#"
+unionResult = union([unionLeft, unionRight])
+unionPiece = unionResult[2]
+
+intersectResult = intersect([intersectLeft, intersectRight])
+intersectPiece = intersectResult[1]
+
+subtractResult = subtract(subtractTarget, tools = [subtractTool])
+subtractPiece = subtractResult[2]
+"#,
+        );
+
+        let ctx = crate::ExecutorContext::new_mock(None).await;
+        let program = crate::Program::parse_no_errs(&code).unwrap();
+        let outcome = ctx.run_mock(&program, &MockConfig::default()).await.unwrap();
+        ctx.close().await;
+
+        assert!(outcome.variables.contains_key("unionPiece"));
+        assert!(outcome.variables.contains_key("intersectPiece"));
+        assert!(outcome.variables.contains_key("subtractPiece"));
     }
 
     #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Fixes #12831.

## Summary

- Add a mock-execution pre-scan that infers minimum output array sizes for top-level CSG declarations from literal indexed uses in the same module.
- Use the inferred minimums when mocking `union`, `intersect`, `subtract`, and `split` outputs.
- Add regressions for the original `hide([splitResult[1], ...])` shape and for boolean CSG outputs that are indexed later in the program.

## Root Cause

Command-bar validation mock-executes the modified program. In mock mode, `split` always produced the default two bodies, so unrelated validation could fail when existing KCL referenced higher indexes such as `split001[2]` or `split001[4]`. Real execution can produce more bodies, so mock execution was rejecting valid program shapes before the command could complete.

## Validation

- `cargo fmt --manifest-path rust/Cargo.toml --all`
- `cargo test --manifest-path rust/kcl-lib/Cargo.toml std::csg::tests:: -- --nocapture`
- `git diff --check`