### PR TITLE
Remove the KCL suffix enforcement on file renames

### DIFF
--- a/src/components/Explorer/ProjectExplorer.tsx
+++ b/src/components/Explorer/ProjectExplorer.tsx
@@ -26,9 +26,7 @@ import fsZds from '@src/lib/fs-zds'
 import {
   desktopSafePathJoin,
   desktopSafePathSplit,
-  enforceFileEXT,
   fileNameHasExtension,
-  getEXTWithPeriod,
   getParentAbsolutePath,
   joinOSPaths,
   parentPathRelativeToApplicationDirectory,
@@ -1312,16 +1310,12 @@ export const ProjectExplorer = ({
                 })
               }
             } else {
-              // rename a file
-              const originalExt = getEXTWithPeriod(name)
-              const fileNameForcedWithOriginalExt = enforceFileEXT(
-                requestedName,
-                originalExt
-              )
-              if (!fileNameForcedWithOriginalExt) {
-                // TODO: OH NO!
-                return
-              }
+              // Respect a user-typed extension otherwise assume the file is KCL.
+              const fileName =
+                fileNameHasExtension(requestedName) ||
+                requestedName.startsWith('.')
+                  ? requestedName
+                  : requestedName + FILE_EXT
 
               const requestedAbsoluteFilePathWithExtension = joinOSPaths(
                 getParentAbsolutePath(row.path),
@@ -1337,7 +1331,7 @@ export const ProjectExplorer = ({
                   ? SystemIOMachineEvents.renameFileAndNavigateToFile
                   : SystemIOMachineEvents.renameFile,
                 data: {
-                  requestedFileNameWithExtension: fileNameForcedWithOriginalExt,
+                  requestedFileNameWithExtension: fileName,
                   fileNameWithExtension: name,
                   absolutePathToParentDirectory: getParentAbsolutePath(
                     row.path

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -299,19 +299,6 @@ export function desktopSafePathJoin(paths: string[]): string {
   return paths.join(fsZds.sep)
 }
 
-/**
- * Don't pass a folder path, only files with extensions for best results.
- */
-export const enforceFileEXT = (
-  filePath: string,
-  ext: string | null
-): string | null => {
-  if (ext === null) {
-    return null
-  }
-  return filePath ? (filePath.endsWith(ext) ? filePath : filePath + ext) : null
-}
-
 export const getEXTNoPeriod = (filePath: string) => {
   const extension = filePath.split('.').pop() || null
   return extension


### PR DESCRIPTION
Since we now support working with non-KCL files (e.g. Markdown) we should stop appending `.kcl` to all renamed files.

To test this:

1. Create a new file without an extension
2. Confirm `.kcl` is appended
3. Rename the file to `test.md`
4. Confirm `.kcl` is not appended