### PR TITLE
Automatically format Rust code as part of 'make all'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ check: format lint
 .PHONY: format
 format: install ## Format the code
 	npm run fmt
+	cd rust && cargo +nightly fmt
 
 .PHONY: lint
 lint: install public/kcl_wasm_lib_bg.wasm ## Lint the code


### PR DESCRIPTION
`make all` is intended run all the fast, pre-commit tasks. This adds the same format command as CI.