### PR TITLE
KCL: ezpz returning Inf/NaN should be an error

### DIFF
--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -1831,6 +1831,16 @@ impl Node<SketchBlock> {
 
         let (solve_outcome, solve_analysis) = match solve_result {
             Ok((solved, freedom)) => {
+                if solved
+                    .final_values()
+                    .iter()
+                    .any(|number| number.is_infinite() || number.is_nan())
+                {
+                    return Err(KclError::new_internal(KclErrorDetails::new(
+                        "KCL's 2D constraint solver returned an invalid number".to_owned(),
+                        vec![SourceRange::from(self)],
+                    )));
+                }
                 let outcome = Solved::from_ezpz_outcome(solved, &all_constraints, num_required_constraints);
                 if !outcome.converged {
                     exec_state.warn(


### PR DESCRIPTION
Currently if ezpz returns Infinity or NaN, we'll silently fail when trying to serialize the data for transmission to the engine. Let's fail fast and loudly instead.