### PR TITLE
Use a better lazy import pattern for extensions

### DIFF
--- a/src/components/ConnectionStream.tsx
+++ b/src/components/ConnectionStream.tsx
@@ -36,6 +36,7 @@ import type {
   EngineSceneExtensionContext,
   EngineSceneStreamLayer,
 } from '@src/registry/contracts/engineScene'
+import { EngineSceneContributionComponent } from '@src/registry/contracts/engineScene'
 import type { MouseEventHandler } from 'react'
 import { use, useCallback, useMemo, useRef, useState } from 'react'
 
@@ -535,7 +536,11 @@ export const ConnectionStream = (props: ConnectionStreamProps) => {
             className={`absolute inset-0 ${layer.wrapperClassName ?? ''}`}
             data-engine-scene-stream-layer-id={layer.id}
           >
-            <layer.Component {...props.streamLayerProps} />
+            <EngineSceneContributionComponent
+              Component={layer.Component}
+              loadComponent={layer.loadComponent}
+              props={props.streamLayerProps}
+            />
           </div>
         )
       })}

--- a/src/components/MlEphantConversation.spec.tsx
+++ b/src/components/MlEphantConversation.spec.tsx
@@ -61,6 +61,7 @@ import type {
   MlCopilotModeOption,
 } from '@src/machines/mlEphantManagerMachine'
 import {
+  EngineSceneContributionComponent,
   type EngineSceneExtensionContext,
   engineSceneRuntimeExtensionsSlot,
   engineSceneStreamLayersValueSpec,
@@ -88,10 +89,14 @@ const TestEngineSceneStreamLayers = () => {
 
   return (
     <>
-      {layers.map((layer) => {
-        const Component = layer.Component
-        return <Component key={layer.id} {...testEngineSceneContext} />
-      })}
+      {layers.map((layer) => (
+        <EngineSceneContributionComponent
+          key={layer.id}
+          Component={layer.Component}
+          loadComponent={layer.loadComponent}
+          props={testEngineSceneContext}
+        />
+      ))}
     </>
   )
 }

--- a/src/components/SelectionStatusBarItem.tsx
+++ b/src/components/SelectionStatusBarItem.tsx
@@ -1,13 +1,22 @@
 import { CustomIcon } from '@src/components/CustomIcon'
 import { defaultStatusBarItemClassNames } from '@src/components/StatusBar/StatusBar'
 import Tooltip from '@src/components/Tooltip'
+import { LazyRegistryComponent } from '@src/registry/lazyComponent'
+import type { RegistryComponentLoader } from '@src/registry/lazyComponent'
 import type { ComponentType } from 'react'
 import { useState } from 'react'
 
-type PopoverSection = {
+type EagerPopoverSection = {
   id: string
   component: ComponentType
 }
+
+type LazyPopoverSection = {
+  id: string
+  loadComponent: RegistryComponentLoader<object>
+}
+
+type PopoverSection = EagerPopoverSection | LazyPopoverSection
 
 export function SelectionStatusBarItem({
   label,
@@ -63,9 +72,20 @@ export function SelectionStatusBarItem({
               Close
             </button>
           </div>
-          {popoverSections.map(({ id, component: Section }) => (
-            <Section key={id} />
-          ))}
+          {popoverSections.map((section) => {
+            if ('loadComponent' in section) {
+              return (
+                <LazyRegistryComponent
+                  key={section.id}
+                  loadComponent={section.loadComponent}
+                  fallback={null}
+                />
+              )
+            }
+
+            const Section = section.component
+            return <Section key={section.id} />
+          })}
         </div>
       )}
     </div>

--- a/src/components/StatusBar/StatusBar.tsx
+++ b/src/components/StatusBar/StatusBar.tsx
@@ -3,6 +3,7 @@ import { ActionButton } from '@src/components/ActionButton'
 import { ActionIcon } from '@src/components/ActionIcon'
 import type { StatusBarItemType } from '@src/components/StatusBar/statusBarTypes'
 import Tooltip, { type TooltipProps } from '@src/components/Tooltip'
+import { LazyRegistryComponent } from '@src/registry/lazyComponent'
 import { useLocation } from 'react-router-dom'
 import { Fragment } from 'react/jsx-runtime'
 
@@ -55,6 +56,16 @@ function StatusBarItem(
   // If the consumer used `component`, just render that
   if ('component' in props) {
     return props.component({})
+  }
+
+  if ('loadComponent' in props) {
+    return (
+      <LazyRegistryComponent
+        loadComponent={props.loadComponent}
+        componentProps={props.componentProps}
+        fallback={props.fallback}
+      />
+    )
   }
 
   switch (props.element) {

--- a/src/components/StatusBar/statusBarTypes.ts
+++ b/src/components/StatusBar/statusBarTypes.ts
@@ -1,5 +1,6 @@
 import type { CustomIconName } from '@src/components/CustomIcon'
 import type { TooltipProps } from '@src/components/Tooltip'
+import type { ErasedLazyRegistryComponentSpec } from '@src/registry/lazyComponent'
 import type { Location } from 'react-router-dom'
 
 export type StatusBarItemType = {
@@ -34,4 +35,5 @@ export type StatusBarItemType = {
   | {
       component: React.FC
     }
+  | ErasedLazyRegistryComponentSpec
 )

--- a/src/registry/contracts/engineScene.tsx
+++ b/src/registry/contracts/engineScene.tsx
@@ -1,5 +1,7 @@
 import { Slot, defineContract, defineValueSpec } from '@kittycad/registry'
 import type { modelingMachine } from '@src/machines/modelingMachine'
+import { LazyRegistryComponent } from '@src/registry/lazyComponent'
+import type { RegistryComponentLoader } from '@src/registry/lazyComponent'
 import type { ComponentType, Dispatch, SetStateAction } from 'react'
 import { twMerge } from 'tailwind-merge'
 import type { EventFrom, StateFrom } from 'xstate'
@@ -31,14 +33,23 @@ export type EngineSceneExtensionContext = {
 export type EngineSceneViewExtensionProps = EngineSceneExtensionContext
 export type EngineSceneStreamLayerProps = EngineSceneExtensionContext
 
+type EngineSceneComponentContribution<Props extends object> =
+  | {
+      Component: ComponentType<Props>
+      loadComponent?: never
+    }
+  | {
+      Component?: never
+      loadComponent: RegistryComponentLoader<Props>
+    }
+
 export type EngineSceneViewExtension = {
   id: string
   zone: EngineSceneViewExtensionZone
   order?: number
-  Component: ComponentType<EngineSceneViewExtensionProps>
   wrapperClassName?: string
   shouldRegister?: (context: EngineSceneExtensionContext) => boolean
-}
+} & EngineSceneComponentContribution<EngineSceneViewExtensionProps>
 
 export type EngineSceneStreamClassName = {
   id: string
@@ -49,9 +60,8 @@ export type EngineSceneStreamClassName = {
 export type EngineSceneStreamLayer = {
   id: string
   order?: number
-  Component: ComponentType<EngineSceneStreamLayerProps>
   wrapperClassName?: string
-}
+} & EngineSceneComponentContribution<EngineSceneStreamLayerProps>
 
 const zoneOrder = Object.fromEntries(
   engineSceneViewExtensionZones.map((zone, index) => [zone, index])
@@ -127,6 +137,32 @@ export function resolveEngineSceneViewExtensions(
   )
 }
 
+export function EngineSceneContributionComponent({
+  Component,
+  loadComponent,
+  props,
+}: {
+  Component?: ComponentType<EngineSceneExtensionContext>
+  loadComponent?: RegistryComponentLoader<EngineSceneExtensionContext>
+  props: EngineSceneExtensionContext
+}) {
+  if (loadComponent) {
+    return (
+      <LazyRegistryComponent
+        loadComponent={loadComponent}
+        componentProps={props}
+        fallback={null}
+      />
+    )
+  }
+
+  if (!Component) {
+    return null
+  }
+
+  return <Component {...props} />
+}
+
 const zoneClassNames: Record<EngineSceneViewExtensionZone, string> = {
   'top-left': 'absolute top-2 left-2 flex items-start justify-start gap-2',
   top: 'absolute top-0 left-2 right-2 flex items-start justify-center gap-2',
@@ -175,7 +211,6 @@ export function EngineSceneViewExtensionOverlay({
             data-engine-scene-view-extension-zone={zone}
           >
             {zoneExtensions.map((extension) => {
-              const Component = extension.Component
               const wrapperClassName = `max-w-full pointer-events-auto ${extension.wrapperClassName ?? ''}`
 
               return (
@@ -184,7 +219,11 @@ export function EngineSceneViewExtensionOverlay({
                   className={wrapperClassName}
                   data-engine-scene-view-extension-id={extension.id}
                 >
-                  <Component {...context} />
+                  <EngineSceneContributionComponent
+                    Component={extension.Component}
+                    loadComponent={extension.loadComponent}
+                    props={context}
+                  />
                 </div>
               )
             })}

--- a/src/registry/extensions/engineScene/GizmoViewExtension.tsx
+++ b/src/registry/extensions/engineScene/GizmoViewExtension.tsx
@@ -1,0 +1,5 @@
+import Gizmo from '@src/components/gizmo/Gizmo'
+
+export function EngineSceneGizmoViewExtension() {
+  return <Gizmo />
+}

--- a/src/registry/extensions/engineScene/ToolbarViewExtension.tsx
+++ b/src/registry/extensions/engineScene/ToolbarViewExtension.tsx
@@ -1,0 +1,9 @@
+import { Toolbar } from '@src/Toolbar'
+
+export function EngineSceneToolbarViewExtension() {
+  return (
+    <div className="toolbar-container">
+      <Toolbar />
+    </div>
+  )
+}

--- a/src/registry/extensions/engineScene/index.spec.ts
+++ b/src/registry/extensions/engineScene/index.spec.ts
@@ -123,6 +123,29 @@ describe('engineScene extension', () => {
     expect(
       registry.get(statusBarLocalItemsValueSpec).map((item) => item.scopes)
     ).toEqual([['file'], ['file'], ['file'], ['file'], ['file']])
+
+    const statusBarItems = registry.get(statusBarLocalItemsValueSpec)
+    expect(statusBarItems.map((item) => 'loadComponent' in item)).toEqual([
+      true,
+      true,
+      true,
+      true,
+      true,
+    ])
+    expect(statusBarItems.some((item) => 'component' in item)).toBe(false)
+
+    const selectionItem = statusBarItems.find((item) => item.id === 'selection')
+    expect(selectionItem && 'loadComponent' in selectionItem).toBe(true)
+    if (selectionItem && 'loadComponent' in selectionItem) {
+      expect(selectionItem.componentProps).toMatchObject({
+        label: 'No selection',
+        popoverSections: [
+          {
+            id: 'selection-references',
+          },
+        ],
+      })
+    }
   })
 
   it('contributes a command and modeling keybinding to open the measure tool', () => {
@@ -202,12 +225,21 @@ describe('engineScene extension', () => {
       registry.get(engineSceneViewExtensionsValueSpec).map((extension) => ({
         id: extension.id,
         zone: extension.zone,
+        lazy: 'loadComponent' in extension,
       }))
     ).toEqual([
-      { id: 'engine-scene.toolbar', zone: 'top' },
-      { id: 'engine-scene.sketch-background-opacity', zone: 'bottom-left' },
-      { id: 'engine-scene.sketch-constraints-toggle', zone: 'bottom-left' },
-      { id: 'engine-scene.gizmo', zone: 'bottom-right' },
+      { id: 'engine-scene.toolbar', zone: 'top', lazy: true },
+      {
+        id: 'engine-scene.sketch-background-opacity',
+        zone: 'bottom-left',
+        lazy: false,
+      },
+      {
+        id: 'engine-scene.sketch-constraints-toggle',
+        zone: 'bottom-left',
+        lazy: false,
+      },
+      { id: 'engine-scene.gizmo', zone: 'bottom-right', lazy: true },
     ])
   })
 

--- a/src/registry/extensions/engineScene/index.ts
+++ b/src/registry/extensions/engineScene/index.ts
@@ -23,12 +23,10 @@ import {
   nullableStatusBarItem,
   statusBarLocalItemsValueSpec,
 } from '@src/registry/contracts/statusBar'
-import { Suspense, createElement, lazy } from 'react'
+import { defineLazyRegistryComponent } from '@src/registry/lazyComponent'
 import executionIndicator from './executionIndicator'
 import { measurementToolService } from './measurementToolService'
 import {
-  EngineSceneGizmoViewExtension,
-  EngineSceneToolbarViewExtension,
   SketchBackgroundOpacityViewExtension,
   SketchConstraintsToggleViewExtension,
 } from './viewExtensionControls'
@@ -63,76 +61,32 @@ const openMeasureToolKeymapItem: KeymapItem = {
   command: ENGINE_SCENE_COMMAND_IDS.openMeasureTool,
 }
 
-// Registry extension entrypoints are imported eagerly while App is still
-// initializing. These status bar components can reach boot.ts, so keep them
-// behind lazy imports to avoid an App <-> boot cycle.
-const SelectionFilterControls = lazy(async () => {
-  const { SelectionFilterControls } = await import('./SelectionFilterControls')
-  return { default: SelectionFilterControls }
-})
+const loadSelectionFilterControls = async () =>
+  (await import('./SelectionFilterControls')).SelectionFilterControls
 
-const UnitsMenu = lazy(async () => {
-  const { UnitsMenu } = await import('@src/components/UnitsMenu')
-  return { default: UnitsMenu }
-})
+const loadUnitsMenu = async () =>
+  (await import('@src/components/UnitsMenu')).UnitsMenu
 
-const ExperimentalFeaturesMenu = lazy(async () => {
-  const { ExperimentalFeaturesMenu } = await import(
-    '@src/components/ExperimentalFeaturesMenu'
-  )
-  return { default: ExperimentalFeaturesMenu }
-})
+const loadExperimentalFeaturesMenu = async () =>
+  (await import('@src/components/ExperimentalFeaturesMenu'))
+    .ExperimentalFeaturesMenu
 
-const SelectionStatusBarItem = lazy(async () => {
-  const { SelectionStatusBarItem } = await import(
-    '@src/components/SelectionStatusBarItem'
-  )
-  return { default: SelectionStatusBarItem }
-})
+const loadSelectionStatusBarItem = async () =>
+  (await import('@src/components/SelectionStatusBarItem'))
+    .SelectionStatusBarItem
 
-const SelectionReferencesPopover = lazy(async () => {
-  const { SelectionReferencesPopover } = await import(
-    '@src/components/SelectionReferencesPopover'
-  )
-  return { default: SelectionReferencesPopover }
-})
+const loadSelectionReferencesPopover = async () =>
+  (await import('@src/components/SelectionReferencesPopover'))
+    .SelectionReferencesPopover
 
-const MeasurementStatusBarItem = lazy(async () => {
-  const { MeasurementStatusBarItem } = await import('./MeasurementTool')
-  return { default: MeasurementStatusBarItem }
-})
+const loadMeasurementStatusBarItem = async () =>
+  (await import('./MeasurementTool')).MeasurementStatusBarItem
 
-const EngineSceneUnitsMenu = () =>
-  createElement(Suspense, { fallback: null }, createElement(UnitsMenu))
+const loadToolbarViewExtension = async () =>
+  (await import('./ToolbarViewExtension')).EngineSceneToolbarViewExtension
 
-const EngineSceneExperimentalFeaturesMenu = () =>
-  createElement(
-    Suspense,
-    { fallback: null },
-    createElement(ExperimentalFeaturesMenu)
-  )
-
-const EngineSceneSelectionStatusBarItem = ({ label }: { label: string }) =>
-  createElement(
-    Suspense,
-    { fallback: null },
-    createElement(SelectionStatusBarItem, {
-      label,
-      popoverSections: [
-        {
-          id: 'selection-references',
-          component: SelectionReferencesPopover,
-        },
-      ],
-    })
-  )
-
-const EngineSceneSelectionFilterControls = () =>
-  createElement(
-    Suspense,
-    { fallback: null },
-    createElement(SelectionFilterControls)
-  )
+const loadGizmoViewExtension = async () =>
+  (await import('./GizmoViewExtension')).EngineSceneGizmoViewExtension
 
 const isSketchSolveMode = (context: EngineSceneExtensionContext) =>
   context.modelingState.matches('sketchSolveMode')
@@ -147,7 +101,7 @@ const toolbarViewExtension = defineEngineSceneViewExtension({
   id: 'engine-scene.toolbar',
   zone: 'top',
   order: 0,
-  Component: EngineSceneToolbarViewExtension,
+  loadComponent: loadToolbarViewExtension,
   wrapperClassName: 'w-full min-w-0 flex justify-center',
 })
 
@@ -171,15 +125,8 @@ const gizmoViewExtension = defineEngineSceneViewExtension({
   id: 'engine-scene.gizmo',
   zone: 'bottom-right',
   order: 0,
-  Component: EngineSceneGizmoViewExtension,
+  loadComponent: loadGizmoViewExtension,
 })
-
-const EngineSceneMeasurementStatusBarItem = () =>
-  createElement(
-    Suspense,
-    { fallback: null },
-    createElement(MeasurementStatusBarItem)
-  )
 
 /**
  * Engine scene extension.
@@ -196,10 +143,18 @@ const engineSceneExtension = defineRegistryItemFactory((ctx) => {
       selectionStatusLabel
         ? {
             id: 'selection',
-            component: () =>
-              createElement(EngineSceneSelectionStatusBarItem, {
+            ...defineLazyRegistryComponent({
+              loadComponent: loadSelectionStatusBarItem,
+              componentProps: {
                 label: selectionStatusLabel.value,
-              }),
+                popoverSections: [
+                  {
+                    id: 'selection-references',
+                    loadComponent: loadSelectionReferencesPopover,
+                  },
+                ],
+              },
+            }),
             order: 10,
             scopes: ['file'],
           }
@@ -211,7 +166,9 @@ const engineSceneExtension = defineRegistryItemFactory((ctx) => {
       executionService.value
         ? {
             id: 'measure',
-            component: EngineSceneMeasurementStatusBarItem,
+            ...defineLazyRegistryComponent({
+              loadComponent: loadMeasurementStatusBarItem,
+            }),
             order: 9,
             scopes: ['file'],
           }
@@ -223,7 +180,9 @@ const engineSceneExtension = defineRegistryItemFactory((ctx) => {
       executionService.value
         ? {
             id: 'selection-filter',
-            component: EngineSceneSelectionFilterControls,
+            ...defineLazyRegistryComponent({
+              loadComponent: loadSelectionFilterControls,
+            }),
             order: 11,
             scopes: ['file'],
           }
@@ -235,7 +194,9 @@ const engineSceneExtension = defineRegistryItemFactory((ctx) => {
       executionService.value?.showExperimentalFeaturesStatusBarItem.value
         ? {
             id: 'experimental-features',
-            component: EngineSceneExperimentalFeaturesMenu,
+            ...defineLazyRegistryComponent({
+              loadComponent: loadExperimentalFeaturesMenu,
+            }),
             order: 30,
             scopes: ['file'],
           }
@@ -247,7 +208,9 @@ const engineSceneExtension = defineRegistryItemFactory((ctx) => {
       executionService.value
         ? {
             id: 'units',
-            component: EngineSceneUnitsMenu,
+            ...defineLazyRegistryComponent({
+              loadComponent: loadUnitsMenu,
+            }),
             order: 20,
             scopes: ['file'],
           }

--- a/src/registry/extensions/engineScene/viewExtensionControls.tsx
+++ b/src/registry/extensions/engineScene/viewExtensionControls.tsx
@@ -1,34 +1,5 @@
 import { CustomIcon } from '@src/components/CustomIcon'
 import type { EngineSceneViewExtensionProps } from '@src/registry/contracts/engineScene'
-import { Suspense, lazy } from 'react'
-
-const Toolbar = lazy(async () => {
-  const { Toolbar } = await import('@src/Toolbar')
-  return { default: Toolbar }
-})
-
-const Gizmo = lazy(async () => {
-  const { default: Gizmo } = await import('@src/components/gizmo/Gizmo')
-  return { default: Gizmo }
-})
-
-export function EngineSceneToolbarViewExtension() {
-  return (
-    <div className="toolbar-container">
-      <Suspense fallback={null}>
-        <Toolbar />
-      </Suspense>
-    </div>
-  )
-}
-
-export function EngineSceneGizmoViewExtension() {
-  return (
-    <Suspense fallback={null}>
-      <Gizmo />
-    </Suspense>
-  )
-}
 
 export function SketchBackgroundOpacityViewExtension({
   sketchSolveStreamDimming,

--- a/src/registry/lazyComponent.tsx
+++ b/src/registry/lazyComponent.tsx
@@ -1,0 +1,69 @@
+import type { ComponentType, ReactNode } from 'react'
+import { Suspense, createElement, lazy, useMemo } from 'react'
+
+export type RegistryComponentLoader<Props extends object> = () => Promise<
+  ComponentType<Props>
+>
+
+/**
+ * Current registry UI contributions use the React-component adapter below
+ * because ZDS itself renders with React. This should not become a permanent
+ * requirement for user-authored extension UI.
+ *
+ * The longer-term contract should be a framework-neutral "renderable" union
+ * where React is one adapter, not the semantic boundary:
+ *
+ * ```ts
+ * type RegistryRenderable<Props> =
+ *   | {
+ *       kind: 'react-component'
+ *       loadComponent: () => Promise<ComponentType<Props>>
+ *     }
+ *   | {
+ *       kind: 'dom'
+ *       mount: (
+ *         container: HTMLElement,
+ *         props: ReadonlySignal<Props>
+ *       ) => void | (() => void)
+ *     }
+ * ```
+ *
+ * The `dom` arm is not just an escape hatch. It is the shape that would let a
+ * Vue, Svelte, or plain-DOM extension own its rendering and cleanup while the
+ * host owns placement and passes signal-backed reactive state across the
+ * boundary. When adding new extension UI surfaces, prefer renderer-owned
+ * adapters like this over requiring every extension to export React components.
+ */
+export type LazyRegistryComponentSpec<Props extends object> = {
+  loadComponent: RegistryComponentLoader<Props>
+  componentProps?: Props
+  fallback?: ReactNode
+}
+
+export type ErasedLazyRegistryComponentSpec = LazyRegistryComponentSpec<object>
+
+export function defineLazyRegistryComponent<Props extends object>(
+  spec: LazyRegistryComponentSpec<Props>
+): ErasedLazyRegistryComponentSpec {
+  return spec as unknown as ErasedLazyRegistryComponentSpec
+}
+
+export function LazyRegistryComponent<Props extends object>({
+  loadComponent,
+  componentProps,
+  fallback = null,
+}: LazyRegistryComponentSpec<Props>) {
+  const Component = useMemo(
+    () =>
+      lazy(async () => ({
+        default: await loadComponent(),
+      })),
+    [loadComponent]
+  )
+
+  return createElement(
+    Suspense,
+    { fallback },
+    createElement(Component, componentProps ?? ({} as Props))
+  )
+}


### PR DESCRIPTION
## Summary

This refactors extension UI loading so extension registry contributions can provide lazy component loaders instead of writing their own `React.lazy` and `Suspense` wrappers.

## What changed

- Added a shared lazy registry component helper that centralizes `React.lazy` and the `Suspense` boundary.
- Extended status bar and engine scene contribution types to support `loadComponent` alongside existing eager component contributions.
- Migrated the engine scene status bar and view extension contributions to use lazy loaders.
- Added a source comment describing the longer-term framework-neutral extension UI direction, including a future DOM mount adapter for Vue, Svelte, or plain DOM renderers.

## Impact

Extension authors get a cleaner lazy import pattern, and the host renderer owns the lazy boundary instead of each extension hand-rolling it. Existing eager component contributions remain supported.

## Validation

- `npm run tsc -- --noEmit`
- `npx vitest run --mode=development src/registry/extensions/engineScene/index.spec.ts src/registry/extensions/engineScene/zoodleRuntimeExtension.spec.ts src/registry/contracts/statusBar.spec.ts`
- targeted `npx eslint --max-warnings 0 ...`
- targeted `npx biome check --write ...`