### PR TITLE
Extract cloud conflict review helpers

### DIFF
--- a/src/components/CloudConflictDialog.spec.tsx
+++ b/src/components/CloudConflictDialog.spec.tsx
@@ -1,9 +1,8 @@
 import { CloudConflictDialog } from '@src/components/CloudConflictDialog'
 import fsZds from '@src/lib/fs-zds'
-import {
-  getCloudSyncProjectMetadata,
-  resolveCloudSyncProjectConflict,
-} from '@src/lib/cloudSync'
+import { resolveCloudSyncProjectConflict } from '@src/lib/cloudSync'
+import { getCloudSyncProjectMetadata } from '@src/lib/cloudSync/syncDb'
+import { Themes } from '@src/lib/theme'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
 
@@ -47,6 +46,20 @@ vi.mock('@src/lib/cloudSync', async () => {
     resolveCloudSyncProjectConflict: vi.fn().mockResolvedValue(undefined),
   }
 })
+
+vi.mock('@src/lib/cloudSync/syncDb', () => ({
+  getCloudSyncProjectMetadata: vi.fn().mockResolvedValue({
+    schemaVersion: 1,
+    localProjectPath: '/projects/local',
+    projectName: 'Local project',
+    remoteProjectId: 'remote-123',
+    conflict: {
+      conflictProjectPath: '/projects/local (cloud conflict)',
+      createdAt: '2026-07-17T12:00:00.000Z',
+      remoteRevision: 'remote-revision-2',
+    },
+  }),
+}))
 
 vi.mock('@src/lib/fs-zds', () => ({
   default: {
@@ -142,7 +155,7 @@ describe('CloudConflictDialog', () => {
       <CloudConflictDialog
         projectPath="/projects/local"
         projectName="local-folder"
-        resolvedTheme="light"
+        resolvedTheme={Themes.Light}
         onDismiss={onDismiss}
       />
     )

--- a/src/components/CloudConflictDialog.tsx
+++ b/src/components/CloudConflictDialog.tsx
@@ -23,48 +23,23 @@ import {
   getCloudSyncProjectMetadataIndex,
   resolveCloudSyncProjectConflict,
 } from '@src/lib/cloudSync'
-import { PROJECT_SETTINGS_FILE_NAME } from '@src/lib/constants'
+import {
+  type ConflictFileComparison,
+  type ConflictFileStatus,
+  type ConflictInspection,
+  formatFileSize,
+  loadConflictInspection,
+} from '@src/lib/cloudSync/conflictInspection'
 import fsZds from '@src/lib/fs-zds'
-import { fsZdsConstants } from '@src/lib/fs-zds/constants'
-import { getProjectTitleFromProjectTomlContents } from '@src/lib/projectTomlMetadata'
+import type { ResolvedTheme } from '@src/lib/theme'
 import { reportRejection } from '@src/lib/trap'
-
-type CloudConflictDialogResolvedTheme = 'light' | 'dark'
 
 type CloudConflictDialogProps = {
   projectPath: string
   projectName?: string
-  resolvedTheme: CloudConflictDialogResolvedTheme
+  resolvedTheme: ResolvedTheme
   onDismiss: () => void
   onResolved?: () => void
-}
-
-type ScannedProjectFile = {
-  absolutePath: string
-  data: Uint8Array
-  modifiedAtMs: number
-  relativePath: string
-  size: number
-}
-
-type ConflictFileStatus = 'changed' | 'local-only' | 'cloud-only'
-
-type ConflictFileComparison = {
-  status: ConflictFileStatus
-  relativePath: string
-  local?: ScannedProjectFile
-  cloud?: ScannedProjectFile
-  localText?: string
-  cloudText?: string
-  textUnavailableReason?: string
-}
-
-type ConflictInspection = {
-  projectTitle?: string
-  remoteProjectId?: string
-  localSavedAtMs?: number
-  cloudSavedAtMs?: number
-  changedFiles: ConflictFileComparison[]
 }
 
 type ConflictInspectionState =
@@ -72,34 +47,8 @@ type ConflictInspectionState =
   | { status: 'ready'; inspection: ConflictInspection }
   | { status: 'error'; message: string }
 
-const INTERNAL_OPFS_META_FILE = '._meta'
-const MAX_MERGE_TEXT_BYTES = 512 * 1024
-const textDecoder = new TextDecoder('utf-8', { fatal: true })
-
 function messageFromError(error: unknown) {
   return error instanceof Error ? error.message : String(error)
-}
-
-function normalizeRelativePath(relativePath: string) {
-  return relativePath.replace(/\\/g, '/').replace(/^\/+/, '')
-}
-
-function statIsDirectory(mode: number) {
-  return Boolean(mode & fsZdsConstants.S_IFDIR)
-}
-
-function bytesEqual(left: Uint8Array, right: Uint8Array) {
-  if (left.byteLength !== right.byteLength) {
-    return false
-  }
-
-  for (let index = 0; index < left.byteLength; index++) {
-    if (left[index] !== right[index]) {
-      return false
-    }
-  }
-
-  return true
 }
 
 function formatDateTime(dateTimeMs: number | undefined) {
@@ -108,22 +57,6 @@ function formatDateTime(dateTimeMs: number | undefined) {
   }
 
   return new Date(dateTimeMs).toLocaleString()
-}
-
-function formatFileSize(size: number | undefined) {
-  if (size === undefined) {
-    return '—'
-  }
-
-  if (size < 1024) {
-    return `${size} B`
-  }
-
-  if (size < 1024 * 1024) {
-    return `${(size / 1024).toFixed(1)} KB`
-  }
-
-  return `${(size / (1024 * 1024)).toFixed(1)} MB`
 }
 
 function conflictStatusLabel(status: ConflictFileStatus) {
@@ -146,175 +79,9 @@ function statusBadgeClassName(status: ConflictFileStatus) {
   return 'bg-warn-20 text-warn-90 dark:bg-warn-80/30 dark:text-warn-10'
 }
 
-function decodeMergeableText(file: ScannedProjectFile | undefined) {
-  if (!file) {
-    return ''
-  }
-
-  if (file.data.byteLength > MAX_MERGE_TEXT_BYTES) {
-    return undefined
-  }
-
-  try {
-    const text = textDecoder.decode(file.data)
-    if (text.includes('\u0000')) {
-      return undefined
-    }
-    return text
-  } catch {
-    return undefined
-  }
-}
-
-function getTextUnavailableReason(
-  local: ScannedProjectFile | undefined,
-  cloud: ScannedProjectFile | undefined,
-  localText: string | undefined,
-  cloudText: string | undefined
-) {
-  const largestSize = Math.max(local?.size ?? 0, cloud?.size ?? 0)
-  if (largestSize > MAX_MERGE_TEXT_BYTES) {
-    return `File is larger than ${formatFileSize(MAX_MERGE_TEXT_BYTES)}.`
-  }
-
-  if (localText === undefined || cloudText === undefined) {
-    return 'Binary or non-UTF-8 file.'
-  }
-
-  return undefined
-}
-
-function latestModifiedAt(files: Iterable<ScannedProjectFile>) {
-  let latest: number | undefined
-  for (const file of files) {
-    latest =
-      latest === undefined
-        ? file.modifiedAtMs
-        : Math.max(latest, file.modifiedAtMs)
-  }
-  return latest
-}
-
-function getProjectTitleFromScannedFiles(
-  files: Map<string, ScannedProjectFile>
-) {
-  const projectToml = files.get(PROJECT_SETTINGS_FILE_NAME)
-  const projectTomlText = decodeMergeableText(projectToml)
-  return projectTomlText
-    ? getProjectTitleFromProjectTomlContents(projectTomlText)
-    : undefined
-}
-
-async function scanProjectFiles(projectRoot: string) {
-  const files = new Map<string, ScannedProjectFile>()
-
-  async function walk(currentPath: string) {
-    const entries = (await fsZds.readdir(currentPath)).toSorted()
-
-    for (const entry of entries) {
-      if (entry === INTERNAL_OPFS_META_FILE) {
-        continue
-      }
-
-      const absolutePath = fsZds.join(currentPath, entry)
-      const stat = await fsZds.stat(absolutePath)
-      if (statIsDirectory(stat.mode)) {
-        await walk(absolutePath)
-        continue
-      }
-
-      const relativePath = normalizeRelativePath(
-        fsZds.relative(projectRoot, absolutePath) ?? ''
-      )
-      const data = Uint8Array.from(await fsZds.readFile(absolutePath))
-      files.set(relativePath, {
-        absolutePath,
-        data,
-        modifiedAtMs: stat.mtimeMs,
-        relativePath,
-        size: data.byteLength,
-      })
-    }
-  }
-
-  await walk(projectRoot)
-  return files
-}
-
-function buildChangedFileComparison({
-  relativePath,
-  local,
-  cloud,
-}: {
-  relativePath: string
-  local?: ScannedProjectFile
-  cloud?: ScannedProjectFile
-}): ConflictFileComparison | undefined {
-  if (local && cloud && bytesEqual(local.data, cloud.data)) {
-    return undefined
-  }
-
-  const localText = decodeMergeableText(local)
-  const cloudText = decodeMergeableText(cloud)
-
-  return {
-    status: local && cloud ? 'changed' : local ? 'local-only' : 'cloud-only',
-    relativePath,
-    local,
-    cloud,
-    localText,
-    cloudText,
-    textUnavailableReason: getTextUnavailableReason(
-      local,
-      cloud,
-      localText,
-      cloudText
-    ),
-  }
-}
-
-async function loadConflictInspection(
-  projectPath: string
-): Promise<ConflictInspection | Error> {
-  const metadata = await getCloudSyncProjectMetadata(projectPath)
-  if (!metadata?.conflict) {
-    return new Error('Cloud conflict metadata was not found for this project.')
-  }
-
-  const conflictProjectPath = metadata.conflict.conflictProjectPath
-  const [localFiles, cloudFiles] = await Promise.all([
-    scanProjectFiles(projectPath),
-    scanProjectFiles(conflictProjectPath),
-  ])
-  const relativePaths = new Set([...localFiles.keys(), ...cloudFiles.keys()])
-  const changedFiles: ConflictFileComparison[] = []
-
-  for (const relativePath of Array.from(relativePaths).toSorted()) {
-    const comparison = buildChangedFileComparison({
-      relativePath,
-      local: localFiles.get(relativePath),
-      cloud: cloudFiles.get(relativePath),
-    })
-
-    if (comparison) {
-      changedFiles.push(comparison)
-    }
-  }
-
-  return {
-    projectTitle:
-      getProjectTitleFromScannedFiles(localFiles) ??
-      getProjectTitleFromScannedFiles(cloudFiles),
-    remoteProjectId: metadata.remoteProjectId,
-    localSavedAtMs: latestModifiedAt(localFiles.values()),
-    cloudSavedAtMs: Date.parse(metadata.conflict.createdAt),
-    changedFiles,
-  }
-}
-
 function mergeLanguageExtensions(
   relativePath: string,
-  resolvedTheme: CloudConflictDialogResolvedTheme
+  resolvedTheme: ResolvedTheme
 ) {
   const extension = fsZds.extname(relativePath).toLowerCase()
   if (extension === '.kcl') {
@@ -354,7 +121,7 @@ const mergeEditorTheme = EditorView.theme({
 
 function mergeEditorExtensions(
   relativePath: string,
-  resolvedTheme: CloudConflictDialogResolvedTheme
+  resolvedTheme: ResolvedTheme
 ): Extension[] {
   return [
     ...mergeLanguageExtensions(relativePath, resolvedTheme),
@@ -370,7 +137,7 @@ function ConflictMergeView({
   resolvedTheme,
 }: {
   comparison: ConflictFileComparison
-  resolvedTheme: CloudConflictDialogResolvedTheme
+  resolvedTheme: ResolvedTheme
 }) {
   const containerRef = useRef<HTMLDivElement>(null)
 
@@ -434,7 +201,7 @@ function ChangedFilesTable({
   resolvedTheme,
 }: {
   files: ConflictFileComparison[]
-  resolvedTheme: CloudConflictDialogResolvedTheme
+  resolvedTheme: ResolvedTheme
 }) {
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(
     () => new Set(files.filter(canShowDiff).map((file) => file.relativePath))

--- a/src/lib/cloudSync/conflictInspection.ts
+++ b/src/lib/cloudSync/conflictInspection.ts
@@ -1,0 +1,240 @@
+import {
+  INTERNAL_OPFS_META_FILE,
+  normalizeRelativePath,
+} from '@src/lib/cloudSync/paths'
+import { getCloudSyncProjectMetadata } from '@src/lib/cloudSync/syncDb'
+import { PROJECT_SETTINGS_FILE_NAME } from '@src/lib/constants'
+import fsZds from '@src/lib/fs-zds'
+import { fsZdsConstants } from '@src/lib/fs-zds/constants'
+import { getProjectTitleFromProjectTomlContents } from '@src/lib/projectTomlMetadata'
+
+export type ScannedProjectFile = {
+  absolutePath: string
+  data: Uint8Array
+  modifiedAtMs: number
+  relativePath: string
+  size: number
+}
+
+export type ConflictFileStatus = 'changed' | 'local-only' | 'cloud-only'
+
+export type ConflictFileComparison = {
+  status: ConflictFileStatus
+  relativePath: string
+  local?: ScannedProjectFile
+  cloud?: ScannedProjectFile
+  localText?: string
+  cloudText?: string
+  textUnavailableReason?: string
+}
+
+export type ConflictInspection = {
+  projectTitle?: string
+  remoteProjectId?: string
+  localSavedAtMs?: number
+  cloudSavedAtMs?: number
+  changedFiles: ConflictFileComparison[]
+}
+
+const MAX_MERGE_TEXT_BYTES = 512 * 1024
+const textDecoder = new TextDecoder('utf-8', { fatal: true })
+
+function statIsDirectory(mode: number) {
+  return Boolean(mode & fsZdsConstants.S_IFDIR)
+}
+
+function bytesEqual(left: Uint8Array, right: Uint8Array) {
+  if (left.byteLength !== right.byteLength) {
+    return false
+  }
+
+  for (let index = 0; index < left.byteLength; index++) {
+    if (left[index] !== right[index]) {
+      return false
+    }
+  }
+
+  return true
+}
+
+export function formatFileSize(size: number | undefined) {
+  if (size === undefined) {
+    return '—'
+  }
+
+  if (size < 1024) {
+    return `${size} B`
+  }
+
+  if (size < 1024 * 1024) {
+    return `${(size / 1024).toFixed(1)} KB`
+  }
+
+  return `${(size / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function decodeMergeableText(file: ScannedProjectFile | undefined) {
+  if (!file) {
+    return ''
+  }
+
+  if (file.data.byteLength > MAX_MERGE_TEXT_BYTES) {
+    return undefined
+  }
+
+  try {
+    const text = textDecoder.decode(file.data)
+    if (text.includes('\u0000')) {
+      return undefined
+    }
+    return text
+  } catch {
+    return undefined
+  }
+}
+
+function getTextUnavailableReason(
+  local: ScannedProjectFile | undefined,
+  cloud: ScannedProjectFile | undefined,
+  localText: string | undefined,
+  cloudText: string | undefined
+) {
+  const largestSize = Math.max(local?.size ?? 0, cloud?.size ?? 0)
+  if (largestSize > MAX_MERGE_TEXT_BYTES) {
+    return `File is larger than ${formatFileSize(MAX_MERGE_TEXT_BYTES)}.`
+  }
+
+  if (localText === undefined || cloudText === undefined) {
+    return 'Binary or non-UTF-8 file.'
+  }
+
+  return undefined
+}
+
+function latestModifiedAt(files: Iterable<ScannedProjectFile>) {
+  let latest: number | undefined
+  for (const file of files) {
+    latest =
+      latest === undefined
+        ? file.modifiedAtMs
+        : Math.max(latest, file.modifiedAtMs)
+  }
+  return latest
+}
+
+function getProjectTitleFromScannedFiles(
+  files: Map<string, ScannedProjectFile>
+) {
+  const projectToml = files.get(PROJECT_SETTINGS_FILE_NAME)
+  const projectTomlText = decodeMergeableText(projectToml)
+  return projectTomlText
+    ? getProjectTitleFromProjectTomlContents(projectTomlText)
+    : undefined
+}
+
+async function scanProjectFiles(projectRoot: string) {
+  const files = new Map<string, ScannedProjectFile>()
+
+  async function walk(currentPath: string) {
+    const entries = (await fsZds.readdir(currentPath)).toSorted()
+
+    for (const entry of entries) {
+      if (entry === INTERNAL_OPFS_META_FILE) {
+        continue
+      }
+
+      const absolutePath = fsZds.join(currentPath, entry)
+      const stat = await fsZds.stat(absolutePath)
+      if (statIsDirectory(stat.mode)) {
+        await walk(absolutePath)
+        continue
+      }
+
+      const relativePath = normalizeRelativePath(
+        fsZds.relative(projectRoot, absolutePath) ?? ''
+      )
+      const data = Uint8Array.from(await fsZds.readFile(absolutePath))
+      files.set(relativePath, {
+        absolutePath,
+        data,
+        modifiedAtMs: stat.mtimeMs,
+        relativePath,
+        size: data.byteLength,
+      })
+    }
+  }
+
+  await walk(projectRoot)
+  return files
+}
+
+function buildChangedFileComparison({
+  relativePath,
+  local,
+  cloud,
+}: {
+  relativePath: string
+  local?: ScannedProjectFile
+  cloud?: ScannedProjectFile
+}): ConflictFileComparison | undefined {
+  if (local && cloud && bytesEqual(local.data, cloud.data)) {
+    return undefined
+  }
+
+  const localText = decodeMergeableText(local)
+  const cloudText = decodeMergeableText(cloud)
+
+  return {
+    status: local && cloud ? 'changed' : local ? 'local-only' : 'cloud-only',
+    relativePath,
+    local,
+    cloud,
+    localText,
+    cloudText,
+    textUnavailableReason: getTextUnavailableReason(
+      local,
+      cloud,
+      localText,
+      cloudText
+    ),
+  }
+}
+
+export async function loadConflictInspection(
+  projectPath: string
+): Promise<ConflictInspection | Error> {
+  const metadata = await getCloudSyncProjectMetadata(projectPath)
+  if (!metadata?.conflict) {
+    return new Error('Cloud conflict metadata was not found for this project.')
+  }
+
+  const conflictProjectPath = metadata.conflict.conflictProjectPath
+  const [localFiles, cloudFiles] = await Promise.all([
+    scanProjectFiles(projectPath),
+    scanProjectFiles(conflictProjectPath),
+  ])
+  const relativePaths = new Set([...localFiles.keys(), ...cloudFiles.keys()])
+  const changedFiles: ConflictFileComparison[] = []
+
+  for (const relativePath of Array.from(relativePaths).toSorted()) {
+    const comparison = buildChangedFileComparison({
+      relativePath,
+      local: localFiles.get(relativePath),
+      cloud: cloudFiles.get(relativePath),
+    })
+
+    if (comparison) {
+      changedFiles.push(comparison)
+    }
+  }
+
+  return {
+    projectTitle:
+      getProjectTitleFromScannedFiles(localFiles) ??
+      getProjectTitleFromScannedFiles(cloudFiles),
+    remoteProjectId: metadata.remoteProjectId,
+    localSavedAtMs: latestModifiedAt(localFiles.values()),
+    cloudSavedAtMs: Date.parse(metadata.conflict.createdAt),
+    changedFiles,
+  }
+}

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -35,7 +35,7 @@ import {
 import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
 import { PATHS } from '@src/lib/paths'
 import { getProjectDisplayName } from '@src/lib/projectDisplayName'
-import { Themes, getResolvedTheme } from '@src/lib/theme'
+import { getResolvedTheme, type ResolvedTheme } from '@src/lib/theme'
 import { reportRejection } from '@src/lib/trap'
 import { userFeaturesContextHas } from '@src/machines/userFeaturesMachine'
 import {
@@ -67,14 +67,6 @@ type CloudSyncStatusBarPresentation = {
   iconClassName: string
   isBlocked: boolean
   tooltip: string
-}
-
-type CloudConflictDialogResolvedTheme = 'light' | 'dark'
-
-function getCloudConflictDialogResolvedTheme(
-  theme: Parameters<typeof getResolvedTheme>[0]
-): CloudConflictDialogResolvedTheme {
-  return getResolvedTheme(theme) === Themes.Dark ? 'dark' : 'light'
 }
 
 type CloudSyncProjectMenuDialog =
@@ -220,7 +212,7 @@ function CloudSyncDisconnectProjectDialog({
 function CloudSyncProjectMenuDialogHost({
   resolvedTheme,
 }: {
-  resolvedTheme: CloudConflictDialogResolvedTheme
+  resolvedTheme: ResolvedTheme
 }) {
   useSignals()
   const dialog = cloudSyncProjectMenuDialog.value
@@ -415,7 +407,7 @@ export function getCloudSyncStatusBarPresentation(
 function CloudSyncStatusBarItem({
   resolvedTheme,
 }: {
-  resolvedTheme: CloudConflictDialogResolvedTheme
+  resolvedTheme: ResolvedTheme
 }) {
   useSignals()
   const location = useLocation()
@@ -550,9 +542,7 @@ const cloudSyncStatusBarItem = defineRegistryItemFactory((ctx) => {
     const settingsValues = settings.value!.useSettings()
     return (
       <CloudSyncStatusBarItem
-        resolvedTheme={getCloudConflictDialogResolvedTheme(
-          settingsValues.app.theme.current
-        )}
+        resolvedTheme={getResolvedTheme(settingsValues.app.theme.current)}
       />
     )
   }

--- a/src/lib/projectLibraries.ts
+++ b/src/lib/projectLibraries.ts
@@ -1,3 +1,4 @@
+import { hashString } from '@src/lib/stringUtils'
 import { isArray } from '@src/lib/utils'
 
 export const DEFAULT_PROJECT_LIBRARY_ID = 'default-project-directory'
@@ -83,17 +84,6 @@ export function mergeProjectLibrarySettings(
   }
 
   return Array.from(librariesByKey.values())
-}
-
-function hashString(input: string) {
-  let hash = 0
-
-  for (let i = 0; i < input.length; i += 1) {
-    hash = (hash << 5) - hash + input.charCodeAt(i)
-    hash |= 0
-  }
-
-  return Math.abs(hash).toString(36)
 }
 
 export function getProjectLibraryIdFromSetting(library: ProjectLibrarySetting) {

--- a/src/lib/stringUtils.ts
+++ b/src/lib/stringUtils.ts
@@ -1,0 +1,16 @@
+export function uniqueStrings(values: readonly (string | null | undefined)[]) {
+  return Array.from(
+    new Set(values.filter((value): value is string => Boolean(value)))
+  )
+}
+
+export function hashString(input: string) {
+  let hash = 0
+
+  for (let i = 0; i < input.length; i += 1) {
+    hash = (hash << 5) - hash + input.charCodeAt(i)
+    hash |= 0
+  }
+
+  return Math.abs(hash).toString(36)
+}

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -13,6 +13,8 @@ export enum Themes {
   System = 'system',
 }
 
+export type ResolvedTheme = Themes.Light | Themes.Dark
+
 export function appThemeToTheme(
   theme: AppTheme | undefined
 ): Themes | undefined {
@@ -29,7 +31,7 @@ export function appThemeToTheme(
 }
 
 // Get the theme from the system settings manually
-export function getSystemTheme(): Exclude<Themes, 'system'> {
+export function getSystemTheme(): ResolvedTheme {
   return typeof globalThis.window !== 'undefined' &&
     'matchMedia' in globalThis.window
     ? darkModeMatcher?.matches
@@ -48,7 +50,7 @@ export function setThemeClass(theme: Themes) {
 }
 
 // Returns the resolved theme in use (Dark || Light)
-export function getResolvedTheme(theme: Themes) {
+export function getResolvedTheme(theme: Themes): ResolvedTheme {
   return theme === Themes.System ? getSystemTheme() : theme
 }
 

--- a/src/registry/contracts/homeProjects.ts
+++ b/src/registry/contracts/homeProjects.ts
@@ -3,6 +3,7 @@ import {
   defineService,
   defineValueSpec,
 } from '@kittycad/registry'
+import { uniqueStrings } from '@src/lib/stringUtils'
 import { isArray } from '@src/lib/utils'
 
 export type HomeProjectSource = 'local' | 'remote' | 'both'
@@ -92,12 +93,6 @@ function contributionStableId(entry: HomeProjectEntryContribution) {
   return `${entry.source}:${entry.id ?? entry.name}`
 }
 
-function uniqueStrings(values: readonly (string | undefined)[]) {
-  return Array.from(
-    new Set(values.filter((value): value is string => Boolean(value)))
-  )
-}
-
 function contributionLibraryIds(entry: HomeProjectEntryContribution) {
   return uniqueStrings([entry.libraryId, ...(entry.libraryIds ?? [])])
 }
@@ -155,6 +150,11 @@ function mergeHomeProjectEntries(
   }
 }
 
+/**
+ * Same-source entries can overlap when multiple libraries point at the same
+ * local or remote project. Keep the newest display data while preserving every
+ * library membership so library-filtered views can still find the project.
+ */
 function mergeSameSourceHomeProjectEntries(
   existing: HomeProjectEntry | undefined,
   next: HomeProjectEntry


### PR DESCRIPTION
## Summary

Follow-up cleanup from review comments on #12525 and #12522.

- Moves cloud conflict project scanning/comparison logic out of the dialog component and into `src/lib/cloudSync/conflictInspection.ts`.
- Reuses a shared `ResolvedTheme` type from `src/lib/theme.ts` instead of plugin/dialog-local aliases.
- Adds `src/lib/stringUtils.ts` for shared `uniqueStrings` and `hashString`, then updates home project coalescing and project library IDs to use it.
- Documents why same-source Home project entry merging still exists while libraries can overlap.

## Review Threads

Addressed:

- https://github.com/KittyCAD/modeling-app/pull/12525#discussion_r3617505353
- https://github.com/KittyCAD/modeling-app/pull/12525#discussion_r3617518262
- https://github.com/KittyCAD/modeling-app/pull/12525#discussion_r3617528576
- https://github.com/KittyCAD/modeling-app/pull/12525#discussion_r3617531933
- https://github.com/KittyCAD/modeling-app/pull/12522#discussion_r3617005998
- https://github.com/KittyCAD/modeling-app/pull/12522#discussion_r3617010871
- https://github.com/KittyCAD/modeling-app/pull/12522#discussion_r3617130840

Related thread intentionally left for a later test-infra cleanup, because it was called out as not for today:

- https://github.com/KittyCAD/modeling-app/pull/12525#discussion_r3617512338

Non-actionable context thread:

- https://github.com/KittyCAD/modeling-app/pull/12522#discussion_r3617065203

## Validation

- `npm run tsc -- --noEmit`
- `npm run lint`
- `npm run test:integration -- src/components/CloudConflictDialog.spec.tsx src/lib/cloudSync/registry/plugin.spec.tsx`
- `npm run test:integration -- src/registry/contracts/homeProjects.spec.ts src/registry/contracts/projectLibraries.spec.ts`