### PR TITLE
Fix markdown highlighting in code pane

### DIFF
--- a/src/components/layout/areas/KclEditorPane.tsx
+++ b/src/components/layout/areas/KclEditorPane.tsx
@@ -1,7 +1,6 @@
 import { Menu } from '@headlessui/react'
 import { defaultKeymap, history, historyKeymap } from '@codemirror/commands'
 import { markdown } from '@codemirror/lang-markdown'
-import { defaultHighlightStyle, syntaxHighlighting } from '@codemirror/language'
 import { searchKeymap } from '@codemirror/search'
 import { Compartment, EditorState } from '@codemirror/state'
 import {
@@ -16,7 +15,10 @@ import { useSignals } from '@preact/signals-react/runtime'
 import { CustomIcon } from '@src/components/CustomIcon'
 import { LayoutPanel, LayoutPanelHeader } from '@src/components/layout/Panel'
 import { HeaderMenu } from '@src/components/layout/Panel/HeaderMenu'
-import { editorTheme } from '@src/editor/plugins/theme'
+import {
+  editorMarkdownHighlight,
+  editorVisualTheme,
+} from '@src/editor/plugins/theme'
 import usePlatform from '@src/hooks/usePlatform'
 import { useConvertToVariable } from '@src/hooks/useToolbarGuards'
 import {
@@ -133,6 +135,23 @@ const textFileEditorTheme = EditorView.theme({
 const textThemeCompartment = new Compartment()
 
 /**
+ * The text editor's theme bundle: the visual (light/dark) theme plus, for
+ * Markdown files, a theme-aware Markdown highlight style. Both live in one
+ * compartment so a theme toggle swaps them together — the Markdown style has to
+ * follow the theme or dark mode renders unreadably (light-tuned colors on a
+ * dark background).
+ */
+function textEditorThemeExtensions(
+  theme: 'light' | 'dark',
+  isMarkdown: boolean
+) {
+  return [
+    editorVisualTheme[theme],
+    ...(isMarkdown ? [editorMarkdownHighlight[theme]] : []),
+  ]
+}
+
+/**
  * A lightweight, editable CodeMirror surface for non-KCL text files (Markdown /
  * plain text). It is deliberately independent of `KclManager` so editing these
  * files never triggers KCL execution, LSP, or WASM project loading. Edits are
@@ -157,18 +176,16 @@ function TextFileEditor({
       return
     }
     const path = activeTextFile.path
-    const languageExtension = path.toLowerCase().endsWith('.md')
-      ? [
-          markdown(),
-          syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
-        ]
-      : []
+    const isMarkdown = path.toLowerCase().endsWith('.md')
+    const languageExtension = isMarkdown ? [markdown()] : []
 
     const view = new EditorView({
       state: EditorState.create({
         doc: activeTextFile.text,
         extensions: [
-          textThemeCompartment.of(editorTheme[resolvedTheme]),
+          textThemeCompartment.of(
+            textEditorThemeExtensions(resolvedTheme, isMarkdown)
+          ),
           textFileEditorTheme,
           ...languageExtension,
           EditorView.lineWrapping,
@@ -202,10 +219,13 @@ function TextFileEditor({
 
   // Reconfigure the theme in place — no recreation, no lost edits.
   useEffect(() => {
+    const isMarkdown = activeTextFile.path.toLowerCase().endsWith('.md')
     viewRef.current?.dispatch({
-      effects: textThemeCompartment.reconfigure(editorTheme[resolvedTheme]),
+      effects: textThemeCompartment.reconfigure(
+        textEditorThemeExtensions(resolvedTheme, isMarkdown)
+      ),
     })
-  }, [resolvedTheme])
+  }, [resolvedTheme, activeTextFile.path])
 
   if (activeTextFile.status === 'loading') {
     return (

--- a/src/editor/plugins/theme/index.ts
+++ b/src/editor/plugins/theme/index.ts
@@ -151,6 +151,82 @@ export const editorTheme = {
   light: [lightTheme, syntaxHighlighting(baseKclHighlights)],
   dark: [darkTheme, syntaxHighlighting(darkKclHighlights)],
 }
+
+/**
+ * The visual (background/selection) theme only, without the KCL syntax
+ * highlighter. Non-KCL editors — e.g. the plain-text/Markdown code pane — want
+ * the light/dark look but must not register the KCL {@link HighlightStyle},
+ * because CodeMirror resolves highlighters all-or-nothing: a KCL "main"
+ * highlighter would suppress any other (e.g. Markdown) highlight style layered
+ * on top of it.
+ */
+export const editorVisualTheme = {
+  light: lightTheme,
+  dark: darkTheme,
+}
+
+// Markdown highlighting for the plain-text code pane. We can't reuse
+// CodeMirror's `defaultHighlightStyle` because its colors are tuned for a light
+// background and are unreadable on our dark theme. Instead, we mirror the KCL
+// theme's approach: palette-based colors with a dark override. A rule on the
+// base `heading` tag cascades to `heading1`–`heading6`.
+const baseMarkdownHighlights = HighlightStyle.define([
+  { tag: tags.heading, color: colors.primary.light, fontWeight: 'bold' },
+  { tag: tags.strong, color: colors.textDefault.light, fontWeight: 'bold' },
+  { tag: tags.emphasis, color: colors.textDefault.light, fontStyle: 'italic' },
+  { tag: tags.strikethrough, textDecoration: 'line-through' },
+  { tag: tags.link, color: colors.primary.light, textDecoration: 'underline' },
+  { tag: tags.url, color: colors.primary.light },
+  { tag: tags.monospace, color: colors.green.light },
+  { tag: tags.list, color: colors.orange.light },
+  { tag: tags.quote, color: colors.textFaded.light, fontStyle: 'italic' },
+  {
+    tag: tags.contentSeparator,
+    color: colors.textFaded.light,
+    fontWeight: 'bold',
+  },
+  {
+    tag: [tags.processingInstruction, tags.labelName],
+    color: colors.textFaded.light,
+  },
+  { tag: tags.comment, color: colors.textFaded.light, fontStyle: 'italic' },
+])
+
+const darkMarkdownHighlights = HighlightStyle.define(
+  [
+    ...baseMarkdownHighlights.specs,
+    { tag: tags.heading, color: colors.primary.dark, fontWeight: 'bold' },
+    { tag: tags.strong, color: colors.textDefault.dark, fontWeight: 'bold' },
+    { tag: tags.emphasis, color: colors.textDefault.dark, fontStyle: 'italic' },
+    { tag: tags.link, color: colors.primary.dark, textDecoration: 'underline' },
+    { tag: tags.url, color: colors.primary.dark },
+    { tag: tags.monospace, color: colors.green.dark },
+    { tag: tags.list, color: colors.orange.dark },
+    { tag: tags.quote, color: colors.textFaded.dark, fontStyle: 'italic' },
+    {
+      tag: tags.contentSeparator,
+      color: colors.textFaded.dark,
+      fontWeight: 'bold',
+    },
+    {
+      tag: [tags.processingInstruction, tags.labelName],
+      color: colors.textFaded.dark,
+    },
+    { tag: tags.comment, color: colors.textFaded.dark, fontStyle: 'italic' },
+  ],
+  { themeType: 'dark' }
+)
+
+/**
+ * Theme-aware Markdown highlight styles for {@link editorVisualTheme}. Keyed by
+ * resolved theme so the correct palette loads; the dark style is gated on
+ * `EditorView.darkTheme`, so it only takes effect when the dark visual theme is
+ * also active.
+ */
+export const editorMarkdownHighlight = {
+  light: syntaxHighlighting(baseMarkdownHighlights),
+  dark: syntaxHighlighting(darkMarkdownHighlights),
+}
 /** Compartment to allow us to reconfigure CodeMirror's theme dynamically outside of React */
 export const themeCompartment = new Compartment()
 

--- a/src/editor/plugins/theme/markdownHighlighting.test.ts
+++ b/src/editor/plugins/theme/markdownHighlighting.test.ts
@@ -1,0 +1,101 @@
+import { markdown } from '@codemirror/lang-markdown'
+import {
+  defaultHighlightStyle,
+  highlightingFor,
+  syntaxHighlighting,
+} from '@codemirror/language'
+import { EditorState, type Extension } from '@codemirror/state'
+import { type Tag, tags } from '@lezer/highlight'
+import {
+  editorMarkdownHighlight,
+  editorTheme,
+  editorVisualTheme,
+} from '@src/editor/plugins/theme'
+import { describe, expect, it } from 'vitest'
+
+// The plain-text/Markdown pane (TextFileEditor) layers a Markdown highlight
+// style on top of the shared editor theme. CodeMirror resolves highlighters
+// all-or-nothing: if any "main" highlighter is registered, every "fallback"
+// highlighter is ignored (see getHighlighters in @codemirror/language). These
+// tests pin down that the theme we hand the text editor styles Markdown, and
+// that dark mode gets its own (readable) palette rather than reusing light
+// colors.
+function classFor(extensions: Extension[], tag: Tag) {
+  const state = EditorState.create({ doc: '# heading', extensions })
+  return highlightingFor(state, [tag])
+}
+
+// `heading` covers heading1–heading6; the rest are the Markdown content tags
+// emitted by @lezer/markdown.
+const MARKDOWN_TAGS: Tag[] = [
+  tags.heading,
+  tags.heading1,
+  tags.emphasis,
+  tags.strong,
+  tags.link,
+  tags.url,
+  tags.monospace,
+  tags.list,
+]
+
+describe('Markdown highlighting in the text file editor', () => {
+  it('regression: the KCL editor theme suppresses Markdown highlighting', () => {
+    // The original bug: editorTheme registers the KCL HighlightStyle as a
+    // "main" highlighter, so a Markdown style added with { fallback: true } is
+    // discarded and Markdown tags render unstyled.
+    const cls = classFor(
+      [
+        editorTheme.light,
+        markdown(),
+        syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+      ],
+      tags.heading
+    )
+    expect(cls).toBeNull()
+  })
+
+  it('styles Markdown in light mode', () => {
+    for (const tag of MARKDOWN_TAGS) {
+      const cls = classFor(
+        [editorVisualTheme.light, markdown(), editorMarkdownHighlight.light],
+        tag
+      )
+      expect(
+        cls,
+        `light: expected a highlight class for ${String(tag)}`
+      ).toBeTruthy()
+    }
+  })
+
+  it('styles Markdown in dark mode with its own dark-tuned style', () => {
+    for (const tag of MARKDOWN_TAGS) {
+      const cls = classFor(
+        [editorVisualTheme.dark, markdown(), editorMarkdownHighlight.dark],
+        tag
+      )
+      expect(
+        cls,
+        `dark: expected a highlight class for ${String(tag)}`
+      ).toBeTruthy()
+    }
+  })
+
+  it('the dark Markdown style only activates under the dark theme', () => {
+    // darkMarkdownHighlights has themeType 'dark', so it is gated on
+    // EditorView.darkTheme. Pairing it with the light visual theme yields no
+    // styling — proving dark mode uses a dedicated palette instead of the
+    // light one, which is what made dark mode unreadable before.
+    const cls = classFor(
+      [editorVisualTheme.light, markdown(), editorMarkdownHighlight.dark],
+      tags.heading
+    )
+    expect(cls).toBeNull()
+  })
+
+  it('editorVisualTheme carries no syntax highlighter of its own', () => {
+    // Without a language + highlight style there is nothing to highlight; the
+    // visual theme must not sneak the KCL highlighter back in.
+    expect(classFor([editorVisualTheme.dark], tags.heading)).toBeNull()
+    expect(classFor([editorVisualTheme.light], tags.heading)).toBeNull()
+  })
+})


### PR DESCRIPTION
This is a follow up to [#12417](https://github.com/KittyCAD/modeling-app/pull/12417). The syntax highlighting for markdown files was broken in that PR