### PR TITLE
Keep inline regions around when editing extrudes

### DIFF
--- a/src/lang/modifyAst/sweeps.spec.ts
+++ b/src/lang/modifyAst/sweeps.spec.ts
@@ -534,6 +534,40 @@ extrude001 = extrude(region001, length = 1)`
       await runNewAstAndCheckForSweep(result.modifiedAst, rustContextInThisFile)
     })
 
+    it('should edit an extrude call with an inline region selection', async () => {
+      const code = `${triangleRegion}
+extrude001 = extrude(region(point = [1mm, 1mm], sketch = s), length = 1)`
+      const { ast, artifactGraph } = await getAstAndArtifactGraphEngineless(
+        code,
+        instanceInThisFile,
+        rustContextInThisFile
+      )
+      const region = [...artifactGraph.values()].findLast(
+        (artifact) => artifact.type === 'path'
+      )
+      const sketches = createSelectionFromArtifacts([region!], artifactGraph)
+      const length = await getKclCommandValue(
+        '2',
+        instanceInThisFile,
+        rustContextInThisFile
+      )
+      const nodeToEdit = createPathToNodeForLastVariable(ast)
+      const result = addExtrude({
+        ast,
+        sketches,
+        length,
+        nodeToEdit,
+        artifactGraph,
+        wasmInstance: instanceInThisFile,
+      })
+      if (err(result)) throw result
+      const newCode = recast(result.modifiedAst, instanceInThisFile)
+      expect(newCode).toContain(
+        `extrude001 = extrude(region(point = [1mm, 1mm], sketch = s), length = 2)`
+      )
+      await runNewAstAndCheckForSweep(result.modifiedAst, rustContextInThisFile)
+    })
+
     it('should add a multi-profile extrude call on a profile and a cap', async () => {
       const code = `sketch001 = startSketchOn(XY)
 profile001 = circle(sketch001, center = [0, 0], radius = 1)

--- a/src/lang/modifyAst/sweeps.ts
+++ b/src/lang/modifyAst/sweeps.ts
@@ -303,7 +303,21 @@ export function addExtrude({
     ? [createLabeledArg('bodyType', createLocalName(bodyType))]
     : []
 
-  const sketchesExpr = createVariableExpressionsArray(vars.exprs)
+  let sketchesExpr = createVariableExpressionsArray(vars.exprs)
+  // Preserve an existing expression, such as an inline region(...), when it
+  // cannot be reconstructed from the artifact selection during an edit.
+  if (!sketchesExpr && mNodeToEdit) {
+    const existingCall = getNodeFromPath<CallExpressionKw>(
+      modifiedAst,
+      mNodeToEdit,
+      wasmInstance,
+      'CallExpressionKw'
+    )
+    if (err(existingCall)) {
+      return existingCall
+    }
+    sketchesExpr = structuredClone(existingCall.node.unlabeled)
+  }
   const call = createCallExpressionStdLibKw(
     modelingStdLibCommandName('Extrude'),
     sketchesExpr,

--- a/src/lang/queryAst.spec.ts
+++ b/src/lang/queryAst.spec.ts
@@ -44,6 +44,7 @@ import {
   enginelessExecutor,
   getAstAndArtifactGraph,
 } from '@src/lib/testHelpers'
+import { enterEditFlow } from '@src/lib/operations'
 import { err } from '@src/lib/trap'
 import type { Selection, Selections } from '@src/machines/modelingSharedTypes'
 
@@ -1458,6 +1459,52 @@ extrude001 = extrude(profile001, length = 1)
 })
 
 describe('Testing retrieveSelectionsFromOpArg', () => {
+  it('finds a profile selection from an inline region extrude argument', async () => {
+    const code = `@settings(defaultLengthUnit = mm, kclVersion = 2.0)
+profileSketch = sketch(on = XY) {
+  profile = circle(center = [0mm, 0mm], start = [10mm, 0mm])
+}
+body = extrude(
+  region(point = [5mm, 0mm], sketch = profileSketch),
+  length = 10mm,
+)
+`
+    const ast = assertParse(code, instanceInThisFile)
+    const { artifactGraph, operations } = await enginelessExecutor(
+      ast,
+      rustContextInThisFile
+    )
+    const op = getAllOperations(operations).find(
+      (operation) =>
+        operation.type === 'StdLibCall' && operation.name === 'extrude'
+    )
+    if (!op || op.type !== 'StdLibCall' || !op.unlabeledArg) {
+      throw new Error('Extrude operation not found')
+    }
+
+    const selections = retrieveSelectionsFromOpArg(
+      op.unlabeledArg,
+      artifactGraph
+    )
+    if (err(selections)) {
+      throw new Error(
+        `${selections.message}: ${JSON.stringify(op.unlabeledArg.value)}`
+      )
+    }
+
+    expect(selections.graphSelections).toHaveLength(1)
+    expect(selections.graphSelections[0].artifact?.type).toBe('path')
+
+    const editEvent = await enterEditFlow({
+      operation: op,
+      code,
+      artifactGraph,
+      rustContext: rustContextInThisFile,
+    })
+    if (err(editEvent)) throw editEvent
+    expect(editEvent.type).toBe('Find and select command')
+  })
+
   it('should find the profile selection from simple extrude op', async () => {
     const circleProfileInVar = `sketch001 = startSketchOn(XY)
 profile001 = circle(sketch001, center = [0, 0], radius = 1)


### PR DESCRIPTION
We normally rebuild the sketch expression from a variable tied to the artifact graph. An inline region doesn't have that variable, so we came up empty and quietly dropped the expression, which meant the extrude couldn't be edited.

When we're editing an existing call and can't reconstruct that expression, this just keeps the one that's already there. That seems like the least surprising thing to do, and gives inline regions the same edit path as variable-backed ones.

Fix in src/lang/modifyAst/sweeps.ts

Closes #12532 