### PR TITLE
Make the regex for externalized playwright deps more strict

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
     ],
     server: {
       deps: {
-        external: [/playwright/],
+        external: [/^playwright(?:\/|$)/, /^@playwright\//],
         inline: [/e2e/, /packages/],
       },
     },


### PR DESCRIPTION
Because the `playwright` layout config started getting picked up too, but it isn't valid.