### PR TITLE
Fetch and display thumbnails from cloud-only projects

### DIFF
--- a/src/lib/cloudSync/cloudApi.spec.ts
+++ b/src/lib/cloudSync/cloudApi.spec.ts
@@ -1,0 +1,89 @@
+import {
+  getRemoteProjectThumbnailUrl,
+  normalizeRemoteProjectThumbnailUrl,
+  remoteProjectThumbnailTargetPathFromUrl,
+  thumbnailUrlFromRemoteProjectPayload,
+} from '@src/lib/cloudSync/cloudApi'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('remote project thumbnail URLs', () => {
+  test('normalizes Zoo project thumbnail URLs to the extensionless API route', () => {
+    expect(
+      normalizeRemoteProjectThumbnailUrl(
+        'https://api.dev.zoo.dev/user/projects/70cc6d47-b316-47ca-ab5c-30b46373b7d0/thumbnail.png?size=small#preview'
+      )
+    ).toBe(
+      'https://api.dev.zoo.dev/user/projects/70cc6d47-b316-47ca-ab5c-30b46373b7d0/thumbnail?size=small#preview'
+    )
+  })
+
+  test('leaves ordinary image URLs alone', () => {
+    expect(
+      normalizeRemoteProjectThumbnailUrl(
+        'https://example.test/assets/remote-123-thumbnail.png'
+      )
+    ).toBe('https://example.test/assets/remote-123-thumbnail.png')
+  })
+
+  test('normalizes thumbnail URLs found in remote project payloads', () => {
+    expect(
+      thumbnailUrlFromRemoteProjectPayload({
+        thumbnail_url:
+          'https://api.dev.zoo.dev/user/projects/70cc6d47-b316-47ca-ab5c-30b46373b7d0/thumbnail.png',
+      })
+    ).toBe(
+      'https://api.dev.zoo.dev/user/projects/70cc6d47-b316-47ca-ab5c-30b46373b7d0/thumbnail'
+    )
+  })
+
+  test('extracts an authenticated fetch target from Zoo project thumbnail URLs', () => {
+    expect(
+      remoteProjectThumbnailTargetPathFromUrl(
+        'https://api.dev.zoo.dev/user/projects/70cc6d47-b316-47ca-ab5c-30b46373b7d0/thumbnail.png?size=small#preview'
+      )
+    ).toBe(
+      '/user/projects/70cc6d47-b316-47ca-ab5c-30b46373b7d0/thumbnail?size=small'
+    )
+  })
+
+  test('fetches protected Zoo thumbnail URLs with cloud auth', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => {
+      return new Response(new Uint8Array([1, 2, 3]), {
+        headers: {
+          'content-type': 'image/png',
+        },
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      getRemoteProjectThumbnailUrl(
+        {
+          enabled: true,
+          baseUrl: 'https://api.dev.zoo.dev',
+          token: 'token-123',
+        },
+        {
+          id: '70cc6d47-b316-47ca-ab5c-30b46373b7d0',
+          thumbnail_url:
+            'https://api.dev.zoo.dev/user/projects/70cc6d47-b316-47ca-ab5c-30b46373b7d0/thumbnail.png',
+        }
+      )
+    ).resolves.toBe('data:image/png;base64,AQID')
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.dev.zoo.dev/user/projects/70cc6d47-b316-47ca-ab5c-30b46373b7d0/thumbnail',
+      expect.objectContaining({
+        credentials: 'include',
+      })
+    )
+    const requestInit = fetchMock.mock.calls[0][1]
+    expect((requestInit?.headers as Headers).get('Authorization')).toBe(
+      'Bearer token-123'
+    )
+  })
+})

--- a/src/lib/cloudSync/cloudApi.ts
+++ b/src/lib/cloudSync/cloudApi.ts
@@ -11,6 +11,7 @@ import type {
   RemoteProjectSummary,
   Revision,
 } from '@src/lib/cloudSync/types'
+import { isArray } from '@src/lib/utils'
 
 export class CloudApiError extends Error {
   status: number
@@ -98,6 +99,182 @@ export async function getRemoteProject(
   projectId: string
 ) {
   return cloudJson<RemoteProject>(config, `/user/projects/${projectId}`)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !isArray(value)
+}
+
+function stringValue(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+function isDisplayableImageUrl(value: string) {
+  return /^(https?:|blob:|data:image\/)/i.test(value)
+}
+
+function imageMimeTypeFromRecord(record: Record<string, unknown>) {
+  const mimeType =
+    stringValue(record.mime_type) ||
+    stringValue(record.mimeType) ||
+    stringValue(record.content_type) ||
+    stringValue(record.contentType)
+
+  return mimeType?.startsWith('image/') ? mimeType : 'image/png'
+}
+
+function maybeDataUrlFromBase64(value: string, mimeType = 'image/png') {
+  const base64 = value.replace(/\s/g, '')
+  if (!base64 || !/^[A-Za-z0-9+/]+={0,2}$/.test(base64)) {
+    return undefined
+  }
+
+  return `data:${mimeType};base64,${base64}`
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer) {
+  const bytes = new Uint8Array(buffer)
+  let binary = ''
+  const chunkSize = 0x8000
+
+  for (let index = 0; index < bytes.length; index += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(index, index + chunkSize))
+  }
+
+  return btoa(binary)
+}
+
+export function thumbnailUrlFromRemoteProjectPayload(
+  payload: unknown
+): string | undefined {
+  const directValue = stringValue(payload)
+  if (directValue) {
+    if (isDisplayableImageUrl(directValue)) {
+      return directValue
+    }
+
+    return maybeDataUrlFromBase64(directValue)
+  }
+
+  if (!isRecord(payload)) {
+    return undefined
+  }
+
+  const directUrlFields = [
+    'url',
+    'uri',
+    'href',
+    'src',
+    'thumbnail_url',
+    'thumbnailUrl',
+    'image_url',
+    'imageUrl',
+    'preview_url',
+    'previewUrl',
+    'data_url',
+    'dataUrl',
+  ]
+  for (const field of directUrlFields) {
+    const fieldValue = stringValue(payload[field])
+    if (fieldValue && isDisplayableImageUrl(fieldValue)) {
+      return fieldValue
+    }
+  }
+
+  const nestedThumbnail: string | undefined =
+    thumbnailUrlFromRemoteProjectPayload(payload.thumbnail) ||
+    thumbnailUrlFromRemoteProjectPayload(payload.image) ||
+    thumbnailUrlFromRemoteProjectPayload(payload.preview)
+  if (nestedThumbnail) {
+    return nestedThumbnail
+  }
+
+  const mimeType = imageMimeTypeFromRecord(payload)
+  const base64Fields = ['base64', 'data', 'content', 'contents']
+  for (const field of base64Fields) {
+    const fieldValue = stringValue(payload[field])
+    if (!fieldValue) {
+      continue
+    }
+
+    const dataUrl = maybeDataUrlFromBase64(fieldValue, mimeType)
+    if (dataUrl) {
+      return dataUrl
+    }
+  }
+
+  return undefined
+}
+
+export async function getRemoteProjectThumbnailUrl(
+  config: CloudSyncConfig,
+  project: RemoteProjectSummary
+) {
+  const urlFromProjectList = thumbnailUrlFromRemoteProjectPayload(project)
+  if (urlFromProjectList) {
+    return urlFromProjectList
+  }
+
+  let response: Response
+  try {
+    response = await cloudFetch(
+      config,
+      `/user/projects/${project.id}/thumbnail`,
+      {
+        headers: {
+          Accept: 'application/json,image/*',
+        },
+      }
+    )
+  } catch (error) {
+    if (error instanceof CloudApiError && error.status === 404) {
+      return undefined
+    }
+
+    // eslint-disable-next-line suggest-no-throw/suggest-no-throw
+    throw error
+  }
+  const contentType =
+    response.headers.get('content-type')?.split(';')[0]?.trim().toLowerCase() ??
+    ''
+
+  if (contentType === 'application/json' || contentType.endsWith('+json')) {
+    try {
+      return thumbnailUrlFromRemoteProjectPayload(await response.json())
+    } catch {
+      return undefined
+    }
+  }
+
+  try {
+    const thumbnailFromJson = thumbnailUrlFromRemoteProjectPayload(
+      await response.clone().json()
+    )
+    if (thumbnailFromJson) {
+      return thumbnailFromJson
+    }
+  } catch {
+    // The thumbnail endpoint may return an image payload instead of JSON.
+  }
+
+  try {
+    const thumbnailFromText = thumbnailUrlFromRemoteProjectPayload(
+      await response.clone().text()
+    )
+    if (thumbnailFromText) {
+      return thumbnailFromText
+    }
+  } catch {
+    // Fall through to binary handling below.
+  }
+
+  const imageBytes = await response.arrayBuffer()
+  if (!imageBytes.byteLength) {
+    return undefined
+  }
+
+  const mimeType = contentType.startsWith('image/') ? contentType : 'image/png'
+  return `data:${mimeType};base64,${arrayBufferToBase64(imageBytes)}`
 }
 
 export async function deleteRemoteProject(

--- a/src/lib/cloudSync/cloudApi.ts
+++ b/src/lib/cloudSync/cloudApi.ts
@@ -113,6 +113,44 @@ function isDisplayableImageUrl(value: string) {
   return /^(https?:|blob:|data:image\/)/i.test(value)
 }
 
+export function normalizeRemoteProjectThumbnailUrl(value: string) {
+  if (!/^https?:/i.test(value)) {
+    return value
+  }
+
+  const withoutExtension = (pathname: string) =>
+    pathname.replace(
+      /(\/user\/projects\/[^/]+\/thumbnail)\.(?:png|jpe?g|webp|gif)$/i,
+      '$1'
+    )
+
+  try {
+    const url = new URL(value)
+    url.pathname = withoutExtension(url.pathname)
+    return url.toString()
+  } catch {
+    return value.replace(
+      /(\/user\/projects\/[^/?#]+\/thumbnail)\.(?:png|jpe?g|webp|gif)(?=[?#]|$)/i,
+      '$1'
+    )
+  }
+}
+
+export function remoteProjectThumbnailTargetPathFromUrl(value: string) {
+  const normalizedValue = normalizeRemoteProjectThumbnailUrl(value)
+  try {
+    const url = new URL(normalizedValue)
+    return /^\/user\/projects\/[^/]+\/thumbnail$/i.test(url.pathname)
+      ? `${url.pathname}${url.search}`
+      : undefined
+  } catch {
+    const match = normalizedValue.match(
+      /(\/user\/projects\/[^/?#]+\/thumbnail)(\?[^#]*)?(?:#.*)?$/i
+    )
+    return match ? `${match[1]}${match[2] ?? ''}` : undefined
+  }
+}
+
 function imageMimeTypeFromRecord(record: Record<string, unknown>) {
   const mimeType =
     stringValue(record.mime_type) ||
@@ -150,7 +188,7 @@ export function thumbnailUrlFromRemoteProjectPayload(
   const directValue = stringValue(payload)
   if (directValue) {
     if (isDisplayableImageUrl(directValue)) {
-      return directValue
+      return normalizeRemoteProjectThumbnailUrl(directValue)
     }
 
     return maybeDataUrlFromBase64(directValue)
@@ -177,7 +215,7 @@ export function thumbnailUrlFromRemoteProjectPayload(
   for (const field of directUrlFields) {
     const fieldValue = stringValue(payload[field])
     if (fieldValue && isDisplayableImageUrl(fieldValue)) {
-      return fieldValue
+      return normalizeRemoteProjectThumbnailUrl(fieldValue)
     }
   }
 
@@ -211,7 +249,10 @@ export async function getRemoteProjectThumbnailUrl(
   project: RemoteProjectSummary
 ) {
   const urlFromProjectList = thumbnailUrlFromRemoteProjectPayload(project)
-  if (urlFromProjectList) {
+  const thumbnailTargetPath = urlFromProjectList
+    ? remoteProjectThumbnailTargetPathFromUrl(urlFromProjectList)
+    : undefined
+  if (urlFromProjectList && !thumbnailTargetPath) {
     return urlFromProjectList
   }
 
@@ -219,7 +260,7 @@ export async function getRemoteProjectThumbnailUrl(
   try {
     response = await cloudFetch(
       config,
-      `/user/projects/${project.id}/thumbnail`,
+      thumbnailTargetPath ?? `/user/projects/${project.id}/thumbnail`,
       {
         headers: {
           Accept: 'application/json,image/*',

--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -6,6 +6,7 @@ import {
   deleteRemoteProject,
   downloadRemoteProjectArchive,
   getRemoteProject,
+  getRemoteProjectThumbnailUrl,
   listRemoteProjects,
   updateRemoteProject,
 } from '@src/lib/cloudSync/cloudApi'
@@ -891,6 +892,16 @@ export async function ensureCloudProjectLocallySynced(
     projectDirectory,
     knownLocalProjectPath
   )
+}
+
+export async function getCloudSyncRemoteProjectThumbnailUrl(
+  remoteProject: RemoteProjectSummary
+) {
+  if (!isConfiguredForCloud()) {
+    return undefined
+  }
+
+  return getRemoteProjectThumbnailUrl(config, remoteProject)
 }
 
 async function readProjectTomlCloudProjectId(projectPath: string) {

--- a/src/lib/cloudSync/registry/contract.ts
+++ b/src/lib/cloudSync/registry/contract.ts
@@ -7,6 +7,7 @@ import type {
   CloudSyncProjectMetadata,
   CloudSyncProjectMetadataIndexEntry,
   CloudSyncStatus,
+  RemoteProjectSummary,
 } from '@src/lib/cloudSync'
 import type { IZooDesignStudioFS } from '@src/lib/fs-zds/interface'
 
@@ -29,6 +30,9 @@ export type CloudSyncRegistryService = {
   ensureProjectLocallySynced: (
     remoteProjectId: string
   ) => Promise<CloudSyncLocalProject | undefined>
+  getRemoteProjectThumbnailUrl: (
+    remoteProject: RemoteProjectSummary
+  ) => Promise<string | undefined>
   getProjectMetadata: (
     projectPath: string
   ) => Promise<CloudSyncProjectMetadata | undefined>

--- a/src/lib/cloudSync/registry/extension.test.ts
+++ b/src/lib/cloudSync/registry/extension.test.ts
@@ -33,6 +33,7 @@ vi.mock('@src/lib/cloudSync', () => ({
   resolveCloudSyncProjectConflict: vi.fn(),
   retryCloudSync: vi.fn(),
   setCloudSyncProjectScope: vi.fn(),
+  getCloudSyncRemoteProjectThumbnailUrl: vi.fn(),
 }))
 
 describe('cloud sync extension', () => {

--- a/src/lib/cloudSync/registry/extension.ts
+++ b/src/lib/cloudSync/registry/extension.ts
@@ -74,6 +74,7 @@ export const cloudSyncExtension = defineRegistryItemFactory((ctx) => {
     getProjectMetadataIndex: getCloudSyncProjectMetadataIndex,
     getProjectModifiedTime: getCloudSyncProjectModifiedTime,
     resolveProjectConflict: resolveCloudSyncProjectConflict,
+    getRemoteProjectThumbnailUrl: getCloudSyncRemoteProjectThumbnailUrl,
   }
 
   return {

--- a/src/lib/cloudSync/registry/extension.ts
+++ b/src/lib/cloudSync/registry/extension.ts
@@ -12,6 +12,7 @@ import {
   getCloudSyncProjectMetadata,
   getCloudSyncProjectMetadataIndex,
   getCloudSyncProjectModifiedTime,
+  getCloudSyncRemoteProjectThumbnailUrl,
   installCloudSyncFileSystemObserver,
   resolveCloudSyncProjectConflict,
   retryCloudSync,

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -71,6 +71,7 @@ function createCloudSyncService(): CloudSyncRegistryService {
     startProjectSync: vi.fn().mockResolvedValue(undefined),
     disconnectProjectSync: vi.fn().mockResolvedValue(undefined),
     ensureProjectLocallySynced: vi.fn().mockResolvedValue(undefined),
+    getRemoteProjectThumbnailUrl: vi.fn().mockResolvedValue(undefined),
     getProjectMetadata: vi.fn().mockResolvedValue(undefined),
     getProjectMetadataIndex: vi.fn().mockResolvedValue(new Map()),
     getProjectModifiedTime: vi.fn((_metadata, localModified) => localModified),
@@ -194,6 +195,53 @@ describe('cloud sync project menu item', () => {
 })
 
 describe('cloud sync home project entries', () => {
+  test('contributes remote thumbnails for cloud-only home entries', async () => {
+    cloudSyncStatus.value = {
+      enabled: true,
+      state: 'idle',
+      pendingCount: 0,
+    }
+    cloudSyncRemoteProjects.value = [
+      {
+        id: 'remote-123',
+        title: 'Remote title',
+        revision: 'remote-rev-2',
+        updated_at: '2026-06-02T20:00:00.000Z',
+      },
+    ]
+    const cloudSync = createCloudSyncService()
+    vi.mocked(cloudSync.getRemoteProjectThumbnailUrl).mockResolvedValue(
+      'https://example.test/remote-123-thumbnail.png'
+    )
+    const registry = new Registry()
+    const cloudSyncServiceExtension = defineRegistryItem({
+      id: 'test-cloud-sync-service',
+      providesServices: [provideService(cloudSyncService, cloudSync)],
+    })
+
+    registry.configure([cloudSyncServiceExtension, cloudSyncPlugin])
+
+    try {
+      await waitFor(() =>
+        expect(registry.get(homeProjectEntriesValueSpec)).toEqual([
+          expect.objectContaining({
+            source: 'remote',
+            status: 'cloud-only',
+            name: 'Remote title',
+            title: 'Remote title',
+            remoteProjectId: 'remote-123',
+            thumbnail: {
+              type: 'remote',
+              url: 'https://example.test/remote-123-thumbnail.png',
+            },
+          }),
+        ])
+      )
+    } finally {
+      registry[Symbol.dispose]()
+    }
+  })
+
   test('marks home entries with both sources as conflicted from cloud sync metadata', async () => {
     cloudSyncStatus.value = {
       enabled: true,

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -5,7 +5,13 @@ import {
   defineRuntimeRegistryItem,
   provide,
 } from '@kittycad/registry'
-import { computed, effect, signal } from '@preact/signals-core'
+import {
+  computed,
+  effect,
+  type Signal,
+  signal,
+  untracked,
+} from '@preact/signals-core'
 import { useSignals } from '@preact/signals-react/runtime'
 import { ActionButton } from '@src/components/ActionButton'
 import { ActionIcon } from '@src/components/ActionIcon'
@@ -23,6 +29,7 @@ import {
   type CloudSyncStatus,
   cloudSyncRemoteProjects,
   cloudSyncStatus,
+  type RemoteProjectSummary,
   retryCloudSync,
 } from '@src/lib/cloudSync'
 import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
@@ -612,10 +619,59 @@ function homeProjectEntryConflictFields(
     : { status: 'cloud-only' }
 }
 
+function remoteThumbnailCacheKey(project: RemoteProjectSummary) {
+  return [
+    project.id,
+    project.revision === undefined ? '' : String(project.revision),
+    project.updated_at ?? '',
+  ].join(':')
+}
+
+function setRemoteThumbnailUrl(
+  thumbnailUrls: Signal<Map<string, string>>,
+  remoteProjectId: string,
+  thumbnailUrl: string
+) {
+  const nextThumbnailUrls = new Map(thumbnailUrls.value)
+  nextThumbnailUrls.set(remoteProjectId, thumbnailUrl)
+  thumbnailUrls.value = nextThumbnailUrls
+}
+
+function pruneRemoteThumbnailState({
+  remoteProjects,
+  requestedThumbnailKeys,
+  thumbnailUrls,
+}: {
+  remoteProjects: RemoteProjectSummary[]
+  requestedThumbnailKeys: Map<string, string>
+  thumbnailUrls: Signal<Map<string, string>>
+}) {
+  const remoteProjectIds = new Set(remoteProjects.map((project) => project.id))
+
+  for (const requestedProjectId of requestedThumbnailKeys.keys()) {
+    if (!remoteProjectIds.has(requestedProjectId)) {
+      requestedThumbnailKeys.delete(requestedProjectId)
+    }
+  }
+
+  const currentThumbnailUrls = untracked(() => thumbnailUrls.value)
+  const nextThumbnailUrls = new Map(
+    Array.from(currentThumbnailUrls).filter(([remoteProjectId]) =>
+      remoteProjectIds.has(remoteProjectId)
+    )
+  )
+
+  if (nextThumbnailUrls.size !== currentThumbnailUrls.size) {
+    thumbnailUrls.value = nextThumbnailUrls
+  }
+}
+
 const cloudSyncRemoteHomeProjectEntryContribution = defineRegistryItemFactory(
   (ctx) => {
     const cloudSync = ctx.services.signal(cloudSyncService)
     const conflictMetadata = signal<CloudSyncProjectMetadataIndexEntry[]>([])
+    const remoteThumbnailUrls = signal<Map<string, string>>(new Map())
+    const requestedThumbnailKeys = new Map<string, string>()
     let disposed = false
     let disposeEffect: (() => void) | undefined
     let loadId = 0
@@ -641,6 +697,7 @@ const cloudSyncRemoteHomeProjectEntryContribution = defineRegistryItemFactory(
         (project) => {
           const metadata = conflictMetadataByRemoteProjectId.get(project.id)
           const name = metadata?.projectName || project.title || project.id
+          const thumbnailUrl = remoteThumbnailUrls.value.get(project.id)
 
           return {
             source: 'remote',
@@ -650,6 +707,14 @@ const cloudSyncRemoteHomeProjectEntryContribution = defineRegistryItemFactory(
             remoteProjectId: project.id,
             modified: getCloudSyncHomeProjectModifiedTime(project, metadata),
             readWriteAccess: true,
+            ...(thumbnailUrl
+              ? {
+                  thumbnail: {
+                    type: 'remote',
+                    url: thumbnailUrl,
+                  },
+                }
+              : {}),
           } satisfies HomeProjectEntryContribution
         }
       )
@@ -693,7 +758,48 @@ const cloudSyncRemoteHomeProjectEntryContribution = defineRegistryItemFactory(
 
         if (!service || !status.enabled) {
           conflictMetadata.value = []
+          remoteThumbnailUrls.value = new Map()
+          requestedThumbnailKeys.clear()
           return
+        }
+
+        const remoteProjects = cloudSyncRemoteProjects.value
+        pruneRemoteThumbnailState({
+          remoteProjects,
+          requestedThumbnailKeys,
+          thumbnailUrls: remoteThumbnailUrls,
+        })
+
+        for (const remoteProject of remoteProjects) {
+          const cacheKey = remoteThumbnailCacheKey(remoteProject)
+          if (requestedThumbnailKeys.get(remoteProject.id) === cacheKey) {
+            continue
+          }
+
+          requestedThumbnailKeys.set(remoteProject.id, cacheKey)
+          service
+            .getRemoteProjectThumbnailUrl(remoteProject)
+            .then((thumbnailUrl) => {
+              if (
+                disposed ||
+                requestedThumbnailKeys.get(remoteProject.id) !== cacheKey ||
+                !thumbnailUrl
+              ) {
+                return
+              }
+
+              setRemoteThumbnailUrl(
+                remoteThumbnailUrls,
+                remoteProject.id,
+                thumbnailUrl
+              )
+            })
+            .catch((error: unknown) => {
+              if (requestedThumbnailKeys.get(remoteProject.id) === cacheKey) {
+                requestedThumbnailKeys.delete(remoteProject.id)
+              }
+              reportRejection(error)
+            })
         }
 
         service


### PR DESCRIPTION
UX polish for #11329, fetching and displaying cloud-only project thumbnails on the home page. Note: cloud thumbnails actually have transparent backgrounds, which is something we've wanted forever from the desktop app 🫠. Maybe we should take local project thumbnail snapshots using the CLI instead of the stream to get the same behavior across the board?

<img width="1502" height="944" alt="Screenshot 2026-07-10 at 10 45 36 AM" src="https://github.com/user-attachments/assets/c2c3b964-6ae7-470c-9032-ef1dbd9dfd23" />
