### PR TITLE
Try show ZK KCL on reconnection resume

### DIFF
--- a/src/lib/zookeeper/components/MlEphantConversationPaneWrapper.spec.tsx
+++ b/src/lib/zookeeper/components/MlEphantConversationPaneWrapper.spec.tsx
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => {
     zookeeperHistoryRecordingInProgress: false,
     addGlobalHistoryEvent: vi.fn(),
     addGlobalHistoryEventWithCodeChange: vi.fn(),
+    updateCodeEditor: vi.fn(),
   }
 
   return {
@@ -181,6 +182,7 @@ async function flushQueuedWork() {
 describe('MlEphantConversationPaneWrapper', () => {
   test('does not start the next patch-backed Zookeeper edit until the previous editor refresh completes', async () => {
     mocks.systemIOSend.mockClear()
+    mocks.kclManager.updateCodeEditor.mockClear()
     mocks.watchCallback = undefined
 
     render(
@@ -218,6 +220,17 @@ describe('MlEphantConversationPaneWrapper', () => {
 
     // Once the editor refresh has completed, the queued final edit can run.
     firstRequest.onSuccess()
+
+    expect(mocks.kclManager.updateCodeEditor).toHaveBeenCalledWith(
+      'intermediate code',
+      {
+        shouldAddToHistory: false,
+        shouldClearHistory: false,
+        shouldExecute: true,
+        shouldResetCamera: true,
+        shouldWriteToDisk: false,
+      }
+    )
 
     await waitFor(() => expect(mocks.systemIOSend).toHaveBeenCalledTimes(2))
 

--- a/src/lib/zookeeper/components/MlEphantConversationPaneWrapper.spec.tsx
+++ b/src/lib/zookeeper/components/MlEphantConversationPaneWrapper.spec.tsx
@@ -183,6 +183,7 @@ describe('MlEphantConversationPaneWrapper', () => {
   test('does not start the next patch-backed Zookeeper edit until the previous editor refresh completes', async () => {
     mocks.systemIOSend.mockClear()
     mocks.kclManager.updateCodeEditor.mockClear()
+    mocks.kclManager.path = '/workspace/demo/main.kcl'
     mocks.watchCallback = undefined
 
     render(
@@ -239,5 +240,38 @@ describe('MlEphantConversationPaneWrapper', () => {
       requestedFileName: 'main.kcl',
       requestedCode: 'final code',
     })
+  })
+
+  test('does not refresh a file that is no longer active or stall later edits', async () => {
+    mocks.systemIOSend.mockClear()
+    mocks.kclManager.updateCodeEditor.mockClear()
+    mocks.kclManager.path = '/workspace/demo/main.kcl'
+    mocks.watchCallback = undefined
+
+    render(
+      <MlEphantConversationPaneWrapper
+        areaConfig={{ hide: () => false }}
+        layout={{
+          areaType: AreaType.TTC,
+          id: 'zookeeper',
+          label: 'Zookeeper',
+          type: LayoutType.Simple,
+        }}
+        onClose={vi.fn()}
+      />
+    )
+
+    emitZookeeperFileRequest('intermediate code')
+    await waitFor(() => expect(mocks.systemIOSend).toHaveBeenCalledTimes(1))
+
+    const firstRequest = mocks.systemIOSend.mock.calls[0][0].data
+    firstRequest.onFileSystemSuccess()
+    mocks.kclManager.path = '/workspace/demo/other.kcl'
+    firstRequest.onSuccess()
+
+    expect(mocks.kclManager.updateCodeEditor).not.toHaveBeenCalled()
+
+    emitZookeeperFileRequest('final code')
+    await waitFor(() => expect(mocks.systemIOSend).toHaveBeenCalledTimes(2))
   })
 })

--- a/src/lib/zookeeper/components/MlEphantConversationPaneWrapper.tsx
+++ b/src/lib/zookeeper/components/MlEphantConversationPaneWrapper.tsx
@@ -320,6 +320,7 @@ function MlEphantConversationPaneInner(props: AreaTypeComponentProps) {
                             if (
                               shouldRefreshActiveEditor &&
                               activeFileOutput &&
+                              kclManager.path === activeFilePath &&
                               kclManager.code !== activeFileOutput.requestedCode
                             ) {
                               kclManager.updateCodeEditor(

--- a/src/lib/zookeeper/components/MlEphantConversationPaneWrapper.tsx
+++ b/src/lib/zookeeper/components/MlEphantConversationPaneWrapper.tsx
@@ -181,9 +181,8 @@ function MlEphantConversationPaneInner(props: AreaTypeComponentProps) {
           normalizeKCLFileDeletePath(file.requestedFileName) ===
           activeRelativePath
       )
-      const shouldRefreshActiveEditorAfterPlainOutput = Boolean(
-        !shouldRecordZookeeperHistory &&
-          !activeFileDeleted &&
+      const shouldRefreshActiveEditor = Boolean(
+        !activeFileDeleted &&
           activeFileOutput &&
           project?.name === payload.requestedProjectName &&
           activeFilePath === kclManager.path
@@ -315,28 +314,24 @@ function MlEphantConversationPaneInner(props: AreaTypeComponentProps) {
                       settleRequest()
                     },
                     ...(shouldRecordZookeeperHistory ||
-                    (shouldRefreshActiveEditorAfterPlainOutput &&
-                      activeFileOutput)
+                    shouldRefreshActiveEditor
                       ? {
                           onSuccess: () => {
-                            if (shouldRecordZookeeperHistory) {
-                              postWriteCompleted = true
-                              settleRequest()
-                              return
-                            }
-                            if (!activeFileOutput) return
-                            if (kclManager.path !== activeFilePath) return
                             if (
+                              shouldRefreshActiveEditor &&
+                              activeFileOutput &&
                               kclManager.code !== activeFileOutput.requestedCode
                             ) {
                               kclManager.updateCodeEditor(
                                 activeFileOutput.requestedCode,
                                 {
                                   shouldAddToHistory: false,
-                                  shouldClearHistory: true,
+                                  shouldClearHistory:
+                                    !shouldRecordZookeeperHistory,
                                   shouldExecute: true,
                                   shouldResetCamera: true,
-                                  shouldWriteToDisk: true,
+                                  shouldWriteToDisk:
+                                    !shouldRecordZookeeperHistory,
                                 }
                               )
                             }

--- a/src/lib/zookeeper/mlEphantManagerMachine.test.ts
+++ b/src/lib/zookeeper/mlEphantManagerMachine.test.ts
@@ -271,6 +271,9 @@ describe('mlEphantManagerMachine', () => {
       )
 
       expect(actor.getSnapshot().context.awaitingResponse).toBe(true)
+      expect(actor.getSnapshot().context.projectNameCurrentlyOpened).toBe(
+        'zoo-project'
+      )
       expect(ws.sentPayloads).toStrictEqual([
         JSON.stringify({
           type: 'system',

--- a/src/lib/zookeeper/mlEphantManagerMachine.ts
+++ b/src/lib/zookeeper/mlEphantManagerMachine.ts
@@ -1133,6 +1133,7 @@ export const mlEphantManagerMachine = setup({
 
       return {
         awaitingResponse: true,
+        projectNameCurrentlyOpened: event.projectName,
       }
     }),
     [MlEphantManagerTransitions.Cancel]: fromPromise(async function (
@@ -1306,6 +1307,12 @@ export const mlEphantManagerMachine = setup({
             assign({
               awaitingResponse({ event }) {
                 return event.output.awaitingResponse ?? false
+              },
+              projectNameCurrentlyOpened({ context, event }) {
+                return (
+                  event.output.projectNameCurrentlyOpened ??
+                  context.projectNameCurrentlyOpened
+                )
               },
             }),
           ],


### PR DESCRIPTION
## Summary

- Show and execute successful Zookeeper KCL edits immediately instead of waiting for the response to finish, so a disconnect does not leave the editor or 3D model stale.
- Preserve the active project during reconnect so resumed tool outputs are applied.
- Keep edits ordered and recheck the active file after asynchronous writes to avoid refreshing the wrong editor.

## Testing

- Zookeeper unit tests: 28 passed.
- Relevant Zookeeper integration tests: 47 passed.
- Verified the disconnect/reconnect flow in the Vercel preview.