### PR TITLE
Bump astral-sh/ruff-action from 3 to 4.1.0

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -20,5 +20,5 @@ jobs:
     runs-on: namespace-profile-ubuntu-2-cores
     steps:
       - uses: actions/checkout@v7.0.0
-      - uses: astral-sh/ruff-action@v3
+      - uses: astral-sh/ruff-action@v4.1.0
 


### PR DESCRIPTION
https://github.com/astral-sh/ruff-action/releases

I don't know why Dependabot hasn't updated this. I noticed the warning about Node 20 being deprecated.

The ruff CI job has been failing since June 6. [Example](https://github.com/KittyCAD/modeling-app/actions/runs/28609170516/job/84837005408). Updating the action doesn't fix it. Hard to tell if it was caused by a change in our repo since it's not always run.