### PR TITLE
feat(kcl): adds `never` type as experimental

### DIFF
--- a/docs/kcl-std/index.md
+++ b/docs/kcl-std/index.md
@@ -255,6 +255,7 @@ See also the [types overview](/docs/kcl-lang/types)
   * [`any`](/docs/kcl-std/types/std-types-any)
   * [`bool`](/docs/kcl-std/types/std-types-bool)
   * [`fn`](/docs/kcl-std/types/std-types-fn)
+  * [`never`](/docs/kcl-std/types/std-types-never) Experimental
   * [`none`](/docs/kcl-std/types/std-types-none) Experimental
   * [`number`](/docs/kcl-std/types/std-types-number)
   * [`string`](/docs/kcl-std/types/std-types-string)

--- a/docs/kcl-std/modules/std-types.md
+++ b/docs/kcl-std/modules/std-types.md
@@ -42,6 +42,7 @@ does.
 * [`in`](/docs/kcl-std/types/std-types-in)
 * [`m`](/docs/kcl-std/types/std-types-m)
 * [`mm`](/docs/kcl-std/types/std-types-mm)
+* [`never`](/docs/kcl-std/types/std-types-never)
 * [`none`](/docs/kcl-std/types/std-types-none)
 * [`number`](/docs/kcl-std/types/std-types-number)
 * [`rad`](/docs/kcl-std/types/std-types-rad)

--- a/docs/kcl-std/types/std-types-never.md
+++ b/docs/kcl-std/types/std-types-never.md
@@ -1,0 +1,18 @@
+---
+title: "never"
+subtitle: "Type in std::types"
+excerpt: "The uninhabited type of computations that never complete normally."
+layout: manual
+---
+
+**WARNING:** This type is experimental and may change or be removed.
+
+The uninhabited type of computations that never complete normally.
+
+[`never`](/docs/kcl-std/types/std-types-never) has no values and is a subtype of every type. Use it as the return
+type of a function that always stops evaluation by raising an error. A
+function declared to return [`never`](/docs/kcl-std/types/std-types-never) produces a type error if it returns a
+value or reaches the end of its body.
+
+
+

--- a/rust/kcl-lib/src/execution/fn_call.rs
+++ b/rust/kcl-lib/src/execution/fn_call.rs
@@ -502,6 +502,9 @@ impl FunctionSource {
         let mut result = match result {
             Ok(Some(value)) => {
                 if value.is_some_return() {
+                    // `Exit` terminates the whole evaluation rather than completing this
+                    // function normally, so it bypasses return-type validation, including
+                    // the `never` contract.
                     return Ok(Some(value));
                 } else {
                     Ok(Some(value.into_value()))
@@ -1160,28 +1163,45 @@ fn coerce_result_type(
     fn_def: &FunctionSource,
     exec_state: &mut ExecState,
 ) -> Result<Option<KclValue>, KclError> {
-    if let Ok(Some(val)) = result {
-        if let Some(ret_ty) = &fn_def.return_type {
-            // Suppress warnings about types because they should only be warned
-            // about once for the function definition.
-            let ty = RuntimeType::from_parsed(ret_ty.inner.clone(), exec_state, ret_ty.as_source_range(), false, true)
-                .map_err(|e| KclError::new_semantic(e.into()))?;
-            let val = val.coerce(&ty, true, exec_state).map_err(|_| {
-                KclError::new_type(KclErrorDetails::new(
-                    format!(
-                        "This function requires its result to be {}",
-                        type_err_str(ret_ty, &val, &(&val).into(), exec_state)
-                    ),
-                    ret_ty.as_source_ranges(),
-                ))
-            })?;
-            Ok(Some(val))
+    let result = result?;
+
+    let Some(ret_ty) = &fn_def.return_type else {
+        return Ok(result);
+    };
+
+    // Suppress warnings about types because they should only be warned
+    // about once for the function definition.
+    let ty = RuntimeType::from_parsed(ret_ty.inner.clone(), exec_state, ret_ty.as_source_range(), false, true)
+        .map_err(|e| KclError::new_semantic(e.into()))?;
+
+    // `never` describes the absence of normal completion, so either successful
+    // result shape violates the function's declared contract.
+    if ty.subtype(&RuntimeType::never()) {
+        let message = if result.is_some() {
+            "This function is declared to return `never`, but it returned a value."
         } else {
-            Ok(Some(val))
-        }
-    } else {
-        result
+            "This function is declared to return `never`, but it completed without returning a value."
+        };
+        return Err(KclError::new_type(KclErrorDetails::new(
+            message.to_owned(),
+            ret_ty.as_source_ranges(),
+        )));
     }
+
+    let Some(val) = result else {
+        return Ok(None);
+    };
+
+    let val = val.coerce(&ty, true, exec_state).map_err(|_| {
+        KclError::new_type(KclErrorDetails::new(
+            format!(
+                "This function requires its result to be {}",
+                type_err_str(ret_ty, &val, &(&val).into(), exec_state)
+            ),
+            ret_ty.as_source_ranges(),
+        ))
+    })?;
+    Ok(Some(val))
 }
 
 #[cfg(test)]
@@ -1432,6 +1452,106 @@ msg2 = makeMessage(prefix = 1, suffix = 3)"#;
             err.message(),
             "prefix requires a value with type `string`, but found a value with type `number`.\nThe found value is a number but has incomplete units information. You can probably fix this error by specifying the units using type ascription, e.g., `len: mm` or `(a * b): deg`."
         )
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn never_function_cannot_return_a_value() {
+        let program = r#"@settings(experimentalFeatures = allow)
+fn bad(): never {
+  return 42
+}
+
+bad()
+"#;
+        let err = parse_execute(program).await.unwrap_err();
+
+        assert!(matches!(&err, KclError::Type { .. }));
+        assert_eq!(
+            err.message(),
+            "This function is declared to return `never`, but it returned a value."
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn never_function_cannot_fall_through() {
+        let program = r#"@settings(experimentalFeatures = allow)
+fn alsoBad(): never {
+  x = 42
+}
+
+alsoBad()
+"#;
+        let err = parse_execute(program).await.unwrap_err();
+
+        assert!(matches!(&err, KclError::Type { .. }));
+        assert_eq!(
+            err.message(),
+            "This function is declared to return `never`, but it completed without returning a value."
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn never_union_function_cannot_return_a_value() {
+        let program = r#"@settings(experimentalFeatures = allow)
+fn bad(): never | never {
+  return 42
+}
+
+bad()
+"#;
+        let err = parse_execute(program).await.unwrap_err();
+
+        assert!(matches!(&err, KclError::Type { .. }));
+        assert_eq!(
+            err.message(),
+            "This function is declared to return `never`, but it returned a value."
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn never_union_function_cannot_fall_through() {
+        let program = r#"@settings(experimentalFeatures = allow)
+fn alsoBad(): never | never {
+  x = 42
+}
+
+alsoBad()
+"#;
+        let err = parse_execute(program).await.unwrap_err();
+
+        assert!(matches!(&err, KclError::Type { .. }));
+        assert_eq!(
+            err.message(),
+            "This function is declared to return `never`, but it completed without returning a value."
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn never_function_contract_is_path_dependent() {
+        let function = r#"@settings(experimentalFeatures = allow)
+fn pathDependent(@propagateError: bool): never {
+  return if propagateError {
+    missingValue
+  } else {
+    42
+  }
+}
+"#;
+
+        let err = parse_execute(&format!("{function}\npathDependent(true)\n"))
+            .await
+            .unwrap_err();
+        assert!(matches!(&err, KclError::UndefinedValue { .. }));
+        assert_eq!(err.message(), "`missingValue` is not defined");
+
+        let err = parse_execute(&format!("{function}\npathDependent(false)\n"))
+            .await
+            .unwrap_err();
+        assert!(matches!(&err, KclError::Type { .. }));
+        assert_eq!(
+            err.message(),
+            "This function is declared to return `never`, but it returned a value."
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/rust/kcl-lib/src/execution/types.rs
+++ b/rust/kcl-lib/src/execution/types.rs
@@ -45,6 +45,10 @@ impl RuntimeType {
         RuntimeType::Primitive(PrimitiveType::Any)
     }
 
+    pub fn never() -> Self {
+        RuntimeType::Primitive(PrimitiveType::Never)
+    }
+
     pub fn any_array() -> Self {
         RuntimeType::Array(Box::new(RuntimeType::Primitive(PrimitiveType::Any)), ArrayLen::None)
     }
@@ -259,6 +263,7 @@ impl RuntimeType {
     ) -> Result<Self, CompilationIssue> {
         Ok(match value {
             AstPrimitiveType::Any => RuntimeType::Primitive(PrimitiveType::Any),
+            AstPrimitiveType::Never => RuntimeType::never(),
             AstPrimitiveType::None => RuntimeType::Primitive(PrimitiveType::None),
             AstPrimitiveType::String => RuntimeType::Primitive(PrimitiveType::String),
             AstPrimitiveType::Boolean => RuntimeType::Primitive(PrimitiveType::Boolean),
@@ -333,12 +338,13 @@ impl RuntimeType {
         use RuntimeType::*;
 
         match (self, sup) {
+            (Primitive(PrimitiveType::Never), _) => true,
             (_, Primitive(PrimitiveType::Any)) => true,
             (Primitive(t1), Primitive(t2)) => t1.subtype(t2),
             (Array(t1, l1), Array(t2, l2)) => t1.subtype(t2) && l1.subtype(*l2),
             (Tuple(t1), Tuple(t2)) => t1.len() == t2.len() && t1.iter().zip(t2).all(|(t1, t2)| t1.subtype(t2)),
 
-            (Union(ts1), Union(ts2)) => ts1.iter().all(|t| ts2.contains(t)),
+            (Union(ts1), t2) => ts1.iter().all(|t| t.subtype(t2)),
             (t1, Union(ts2)) => ts2.iter().any(|t| t1.subtype(t)),
 
             (Object(t1, _), Object(t2, _)) => t2
@@ -474,6 +480,7 @@ impl ArrayLen {
 #[derive(Debug, Clone, PartialEq)]
 pub enum PrimitiveType {
     Any,
+    Never,
     None,
     Number(NumericType),
     String,
@@ -501,6 +508,7 @@ impl PrimitiveType {
     fn display_multiple(&self) -> String {
         match self {
             PrimitiveType::Any => "any values".to_owned(),
+            PrimitiveType::Never => "values of type `never`".to_owned(),
             PrimitiveType::None => "none values".to_owned(),
             PrimitiveType::Number(NumericType::Known(unit)) => format!("numbers({unit})"),
             PrimitiveType::Number(_) => "numbers".to_owned(),
@@ -528,6 +536,7 @@ impl PrimitiveType {
 
     fn subtype(&self, other: &PrimitiveType) -> bool {
         match (self, other) {
+            (PrimitiveType::Never, _) => true,
             (_, PrimitiveType::Any) => true,
             (PrimitiveType::Number(n1), PrimitiveType::Number(n2)) => n1.subtype(n2),
             (PrimitiveType::TaggedEdge, PrimitiveType::TaggedFace)
@@ -541,6 +550,7 @@ impl std::fmt::Display for PrimitiveType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             PrimitiveType::Any => write!(f, "any"),
+            PrimitiveType::Never => write!(f, "never"),
             PrimitiveType::None => write!(f, "none"),
             PrimitiveType::Number(NumericType::Known(unit)) => write!(f, "number({unit})"),
             PrimitiveType::Number(NumericType::Unknown) => write!(f, "number(unknown units)"),
@@ -1339,6 +1349,7 @@ impl KclValue {
     ) -> Result<KclValue, CoercionError> {
         match ty {
             PrimitiveType::Any => Ok(self.clone()),
+            PrimitiveType::Never => Err(self.into()),
             PrimitiveType::None => match self {
                 KclValue::KclNone { .. } => Ok(self.clone()),
                 _ => Err(self.into()),
@@ -2342,6 +2353,87 @@ mod test {
         ]);
         count.coerce(&tyb, true, &mut exec_state).unwrap_err();
         count.coerce(&tyb2, true, &mut exec_state).unwrap_err();
+        ctx.close().await;
+    }
+
+    #[test]
+    fn union_subtyping_uses_member_subtyping() {
+        let tagged_edge = RuntimeType::Primitive(PrimitiveType::TaggedEdge);
+        let edge = RuntimeType::Primitive(PrimitiveType::Edge);
+        let string = RuntimeType::string();
+        let boolean = RuntimeType::bool();
+
+        let tagged_edge_or_string = RuntimeType::Union(vec![tagged_edge.clone(), string.clone()]);
+        let edge_or_string = RuntimeType::Union(vec![edge.clone(), string.clone()]);
+
+        // TaggedEdge | string <: Edge | string
+        assert!(tagged_edge_or_string.subtype(&edge_or_string));
+        // Edge | string is not a subtype of TaggedEdge | string.
+        assert!(!edge_or_string.subtype(&tagged_edge_or_string));
+
+        // TaggedEdge | Edge <: Edge
+        assert!(RuntimeType::Union(vec![tagged_edge.clone(), edge.clone()]).subtype(&edge));
+        // TaggedEdge | bool is not a subtype of Edge.
+        assert!(!RuntimeType::Union(vec![tagged_edge, boolean]).subtype(&edge));
+
+        // The empty union is a subtype of string.
+        assert!(RuntimeType::Union(vec![]).subtype(&string));
+    }
+
+    #[test]
+    fn nested_union_subtyping_is_associative_and_recursive() {
+        let tagged_edge = RuntimeType::Primitive(PrimitiveType::TaggedEdge);
+        let edge = RuntimeType::Primitive(PrimitiveType::Edge);
+        let string = RuntimeType::string();
+        let boolean = RuntimeType::bool();
+
+        let left_associative = RuntimeType::Union(vec![
+            RuntimeType::Union(vec![string.clone(), boolean.clone()]),
+            edge.clone(),
+        ]);
+        let right_associative =
+            RuntimeType::Union(vec![string, RuntimeType::Union(vec![boolean.clone(), edge.clone()])]);
+
+        // (string | bool) | Edge <: string | (bool | Edge)
+        assert!(left_associative.subtype(&right_associative));
+        // string | (bool | Edge) <: (string | bool) | Edge
+        assert!(right_associative.subtype(&left_associative));
+
+        let nested_edges = RuntimeType::Union(vec![
+            RuntimeType::Union(vec![tagged_edge.clone(), edge.clone()]),
+            tagged_edge.clone(),
+        ]);
+        // (TaggedEdge | Edge) | TaggedEdge <: Edge
+        assert!(nested_edges.subtype(&edge));
+
+        let nested_with_bool = RuntimeType::Union(vec![RuntimeType::Union(vec![tagged_edge, boolean]), edge.clone()]);
+        // (TaggedEdge | bool) | Edge is not a subtype of Edge.
+        assert!(!nested_with_bool.subtype(&edge));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn never_is_bottom_and_uninhabited() {
+        let (ctx, mut exec_state) = new_exec_state().await;
+        let never = RuntimeType::never();
+        let string = RuntimeType::string();
+
+        for ty in [
+            RuntimeType::any(),
+            string.clone(),
+            RuntimeType::Array(Box::new(string.clone()), ArrayLen::None),
+            RuntimeType::Tuple(vec![string.clone()]),
+            RuntimeType::Object(vec![("value".to_owned(), string.clone())], false),
+            RuntimeType::Union(vec![string.clone(), RuntimeType::bool()]),
+        ] {
+            assert!(never.subtype(&ty), "`never` should be a subtype of {ty}");
+        }
+
+        assert!(!string.subtype(&never));
+        assert!(RuntimeType::Union(vec![never.clone(), string.clone()]).subtype(&string));
+
+        for value in values(&mut exec_state) {
+            value.coerce(&never, true, &mut exec_state).unwrap_err();
+        }
         ctx.close().await;
     }
 

--- a/rust/kcl-lib/src/parsing/ast/digest.rs
+++ b/rust/kcl-lib/src/parsing/ast/digest.rs
@@ -289,6 +289,7 @@ impl PrimitiveType {
         let mut hasher = Sha256::new();
         match self {
             PrimitiveType::Any => hasher.update(b"any"),
+            PrimitiveType::Never => hasher.update(b"never"),
             PrimitiveType::None => hasher.update(b"none"),
             PrimitiveType::Named { id } => hasher.update(id.compute_digest()),
             PrimitiveType::String => hasher.update(b"string"),

--- a/rust/kcl-lib/src/parsing/ast/types/mod.rs
+++ b/rust/kcl-lib/src/parsing/ast/types/mod.rs
@@ -3848,6 +3848,8 @@ impl PipeExpression {
 pub enum PrimitiveType {
     /// The super type of all other types.
     Any,
+    /// `never`, the uninhabited subtype of all other types.
+    Never,
     /// `none`, the type of none values.
     None,
     /// A string type.
@@ -3871,6 +3873,7 @@ impl PrimitiveType {
     pub fn primitive_from_str(s: &str, suffix: Option<NumericSuffix>) -> Option<Self> {
         match (s, suffix) {
             ("any", None) => Some(PrimitiveType::Any),
+            ("never", None) => Some(PrimitiveType::Never),
             ("none", None) => Some(PrimitiveType::None),
             ("string", None) => Some(PrimitiveType::String),
             ("bool", None) => Some(PrimitiveType::Boolean),
@@ -3885,6 +3888,7 @@ impl PrimitiveType {
     fn display_multiple(&self) -> String {
         match self {
             PrimitiveType::Any => "values".to_owned(),
+            PrimitiveType::Never => "values of type `never`".to_owned(),
             PrimitiveType::None => "none".to_owned(),
             PrimitiveType::Number(_) => "numbers".to_owned(),
             PrimitiveType::String => "strings".to_owned(),
@@ -3901,6 +3905,7 @@ impl fmt::Display for PrimitiveType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             PrimitiveType::Any => write!(f, "any"),
+            PrimitiveType::Never => write!(f, "never"),
             PrimitiveType::None => write!(f, "none"),
             PrimitiveType::Number(suffix) => {
                 write!(f, "number")?;
@@ -4708,6 +4713,31 @@ cylinder = startSketchOn(-XZ)
         assert_eq!(
             params[2].param_type.as_ref().unwrap().inner,
             Type::Primitive(PrimitiveType::String)
+        );
+    }
+
+    #[test]
+    fn test_parse_never_type() {
+        let program =
+            parse("@settings(experimentalFeatures = allow)\nfn stop(@impossible: never): never { return impossible }");
+        let BodyItem::VariableDeclaration(var_decl) = program.body.first().unwrap() else {
+            panic!("expected a variable declaration")
+        };
+        let Expr::FunctionExpression(function) = &var_decl.declaration.init else {
+            panic!("expected a function expression")
+        };
+
+        assert_eq!(
+            function.params[0].param_type.as_ref().unwrap().inner,
+            Type::Primitive(PrimitiveType::Never)
+        );
+        assert_eq!(
+            function.return_type.as_ref().unwrap().inner,
+            Type::Primitive(PrimitiveType::Never)
+        );
+        assert_eq!(
+            serde_json::to_value(PrimitiveType::Never).unwrap(),
+            serde_json::json!({ "p_type": "Never" })
         );
     }
 

--- a/rust/kcl-lib/src/parsing/parser.rs
+++ b/rust/kcl-lib/src/parsing/parser.rs
@@ -3614,6 +3614,9 @@ fn primitive_type(i: &mut TokenSlice) -> ModalResult<Node<PrimitiveType>> {
             if *result == PrimitiveType::None {
                 ParseContext::experimental("none type", result.as_source_range());
             }
+            if *result == PrimitiveType::Never {
+                ParseContext::experimental("never type", result.as_source_range());
+            }
 
             result
         }),
@@ -6333,6 +6336,29 @@ type foo = fn(fn, f: fn(number(_))): [fn([any]): string]
     "#;
         let (_, errs) = assert_no_err(code);
         assert_eq!(errs.len(), 1);
+    }
+
+    #[test]
+    fn never_type_is_experimental() {
+        let code = "fn stop(): never {}";
+        assert_err(
+            code,
+            "Use of never type is experimental and may change or be removed.",
+            [11, 16],
+        );
+
+        let code = r#"@settings(experimentalFeatures = allow)
+fn stop(): never {}"#;
+        assert_no_err(code);
+
+        let code = r#"@settings(experimentalFeatures = warn)
+fn stop(): never {}"#;
+        let (_, errs) = assert_no_err(code);
+        assert_eq!(errs.len(), 1);
+        assert_eq!(
+            errs[0].message,
+            "Use of never type is experimental and may change or be removed."
+        );
     }
 
     #[test]

--- a/rust/kcl-lib/std/types.kcl
+++ b/rust/kcl-lib/std/types.kcl
@@ -23,6 +23,15 @@
 @(impl = primitive)
 export type any
 
+/// The uninhabited type of computations that never complete normally.
+///
+/// `never` has no values and is a subtype of every type. Use it as the return
+/// type of a function that always stops evaluation by raising an error. A
+/// function declared to return `never` produces a type error if it returns a
+/// value or reaches the end of its body.
+@(impl = primitive, experimental = true)
+export type never
+
 /// The type of the none (aka null) value.
 ///
 /// Note that this is not the empty type, i.e., a type which represents no values.


### PR DESCRIPTION
- Add `never` as an experimental primitive KCL type across parsing, AST serialization, runtime types, generated bindings, and stdlib documentation.
- Treat `never` as the uninhabited bottom type:
  - `never <: T` for every type `T`.
  - No runtime value can be coerced to `never`.
- Correct union subtyping to compare alternatives recursively, including nested unions.
- Enforce the runtime contract for functions whose resolved return type satisfies `T <: never`:
  - errors propagate normally;
  - returning a value produces a type error;
  - reaching the end of the function produces a type error.
- Preserve whole-evaluation `Exit` control flow, which intentionally bypasses function return validation.

Follow-up PR to add err() function in KCL std lib.