### PR TITLE
Keep app library defaults separate from legacy migration

### DIFF
--- a/src/lib/projectLibraries/index.ts
+++ b/src/lib/projectLibraries/index.ts
@@ -2,7 +2,7 @@ import { hashString } from '@src/lib/stringUtils'
 import { isArray } from '@src/lib/utils'
 
 export const DEFAULT_PROJECT_LIBRARY_ID = 'default-project-directory'
-export const DEFAULT_PROJECT_LIBRARY_TITLE = 'Default Projects Directory'
+export const DEFAULT_PROJECT_LIBRARY_TITLE = 'Projects'
 export const NEW_PROJECT_LIBRARY_TITLE = 'Project Library'
 export const DIRECTORY_PROJECT_LIBRARY_TYPE = 'directory'
 export const PERSONAL_CLOUD_PROJECT_LIBRARY_ID = 'cloud-personal'

--- a/src/lib/settings/settingsUtils.spec.ts
+++ b/src/lib/settings/settingsUtils.spec.ts
@@ -17,11 +17,13 @@ import { projectLibrariesSettingsContribution } from '@src/lib/projectLibraries/
 import { defineBooleanExtensionSetting } from '@src/lib/settings/extensionSettings'
 import { createSettings, type Setting } from '@src/lib/settings/initialSettings'
 import {
+  clearSettingsAtLevel,
   configurationToSettingsPayload,
   formatSettingsLabel,
   getAllCurrentSettings,
   getChangedSettingsAtLevel,
   hiddenOnPlatform,
+  migrateLegacyProjectDirectoryToLibraries,
   mergeProjectConfiguration,
   projectConfigurationToSettingsPayload,
   replaceProjectSettingsPreservingMetadata,
@@ -118,7 +120,7 @@ describe('testing settings initialization', () => {
 
     expect(settings.app.libraries.current).toEqual([
       {
-        title: 'Default Projects Directory',
+        title: 'Projects',
         path: '/tmp/projects',
         type: 'directory',
       },
@@ -134,6 +136,111 @@ describe('testing settings initialization', () => {
     expect(getChangedSettingsAtLevel(settings, 'user').app?.libraries).toEqual(
       []
     )
+  })
+
+  it('migrates changed legacy project directory to a user library value', () => {
+    expect(
+      migrateLegacyProjectDirectoryToLibraries(
+        {
+          app: {
+            projectDirectory: '/custom/projects',
+          },
+        },
+        '/default/projects'
+      )
+    ).toEqual({
+      app: {
+        projectDirectory: '/custom/projects',
+        libraries: [
+          {
+            title: 'Projects',
+            path: '/custom/projects',
+            type: 'directory',
+          },
+        ],
+      },
+    })
+  })
+
+  it('keeps the app-owned libraries default when legacy project directory is unchanged', () => {
+    expect(
+      migrateLegacyProjectDirectoryToLibraries(
+        {
+          app: {
+            projectDirectory: '/default/projects',
+          },
+        },
+        '/default/projects'
+      )
+    ).toEqual({
+      app: {
+        projectDirectory: '/default/projects',
+      },
+    })
+  })
+
+  it('does not migrate legacy project directory over explicit libraries', () => {
+    expect(
+      migrateLegacyProjectDirectoryToLibraries(
+        {
+          app: {
+            projectDirectory: '/custom/projects',
+            libraries: [],
+          },
+        },
+        '/default/projects'
+      )
+    ).toEqual({
+      app: {
+        projectDirectory: '/custom/projects',
+        libraries: [],
+      },
+    })
+  })
+
+  it('keeps migrated legacy project directory separate from the libraries default', () => {
+    const settings = createSettings()
+    settings.app.projectDirectory.default = '/default/projects'
+    settings.app.libraries.default =
+      getDefaultProjectLibrarySettings('/default/projects')
+
+    setSettingsAtLevel(
+      settings,
+      'user',
+      migrateLegacyProjectDirectoryToLibraries(
+        {
+          app: {
+            projectDirectory: '/custom/projects',
+          },
+        },
+        '/default/projects'
+      )
+    )
+
+    expect(settings.app.libraries.default).toEqual([
+      {
+        title: 'Projects',
+        path: '/default/projects',
+        type: 'directory',
+      },
+    ])
+    expect(settings.app.libraries.current).toEqual([
+      {
+        title: 'Projects',
+        path: '/custom/projects',
+        type: 'directory',
+      },
+    ])
+
+    clearSettingsAtLevel(settings, 'user')
+
+    expect(settings.app.libraries.current).toEqual([
+      {
+        title: 'Projects',
+        path: '/default/projects',
+        type: 'directory',
+      },
+    ])
   })
 })
 

--- a/src/lib/settings/settingsUtils.ts
+++ b/src/lib/settings/settingsUtils.ts
@@ -403,6 +403,30 @@ function mergeSettingsPayloads(
   )
 }
 
+export function migrateLegacyProjectDirectoryToLibraries(
+  payload: DeepPartial<SaveSettingsPayload>,
+  initialDefaultDir: string
+): DeepPartial<SaveSettingsPayload> {
+  const legacyProjectDirectory =
+    typeof payload.app?.projectDirectory === 'string'
+      ? payload.app.projectDirectory
+      : undefined
+
+  if (
+    !legacyProjectDirectory ||
+    payload.app?.libraries !== undefined ||
+    legacyProjectDirectory === initialDefaultDir
+  ) {
+    return payload
+  }
+
+  return mergeSettingsPayloads(payload, {
+    app: {
+      libraries: getDefaultProjectLibrarySettings(legacyProjectDirectory),
+    },
+  })
+}
+
 function withLegacyProjectDirectoryMirroredFromLibraries(
   payload: DeepPartial<SaveSettingsPayload>
 ): DeepPartial<SaveSettingsPayload> {
@@ -990,30 +1014,19 @@ export async function loadAndValidateSettings(
     extensionSettings
   )
   const initialDefaultDir = await getInitialDefaultDir()
-  const legacyProjectDirectory =
-    typeof appSettings.app?.projectDirectory === 'string'
-      ? appSettings.app.projectDirectory
-      : undefined
-
-  const policyDefaultProjectLibraries = resolveProjectLibrarySettingDefaults(
-    projectLibrarySettingDefaultPolicies,
-    {
-      initialDefaultDir,
-      legacyProjectDirectory,
-      isDesktop: isDesktop(),
-    }
-  )
 
   let settingsNext = createSettings(extensionSettings)
   settingsNext.app.projectDirectory.default = initialDefaultDir
-  if (settingsNext.app.libraries) {
-    settingsNext.app.libraries.default = mergeProjectLibrarySettings(
-      policyDefaultProjectLibraries,
-      defaultProjectLibraries
-    )
-  }
+  settingsNext.app.libraries.default = mergeProjectLibrarySettings(
+    getDefaultProjectLibrarySettings(initialDefaultDir),
+    defaultProjectLibraries
+  )
 
-  settingsNext = setSettingsAtLevel(settingsNext, 'user', appSettings)
+  settingsNext = setSettingsAtLevel(
+    settingsNext,
+    'user',
+    migrateLegacyProjectDirectoryToLibraries(appSettings, initialDefaultDir)
+  )
 
   // Load the project settings if they exist
   if (projectPath) {


### PR DESCRIPTION
## Summary

- Keep the app-owned `app.libraries` default anchored to the base default project directory instead of any migrated legacy `app.projectDirectory` value.
- Migrate a changed legacy `app.projectDirectory` into a user-level directory library only when `app.libraries` is absent.
- Rename the default directory library title to `Projects`.
- Add regression coverage for custom legacy migration, explicit empty libraries, unchanged legacy defaults, and reset fallback behavior.

## Review Context

Addresses the concern raised in [this review comment](https://github.com/KittyCAD/modeling-app/pull/12527#pullrequestreview-4747934366): migrating `app.projectDirectory` into `app.libraries` should not make a user-specific legacy path become the app-defined default value that reset/rollback returns to.

## Validation

- `npm run test:integration -- src/lib/settings/settingsUtils.spec.ts src/registry/contracts/projectLibraries.spec.ts`
- `npm run tsc -- --noEmit`
- `npm run lint -- src/lib/projectLibraries.ts src/lib/settings/settingsUtils.ts src/lib/settings/settingsUtils.spec.ts`