### PR TITLE
Guard empty project deletion

### DIFF
--- a/src/machines/systemIO/systemIOMachine.spec.ts
+++ b/src/machines/systemIO/systemIOMachine.spec.ts
@@ -1,6 +1,7 @@
 import path from 'node:path'
 import { App } from '@src/lib/app'
 import { DEFAULT_PROJECT_NAME } from '@src/lib/constants'
+import fsZds from '@src/lib/fs-zds'
 import type { Project } from '@src/lib/project'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { systemIOMachine } from '@src/machines/systemIO/systemIOMachine'
@@ -471,6 +472,57 @@ describe('systemIOMachine - XState', () => {
           )
         } finally {
           actor.stop()
+        }
+      })
+      it('should reject project deletion with an empty project name', async () => {
+        const rmSpy = vi.spyOn(fsZds, 'rm').mockResolvedValue(undefined)
+        const actor = createActor(
+          systemIOMachineImpl.provide({
+            actors: {
+              [SystemIOMachineActors.readFoldersFromProjectDirectory]:
+                fromPromise(async () => new Promise(() => {})),
+            },
+          }),
+          {
+            input: {
+              wasmInstancePromise: Promise.resolve(instanceInThisFile),
+              app: appInstanceInThisFile,
+            },
+          }
+        ).start()
+
+        let sawDeletingProject = false
+        const settled = new Promise<ReturnType<typeof actor.getSnapshot>>(
+          (resolve) => {
+            actor.subscribe((state) => {
+              if (state.matches(SystemIOMachineStates.deletingProject)) {
+                sawDeletingProject = true
+              }
+              if (
+                sawDeletingProject &&
+                (state.matches(SystemIOMachineStates.idle) ||
+                  state.matches(SystemIOMachineStates.readingFolders))
+              ) {
+                resolve(state)
+              }
+            })
+          }
+        )
+
+        try {
+          actor.send({
+            type: SystemIOMachineEvents.deleteProject,
+            data: { requestedProjectName: '' },
+          })
+
+          const settledState = await settled
+          expect(settledState).toMatchObject({
+            value: SystemIOMachineStates.idle,
+          })
+          expect(rmSpy).not.toHaveBeenCalled()
+        } finally {
+          actor.stop()
+          rmSpy.mockRestore()
         }
       })
       it('should accept file rename while reading folders', async () => {

--- a/src/machines/systemIO/systemIOMachineImpl.ts
+++ b/src/machines/systemIO/systemIOMachineImpl.ts
@@ -46,11 +46,11 @@ import type {
   SystemIOContext,
 } from '@src/machines/systemIO/utils'
 import {
+  collectProjectFiles,
   NO_PROJECT_DIRECTORY,
+  normalizeKCLFileDeletePath,
   SystemIOMachineActors,
   SystemIOMachineEvents,
-  collectProjectFiles,
-  normalizeKCLFileDeletePath,
 } from '@src/machines/systemIO/utils'
 import { fromPromise } from 'xstate'
 
@@ -674,6 +674,12 @@ export const systemIOMachineImpl = systemIOMachine.provide({
       }: {
         input: { context: SystemIOContext; requestedProjectName: string }
       }) => {
+        if (!input.requestedProjectName) {
+          return Promise.reject(
+            new Error('Cannot delete a project without a project name')
+          )
+        }
+
         await fsZds.rm(
           fsZds.join(
             input.context.projectDirectoryPath,


### PR DESCRIPTION
## Summary
- reject project deletion requests with a falsey project name before constructing a filesystem path
- add an integration regression test that verifies the error path and confirms `fsZds.rm` is not called

No call sites in the app as it exists today allow for an empty project name to be passed in to lead to this actor to be invoked an empty string, but it would be very bad if we ever introduced such a case! So we should guard against it now.