### PR TITLE
Fix security issues with deps

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"
@@ -4997,9 +4997,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]


### PR DESCRIPTION
Dependabot is currently blocked: #12369.

`anyhow` 1.0.103: https://github.com/dtolnay/anyhow/releases/tag/1.0.103.

`spin` 0.9.8 was yanked. See https://codeberg.org/zesterer/spin/src/branch/v0.9/CHANGELOG.md.