### PR TITLE
Fix measure tool unit conversion

### DIFF
--- a/src/registry/extensions/engineScene/MeasurementTool.test.ts
+++ b/src/registry/extensions/engineScene/MeasurementTool.test.ts
@@ -9,7 +9,7 @@ import {
   measurementCapabilities,
 } from './measurementCapabilities'
 import {
-  type MeasurementEntity,
+  convertLengthFromMm,
   formatDistance,
   formatPoint3d,
   getAreaUnit,
@@ -17,6 +17,7 @@ import {
   getMeasurementEntities,
   getMeasurementEntityIds,
   getVolumeUnit,
+  type MeasurementEntity,
 } from './measurementUtils'
 
 describe('MeasurementTool helpers', () => {
@@ -295,11 +296,27 @@ describe('MeasurementTool helpers', () => {
     expect(formatDistance(Number.NaN)).toBe('-')
   })
 
-  it('derives measurement units from length units', () => {
-    expect(getAreaUnit('mm')).toBe('mm2')
-    expect(getAreaUnit('in')).toBe('in2')
-    expect(getVolumeUnit('cm')).toBe('cm3')
-    expect(getVolumeUnit('ft')).toBe('ft3')
+  it('derives area and volume measurement units from length units', () => {
+    expect(
+      (['mm', 'cm', 'm', 'in', 'ft', 'yd'] as const).map((unit) => [
+        unit,
+        getAreaUnit(unit),
+        getVolumeUnit(unit),
+      ])
+    ).toEqual([
+      ['mm', 'mm2', 'mm3'],
+      ['cm', 'cm2', 'cm3'],
+      ['m', 'm2', 'm3'],
+      ['in', 'in2', 'in3'],
+      ['ft', 'ft2', 'ft3'],
+      ['yd', 'yd2', 'yd3'],
+    ])
+  })
+
+  it('converts engine millimeter length measurements to display units', () => {
+    expect(convertLengthFromMm(609.6, 'in')).toBe(24)
+    expect(convertLengthFromMm(609.6, 'ft')).toBe(2)
+    expect(convertLengthFromMm(609.6, 'mm')).toBe(609.6)
   })
 
   it('formats 3d points', () => {

--- a/src/registry/extensions/engineScene/MeasurementTool.tsx
+++ b/src/registry/extensions/engineScene/MeasurementTool.tsx
@@ -26,19 +26,19 @@ import {
 import { createPortal } from 'react-dom'
 import toast from 'react-hot-toast'
 import {
-  type MeasurementTarget,
   getDefaultDistanceModeForTarget,
   getDistanceMeasurementLabel,
   getDistanceModeLabel,
   getMeasurementTarget,
   isUnsupportedDistanceMode,
+  type MeasurementTarget,
   unsupportedFaceSurfaceAreaMessage,
   unsupportedTopologyDistanceMessage,
 } from './measurementCapabilities'
 import { measurementToolService } from './measurementToolService'
 import {
+  convertLengthFromMm,
   type DistanceMode,
-  type MeasurementEntity,
   distanceModes,
   formatDistance,
   formatPoint3d,
@@ -46,6 +46,7 @@ import {
   getDistanceTypeForMode,
   getMeasurementEntities,
   getVolumeUnit,
+  type MeasurementEntity,
 } from './measurementUtils'
 
 type MeasurementStatus = 'idle' | 'measuring'
@@ -55,6 +56,7 @@ type MeasurementResult =
       type: 'distance'
       min: number
       max: number
+      unit: UnitLength
       entityIdsKey: string
       mode: DistanceMode
     }
@@ -227,13 +229,26 @@ function MeasurementSelectionSummary({
 function resultMatchesSelection(
   result: MeasurementResult,
   entityIdsKey: string,
-  distanceMode: DistanceMode
+  distanceMode: DistanceMode,
+  unit: UnitLength
 ): boolean {
   if (result.entityIdsKey !== entityIdsKey) {
     return false
   }
 
-  return result.type !== 'distance' || result.mode === distanceMode
+  if (result.type === 'distance') {
+    return result.mode === distanceMode && result.unit === unit
+  }
+
+  if (result.type === 'edgeLength') {
+    return result.unit === unit
+  }
+
+  return (
+    result.centerOfMassUnit === unit &&
+    result.surfaceAreaUnit === getAreaUnit(unit) &&
+    result.volumeUnit === getVolumeUnit(unit)
+  )
 }
 
 async function requestMeasurement({
@@ -286,8 +301,9 @@ async function requestMeasurement({
 
     return {
       type: 'distance',
-      min: data.min_distance,
-      max: data.max_distance,
+      min: convertLengthFromMm(data.min_distance, unit),
+      max: convertLengthFromMm(data.max_distance, unit),
+      unit,
       entityIdsKey: selectedEntityIdsKey,
       mode: distanceMode,
     }
@@ -317,7 +333,7 @@ async function requestMeasurement({
 
     return {
       type: 'edgeLength',
-      length: data.length,
+      length: convertLengthFromMm(data.length, unit),
       entityIdsKey: selectedEntityIdsKey,
       unit,
     }
@@ -395,16 +411,13 @@ async function requestMeasurement({
   }
 }
 
-function getMeasurementResultSummary(
-  result: MeasurementResult,
-  unit: UnitLength
-): string {
+function getMeasurementResultSummary(result: MeasurementResult): string {
   if (result.type === 'distance') {
     const hasDistanceRange = Math.abs(result.max - result.min) > 1e-9
     const value = hasDistanceRange
       ? `${formatDistance(result.min)}-${formatDistance(result.max)}`
       : formatDistance(result.min)
-    return `${getDistanceMeasurementLabel(result.mode)}: ${value} ${unit}`
+    return `${getDistanceMeasurementLabel(result.mode)}: ${value} ${result.unit}`
   }
 
   if (result.type === 'edgeLength') {
@@ -414,20 +427,17 @@ function getMeasurementResultSummary(
   return `${formatDistance(result.volume)} ${result.volumeUnit}`
 }
 
-function getMeasurementResultText(
-  result: MeasurementResult,
-  unit: UnitLength
-): string {
+function getMeasurementResultText(result: MeasurementResult): string {
   if (result.type === 'distance') {
     const label = getDistanceMeasurementLabel(result.mode)
     const hasDistanceRange = Math.abs(result.max - result.min) > 1e-9
     if (!hasDistanceRange) {
-      return `${label}: ${formatDistance(result.min)} ${unit}`
+      return `${label}: ${formatDistance(result.min)} ${result.unit}`
     }
 
     return [
-      `${label} min: ${formatDistance(result.min)} ${unit}`,
-      `${label} max: ${formatDistance(result.max)} ${unit}`,
+      `${label} min: ${formatDistance(result.min)} ${result.unit}`,
+      `${label} max: ${formatDistance(result.max)} ${result.unit}`,
     ].join('\n')
   }
 
@@ -574,7 +584,8 @@ export function MeasurementTool() {
   }
 
   const matchingResult =
-    result && resultMatchesSelection(result, selectedEntityIdsKey, distanceMode)
+    result &&
+    resultMatchesSelection(result, selectedEntityIdsKey, distanceMode, unit)
       ? result
       : null
   const hasDistanceRange =
@@ -635,7 +646,7 @@ export function MeasurementTool() {
 
       {matchingResult?.type === 'distance' && (
         <CopyTextButton
-          textToCopy={getMeasurementResultText(matchingResult, unit)}
+          textToCopy={getMeasurementResultText(matchingResult)}
           title="Copy measurement"
           onCopySuccess={showMeasurementCopySuccess}
           onCopyError={showMeasurementCopyError}
@@ -648,13 +659,13 @@ export function MeasurementTool() {
                 : getDistanceMeasurementLabel(matchingResult.mode)
             }
             value={matchingResult.min}
-            unit={unit}
+            unit={matchingResult.unit}
           />
           {hasDistanceRange && (
             <MeasurementValue
               label={`${getDistanceModeLabel(matchingResult.mode)} max`}
               value={matchingResult.max}
-              unit={unit}
+              unit={matchingResult.unit}
             />
           )}
         </CopyTextButton>
@@ -662,7 +673,7 @@ export function MeasurementTool() {
 
       {matchingResult?.type === 'edgeLength' && (
         <CopyTextButton
-          textToCopy={getMeasurementResultText(matchingResult, unit)}
+          textToCopy={getMeasurementResultText(matchingResult)}
           title="Copy measurement"
           onCopySuccess={showMeasurementCopySuccess}
           onCopyError={showMeasurementCopyError}
@@ -678,7 +689,7 @@ export function MeasurementTool() {
 
       {matchingResult?.type === 'bodyDetails' && (
         <CopyTextButton
-          textToCopy={getMeasurementResultText(matchingResult, unit)}
+          textToCopy={getMeasurementResultText(matchingResult)}
           title="Copy measurement"
           onCopySuccess={showMeasurementCopySuccess}
           onCopyError={showMeasurementCopyError}
@@ -815,12 +826,13 @@ export function MeasurementStatusBarItem() {
     resultMatchesSelection(
       result,
       selectedEntityIdsKey,
-      defaultStatusDistanceMode
+      defaultStatusDistanceMode,
+      unit
     )
       ? result
       : null
   const summary = matchingResult
-    ? getMeasurementResultSummary(matchingResult, unit)
+    ? getMeasurementResultSummary(matchingResult)
     : null
   const isOpen = measurementToolService.isOpen.value
   const streamContainerRef = useMemo<RefObject<HTMLElement | null>>(

--- a/src/registry/extensions/engineScene/measurementUtils.ts
+++ b/src/registry/extensions/engineScene/measurementUtils.ts
@@ -65,6 +65,17 @@ const volumeUnitByLengthUnit: Record<UnitLength, UnitVolume> = {
   yd: 'yd3',
 }
 
+const millimetersByLengthUnit: Record<UnitLength, number> = {
+  mm: 1,
+  cm: 10,
+  m: 1000,
+  in: 25.4,
+  ft: 304.8,
+  yd: 914.4,
+}
+
+const lengthUnitConversionDecimalPlaces = 7
+
 function getMeasurementKindForArtifact(
   artifact: Artifact | undefined
 ): MeasurementSelectionKind {
@@ -198,6 +209,16 @@ export function getAreaUnit(unit: UnitLength): UnitArea {
 
 export function getVolumeUnit(unit: UnitLength): UnitVolume {
   return volumeUnitByLengthUnit[unit]
+}
+
+/** Converts engine length measurements, returned in millimeters, to a display unit. */
+export function convertLengthFromMm(value: number, unit: UnitLength): number {
+  const roundedValue = Number(
+    (value / millimetersByLengthUnit[unit]).toFixed(
+      lengthUnitConversionDecimalPlaces
+    )
+  )
+  return Object.is(roundedValue, -0) ? 0 : roundedValue
 }
 
 export function formatDistance(value: number): string {


### PR DESCRIPTION
## Summary

- Convert measure-tool distance and edge-length values from engine millimeters into the active default length unit before display and copy output.
- Keep body measurements tied to the default unit by validating volume, surface-area, and center-of-mass result units together.
- Expand helper coverage for length, area, and volume unit derivation.

## Root Cause

The measure tool displayed the active unit suffix for distance and edge-length results, but those engine endpoints return raw millimeter values. That produced values such as `609.6 in` for a 24 inch edge.

## Validation

- `NODE_OPTIONS=--localstorage-file=/private/tmp/zds-vitest-localstorage npm run test:unit -- src/registry/extensions/engineScene/MeasurementTool.test.ts`
- `npm run tsc -- --noEmit`
- `git diff --check`

Closes #12383