### PR TITLE
Remove @nabla/vite-plugin-eslint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,6 @@
         "@eslint/js": "^9.39.2",
         "@iarna/toml": "^2.2.5",
         "@lezer/generator": "^1.7.3",
-        "@nabla/vite-plugin-eslint": "^3.0.1",
         "@playwright/test": "^1.60.0",
         "@preact/signals-react-transform": "^0.8.1",
         "@testing-library/jest-dom": "^6.8.0",
@@ -9586,22 +9585,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@nabla/vite-plugin-eslint": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@nabla/vite-plugin-eslint/-/vite-plugin-eslint-3.0.1.tgz",
-      "integrity": "sha512-iN7WF0izOiPhJaOGzKaNzGEvBSX5WuHA2eRPqo+cGfTsWd/DTWCAur0Jkm/8Fq0sqIB48RTOO3T+VFfRaCIt/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint": "*",
-        "chalk": "^4",
-        "debug": "^4"
-      },
-      "peerDependencies": {
-        "eslint": "^9 || ^10",
-        "vite": "^4 || ^5 || ^6 || ^7 || ^8"
-      }
-    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -12834,17 +12817,6 @@
       "integrity": "sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/eslint": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",

--- a/package.json
+++ b/package.json
@@ -174,7 +174,6 @@
     "@eslint/js": "^9.39.2",
     "@iarna/toml": "^2.2.5",
     "@lezer/generator": "^1.7.3",
-    "@nabla/vite-plugin-eslint": "^3.0.1",
     "@playwright/test": "^1.60.0",
     "@preact/signals-react-transform": "^0.8.1",
     "@testing-library/jest-dom": "^6.8.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,5 @@
 // @ts-ignore: No types available
 import { lezer } from '@lezer/generator/rollup'
-import eslint from '@nabla/vite-plugin-eslint'
 import react from '@vitejs/plugin-react'
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
 import version from 'vite-plugin-package-version'
@@ -98,7 +97,6 @@ export default defineConfig(({ command, mode }) => {
       }),
       indexHtmlCsp(!process.env.VERCEL && mode !== 'development'),
       viteTsconfigPaths(),
-      eslint(),
       version(),
       lezer(),
       topLevelAwait({

--- a/vite.main.config.ts
+++ b/vite.main.config.ts
@@ -1,8 +1,7 @@
 // @ts-ignore: No types available
 import { lezer } from '@lezer/generator/rollup'
-import vitePluginEslint from '@nabla/vite-plugin-eslint'
 import viteJsPluginReact from '@vitejs/plugin-react'
-import type { ConfigEnv, UserConfig as ViteUserConfig } from 'vite'
+import type { ConfigEnv, UserConfig } from 'vite'
 import { mergeConfig } from 'vite'
 import vitePluginPackageVersion from 'vite-plugin-package-version'
 import viteTsconfigPaths from 'vite-tsconfig-paths'
@@ -87,7 +86,6 @@ export default defineConfig((env) => {
         },
       }),
       viteTsconfigPaths(),
-      vitePluginEslint(),
       vitePluginPackageVersion(),
       lezer(),
     ],


### PR DESCRIPTION
I don't think we need eslint errors when running tron:start? And it's throwing errors with TS7