### PR TITLE
Upgrade to rust toolchain 1.97.1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,7 @@
 # Dependencies
 Cargo.toml                        @KittyCAD/frontend @KittyCAD/kcl
 Cargo.lock                        @KittyCAD/frontend @KittyCAD/kcl
+rust-toolchain.toml               @KittyCAD/frontend @KittyCAD/kcl
 package.json                      @KittyCAD/frontend @KittyCAD/kcl
 package-lock.json                 @KittyCAD/frontend @KittyCAD/kcl
 

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.97.0"
+channel = "1.97.1"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
https://blog.rust-lang.org/2026/07/16/Rust-1.97.1/

I'm also changing the code-owners of this file so that frontend can update and approve it.