### PR TITLE
Make it possible to suppress `useAbsoluteFilePath` warning

### DIFF
--- a/src/components/HelpMenu.tsx
+++ b/src/components/HelpMenu.tsx
@@ -23,7 +23,7 @@ export function HelpMenu() {
   const { settings, systemIOActor } = useApp()
   const { kclManager } = useSingletons()
   const navigate = useNavigate()
-  const filePath = useAbsoluteFilePath()
+  const filePath = useAbsoluteFilePath({ warnIfNoExecutingPath: false })
 
   const resetOnboardingWorkflow = () => {
     const props = {

--- a/src/hooks/useAbsoluteFilePath.ts
+++ b/src/hooks/useAbsoluteFilePath.ts
@@ -1,13 +1,19 @@
 import { useApp } from '@src/lib/boot'
 import { PATHS } from '@src/lib/paths'
 
-export function useAbsoluteFilePath() {
+const defaultOptions = {
+  warnIfNoExecutingPath: true,
+}
+
+export function useAbsoluteFilePath(options = defaultOptions) {
   const app = useApp()
 
   const executingPath = app.project?.executingPathSignal.value?.value
 
   if (!executingPath) {
-    console.warn('bug: executingPath undefined, not navigating')
+    if (options.warnIfNoExecutingPath) {
+      console.warn('executingPath undefined but expected')
+    }
     return
   }
 

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -111,7 +111,7 @@ const Home = () => {
   } = useApp()
   const keymap = registry.optional(keymapService)
   const { kclManager } = useSingletons()
-  const executingPath = useAbsoluteFilePath()
+  const executingPath = useAbsoluteFilePath({ warnIfNoExecutingPath: false })
   const settingsActor = settings.actor
   useQueryParamEffects(kclManager)
 


### PR DESCRIPTION
We added a `console.warn` to this hook a while back, but there are legitimate places where it is used and there will not be an `executingPath`, such as on the `/home/*` routes. This lets calls suppress the warning, and then uses that configuration in two places where it is used where the legitimately might not be a value.