### PR TITLE
Change EngineTransport to be public

### DIFF
--- a/rust/kcl-lib/src/engine/engine_manager.rs
+++ b/rust/kcl-lib/src/engine/engine_manager.rs
@@ -72,7 +72,7 @@ impl ResponseInformation {
 pub struct EngineManager {
     // Replaces `engine_req_tx: mpsc::Sender<ToEngineReq>`
     // from the original native connection type.
-    transport: Arc<Box<dyn EngineTransport>>,
+    pub transport: Arc<Box<dyn EngineTransport>>,
     responses: ResponseInformation,
     pending_errors: Arc<RwLock<Vec<String>>>,
     socket_health: Arc<RwLock<SocketHealth>>,


### PR DESCRIPTION
This used to be public before the refactor, so some callers rely on its functions. We considered forwarding function calls from the EngineManager. But since the manager can be constructed with a transport, we figured it's okay to read it.