### PR TITLE
Release kcl 169, part 2 of 2

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -585,7 +585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1159,7 +1159,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2250,7 +2250,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2380,11 +2380,10 @@ dependencies = [
 
 [[package]]
 name = "kcl-error"
-version = "0.2.168"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d588cb20a684680750287aea376875d89fa55feb31177cdd4f94b6973fadbeab"
+version = "0.2.169"
 dependencies = [
  "miette",
+ "pyo3",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -2395,9 +2394,10 @@ dependencies = [
 [[package]]
 name = "kcl-error"
 version = "0.2.169"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b5a1ff4c0d1144670357aa7fdc8b4a8ae32f570a9580904d7850c7ec0ad05d4"
 dependencies = [
  "miette",
- "pyo3",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -2664,7 +2664,7 @@ dependencies = [
  "enum-iterator-derive",
  "euler",
  "http 1.4.2",
- "kcl-error 0.2.168",
+ "kcl-error 0.2.169 (registry+https://github.com/rust-lang/crates.io-index)",
  "kittycad-measurements",
  "kittycad-modeling-cmds-macros",
  "kittycad-unit-conversion-derive",
@@ -4022,7 +4022,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4391,7 +4391,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4404,7 +4404,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5210,7 +5210,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6243,7 +6243,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/rust/README.md
+++ b/rust/README.md
@@ -15,7 +15,11 @@
 4. Push the changes and get your PR approved.
 5. Publish the crates:
     ```bash
-    just publish-kcl {version}
+    just publish-kcl-part1
+    ```
+    Follow the instructions for updating the old crate versions.
+    ```bash
+    just publish-kcl-part2 {version}
     ```
     - This will publish the relevant crates and push a new tag with the prefix
     `kcl-`. DO NOT SET THE PREFIX TO `kcl-` when you run the command. The `just`

--- a/rust/justfile
+++ b/rust/justfile
@@ -89,7 +89,12 @@ bump-kcl-crate-versions bump='patch':
     ./target/debug/kcl-bumper --bump {{ bump }}
     cargo check -p kcl-bumper # this way Cargo.lock gets updated
 
-publish-kcl version:
+publish-kcl-part1:
+    cargo publish -p kcl-error
+    @echo "You should now update the transitive kcl-error dependency and commit this."
+    @echo "    cargo update -p kcl-error@<old-version>"
+
+publish-kcl-part2 version:
     git tag kcl-{{ version }} -m "Release kcl-{{ version }}"
     cargo publish -p kcl-derive-docs
     cargo publish -p kcl-directory-test-macro


### PR DESCRIPTION
Now that we've published the new kcl-error https://github.com/KittyCAD/modeling-app/pull/12458, we update Cargo.lock to use it. Once this is merged, we'll publish the rest of the crates.