### PR TITLE
KCL: Frontend module's tests should use insta 

### DIFF
--- a/rust/kcl-lib/src/frontend.rs
+++ b/rust/kcl-lib/src/frontend.rs
@@ -7658,13 +7658,7 @@ bad = missing_name
             .add_segment(&mock_ctx, version, sketch_id, segment, None)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "sketch001 = sketch(on = XY) {
-  point(at = [1in, 2in])
-}
-"
-        );
+        insta::assert_snapshot!("test_new_sketch_add_point_edit_point_1", src_delta.text.as_str());
         assert_eq!(scene_delta.new_objects, vec![ObjectId(2)]);
         assert_eq!(scene_delta.new_graph.objects.len(), 3);
         for (i, scene_object) in scene_delta.new_graph.objects.iter().enumerate() {
@@ -7693,13 +7687,7 @@ bad = missing_name
             .edit_segments(&mock_ctx, version, sketch_id, segments)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "sketch001 = sketch(on = XY) {
-  point(at = [3in, 4in])
-}
-"
-        );
+        insta::assert_snapshot!("test_new_sketch_add_point_edit_point_2", src_delta.text.as_str());
         assert_eq!(scene_delta.new_objects, vec![]);
         assert_eq!(scene_delta.new_graph.objects.len(), 3);
 
@@ -7770,13 +7758,7 @@ bad = missing_name
             .add_segment(&mock_ctx, version, sketch_id, segment, None)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "sketch001 = sketch(on = XY) {
-  line(start = [0mm, 0mm], end = [10mm, 10mm])
-}
-"
-        );
+        insta::assert_snapshot!("test_new_sketch_add_line_edit_line_1", src_delta.text.as_str());
         assert_eq!(scene_delta.new_objects, vec![ObjectId(2), ObjectId(3), ObjectId(4)]);
         assert_eq!(scene_delta.new_graph.objects.len(), 5);
         for (i, scene_object) in scene_delta.new_graph.objects.iter().enumerate() {
@@ -7817,13 +7799,7 @@ bad = missing_name
             .edit_segments(&mock_ctx, version, sketch_id, segments)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "sketch001 = sketch(on = XY) {
-  line(start = [1mm, 2mm], end = [13mm, 14mm])
-}
-"
-        );
+        insta::assert_snapshot!("test_new_sketch_add_line_edit_line_2", src_delta.text.as_str());
         assert_eq!(scene_delta.new_objects, vec![]);
         assert_eq!(scene_delta.new_graph.objects.len(), 5);
 
@@ -7904,13 +7880,7 @@ bad = missing_name
             .add_segment(&mock_ctx, version, sketch_id, segment, None)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "sketch001 = sketch(on = XY) {
-  arc(start = [var 0mm, var 0mm], end = [var 10mm, var 10mm], center = [var 10mm, var 0mm])
-}
-"
-        );
+        insta::assert_snapshot!("test_new_sketch_add_arc_edit_arc_1", src_delta.text.as_str());
         assert_eq!(
             scene_delta.new_objects,
             vec![ObjectId(2), ObjectId(3), ObjectId(4), ObjectId(5)]
@@ -7964,13 +7934,7 @@ bad = missing_name
             .edit_segments(&mock_ctx, version, sketch_id, segments)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "sketch001 = sketch(on = XY) {
-  arc(start = [var 1mm, var 2mm], end = [var 13mm, var 14mm], center = [var 13mm, var 2mm])
-}
-"
-        );
+        insta::assert_snapshot!("test_new_sketch_add_arc_edit_arc_2", src_delta.text.as_str());
         assert_eq!(scene_delta.new_objects, vec![]);
         assert_eq!(scene_delta.new_graph.objects.len(), 6);
 
@@ -8026,13 +7990,7 @@ bad = missing_name
             .add_segment(&mock_ctx, version, sketch_id, segment, None)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "sketch001 = sketch(on = XY) {
-  circle1 = circle(start = [var 5mm, var 0mm], center = [var 0mm, var 0mm])
-}
-"
-        );
+        insta::assert_snapshot!("test_new_sketch_add_circle_edit_circle_1", src_delta.text.as_str());
         // The new objects are start, center, and then the circle segment.
         assert_eq!(scene_delta.new_objects, vec![ObjectId(2), ObjectId(3), ObjectId(4)]);
         assert_eq!(scene_delta.new_graph.objects.len(), 5);
@@ -8071,13 +8029,7 @@ bad = missing_name
             .edit_segments(&mock_ctx, version, sketch_id, segments)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "sketch001 = sketch(on = XY) {
-  circle1 = circle(start = [var 10mm, var 0mm], center = [var 3mm, var 4mm])
-}
-"
-        );
+        insta::assert_snapshot!("test_new_sketch_add_circle_edit_circle_2", src_delta.text.as_str());
         assert_eq!(scene_delta.new_objects, vec![]);
         assert_eq!(scene_delta.new_graph.objects.len(), 5);
 
@@ -8113,12 +8065,7 @@ bad = missing_name
             .delete_objects(&mock_ctx, version, sketch_id, vec![], vec![circle_id])
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "sketch001 = sketch(on = XY) {
-}
-"
-        );
+        insta::assert_snapshot!("test_delete_circle", src_delta.text.as_str());
         let new_sketch_object = find_first_sketch_object(&scene_delta.new_graph).unwrap();
         let new_sketch = expect_sketch(new_sketch_object);
         assert_eq!(new_sketch.segments.len(), 0);
@@ -8189,13 +8136,7 @@ bad = missing_name
             .edit_segments(&mock_ctx, version, sketch_id, segments)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "sketch001 = sketch(on = XY) {
-  circle(start = [var 7mm, var 1mm], center = [var 0mm, var 0mm])
-}
-"
-        );
+        insta::assert_snapshot!("test_edit_circle_via_point", src_delta.text.as_str());
 
         ctx.close().await;
         mock_ctx.close().await;
@@ -8246,13 +8187,7 @@ bad = missing_name
             .add_segment(&mock_ctx, version, sketch_id, segment, None)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "s = sketch(on = XY) {
-  line(start = [0mm, 0mm], end = [10mm, 10mm])
-}
-"
-        );
+        insta::assert_snapshot!("test_add_line_when_sketch_block_uses_variable", src_delta.text.as_str());
         assert_eq!(scene_delta.new_objects, vec![ObjectId(2), ObjectId(3), ObjectId(4)]);
         assert_eq!(scene_delta.new_graph.objects.len(), 5);
 
@@ -8323,17 +8258,11 @@ bad = missing_name
             .add_segment(&mock_ctx, version, sketch_id, segment, None)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "sketch001 = sketch(on = XY) {
-  line(start = [0mm, 0mm], end = [10mm, 10mm])
-}
-"
-        );
+        insta::assert_snapshot!("test_new_sketch_add_line_delete_sketch_1", src_delta.text.as_str());
         assert_eq!(scene_delta.new_graph.objects.len(), 5);
 
         let (src_delta, scene_delta) = frontend.delete_sketch(&ctx, version, sketch_id).await.unwrap();
-        assert_eq!(src_delta.text.as_str(), "");
+        insta::assert_snapshot!("test_new_sketch_add_line_delete_sketch_2", src_delta.text.as_str());
         assert_eq!(scene_delta.new_graph.objects.len(), 0);
 
         ctx.close().await;
@@ -8357,7 +8286,10 @@ bad = missing_name
         let sketch_id = sketch_object.id;
 
         let (src_delta, scene_delta) = frontend.delete_sketch(&ctx, version, sketch_id).await.unwrap();
-        assert_eq!(src_delta.text.as_str(), "");
+        insta::assert_snapshot!(
+            "test_delete_sketch_when_sketch_block_uses_variable",
+            src_delta.text.as_str()
+        );
         assert_eq!(scene_delta.new_graph.objects.len(), 0);
 
         ctx.close().await;
@@ -8397,7 +8329,7 @@ sketch001 = sketch(on = XZ) {
             src_delta.text
         );
         // The leading line comment must survive deletion.
-        assert_eq!(src_delta.text.as_str(), "// test 1\n");
+        insta::assert_snapshot!("test_delete_sketch_after_comment", src_delta.text.as_str());
         assert_eq!(scene_delta.new_graph.objects.len(), 0);
 
         ctx.close().await;
@@ -8430,7 +8362,10 @@ foo = 1
 
         let (src_delta, _scene_delta) = frontend.delete_sketch(&ctx, version, sketch_id).await.unwrap();
         // The leading comment should remain, now attached to the following body item.
-        assert_eq!(src_delta.text.as_str(), "// keep me\nfoo = 1\n");
+        insta::assert_snapshot!(
+            "test_delete_sketch_preserves_pre_comment_when_followed_by_code",
+            src_delta.text.as_str()
+        );
 
         ctx.close().await;
     }
@@ -8466,16 +8401,7 @@ sketch(on = XY) {
             .unwrap();
         // The line comment on the line above the deleted point must be preserved.
         // It is reattached to the next surviving body item.
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  point(at = [var 1, var 2])
-  // describe the middle point
-  point(at = [var 5, var 6])
-}
-"
-        );
+        insta::assert_snapshot!("test_delete_segment_preserves_pre_comment", src_delta.text.as_str());
 
         ctx.close().await;
         mock_ctx.close().await;
@@ -8511,14 +8437,9 @@ sketch(on = XY) {
             .unwrap();
         // No following item to attach to; the comment is kept inside the sketch
         // block as trailing non-code metadata so the user does not lose it.
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  point(at = [var 1, var 2])
-  // describe the trailing point
-}
-"
+        insta::assert_snapshot!(
+            "test_delete_last_segment_preserves_pre_comment",
+            src_delta.text.as_str()
         );
 
         ctx.close().await;
@@ -8609,16 +8530,9 @@ sketch(on = XY) {
             )
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  /* above first - moves to middle */
-  /* above middle - stays */
-  point(at = [var 3, var 4])
-  /* above last - moves to trailing meta */
-}
-"
+        insta::assert_snapshot!(
+            "test_delete_segments_preserves_block_comments_across_positions",
+            src_delta.text.as_str()
         );
 
         ctx.close().await;
@@ -8668,14 +8582,7 @@ sketch(on = XY) {
             .edit_segments(&mock_ctx, version, sketch_id, segments)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  line(start = [var 5in, var 6in], end = [var 3, var 4])
-}
-"
-        );
+        insta::assert_snapshot!("test_edit_line_when_editing_its_start_point", src_delta.text.as_str());
         assert_eq!(scene_delta.new_objects, vec![]);
         assert_eq!(scene_delta.new_graph.objects.len(), 5);
 
@@ -8725,14 +8632,7 @@ sketch(on = XY) {
             .edit_segments(&mock_ctx, version, sketch_id, segments)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  line(start = [var 1, var 2], end = [var 5in, var 6in])
-}
-"
-        );
+        insta::assert_snapshot!("test_edit_line_when_editing_its_end_point", src_delta.text.as_str());
         assert_eq!(scene_delta.new_objects, vec![]);
         assert_eq!(
             scene_delta.new_graph.objects.len(),
@@ -8790,18 +8690,7 @@ sketch(on = XY) {
             .edit_segments(&mock_ctx, version, sketch_id, segments)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  line1 = line(start = [var 0, var 0], end = [var 4.14, var 5.32])
-  line2 = line(start = [var 4.14, var 5.32], end = [var 9, var 10])
-  fixed([line1.start, [0, 0]])
-  coincident([line1.end, line2.start])
-  equalLength([line1, line2])
-}
-"
-        );
+        insta::assert_snapshot!("test_edit_line_with_coincident_feedback", src_delta.text.as_str());
         assert_eq!(
             scene_delta.new_graph.objects.len(),
             11,
@@ -9194,13 +9083,9 @@ sketch(on = XY) {
 
         let source_delta = frontend.commit_var_solutions_to_program(&outcome, "testing").unwrap();
 
-        assert_eq!(
-            source_delta.text,
-            "\
-sketch(on = XY) {
-  line1 = line(start = [var 0, var 0], end = [var 25mm, var 0])
-}
-",
+        insta::assert_snapshot!(
+            "test_commit_var_solution_by_node_path_updates_sketch_var",
+            source_delta.text
         );
     }
 
@@ -9258,16 +9143,9 @@ sketch(on = XY) {
 
         let source_delta = frontend.commit_var_solutions_to_program(&outcome, "testing").unwrap();
 
-        assert_eq!(
-            source_delta.text,
-            "\
-// added comment
-// added comment
-
-sketch(on = XY) {
-  line1 = line(start = [var 0, var 0], end = [var 30mm, var 0])
-}
-",
+        insta::assert_snapshot!(
+            "test_commit_var_solution_survives_whitespace_shift_earlier_in_file",
+            source_delta.text
         );
     }
 
@@ -9307,13 +9185,9 @@ sketch(on = XY) {
 
         let source_delta = frontend.commit_var_solutions_to_program(&outcome, "testing").unwrap();
 
-        assert_eq!(
-            source_delta.text,
-            "\
-sketch(on = XY) {
-  line1 = line(start = [var 33mm, var 0mm], end = [var 20mm, var 0mm])
-}
-",
+        insta::assert_snapshot!(
+            "test_commit_var_solution_node_path_wins_when_source_range_points_at_wrong_var",
+            source_delta.text
         );
     }
 
@@ -9360,16 +9234,7 @@ sketch(on = XY) {
         // Default length unit (mm; no `@settings(defaultLengthUnit = …)`) is
         // written as an explicit suffix so the bare var commits with units.
         // The recast adds a blank line after the `@settings` annotation.
-        assert_eq!(
-            source_delta.text,
-            "\
-@settings(experimentalFeatures = allow, kclVersion = 2.0)
-
-sketch(on = XY) {
-  line1 = line(start = [var 7mm, var 0mm], end = [var 10mm, var 0])
-}
-",
-        );
+        insta::assert_snapshot!("test_commit_var_solution_writes_back_into_bare_var", source_delta.text);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -9401,15 +9266,7 @@ sketch(on = XY) {
             .delete_objects(&mock_ctx, version, sketch_id, Vec::new(), vec![point_id])
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  point(at = [var 1, var 2])
-  point(at = [var 5, var 6])
-}
-"
-        );
+        insta::assert_snapshot!("test_delete_point_without_var", src_delta.text.as_str());
         assert_eq!(scene_delta.new_objects, vec![]);
         assert_eq!(scene_delta.new_graph.objects.len(), 4);
 
@@ -9446,15 +9303,7 @@ sketch(on = XY) {
             .delete_objects(&mock_ctx, version, sketch_id, Vec::new(), vec![point_id])
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  point(at = [var 1, var 2])
-  point(at = [var 5, var 6])
-}
-"
-        );
+        insta::assert_snapshot!("test_delete_point_with_var", src_delta.text.as_str());
         assert_eq!(scene_delta.new_objects, vec![]);
         assert_eq!(scene_delta.new_graph.objects.len(), 4);
 
@@ -9493,14 +9342,7 @@ sketch(on = XY) {
             .delete_objects(&mock_ctx, version, sketch_id, Vec::new(), vec![point1_id, point2_id])
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  point(at = [var 5, var 6])
-}
-"
-        );
+        insta::assert_snapshot!("test_delete_multiple_points", src_delta.text.as_str());
         assert_eq!(scene_delta.new_objects, vec![]);
         assert_eq!(scene_delta.new_graph.objects.len(), 3);
 
@@ -9538,16 +9380,7 @@ sketch(on = XY) {
             .delete_objects(&mock_ctx, version, sketch_id, vec![coincident_id], Vec::new())
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  point1 = point(at = [var 1, var 2])
-  point2 = point(at = [var 3, var 4])
-  point(at = [var 5, var 6])
-}
-"
-        );
+        insta::assert_snapshot!("test_delete_coincident_constraint", src_delta.text.as_str());
         assert_eq!(scene_delta.new_objects, vec![]);
         assert_eq!(scene_delta.new_graph.objects.len(), 5);
 
@@ -9583,13 +9416,9 @@ sketch(on = XY) {
             .delete_objects(&mock_ctx, version, sketch_id, Vec::new(), vec![line_id])
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  line1 = line(start = [var 1, var 2], end = [var 3, var 4])
-}
-"
+        insta::assert_snapshot!(
+            "test_delete_line_cascades_to_coincident_constraint",
+            src_delta.text.as_str()
         );
         assert_eq!(
             scene_delta.new_graph.objects.len(),
@@ -9630,13 +9459,9 @@ sketch(on = XY) {
             .delete_objects(&mock_ctx, version, sketch_id, Vec::new(), vec![line_id])
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  line1 = line(start = [var 1, var 2], end = [var 3, var 4])
-}
-"
+        insta::assert_snapshot!(
+            "test_delete_line_cascades_to_distance_constraint",
+            src_delta.text.as_str()
         );
         assert_eq!(
             scene_delta.new_graph.objects.len(),
@@ -9678,13 +9503,9 @@ sketch(on = XY) {
             .delete_objects(&mock_ctx, version, sketch_id, Vec::new(), vec![point2_id])
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  point1 = point(at = [var 1, var 2])
-}
-"
+        insta::assert_snapshot!(
+            "test_delete_point_cascades_to_horizontal_distance_constraint",
+            src_delta.text.as_str()
         );
         assert_eq!(
             scene_delta.new_graph.objects.len(),
@@ -9725,14 +9546,7 @@ sketch(on = XY) {
             .delete_objects(&mock_ctx, version, sketch_id, Vec::new(), vec![line1_id])
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  line2 = line(start = [var 5, var 6], end = [var 7, var 8])
-}
-"
-        );
+        insta::assert_snapshot!("test_delete_line_cascades_to_fixed_constraint", src_delta.text.as_str());
         assert_eq!(
             scene_delta.new_graph.objects.len(),
             5,
@@ -9772,13 +9586,9 @@ sketch(on = XY) {
             .delete_objects(&mock_ctx, version, sketch_id, Vec::new(), vec![line1_id])
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  point1 = point(at = [var 1, var 2])
-}
-"
+        insta::assert_snapshot!(
+            "test_delete_line_cascades_to_midpoint_constraint",
+            src_delta.text.as_str()
         );
         assert_eq!(
             scene_delta.new_graph.objects.len(),
@@ -9883,15 +9693,9 @@ sketch(on = XY) {
             .delete_objects(&mock_ctx, version, sketch_id, Vec::new(), vec![line3_id])
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  line1 = line(start = [var 1, var 2], end = [var 3, var 4])
-  line2 = line(start = [var 5, var 6], end = [var 7, var 8])
-  equalLength([line1, line2])
-}
-"
+        insta::assert_snapshot!(
+            "test_delete_line_preserves_multiline_equal_length_constraint",
+            src_delta.text.as_str()
         );
 
         let sketch_object = find_first_sketch_object(&scene_delta.new_graph).unwrap();
@@ -10109,13 +9913,9 @@ sketch(on = XY) {
             .delete_objects(&mock_ctx, version, sketch_id, Vec::new(), vec![line2_id, line3_id])
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  line1 = line(start = [var 1, var 2], end = [var 3, var 4])
-}
-"
+        insta::assert_snapshot!(
+            "test_delete_lines_removes_multiline_equal_length_constraint_below_minimum",
+            src_delta.text.as_str()
         );
 
         let sketch_object = find_first_sketch_object(&scene_delta.new_graph).unwrap();
@@ -10155,15 +9955,9 @@ sketch(on = XY) {
             .delete_objects(&mock_ctx, version, sketch_id, Vec::new(), vec![line3_id])
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  line1 = line(start = [var 1, var 2], end = [var 3, var 4])
-  line2 = line(start = [var 5, var 6], end = [var 7, var 8])
-  parallel([line1, line2])
-}
-"
+        insta::assert_snapshot!(
+            "test_delete_line_preserves_multiline_parallel_constraint",
+            src_delta.text.as_str()
         );
 
         let sketch_object = find_first_sketch_object(&scene_delta.new_graph).unwrap();
@@ -10213,13 +10007,9 @@ sketch(on = XY) {
             .delete_objects(&mock_ctx, version, sketch_id, Vec::new(), vec![line2_id, line3_id])
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  line1 = line(start = [var 1, var 2], end = [var 3, var 4])
-}
-"
+        insta::assert_snapshot!(
+            "test_delete_lines_removes_multiline_parallel_constraint_below_minimum",
+            src_delta.text.as_str()
         );
 
         let sketch_object = find_first_sketch_object(&scene_delta.new_graph).unwrap();
@@ -10259,15 +10049,7 @@ sketch(on = XY) {
             .delete_objects(&mock_ctx, version, sketch_id, vec![coincident_id], Vec::new())
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  line1 = line(start = [var 1, var 2], end = [var 3, var 4])
-  line2 = line(start = [var 5, var 6], end = [var 7, var 8])
-}
-"
-        );
+        insta::assert_snapshot!("test_delete_line_line_coincident_constraint", src_delta.text.as_str());
         assert_eq!(scene_delta.new_objects, vec![]);
         assert_eq!(scene_delta.new_graph.objects.len(), 8);
 
@@ -10306,16 +10088,7 @@ sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  point1 = point(at = [var 3, var 4])
-  point2 = point(at = [3, 4])
-  coincident([point1, point2])
-}
-"
-        );
+        insta::assert_snapshot!("test_two_points_coincident", src_delta.text.as_str());
         assert_eq!(
             scene_delta.new_graph.objects.len(),
             5,
@@ -10365,17 +10138,7 @@ sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  point1 = point(at = [var 3, var 4])
-  point2 = point(at = [var 3, var 4])
-  point3 = point(at = [var 3, var 4])
-  coincident([point1, point2, point3])
-}
-"
-        );
+        insta::assert_snapshot!("test_three_points_coincident", src_delta.text.as_str());
 
         let constraint_object = scene_delta
             .new_graph
@@ -10451,25 +10214,9 @@ sketch(on = XY) {
 }
 ";
 
-        for (origin_first, expected_source) in [
-            (
-                true,
-                "\
-sketch(on = XY) {
-  point1 = point(at = [var 0, var 0])
-  coincident([ORIGIN, point1])
-}
-",
-            ),
-            (
-                false,
-                "\
-sketch(on = XY) {
-  point1 = point(at = [var 0, var 0])
-  coincident([point1, ORIGIN])
-}
-",
-            ),
+        for (origin_first, snapshot_name) in [
+            (true, "test_point_origin_coincident_preserves_order_origin_first"),
+            (false, "test_point_origin_coincident_preserves_order_point_first"),
         ] {
             let program = Program::parse(initial_source).unwrap().0.unwrap();
 
@@ -10497,7 +10244,7 @@ sketch(on = XY) {
                 .add_constraint(&mock_ctx, version, sketch_id, constraint)
                 .await
                 .unwrap();
-            assert_eq!(src_delta.text.as_str(), expected_source);
+            insta::assert_snapshot!(snapshot_name, src_delta.text.as_str());
 
             let constraint_object = scene_delta
                 .new_graph
@@ -10548,16 +10295,7 @@ sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  line1 = line(start = [var 1, var 2], end = [var 4, var 5])
-  line2 = line(start = [var 4, var 5], end = [var 7, var 8])
-  coincident([line1.end, line2.start])
-}
-"
-        );
+        insta::assert_snapshot!("test_coincident_of_line_end_points", src_delta.text.as_str());
         assert_eq!(
             scene_delta.new_graph.objects.len(),
             9,
@@ -10629,15 +10367,9 @@ sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  circle1 = circle(start = [var 7.02mm, var 0mm], center = [var -0.01mm, var 0.22mm])
-  line1 = line(start = [var 7mm, var 0.78mm], end = [var 10mm, var 2mm])
-  coincident([line1.start, circle1])
-}
-"
+        insta::assert_snapshot!(
+            "test_coincident_of_line_point_and_circle_segment",
+            src_delta.text.as_str()
         );
 
         mock_ctx.close().await;
@@ -10835,17 +10567,7 @@ sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            // The lack indentation is a formatter bug.
-            "\
-sketch(on = XY) {
-  point1 = point(at = [var 1.29, var 2.29])
-  point2 = point(at = [var 2.71, var 3.71])
-  distance([point1, point2]) == 2mm
-}
-"
-        );
+        insta::assert_snapshot!("test_distance_two_points", src_delta.text.as_str());
         assert_eq!(
             scene_delta.new_graph.objects.len(),
             5,
@@ -10905,16 +10627,7 @@ sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  point1 = point(at = [var 1.29, var 2.29])
-  point2 = point(at = [var 2.71, var 3.71])
-  distance([point1, point2], labelPosition = [10mm, 11mm]) == 2mm
-}
-"
-        );
+        insta::assert_snapshot!("test_distance_two_points_with_label", src_delta.text.as_str());
 
         let sketch_object = find_first_sketch_object(&scene_delta.new_graph).unwrap();
         let sketch = expect_sketch(sketch_object);
@@ -10993,16 +10706,7 @@ sketch(on = XY) {
             )
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  point1 = point(at = [var 1, var 2])
-  point2 = point(at = [var 3, var 2])
-  distance([point1, point2], labelPosition = [10mm, 11mm]) == 2mm
-}
-"
-        );
+        insta::assert_snapshot!("test_edit_distance_constraint_label_position", src_delta.text.as_str());
 
         let constraint_object = scene_delta.new_graph.objects.get(constraint_id.0).unwrap();
         let ObjectKind::Constraint { constraint } = &constraint_object.kind else {
@@ -11155,16 +10859,7 @@ sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  point1 = point(at = [var 0, var 5])
-  line1 = line(start = [var 0, var 0], end = [var 10, var 0])
-  distance([point1, line1], labelPosition = [10mm, 11mm]) == 5mm
-}
-"
-        );
+        insta::assert_snapshot!("test_distance_point_line", src_delta.text.as_str());
         let sketch_object = find_first_sketch_object(&scene_delta.new_graph).unwrap();
         let sketch = expect_sketch(sketch_object);
         let constraint_object = scene_delta.new_graph.objects.get(sketch.constraints[0].0).unwrap();
@@ -11228,16 +10923,7 @@ sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  point1 = point(at = [var 0, var 8])
-  arc1 = arc(start = [var 5, var 0], end = [var 0, var 5], center = [var 0, var 0])
-  distance([point1, arc1]) == 3mm
-}
-"
-        );
+        insta::assert_snapshot!("test_distance_point_arc", src_delta.text.as_str());
 
         ctx.close().await;
         mock_ctx.close().await;
@@ -11290,15 +10976,7 @@ sketch001 = sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch001 = sketch(on = XY) {
-  arc1 = arc(start = [var -4.16mm, var -0.43mm], end = [var -3.53mm, var 3.28mm], center = [var -4.91mm, var 1.61mm])
-  distance([arc1, ORIGIN]) == 3mm
-}
-"
-        );
+        insta::assert_snapshot!("test_distance_arc_origin", src_delta.text.as_str());
 
         mock_ctx.close().await;
     }
@@ -11350,15 +11028,7 @@ sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  line1 = line(start = [var 5, var 0], end = [var 5, var 10])
-  distance([ORIGIN, line1]) == 5mm
-}
-"
-        );
+        insta::assert_snapshot!("test_distance_line_origin", src_delta.text.as_str());
 
         mock_ctx.close().await;
     }
@@ -11422,16 +11092,7 @@ sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  line1 = line(start = [var -10, var 8], end = [var 10, var 8])
-  circle1 = circle(start = [var 5, var 0], center = [var 0, var 0])
-  distance([line1, circle1]) == 3mm
-}
-"
-        );
+        insta::assert_snapshot!("test_distance_line_circle", src_delta.text.as_str());
 
         ctx.close().await;
         mock_ctx.close().await;
@@ -11496,16 +11157,7 @@ sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  circle1 = circle(start = [var 4.33, var 0], center = [var -0.34, var -0.09])
-  arc1 = arc(start = [var 15.33, var -0.01], end = [var 10.01, var 4.33], center = [var 11.34, var 0.53])
-  distance([circle1, arc1]) == 3mm
-}
-"
-        );
+        insta::assert_snapshot!("test_distance_circle_arc", src_delta.text.as_str());
 
         ctx.close().await;
         mock_ctx.close().await;
@@ -11559,16 +11211,7 @@ sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  line1 = line(start = [var 0, var 0], end = [var 10, var 0])
-  line2 = line(start = [var 0, var 5], end = [var 10, var 5])
-  distance([line1, line2]) == 5mm
-}
-"
-        );
+        insta::assert_snapshot!("test_distance_parallel_lines", src_delta.text.as_str());
 
         ctx.close().await;
         mock_ctx.close().await;
@@ -11622,15 +11265,9 @@ sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  line1 = line(start = [var 4.98, var -0.07], end = [var 4.98, var 0.14])
-  line2 = line(start = [var 0.02, var 4.3], end = [var 0.03, var 5.65])
-  distance([line1, line2]) == 5mm
-}
-"
+        insta::assert_snapshot!(
+            "test_distance_non_parallel_lines_lowers_to_distance",
+            src_delta.text.as_str()
         );
 
         ctx.close().await;
@@ -11685,17 +11322,7 @@ sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            // The lack indentation is a formatter bug.
-            "\
-sketch(on = XY) {
-  point1 = point(at = [var 1, var 2])
-  point2 = point(at = [var 3, var 4])
-  horizontalDistance([point1, point2], labelPosition = [10mm, 11mm]) == 2mm
-}
-"
-        );
+        insta::assert_snapshot!("test_horizontal_distance_two_points", src_delta.text.as_str());
         assert_eq!(
             scene_delta.new_graph.objects.len(),
             5,
@@ -11764,16 +11391,7 @@ sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            // The lack indentation is a formatter bug.
-            "\
-sketch(on = XY) {
-  arc1 = arc(start = [var 1.83, var 3.62], end = [var 2.42, var 3.3], center = [var -0.25, var -0.92])
-  radius(arc1) == 5mm
-}
-"
-        );
+        insta::assert_snapshot!("test_radius_single_arc_segment", src_delta.text.as_str());
         assert_eq!(
             scene_delta.new_graph.objects.len(),
             7, // Plane (0) + Sketch (1) + Start point (2) + End point (3) + Center point (4) + Arc (5) + Constraint (6)
@@ -11841,14 +11459,9 @@ sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  arc1 = arc(start = [var 1.83, var 3.62], end = [var 2.42, var 3.3], center = [var -0.25, var -0.92])
-  radius(arc1, labelPosition = [10mm, 11mm]) == 5mm
-}
-"
+        insta::assert_snapshot!(
+            "test_radius_single_arc_segment_with_label_position",
+            src_delta.text.as_str()
         );
 
         let sketch_object = find_first_sketch_object(&scene_delta.new_graph).unwrap();
@@ -11908,15 +11521,7 @@ sketch(on = XY) {
             )
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  arc1 = arc(start = [var 5mm, var 0mm], end = [var 0mm, var 5mm], center = [var 0mm, var 0mm])
-  radius(arc1, labelPosition = [10mm, 11mm]) == 5mm
-}
-"
-        );
+        insta::assert_snapshot!("test_edit_radius_constraint_label_position", src_delta.text.as_str());
 
         let constraint_object = scene_delta.new_graph.objects.get(constraint_id.0).unwrap();
         let ObjectKind::Constraint { constraint } = &constraint_object.kind else {
@@ -11978,17 +11583,7 @@ sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            // The lack indentation is a formatter bug.
-            "\
-sketch(on = XY) {
-  point1 = point(at = [var 1, var 2])
-  point2 = point(at = [var 3, var 4])
-  verticalDistance([point1, point2], labelPosition = [10mm, 11mm]) == 2mm
-}
-"
-        );
+        insta::assert_snapshot!("test_vertical_distance_two_points", src_delta.text.as_str());
         assert_eq!(
             scene_delta.new_graph.objects.len(),
             5,
@@ -12054,15 +11649,7 @@ sketch(on = XY) {
             )
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  point1 = point(at = [var 2, var 3])
-  fixed([point1, [2mm, 3mm]])
-}
-"
-        );
+        insta::assert_snapshot!("test_add_fixed_standalone_point", src_delta.text.as_str());
         assert_eq!(
             scene_delta.new_graph.objects.len(),
             4,
@@ -12136,17 +11723,7 @@ sketch(on = XY) {
             )
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  point1 = point(at = [var 2, var 3])
-  point2 = point(at = [var 4, var 5])
-  fixed([point1, [2mm, 3mm]])
-  fixed([point2, [4mm, 5mm]])
-}
-"
-        );
+        insta::assert_snapshot!("test_add_fixed_multiple_points", src_delta.text.as_str());
         assert_eq!(
             scene_delta.new_graph.objects.len(),
             6,
@@ -12203,15 +11780,7 @@ sketch(on = XY) {
             )
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  line1 = line(start = [var 2, var 3], end = [var 3, var 4])
-  fixed([line1.start, [2mm, 3mm]])
-}
-"
-        );
+        insta::assert_snapshot!("test_add_fixed_owned_point", src_delta.text.as_str());
         assert_eq!(
             scene_delta.new_graph.objects.len(),
             6,
@@ -12337,16 +11906,7 @@ sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            // The lack indentation is a formatter bug.
-            "\
-sketch(on = XY) {
-  arc1 = arc(start = [var 1.83, var 3.62], end = [var 2.42, var 3.3], center = [var -0.25, var -0.92])
-  diameter(arc1) == 10mm
-}
-"
-        );
+        insta::assert_snapshot!("test_diameter_single_arc_segment", src_delta.text.as_str());
         assert_eq!(
             scene_delta.new_graph.objects.len(),
             7, // Plane (0) + Sketch (1) + Start point (2) + End point (3) + Center point (4) + Arc (5) + Constraint (6)
@@ -12414,14 +11974,9 @@ sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  arc1 = arc(start = [var 1.83, var 3.62], end = [var 2.42, var 3.3], center = [var -0.25, var -0.92])
-  diameter(arc1, labelPosition = [10mm, 11mm]) == 10mm
-}
-"
+        insta::assert_snapshot!(
+            "test_diameter_single_arc_segment_with_label_position",
+            src_delta.text.as_str()
         );
 
         let sketch_object = find_first_sketch_object(&scene_delta.new_graph).unwrap();
@@ -12481,15 +12036,7 @@ sketch(on = XY) {
             )
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  arc1 = arc(start = [var 5mm, var 0mm], end = [var 0mm, var 5mm], center = [var 0mm, var 0mm])
-  diameter(arc1, labelPosition = [10mm, 11mm]) == 10mm
-}
-"
-        );
+        insta::assert_snapshot!("test_edit_diameter_constraint_label_position", src_delta.text.as_str());
 
         let constraint_object = scene_delta.new_graph.objects.get(constraint_id.0).unwrap();
         let ObjectKind::Constraint { constraint } = &constraint_object.kind else {
@@ -12596,15 +12143,7 @@ sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  line1 = line(start = [var 1, var 3], end = [var 3, var 3])
-  horizontal(line1)
-}
-"
-        );
+        insta::assert_snapshot!("test_line_horizontal", src_delta.text.as_str());
         assert_eq!(
             scene_delta.new_graph.objects.len(),
             6,
@@ -12991,15 +12530,7 @@ sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  line1 = line(start = [var 2, var 2], end = [var 2, var 4])
-  vertical(line1)
-}
-"
-        );
+        insta::assert_snapshot!("test_line_vertical", src_delta.text.as_str());
         assert_eq!(
             scene_delta.new_graph.objects.len(),
             6,
@@ -13044,16 +12575,7 @@ sketch001 = sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch001 = sketch(on = XY) {
-  p0 = point(at = [var 4mm, var 3.1mm])
-  pf = point(at = [4, 4])
-  vertical([p0, pf])
-}
-"
-        );
+        insta::assert_snapshot!("test_points_vertical", src_delta.text.as_str());
         assert_eq!(
             scene_delta.new_graph.objects.len(),
             5,
@@ -13098,16 +12620,7 @@ sketch001 = sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch001 = sketch(on = XY) {
-  p0 = point(at = [var -2.23mm, var 4mm])
-  pf = point(at = [4, 4])
-  horizontal([p0, pf])
-}
-"
-        );
+        insta::assert_snapshot!("test_points_horizontal", src_delta.text.as_str());
         assert_eq!(
             scene_delta.new_graph.objects.len(),
             5,
@@ -13148,15 +12661,7 @@ sketch001 = sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch001 = sketch(on = XY) {
-  p0 = point(at = [var -2.23mm, var 0mm])
-  horizontal([p0, ORIGIN])
-}
-"
-        );
+        insta::assert_snapshot!("test_point_horizontal_with_origin", src_delta.text.as_str());
         assert_eq!(
             scene_delta.new_graph.objects.len(),
             4,
@@ -13199,16 +12704,7 @@ sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  line1 = line(start = [var 1, var 2], end = [var 3, var 4])
-  line2 = line(start = [var 5, var 6], end = [var 7, var 8])
-  equalLength([line1, line2])
-}
-"
-        );
+        insta::assert_snapshot!("test_lines_equal_length", src_delta.text.as_str());
         assert_eq!(
             scene_delta.new_graph.objects.len(),
             9,
@@ -13252,17 +12748,7 @@ sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  line1 = line(start = [var 1, var 2], end = [var 3, var 4])
-  line2 = line(start = [var 5, var 6], end = [var 7, var 8])
-  line3 = line(start = [var 9, var 10], end = [var 11, var 12])
-  equalLength([line1, line2, line3])
-}
-"
-        );
+        insta::assert_snapshot!("test_add_constraint_multi_line_equal_length", src_delta.text.as_str());
         let constraints = scene_delta
             .new_graph
             .objects
@@ -13316,16 +12802,7 @@ sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  line1 = line(start = [var 1, var 2], end = [var 3, var 4])
-  line2 = line(start = [var 5, var 6], end = [var 7, var 8])
-  parallel([line1, line2])
-}
-"
-        );
+        insta::assert_snapshot!("test_lines_parallel", src_delta.text.as_str());
         assert_eq!(
             scene_delta.new_graph.objects.len(),
             9,
@@ -13370,17 +12847,7 @@ sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  line1 = line(start = [var 1, var 2], end = [var 3, var 4])
-  line2 = line(start = [var 5, var 6], end = [var 7, var 8])
-  line3 = line(start = [var 9, var 10], end = [var 11, var 12])
-  parallel([line1, line2, line3])
-}
-"
-        );
+        insta::assert_snapshot!("test_lines_parallel_multiline", src_delta.text.as_str());
 
         let sketch_object = find_first_sketch_object(&scene_delta.new_graph).unwrap();
         let sketch = expect_sketch(sketch_object);
@@ -13430,16 +12897,7 @@ sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  line1 = line(start = [var 2, var 3], end = [var 2, var 3])
-  line2 = line(start = [var 6, var 7], end = [var 6, var 7])
-  perpendicular([line1, line2])
-}
-"
-        );
+        insta::assert_snapshot!("test_lines_perpendicular", src_delta.text.as_str());
         assert_eq!(
             scene_delta.new_graph.objects.len(),
             9,
@@ -13487,17 +12945,7 @@ sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            // The lack indentation is a formatter bug.
-            "\
-sketch(on = XY) {
-  line1 = line(start = [var 0.9, var 2.36], end = [var 3.1, var 3.64])
-  line2 = line(start = [var 5.36, var 5.9], end = [var 6.64, var 8.1])
-  angle([line1, line2]) == 30deg
-}
-"
-        );
+        insta::assert_snapshot!("test_lines_angle", src_delta.text.as_str());
         assert_eq!(
             scene_delta.new_graph.objects.len(),
             9,
@@ -13540,16 +12988,7 @@ sketch(on = XY) {
             .add_constraint(&mock_ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  line1 = line(start = [var 0.84, var 2.13], end = [var 3.82, var 3.27])
-  arc1 = arc(start = [var 4.51, var 2.03], end = [var 7.05, var 2.02], center = [var 5.78, var 2.55])
-  tangent([line1, arc1])
-}
-"
-        );
+        insta::assert_snapshot!("test_segments_tangent", src_delta.text.as_str());
         assert_eq!(
             scene_delta.new_graph.objects.len(),
             10,
@@ -13594,16 +13033,7 @@ sketch(on = XY) {
             .add_constraint(&ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  point1 = point(at = [var 2.33, var 1.67])
-  line1 = line(start = [var -0.67, var -0.33], end = [var 5.33, var 3.67])
-  midpoint(line1, point = point1)
-}
-"
-        );
+        insta::assert_snapshot!("test_point_midpoint", src_delta.text.as_str());
         assert_eq!(
             scene_delta.new_graph.objects.len(),
             7,
@@ -13649,17 +13079,7 @@ sketch(on = XY) {
             .add_constraint(&ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  line1 = line(start = [var 0, var 0], end = [var 0, var 4])
-  line2 = line(start = [var 4, var 0], end = [var 4, var 4])
-  line3 = line(start = [var 2, var -1], end = [var 2, var 5])
-  symmetric([line1, line2], axis = line3)
-}
-"
-        );
+        insta::assert_snapshot!("test_segments_symmetric", src_delta.text.as_str());
         assert_eq!(
             scene_delta.new_graph.objects.len(),
             12,
@@ -13703,16 +13123,7 @@ sketch(on = XY) {
             .add_constraint(&ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  point1 = point(at = [var 6, var 2.35])
-  arc1 = arc(start = [var 6, var 2.35], end = [var 6, var 2.35], center = [var 6, var 1.94])
-  midpoint(arc1, point = point1)
-}
-"
-        );
+        insta::assert_snapshot!("test_point_arc_midpoint", src_delta.text.as_str());
         assert_eq!(
             scene_delta.new_graph.objects.len(),
             8,
@@ -13754,15 +13165,7 @@ sketch(on = XY) {
             .add_constraint(&ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  line1 = line(start = [var -3, var -2], end = [var 3, var 2])
-  midpoint(line1, point = ORIGIN)
-}
-"
-        );
+        insta::assert_snapshot!("test_origin_line_midpoint", src_delta.text.as_str());
         assert_eq!(
             scene_delta.new_graph.objects.len(),
             6,
@@ -13804,15 +13207,7 @@ sketch(on = XY) {
             .add_constraint(&ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  arc1 = arc(start = [var 0.35, var 2.24], end = [var 1.62, var -1.58], center = [var 2.34, var 0.78])
-  midpoint(arc1, point = ORIGIN)
-}
-"
-        );
+        insta::assert_snapshot!("test_origin_arc_midpoint", src_delta.text.as_str());
         assert_eq!(
             scene_delta.new_graph.objects.len(),
             7,
@@ -13858,17 +13253,7 @@ sketch(on = XY) {
             .add_constraint(&ctx, version, sketch_id, constraint)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch(on = XY) {
-  arc1 = arc(start = [var -14.46, var 0], end = [var -10, var 4.65], center = [var -10.14, var 0.31])
-  arc2 = arc(start = [var 5.49, var 2.26], end = [var 11.58, var -3.47], center = [var 9.34, var 0.25])
-  line1 = line(start = [var -0.44, var -10], end = [var -0.37, var 10])
-  symmetric([arc1, arc2], axis = line1)
-}
-"
-        );
+        insta::assert_snapshot!("test_segments_symmetric_arcs", src_delta.text.as_str());
         assert_eq!(
             scene_delta.new_graph.objects.len(),
             14,
@@ -14294,24 +13679,7 @@ plane = planeOf(cube, face = side)
             .new_sketch(&ctx, ProjectId(0), FileId(0), version, sketch_args)
             .await
             .unwrap();
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-len = 2mm
-cube = startSketchOn(XY)
-  |> startProfile(at = [0, 0])
-  |> line(end = [len, 0], tag = $side)
-  |> line(end = [0, len])
-  |> line(end = [-len, 0])
-  |> line(end = [0, -len])
-  |> close()
-  |> extrude(length = len)
-
-plane = planeOf(cube, face = side)
-sketch001 = sketch(on = plane) {
-}
-"
-        );
+        insta::assert_snapshot!("test_sketch_on_plane_incremental", src_delta.text.as_str());
         assert_eq!(sketch_id, ObjectId(2));
         assert_eq!(scene_delta.new_objects, vec![ObjectId(2)]);
         let sketch_object = &scene_delta.new_graph.objects[2];
@@ -14360,15 +13728,7 @@ sketch1 = sketch(on = XY) {
             .await
             .unwrap();
 
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch1 = sketch(on = XY) {
-}
-sketch001 = sketch(on = YZ) {
-}
-"
-        );
+        insta::assert_snapshot!("test_new_sketch_uses_unique_variable_name", src_delta.text.as_str());
 
         ctx.close().await;
     }
@@ -14396,15 +13756,7 @@ sketch1 = sketch(on = XY) {
             .await
             .unwrap();
 
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-sketch1 = sketch(on = XY) {
-}
-sketch001 = sketch(on = XY) {
-}
-"
-        );
+        insta::assert_snapshot!("test_new_sketch_twice_using_same_plane", src_delta.text.as_str());
 
         ctx.close().await;
     }
@@ -14552,43 +13904,7 @@ sketch2 = sketch(on = XY) {
             .await
             .unwrap();
         // Only the first sketch block changes.
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-// Cube that requires the engine.
-width = 2
-sketch001 = startSketchOn(XY)
-profile001 = startProfile(sketch001, at = [0, 0])
-  |> yLine(length = width, tag = $seg1)
-  |> xLine(length = width)
-  |> yLine(length = -width)
-  |> line(endAbsolute = [profileStartX(%), profileStartY(%)])
-  |> close()
-extrude001 = extrude(profile001, length = width)
-
-// Get a value that requires the engine.
-x = segLen(seg1)
-
-// Triangle with side length 2*x.
-sketch(on = XY) {
-  line1 = line(start = [var 1mm, var 2mm], end = [var 2.32mm, var -1.78mm])
-  line2 = line(start = [var 2.32mm, var -1.78mm], end = [var -1.61mm, var -1.03mm])
-  coincident([line1.end, line2.start])
-  line3 = line(start = [var -1.61mm, var -1.03mm], end = [var 1mm, var 2mm])
-  coincident([line2.end, line3.start])
-  coincident([line3.end, line1.start])
-  equalLength([line3, line1])
-  equalLength([line1, line2])
-  distance([line1.start, line1.end]) == 2 * x
-}
-
-// Line segment with length x.
-sketch2 = sketch(on = XY) {
-  line1 = line(start = [var 0.14mm, var 0.86mm], end = [var 1.283mm, var -0.781mm])
-  distance([line1.start, line1.end]) == x
-}
-"
-        );
+        insta::assert_snapshot!("test_multiple_sketch_blocks_1", src_delta.text.as_str());
         let edited_sketch1_source = src_delta.text.clone();
 
         // Execute mock to simulate drag end.
@@ -14644,43 +13960,7 @@ sketch2 = sketch(on = XY) {
             .await
             .unwrap();
         // Only the second sketch block changes.
-        assert_eq!(
-            src_delta.text.as_str(),
-            "\
-// Cube that requires the engine.
-width = 2
-sketch001 = startSketchOn(XY)
-profile001 = startProfile(sketch001, at = [0, 0])
-  |> yLine(length = width, tag = $seg1)
-  |> xLine(length = width)
-  |> yLine(length = -width)
-  |> line(endAbsolute = [profileStartX(%), profileStartY(%)])
-  |> close()
-extrude001 = extrude(profile001, length = width)
-
-// Get a value that requires the engine.
-x = segLen(seg1)
-
-// Triangle with side length 2*x.
-sketch(on = XY) {
-  line1 = line(start = [var 1mm, var 2mm], end = [var 2.32mm, var -1.78mm])
-  line2 = line(start = [var 2.32mm, var -1.78mm], end = [var -1.61mm, var -1.03mm])
-  coincident([line1.end, line2.start])
-  line3 = line(start = [var -1.61mm, var -1.03mm], end = [var 1mm, var 2mm])
-  coincident([line2.end, line3.start])
-  coincident([line3.end, line1.start])
-  equalLength([line3, line1])
-  equalLength([line1, line2])
-  distance([line1.start, line1.end]) == 2 * x
-}
-
-// Line segment with length x.
-sketch2 = sketch(on = XY) {
-  line1 = line(start = [var 3mm, var 4mm], end = [var 2.32mm, var 2.12mm])
-  distance([line1.start, line1.end]) == x
-}
-"
-        );
+        insta::assert_snapshot!("test_multiple_sketch_blocks_2", src_delta.text.as_str());
         let edited_sketch2_source = src_delta.text.clone();
 
         // Execute mock to simulate drag end.
@@ -14761,8 +14041,6 @@ sketch002 = sketch(on = XY) {
         // Extra newlines after @settings line - this shifts all source ranges.
         let initial_source = "@settings(defaultLengthUnit = mm)
 
-
-
 sketch001 = sketch(on = XY) {
   point(at = [1in, 2in])
 }
@@ -14836,8 +14114,6 @@ sketch001 = sketch(on = XY) {
         // Extra newlines after @settings, with an empty sketch block.
         let initial_source = "@settings(defaultLengthUnit = mm)
 
-
-
 s = sketch(on = XY) {}
 ";
 
@@ -14896,7 +14172,6 @@ s = sketch(on = XY) {}
     async fn test_extra_newlines_between_operations_edit_line() {
         // Extra newlines between @settings and sketch, and inside the sketch block.
         let initial_source = "@settings(defaultLengthUnit = mm)
-
 
 sketch001 = sketch(on = XY) {
 
@@ -14989,8 +14264,6 @@ sketch001 = sketch(on = XY) {
         // Extra whitespace before and after the sketch block.
         let initial_source = "@settings(defaultLengthUnit = mm)
 
-
-
 sketch001 = sketch(on = XY) {
   circle(start = [var 5mm, var 0mm], center = [var 0mm, var 0mm])
 }
@@ -15034,9 +14307,6 @@ sketch001 = sketch(on = XY) {
     async fn test_unformatted_source_add_arc() {
         // Source with inconsistent whitespace - tabs, extra spaces, multiple blank lines.
         let initial_source = "@settings(defaultLengthUnit = mm)
-
-
-
 
 sketch001 = sketch(on = XY) {
 }
@@ -15109,8 +14379,6 @@ sketch001 = sketch(on = XY) {
         // Extra blank lines between settings and sketch.
         let initial_source = "@settings(defaultLengthUnit = mm)
 
-
-
 sketch001 = sketch(on = XY) {
 }
 ";
@@ -15171,8 +14439,6 @@ sketch001 = sketch(on = XY) {
     async fn test_extra_newlines_add_constraint() {
         // Extra newlines with a sketch containing two lines - add a coincident constraint.
         let initial_source = "@settings(defaultLengthUnit = mm)
-
-
 
 sketch001 = sketch(on = XY) {
   line1 = line(start = [var 0mm, var 0mm], end = [var 10mm, var 10mm])
@@ -15253,8 +14519,6 @@ sketch001 = sketch(on = XY) {
     async fn test_extra_newlines_add_line_then_edit_line() {
         // Extra newlines after @settings - add a line, then edit it.
         let initial_source = "@settings(defaultLengthUnit = mm)
-
-
 
 sketch001 = sketch(on = XY) {
 }

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__point_on_arc_coincident_should_not_effect_initial_guesses.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__point_on_arc_coincident_should_not_effect_initial_guesses.snap
@@ -1,0 +1,12 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch(on = XY) {
+  line3 = line(start = [var 4.32mm, var 3.72mm], end = [var 1.06mm, var -3.26mm])
+  line4 = line(start = [var -2.31mm, var -3.06mm], end = [var -6.71mm, var -2.8mm])
+  arc1 = arc(start = [var -1.44mm, var -0.99mm], end = [var 2.49mm, var -0.2mm], center = [var 1.06mm, var -3.26mm])
+  coincident([arc1.center, line3.end])
+  coincident([arc1.end, line3])
+  coincident([line4.start, arc1])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_arc_line_trim_replace_point_segment_coincident.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_arc_line_trim_replace_point_segment_coincident.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch(on = YZ) {
+  arc1 = arc(start = [var -0.41mm, var -0.17mm], end = [var 0mm, var -5mm], center = [var 30mm, var 0mm])
+  line1 = line(start = [var -5mm, var -2mm], end = [var -0.41mm, var -0.17mm])
+  coincident([arc1.start, line1.end])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_split_arc_duplicate_center_point_constraints.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_split_arc_duplicate_center_point_constraints.snap
@@ -1,0 +1,30 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch(on = YZ) {
+  arcToSplit = arc(start = [var 11.06mm, var 1.06mm], end = [var 3.54mm, var 5.28mm], center = [var 0.65mm, var -8.7mm])
+  line1 = line(start = [var -6mm, var 8mm], end = [var -5.5mm, var 0mm])
+  line2 = line(start = [var 4mm, var 8.5mm], end = [var 3mm, var 1.5mm])
+  lineCoincidentWithArcCen = line(start = [var 0.65mm, var -8.7mm], end = [var 11.5mm, var -7.5mm])
+  line4 = line(start = [var 11.06mm, var 1.06mm], end = [var 13.32mm, var 6.78mm])
+  line5 = line(start = [var 7.62mm, var 3.75mm], end = [var 10mm, var 8mm])
+  coincident([line5.start, arcToSplit])
+  coincident([line4.start, arcToSplit.start])
+  coincident([
+    lineCoincidentWithArcCen.start,
+    arcToSplit.center
+  ])
+  distance([arcToSplit.center, line4.end]) == 20mm
+  line3 = line(start = [var -0.92mm, var -6.93mm], end = [var 2.89mm, var -11.21mm])
+  coincident([arcToSplit.center, line3])
+  arc1 = arc(start = [var -5.75mm, var 4.08mm], end = [var -10.37mm, var 0.39mm], center = [var 0.65mm, var -8.7mm])
+  coincident([arcToSplit.end, line2])
+  coincident([arc1.start, line1])
+  coincident([
+    lineCoincidentWithArcCen.start,
+    arc1.center
+  ])
+  distance([arc1.center, line4.end]) == 20mm
+  coincident([arc1.center, line3])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_split_arc_with_point_segment_coincident_constraints_1.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_split_arc_with_point_segment_coincident_constraints_1.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch(on = YZ) {
+  arc1 = arc(start = [var -3.08mm, var 6.08mm], end = [var -5.01mm, var 1mm], center = [var 1.84mm, var 1.3mm])
+  arc2 = arc(start = [var -4.82mm, var -0.72mm], end = [var -6.76mm, var -1.16mm], center = [var -4.12mm, var -8.15mm])
+  line1 = line(start = [var -7.5mm, var 2.5mm], end = [var -5.01mm, var 1mm])
+  coincident([arc1.end, line1.end])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_split_arc_with_point_segment_coincident_constraints_2.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_split_arc_with_point_segment_coincident_constraints_2.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch(on = YZ) {
+  arc2 = arc(start = [var -4.82mm, var -0.72mm], end = [var -6.76mm, var -1.17mm], center = [var -4.12mm, var -8.15mm])
+  line1 = line(start = [var -7.5mm, var 2.5mm], end = [var -5.01mm, var 1mm])
+  arc3 = arc(start = [var -4.82mm, var -0.72mm], end = [var -1.77mm, var -4.66mm], center = [var 1.83mm, var 1.27mm])
+  coincident([arc3.start, arc2.start])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_split_arc_with_point_segment_coincident_constraints_3.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_split_arc_with_point_segment_coincident_constraints_3.snap
@@ -1,0 +1,12 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch(on = YZ) {
+  arc1 = arc(start = [var -3.08mm, var 6.08mm], end = [var -5.01mm, var 1mm], center = [var 1.84mm, var 1.3mm])
+  arc2 = arc(start = [var -4.82mm, var -0.72mm], end = [var -6.76mm, var -1.16mm], center = [var -4.12mm, var -8.15mm])
+  line1 = line(start = [var -7.5mm, var 2.5mm], end = [var -5.01mm, var 1mm])
+  arc3 = arc(start = [var -4.82mm, var -0.72mm], end = [var -1.77mm, var -4.66mm], center = [var 1.83mm, var 1.27mm])
+  coincident([arc1.end, line1.end])
+  coincident([arc3.start, arc2.start])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_split_arc_with_point_segment_coincident_on_one_side_and_intersection_on_other.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_split_arc_with_point_segment_coincident_on_one_side_and_intersection_on_other.snap
@@ -1,0 +1,13 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch(on = YZ) {
+  arc2 = arc(start = [var 1.97mm, var -5.31mm], end = [var 1.27mm, var 6.32mm], center = [var -7.5mm, var -0.04mm])
+  arc1 = arc(start = [var 5.66mm, var 4.25mm], end = [var 2.6mm, var 3.89mm], center = [var 5.17mm, var -4.68mm])
+  line1 = line(start = [var -4.28mm, var 4.29mm], end = [var 1.34mm, var -4.76mm])
+  line4 = line(start = [var 0.02mm, var 2.88mm], end = [var -2.01mm, var -6.62mm])
+  arc3 = arc(start = [var 0.02mm, var 2.88mm], end = [var -3.91mm, var -3.06mm], center = [var 5.07mm, var -4.73mm])
+  coincident([arc1.end, arc2])
+  coincident([arc3.start, line4.start])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_split_lines_with_point_segment_coincident_points.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_split_lines_with_point_segment_coincident_points.snap
@@ -1,0 +1,14 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch(on = YZ) {
+  line1 = line(start = [var -3.86mm, var 5.53mm], end = [var -4.35mm, var 2.3mm])
+  line2 = line(start = [var -6.13mm, var 1.67mm], end = [var -3.01mm, var 2.78mm])
+  arc4 = arc(start = [var 3.09mm, var 4.94mm], end = [var 2.69mm, var 6.42mm], center = [var -7.39mm, var 2.91mm])
+  coincident([line1.end, line2])
+  arc3 = arc(start = [var -2.42mm, var 5.38mm], end = [var -0.69mm, var -0.66mm], center = [var 1.29mm, var 3.17mm])
+  line3 = line(start = [var 3.09mm, var 4.94mm], end = [var 4.25mm, var 5.35mm])
+  coincident([line2.end, arc3])
+  coincident([line3.start, arc4.start])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_split_straight_segments_migrate_constraints.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_split_straight_segments_migrate_constraints.snap
@@ -1,0 +1,38 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch(on = YZ) {
+  segmentToBeTrimmedAndSplit = line(start = [var -6mm, var 0mm], end = [var -2mm, var 0mm])
+  startSideCoincidentWithTrimSegStart = line(start = [var -6mm, var 3mm], end = [var -6mm, var -3mm])
+  startSideEndPointCoincidentWithTrimSeg = line(start = [var -4mm, var 0mm], end = [var -4mm, var 3mm])
+  startSideIntersectionTrimTermination = line(start = [var -2mm, var 3mm], end = [var -2mm, var -3mm])
+  endSideIntersectionTrimTermination = line(start = [var 2mm, var 3mm], end = [var 2mm, var -3mm])
+  endSideEndPointCoincidentWithTrimSeg = line(start = [var 4mm, var -3mm], end = [var 4mm, var 0mm])
+  endSideCoincidentWithTrimSegStart = line(start = [var 0.67mm, var 3mm], end = [var 0.67mm, var -3mm])
+  coincident([
+    segmentToBeTrimmedAndSplit.start,
+    startSideCoincidentWithTrimSegStart
+  ])
+  coincident([
+    startSideEndPointCoincidentWithTrimSeg.start,
+    segmentToBeTrimmedAndSplit
+  ])
+  line1 = line(start = [var 2mm, var 0mm], end = [var 0.67mm, var 0mm])
+  coincident([
+    segmentToBeTrimmedAndSplit.end,
+    startSideIntersectionTrimTermination
+  ])
+  coincident([
+    line1.start,
+    endSideIntersectionTrimTermination
+  ])
+  coincident([
+    line1.end,
+    endSideCoincidentWithTrimSegStart
+  ])
+  coincident([
+    endSideEndPointCoincidentWithTrimSeg.end,
+    line1
+  ])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_split_trim_line_trimmed_between_two_intersections.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_split_trim_line_trimmed_between_two_intersections.snap
@@ -1,0 +1,12 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch(on = YZ) {
+  line1 = line(start = [var -4mm, var 0mm], end = [var -2mm, var 0mm])
+  line2 = line(start = [var -2mm, var 4mm], end = [var -2mm, var -4mm])
+  arc1 = arc(start = [var 2mm, var 4mm], end = [var 2mm, var -4mm], center = [var 500mm, var 0mm])
+  line3 = line(start = [var 1.98mm, var 0mm], end = [var 5mm, var 0mm])
+  coincident([line1.end, line2])
+  coincident([line3.start, arc1])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_split_trim_migrate_angle_constraints.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_split_trim_migrate_angle_constraints.snap
@@ -1,0 +1,19 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch(on = YZ) {
+  line1 = line(start = [var -2mm, var 6.13mm], end = [var 0.22mm, var 4.54mm])
+  line2 = line(start = [var -4.15mm, var 0mm], end = [var -3.03mm, var -0.82mm])
+  parallel([line1, line2])
+  line3 = line(start = [var -3.1mm, var 1.3mm], end = [var -2.96mm, var -3.08mm])
+  line4 = line(start = [var -0.59mm, var -0.81mm], end = [var -1.13mm, var -4.94mm])
+  line5 = line(start = [var 0.09mm, var -3.02mm], end = [var -0.11mm, var -5.63mm])
+  line6 = line(start = [var -1.01mm, var -2.24mm], end = [var 3.5mm, var -1.84mm])
+  line7 = line(start = [var -0.8mm, var -2.39mm], end = [var -1.01mm, var -2.24mm])
+  coincident([line2.end, line3])
+  coincident([line7.start, line4])
+  coincident([line7.end, line6.start])
+  coincident([line5.start, line7])
+  parallel([line1, line7])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_split_trim_migrate_horizontal_constraint.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_split_trim_migrate_horizontal_constraint.snap
@@ -1,0 +1,14 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch(on = YZ) {
+  line1 = line(start = [var -3.64mm, var 1.26mm], end = [var -1.7mm, var 1.26mm])
+  line2 = line(start = [var 3.32mm, var 5.32mm], end = [var -4.67mm, var -1.14mm])
+  line3 = line(start = [var 4.34mm, var 3.17mm], end = [var -3.94mm, var -3.95mm])
+  horizontal(line1)
+  line4 = line(start = [var 2.12mm, var 1.26mm], end = [var 3.8mm, var 1.26mm])
+  coincident([line1.end, line2])
+  coincident([line4.start, line3])
+  horizontal(line4)
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_split_trim_migrate_horizontal_points_constraint.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_split_trim_migrate_horizontal_points_constraint.snap
@@ -1,0 +1,14 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch(on = YZ) {
+  line1 = line(start = [var -3.64mm, var 1.26mm], end = [var -1.7mm, var 1.26mm])
+  line2 = line(start = [var 3.32mm, var 5.32mm], end = [var -4.67mm, var -1.14mm])
+  line3 = line(start = [var 4.34mm, var 3.17mm], end = [var -3.94mm, var -3.95mm])
+  point1 = point(at = [var 5mm, var 1.26mm])
+  line4 = line(start = [var 2.12mm, var 1.26mm], end = [var 3.8mm, var 1.26mm])
+  coincident([line1.end, line2])
+  coincident([line4.start, line3])
+  horizontal([line4.end, point1])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_split_trim_migrate_perpendicular_constraint.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_split_trim_migrate_perpendicular_constraint.snap
@@ -1,0 +1,15 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch(on = YZ) {
+  line4 = line(start = [var -0.95mm, var 5.87mm], end = [var 1.9mm, var 7.14mm])
+  line1 = line(start = [var -1.97mm, var 3.24mm], end = [var -1.25mm, var 1.62mm])
+  line2 = line(start = [var 3.32mm, var 5.32mm], end = [var -4.67mm, var -1.14mm])
+  line3 = line(start = [var 4.34mm, var 3.17mm], end = [var -3.94mm, var -3.95mm])
+  perpendicular([line4, line1])
+  line5 = line(start = [var -0.15mm, var -0.69mm], end = [var 0.57mm, var -2.3mm])
+  coincident([line1.end, line2])
+  coincident([line5.start, line3])
+  perpendicular([line4, line5])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_split_trim_migrate_vertical_constraint.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_split_trim_migrate_vertical_constraint.snap
@@ -1,0 +1,14 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch(on = YZ) {
+  line1 = line(start = [var -0.36mm, var 3.66mm], end = [var -0.36mm, var 2.34mm])
+  line2 = line(start = [var 3.32mm, var 5.32mm], end = [var -4.67mm, var -1.14mm])
+  line3 = line(start = [var 4.34mm, var 3.17mm], end = [var -3.94mm, var -3.95mm])
+  vertical(line1)
+  line4 = line(start = [var -0.36mm, var -0.87mm], end = [var -0.36mm, var -2.66mm])
+  coincident([line1.end, line2])
+  coincident([line4.start, line3])
+  vertical(line4)
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_split_trim_migrate_vertical_points_constraint.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_split_trim_migrate_vertical_points_constraint.snap
@@ -1,0 +1,14 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch(on = YZ) {
+  line1 = line(start = [var -0.36mm, var 3.66mm], end = [var -0.36mm, var 2.34mm])
+  line2 = line(start = [var 3.32mm, var 5.32mm], end = [var -4.67mm, var -1.14mm])
+  line3 = line(start = [var 4.34mm, var 3.17mm], end = [var -3.94mm, var -3.95mm])
+  point1 = point(at = [var -0.36mm, var -4mm])
+  line4 = line(start = [var -0.36mm, var -0.87mm], end = [var -0.36mm, var -2.66mm])
+  coincident([line1.end, line2])
+  coincident([line4.start, line3])
+  vertical([line4.end, point1])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_split_trim_with_point_line_coincident_constraint.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_split_trim_with_point_line_coincident_constraint.snap
@@ -1,0 +1,11 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch(on = YZ) {
+  line5 = line(start = [var -7.81mm, var 3.77mm], end = [var -6.89mm, var 3.79mm])
+  line6 = line(start = [var -7.19mm, var 2.53mm], end = [var -6.14mm, var 4.02mm])
+  arc1 = arc(start = [var -6.89mm, var 3.79mm], end = [var -6.94mm, var 2.89mm], center = [var -0.29mm, var 3mm])
+  coincident([arc1.start, line5.end])
+  coincident([arc1.end, line6])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_tail_cut_should_remove_constraints_on_that_end_of_trimmed_segment.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_tail_cut_should_remove_constraints_on_that_end_of_trimmed_segment.snap
@@ -1,0 +1,12 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch(on = YZ) {
+  line1 = line(start = [var -5.33mm, var 3.69mm], end = [var -5.93mm, var -2.59mm])
+  line2 = line(start = [var -0.9mm, var 0.63mm], end = [var 4.01mm, var 0.68mm])
+  line3 = line(start = [var 4.02mm, var -3.44mm], end = [var 4mm, var 3.61mm])
+  line4 = line(start = [var -0.9mm, var 0.63mm], end = [var -1.28mm, var -3.04mm])
+  coincident([line2.end, line3])
+  coincident([line2.start, line4.start])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_arc1_bottom.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_arc1_bottom.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch(on = YZ) {
+  arc1 = arc(start = [var -0.41mm, var 0.41mm], end = [var 0mm, var -5mm], center = [var 30mm, var 0mm])
+  arc2 = arc(start = [var 5mm, var 0mm], end = [var -5mm, var 0mm], center = [var 0mm, var -30mm])
+  coincident([arc1.start, arc2])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_arc1_top.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_arc1_top.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch(on = YZ) {
+  arc1 = arc(start = [var 0mm, var 5mm], end = [var -0.41mm, var 0.41mm], center = [var 30mm, var 0mm])
+  arc2 = arc(start = [var 5mm, var 0mm], end = [var -5mm, var 0mm], center = [var 0mm, var -30mm])
+  coincident([arc1.end, arc2])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_arc2_left_side.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_arc2_left_side.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch(on = YZ) {
+  arc1 = arc(start = [var 0mm, var 5mm], end = [var 0mm, var -5mm], center = [var 30mm, var 0mm])
+  arc2 = arc(start = [var 5mm, var 0mm], end = [var -0.41mm, var 0.41mm], center = [var 0mm, var -30mm])
+  coincident([arc2.end, arc1])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_arc2_right_side.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_arc2_right_side.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch(on = YZ) {
+  arc1 = arc(start = [var 0mm, var 5mm], end = [var 0mm, var -5mm], center = [var 30mm, var 0mm])
+  arc2 = arc(start = [var -0.41mm, var 0.41mm], end = [var -5mm, var 0mm], center = [var 0mm, var -30mm])
+  coincident([arc2.start, arc1])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_arc_start_coincident_with_line_segment.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_arc_start_coincident_with_line_segment.snap
@@ -1,0 +1,21 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch001 = sketch(on = YZ) {
+  line6 = line(start = [var 0.88mm, var 3.43mm], end = [var 1.87mm, var 3.43mm])
+  line7 = line(start = [var 1.87mm, var 3.43mm], end = [var 1.87mm, var 2.22mm])
+  line8 = line(start = [var 1.87mm, var 2.22mm], end = [var 0.33mm, var 2.22mm])
+  line9 = line(start = [var 0.33mm, var 2.22mm], end = [var 0.33mm, var 2.91mm])
+  coincident([line6.end, line7.start])
+  coincident([line7.end, line8.start])
+  coincident([line8.end, line9.start])
+  parallel([line7, line9])
+  parallel([line8, line6])
+  perpendicular([line6, line7])
+  horizontal(line8)
+  arc2 = arc(start = [var 0.88mm, var 3.43mm], end = [var 0.33mm, var 2.87mm], center = [var 0.87mm, var 2.89mm])
+  coincident([arc2.end, line9])
+  coincident([line9.end, arc2])
+  coincident([line6.start, arc2.start])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_circle_case_1_1_circle_to_arc_trimmed_without_start_point_side.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_circle_case_1_1_circle_to_arc_trimmed_without_start_point_side.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch001 = sketch(on = YZ) {
+  line1 = line(start = [var -0.56mm, var 2.8mm], end = [var -3.58mm, var -0.78mm])
+  arc1 = arc(start = [var -1.04mm, var 2.23mm], end = [var -2.88mm, var 0.05mm], center = [var -1.53mm, var 0.78mm])
+  coincident([arc1.start, line1])
+  coincident([arc1.end, line1])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_circle_case_1_2_circle_to_arc_trimmed_with_start_point_side.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_circle_case_1_2_circle_to_arc_trimmed_with_start_point_side.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch001 = sketch(on = YZ) {
+  line1 = line(start = [var -0.56mm, var 2.8mm], end = [var -3.58mm, var -0.78mm])
+  arc1 = arc(start = [var -2.88mm, var 0.05mm], end = [var -1.04mm, var 2.23mm], center = [var -1.53mm, var 0.78mm])
+  coincident([arc1.start, line1])
+  coincident([arc1.end, line1])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_circle_case_1_3_trim_line_to_be_coincident_with_circle.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_circle_case_1_3_trim_line_to_be_coincident_with_circle.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch001 = sketch(on = YZ) {
+  circle1 = circle(start = [var -2.67mm, var 1.8mm], center = [var -1.53mm, var 0.78mm])
+  line1 = line(start = [var -1.04mm, var 2.23mm], end = [var -3.58mm, var -0.78mm])
+  coincident([line1.start, circle1])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_circle_case_1_4_trim_line_and_circle_arc_with_coincident_endpoints.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_circle_case_1_4_trim_line_and_circle_arc_with_coincident_endpoints.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch001 = sketch(on = YZ) {
+  line1 = line(start = [var -1.04mm, var 2.23mm], end = [var -3.58mm, var -0.78mm])
+  arc1 = arc(start = [var -1.04mm, var 2.23mm], end = [var -2.88mm, var 0.05mm], center = [var -1.53mm, var 0.78mm])
+  coincident([arc1.start, line1.start])
+  coincident([arc1.end, line1])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_circle_case_2_convert_circle_to_arc_between_two_segments.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_circle_case_2_convert_circle_to_arc_between_two_segments.snap
@@ -1,0 +1,11 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch001 = sketch(on = YZ) {
+  line1 = line(start = [var -0.75mm, var 2.93mm], end = [var -2.97mm, var -1.17mm])
+  line2 = line(start = [var -0.1mm, var 2.46mm], end = [var -0.67mm, var 0.97mm])
+  arc1 = arc(start = [var -1.12mm, var 2.25mm], end = [var -0.36mm, var 1.77mm], center = [var -1.53mm, var 0.78mm])
+  coincident([arc1.start, line1])
+  coincident([arc1.end, line2])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_delete_both_segments.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_delete_both_segments.snap
@@ -1,0 +1,6 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch(on = YZ) {
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_line1_bottom.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_line1_bottom.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch(on = YZ) {
+  line1 = line(start = [var 0mm, var 0mm], end = [var 0mm, var -5mm])
+  line2 = line(start = [var 5mm, var 0mm], end = [var -5mm, var 0mm])
+  coincident([line1.start, line2])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_line1_top.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_line1_top.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch(on = YZ) {
+  line1 = line(start = [var 0mm, var 5mm], end = [var 0mm, var 0mm])
+  line2 = line(start = [var 5mm, var 0mm], end = [var -5mm, var 0mm])
+  coincident([line1.end, line2])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_line2_left_side.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_line2_left_side.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch(on = YZ) {
+  line1 = line(start = [var 0mm, var 5mm], end = [var 0mm, var -5mm])
+  line2 = line(start = [var 5mm, var 0mm], end = [var 0mm, var 0mm])
+  coincident([line2.end, line1])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_line2_right_side.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_line2_right_side.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch(on = YZ) {
+  line1 = line(start = [var 0mm, var 5mm], end = [var 0mm, var -5mm])
+  line2 = line(start = [var 0mm, var 0mm], end = [var -5mm, var 0mm])
+  coincident([line2.start, line1])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_line_with_midpoint_coincident_arc_endpoint.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_line_with_midpoint_coincident_arc_endpoint.snap
@@ -1,0 +1,21 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch001 = sketch(on = YZ) {
+  line6 = line(start = [var 0.32mm, var 3.43mm], end = [var 1.87mm, var 3.43mm])
+  line7 = line(start = [var 1.87mm, var 3.43mm], end = [var 1.87mm, var 2.22mm])
+  line8 = line(start = [var 1.87mm, var 2.22mm], end = [var 0.33mm, var 2.22mm])
+  line9 = line(start = [var 0.33mm, var 2.22mm], end = [var 0.33mm, var 2.91mm])
+  coincident([line6.end, line7.start])
+  coincident([line7.end, line8.start])
+  coincident([line8.end, line9.start])
+  parallel([line7, line9])
+  parallel([line8, line6])
+  perpendicular([line6, line7])
+  horizontal(line8)
+  arc2 = arc(start = [var 0.88mm, var 3.43mm], end = [var 0.33mm, var 2.86mm], center = [var 0.87mm, var 2.89mm])
+  coincident([arc2.end, line9])
+  coincident([arc2.start, line6])
+  coincident([line9.end, arc2])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_rect_arc_corner_reconnects_arc_endpoints_to_trimmed_lines.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_rect_arc_corner_reconnects_arc_endpoints_to_trimmed_lines.snap
@@ -1,0 +1,26 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch001 = sketch(on = YZ) {
+  line1 = line(start = [var -0.85mm, var 0.72mm], end = [var -4.07mm, var 0.72mm])
+  line2 = line(start = [var -4.07mm, var 0.72mm], end = [var -4.07mm, var 1.54mm])
+  line3 = line(start = [var -2.69mm, var 2.92mm], end = [var -0.85mm, var 2.92mm])
+  line4 = line(start = [var -0.85mm, var 2.92mm], end = [var -0.85mm, var 0.72mm])
+  coincident([line1.end, line2.start])
+  coincident([line3.end, line4.start])
+  coincident([line4.end, line1.start])
+  parallel([line2, line4])
+  parallel([line3, line1])
+  perpendicular([line1, line2])
+  horizontal(line3)
+  arc1 = arc(start = [var -2.69mm, var 2.92mm], end = [var -4.07mm, var 1.54mm], center = [var -2.69mm, var 1.54mm])
+  line5 = line(start = [var -0.85mm, var 1.82mm], end = [var -1.9mm, var 0.72mm])
+  coincident([line5.start, line4])
+  midpoint(line4, point = line5.start)
+  coincident([line5.end, line1])
+  tangent([line3, arc1])
+  tangent([line2, arc1])
+  coincident([line3.start, arc1.start])
+  coincident([line2.end, arc1.end])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_rect_diagonal_corner_reconnects_line5_endpoints.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_rect_diagonal_corner_reconnects_line5_endpoints.snap
@@ -1,0 +1,25 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch001 = sketch(on = YZ) {
+  line1 = line(start = [var -1.9mm, var 0.72mm], end = [var -4.07mm, var 0.72mm])
+  line2 = line(start = [var -4.07mm, var 0.72mm], end = [var -4.07mm, var 2.92mm])
+  line3 = line(start = [var -4.07mm, var 2.92mm], end = [var -0.85mm, var 2.92mm])
+  line4 = line(start = [var -0.85mm, var 2.92mm], end = [var -0.85mm, var 1.82mm])
+  coincident([line1.end, line2.start])
+  coincident([line2.end, line3.start])
+  coincident([line3.end, line4.start])
+  parallel([line2, line4])
+  parallel([line3, line1])
+  perpendicular([line1, line2])
+  horizontal(line3)
+  arc1 = arc(start = [var -2.69mm, var 2.92mm], end = [var -4.07mm, var 1.54mm], center = [var -2.69mm, var 1.54mm])
+  coincident([arc1.end, line2])
+  coincident([arc1.start, line3])
+  line5 = line(start = [var -0.85mm, var 1.82mm], end = [var -1.9mm, var 0.72mm])
+  tangent([line3, arc1])
+  tangent([line2, arc1])
+  coincident([line4.end, line5.start])
+  coincident([line1.start, line5.end])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_remove_coincident_point_from_segment_end.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_remove_coincident_point_from_segment_end.snap
@@ -1,0 +1,12 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch(on = YZ) {
+  line1 = line(start = [var -5mm, var 5mm], end = [var -3mm, var 2mm])
+  line2 = line(start = [var 0mm, var 2mm], end = [var 3mm, var 2mm])
+  line3 = line(start = [var 3mm, var 2mm], end = [var 5mm, var 5mm])
+  coincident([line2.end, line3.start])
+  arc1 = arc(start = [var 1mm, var 5mm], end = [var 1mm, var -1mm], center = [var 5mm, var 2mm])
+  coincident([line2.start, arc1])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_remove_point_axis_constraint_from_segment_end.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_remove_point_axis_constraint_from_segment_end.snap
@@ -1,0 +1,12 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch(on = YZ) {
+  line1 = line(start = [var -5mm, var 5mm], end = [var -3mm, var 2mm])
+  line2 = line(start = [var 0mm, var 2mm], end = [var 3mm, var 2mm])
+  line3 = line(start = [var 3.5mm, var 2mm], end = [var 5mm, var 5mm])
+  horizontal([line2.end, line3.start])
+  arc1 = arc(start = [var 1mm, var 5mm], end = [var 1mm, var -1mm], center = [var 5mm, var 2mm])
+  coincident([line2.start, arc1])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_should_work_with_different_units_1.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_should_work_with_different_units_1.snap
@@ -1,0 +1,11 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+@settings(defaultLengthUnit = mm)
+
+sketch(on = YZ) {
+  line1 = line(start = [var -10mm, var 50mm], end = [var -10mm, var -50mm])
+  line2 = line(start = [var -10mm, var 0mm], end = [var 50mm, var 0mm])
+  coincident([line2.start, line1])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_should_work_with_different_units_2.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_should_work_with_different_units_2.snap
@@ -1,0 +1,11 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+@settings(defaultLengthUnit = cm)
+
+sketch(on = YZ) {
+  line1 = line(start = [var -1cm, var 5cm], end = [var -1cm, var -5cm])
+  line2 = line(start = [var -1cm, var 0cm], end = [var 5cm, var 0cm])
+  coincident([line2.start, line1])
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_with_distance_constraints_preserve_constraints.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trim_with_distance_constraints_preserve_constraints.snap
@@ -1,0 +1,46 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch(on = YZ) {
+  line1 = line(start = [var -5.5mm, var 7mm], end = [var -3mm, var 5mm])
+  line4 = line(start = [var -6mm, var 4mm], end = [var -3.5mm, var 2mm])
+  endTrimmedShouldDeleteDisConstraint = line(start = [var -3.5mm, var 2mm], end = [var -2.33mm, var 2mm])
+  coincident([
+    line4.end,
+    endTrimmedShouldDeleteDisConstraint.start
+  ])
+  line6 = line(start = [var -3mm, var 1mm], end = [var -2mm, var 2.5mm])
+  startTrimmedAlsoDeleteDisConstraint = line(start = [var 1.63mm, var -0.73mm], end = [var 3.02mm, var -0.75mm])
+  line3 = line(start = [var 3.02mm, var -0.75mm], end = [var 5.38mm, var 1.14mm])
+  coincident([
+    startTrimmedAlsoDeleteDisConstraint.end,
+    line3.start
+  ])
+  line5 = line(start = [var 1.24mm, var 0.92mm], end = [var 1.84mm, var -1.64mm])
+  splitTrimLineDistanceConstraintMigrated = line(start = [var -3.7mm, var -3.56mm], end = [var -0.71mm, var -3.93mm])
+  line8 = line(start = [var 1.84mm, var -3.74mm], end = [var 5.42mm, var -1.72mm])
+  line9 = line(start = [var 1.1mm, var -3.71mm], end = [var 1.28mm, var -5.69mm])
+  line10 = line(start = [var 1.98mm, var -3.74mm], end = [var 2.57mm, var -5.65mm])
+  line11 = line(start = [var -1.05mm, var -2.11mm], end = [var -0.45mm, var -5.31mm])
+  coincident([
+    endTrimmedShouldDeleteDisConstraint.end,
+    line6
+  ])
+  coincident([
+    startTrimmedAlsoDeleteDisConstraint.start,
+    line5
+  ])
+  line2 = line(start = [var 1.1mm, var -3.71mm], end = [var 1.84mm, var -3.74mm])
+  coincident([
+    splitTrimLineDistanceConstraintMigrated.end,
+    line11
+  ])
+  coincident([line2.start, line9.start])
+  coincident([line2.end, line8.start])
+  coincident([line10.start, line2])
+  distance([
+  splitTrimLineDistanceConstraintMigrated.start,
+  line2.end
+]) == 5.54mm
+}

--- a/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trimming_arcs_preserve_distance_constraints.snap
+++ b/rust/kcl-lib/src/frontend/trim/snapshots/kcl_lib__frontend__trim__tests__test_trimming_arcs_preserve_distance_constraints.snap
@@ -1,0 +1,16 @@
+---
+source: kcl-lib/src/frontend/trim/tests.rs
+expression: "result_normalized"
+---
+sketch(on = YZ) {
+  arc1 = arc(start = [var -3.89mm, var 1.85mm], end = [var -5.31mm, var -1.34mm], center = [var -0.65mm, var -1.5mm])
+  line1 = line(start = [var -4.72mm, var 3.54mm], end = [var -2.24mm, var -1.48mm])
+  line2 = line(start = [var 2.27mm, var -4.04mm], end = [var 4.65mm, var -1.26mm])
+  distance([arc1.center, line2.start]) == 3.87mm
+  line3 = line(start = [var -5.61mm, var 5.38mm], end = [var -0.9mm, var 5.49mm])
+  line4 = line(start = [var 1.03mm, var 5.53mm], end = [var 6.15mm, var 3.11mm])
+  line5 = line(start = [var -1.05mm, var 6.42mm], end = [var -0.9mm, var 5.49mm])
+  distance([line4.end, line3.start]) == 11.98mm
+  coincident([line5.end, line3.end])
+  coincident([arc1.start, line1])
+}

--- a/rust/kcl-lib/src/frontend/trim/tests.rs
+++ b/rust/kcl-lib/src/frontend/trim/tests.rs
@@ -4,20 +4,14 @@ use crate::frontend::trim::execute_trim_flow;
 
 /// Helper function to run a trim test with the common pattern:
 /// - Execute trim flow with base code and trim points
-/// - Compare result with expected code (normalized by trimming whitespace)
-async fn assert_trim_result(base_kcl_code: &str, trim_points: &[Coords2d], expected_code: &str, sketch_id: ObjectId) {
+/// - Snapshot the result after normalizing leading and trailing whitespace
+async fn assert_trim_result(snapshot_name: &str, base_kcl_code: &str, trim_points: &[Coords2d], sketch_id: ObjectId) {
     let result = execute_trim_flow(base_kcl_code, trim_points, sketch_id).await;
 
     match result {
         Ok(result) => {
             let result_normalized = result.kcl_code.trim();
-            let expected_normalized = expected_code.trim();
-
-            pretty_assertions::assert_eq!(
-                result_normalized,
-                expected_normalized,
-                "Trim result should match expected KCL code (left = actual, right = expected)"
-            );
+            insta::assert_snapshot!(snapshot_name, result_normalized);
         }
         Err(e) => {
             panic!("trim flow failed: {}", e);
@@ -26,8 +20,8 @@ async fn assert_trim_result(base_kcl_code: &str, trim_points: &[Coords2d], expec
 }
 
 /// Convenience wrapper that uses the default sketch_id (ObjectId(1))
-async fn assert_trim_result_default_sketch(base_kcl_code: &str, trim_points: &[Coords2d], expected_code: &str) {
-    assert_trim_result(base_kcl_code, trim_points, expected_code, ObjectId(1)).await;
+async fn assert_trim_result_default_sketch(snapshot_name: &str, base_kcl_code: &str, trim_points: &[Coords2d]) {
+    assert_trim_result(snapshot_name, base_kcl_code, trim_points, ObjectId(1)).await;
 }
 
 fn assert_no_zero_length_line_or_arc_constructors(kcl_code: &str) {
@@ -1383,14 +1377,7 @@ async fn test_trim_line2_left_side() {
 
     let trim_points = vec![Coords2d { x: -2.0, y: -2.0 }, Coords2d { x: -2.0, y: 2.0 }];
 
-    let expected_code = r#"sketch(on = YZ) {
-  line1 = line(start = [var 0mm, var 5mm], end = [var 0mm, var -5mm])
-  line2 = line(start = [var 5mm, var 0mm], end = [var 0mm, var 0mm])
-  coincident([line2.end, line1])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch("test_trim_line2_left_side", base_kcl_code, &trim_points).await;
 }
 #[tokio::test]
 async fn test_tail_cut_should_remove_constraints_on_that_end_of_trimmed_segment() {
@@ -1409,17 +1396,12 @@ async fn test_tail_cut_should_remove_constraints_on_that_end_of_trimmed_segment(
 
     let trim_points = vec![Coords2d { x: -2.18, y: 4.92 }, Coords2d { x: -4.23, y: -5.15 }];
 
-    let expected_code = r#"sketch(on = YZ) {
-  line1 = line(start = [var -5.33mm, var 3.69mm], end = [var -5.93mm, var -2.59mm])
-  line2 = line(start = [var -0.9mm, var 0.63mm], end = [var 4.01mm, var 0.68mm])
-  line3 = line(start = [var 4.02mm, var -3.44mm], end = [var 4mm, var 3.61mm])
-  line4 = line(start = [var -0.9mm, var 0.63mm], end = [var -1.28mm, var -3.04mm])
-  coincident([line2.end, line3])
-  coincident([line2.start, line4.start])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch(
+        "test_tail_cut_should_remove_constraints_on_that_end_of_trimmed_segment",
+        base_kcl_code,
+        &trim_points,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -1433,14 +1415,7 @@ async fn test_trim_line2_right_side() {
 
     let trim_points = vec![Coords2d { x: 2.0, y: -2.0 }, Coords2d { x: 2.0, y: 2.0 }];
 
-    let expected_code = r#"sketch(on = YZ) {
-  line1 = line(start = [var 0mm, var 5mm], end = [var 0mm, var -5mm])
-  line2 = line(start = [var 0mm, var 0mm], end = [var -5mm, var 0mm])
-  coincident([line2.start, line1])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch("test_trim_line2_right_side", base_kcl_code, &trim_points).await;
 }
 
 #[tokio::test]
@@ -1454,14 +1429,7 @@ async fn test_trim_line1_bottom() {
 
     let trim_points = vec![Coords2d { x: -2.0, y: 2.0 }, Coords2d { x: 2.0, y: 2.0 }];
 
-    let expected_code = r#"sketch(on = YZ) {
-  line1 = line(start = [var 0mm, var 0mm], end = [var 0mm, var -5mm])
-  line2 = line(start = [var 5mm, var 0mm], end = [var -5mm, var 0mm])
-  coincident([line1.start, line2])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch("test_trim_line1_bottom", base_kcl_code, &trim_points).await;
 }
 
 #[tokio::test]
@@ -1475,14 +1443,7 @@ async fn test_trim_line1_top() {
 
     let trim_points = vec![Coords2d { x: -2.0, y: -2.0 }, Coords2d { x: 2.0, y: -2.0 }];
 
-    let expected_code = r#"sketch(on = YZ) {
-  line1 = line(start = [var 0mm, var 5mm], end = [var 0mm, var 0mm])
-  line2 = line(start = [var 5mm, var 0mm], end = [var -5mm, var 0mm])
-  coincident([line1.end, line2])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch("test_trim_line1_top", base_kcl_code, &trim_points).await;
 }
 
 #[tokio::test]
@@ -1496,14 +1457,7 @@ async fn test_trim_arc2_left_side() {
 
     let trim_points = vec![Coords2d { x: -2.0, y: -2.0 }, Coords2d { x: -2.0, y: 2.0 }];
 
-    let expected_code = r#"sketch(on = YZ) {
-  arc1 = arc(start = [var 0mm, var 5mm], end = [var 0mm, var -5mm], center = [var 30mm, var 0mm])
-  arc2 = arc(start = [var 5mm, var 0mm], end = [var -0.41mm, var 0.41mm], center = [var 0mm, var -30mm])
-  coincident([arc2.end, arc1])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch("test_trim_arc2_left_side", base_kcl_code, &trim_points).await;
 }
 
 #[tokio::test]
@@ -1517,14 +1471,7 @@ async fn test_trim_arc2_right_side() {
 
     let trim_points = vec![Coords2d { x: 2.0, y: -2.0 }, Coords2d { x: 2.0, y: 2.0 }];
 
-    let expected_code = r#"sketch(on = YZ) {
-  arc1 = arc(start = [var 0mm, var 5mm], end = [var 0mm, var -5mm], center = [var 30mm, var 0mm])
-  arc2 = arc(start = [var -0.41mm, var 0.41mm], end = [var -5mm, var 0mm], center = [var 0mm, var -30mm])
-  coincident([arc2.start, arc1])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch("test_trim_arc2_right_side", base_kcl_code, &trim_points).await;
 }
 
 #[tokio::test]
@@ -1538,14 +1485,7 @@ async fn test_trim_arc1_bottom() {
 
     let trim_points = vec![Coords2d { x: -2.0, y: 2.0 }, Coords2d { x: 2.0, y: 2.0 }];
 
-    let expected_code = r#"sketch(on = YZ) {
-  arc1 = arc(start = [var -0.41mm, var 0.41mm], end = [var 0mm, var -5mm], center = [var 30mm, var 0mm])
-  arc2 = arc(start = [var 5mm, var 0mm], end = [var -5mm, var 0mm], center = [var 0mm, var -30mm])
-  coincident([arc1.start, arc2])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch("test_trim_arc1_bottom", base_kcl_code, &trim_points).await;
 }
 
 #[tokio::test]
@@ -1559,14 +1499,7 @@ async fn test_trim_arc1_top() {
 
     let trim_points = vec![Coords2d { x: -2.0, y: -2.0 }, Coords2d { x: 2.0, y: -2.0 }];
 
-    let expected_code = r#"sketch(on = YZ) {
-  arc1 = arc(start = [var 0mm, var 5mm], end = [var -0.41mm, var 0.41mm], center = [var 30mm, var 0mm])
-  arc2 = arc(start = [var 5mm, var 0mm], end = [var -5mm, var 0mm], center = [var 0mm, var -30mm])
-  coincident([arc1.end, arc2])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch("test_trim_arc1_top", base_kcl_code, &trim_points).await;
 }
 
 #[tokio::test]
@@ -1580,11 +1513,7 @@ async fn test_trim_delete_both_segments() {
 
     let trim_points = vec![Coords2d { x: -5.0, y: 1.0 }, Coords2d { x: 5.0, y: 1.0 }];
 
-    let expected_code = r#"sketch(on = YZ) {
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch("test_trim_delete_both_segments", base_kcl_code, &trim_points).await;
 }
 
 #[tokio::test]
@@ -1602,17 +1531,12 @@ async fn test_trim_remove_coincident_point_from_segment_end() {
 
     let trim_points = vec![Coords2d { x: -1.5, y: 5.0 }, Coords2d { x: -1.5, y: -5.0 }];
 
-    let expected_code = r#"sketch(on = YZ) {
-  line1 = line(start = [var -5mm, var 5mm], end = [var -3mm, var 2mm])
-  line2 = line(start = [var 0mm, var 2mm], end = [var 3mm, var 2mm])
-  line3 = line(start = [var 3mm, var 2mm], end = [var 5mm, var 5mm])
-  coincident([line2.end, line3.start])
-  arc1 = arc(start = [var 1mm, var 5mm], end = [var 1mm, var -1mm], center = [var 5mm, var 2mm])
-  coincident([line2.start, arc1])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch(
+        "test_trim_remove_coincident_point_from_segment_end",
+        base_kcl_code,
+        &trim_points,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -1629,17 +1553,12 @@ async fn test_trim_remove_point_axis_constraint_from_segment_end() {
 
     let trim_points = vec![Coords2d { x: -1.5, y: 5.0 }, Coords2d { x: -1.5, y: -5.0 }];
 
-    let expected_code = r#"sketch(on = YZ) {
-  line1 = line(start = [var -5mm, var 5mm], end = [var -3mm, var 2mm])
-  line2 = line(start = [var 0mm, var 2mm], end = [var 3mm, var 2mm])
-  line3 = line(start = [var 3.5mm, var 2mm], end = [var 5mm, var 5mm])
-  horizontal([line2.end, line3.start])
-  arc1 = arc(start = [var 1mm, var 5mm], end = [var 1mm, var -1mm], center = [var 5mm, var 2mm])
-  coincident([line2.start, arc1])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch(
+        "test_trim_remove_point_axis_constraint_from_segment_end",
+        base_kcl_code,
+        &trim_points,
+    )
+    .await;
 }
 
 /// Same logical trim line [[-15, 50], [-15, -50]] (vertical at -15mm) and equivalent sketches in cm vs mm.
@@ -1657,16 +1576,13 @@ sketch(on = YZ) {
     let trim_points = vec![Coords2d { x: -15.0, y: 50.0 }, Coords2d { x: -15.0, y: -50.0 }];
 
     // Expected: trim line at -15mm trims line2 to the intersection with line1 at -10mm.
-    let expected_code = r#"@settings(defaultLengthUnit = mm)
 
-sketch(on = YZ) {
-  line1 = line(start = [var -10mm, var 50mm], end = [var -10mm, var -50mm])
-  line2 = line(start = [var -10mm, var 0mm], end = [var 50mm, var 0mm])
-  coincident([line2.start, line1])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch(
+        "test_trim_should_work_with_different_units_1",
+        base_kcl_code,
+        &trim_points,
+    )
+    .await;
 
     let base_kcl_code = r#"@settings(defaultLengthUnit = cm)
 
@@ -1679,16 +1595,12 @@ sketch(on = YZ) {
     // Same physical trim line as mm case, still provided in mm.
     let trim_points = vec![Coords2d { x: -15.0, y: 50.0 }, Coords2d { x: -15.0, y: -50.0 }];
 
-    let expected_code = r#"@settings(defaultLengthUnit = cm)
-
-sketch(on = YZ) {
-  line1 = line(start = [var -1cm, var 5cm], end = [var -1cm, var -5cm])
-  line2 = line(start = [var -1cm, var 0cm], end = [var 5cm, var 0cm])
-  coincident([line2.start, line1])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch(
+        "test_trim_should_work_with_different_units_2",
+        base_kcl_code,
+        &trim_points,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -1708,16 +1620,12 @@ async fn test_split_trim_with_point_line_coincident_constraint() {
     // Trim line that intersects arc9 at two points to cause a split trim
     let trim_points = vec![Coords2d { x: -5.69, y: 4.67 }, Coords2d { x: -7.65, y: 4.83 }];
 
-    let expected_code = r#"sketch(on = YZ) {
-  line5 = line(start = [var -7.81mm, var 3.77mm], end = [var -6.89mm, var 3.79mm])
-  line6 = line(start = [var -7.19mm, var 2.53mm], end = [var -6.14mm, var 4.02mm])
-  arc1 = arc(start = [var -6.89mm, var 3.79mm], end = [var -6.94mm, var 2.89mm], center = [var -0.29mm, var 3mm])
-  coincident([arc1.start, line5.end])
-  coincident([arc1.end, line6])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch(
+        "test_split_trim_with_point_line_coincident_constraint",
+        base_kcl_code,
+        &trim_points,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -1732,14 +1640,12 @@ async fn test_arc_line_trim_replace_point_segment_coincident() {
 
     let trim_points = vec![Coords2d { x: -2.0, y: 2.0 }, Coords2d { x: 2.0, y: 2.0 }];
 
-    let expected_code = r#"sketch(on = YZ) {
-  arc1 = arc(start = [var -0.41mm, var -0.17mm], end = [var 0mm, var -5mm], center = [var 30mm, var 0mm])
-  line1 = line(start = [var -5mm, var -2mm], end = [var -0.41mm, var -0.17mm])
-  coincident([arc1.start, line1.end])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch(
+        "test_arc_line_trim_replace_point_segment_coincident",
+        base_kcl_code,
+        &trim_points,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -1766,26 +1672,12 @@ async fn test_trim_line_with_midpoint_coincident_arc_endpoint() {
 
     let trim_points = vec![Coords2d { x: 0.19, y: 3.25 }, Coords2d { x: 0.41, y: 3.32 }];
 
-    let expected_code = r#"sketch001 = sketch(on = YZ) {
-  line6 = line(start = [var 0.32mm, var 3.43mm], end = [var 1.87mm, var 3.43mm])
-  line7 = line(start = [var 1.87mm, var 3.43mm], end = [var 1.87mm, var 2.22mm])
-  line8 = line(start = [var 1.87mm, var 2.22mm], end = [var 0.33mm, var 2.22mm])
-  line9 = line(start = [var 0.33mm, var 2.22mm], end = [var 0.33mm, var 2.91mm])
-  coincident([line6.end, line7.start])
-  coincident([line7.end, line8.start])
-  coincident([line8.end, line9.start])
-  parallel([line7, line9])
-  parallel([line8, line6])
-  perpendicular([line6, line7])
-  horizontal(line8)
-  arc2 = arc(start = [var 0.88mm, var 3.43mm], end = [var 0.33mm, var 2.86mm], center = [var 0.87mm, var 2.89mm])
-  coincident([arc2.end, line9])
-  coincident([arc2.start, line6])
-  coincident([line9.end, arc2])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch(
+        "test_trim_line_with_midpoint_coincident_arc_endpoint",
+        base_kcl_code,
+        &trim_points,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -1811,26 +1703,12 @@ async fn test_trim_arc_start_coincident_with_line_segment() {
 
     let trim_points = vec![Coords2d { x: 0.4, y: 3.32 }, Coords2d { x: 0.54, y: 3.53 }];
 
-    let expected_code = r#"sketch001 = sketch(on = YZ) {
-  line6 = line(start = [var 0.88mm, var 3.43mm], end = [var 1.87mm, var 3.43mm])
-  line7 = line(start = [var 1.87mm, var 3.43mm], end = [var 1.87mm, var 2.22mm])
-  line8 = line(start = [var 1.87mm, var 2.22mm], end = [var 0.33mm, var 2.22mm])
-  line9 = line(start = [var 0.33mm, var 2.22mm], end = [var 0.33mm, var 2.91mm])
-  coincident([line6.end, line7.start])
-  coincident([line7.end, line8.start])
-  coincident([line8.end, line9.start])
-  parallel([line7, line9])
-  parallel([line8, line6])
-  perpendicular([line6, line7])
-  horizontal(line8)
-  arc2 = arc(start = [var 0.88mm, var 3.43mm], end = [var 0.33mm, var 2.87mm], center = [var 0.87mm, var 2.89mm])
-  coincident([arc2.end, line9])
-  coincident([line9.end, arc2])
-  coincident([line6.start, arc2.start])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch(
+        "test_trim_arc_start_coincident_with_line_segment",
+        base_kcl_code,
+        &trim_points,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -1928,17 +1806,12 @@ async fn test_split_trim_line_trimmed_between_two_intersections() {
 
     let trim_points = vec![Coords2d { x: 0.0, y: 2.0 }, Coords2d { x: 0.0, y: -2.0 }];
 
-    let expected_code = r#"sketch(on = YZ) {
-  line1 = line(start = [var -4mm, var 0mm], end = [var -2mm, var 0mm])
-  line2 = line(start = [var -2mm, var 4mm], end = [var -2mm, var -4mm])
-  arc1 = arc(start = [var 2mm, var 4mm], end = [var 2mm, var -4mm], center = [var 500mm, var 0mm])
-  line3 = line(start = [var 1.98mm, var 0mm], end = [var 5mm, var 0mm])
-  coincident([line1.end, line2])
-  coincident([line3.start, arc1])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch(
+        "test_split_trim_line_trimmed_between_two_intersections",
+        base_kcl_code,
+        &trim_points,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -1956,19 +1829,12 @@ async fn test_split_lines_with_point_segment_coincident_points() {
 
     let trim_points = vec![Coords2d { x: 0.0, y: 6.0 }, Coords2d { x: -1.1, y: 1.6 }];
 
-    let expected_code = r#"sketch(on = YZ) {
-  line1 = line(start = [var -3.86mm, var 5.53mm], end = [var -4.35mm, var 2.3mm])
-  line2 = line(start = [var -6.13mm, var 1.67mm], end = [var -3.01mm, var 2.78mm])
-  arc4 = arc(start = [var 3.09mm, var 4.94mm], end = [var 2.69mm, var 6.42mm], center = [var -7.39mm, var 2.91mm])
-  coincident([line1.end, line2])
-  arc3 = arc(start = [var -2.42mm, var 5.38mm], end = [var -0.69mm, var -0.66mm], center = [var 1.29mm, var 3.17mm])
-  line3 = line(start = [var 3.09mm, var 4.94mm], end = [var 4.25mm, var 5.35mm])
-  coincident([line2.end, arc3])
-  coincident([line3.start, arc4.start])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch(
+        "test_split_lines_with_point_segment_coincident_points",
+        base_kcl_code,
+        &trim_points,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -1985,43 +1851,23 @@ async fn test_split_arc_with_point_segment_coincident_constraints() {
 
     let trim_cases = [
         (
+            "test_split_arc_with_point_segment_coincident_constraints_1",
             vec![Coords2d { x: -3.45, y: -1.3 }, Coords2d { x: -5.53, y: -1.3 }],
-            r#"sketch(on = YZ) {
-  arc1 = arc(start = [var -3.08mm, var 6.08mm], end = [var -5.01mm, var 1mm], center = [var 1.84mm, var 1.3mm])
-  arc2 = arc(start = [var -4.82mm, var -0.72mm], end = [var -6.76mm, var -1.16mm], center = [var -4.12mm, var -8.15mm])
-  line1 = line(start = [var -7.5mm, var 2.5mm], end = [var -5.01mm, var 1mm])
-  coincident([arc1.end, line1.end])
-}
-"#,
         ),
         (
+            "test_split_arc_with_point_segment_coincident_constraints_2",
             vec![Coords2d { x: -3.93, y: 2.17 }, Coords2d { x: -6.24, y: 2.14 }],
-            r#"sketch(on = YZ) {
-  arc2 = arc(start = [var -4.82mm, var -0.72mm], end = [var -6.76mm, var -1.17mm], center = [var -4.12mm, var -8.15mm])
-  line1 = line(start = [var -7.5mm, var 2.5mm], end = [var -5.01mm, var 1mm])
-  arc3 = arc(start = [var -4.82mm, var -0.72mm], end = [var -1.77mm, var -4.66mm], center = [var 1.83mm, var 1.27mm])
-  coincident([arc3.start, arc2.start])
-}
-"#,
         ),
         (
+            "test_split_arc_with_point_segment_coincident_constraints_3",
             vec![Coords2d { x: -3.77, y: 0.5 }, Coords2d { x: -6.11, y: 0.37 }],
-            r#"sketch(on = YZ) {
-  arc1 = arc(start = [var -3.08mm, var 6.08mm], end = [var -5.01mm, var 1mm], center = [var 1.84mm, var 1.3mm])
-  arc2 = arc(start = [var -4.82mm, var -0.72mm], end = [var -6.76mm, var -1.16mm], center = [var -4.12mm, var -8.15mm])
-  line1 = line(start = [var -7.5mm, var 2.5mm], end = [var -5.01mm, var 1mm])
-  arc3 = arc(start = [var -4.82mm, var -0.72mm], end = [var -1.77mm, var -4.66mm], center = [var 1.83mm, var 1.27mm])
-  coincident([arc1.end, line1.end])
-  coincident([arc3.start, arc2.start])
-}
-"#,
         ),
     ];
 
     let sketch_id = ObjectId(1);
 
-    for (trim_points, expected_code) in trim_cases.iter() {
-        assert_trim_result(base_kcl_code, trim_points, expected_code, sketch_id).await;
+    for (snapshot_name, trim_points) in trim_cases.iter() {
+        assert_trim_result(snapshot_name, base_kcl_code, trim_points, sketch_id).await;
     }
 }
 
@@ -2039,18 +1885,12 @@ async fn test_split_arc_with_point_segment_coincident_on_one_side_and_intersecti
 
     let trim_points = vec![Coords2d { x: -0.4, y: 4.4 }, Coords2d { x: 1.3, y: 2.4 }];
 
-    let expected_code = r#"sketch(on = YZ) {
-  arc2 = arc(start = [var 1.97mm, var -5.31mm], end = [var 1.27mm, var 6.32mm], center = [var -7.5mm, var -0.04mm])
-  arc1 = arc(start = [var 5.66mm, var 4.25mm], end = [var 2.6mm, var 3.89mm], center = [var 5.17mm, var -4.68mm])
-  line1 = line(start = [var -4.28mm, var 4.29mm], end = [var 1.34mm, var -4.76mm])
-  line4 = line(start = [var 0.02mm, var 2.88mm], end = [var -2.01mm, var -6.62mm])
-  arc3 = arc(start = [var 0.02mm, var 2.88mm], end = [var -3.91mm, var -3.06mm], center = [var 5.07mm, var -4.73mm])
-  coincident([arc1.end, arc2])
-  coincident([arc3.start, line4.start])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch(
+        "test_split_arc_with_point_segment_coincident_on_one_side_and_intersection_on_other",
+        base_kcl_code,
+        &trim_points,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -2085,43 +1925,12 @@ async fn test_split_straight_segments_migrate_constraints() {
 
     let trim_points = vec![Coords2d { x: 0.0, y: 4.0 }, Coords2d { x: 0.0, y: -4.0 }];
 
-    let expected_code = r#"sketch(on = YZ) {
-  segmentToBeTrimmedAndSplit = line(start = [var -6mm, var 0mm], end = [var -2mm, var 0mm])
-  startSideCoincidentWithTrimSegStart = line(start = [var -6mm, var 3mm], end = [var -6mm, var -3mm])
-  startSideEndPointCoincidentWithTrimSeg = line(start = [var -4mm, var 0mm], end = [var -4mm, var 3mm])
-  startSideIntersectionTrimTermination = line(start = [var -2mm, var 3mm], end = [var -2mm, var -3mm])
-  endSideIntersectionTrimTermination = line(start = [var 2mm, var 3mm], end = [var 2mm, var -3mm])
-  endSideEndPointCoincidentWithTrimSeg = line(start = [var 4mm, var -3mm], end = [var 4mm, var 0mm])
-  endSideCoincidentWithTrimSegStart = line(start = [var 0.67mm, var 3mm], end = [var 0.67mm, var -3mm])
-  coincident([
-    segmentToBeTrimmedAndSplit.start,
-    startSideCoincidentWithTrimSegStart
-  ])
-  coincident([
-    startSideEndPointCoincidentWithTrimSeg.start,
-    segmentToBeTrimmedAndSplit
-  ])
-  line1 = line(start = [var 2mm, var 0mm], end = [var 0.67mm, var 0mm])
-  coincident([
-    segmentToBeTrimmedAndSplit.end,
-    startSideIntersectionTrimTermination
-  ])
-  coincident([
-    line1.start,
-    endSideIntersectionTrimTermination
-  ])
-  coincident([
-    line1.end,
-    endSideCoincidentWithTrimSegStart
-  ])
-  coincident([
-    endSideEndPointCoincidentWithTrimSeg.end,
-    line1
-  ])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch(
+        "test_split_straight_segments_migrate_constraints",
+        base_kcl_code,
+        &trim_points,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -2198,51 +2007,12 @@ async fn test_trim_with_distance_constraints_preserve_constraints() {
         Coords2d { x: 0.14, y: -4.8 },
     ];
 
-    let expected_code = r#"sketch(on = YZ) {
-  line1 = line(start = [var -5.5mm, var 7mm], end = [var -3mm, var 5mm])
-  line4 = line(start = [var -6mm, var 4mm], end = [var -3.5mm, var 2mm])
-  endTrimmedShouldDeleteDisConstraint = line(start = [var -3.5mm, var 2mm], end = [var -2.33mm, var 2mm])
-  coincident([
-    line4.end,
-    endTrimmedShouldDeleteDisConstraint.start
-  ])
-  line6 = line(start = [var -3mm, var 1mm], end = [var -2mm, var 2.5mm])
-  startTrimmedAlsoDeleteDisConstraint = line(start = [var 1.63mm, var -0.73mm], end = [var 3.02mm, var -0.75mm])
-  line3 = line(start = [var 3.02mm, var -0.75mm], end = [var 5.38mm, var 1.14mm])
-  coincident([
-    startTrimmedAlsoDeleteDisConstraint.end,
-    line3.start
-  ])
-  line5 = line(start = [var 1.24mm, var 0.92mm], end = [var 1.84mm, var -1.64mm])
-  splitTrimLineDistanceConstraintMigrated = line(start = [var -3.7mm, var -3.56mm], end = [var -0.71mm, var -3.93mm])
-  line8 = line(start = [var 1.84mm, var -3.74mm], end = [var 5.42mm, var -1.72mm])
-  line9 = line(start = [var 1.1mm, var -3.71mm], end = [var 1.28mm, var -5.69mm])
-  line10 = line(start = [var 1.98mm, var -3.74mm], end = [var 2.57mm, var -5.65mm])
-  line11 = line(start = [var -1.05mm, var -2.11mm], end = [var -0.45mm, var -5.31mm])
-  coincident([
-    endTrimmedShouldDeleteDisConstraint.end,
-    line6
-  ])
-  coincident([
-    startTrimmedAlsoDeleteDisConstraint.start,
-    line5
-  ])
-  line2 = line(start = [var 1.1mm, var -3.71mm], end = [var 1.84mm, var -3.74mm])
-  coincident([
-    splitTrimLineDistanceConstraintMigrated.end,
-    line11
-  ])
-  coincident([line2.start, line9.start])
-  coincident([line2.end, line8.start])
-  coincident([line10.start, line2])
-  distance([
-  splitTrimLineDistanceConstraintMigrated.start,
-  line2.end
-]) == 5.54mm
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch(
+        "test_trim_with_distance_constraints_preserve_constraints",
+        base_kcl_code,
+        &trim_points,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -2263,24 +2033,7 @@ async fn test_split_trim_migrate_angle_constraints() {
 
     let trim_points = vec![Coords2d { x: -1.75, y: -0.56 }, Coords2d { x: -1.75, y: -2.93 }];
 
-    let expected_code = r#"sketch(on = YZ) {
-  line1 = line(start = [var -2mm, var 6.13mm], end = [var 0.22mm, var 4.54mm])
-  line2 = line(start = [var -4.15mm, var 0mm], end = [var -3.03mm, var -0.82mm])
-  parallel([line1, line2])
-  line3 = line(start = [var -3.1mm, var 1.3mm], end = [var -2.96mm, var -3.08mm])
-  line4 = line(start = [var -0.59mm, var -0.81mm], end = [var -1.13mm, var -4.94mm])
-  line5 = line(start = [var 0.09mm, var -3.02mm], end = [var -0.11mm, var -5.63mm])
-  line6 = line(start = [var -1.01mm, var -2.24mm], end = [var 3.5mm, var -1.84mm])
-  line7 = line(start = [var -0.8mm, var -2.39mm], end = [var -1.01mm, var -2.24mm])
-  coincident([line2.end, line3])
-  coincident([line7.start, line4])
-  coincident([line7.end, line6.start])
-  coincident([line5.start, line7])
-  parallel([line1, line7])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch("test_split_trim_migrate_angle_constraints", base_kcl_code, &trim_points).await;
 }
 
 #[tokio::test]
@@ -2296,19 +2049,12 @@ async fn test_split_trim_migrate_horizontal_constraint() {
 
     let trim_points = vec![Coords2d { x: 0.73, y: 1.85 }, Coords2d { x: -0.8, y: 0.25 }];
 
-    let expected_code = r#"sketch(on = YZ) {
-  line1 = line(start = [var -3.64mm, var 1.26mm], end = [var -1.7mm, var 1.26mm])
-  line2 = line(start = [var 3.32mm, var 5.32mm], end = [var -4.67mm, var -1.14mm])
-  line3 = line(start = [var 4.34mm, var 3.17mm], end = [var -3.94mm, var -3.95mm])
-  horizontal(line1)
-  line4 = line(start = [var 2.12mm, var 1.26mm], end = [var 3.8mm, var 1.26mm])
-  coincident([line1.end, line2])
-  coincident([line4.start, line3])
-  horizontal(line4)
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch(
+        "test_split_trim_migrate_horizontal_constraint",
+        base_kcl_code,
+        &trim_points,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -2324,19 +2070,12 @@ async fn test_split_trim_migrate_horizontal_points_constraint() {
 
     let trim_points = vec![Coords2d { x: 0.73, y: 1.85 }, Coords2d { x: -0.8, y: 0.25 }];
 
-    let expected_code = r#"sketch(on = YZ) {
-  line1 = line(start = [var -3.64mm, var 1.26mm], end = [var -1.7mm, var 1.26mm])
-  line2 = line(start = [var 3.32mm, var 5.32mm], end = [var -4.67mm, var -1.14mm])
-  line3 = line(start = [var 4.34mm, var 3.17mm], end = [var -3.94mm, var -3.95mm])
-  point1 = point(at = [var 5mm, var 1.26mm])
-  line4 = line(start = [var 2.12mm, var 1.26mm], end = [var 3.8mm, var 1.26mm])
-  coincident([line1.end, line2])
-  coincident([line4.start, line3])
-  horizontal([line4.end, point1])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch(
+        "test_split_trim_migrate_horizontal_points_constraint",
+        base_kcl_code,
+        &trim_points,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -2352,19 +2091,12 @@ async fn test_split_trim_migrate_vertical_constraint() {
 
     let trim_points = vec![Coords2d { x: 0.47, y: 1.45 }, Coords2d { x: -1.72, y: 0.1 }];
 
-    let expected_code = r#"sketch(on = YZ) {
-  line1 = line(start = [var -0.36mm, var 3.66mm], end = [var -0.36mm, var 2.34mm])
-  line2 = line(start = [var 3.32mm, var 5.32mm], end = [var -4.67mm, var -1.14mm])
-  line3 = line(start = [var 4.34mm, var 3.17mm], end = [var -3.94mm, var -3.95mm])
-  vertical(line1)
-  line4 = line(start = [var -0.36mm, var -0.87mm], end = [var -0.36mm, var -2.66mm])
-  coincident([line1.end, line2])
-  coincident([line4.start, line3])
-  vertical(line4)
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch(
+        "test_split_trim_migrate_vertical_constraint",
+        base_kcl_code,
+        &trim_points,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -2380,19 +2112,12 @@ async fn test_split_trim_migrate_vertical_points_constraint() {
 
     let trim_points = vec![Coords2d { x: 0.47, y: 1.45 }, Coords2d { x: -1.72, y: 0.1 }];
 
-    let expected_code = r#"sketch(on = YZ) {
-  line1 = line(start = [var -0.36mm, var 3.66mm], end = [var -0.36mm, var 2.34mm])
-  line2 = line(start = [var 3.32mm, var 5.32mm], end = [var -4.67mm, var -1.14mm])
-  line3 = line(start = [var 4.34mm, var 3.17mm], end = [var -3.94mm, var -3.95mm])
-  point1 = point(at = [var -0.36mm, var -4mm])
-  line4 = line(start = [var -0.36mm, var -0.87mm], end = [var -0.36mm, var -2.66mm])
-  coincident([line1.end, line2])
-  coincident([line4.start, line3])
-  vertical([line4.end, point1])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch(
+        "test_split_trim_migrate_vertical_points_constraint",
+        base_kcl_code,
+        &trim_points,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -2409,20 +2134,12 @@ async fn test_split_trim_migrate_perpendicular_constraint() {
 
     let trim_points = vec![Coords2d { x: 0.95, y: 1.67 }, Coords2d { x: -2.3, y: -0.08 }];
 
-    let expected_code = r#"sketch(on = YZ) {
-  line4 = line(start = [var -0.95mm, var 5.87mm], end = [var 1.9mm, var 7.14mm])
-  line1 = line(start = [var -1.97mm, var 3.24mm], end = [var -1.25mm, var 1.62mm])
-  line2 = line(start = [var 3.32mm, var 5.32mm], end = [var -4.67mm, var -1.14mm])
-  line3 = line(start = [var 4.34mm, var 3.17mm], end = [var -3.94mm, var -3.95mm])
-  perpendicular([line4, line1])
-  line5 = line(start = [var -0.15mm, var -0.69mm], end = [var 0.57mm, var -2.3mm])
-  coincident([line1.end, line2])
-  coincident([line5.start, line3])
-  perpendicular([line4, line5])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch(
+        "test_split_trim_migrate_perpendicular_constraint",
+        base_kcl_code,
+        &trim_points,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -2449,35 +2166,12 @@ async fn test_split_arc_duplicate_center_point_constraints() {
 
     let trim_points = vec![Coords2d { x: -1.66, y: 7.54 }, Coords2d { x: -1.81, y: 2.11 }];
 
-    let expected_code = r#"sketch(on = YZ) {
-  arcToSplit = arc(start = [var 11.06mm, var 1.06mm], end = [var 3.54mm, var 5.28mm], center = [var 0.65mm, var -8.7mm])
-  line1 = line(start = [var -6mm, var 8mm], end = [var -5.5mm, var 0mm])
-  line2 = line(start = [var 4mm, var 8.5mm], end = [var 3mm, var 1.5mm])
-  lineCoincidentWithArcCen = line(start = [var 0.65mm, var -8.7mm], end = [var 11.5mm, var -7.5mm])
-  line4 = line(start = [var 11.06mm, var 1.06mm], end = [var 13.32mm, var 6.78mm])
-  line5 = line(start = [var 7.62mm, var 3.75mm], end = [var 10mm, var 8mm])
-  coincident([line5.start, arcToSplit])
-  coincident([line4.start, arcToSplit.start])
-  coincident([
-    lineCoincidentWithArcCen.start,
-    arcToSplit.center
-  ])
-  distance([arcToSplit.center, line4.end]) == 20mm
-  line3 = line(start = [var -0.92mm, var -6.93mm], end = [var 2.89mm, var -11.21mm])
-  coincident([arcToSplit.center, line3])
-  arc1 = arc(start = [var -5.75mm, var 4.08mm], end = [var -10.37mm, var 0.39mm], center = [var 0.65mm, var -8.7mm])
-  coincident([arcToSplit.end, line2])
-  coincident([arc1.start, line1])
-  coincident([
-    lineCoincidentWithArcCen.start,
-    arc1.center
-  ])
-  distance([arc1.center, line4.end]) == 20mm
-  coincident([arc1.center, line3])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch(
+        "test_split_arc_duplicate_center_point_constraints",
+        base_kcl_code,
+        &trim_points,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -2502,21 +2196,12 @@ async fn test_trimming_arcs_preserve_distance_constraints() {
         Coords2d { x: -1.57, y: 1.03 },
     ];
 
-    let expected_code = r#"sketch(on = YZ) {
-  arc1 = arc(start = [var -3.89mm, var 1.85mm], end = [var -5.31mm, var -1.34mm], center = [var -0.65mm, var -1.5mm])
-  line1 = line(start = [var -4.72mm, var 3.54mm], end = [var -2.24mm, var -1.48mm])
-  line2 = line(start = [var 2.27mm, var -4.04mm], end = [var 4.65mm, var -1.26mm])
-  distance([arc1.center, line2.start]) == 3.87mm
-  line3 = line(start = [var -5.61mm, var 5.38mm], end = [var -0.9mm, var 5.49mm])
-  line4 = line(start = [var 1.03mm, var 5.53mm], end = [var 6.15mm, var 3.11mm])
-  line5 = line(start = [var -1.05mm, var 6.42mm], end = [var -0.9mm, var 5.49mm])
-  distance([line4.end, line3.start]) == 11.98mm
-  coincident([line5.end, line3.end])
-  coincident([arc1.start, line1])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch(
+        "test_trimming_arcs_preserve_distance_constraints",
+        base_kcl_code,
+        &trim_points,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -3457,17 +3142,12 @@ async fn point_on_arc_coincident_should_not_effect_initial_guesses() {
 
     let trim_points = vec![Coords2d { x: -0.29, y: -1.91 }, Coords2d { x: -0.34, y: -4.42 }];
 
-    let expected_code = r#"sketch(on = XY) {
-  line3 = line(start = [var 4.32mm, var 3.72mm], end = [var 1.06mm, var -3.26mm])
-  line4 = line(start = [var -2.31mm, var -3.06mm], end = [var -6.71mm, var -2.8mm])
-  arc1 = arc(start = [var -1.44mm, var -0.99mm], end = [var 2.49mm, var -0.2mm], center = [var 1.06mm, var -3.26mm])
-  coincident([arc1.center, line3.end])
-  coincident([arc1.end, line3])
-  coincident([line4.start, arc1])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch(
+        "point_on_arc_coincident_should_not_effect_initial_guesses",
+        base_kcl_code,
+        &trim_points,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -3483,15 +3163,12 @@ async fn test_trim_circle_case_1_1_circle_to_arc_trimmed_without_start_point_sid
 
     let trim_points = vec![Coords2d { x: 0.21, y: 2.24 }, Coords2d { x: -1.23, y: 1.12 }];
 
-    let expected_code = r#"sketch001 = sketch(on = YZ) {
-  line1 = line(start = [var -0.56mm, var 2.8mm], end = [var -3.58mm, var -0.78mm])
-  arc1 = arc(start = [var -1.04mm, var 2.23mm], end = [var -2.88mm, var 0.05mm], center = [var -1.53mm, var 0.78mm])
-  coincident([arc1.start, line1])
-  coincident([arc1.end, line1])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch(
+        "test_trim_circle_case_1_1_circle_to_arc_trimmed_without_start_point_side",
+        base_kcl_code,
+        &trim_points,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -3507,15 +3184,12 @@ async fn test_trim_circle_case_1_2_circle_to_arc_trimmed_with_start_point_side()
 
     let trim_points = vec![Coords2d { x: -2.0, y: 2.86 }, Coords2d { x: -2.53, y: 1.1 }];
 
-    let expected_code = r#"sketch001 = sketch(on = YZ) {
-  line1 = line(start = [var -0.56mm, var 2.8mm], end = [var -3.58mm, var -0.78mm])
-  arc1 = arc(start = [var -2.88mm, var 0.05mm], end = [var -1.04mm, var 2.23mm], center = [var -1.53mm, var 0.78mm])
-  coincident([arc1.start, line1])
-  coincident([arc1.end, line1])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch(
+        "test_trim_circle_case_1_2_circle_to_arc_trimmed_with_start_point_side",
+        base_kcl_code,
+        &trim_points,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -3530,14 +3204,12 @@ async fn test_trim_circle_case_1_3_trim_line_to_be_coincident_with_circle() {
 
     let trim_points = vec![Coords2d { x: -1.24, y: 2.78 }, Coords2d { x: -0.5, y: 2.3 }];
 
-    let expected_code = r#"sketch001 = sketch(on = YZ) {
-  circle1 = circle(start = [var -2.67mm, var 1.8mm], center = [var -1.53mm, var 0.78mm])
-  line1 = line(start = [var -1.04mm, var 2.23mm], end = [var -3.58mm, var -0.78mm])
-  coincident([line1.start, circle1])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch(
+        "test_trim_circle_case_1_3_trim_line_to_be_coincident_with_circle",
+        base_kcl_code,
+        &trim_points,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -3557,15 +3229,12 @@ async fn test_trim_circle_case_1_4_trim_line_and_circle_arc_with_coincident_endp
         Coords2d { x: -0.4, y: 0.57 },
     ];
 
-    let expected_code = r#"sketch001 = sketch(on = YZ) {
-  line1 = line(start = [var -1.04mm, var 2.23mm], end = [var -3.58mm, var -0.78mm])
-  arc1 = arc(start = [var -1.04mm, var 2.23mm], end = [var -2.88mm, var 0.05mm], center = [var -1.53mm, var 0.78mm])
-  coincident([arc1.start, line1.start])
-  coincident([arc1.end, line1])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch(
+        "test_trim_circle_case_1_4_trim_line_and_circle_arc_with_coincident_endpoints",
+        base_kcl_code,
+        &trim_points,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -3582,16 +3251,12 @@ async fn test_trim_circle_case_2_convert_circle_to_arc_between_two_segments() {
 
     let trim_points = vec![Coords2d { x: -0.44, y: 2.72 }, Coords2d { x: -0.99, y: 1.38 }];
 
-    let expected_code = r#"sketch001 = sketch(on = YZ) {
-  line1 = line(start = [var -0.75mm, var 2.93mm], end = [var -2.97mm, var -1.17mm])
-  line2 = line(start = [var -0.1mm, var 2.46mm], end = [var -0.67mm, var 0.97mm])
-  arc1 = arc(start = [var -1.12mm, var 2.25mm], end = [var -0.36mm, var 1.77mm], center = [var -1.53mm, var 0.78mm])
-  coincident([arc1.start, line1])
-  coincident([arc1.end, line2])
-}
-"#;
-
-    assert_trim_result_default_sketch(base_kcl_code, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch(
+        "test_trim_circle_case_2_convert_circle_to_arc_between_two_segments",
+        base_kcl_code,
+        &trim_points,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -3605,31 +3270,12 @@ async fn test_trim_rect_arc_corner_reconnects_arc_endpoints_to_trimmed_lines() {
         Coords2d { x: -4.47, y: 2.48 },
     ];
 
-    let expected_code = r#"sketch001 = sketch(on = YZ) {
-  line1 = line(start = [var -0.85mm, var 0.72mm], end = [var -4.07mm, var 0.72mm])
-  line2 = line(start = [var -4.07mm, var 0.72mm], end = [var -4.07mm, var 1.54mm])
-  line3 = line(start = [var -2.69mm, var 2.92mm], end = [var -0.85mm, var 2.92mm])
-  line4 = line(start = [var -0.85mm, var 2.92mm], end = [var -0.85mm, var 0.72mm])
-  coincident([line1.end, line2.start])
-  coincident([line3.end, line4.start])
-  coincident([line4.end, line1.start])
-  parallel([line2, line4])
-  parallel([line3, line1])
-  perpendicular([line1, line2])
-  horizontal(line3)
-  arc1 = arc(start = [var -2.69mm, var 2.92mm], end = [var -4.07mm, var 1.54mm], center = [var -2.69mm, var 1.54mm])
-  line5 = line(start = [var -0.85mm, var 1.82mm], end = [var -1.9mm, var 0.72mm])
-  coincident([line5.start, line4])
-  midpoint(line4, point = line5.start)
-  coincident([line5.end, line1])
-  tangent([line3, arc1])
-  tangent([line2, arc1])
-  coincident([line3.start, arc1.start])
-  coincident([line2.end, arc1.end])
-}
-"#;
-
-    assert_trim_result_default_sketch(RECT_ARC_LINE5_TRIM_BASE_KCL, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch(
+        "test_trim_rect_arc_corner_reconnects_arc_endpoints_to_trimmed_lines",
+        RECT_ARC_LINE5_TRIM_BASE_KCL,
+        &trim_points,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -3643,30 +3289,12 @@ async fn test_trim_rect_diagonal_corner_reconnects_line5_endpoints() {
         Coords2d { x: -1.38, y: 0.31 },
     ];
 
-    let expected_code = r#"sketch001 = sketch(on = YZ) {
-  line1 = line(start = [var -1.9mm, var 0.72mm], end = [var -4.07mm, var 0.72mm])
-  line2 = line(start = [var -4.07mm, var 0.72mm], end = [var -4.07mm, var 2.92mm])
-  line3 = line(start = [var -4.07mm, var 2.92mm], end = [var -0.85mm, var 2.92mm])
-  line4 = line(start = [var -0.85mm, var 2.92mm], end = [var -0.85mm, var 1.82mm])
-  coincident([line1.end, line2.start])
-  coincident([line2.end, line3.start])
-  coincident([line3.end, line4.start])
-  parallel([line2, line4])
-  parallel([line3, line1])
-  perpendicular([line1, line2])
-  horizontal(line3)
-  arc1 = arc(start = [var -2.69mm, var 2.92mm], end = [var -4.07mm, var 1.54mm], center = [var -2.69mm, var 1.54mm])
-  coincident([arc1.end, line2])
-  coincident([arc1.start, line3])
-  line5 = line(start = [var -0.85mm, var 1.82mm], end = [var -1.9mm, var 0.72mm])
-  tangent([line3, arc1])
-  tangent([line2, arc1])
-  coincident([line4.end, line5.start])
-  coincident([line1.start, line5.end])
-}
-"#;
-
-    assert_trim_result_default_sketch(RECT_ARC_LINE5_TRIM_BASE_KCL, &trim_points, expected_code).await;
+    assert_trim_result_default_sketch(
+        "test_trim_rect_diagonal_corner_reconnects_line5_endpoints",
+        RECT_ARC_LINE5_TRIM_BASE_KCL,
+        &trim_points,
+    )
+    .await;
 }
 
 #[tokio::test]

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_add_constraint_multi_line_equal_length.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_add_constraint_multi_line_equal_length.snap
@@ -1,0 +1,11 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  line1 = line(start = [var 1, var 2], end = [var 3, var 4])
+  line2 = line(start = [var 5, var 6], end = [var 7, var 8])
+  line3 = line(start = [var 9, var 10], end = [var 11, var 12])
+  equalLength([line1, line2, line3])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_add_fixed_multiple_points.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_add_fixed_multiple_points.snap
@@ -1,0 +1,11 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  point1 = point(at = [var 2, var 3])
+  point2 = point(at = [var 4, var 5])
+  fixed([point1, [2mm, 3mm]])
+  fixed([point2, [4mm, 5mm]])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_add_fixed_owned_point.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_add_fixed_owned_point.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  line1 = line(start = [var 2, var 3], end = [var 3, var 4])
+  fixed([line1.start, [2mm, 3mm]])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_add_fixed_standalone_point.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_add_fixed_standalone_point.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  point1 = point(at = [var 2, var 3])
+  fixed([point1, [2mm, 3mm]])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_add_line_when_sketch_block_uses_variable.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_add_line_when_sketch_block_uses_variable.snap
@@ -1,0 +1,8 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+s = sketch(on = XY) {
+  line(start = [0mm, 0mm], end = [10mm, 10mm])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_coincident_of_line_end_points.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_coincident_of_line_end_points.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  line1 = line(start = [var 1, var 2], end = [var 4, var 5])
+  line2 = line(start = [var 4, var 5], end = [var 7, var 8])
+  coincident([line1.end, line2.start])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_coincident_of_line_point_and_circle_segment.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_coincident_of_line_point_and_circle_segment.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  circle1 = circle(start = [var 7.02mm, var 0mm], center = [var -0.01mm, var 0.22mm])
+  line1 = line(start = [var 7mm, var 0.78mm], end = [var 10mm, var 2mm])
+  coincident([line1.start, circle1])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_commit_var_solution_by_node_path_updates_sketch_var.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_commit_var_solution_by_node_path_updates_sketch_var.snap
@@ -1,0 +1,8 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "source_delta.text"
+---
+sketch(on = XY) {
+  line1 = line(start = [var 0, var 0], end = [var 25mm, var 0])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_commit_var_solution_node_path_wins_when_source_range_points_at_wrong_var.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_commit_var_solution_node_path_wins_when_source_range_points_at_wrong_var.snap
@@ -1,0 +1,8 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "source_delta.text"
+---
+sketch(on = XY) {
+  line1 = line(start = [var 33mm, var 0mm], end = [var 20mm, var 0mm])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_commit_var_solution_survives_whitespace_shift_earlier_in_file.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_commit_var_solution_survives_whitespace_shift_earlier_in_file.snap
@@ -1,0 +1,11 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "source_delta.text"
+---
+// added comment
+// added comment
+
+sketch(on = XY) {
+  line1 = line(start = [var 0, var 0], end = [var 30mm, var 0])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_commit_var_solution_writes_back_into_bare_var.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_commit_var_solution_writes_back_into_bare_var.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "source_delta.text"
+---
+@settings(experimentalFeatures = allow, kclVersion = 2.0)
+
+sketch(on = XY) {
+  line1 = line(start = [var 7mm, var 0mm], end = [var 10mm, var 0])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_circle.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_circle.snap
@@ -1,0 +1,7 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch001 = sketch(on = XY) {
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_coincident_constraint.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_coincident_constraint.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  point1 = point(at = [var 1, var 2])
+  point2 = point(at = [var 3, var 4])
+  point(at = [var 5, var 6])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_last_segment_preserves_pre_comment.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_last_segment_preserves_pre_comment.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  point(at = [var 1, var 2])
+  // describe the trailing point
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_line_cascades_to_coincident_constraint.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_line_cascades_to_coincident_constraint.snap
@@ -1,0 +1,8 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  line1 = line(start = [var 1, var 2], end = [var 3, var 4])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_line_cascades_to_distance_constraint.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_line_cascades_to_distance_constraint.snap
@@ -1,0 +1,8 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  line1 = line(start = [var 1, var 2], end = [var 3, var 4])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_line_cascades_to_fixed_constraint.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_line_cascades_to_fixed_constraint.snap
@@ -1,0 +1,8 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  line2 = line(start = [var 5, var 6], end = [var 7, var 8])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_line_cascades_to_midpoint_constraint.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_line_cascades_to_midpoint_constraint.snap
@@ -1,0 +1,8 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  point1 = point(at = [var 1, var 2])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_line_line_coincident_constraint.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_line_line_coincident_constraint.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  line1 = line(start = [var 1, var 2], end = [var 3, var 4])
+  line2 = line(start = [var 5, var 6], end = [var 7, var 8])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_line_preserves_multiline_equal_length_constraint.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_line_preserves_multiline_equal_length_constraint.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  line1 = line(start = [var 1, var 2], end = [var 3, var 4])
+  line2 = line(start = [var 5, var 6], end = [var 7, var 8])
+  equalLength([line1, line2])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_line_preserves_multiline_parallel_constraint.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_line_preserves_multiline_parallel_constraint.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  line1 = line(start = [var 1, var 2], end = [var 3, var 4])
+  line2 = line(start = [var 5, var 6], end = [var 7, var 8])
+  parallel([line1, line2])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_lines_removes_multiline_equal_length_constraint_below_minimum.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_lines_removes_multiline_equal_length_constraint_below_minimum.snap
@@ -1,0 +1,8 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  line1 = line(start = [var 1, var 2], end = [var 3, var 4])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_lines_removes_multiline_parallel_constraint_below_minimum.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_lines_removes_multiline_parallel_constraint_below_minimum.snap
@@ -1,0 +1,8 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  line1 = line(start = [var 1, var 2], end = [var 3, var 4])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_multiple_points.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_multiple_points.snap
@@ -1,0 +1,8 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  point(at = [var 5, var 6])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_point_cascades_to_horizontal_distance_constraint.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_point_cascades_to_horizontal_distance_constraint.snap
@@ -1,0 +1,8 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  point1 = point(at = [var 1, var 2])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_point_with_var.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_point_with_var.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  point(at = [var 1, var 2])
+  point(at = [var 5, var 6])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_point_without_var.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_point_without_var.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  point(at = [var 1, var 2])
+  point(at = [var 5, var 6])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_segment_preserves_pre_comment.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_segment_preserves_pre_comment.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  point(at = [var 1, var 2])
+  // describe the middle point
+  point(at = [var 5, var 6])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_segments_preserves_block_comments_across_positions.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_segments_preserves_block_comments_across_positions.snap
@@ -1,0 +1,11 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  /* above first - moves to middle */
+  /* above middle - stays */
+  point(at = [var 3, var 4])
+  /* above last - moves to trailing meta */
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_sketch_after_comment.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_sketch_after_comment.snap
@@ -1,0 +1,6 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+// test 1
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_sketch_preserves_pre_comment_when_followed_by_code.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_sketch_preserves_pre_comment_when_followed_by_code.snap
@@ -1,0 +1,7 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+// keep me
+foo = 1
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_sketch_when_sketch_block_uses_variable.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_delete_sketch_when_sketch_block_uses_variable.snap
@@ -1,0 +1,4 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_diameter_single_arc_segment.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_diameter_single_arc_segment.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  arc1 = arc(start = [var 1.83, var 3.62], end = [var 2.42, var 3.3], center = [var -0.25, var -0.92])
+  diameter(arc1) == 10mm
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_diameter_single_arc_segment_with_label_position.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_diameter_single_arc_segment_with_label_position.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  arc1 = arc(start = [var 1.83, var 3.62], end = [var 2.42, var 3.3], center = [var -0.25, var -0.92])
+  diameter(arc1, labelPosition = [10mm, 11mm]) == 10mm
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_distance_arc_origin.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_distance_arc_origin.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch001 = sketch(on = XY) {
+  arc1 = arc(start = [var -4.16mm, var -0.43mm], end = [var -3.53mm, var 3.28mm], center = [var -4.91mm, var 1.61mm])
+  distance([arc1, ORIGIN]) == 3mm
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_distance_circle_arc.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_distance_circle_arc.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  circle1 = circle(start = [var 4.33, var 0], center = [var -0.34, var -0.09])
+  arc1 = arc(start = [var 15.33, var -0.01], end = [var 10.01, var 4.33], center = [var 11.34, var 0.53])
+  distance([circle1, arc1]) == 3mm
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_distance_line_circle.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_distance_line_circle.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  line1 = line(start = [var -10, var 8], end = [var 10, var 8])
+  circle1 = circle(start = [var 5, var 0], center = [var 0, var 0])
+  distance([line1, circle1]) == 3mm
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_distance_line_origin.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_distance_line_origin.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  line1 = line(start = [var 5, var 0], end = [var 5, var 10])
+  distance([ORIGIN, line1]) == 5mm
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_distance_non_parallel_lines_lowers_to_distance.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_distance_non_parallel_lines_lowers_to_distance.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  line1 = line(start = [var 4.98, var -0.07], end = [var 4.98, var 0.14])
+  line2 = line(start = [var 0.02, var 4.3], end = [var 0.03, var 5.65])
+  distance([line1, line2]) == 5mm
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_distance_parallel_lines.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_distance_parallel_lines.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  line1 = line(start = [var 0, var 0], end = [var 10, var 0])
+  line2 = line(start = [var 0, var 5], end = [var 10, var 5])
+  distance([line1, line2]) == 5mm
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_distance_point_arc.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_distance_point_arc.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  point1 = point(at = [var 0, var 8])
+  arc1 = arc(start = [var 5, var 0], end = [var 0, var 5], center = [var 0, var 0])
+  distance([point1, arc1]) == 3mm
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_distance_point_line.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_distance_point_line.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  point1 = point(at = [var 0, var 5])
+  line1 = line(start = [var 0, var 0], end = [var 10, var 0])
+  distance([point1, line1], labelPosition = [10mm, 11mm]) == 5mm
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_distance_two_points.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_distance_two_points.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  point1 = point(at = [var 1.29, var 2.29])
+  point2 = point(at = [var 2.71, var 3.71])
+  distance([point1, point2]) == 2mm
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_distance_two_points_with_label.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_distance_two_points_with_label.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  point1 = point(at = [var 1.29, var 2.29])
+  point2 = point(at = [var 2.71, var 3.71])
+  distance([point1, point2], labelPosition = [10mm, 11mm]) == 2mm
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_edit_circle_via_point.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_edit_circle_via_point.snap
@@ -1,0 +1,8 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch001 = sketch(on = XY) {
+  circle(start = [var 7mm, var 1mm], center = [var 0mm, var 0mm])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_edit_diameter_constraint_label_position.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_edit_diameter_constraint_label_position.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  arc1 = arc(start = [var 5mm, var 0mm], end = [var 0mm, var 5mm], center = [var 0mm, var 0mm])
+  diameter(arc1, labelPosition = [10mm, 11mm]) == 10mm
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_edit_distance_constraint_label_position.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_edit_distance_constraint_label_position.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  point1 = point(at = [var 1, var 2])
+  point2 = point(at = [var 3, var 2])
+  distance([point1, point2], labelPosition = [10mm, 11mm]) == 2mm
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_edit_line_when_editing_its_end_point.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_edit_line_when_editing_its_end_point.snap
@@ -1,0 +1,8 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  line(start = [var 1, var 2], end = [var 5in, var 6in])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_edit_line_when_editing_its_start_point.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_edit_line_when_editing_its_start_point.snap
@@ -1,0 +1,8 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  line(start = [var 5in, var 6in], end = [var 3, var 4])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_edit_line_with_coincident_feedback.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_edit_line_with_coincident_feedback.snap
@@ -1,0 +1,12 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  line1 = line(start = [var 0, var 0], end = [var 4.14, var 5.32])
+  line2 = line(start = [var 4.14, var 5.32], end = [var 9, var 10])
+  fixed([line1.start, [0, 0]])
+  coincident([line1.end, line2.start])
+  equalLength([line1, line2])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_edit_radius_constraint_label_position.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_edit_radius_constraint_label_position.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  arc1 = arc(start = [var 5mm, var 0mm], end = [var 0mm, var 5mm], center = [var 0mm, var 0mm])
+  radius(arc1, labelPosition = [10mm, 11mm]) == 5mm
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_horizontal_distance_two_points.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_horizontal_distance_two_points.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  point1 = point(at = [var 1, var 2])
+  point2 = point(at = [var 3, var 4])
+  horizontalDistance([point1, point2], labelPosition = [10mm, 11mm]) == 2mm
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_line_horizontal.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_line_horizontal.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  line1 = line(start = [var 1, var 3], end = [var 3, var 3])
+  horizontal(line1)
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_line_vertical.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_line_vertical.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  line1 = line(start = [var 2, var 2], end = [var 2, var 4])
+  vertical(line1)
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_lines_angle.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_lines_angle.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  line1 = line(start = [var 0.9, var 2.36], end = [var 3.1, var 3.64])
+  line2 = line(start = [var 5.36, var 5.9], end = [var 6.64, var 8.1])
+  angle([line1, line2]) == 30deg
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_lines_equal_length.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_lines_equal_length.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  line1 = line(start = [var 1, var 2], end = [var 3, var 4])
+  line2 = line(start = [var 5, var 6], end = [var 7, var 8])
+  equalLength([line1, line2])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_lines_parallel.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_lines_parallel.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  line1 = line(start = [var 1, var 2], end = [var 3, var 4])
+  line2 = line(start = [var 5, var 6], end = [var 7, var 8])
+  parallel([line1, line2])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_lines_parallel_multiline.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_lines_parallel_multiline.snap
@@ -1,0 +1,11 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  line1 = line(start = [var 1, var 2], end = [var 3, var 4])
+  line2 = line(start = [var 5, var 6], end = [var 7, var 8])
+  line3 = line(start = [var 9, var 10], end = [var 11, var 12])
+  parallel([line1, line2, line3])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_lines_perpendicular.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_lines_perpendicular.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  line1 = line(start = [var 2, var 3], end = [var 2, var 3])
+  line2 = line(start = [var 6, var 7], end = [var 6, var 7])
+  perpendicular([line1, line2])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_multiple_sketch_blocks_1.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_multiple_sketch_blocks_1.snap
@@ -1,0 +1,37 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+// Cube that requires the engine.
+width = 2
+sketch001 = startSketchOn(XY)
+profile001 = startProfile(sketch001, at = [0, 0])
+  |> yLine(length = width, tag = $seg1)
+  |> xLine(length = width)
+  |> yLine(length = -width)
+  |> line(endAbsolute = [profileStartX(%), profileStartY(%)])
+  |> close()
+extrude001 = extrude(profile001, length = width)
+
+// Get a value that requires the engine.
+x = segLen(seg1)
+
+// Triangle with side length 2*x.
+sketch(on = XY) {
+  line1 = line(start = [var 1mm, var 2mm], end = [var 2.32mm, var -1.78mm])
+  line2 = line(start = [var 2.32mm, var -1.78mm], end = [var -1.61mm, var -1.03mm])
+  coincident([line1.end, line2.start])
+  line3 = line(start = [var -1.61mm, var -1.03mm], end = [var 1mm, var 2mm])
+  coincident([line2.end, line3.start])
+  coincident([line3.end, line1.start])
+  equalLength([line3, line1])
+  equalLength([line1, line2])
+  distance([line1.start, line1.end]) == 2 * x
+}
+
+// Line segment with length x.
+sketch2 = sketch(on = XY) {
+  line1 = line(start = [var 0.14mm, var 0.86mm], end = [var 1.283mm, var -0.781mm])
+  distance([line1.start, line1.end]) == x
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_multiple_sketch_blocks_2.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_multiple_sketch_blocks_2.snap
@@ -1,0 +1,37 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+// Cube that requires the engine.
+width = 2
+sketch001 = startSketchOn(XY)
+profile001 = startProfile(sketch001, at = [0, 0])
+  |> yLine(length = width, tag = $seg1)
+  |> xLine(length = width)
+  |> yLine(length = -width)
+  |> line(endAbsolute = [profileStartX(%), profileStartY(%)])
+  |> close()
+extrude001 = extrude(profile001, length = width)
+
+// Get a value that requires the engine.
+x = segLen(seg1)
+
+// Triangle with side length 2*x.
+sketch(on = XY) {
+  line1 = line(start = [var 1mm, var 2mm], end = [var 2.32mm, var -1.78mm])
+  line2 = line(start = [var 2.32mm, var -1.78mm], end = [var -1.61mm, var -1.03mm])
+  coincident([line1.end, line2.start])
+  line3 = line(start = [var -1.61mm, var -1.03mm], end = [var 1mm, var 2mm])
+  coincident([line2.end, line3.start])
+  coincident([line3.end, line1.start])
+  equalLength([line3, line1])
+  equalLength([line1, line2])
+  distance([line1.start, line1.end]) == 2 * x
+}
+
+// Line segment with length x.
+sketch2 = sketch(on = XY) {
+  line1 = line(start = [var 3mm, var 4mm], end = [var 2.32mm, var 2.12mm])
+  distance([line1.start, line1.end]) == x
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_new_sketch_add_arc_edit_arc_1.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_new_sketch_add_arc_edit_arc_1.snap
@@ -1,0 +1,8 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch001 = sketch(on = XY) {
+  arc(start = [var 0mm, var 0mm], end = [var 10mm, var 10mm], center = [var 10mm, var 0mm])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_new_sketch_add_arc_edit_arc_2.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_new_sketch_add_arc_edit_arc_2.snap
@@ -1,0 +1,8 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch001 = sketch(on = XY) {
+  arc(start = [var 1mm, var 2mm], end = [var 13mm, var 14mm], center = [var 13mm, var 2mm])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_new_sketch_add_circle_edit_circle_1.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_new_sketch_add_circle_edit_circle_1.snap
@@ -1,0 +1,8 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch001 = sketch(on = XY) {
+  circle1 = circle(start = [var 5mm, var 0mm], center = [var 0mm, var 0mm])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_new_sketch_add_circle_edit_circle_2.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_new_sketch_add_circle_edit_circle_2.snap
@@ -1,0 +1,8 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch001 = sketch(on = XY) {
+  circle1 = circle(start = [var 10mm, var 0mm], center = [var 3mm, var 4mm])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_new_sketch_add_line_delete_sketch_1.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_new_sketch_add_line_delete_sketch_1.snap
@@ -1,0 +1,8 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch001 = sketch(on = XY) {
+  line(start = [0mm, 0mm], end = [10mm, 10mm])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_new_sketch_add_line_delete_sketch_2.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_new_sketch_add_line_delete_sketch_2.snap
@@ -1,0 +1,4 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_new_sketch_add_line_edit_line_1.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_new_sketch_add_line_edit_line_1.snap
@@ -1,0 +1,8 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch001 = sketch(on = XY) {
+  line(start = [0mm, 0mm], end = [10mm, 10mm])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_new_sketch_add_line_edit_line_2.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_new_sketch_add_line_edit_line_2.snap
@@ -1,0 +1,8 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch001 = sketch(on = XY) {
+  line(start = [1mm, 2mm], end = [13mm, 14mm])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_new_sketch_add_point_edit_point_1.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_new_sketch_add_point_edit_point_1.snap
@@ -1,0 +1,8 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch001 = sketch(on = XY) {
+  point(at = [1in, 2in])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_new_sketch_add_point_edit_point_2.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_new_sketch_add_point_edit_point_2.snap
@@ -1,0 +1,8 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch001 = sketch(on = XY) {
+  point(at = [3in, 4in])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_new_sketch_twice_using_same_plane.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_new_sketch_twice_using_same_plane.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch1 = sketch(on = XY) {
+}
+sketch001 = sketch(on = XY) {
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_new_sketch_uses_unique_variable_name.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_new_sketch_uses_unique_variable_name.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch1 = sketch(on = XY) {
+}
+sketch001 = sketch(on = YZ) {
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_origin_arc_midpoint.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_origin_arc_midpoint.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  arc1 = arc(start = [var 0.35, var 2.24], end = [var 1.62, var -1.58], center = [var 2.34, var 0.78])
+  midpoint(arc1, point = ORIGIN)
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_origin_line_midpoint.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_origin_line_midpoint.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  line1 = line(start = [var -3, var -2], end = [var 3, var 2])
+  midpoint(line1, point = ORIGIN)
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_point_arc_midpoint.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_point_arc_midpoint.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  point1 = point(at = [var 6, var 2.35])
+  arc1 = arc(start = [var 6, var 2.35], end = [var 6, var 2.35], center = [var 6, var 1.94])
+  midpoint(arc1, point = point1)
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_point_horizontal_with_origin.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_point_horizontal_with_origin.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch001 = sketch(on = XY) {
+  p0 = point(at = [var -2.23mm, var 0mm])
+  horizontal([p0, ORIGIN])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_point_midpoint.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_point_midpoint.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  point1 = point(at = [var 2.33, var 1.67])
+  line1 = line(start = [var -0.67, var -0.33], end = [var 5.33, var 3.67])
+  midpoint(line1, point = point1)
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_point_origin_coincident_preserves_order_origin_first.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_point_origin_coincident_preserves_order_origin_first.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  point1 = point(at = [var 0, var 0])
+  coincident([ORIGIN, point1])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_point_origin_coincident_preserves_order_point_first.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_point_origin_coincident_preserves_order_point_first.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  point1 = point(at = [var 0, var 0])
+  coincident([point1, ORIGIN])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_points_horizontal.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_points_horizontal.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch001 = sketch(on = XY) {
+  p0 = point(at = [var -2.23mm, var 4mm])
+  pf = point(at = [4, 4])
+  horizontal([p0, pf])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_points_vertical.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_points_vertical.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch001 = sketch(on = XY) {
+  p0 = point(at = [var 4mm, var 3.1mm])
+  pf = point(at = [4, 4])
+  vertical([p0, pf])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_radius_single_arc_segment.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_radius_single_arc_segment.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  arc1 = arc(start = [var 1.83, var 3.62], end = [var 2.42, var 3.3], center = [var -0.25, var -0.92])
+  radius(arc1) == 5mm
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_radius_single_arc_segment_with_label_position.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_radius_single_arc_segment_with_label_position.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  arc1 = arc(start = [var 1.83, var 3.62], end = [var 2.42, var 3.3], center = [var -0.25, var -0.92])
+  radius(arc1, labelPosition = [10mm, 11mm]) == 5mm
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_segments_symmetric.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_segments_symmetric.snap
@@ -1,0 +1,11 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  line1 = line(start = [var 0, var 0], end = [var 0, var 4])
+  line2 = line(start = [var 4, var 0], end = [var 4, var 4])
+  line3 = line(start = [var 2, var -1], end = [var 2, var 5])
+  symmetric([line1, line2], axis = line3)
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_segments_symmetric_arcs.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_segments_symmetric_arcs.snap
@@ -1,0 +1,11 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  arc1 = arc(start = [var -14.46, var 0], end = [var -10, var 4.65], center = [var -10.14, var 0.31])
+  arc2 = arc(start = [var 5.49, var 2.26], end = [var 11.58, var -3.47], center = [var 9.34, var 0.25])
+  line1 = line(start = [var -0.44, var -10], end = [var -0.37, var 10])
+  symmetric([arc1, arc2], axis = line1)
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_segments_tangent.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_segments_tangent.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  line1 = line(start = [var 0.84, var 2.13], end = [var 3.82, var 3.27])
+  arc1 = arc(start = [var 4.51, var 2.03], end = [var 7.05, var 2.02], center = [var 5.78, var 2.55])
+  tangent([line1, arc1])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_sketch_on_plane_incremental.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_sketch_on_plane_incremental.snap
@@ -1,0 +1,18 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+len = 2mm
+cube = startSketchOn(XY)
+  |> startProfile(at = [0, 0])
+  |> line(end = [len, 0], tag = $side)
+  |> line(end = [0, len])
+  |> line(end = [-len, 0])
+  |> line(end = [0, -len])
+  |> close()
+  |> extrude(length = len)
+
+plane = planeOf(cube, face = side)
+sketch001 = sketch(on = plane) {
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_three_points_coincident.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_three_points_coincident.snap
@@ -1,0 +1,11 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  point1 = point(at = [var 3, var 4])
+  point2 = point(at = [var 3, var 4])
+  point3 = point(at = [var 3, var 4])
+  coincident([point1, point2, point3])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_two_points_coincident.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_two_points_coincident.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  point1 = point(at = [var 3, var 4])
+  point2 = point(at = [3, 4])
+  coincident([point1, point2])
+}
+

--- a/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_vertical_distance_two_points.snap
+++ b/rust/kcl-lib/src/snapshots/kcl_lib__frontend__tests__test_vertical_distance_two_points.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/frontend.rs
+expression: "src_delta.text.as_str()"
+---
+sketch(on = XY) {
+  point1 = point(at = [var 1, var 2])
+  point2 = point(at = [var 3, var 4])
+  verticalDistance([point1, point2], labelPosition = [10mm, 11mm]) == 2mm
+}
+


### PR DESCRIPTION
Closes https://github.com/KittyCAD/modeling-app/issues/11867

Done with Codex via this prompt:

Take a look at the `frontend` module (frontend.rs and its child modules). There's many tests that assert on specific strings of KCL source code, including specific rounded numeric measurements. For example:

- test_point_arc_midpoint
- test_radius_single_arc_segment_with_label_position
- Most of the tests under `trim/tests.rs`

Let's change those to use the `insta` library. My motivation is that when the underlying 2D constraint solver implementation changes, we often see small adjustments made to the literals being asserted against. This causes lots of manual toil, like having to go through all the strings and update them by hand. I would rather just run `cargo insta test --accept` and then review the changes.