### PR TITLE
Upgrade to rust toolchain 1.97.0

### DIFF
--- a/rust/kcl-language-server-release/src/main.rs
+++ b/rust/kcl-language-server-release/src/main.rs
@@ -132,7 +132,7 @@ async fn main() -> Result<()> {
     tracing_subscriber::registry().with(json).with(plain).init();
 
     if let Err(err) = run_cmd(&opts).await {
-        bail!("running cmd `{:?}` failed: {:?}", &opts.subcmd, err);
+        bail!("running cmd `{:?}` failed: {:?}", opts.subcmd, err);
     }
 
     Ok(())

--- a/rust/kcl-language-server/src/main.rs
+++ b/rust/kcl-language-server/src/main.rs
@@ -126,7 +126,7 @@ async fn main() -> Result<()> {
     tracing_subscriber::registry().with(json).with(plain).init();
 
     if let Err(err) = run_cmd(&opts).await {
-        bail!("running cmd `{:?}` failed: {:?}", &opts.subcmd, err);
+        bail!("running cmd `{:?}` failed: {:?}", opts.subcmd, err);
     }
 
     Ok(())

--- a/rust/kcl-lib/src/docs/kcl_doc.rs
+++ b/rust/kcl-lib/src/docs/kcl_doc.rs
@@ -136,7 +136,7 @@ fn visit_module(name: &str, preferred_prefix: &str, names: WalkForNames) -> Resu
                         )?),
                     };
                     if let Some(m) = m {
-                        let key = format!("M:{}", &m.qual_name);
+                        let key = format!("M:{}", m.qual_name);
                         let mut dd = DocData::Mod(m);
                         dd.with_meta(&import.outer_attrs);
                         result.children.insert(key, dd);
@@ -148,7 +148,7 @@ fn visit_module(name: &str, preferred_prefix: &str, names: WalkForNames) -> Resu
                 if !names.contains(var.name()) {
                     continue;
                 }
-                let qual = format!("{}::", &result.qual_name);
+                let qual = format!("{}::", result.qual_name);
                 let mut dd = match var.kind {
                     VariableKind::Fn => DocData::Fn(FnData::from_ast(var, qual, preferred_prefix, &result.name)),
                     VariableKind::Const => {
@@ -172,7 +172,7 @@ fn visit_module(name: &str, preferred_prefix: &str, names: WalkForNames) -> Resu
                 if !names.contains(ty.name()) {
                     continue;
                 }
-                let qual = format!("{}::", &result.qual_name);
+                let qual = format!("{}::", result.qual_name);
                 let mut dd = DocData::Ty(TyData::from_ast(ty, qual, preferred_prefix, &result.name));
                 let key = format!("T:{}", dd.qual_name());
                 if result.children.contains_key(&key) {

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -1876,14 +1876,14 @@ impl Node<SketchBlock> {
                             &format!("Internal error from constraint solver: {}", &failure.error).into(),
                         );
                         return Err(internal_err(
-                            format!("Internal error from constraint solver: {}", &failure.error),
+                            format!("Internal error from constraint solver: {}", failure.error),
                             self,
                         ));
                     }
                     _ => {
                         // Catch all error case so that it's not a breaking change to publish new errors.
                         return Err(internal_err(
-                            format!("Error from constraint solver: {}", &failure.error),
+                            format!("Error from constraint solver: {}", failure.error),
                             self,
                         ));
                     }
@@ -1893,9 +1893,9 @@ impl Node<SketchBlock> {
         // Propagate warnings.
         for warning in &solve_outcome.warnings {
             let message = if let Some(index) = warning.about_constraint.as_ref() {
-                format!("{}; constraint index {}", &warning.content, index)
+                format!("{}; constraint index {}", warning.content, index)
             } else {
-                format!("{}", &warning.content)
+                format!("{}", warning.content)
             };
             exec_state.warn(CompilationIssue::err(range, message), annotations::WARN_SOLVER);
         }
@@ -1984,7 +1984,7 @@ impl Node<SketchBlock> {
             debug_assert!(
                 false,
                 "{}; scene_objects={:#?}",
-                &message, &exec_state.mod_local.artifacts.scene_objects
+                message, exec_state.mod_local.artifacts.scene_objects
             );
             return Err(internal_err(message, range));
         };

--- a/rust/kcl-lib/src/execution/import_graph.rs
+++ b/rust/kcl-lib/src/execution/import_graph.rs
@@ -93,7 +93,7 @@ fn topsort(all_modules: &[&str], graph: Graph) -> Result<Vec<Vec<String>>, KclEr
             waiting_modules.retain(|v| *v != stage_module.as_str());
 
             // remove any dependencies for the next run
-            for (_, waiting_for) in dep_map.iter_mut() {
+            for waiting_for in dep_map.values_mut() {
                 waiting_for.retain(|v| v != stage_module);
             }
         }

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -3617,7 +3617,7 @@ w = f() + f()
         let ctx = ExecutorContext::new_mock(None).await;
         let program = crate::Program::parse_no_errs(code).unwrap();
         let result = ctx.run_mock(&program, &MockConfig::default()).await.unwrap();
-        assert!(result.variables.contains_key("s"), "actual: {:?}", &result.variables);
+        assert!(result.variables.contains_key("s"), "actual: {:?}", result.variables);
 
         let code2 = code.to_owned()
             + "
@@ -3629,7 +3629,7 @@ extrude001 = extrude(region001, length = 1)
         assert!(
             result.variables.contains_key("region001"),
             "actual: {:?}",
-            &result.variables
+            result.variables
         );
 
         ctx.close().await;

--- a/rust/kcl-lib/src/parsing/parser.rs
+++ b/rust/kcl-lib/src/parsing/parser.rs
@@ -2857,8 +2857,8 @@ fn declaration(i: &mut TokenSlice) -> ModalResult<BoxNode<VariableDeclaration>> 
                                 "Define a function with `fn name()` instead of assigning the function to a variable",
                             )
                             .with_suggestion(
-                                format!("Use `fn {}`", &id.name),
-                                format!("fn {}", &id.name),
+                                format!("Use `fn {}`", id.name),
+                                format!("fn {}", id.name),
                                 Some(SourceRange::new(start, fn_end, id.module_id)),
                                 Tag::None,
                             ),
@@ -3868,7 +3868,7 @@ fn binding_name(i: &mut TokenSlice) -> ModalResult<Node<Identifier>> {
     if !is_safe_binding_name(&ident.name) {
         ParseContext::err(CompilationIssue::err(
             SourceRange::new(ident.start, ident.end, ident.module_id),
-            format!("`{}` is a reserved name and cannot be defined.", &ident.name),
+            format!("`{}` is a reserved name and cannot be defined.", ident.name),
         ));
     }
 

--- a/rust/kcl-lib/src/parsing/token/tokeniser.rs
+++ b/rust/kcl-lib/src/parsing/token/tokeniser.rs
@@ -794,13 +794,13 @@ const things = "things"
                 assert!(
                     !actual.tokens[i].is_code_token(),
                     "failed test {i}: {:?}",
-                    &actual.tokens[i],
+                    actual.tokens[i],
                 );
             } else {
                 assert!(
                     actual.tokens[i].is_code_token(),
                     "failed test {i}: {:?}",
-                    &actual.tokens[i],
+                    actual.tokens[i],
                 );
             }
         }

--- a/rust/kcl-lib/src/simulation_tests.rs
+++ b/rust/kcl-lib/src/simulation_tests.rs
@@ -114,7 +114,7 @@ impl ExecState {
             let relative_path = relative_module_path(&info.path, &project_directory).unwrap_or_else(|err| {
                 panic!(
                     "Failed to get relative module path for {:?} in {:?}; caused by {err:?}",
-                    &info.path, project_directory
+                    info.path, project_directory
                 )
             });
             match &info.repr {
@@ -160,7 +160,7 @@ where
     settings.set_omit_expression(true);
     settings.set_snapshot_path(Path::new("..").join(&test.output_dir));
     settings.set_prepend_module_to_snapshot(false);
-    settings.set_description(format!("{operation} {}.kcl", &test.name));
+    settings.set_description(format!("{operation} {}.kcl", test.name));
     // We don't do it on the flowchart
     if operation != "Artifact graph flowchart" {
         // Sorting maps makes them easier to diff.

--- a/rust/kcl-lib/src/simulation_tests/kcl_samples.rs
+++ b/rust/kcl-lib/src/simulation_tests/kcl_samples.rs
@@ -112,7 +112,7 @@ fn test_after_engine_ensure_kcl_samples_manifest_etc() {
         }
         std::fs::copy(
             screenshot_file,
-            public_screenshot_dir.join(format!("{}.png", &tests.name)),
+            public_screenshot_dir.join(format!("{}.png", tests.name)),
         )
         .unwrap();
     }

--- a/rust/kcl-lib/src/std/constraints.rs
+++ b/rust/kcl-lib/src/std/constraints.rs
@@ -2005,7 +2005,7 @@ pub async fn coincident(exec_state: &mut ExecState, args: Args) -> Result<KclVal
                 _ => Err(KclError::new_semantic(KclErrorDetails::new(
                     format!(
                         "coincident supports point-point, point-segment, or segment-segment; found {:?} and {:?}",
-                        &unsolved0.kind, &unsolved1.kind
+                        unsolved0.kind, unsolved1.kind
                     ),
                     vec![args.source_range],
                 ))),

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.96.1"
+channel = "1.97.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
https://blog.rust-lang.org/2026/07/09/Rust-1.97.0/

Note, we have this warning now:

> warning: the following packages contain code that will be rejected by a future version of Rust: proc-macro-error2 v2.0.1
> note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`