### PR TITLE
KCL: do not warn about sketch1 inside stdlib

### DIFF
--- a/rust/kcl-lib/src/execution/fn_call.rs
+++ b/rust/kcl-lib/src/execution/fn_call.rs
@@ -1872,4 +1872,32 @@ x = f(1)
             "unused deprecated parameter should not warn: {warnings:#?}"
         );
     }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn deprecated_calls_inside_kcl_stdlib_do_not_warn() {
+        let program = include_str!("../../tests/cube_with_hole/input.kcl");
+
+        let result = parse_execute(program).await.unwrap();
+        let warnings = deprecation_warnings(&result);
+        assert!(
+            warnings.is_empty(),
+            "KCL stdlib internals should not emit deprecation warnings: {warnings:#?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn deprecated_stdlib_call_from_user_code_still_warns() {
+        let program = r#"@settings(kclVersion = 2.0)
+plane = startSketchOn(XY)
+"#;
+
+        let result = parse_execute(program).await.unwrap();
+        let warnings = deprecation_warnings(&result);
+        assert_eq!(warnings.len(), 1, "expected one deprecation warning, got {warnings:#?}");
+        assert!(
+            warnings[0].message.contains("`startSketchOn` is deprecated"),
+            "found {}",
+            warnings[0].message
+        );
+    }
 }

--- a/rust/kcl-lib/src/execution/fn_call.rs
+++ b/rust/kcl-lib/src/execution/fn_call.rs
@@ -278,7 +278,9 @@ impl FunctionSource {
         args: Args<Sugary>,
         callsite: SourceRange,
     ) -> Result<Option<KclValueControlFlow>, KclError> {
-        if self.deprecated {
+        // The KCL stdlib is allowed to use deprecated sketch1 functions inside.
+        let warn_on_deprecated_usage = !exec_state.mod_local.inside_stdlib;
+        if warn_on_deprecated_usage && self.deprecated {
             exec_state.warn(
                 CompilationIssue::err(
                     callsite,
@@ -292,7 +294,8 @@ impl FunctionSource {
                 ),
                 annotations::WARN_DEPRECATED,
             );
-        } else if let Some(since) = &self.deprecated_since
+        } else if warn_on_deprecated_usage
+            && let Some(since) = &self.deprecated_since
             && annotations::version_ge(&exec_state.mod_local.settings.kcl_version, since)
         {
             exec_state.warn(
@@ -338,7 +341,9 @@ impl FunctionSource {
             }
             // `deprecated` deprecates the parameter for all versions, whereas
             // `deprecated_since` only deprecates it at or after a given version.
-            let deprecation_suffix = if param.deprecated {
+            let deprecation_suffix = if !warn_on_deprecated_usage {
+                None
+            } else if param.deprecated {
                 Some("is deprecated, see the docs for a recommended replacement".to_owned())
             } else if let Some(since) = &param.deprecated_since
                 && annotations::version_ge(&exec_state.mod_local.settings.kcl_version, since)

--- a/rust/kcl-lib/tests/cube_with_hole/input.kcl
+++ b/rust/kcl-lib/tests/cube_with_hole/input.kcl
@@ -1,0 +1,70 @@
+// Counterbored grid plate
+// 100 mm square plate with a 5 x 5 counterbored hole pattern.
+@settings(kclVersion = 2.0, defaultLengthUnit = mm)
+
+plateLength = 100mm
+plateWidth = 100mm
+plateThickness = 10mm
+
+holeGridCount = 5
+holePitch = 20mm
+holeGridSpan = holePitch * (holeGridCount - 1)
+holeOffset = holeGridSpan / 2
+clearanceHoleDiameter = 5.5mm
+counterboreDiameter = 10mm
+counterboreDepth = 4mm
+throughCutDepth = plateThickness + 1mm
+
+holeCenters = [
+  [-holeOffset, -holeOffset],
+  [-holePitch, -holeOffset],
+  [0mm, -holeOffset],
+  [holePitch, -holeOffset],
+]
+
+plateSketch = sketch(on = XY) {
+  bottomEdge = line(start = [var -50mm, var -50mm], end = [var 50mm, var -50mm])
+  rightEdge = line(start = [var 50mm, var -50mm], end = [var 50mm, var 50mm])
+  topEdge = line(start = [var 50mm, var 50mm], end = [var -50mm, var 50mm])
+  leftEdge = line(start = [var -50mm, var 50mm], end = [var -50mm, var -50mm])
+
+  coincident([bottomEdge.end, rightEdge.start])
+  coincident([rightEdge.end, topEdge.start])
+  coincident([topEdge.end, leftEdge.start])
+  coincident([leftEdge.end, bottomEdge.start])
+
+  horizontal(bottomEdge)
+  vertical(rightEdge)
+  horizontal(topEdge)
+  vertical(leftEdge)
+
+  distance([bottomEdge.start, bottomEdge.end]) == plateLength
+  distance([rightEdge.start, rightEdge.end]) == plateWidth
+  horizontalDistance([bottomEdge.start, ORIGIN]) == plateLength / 2
+  verticalDistance([bottomEdge.start, ORIGIN]) == plateWidth / 2
+}
+
+plateRegion = region(point = [0mm, 0mm], sketch = plateSketch)
+basePlate = extrude(
+  plateRegion,
+  length = plateThickness,
+  tagStart = $bottomFace,
+  tagEnd = $topFace,
+)
+hiddenPlateSketch = hide(plateSketch)
+
+counterboredPlate = hole::holes(
+  basePlate,
+  face = topFace,
+  cutsAt = holeCenters,
+  holeBottom = hole::flat(),
+  holeBody = hole::blind(depth = throughCutDepth, diameter = clearanceHoleDiameter),
+  holeType = hole::counterbore(diameter = counterboreDiameter, depth = counterboreDepth),
+)
+
+finishedPlate = appearance(
+  counterboredPlate,
+  color = "#b8b8b8",
+  metalness = 35,
+  roughness = 32,
+)


### PR DESCRIPTION
Currently the `hole` module in KCL uses sketch1 under the hood. This should not produce any warnings visible to users (or Zookeeper).

First commit adds a failing test, second commit fixes it.

Tyvm @r-barton for reporting and diagnosing the issue.