### PR TITLE
Fix to not fall back to first array element in sketch mode execution

### DIFF
--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -3377,12 +3377,16 @@ impl Node<MemberExpression> {
                 if let Some(value) = value_of_arr {
                     // Indexing into the array was successful.
                     Ok(value.to_owned().continue_())
-                } else if ctx.no_engine_commands().await {
+                } else if ctx.no_engine_commands().await && !exec_state.is_sketch_mode_execution() {
                     // In mock execution, we handle OOB errors
                     // by trying to get index 0. This is because the array value might have
                     // come from the engine, so the array's actual length isn't
                     // known during mock execution runtime. Because it's mock execution
                     // the specific value is hopefully not important.
+                    //
+                    // We don't do this in sketch mode execution since it's
+                    // forbidden from contacting the engine, meaning array
+                    // lengths are always accurate, and the OOB error is real.
                     let value = arr.first();
                     value.map(|value| value.to_owned().continue_()).ok_or(oob_error)
                 } else {

--- a/rust/kcl-lib/src/execution/state.rs
+++ b/rust/kcl-lib/src/execution/state.rs
@@ -92,6 +92,11 @@ pub(super) struct GlobalState {
     pub segment_ids_edited: AhashIndexSet<ObjectId>,
     /// Segment-body drag anchors that temporarily pull a point on a segment toward the cursor.
     pub drag_anchors: Vec<SegmentDragAnchor>,
+    /// True if this execution is sketch mode execution, executing a single
+    /// sketch block. Unlike [`ModuleState::sketch_mode`], this is constant for
+    /// the entire execution, including while executing the body of the sketch
+    /// block being edited.
+    pub sketch_mode: bool,
 }
 
 impl GlobalState {
@@ -432,6 +437,7 @@ impl ExecState {
         let segment_ids_edited = mock_config.segment_ids_edited.clone();
         let mut global = GlobalState::new(&exec_context.settings, segment_ids_edited);
         global.drag_anchors = mock_config.drag_anchors.clone();
+        global.sketch_mode = mock_config.sketch_block_id.is_some();
         ExecState {
             execution_callbacks: exec_context.execution_callbacks.clone(),
             global,
@@ -454,6 +460,7 @@ impl ExecState {
         let segment_ids_edited = mock_config.segment_ids_edited.clone();
         let mut global = GlobalState::new(&exec_context.settings, segment_ids_edited);
         global.drag_anchors = mock_config.drag_anchors.clone();
+        global.sketch_mode = mock_config.sketch_block_id.is_some();
         ExecState {
             execution_callbacks: exec_context.execution_callbacks.clone(),
             global,
@@ -618,6 +625,13 @@ impl ExecState {
                 ModulePath::Local { .. } => true,
                 ModulePath::Std { .. } => false,
             }
+    }
+
+    /// Returns true if this execution is sketch mode execution, executing a
+    /// single sketch block. Unlike [`Self::sketch_mode`], this doesn't vary
+    /// during the execution.
+    pub(crate) fn is_sketch_mode_execution(&self) -> bool {
+        self.global.sketch_mode
     }
 
     pub fn next_object_id(&mut self) -> ObjectId {
@@ -1162,6 +1176,7 @@ impl GlobalState {
             id_to_source: Default::default(),
             segment_ids_edited,
             drag_anchors: Vec::new(),
+            sketch_mode: false,
         };
 
         let root_id = ModuleId::default();

--- a/rust/kcl-lib/src/frontend.rs
+++ b/rust/kcl-lib/src/frontend.rs
@@ -7325,6 +7325,43 @@ sketch(on = XY) {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_edit_constraint_array_index_oob_fails_in_sketch_mode() {
+        let initial_source = "\
+arr = [0]
+sketch(on = XY) {
+  line1 = line(start = [var 0, var 0], end = [var 10, var 0])
+  distance([line1.start, line1.end]) == 10
+}
+";
+        let program = Program::parse(initial_source).unwrap().0.unwrap();
+
+        let mut frontend = FrontendState::new();
+        let mock_ctx = ExecutorContext::new_mock(None).await;
+        let version = Version(0);
+
+        seed_frontend_with_mock(&mut frontend, &mock_ctx, &program).await;
+        let sketch_object = find_first_sketch_object(&frontend.scene_graph).unwrap();
+        let sketch_id = sketch_object.id;
+        let sketch = expect_sketch(sketch_object);
+        let constraint_id = *sketch.constraints.first().expect("expected distance constraint");
+
+        // In sketch mode execution, an out-of-bounds array index is an error.
+        // It should not fall back to the first element of the array the way
+        // plain mock execution does.
+        let err = frontend
+            .edit_constraint(&mock_ctx, version, sketch_id, constraint_id, "arr[5]".to_owned())
+            .await
+            .expect_err("expected out-of-bounds array index to be an error in sketch mode execution");
+        let message = err.error.message();
+        assert!(
+            message.contains("The array doesn't have any item at index 5"),
+            "unexpected error message: {message}"
+        );
+
+        mock_ctx.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_sketch_checkpoint_round_trip_restores_state() {
         let mut frontend = FrontendState::new();
         let ctx = ExecutorContext::new_with_default_client().await.unwrap();


### PR DESCRIPTION
Mock execution is used for validation, and also sketch mode execution. Sketch mode execution is forbidden from contacting the engine, so an array index out of bounds is a real problem that should result in an error.

Follow-up to #12499.
Alternative to #12406.