### PR TITLE
Update CODEOWNERS for rust directory ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 /src/                             @KittyCAD/frontend
 
 # KCL
-/rust/                            @KittyCAD/kcl  @KittyCAD/frontend
+/rust/                            @KittyCAD/kcl @KittyCAD/frontend
 
 # ZDS-KCL bridge
 /rust/**/frontend.rs              @KittyCAD/frontend @KittyCAD/kcl

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 /src/                             @KittyCAD/frontend
 
 # KCL
-/rust/                            @KittyCAD/kcl
+/rust/                            @KittyCAD/kcl  @KittyCAD/frontend
 
 # ZDS-KCL bridge
 /rust/**/frontend.rs              @KittyCAD/frontend @KittyCAD/kcl


### PR DESCRIPTION
Temporary 1 week change given that most of the KCL team is OOO


will revert this change in a week