### PR TITLE
Fix to not publish kcl-error in publish-part2

### DIFF
--- a/rust/justfile
+++ b/rust/justfile
@@ -98,7 +98,6 @@ publish-kcl-part2 version:
     git tag kcl-{{ version }} -m "Release kcl-{{ version }}"
     cargo publish -p kcl-derive-docs
     cargo publish -p kcl-directory-test-macro
-    cargo publish -p kcl-error
     cargo publish -p kcl-api
     cargo publish -p kcl-syntax
     cargo publish -p kcl-lib


### PR DESCRIPTION
Follow-up to #12459. Publishing kcl-error is moved to publish-part1.