### PR TITLE
Andrewvarga/jtran face api pr2 lint fixes

### DIFF
--- a/src/lang/modifyAst/rewire.spec.ts
+++ b/src/lang/modifyAst/rewire.spec.ts
@@ -126,6 +126,28 @@ result001 = fillet(extrude001, radius = 1)`)
     expect(result001Init.unlabeled.name.name).toBe('sketch001')
   })
 
+  // App repro: create an extrusion and a function parameter with the same name,
+  // then remove the extrusion in the Feature Tree. The local reference is
+  // incorrectly rewired to its region.
+  it('does not rewire a function parameter that shadows a deleted feature', () => {
+    const beforeDeleteAst = parseProgram(`parent001 = 1
+deleted001 = parent001
+fn keepLocal(deleted001) {
+  copy = deleted001
+  return copy
+}`)
+
+    const afterDeleteAst = parseProgram(`parent001 = 1
+fn keepLocal(deleted001) {
+  copy = deleted001
+  return copy
+}`)
+
+    const rewiredAst = rewireAfterDelete(beforeDeleteAst, afterDeleteAst)
+
+    expect(recast(rewiredAst, getInstance())).toContain('copy = deleted001')
+  })
+
   it('does not rewrite when deleted feature has no parent reference', () => {
     const beforeDeleteAst = parseProgram(`deleted001 = 5
 keep001 = deleted001 + 1`)

--- a/src/lang/modifyAst/rewire.ts
+++ b/src/lang/modifyAst/rewire.ts
@@ -105,11 +105,31 @@ export function rewireAfterDelete(
 
   const rewiredAst = structuredClone(afterDeleteAst)
   let didRewire = false
+  const functionScopes: Set<string>[] = []
 
   // First pass is intentionally generic: if a deleted feature had a parent
-  // reference, every downstream local reference gets rebound through that parent chain.
+  // reference, every unshadowed downstream reference gets rebound through that
+  // parent chain.
   traverse(rewiredAst, {
     enter: (node, pathToNode) => {
+      if (node.type === 'FunctionExpression') {
+        const bindings = new Set(
+          node.params.map((param) => param.identifier.name)
+        )
+        if (node.name) {
+          bindings.add(node.name.name)
+        }
+        functionScopes.push(bindings)
+        return
+      }
+
+      if (node.type === 'VariableDeclaration' && functionScopes.length > 0) {
+        functionScopes[functionScopes.length - 1].add(
+          node.declaration.id.name
+        )
+        return
+      }
+
       if (node.type !== 'Name') {
         return
       }
@@ -120,6 +140,9 @@ export function rewireAfterDelete(
         return
       }
       if (pathToNode[pathToNode.length - 1]?.[0] === 'callee') {
+        return
+      }
+      if (functionScopes.some((scope) => scope.has(node.name.name))) {
         return
       }
 
@@ -133,6 +156,11 @@ export function rewireAfterDelete(
 
       node.name.name = replacement
       didRewire = true
+    },
+    leave: (node) => {
+      if (node.type === 'FunctionExpression') {
+        functionScopes.pop()
+      }
     },
   })
 

--- a/src/lang/modifyAst/rewire.ts
+++ b/src/lang/modifyAst/rewire.ts
@@ -124,9 +124,7 @@ export function rewireAfterDelete(
       }
 
       if (node.type === 'VariableDeclaration' && functionScopes.length > 0) {
-        functionScopes[functionScopes.length - 1].add(
-          node.declaration.id.name
-        )
+        functionScopes[functionScopes.length - 1].add(node.declaration.id.name)
         return
       }
 


### PR DESCRIPTION
Small regression discovered during reviewing https://github.com/KittyCAD/modeling-app/pull/12062

- Create a new project:
```
sketch001 = startSketchOn(XY)
profile001 = circle(sketch001, center = [0, 0], radius = 10)
extrude001 = extrude(profile001, length = 5)

fn keepLocal(extrude001) {
  copy = extrude001
  return copy
}
```
- In the Feature Tree, right-click and remove extrude001
-> Expected:
```
fn keepLocal(extrude001) {
  copy = extrude001
  return copy
}
```
Got:
```
fn keepLocal(extrude001) {
  copy = profile001
  return copy
}
```

Small bug in rewire.ts that was surfaced now because of changes in queryAst.
