### PR TITLE
Canonicalize project.toml for cloud sync

### DIFF
--- a/e2e/playwright/named-views.spec.ts-snapshots/verify-named-view-gets-created.toml
+++ b/e2e/playwright/named-views.spec.ts-snapshots/verify-named-view-gets-created.toml
@@ -1,17 +1,17 @@
-default_file = "main.kcl"
 title = "named-views"
+default_file = "main.kcl"
 
 [settings]
 modeling = { }
 
 [settings.app.named_views.0656fb1a-9640-473e-b334-591dc70c0138]
-name = "uuid1"
 eye_offset = 20.907703
 fov_y = 45
 is_ortho = false
+name = "uuid1"
 ortho_scale_enabled = true
 ortho_scale_factor = 1.6
 pivot_position = [ 0, 0, 0 ]
 pivot_rotation = [ 0.4247082, 0.1759199, 0.33985114, 0.8204732 ]
-world_coord_system = "right_handed_up_z"
 version = 1
+world_coord_system = "right_handed_up_z"

--- a/e2e/playwright/named-views.spec.ts-snapshots/verify-named-view-gets-deleted.toml
+++ b/e2e/playwright/named-views.spec.ts-snapshots/verify-named-view-gets-deleted.toml
@@ -1,5 +1,5 @@
-default_file = "main.kcl"
 title = "named-views"
+default_file = "main.kcl"
 
 [settings]
 app = { }

--- a/e2e/playwright/named-views.spec.ts-snapshots/verify-two-named-view-gets-created.toml
+++ b/e2e/playwright/named-views.spec.ts-snapshots/verify-two-named-view-gets-created.toml
@@ -1,29 +1,29 @@
-default_file = "main.kcl"
 title = "named-views"
+default_file = "main.kcl"
 
 [settings]
 modeling = { }
 
 [settings.app.named_views.0656fb1a-9640-473e-b334-591dc70c0138]
-name = "uuid1"
 eye_offset = 20.907703
 fov_y = 45
 is_ortho = false
+name = "uuid1"
 ortho_scale_enabled = true
 ortho_scale_factor = 1.6
 pivot_position = [ 0, 0, 0 ]
 pivot_rotation = [ 0.4247082, 0.1759199, 0.33985114, 0.8204732 ]
-world_coord_system = "right_handed_up_z"
 version = 1
+world_coord_system = "right_handed_up_z"
 
 [settings.app.named_views.c810cf04-c6cc-4a4a-8b11-17bf445dcab7]
-name = "uuid2"
 eye_offset = 608
 fov_y = 45
 is_ortho = false
+name = "uuid2"
 ortho_scale_enabled = true
 ortho_scale_factor = 1.6
 pivot_position = [ 0, 0, 0 ]
 pivot_rotation = [ 0.5, 0.5, 0.5, 0.5 ]
-world_coord_system = "right_handed_up_z"
 version = 1
+world_coord_system = "right_handed_up_z"

--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -20,6 +20,7 @@ import {
 } from '@src/lib/cloudSync/paths'
 import {
   getRemoteProjectTitleForProjectToml,
+  normalizeProjectArchiveFilesForCloudSync,
   parseProjectArchive,
   projectManifestFromFiles,
   projectManifestsEqual,
@@ -318,10 +319,7 @@ export function getCloudSyncConflictCopyCleanupPlan(
 export function filterCloudSyncProjectFilesForSync(
   files: ProjectArchiveFile[]
 ) {
-  const normalizedFiles = files.map((file) => ({
-    ...file,
-    relativePath: normalizeRelativePath(file.relativePath),
-  }))
+  const normalizedFiles = normalizeProjectArchiveFilesForCloudSync(files)
   const gitignoreStack = createGitignoreStackFromFiles(
     normalizedFiles
       .filter((file) => projectNameFromPath(file.relativePath) === '.gitignore')
@@ -680,7 +678,9 @@ async function collectLocalProjectFiles(projectRoot: string) {
     projectRoot
   )
   await walk(projectRoot, gitignoreStack)
-  return files.sort((a, b) => a.relativePath.localeCompare(b.relativePath))
+  return normalizeProjectArchiveFilesForCloudSync(files).sort((a, b) =>
+    a.relativePath.localeCompare(b.relativePath)
+  )
 }
 
 async function replaceLocalProjectWithFiles(

--- a/src/lib/cloudSync/index.test.ts
+++ b/src/lib/cloudSync/index.test.ts
@@ -18,7 +18,11 @@ import {
   projectManifestsEqual,
   shouldCloudSyncAutoSyncLocalProject,
 } from '@src/lib/cloudSync'
-import { withRemoteProjectMetadataInArchiveFiles } from '@src/lib/cloudSync/projectArchive'
+import {
+  normalizeProjectArchiveFilesForCloudSync,
+  projectManifestFromFiles,
+  withRemoteProjectMetadataInArchiveFiles,
+} from '@src/lib/cloudSync/projectArchive'
 import {
   PROJECT_FOLDER,
   PROJECT_IMAGE_NAME,
@@ -33,6 +37,12 @@ function projectFile(relativePath: string, contents = ''): ProjectArchiveFile {
     relativePath,
     data: encoder.encode(contents),
   }
+}
+
+function readProjectFile(files: ProjectArchiveFile[], relativePath: string) {
+  return new TextDecoder().decode(
+    files.find((file) => file.relativePath === relativePath)?.data
+  )
 }
 
 describe('cloudSync sync helpers', () => {
@@ -146,6 +156,40 @@ describe('cloudSync sync helpers', () => {
     expect(payload.body.title).toBe('bracket')
     expect(projectToml).toContain('default_file = "main.kcl"')
     expect(projectToml).toContain('title = "bracket"')
+  })
+
+  it('normalizes project.toml table order before cloud sync upload and manifest hashing', async () => {
+    const localOrderFiles = normalizeProjectArchiveFilesForCloudSync([
+      projectFile('main.kcl', 'cube = 1'),
+      projectFile(
+        PROJECT_SETTINGS_FILE_NAME,
+        'title = "demo-project"\ndefault_file = "main.kcl"\n\n[settings.meta]\nid = "settings-id"\n\n[settings.app]\n[settings.modeling]\n[cloud."dev.zoo.dev"]\nproject_id = "project-123"\n'
+      ),
+    ])
+    const cloudOrderFiles = normalizeProjectArchiveFilesForCloudSync([
+      projectFile('main.kcl', 'cube = 1'),
+      projectFile(
+        PROJECT_SETTINGS_FILE_NAME,
+        'default_file = "main.kcl"\ntitle = "demo-project"\n\n[cloud."dev.zoo.dev"]\nproject_id = "project-123"\n\n[settings.app]\n[settings.meta]\nid = "settings-id"\n\n[settings.modeling]\n'
+      ),
+    ])
+    const uploadPayload = prepareProjectFilesForCloudUpload(
+      '/projects/demo-project',
+      cloudOrderFiles
+    )
+
+    expect(readProjectFile(localOrderFiles, PROJECT_SETTINGS_FILE_NAME)).toBe(
+      readProjectFile(cloudOrderFiles, PROJECT_SETTINGS_FILE_NAME)
+    )
+    expect(
+      readProjectFile(uploadPayload.files, PROJECT_SETTINGS_FILE_NAME)
+    ).toBe(readProjectFile(localOrderFiles, PROJECT_SETTINGS_FILE_NAME))
+    expect(
+      projectManifestsEqual(
+        await projectManifestFromFiles(localOrderFiles),
+        await projectManifestFromFiles(cloudOrderFiles)
+      )
+    ).toBe(true)
   })
 
   it('adds an Untitled project.toml title when remote project metadata has no title', () => {

--- a/src/lib/cloudSync/projectArchive.ts
+++ b/src/lib/cloudSync/projectArchive.ts
@@ -13,6 +13,7 @@ import opfs from '@src/lib/fs-zds/opfs'
 import { webSafePathSplit } from '@src/lib/pathUtils'
 import {
   getProjectTitleFromProjectTomlContents,
+  normalizeProjectTomlContents,
   setCloudProjectIdInProjectTomlContents,
   setProjectTitleInProjectTomlContents,
 } from '@src/lib/projectTomlMetadata'
@@ -31,7 +32,7 @@ export function prepareProjectFilesForCloudUpload(
   files: ProjectArchiveFile[],
   expectedRevision?: Revision
 ) {
-  const normalizedFiles = normalizeProjectArchiveFiles(files)
+  const normalizedFiles = normalizeProjectArchiveFilesForCloudSync(files)
   const entrypointPath = getUploadEntrypointPath(normalizedFiles)
   const projectTomlPath = ensureProjectTomlUploadFile(
     normalizedFiles,
@@ -58,11 +59,22 @@ export function prepareProjectFilesForCloudUpload(
   }
 }
 
-function normalizeProjectArchiveFiles(files: ProjectArchiveFile[]) {
-  return files.map((file) => ({
-    ...file,
-    relativePath: normalizeRelativePath(file.relativePath),
-  }))
+export function normalizeProjectArchiveFilesForCloudSync(
+  files: ProjectArchiveFile[]
+) {
+  return files.map((file) => {
+    const relativePath = normalizeRelativePath(file.relativePath)
+    return {
+      ...file,
+      relativePath,
+      data:
+        relativePath === PROJECT_SETTINGS_FILE_NAME
+          ? new TextEncoder().encode(
+              normalizeProjectTomlContents(new TextDecoder().decode(file.data))
+            )
+          : file.data,
+    }
+  })
 }
 
 function ensureProjectTomlUploadFile(

--- a/src/lib/projectTomlMetadata.test.ts
+++ b/src/lib/projectTomlMetadata.test.ts
@@ -1,12 +1,22 @@
 import {
   getCloudProjectIdFromProjectTomlContents,
   getProjectTitleFromProjectTomlContents,
+  normalizeProjectTomlContents,
   preserveProjectTomlMetadataInProjectSettingsContents,
   removeCloudProjectIdFromProjectTomlContents,
   setCloudProjectIdInProjectTomlContents,
   setProjectTitleInProjectTomlContents,
 } from '@src/lib/projectTomlMetadata'
 import { describe, expect, it } from 'vitest'
+
+function expectOrdered(contents: string, markers: string[]) {
+  let previousIndex = -1
+  for (const marker of markers) {
+    const index = contents.indexOf(marker)
+    expect(index, marker).toBeGreaterThan(previousIndex)
+    previousIndex = index
+  }
+}
 
 describe('projectTomlMetadata', () => {
   it('reads project title from the root title field', () => {
@@ -55,6 +65,24 @@ describe('projectTomlMetadata', () => {
     expect(toml).not.toContain('old-settings-id')
   })
 
+  it('normalizes project metadata table ordering', () => {
+    const localOrder =
+      'title = "demo-project"\ndefault_file = "main.kcl"\n\n[settings.meta]\nid = "settings-id"\n\n[settings.app]\n[settings.modeling]\n[cloud."dev.zoo.dev"]\nproject_id = "project-123"\n'
+    const cloudOrder =
+      'default_file = "main.kcl"\ntitle = "demo-project"\n\n[cloud."dev.zoo.dev"]\nproject_id = "project-123"\n\n[settings.app]\n[settings.meta]\nid = "settings-id"\n\n[settings.modeling]\n'
+    const normalized = normalizeProjectTomlContents(localOrder)
+
+    expect(normalized).toBe(normalizeProjectTomlContents(cloudOrder))
+    expectOrdered(normalized, [
+      'title = "demo-project"',
+      'default_file = "main.kcl"',
+      '[settings.app]',
+      '[settings.meta]',
+      '[settings.modeling]',
+      '[cloud."dev.zoo.dev"]',
+    ])
+  })
+
   it('reads cloud project ids from environment-scoped metadata', () => {
     const toml =
       '[cloud."zoo.dev"]\nproject_id = "project-123"\n\n[cloud."dev.zoo.dev"]\nproject_id = "project-456"\n'
@@ -67,7 +95,7 @@ describe('projectTomlMetadata', () => {
 
   it('writes cloud project ids without dropping project settings', () => {
     const toml = setCloudProjectIdInProjectTomlContents(
-      'title = "Some demo"\ndefault_file = "main.kcl"\n',
+      'title = "Some demo"\ndefault_file = "main.kcl"\n\n[settings.meta]\nid = "settings-id"\n',
       'zoo.dev',
       'project-123'
     )
@@ -77,6 +105,12 @@ describe('projectTomlMetadata', () => {
       'project-123'
     )
     expect(toml).toContain('default_file = "main.kcl"')
+    expectOrdered(toml, [
+      'title = "Some demo"',
+      'default_file = "main.kcl"',
+      '[settings.meta]',
+      '[cloud."zoo.dev"]',
+    ])
   })
 
   it('updates existing cloud project ids for an environment', () => {

--- a/src/lib/projectTomlMetadata.ts
+++ b/src/lib/projectTomlMetadata.ts
@@ -70,9 +70,7 @@ function normalizeTomlValue(value: TomlValue, path: string[]): TomlValue {
     return normalizeTomlTable(value, path)
   }
   if (isArray(value)) {
-    return value.map((item) =>
-      normalizeTomlValue(item as TomlValue, path)
-    ) as TomlValue
+    return value.map((item) => normalizeTomlValue(item, path))
   }
   return value
 }

--- a/src/lib/projectTomlMetadata.ts
+++ b/src/lib/projectTomlMetadata.ts
@@ -31,6 +31,87 @@ function isEmptyTomlTable(value: TomlTable) {
   return Object.keys(value).length === 0
 }
 
+const ROOT_SCALAR_KEY_ORDER = ['title', 'default_file']
+const ROOT_TABLE_KEY_ORDER = ['settings', 'cloud']
+const SETTINGS_TABLE_KEY_ORDER = ['app', 'meta', 'modeling']
+const CLOUD_ENVIRONMENT_SCALAR_KEY_ORDER = ['project_id']
+
+function orderedKeys(keys: string[], preferredKeys: string[]) {
+  return [
+    ...preferredKeys.filter((key) => keys.includes(key)),
+    ...keys
+      .filter((key) => !preferredKeys.includes(key))
+      .toSorted((a, b) => a.localeCompare(b)),
+  ]
+}
+
+function scalarKeyOrderForPath(path: string[]) {
+  if (path.length === 0) {
+    return ROOT_SCALAR_KEY_ORDER
+  }
+  if (path[0] === 'cloud' && path.length === 2) {
+    return CLOUD_ENVIRONMENT_SCALAR_KEY_ORDER
+  }
+  return []
+}
+
+function tableKeyOrderForPath(path: string[]) {
+  if (path.length === 0) {
+    return ROOT_TABLE_KEY_ORDER
+  }
+  if (path.length === 1 && path[0] === 'settings') {
+    return SETTINGS_TABLE_KEY_ORDER
+  }
+  return []
+}
+
+function normalizeTomlValue(value: TomlValue, path: string[]): TomlValue {
+  if (isTomlTable(value)) {
+    return normalizeTomlTable(value, path)
+  }
+  if (isArray(value)) {
+    return value.map((item) =>
+      normalizeTomlValue(item as TomlValue, path)
+    ) as TomlValue
+  }
+  return value
+}
+
+function normalizeTomlTable(table: TomlTable, path: string[] = []) {
+  const nextTable: TomlTable = {}
+  const scalarKeys: string[] = []
+  const tableKeys: string[] = []
+
+  for (const [key, value] of Object.entries(table)) {
+    if (isTomlTable(value)) {
+      tableKeys.push(key)
+    } else {
+      scalarKeys.push(key)
+    }
+  }
+
+  for (const key of orderedKeys(scalarKeys, scalarKeyOrderForPath(path))) {
+    nextTable[key] = normalizeTomlValue(table[key], [...path, key])
+  }
+  for (const key of orderedKeys(tableKeys, tableKeyOrderForPath(path))) {
+    nextTable[key] = normalizeTomlValue(table[key], [...path, key])
+  }
+
+  return nextTable
+}
+
+function stringifyProjectToml(table: TomlTable) {
+  return stringifyToml(normalizeTomlTable(table))
+}
+
+export function normalizeProjectTomlContents(contents: string) {
+  const table = parseProjectToml(contents)
+  if (!table) {
+    return contents
+  }
+  return stringifyProjectToml(table)
+}
+
 export function getProjectTitleFromProjectTomlContents(contents: string) {
   const table = parseProjectToml(contents)
   if (!table) {
@@ -46,7 +127,7 @@ export function setProjectTitleInProjectTomlContents(
 ) {
   const table = parseProjectToml(contents) ?? {}
   table.title = title
-  return stringifyToml(table)
+  return stringifyProjectToml(table)
 }
 
 export function preserveProjectTomlMetadataInProjectSettingsContents(
@@ -55,7 +136,7 @@ export function preserveProjectTomlMetadataInProjectSettingsContents(
 ) {
   const existingTable = parseProjectToml(existingContents)
   if (!existingTable) {
-    return nextProjectSettingsContents
+    return normalizeProjectTomlContents(nextProjectSettingsContents)
   }
 
   const nextTable = parseProjectToml(nextProjectSettingsContents) ?? {}
@@ -65,7 +146,7 @@ export function preserveProjectTomlMetadataInProjectSettingsContents(
     }
   }
 
-  return stringifyToml(nextTable)
+  return stringifyProjectToml(nextTable)
 }
 
 export function setCloudProjectIdInProjectTomlContents(
@@ -86,7 +167,7 @@ export function setCloudProjectIdInProjectTomlContents(
   }
 
   environment.project_id = projectId
-  return stringifyToml(table)
+  return stringifyProjectToml(table)
 }
 
 export function getCloudProjectIdFromProjectTomlContents(
@@ -141,5 +222,5 @@ export function removeCloudProjectIdFromProjectTomlContents(
     delete table.cloud
   }
 
-  return stringifyToml(table)
+  return stringifyProjectToml(table)
 }


### PR DESCRIPTION
## Summary

- Add canonical `project.toml` serialization for project metadata writes.
- Normalize `project.toml` in cloud sync archive file sets before upload and manifest hashing.
- Cover order-only `project.toml` differences so equivalent local/cloud TOML does not produce noisy conflict changes.

## Why

`smol-toml` stringifies tables in JavaScript insertion order, while cloud sync hashes raw file bytes. Different desktop/cloud write paths could produce semantically equivalent `project.toml` files with different table order, which then appeared as changed files and contributed to false-positive cloud conflicts.

## Validation

- `npm run test:unit -- src/lib/projectTomlMetadata.test.ts src/lib/cloudSync/index.test.ts`
- `npm run build:wasm:dev`
- `npm run tsc -- --noEmit`