### PR TITLE
Add KCL check API

### DIFF
--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -3355,7 +3355,10 @@ impl Node<MemberExpression> {
                 )))
             }
             (KclValue::HomArray { value: arr, .. }, Property::UInt(index), _) => {
-                let value_of_arr = arr.get(index);
+                let mut value_of_arr = arr.get(index);
+                if value_of_arr.is_none() && exec_state.global.check_only {
+                    value_of_arr = arr.first();
+                }
                 if let Some(value) = value_of_arr {
                     Ok(value.to_owned().continue_())
                 } else {
@@ -3371,6 +3374,10 @@ impl Node<MemberExpression> {
             // Singletons and single-element arrays should be interchangeable, but only indexing by 0 should work.
             // This is kind of a silly property, but it's possible it occurs in generic code or something.
             (obj, Property::UInt(0), _) => Ok(obj.continue_()),
+            // Since singletons are interchangeable with single-element arrays, an
+            // out-of-bounds index falls back to the singleton itself, the item at
+            // index 0.
+            (obj, Property::UInt(_), _) if exec_state.global.check_only => Ok(obj.continue_()),
             (KclValue::HomArray { .. }, p, _) => {
                 let t = p.type_name();
                 let article = article_for(t);

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -536,6 +536,13 @@ pub struct MockConfig {
     pub segment_ids_edited: AhashIndexSet<ObjectId>,
     /// Segment-body drag anchors that temporarily pull a point on a segment toward the cursor.
     pub drag_anchors: Vec<SegmentDragAnchor>,
+    /// When true, we're not actually executing to produce a sketch or model.
+    /// Instead, simply check that the code makes sense, like by checking
+    /// function arguments. Currently, there are very few differences, like
+    /// ignoring many array index out of bounds errors. But we may change this
+    /// in the future to have more differences from regular execution. Used by
+    /// [`ExecutorContext::check`].
+    pub check_only: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, ts_rs::TS)]
@@ -555,6 +562,7 @@ impl Default for MockConfig {
             freedom_analysis: true,
             segment_ids_edited: AhashIndexSet::default(),
             drag_anchors: Vec::new(),
+            check_only: false,
         }
     }
 }
@@ -1289,6 +1297,39 @@ impl ExecutorContext {
         cache::write_old_memory(state).await;
 
         Ok(outcome)
+    }
+
+    /// Check a KCL program for problems by executing it without an engine.
+    ///
+    /// This is mock execution with extra leniency so that checking can get
+    /// further.
+    ///
+    /// List of differences from mock execution:
+    ///
+    /// 1. If a numeric index into an array is out of bounds, indexing falls
+    ///    back to the item at index 0 instead of producing an error. Indexing
+    ///    an empty array is still an error.
+    ///
+    /// Unlike [`Self::run_mock`], this neither reads nor writes the memory
+    /// cache shared with sketch mode and partial execution, so checking a
+    /// program cannot affect those.
+    pub async fn check(&self, program: &crate::Program) -> Result<ExecOutcome, KclErrorWithOutputs> {
+        assert!(
+            self.is_mock(),
+            "To use check, instantiate via ExecutorContext::new_mock, not ::new"
+        );
+
+        let mock_config = MockConfig {
+            use_prev_memory: false,
+            check_only: true,
+            ..Default::default()
+        };
+        let mut exec_state = ExecState::new_mock(self, &mock_config);
+        let result = self.run(program, &mut exec_state).await?;
+        exec_state
+            .into_exec_outcome(result.0, self)
+            .await
+            .map_err(KclErrorWithOutputs::no_outputs)
     }
 
     pub async fn run_with_caching(&self, program: crate::Program) -> Result<ExecOutcome, KclErrorWithOutputs> {
@@ -3652,6 +3693,70 @@ solid7 = extrude(r7, length = width)
         assert_eq!(ids, ids2, "Generated IDs should match");
         ctx.close().await;
         ctx2.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn check_index_out_of_bounds_falls_back_to_first_item() {
+        let ctx = ExecutorContext::new_mock(None).await;
+        let program = crate::Program::parse_no_errs(
+            "arr = [1, 2, 3]
+x = arr[5]",
+        )
+        .unwrap();
+        let outcome = ctx.check(&program).await.unwrap();
+        let Some(KclValueView::Number { value, .. }) = outcome.variables.get("x") else {
+            panic!("expected x to be a number, got {:?}", outcome.variables.get("x"));
+        };
+        assert_eq!(*value, 1.0);
+        ctx.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn check_index_out_of_bounds_singleton_falls_back_to_itself() {
+        let ctx = ExecutorContext::new_mock(None).await;
+        let program = crate::Program::parse_no_errs(
+            "a = 42
+x = a[2]",
+        )
+        .unwrap();
+        let outcome = ctx.check(&program).await.unwrap();
+        let Some(KclValueView::Number { value, .. }) = outcome.variables.get("x") else {
+            panic!("expected x to be a number, got {:?}", outcome.variables.get("x"));
+        };
+        assert_eq!(*value, 42.0);
+        ctx.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn check_index_out_of_bounds_empty_array_error_mentions_original_index() {
+        let ctx = ExecutorContext::new_mock(None).await;
+        let program = crate::Program::parse_no_errs(
+            "arr = []
+x = arr[5]",
+        )
+        .unwrap();
+        let err = ctx.check(&program).await.unwrap_err();
+        assert_eq!(err.error.message(), "The array doesn't have any item at index 5");
+        ctx.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn mock_execution_index_out_of_bounds_is_still_an_error() {
+        // check() is the only way to opt into the index fallback. Mock
+        // execution through the existing API must keep erroring.
+        let ctx = ExecutorContext::new_mock(None).await;
+        let program = crate::Program::parse_no_errs(
+            "arr = [1, 2, 3]
+x = arr[5]",
+        )
+        .unwrap();
+        let mock_config = MockConfig {
+            use_prev_memory: false,
+            ..Default::default()
+        };
+        let err = ctx.run_mock(&program, &mock_config).await.unwrap_err();
+        assert_eq!(err.error.message(), "The array doesn't have any item at index 5");
+        ctx.close().await;
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/rust/kcl-lib/src/execution/state.rs
+++ b/rust/kcl-lib/src/execution/state.rs
@@ -72,6 +72,8 @@ pub struct ExecState {
 
 pub type ModuleInfoMap = IndexMap<ModuleId, ModuleInfo>;
 
+/// This is read-only after creation. Any state that needs to be modified during
+/// execution should be in [`ModuleState`].
 #[derive(Debug, Clone)]
 pub(super) struct GlobalState {
     /// Map from source file absolute path to module ID.
@@ -92,6 +94,10 @@ pub(super) struct GlobalState {
     pub segment_ids_edited: AhashIndexSet<ObjectId>,
     /// Segment-body drag anchors that temporarily pull a point on a segment toward the cursor.
     pub drag_anchors: Vec<SegmentDragAnchor>,
+    /// When true, we're not actually executing to produce a sketch or model.
+    /// Instead, simply check that the code makes sense, like by checking
+    /// function arguments.
+    pub check_only: bool,
 }
 
 impl GlobalState {
@@ -364,6 +370,7 @@ impl ExecState {
         let segment_ids_edited = mock_config.segment_ids_edited.clone();
         let mut global = GlobalState::new(&exec_context.settings, segment_ids_edited);
         global.drag_anchors = mock_config.drag_anchors.clone();
+        global.check_only = mock_config.check_only;
         ExecState {
             execution_callbacks: exec_context.execution_callbacks.clone(),
             global,
@@ -386,6 +393,7 @@ impl ExecState {
         let segment_ids_edited = mock_config.segment_ids_edited.clone();
         let mut global = GlobalState::new(&exec_context.settings, segment_ids_edited);
         global.drag_anchors = mock_config.drag_anchors.clone();
+        global.check_only = mock_config.check_only;
         ExecState {
             execution_callbacks: exec_context.execution_callbacks.clone(),
             global,
@@ -990,6 +998,7 @@ impl GlobalState {
             id_to_source: Default::default(),
             segment_ids_edited,
             drag_anchors: Vec::new(),
+            check_only: false,
         };
 
         let root_id = ModuleId::default();

--- a/rust/kcl-wasm-lib/src/context.rs
+++ b/rust/kcl-wasm-lib/src/context.rs
@@ -240,6 +240,52 @@ impl Context {
         ctx.run_mock(&program, &mock_config).await
     }
 
+    /// Check a program for problems by executing it without an engine.
+    ///
+    /// This is mock execution with extra leniency. Unlike `executeMock`, it
+    /// doesn't read or write the memory cache shared with sketch mode.
+    #[wasm_bindgen(js_name = check)]
+    pub async fn check(
+        &self,
+        program_ast_json: &str,
+        path: Option<String>,
+        settings: &str,
+    ) -> Result<JsValue, JsValue> {
+        console_error_panic_hook::set_once();
+
+        self.check_typed(program_ast_json, path, settings)
+            .await
+            .and_then(|outcome| {
+                JsValue::from_serde(&outcome).map_err(|e| {
+                    // The serde-wasm-bindgen does not work here because of weird HashMap issues.
+                    // DO NOT USE serde_wasm_bindgen::to_value it will break the frontend.
+                    KclErrorWithOutputs::no_outputs(KclError::internal(format!(
+                        "Could not serialize successful KCL result. {TRUE_BUG} Details: {e}"
+                    )))
+                })
+            })
+            .map_err(|e: KclErrorWithOutputs| JsValue::from_serde(&e).unwrap())
+    }
+
+    async fn check_typed(
+        &self,
+        program_ast_json: &str,
+        path: Option<String>,
+        settings: &str,
+    ) -> Result<ExecOutcome, KclErrorWithOutputs> {
+        let program: Program = serde_json::from_str(program_ast_json).map_err(|e| {
+            let err = KclError::internal(format!("Could not deserialize KCL AST. {TRUE_BUG} Details: {e}"));
+            KclErrorWithOutputs::no_outputs(err)
+        })?;
+        let program = program.fill_node_paths();
+        let ctx = self.create_executor_ctx(settings, path, true).map_err(|e| {
+            KclErrorWithOutputs::no_outputs(KclError::internal(format!(
+                "Could not create KCL executor context. {TRUE_BUG} Details: {e}"
+            )))
+        })?;
+        ctx.check(&program).await
+    }
+
     /// Export a scene to a file.
     #[wasm_bindgen]
     pub async fn export(&self, format_json: &str, settings: &str) -> Result<JsValue, String> {

--- a/src/lang/langHelpers.ts
+++ b/src/lang/langHelpers.ts
@@ -3,8 +3,8 @@ import { lspCodeActionEvent } from '@kittycad/codemirror-lsp-client'
 import type { Node } from '@rust/kcl-lib/bindings/Node'
 
 import { KCLError, toUtf16 } from '@src/lang/errors'
-import type { ExecCallbacks, ExecState, Program } from '@src/lang/wasm'
-import { emptyExecState, kclLint } from '@src/lang/wasm'
+import type { CheckOutcome, ExecCallbacks, ExecState, Program } from '@src/lang/wasm'
+import { checkOutcomeFromExecState, emptyExecState, kclLint } from '@src/lang/wasm'
 import { EXECUTE_AST_INTERRUPT_ERROR_STRING } from '@src/lib/constants'
 import type RustContext from '@src/lib/rustContext'
 import { jsAppSettings } from '@src/lib/settings/settingsUtils'
@@ -62,6 +62,13 @@ interface ExecutionResult {
   logs: string[]
   errors: KCLError[]
   execState: ExecState
+  isInterrupted: boolean
+}
+
+interface CheckResult {
+  logs: string[]
+  errors: KCLError[]
+  checkOutcome: CheckOutcome
   isInterrupted: boolean
 }
 
@@ -123,6 +130,44 @@ export async function executeAstMock({
     }
   } catch (e: any) {
     return handleExecuteError(e)
+  }
+}
+
+export async function checkAst({
+  ast,
+  rustContext,
+  path,
+}: {
+  ast: Node<Program>
+  rustContext: RustContext
+  path?: string
+}): Promise<CheckResult> {
+  try {
+    const settings = jsAppSettings(rustContext.settingsActor)
+    const checkOutcome = await rustContext.check(
+      ast,
+      settings,
+      path,
+    )
+
+    await rustContext.waitForAllEngineModelingCommands()
+    return {
+      logs: [],
+      errors: [],
+      checkOutcome,
+      isInterrupted: false,
+    }
+  } catch (e: any) {
+    return checkResultFromExecutionResult(handleExecuteError(e))
+  }
+}
+
+function checkResultFromExecutionResult(execResult: ExecutionResult): CheckResult {
+  return {
+    logs: execResult.logs,
+    errors: execResult.errors,
+    checkOutcome: checkOutcomeFromExecState(execResult.execState),
+    isInterrupted: execResult.isInterrupted,
   }
 }
 

--- a/src/lang/wasm.ts
+++ b/src/lang/wasm.ts
@@ -276,6 +276,10 @@ export interface ExecState {
   defaultPlanes: DefaultPlanes | null
 }
 
+export interface CheckOutcome {
+  issues: CompilationIssue[]
+}
+
 export function emptyOperationsByModule(): OperationsByModule {
   return { map: {} }
 }
@@ -313,6 +317,12 @@ export function emptyExecState(): ExecState {
     issues: [],
     filenames: [],
     defaultPlanes: null,
+  }
+}
+
+export function checkOutcomeFromExecState(execState: ExecState): CheckOutcome {
+  return {
+    issues: execState.issues,
   }
 }
 

--- a/src/lib/rustContext.ts
+++ b/src/lib/rustContext.ts
@@ -29,8 +29,8 @@ import { type Context } from '@rust/kcl-wasm-lib/pkg/kcl_wasm_lib'
 import type { WebSocketResponse } from '@kittycad/lib'
 
 import { projectFsManager } from '@src/lang/std/fileSystemManager'
-import type { ExecCallbacks, ExecState } from '@src/lang/wasm'
-import { errFromErrWithOutputs, execStateFromRust } from '@src/lang/wasm'
+import type { CheckOutcome, ExecCallbacks, ExecState } from '@src/lang/wasm'
+import { checkOutcomeFromExecState, errFromErrWithOutputs, execStateFromRust } from '@src/lang/wasm'
 import type ModelingAppFile from '@src/lib/modelingAppFile'
 import type { DefaultPlaneStr } from '@src/lib/planes'
 import { defaultPlaneStrToKey } from '@src/lib/planes'
@@ -211,7 +211,7 @@ export default class RustContext {
     settings: DeepPartial<Configuration>,
     path?: string,
     callbacks?: ExecCallbacks
-  ): Promise<ExecState> {
+  ): Promise<CheckOutcome> {
     const instance = await this._checkContextInstance()
     const executionContext = callbacks
       ? instance.cloneWithExecuteCallbacks(callbacks)
@@ -223,7 +223,7 @@ export default class RustContext {
         path,
         JSON.stringify(settings)
       )
-      return execStateFromRust(result)
+      return checkOutcomeFromExecState(execStateFromRust(result))
     } catch (e: any) {
       return Promise.reject(errFromErrWithOutputs(e))
     }

--- a/src/lib/rustContext.ts
+++ b/src/lib/rustContext.ts
@@ -200,6 +200,35 @@ export default class RustContext {
     }
   }
 
+  /**
+   * Check a program for problems by executing it without an engine.
+   *
+   * This is mock execution with extra leniency. Unlike `executeMock`, it
+   * doesn't read or write the memory cache shared with sketch mode.
+   */
+  async check(
+    node: Node<Program>,
+    settings: DeepPartial<Configuration>,
+    path?: string,
+    callbacks?: ExecCallbacks
+  ): Promise<ExecState> {
+    const instance = await this._checkContextInstance()
+    const executionContext = callbacks
+      ? instance.cloneWithExecuteCallbacks(callbacks)
+      : instance
+
+    try {
+      const result = await executionContext.check(
+        JSON.stringify(node),
+        path,
+        JSON.stringify(settings)
+      )
+      return execStateFromRust(result)
+    } catch (e: any) {
+      return Promise.reject(errFromErrWithOutputs(e))
+    }
+  }
+
   /** Export a scene to a file. */
   async export(
     format: DeepPartial<OutputFormat3d>,


### PR DESCRIPTION
#12381

This is simpler than mock execution because it doesn't read or write to the execution cache.

Checklist

- [ ] Remove execution outputs from Rust return values