### PR TITLE
docs: Add docs for exit() across module boundaries

### DIFF
--- a/docs/kcl-std/functions/std-runtime-exit.md
+++ b/docs/kcl-std/functions/std-runtime-exit.md
@@ -13,7 +13,16 @@ Exit the program early.
 exit()
 ```
 
+Exiting early can be helpful to see the intermediate output of a program to
+help debug. Remember to always remove the call to `exit()` after debugging
+is complete.
 
+When `exit()` is used in an imported module, only the imported module exits
+early. Because imported modules execute concurrently, `exit()` in one module
+does not affect other modules.
+
+On the other hand, if you import a function from another module, and that
+function calls `exit()`, then calling the function exits the caller.
 
 
 

--- a/rust/kcl-lib/std/runtime.kcl
+++ b/rust/kcl-lib/std/runtime.kcl
@@ -4,5 +4,16 @@
 @settings(defaultLengthUnit = mm, kclVersion = 1.0, experimentalFeatures = allow)
 
 /// Exit the program early.
+///
+/// Exiting early can be helpful to see the intermediate output of a program to
+/// help debug. Remember to always remove the call to `exit()` after debugging
+/// is complete.
+///
+/// When `exit()` is used in an imported module, only the imported module exits
+/// early. Because imported modules execute concurrently, `exit()` in one module
+/// does not affect other modules.
+///
+/// On the other hand, if you import a function from another module, and that
+/// function calls `exit()`, then calling the function exits the caller.
 @(impl = std_rust, experimental = true, feature_tree = true)
 export fn exit() {}


### PR DESCRIPTION
Resolves #12545.

This documents an edge case of `exit()`. I had considered changing the behavior to make `exit()` halt the entire program regardless of module. But after consideration, I think that the module design, specifically concurrent execution, dictates that one module cannot affect another module. If it did, it would lead to non-determinism. We cannot allow that.