### PR TITLE
Dashboard settings can open project tab without an active project

### DIFF
--- a/src/components/Settings/SettingsSearchBar.tsx
+++ b/src/components/Settings/SettingsSearchBar.tsx
@@ -29,6 +29,7 @@ type ExtendedSettingsLevel = SettingsLevel | 'keybindings'
 
 interface SettingsSearchBarProps {
   keybinding?: string
+  hasOpenProject: boolean
 }
 
 export type SettingsSearchItem = {
@@ -39,7 +40,10 @@ export type SettingsSearchItem = {
   level: ExtendedSettingsLevel
 }
 
-export function SettingsSearchBar({ keybinding }: SettingsSearchBarProps) {
+export function SettingsSearchBar({
+  keybinding,
+  hasOpenProject,
+}: SettingsSearchBarProps) {
   useSignals()
   const { settings, registry } = useApp()
   const keymap = registry.optional(keymapService)
@@ -72,7 +76,11 @@ export function SettingsSearchBar({ keybinding }: SettingsSearchBarProps) {
         ([category, categorySettings]) =>
           Object.entries(categorySettings).flatMap(([settingName, setting]) => {
             const s = setting
-            return (['project', 'user'] satisfies SettingsLevel[])
+            return (
+              hasOpenProject
+                ? (['project', 'user'] satisfies SettingsLevel[])
+                : (['user'] satisfies SettingsLevel[])
+            )
               .filter(
                 (l) => s.hideOnLevel !== l && !hiddenOnPlatform(s, isDesktop())
               )
@@ -99,7 +107,7 @@ export function SettingsSearchBar({ keybinding }: SettingsSearchBarProps) {
           }) satisfies SettingsSearchItem
       ),
     ],
-    [settingsValues, keybindingRows, keymapScopes]
+    [settingsValues, keybindingRows, keymapScopes, hasOpenProject]
   )
   const fuse = useMemo(
     () =>

--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -49,12 +49,41 @@ export const Settings = () => {
   }
   const location = useLocation()
   const isFileSettings = location.pathname.includes(PATHS.FILE)
-  const defaultTab: SettingsLevel = isFileSettings ? 'project' : 'user'
+  const hasOpenProject = app.project !== undefined
+  const defaultTab: SettingsLevel =
+    isFileSettings && hasOpenProject ? 'project' : 'user'
   const requestedTab = searchParams.get('tab')
-  const requestedSettingsTab = isSettingsTab(requestedTab)
-    ? requestedTab
-    : defaultTab
+  const requestedSettingsTab =
+    requestedTab === 'project' && !hasOpenProject
+      ? 'user'
+      : isSettingsTab(requestedTab)
+        ? requestedTab
+        : defaultTab
   const searchParamTab = requestedSettingsTab
+
+  useEffect(() => {
+    if (requestedTab !== 'project' || hasOpenProject) {
+      return
+    }
+
+    const nextSearchParams = new URLSearchParams(searchParams)
+    nextSearchParams.set('tab', 'user')
+    void navigate(
+      {
+        pathname: location.pathname,
+        search: `?${nextSearchParams.toString()}`,
+        hash: location.hash,
+      },
+      { replace: true }
+    )
+  }, [
+    hasOpenProject,
+    location.hash,
+    location.pathname,
+    navigate,
+    requestedTab,
+    searchParams,
+  ])
 
   const scrollRef = useRef<HTMLDivElement>(null)
   const settingsSearchKeybinding = keymapKeystrokesDisplay(
@@ -137,7 +166,7 @@ export const Settings = () => {
               <div className="flex gap-4 items-start">
                 <SettingsSearchBar
                   keybinding={settingsSearchKeybinding}
-                  hasOpenProject={app.project !== undefined}
+                  hasOpenProject={hasOpenProject}
                 />
                 <button
                   type="button"

--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -135,7 +135,10 @@ export const Settings = () => {
             <div className="p-5 pb-0 flex justify-between items-center">
               <h1 className="text-2xl font-bold">Settings</h1>
               <div className="flex gap-4 items-start">
-                <SettingsSearchBar keybinding={settingsSearchKeybinding} />
+                <SettingsSearchBar
+                  keybinding={settingsSearchKeybinding}
+                  hasOpenProject={app.project !== undefined}
+                />
                 <button
                   type="button"
                   onClick={close}


### PR DESCRIPTION

You can search and select a project level setting in User settings even if you have no project opened.
That caused some buggy behaviour because the app tried to set a project level setting without having an active project.

Fixes in this PR:
- Don't list project level settings in search bar if there's no active project
- If the app tries to open the project settings anyway (eg. the web app where users can type any url) it redirects to the user tab.