### PR TITLE
Collapse bulk edits into a single toast notification

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -218,6 +218,9 @@ export const WASM_INIT_FAILED_TOAST_ID = 'wasm-init-failed-toast'
 /** Toast id for the changes requested banner */
 export const CHANGES_REQUESTED_TOAST_ID = 'changes-requested-toast'
 
+/** Toast id for Zookeeper bulk file writes */
+export const ZOOKEEPER_FILE_WRITE_TOAST_ID = 'zookeeper-file-write-toast'
+
 /** Local sketch axis values in KCL for operations, it could either be 'X' or 'Y' */
 export const KCL_AXIS_X = 'X'
 export const KCL_AXIS_Y = 'Y'

--- a/src/machines/systemIO/systemIOMachine.ts
+++ b/src/machines/systemIO/systemIOMachine.ts
@@ -2,6 +2,7 @@ import type { App } from '@src/lib/app'
 import {
   DEFAULT_PROJECT_NAME,
   MAX_PROJECT_NAME_LENGTH,
+  ZOOKEEPER_FILE_WRITE_TOAST_ID,
 } from '@src/lib/constants'
 import type { Project } from '@src/lib/project'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
@@ -169,6 +170,8 @@ export const systemIOMachine = setup({
             fileName: string
             shouldNavigate: boolean
             onProjectLoaderComplete?: () => void
+            message?: string
+            toastId?: string
           }
         }
       | {
@@ -385,6 +388,17 @@ export const systemIOMachine = setup({
       },
     }),
     [SystemIOMachineActions.toastSuccess]: ({ event }) => {
+      // Operations may carry a stable `toastId` on their output so repeated
+      // completions collapse into a single updating toast instead of stacking
+      // duplicates (e.g. Zookeeper streams several bulk writes per edit).
+      const toastId =
+        'output' in event &&
+        event.output !== null &&
+        typeof event.output === 'object' &&
+        'toastId' in event.output &&
+        typeof event.output.toastId === 'string'
+          ? event.output.toastId
+          : undefined
       toast.success(
         ('data' in event && typeof event.data === 'string' && event.data) ||
           ('output' in event &&
@@ -392,7 +406,8 @@ export const systemIOMachine = setup({
             'message' in event.output &&
             typeof event.output.message === 'string' &&
             event.output.message) ||
-          ''
+          '',
+        toastId ? { id: toastId } : undefined
       )
     },
     [SystemIOMachineActions.toastError]: ({ event }) => {
@@ -405,6 +420,18 @@ export const systemIOMachine = setup({
             event.error instanceof Error &&
             event.error.message) ||
           'Unknown error in SystemIOMachine.'
+      )
+    },
+    // Zookeeper streams several bulk writes per edit; a failing edit can reject
+    // each one back-to-back. Share a stable toast id so those errors collapse
+    // into a single toast instead of stacking duplicates.
+    [SystemIOMachineActions.toastErrorZookeeperFileWrite]: ({ event }) => {
+      toast.error(
+        ('error' in event &&
+          event.error instanceof Error &&
+          event.error.message) ||
+          'Unknown error in SystemIOMachine.',
+        { id: ZOOKEEPER_FILE_WRITE_TOAST_ID }
       )
     },
     [SystemIOMachineActions.setReadWriteProjectDirectory]: assign({
@@ -1657,7 +1684,7 @@ export const systemIOMachine = setup({
         },
         onError: {
           target: SystemIOMachineStates.idle,
-          actions: [SystemIOMachineActions.toastError],
+          actions: [SystemIOMachineActions.toastErrorZookeeperFileWrite],
         },
       },
     },

--- a/src/machines/systemIO/systemIOMachineImpl.ts
+++ b/src/machines/systemIO/systemIOMachineImpl.ts
@@ -4,7 +4,11 @@ import {
   getCloudSyncProjectMetadataIndex,
   getCloudSyncProjectModifiedTime,
 } from '@src/lib/cloudSync'
-import { DEFAULT_DEFAULT_LENGTH_UNIT, FILE_EXT } from '@src/lib/constants'
+import {
+  DEFAULT_DEFAULT_LENGTH_UNIT,
+  FILE_EXT,
+  ZOOKEEPER_FILE_WRITE_TOAST_ID,
+} from '@src/lib/constants'
 import {
   canReadWriteDirectory,
   createNewProjectDirectory,
@@ -927,6 +931,10 @@ export const systemIOMachineImpl = systemIOMachine.provide({
               fileName: input.requestedFileNameWithExtension || '',
               subRoute: input.requestedSubRoute || '',
               shouldNavigate,
+              // Zookeeper streams cumulative edit patches, so one edit triggers
+              // several of these bulk writes back-to-back. Sharing a toast id
+              // collapses the otherwise-identical success toasts into one.
+              toastId: ZOOKEEPER_FILE_WRITE_TOAST_ID,
               ...(shouldNavigate && input.onSuccess
                 ? { onProjectLoaderComplete: input.onSuccess }
                 : {}),

--- a/src/machines/systemIO/utils.ts
+++ b/src/machines/systemIO/utils.ts
@@ -97,6 +97,7 @@ export enum SystemIOMachineActions {
   setDefaultProjectFolderName = 'set default project folder name',
   toastSuccess = 'toastSuccess',
   toastError = 'toastError',
+  toastErrorZookeeperFileWrite = 'toastErrorZookeeperFileWrite',
   setReadWriteProjectDirectory = 'set read write project directory',
   setRequestedTextToCadGeneration = 'set requested text to cad generation',
   setLastProjectDeleteRequest = 'set last project delete request',


### PR DESCRIPTION
## Dedupe Zookeeper file-write toasts

**Problem:** When Zookeeper updates project files, multiple identical toast notifications appear in rapid succession.

**Cause:** Zookeeper streams *cumulative* edit patches, so a single edit arrives as several `tool_output` messages. Each one triggers a `bulkCreateAndDeleteKCLFilesAndNavigateToFile` operation whose `onDone` fires `toast.success(...)` **without a toast `id`** — so react-hot-toast stacks a brand-new toast per streamed chunk instead of reusing one. (The history-recording path already coalesces per-exchange; only the toast layer was missing dedup.)

**Fix:** Give the Zookeeper bulk-write toast a stable `id` (`ZOOKEEPER_FILE_WRITE_TOAST_ID`) so the otherwise-identical toasts collapse into a single updating toast — the same `{ id }` dedup pattern already used elsewhere in the app (`exportSave`, `browserSaveFile`, etc.).

- `constants.ts` - new `ZOOKEEPER_FILE_WRITE_TOAST_ID`
- `systemIOMachineImpl.ts` — bulk-write actor returns `toastId`
- `systemIOMachine.ts` — `toastSuccess` honors an optional `toastId` (backward-compatible); new `toastErrorZookeeperFileWrite` action wired into the state's `onError`
- `utils.ts` — action enum entry
