### PR TITLE
Deflake named view snapshot ordering

### DIFF
--- a/e2e/playwright/named-views.spec.ts
+++ b/e2e/playwright/named-views.spec.ts
@@ -44,16 +44,20 @@ function tomlStringMakeTestDataNotAsFragile(toml: string): string {
   delete settings.settings?.meta
   const namedViews = settings.settings?.app?.named_views
   if (namedViews) {
-    const entries = Object.entries(namedViews)
-    const remappedNamedViews: { [key: string]: NamedView } = {}
-    entries.forEach(([_, value]) => {
-      if (value) {
-        // {name:'uuid1'} -> uuid1 lookup
-        const staticUuid = nameToUuid.get(value.name)
-        if (staticUuid) {
-          remappedNamedViews[staticUuid] = value
+    const entries = Object.values(namedViews)
+      .flatMap((value) => {
+        if (!value) {
+          return []
         }
-      }
+        const staticUuid = nameToUuid.get(value.name)
+        return staticUuid ? [{ staticUuid, value }] : []
+      })
+      .toSorted((left, right) =>
+        left.staticUuid.localeCompare(right.staticUuid)
+      )
+    const remappedNamedViews: { [key: string]: NamedView } = {}
+    entries.forEach(({ staticUuid, value }) => {
+      remappedNamedViews[staticUuid] = value
     })
     if (settings && settings.settings && settings.settings.app) {
       settings.settings.app.named_views = remappedNamedViews


### PR DESCRIPTION
## Summary

Deflakes the desktop named-view snapshot test by making the test's TOML normalization emit deterministic named-view table order.

## Root cause

The app creates named views with random UUID keys. The test helper remaps those random UUIDs to stable snapshot UUIDs based on each named view's `name`, but it preserved the incoming TOML/object entry order. After the project TOML canonicalization work, the incoming table order can depend on the generated random UUIDs. That means valid TOML can serialize as `uuid2` before `uuid1` even though both named-view bodies are correct.

Because the snapshot assertion lives inside `expect(...).toPass()`, a reversed-but-valid order causes Playwright to keep rereading the same file until the full 120s test timeout.

## Changes

- Sort remapped named views by their static snapshot UUID before serializing the normalized TOML.
- Keep the production app behavior unchanged; this only stabilizes the E2E snapshot helper.

## Validation

- `npm run tsc -- --noEmit`
- `npm run lint`
- `npm run tronb:vite:dev`
- `npm run test:e2e:desktop -- --grep="Named view tests.*Verify two named views get created" --max-failures=1`