### PR TITLE
Run the 'ruff' job unconditionally

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,20 +1,19 @@
 name: ruff
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
-on:
-  push:
-    branches: main
-    paths:
-      - '**.py'
-      - .github/workflows/ruff.yml
-  pull_request:
-    paths:
-      - '**.py'
-      - .github/workflows/ruff.yml
+
 permissions:
   contents: read
   pull-requests: write
+
 jobs:
   ruff:
     runs-on: namespace-profile-ubuntu-2-cores


### PR DESCRIPTION
Skipping it doesn’t reduce the overall feedback cycle time (job completes in seconds) but it does lead to surprises when we haven’t touched Python code in a while.