### PR TITLE
Fix clone edge references for fillet and chamfer

### DIFF
--- a/rust/kcl-lib/src/execution/state.rs
+++ b/rust/kcl-lib/src/execution/state.rs
@@ -231,6 +231,11 @@ pub(super) struct ModuleState {
     /// the exact key lookup misses, this map lets us reject that solid by
     /// `engine_id`, unless the key is a recorded operation output.
     pub(super) consumed_solid_ids: AHashMap<Uuid, ConsumedSolidInfo>,
+    /// Deprecated edge helpers return bare edge UUIDs, so consumers cannot see
+    /// whether the original expression referenced a clone. Keep equivalent
+    /// original/clone edge IDs here so fillet/chamfer can pick the edge owned by
+    /// their target solid.
+    pub(super) legacy_edge_id_alternates: AHashMap<Uuid, Vec<Uuid>>,
 }
 
 /// Internal identity for one runtime KCL solid value.
@@ -685,6 +690,27 @@ impl ExecState {
     /// boolean operation.
     pub(crate) fn check_solid_id_consumed(&self, id: &Uuid) -> Option<&ConsumedSolidInfo> {
         self.mod_local.consumed_solid_ids.get(id)
+    }
+
+    pub(crate) fn record_legacy_edge_id_alternates(&mut self, edge_ids: impl IntoIterator<Item = Uuid>) {
+        let edge_ids: Vec<Uuid> = edge_ids.into_iter().collect();
+        for edge_id in &edge_ids {
+            let entry = self.mod_local.legacy_edge_id_alternates.entry(*edge_id).or_default();
+            for alternate_id in &edge_ids {
+                if alternate_id != edge_id && !entry.contains(alternate_id) {
+                    entry.push(*alternate_id);
+                }
+            }
+        }
+    }
+
+    pub(crate) fn legacy_edge_id_alternates(&self, edge_id: Uuid) -> impl Iterator<Item = Uuid> + '_ {
+        self.mod_local
+            .legacy_edge_id_alternates
+            .get(&edge_id)
+            .into_iter()
+            .flatten()
+            .copied()
     }
 
     /// Follow direct replacement links until we find the latest known output.
@@ -1161,6 +1187,7 @@ impl ModuleState {
             denied_warnings: Vec::new(),
             consumed_solids: AHashMap::default(),
             consumed_solid_ids: AHashMap::default(),
+            legacy_edge_id_alternates: AHashMap::default(),
             inside_stdlib: false,
         }
     }

--- a/rust/kcl-lib/src/std/chamfer.rs
+++ b/rust/kcl-lib/src/std/chamfer.rs
@@ -180,7 +180,10 @@ async fn inner_chamfer(
 
     let mut solid = solid.clone();
     for edge_tag in tags {
-        let edge_ids = edge_tag.get_all_engine_ids(exec_state, &args)?;
+        let mut edge_ids = Vec::new();
+        for edge_id in edge_tag.get_all_engine_ids(exec_state, &args)? {
+            edge_ids.push(super::edge::resolve_legacy_edge_id_for_solid(exec_state, &solid, edge_id, &args).await);
+        }
         for edge_id in edge_ids {
             let id = exec_state.next_uuid();
             exec_state

--- a/rust/kcl-lib/src/std/clone.rs
+++ b/rust/kcl-lib/src/std/clone.rs
@@ -14,11 +14,15 @@ use crate::errors::KclError;
 use crate::errors::KclErrorDetails;
 use crate::execution::ExecState;
 use crate::execution::ExtrudeSurface;
+use crate::execution::Geometry;
 use crate::execution::GeometryWithImportedGeometry;
 use crate::execution::KclValue;
+use crate::execution::Metadata;
 use crate::execution::ModelingCmdMeta;
 use crate::execution::Sketch;
 use crate::execution::Solid;
+use crate::execution::TagEngineInfo;
+use crate::execution::TagIdentifier;
 use crate::execution::types::ArrayLen;
 use crate::execution::types::PrimitiveType;
 use crate::execution::types::RuntimeType;
@@ -26,6 +30,7 @@ use crate::parsing::ast::types::TagNode;
 use crate::std::Args;
 use crate::std::extrude::BeingExtruded;
 use crate::std::extrude::NamedCapTags;
+use indexmap::IndexSet;
 
 type Result<T> = std::result::Result<T, KclError>;
 
@@ -138,6 +143,7 @@ pub(super) async fn fix_tags_and_references(
         }
         GeometryWithImportedGeometry::Solid(solid) => {
             let (start_tag, end_tag) = get_named_cap_tags(solid);
+            let face_tag_names = solid.faces.keys().cloned().collect::<IndexSet<_>>();
             let solid_value = solid.value.clone();
 
             // Make the sketch id the new geometry id.
@@ -174,7 +180,7 @@ pub(super) async fn fix_tags_and_references(
 
             // Do the after extrude things to update those ids, based on the new sketch
             // information.
-            let new_solid = do_post_extrude(
+            let mut new_solid = do_post_extrude(
                 &sketch_for_post,
                 new_geometry_id.into(),
                 solid.sectional,
@@ -191,6 +197,8 @@ pub(super) async fn fix_tags_and_references(
                 BeingExtruded::Sketch,
             )
             .await?;
+
+            add_cloned_solid_face_tags(&mut new_solid, exec_state, &face_tag_names);
 
             *solid = new_solid;
         }
@@ -266,6 +274,8 @@ async fn fix_sketch_tags_and_references(
     args: &Args,
     surfaces: Option<Vec<ExtrudeSurface>>,
 ) -> Result<()> {
+    let original_tags = new_sketch.tags.clone();
+
     // Fix the path references in the sketch.
     for path in new_sketch.paths.as_mut_slice() {
         if let Some(new_path_id) = entity_id_map.get(&path.get_id()) {
@@ -309,6 +319,22 @@ async fn fix_sketch_tags_and_references(
             }
 
             new_sketch.add_tag(&tag, &path, exec_state, surface.as_ref());
+            if let Some(original_tag) = original_tags.get(&tag.name)
+                && let Some(cloned_tag) = new_sketch.tags.get_mut(&tag.name)
+            {
+                let cloned_epoch = cloned_tag
+                    .info
+                    .last()
+                    .map(|(epoch, _)| *epoch)
+                    .unwrap_or_else(|| exec_state.stack().current_epoch());
+                let original_epoch = cloned_epoch.saturating_sub(1);
+                let original_info = original_tag.info.iter().map(|(_, info)| (original_epoch, info.clone()));
+                // Keep the original tag info around for deprecated edge helper
+                // compatibility. It is intentionally historical metadata, not
+                // current metadata, so face API refs still use cloned faces and
+                // getOppositeEdge-style helpers can opt into the original.
+                cloned_tag.info.splice(0..0, original_info);
+            }
         }
     }
 
@@ -323,6 +349,44 @@ async fn fix_sketch_tags_and_references(
     }
 
     Ok(())
+}
+
+fn add_cloned_solid_face_tags(solid: &mut Solid, exec_state: &mut ExecState, face_tag_names: &IndexSet<String>) {
+    let solid_for_tag = {
+        let mut solid_copy = solid.clone();
+        if let Some(sketch) = solid_copy.sketch_mut() {
+            sketch.tags.clear();
+        }
+        solid_copy.faces.clear();
+        solid_copy
+    };
+
+    for surface in &solid.value {
+        let Some(tag) = surface.get_tag() else {
+            continue;
+        };
+        if !face_tag_names.contains(&tag.name) {
+            continue;
+        }
+        solid.faces.insert(
+            tag.name.clone(),
+            TagIdentifier {
+                value: tag.name.clone(),
+                info: vec![(
+                    exec_state.stack().current_epoch(),
+                    TagEngineInfo {
+                        id: surface.get_id(),
+                        surface: Some(surface.clone()),
+                        path: None,
+                        geometry: Geometry::Solid(solid_for_tag.clone()),
+                    },
+                )],
+                meta: vec![Metadata {
+                    source_range: tag.clone().into(),
+                }],
+            },
+        );
+    }
 }
 
 // Return the named cap tags for the original solid.
@@ -590,6 +654,108 @@ clonedCube = clone(cube)
 
         assert_eq!(cube.edge_cuts.len(), 0);
         assert_eq!(cloned_cube.edge_cuts.len(), 0);
+
+        ctx.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn kcl_test_clone_solid_with_face_api_edge_specifier() {
+        let code = r#"unitSquareSketch = sketch(on = XY) {
+  s1 = line(start = [var -0.5mm, var -0.5mm], end = [var 0.5mm, var -0.5mm])
+  s2 = line(start = [var 0.5mm, var -0.5mm], end = [var 0.5mm, var 0.5mm])
+  s3 = line(start = [var 0.5mm, var 0.5mm], end = [var -0.5mm, var 0.5mm])
+  s4 = line(start = [var -0.5mm, var 0.5mm], end = [var -0.5mm, var -0.5mm])
+  coincident([s1.end, s2.start])
+  coincident([s2.end, s3.start])
+  coincident([s3.end, s4.start])
+  coincident([s4.end, s1.start])
+}
+unitBlock = extrude(
+  region(point = [0mm, 0mm], sketch = unitSquareSketch),
+  length = 1mm,
+  symmetric = true,
+  tagEnd = $capEnd001,
+)
+unitSoftBlockBase = clone(unitBlock)
+unitSoftBlock = chamfer(
+  unitSoftBlockBase,
+  length = 0.05mm,
+  edges = [
+    {
+      sideFaces = [
+        unitSoftBlockBase.sketch.tags.s1,
+        unitSoftBlockBase.faces.capEnd001
+      ]
+    }
+  ],
+)
+"#;
+        let ctx = crate::test_server::new_context(true, None).await.unwrap();
+        let program = crate::Program::parse_no_errs(code).unwrap();
+
+        ctx.run_with_caching(program.clone()).await.unwrap();
+
+        ctx.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn kcl_test_clone_solid_with_deprecated_edge_helper() {
+        let code = r#"unitSquareSketch = sketch(on = XY) {
+  s1 = line(start = [var -0.5mm, var -0.5mm], end = [var 0.5mm, var -0.5mm])
+  s2 = line(start = [var 0.5mm, var -0.5mm], end = [var 0.5mm, var 0.5mm])
+  s3 = line(start = [var 0.5mm, var 0.5mm], end = [var -0.5mm, var 0.5mm])
+  s4 = line(start = [var -0.5mm, var 0.5mm], end = [var -0.5mm, var -0.5mm])
+  coincident([s1.end, s2.start])
+  coincident([s2.end, s3.start])
+  coincident([s3.end, s4.start])
+  coincident([s4.end, s1.start])
+}
+unitBlock = extrude(region(point = [0mm, 0mm], sketch = unitSquareSketch), length = 1mm, symmetric = true)
+unitSoftBlockBase = clone(unitBlock)
+unitSoftBlock = chamfer(
+  unitBlock,
+  length = 0.05mm,
+  tags = [
+    getOppositeEdge(unitSoftBlockBase.sketch.tags.s1),
+    getOppositeEdge(unitSoftBlockBase.sketch.tags.s2),
+    getOppositeEdge(unitSoftBlockBase.sketch.tags.s3),
+    getOppositeEdge(unitSoftBlockBase.sketch.tags.s4)
+  ],
+)
+"#;
+        let ctx = crate::test_server::new_context(true, None).await.unwrap();
+        let program = crate::Program::parse_no_errs(code).unwrap();
+
+        ctx.run_with_caching(program.clone()).await.unwrap();
+
+        ctx.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn kcl_test_clone_solid_target_with_deprecated_edge_helper() {
+        let code = r#"unitCircleSketch = sketch(on = XY) {
+  guide = line(start = [var 0mm, var 0mm], end = [var 1mm, var 0mm], construction = true)
+  c = circle(start = [var 1mm, var 0mm], center = [var 0mm, var 0mm])
+  coincident([guide.start, ORIGIN])
+  coincident([guide.start, c.center])
+  coincident([guide.end, c.start])
+  horizontal(guide)
+  horizontalDistance([guide.start, guide.end]) == 1mm
+}
+unitCylinder = extrude(region(point = [0mm, 0mm], sketch = unitCircleSketch), length = 1mm, symmetric = true)
+unitSoftCylinderBase = clone(unitCylinder)
+unitSoftCylinder = chamfer(
+  unitSoftCylinderBase,
+  length = 0.05mm,
+  tags = [
+    getOppositeEdge(unitSoftCylinderBase.sketch.tags.c)
+  ],
+)
+"#;
+        let ctx = crate::test_server::new_context(true, None).await.unwrap();
+        let program = crate::Program::parse_no_errs(code).unwrap();
+
+        ctx.run_with_caching(program.clone()).await.unwrap();
 
         ctx.close().await;
     }

--- a/rust/kcl-lib/src/std/edge.rs
+++ b/rust/kcl-lib/src/std/edge.rs
@@ -16,10 +16,12 @@ use crate::errors::KclErrorDetails;
 use crate::execution::BoundedEdge;
 use crate::execution::ExecState;
 use crate::execution::ExtrudeSurface;
+use crate::execution::Geometry;
 use crate::execution::KclObjectFields;
 use crate::execution::KclValue;
 use crate::execution::ModelingCmdMeta;
 use crate::execution::Solid;
+use crate::execution::TagEngineInfo;
 use crate::execution::TagIdentifier;
 use crate::execution::types::ArrayLen;
 use crate::execution::types::RuntimeType;
@@ -95,6 +97,29 @@ pub(crate) async fn get_face_ids_for_edge(
     Ok(info.faces.clone())
 }
 
+pub(super) async fn resolve_legacy_edge_id_for_solid(
+    exec_state: &mut ExecState,
+    solid: &Solid,
+    edge_id: Uuid,
+    args: &Args,
+) -> Uuid {
+    if get_face_ids_for_edge(exec_state, solid.id, edge_id, args).await.is_ok() {
+        return edge_id;
+    }
+
+    let alternate_ids: Vec<Uuid> = exec_state.legacy_edge_id_alternates(edge_id).collect();
+    for alternate_id in alternate_ids {
+        if get_face_ids_for_edge(exec_state, solid.id, alternate_id, args)
+            .await
+            .is_ok()
+        {
+            return alternate_id;
+        }
+    }
+
+    edge_id
+}
+
 /// Check that a tag does not map to multiple edges (ambiguous region mapping).
 pub(super) fn check_tag_not_ambiguous(tag: &TagIdentifier, args: &Args) -> Result<(), KclError> {
     let all_infos = tag.get_all_cur_info();
@@ -109,6 +134,66 @@ pub(super) fn check_tag_not_ambiguous(tag: &TagIdentifier, args: &Args) -> Resul
         )));
     }
     Ok(())
+}
+
+fn legacy_edge_helper_info(edge: &TagIdentifier, current_info: TagEngineInfo) -> TagEngineInfo {
+    if !geometry_is_clone(&current_info.geometry) {
+        return current_info;
+    }
+
+    let current_id = current_info.geometry.id();
+    edge.info
+        .iter()
+        .rev()
+        .skip_while(|(_, info)| info.geometry.id() == current_id)
+        .find_map(|(_, info)| info.surface.is_some().then_some(info.clone()))
+        .unwrap_or(current_info)
+}
+
+fn geometry_is_clone(geometry: &Geometry) -> bool {
+    match geometry {
+        Geometry::Sketch(sketch) => sketch.clone.is_some(),
+        Geometry::Solid(solid) => solid.sketch().is_some_and(|sketch| sketch.clone.is_some()),
+    }
+}
+
+fn face_id_from_tag_engine_info(edge: &TagIdentifier, info: &TagEngineInfo, args: &Args) -> Result<Uuid, KclError> {
+    let surface = info.surface.as_ref().ok_or_else(|| {
+        KclError::new_type(KclErrorDetails::new(
+            format!("Tag `{}` refers to non-face geometry", edge.value),
+            vec![args.source_range],
+        ))
+    })?;
+
+    let tagged_surface = match surface {
+        ExtrudeSurface::ExtrudePlane(extrude_plane) => extrude_plane
+            .tag
+            .as_ref()
+            .is_some_and(|plane_tag| plane_tag.name == edge.value)
+            .then_some(extrude_plane.face_id),
+        ExtrudeSurface::ExtrudeArc(extrude_arc) => extrude_arc
+            .tag
+            .as_ref()
+            .is_some_and(|arc_tag| arc_tag.name == edge.value)
+            .then_some(extrude_arc.face_id),
+        ExtrudeSurface::Chamfer(chamfer) => chamfer
+            .tag
+            .as_ref()
+            .is_some_and(|chamfer_tag| chamfer_tag.name == edge.value)
+            .then_some(chamfer.face_id),
+        ExtrudeSurface::Fillet(fillet) => fillet
+            .tag
+            .as_ref()
+            .is_some_and(|fillet_tag| fillet_tag.name == edge.value)
+            .then_some(fillet.face_id),
+    };
+
+    tagged_surface.ok_or_else(|| {
+        KclError::new_type(KclErrorDetails::new(
+            format!("Expected a face with the tag `{}`", edge.value),
+            vec![args.source_range],
+        ))
+    })
 }
 
 /// Get the opposite edge to the edge given.
@@ -131,9 +216,9 @@ async fn inner_get_opposite_edge(
     if args.ctx.no_engine_commands().await {
         return Ok(exec_state.next_uuid());
     }
-    let face_id = args.get_adjacent_face_to_tag(exec_state, &edge, false).await?;
-
-    let tagged_path = args.get_tag_engine_info(exec_state, &edge)?;
+    let current_tagged_path = args.get_tag_engine_info(exec_state, &edge)?;
+    let tagged_path = legacy_edge_helper_info(&edge, current_tagged_path.clone());
+    let face_id = face_id_from_tag_engine_info(&edge, &tagged_path, &args)?;
     let tagged_path_id = tagged_path.id;
     let sketch_id = tagged_path.geometry.id();
 
@@ -159,7 +244,56 @@ async fn inner_get_opposite_edge(
         )));
     };
 
+    record_clone_legacy_opposite_edge_alternate(
+        exec_state,
+        &args,
+        &edge,
+        &tagged_path,
+        &current_tagged_path,
+        opposite_edge.edge,
+    )
+    .await?;
+
     Ok(opposite_edge.edge)
+}
+
+async fn record_clone_legacy_opposite_edge_alternate(
+    exec_state: &mut ExecState,
+    args: &Args,
+    edge: &TagIdentifier,
+    selected_info: &TagEngineInfo,
+    current_info: &TagEngineInfo,
+    selected_edge_id: Uuid,
+) -> Result<(), KclError> {
+    if selected_info.id == current_info.id || !geometry_is_clone(&current_info.geometry) {
+        return Ok(());
+    }
+
+    let face_id = face_id_from_tag_engine_info(edge, current_info, args)?;
+    let resp = exec_state
+        .send_modeling_cmd(
+            ModelingCmdMeta::from_args(exec_state, args),
+            ModelingCmd::from(
+                mcmd::Solid3dGetOppositeEdge::builder()
+                    .edge_id(current_info.id)
+                    .object_id(current_info.geometry.id())
+                    .face_id(face_id)
+                    .build(),
+            ),
+        )
+        .await?;
+    let OkWebSocketResponseData::Modeling {
+        modeling_response: OkModelingCmdResponse::Solid3dGetOppositeEdge(opposite_edge),
+    } = &resp
+    else {
+        return Err(KclError::new_engine(KclErrorDetails::new(
+            format!("mcmd::Solid3dGetOppositeEdge response was not as expected: {resp:?}"),
+            vec![args.source_range],
+        )));
+    };
+
+    exec_state.record_legacy_edge_id_alternates([selected_edge_id, opposite_edge.edge]);
+    Ok(())
 }
 
 /// Get the next adjacent edge to the edge given.
@@ -182,9 +316,8 @@ async fn inner_get_next_adjacent_edge(
     if args.ctx.no_engine_commands().await {
         return Ok(exec_state.next_uuid());
     }
-    let face_id = args.get_adjacent_face_to_tag(exec_state, &edge, false).await?;
-
-    let tagged_path = args.get_tag_engine_info(exec_state, &edge)?;
+    let tagged_path = legacy_edge_helper_info(&edge, args.get_tag_engine_info(exec_state, &edge)?);
+    let face_id = face_id_from_tag_engine_info(&edge, &tagged_path, &args)?;
     let tagged_path_id = tagged_path.id;
     let sketch_id = tagged_path.geometry.id();
 
@@ -239,9 +372,8 @@ async fn inner_get_previous_adjacent_edge(
     if args.ctx.no_engine_commands().await {
         return Ok(exec_state.next_uuid());
     }
-    let face_id = args.get_adjacent_face_to_tag(exec_state, &edge, false).await?;
-
-    let tagged_path = args.get_tag_engine_info(exec_state, &edge)?;
+    let tagged_path = legacy_edge_helper_info(&edge, args.get_tag_engine_info(exec_state, &edge)?);
+    let face_id = face_id_from_tag_engine_info(&edge, &tagged_path, &args)?;
     let tagged_path_id = tagged_path.id;
     let sketch_id = tagged_path.geometry.id();
 

--- a/rust/kcl-lib/src/std/extrude.rs
+++ b/rust/kcl-lib/src/std/extrude.rs
@@ -1093,8 +1093,8 @@ pub(crate) async fn do_post_extrude<'a>(
 
     let Faces {
         sides: mut face_id_map,
-        start_cap_id,
-        end_cap_id,
+        mut start_cap_id,
+        mut end_cap_id,
     } = analyze_faces(exec_state, args, face_infos).await;
 
     // If this is a clone, we will use the clone_id_map to map the face info from the original sketch to the clone sketch.
@@ -1109,6 +1109,8 @@ pub(crate) async fn do_post_extrude<'a>(
                 Some((*fe_key, fe_value))
             })
             .collect::<HashMap<Uuid, Option<Uuid>>>();
+        start_cap_id = start_cap_id.and_then(|id| clone_id_map.get(&id).copied());
+        end_cap_id = end_cap_id.and_then(|id| clone_id_map.get(&id).copied());
     }
 
     // Iterate over the sketch.value array and add face_id to GeoMeta

--- a/rust/kcl-lib/src/std/fillet.rs
+++ b/rust/kcl-lib/src/std/fillet.rs
@@ -221,16 +221,12 @@ async fn inner_fillet(
     }
 
     let mut solid = solid.clone();
-    let edge_ids = tags
-        .into_iter()
-        .map(|edge_tag| edge_tag.get_all_engine_ids(exec_state, &args))
-        .try_fold(Vec::new(), |mut acc, item| match item {
-            Ok(ids) => {
-                acc.extend(ids);
-                Ok(acc)
-            }
-            Err(e) => Err(e),
-        })?;
+    let mut edge_ids = Vec::new();
+    for edge_tag in tags {
+        for edge_id in edge_tag.get_all_engine_ids(exec_state, &args)? {
+            edge_ids.push(super::edge::resolve_legacy_edge_id_for_solid(exec_state, &solid, edge_id, &args).await);
+        }
+    }
 
     let id = exec_state.next_uuid();
     let mut extra_face_ids = Vec::new();


### PR DESCRIPTION
This fixes an existing clone/runtime issue that showed up while migrating the corpus to the new face API edge syntax.

The short version is that cloned solids were not keeping enough tag/face identity around for edge selection to keep working reliably. That meant code that should be valid after a clone could fail with errors like `The given Edge is not owned by this object`.

What changed:

- Preserve cloned solid face tags so `clonedSolid.faces.someCapTag` can refer to the cloned face, not the original solid's face.
- Keep historical tag info on cloned sketch tags so legacy helpers like `getOppositeEdge(clonedSolid.sketch.tags.s1)` can still resolve the intended original edge relationship.
- Record equivalent original/clone edge IDs for deprecated edge helpers, because those helpers return a bare UUID and the later `fillet` or `chamfer` call otherwise cannot tell which solid that UUID came from.
- Make `fillet` and `chamfer` resolve legacy helper edge IDs against the solid they are actually editing before sending the cut command to the engine.
- Added regression tests for cloned face API edge specifiers and the old `getOppositeEdge` clone cases.
