### PR TITLE
Update KCL for optional extrude targets

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1778469574,
-        "narHash": "sha256-NTZzJ7xJvMXOonYqut3WLUhryeZj5QuuL0ANcqS7d30=",
+        "lastModified": 1784091390,
+        "narHash": "sha256-aILAwrBQPhKldL98N8lmsbfst3OPtbMM4vT2VXn40/Y=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "4852a8aa041c94af55e136cde5b8b6d42c3563e8",
+        "rev": "a7887636a3959168bd1ba7ef24a8a70b168dcb56",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
     overlays = [
       (import rust-overlay)
       (self: super: {
-        rustToolchain = super.rust-bin.stable."1.95.0".default.override {
+        rustToolchain = super.rust-bin.stable."1.96.0".default.override {
           targets = ["wasm32-unknown-unknown"];
           extensions = [
             "rustfmt"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2652,9 +2652,9 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.211"
+version = "0.2.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0aadfd54a7843e2dc5852c00dc5da84ae4c4292938fcb4e8f31c04a42b6422"
+checksum = "cbe49a08187e35a2ef6429c7eb9eae843334cfeff8f7879e4ad22ff4a0c360e3"
 dependencies = [
  "anyhow",
  "bon",
@@ -5219,7 +5219,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6243,7 +6243,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -29,7 +29,7 @@ kittycad = { version = "0.4.13", default-features = false, features = [
   "js",
   "requests",
 ] }
-kittycad-modeling-cmds = { version = "0.2.207", features = [
+kittycad-modeling-cmds = { version = "0.2.213", features = [
   "ts-rs",
   "websocket",
 ] }

--- a/rust/kcl-lib/src/execution/artifact.rs
+++ b/rust/kcl-lib/src/execution/artifact.rs
@@ -2177,11 +2177,24 @@ fn artifacts_to_update(
 
             return Ok(cloned_artifacts);
         }
-        ModelingCmd::Extrude(kcmc::Extrude { target, .. })
-        | ModelingCmd::TwistExtrude(kcmc::TwistExtrude { target, .. })
-        | ModelingCmd::Revolve(kcmc::Revolve { target, .. })
-        | ModelingCmd::RevolveAboutEdge(kcmc::RevolveAboutEdge { target, .. })
-        | ModelingCmd::ExtrudeToReference(kcmc::ExtrudeToReference { target, .. }) => {
+        ModelingCmd::Extrude(_)
+        | ModelingCmd::TwistExtrude(_)
+        | ModelingCmd::Revolve(_)
+        | ModelingCmd::RevolveAboutEdge(_)
+        | ModelingCmd::ExtrudeToReference(_) => {
+            let target = match cmd {
+                ModelingCmd::Extrude(kcmc::Extrude {
+                    target: Some(target), ..
+                }) => target,
+                // Reference-based extrusions do not have a path UUID until the
+                // engine resolves their topology payload.
+                ModelingCmd::Extrude(kcmc::Extrude { target: None, .. }) => return Ok(Vec::new()),
+                ModelingCmd::TwistExtrude(kcmc::TwistExtrude { target, .. })
+                | ModelingCmd::Revolve(kcmc::Revolve { target, .. })
+                | ModelingCmd::RevolveAboutEdge(kcmc::RevolveAboutEdge { target, .. })
+                | ModelingCmd::ExtrudeToReference(kcmc::ExtrudeToReference { target, .. }) => target,
+                _ => internal_error!(range, "Sweep-like command variant not handled: id={id:?}, cmd={cmd:?}"),
+            };
             // Determine the resulting method from the specific command, if provided
             let method = match cmd {
                 ModelingCmd::Extrude(kcmc::Extrude { extrude_method, .. }) => *extrude_method,


### PR DESCRIPTION
This updates KCL to use kittycad-modeling-cmds 0.2.213, where an extrude target can be provided as either a legacy UUID or an edge reference.
For now, KCL still only produces extrude commands with a legacy target UUID. This change just updates artifact tracking to handle the optional field safely and unblock the corresponding engine work.
There is no user-facing KCL behavior or signature change here. Passing an edge-specifier object to extrude will continue to return a KCL type error until the follow-up KCL feature is merged.

Needed for https://github.com/KittyCAD/engine/pull/4784 (so we can point kcl-lib and kcl-error back at main)

Follow up from 
https://github.com/KittyCAD/modeling-api/pull/1277

Bigger modeling app changes will come after the engine changes (draft up though https://github.com/KittyCAD/modeling-app/pull/12456)