### PR TITLE
feat(kcl): support string comparison with `==` and `!=`

### DIFF
--- a/docs/kcl-lang/arithmetic.md
+++ b/docs/kcl-lang/arithmetic.md
@@ -18,7 +18,9 @@ KCL supports the usual arithmetic operators on numbers and logic operators on bo
 | `\|` | Logical 'or' |
 | `!` | Unary logical 'not' |
 
-KCL also supports comparsion operators which operate on numbers and produce booleans:
+KCL also supports comparison operators which produce booleans. Ordering
+comparisons operate on numbers, while `==` and `!=` operate on numbers or
+strings:
 
 | Operator | Meaning |
 |----------|---------|
@@ -28,6 +30,9 @@ KCL also supports comparsion operators which operate on numbers and produce bool
 | `>` | Greater than |
 | `<=` | Less than or equal |
 | `>=` | Greater than or equal |
+
+String equality is exact and case-sensitive. It does not perform Unicode
+normalization.
 
 Arithmetics and logic expressions can be arbitrairly combined with the usual rules of associativity and precedence, e.g.,
 

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -3582,21 +3582,6 @@ impl Node<BinaryExpression> {
             });
         }
 
-        // String equality remains an ordinary boolean expression inside sketch
-        // blocks; only non-string `==` reaches constraint handling below.
-        if matches!(self.operator, BinaryOperator::Eq | BinaryOperator::Neq)
-            && let (KclValue::String { value: left, .. }, KclValue::String { value: right, .. }) =
-                (&left_value, &right_value)
-        {
-            let is_equal = left == right;
-            let value = if self.operator == BinaryOperator::Eq {
-                is_equal
-            } else {
-                !is_equal
-            };
-            return Ok(KclValue::Bool { value, meta });
-        }
-
         // Then check if we have solids.
         if self.operator == BinaryOperator::Add || self.operator == BinaryOperator::Or {
             if let (KclValue::Solid { value: left }, KclValue::Solid { value: right }) = (&left_value, &right_value) {
@@ -5207,6 +5192,21 @@ impl Node<BinaryExpression> {
                     )));
                 }
             }
+        }
+
+        // Inside sketch blocks, `==` is reserved for equivalence constraints
+        // and has already been handled above.
+        if matches!(self.operator, BinaryOperator::Eq | BinaryOperator::Neq)
+            && let (KclValue::String { value: left, .. }, KclValue::String { value: right, .. }) =
+                (&left_value, &right_value)
+        {
+            let is_equal = left == right;
+            let value = if self.operator == BinaryOperator::Eq {
+                is_equal
+            } else {
+                !is_equal
+            };
+            return Ok(KclValue::Bool { value, meta });
         }
 
         let left = number_as_f64(&left_value, self.left.clone().into())?;

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -3582,6 +3582,21 @@ impl Node<BinaryExpression> {
             });
         }
 
+        // String equality remains an ordinary boolean expression inside sketch
+        // blocks; only non-string `==` reaches constraint handling below.
+        if matches!(self.operator, BinaryOperator::Eq | BinaryOperator::Neq)
+            && let (KclValue::String { value: left, .. }, KclValue::String { value: right, .. }) =
+                (&left_value, &right_value)
+        {
+            let is_equal = left == right;
+            let value = if self.operator == BinaryOperator::Eq {
+                is_equal
+            } else {
+                !is_equal
+            };
+            return Ok(KclValue::Bool { value, meta });
+        }
+
         // Then check if we have solids.
         if self.operator == BinaryOperator::Add || self.operator == BinaryOperator::Or {
             if let (KclValue::Solid { value: left }, KclValue::Solid { value: right }) = (&left_value, &right_value) {

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -3075,6 +3075,58 @@ shape = layer() |> patternTransform(instances = 10, transform = transform)
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_string_equality_operators() {
+        let composed = "\u{e9}";
+        let decomposed = "e\u{301}";
+        let code = format!(
+            r#"
+equal_same_ascii = "KCL" == "KCL"
+equal_different_case = "KCL" == "kcl"
+not_equal_same_ascii = "KCL" != "KCL"
+not_equal_different_case = "KCL" != "kcl"
+equal_same_unicode = "{composed}" == "{composed}"
+not_equal_same_unicode = "{composed}" != "{composed}"
+equal_without_normalization = "{composed}" == "{decomposed}"
+not_equal_without_normalization = "{composed}" != "{decomposed}"
+"#
+        );
+
+        let result = parse_execute(&code).await.unwrap();
+        for (name, expected) in [
+            ("equal_same_ascii", true),
+            ("equal_different_case", false),
+            ("not_equal_same_ascii", false),
+            ("not_equal_different_case", true),
+            ("equal_same_unicode", true),
+            ("not_equal_same_unicode", false),
+            ("equal_without_normalization", false),
+            ("not_equal_without_normalization", true),
+        ] {
+            assert_eq!(
+                mem_get_json(result.exec_state.stack(), result.mem_env, name)
+                    .as_bool()
+                    .unwrap(),
+                expected,
+                "{name}"
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_string_equality_inside_sketch_block() {
+        let code = r#"
+@settings(experimentalFeatures = allow)
+
+sketch(on = XY) {
+  stringsAreEqual = "KCL" == "KCL"
+  assertIs(stringsAreEqual, error = "expected strings to be equal")
+}
+"#;
+
+        parse_execute(code).await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_math_execute_start_negative() {
         let ast = r#"myVar = -5 + 6"#;
         let result = parse_execute(ast).await.unwrap();

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -3113,17 +3113,30 @@ not_equal_without_normalization = "{composed}" != "{decomposed}"
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_string_equality_inside_sketch_block() {
-        let code = r#"
+    async fn test_string_equality_inside_sketch_block_fails_like_number_equality() {
+        let string_code = r#"
 @settings(experimentalFeatures = allow)
 
 sketch(on = XY) {
   stringsAreEqual = "KCL" == "KCL"
-  assertIs(stringsAreEqual, error = "expected strings to be equal")
+}
+"#;
+        let number_code = r#"
+@settings(experimentalFeatures = allow)
+
+sketch(on = XY) {
+  numbersAreEqual = 1 == 1
 }
 "#;
 
-        parse_execute(code).await.unwrap();
+        assert_eq!(
+            parse_execute(string_code).await.unwrap_err().message(),
+            "Cannot create an equivalence constraint between values of these types: a string and a string"
+        );
+        assert_eq!(
+            parse_execute(number_code).await.unwrap_err().message(),
+            "Cannot create an equivalence constraint between values of these types: a number and a number"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/rust/kcl-lib/src/parsing/ast/types/mod.rs
+++ b/rust/kcl-lib/src/parsing/ast/types/mod.rs
@@ -3611,11 +3611,11 @@ pub enum BinaryOperator {
     #[serde(rename = "^")]
     #[display("^")]
     Pow,
-    /// Are two numbers equal?
+    /// Are two numbers or strings equal?
     #[serde(rename = "==")]
     #[display("==")]
     Eq,
-    /// Are two numbers not equal?
+    /// Are two numbers or strings not equal?
     #[serde(rename = "!=")]
     #[display("!=")]
     Neq,


### PR DESCRIPTION
Allows KCL programs to compare strings with `==` and `!=`

String comparison with `==` and `!=` is case sensitive and without Unicode normalization. Those are followup PRs for a KCL String module.