### PR TITLE
Fix Zookeeper reasoning time after reconnect

### DIFF
--- a/src/components/ExchangeCard.tsx
+++ b/src/components/ExchangeCard.tsx
@@ -425,7 +425,8 @@ export const ResponsesCard = (props: ResponsesCardProp) => {
 }
 
 export const ExchangeCard = (props: ExchangeCardProps) => {
-  let [startedAt] = useState<Date>(new Date())
+  const [mountedAt] = useState<Date>(new Date())
+  let startedAt = props.startedAt ?? mountedAt
   const [updatedAt, setUpdatedAt] = useState<Date | undefined>(undefined)
 
   const [showFullReasoning, setShowFullReasoning] = useState<boolean>(true)

--- a/src/components/ExchangeCard.tsx
+++ b/src/components/ExchangeCard.tsx
@@ -425,8 +425,7 @@ export const ResponsesCard = (props: ResponsesCardProp) => {
 }
 
 export const ExchangeCard = (props: ExchangeCardProps) => {
-  const [mountedAt] = useState<Date>(new Date())
-  let startedAt = props.startedAt ?? mountedAt
+  let [startedAt] = useState<Date>(props.startedAt ?? new Date())
   const [updatedAt, setUpdatedAt] = useState<Date | undefined>(undefined)
 
   const [showFullReasoning, setShowFullReasoning] = useState<boolean>(true)

--- a/src/lib/zookeeper/components/MlEphantConversation.spec.tsx
+++ b/src/lib/zookeeper/components/MlEphantConversation.spec.tsx
@@ -575,6 +575,69 @@ describe('MlEphantConversation', () => {
     }
   )
 
+  test('preserves active reasoning time when reconnect remounts the conversation', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-15T12:20:00.000Z'))
+
+    const conversation: Conversation = {
+      exchanges: [
+        {
+          request: {
+            type: 'user',
+            content: 'Render a detailed assembly',
+          },
+          responses: [
+            {
+              reasoning: {
+                type: 'text',
+                content: 'Checking the assembly constraints...',
+              },
+            },
+          ],
+          deltasAggregated: '',
+          startedAt: new Date('2026-07-15T12:00:00.000Z'),
+        },
+      ],
+    }
+    const renderConversation = (needsReconnect: boolean) => (
+      <MlEphantConversation
+        isLoading={false}
+        conversation={conversation}
+        onProcess={vi.fn()}
+        onClickClearChat={() => {}}
+        onReconnect={() => {}}
+        onCancel={() => {}}
+        needsReconnect={needsReconnect}
+        disabled={needsReconnect}
+        hasPromptCompleted={false}
+        contexts={[]}
+        isProcessing={true}
+        queue={[]}
+        onRemoveFromQueue={() => {}}
+        onSteer={() => {}}
+      />
+    )
+
+    try {
+      const { rerender } = render(renderConversation(false))
+
+      expect(screen.getByText('Reasoned for 20 minutes')).toBeInTheDocument()
+
+      rerender(renderConversation(true))
+      expect(
+        screen.queryByText('Reasoned for 20 minutes')
+      ).not.toBeInTheDocument()
+
+      vi.setSystemTime(new Date('2026-07-15T12:21:00.000Z'))
+      rerender(renderConversation(false))
+
+      expect(screen.getByText('Reasoned for 21 minutes')).toBeInTheDocument()
+    } finally {
+      vi.clearAllTimers()
+      vi.useRealTimers()
+    }
+  })
+
   test('hides the immediate thought when end_of_stream is followed by another response', () => {
     const finalResponse = 'Rendered.'
 

--- a/src/lib/zookeeper/components/MlEphantConversation.spec.tsx
+++ b/src/lib/zookeeper/components/MlEphantConversation.spec.tsx
@@ -50,6 +50,7 @@ vi.mock('@src/lib/screenshot', async (importOriginal) => {
 
 import { Registry } from '@kittycad/registry'
 import { useSignals } from '@preact/signals-react/runtime'
+import { ExchangeCard } from '@src/components/ExchangeCard'
 import { MAKEATHON_ANNOUNCEMENT_DISMISSED_STORAGE_KEY } from '@src/components/MakeathonAnnouncement'
 import { MlEphantConversation } from '@src/lib/zookeeper/components/MlEphantConversation'
 import { takeViewportScreenshot } from '@src/lib/screenshot'
@@ -575,62 +576,31 @@ describe('MlEphantConversation', () => {
     }
   )
 
-  test('preserves active reasoning time when reconnect remounts the conversation', () => {
+  test('preserves active reasoning time when its exchange remounts', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-07-15T12:20:00.000Z'))
 
-    const conversation: Conversation = {
-      exchanges: [
-        {
-          request: {
-            type: 'user',
-            content: 'Render a detailed assembly',
-          },
-          responses: [
-            {
-              reasoning: {
-                type: 'text',
-                content: 'Checking the assembly constraints...',
-              },
-            },
-          ],
-          deltasAggregated: '',
-          startedAt: new Date('2026-07-15T12:00:00.000Z'),
-        },
-      ],
-    }
-    const renderConversation = (needsReconnect: boolean) => (
-      <MlEphantConversation
-        isLoading={false}
-        conversation={conversation}
-        onProcess={vi.fn()}
-        onClickClearChat={() => {}}
-        onReconnect={() => {}}
-        onCancel={() => {}}
-        needsReconnect={needsReconnect}
-        disabled={needsReconnect}
-        hasPromptCompleted={false}
-        contexts={[]}
-        isProcessing={true}
-        queue={[]}
-        onRemoveFromQueue={() => {}}
-        onSteer={() => {}}
-      />
-    )
+    const renderExchange = () =>
+      render(
+        <ExchangeCard
+          request={{ type: 'user', content: 'Render an assembly' }}
+          responses={[
+            { reasoning: { type: 'text', content: 'Checking constraints' } },
+          ]}
+          deltasAggregated=""
+          startedAt={new Date('2026-07-15T12:00:00.000Z')}
+          isLastResponse={true}
+          onClickClearChat={() => {}}
+        />
+      )
 
     try {
-      const { rerender } = render(renderConversation(false))
-
+      const { unmount } = renderExchange()
       expect(screen.getByText('Reasoned for 20 minutes')).toBeInTheDocument()
-
-      rerender(renderConversation(true))
-      expect(
-        screen.queryByText('Reasoned for 20 minutes')
-      ).not.toBeInTheDocument()
+      unmount()
 
       vi.setSystemTime(new Date('2026-07-15T12:21:00.000Z'))
-      rerender(renderConversation(false))
-
+      renderExchange()
       expect(screen.getByText('Reasoned for 21 minutes')).toBeInTheDocument()
     } finally {
       vi.clearAllTimers()

--- a/src/lib/zookeeper/mlEphantManagerMachine.test.ts
+++ b/src/lib/zookeeper/mlEphantManagerMachine.test.ts
@@ -350,16 +350,31 @@ describe('mlEphantManagerMachine', () => {
     it('keeps recoverable context after an abrupt close', async () => {
       const { fetchMock } = stubClientErrorFetch()
       const ws: TestWebSocket = new TestSocket() as TestWebSocket
+      const startedAt = new Date('2026-07-15T12:00:00.000Z')
+      const recoverableConversation: Conversation = {
+        exchanges: completedConversation.exchanges.map((exchange) => ({
+          ...exchange,
+          startedAt,
+        })),
+      }
+      let setupCount = 0
+      let reconnectSetupContext: MlEphantManagerContext | undefined
       const machine = mlEphantManagerMachine.provide({
         actors: {
           [MlEphantManagerStates.Setup]: fromPromise<
             Partial<MlEphantManagerContext>,
             SetupActorInput
-          >(async () => ({
-            ws,
-            conversation: completedConversation,
-            conversationId: 'conversation-id',
-          })),
+          >(async ({ input }) => {
+            setupCount += 1
+            if (setupCount === 2) {
+              reconnectSetupContext = input.context
+            }
+            return {
+              ws,
+              conversation: recoverableConversation,
+              conversationId: 'conversation-id',
+            }
+          }),
         },
       })
       const actor = createActor(machine, {
@@ -394,11 +409,25 @@ describe('mlEphantManagerMachine', () => {
       await waitFor(actor, (state) => state.matches(S.Await))
 
       expect(actor.getSnapshot().context.conversation).toBe(
-        completedConversation
+        recoverableConversation
       )
       expect(actor.getSnapshot().context.conversationId).toBe('conversation-id')
       expect(actor.getSnapshot().context.abruptlyClosed).toBe(true)
       expect(fetchMock).not.toHaveBeenCalled()
+
+      actor.send({
+        type: MlEphantManagerTransitions.CacheSetupAndConnect,
+        refParentSend: vi.fn(),
+        conversationId: 'conversation-id',
+      })
+
+      await waitFor(actor, (state) =>
+        state.matches(MlEphantManagerStates.WaitForContinueCheck)
+      )
+
+      expect(
+        reconnectSetupContext?.cachedSetup?.exchangeStartedAts
+      ).toStrictEqual([startedAt])
 
       actor.stop()
     })

--- a/src/lib/zookeeper/mlEphantManagerMachine.test.ts
+++ b/src/lib/zookeeper/mlEphantManagerMachine.test.ts
@@ -4,6 +4,7 @@ import type { FileMeta } from '@src/lib/types'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  appendReplayMessagesToExchanges,
   type Conversation,
   type MlCopilotModeOption,
   MlEphantConversationToMarkdown,
@@ -143,6 +144,49 @@ describe('mlEphantManagerMachine', () => {
           },
         })
       ).toStrictEqual({ defaultMode: 'standard', modeOptions: [] })
+    })
+  })
+
+  describe('appendReplayMessagesToExchanges', () => {
+    it('restores start times by request order across replay-only exchanges', () => {
+      const firstStartedAt = new Date('2026-07-15T12:00:00.000Z')
+      const secondStartedAt = new Date('2026-07-15T12:10:00.000Z')
+      const exchanges: Conversation['exchanges'] = []
+
+      appendReplayMessagesToExchanges(
+        exchanges,
+        [
+          { type: 'user', content: 'First request' },
+          {
+            end_of_stream: {
+              whole_response: 'First response',
+            },
+          },
+          { info: { text: 'Replay-only notice' } },
+          { type: 'user', content: 'Second request' },
+          {
+            reasoning: {
+              type: 'text',
+              content: 'Still working',
+            },
+          },
+        ],
+        [firstStartedAt, secondStartedAt]
+      )
+
+      expect(
+        exchanges
+          .filter((exchange) => exchange.request)
+          .map((exchange) => exchange.startedAt)
+      ).toStrictEqual([firstStartedAt, secondStartedAt])
+      expect(exchanges.at(-1)?.responses).toStrictEqual([
+        {
+          reasoning: {
+            type: 'text',
+            content: 'Still working',
+          },
+        },
+      ])
     })
   })
 

--- a/src/lib/zookeeper/mlEphantManagerMachine.test.ts
+++ b/src/lib/zookeeper/mlEphantManagerMachine.test.ts
@@ -53,6 +53,7 @@ type SetupActorInput = {
   context: MlEphantManagerContext
 }
 
+const completedConversationStartedAt = new Date('2026-07-15T12:00:00.000Z')
 const completedConversation: Conversation = {
   exchanges: [
     {
@@ -68,6 +69,7 @@ const completedConversation: Conversation = {
           },
         },
       ],
+      startedAt: completedConversationStartedAt,
     },
   ],
 }
@@ -350,28 +352,17 @@ describe('mlEphantManagerMachine', () => {
     it('keeps recoverable context after an abrupt close', async () => {
       const { fetchMock } = stubClientErrorFetch()
       const ws: TestWebSocket = new TestSocket() as TestWebSocket
-      const startedAt = new Date('2026-07-15T12:00:00.000Z')
-      const recoverableConversation: Conversation = {
-        exchanges: completedConversation.exchanges.map((exchange) => ({
-          ...exchange,
-          startedAt,
-        })),
-      }
-      let setupCount = 0
-      let reconnectSetupContext: MlEphantManagerContext | undefined
+      let setupContext: MlEphantManagerContext | undefined
       const machine = mlEphantManagerMachine.provide({
         actors: {
           [MlEphantManagerStates.Setup]: fromPromise<
             Partial<MlEphantManagerContext>,
             SetupActorInput
           >(async ({ input }) => {
-            setupCount += 1
-            if (setupCount === 2) {
-              reconnectSetupContext = input.context
-            }
+            setupContext = input.context
             return {
               ws,
-              conversation: recoverableConversation,
+              conversation: completedConversation,
               conversationId: 'conversation-id',
             }
           }),
@@ -409,7 +400,7 @@ describe('mlEphantManagerMachine', () => {
       await waitFor(actor, (state) => state.matches(S.Await))
 
       expect(actor.getSnapshot().context.conversation).toBe(
-        recoverableConversation
+        completedConversation
       )
       expect(actor.getSnapshot().context.conversationId).toBe('conversation-id')
       expect(actor.getSnapshot().context.abruptlyClosed).toBe(true)
@@ -425,9 +416,9 @@ describe('mlEphantManagerMachine', () => {
         state.matches(MlEphantManagerStates.WaitForContinueCheck)
       )
 
-      expect(
-        reconnectSetupContext?.cachedSetup?.exchangeStartedAts
-      ).toStrictEqual([startedAt])
+      expect(setupContext?.cachedSetup?.activeExchangeStartedAt).toBe(
+        completedConversationStartedAt
+      )
 
       actor.stop()
     })

--- a/src/lib/zookeeper/mlEphantManagerMachine.test.ts
+++ b/src/lib/zookeeper/mlEphantManagerMachine.test.ts
@@ -4,7 +4,6 @@ import type { FileMeta } from '@src/lib/types'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
-  appendReplayMessagesToExchanges,
   type Conversation,
   type MlCopilotModeOption,
   MlEphantConversationToMarkdown,
@@ -144,49 +143,6 @@ describe('mlEphantManagerMachine', () => {
           },
         })
       ).toStrictEqual({ defaultMode: 'standard', modeOptions: [] })
-    })
-  })
-
-  describe('appendReplayMessagesToExchanges', () => {
-    it('restores start times by request order across replay-only exchanges', () => {
-      const firstStartedAt = new Date('2026-07-15T12:00:00.000Z')
-      const secondStartedAt = new Date('2026-07-15T12:10:00.000Z')
-      const exchanges: Conversation['exchanges'] = []
-
-      appendReplayMessagesToExchanges(
-        exchanges,
-        [
-          { type: 'user', content: 'First request' },
-          {
-            end_of_stream: {
-              whole_response: 'First response',
-            },
-          },
-          { info: { text: 'Replay-only notice' } },
-          { type: 'user', content: 'Second request' },
-          {
-            reasoning: {
-              type: 'text',
-              content: 'Still working',
-            },
-          },
-        ],
-        [firstStartedAt, secondStartedAt]
-      )
-
-      expect(
-        exchanges
-          .filter((exchange) => exchange.request)
-          .map((exchange) => exchange.startedAt)
-      ).toStrictEqual([firstStartedAt, secondStartedAt])
-      expect(exchanges.at(-1)?.responses).toStrictEqual([
-        {
-          reasoning: {
-            type: 'text',
-            content: 'Still working',
-          },
-        },
-      ])
     })
   })
 

--- a/src/lib/zookeeper/mlEphantManagerMachine.ts
+++ b/src/lib/zookeeper/mlEphantManagerMachine.ts
@@ -677,27 +677,29 @@ export const mlEphantManagerMachine = setup({
         context.ws?.close()
       }
     },
-    cacheSetup: assign({
-      conversationId: ({ event }) => {
-        assertEvent(event, MlEphantManagerTransitions.CacheSetupAndConnect)
+    prepareSetup: assign(({ context, event }) => {
+      assertEvent(event, MlEphantManagerTransitions.CacheSetupAndConnect)
 
-        if (event.conversationId) {
-          return event.conversationId
-        }
-
-        return undefined
-      },
-      cachedSetup: ({ context, event }) => {
-        assertEvent(event, MlEphantManagerTransitions.CacheSetupAndConnect)
-        return {
+      return {
+        abruptlyClosed: false,
+        lastMessageId: undefined,
+        lastMessageType: undefined,
+        conversation: undefined,
+        conversationId: event.conversationId || undefined,
+        defaultMode: undefined,
+        modeOptions: undefined,
+        awaitingResponse: false,
+        attachmentsLoadedForCurrentPrompt: true,
+        pendingBackendShutdown: false,
+        cachedSetup: {
           refParentSend: event.refParentSend,
           conversationId: event.conversationId,
           activeExchangeStartedAt:
             context.conversation?.exchanges.findLast((exchange) =>
               isMlCopilotUserRequest(exchange.request)
             )?.startedAt ?? context.cachedSetup?.activeExchangeStartedAt,
-        }
-      },
+        },
+      }
     }),
     clearCacheSetup: assign({
       cachedSetup: undefined,
@@ -1204,20 +1206,7 @@ export const mlEphantManagerMachine = setup({
       on: {
         [MlEphantManagerTransitions.CacheSetupAndConnect]: {
           target: MlEphantManagerStates.Setup,
-          actions: [
-            'cacheSetup',
-            assign({
-              abruptlyClosed: false,
-              lastMessageId: undefined,
-              lastMessageType: undefined,
-              conversation: undefined,
-              defaultMode: undefined,
-              modeOptions: undefined,
-              awaitingResponse: false,
-              attachmentsLoadedForCurrentPrompt: true,
-              pendingBackendShutdown: false,
-            }),
-          ],
+          actions: ['prepareSetup'],
         },
         ...transitions([MlEphantManagerStates.Setup]),
       },

--- a/src/lib/zookeeper/mlEphantManagerMachine.ts
+++ b/src/lib/zookeeper/mlEphantManagerMachine.ts
@@ -267,6 +267,11 @@ export interface Exchange {
   // BELOW:
   // An optimization. `delta` messages will be appended here.
   deltasAggregated: string
+
+  // Client-side wall-clock time for an in-progress response. The server only
+  // provides its authoritative start time with `end_of_stream`, so this must
+  // survive reconnect replay while a response is still running.
+  startedAt?: Date
 }
 
 export type Conversation = {
@@ -292,6 +297,7 @@ export interface MlEphantManagerContext {
   cachedSetup?: {
     refParentSend?: (event: MlEphantManagerEvents) => void
     conversationId?: string
+    exchangeStartedAts?: Array<Date | undefined>
   }
 }
 
@@ -673,24 +679,6 @@ export const mlEphantManagerMachine = setup({
         context.ws?.close()
       }
     },
-    cacheSetup: assign({
-      conversationId: ({ event }) => {
-        assertEvent(event, MlEphantManagerTransitions.CacheSetupAndConnect)
-
-        if (event.conversationId) {
-          return event.conversationId
-        }
-
-        return undefined
-      },
-      cachedSetup: ({ event }) => {
-        assertEvent(event, MlEphantManagerTransitions.CacheSetupAndConnect)
-        return {
-          refParentSend: event.refParentSend,
-          conversationId: event.conversationId,
-        }
-      },
-    }),
     clearCacheSetup: assign({
       cachedSetup: undefined,
     }),
@@ -738,6 +726,7 @@ export const mlEphantManagerMachine = setup({
       })
 
       let maybeReplayedExchanges: Exchange[] = []
+      let replayedRequestIndex = 0
       let maybeModeOptions: MlCopilotModeOption[] | undefined
       let maybeDefaultMode: MlCopilotModeId | undefined
       let setupResolved = false
@@ -904,11 +893,17 @@ export const mlEphantManagerMachine = setup({
                   responseReplay.type === 'user'
                 ) {
                   if (isMlCopilotUserRequest(responseReplay)) {
+                    const startedAt =
+                      args.input.context.cachedSetup?.exchangeStartedAts?.[
+                        replayedRequestIndex
+                      ]
                     maybeReplayedExchanges.push({
                       request: responseReplay,
                       responses: [],
                       deltasAggregated: '',
+                      startedAt,
                     })
+                    replayedRequestIndex += 1
                   }
                   continue
                 }
@@ -1064,6 +1059,7 @@ export const mlEphantManagerMachine = setup({
         request,
         responses: [],
         deltasAggregated: '',
+        startedAt: new Date(),
       })
 
       return {
@@ -1188,19 +1184,36 @@ export const mlEphantManagerMachine = setup({
         [MlEphantManagerTransitions.CacheSetupAndConnect]: {
           target: MlEphantManagerStates.Setup,
           actions: [
-            assign({
-              abruptlyClosed: false,
-              lastMessageId: undefined,
-              lastMessageType: undefined,
-              conversation: undefined,
-              conversationId: undefined,
-              defaultMode: undefined,
-              modeOptions: undefined,
-              awaitingResponse: false,
-              attachmentsLoadedForCurrentPrompt: true,
-              pendingBackendShutdown: false,
+            assign(({ context, event }) => {
+              assertEvent(
+                event,
+                MlEphantManagerTransitions.CacheSetupAndConnect
+              )
+
+              const exchangeStartedAts = context.abruptlyClosed
+                ? context.conversation?.exchanges.flatMap((exchange) =>
+                    exchange.request ? [exchange.startedAt] : []
+                  )
+                : undefined
+
+              return {
+                abruptlyClosed: false,
+                lastMessageId: undefined,
+                lastMessageType: undefined,
+                conversation: undefined,
+                conversationId: event.conversationId,
+                defaultMode: undefined,
+                modeOptions: undefined,
+                awaitingResponse: false,
+                attachmentsLoadedForCurrentPrompt: true,
+                pendingBackendShutdown: false,
+                cachedSetup: {
+                  refParentSend: event.refParentSend,
+                  conversationId: event.conversationId,
+                  exchangeStartedAts,
+                },
+              }
             }),
-            'cacheSetup',
           ],
         },
         ...transitions([MlEphantManagerStates.Setup]),
@@ -1256,6 +1269,7 @@ export const mlEphantManagerMachine = setup({
                   cachedSetup: {
                     refParentSend: context.cachedSetup?.refParentSend,
                     conversationId: undefined,
+                    exchangeStartedAts: context.cachedSetup?.exchangeStartedAts,
                   },
                 }
               }
@@ -1265,6 +1279,7 @@ export const mlEphantManagerMachine = setup({
                 cachedSetup: {
                   refParentSend: context.cachedSetup?.refParentSend,
                   conversationId: context.cachedSetup?.conversationId,
+                  exchangeStartedAts: context.cachedSetup?.exchangeStartedAts,
                 },
               }
             }),

--- a/src/lib/zookeeper/mlEphantManagerMachine.ts
+++ b/src/lib/zookeeper/mlEphantManagerMachine.ts
@@ -560,6 +560,55 @@ function isMlCopilotServerMessage(
   return true
 }
 
+export function appendReplayMessagesToExchanges(
+  exchanges: Exchange[],
+  replayMessages: readonly unknown[],
+  exchangeStartedAts: readonly (Date | undefined)[] = []
+) {
+  let replayedRequestIndex = exchanges.filter((exchange) =>
+    isMlCopilotUserRequest(exchange.request)
+  ).length
+
+  for (const responseReplay of replayMessages) {
+    if (!isMlCopilotServerMessage(responseReplay)) continue
+
+    // Don't show deltas because they are aggregated in the end_of_stream.
+    if ('delta' in responseReplay) continue
+
+    if ('type' in responseReplay && responseReplay.type === 'user') {
+      if (isMlCopilotUserRequest(responseReplay)) {
+        exchanges.push({
+          request: responseReplay,
+          responses: [],
+          deltasAggregated: '',
+          startedAt: exchangeStartedAts[replayedRequestIndex],
+        })
+        replayedRequestIndex += 1
+      }
+      continue
+    }
+
+    if ('error' in responseReplay || 'info' in responseReplay) {
+      exchanges.push({
+        responses: [responseReplay],
+        deltasAggregated: '',
+      })
+      continue
+    }
+
+    const lastExchange = exchanges.slice(-1)[0] ?? {
+      responses: [],
+    }
+
+    // Instead we transform an end_of_stream into a delta.
+    if ('end_of_stream' in responseReplay) {
+      lastExchange.deltasAggregated =
+        responseReplay.end_of_stream.whole_response ?? ''
+    }
+    lastExchange.responses.push(responseReplay)
+  }
+}
+
 const hasBeenInterruptedOnLast = (exchanges: Exchange[]) => {
   const lastExchange = exchanges.slice(-1)[0]
   const lastResponse = lastExchange?.responses.slice(-1)[0]
@@ -726,7 +775,6 @@ export const mlEphantManagerMachine = setup({
       })
 
       let maybeReplayedExchanges: Exchange[] = []
-      let replayedRequestIndex = 0
       let maybeModeOptions: MlCopilotModeOption[] | undefined
       let maybeDefaultMode: MlCopilotModeId | undefined
       let setupResolved = false
@@ -876,57 +924,20 @@ export const mlEphantManagerMachine = setup({
             // If it's a replay, we'll unravel it and process as if they are real
             // messages being sent from the server.
             if ('replay' in response) {
+              const replayMessages: unknown[] = []
               for (let byteMessage of response.replay.messages) {
                 const data: Uint8Array = Uint8Array.from(
                   Object.values(byteMessage)
                 )
-                const responseReplay: unknown = Object.freeze(
-                  JSON.parse(new TextDecoder().decode(data))
+                replayMessages.push(
+                  Object.freeze(JSON.parse(new TextDecoder().decode(data)))
                 )
-                if (!isMlCopilotServerMessage(responseReplay)) continue
-
-                // Don't show deltas because they are aggregated in the end_of_stream
-                if ('delta' in responseReplay) continue
-
-                if (
-                  'type' in responseReplay &&
-                  responseReplay.type === 'user'
-                ) {
-                  if (isMlCopilotUserRequest(responseReplay)) {
-                    const startedAt =
-                      args.input.context.cachedSetup?.exchangeStartedAts?.[
-                        replayedRequestIndex
-                      ]
-                    maybeReplayedExchanges.push({
-                      request: responseReplay,
-                      responses: [],
-                      deltasAggregated: '',
-                      startedAt,
-                    })
-                    replayedRequestIndex += 1
-                  }
-                  continue
-                }
-
-                if ('error' in responseReplay || 'info' in responseReplay) {
-                  maybeReplayedExchanges.push({
-                    responses: [responseReplay],
-                    deltasAggregated: '',
-                  })
-                  continue
-                }
-
-                const lastExchange = maybeReplayedExchanges.slice(-1)[0] ?? {
-                  responses: [],
-                }
-
-                // Instead we transform a end_of_stream into a delta!
-                if ('end_of_stream' in responseReplay) {
-                  lastExchange.deltasAggregated =
-                    responseReplay.end_of_stream.whole_response ?? ''
-                }
-                lastExchange.responses.push(responseReplay)
               }
+              appendReplayMessagesToExchanges(
+                maybeReplayedExchanges,
+                replayMessages,
+                args.input.context.cachedSetup?.exchangeStartedAts
+              )
             }
 
             // We're only considered setup when a conversation_id is assigned

--- a/src/lib/zookeeper/mlEphantManagerMachine.ts
+++ b/src/lib/zookeeper/mlEphantManagerMachine.ts
@@ -268,9 +268,7 @@ export interface Exchange {
   // An optimization. `delta` messages will be appended here.
   deltasAggregated: string
 
-  // Client-side wall-clock time for an in-progress response. The server only
-  // provides its authoritative start time with `end_of_stream`, so this must
-  // survive reconnect replay while a response is still running.
+  // Client-side start time for an in-progress response.
   startedAt?: Date
 }
 
@@ -297,7 +295,7 @@ export interface MlEphantManagerContext {
   cachedSetup?: {
     refParentSend?: (event: MlEphantManagerEvents) => void
     conversationId?: string
-    exchangeStartedAts?: Array<Date | undefined>
+    activeExchangeStartedAt?: Date
   }
 }
 
@@ -679,6 +677,28 @@ export const mlEphantManagerMachine = setup({
         context.ws?.close()
       }
     },
+    cacheSetup: assign({
+      conversationId: ({ event }) => {
+        assertEvent(event, MlEphantManagerTransitions.CacheSetupAndConnect)
+
+        if (event.conversationId) {
+          return event.conversationId
+        }
+
+        return undefined
+      },
+      cachedSetup: ({ context, event }) => {
+        assertEvent(event, MlEphantManagerTransitions.CacheSetupAndConnect)
+        return {
+          refParentSend: event.refParentSend,
+          conversationId: event.conversationId,
+          activeExchangeStartedAt:
+            context.conversation?.exchanges.findLast((exchange) =>
+              isMlCopilotUserRequest(exchange.request)
+            )?.startedAt ?? context.cachedSetup?.activeExchangeStartedAt,
+        }
+      },
+    }),
     clearCacheSetup: assign({
       cachedSetup: undefined,
     }),
@@ -875,10 +895,6 @@ export const mlEphantManagerMachine = setup({
             // If it's a replay, we'll unravel it and process as if they are real
             // messages being sent from the server.
             if ('replay' in response) {
-              let replayedRequestIndex = maybeReplayedExchanges.filter(
-                (exchange) => isMlCopilotUserRequest(exchange.request)
-              ).length
-
               for (let byteMessage of response.replay.messages) {
                 const data: Uint8Array = Uint8Array.from(
                   Object.values(byteMessage)
@@ -900,12 +916,7 @@ export const mlEphantManagerMachine = setup({
                       request: responseReplay,
                       responses: [],
                       deltasAggregated: '',
-                      startedAt:
-                        args.input.context.cachedSetup?.exchangeStartedAts?.[
-                          replayedRequestIndex
-                        ],
                     })
-                    replayedRequestIndex += 1
                   }
                   continue
                 }
@@ -934,6 +945,14 @@ export const mlEphantManagerMachine = setup({
             // We're only considered setup when a conversation_id is assigned
             // to us. That means data is being stored and the system is ready.
             if ('conversation_id' in response) {
+              const activeExchange = maybeReplayedExchanges.findLast(
+                (exchange) => isMlCopilotUserRequest(exchange.request)
+              )
+              if (activeExchange) {
+                activeExchange.startedAt =
+                  args.input.context.cachedSetup?.activeExchangeStartedAt
+              }
+
               setupResolved = true
               onFulfilled({
                 abruptlyClosed: false,
@@ -1186,35 +1205,17 @@ export const mlEphantManagerMachine = setup({
         [MlEphantManagerTransitions.CacheSetupAndConnect]: {
           target: MlEphantManagerStates.Setup,
           actions: [
-            assign(({ context, event }) => {
-              assertEvent(
-                event,
-                MlEphantManagerTransitions.CacheSetupAndConnect
-              )
-
-              const exchangeStartedAts = context.abruptlyClosed
-                ? context.conversation?.exchanges.flatMap((exchange) =>
-                    exchange.request ? [exchange.startedAt] : []
-                  )
-                : undefined
-
-              return {
-                abruptlyClosed: false,
-                lastMessageId: undefined,
-                lastMessageType: undefined,
-                conversation: undefined,
-                conversationId: event.conversationId,
-                defaultMode: undefined,
-                modeOptions: undefined,
-                awaitingResponse: false,
-                attachmentsLoadedForCurrentPrompt: true,
-                pendingBackendShutdown: false,
-                cachedSetup: {
-                  refParentSend: event.refParentSend,
-                  conversationId: event.conversationId,
-                  exchangeStartedAts,
-                },
-              }
+            'cacheSetup',
+            assign({
+              abruptlyClosed: false,
+              lastMessageId: undefined,
+              lastMessageType: undefined,
+              conversation: undefined,
+              defaultMode: undefined,
+              modeOptions: undefined,
+              awaitingResponse: false,
+              attachmentsLoadedForCurrentPrompt: true,
+              pendingBackendShutdown: false,
             }),
           ],
         },
@@ -1271,7 +1272,8 @@ export const mlEphantManagerMachine = setup({
                   cachedSetup: {
                     refParentSend: context.cachedSetup?.refParentSend,
                     conversationId: undefined,
-                    exchangeStartedAts: context.cachedSetup?.exchangeStartedAts,
+                    activeExchangeStartedAt:
+                      context.cachedSetup?.activeExchangeStartedAt,
                   },
                 }
               }
@@ -1281,7 +1283,8 @@ export const mlEphantManagerMachine = setup({
                 cachedSetup: {
                   refParentSend: context.cachedSetup?.refParentSend,
                   conversationId: context.cachedSetup?.conversationId,
-                  exchangeStartedAts: context.cachedSetup?.exchangeStartedAts,
+                  activeExchangeStartedAt:
+                    context.cachedSetup?.activeExchangeStartedAt,
                 },
               }
             }),

--- a/src/lib/zookeeper/mlEphantManagerMachine.ts
+++ b/src/lib/zookeeper/mlEphantManagerMachine.ts
@@ -560,55 +560,6 @@ function isMlCopilotServerMessage(
   return true
 }
 
-export function appendReplayMessagesToExchanges(
-  exchanges: Exchange[],
-  replayMessages: readonly unknown[],
-  exchangeStartedAts: readonly (Date | undefined)[] = []
-) {
-  let replayedRequestIndex = exchanges.filter((exchange) =>
-    isMlCopilotUserRequest(exchange.request)
-  ).length
-
-  for (const responseReplay of replayMessages) {
-    if (!isMlCopilotServerMessage(responseReplay)) continue
-
-    // Don't show deltas because they are aggregated in the end_of_stream.
-    if ('delta' in responseReplay) continue
-
-    if ('type' in responseReplay && responseReplay.type === 'user') {
-      if (isMlCopilotUserRequest(responseReplay)) {
-        exchanges.push({
-          request: responseReplay,
-          responses: [],
-          deltasAggregated: '',
-          startedAt: exchangeStartedAts[replayedRequestIndex],
-        })
-        replayedRequestIndex += 1
-      }
-      continue
-    }
-
-    if ('error' in responseReplay || 'info' in responseReplay) {
-      exchanges.push({
-        responses: [responseReplay],
-        deltasAggregated: '',
-      })
-      continue
-    }
-
-    const lastExchange = exchanges.slice(-1)[0] ?? {
-      responses: [],
-    }
-
-    // Instead we transform an end_of_stream into a delta.
-    if ('end_of_stream' in responseReplay) {
-      lastExchange.deltasAggregated =
-        responseReplay.end_of_stream.whole_response ?? ''
-    }
-    lastExchange.responses.push(responseReplay)
-  }
-}
-
 const hasBeenInterruptedOnLast = (exchanges: Exchange[]) => {
   const lastExchange = exchanges.slice(-1)[0]
   const lastResponse = lastExchange?.responses.slice(-1)[0]
@@ -924,20 +875,60 @@ export const mlEphantManagerMachine = setup({
             // If it's a replay, we'll unravel it and process as if they are real
             // messages being sent from the server.
             if ('replay' in response) {
-              const replayMessages: unknown[] = []
+              let replayedRequestIndex = maybeReplayedExchanges.filter(
+                (exchange) => isMlCopilotUserRequest(exchange.request)
+              ).length
+
               for (let byteMessage of response.replay.messages) {
                 const data: Uint8Array = Uint8Array.from(
                   Object.values(byteMessage)
                 )
-                replayMessages.push(
-                  Object.freeze(JSON.parse(new TextDecoder().decode(data)))
+                const responseReplay: unknown = Object.freeze(
+                  JSON.parse(new TextDecoder().decode(data))
                 )
+                if (!isMlCopilotServerMessage(responseReplay)) continue
+
+                // Don't show deltas because they are aggregated in the end_of_stream
+                if ('delta' in responseReplay) continue
+
+                if (
+                  'type' in responseReplay &&
+                  responseReplay.type === 'user'
+                ) {
+                  if (isMlCopilotUserRequest(responseReplay)) {
+                    maybeReplayedExchanges.push({
+                      request: responseReplay,
+                      responses: [],
+                      deltasAggregated: '',
+                      startedAt:
+                        args.input.context.cachedSetup?.exchangeStartedAts?.[
+                          replayedRequestIndex
+                        ],
+                    })
+                    replayedRequestIndex += 1
+                  }
+                  continue
+                }
+
+                if ('error' in responseReplay || 'info' in responseReplay) {
+                  maybeReplayedExchanges.push({
+                    responses: [responseReplay],
+                    deltasAggregated: '',
+                  })
+                  continue
+                }
+
+                const lastExchange = maybeReplayedExchanges.slice(-1)[0] ?? {
+                  responses: [],
+                }
+
+                // Instead we transform a end_of_stream into a delta!
+                if ('end_of_stream' in responseReplay) {
+                  lastExchange.deltasAggregated =
+                    responseReplay.end_of_stream.whole_response ?? ''
+                }
+                lastExchange.responses.push(responseReplay)
               }
-              appendReplayMessagesToExchanges(
-                maybeReplayedExchanges,
-                replayMessages,
-                args.input.context.cachedSetup?.exchangeStartedAts
-              )
             }
 
             // We're only considered setup when a conversation_id is assigned


### PR DESCRIPTION
Fixes #11323

- Record the client-side start time for an active Zookeeper exchange.
- Preserve that timestamp across WebSocket reconnect attempts.
- Restore it onto the active exchange after conversation replay.
- Initialize the reasoning timer from the restored timestamp when the UI remounts.