### PR TITLE
KCL: Geometry debug tests

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -332,7 +332,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -421,6 +421,12 @@ checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
  "libbz2-rs-sys",
 ]
+
+[[package]]
+name = "camino"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
 
 [[package]]
 name = "cast"
@@ -585,7 +591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1159,7 +1165,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2250,7 +2256,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2457,6 +2463,7 @@ dependencies = [
  "async-trait",
  "base64",
  "bon",
+ "camino",
  "chrono",
  "clap",
  "console_error_panic_hook",
@@ -2653,8 +2660,7 @@ dependencies = [
 [[package]]
 name = "kittycad-modeling-cmds"
 version = "0.2.213"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbe49a08187e35a2ef6429c7eb9eae843334cfeff8f7879e4ad22ff4a0c360e3"
+source = "git+https://github.com/KittyCAD/modeling-api.git?branch=achalmers%2Fkcl-profile-dbg#55c7068796f608895fccc01445eda579265556d8"
 dependencies = [
  "anyhow",
  "bon",
@@ -2685,8 +2691,7 @@ dependencies = [
 [[package]]
 name = "kittycad-modeling-cmds-macros"
 version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb4ba190f74f6d32f4607ecac4bdebd4a935d4943b8ca8369305e6e7a59b5976"
+source = "git+https://github.com/KittyCAD/modeling-api.git?branch=achalmers%2Fkcl-profile-dbg#55c7068796f608895fccc01445eda579265556d8"
 dependencies = [
  "kittycad-modeling-cmds-macros-impl",
  "proc-macro2",
@@ -2697,8 +2702,7 @@ dependencies = [
 [[package]]
 name = "kittycad-modeling-cmds-macros-impl"
 version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743b6533d1848de67e3455a28614a2b7896807ab0d3358ccd3ea1863de3c4e6b"
+source = "git+https://github.com/KittyCAD/modeling-api.git?branch=achalmers%2Fkcl-profile-dbg#55c7068796f608895fccc01445eda579265556d8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4022,7 +4026,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4391,7 +4395,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4404,7 +4408,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5210,7 +5214,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5219,7 +5223,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6243,7 +6247,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -92,7 +92,7 @@ insta = { opt-level = 3 }
 debug = "line-tables-only"
 
 #Example: how to point modeling-app at a different repo (e.g. a branch or a local clone)
-# [patch.crates-io]
+[patch.crates-io]
 # ezpz = { git = "https://github.com/KittyCAD/ezpz.git", branch = "david/circle-circle-tangent" }
-# kittycad-modeling-cmds = { git = "https://github.com/KittyCAD/modeling-api.git", branch = "main" }
+kittycad-modeling-cmds = { git = "https://github.com/KittyCAD/modeling-api.git", branch = "achalmers/kcl-profile-dbg" }
 # kittycad-modeling-cmds = { path = "../../modeling-api/modeling-cmds" }

--- a/rust/kcl-lib/Cargo.toml
+++ b/rust/kcl-lib/Cargo.toml
@@ -151,6 +151,7 @@ web-sys = { version = "0.3.76", features = ["console"] }
 [dev-dependencies]
 approx = "0.5"
 base64 = "0.22.1"
+camino = "1.2.4"
 criterion = { version = "0.8.2", features = ["async_tokio"] }
 expectorate = "1.2.0"
 handlebars = "6.4.1"
@@ -160,6 +161,7 @@ kcl-directory-test-macro = { version = "0.1", path = "../kcl-directory-test-macr
 miette = { version = "7.6.0", features = ["fancy"] }
 pretty_assertions = "1.4.1"
 proptest = { workspace = true }
+tabled = "0.21.0"
 tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "time"] }
 twenty-twenty = "0.8.3"
 

--- a/rust/kcl-lib/src/execution/geometry.rs
+++ b/rust/kcl-lib/src/execution/geometry.rs
@@ -2462,6 +2462,20 @@ pub enum SegmentKind {
     },
 }
 
+impl SegmentKind {
+    /// Should not be used for typechecking or anything,
+    /// but can be used for display in error msgs.
+    pub fn human_friendly_type(&self) -> &'static str {
+        match self {
+            SegmentKind::Point { .. } => "Point ",
+            SegmentKind::Line { .. } => "Line ",
+            SegmentKind::Arc { .. } => "Arc ",
+            SegmentKind::Circle { .. } => "Circle ",
+            SegmentKind::ControlPointSpline { .. } => "ControlPointSpline ",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
 #[ts(export_to = "Geometry.ts")]
 #[serde(rename_all = "camelCase")]

--- a/rust/kcl-lib/src/geo_dbg.rs
+++ b/rust/kcl-lib/src/geo_dbg.rs
@@ -87,20 +87,21 @@ async fn execute_test(test: &Test) {
     };
 
     // Find the sketch ID.
-    let mut sketch_id = String::new();
-    for (k, v) in kcl_object.iter() {
-        if k == "meta" {
-            continue;
-        }
-        let KclValueView::Segment { value } = v else {
-            panic!("Expected {variable_name}.{k} to be a segment");
-        };
-        let crate::execution::SegmentRepr::Solved { segment } = &value.repr else {
-            panic!("Expected {variable_name}.{k} to be solved");
-        };
-        sketch_id = segment.sketch_id.to_string();
-    }
-    let sketch_id = sketch_id;
+    let sketch_id = kcl_object
+        .iter()
+        .find_map(|(k, v)| {
+            if k == "meta" {
+                return None;
+            }
+            let KclValueView::Segment { value } = v else {
+                return None;
+            };
+            let crate::execution::SegmentRepr::Solved { segment } = &value.repr else {
+                return None;
+            };
+            Some(segment.sketch_id.to_string())
+        })
+        .unwrap();
     assert!(sketch_id.is_empty().not());
 
     // Query engine's view of the data.

--- a/rust/kcl-lib/src/geo_dbg.rs
+++ b/rust/kcl-lib/src/geo_dbg.rs
@@ -1,0 +1,300 @@
+use std::ops::Not;
+
+use camino::Utf8Path;
+use camino::Utf8PathBuf;
+use kittycad_modeling_cmds::ModelingCmd;
+use kittycad_modeling_cmds::each_cmd as mcmd;
+use kittycad_modeling_cmds::id::ModelingCmdId;
+use kittycad_modeling_cmds::ok_response::OkModelingCmdResponse;
+use kittycad_modeling_cmds::ok_response::output as mout;
+use kittycad_modeling_cmds::shared::Point2d;
+use kittycad_modeling_cmds::websocket::OkWebSocketResponseData;
+use tabled::Tabled;
+use uuid::Uuid;
+
+use crate::ExecutorContext;
+use crate::KclValueView;
+use crate::SourceRange;
+use crate::execution::Segment;
+use crate::execution::SegmentKind;
+use crate::std::args::TyF64;
+use crate::util::RetryConfig;
+use crate::util::execute_with_retries;
+
+/// A simulation test.
+#[derive(Debug, Clone)]
+struct Test {
+    /// The name of the test.
+    program_name: String,
+    /// The KCL file that's the entry point, e.g. "main.kcl", in the `input_dir`.
+    entry_point: Utf8PathBuf,
+    /// Input KCL files are in this directory.
+    input_dir: Utf8PathBuf,
+    /// Variable name of the profile to interrogate
+    variable_name: String,
+}
+
+impl Test {
+    fn new(program_name: &str, variable_name: &str) -> Self {
+        Self {
+            program_name: program_name.to_owned(),
+            variable_name: variable_name.to_owned(),
+            entry_point: Utf8Path::new("tests").join(program_name).join("input.kcl"),
+            input_dir: Utf8Path::new("tests").join(program_name),
+        }
+    }
+
+    /// Read in the entry point file and return its contents as a string.
+    pub fn read(&self) -> String {
+        std::fs::read_to_string(&self.entry_point)
+            .unwrap_or_else(|e| panic!("Failed to read file: {} due to {e}", self.entry_point))
+    }
+}
+
+async fn execute_test(test: &Test) {
+    println!("Program: {}/{}", test.program_name, test.entry_point);
+    let input = test.read();
+    let ast = crate::Program::parse_no_errs(&input).unwrap();
+
+    // Run the program.
+    let exec_res = execute_with_retries(&RetryConfig::default(), || {
+        crate::test_server::execute_and_snapshot_ast_with_open_context(
+            ast.clone(),
+            Some(test.entry_point.clone().into_std_path_buf()),
+            false,
+        )
+    })
+    .await;
+    let (exec_state, ctx, env_ref, _png, _step) = exec_res.unwrap();
+
+    let (outcome, _module_state, _responses) = exec_state
+        .into_test_exec_outcome(env_ref, &ctx, test.input_dir.as_std_path())
+        .await;
+
+    // Find the sketch in program memory.
+    let mut program_memory = outcome.variables;
+    let variable_name = &test.variable_name;
+    let Some(sketch) = program_memory.shift_remove(variable_name) else {
+        panic!("No variable named {variable_name} found in program memory after execution");
+    };
+    let KclValueView::Object {
+        value: kcl_object,
+        constrainable: _,
+        object_kind: _,
+    } = sketch
+    else {
+        panic!("Expected {variable_name} to be an object");
+    };
+
+    // Find the sketch ID.
+    let mut sketch_id = String::new();
+    for (k, v) in kcl_object.iter() {
+        if k == "meta" {
+            continue;
+        }
+        let KclValueView::Segment { value } = v else {
+            panic!("Expected {variable_name}.{k} to be a segment");
+        };
+        let crate::execution::SegmentRepr::Solved { segment } = &value.repr else {
+            panic!("Expected {variable_name}.{k} to be solved");
+        };
+        sketch_id = segment.sketch_id.to_string();
+    }
+    let sketch_id = sketch_id;
+    assert!(sketch_id.is_empty().not());
+
+    // Query engine's view of the data.
+    let engine_data = query_engine_endpoints(&ctx, sketch_id.parse::<Uuid>().unwrap()).await;
+
+    // Look up all segments.
+    let mut kcl_object_fields: Vec<_> = kcl_object.into_iter().collect();
+    kcl_object_fields.sort_unstable_by(|(k, _v), (k2, _v2)| k.cmp(k2));
+    let mut all_segments: Vec<SegmentDisplay> = Vec::with_capacity(kcl_object_fields.len() * SegmentDisplay::LENGTH);
+    for (k, v) in kcl_object_fields {
+        if k == "meta" {
+            continue;
+        }
+        let KclValueView::Segment { value } = v else {
+            panic!("Expected {variable_name}.{k} to be a segment");
+        };
+        let crate::execution::SegmentRepr::Solved { segment } = value.repr else {
+            panic!("Expected {variable_name}.{k} to be solved");
+        };
+
+        let Some(disp) = segment_kind_display(segment, &k, &engine_data).await else {
+            continue;
+        };
+        all_segments.push(disp);
+    }
+
+    let tbl = {
+        use tabled::Table;
+        use tabled::settings::Style;
+        let mut table = Table::new(all_segments);
+        table.with(Style::sharp());
+        table
+    };
+    println!("Sketch name: {}", variable_name);
+    println!("Sketch ID: {}", sketch_id);
+    println!("Regions: {}", engine_data.region_count);
+    println!("{tbl}");
+    println!("Regions as OBJ:\n{}", engine_data.region_obj);
+    ctx.close().await;
+}
+
+async fn segment_kind_display(
+    segment: Box<Segment>,
+    segment_name: &str,
+    engine_data: &mout::SketchGetInfo,
+) -> Option<SegmentDisplay> {
+    let human_friendly_segment_kind = segment.kind.human_friendly_type();
+    let segment_id = segment.id;
+    let (kcl_start, kcl_end) = match segment.kind {
+        SegmentKind::Point { .. } | SegmentKind::ControlPointSpline { .. } => {
+            return None;
+        }
+        SegmentKind::Line {
+            start,
+            end,
+            construction,
+            ..
+        } => {
+            if construction {
+                return None;
+            }
+            (start, Some(end))
+        }
+        SegmentKind::Arc {
+            start,
+            end,
+            construction,
+            ..
+        } => {
+            if construction {
+                return None;
+            }
+            (start, Some(end))
+        }
+        SegmentKind::Circle {
+            start, construction, ..
+        } => {
+            if construction {
+                return None;
+            }
+            (start, None)
+        }
+    };
+    let engine_curve = engine_data
+        .curves
+        .iter()
+        .find(|curve| curve.id == segment_id.into())
+        .expect("Could not find KCL segment in engine segment list");
+    Some(SegmentDisplay {
+        segment_name: segment_name.to_owned(),
+        segment_kind: human_friendly_segment_kind,
+        segment_id,
+        kcl_start: Some(kcl_start),
+        kcl_end,
+        engine_start: engine_curve.start,
+        engine_end: engine_curve.end,
+        engine_center: engine_curve.center,
+        engine_midpoint: engine_curve.mid,
+    })
+}
+
+async fn query_engine_endpoints(ctx: &ExecutorContext, path_id: Uuid) -> mout::SketchGetInfo {
+    let req_body = mcmd::SketchGetInfo::builder()
+        .path_id(ModelingCmdId::from(path_id))
+        .build();
+    let response = ctx
+        .engine
+        .send_modeling_cmd(
+            &ctx.engine_batch,
+            uuid::Uuid::new_v4(),
+            SourceRange::default(),
+            &ModelingCmd::from(req_body),
+        )
+        .await
+        .unwrap_or_else(|err| panic!("Failed to get engine endpoints for sketch: {err}"));
+    let OkWebSocketResponseData::Modeling {
+        modeling_response: OkModelingCmdResponse::SketchGetInfo(engine_data),
+    } = response
+    else {
+        panic!("Expected SketchGetInfo, got {response:#?}");
+    };
+
+    engine_data
+}
+
+/// Represents all the data we need to display a segment.
+/// Everything a user might care to know about the segment.
+struct SegmentDisplay {
+    segment_name: String,
+    segment_kind: &'static str,
+    segment_id: Uuid,
+    kcl_start: Option<[TyF64; 2]>,
+    kcl_end: Option<[TyF64; 2]>,
+    engine_start: Option<Point2d<f64>>,
+    engine_end: Option<Point2d<f64>>,
+    engine_center: Option<Point2d<f64>>,
+    engine_midpoint: Option<Point2d<f64>>,
+}
+
+impl tabled::Tabled for SegmentDisplay {
+    const LENGTH: usize = 9;
+
+    fn fields(&self) -> Vec<std::borrow::Cow<'_, str>> {
+        vec![
+            self.segment_name.as_str().into(),
+            self.segment_kind.into(),
+            self.segment_id.to_string().into(),
+            print_point(&self.kcl_start).into(),
+            print_point(&self.kcl_end).into(),
+            print_engine_point(&self.engine_start).into(),
+            print_engine_point(&self.engine_end).into(),
+            print_engine_point(&self.engine_center).into(),
+            print_engine_point(&self.engine_midpoint).into(),
+        ]
+    }
+
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec![
+            "Name".into(),
+            "Kind".into(),
+            "ID".into(),
+            "KCL start".into(),
+            "KCL end".into(),
+            "Engine start".into(),
+            "Engine end".into(),
+            "Engine center".into(),
+            "Engine midpoint".into(),
+        ]
+    }
+}
+
+fn print_point(point: &Option<[TyF64; 2]>) -> String {
+    let Some([x, y]) = point else {
+        return String::new();
+    };
+    let x = x.to_mm();
+    let y = y.to_mm();
+    format!("({x}, {y})")
+}
+
+fn print_engine_point(point: &Option<Point2d<f64>>) -> String {
+    match point {
+        None => String::new(),
+        Some(point) => format!("({}, {})", point.x, point.y),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn simple_rectangle() {
+        let test = Test::new("rectangle", "sketch001");
+        execute_test(&test).await;
+    }
+}

--- a/rust/kcl-lib/src/lib.rs
+++ b/rust/kcl-lib/src/lib.rs
@@ -64,6 +64,8 @@ mod execution;
 mod fmt;
 mod frontend;
 mod fs;
+#[cfg(test)]
+mod geo_dbg;
 pub(crate) mod id;
 pub mod lint;
 mod log;

--- a/rust/kcl-lib/src/simulation_tests.rs
+++ b/rust/kcl-lib/src/simulation_tests.rs
@@ -69,7 +69,8 @@ impl Test {
 
 impl ExecState {
     /// Same as [`Self::into_exec_outcome`], but also returns the module state.
-    async fn into_test_exec_outcome(
+    #[cfg(test)]
+    pub(crate) async fn into_test_exec_outcome(
         self,
         main_ref: EnvironmentRef,
         ctx: &ExecutorContext,

--- a/rust/kcl-lib/src/test_server.rs
+++ b/rust/kcl-lib/src/test_server.rs
@@ -91,6 +91,30 @@ pub async fn execute_and_snapshot_ast(
     ),
     ExecErrorWithState,
 > {
+    let result = execute_and_snapshot_ast_with_open_context(ast, current_file, with_export_step).await;
+    if let Ok((_, ctx, _, _, _)) = &result {
+        ctx.close().await;
+    }
+    result
+}
+
+/// Executes a KCL program and takes a snapshot, leaving the returned engine context open.
+/// The caller is responsible for closing the context.
+#[cfg(test)]
+pub(crate) async fn execute_and_snapshot_ast_with_open_context(
+    ast: Program,
+    current_file: Option<PathBuf>,
+    with_export_step: bool,
+) -> Result<
+    (
+        ExecState,
+        ExecutorContext,
+        EnvironmentRef,
+        image::DynamicImage,
+        Option<Vec<u8>>,
+    ),
+    ExecErrorWithState,
+> {
     let ctx = new_context(true, current_file).await?;
     let (exec_state, env, img) = match do_execute_and_snapshot(&ctx, ast).await {
         Ok((exec_state, env_ref, img)) => (exec_state, env_ref, img),
@@ -118,7 +142,6 @@ pub async fn execute_and_snapshot_ast(
 
         step = files.into_iter().next().map(|f| f.contents);
     }
-    ctx.close().await;
     Ok((exec_state, ctx, env, img, step))
 }
 

--- a/rust/kcl-lib/tests/rectangle/input.kcl
+++ b/rust/kcl-lib/tests/rectangle/input.kcl
@@ -1,0 +1,19 @@
+sketch001 = sketch(on = XY) {
+  line1 = line(start = [var -10mm, var -10mm], end = [var 40mm, var -10mm])
+  line2 = line(start = [var 40mm, var -10mm], end = [var 40mm, var 90mm])
+  line3 = line(start = [var 40mm, var 90mm], end = [var -10mm, var 90mm])
+  line4 = line(start = [var -10mm, var 90mm], end = [var -10mm, var -10mm])
+  coincident([line1.end, line2.start])
+  coincident([line2.end, line3.start])
+  coincident([line3.end, line4.start])
+  coincident([line4.end, line1.start])
+  parallel([line2, line4])
+  parallel([line3, line1])
+  perpendicular([line1, line2])
+  horizontal(line3)
+  distance([line1.start, line1.end]) == 50
+  distance([line2.start, line2.end]) == 100
+  verticalDistance([line4.end, ORIGIN]) == 10
+  horizontalDistance([line4.end, ORIGIN]) == 10
+}
+region001 = region(point = [15mm, -9.9975mm], sketch = sketch001)


### PR DESCRIPTION
```
cargo nextest run -p kcl-lib --nocapture -- geo_dbg::tests::simple_rectangle
```

should output data about the profiles in a KCL program, including how they're represented in KCL, in the engine, and in toolpaths.

It looks like this:

<img width="1188" height="335" alt="demo" src="https://github.com/user-attachments/assets/0dc13231-7a9f-470f-b3f1-58bfd8a7925e" />

The OBJ data can be copied into the toolpaths repo and interactively viewed in their debugging tools. 

Once this has been used a bit, and proven to be useful, we'll port it to the CLI. That way customers can use this and send us redacted data, or so that we can run it in a customer environment.

Part of https://github.com/KittyCAD/modeling-app/issues/12477