### PR TITLE
Surface blocked cloud sync uploads

### DIFF
--- a/src/components/AppProjectCard/AppProjectCard.spec.tsx
+++ b/src/components/AppProjectCard/AppProjectCard.spec.tsx
@@ -273,6 +273,44 @@ describe('ProjectCard', () => {
     expect(input.selectionEnd).toBe(input.value.length)
   })
 
+  test('shows cloud sync blocked badge for upload permission failures', () => {
+    renderProjectCard({
+      project: {
+        ...cloudProject,
+        source: 'both',
+        syncFailure: {
+          kind: 'remote-upload-forbidden',
+          message: 'Cloud sync cannot upload local changes.',
+          at: new Date(now).toISOString(),
+        },
+      },
+    })
+
+    expect(screen.getByTestId('cloud-sync-blocked-badge')).toHaveTextContent(
+      'Cloud sync blocked'
+    )
+    expect(screen.queryByTestId('project-status-badge')).not.toBeInTheDocument()
+  })
+
+  test('shows cloud sync blocked badge for upload permission failures', () => {
+    renderProjectCard({
+      project: {
+        ...cloudProject,
+        source: 'both',
+        syncFailure: {
+          kind: 'remote-upload-forbidden',
+          message: 'Cloud sync cannot upload local changes.',
+          at: new Date(now).toISOString(),
+        },
+      },
+    })
+
+    expect(screen.getByTestId('cloud-sync-blocked-badge')).toHaveTextContent(
+      'Cloud sync blocked'
+    )
+    expect(screen.queryByTestId('project-status-badge')).not.toBeInTheDocument()
+  })
+
   test('keeps local thumbnail object URLs stable when the project object changes', async () => {
     vi.mocked(fsZds.readFile).mockResolvedValue(new Uint8Array([1, 2, 3]))
     const projectActions = createProjectActions()

--- a/src/components/AppProjectCard/AppProjectCard.tsx
+++ b/src/components/AppProjectCard/AppProjectCard.tsx
@@ -17,6 +17,7 @@ import type { FormEvent, HTMLAttributes } from 'react'
 import { useEffect, useRef, useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { Link, useNavigate } from 'react-router-dom'
+import Tooltip from '@src/components/Tooltip'
 
 type AppProjectCardProps = HTMLAttributes<HTMLLIElement> & {
   project: HomeProjectEntry
@@ -33,6 +34,13 @@ const homeProjectStatusBadgeLabels: Record<HomeProjectEntry['status'], string> =
     synced: 'Synced',
     conflicted: 'Conflicted',
   }
+
+function getCloudSyncFailureTooltip(project: HomeProjectEntry) {
+  return (
+    project.syncFailure?.message ||
+    'Cloud sync cannot upload local changes right now.'
+  )
+}
 
 function getDisplayedTime(dateTimeMs: number) {
   const date = new Date(dateTimeMs)
@@ -124,6 +132,7 @@ function AppProjectCard({
   const hasCloudConflict = Boolean(
     showCloudSyncUi && project.conflict && project.localProjectPath
   )
+  const hasCloudSyncFailure = Boolean(showCloudSyncUi && project.syncFailure)
   const imageUrl = useProjectThumbnailUrl(project.thumbnail)
   /** "Optimistic" in that it updates before any remote/cloud sync completes, and may be rolled back on failure to sync. */
   const [optimisticProjectName, setOptimisticProjectName] = useState<{
@@ -220,6 +229,7 @@ function AppProjectCard({
 
   const badges = (statusBadgeLabel ||
     hasCloudConflict ||
+    hasCloudSyncFailure ||
     hasChangesRequested) && (
     <>
       {statusBadgeLabel && (
@@ -236,6 +246,15 @@ function AppProjectCard({
           data-testid="cloud-conflict-badge"
         >
           Cloud conflict
+        </span>
+      )}
+      {hasCloudSyncFailure && (
+        <span
+          className="rounded bg-destroy-10 px-1.5 py-0.5 text-[10px] font-medium text-destroy-80 dark:bg-destroy-80 dark:text-destroy-10"
+          data-testid="cloud-sync-blocked-badge"
+        >
+          Cloud sync blocked
+          <Tooltip>{getCloudSyncFailureTooltip(project)}</Tooltip>
         </span>
       )}
       {hasChangesRequested && (

--- a/src/lib/cloudSync/README.md
+++ b/src/lib/cloudSync/README.md
@@ -109,7 +109,7 @@ Cloud sync state is stored outside React state so it can survive page reloads an
 - `ProjectMetadata.baseManifest` stores the last cloud-acknowledged local file manifest.
 - `ProjectMetadata.tombstone` records an explicit local project delete.
 - `ProjectMetadata.conflict` records a blocked sync and the local path of the remote conflict copy.
-- `ProjectMetadata.lastFailure` records the latest sync error without clearing dirty state.
+- `ProjectMetadata.lastFailure` records the latest sync error without clearing dirty state. `lastFailure.kind = 'remote-upload-forbidden'` identifies a readable cloud project that the current account cannot update.
 - The outbox records durable `upsert` and `delete` work by project path.
 
 ## Versioning Considerations

--- a/src/lib/cloudSync/disconnect.spec.ts
+++ b/src/lib/cloudSync/disconnect.spec.ts
@@ -1,10 +1,13 @@
 import 'fake-indexeddb/auto'
 import {
+  cloudSyncStatus,
   cloudSyncRemoteProjects,
   configureCloudSyncEngine,
   configureCloudSyncLocalFileSystem,
   disconnectCloudSyncProject,
   getCloudSyncProjectMetadata,
+  retryCloudSync,
+  setCloudSyncProjectScope,
 } from '@src/lib/cloudSync'
 import {
   appendOutboxEntry,
@@ -366,5 +369,117 @@ describe('disconnectCloudSyncProject', () => {
     expect(files.get(projectTomlPath)).toContain(
       `project_id = "${remoteProjectId}"`
     )
+  })
+})
+
+describe('cloud sync upload failures', () => {
+  beforeEach(async () => {
+    await deleteSyncDatabase()
+    installFetchMock()
+  })
+
+  afterEach(async () => {
+    setCloudSyncProjectScope(undefined)
+    configureCloudSyncEngine({ enabled: false })
+    vi.unstubAllGlobals()
+    await deleteSyncDatabase()
+  })
+
+  it('records a blocked upload failure when the remote project is readable but not writable', async () => {
+    const files = new Map([
+      [`${projectPath}/main.kcl`, 'cube = 1'],
+      [
+        projectTomlPath,
+        `title = "Bracket"\n\n[cloud."dev.zoo.dev"]\nproject_id = "${remoteProjectId}"\n`,
+      ],
+    ])
+    configureCloudSyncLocalFileSystem(createTestFs(files))
+    await seedLinkedProject()
+    await appendOutboxEntry({
+      projectPath,
+      kind: 'upsert',
+      targetPath: `${projectPath}/main.kcl`,
+      createdAt: '2026-07-08T12:00:00.000Z',
+    })
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = getFetchUrl(input)
+      const method = getFetchMethod(input, init)
+
+      if (url === remoteProjectUrl && method === 'GET') {
+        return new Response(
+          JSON.stringify({
+            id: remoteProjectId,
+            title: 'Bracket',
+            revision: remoteRevision,
+          }),
+          {
+            status: 200,
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          }
+        )
+      }
+
+      if (
+        url === `${remoteProjectUrl}?expected_revision=${remoteRevision}` &&
+        method === 'PUT'
+      ) {
+        return new Response(JSON.stringify({ message: 'Forbidden' }), {
+          status: 403,
+          statusText: 'Forbidden',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        })
+      }
+
+      return new Response(
+        JSON.stringify({ message: `Unexpected fetch: ${method} ${url}` }),
+        {
+          status: 500,
+          statusText: 'Unexpected fetch',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      )
+    })
+
+    configureCloudSyncEngine({
+      enabled: false,
+      baseUrl: 'https://example.test',
+      environmentName: 'dev.zoo.dev',
+      projectDirectoryPath: '/documents/Projects',
+    })
+    setCloudSyncProjectScope(projectPath)
+    configureCloudSyncEngine({ enabled: true })
+    retryCloudSync()
+    await vi.waitFor(() => {
+      expect(cloudSyncStatus.value.lastFailureKind).toBe(
+        'remote-upload-forbidden'
+      )
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${remoteProjectUrl}?expected_revision=${remoteRevision}`,
+      expect.objectContaining({
+        credentials: 'include',
+        method: 'PUT',
+      })
+    )
+    await expect(getAllOutboxEntries()).resolves.toHaveLength(1)
+    const metadata = await getCloudSyncProjectMetadata(projectPath)
+    expect(metadata?.conflict).toBeUndefined()
+    expect(metadata?.lastFailure).toMatchObject({
+      kind: 'remote-upload-forbidden',
+      message: expect.stringContaining('does not have edit access'),
+    })
+    expect(cloudSyncStatus.value).toMatchObject({
+      state: 'failed',
+      activeProjectPath: projectPath,
+      lastFailureKind: 'remote-upload-forbidden',
+      lastFailure: expect.stringContaining('does not have edit access'),
+    })
   })
 })

--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -46,6 +46,7 @@ import type {
   ProjectArchiveFile,
   ProjectManifest,
   ProjectMetadata,
+  ProjectSyncFailureKind,
   RemoteProject,
   RemoteProjectSummary,
   Revision,
@@ -96,6 +97,8 @@ export type CloudSyncConflictResolution = 'local' | 'cloud'
 const SYNC_DEBOUNCE_MS = 2500
 const SYNC_RETRY_MS = 30_000
 const REMOTE_INDEX_INTERVAL_MS = 5 * 60 * 1000
+const REMOTE_UPLOAD_FORBIDDEN_MESSAGE =
+  'Cloud sync cannot upload local changes because this account does not have edit access to the linked cloud project. Local changes are safe on this device.'
 
 let localFs: IZooDesignStudioFS = opfs.impl
 
@@ -119,9 +122,13 @@ export const cloudSyncStatus = signal<CloudSyncStatus>({
 export const cloudSyncRemoteProjects = signal<RemoteProjectSummary[]>([])
 
 function updateStatus(next: Partial<CloudSyncStatus>) {
+  const shouldClearFailureKind =
+    Object.prototype.hasOwnProperty.call(next, 'lastFailure') &&
+    !Object.prototype.hasOwnProperty.call(next, 'lastFailureKind')
   cloudSyncStatus.value = {
     ...cloudSyncStatus.value,
     ...next,
+    ...(shouldClearFailureKind ? { lastFailureKind: undefined } : {}),
   }
 }
 
@@ -131,6 +138,42 @@ function nowIso() {
 
 function errorMessage(error: unknown) {
   return error instanceof Error ? error.message : String(error)
+}
+
+function isProjectSyncFailureKind(
+  value: unknown
+): value is ProjectSyncFailureKind {
+  return value === 'remote-upload-forbidden'
+}
+
+function projectFailureKind(error: unknown) {
+  if (typeof error === 'object' && error !== null && 'kind' in error) {
+    const kind = error.kind
+    return isProjectSyncFailureKind(kind) ? kind : undefined
+  }
+  return undefined
+}
+
+function projectFailureError(
+  kind: ProjectSyncFailureKind,
+  message: string
+): Error & { kind: ProjectSyncFailureKind } {
+  const error = new Error(message) as Error & { kind: ProjectSyncFailureKind }
+  error.kind = kind
+  return error
+}
+
+function remoteUploadFailureFromError(error: unknown) {
+  return error instanceof CloudApiError && error.status === 403
+    ? projectFailureError(
+        'remote-upload-forbidden',
+        REMOTE_UPLOAD_FORBIDDEN_MESSAGE
+      )
+    : error
+}
+
+function rejectRemoteUploadFailure(error: unknown): Promise<never> {
+  return Promise.reject(remoteUploadFailureFromError(error))
 }
 
 function getConfiguredProjectDirectoryPath() {
@@ -1069,11 +1112,13 @@ async function markProjectFailure(
   error: unknown
 ): Promise<void> {
   const message = errorMessage(error)
+  const kind = projectFailureKind(error)
   const next = {
     ...metadata,
     lastFailure: {
       message,
       at: nowIso(),
+      kind,
     },
   }
   await putProjectMetadata(next)
@@ -1082,6 +1127,7 @@ async function markProjectFailure(
       state: 'failed',
       activeProjectPath: metadata.localProjectPath,
       lastFailure: message,
+      lastFailureKind: kind,
       lastFailureAt: next.lastFailure.at,
     })
   }
@@ -1186,7 +1232,7 @@ async function applyLocalDataForConflict(metadata: ProjectMetadata) {
     projectId: metadata.remoteProjectId,
     files: localFiles,
     expectedRevision: conflict.remoteRevision ?? metadata.remoteRevision,
-  })
+  }).catch(rejectRemoteUploadFailure)
   await clearOutboxEntriesForProject(metadata.localProjectPath)
   await deleteConflictCopy(conflict.conflictProjectPath)
   await markProjectSynced(
@@ -1714,7 +1760,7 @@ async function syncProject(projectPath: string, entries: OutboxEntry[]) {
         projectId: remoteProjectId,
         files: localFiles,
         expectedRevision: metadata.remoteRevision,
-      })
+      }).catch(rejectRemoteUploadFailure)
       await clearOutboxEntriesForProject(metadata.localProjectPath)
       await markProjectSynced(
         metadata,
@@ -2112,9 +2158,11 @@ async function runCloudSync() {
     }
   } catch (error) {
     const syncedAt = pendingStatusSyncedAt
+    const kind = projectFailureKind(error)
     updateStatus({
       state: 'failed',
       lastFailure: errorMessage(error),
+      lastFailureKind: kind,
       lastFailureAt: nowIso(),
       activeProjectPath: scopedProjectPath,
       ...(syncedAt ? { lastSyncedAt: syncedAt } : {}),
@@ -2507,6 +2555,8 @@ export function configureCloudSyncEngine(nextConfig: CloudSyncConfig) {
       enabled: false,
       state: 'disabled',
       activeProjectPath: undefined,
+      lastFailure: undefined,
+      lastFailureAt: undefined,
     })
     return
   }
@@ -2515,6 +2565,8 @@ export function configureCloudSyncEngine(nextConfig: CloudSyncConfig) {
   updateStatus({
     enabled: true,
     state: 'idle',
+    lastFailure: undefined,
+    lastFailureAt: undefined,
   })
   void refreshPendingCount()
   scheduleSync(0)

--- a/src/lib/cloudSync/index.ts
+++ b/src/lib/cloudSync/index.ts
@@ -16,6 +16,8 @@ export type {
   CloudSyncProjectMetadataIndexEntry,
   CloudSyncStatus,
   ProjectMetadata as CloudSyncProjectMetadata,
+  ProjectSyncFailure,
+  ProjectSyncFailureKind,
 } from '@src/lib/cloudSync/types'
 
 let fsObserverInstalled = false

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -7,7 +7,10 @@ import { signal } from '@preact/signals-core'
 import ProjectSidebarMenu from '@src/components/ProjectSidebarMenu'
 import type { App } from '@src/lib/app'
 import { cloudSyncRemoteProjects, cloudSyncStatus } from '@src/lib/cloudSync'
-import { cloudSyncPlugin } from '@src/lib/cloudSync/registry/plugin'
+import {
+  cloudSyncPlugin,
+  getCloudSyncStatusBarPresentation,
+} from '@src/lib/cloudSync/registry/plugin'
 import type { Project } from '@src/lib/project'
 import type { CloudSyncRegistryService } from '@src/registry/contracts/cloudSync'
 import { cloudSyncService } from '@src/registry/contracts/cloudSync'
@@ -130,6 +133,25 @@ afterEach(() => {
   }
   cloudSyncRemoteProjects.value = []
   vi.restoreAllMocks()
+})
+
+describe('cloud sync status presentation', () => {
+  test('labels remote upload permission failures as blocked sync', () => {
+    expect(
+      getCloudSyncStatusBarPresentation({
+        enabled: true,
+        state: 'failed',
+        pendingCount: 1,
+        lastFailure: 'Cloud sync cannot upload local changes.',
+        lastFailureKind: 'remote-upload-forbidden',
+        lastFailureAt: new Date(now).toISOString(),
+      })
+    ).toMatchObject({
+      label: 'Cloud sync blocked',
+      tooltip: 'Cloud sync cannot upload local changes.',
+      isBlocked: true,
+    })
+  })
 })
 
 describe('cloud sync project menu item', () => {
@@ -298,6 +320,74 @@ describe('cloud sync home project entries', () => {
             localProjectPath: '/some/path/local-project',
             conflict: expect.objectContaining({
               conflictProjectPath: '/some/path/local-project (cloud conflict)',
+            }),
+          }),
+        ])
+      )
+    } finally {
+      registry[Symbol.dispose]()
+    }
+  })
+
+  test('adds sync failure metadata for remote upload permission failures', async () => {
+    cloudSyncStatus.value = {
+      enabled: true,
+      state: 'failed',
+      pendingCount: 1,
+      lastFailure: 'Cloud sync cannot upload local changes.',
+      lastFailureKind: 'remote-upload-forbidden',
+      lastFailureAt: new Date(now).toISOString(),
+    }
+    cloudSyncRemoteProjects.value = [
+      {
+        id: 'remote-123',
+        title: 'Remote title',
+        revision: 'remote-rev-1',
+        updated_at: '2026-06-02T20:00:00.000Z',
+      },
+    ]
+    const cloudSync = createCloudSyncService()
+    vi.mocked(cloudSync.getProjectMetadataIndex).mockResolvedValue(
+      new Map([
+        [
+          '/some/path/local-project',
+          {
+            schemaVersion: 1,
+            localProjectPath: '/some/path/local-project',
+            projectName: 'Local project',
+            remoteProjectId: 'remote-123',
+            remoteRevision: 'remote-rev-1',
+            hasPendingChanges: true,
+            lastFailure: {
+              kind: 'remote-upload-forbidden',
+              message: 'Cloud sync cannot upload local changes.',
+              at: new Date(now).toISOString(),
+            },
+          },
+        ],
+      ])
+    )
+    const registry = new Registry()
+    const cloudSyncServiceExtension = defineRegistryItem({
+      id: 'test-cloud-sync-service',
+      providesServices: [provideService(cloudSyncService, cloudSync)],
+    })
+
+    registry.configure([cloudSyncServiceExtension, cloudSyncPlugin])
+
+    try {
+      await waitFor(() =>
+        expect(registry.get(homeProjectEntriesValueSpec)).toEqual([
+          expect.objectContaining({
+            source: 'remote',
+            status: 'cloud-only',
+            name: 'Local project',
+            title: 'Local project',
+            remoteProjectId: 'remote-123',
+            localProjectPath: '/some/path/local-project',
+            syncFailure: expect.objectContaining({
+              kind: 'remote-upload-forbidden',
+              message: 'Cloud sync cannot upload local changes.',
             }),
           }),
         ])

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -372,12 +372,16 @@ export function getCloudSyncStatusBarPresentation(
   const isSyncing = status.state === 'syncing'
   const isBlocked = status.state === 'failed' || status.state === 'conflict'
   const hasPendingChanges = status.pendingCount > 0
+  const isRemoteUploadBlocked =
+    status.lastFailureKind === 'remote-upload-forbidden'
   const label = isSyncing
     ? 'Cloud syncing'
     : status.state === 'conflict'
       ? 'Cloud conflict'
       : status.state === 'failed'
-        ? 'Cloud sync failed'
+        ? isRemoteUploadBlocked
+          ? 'Cloud sync blocked'
+          : 'Cloud sync failed'
         : hasPendingChanges
           ? 'Cloud sync pending'
           : 'Cloud synced'
@@ -621,19 +625,40 @@ function getCloudSyncHomeProjectModifiedTime(
   return Number.isNaN(modified) ? undefined : modified
 }
 
-function homeProjectEntryConflictFields(
+function homeProjectEntryCloudSyncFields(
   metadata: CloudSyncProjectMetadataIndexEntry | undefined
 ): Pick<
   HomeProjectEntryContribution,
-  'conflict' | 'localProjectPath' | 'status'
+  'conflict' | 'localProjectPath' | 'status' | 'syncFailure'
 > {
-  return metadata?.conflict
-    ? {
-        status: 'conflicted',
-        conflict: metadata.conflict,
-        localProjectPath: metadata.localProjectPath,
-      }
-    : { status: 'cloud-only' }
+  const syncFailure =
+    metadata?.lastFailure?.kind === 'remote-upload-forbidden'
+      ? metadata.lastFailure
+      : undefined
+  if (!metadata?.conflict) {
+    return {
+      status: 'cloud-only',
+      ...(syncFailure
+        ? { syncFailure, localProjectPath: metadata?.localProjectPath }
+        : {}),
+    }
+  }
+
+  return {
+    status: 'conflicted',
+    conflict: metadata.conflict,
+    localProjectPath: metadata.localProjectPath,
+    ...(syncFailure ? { syncFailure } : {}),
+  }
+}
+
+function shouldContributeCloudSyncMetadata(
+  metadata: CloudSyncProjectMetadataIndexEntry
+) {
+  return (
+    Boolean(metadata.conflict) ||
+    metadata.lastFailure?.kind === 'remote-upload-forbidden'
+  )
 }
 
 function remoteThumbnailCacheKey(project: RemoteProjectSummary) {
@@ -686,7 +711,7 @@ function pruneRemoteThumbnailState({
 const cloudSyncRemoteHomeProjectEntryContribution = defineRegistryItemFactory(
   (ctx) => {
     const cloudSync = ctx.services.signal(cloudSyncService)
-    const conflictMetadata = signal<CloudSyncProjectMetadataIndexEntry[]>([])
+    const cloudSyncMetadata = signal<CloudSyncProjectMetadataIndexEntry[]>([])
     const remoteThumbnailUrls = signal<Map<string, string>>(new Map())
     const requestedThumbnailKeys = new Map<string, string>()
     let disposed = false
@@ -700,8 +725,8 @@ const cloudSyncRemoteHomeProjectEntryContribution = defineRegistryItemFactory(
         return []
       }
 
-      const conflictMetadataByRemoteProjectId = new Map(
-        conflictMetadata.value.flatMap((metadata) =>
+      const cloudSyncMetadataByRemoteProjectId = new Map(
+        cloudSyncMetadata.value.flatMap((metadata) =>
           metadata.remoteProjectId
             ? ([[metadata.remoteProjectId, metadata]] as const)
             : []
@@ -712,13 +737,13 @@ const cloudSyncRemoteHomeProjectEntryContribution = defineRegistryItemFactory(
       )
       const remoteProjectEntries = cloudSyncRemoteProjects.value.map(
         (project) => {
-          const metadata = conflictMetadataByRemoteProjectId.get(project.id)
+          const metadata = cloudSyncMetadataByRemoteProjectId.get(project.id)
           const name = metadata?.projectName || project.title || project.id
           const thumbnailUrl = remoteThumbnailUrls.value.get(project.id)
 
           return {
             source: 'remote',
-            ...homeProjectEntryConflictFields(metadata),
+            ...homeProjectEntryCloudSyncFields(metadata),
             name,
             title: metadata?.projectName || project.title,
             remoteProjectId: project.id,
@@ -735,7 +760,7 @@ const cloudSyncRemoteHomeProjectEntryContribution = defineRegistryItemFactory(
           } satisfies HomeProjectEntryContribution
         }
       )
-      const localOnlyConflictEntries = conflictMetadata.value
+      const localOnlyCloudSyncEntries = cloudSyncMetadata.value
         .filter(
           (metadata) =>
             !metadata.remoteProjectId ||
@@ -745,18 +770,17 @@ const cloudSyncRemoteHomeProjectEntryContribution = defineRegistryItemFactory(
           (metadata) =>
             ({
               source: 'remote',
-              status: 'conflicted',
+              ...homeProjectEntryCloudSyncFields(metadata),
               name: metadata.projectName,
               title: metadata.projectName,
               localProjectPath: metadata.localProjectPath,
               remoteProjectId: metadata.remoteProjectId,
               modified: getCloudSyncHomeProjectModifiedTime({}, metadata),
               readWriteAccess: true,
-              conflict: metadata.conflict,
             }) satisfies HomeProjectEntryContribution
         )
 
-      return [...remoteProjectEntries, ...localOnlyConflictEntries]
+      return [...remoteProjectEntries, ...localOnlyCloudSyncEntries]
     })
 
     // Defer because `effect` runs immediately, and service reads are blocked
@@ -766,7 +790,7 @@ const cloudSyncRemoteHomeProjectEntryContribution = defineRegistryItemFactory(
         return
       }
 
-      // Keep Home conflict badges in sync with cloud sync metadata, even
+      // Keep Home cloud sync badges in sync with cloud sync metadata, even
       // before System IO rereads local project folders.
       disposeEffect = effect(() => {
         const service = cloudSync.value
@@ -774,7 +798,7 @@ const cloudSyncRemoteHomeProjectEntryContribution = defineRegistryItemFactory(
         const nextLoadId = ++loadId
 
         if (!service || !status.enabled) {
-          conflictMetadata.value = []
+          cloudSyncMetadata.value = []
           remoteThumbnailUrls.value = new Map()
           requestedThumbnailKeys.clear()
           return
@@ -826,16 +850,16 @@ const cloudSyncRemoteHomeProjectEntryContribution = defineRegistryItemFactory(
               return
             }
 
-            conflictMetadata.value = Array.from(metadataIndex.values()).filter(
+            cloudSyncMetadata.value = Array.from(metadataIndex.values()).filter(
               (metadata) =>
-                Boolean(metadata.conflict) &&
+                shouldContributeCloudSyncMetadata(metadata) &&
                 !metadata.tombstone &&
                 !metadata.syncExcluded
             )
           })
           .catch((error: unknown) => {
             if (!disposed && nextLoadId === loadId) {
-              conflictMetadata.value = []
+              cloudSyncMetadata.value = []
             }
             reportRejection(error)
           })

--- a/src/lib/cloudSync/types.ts
+++ b/src/lib/cloudSync/types.ts
@@ -39,11 +39,16 @@ export type ProjectMetadata = {
     remoteProjectId?: string
     createdAt: string
   }
-  lastFailure?: {
-    message: string
-    at: string
-  }
+  lastFailure?: ProjectSyncFailure
   lastSyncedAt?: string
+}
+
+export type ProjectSyncFailureKind = 'remote-upload-forbidden'
+
+export type ProjectSyncFailure = {
+  message: string
+  at: string
+  kind?: ProjectSyncFailureKind
 }
 
 /** Durable queued local mutation that should be replicated to the cloud later. */
@@ -103,6 +108,7 @@ export type CloudSyncStatus = {
   pendingCount: number
   activeProjectPath?: string
   lastFailure?: string
+  lastFailureKind?: ProjectSyncFailureKind
   lastFailureAt?: string
   lastSyncedAt?: string
 }

--- a/src/registry/contracts/homeProjects.ts
+++ b/src/registry/contracts/homeProjects.ts
@@ -25,6 +25,12 @@ export type HomeProjectThumbnail =
       url: string
     }
 
+export type HomeProjectSyncFailure = {
+  message: string
+  at?: string
+  kind?: string
+}
+
 export interface HomeProjectEntry {
   id: string
   source: HomeProjectSource
@@ -42,6 +48,7 @@ export interface HomeProjectEntry {
   readWriteAccess: boolean
   thumbnail?: HomeProjectThumbnail
   conflict?: unknown
+  syncFailure?: HomeProjectSyncFailure
 }
 
 export type HomeProjectEntryContribution = Omit<
@@ -128,6 +135,7 @@ function mergeHomeProjectEntries(
   }
 
   const conflict = local.conflict ?? remote.conflict
+  const syncFailure = local.syncFailure ?? remote.syncFailure
 
   return {
     ...remote,
@@ -140,6 +148,7 @@ function mergeHomeProjectEntries(
         ? 'syncing'
         : 'synced',
     conflict,
+    syncFailure,
     modified: Math.max(local.modified ?? 0, remote.modified ?? 0) || undefined,
     thumbnail: local.thumbnail ?? remote.thumbnail,
     readWriteAccess: local.readWriteAccess,


### PR DESCRIPTION
## Summary

- Detect `403` responses from guarded cloud project upload `PUT` requests as a structured `remote-upload-forbidden` project sync failure.
- Show the aggregate status as `Cloud sync blocked` for that case instead of a generic failed sync.
- Add Home project entry metadata and a `Cloud sync blocked` card badge so users can see which project is affected.
- Document the new `lastFailure.kind` value in the cloud sync README.

## Scope

This PR only illuminates the blocked status. It does not add UI resolution actions yet. Follow-up actions such as retry, keep local-only, or upload as a new cloud project should be registered after the project-card context menu work in #12550 is available on `main`.

## Validation

- `npm run test:integration -- src/lib/cloudSync/disconnect.spec.ts src/lib/cloudSync/registry/plugin.spec.tsx src/components/AppProjectCard/AppProjectCard.spec.tsx src/registry/contracts/homeProjects.spec.ts`
- Targeted ESLint over the touched TS/TSX files
- `git diff --check`