### PR TITLE
Send Begin/End Execution commands

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -332,7 +332,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -585,7 +585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1159,7 +1159,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2250,7 +2250,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2652,9 +2652,9 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.209"
+version = "0.2.211"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1068db9b2fe4d8fbf20f9002d2433837a9f7afded7510cf7ed973b4cb69dd24"
+checksum = "cb0aadfd54a7843e2dc5852c00dc5da84ae4c4292938fcb4e8f31c04a42b6422"
 dependencies = [
  "anyhow",
  "bon",
@@ -4022,7 +4022,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4391,7 +4391,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4404,7 +4404,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5210,7 +5210,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6243,7 +6243,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -29,7 +29,7 @@ kittycad = { version = "0.4.13", default-features = false, features = [
   "js",
   "requests",
 ] }
-kittycad-modeling-cmds = { version = "0.2.207", features = [
+kittycad-modeling-cmds = { version = "0.2.211", features = [
   "ts-rs",
   "websocket",
 ] }

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -1574,6 +1574,34 @@ impl ExecutorContext {
         universe_info: Option<(Universe, UniverseMap)>,
         preserve_mem: PreserveMem,
     ) -> Result<(EnvironmentRef, Option<ModelingSessionData>), KclErrorWithOutputs> {
+        // Tell the engine we're about to execute a lot of modeling commands.
+        let enable_render = true;
+        exec_state
+            .begin_execution(self, enable_render)
+            .await
+            .map_err(KclErrorWithOutputs::no_outputs)?;
+
+        // Execute the program, which executes modeling commands.
+        let exec_res = self
+            .run_concurrent_inner(program, exec_state, universe_info, preserve_mem)
+            .await;
+
+        // Tell the engine we're done.
+        let end_exec_res = exec_state.end_execution(self).await;
+        match (exec_res, end_exec_res) {
+            (Ok(res), Ok(())) => Ok(res),
+            (Err(e), _) => Err(e),
+            (Ok(_), Err(e)) => Err(KclErrorWithOutputs::no_outputs(e)),
+        }
+    }
+
+    async fn run_concurrent_inner(
+        &self,
+        program: &crate::Program,
+        exec_state: &mut ExecState,
+        universe_info: Option<(Universe, UniverseMap)>,
+        preserve_mem: PreserveMem,
+    ) -> Result<(EnvironmentRef, Option<ModelingSessionData>), KclErrorWithOutputs> {
         // Reuse our cached universe if we have one.
 
         let (universe, universe_map) = if let Some((universe, universe_map)) = universe_info {

--- a/rust/kcl-lib/src/execution/state.rs
+++ b/rust/kcl-lib/src/execution/state.rs
@@ -961,23 +961,25 @@ impl ExecState {
     /// Call this before sending modeling commands for execution.
     pub(crate) async fn begin_execution(&mut self, ctx: &ExecutorContext, enable_render: bool) -> Result<(), KclError> {
         let cmd_id = self.next_uuid();
-        self.send_modeling_cmd(
-            ModelingCmdMeta::with_id(self, ctx, Default::default(), cmd_id),
-            ModelingCmd::from(BeginExecution::builder().enable_render(enable_render).build()),
-        )
-        .await
-        .map(|_| ())
+        let cmd = ModelingCmd::from(BeginExecution::builder().enable_render(enable_render).build());
+        let meta = ModelingCmdMeta::with_id(self, ctx, Default::default(), cmd_id);
+        meta.ctx
+            .engine
+            .send_modeling_cmd(&meta.ctx.engine_batch, cmd_id, meta.source_range, &cmd)
+            .await
+            .map(|_| ())
     }
 
     /// Call this after sending modeling commands for execution.
     pub(crate) async fn end_execution(&mut self, ctx: &ExecutorContext) -> Result<(), KclError> {
         let cmd_id = self.next_uuid();
-        self.send_modeling_cmd(
-            ModelingCmdMeta::with_id(self, ctx, Default::default(), cmd_id),
-            ModelingCmd::from(EndExecution::default()),
-        )
-        .await
-        .map(|_| ())
+        let cmd = ModelingCmd::from(EndExecution::default());
+        let meta = ModelingCmdMeta::with_id(self, ctx, Default::default(), cmd_id);
+        meta.ctx
+            .engine
+            .send_modeling_cmd(&meta.ctx.engine_batch, cmd_id, meta.source_range, &cmd)
+            .await
+            .map(|_| ())
     }
 }
 

--- a/rust/kcl-lib/src/execution/state.rs
+++ b/rust/kcl-lib/src/execution/state.rs
@@ -7,6 +7,9 @@ use anyhow::Result;
 use indexmap::IndexMap;
 use kcl_api::UnitAngle;
 use kcl_api::UnitLength;
+use kittycad_modeling_cmds::BeginExecution;
+use kittycad_modeling_cmds::EndExecution;
+use kittycad_modeling_cmds::ModelingCmd;
 use serde::Deserialize;
 use serde::Serialize;
 use uuid::Uuid;
@@ -33,6 +36,7 @@ use crate::execution::ExecOutcome;
 use crate::execution::ExecutorSettings;
 use crate::execution::KclValue;
 use crate::execution::KclValueView;
+use crate::execution::ModelingCmdMeta;
 use crate::execution::OperationCallbackArgs;
 use crate::execution::OperationsByModule;
 use crate::execution::ProgramLookup;
@@ -952,6 +956,28 @@ impl ExecState {
 
     pub(crate) fn kcl_version(&self) -> KclVersion {
         self.mod_local.settings.kcl_version.parse().unwrap_or_default()
+    }
+
+    /// Call this before sending modeling commands for execution.
+    pub(crate) async fn begin_execution(&mut self, ctx: &ExecutorContext, enable_render: bool) -> Result<(), KclError> {
+        let cmd_id = self.next_uuid();
+        self.send_modeling_cmd(
+            ModelingCmdMeta::with_id(self, ctx, Default::default(), cmd_id),
+            ModelingCmd::from(BeginExecution::builder().enable_render(enable_render).build()),
+        )
+        .await
+        .map(|_| ())
+    }
+
+    /// Call this after sending modeling commands for execution.
+    pub(crate) async fn end_execution(&mut self, ctx: &ExecutorContext) -> Result<(), KclError> {
+        let cmd_id = self.next_uuid();
+        self.send_modeling_cmd(
+            ModelingCmdMeta::with_id(self, ctx, Default::default(), cmd_id),
+            ModelingCmd::from(EndExecution::default()),
+        )
+        .await
+        .map(|_| ())
     }
 }
 


### PR DESCRIPTION
This should speed up execution of complex models, by making them render at lower resolution while they're being built.

These engine commands don't emit artifacts, as they're an implementation detail and shouldn't matter to the user. Also they happen "globally" (outside any particular module) so they don't quite fit with the current way artifacts are collected per-module.