### PR TITLE
Cut over default projects directory to libraries

### DIFF
--- a/e2e/playwright/native-file-menu.spec.ts
+++ b/e2e/playwright/native-file-menu.spec.ts
@@ -8,6 +8,9 @@ import {
 } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
 import type { Page } from '@playwright/test'
+import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
+
+test.use({ userFeatures: [OPFS_CLOUD_FEATURE_FLAG] })
 
 async function expectNewWindowMenuItem(
   nativeMenu: NativeMenuFixture,

--- a/e2e/playwright/native-file-menu.spec.ts
+++ b/e2e/playwright/native-file-menu.spec.ts
@@ -190,7 +190,7 @@ test.describe(
         await homePage.projectsLoaded()
         await homePage.isNativeFileMenuCreated()
         await nativeMenu.click('Edit.Change project directory')
-        await openSettingsExpectLocator(page, '#projectDirectory')
+        await openSettingsExpectLocator(page, '#libraries')
       })
 
       await test.step('Home.View.Command Palette...', async () => {
@@ -334,7 +334,7 @@ test.describe(
       await test.step('Modeling.Edit.Change project directory', async () => {
         await page.waitForTimeout(250)
         await nativeMenu.click('Edit.Change project directory')
-        await openSettingsExpectLocator(page, '#projectDirectory')
+        await openSettingsExpectLocator(page, '#libraries')
       })
       await test.step('Modeling.View.Orthographic view', async () => {
         await nativeMenu.click('View.Orthographic view')

--- a/e2e/playwright/projects.spec.ts
+++ b/e2e/playwright/projects.spec.ts
@@ -1,6 +1,10 @@
 import nodeFsSync from 'fs'
 import path from 'path'
-import { DEFAULT_PROJECT_KCL_FILE, REGEXP_UUIDV4 } from '@src/lib/constants'
+import {
+  DEFAULT_PROJECT_KCL_FILE,
+  OPFS_CLOUD_FEATURE_FLAG,
+  REGEXP_UUIDV4,
+} from '@src/lib/constants'
 import nodeFs from 'fs/promises'
 import { NIL as uuidNIL } from 'uuid'
 
@@ -1319,113 +1323,117 @@ test(
   }
 )
 
-// desktop-only reason: changing roots in OPFS is not a thing.
-test(
-  'You can change the root projects directory and nothing is lost',
-  {
-    tag: '@desktop',
-  },
-  async ({ page, tronApp, homePage, folderSetupFn }, testInfo) => {
-    if (!tronApp) throw new Error('tronApp is missing.')
+test.describe('project library settings', () => {
+  test.use({ userFeatures: [OPFS_CLOUD_FEATURE_FLAG] })
 
-    await folderSetupFn(async (dir) => {
-      await Promise.all([
-        nodeFs.mkdir(`${dir}/router-template-slate`, { recursive: true }),
-        nodeFs.mkdir(`${dir}/bracket`, { recursive: true }),
-      ])
-      await Promise.all([
-        nodeFs.copyFile(
-          executorInputPath('router-template-slate.kcl'),
-          `${dir}/router-template-slate/main.kcl`
-        ),
-        nodeFs.copyFile(
-          executorInputPath('focusrite_scarlett_mounting_bracket.kcl'),
-          `${dir}/bracket/main.kcl`
-        ),
-      ])
-    })
-    await page.setBodyDimensions({ width: 1200, height: 500 })
+  // desktop-only reason: changing roots in OPFS is not a thing.
+  test(
+    'You can change the root projects directory and nothing is lost',
+    {
+      tag: '@desktop',
+    },
+    async ({ page, tronApp, homePage, folderSetupFn }, testInfo) => {
+      if (!tronApp) throw new Error('tronApp is missing.')
 
-    // we'll grab this from the settings on screen before we switch
-    let originalProjectDirName: string
-    const newProjectDirName = testInfo.outputPath(
-      'electron-test-projects-dir-2'
-    )
-    if (nodeFsSync.existsSync(newProjectDirName)) {
-      await nodeFs.rm(newProjectDirName, { recursive: true })
+      await folderSetupFn(async (dir) => {
+        await Promise.all([
+          nodeFs.mkdir(`${dir}/router-template-slate`, { recursive: true }),
+          nodeFs.mkdir(`${dir}/bracket`, { recursive: true }),
+        ])
+        await Promise.all([
+          nodeFs.copyFile(
+            executorInputPath('router-template-slate.kcl'),
+            `${dir}/router-template-slate/main.kcl`
+          ),
+          nodeFs.copyFile(
+            executorInputPath('focusrite_scarlett_mounting_bracket.kcl'),
+            `${dir}/bracket/main.kcl`
+          ),
+        ])
+      })
+      await page.setBodyDimensions({ width: 1200, height: 500 })
+
+      // we'll grab this from the settings on screen before we switch
+      let originalProjectDirName: string
+      const newProjectDirName = testInfo.outputPath(
+        'electron-test-projects-dir-2'
+      )
+      if (nodeFsSync.existsSync(newProjectDirName)) {
+        await nodeFs.rm(newProjectDirName, { recursive: true })
+      }
+
+      await homePage.projectsLoaded()
+
+      await test.step('We can change the root project directory', async () => {
+        // expect to see the project directory settings link
+        await expect(
+          page.getByTestId('project-directory-settings-link')
+        ).toBeVisible()
+
+        await page.getByTestId('project-directory-settings-link').click()
+
+        await expect(page.getByTestId('project-directory-button')).toBeVisible()
+        originalProjectDirName = await page
+          .getByTestId('project-directory-input')
+          .inputValue()
+
+        const handleFile = tronApp.electron.evaluate(
+          async ({ dialog }, filePaths) => {
+            dialog.showOpenDialog = () =>
+              Promise.resolve({ canceled: false, filePaths })
+          },
+          [newProjectDirName]
+        )
+        await page.getByTestId('project-directory-button').click()
+        await handleFile
+
+        await expect
+          .poll(() => page.getByTestId('project-directory-input').inputValue())
+          .toContain(newProjectDirName)
+
+        await page.getByTestId('settings-close-button').click()
+
+        await homePage.projectsLoaded()
+
+        await expect(page.getByText('No projects found')).toBeVisible()
+        await createProject({ name: 'project-000', page, returnHome: true })
+        await expect(
+          page.getByTestId('project-link').filter({ hasText: 'project-000' })
+        ).toBeVisible()
+      })
+
+      await test.step('We can change back to the original root project directory', async () => {
+        await expect(
+          page.getByTestId('project-directory-settings-link')
+        ).toBeVisible()
+
+        await page.getByTestId('project-directory-settings-link').click()
+
+        const handleFile = tronApp.electron.evaluate(
+          async ({ dialog }, filePaths) => {
+            dialog.showOpenDialog = () =>
+              Promise.resolve({ canceled: false, filePaths })
+          },
+          [originalProjectDirName]
+        )
+        await expect(page.getByTestId('project-directory-button')).toBeVisible()
+
+        await page.getByTestId('project-directory-button').click()
+        await handleFile
+
+        await homePage.projectsLoaded()
+        await expect(page.getByTestId('project-directory-input')).toHaveValue(
+          originalProjectDirName
+        )
+
+        await page.getByTestId('settings-close-button').click()
+
+        await expect(page.getByText('bracket')).toBeVisible()
+        await expect(page.getByText('router-template-slate')).toBeVisible()
+      })
     }
-
-    await homePage.projectsLoaded()
-
-    await test.step('We can change the root project directory', async () => {
-      // expect to see the project directory settings link
-      await expect(
-        page.getByTestId('project-directory-settings-link')
-      ).toBeVisible()
-
-      await page.getByTestId('project-directory-settings-link').click()
-
-      await expect(page.getByTestId('project-directory-button')).toBeVisible()
-      originalProjectDirName = await page
-        .getByTestId('project-directory-input')
-        .inputValue()
-
-      const handleFile = tronApp.electron.evaluate(
-        async ({ dialog }, filePaths) => {
-          dialog.showOpenDialog = () =>
-            Promise.resolve({ canceled: false, filePaths })
-        },
-        [newProjectDirName]
-      )
-      await page.getByTestId('project-directory-button').click()
-      await handleFile
-
-      await expect
-        .poll(() => page.getByTestId('project-directory-input').inputValue())
-        .toContain(newProjectDirName)
-
-      await page.getByTestId('settings-close-button').click()
-
-      await homePage.projectsLoaded()
-
-      await expect(page.getByText('No projects found')).toBeVisible()
-      await createProject({ name: 'project-000', page, returnHome: true })
-      await expect(
-        page.getByTestId('project-link').filter({ hasText: 'project-000' })
-      ).toBeVisible()
-    })
-
-    await test.step('We can change back to the original root project directory', async () => {
-      await expect(
-        page.getByTestId('project-directory-settings-link')
-      ).toBeVisible()
-
-      await page.getByTestId('project-directory-settings-link').click()
-
-      const handleFile = tronApp.electron.evaluate(
-        async ({ dialog }, filePaths) => {
-          dialog.showOpenDialog = () =>
-            Promise.resolve({ canceled: false, filePaths })
-        },
-        [originalProjectDirName]
-      )
-      await expect(page.getByTestId('project-directory-button')).toBeVisible()
-
-      await page.getByTestId('project-directory-button').click()
-      await handleFile
-
-      await homePage.projectsLoaded()
-      await expect(page.getByTestId('project-directory-input')).toHaveValue(
-        originalProjectDirName
-      )
-
-      await page.getByTestId('settings-close-button').click()
-
-      await expect(page.getByText('bracket')).toBeVisible()
-      await expect(page.getByText('router-template-slate')).toBeVisible()
-    })
-  }
-)
+  )
+})
 
 test(
   'Search projects on desktop home',

--- a/e2e/playwright/projects.spec.ts
+++ b/e2e/playwright/projects.spec.ts
@@ -1367,7 +1367,7 @@ test(
 
       await expect(page.getByTestId('project-directory-button')).toBeVisible()
       originalProjectDirName = await page
-        .locator('section#projectDirectory input')
+        .getByTestId('project-directory-input')
         .inputValue()
 
       const handleFile = tronApp.electron.evaluate(
@@ -1381,7 +1381,7 @@ test(
       await handleFile
 
       await expect
-        .poll(() => page.locator('section#projectDirectory input').inputValue())
+        .poll(() => page.getByTestId('project-directory-input').inputValue())
         .toContain(newProjectDirName)
 
       await page.getByTestId('settings-close-button').click()
@@ -1415,7 +1415,7 @@ test(
       await handleFile
 
       await homePage.projectsLoaded()
-      await expect(page.locator('section#projectDirectory input')).toHaveValue(
+      await expect(page.getByTestId('project-directory-input')).toHaveValue(
         originalProjectDirName
       )
 

--- a/e2e/playwright/projects.spec.ts
+++ b/e2e/playwright/projects.spec.ts
@@ -1,10 +1,6 @@
 import nodeFsSync from 'fs'
 import path from 'path'
-import {
-  DEFAULT_PROJECT_KCL_FILE,
-  OPFS_CLOUD_FEATURE_FLAG,
-  REGEXP_UUIDV4,
-} from '@src/lib/constants'
+import { DEFAULT_PROJECT_KCL_FILE, REGEXP_UUIDV4 } from '@src/lib/constants'
 import nodeFs from 'fs/promises'
 import { NIL as uuidNIL } from 'uuid'
 
@@ -1323,117 +1319,113 @@ test(
   }
 )
 
-test.describe('project library settings', () => {
-  test.use({ userFeatures: [OPFS_CLOUD_FEATURE_FLAG] })
+// desktop-only reason: changing roots in OPFS is not a thing.
+test(
+  'You can change the root projects directory and nothing is lost',
+  {
+    tag: '@desktop',
+  },
+  async ({ page, tronApp, homePage, folderSetupFn }, testInfo) => {
+    if (!tronApp) throw new Error('tronApp is missing.')
 
-  // desktop-only reason: changing roots in OPFS is not a thing.
-  test(
-    'You can change the root projects directory and nothing is lost',
-    {
-      tag: '@desktop',
-    },
-    async ({ page, tronApp, homePage, folderSetupFn }, testInfo) => {
-      if (!tronApp) throw new Error('tronApp is missing.')
+    await folderSetupFn(async (dir) => {
+      await Promise.all([
+        nodeFs.mkdir(`${dir}/router-template-slate`, { recursive: true }),
+        nodeFs.mkdir(`${dir}/bracket`, { recursive: true }),
+      ])
+      await Promise.all([
+        nodeFs.copyFile(
+          executorInputPath('router-template-slate.kcl'),
+          `${dir}/router-template-slate/main.kcl`
+        ),
+        nodeFs.copyFile(
+          executorInputPath('focusrite_scarlett_mounting_bracket.kcl'),
+          `${dir}/bracket/main.kcl`
+        ),
+      ])
+    })
+    await page.setBodyDimensions({ width: 1200, height: 500 })
 
-      await folderSetupFn(async (dir) => {
-        await Promise.all([
-          nodeFs.mkdir(`${dir}/router-template-slate`, { recursive: true }),
-          nodeFs.mkdir(`${dir}/bracket`, { recursive: true }),
-        ])
-        await Promise.all([
-          nodeFs.copyFile(
-            executorInputPath('router-template-slate.kcl'),
-            `${dir}/router-template-slate/main.kcl`
-          ),
-          nodeFs.copyFile(
-            executorInputPath('focusrite_scarlett_mounting_bracket.kcl'),
-            `${dir}/bracket/main.kcl`
-          ),
-        ])
-      })
-      await page.setBodyDimensions({ width: 1200, height: 500 })
+    // we'll grab this from the settings on screen before we switch
+    let originalProjectDirName: string
+    const newProjectDirName = testInfo.outputPath(
+      'electron-test-projects-dir-2'
+    )
+    if (nodeFsSync.existsSync(newProjectDirName)) {
+      await nodeFs.rm(newProjectDirName, { recursive: true })
+    }
 
-      // we'll grab this from the settings on screen before we switch
-      let originalProjectDirName: string
-      const newProjectDirName = testInfo.outputPath(
-        'electron-test-projects-dir-2'
+    await homePage.projectsLoaded()
+
+    await test.step('We can change the root project directory', async () => {
+      // expect to see the project directory settings link
+      await expect(
+        page.getByTestId('project-directory-settings-link')
+      ).toBeVisible()
+
+      await page.getByTestId('project-directory-settings-link').click()
+
+      await expect(page.getByTestId('project-directory-button')).toBeVisible()
+      originalProjectDirName = await page
+        .getByTestId('project-directory-input')
+        .inputValue()
+
+      const handleFile = tronApp.electron.evaluate(
+        async ({ dialog }, filePaths) => {
+          dialog.showOpenDialog = () =>
+            Promise.resolve({ canceled: false, filePaths })
+        },
+        [newProjectDirName]
       )
-      if (nodeFsSync.existsSync(newProjectDirName)) {
-        await nodeFs.rm(newProjectDirName, { recursive: true })
-      }
+      await page.getByTestId('project-directory-button').click()
+      await handleFile
+
+      await expect
+        .poll(() => page.getByTestId('project-directory-input').inputValue())
+        .toContain(newProjectDirName)
+
+      await page.getByTestId('settings-close-button').click()
 
       await homePage.projectsLoaded()
 
-      await test.step('We can change the root project directory', async () => {
-        // expect to see the project directory settings link
-        await expect(
-          page.getByTestId('project-directory-settings-link')
-        ).toBeVisible()
+      await expect(page.getByText('No projects found')).toBeVisible()
+      await createProject({ name: 'project-000', page, returnHome: true })
+      await expect(
+        page.getByTestId('project-link').filter({ hasText: 'project-000' })
+      ).toBeVisible()
+    })
 
-        await page.getByTestId('project-directory-settings-link').click()
+    await test.step('We can change back to the original root project directory', async () => {
+      await expect(
+        page.getByTestId('project-directory-settings-link')
+      ).toBeVisible()
 
-        await expect(page.getByTestId('project-directory-button')).toBeVisible()
-        originalProjectDirName = await page
-          .getByTestId('project-directory-input')
-          .inputValue()
+      await page.getByTestId('project-directory-settings-link').click()
 
-        const handleFile = tronApp.electron.evaluate(
-          async ({ dialog }, filePaths) => {
-            dialog.showOpenDialog = () =>
-              Promise.resolve({ canceled: false, filePaths })
-          },
-          [newProjectDirName]
-        )
-        await page.getByTestId('project-directory-button').click()
-        await handleFile
+      const handleFile = tronApp.electron.evaluate(
+        async ({ dialog }, filePaths) => {
+          dialog.showOpenDialog = () =>
+            Promise.resolve({ canceled: false, filePaths })
+        },
+        [originalProjectDirName]
+      )
+      await expect(page.getByTestId('project-directory-button')).toBeVisible()
 
-        await expect
-          .poll(() => page.getByTestId('project-directory-input').inputValue())
-          .toContain(newProjectDirName)
+      await page.getByTestId('project-directory-button').click()
+      await handleFile
 
-        await page.getByTestId('settings-close-button').click()
+      await homePage.projectsLoaded()
+      await expect(page.getByTestId('project-directory-input')).toHaveValue(
+        originalProjectDirName
+      )
 
-        await homePage.projectsLoaded()
+      await page.getByTestId('settings-close-button').click()
 
-        await expect(page.getByText('No projects found')).toBeVisible()
-        await createProject({ name: 'project-000', page, returnHome: true })
-        await expect(
-          page.getByTestId('project-link').filter({ hasText: 'project-000' })
-        ).toBeVisible()
-      })
-
-      await test.step('We can change back to the original root project directory', async () => {
-        await expect(
-          page.getByTestId('project-directory-settings-link')
-        ).toBeVisible()
-
-        await page.getByTestId('project-directory-settings-link').click()
-
-        const handleFile = tronApp.electron.evaluate(
-          async ({ dialog }, filePaths) => {
-            dialog.showOpenDialog = () =>
-              Promise.resolve({ canceled: false, filePaths })
-          },
-          [originalProjectDirName]
-        )
-        await expect(page.getByTestId('project-directory-button')).toBeVisible()
-
-        await page.getByTestId('project-directory-button').click()
-        await handleFile
-
-        await homePage.projectsLoaded()
-        await expect(page.getByTestId('project-directory-input')).toHaveValue(
-          originalProjectDirName
-        )
-
-        await page.getByTestId('settings-close-button').click()
-
-        await expect(page.getByText('bracket')).toBeVisible()
-        await expect(page.getByText('router-template-slate')).toBeVisible()
-      })
-    }
-  )
-})
+      await expect(page.getByText('bracket')).toBeVisible()
+      await expect(page.getByText('router-template-slate')).toBeVisible()
+    })
+  }
+)
 
 test(
   'Search projects on desktop home',

--- a/src/components/Settings/AllSettingsFields.tsx
+++ b/src/components/Settings/AllSettingsFields.tsx
@@ -1,4 +1,5 @@
 import { ActionButton } from '@src/components/ActionButton'
+import type { Feature } from '@kittycad/lib'
 import { SettingsFieldInput } from '@src/components/Settings/SettingsFieldInput'
 import { SettingsSection } from '@src/components/Settings/SettingsSection'
 import { useAbsoluteFilePath } from '@src/hooks/useAbsoluteFilePath'
@@ -24,6 +25,7 @@ import {
 } from '@src/lib/settings/settingsUtils'
 import { reportRejection } from '@src/lib/trap'
 import { capitaliseFC, toSync } from '@src/lib/utils'
+import { userFeaturesContextHas } from '@src/machines/userFeaturesMachine'
 import { acceptOnboarding } from '@src/routes/Onboarding/utils'
 import { APP_VERSION, getReleaseUrl } from '@src/routes/utils'
 import type { ForwardedRef } from 'react'
@@ -42,11 +44,14 @@ export const AllSettingsFields = forwardRef(
     { searchParamTab, isFileSettings }: AllSettingsFieldsProps,
     scrollRef: ForwardedRef<HTMLDivElement>
   ) => {
-    const { settings, layout, systemIOActor } = useApp()
+    const { settings, layout, systemIOActor, userFeatures } = useApp()
     const { kclManager } = useSingletons()
     const location = useLocation()
     const navigate = useNavigate()
     const context = settings.useSettings()
+    const userFeaturesContext = userFeatures.useContext()
+    const hasFeature = (feature: Feature) =>
+      userFeaturesContextHas(userFeaturesContext, feature, false)
     const executingPath = useAbsoluteFilePath()
 
     const projectPath = useMemo(() => {
@@ -85,7 +90,8 @@ export const AllSettingsFields = forwardRef(
             .filter(([_, categorySettings]) =>
               // Filter out categories that don't have any non-hidden settings
               Object.values(categorySettings).some(
-                (setting) => !shouldHideSetting(setting, searchParamTab)
+                (setting) =>
+                  !shouldHideSetting(setting, searchParamTab, hasFeature)
               )
             )
             .map(([category, categorySettings]) => (
@@ -98,7 +104,7 @@ export const AllSettingsFields = forwardRef(
                 </h2>
                 {Object.entries(categorySettings)
                   .filter((item: [string, Setting<unknown>]) =>
-                    shouldShowSettingInput(item[1], searchParamTab)
+                    shouldShowSettingInput(item[1], searchParamTab, hasFeature)
                   )
                   .map(([settingName, s]) => {
                     const setting = s as Setting

--- a/src/components/Settings/SettingsSearchBar.tsx
+++ b/src/components/Settings/SettingsSearchBar.tsx
@@ -1,21 +1,22 @@
 import { Combobox } from '@headlessui/react'
+import type { Feature } from '@kittycad/lib'
 import { useSignalEffect } from '@preact/signals-react'
 import { useSignals } from '@preact/signals-react/runtime'
 import { getKeybindingRows } from '@src/components/Settings/keybindingRows'
 import Fuse from 'fuse.js'
-import { useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { CustomIcon } from '@src/components/CustomIcon'
 import { noAutofillInputProps } from '@src/lib/autofill'
 import { useApp } from '@src/lib/boot'
-import { isDesktop } from '@src/lib/isDesktop'
 import { settingsSearchFocusRequest } from '@src/lib/searchFocusRequests'
 import type { SettingsLevel } from '@src/lib/settings/settingsTypes'
 import {
   formatSettingsLabel,
-  hiddenOnPlatform,
+  shouldHideSetting,
 } from '@src/lib/settings/settingsUtils'
+import { userFeaturesContextHas } from '@src/machines/userFeaturesMachine'
 import {
   KEYMAP_SCHEMA_VERSION,
   type KeymapScope,
@@ -45,7 +46,7 @@ export function SettingsSearchBar({
   hasOpenProject,
 }: SettingsSearchBarProps) {
   useSignals()
-  const { settings, registry } = useApp()
+  const { settings, registry, userFeatures } = useApp()
   const keymap = registry.optional(keymapService)
   const contributedKeymap = registry.signal(keymapValueSpec).value
   const persistedKeymap = keymap?.persistedKeymap.value ?? {
@@ -70,6 +71,12 @@ export function SettingsSearchBar({
   const navigate = useNavigate()
   const [query, setQuery] = useState('')
   const settingsValues = settings.useSettings()
+  const userFeaturesContext = userFeatures.useContext()
+  const hasFeature = useCallback(
+    (feature: Feature) =>
+      userFeaturesContextHas(userFeaturesContext, feature, false),
+    [userFeaturesContext]
+  )
   const settingsAsSearchable: SettingsSearchItem[] = useMemo(
     () => [
       ...Object.entries(settingsValues).flatMap(
@@ -81,9 +88,7 @@ export function SettingsSearchBar({
                 ? (['project', 'user'] satisfies SettingsLevel[])
                 : (['user'] satisfies SettingsLevel[])
             )
-              .filter(
-                (l) => s.hideOnLevel !== l && !hiddenOnPlatform(s, isDesktop())
-              )
+              .filter((l) => !shouldHideSetting(s, l, hasFeature))
               .map((l) => ({
                 category: formatSettingsLabel(category),
                 name: settingName,
@@ -107,7 +112,7 @@ export function SettingsSearchBar({
           }) satisfies SettingsSearchItem
       ),
     ],
-    [settingsValues, keybindingRows, keymapScopes, hasOpenProject]
+    [settingsValues, keybindingRows, keymapScopes, hasOpenProject, hasFeature]
   )
   const fuse = useMemo(
     () =>

--- a/src/components/Settings/SettingsSectionsList.tsx
+++ b/src/components/Settings/SettingsSectionsList.tsx
@@ -1,9 +1,11 @@
+import type { Feature } from '@kittycad/lib'
 import { useApp } from '@src/lib/boot'
 import type { SettingsLevel } from '@src/lib/settings/settingsTypes'
 import {
   formatSettingsLabel,
   shouldHideSetting,
 } from '@src/lib/settings/settingsUtils'
+import { userFeaturesContextHas } from '@src/machines/userFeaturesMachine'
 
 interface SettingsSectionsListProps {
   searchParamTab: SettingsLevel
@@ -14,14 +16,17 @@ export function SettingsSectionsList({
   searchParamTab,
   scrollRef,
 }: SettingsSectionsListProps) {
-  const { settings } = useApp()
+  const { settings, userFeatures } = useApp()
   const context = settings.useSettings()
+  const userFeaturesContext = userFeatures.useContext()
+  const hasFeature = (feature: Feature) =>
+    userFeaturesContextHas(userFeaturesContext, feature, false)
 
   const visibleCategories = Object.entries(context).filter(
     ([_, categorySettings]) =>
       // Filter out categories that don't have any non-hidden settings
       Object.values(categorySettings).some(
-        (setting) => !shouldHideSetting(setting, searchParamTab)
+        (setting) => !shouldHideSetting(setting, searchParamTab, hasFeature)
       )
   )
 

--- a/src/components/SystemIOMachineLogicListener.tsx
+++ b/src/components/SystemIOMachineLogicListener.tsx
@@ -16,6 +16,7 @@ import {
   safeEncodeForRouterPaths,
   webSafePathSplit,
 } from '@src/lib/paths'
+import { getDefaultDirectoryProjectLibraryPath } from '@src/lib/projectLibraries'
 import {
   useHasListedProjects,
   useLastOperation,
@@ -44,6 +45,10 @@ export function SystemIOMachineLogicListener() {
 
   const navigate = useNavigate()
   const settingsValues = settings.useSettings()
+  const defaultDirectoryLibraryPath =
+    getDefaultDirectoryProjectLibraryPath(
+      settingsValues.app.libraries.current
+    ) || ''
   const { onFileOpen, onFileClose } = useLspContext()
   const { pathname } = useLocation()
 
@@ -67,11 +72,9 @@ export function SystemIOMachineLogicListener() {
       encodedURI
     ) {
       filePathWithExtension = decodeURIComponent(encodedURI)
-      const applicationProjectDirectory =
-        settingsValues.app.projectDirectory.current
       projectDirectory = getProjectDirectoryFromKCLFilePath(
         filePathWithExtension,
-        applicationProjectDirectory
+        defaultDirectoryLibraryPath
       )
     }
 
@@ -215,13 +218,12 @@ export function SystemIOMachineLogicListener() {
         systemIOActor.send({
           type: SystemIOMachineEvents.setProjectDirectoryPath,
           data: {
-            requestedProjectDirectoryPath:
-              settingsValues.app.projectDirectory.current || '',
+            requestedProjectDirectoryPath: defaultDirectoryLibraryPath,
           },
         })
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
-    }, [settingsValues.app.projectDirectory.current, pathname])
+    }, [defaultDirectoryLibraryPath, pathname])
   }
 
   const useDefaultProjectName = () => {
@@ -267,9 +269,7 @@ export function SystemIOMachineLogicListener() {
           })
         }
       },
-      settingsValues.app.projectDirectory.current
-        ? [settingsValues.app.projectDirectory.current]
-        : []
+      defaultDirectoryLibraryPath ? [defaultDirectoryLibraryPath] : []
     )
   }
 

--- a/src/hooks/useQueryParamEffects.ts
+++ b/src/hooks/useQueryParamEffects.ts
@@ -27,6 +27,7 @@ import {
 import fsZds from '@src/lib/fs-zds'
 import { isDesktop } from '@src/lib/isDesktop'
 import { PATHS, safeEncodeForRouterPaths } from '@src/lib/paths'
+import { getDefaultDirectoryProjectLibraryPath } from '@src/lib/projectLibraries'
 import { DEFAULT_WEB_PROJECT_NAME } from '@src/lib/routeLoaders'
 import { err } from '@src/lib/trap'
 import { getAllSubDirectoriesAtProjectRoot } from '@src/machines/systemIO/snapshotContext'
@@ -226,7 +227,9 @@ export function useQueryParamEffects(kclManager: KclManager) {
     await waitFor(app.settings.actor, (state) => state.matches('idle'))
 
     const systemIOContext = app.systemIOActor.getSnapshot().context
-    const projectDirectoryPath = app.settings.get().app.projectDirectory.current
+    const projectDirectoryPath = getDefaultDirectoryProjectLibraryPath(
+      app.settings.get().app.libraries.current
+    )
     if (!projectDirectoryPath) {
       return new Error('Unable to determine the project directory.')
     }

--- a/src/lib/cloudSync/registry/extension.test.ts
+++ b/src/lib/cloudSync/registry/extension.test.ts
@@ -107,6 +107,15 @@ function createSettingsSnapshot({
 }): SettingsType {
   return {
     app: {
+      libraries: {
+        current: [
+          {
+            title: 'Projects',
+            path: projectDirectoryPath,
+            type: 'directory',
+          },
+        ],
+      },
       projectDirectory: {
         current: projectDirectoryPath,
       },

--- a/src/lib/cloudSync/registry/extension.ts
+++ b/src/lib/cloudSync/registry/extension.ts
@@ -23,6 +23,7 @@ import {
   type CloudSyncRegistryService,
   cloudSyncService,
 } from '@src/lib/cloudSync/registry/contract'
+import { getDefaultDirectoryProjectLibraryPath } from '@src/lib/projectLibraries'
 import { settingsService } from '@src/registry/contracts/settings'
 
 const CLOUD_SYNC_PLUGIN_ID = 'cloud-sync'
@@ -41,7 +42,11 @@ export const cloudSyncExtension = defineRegistryItemFactory((ctx) => {
     const nextConfig = {
       ...runtimeConfig.value,
       enabled: runtimeConfig.value.enabled && cloudSyncPluginEnabled,
-      projectDirectoryPath: currentSettings?.app.projectDirectory.current,
+      projectDirectoryPath: currentSettings
+        ? getDefaultDirectoryProjectLibraryPath(
+            currentSettings.app.libraries.current
+          )
+        : undefined,
     }
 
     untracked(() => configureCloudSync(nextConfig))

--- a/src/lib/desktop.test.ts
+++ b/src/lib/desktop.test.ts
@@ -93,6 +93,39 @@ describe('createNewProjectDirectory', () => {
     expect(projectToml).toContain('title = "Human Project"')
   })
 
+  it('uses the default directory library when creating new projects from settings', async () => {
+    const projectDirectoryPath = `/tmp/create-project-${crypto.randomUUID()}`
+    const legacyProjectDirectoryPath = `/tmp/create-project-${crypto.randomUUID()}`
+    createdProjectDirectoryPaths.push(projectDirectoryPath)
+    createdProjectDirectoryPaths.push(legacyProjectDirectoryPath)
+
+    const project = await createNewProjectDirectory(
+      'library-project',
+      wasmInstance,
+      undefined,
+      {
+        settings: {
+          app: {
+            libraries: [
+              {
+                title: 'Projects',
+                path: projectDirectoryPath,
+                type: 'directory',
+              },
+            ],
+          },
+          project: {
+            directory: legacyProjectDirectoryPath,
+          },
+        },
+      }
+    )
+
+    expect(project.path).toBe(
+      fsZds.join(projectDirectoryPath, 'library-project')
+    )
+  })
+
   it('treats serialized ENOENT strings as missing project.toml metadata', async () => {
     const projectDirectoryPath = `/tmp/create-project-${crypto.randomUUID()}`
     createdProjectDirectoryPaths.push(projectDirectoryPath)

--- a/src/lib/desktop.ts
+++ b/src/lib/desktop.ts
@@ -36,6 +36,10 @@ import {
 import { createKCClient, kcCall } from '@src/lib/kcClient'
 import type { FileEntry, FileMetadata, Project } from '@src/lib/project'
 import {
+  getDefaultDirectoryProjectLibraryPath,
+  isProjectLibrarySettings,
+} from '@src/lib/projectLibraries'
+import {
   getCloudProjectIdFromProjectTomlContents,
   getProjectTitleFromProjectTomlContents,
   preserveProjectTomlMetadataInProjectSettingsContents,
@@ -61,8 +65,20 @@ function getProjectSettingsSection(
 function getProjectDirectorySetting(
   config: DeepPartial<Configuration> | Configuration
 ): string | undefined {
+  const libraries = getProjectLibrarySettingsFromConfiguration(config)
+  if (libraries) {
+    return getDefaultDirectoryProjectLibraryPath(libraries)
+  }
+
   const directory = getProjectSettingsSection(config)?.directory
   return typeof directory === 'string' ? directory : undefined
+}
+
+function getProjectLibrarySettingsFromConfiguration(
+  config: DeepPartial<Configuration> | Configuration
+) {
+  const libraries = config.settings?.app?.libraries
+  return isProjectLibrarySettings(libraries) ? libraries : undefined
 }
 
 const convertIStatToFileMetadata = (

--- a/src/lib/paths.test.ts
+++ b/src/lib/paths.test.ts
@@ -86,6 +86,52 @@ describe('testing parseProjectRoute', () => {
     })
   })
 
+  it('should prefer the default directory library over the legacy project directory', async () => {
+    let config = {
+      settings: {
+        app: {
+          libraries: [
+            {
+              title: 'Projects',
+              path: '/home/somebody/library-projects',
+              type: 'directory',
+            },
+          ],
+        },
+        project: {
+          directory: '/home/somebody/legacy-projects',
+        },
+      },
+    }
+    const route = '/home/somebody/library-projects/assembly/main.kcl'
+    expect(parseProjectRoute(config, route)).toEqual({
+      projectName: 'assembly',
+      projectPath: '/home/somebody/library-projects/assembly',
+      currentFileName: 'main.kcl',
+      currentFilePath: route,
+    })
+  })
+
+  it('should respect an explicit empty libraries setting', async () => {
+    let config = {
+      settings: {
+        app: {
+          libraries: [],
+        },
+        project: {
+          directory: '/home/somebody/legacy-projects',
+        },
+      },
+    }
+    const route = '/home/somebody/legacy-projects/assembly/subdir/main.kcl'
+    expect(parseProjectRoute(config, route)).toEqual({
+      projectName: 'subdir',
+      projectPath: '/home/somebody/legacy-projects/assembly/subdir',
+      currentFileName: 'main.kcl',
+      currentFilePath: route,
+    })
+  })
+
   it('should not parse a sibling path with the same prefix as inside the project dir', async () => {
     let config = {
       settings: {

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -2,6 +2,10 @@ import type { Configuration } from '@rust/kcl-lib/bindings/Configuration'
 import { APP_NAME, ARCHIVE_DIR, IS_PLAYWRIGHT_KEY } from '@src/lib/constants'
 import fsZds from '@src/lib/fs-zds'
 import { webSafeJoin } from '@src/lib/pathUtils'
+import {
+  getDefaultDirectoryProjectLibraryPath,
+  isProjectLibrarySettings,
+} from '@src/lib/projectLibraries'
 
 import type { FileEntry, Project } from '@src/lib/project'
 import { err } from '@src/lib/trap'
@@ -22,6 +26,11 @@ export type ProjectRoute = {
 function getProjectDirectorySetting(
   configuration: DeepPartial<Configuration>
 ): string | undefined {
+  const libraries = configuration.settings?.app?.libraries
+  if (isProjectLibrarySettings(libraries)) {
+    return getDefaultDirectoryProjectLibraryPath(libraries)
+  }
+
   const projectSettings = configuration.settings?.project
   if (
     !projectSettings ||

--- a/src/lib/projectLibraries.ts
+++ b/src/lib/projectLibraries.ts
@@ -1,6 +1,8 @@
 import { isArray } from '@src/lib/utils'
 
 export const DEFAULT_PROJECT_LIBRARY_ID = 'default-project-directory'
+export const DEFAULT_PROJECT_LIBRARY_TITLE = 'Default Projects Directory'
+export const DIRECTORY_PROJECT_LIBRARY_TYPE = 'directory'
 
 export type ProjectLibraryType = string
 
@@ -21,9 +23,9 @@ export function getDefaultProjectLibrarySettings(
 ): ProjectLibrarySetting[] {
   return [
     {
-      title: 'Default Projects Directory',
+      title: DEFAULT_PROJECT_LIBRARY_TITLE,
       path: projectDirectory,
-      type: 'directory',
+      type: DIRECTORY_PROJECT_LIBRARY_TYPE,
     },
   ]
 }
@@ -31,7 +33,9 @@ export function getDefaultProjectLibrarySettings(
 export function getDefaultDirectoryProjectLibrarySetting(
   libraries: readonly ProjectLibrarySetting[]
 ) {
-  return libraries.find((library) => library.type === 'directory')
+  return libraries.find(
+    (library) => library.type === DIRECTORY_PROJECT_LIBRARY_TYPE
+  )
 }
 
 export function getDefaultDirectoryProjectLibraryPath(
@@ -51,6 +55,10 @@ export function isPathInDirectoryProjectLibrary(
   const normalizedTargetPath = normalizeLibraryPath(targetPath)
   const normalizedLibraryPath = normalizeLibraryPath(libraryPath)
 
+  if (!normalizedLibraryPath) {
+    return false
+  }
+
   return (
     normalizedTargetPath === normalizedLibraryPath ||
     normalizedTargetPath.startsWith(`${normalizedLibraryPath}/`)
@@ -62,7 +70,7 @@ export function getContainingDirectoryProjectLibraryPath(
   projectPath: string
 ) {
   return libraries
-    .filter((library) => library.type === 'directory')
+    .filter((library) => library.type === DIRECTORY_PROJECT_LIBRARY_TYPE)
     .filter((library) =>
       isPathInDirectoryProjectLibrary(projectPath, library.path)
     )
@@ -134,10 +142,31 @@ export function projectLibraryFromSetting(
   return {
     ...library,
     id:
-      library.type === 'directory' &&
+      library.type === DIRECTORY_PROJECT_LIBRARY_TYPE &&
       library.path === options.defaultProjectDirectory
         ? DEFAULT_PROJECT_LIBRARY_ID
         : getProjectLibraryIdFromSetting(library),
     order: index,
   }
+}
+
+export function updateDefaultDirectoryProjectLibrarySetting(
+  libraries: readonly ProjectLibrarySetting[],
+  updates: Partial<Pick<ProjectLibrarySetting, 'title' | 'path'>>
+): ProjectLibrarySetting[] {
+  const defaultDirectoryLibrary =
+    getDefaultDirectoryProjectLibrarySetting(libraries)
+
+  if (!defaultDirectoryLibrary) {
+    return [...libraries]
+  }
+
+  return libraries.map((library) =>
+    library === defaultDirectoryLibrary
+      ? {
+          ...library,
+          ...updates,
+        }
+      : library
+  )
 }

--- a/src/lib/routeLoaders.ts
+++ b/src/lib/routeLoaders.ts
@@ -15,7 +15,10 @@ import {
   getRouterSearchFromRequestUrl,
   safeEncodeForRouterPaths,
 } from '@src/lib/paths'
-import { isPathInDirectoryProjectLibrary } from '@src/lib/projectLibraries'
+import {
+  getDefaultDirectoryProjectLibraryPath,
+  isPathInDirectoryProjectLibrary,
+} from '@src/lib/projectLibraries'
 import {
   loadHomeProjects,
   webHomeRouteEnabled,
@@ -67,8 +70,11 @@ export const baseLoader =
 
     const settings = await loadAndValidateSettings(wasmInstance, undefined)
 
+    const defaultDirectoryLibraryPath = getDefaultDirectoryProjectLibraryPath(
+      settings.settings.app.libraries.current
+    )
     const requestedProjectName = fsZds.resolve(
-      settings.settings.app.projectDirectory.current,
+      defaultDirectoryLibraryPath ?? '',
       DEFAULT_WEB_PROJECT_NAME
     )
 
@@ -223,7 +229,10 @@ export const fileLoader =
       requestedFileName.onProjectLoaderComplete?.()
     }
 
-    const appProjectDir = settings.settings.app.projectDirectory.current
+    const appProjectDir =
+      getDefaultDirectoryProjectLibraryPath(
+        settings.settings.app.libraries.current
+      ) ?? ''
     const requestedProjectDirectoryPath = isPathInDirectoryProjectLibrary(
       project.path,
       appProjectDir

--- a/src/lib/settings/initialSettings.tsx
+++ b/src/lib/settings/initialSettings.tsx
@@ -16,6 +16,7 @@ import {
   DEFAULT_DEFAULT_LENGTH_UNIT,
   DEFAULT_PROJECT_NAME,
   REGEXP_UUIDV4,
+  OPFS_CLOUD_FEATURE_FLAG,
 } from '@src/lib/constants'
 import { isDesktop } from '@src/lib/isDesktop'
 import {
@@ -51,6 +52,7 @@ export class Setting<T = unknown> {
   public current: T
   public hideOnLevel: SettingProps<T>['hideOnLevel']
   public hideOnPlatform: SettingProps<T>['hideOnPlatform']
+  public hideWithoutFeature: SettingProps<T>['hideWithoutFeature']
   public commandConfig: SettingProps<T>['commandConfig']
   public Component: SettingProps<T>['Component']
   public description?: string
@@ -68,6 +70,7 @@ export class Setting<T = unknown> {
     this.description = props.description
     this.hideOnLevel = props.hideOnLevel
     this.hideOnPlatform = props.hideOnPlatform
+    this.hideWithoutFeature = props.hideWithoutFeature
     this.commandConfig = props.commandConfig
     this.Component = props.Component
   }
@@ -261,7 +264,7 @@ function createCoreSettings() {
         defaultValue: [],
         description: 'The default library to save and load projects from.',
         hideOnLevel: 'project',
-        hideOnPlatform: 'web',
+        hideWithoutFeature: OPFS_CLOUD_FEATURE_FLAG,
         validate: isProjectLibrarySettings,
         Component: ({ value, updateValue }) => {
           const inputRef = useRef<HTMLInputElement>(null)

--- a/src/lib/settings/initialSettings.tsx
+++ b/src/lib/settings/initialSettings.tsx
@@ -53,6 +53,7 @@ export class Setting<T = unknown> {
   public hideOnLevel: SettingProps<T>['hideOnLevel']
   public hideOnPlatform: SettingProps<T>['hideOnPlatform']
   public hideWithoutFeature: SettingProps<T>['hideWithoutFeature']
+  public hideWithoutFeatureOnPlatform: SettingProps<T>['hideWithoutFeatureOnPlatform']
   public commandConfig: SettingProps<T>['commandConfig']
   public Component: SettingProps<T>['Component']
   public description?: string
@@ -71,6 +72,7 @@ export class Setting<T = unknown> {
     this.hideOnLevel = props.hideOnLevel
     this.hideOnPlatform = props.hideOnPlatform
     this.hideWithoutFeature = props.hideWithoutFeature
+    this.hideWithoutFeatureOnPlatform = props.hideWithoutFeatureOnPlatform
     this.commandConfig = props.commandConfig
     this.Component = props.Component
   }
@@ -264,7 +266,9 @@ function createCoreSettings() {
         defaultValue: [],
         description: 'The default library to save and load projects from.',
         hideOnLevel: 'project',
-        hideWithoutFeature: OPFS_CLOUD_FEATURE_FLAG,
+        hideWithoutFeatureOnPlatform: {
+          web: OPFS_CLOUD_FEATURE_FLAG,
+        },
         validate: isProjectLibrarySettings,
         Component: ({ value, updateValue }) => {
           const inputRef = useRef<HTMLInputElement>(null)

--- a/src/lib/settings/initialSettings.tsx
+++ b/src/lib/settings/initialSettings.tsx
@@ -19,8 +19,10 @@ import {
 } from '@src/lib/constants'
 import { isDesktop } from '@src/lib/isDesktop'
 import {
+  getDefaultDirectoryProjectLibrarySetting,
   isProjectLibrarySettings,
   type ProjectLibrarySetting,
+  updateDefaultDirectoryProjectLibrarySetting,
 } from '@src/lib/projectLibraries'
 import type {
   DynamicSettingsCategories,
@@ -251,60 +253,103 @@ function createCoreSettings() {
         defaultValue: '', // gets set async in settingsUtils.ts
         description: 'The directory to save and load projects from.',
         hideOnLevel: 'project',
-        hideOnPlatform: 'web',
+        hideOnPlatform: 'both',
         validate: (v) =>
           typeof v === 'string' && (v.length > 0 || !isDesktop()),
-        Component: ({ value, updateValue }) => {
-          const inputRef = useRef<HTMLInputElement>(null)
-          return (
-            <div className="flex gap-4 p-1 border rounded-sm border-chalkboard-30">
-              <input
-                className="flex-grow text-xs px-2 bg-transparent"
-                value={value}
-                disabled
-                data-testid="project-directory-input"
-                ref={inputRef}
-              />
-              <button
-                onClick={toSync(async () => {
-                  // In desktop end-to-end tests we can't control the file picker,
-                  // so we seed the new directory value in the element's dataset
-                  const inputRefVal = inputRef.current?.dataset.testValue
-                  if (
-                    inputRef.current &&
-                    inputRefVal &&
-                    !isArray(inputRefVal)
-                  ) {
-                    updateValue(inputRefVal)
-                  } else {
-                    if (!window.electron) {
-                      return Promise.reject(new Error("Can't open file dialog"))
-                    }
-                    const newPath = await window.electron.open({
-                      properties: ['openDirectory', 'createDirectory'],
-                      defaultPath: value,
-                      title: 'Choose a new project directory',
-                    })
-                    if (newPath.canceled) return
-                    updateValue(newPath.filePaths[0])
-                  }
-                }, reportRejection)}
-                className="p-0 m-0 border-none hover:bg-primary/10 focus:bg-primary/10 dark:hover:bg-primary/20 dark:focus::bg-primary/20"
-                data-testid="project-directory-button"
-              >
-                <CustomIcon name="folder" className="w-5 h-5" />
-                <Tooltip position="top-right">Choose a folder</Tooltip>
-              </button>
-            </div>
-          )
-        },
       }),
       libraries: new Setting<ProjectLibrarySetting[]>({
         defaultValue: [],
-        description: 'Project libraries shown on the home page.',
+        description: 'The default library to save and load projects from.',
         hideOnLevel: 'project',
-        hideOnPlatform: 'both',
+        hideOnPlatform: 'web',
         validate: isProjectLibrarySettings,
+        Component: ({ value, updateValue }) => {
+          const inputRef = useRef<HTMLInputElement>(null)
+          const defaultDirectoryLibrary =
+            getDefaultDirectoryProjectLibrarySetting(value)
+
+          if (!defaultDirectoryLibrary) {
+            return (
+              <p className="text-xs text-chalkboard-80 dark:text-chalkboard-30">
+                No default projects directory library is configured.
+              </p>
+            )
+          }
+
+          const updateDefaultDirectoryLibrary = (
+            updates: Partial<Pick<ProjectLibrarySetting, 'title' | 'path'>>
+          ) => {
+            updateValue(
+              updateDefaultDirectoryProjectLibrarySetting(value, updates)
+            )
+          }
+
+          return (
+            <div className="flex flex-col gap-3 p-1">
+              <label className="flex flex-col gap-1 text-xs">
+                <span className="font-medium text-chalkboard-80 dark:text-chalkboard-30">
+                  Title
+                </span>
+                <input
+                  className="w-full px-2 py-1 bg-transparent border rounded-sm border-chalkboard-30"
+                  value={defaultDirectoryLibrary.title}
+                  data-testid="project-library-title-input"
+                  onChange={(event) =>
+                    updateDefaultDirectoryLibrary({
+                      title: event.target.value,
+                    })
+                  }
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-xs">
+                <span className="font-medium text-chalkboard-80 dark:text-chalkboard-30">
+                  Folder
+                </span>
+                <div className="flex gap-4 p-1 border rounded-sm border-chalkboard-30">
+                  <input
+                    className="flex-grow text-xs px-2 bg-transparent"
+                    value={defaultDirectoryLibrary.path}
+                    disabled
+                    data-testid="project-directory-input"
+                    ref={inputRef}
+                  />
+                  <button
+                    onClick={toSync(async () => {
+                      const inputRefVal = inputRef.current?.dataset.testValue
+                      if (
+                        inputRef.current &&
+                        inputRefVal &&
+                        !isArray(inputRefVal)
+                      ) {
+                        updateDefaultDirectoryLibrary({ path: inputRefVal })
+                      } else {
+                        if (!window.electron) {
+                          return Promise.reject(
+                            new Error("Can't open file dialog")
+                          )
+                        }
+                        const newPath = await window.electron.open({
+                          properties: ['openDirectory', 'createDirectory'],
+                          defaultPath: defaultDirectoryLibrary.path,
+                          title: 'Choose a projects library folder',
+                        })
+                        if (newPath.canceled) return
+                        updateDefaultDirectoryLibrary({
+                          path: newPath.filePaths[0],
+                        })
+                      }
+                    }, reportRejection)}
+                    className="p-0 m-0 border-none hover:bg-primary/10 focus:bg-primary/10 dark:hover:bg-primary/20 dark:focus::bg-primary/20"
+                    data-testid="project-directory-button"
+                  >
+                    <CustomIcon name="folder" className="w-5 h-5" />
+                    <Tooltip position="top-right">Choose a folder</Tooltip>
+                  </button>
+                </div>
+              </label>
+            </div>
+          )
+        },
       }),
       namedViews: new Setting<{ [key in string]: NamedView }>({
         defaultValue: {},

--- a/src/lib/settings/settingsTypes.ts
+++ b/src/lib/settings/settingsTypes.ts
@@ -136,6 +136,14 @@ export interface SettingProps<T = unknown> {
    */
   hideWithoutFeature?: Feature
   /**
+   * Whether to hide the setting on a specific platform unless a user feature
+   * flag is enabled. This is useful when a feature flag gates web-only access
+   * to a desktop-default capability.
+   */
+  hideWithoutFeatureOnPlatform?: Partial<
+    Record<Exclude<HideOnPlatformValue, 'both'>, Feature>
+  >
+  /**
    * A React component to use for the setting in the settings panel.
    * If this is not provided but a commandConfig is, the `inputType`
    * of the commandConfig will be used to determine the component.

--- a/src/lib/settings/settingsTypes.ts
+++ b/src/lib/settings/settingsTypes.ts
@@ -1,4 +1,4 @@
-import type { UnitAngle, UnitLength } from '@kittycad/lib'
+import type { Feature, UnitAngle, UnitLength } from '@kittycad/lib'
 
 import type { CameraOrbitType } from '@rust/kcl-lib/bindings/CameraOrbitType'
 import type { CameraProjectionType } from '@rust/kcl-lib/bindings/CameraProjectionType'
@@ -130,6 +130,11 @@ export interface SettingProps<T = unknown> {
   hideOnPlatform?:
     | HideOnPlatformValue
     | (() => Promise<HideOnPlatformValue | null>)
+  /**
+   * Whether to hide the setting unless a user feature flag is enabled.
+   * This will be applied in the settings panel, settings search, and command bar.
+   */
+  hideWithoutFeature?: Feature
   /**
    * A React component to use for the setting in the settings panel.
    * If this is not provided but a commandConfig is, the `inputType`

--- a/src/lib/settings/settingsUtils.spec.ts
+++ b/src/lib/settings/settingsUtils.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '@src/lang/wasm'
 import { loadAndInitialiseWasmInstance } from '@src/lang/wasmUtilsNode'
 import { defaultLayoutConfig } from '@src/lib/layout/configs/default'
+import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
 import { createLayoutWithMetadata } from '@src/lib/layout/utils'
 import { getDefaultProjectLibrarySettings } from '@src/lib/projectLibraries'
 import { defineBooleanExtensionSetting } from '@src/lib/settings/extensionSettings'
@@ -193,6 +194,22 @@ describe('testing hiddenOnPlatform', () => {
     expect(hiddenOnPlatform(setting2, false)).toBe(false)
     expect(hiddenOnPlatform(setting3, false)).toBe(true)
     expect(hiddenOnPlatform(setting4, false)).toBe(false)
+  })
+
+  it('hides feature-gated settings unless the feature is enabled', () => {
+    const setting = {
+      hideWithoutFeature: OPFS_CLOUD_FEATURE_FLAG,
+    } as Setting<unknown>
+
+    expect(hiddenOnPlatform(setting, true)).toBe(true)
+    expect(hiddenOnPlatform(setting, false, () => false)).toBe(true)
+    expect(
+      hiddenOnPlatform(
+        setting,
+        false,
+        (feature) => feature === OPFS_CLOUD_FEATURE_FLAG
+      )
+    ).toBe(false)
   })
 })
 

--- a/src/lib/settings/settingsUtils.spec.ts
+++ b/src/lib/settings/settingsUtils.spec.ts
@@ -327,6 +327,54 @@ describe('project settings serialization regression', () => {
     )
   })
 
+  it('uses the default directory library as the legacy project directory when parsing settings', () => {
+    const parsedPayload = configurationToSettingsPayload({
+      settings: {
+        app: {
+          libraries: [
+            {
+              title: 'Projects',
+              path: '/library-projects',
+              type: 'directory',
+            },
+          ],
+        },
+        project: {
+          directory: '/legacy-projects',
+        },
+      },
+    })
+
+    expect(parsedPayload.app?.projectDirectory).toBe('/library-projects')
+  })
+
+  it('mirrors the default directory library into the legacy project directory when serializing settings', async () => {
+    const WASM_PATH = join(process.cwd(), 'public/kcl_wasm_lib_bg.wasm')
+    const wasmInstance = await loadAndInitialiseWasmInstance(WASM_PATH)
+
+    const serializedToml = serializeConfiguration(
+      settingsPayloadToConfiguration({
+        app: {
+          projectDirectory: '/legacy-projects',
+          libraries: [
+            {
+              title: 'Projects',
+              path: '/library-projects',
+              type: 'directory',
+            },
+          ],
+        },
+      }),
+      wasmInstance
+    )
+    if (serializedToml instanceof Error) {
+      throw serializedToml
+    }
+
+    expect(serializedToml).toContain('[settings.project]')
+    expect(serializedToml).toContain('directory = "/library-projects"')
+  })
+
   it('preserves extension-contributed plugin settings through wasm round-trip', async () => {
     const WASM_PATH = join(process.cwd(), 'public/kcl_wasm_lib_bg.wasm')
     const wasmInstance = await loadAndInitialiseWasmInstance(WASM_PATH)

--- a/src/lib/settings/settingsUtils.spec.ts
+++ b/src/lib/settings/settingsUtils.spec.ts
@@ -211,6 +211,39 @@ describe('testing hiddenOnPlatform', () => {
       )
     ).toBe(false)
   })
+
+  it('can scope feature-gated settings to web', () => {
+    const setting = {
+      hideWithoutFeatureOnPlatform: {
+        web: OPFS_CLOUD_FEATURE_FLAG,
+      },
+    } as Setting<unknown>
+
+    expect(hiddenOnPlatform(setting, true)).toBe(false)
+    expect(hiddenOnPlatform(setting, false, () => false)).toBe(true)
+    expect(
+      hiddenOnPlatform(
+        setting,
+        false,
+        (feature) => feature === OPFS_CLOUD_FEATURE_FLAG
+      )
+    ).toBe(false)
+  })
+
+  it('keeps libraries visible on desktop and feature-gated on web', () => {
+    const settings = createSettings()
+    const libraries = settings.app.libraries as Setting
+
+    expect(hiddenOnPlatform(libraries, true, () => false)).toBe(false)
+    expect(hiddenOnPlatform(libraries, false, () => false)).toBe(true)
+    expect(
+      hiddenOnPlatform(
+        libraries,
+        false,
+        (feature) => feature === OPFS_CLOUD_FEATURE_FLAG
+      )
+    ).toBe(false)
+  })
 })
 
 // This tests if default project level settings can override non-default user level settings.

--- a/src/lib/settings/settingsUtils.ts
+++ b/src/lib/settings/settingsUtils.ts
@@ -28,6 +28,7 @@ import {
   parseLayoutWithMigrations,
 } from '@src/lib/layout/utils'
 import {
+  getDefaultDirectoryProjectLibraryPath,
   getDefaultProjectLibrarySettings,
   isProjectLibrarySettings,
   mergeProjectLibrarySettings,
@@ -400,6 +401,27 @@ function mergeSettingsPayloads(
   )
 }
 
+function withLegacyProjectDirectoryMirroredFromLibraries(
+  payload: DeepPartial<SaveSettingsPayload>
+): DeepPartial<SaveSettingsPayload> {
+  const libraries = payload.app?.libraries
+  if (!isProjectLibrarySettings(libraries)) {
+    return payload
+  }
+
+  const defaultDirectoryLibraryPath =
+    getDefaultDirectoryProjectLibraryPath(libraries)
+  if (!defaultDirectoryLibraryPath) {
+    return payload
+  }
+
+  return mergeSettingsPayloads(payload, {
+    app: {
+      projectDirectory: defaultDirectoryLibraryPath,
+    },
+  })
+}
+
 function mergeTomlSections(
   ...sections: (Record<string, unknown> | undefined)[]
 ): Record<string, unknown> | undefined {
@@ -614,7 +636,7 @@ export function configurationToSettingsPayload(
   configuration: DeepPartial<Configuration>,
   extensionSettings: ResolvedExtensionSettings = {}
 ): DeepPartial<SaveSettingsPayload> {
-  return mergeSettingsPayloads(
+  const payload = mergeSettingsPayloads(
     {
       app: {
         theme: configuration?.settings?.app?.appearance?.theme
@@ -661,40 +683,66 @@ export function configurationToSettingsPayload(
       'user'
     )
   )
+
+  return withLegacyProjectDirectoryMirroredFromLibraries(payload)
 }
 
 export function settingsPayloadToConfiguration(
   configuration: DeepPartial<SaveSettingsPayload>,
   extensionSettings: ResolvedExtensionSettings = {}
 ): DeepPartial<Configuration> {
+  const configurationWithLegacyProjectDirectory =
+    withLegacyProjectDirectoryMirroredFromLibraries(configuration)
   const appearance = compactRecord({
-    theme: toUndefinedIfNull(configuration?.app?.theme),
+    theme: toUndefinedIfNull(
+      configurationWithLegacyProjectDirectory?.app?.theme
+    ),
   })
 
   const typedAppSection = compactRecord({
     appearance,
-    stream_idle_mode: toUndefinedIfNull(configuration?.app?.streamIdleMode),
+    stream_idle_mode: toUndefinedIfNull(
+      configurationWithLegacyProjectDirectory?.app?.streamIdleMode
+    ),
   })
 
   const typedModelingSection = compactRecord({
-    base_unit: toUndefinedIfNull(configuration?.modeling?.defaultUnit),
-    camera_projection: toUndefinedIfNull(
-      configuration?.modeling?.cameraProjection
+    base_unit: toUndefinedIfNull(
+      configurationWithLegacyProjectDirectory?.modeling?.defaultUnit
     ),
-    camera_orbit: toUndefinedIfNull(configuration?.modeling?.cameraOrbit),
-    highlight_edges: toUndefinedIfNull(configuration?.modeling?.highlightEdges),
-    enable_ssao: toUndefinedIfNull(configuration?.modeling?.enableSSAO),
-    backface_color: toUndefinedIfNull(configuration?.modeling?.backfaceColor),
-    show_scale_grid: toUndefinedIfNull(configuration?.modeling?.showScaleGrid),
-    fixed_size_grid: toUndefinedIfNull(configuration?.modeling?.fixedSizeGrid),
+    camera_projection: toUndefinedIfNull(
+      configurationWithLegacyProjectDirectory?.modeling?.cameraProjection
+    ),
+    camera_orbit: toUndefinedIfNull(
+      configurationWithLegacyProjectDirectory?.modeling?.cameraOrbit
+    ),
+    highlight_edges: toUndefinedIfNull(
+      configurationWithLegacyProjectDirectory?.modeling?.highlightEdges
+    ),
+    enable_ssao: toUndefinedIfNull(
+      configurationWithLegacyProjectDirectory?.modeling?.enableSSAO
+    ),
+    backface_color: toUndefinedIfNull(
+      configurationWithLegacyProjectDirectory?.modeling?.backfaceColor
+    ),
+    show_scale_grid: toUndefinedIfNull(
+      configurationWithLegacyProjectDirectory?.modeling?.showScaleGrid
+    ),
+    fixed_size_grid: toUndefinedIfNull(
+      configurationWithLegacyProjectDirectory?.modeling?.fixedSizeGrid
+    ),
   })
 
   const appOnlySections = mergeSettingsSectionMaps(
     writeAppOnlySettingsSections(
-      configuration,
+      configurationWithLegacyProjectDirectory,
       USER_APP_ONLY_SETTINGS_SECTIONS
     ),
-    writeExtensionSettingsSections(configuration, extensionSettings, 'user')
+    writeExtensionSettingsSections(
+      configurationWithLegacyProjectDirectory,
+      extensionSettings,
+      'user'
+    )
   )
 
   const settings = compactRecord({
@@ -1078,7 +1126,17 @@ export async function saveSettings(
   const wasmInstance = await initPromise
 
   // Get the user settings.
-  const jsAppSettings = getChangedSettingsAtLevel(allSettings, 'user')
+  const userSettingsChanges = getChangedSettingsAtLevel(allSettings, 'user')
+  const defaultDirectoryLibraryPath = getDefaultDirectoryProjectLibraryPath(
+    allSettings.app.libraries.current
+  )
+  const jsAppSettings = defaultDirectoryLibraryPath
+    ? mergeSettingsPayloads(userSettingsChanges, {
+        app: {
+          projectDirectory: defaultDirectoryLibraryPath,
+        },
+      })
+    : userSettingsChanges
   const appTomlString = serializeConfiguration(
     settingsPayloadToConfiguration(jsAppSettings, extensionSettings),
     wasmInstance

--- a/src/lib/settings/settingsUtils.ts
+++ b/src/lib/settings/settingsUtils.ts
@@ -2,6 +2,7 @@ import type { Configuration } from '@rust/kcl-lib/bindings/Configuration'
 import type { NamedView } from '@rust/kcl-lib/bindings/NamedView'
 import type { ProjectConfiguration } from '@rust/kcl-lib/bindings/ProjectConfiguration'
 import type { JsonValue } from '@rust/kcl-lib/bindings/serde_json/JsonValue'
+import type { Feature } from '@kittycad/lib'
 import {
   serializeConfiguration,
   serializeProjectConfiguration,
@@ -1277,12 +1278,17 @@ export function setSettingsAtLevel(
  */
 export function shouldHideSetting(
   setting: Setting<unknown>,
-  settingsLevel: SettingsLevel
+  settingsLevel: SettingsLevel,
+  hasFeature?: (feature: Feature) => boolean
 ): boolean {
   // Async functions should have been resolved in loadAndValidateSettings,
   // but if we encounter one (shouldn't happen), default to hidden
   const hideOnPlatform = setting.hideOnPlatform
   if (typeof hideOnPlatform === 'function') {
+    return true
+  }
+
+  if (setting.hideWithoutFeature && !hasFeature?.(setting.hideWithoutFeature)) {
     return true
   }
 
@@ -1302,9 +1308,10 @@ export function shouldHideSetting(
  */
 export function shouldShowSettingInput(
   setting: Setting<unknown>,
-  settingsLevel: SettingsLevel
+  settingsLevel: SettingsLevel,
+  hasFeature?: (feature: Feature) => boolean
 ): boolean {
-  const isHidden = shouldHideSetting(setting, settingsLevel)
+  const isHidden = shouldHideSetting(setting, settingsLevel, hasFeature)
   if (isHidden) {
     return false
   }
@@ -1363,8 +1370,16 @@ export function jsAppSettings(s: SettingsType | SettingsActorType) {
  * we can't resolve them synchronously. The actual visibility will be resolved
  * asynchronously and commands will be updated reactively.
  */
-export function hiddenOnPlatform(setting: Setting, desktop: boolean): boolean {
+export function hiddenOnPlatform(
+  setting: Setting,
+  desktop: boolean,
+  hasFeature?: (feature: Feature) => boolean
+): boolean {
   const hideOnPlatform = setting.hideOnPlatform
+
+  if (setting.hideWithoutFeature && !hasFeature?.(setting.hideWithoutFeature)) {
+    return true
+  }
 
   // Async functions should have been resolved in loadAndValidateSettings,
   // but if we encounter one (shouldn't happen), default to hidden

--- a/src/lib/settings/settingsUtils.ts
+++ b/src/lib/settings/settingsUtils.ts
@@ -1288,7 +1288,7 @@ export function shouldHideSetting(
     return true
   }
 
-  if (setting.hideWithoutFeature && !hasFeature?.(setting.hideWithoutFeature)) {
+  if (hiddenWithoutFeature(setting, isDesktop(), hasFeature)) {
     return true
   }
 
@@ -1377,7 +1377,7 @@ export function hiddenOnPlatform(
 ): boolean {
   const hideOnPlatform = setting.hideOnPlatform
 
-  if (setting.hideWithoutFeature && !hasFeature?.(setting.hideWithoutFeature)) {
+  if (hiddenWithoutFeature(setting, desktop, hasFeature)) {
     return true
   }
 
@@ -1396,4 +1396,18 @@ export function hiddenOnPlatform(
     hideOnPlatform === 'both' ||
     hideOnPlatform === (desktop ? 'desktop' : 'web')
   )
+}
+
+function hiddenWithoutFeature(
+  setting: Setting<unknown>,
+  desktop: boolean,
+  hasFeature?: (feature: Feature) => boolean
+): boolean {
+  if (setting.hideWithoutFeature && !hasFeature?.(setting.hideWithoutFeature)) {
+    return true
+  }
+
+  const platformFeature =
+    setting.hideWithoutFeatureOnPlatform?.[desktop ? 'desktop' : 'web']
+  return !!platformFeature && !hasFeature?.(platformFeature)
 }

--- a/src/machines/settingsMachine.ts
+++ b/src/machines/settingsMachine.ts
@@ -273,6 +273,12 @@ export const settingsMachine = setup({
         return
       }
       const eventParts = settingPath.split('.') as [keyof SettingsType, string]
+      if (settingPath === 'app.libraries') {
+        toast.success('Updated projects library.', {
+          id: `${event.type}.success`,
+        })
+        return
+      }
       const truncatedNewValue = event.data.value?.toString().slice(0, 28)
       const message =
         `Set ${decamelize(eventParts[1], { separator: ' ' })}` +

--- a/src/menu/register.ts
+++ b/src/menu/register.ts
@@ -91,7 +91,7 @@ export function modelingMenuCallbackMostActions({
         console.warn('filePath is undefined')
         return
       }
-      void navigate(filePath + PATHS.SETTINGS_USER + '#projectDirectory')
+      void navigate(filePath + PATHS.SETTINGS_USER + '#libraries')
     } else if (data.menuLabel === 'File.Preferences.Project settings') {
       if (!filePath) {
         console.warn('filePath is undefined')

--- a/src/registry/contracts/projectLibraries.spec.ts
+++ b/src/registry/contracts/projectLibraries.spec.ts
@@ -11,6 +11,7 @@ import {
   getDefaultDirectoryProjectLibraryPath,
   getProjectLibraryIdFromSetting,
   projectLibraryFromSetting,
+  updateDefaultDirectoryProjectLibrarySetting,
 } from '@src/lib/projectLibraries'
 import { describe, expect, test } from 'vitest'
 
@@ -101,6 +102,55 @@ describe('project library settings', () => {
         '/projects/client/bracket'
       )
     ).toBe('/projects/client')
+  })
+
+  test('does not treat an empty directory library path as containing every path', () => {
+    expect(
+      getContainingDirectoryProjectLibraryPath(
+        [
+          {
+            title: 'Empty Projects',
+            path: '',
+            type: 'directory',
+          },
+        ],
+        '/projects/client/bracket'
+      )
+    ).toBeUndefined()
+  })
+
+  test('updates the first directory library without changing other libraries', () => {
+    expect(
+      updateDefaultDirectoryProjectLibrarySetting(
+        [
+          {
+            title: 'Default',
+            path: '/projects',
+            type: 'directory',
+          },
+          {
+            title: 'External',
+            path: 'external://projects',
+            type: 'external',
+          },
+        ],
+        {
+          title: 'Renamed',
+          path: '/renamed',
+        }
+      )
+    ).toEqual([
+      {
+        title: 'Renamed',
+        path: '/renamed',
+        type: 'directory',
+      },
+      {
+        title: 'External',
+        path: 'external://projects',
+        type: 'external',
+      },
+    ])
   })
 })
 

--- a/src/registry/contracts/projectLibraries.spec.ts
+++ b/src/registry/contracts/projectLibraries.spec.ts
@@ -3,6 +3,7 @@ import {
   combineProjectLibraryTypes,
   combineProjectLibraries,
   getHomeProjectEntriesForLibrary,
+  getProjectLibraryOperation,
 } from '@src/registry/contracts/projectLibraries'
 import {
   DEFAULT_PROJECT_LIBRARY_ID,
@@ -199,6 +200,15 @@ describe('combineProjectLibraryTypes', () => {
     const createProject = {
       run: async () => undefined,
     }
+    const openProject = {
+      run: async () => undefined,
+    }
+    const renameProject = {
+      run: async () => undefined,
+    }
+    const deleteProject = {
+      run: async () => undefined,
+    }
 
     expect(
       combineProjectLibraryTypes([
@@ -208,12 +218,17 @@ describe('combineProjectLibraryTypes', () => {
           icon: 'folder',
           operations: {
             createProject,
+            openProject,
           },
         },
         {
           type: 'directory',
           title: 'Folder',
           readEntries,
+          operations: {
+            renameProject,
+            deleteProject,
+          },
         },
       ]).get('directory')
     ).toEqual({
@@ -222,9 +237,38 @@ describe('combineProjectLibraryTypes', () => {
       icon: 'folder',
       operations: {
         createProject,
+        openProject,
+        renameProject,
+        deleteProject,
       },
       readEntries,
     })
+  })
+
+  test('omits unavailable library type operations', () => {
+    const library = {
+      id: 'default-project-directory',
+      title: 'Default Projects Directory',
+      path: '/projects',
+      type: 'directory',
+    }
+
+    expect(
+      getProjectLibraryOperation(
+        {
+          type: 'directory',
+          title: 'Directory',
+          operations: {
+            deleteProject: {
+              isAvailable: () => false,
+              run: async () => undefined,
+            },
+          },
+        },
+        library,
+        'deleteProject'
+      )
+    ).toBeUndefined()
   })
 })
 

--- a/src/registry/contracts/projectLibraries.ts
+++ b/src/registry/contracts/projectLibraries.ts
@@ -2,6 +2,7 @@ import { defineContract, defineValueSpec } from '@kittycad/registry'
 import type {
   HomeProjectEntry,
   HomeProjectEntryContribution,
+  HomeProjectOpenResult,
 } from '@src/registry/contracts/homeProjects'
 import type {
   ProjectLibrary,
@@ -19,7 +20,10 @@ export type ProjectLibrarySettingDefaultContribution =
   | ProjectLibrarySetting
   | readonly ProjectLibrarySetting[]
 
-export interface ProjectLibraryOperation<Input, Result = unknown> {
+export interface ProjectLibraryOperation<
+  Input extends { library: ProjectLibrary },
+  Result = unknown,
+> {
   isAvailable?: (input: { library: ProjectLibrary }) => boolean
   run: (input: Input) => Result | Promise<Result>
 }
@@ -30,8 +34,28 @@ export interface ProjectLibraryCreateProjectInput {
   requestedProjectTitle: string
 }
 
+export interface ProjectLibraryProjectInput {
+  library: ProjectLibrary
+  project: HomeProjectEntry
+}
+
+export type ProjectLibraryOpenProjectInput = ProjectLibraryProjectInput
+
+export interface ProjectLibraryRenameProjectInput
+  extends ProjectLibraryProjectInput {
+  requestedName: string
+}
+
+export type ProjectLibraryDeleteProjectInput = ProjectLibraryProjectInput
+
 export interface ProjectLibraryTypeOperations {
   createProject?: ProjectLibraryOperation<ProjectLibraryCreateProjectInput>
+  openProject?: ProjectLibraryOperation<
+    ProjectLibraryOpenProjectInput,
+    HomeProjectOpenResult | undefined
+  >
+  renameProject?: ProjectLibraryOperation<ProjectLibraryRenameProjectInput>
+  deleteProject?: ProjectLibraryOperation<ProjectLibraryDeleteProjectInput>
 }
 
 export interface ProjectLibraryTypeContribution {
@@ -99,11 +123,14 @@ export function combineProjectLibraryTypes(
   return typeById
 }
 
-export function getProjectLibraryCreateProjectOperation(
+export function getProjectLibraryOperation<
+  OperationName extends keyof ProjectLibraryTypeOperations,
+>(
   libraryType: ProjectLibraryTypeContribution | undefined,
-  library: ProjectLibrary
-) {
-  const operation = libraryType?.operations?.createProject
+  library: ProjectLibrary,
+  operationName: OperationName
+): ProjectLibraryTypeOperations[OperationName] | undefined {
+  const operation = libraryType?.operations?.[operationName]
   if (!operation) {
     return undefined
   }
@@ -113,6 +140,13 @@ export function getProjectLibraryCreateProjectOperation(
   }
 
   return operation
+}
+
+export function getProjectLibraryCreateProjectOperation(
+  libraryType: ProjectLibraryTypeContribution | undefined,
+  library: ProjectLibrary
+) {
+  return getProjectLibraryOperation(libraryType, library, 'createProject')
 }
 
 export function combineProjectLibrarySettingDefaults(

--- a/src/registry/extensions/homeProjects/index.ts
+++ b/src/registry/extensions/homeProjects/index.ts
@@ -7,6 +7,7 @@ import {
 } from '@kittycad/registry'
 import { computed, effect, signal } from '@preact/signals-core'
 import {
+  createNewProjectDirectory,
   getProjectInfo,
   writeProjectTitleToProjectToml,
 } from '@src/lib/desktop'
@@ -15,8 +16,10 @@ import {
   homeProjectEntryFromProject,
 } from '@src/lib/homeProjects'
 import type { Project } from '@src/lib/project'
+import { readProjectsFromProjectDirectory } from '@src/lib/projectDirectoryScanner'
 import {
   DEFAULT_PROJECT_LIBRARY_ID,
+  DIRECTORY_PROJECT_LIBRARY_TYPE,
   getDefaultDirectoryProjectLibraryPath,
   type ProjectLibrary,
   projectLibraryFromSetting,
@@ -248,16 +251,58 @@ const configuredProjectLibraries = defineRegistryItemFactory((ctx) => {
   }
 }, 'home-projects.configured-project-libraries')
 
-const directoryProjectLibraryType = defineRegistryItem({
-  id: 'home-projects.directory-library-type',
-  provides: [
-    provide(projectLibraryTypesValueSpec, {
-      type: 'directory',
-      title: 'Directory',
-      icon: 'folder',
+const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
+  const systemIO = ctx.services.signal(systemIOService)
+  const getWasmPromise = () =>
+    ctx.valueSpecs.get(wasmPromiseValueSpec) ??
+    Promise.reject(new Error('Missing WASM promise registry value.'))
+
+  return {
+    item: defineRuntimeRegistryItem({
+      id: 'home-projects.directory-library-type',
+      provides: [
+        provide(projectLibraryTypesValueSpec, {
+          type: DIRECTORY_PROJECT_LIBRARY_TYPE,
+          title: 'Directory',
+          icon: 'folder',
+          readEntries: async ({ library, signal }) => {
+            const projects = await readProjectsFromProjectDirectory({
+              projectDirectoryPath: library.path,
+              wasmInstancePromise: getWasmPromise(),
+              signal,
+            })
+
+            return localHomeProjectEntriesFromProjects(projects, library.id)
+          },
+          operations: {
+            createProject: {
+              run: async ({
+                library,
+                requestedProjectName,
+                requestedProjectTitle,
+              }) => {
+                const project = await createNewProjectDirectory(
+                  requestedProjectName,
+                  await getWasmPromise(),
+                  undefined,
+                  undefined,
+                  undefined,
+                  library.path,
+                  requestedProjectTitle
+                )
+                systemIO.value?.actor.send({
+                  type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
+                })
+
+                return project
+              },
+            },
+          },
+        }),
+      ],
     }),
-  ],
-})
+  }
+}, 'home-projects.directory-library-type')
 
 const homeProjectsExtension = defineRegistryItem({
   id: 'home-projects',

--- a/src/registry/extensions/homeProjects/index.ts
+++ b/src/registry/extensions/homeProjects/index.ts
@@ -11,6 +11,7 @@ import {
   getProjectInfo,
   writeProjectTitleToProjectToml,
 } from '@src/lib/desktop'
+import fsZds from '@src/lib/fs-zds'
 import {
   getHomeProjectDisplayName,
   homeProjectEntryFromProject,
@@ -34,8 +35,10 @@ import {
   homeProjectEntriesValueSpec,
 } from '@src/registry/contracts/homeProjects'
 import {
+  getProjectLibraryOperation,
   projectLibrariesValueSpec,
   projectLibraryTypesValueSpec,
+  type ProjectLibraryTypeOperations,
 } from '@src/registry/contracts/projectLibraries'
 import { settingsService } from '@src/registry/contracts/settings'
 import { systemIOService } from '@src/registry/contracts/systemIO'
@@ -80,19 +83,73 @@ const homeProjectActions = defineRegistryItemFactory((ctx) => {
     ctx.valueSpecs.get(wasmPromiseValueSpec) ??
     Promise.reject(new Error('Missing WASM promise registry value.'))
 
+  const getProjectOperation = <
+    OperationName extends keyof ProjectLibraryTypeOperations,
+  >(
+    project: HomeProjectEntry,
+    operationName: OperationName
+  ):
+    | {
+        library: ProjectLibrary
+        operation: NonNullable<ProjectLibraryTypeOperations[OperationName]>
+      }
+    | undefined => {
+    const projectLibraryIds = new Set(project.libraryIds ?? [])
+    if (projectLibraryIds.size === 0) {
+      return undefined
+    }
+
+    const libraryTypes = ctx.valueSpecs.get(projectLibraryTypesValueSpec)
+    for (const library of ctx.valueSpecs.get(projectLibrariesValueSpec)) {
+      if (!projectLibraryIds.has(library.id)) {
+        continue
+      }
+
+      const operation = getProjectLibraryOperation(
+        libraryTypes.get(library.type),
+        library,
+        operationName
+      )
+      if (!operation) {
+        continue
+      }
+
+      return {
+        library,
+        operation,
+      }
+    }
+
+    return undefined
+  }
+
   const serviceImpl: HomeProjectActionsService = {
     canOpen: (project) =>
       Boolean(
-        (project.readWriteAccess && project.defaultFile) ||
+        (project.readWriteAccess &&
+          project.defaultFile &&
+          getProjectOperation(project, 'openProject')) ||
           project.remoteProjectId
       ),
     canRename: (project) =>
-      Boolean(project.localProjectPath && project.readWriteAccess),
+      Boolean(
+        project.localProjectPath &&
+          project.readWriteAccess &&
+          getProjectOperation(project, 'renameProject')
+      ),
     canDelete: (project) =>
-      Boolean(project.localProjectName && project.readWriteAccess),
+      Boolean(
+        project.localProjectPath &&
+          project.readWriteAccess &&
+          getProjectOperation(project, 'deleteProject')
+      ),
     open: async (project) => {
-      if (project.readWriteAccess && project.defaultFile) {
-        return { defaultFile: project.defaultFile }
+      const openProject = getProjectOperation(project, 'openProject')
+      if (openProject && project.readWriteAccess && project.defaultFile) {
+        return openProject.operation.run({
+          library: openProject.library,
+          project,
+        })
       }
 
       if (!project.remoteProjectId) {
@@ -116,7 +173,8 @@ const homeProjectActions = defineRegistryItemFactory((ctx) => {
       return { defaultFile: projectInfo.default_file }
     },
     rename: async (project, requestedName) => {
-      if (!serviceImpl.canRename(project) || !project.localProjectPath) {
+      const renameProject = getProjectOperation(project, 'renameProject')
+      if (!serviceImpl.canRename(project) || !renameProject) {
         return
       }
 
@@ -132,28 +190,28 @@ const homeProjectActions = defineRegistryItemFactory((ctx) => {
         return Promise.reject(new Error(message))
       }
 
-      await writeProjectTitleToProjectToml(
-        project.localProjectPath,
-        requestedName
-      )
+      await renameProject.operation.run({
+        library: renameProject.library,
+        project,
+        requestedName,
+      })
       toast.success(
         `Successfully renamed "${getHomeProjectDisplayName(project)}" to "${requestedName}"`
       )
-      systemIO.value?.actor.send({
-        type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
-      })
     },
     delete: async (project) => {
-      if (!serviceImpl.canDelete(project) || !project.localProjectName) {
+      const deleteProject = getProjectOperation(project, 'deleteProject')
+      if (!serviceImpl.canDelete(project) || !deleteProject) {
         return
       }
 
-      systemIO.value?.actor.send({
-        type: SystemIOMachineEvents.deleteProject,
-        data: {
-          requestedProjectName: project.localProjectName,
-        },
+      await deleteProject.operation.run({
+        library: deleteProject.library,
+        project,
       })
+      toast.success(
+        `Successfully deleted "${getHomeProjectDisplayName(project)}"`
+      )
     },
   }
 
@@ -295,6 +353,44 @@ const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
                 })
 
                 return project
+              },
+            },
+            openProject: {
+              run: ({ project }) => {
+                if (!project.readWriteAccess || !project.defaultFile) {
+                  return undefined
+                }
+
+                return { defaultFile: project.defaultFile }
+              },
+            },
+            renameProject: {
+              run: async ({ project, requestedName }) => {
+                if (!project.localProjectPath || !project.readWriteAccess) {
+                  return
+                }
+
+                await writeProjectTitleToProjectToml(
+                  project.localProjectPath,
+                  requestedName
+                )
+                systemIO.value?.actor.send({
+                  type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
+                })
+              },
+            },
+            deleteProject: {
+              run: async ({ project }) => {
+                if (!project.localProjectPath || !project.readWriteAccess) {
+                  return
+                }
+
+                await fsZds.rm(project.localProjectPath, {
+                  recursive: true,
+                })
+                systemIO.value?.actor.send({
+                  type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
+                })
               },
             },
           },

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -36,6 +36,7 @@ import { isDesktop } from '@src/lib/isDesktop'
 import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
 import { PATHS } from '@src/lib/paths'
 import { markOnce } from '@src/lib/performance'
+import { getDefaultDirectoryProjectLibraryPath } from '@src/lib/projectLibraries'
 import type { SettingsType } from '@src/lib/settings/initialSettings'
 import {
   getNextSearchParams,
@@ -305,7 +306,7 @@ const Home = () => {
     } else if (data.menuLabel === 'File.Preferences.User default units') {
       void navigate(`${PATHS.HOME}${PATHS.SETTINGS_USER}#defaultUnit`)
     } else if (data.menuLabel === 'Edit.Change project directory') {
-      void navigate(`${PATHS.HOME}${PATHS.SETTINGS_USER}#projectDirectory`)
+      void navigate(`${PATHS.HOME}${PATHS.SETTINGS_USER}#libraries`)
     } else if (data.menuLabel === 'File.Sign out') {
       auth.send({ type: 'Log out' })
     } else if (
@@ -558,6 +559,8 @@ function HomeHeader({
   ...rest
 }: HomeHeaderProps) {
   const isSortByModified = sort?.includes('modified') || !sort || sort === null
+  const defaultDirectoryLibraryPath =
+    getDefaultDirectoryProjectLibraryPath(settings.app.libraries.current) || ''
 
   return (
     <section {...rest}>
@@ -619,10 +622,10 @@ function HomeHeader({
         Loaded from{' '}
         <Link
           data-testid="project-directory-settings-link"
-          to={`${PATHS.HOME + PATHS.SETTINGS_USER}#projectDirectory`}
+          to={`${PATHS.HOME + PATHS.SETTINGS_USER}#libraries`}
           className="text-chalkboard-90 dark:text-chalkboard-20 underline underline-offset-2"
         >
-          {settings.app.projectDirectory.current}
+          {defaultDirectoryLibraryPath}
         </Link>
         .
       </p>
@@ -633,10 +636,10 @@ function HomeHeader({
               <p className="">{errorMessage(readWriteProjectDir.error)}</p>
               <Link
                 data-testid="project-directory-settings-link"
-                to={`${PATHS.HOME + PATHS.SETTINGS_USER}#projectDirectory`}
+                to={`${PATHS.HOME + PATHS.SETTINGS_USER}#libraries`}
                 className="py-1 text-white underline underline-offset-2 text-sm"
               >
-                Change Project Directory
+                Change Projects Library
               </Link>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Make the default directory library the source of truth for the app project root while preserving `settings.project.directory` as a compatibility mirror.
- Expose a temporary desktop settings UI for editing the single default project library title and folder, hiding the legacy `projectDirectory` setting.
- Route Home/SystemIO/query import/cloud sync local-root policy through the default directory library.
- Add directory library type read/create operation handlers for follow-up library-driven project loading.

## Migration behavior
- Existing users with `settings.project.directory` and no `settings.app.libraries` continue to seed the default directory library from the legacy value.
- An explicit `settings.app.libraries = []` remains an intentional empty value.
- When a default directory library exists, saves mirror its path back to `settings.project.directory` for older code and compatibility.

## Validation
- `npm run build:wasm:dev`
- `npm run tsc -- --noEmit`
- `npm run lint`
- `npm run test:integration -- src/lib/settings/settingsUtils.spec.ts src/registry/contracts/projectLibraries.spec.ts src/registry/contracts/homeProjects.spec.ts`
- `npm run test:unit -- src/lib/paths.test.ts src/lib/desktop.test.ts src/lib/cloudSync/registry/extension.test.ts`
- `git diff --check`