### PR TITLE
Add Personal Cloud project library

### DIFF
--- a/e2e/playwright/cloud-sync.spec.ts
+++ b/e2e/playwright/cloud-sync.spec.ts
@@ -30,6 +30,12 @@ async function expectProjectFileRoute(page: Page) {
   })
 }
 
+async function expectCloudSyncHomeReady(page: Page) {
+  await expect(
+    page.getByRole('heading', { name: /^(Project Libraries|Personal Cloud)$/ })
+  ).toBeVisible({ timeout: CLOUD_SYNC_E2E_TIMEOUT })
+}
+
 test(
   'streams remote-only projects into an empty local list and materializes opened clones',
   { tag: ['@web'] },
@@ -85,8 +91,10 @@ test(
 
     await setup(context, page, testInfo, [OPFS_CLOUD_FEATURE_FLAG])
     await page.goto('/')
-    await expect(page.getByRole('heading', { name: 'Projects' })).toBeVisible()
-    await expect(page.getByTestId('projects-none')).toBeVisible()
+    await expectCloudSyncHomeReady(page)
+    await expect(
+      page.getByTestId('project-library-empty').first()
+    ).toBeVisible()
 
     remoteListGate.release()
 
@@ -136,7 +144,7 @@ test(
     remoteListGate.hold()
 
     await page.goto('/')
-    await expect(page.getByRole('heading', { name: 'Projects' })).toBeVisible()
+    await expectCloudSyncHomeReady(page)
     await expect
       .poll(() => projectTitles(page), { timeout: CLOUD_SYNC_E2E_TIMEOUT })
       .toEqual(expect.arrayContaining(['Remote empty one']))
@@ -222,7 +230,7 @@ test(
 
     await setup(context, page, testInfo, [OPFS_CLOUD_FEATURE_FLAG])
     await page.goto('/')
-    await expect(page.getByRole('heading', { name: 'Projects' })).toBeVisible()
+    await expectCloudSyncHomeReady(page)
 
     const localOnlyFiles = {
       'main.kcl': 'localOnly = 1\n',
@@ -287,7 +295,7 @@ test(
     })
 
     await page.reload()
-    await expect(page.getByRole('heading', { name: 'Projects' })).toBeVisible()
+    await expectCloudSyncHomeReady(page)
     await expect
       .poll(() => projectTitles(page), { timeout: CLOUD_SYNC_E2E_TIMEOUT })
       .toEqual(
@@ -428,7 +436,7 @@ test(
     // project should now behave like a normal local OPFS project, so Home should
     // show it from local state without needing another remote list response.
     await page.goto('/')
-    await expect(page.getByRole('heading', { name: 'Projects' })).toBeVisible()
+    await expectCloudSyncHomeReady(page)
     await expect
       .poll(() => projectTitles(page), { timeout: CLOUD_SYNC_E2E_TIMEOUT })
       .toEqual(
@@ -465,7 +473,7 @@ test(
     // restores the Home card without restoring OPFS files until the card opens.
     remoteListGate.hold()
     await page.reload()
-    await expect(page.getByRole('heading', { name: 'Projects' })).toBeVisible()
+    await expectCloudSyncHomeReady(page)
     remoteListGate.release()
     await expect
       .poll(() => projectTitles(page), { timeout: CLOUD_SYNC_E2E_TIMEOUT })

--- a/e2e/playwright/fixtures/fixtureSetup.ts
+++ b/e2e/playwright/fixtures/fixtureSetup.ts
@@ -26,7 +26,11 @@ import { SceneFixture } from '@e2e/playwright/fixtures/sceneFixture'
 import { SignInPageFixture } from '@e2e/playwright/fixtures/signInPageFixture'
 import { ToolbarFixture } from '@e2e/playwright/fixtures/toolbarFixture'
 
-import { TEST_SETTINGS } from '@e2e/playwright/storageStates'
+import {
+  TEST_SETTINGS,
+  playwrightPluginSettings,
+  playwrightProjectLibraries,
+} from '@e2e/playwright/storageStates'
 import {
   PLAYWRIGHT_LAYOUT_SETTINGS,
   getUtils,
@@ -323,37 +327,34 @@ export class ElectronZoo {
 
     let settingsOverridesToml = ''
 
-    if (appSettings) {
-      settingsOverridesToml = settingsToToml({
-        settings: {
-          ...TEST_SETTINGS,
-          ...appSettings,
-          ...PLAYWRIGHT_LAYOUT_SETTINGS,
-          app: {
-            ...TEST_SETTINGS.app,
-            ...appSettings.app,
-          },
-          project: {
-            ...TEST_PROJECT_SETTINGS,
-            directory: this.projectDirName,
-          },
+    const appSettingsPlugins =
+      appSettings &&
+      typeof appSettings.plugins === 'object' &&
+      appSettings.plugins !== null &&
+      !isArray(appSettings.plugins)
+        ? appSettings.plugins
+        : {}
+
+    settingsOverridesToml = settingsToToml({
+      settings: {
+        ...TEST_SETTINGS,
+        ...appSettings,
+        plugins: {
+          ...playwrightPluginSettings(),
+          ...appSettingsPlugins,
         },
-      })
-    } else {
-      settingsOverridesToml = settingsToToml({
-        settings: {
-          ...TEST_SETTINGS,
-          ...PLAYWRIGHT_LAYOUT_SETTINGS,
-          app: {
-            ...TEST_SETTINGS.app,
-          },
-          project: {
-            ...TEST_PROJECT_SETTINGS,
-            directory: this.projectDirName,
-          },
+        ...PLAYWRIGHT_LAYOUT_SETTINGS,
+        app: {
+          ...TEST_SETTINGS.app,
+          libraries: playwrightProjectLibraries(this.projectDirName),
+          ...appSettings?.app,
         },
-      })
-    }
+        project: {
+          ...TEST_PROJECT_SETTINGS,
+          directory: this.projectDirName,
+        },
+      },
+    })
     await fsp.writeFile(tempSettingsFilePath, settingsOverridesToml)
   }
 }

--- a/e2e/playwright/native-file-menu.spec.ts
+++ b/e2e/playwright/native-file-menu.spec.ts
@@ -8,9 +8,6 @@ import {
 } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
 import type { Page } from '@playwright/test'
-import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
-
-test.use({ userFeatures: [OPFS_CLOUD_FEATURE_FLAG] })
 
 async function expectNewWindowMenuItem(
   nativeMenu: NativeMenuFixture,

--- a/e2e/playwright/storageStates.ts
+++ b/e2e/playwright/storageStates.ts
@@ -1,10 +1,36 @@
 import type { SaveSettingsPayload } from '@src/lib/settings/settingsTypes'
+import { PROJECT_FOLDER } from '@src/lib/constants'
 import { Themes } from '@src/lib/theme'
 import type { DeepPartial } from '@src/lib/types'
 
 import type { Settings } from '@rust/kcl-lib/bindings/Settings'
 
 export const TEST_SETTINGS_KEY = '/settings.toml'
+export const PLAYWRIGHT_PROJECT_DIRECTORY = `/documents/${PROJECT_FOLDER}`
+export const PLAYWRIGHT_PROJECT_LIBRARY_TITLE = 'Projects'
+
+export function playwrightProjectLibraries(
+  projectDirectory: string = PLAYWRIGHT_PROJECT_DIRECTORY
+) {
+  return [
+    {
+      title: PLAYWRIGHT_PROJECT_LIBRARY_TITLE,
+      path: projectDirectory,
+      type: 'directory',
+    },
+  ]
+}
+
+export function playwrightPluginSettings({
+  cloudSyncEnabled = false,
+}: {
+  cloudSyncEnabled?: boolean
+} = {}) {
+  return {
+    'cloud-sync': cloudSyncEnabled,
+  }
+}
+
 export const TEST_SETTINGS: DeepPartial<Settings> = {
   app: {
     appearance: {

--- a/e2e/playwright/test-utils.ts
+++ b/e2e/playwright/test-utils.ts
@@ -8,6 +8,7 @@ import type { Configuration } from '@src/lang/wasm'
 import {
   COOKIE_NAME_PREFIX,
   IS_PLAYWRIGHT_KEY,
+  OPFS_CLOUD_FEATURE_FLAG,
   SIDEBAR_BUTTON_SUFFIX,
   TOKEN_PERSIST_KEY,
   VERCEL_PLAYWRIGHT_TOKEN_QUERY_PARAM,
@@ -34,7 +35,13 @@ import type { ProjectConfiguration } from '@rust/kcl-lib/bindings/ProjectConfigu
 import type { CmdBarFixture } from '@e2e/playwright/fixtures/cmdBarFixture'
 import type { ElectronZoo } from '@e2e/playwright/fixtures/fixtureSetup'
 import { isErrorWhitelisted } from '@e2e/playwright/lib/console-error-whitelist'
-import { TEST_SETTINGS, TEST_SETTINGS_KEY } from '@e2e/playwright/storageStates'
+import {
+  PLAYWRIGHT_PROJECT_DIRECTORY,
+  TEST_SETTINGS,
+  TEST_SETTINGS_KEY,
+  playwrightPluginSettings,
+  playwrightProjectLibraries,
+} from '@e2e/playwright/storageStates'
 import { test } from '@e2e/playwright/zoo-test'
 import { createLayoutWithMetadata } from '@src/lib/layout'
 import { playwrightLayoutConfig } from '@src/lib/layout/configs/playwright'
@@ -975,19 +982,21 @@ export async function setup(
       settings: settingsToToml({
         settings: {
           ...TEST_SETTINGS,
+          plugins: playwrightPluginSettings({
+            cloudSyncEnabled: userFeatures.includes(OPFS_CLOUD_FEATURE_FLAG),
+          }),
           ...PLAYWRIGHT_LAYOUT_SETTINGS,
           app: {
             appearance: {
               ...TEST_SETTINGS.app?.appearance,
               theme: 'dark',
             },
+            libraries: playwrightProjectLibraries(),
             onboarding_status: 'dismissed',
           },
           project: {
             ...testProjectSettings,
-            ...(typeof testProjectSettings?.directory === 'string'
-              ? { directory: testProjectSettings.directory }
-              : {}),
+            directory: PLAYWRIGHT_PROJECT_DIRECTORY,
           },
         },
       }),

--- a/src/components/PluginList.tsx
+++ b/src/components/PluginList.tsx
@@ -1,3 +1,4 @@
+import type { Feature } from '@kittycad/lib'
 import type {
   PluginRecord,
   Registry,
@@ -5,8 +6,10 @@ import type {
 } from '@kittycad/registry'
 import { Toggle } from '@src/components/Toggle/Toggle'
 import { useApp } from '@src/lib/boot'
-import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
+import type { Setting } from '@src/lib/settings/initialSettings'
 import type { DynamicBooleanSetEvent } from '@src/lib/settings/settingsTypes'
+import { shouldHideSetting } from '@src/lib/settings/settingsUtils'
+import { userFeaturesContextHas } from '@src/machines/userFeaturesMachine'
 import {
   type ZdsPluginActivationSetting,
   zdsPluginActivationSettingsValueSpec,
@@ -22,13 +25,36 @@ type PluginsListProps = {
 export const PluginsList = forwardRef(
   (props: PluginsListProps, scrollRef: ForwardedRef<HTMLDivElement>) => {
     const app = useApp()
-    const hasCloudSyncFeature = app.userFeatures.useHas(
-      OPFS_CLOUD_FEATURE_FLAG,
-      false
+    const settingsContext = app.settings.useSettings()
+    const userFeaturesContext = app.userFeatures.useContext()
+    const hasFeature = (feature: Feature) =>
+      userFeaturesContextHas(userFeaturesContext, feature, false)
+    const activationSettings = props.registry.get(
+      zdsPluginActivationSettingsValueSpec
     )
-    const visiblePlugins = props.plugins.filter(
-      (plugin) => plugin.id !== 'cloud-sync' || hasCloudSyncFeature
-    )
+
+    // A plugin's activation toggle is a settings entry, so it obeys the same
+    // visibility rules: hide it here whenever that setting is hidden on this
+    // platform/level or gated behind a feature the user lacks. This keeps the
+    // plugins list in sync with the settings panel and command bar instead of
+    // hardcoding per-plugin exceptions (e.g. cloud sync, which is web-only
+    // infrastructure and must not expose a toggle there).
+    const settingsByCategory = settingsContext as unknown as Record<
+      string,
+      Record<string, Setting | undefined> | undefined
+    >
+    const visiblePlugins = props.plugins.filter((plugin) => {
+      const activation = activationSettings.find(
+        (setting) => setting.pluginId === plugin.id
+      )
+      if (!activation) {
+        return true
+      }
+
+      const setting =
+        settingsByCategory[activation.category]?.[activation.settingName]
+      return !setting || !shouldHideSetting(setting, 'user', hasFeature)
+    })
 
     // This is how we will get the interaction map from the context
     // in the future whene franknoirot/editable-hotkeys is merged.

--- a/src/hooks/useQueryParamEffects.ts
+++ b/src/hooks/useQueryParamEffects.ts
@@ -7,6 +7,7 @@ import type { KclManager } from '@src/lang/KclManager'
 import { base64ToString } from '@src/lib/base64'
 import { useApp } from '@src/lib/boot'
 import { ensureCloudProjectLocallySynced } from '@src/lib/cloudSync'
+import { getDefaultCloudProjectDirectoryPath } from '@src/lib/cloudSync/paths'
 import type { ProjectsCommandSchema } from '@src/lib/commandBarConfigs/projectsCommandConfig'
 import {
   ASK_TO_OPEN_QUERY_PARAM,
@@ -128,7 +129,8 @@ export function useQueryParamEffects(kclManager: KclManager) {
       }
 
       const localCloudProject = await ensureCloudProjectLocallySynced(
-        projectId
+        projectId,
+        await getDefaultCloudProjectDirectoryPath()
       ).catch(() => undefined)
       if (cancelled) {
         return

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -10,6 +10,10 @@ import {
 import fsZds, { moduleFsViaModuleImport, StorageName } from '@src/lib/fs-zds'
 import type { Project } from '@src/lib/project'
 import { rustContextService } from '@src/lib/rustContext/registry/contract'
+import {
+  PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+  getDefaultCloudProjectLibrarySetting,
+} from '@src/lib/projectLibraries'
 import { getChangedSettingsAtLevel } from '@src/lib/settings/settingsUtils'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { notifyActiveWasmInstance } from '@src/lib/wasmLifecycle'
@@ -23,6 +27,7 @@ import { commandsValueSpec } from '@src/registry/contracts/commands'
 import { engineConnectionService } from '@src/registry/contracts/engineConnection'
 import { executingEditorService } from '@src/registry/contracts/executingEditor'
 import { machineManagerService } from '@src/registry/contracts/machineManager'
+import { projectLibrariesValueSpec } from '@src/registry/contracts/projectLibraries'
 import { userFeaturesService } from '@src/registry/contracts/userFeatures'
 import { wasmPromiseValueSpec } from '@src/registry/contracts/wasm'
 import { createTestWasmRegistryItem } from '@src/unitTestUtils'
@@ -196,6 +201,43 @@ function expectedRuntimeFlags(useNewLexerParser: 'On' | 'Off') {
   })
 }
 
+function getCloudSyncPluginSetting(app: App) {
+  return (
+    app.settings.get().plugins as
+      | Record<
+          string,
+          {
+            current?: unknown
+            user?: unknown
+          }
+        >
+      | undefined
+  )?.['cloud-sync']
+}
+
+function getPluginToggle(app: App, pluginId: string) {
+  const plugin = app.registry
+    .get(pluginsValueSpec)
+    .find((plugin) => plugin.id === pluginId)
+  expect(plugin).toBeDefined()
+  if (!plugin) {
+    throw new Error(`Missing ${pluginId} plugin registry item`)
+  }
+
+  return app.registry.get(plugin.service)
+}
+
+function hasPersonalCloudLibrarySetting(app: App) {
+  const defaultCloudLibrary = getDefaultCloudProjectLibrarySetting()
+  return app.settings
+    .get()
+    .app.libraries.current.some(
+      (library) =>
+        library.type === defaultCloudLibrary.type &&
+        library.path === defaultCloudLibrary.path
+    )
+}
+
 describe('project system', () => {
   it('uses registry runtime dependencies by default', () => {
     const app = createAppForTest()
@@ -362,6 +404,78 @@ describe('project system', () => {
     } finally {
       app.dispose()
       window.electron = previousElectron
+    }
+  })
+
+  it('keeps cloud sync disabled by default without the cloud projects feature', async () => {
+    const userFeatures = createUserFeaturesForTest(new Set())
+    const app = createAppForTest({
+      userFeatures,
+    })
+
+    try {
+      await waitForSettingsIdle(app)
+
+      expect(getCloudSyncPluginSetting(app)?.current).toBe(false)
+      expect(getCloudSyncPluginSetting(app)?.user).toBeUndefined()
+      expect(getPluginToggle(app, 'cloud-sync').active.value).toBe(false)
+      expect(hasPersonalCloudLibrarySetting(app)).toBe(false)
+      expect(
+        app.registry
+          .get(projectLibrariesValueSpec)
+          .some((library) => library.id === PERSONAL_CLOUD_PROJECT_LIBRARY_ID)
+      ).toBe(false)
+    } finally {
+      app.dispose()
+    }
+  })
+
+  it('auto-enables cloud sync for feature-flagged users and materializes Personal Cloud', async () => {
+    const userFeatures = createUserFeaturesForTest(
+      new Set([OPFS_CLOUD_FEATURE_FLAG])
+    )
+    const app = createAppForTest({
+      userFeatures,
+    })
+
+    try {
+      await expect
+        .poll(() => ({
+          active: getPluginToggle(app, 'cloud-sync').active.value,
+          current: getCloudSyncPluginSetting(app)?.current,
+          user: getCloudSyncPluginSetting(app)?.user,
+          hasPersonalCloudLibrarySetting: hasPersonalCloudLibrarySetting(app),
+          hasPersonalCloudLibrary: app.registry
+            .get(projectLibrariesValueSpec)
+            .some(
+              (library) => library.id === PERSONAL_CLOUD_PROJECT_LIBRARY_ID
+            ),
+        }))
+        .toEqual({
+          active: true,
+          current: true,
+          user: true,
+          hasPersonalCloudLibrarySetting: true,
+          hasPersonalCloudLibrary: true,
+        })
+
+      app.settings.actor.send({
+        type: 'set.plugins.cloud-sync',
+        data: {
+          level: 'user',
+          value: false,
+        },
+        doNotPersist: true,
+      } as never)
+
+      await waitForSettingsIdle(app)
+      userFeatures.setFeatureIds(new Set([OPFS_CLOUD_FEATURE_FLAG]))
+
+      expect(getCloudSyncPluginSetting(app)?.current).toBe(false)
+      expect(getCloudSyncPluginSetting(app)?.user).toBe(false)
+      expect(getPluginToggle(app, 'cloud-sync').active.value).toBe(false)
+    } finally {
+      app.dispose()
     }
   })
 

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -475,6 +475,67 @@ describe('project system', () => {
           hasPersonalCloudLibrary: true,
         })
 
+      // On web, cloud sync is the project storage layer, not an optional
+      // feature: a disable attempt is overridden, the plugin stays active, and
+      // a usable library plus a create target remain (the strand-repro fix).
+      app.settings.actor.send({
+        type: 'set.plugins.cloud-sync',
+        data: {
+          level: 'user',
+          value: false,
+        },
+        doNotPersist: true,
+      } as never)
+
+      await expect
+        .poll(() => ({
+          current: getCloudSyncPluginSetting(app)?.current,
+          active: getPluginToggle(app, 'cloud-sync').active.value,
+          hasPersonalCloudLibrary: app.registry
+            .get(projectLibrariesValueSpec)
+            .some(
+              (library) => library.id === PERSONAL_CLOUD_PROJECT_LIBRARY_ID
+            ),
+          canCreateInPersonalCloud: app
+            .getCreateProjectLibraryTargets()
+            .some(
+              (target) =>
+                target.library.id === PERSONAL_CLOUD_PROJECT_LIBRARY_ID
+            ),
+        }))
+        .toEqual({
+          current: true,
+          active: true,
+          hasPersonalCloudLibrary: true,
+          canCreateInPersonalCloud: true,
+        })
+    } finally {
+      app.dispose()
+    }
+  })
+
+  it('respects an explicit cloud sync opt-out on desktop', async () => {
+    const previousElectron = window.electron
+    window.electron = {
+      os: { isMac: false },
+      pluginIpc: {
+        invoke: vi.fn(),
+        syncActivePlugins: vi.fn().mockResolvedValue(undefined),
+      },
+    } as unknown as typeof window.electron
+    const userFeatures = createUserFeaturesForTest(
+      new Set([OPFS_CLOUD_FEATURE_FLAG])
+    )
+    const app = createAppForTest({ userFeatures })
+
+    try {
+      // Cloud sync auto-enables for the flag on desktop too.
+      await expect
+        .poll(() => getPluginToggle(app, 'cloud-sync').active.value)
+        .toBe(true)
+
+      // Unlike web (where the disable attempt is overridden), desktop keeps
+      // cloud sync optional and honors the opt-out.
       app.settings.actor.send({
         type: 'set.plugins.cloud-sync',
         data: {
@@ -485,13 +546,13 @@ describe('project system', () => {
       } as never)
 
       await waitForSettingsIdle(app)
-      userFeatures.setFeatureIds(new Set([OPFS_CLOUD_FEATURE_FLAG]))
 
       expect(getCloudSyncPluginSetting(app)?.current).toBe(false)
       expect(getCloudSyncPluginSetting(app)?.user).toBe(false)
       expect(getPluginToggle(app, 'cloud-sync').active.value).toBe(false)
     } finally {
       app.dispose()
+      window.electron = previousElectron
     }
   })
 

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -11,6 +11,7 @@ import fsZds, { moduleFsViaModuleImport, StorageName } from '@src/lib/fs-zds'
 import type { Project } from '@src/lib/project'
 import { rustContextService } from '@src/lib/rustContext/registry/contract'
 import {
+  DIRECTORY_PROJECT_LIBRARY_TYPE,
   PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
   getDefaultCloudProjectLibrarySetting,
 } from '@src/lib/projectLibraries'
@@ -238,6 +239,17 @@ function hasPersonalCloudLibrarySetting(app: App) {
     )
 }
 
+function hasDefaultDirectoryLibrarySetting(app: App) {
+  const projectDirectory = app.settings.get().app.projectDirectory.current
+  return app.settings
+    .get()
+    .app.libraries.current.some(
+      (library) =>
+        library.type === DIRECTORY_PROJECT_LIBRARY_TYPE &&
+        library.path === projectDirectory
+    )
+}
+
 describe('project system', () => {
   it('uses registry runtime dependencies by default', () => {
     const app = createAppForTest()
@@ -420,6 +432,7 @@ describe('project system', () => {
       expect(getCloudSyncPluginSetting(app)?.user).toBeUndefined()
       expect(getPluginToggle(app, 'cloud-sync').active.value).toBe(false)
       expect(hasPersonalCloudLibrarySetting(app)).toBe(false)
+      expect(hasDefaultDirectoryLibrarySetting(app)).toBe(true)
       expect(
         app.registry
           .get(projectLibrariesValueSpec)
@@ -445,6 +458,8 @@ describe('project system', () => {
           current: getCloudSyncPluginSetting(app)?.current,
           user: getCloudSyncPluginSetting(app)?.user,
           hasPersonalCloudLibrarySetting: hasPersonalCloudLibrarySetting(app),
+          hasDefaultDirectoryLibrarySetting:
+            hasDefaultDirectoryLibrarySetting(app),
           hasPersonalCloudLibrary: app.registry
             .get(projectLibrariesValueSpec)
             .some(
@@ -456,6 +471,7 @@ describe('project system', () => {
           current: true,
           user: true,
           hasPersonalCloudLibrarySetting: true,
+          hasDefaultDirectoryLibrarySetting: false,
           hasPersonalCloudLibrary: true,
         })
 

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -24,6 +24,11 @@ import type { MachineManager } from '@src/lib/MachineManager'
 import type { Project } from '@src/lib/project'
 import type RustContext from '@src/lib/rustContext'
 import { rustContextService } from '@src/lib/rustContext/registry/contract'
+import {
+  areProjectLibrarySettingsEqual,
+  getDefaultCloudProjectLibrarySetting,
+  mergeProjectLibrarySettings,
+} from '@src/lib/projectLibraries'
 import type { SaveSettingsPayload } from '@src/lib/settings/settingsTypes'
 import {
   getAllCurrentSettings,
@@ -91,6 +96,7 @@ import {
 import type { SnapshotFrom, Subscription } from 'xstate'
 import { createActor } from 'xstate'
 
+const CLOUD_SYNC_PLUGIN_ID = 'cloud-sync'
 const appCommandsSlot = new Slot()
 
 type AppRegistryOptions = {
@@ -248,6 +254,7 @@ export class App implements AppSubsystems {
     this.userFeatures.actor.subscribe(this.syncCloudSyncRuntimePolicy)
     this.userFeatures.actor.subscribe(this.syncAppCommands)
     this.userFeatures.actor.subscribe(this.syncKclRuntimeFlags)
+    this.userFeatures.actor.subscribe(this.syncPluginSettingsFromCurrent)
     this.unsubscribeFromActiveWasmInstance = onActiveWasmInstance(
       this.setActiveWasmInstance
     )
@@ -261,8 +268,9 @@ export class App implements AppSubsystems {
     this.lastSettings = getAllCurrentSettings(
       getOnlySettingsFromContext(this.settings.actor.getSnapshot().context)
     )
+    this.settings.actor.subscribe(this.syncCloudSyncRuntimePolicy)
     this.settings.actor.subscribe(this.syncPluginSettings)
-    this.syncPluginSettings(this.settings.actor.getSnapshot())
+    this.syncPluginSettingsFromCurrent()
   }
 
   /**
@@ -458,6 +466,7 @@ export class App implements AppSubsystems {
       : undefined
     const enabled =
       Boolean(token) &&
+      this.cloudSyncPluginSettingEnabled() &&
       userFeaturesContextHas(
         this.userFeatures.actor.getSnapshot().context,
         OPFS_CLOUD_FEATURE_FLAG,
@@ -469,6 +478,17 @@ export class App implements AppSubsystems {
       token,
       syncExistingLocalProjects: !window.electron,
     })
+  }
+
+  private cloudSyncPluginSettingEnabled = () => {
+    const cloudSyncSetting = (
+      this.settings.actor.getSnapshot().context as unknown as Record<
+        string,
+        Record<string, { current?: unknown } | undefined> | undefined
+      >
+    ).plugins?.[CLOUD_SYNC_PLUGIN_ID]
+
+    return cloudSyncSetting?.current === true
   }
 
   setActiveWasmInstance = (wasmInstance: ModuleType) => {
@@ -531,13 +551,138 @@ export class App implements AppSubsystems {
     ])
   }
 
+  syncPluginSettingsFromCurrent = () => {
+    this.syncPluginSettings(this.settings.actor.getSnapshot())
+  }
+
+  private getPluginActivationSettingValue = (
+    snapshot: SnapshotFrom<typeof this.settings.actor>,
+    activationSetting: {
+      category: string
+      settingName: string
+    }
+  ) => {
+    return (
+      snapshot.context as unknown as Record<
+        string,
+        | Record<string, { current?: unknown; user?: unknown } | undefined>
+        | undefined
+      >
+    )[activationSetting.category]?.[activationSetting.settingName]
+  }
+
+  /**
+   * Product policy: Cloud sync is feature-gated, but feature-flagged users
+   * should get the plugin enabled by default until they explicitly opt out.
+   *
+   * Keep the plugin's static default off so registry startup stays
+   * deterministic. Once settings and user features are both settled in the app
+   * runtime, this writes the first user-level enablement only when there is no
+   * existing user preference.
+   */
+  private maybeEnableCloudSyncPluginForFeature = (
+    snapshot: SnapshotFrom<typeof this.settings.actor>,
+    pluginActivationSettings: Map<
+      string,
+      {
+        category: string
+        settingName: string
+      }
+    >
+  ) => {
+    if (!snapshot.matches('idle')) {
+      return false
+    }
+
+    const activationSetting = pluginActivationSettings.get(CLOUD_SYNC_PLUGIN_ID)
+    if (!activationSetting) {
+      return false
+    }
+
+    const settingValue = this.getPluginActivationSettingValue(
+      snapshot,
+      activationSetting
+    )
+    if (!settingValue || settingValue.current === true) {
+      return false
+    }
+
+    if (settingValue.user !== undefined) {
+      return false
+    }
+
+    if (
+      !userFeaturesContextHas(
+        this.userFeatures.actor.getSnapshot().context,
+        OPFS_CLOUD_FEATURE_FLAG,
+        false
+      )
+    ) {
+      return false
+    }
+
+    this.settings.actor.send({
+      type: `set.${activationSetting.category}.${activationSetting.settingName}`,
+      data: {
+        level: 'user',
+        value: true,
+      },
+    } as never)
+    return true
+  }
+
+  /**
+   * Product policy: enabling Cloud sync materializes the explicit Personal
+   * Cloud library row in user settings.
+   *
+   * This is intentionally tied to the plugin activation lifecycle instead of a
+   * plugin-side startup reconciliation pass. Users can reorder, rename, or
+   * remove the library without an always-on boot effect fighting their settings;
+   * toggling the plugin on again is the action that restores the default row.
+   */
+  private materializePersonalCloudLibraryOnEnable = (
+    snapshot: SnapshotFrom<typeof this.settings.actor>
+  ) => {
+    if (!snapshot.matches('idle')) {
+      return false
+    }
+
+    const currentLibraries = snapshot.context.app.libraries?.current ?? []
+    const defaultCloudLibrary = getDefaultCloudProjectLibrarySetting()
+    const hasDefaultCloudLibrary = currentLibraries.some(
+      (library) =>
+        library.type === defaultCloudLibrary.type &&
+        library.path === defaultCloudLibrary.path
+    )
+    const nextLibraries = mergeProjectLibrarySettings(
+      currentLibraries,
+      hasDefaultCloudLibrary ? [] : [defaultCloudLibrary]
+    )
+
+    if (
+      hasDefaultCloudLibrary ||
+      areProjectLibrarySettingsEqual(nextLibraries, currentLibraries)
+    ) {
+      return false
+    }
+
+    this.settings.actor.send({
+      type: 'set.app.libraries',
+      data: {
+        level: 'user',
+        value: nextLibraries,
+      },
+    })
+    return true
+  }
+
   /**
    * Keep plugin runtime state aligned with the persisted settings model.
    *
-   * For now the settings actor is the source of truth and plugin toggle
-   * services are an imperative projection of that state. A narrower follow-up
-   * can invert this by deriving both the UI and persistence model directly from
-   * extension-owned settings state.
+   * Settings stay the source of truth. Plugin toggle services are an imperative
+   * projection of settled settings, and cloud-sync's feature-flag auto-enable
+   * policy is applied here so plugins do not mutate settings while the registry
+   * graph is being built.
    */
   syncPluginSettings = (snapshot: SnapshotFrom<typeof this.settings.actor>) => {
     const pluginActivationSettings = new Map(
@@ -545,7 +690,22 @@ export class App implements AppSubsystems {
         .get(zdsPluginActivationSettingsValueSpec)
         .map((setting) => [setting.pluginId, setting])
     )
+
+    if (!snapshot.matches('idle')) {
+      return
+    }
+
+    if (
+      this.maybeEnableCloudSyncPluginForFeature(
+        snapshot,
+        pluginActivationSettings
+      )
+    ) {
+      return
+    }
+
     const activePluginIds: string[] = []
+    let shouldMaterializePersonalCloudLibrary = false
 
     for (const plugin of this.registry.get(pluginsValueSpec)) {
       const activationSetting = pluginActivationSettings.get(plugin.id)
@@ -553,26 +713,37 @@ export class App implements AppSubsystems {
         continue
       }
 
-      const desiredActive = (
-        snapshot.context as unknown as Record<
-          string,
-          Record<string, { current: unknown } | undefined> | undefined
-        >
-      )[activationSetting.category]?.[activationSetting.settingName]?.current
-      if (typeof desiredActive !== 'boolean') {
+      const settingValue = this.getPluginActivationSettingValue(
+        snapshot,
+        activationSetting
+      )
+      const settingDesiredActive = settingValue?.current
+      if (typeof settingDesiredActive !== 'boolean') {
         continue
       }
+      const featureAllowsCloudSyncPlugin =
+        plugin.id !== CLOUD_SYNC_PLUGIN_ID ||
+        userFeaturesContextHas(
+          this.userFeatures.actor.getSnapshot().context,
+          OPFS_CLOUD_FEATURE_FLAG,
+          false
+        )
+      const desiredActive = settingDesiredActive && featureAllowsCloudSyncPlugin
       if (desiredActive) {
         activePluginIds.push(plugin.id)
       }
 
       const toggle = this.registry.get(plugin.service)
+      const wasActive = toggle.active.value
       if (toggle.active.value === desiredActive) {
         continue
       }
 
       if (desiredActive) {
         toggle.enable()
+        if (plugin.id === CLOUD_SYNC_PLUGIN_ID && !wasActive) {
+          shouldMaterializePersonalCloudLibrary = true
+        }
         continue
       }
 
@@ -585,6 +756,10 @@ export class App implements AppSubsystems {
         : undefined
     if (syncActivePlugins) {
       void syncActivePlugins(activePluginIds).catch(reportRejection)
+    }
+
+    if (shouldMaterializePersonalCloudLibrary) {
+      this.materializePersonalCloudLibraryOnEnable(snapshot)
     }
   }
 

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -512,7 +512,8 @@ export class App implements AppSubsystems {
 
   getCreateProjectLibraryTargets = () => {
     const libraryTypes = this.registry.get(projectLibraryTypesValueSpec)
-    return this.registry.get(projectLibrariesValueSpec).flatMap((library) => {
+    const libraries = this.registry.get(projectLibrariesValueSpec)
+    const targets = libraries.flatMap((library) => {
       const createProject = getProjectLibraryCreateProjectOperation(
         libraryTypes.get(library.type),
         library
@@ -520,6 +521,17 @@ export class App implements AppSubsystems {
 
       return createProject ? [{ library, createProject }] : []
     })
+
+    // Configured libraries exist but none can create a project — the user would
+    // see an actionless Home. This should not happen (the cloud and directory
+    // types are always-on); surface it rather than silently returning nothing.
+    if (targets.length === 0 && libraries.length > 0) {
+      console.warn(
+        'No project library can create projects; the configured libraries have no available createProject handler.'
+      )
+    }
+
+    return targets
   }
 
   syncAppCommands = () => {
@@ -579,12 +591,18 @@ export class App implements AppSubsystems {
 
   /**
    * Product policy: Cloud sync is feature-gated, but feature-flagged users
-   * should get the plugin enabled by default until they explicitly opt out.
+   * should get the plugin enabled by default.
    *
    * Keep the plugin's static default off so registry startup stays
    * deterministic. Once settings and user features are both settled in the app
-   * runtime, this writes the first user-level enablement only when there is no
-   * existing user preference.
+   * runtime, this writes the user-level enablement.
+   *
+   * Desktop is opt-in: only write when there is no existing user preference, so
+   * an explicit opt-out is respected. Web treats cloud sync as the project
+   * storage layer rather than an optional feature, so it is mandatory for
+   * eligible users regardless of any prior opt-out (the toggle is also hidden
+   * on web via the plugin activation setting). This makes the setting the
+   * single source of truth that everything downstream follows.
    */
   private maybeEnableCloudSyncPluginForFeature = (
     snapshot: SnapshotFrom<typeof this.settings.actor>,
@@ -613,7 +631,8 @@ export class App implements AppSubsystems {
       return false
     }
 
-    if (settingValue.user !== undefined) {
+    const isWeb = typeof window !== 'undefined' && !window.electron
+    if (!isWeb && settingValue.user !== undefined) {
       return false
     }
 

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -26,8 +26,10 @@ import type RustContext from '@src/lib/rustContext'
 import { rustContextService } from '@src/lib/rustContext/registry/contract'
 import {
   areProjectLibrarySettingsEqual,
+  DIRECTORY_PROJECT_LIBRARY_TYPE,
   getDefaultCloudProjectLibrarySetting,
   mergeProjectLibrarySettings,
+  type ProjectLibrarySetting,
 } from '@src/lib/projectLibraries'
 import type { SaveSettingsPayload } from '@src/lib/settings/settingsTypes'
 import {
@@ -123,6 +125,10 @@ function getZookeeperReplayFallbackFilePath(
   ].filter((path, index, paths) => paths.indexOf(path) === index)
 
   return candidates.find((path) => path && !deletedPaths.has(path))
+}
+
+function normalizeProjectLibrarySettingPath(path: string) {
+  return path.trim().replaceAll('\\', '/').replace(/\/+$/g, '')
 }
 
 // We set some of our singletons on the window for debugging and E2E tests
@@ -636,9 +642,9 @@ export class App implements AppSubsystems {
    * Cloud library row in user settings.
    *
    * This is intentionally tied to the plugin activation lifecycle instead of a
-   * plugin-side startup reconciliation pass. Users can reorder, rename, or
-   * remove the library without an always-on boot effect fighting their settings;
-   * toggling the plugin on again is the action that restores the default row.
+   * plugin-side startup reconciliation pass. Desktop keeps directory and cloud
+   * libraries side by side; web treats Personal Cloud as the canonical project
+   * library and replaces only the recognized default directory row.
    */
   private materializePersonalCloudLibraryOnEnable = (
     snapshot: SnapshotFrom<typeof this.settings.actor>
@@ -648,21 +654,54 @@ export class App implements AppSubsystems {
     }
 
     const currentLibraries = snapshot.context.app.libraries?.current ?? []
-    const defaultCloudLibrary = getDefaultCloudProjectLibrarySetting()
-    const hasDefaultCloudLibrary = currentLibraries.some(
-      (library) =>
-        library.type === defaultCloudLibrary.type &&
-        library.path === defaultCloudLibrary.path
+    const defaultDirectoryLibraryPaths = new Set(
+      [
+        snapshot.context.app.projectDirectory?.current,
+        snapshot.context.app.projectDirectory?.default,
+        ...(snapshot.context.app.libraries?.default ?? [])
+          .filter((library) => library.type === DIRECTORY_PROJECT_LIBRARY_TYPE)
+          .map((library) => library.path),
+      ]
+        .filter((path): path is string => Boolean(path?.trim()))
+        .map(normalizeProjectLibrarySettingPath)
     )
+    const defaultCloudLibrary = getDefaultCloudProjectLibrarySetting()
+    const isDefaultCloudLibrary = (library: ProjectLibrarySetting) =>
+      library.type === defaultCloudLibrary.type &&
+      library.path === defaultCloudLibrary.path
+    const shouldReplaceDirectoryLibraryOnWeb = (
+      library: ProjectLibrarySetting
+    ) =>
+      typeof window !== 'undefined' &&
+      !window.electron &&
+      library.type === DIRECTORY_PROJECT_LIBRARY_TYPE &&
+      defaultDirectoryLibraryPaths.has(
+        normalizeProjectLibrarySettingPath(library.path)
+      )
+
+    let hasPersonalCloudLibrary = false
     const nextLibraries = mergeProjectLibrarySettings(
-      currentLibraries,
-      hasDefaultCloudLibrary ? [] : [defaultCloudLibrary]
+      currentLibraries.flatMap((library) => {
+        if (isDefaultCloudLibrary(library)) {
+          hasPersonalCloudLibrary = true
+          return [library]
+        }
+
+        if (shouldReplaceDirectoryLibraryOnWeb(library)) {
+          if (hasPersonalCloudLibrary) {
+            return []
+          }
+
+          hasPersonalCloudLibrary = true
+          return [defaultCloudLibrary]
+        }
+
+        return [library]
+      }),
+      hasPersonalCloudLibrary ? [] : [defaultCloudLibrary]
     )
 
-    if (
-      hasDefaultCloudLibrary ||
-      areProjectLibrarySettingsEqual(nextLibraries, currentLibraries)
-    ) {
+    if (areProjectLibrarySettingsEqual(nextLibraries, currentLibraries)) {
       return false
     }
 

--- a/src/lib/cloudSync/README.md
+++ b/src/lib/cloudSync/README.md
@@ -17,7 +17,7 @@ The files under `src/registry/extensions/cloudSync`, `src/registry/plugins/cloud
 The cloud sync system supports syncing on a per-project basis. However, cloud sync also pairs with our project library capability to register a "cloud" library type to the application, which maps local project directories to user cloud libraries. At present, we only support a "personal" cloud library in our API (see [our docs](https://zoo.dev/docs/developer-tools/api/projects)), and the location on the disk where this library's contents are synced locally is not editable by users. The chosen locations are:
 - On web: `<opfs-root>/documents/zoo-design-studio-projects`
 - Linux and Windows: `~/documents/zoo-design-studio-projects`
-- MacOS: `~/Cloud/Zoo/personal`, by MacOS convention.
+- macOS: `~/Library/CloudStorage/Zoo/personal`, by macOS convention
 
 ## Sync Flows
 

--- a/src/lib/cloudSync/README.md
+++ b/src/lib/cloudSync/README.md
@@ -12,6 +12,13 @@ The cloud sync subsystem has both always-on infrastructure and toggleable runtim
 
 The files under `src/registry/extensions/cloudSync`, `src/registry/plugins/cloudSync`, and `src/registry/contracts/cloudSync.ts` are intentionally thin shims for registry discovery and compatibility with existing import paths.
 
+## Libraries and disk persistence
+
+The cloud sync system supports syncing on a per-project basis. However, cloud sync also pairs with our project library capability to register a "cloud" library type to the application, which maps local project directories to user cloud libraries. At present, we only support a "personal" cloud library in our API (see [our docs](https://zoo.dev/docs/developer-tools/api/projects)), and the location on the disk where this library's contents are synced locally is not editable by users. The chosen locations are:
+- On web: `<opfs-root>/documents/zoo-design-studio-projects`
+- Linux and Windows: `~/documents/zoo-design-studio-projects`
+- MacOS: `~/Cloud/Zoo/personal`, by MacOS convention.
+
 ## Sync Flows
 
 ### Local Reads And Home Loading

--- a/src/lib/cloudSync/README.md
+++ b/src/lib/cloudSync/README.md
@@ -105,6 +105,7 @@ flowchart TD
 - If local and remote both changed differently, local remains primary and the remote archive is written as a conflict copy.
 - Sync failures must preserve outbox and dirty metadata.
 - Cloud project title is user-facing metadata; the OPFS folder name is an implementation detail that may be uniquified.
+- Home rename/delete of a cloud project act on the local materialization when one exists (and let normal sync replicate the change), and act directly on the remote project when the project is still remote-only. Because the cloud API has no title-only update, a remote-only rename re-uploads the downloaded project archive with the new title under `expected_revision`.
 
 ## Persistent State
 

--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -944,6 +944,101 @@ export async function ensureCloudProjectLocallySynced(
   )
 }
 
+/**
+ * Rename the remote cloud project identified by `remoteProjectId`.
+ *
+ * This targets *remote-only* projects that have not been materialized locally,
+ * so there is no local `project.toml` to edit. The cloud API has no title-only
+ * update, so the whole-project archive is downloaded and re-uploaded with the
+ * new title. Callers that own a local materialization should edit the local
+ * `project.toml` instead and let sync replicate the rename to the remote.
+ */
+export async function renameRemoteCloudProject(
+  remoteProjectId: string,
+  requestedName: string
+): Promise<void> {
+  if (!isConfiguredForCloud()) {
+    return
+  }
+
+  const projectId = remoteProjectId.trim()
+  const title = requestedName.trim()
+  if (!projectId || !title) {
+    return
+  }
+
+  const remoteProject = await getRemoteProject(config, projectId)
+  const files = withRemoteProjectMetadataInArchiveFiles(
+    filterCloudSyncProjectFilesForSync(
+      await parseProjectArchive(
+        await downloadRemoteProjectArchive(config, projectId)
+      )
+    ),
+    title,
+    projectId,
+    getEnvironmentName()
+  )
+  const updated = await updateRemoteProject({
+    config,
+    projectPath: localProjectNameForRemoteProject(remoteProject),
+    projectId,
+    files,
+    expectedRevision: getRevision(remoteProject),
+  }).catch(rejectRemoteUploadFailure)
+
+  // Reflect the new title in the in-memory remote index immediately so Home
+  // updates before the next full remote index sync completes.
+  cloudSyncRemoteProjects.value = cloudSyncRemoteProjects.value.map(
+    (project) =>
+      project.id === projectId
+        ? { ...project, title: updated.title ?? title }
+        : project
+  )
+  scheduleRemoteIndexSync(0)
+}
+
+/**
+ * Delete the remote cloud project identified by `remoteProjectId`, tolerating a
+ * remote that is already gone (404). Any local sync metadata still pointing at
+ * it is cleared so the project neither reappears nor lingers as a tombstone.
+ *
+ * This targets *remote-only* projects; callers that own a local materialization
+ * should remove the local project instead and let sync replicate the deletion.
+ */
+export async function deleteRemoteCloudProject(
+  remoteProjectId: string
+): Promise<void> {
+  if (!isConfiguredForCloud()) {
+    return
+  }
+
+  const projectId = remoteProjectId.trim()
+  if (!projectId) {
+    return
+  }
+
+  try {
+    await deleteRemoteProject(config, projectId)
+  } catch (error) {
+    if (!(error instanceof CloudApiError && error.status === 404)) {
+      // eslint-disable-next-line suggest-no-throw/suggest-no-throw
+      throw error
+    }
+  }
+
+  for (const metadata of await getAllProjectMetadata()) {
+    if (metadata.remoteProjectId === projectId) {
+      await clearOutboxEntriesForProject(metadata.localProjectPath)
+      await deleteProjectMetadata(metadata.localProjectPath)
+    }
+  }
+
+  cloudSyncRemoteProjects.value = cloudSyncRemoteProjects.value.filter(
+    (project) => project.id !== projectId
+  )
+  scheduleRemoteIndexSync(0)
+}
+
 export async function getCloudSyncRemoteProjectThumbnailUrl(
   remoteProject: RemoteProjectSummary
 ) {

--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -864,7 +864,8 @@ async function cloneRemoteProjectToLocal(
 }
 
 export async function ensureCloudProjectLocallySynced(
-  remoteProjectId: string
+  remoteProjectId: string,
+  targetProjectDirectoryPath?: string
 ): Promise<CloudSyncLocalProject | undefined> {
   if (!isConfiguredForCloud()) {
     return undefined
@@ -879,7 +880,13 @@ export async function ensureCloudProjectLocallySynced(
   const knownLocalMetadata = metadata.find(
     (entry) => entry.remoteProjectId === projectId && !entry.tombstone
   )
-  const projectDirectory = getConfiguredProjectDirectoryPath()
+  // The destination directory is the local materialization path of the
+  // project library the caller is opening this remote project from (e.g. the
+  // Personal Cloud library). Fall back to the configured directory only when
+  // the caller cannot resolve a target library.
+  const projectDirectory = targetProjectDirectoryPath?.trim()
+    ? normalizePathForSync(targetProjectDirectoryPath)
+    : getConfiguredProjectDirectoryPath()
   const knownLocalProjectPath = knownLocalMetadata
     ? projectPathInDirectory(knownLocalMetadata, projectDirectory)
     : undefined

--- a/src/lib/cloudSync/index.test.ts
+++ b/src/lib/cloudSync/index.test.ts
@@ -47,8 +47,10 @@ function readProjectFile(files: ProjectArchiveFile[], relativePath: string) {
 }
 
 describe('cloudSync sync helpers', () => {
-  it('uses a personal Zoo folder as the default cloud project directory fallback', () => {
-    expect(DEFAULT_CLOUD_PROJECT_DIRECTORY_PATH).toBe('/documents/Zoo/personal')
+  it('uses the web project directory as the default cloud project directory fallback', () => {
+    expect(DEFAULT_CLOUD_PROJECT_DIRECTORY_PATH).toBe(
+      `/documents/${PROJECT_FOLDER}`
+    )
   })
 
   it('identifies project roots beneath the personal Zoo cloud directory', () => {

--- a/src/lib/cloudSync/index.test.ts
+++ b/src/lib/cloudSync/index.test.ts
@@ -18,6 +18,7 @@ import {
   projectManifestsEqual,
   shouldCloudSyncAutoSyncLocalProject,
 } from '@src/lib/cloudSync'
+import { DEFAULT_CLOUD_PROJECT_DIRECTORY_PATH } from '@src/lib/cloudSync/paths'
 import {
   normalizeProjectArchiveFilesForCloudSync,
   projectManifestFromFiles,
@@ -46,6 +47,22 @@ function readProjectFile(files: ProjectArchiveFile[], relativePath: string) {
 }
 
 describe('cloudSync sync helpers', () => {
+  it('uses a personal Zoo folder as the default cloud project directory fallback', () => {
+    expect(DEFAULT_CLOUD_PROJECT_DIRECTORY_PATH).toBe('/documents/Zoo/personal')
+  })
+
+  it('identifies project roots beneath the personal Zoo cloud directory', () => {
+    expect(
+      getCloudSyncProjectRoot(
+        '/Users/frank/Library/CloudStorage/Zoo/personal/bracket/main.kcl'
+      )
+    ).toBe('/Users/frank/Library/CloudStorage/Zoo/personal/bracket')
+
+    expect(
+      getCloudSyncProjectRoot('/Users/frank/Library/CloudStorage/Zoo/personal')
+    ).toBeUndefined()
+  })
+
   it('identifies project roots beneath the OPFS project directory', () => {
     expect(
       getCloudSyncProjectRoot(`/documents/${PROJECT_FOLDER}/bracket/main.kcl`)

--- a/src/lib/cloudSync/paths.ts
+++ b/src/lib/cloudSync/paths.ts
@@ -7,8 +7,7 @@ export const CLOUD_PROJECT_LIBRARY_FOLDER = 'Zoo'
 export const PERSONAL_CLOUD_PROJECT_LIBRARY_FOLDER = 'personal'
 export const DEFAULT_CLOUD_PROJECT_DIRECTORY_PATH = `/${webSafeJoin([
   'documents',
-  CLOUD_PROJECT_LIBRARY_FOLDER,
-  PERSONAL_CLOUD_PROJECT_LIBRARY_FOLDER,
+  PROJECT_FOLDER,
 ])}`
 
 export async function getDefaultCloudProjectDirectoryPath() {
@@ -22,6 +21,14 @@ export async function getDefaultCloudProjectDirectoryPath() {
       )
     } catch {
       // Fall back to the cross-platform documents location below.
+    }
+  }
+
+  if (typeof window !== 'undefined' && !window.electron) {
+    try {
+      return fsZds.join(await fsZds.getPath('documents'), PROJECT_FOLDER)
+    } catch {
+      return DEFAULT_CLOUD_PROJECT_DIRECTORY_PATH
     }
   }
 

--- a/src/lib/cloudSync/paths.ts
+++ b/src/lib/cloudSync/paths.ts
@@ -3,14 +3,34 @@ import fsZds from '@src/lib/fs-zds'
 import { webSafeJoin, webSafePathSplit } from '@src/lib/pathUtils'
 
 export const INTERNAL_OPFS_META_FILE = '._meta'
+export const CLOUD_PROJECT_LIBRARY_FOLDER = 'Zoo'
+export const PERSONAL_CLOUD_PROJECT_LIBRARY_FOLDER = 'personal'
 export const DEFAULT_CLOUD_PROJECT_DIRECTORY_PATH = `/${webSafeJoin([
   'documents',
-  PROJECT_FOLDER,
+  CLOUD_PROJECT_LIBRARY_FOLDER,
+  PERSONAL_CLOUD_PROJECT_LIBRARY_FOLDER,
 ])}`
 
 export async function getDefaultCloudProjectDirectoryPath() {
+  if (typeof window !== 'undefined' && window.electron?.os.isMac) {
+    try {
+      return fsZds.join(
+        fsZds.dirname(await fsZds.getPath('appData')),
+        'CloudStorage',
+        CLOUD_PROJECT_LIBRARY_FOLDER,
+        PERSONAL_CLOUD_PROJECT_LIBRARY_FOLDER
+      )
+    } catch {
+      // Fall back to the cross-platform documents location below.
+    }
+  }
+
   try {
-    return fsZds.join(await fsZds.getPath('documents'), PROJECT_FOLDER)
+    return fsZds.join(
+      await fsZds.getPath('documents'),
+      CLOUD_PROJECT_LIBRARY_FOLDER,
+      PERSONAL_CLOUD_PROJECT_LIBRARY_FOLDER
+    )
   } catch {
     return DEFAULT_CLOUD_PROJECT_DIRECTORY_PATH
   }
@@ -31,20 +51,39 @@ export function normalizeRelativePath(relativePath: string) {
     .replace(/^(?:\.\/)+/g, '')
 }
 
+function getProjectRootFromProjectDirectoryParts(
+  parts: readonly string[],
+  projectDirectoryParts: readonly string[]
+) {
+  const maxStartIndex = parts.length - projectDirectoryParts.length - 1
+  for (let index = maxStartIndex; index >= 0; index -= 1) {
+    const isMatch = projectDirectoryParts.every(
+      (part, offset) => parts[index + offset] === part
+    )
+    if (!isMatch) {
+      continue
+    }
+
+    return `/${webSafeJoin(
+      parts.slice(0, index + projectDirectoryParts.length + 1)
+    )}`
+  }
+
+  return undefined
+}
+
 export function getCloudSyncProjectRoot(
   targetPath: string
 ): string | undefined {
   const normalized = normalizePathForSync(targetPath)
   const parts = webSafePathSplit(normalized).filter(Boolean)
-  const projectDirectoryIndex = parts.lastIndexOf(PROJECT_FOLDER)
-  if (
-    projectDirectoryIndex === -1 ||
-    parts.length <= projectDirectoryIndex + 1
-  ) {
-    return undefined
-  }
-
-  return `/${webSafeJoin(parts.slice(0, projectDirectoryIndex + 2))}`
+  return (
+    getProjectRootFromProjectDirectoryParts(parts, [PROJECT_FOLDER]) ??
+    getProjectRootFromProjectDirectoryParts(parts, [
+      CLOUD_PROJECT_LIBRARY_FOLDER,
+      PERSONAL_CLOUD_PROJECT_LIBRARY_FOLDER,
+    ])
+  )
 }
 
 export function isProjectRootPath(targetPath: string, projectRoot: string) {
@@ -53,5 +92,13 @@ export function isProjectRootPath(targetPath: string, projectRoot: string) {
 
 export function isCloudSyncProjectDirectoryPath(targetPath: string) {
   const normalized = normalizePathForSync(targetPath)
-  return normalized.endsWith(`/${PROJECT_FOLDER}`)
+  return (
+    normalized.endsWith(`/${PROJECT_FOLDER}`) ||
+    normalized.endsWith(
+      `/${webSafeJoin([
+        CLOUD_PROJECT_LIBRARY_FOLDER,
+        PERSONAL_CLOUD_PROJECT_LIBRARY_FOLDER,
+      ])}`
+    )
+  )
 }

--- a/src/lib/cloudSync/paths.ts
+++ b/src/lib/cloudSync/paths.ts
@@ -1,7 +1,20 @@
 import { PROJECT_FOLDER } from '@src/lib/constants'
+import fsZds from '@src/lib/fs-zds'
 import { webSafeJoin, webSafePathSplit } from '@src/lib/pathUtils'
 
 export const INTERNAL_OPFS_META_FILE = '._meta'
+export const DEFAULT_CLOUD_PROJECT_DIRECTORY_PATH = `/${webSafeJoin([
+  'documents',
+  PROJECT_FOLDER,
+])}`
+
+export async function getDefaultCloudProjectDirectoryPath() {
+  try {
+    return fsZds.join(await fsZds.getPath('documents'), PROJECT_FOLDER)
+  } catch {
+    return DEFAULT_CLOUD_PROJECT_DIRECTORY_PATH
+  }
+}
 
 export function normalizePathForSync(targetPath: string) {
   const normalized = targetPath.replaceAll('\\', '/')

--- a/src/lib/cloudSync/registry/contract.ts
+++ b/src/lib/cloudSync/registry/contract.ts
@@ -27,8 +27,15 @@ export type CloudSyncRegistryService = {
    * The local project is marked excluded so later edits do not recreate it.
    */
   disconnectProjectSync: (projectPath: string) => Promise<void>
+  /**
+   * Materialize a remote cloud project into the local library directory the
+   * caller is opening it from. `targetProjectDirectoryPath` is the resolved
+   * local path of that library; when omitted the engine falls back to the
+   * configured project directory.
+   */
   ensureProjectLocallySynced: (
-    remoteProjectId: string
+    remoteProjectId: string,
+    targetProjectDirectoryPath?: string
   ) => Promise<CloudSyncLocalProject | undefined>
   getRemoteProjectThumbnailUrl: (
     remoteProject: RemoteProjectSummary

--- a/src/lib/cloudSync/registry/extension.ts
+++ b/src/lib/cloudSync/registry/extension.ts
@@ -38,7 +38,7 @@ export const cloudSyncExtension = defineRegistryItemFactory((ctx) => {
   const applyRuntimePolicy = () => {
     const currentSettings = settings.value?.current.value
     const cloudSyncPluginEnabled =
-      currentSettings?.plugins?.[CLOUD_SYNC_PLUGIN_ID]?.current !== false
+      currentSettings?.plugins?.[CLOUD_SYNC_PLUGIN_ID]?.current === true
     const nextConfig = {
       ...runtimeConfig.value,
       enabled: runtimeConfig.value.enabled && cloudSyncPluginEnabled,

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -14,8 +14,8 @@ import {
 } from '@src/lib/cloudSync/registry/plugin'
 import type { Project } from '@src/lib/project'
 import {
-  CLOUD_PROJECT_LIBRARY_ID,
   CLOUD_PROJECT_LIBRARY_TYPE,
+  PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
   getDefaultCloudProjectLibrarySetting,
   type ProjectLibrarySetting,
 } from '@src/lib/projectLibraries'
@@ -321,8 +321,8 @@ describe('cloud sync project library', () => {
       })
       expect(registry.get(projectLibrariesValueSpec)).toEqual([
         expect.objectContaining({
-          id: CLOUD_PROJECT_LIBRARY_ID,
-          title: 'Cloud',
+          id: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+          title: 'Personal Cloud',
           path: getDefaultCloudProjectLibrarySetting().path,
           type: CLOUD_PROJECT_LIBRARY_TYPE,
           icon: 'network',
@@ -435,7 +435,7 @@ describe('cloud sync home project entries', () => {
           expect.objectContaining({
             source: 'remote',
             status: 'cloud-only',
-            libraryIds: [CLOUD_PROJECT_LIBRARY_ID],
+            libraryIds: [PERSONAL_CLOUD_PROJECT_LIBRARY_ID],
             name: 'Remote title',
             title: 'Remote title',
             remoteProjectId: 'remote-123',

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -170,6 +170,19 @@ function createSettingsService({
   }
 }
 
+function enableCloudSyncPlugin(registry: Registry) {
+  const plugin = registry
+    .get(pluginsValueSpec)
+    .find((plugin) => plugin.id === CLOUD_SYNC_PLUGIN_ID)
+  const pluginService = plugin?.service
+  expect(pluginService).toBeDefined()
+  if (!pluginService) {
+    return
+  }
+
+  registry.get(pluginService).enable()
+}
+
 function createProjectMenuApp(cloudSync: CloudSyncRegistryService) {
   const registry = new Registry()
   const cloudSyncServiceExtension = defineRegistryItem({
@@ -177,6 +190,7 @@ function createProjectMenuApp(cloudSync: CloudSyncRegistryService) {
     providesServices: [provideService(cloudSyncService, cloudSync)],
   })
   registry.configure([cloudSyncServiceExtension, cloudSyncPlugin])
+  enableCloudSyncPlugin(registry)
   const commandsActor = createActor(
     createMachine({
       context: {
@@ -310,6 +324,26 @@ describe('cloud sync project library', () => {
     registry.configure([cloudSyncPlugin])
 
     try {
+      const plugin = registry
+        .get(pluginsValueSpec)
+        .find((plugin) => plugin.id === CLOUD_SYNC_PLUGIN_ID)
+      const pluginService = plugin?.service
+      expect(pluginService).toBeDefined()
+      if (!pluginService) {
+        return
+      }
+
+      const pluginToggle = registry.get(pluginService)
+      expect(pluginToggle.active.value).toBe(false)
+      expect(
+        registry
+          .get(projectLibraryTypesValueSpec)
+          .has(CLOUD_PROJECT_LIBRARY_TYPE)
+      ).toBe(false)
+      expect(registry.get(projectLibrariesValueSpec)).toEqual([])
+
+      pluginToggle.enable()
+
       expect(
         registry
           .get(projectLibraryTypesValueSpec)
@@ -329,16 +363,7 @@ describe('cloud sync project library', () => {
         }),
       ])
 
-      const plugin = registry
-        .get(pluginsValueSpec)
-        .find((plugin) => plugin.id === CLOUD_SYNC_PLUGIN_ID)
-      const pluginService = plugin?.service
-      expect(pluginService).toBeDefined()
-      if (!pluginService) {
-        return
-      }
-
-      registry.get(pluginService).disable()
+      pluginToggle.disable()
 
       expect(
         registry
@@ -371,6 +396,17 @@ describe('cloud sync project library', () => {
     registry.configure([settingsExtension, cloudSyncPlugin])
 
     try {
+      const plugin = registry
+        .get(pluginsValueSpec)
+        .find((plugin) => plugin.id === CLOUD_SYNC_PLUGIN_ID)
+      const pluginService = plugin?.service
+      expect(pluginService).toBeDefined()
+      if (!pluginService) {
+        return
+      }
+
+      registry.get(pluginService).enable()
+
       expect(registry.get(projectLibrariesValueSpec)).toEqual([
         expect.objectContaining({
           id: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
@@ -382,7 +418,7 @@ describe('cloud sync project library', () => {
     }
   })
 
-  test('adds the default cloud library to user settings when enabled', async () => {
+  test('does not mutate project library settings from plugin activation', async () => {
     const registry = new Registry()
     const settings = createSettingsService({})
     const settingsExtension = defineRegistryItem({
@@ -393,38 +429,19 @@ describe('cloud sync project library', () => {
     registry.configure([settingsExtension, cloudSyncPlugin])
 
     try {
-      registry.get(projectLibraryTypesValueSpec)
-      await waitFor(() =>
-        expect(settings.send).toHaveBeenCalledWith({
-          type: 'set.app.libraries',
-          data: {
-            level: 'user',
-            value: [getDefaultCloudProjectLibrarySetting()],
-          },
-        })
-      )
-      expect(settings.settingsSignal.value.app.libraries.current).toEqual([
-        getDefaultCloudProjectLibrarySetting(),
-      ])
-    } finally {
-      registry[Symbol.dispose]()
-    }
-  })
+      const plugin = registry
+        .get(pluginsValueSpec)
+        .find((plugin) => plugin.id === CLOUD_SYNC_PLUGIN_ID)
+      const pluginService = plugin?.service
+      expect(pluginService).toBeDefined()
+      if (!pluginService) {
+        return
+      }
 
-  test('does not add the default cloud library when settings disable the plugin', async () => {
-    const registry = new Registry()
-    const settings = createSettingsService({ cloudSyncEnabled: false })
-    const settingsExtension = defineRegistryItem({
-      id: 'test-settings-service',
-      providesServices: [provideService(settingsService, settings.service)],
-    })
-
-    registry.configure([settingsExtension, cloudSyncPlugin])
-
-    try {
-      registry.get(projectLibraryTypesValueSpec)
+      registry.get(pluginService).enable()
       await Promise.resolve()
       await Promise.resolve()
+
       expect(settings.send).not.toHaveBeenCalled()
       expect(settings.settingsSignal.value.app.libraries.current).toEqual([])
     } finally {
@@ -459,6 +476,7 @@ describe('cloud sync home project entries', () => {
     })
 
     registry.configure([cloudSyncServiceExtension, cloudSyncPlugin])
+    enableCloudSyncPlugin(registry)
 
     try {
       await waitFor(() =>
@@ -525,6 +543,7 @@ describe('cloud sync home project entries', () => {
     })
 
     registry.configure([cloudSyncServiceExtension, cloudSyncPlugin])
+    enableCloudSyncPlugin(registry)
 
     try {
       await waitFor(() =>
@@ -592,6 +611,7 @@ describe('cloud sync home project entries', () => {
     })
 
     registry.configure([cloudSyncServiceExtension, cloudSyncPlugin])
+    enableCloudSyncPlugin(registry)
 
     try {
       await waitFor(() =>

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -76,6 +76,7 @@ const projectWellFormed = {
 } satisfies Project
 
 const CLOUD_SYNC_PLUGIN_ID = 'cloud-sync'
+const originalElectron = window.electron
 
 type TestSettings = {
   app: {
@@ -228,6 +229,7 @@ function createProjectMenuApp(cloudSync: CloudSyncRegistryService) {
 }
 
 afterEach(() => {
+  window.electron = originalElectron
   cloudSyncStatus.value = {
     enabled: false,
     state: 'disabled',
@@ -413,6 +415,50 @@ describe('cloud sync project library', () => {
           order: 1,
         }),
       ])
+    } finally {
+      registry[Symbol.dispose]()
+    }
+  })
+
+  test('reveals the resolved local storage path from settings details', async () => {
+    const registry = new Registry()
+    const showInFolder = vi.fn()
+    vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue('Electron')
+    window.electron = {
+      os: {
+        isMac: true,
+      },
+      showInFolder,
+    } as unknown as Window['electron']
+
+    registry.configure([cloudSyncPlugin])
+
+    try {
+      enableCloudSyncPlugin(registry)
+      const cloudLibraryType = registry
+        .get(projectLibraryTypesValueSpec)
+        .get(CLOUD_PROJECT_LIBRARY_TYPE)
+      expect(cloudLibraryType?.settingsDetails).toBeDefined()
+      const SettingsDetails = cloudLibraryType?.settingsDetails
+      if (!SettingsDetails) {
+        return
+      }
+
+      render(
+        <SettingsDetails
+          library={getDefaultCloudProjectLibrarySetting()}
+          index={0}
+          updateLibrary={vi.fn()}
+          commitLibrary={vi.fn()}
+        />
+      )
+
+      const revealButton = await screen.findByRole('button')
+      await waitFor(() => expect(revealButton).not.toBeDisabled())
+
+      fireEvent.click(revealButton)
+
+      expect(showInFolder).toHaveBeenCalled()
     } finally {
       registry[Symbol.dispose]()
     }

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -10,6 +10,7 @@ import type { App } from '@src/lib/app'
 import { cloudSyncRemoteProjects, cloudSyncStatus } from '@src/lib/cloudSync'
 import {
   cloudSyncPlugin,
+  cloudSyncProjectLibraryType,
   getCloudSyncStatusBarPresentation,
 } from '@src/lib/cloudSync/registry/plugin'
 import type { Project } from '@src/lib/project'
@@ -23,6 +24,7 @@ import type { CloudSyncRegistryService } from '@src/registry/contracts/cloudSync
 import { cloudSyncService } from '@src/registry/contracts/cloudSync'
 import { homeProjectEntriesValueSpec } from '@src/registry/contracts/homeProjects'
 import {
+  getProjectLibraryCreateProjectOperation,
   projectLibrariesValueSpec,
   projectLibraryTypesValueSpec,
 } from '@src/registry/contracts/projectLibraries'
@@ -321,9 +323,29 @@ describe('cloud sync project menu item', () => {
 })
 
 describe('cloud sync project library', () => {
-  test('contributes the cloud project library type while the plugin is active', () => {
+  test('registers the cloud project library type as always-on infrastructure', () => {
     const registry = new Registry()
-    registry.configure([cloudSyncPlugin])
+    // The type handler is registered independently of the toggle-able plugin.
+    registry.configure([cloudSyncProjectLibraryType])
+
+    try {
+      expect(
+        registry
+          .get(projectLibraryTypesValueSpec)
+          .get(CLOUD_PROJECT_LIBRARY_TYPE)
+      ).toMatchObject({
+        title: 'Cloud',
+        icon: 'network',
+        defaultSetting: getDefaultCloudProjectLibrarySetting(),
+      })
+    } finally {
+      registry[Symbol.dispose]()
+    }
+  })
+
+  test('toggles only the personal cloud library row with the plugin, keeping the type', () => {
+    const registry = new Registry()
+    registry.configure([cloudSyncProjectLibraryType, cloudSyncPlugin])
 
     try {
       const plugin = registry
@@ -337,24 +359,16 @@ describe('cloud sync project library', () => {
 
       const pluginToggle = registry.get(pluginService)
       expect(pluginToggle.active.value).toBe(false)
+      // Type is always available; only the Personal Cloud row is gated.
       expect(
         registry
           .get(projectLibraryTypesValueSpec)
           .has(CLOUD_PROJECT_LIBRARY_TYPE)
-      ).toBe(false)
+      ).toBe(true)
       expect(registry.get(projectLibrariesValueSpec)).toEqual([])
 
       pluginToggle.enable()
 
-      expect(
-        registry
-          .get(projectLibraryTypesValueSpec)
-          .get(CLOUD_PROJECT_LIBRARY_TYPE)
-      ).toMatchObject({
-        title: 'Cloud',
-        icon: 'network',
-        defaultSetting: getDefaultCloudProjectLibrarySetting(),
-      })
       expect(registry.get(projectLibrariesValueSpec)).toEqual([
         expect.objectContaining({
           id: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
@@ -367,12 +381,48 @@ describe('cloud sync project library', () => {
 
       pluginToggle.disable()
 
+      // Disabling sync removes the row contribution but must NOT remove the
+      // type handler — otherwise a settings-configured cloud library would
+      // become unusable.
       expect(
         registry
           .get(projectLibraryTypesValueSpec)
           .has(CLOUD_PROJECT_LIBRARY_TYPE)
-      ).toBe(false)
+      ).toBe(true)
       expect(registry.get(projectLibrariesValueSpec)).toEqual([])
+    } finally {
+      registry[Symbol.dispose]()
+    }
+  })
+
+  test('offers project creation in the cloud library while sync is disabled', () => {
+    const registry = new Registry()
+    registry.configure([cloudSyncProjectLibraryType])
+    cloudSyncStatus.value = {
+      enabled: false,
+      state: 'disabled',
+      pendingCount: 0,
+    }
+
+    try {
+      const cloudLibraryType = registry
+        .get(projectLibraryTypesValueSpec)
+        .get(CLOUD_PROJECT_LIBRARY_TYPE)
+      expect(cloudLibraryType).toBeDefined()
+      if (!cloudLibraryType) {
+        return
+      }
+
+      const cloudLibrary = {
+        ...getDefaultCloudProjectLibrarySetting(),
+        id: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+      }
+      // readEntries and createProject stay available even though cloud sync is
+      // off, so a web user who is not actively syncing can still list/create.
+      expect(cloudLibraryType.readEntries).toBeDefined()
+      expect(
+        getProjectLibraryCreateProjectOperation(cloudLibraryType, cloudLibrary)
+      ).toBeDefined()
     } finally {
       registry[Symbol.dispose]()
     }
@@ -431,7 +481,7 @@ describe('cloud sync project library', () => {
       showInFolder,
     } as unknown as Window['electron']
 
-    registry.configure([cloudSyncPlugin])
+    registry.configure([cloudSyncProjectLibraryType, cloudSyncPlugin])
 
     try {
       enableCloudSyncPlugin(registry)

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -351,6 +351,37 @@ describe('cloud sync project library', () => {
     }
   })
 
+  test('preserves configured personal cloud library order', () => {
+    const registry = new Registry()
+    const settings = createSettingsService({
+      libraries: [
+        {
+          title: 'Directory',
+          path: '/projects',
+          type: 'directory',
+        },
+        getDefaultCloudProjectLibrarySetting(),
+      ],
+    })
+    const settingsExtension = defineRegistryItem({
+      id: 'test-settings-service',
+      providesServices: [provideService(settingsService, settings.service)],
+    })
+
+    registry.configure([settingsExtension, cloudSyncPlugin])
+
+    try {
+      expect(registry.get(projectLibrariesValueSpec)).toEqual([
+        expect.objectContaining({
+          id: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+          order: 1,
+        }),
+      ])
+    } finally {
+      registry[Symbol.dispose]()
+    }
+  })
+
   test('adds the default cloud library to user settings when enabled', async () => {
     const registry = new Registry()
     const settings = createSettingsService({})

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -1,5 +1,6 @@
 import {
   defineRegistryItem,
+  pluginsValueSpec,
   provideService,
   Registry,
 } from '@kittycad/registry'
@@ -12,9 +13,23 @@ import {
   getCloudSyncStatusBarPresentation,
 } from '@src/lib/cloudSync/registry/plugin'
 import type { Project } from '@src/lib/project'
+import {
+  CLOUD_PROJECT_LIBRARY_ID,
+  CLOUD_PROJECT_LIBRARY_TYPE,
+  getDefaultCloudProjectLibrarySetting,
+  type ProjectLibrarySetting,
+} from '@src/lib/projectLibraries'
 import type { CloudSyncRegistryService } from '@src/registry/contracts/cloudSync'
 import { cloudSyncService } from '@src/registry/contracts/cloudSync'
 import { homeProjectEntriesValueSpec } from '@src/registry/contracts/homeProjects'
+import {
+  projectLibrariesValueSpec,
+  projectLibraryTypesValueSpec,
+} from '@src/registry/contracts/projectLibraries'
+import {
+  type SettingsRegistryService,
+  settingsService,
+} from '@src/registry/contracts/settings'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { BrowserRouter } from 'react-router-dom'
@@ -60,6 +75,21 @@ const projectWellFormed = {
   default_file: '/some/path/550e8400-e29b-41d4-a716-446655440000/main.kcl',
 } satisfies Project
 
+const CLOUD_SYNC_PLUGIN_ID = 'cloud-sync'
+
+type TestSettings = {
+  app: {
+    libraries: {
+      current: ProjectLibrarySetting[]
+    }
+  }
+  plugins: {
+    [CLOUD_SYNC_PLUGIN_ID]: {
+      current: boolean
+    }
+  }
+}
+
 function renderWithRouter(children: ReactNode) {
   return render(<BrowserRouter>{children}</BrowserRouter>)
 }
@@ -79,6 +109,64 @@ function createCloudSyncService(): CloudSyncRegistryService {
     getProjectMetadataIndex: vi.fn().mockResolvedValue(new Map()),
     getProjectModifiedTime: vi.fn((_metadata, localModified) => localModified),
     resolveProjectConflict: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+function createSettingsService({
+  cloudSyncEnabled = true,
+  libraries = [],
+}: {
+  cloudSyncEnabled?: boolean
+  libraries?: ProjectLibrarySetting[]
+}) {
+  const settingsSignal = signal<TestSettings>({
+    app: {
+      libraries: {
+        current: libraries,
+      },
+    },
+    plugins: {
+      [CLOUD_SYNC_PLUGIN_ID]: {
+        current: cloudSyncEnabled,
+      },
+    },
+  })
+  const send = vi.fn(
+    (event: {
+      type: 'set.app.libraries'
+      data: { value: ProjectLibrarySetting[] }
+    }) => {
+      if (event.type !== 'set.app.libraries') {
+        return
+      }
+
+      settingsSignal.value = {
+        ...settingsSignal.value,
+        app: {
+          ...settingsSignal.value.app,
+          libraries: {
+            current: event.data.value,
+          },
+        },
+      }
+    }
+  )
+  const service = {
+    actor: {
+      getSnapshot: () => ({
+        matches: (state: string) => state === 'idle',
+      }),
+    },
+    current: settingsSignal,
+    get: () => settingsSignal.value,
+    send,
+    useSettings: () => settingsSignal.value,
+  } as unknown as SettingsRegistryService
+
+  return {
+    service,
+    settingsSignal,
+    send,
   }
 }
 
@@ -216,6 +304,104 @@ describe('cloud sync project menu item', () => {
   })
 })
 
+describe('cloud sync project library', () => {
+  test('contributes the cloud project library type while the plugin is active', () => {
+    const registry = new Registry()
+    registry.configure([cloudSyncPlugin])
+
+    try {
+      expect(
+        registry
+          .get(projectLibraryTypesValueSpec)
+          .get(CLOUD_PROJECT_LIBRARY_TYPE)
+      ).toMatchObject({
+        title: 'Cloud',
+        icon: 'network',
+        defaultSetting: getDefaultCloudProjectLibrarySetting(),
+      })
+      expect(registry.get(projectLibrariesValueSpec)).toEqual([
+        expect.objectContaining({
+          id: CLOUD_PROJECT_LIBRARY_ID,
+          title: 'Cloud',
+          path: getDefaultCloudProjectLibrarySetting().path,
+          type: CLOUD_PROJECT_LIBRARY_TYPE,
+          icon: 'network',
+        }),
+      ])
+
+      const plugin = registry
+        .get(pluginsValueSpec)
+        .find((plugin) => plugin.id === CLOUD_SYNC_PLUGIN_ID)
+      const pluginService = plugin?.service
+      expect(pluginService).toBeDefined()
+      if (!pluginService) {
+        return
+      }
+
+      registry.get(pluginService).disable()
+
+      expect(
+        registry
+          .get(projectLibraryTypesValueSpec)
+          .has(CLOUD_PROJECT_LIBRARY_TYPE)
+      ).toBe(false)
+      expect(registry.get(projectLibrariesValueSpec)).toEqual([])
+    } finally {
+      registry[Symbol.dispose]()
+    }
+  })
+
+  test('adds the default cloud library to user settings when enabled', async () => {
+    const registry = new Registry()
+    const settings = createSettingsService({})
+    const settingsExtension = defineRegistryItem({
+      id: 'test-settings-service',
+      providesServices: [provideService(settingsService, settings.service)],
+    })
+
+    registry.configure([settingsExtension, cloudSyncPlugin])
+
+    try {
+      registry.get(projectLibraryTypesValueSpec)
+      await waitFor(() =>
+        expect(settings.send).toHaveBeenCalledWith({
+          type: 'set.app.libraries',
+          data: {
+            level: 'user',
+            value: [getDefaultCloudProjectLibrarySetting()],
+          },
+        })
+      )
+      expect(settings.settingsSignal.value.app.libraries.current).toEqual([
+        getDefaultCloudProjectLibrarySetting(),
+      ])
+    } finally {
+      registry[Symbol.dispose]()
+    }
+  })
+
+  test('does not add the default cloud library when settings disable the plugin', async () => {
+    const registry = new Registry()
+    const settings = createSettingsService({ cloudSyncEnabled: false })
+    const settingsExtension = defineRegistryItem({
+      id: 'test-settings-service',
+      providesServices: [provideService(settingsService, settings.service)],
+    })
+
+    registry.configure([settingsExtension, cloudSyncPlugin])
+
+    try {
+      registry.get(projectLibraryTypesValueSpec)
+      await Promise.resolve()
+      await Promise.resolve()
+      expect(settings.send).not.toHaveBeenCalled()
+      expect(settings.settingsSignal.value.app.libraries.current).toEqual([])
+    } finally {
+      registry[Symbol.dispose]()
+    }
+  })
+})
+
 describe('cloud sync home project entries', () => {
   test('contributes remote thumbnails for cloud-only home entries', async () => {
     cloudSyncStatus.value = {
@@ -249,6 +435,7 @@ describe('cloud sync home project entries', () => {
           expect.objectContaining({
             source: 'remote',
             status: 'cloud-only',
+            libraryIds: [CLOUD_PROJECT_LIBRARY_ID],
             name: 'Remote title',
             title: 'Remote title',
             remoteProjectId: 'remote-123',

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -32,9 +32,20 @@ import {
   type RemoteProjectSummary,
   retryCloudSync,
 } from '@src/lib/cloudSync'
+import { getDefaultCloudProjectDirectoryPath } from '@src/lib/cloudSync/paths'
 import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
 import { PATHS } from '@src/lib/paths'
 import { getProjectDisplayName } from '@src/lib/projectDisplayName'
+import {
+  CLOUD_PROJECT_LIBRARY_ID,
+  CLOUD_PROJECT_LIBRARY_TITLE,
+  CLOUD_PROJECT_LIBRARY_TYPE,
+  areProjectLibrarySettingsEqual,
+  getDefaultCloudProjectLibrarySetting,
+  mergeProjectLibrarySettings,
+  type ProjectLibrary,
+} from '@src/lib/projectLibraries'
+import { createProjectInLocalDirectory } from '@src/lib/projectLibraries/operations'
 import { getResolvedTheme, type ResolvedTheme } from '@src/lib/theme'
 import { reportRejection } from '@src/lib/trap'
 import { userFeaturesContextHas } from '@src/machines/userFeaturesMachine'
@@ -51,15 +62,23 @@ import {
   projectExplorerProjectMenuItemsValueSpec,
 } from '@src/registry/contracts/projectExplorer'
 import {
+  type ProjectLibraryTypeContribution,
+  projectLibrariesValueSpec,
+  projectLibraryTypesValueSpec,
+} from '@src/registry/contracts/projectLibraries'
+import {
   nullableStatusBarItem,
   statusBarGlobalItemsValueSpec,
 } from '@src/registry/contracts/statusBar'
 import { settingsService } from '@src/registry/contracts/settings'
 import { userFeaturesService } from '@src/registry/contracts/userFeatures'
+import { wasmPromiseValueSpec } from '@src/registry/contracts/wasm'
 import { createZdsPlugin } from '@src/registry/createZdsPlugin'
 import { Fragment, useEffect, useState } from 'react'
 import toast from 'react-hot-toast'
 import { useLocation } from 'react-router-dom'
+
+const CLOUD_SYNC_PLUGIN_ID = 'cloud-sync'
 
 type CloudSyncStatusBarPresentation = {
   label: string
@@ -884,11 +903,153 @@ const cloudSyncRemoteHomeProjectEntryContribution = defineRegistryItemFactory(
   'cloud-sync.remote-home-project-entries'
 )
 
+const cloudSyncProjectLibraryContribution = defineRegistryItemFactory((ctx) => {
+  const settings = ctx.services.signal(settingsService)
+  const library = computed<ProjectLibrary[]>(() => {
+    const defaultCloudLibrary = getDefaultCloudProjectLibrarySetting()
+    const configuredCloudLibrary =
+      settings.value?.current.value.app.libraries?.current.find(
+        (library) =>
+          library.type === defaultCloudLibrary.type &&
+          library.path === defaultCloudLibrary.path
+      )
+
+    return [
+      {
+        ...defaultCloudLibrary,
+        ...configuredCloudLibrary,
+        id: CLOUD_PROJECT_LIBRARY_ID,
+        icon: 'network',
+        order: 10,
+      },
+    ]
+  })
+
+  return {
+    item: defineRuntimeRegistryItem({
+      id: 'cloud-sync.project-library',
+      provides: [
+        provide(projectLibrariesValueSpec, library, {
+          key: 'cloud-sync.project-library',
+        }),
+      ],
+    }),
+  }
+}, 'cloud-sync.project-library')
+
+const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
+  const settings = ctx.services.signal(settingsService)
+  let disposed = false
+  let didReconcile = false
+  let disposeEffect: (() => void) | undefined
+
+  const getWasmPromise = () =>
+    ctx.valueSpecs.get(wasmPromiseValueSpec) ??
+    Promise.reject(new Error('Missing WASM promise registry value.'))
+
+  const cloudLibraryType: ProjectLibraryTypeContribution = {
+    type: CLOUD_PROJECT_LIBRARY_TYPE,
+    title: CLOUD_PROJECT_LIBRARY_TITLE,
+    icon: 'network',
+    order: 10,
+    defaultSetting: getDefaultCloudProjectLibrarySetting(),
+    newLibrarySetting: getDefaultCloudProjectLibrarySetting(),
+    operations: {
+      createProject: {
+        isAvailable: () => cloudSyncStatus.value.enabled,
+        run: async ({ requestedProjectName, requestedProjectTitle }) => {
+          if (!cloudSyncStatus.value.enabled) {
+            return Promise.reject(new Error('Cloud sync is not enabled.'))
+          }
+
+          const project = await createProjectInLocalDirectory({
+            projectDirectoryPath: await getDefaultCloudProjectDirectoryPath(),
+            requestedProjectName,
+            requestedProjectTitle,
+            wasmInstancePromise: getWasmPromise(),
+          })
+
+          await ctx.services
+            .get(cloudSyncService)
+            .startProjectSync(project.path)
+
+          return project
+        },
+      },
+    },
+  }
+
+  queueMicrotask(() => {
+    if (disposed) {
+      return
+    }
+
+    disposeEffect = effect(() => {
+      const service = settings.value
+      if (!service || didReconcile) {
+        return
+      }
+
+      const currentSettings = service.current.value
+      const cloudSyncPluginEnabled =
+        currentSettings.plugins?.[CLOUD_SYNC_PLUGIN_ID]?.current !== false
+      if (
+        !cloudSyncPluginEnabled ||
+        !service.actor.getSnapshot().matches('idle')
+      ) {
+        return
+      }
+
+      didReconcile = true
+      const currentLibraries = currentSettings.app.libraries?.current ?? []
+      const defaultCloudLibrary = getDefaultCloudProjectLibrarySetting()
+      const hasDefaultCloudLibrary = currentLibraries.some(
+        (library) =>
+          library.type === defaultCloudLibrary.type &&
+          library.path === defaultCloudLibrary.path
+      )
+      const nextLibraries = mergeProjectLibrarySettings(
+        currentLibraries,
+        hasDefaultCloudLibrary ? [] : [defaultCloudLibrary]
+      )
+
+      if (areProjectLibrarySettingsEqual(nextLibraries, currentLibraries)) {
+        return
+      }
+
+      service.send({
+        type: 'set.app.libraries',
+        data: {
+          level: 'user',
+          value: nextLibraries,
+        },
+      })
+    })
+  })
+
+  return {
+    item: defineRuntimeRegistryItem({
+      id: 'cloud-sync.project-library-type',
+      provides: [
+        provide(projectLibraryTypesValueSpec, cloudLibraryType, {
+          key: 'cloud-sync.project-library-type',
+        }),
+      ],
+      dispose: () => {
+        disposed = true
+        disposeEffect?.()
+      },
+    }),
+  }
+}, 'cloud-sync.project-library-type')
+
 export const cloudSyncPlugin = createZdsPlugin({
-  id: 'cloud-sync',
+  id: CLOUD_SYNC_PLUGIN_ID,
   title: 'Cloud sync',
   description: 'Cloud-backed project sync controls and status.',
   items: [
+    cloudSyncProjectLibraryContribution,
+    cloudSyncProjectLibraryType,
     cloudSyncStatusBarItemContribution,
     cloudSyncProjectMenuItem,
     cloudSyncRemoteHomeProjectEntryContribution,

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -1098,6 +1098,10 @@ export const cloudSyncPlugin = createZdsPlugin({
     description: 'Whether the Cloud sync plugin is enabled.',
     hideOnLevel: 'project',
     hideOnPlatform: 'web',
+    // Cloud sync is feature-gated; keep the toggle out of every settings
+    // surface (settings panel, command bar, plugins list) for users without
+    // the flag instead of special-casing the plugin id per surface.
+    hideWithoutFeature: OPFS_CLOUD_FEATURE_FLAG,
     userToml: {
       sectionKey: 'plugins',
       tomlKey: CLOUD_SYNC_PLUGIN_ID,

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -61,6 +61,7 @@ import {
   projectExplorerProjectMenuItemsValueSpec,
 } from '@src/registry/contracts/projectExplorer'
 import {
+  type ProjectLibrarySettingsDetailsProps,
   type ProjectLibraryTypeContribution,
   projectLibrariesValueSpec,
   projectLibraryTypesValueSpec,
@@ -85,6 +86,45 @@ type CloudSyncStatusBarPresentation = {
   iconClassName: string
   isBlocked: boolean
   tooltip: string
+}
+
+function CloudProjectLibrarySettingsDetails({
+  library,
+}: ProjectLibrarySettingsDetailsProps) {
+  const [storagePath, setStoragePath] = useState<string>()
+
+  useEffect(() => {
+    let disposed = false
+
+    getDefaultCloudProjectDirectoryPath()
+      .then((projectDirectoryPath) => {
+        if (!disposed) {
+          setStoragePath(projectDirectoryPath)
+        }
+      })
+      .catch(() => {
+        if (!disposed) {
+          setStoragePath(undefined)
+        }
+      })
+
+    return () => {
+      disposed = true
+    }
+  }, [])
+
+  return (
+    <div className="min-w-0 rounded-sm border border-chalkboard-30 bg-chalkboard-10 px-2 py-1 text-xs leading-5 dark:border-chalkboard-70 dark:bg-chalkboard-90">
+      <p className="truncate font-medium text-chalkboard-90 dark:text-chalkboard-10">
+        {library.title || 'Personal Cloud'}
+      </p>
+      <p className="truncate text-chalkboard-70 dark:text-chalkboard-30">
+        {storagePath
+          ? `Stored locally at ${storagePath}`
+          : 'Resolving local storage path...'}
+      </p>
+    </div>
+  )
 }
 
 type CloudSyncProjectMenuDialog =
@@ -962,6 +1002,7 @@ const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
     order: 10,
     defaultSetting: getDefaultCloudProjectLibrarySetting(),
     newLibrarySetting: getDefaultCloudProjectLibrarySetting(),
+    settingsDetails: CloudProjectLibrarySettingsDetails,
     operations: {
       createProject: {
         isAvailable: () => cloudSyncStatus.value.enabled,

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -36,12 +36,14 @@ import { getDefaultCloudProjectDirectoryPath } from '@src/lib/cloudSync/paths'
 import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
 import { PATHS } from '@src/lib/paths'
 import { getProjectDisplayName } from '@src/lib/projectDisplayName'
+import { homeProjectEntryFromProject } from '@src/lib/homeProjects'
 import {
   CLOUD_PROJECT_LIBRARY_TYPE,
   PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
   getDefaultCloudProjectLibrarySetting,
   type ProjectLibrary,
 } from '@src/lib/projectLibraries'
+import { readProjectsFromProjectDirectory } from '@src/lib/projectLibraries/directoryScanner'
 import { createProjectInLocalDirectory } from '@src/lib/projectLibraries/operations'
 import {
   canRevealInFileExplorer,
@@ -1039,6 +1041,18 @@ const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
           return project
         },
       },
+    },
+    readEntries: async ({ signal }) => {
+      const projects = await readProjectsFromProjectDirectory({
+        projectDirectoryPath: await getDefaultCloudProjectDirectoryPath(),
+        wasmInstancePromise: getWasmPromise(),
+        signal,
+      })
+
+      return projects.map((project) => ({
+        ...homeProjectEntryFromProject(project),
+        libraryId: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+      }))
     },
   }
 

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -908,12 +908,18 @@ const cloudSyncProjectLibraryContribution = defineRegistryItemFactory((ctx) => {
   const settings = ctx.services.signal(settingsService)
   const library = computed<ProjectLibrary[]>(() => {
     const defaultCloudLibrary = getDefaultCloudProjectLibrarySetting()
-    const configuredCloudLibrary =
-      settings.value?.current.value.app.libraries?.current.find(
+    const configuredLibraries =
+      settings.value?.current.value.app.libraries?.current
+    const configuredCloudLibraryIndex =
+      configuredLibraries?.findIndex(
         (library) =>
           library.type === defaultCloudLibrary.type &&
           library.path === defaultCloudLibrary.path
-      )
+      ) ?? -1
+    const configuredCloudLibrary =
+      configuredCloudLibraryIndex === -1
+        ? undefined
+        : configuredLibraries?.[configuredCloudLibraryIndex]
 
     return [
       {
@@ -921,7 +927,8 @@ const cloudSyncProjectLibraryContribution = defineRegistryItemFactory((ctx) => {
         ...configuredCloudLibrary,
         id: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
         icon: 'network',
-        order: 10,
+        order:
+          configuredCloudLibraryIndex === -1 ? 10 : configuredCloudLibraryIndex,
       },
     ]
   })

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -29,18 +29,22 @@ import {
   type CloudSyncStatus,
   cloudSyncRemoteProjects,
   cloudSyncStatus,
+  deleteRemoteCloudProject,
   type RemoteProjectSummary,
+  renameRemoteCloudProject,
   retryCloudSync,
 } from '@src/lib/cloudSync'
 import { getDefaultCloudProjectDirectoryPath } from '@src/lib/cloudSync/paths'
 import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
+import { writeProjectTitleToProjectToml } from '@src/lib/desktop'
+import fsZds from '@src/lib/fs-zds'
+import { homeProjectEntryFromProject } from '@src/lib/homeProjects'
 import { PATHS } from '@src/lib/paths'
 import { getProjectDisplayName } from '@src/lib/projectDisplayName'
-import { homeProjectEntryFromProject } from '@src/lib/homeProjects'
 import {
   CLOUD_PROJECT_LIBRARY_TYPE,
-  PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
   getDefaultCloudProjectLibrarySetting,
+  PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
   type ProjectLibrary,
 } from '@src/lib/projectLibraries'
 import { readProjectsFromProjectDirectory } from '@src/lib/projectLibraries/directoryScanner'
@@ -51,6 +55,7 @@ import {
 } from '@src/lib/revealInFileExplorer'
 import { getResolvedTheme, type ResolvedTheme } from '@src/lib/theme'
 import { reportRejection } from '@src/lib/trap'
+import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
 import { userFeaturesContextHas } from '@src/machines/userFeaturesMachine'
 import {
   type CloudSyncRegistryService,
@@ -70,14 +75,16 @@ import {
   projectLibrariesValueSpec,
   projectLibraryTypesValueSpec,
 } from '@src/registry/contracts/projectLibraries'
+import { settingsService } from '@src/registry/contracts/settings'
 import {
   nullableStatusBarItem,
   statusBarGlobalItemsValueSpec,
 } from '@src/registry/contracts/statusBar'
-import { settingsService } from '@src/registry/contracts/settings'
+import { systemIOService } from '@src/registry/contracts/systemIO'
 import { userFeaturesService } from '@src/registry/contracts/userFeatures'
 import { wasmPromiseValueSpec } from '@src/registry/contracts/wasm'
 import { createZdsPlugin } from '@src/registry/createZdsPlugin'
+import { invalidateConfiguredProjectLibraryEntries } from '@src/registry/extensions/homeProjects'
 import { Fragment, useEffect, useState } from 'react'
 import toast from 'react-hot-toast'
 import { useLocation } from 'react-router-dom'
@@ -1015,9 +1022,21 @@ const cloudSyncProjectLibraryContribution = defineRegistryItemFactory((ctx) => {
  * sync-only surface (remote entries, status bar, project-menu sync actions).
  */
 export const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
+  const systemIO = ctx.services.signal(systemIOService)
   const getWasmPromise = () =>
     ctx.valueSpecs.get(wasmPromiseValueSpec) ??
     Promise.reject(new Error('Missing WASM promise registry value.'))
+
+  // A materialized cloud project can be listed either by System IO (when the
+  // cloud folder is the app's project directory, e.g. on web) or by the
+  // configured Personal Cloud library scan (e.g. on desktop). Refresh both so
+  // local mutations show up regardless of which surface owns the entry.
+  const refreshLocalCloudProjectEntries = () => {
+    systemIO.value?.actor.send({
+      type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
+    })
+    invalidateConfiguredProjectLibraryEntries()
+  }
 
   const cloudLibraryType: ProjectLibraryTypeContribution = {
     type: CLOUD_PROJECT_LIBRARY_TYPE,
@@ -1049,6 +1068,44 @@ export const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
           }
 
           return project
+        },
+      },
+      // Rename/delete act on the remote project directly when it has not been
+      // materialized locally. Once a local copy exists, they behave like a
+      // normal local project: mutate the local files and let cloud sync
+      // replicate the change to the remote.
+      renameProject: {
+        run: async ({ project, requestedName }) => {
+          const title = requestedName.trim()
+          if (!title) {
+            return
+          }
+
+          if (project.localProjectPath && project.readWriteAccess) {
+            await writeProjectTitleToProjectToml(
+              project.localProjectPath,
+              title
+            )
+            refreshLocalCloudProjectEntries()
+            return
+          }
+
+          if (project.remoteProjectId) {
+            await renameRemoteCloudProject(project.remoteProjectId, title)
+          }
+        },
+      },
+      deleteProject: {
+        run: async ({ project }) => {
+          if (project.localProjectPath && project.readWriteAccess) {
+            await fsZds.rm(project.localProjectPath, { recursive: true })
+            refreshLocalCloudProjectEntries()
+            return
+          }
+
+          if (project.remoteProjectId) {
+            await deleteRemoteCloudProject(project.remoteProjectId)
+          }
         },
       },
     },

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -43,6 +43,10 @@ import {
   type ProjectLibrary,
 } from '@src/lib/projectLibraries'
 import { createProjectInLocalDirectory } from '@src/lib/projectLibraries/operations'
+import {
+  canRevealInFileExplorer,
+  revealInFileExplorer,
+} from '@src/lib/revealInFileExplorer'
 import { getResolvedTheme, type ResolvedTheme } from '@src/lib/theme'
 import { reportRejection } from '@src/lib/trap'
 import { userFeaturesContextHas } from '@src/machines/userFeaturesMachine'
@@ -112,15 +116,32 @@ function CloudProjectLibrarySettingsDetails({
   }, [])
 
   return (
-    <div className="min-w-0 rounded-sm border border-chalkboard-30 bg-chalkboard-10 px-2 py-1 text-xs leading-5 dark:border-chalkboard-70 dark:bg-chalkboard-90">
-      <p className="truncate font-medium text-chalkboard-90 dark:text-chalkboard-10">
-        {library.title || 'Personal Cloud'}
-      </p>
-      <p className="truncate text-chalkboard-70 dark:text-chalkboard-30">
+    <div className="min-w-0 text-sm m-0 flex items-stretch gap-2">
+      <p className="min-w-0 px-2 py-1 flex-1 truncate text-2">
         {storagePath
           ? `Stored locally at ${storagePath}`
           : 'Resolving local storage path...'}
       </p>
+      {canRevealInFileExplorer() && (
+        <ActionButton
+          Element="button"
+          type="button"
+          tabIndex={0}
+          className="!p-0"
+          iconStart={{
+            icon: 'folder',
+            bgClassName: '!bg-transparent',
+          }}
+          disabled={!storagePath}
+          onClick={() => {
+            if (storagePath) {
+              revealInFileExplorer(storagePath)
+            }
+          }}
+        >
+          <Tooltip position="top-right">Reveal in file explorer</Tooltip>
+        </ActionButton>
+      )}
     </div>
   )
 }

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -39,9 +39,7 @@ import { getProjectDisplayName } from '@src/lib/projectDisplayName'
 import {
   CLOUD_PROJECT_LIBRARY_TYPE,
   PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
-  areProjectLibrarySettingsEqual,
   getDefaultCloudProjectLibrarySetting,
-  mergeProjectLibrarySettings,
   type ProjectLibrary,
 } from '@src/lib/projectLibraries'
 import { createProjectInLocalDirectory } from '@src/lib/projectLibraries/operations'
@@ -986,11 +984,6 @@ const cloudSyncProjectLibraryContribution = defineRegistryItemFactory((ctx) => {
 }, 'cloud-sync.project-library')
 
 const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
-  const settings = ctx.services.signal(settingsService)
-  let disposed = false
-  let didReconcile = false
-  let disposeEffect: (() => void) | undefined
-
   const getWasmPromise = () =>
     ctx.valueSpecs.get(wasmPromiseValueSpec) ??
     Promise.reject(new Error('Missing WASM promise registry value.'))
@@ -1028,54 +1021,6 @@ const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
     },
   }
 
-  queueMicrotask(() => {
-    if (disposed) {
-      return
-    }
-
-    disposeEffect = effect(() => {
-      const service = settings.value
-      if (!service || didReconcile) {
-        return
-      }
-
-      const currentSettings = service.current.value
-      const cloudSyncPluginEnabled =
-        currentSettings.plugins?.[CLOUD_SYNC_PLUGIN_ID]?.current !== false
-      if (
-        !cloudSyncPluginEnabled ||
-        !service.actor.getSnapshot().matches('idle')
-      ) {
-        return
-      }
-
-      didReconcile = true
-      const currentLibraries = currentSettings.app.libraries?.current ?? []
-      const defaultCloudLibrary = getDefaultCloudProjectLibrarySetting()
-      const hasDefaultCloudLibrary = currentLibraries.some(
-        (library) =>
-          library.type === defaultCloudLibrary.type &&
-          library.path === defaultCloudLibrary.path
-      )
-      const nextLibraries = mergeProjectLibrarySettings(
-        currentLibraries,
-        hasDefaultCloudLibrary ? [] : [defaultCloudLibrary]
-      )
-
-      if (areProjectLibrarySettingsEqual(nextLibraries, currentLibraries)) {
-        return
-      }
-
-      service.send({
-        type: 'set.app.libraries',
-        data: {
-          level: 'user',
-          value: nextLibraries,
-        },
-      })
-    })
-  })
-
   return {
     item: defineRuntimeRegistryItem({
       id: 'cloud-sync.project-library-type',
@@ -1084,10 +1029,6 @@ const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
           key: 'cloud-sync.project-library-type',
         }),
       ],
-      dispose: () => {
-        disposed = true
-        disposeEffect?.()
-      },
     }),
   }
 }, 'cloud-sync.project-library-type')
@@ -1103,5 +1044,5 @@ export const cloudSyncPlugin = createZdsPlugin({
     cloudSyncProjectMenuItem,
     cloudSyncRemoteHomeProjectEntryContribution,
   ],
-  defaultSetting: 'core',
+  defaultSetting: 'off',
 })

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -37,9 +37,8 @@ import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
 import { PATHS } from '@src/lib/paths'
 import { getProjectDisplayName } from '@src/lib/projectDisplayName'
 import {
-  CLOUD_PROJECT_LIBRARY_ID,
-  CLOUD_PROJECT_LIBRARY_TITLE,
   CLOUD_PROJECT_LIBRARY_TYPE,
+  PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
   areProjectLibrarySettingsEqual,
   getDefaultCloudProjectLibrarySetting,
   mergeProjectLibrarySettings,
@@ -648,7 +647,7 @@ function homeProjectEntryCloudSyncFields(
   metadata: CloudSyncProjectMetadataIndexEntry | undefined
 ): Pick<
   HomeProjectEntryContribution,
-  'conflict' | 'localProjectPath' | 'status' | 'syncFailure'
+  'conflict' | 'libraryId' | 'localProjectPath' | 'status' | 'syncFailure'
 > {
   const syncFailure =
     metadata?.lastFailure?.kind === 'remote-upload-forbidden'
@@ -656,6 +655,7 @@ function homeProjectEntryCloudSyncFields(
       : undefined
   if (!metadata?.conflict) {
     return {
+      libraryId: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
       status: 'cloud-only',
       ...(syncFailure
         ? { syncFailure, localProjectPath: metadata?.localProjectPath }
@@ -664,6 +664,7 @@ function homeProjectEntryCloudSyncFields(
   }
 
   return {
+    libraryId: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
     status: 'conflicted',
     conflict: metadata.conflict,
     localProjectPath: metadata.localProjectPath,
@@ -918,7 +919,7 @@ const cloudSyncProjectLibraryContribution = defineRegistryItemFactory((ctx) => {
       {
         ...defaultCloudLibrary,
         ...configuredCloudLibrary,
-        id: CLOUD_PROJECT_LIBRARY_ID,
+        id: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
         icon: 'network',
         order: 10,
       },
@@ -949,7 +950,7 @@ const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
 
   const cloudLibraryType: ProjectLibraryTypeContribution = {
     type: CLOUD_PROJECT_LIBRARY_TYPE,
-    title: CLOUD_PROJECT_LIBRARY_TITLE,
+    title: 'Cloud',
     icon: 'network',
     order: 10,
     defaultSetting: getDefaultCloudProjectLibrarySetting(),

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -1006,7 +1006,15 @@ const cloudSyncProjectLibraryContribution = defineRegistryItemFactory((ctx) => {
   }
 }, 'cloud-sync.project-library')
 
-const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
+/**
+ * The `cloud` project-library *type* handler (browse/create in the local
+ * Personal Cloud folder). This is registered as an always-on extension rather
+ * than inside the cloud-sync plugin's toggle-able slot: on web the cloud folder
+ * is the canonical project storage, so disabling cloud *sync* must not remove
+ * the ability to list or create projects there. The plugin continues to own the
+ * sync-only surface (remote entries, status bar, project-menu sync actions).
+ */
+export const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
   const getWasmPromise = () =>
     ctx.valueSpecs.get(wasmPromiseValueSpec) ??
     Promise.reject(new Error('Missing WASM promise registry value.'))
@@ -1021,12 +1029,12 @@ const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
     settingsDetails: CloudProjectLibrarySettingsDetails,
     operations: {
       createProject: {
-        isAvailable: () => cloudSyncStatus.value.enabled,
+        // Creating a project only needs the local library folder, so it stays
+        // available whether or not cloud sync is currently enabled. When sync
+        // is on we also enroll the new project; otherwise it is picked up the
+        // next time sync is enabled (via syncExistingLocalProjects on web /
+        // startProjectSync on desktop).
         run: async ({ requestedProjectName, requestedProjectTitle }) => {
-          if (!cloudSyncStatus.value.enabled) {
-            return Promise.reject(new Error('Cloud sync is not enabled.'))
-          }
-
           const project = await createProjectInLocalDirectory({
             projectDirectoryPath: await getDefaultCloudProjectDirectoryPath(),
             requestedProjectName,
@@ -1034,9 +1042,11 @@ const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
             wasmInstancePromise: getWasmPromise(),
           })
 
-          await ctx.services
-            .get(cloudSyncService)
-            .startProjectSync(project.path)
+          if (cloudSyncStatus.value.enabled) {
+            await ctx.services
+              .get(cloudSyncService)
+              .startProjectSync(project.path)
+          }
 
           return project
         },
@@ -1074,10 +1084,23 @@ export const cloudSyncPlugin = createZdsPlugin({
   description: 'Cloud-backed project sync controls and status.',
   items: [
     cloudSyncProjectLibraryContribution,
-    cloudSyncProjectLibraryType,
     cloudSyncStatusBarItemContribution,
     cloudSyncProjectMenuItem,
     cloudSyncRemoteHomeProjectEntryContribution,
   ],
   defaultSetting: 'off',
+  // On web, cloud sync is the project storage layer rather than an optional
+  // feature, so its toggle is hidden there (and forced active by the app
+  // runtime). Mirrors createZdsPlugin's default activation setting otherwise.
+  activationSetting: {
+    category: 'plugins',
+    settingName: CLOUD_SYNC_PLUGIN_ID,
+    description: 'Whether the Cloud sync plugin is enabled.',
+    hideOnLevel: 'project',
+    hideOnPlatform: 'web',
+    userToml: {
+      sectionKey: 'plugins',
+      tomlKey: CLOUD_SYNC_PLUGIN_ID,
+    },
+  },
 })

--- a/src/lib/cloudSync/renameDeleteRemote.spec.ts
+++ b/src/lib/cloudSync/renameDeleteRemote.spec.ts
@@ -1,0 +1,219 @@
+import 'fake-indexeddb/auto'
+import {
+  cloudSyncRemoteProjects,
+  configureCloudSyncEngine,
+  deleteRemoteCloudProject,
+  getCloudSyncProjectMetadata,
+  renameRemoteCloudProject,
+} from '@src/lib/cloudSync'
+import { putProjectMetadata } from '@src/lib/cloudSync/syncDb'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const syncDatabaseName = 'zds-opfs-cloud-sync'
+const projectPath = '/documents/Projects/bracket'
+const remoteProjectId = 'remote-project-123'
+const baseUrl = 'https://example.test'
+const remoteProjectUrl = `${baseUrl}/user/projects/${remoteProjectId}`
+const remoteProjectDownloadUrl = `${remoteProjectUrl}/download?format=zip`
+
+const fetchMock = vi.fn<typeof fetch>()
+
+function getFetchUrl(input: Parameters<typeof fetch>[0]) {
+  if (typeof input === 'string') {
+    return input
+  }
+  if (input instanceof URL) {
+    return input.toString()
+  }
+  return input.url
+}
+
+function getFetchMethod(
+  input: Parameters<typeof fetch>[0],
+  init?: Parameters<typeof fetch>[1]
+) {
+  if (init?.method) {
+    return init.method
+  }
+  if (typeof input === 'object' && 'method' in input) {
+    return input.method
+  }
+  return 'GET'
+}
+
+function jsonResponse(value: unknown, status = 200) {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+async function deleteSyncDatabase() {
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`IndexedDB database ${syncDatabaseName} is blocked.`))
+    }, 1000)
+    const request = indexedDB.deleteDatabase(syncDatabaseName)
+    request.onerror = () => {
+      clearTimeout(timeout)
+      reject(
+        request.error ??
+          new Error(`Failed to delete IndexedDB database ${syncDatabaseName}.`)
+      )
+    }
+    request.onblocked = () => undefined
+    request.onsuccess = () => {
+      clearTimeout(timeout)
+      resolve()
+    }
+  })
+}
+
+describe('renameRemoteCloudProject', () => {
+  beforeEach(async () => {
+    await deleteSyncDatabase()
+    fetchMock.mockReset()
+    cloudSyncRemoteProjects.value = [{ id: remoteProjectId, title: 'Bracket' }]
+    configureCloudSyncEngine({
+      enabled: true,
+      baseUrl,
+      environmentName: 'dev.zoo.dev',
+      projectDirectoryPath: '/documents/Projects',
+    })
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(async () => {
+    configureCloudSyncEngine({ enabled: false })
+    vi.unstubAllGlobals()
+    await deleteSyncDatabase()
+  })
+
+  it('re-uploads the remote project archive with the new title', async () => {
+    let uploadedTitle: string | undefined
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = getFetchUrl(input)
+      const method = getFetchMethod(input, init)
+
+      if (url === remoteProjectUrl && method === 'GET') {
+        return jsonResponse({
+          id: remoteProjectId,
+          title: 'Bracket',
+          revision: 'rev-1',
+        })
+      }
+      if (url === remoteProjectDownloadUrl && method === 'GET') {
+        return jsonResponse({
+          files: [
+            { relativePath: 'main.kcl', contents: 'foo = 1' },
+            { relativePath: 'project.toml', contents: 'title = "Bracket"\n' },
+          ],
+        })
+      }
+      if (url.startsWith(remoteProjectUrl) && method === 'PUT') {
+        const body = init?.body as FormData
+        uploadedTitle = JSON.parse(
+          await (body.get('body') as Blob).text()
+        ).title
+        return jsonResponse({
+          id: remoteProjectId,
+          title: 'Housing',
+          revision: 'rev-2',
+        })
+      }
+
+      return jsonResponse(
+        { message: `Unexpected fetch: ${method} ${url}` },
+        500
+      )
+    })
+
+    await renameRemoteCloudProject(remoteProjectId, 'Housing')
+
+    expect(uploadedTitle).toBe('Housing')
+    expect(fetchMock).toHaveBeenCalledWith(
+      remoteProjectDownloadUrl,
+      expect.objectContaining({ credentials: 'include' })
+    )
+    expect(
+      fetchMock.mock.calls.some(
+        ([input, init]) =>
+          getFetchUrl(input) ===
+            `${remoteProjectUrl}?expected_revision=rev-1` &&
+          getFetchMethod(input, init) === 'PUT'
+      )
+    ).toBe(true)
+    expect(cloudSyncRemoteProjects.value).toEqual([
+      { id: remoteProjectId, title: 'Housing' },
+    ])
+  })
+
+  it('does nothing when the requested name is blank', async () => {
+    await renameRemoteCloudProject(remoteProjectId, '   ')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('deleteRemoteCloudProject', () => {
+  beforeEach(async () => {
+    await deleteSyncDatabase()
+    fetchMock.mockReset()
+    cloudSyncRemoteProjects.value = [
+      { id: remoteProjectId },
+      { id: 'other-project' },
+    ]
+    configureCloudSyncEngine({
+      enabled: true,
+      baseUrl,
+      environmentName: 'dev.zoo.dev',
+      projectDirectoryPath: '/documents/Projects',
+    })
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(async () => {
+    configureCloudSyncEngine({ enabled: false })
+    vi.unstubAllGlobals()
+    await deleteSyncDatabase()
+  })
+
+  it('deletes the remote project and clears any lingering local metadata', async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = getFetchUrl(input)
+      const method = getFetchMethod(input, init)
+      if (url === remoteProjectUrl && method === 'DELETE') {
+        return new Response(null, { status: 204 })
+      }
+      return jsonResponse(
+        { message: `Unexpected fetch: ${method} ${url}` },
+        500
+      )
+    })
+    await putProjectMetadata({
+      schemaVersion: 1,
+      localProjectPath: projectPath,
+      projectName: 'bracket',
+      remoteProjectId,
+    })
+
+    await deleteRemoteCloudProject(remoteProjectId)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      remoteProjectUrl,
+      expect.objectContaining({ credentials: 'include', method: 'DELETE' })
+    )
+    expect(await getCloudSyncProjectMetadata(projectPath)).toBeUndefined()
+    expect(cloudSyncRemoteProjects.value).toEqual([{ id: 'other-project' }])
+  })
+
+  it('tolerates a remote project that is already gone (404)', async () => {
+    fetchMock.mockImplementation(async () =>
+      jsonResponse({ message: 'Not found.' }, 404)
+    )
+
+    await expect(
+      deleteRemoteCloudProject(remoteProjectId)
+    ).resolves.toBeUndefined()
+    expect(cloudSyncRemoteProjects.value).toEqual([{ id: 'other-project' }])
+  })
+})

--- a/src/lib/projectLibraries/index.ts
+++ b/src/lib/projectLibraries/index.ts
@@ -5,10 +5,10 @@ export const DEFAULT_PROJECT_LIBRARY_ID = 'default-project-directory'
 export const DEFAULT_PROJECT_LIBRARY_TITLE = 'Default Projects Directory'
 export const NEW_PROJECT_LIBRARY_TITLE = 'Project Library'
 export const DIRECTORY_PROJECT_LIBRARY_TYPE = 'directory'
-export const CLOUD_PROJECT_LIBRARY_ID = 'cloud'
-export const CLOUD_PROJECT_LIBRARY_TITLE = 'Cloud'
+export const PERSONAL_CLOUD_PROJECT_LIBRARY_ID = 'cloud-personal'
+export const PERSONAL_CLOUD_PROJECT_LIBRARY_TITLE = 'Personal Cloud'
 export const CLOUD_PROJECT_LIBRARY_TYPE = 'cloud'
-export const DEFAULT_CLOUD_PROJECT_LIBRARY_PATH = 'zoo://user/projects'
+export const DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH = '/personal'
 
 export type ProjectLibraryType = string
 
@@ -38,8 +38,8 @@ export function getDefaultProjectLibrarySettings(
 
 export function getDefaultCloudProjectLibrarySetting(): ProjectLibrarySetting {
   return {
-    title: CLOUD_PROJECT_LIBRARY_TITLE,
-    path: DEFAULT_CLOUD_PROJECT_LIBRARY_PATH,
+    title: PERSONAL_CLOUD_PROJECT_LIBRARY_TITLE,
+    path: DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH,
     type: CLOUD_PROJECT_LIBRARY_TYPE,
   }
 }
@@ -213,8 +213,8 @@ export function projectLibraryFromSetting(
       library.path === options.defaultProjectDirectory
         ? DEFAULT_PROJECT_LIBRARY_ID
         : library.type === CLOUD_PROJECT_LIBRARY_TYPE &&
-            library.path === DEFAULT_CLOUD_PROJECT_LIBRARY_PATH
-          ? CLOUD_PROJECT_LIBRARY_ID
+            library.path === DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH
+          ? PERSONAL_CLOUD_PROJECT_LIBRARY_ID
           : getProjectLibraryIdFromSetting(library),
     order: index,
   }

--- a/src/lib/projectLibraries/index.ts
+++ b/src/lib/projectLibraries/index.ts
@@ -5,6 +5,10 @@ export const DEFAULT_PROJECT_LIBRARY_ID = 'default-project-directory'
 export const DEFAULT_PROJECT_LIBRARY_TITLE = 'Default Projects Directory'
 export const NEW_PROJECT_LIBRARY_TITLE = 'Project Library'
 export const DIRECTORY_PROJECT_LIBRARY_TYPE = 'directory'
+export const CLOUD_PROJECT_LIBRARY_ID = 'cloud'
+export const CLOUD_PROJECT_LIBRARY_TITLE = 'Cloud'
+export const CLOUD_PROJECT_LIBRARY_TYPE = 'cloud'
+export const DEFAULT_CLOUD_PROJECT_LIBRARY_PATH = 'zoo://user/projects'
 
 export type ProjectLibraryType = string
 
@@ -30,6 +34,14 @@ export function getDefaultProjectLibrarySettings(
       type: DIRECTORY_PROJECT_LIBRARY_TYPE,
     },
   ]
+}
+
+export function getDefaultCloudProjectLibrarySetting(): ProjectLibrarySetting {
+  return {
+    title: CLOUD_PROJECT_LIBRARY_TITLE,
+    path: DEFAULT_CLOUD_PROJECT_LIBRARY_PATH,
+    type: CLOUD_PROJECT_LIBRARY_TYPE,
+  }
 }
 
 export function getDefaultDirectoryProjectLibrarySetting(
@@ -200,7 +212,10 @@ export function projectLibraryFromSetting(
       library.type === DIRECTORY_PROJECT_LIBRARY_TYPE &&
       library.path === options.defaultProjectDirectory
         ? DEFAULT_PROJECT_LIBRARY_ID
-        : getProjectLibraryIdFromSetting(library),
+        : library.type === CLOUD_PROJECT_LIBRARY_TYPE &&
+            library.path === DEFAULT_CLOUD_PROJECT_LIBRARY_PATH
+          ? CLOUD_PROJECT_LIBRARY_ID
+          : getProjectLibraryIdFromSetting(library),
     order: index,
   }
 }

--- a/src/lib/projectLibraries/settings/ProjectLibrariesSetting.tsx
+++ b/src/lib/projectLibraries/settings/ProjectLibrariesSetting.tsx
@@ -1,8 +1,10 @@
 import { useSignals } from '@preact/signals-react/runtime'
+import { isDesktop } from '@src/lib/isDesktop'
 import type { ProjectLibrarySetting } from '@src/lib/projectLibraries'
 import type { SettingComponentProps } from '@src/lib/settings/settingsTypes'
 import { projectLibraryTypesValueSpec } from '@src/registry/contracts/projectLibraries'
 import {
+  filterProjectLibraryTypeOptionsForSettings,
   ProjectLibrariesSettingInput,
   projectLibraryTypeOptionsFromContributions,
 } from '@src/lib/projectLibraries/settings/ProjectLibrariesSettingInput'
@@ -13,15 +15,22 @@ export function ProjectLibrariesSetting({
   registry,
 }: SettingComponentProps<ProjectLibrarySetting[]>) {
   useSignals()
+  const canManageLibraries = isDesktop()
   const libraryTypeOptions = projectLibraryTypeOptionsFromContributions(
     registry.signal(projectLibraryTypesValueSpec).value
   )
+  const selectableLibraryTypeOptions =
+    filterProjectLibraryTypeOptionsForSettings(libraryTypeOptions, {
+      isDesktop: canManageLibraries,
+    })
 
   return (
     <ProjectLibrariesSettingInput
       value={value}
       updateValue={updateValue}
       libraryTypeOptions={libraryTypeOptions}
+      selectableLibraryTypeOptions={selectableLibraryTypeOptions}
+      canManageLibraries={canManageLibraries}
     />
   )
 }

--- a/src/lib/projectLibraries/settings/ProjectLibrariesSetting.tsx
+++ b/src/lib/projectLibraries/settings/ProjectLibrariesSetting.tsx
@@ -1,13 +1,16 @@
 import { useSignals } from '@preact/signals-react/runtime'
 import { isDesktop } from '@src/lib/isDesktop'
-import type { ProjectLibrarySetting } from '@src/lib/projectLibraries'
-import type { SettingComponentProps } from '@src/lib/settings/settingsTypes'
-import { projectLibraryTypesValueSpec } from '@src/registry/contracts/projectLibraries'
+import {
+  DIRECTORY_PROJECT_LIBRARY_TYPE,
+  type ProjectLibrarySetting,
+} from '@src/lib/projectLibraries'
 import {
   filterProjectLibraryTypeOptionsForSettings,
   ProjectLibrariesSettingInput,
   projectLibraryTypeOptionsFromContributions,
 } from '@src/lib/projectLibraries/settings/ProjectLibrariesSettingInput'
+import type { SettingComponentProps } from '@src/lib/settings/settingsTypes'
+import { projectLibraryTypesValueSpec } from '@src/registry/contracts/projectLibraries'
 
 export function ProjectLibrariesSetting({
   value,
@@ -30,7 +33,13 @@ export function ProjectLibrariesSetting({
       updateValue={updateValue}
       libraryTypeOptions={libraryTypeOptions}
       selectableLibraryTypeOptions={selectableLibraryTypeOptions}
-      canManageLibraries={canManageLibraries}
+      canAddLibraries={canManageLibraries}
+      canReorderLibraries={canManageLibraries}
+      canChangeLibraryType={canManageLibraries}
+      canEditLibraryDetails={canManageLibraries}
+      canRemoveLibrary={(library) =>
+        canManageLibraries || library.type === DIRECTORY_PROJECT_LIBRARY_TYPE
+      }
     />
   )
 }

--- a/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.spec.tsx
+++ b/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.spec.tsx
@@ -1,5 +1,6 @@
 import {
   DirectoryProjectLibrarySettingsDetails,
+  filterProjectLibraryTypeOptionsForSettings,
   ProjectLibrariesSettingInput,
   projectLibraryTypeOptionsFromContributions,
   type ProjectLibraryTypeOption,
@@ -117,6 +118,33 @@ describe('ProjectLibrariesSettingInput', () => {
     expect(screen.queryByTestId('project-directory-input')).toBeNull()
   })
 
+  test('filters library types hidden on the current platform from settings options', () => {
+    expect(
+      filterProjectLibraryTypeOptionsForSettings(
+        projectLibraryTypeOptionsFromContributions(
+          new Map([
+            [
+              'directory',
+              {
+                type: 'directory',
+                title: 'Directory',
+                hideInSettingsOnPlatform: 'web',
+              },
+            ],
+            [
+              'cloud',
+              {
+                type: 'cloud',
+                title: 'Cloud',
+              },
+            ],
+          ])
+        ),
+        { isDesktop: false }
+      ).map((option) => option.value)
+    ).toEqual(['cloud'])
+  })
+
   test('does not update project libraries when normalization matches the current value', () => {
     const updateValue = vi.fn()
     render(
@@ -185,6 +213,29 @@ describe('ProjectLibrariesSettingInput', () => {
         type: 'directory',
       },
     ])
+  })
+
+  test('hides library management controls when management is disabled', () => {
+    const updateValue = vi.fn()
+    render(
+      <ProjectLibrariesSettingInput
+        value={defaultLibraries}
+        updateValue={updateValue}
+        libraryTypeOptions={libraryTypeOptions}
+        canManageLibraries={false}
+      />
+    )
+
+    expect(screen.queryByTestId('project-library-add')).toBeNull()
+    expect(screen.queryByTestId('project-library-remove')).toBeNull()
+    expect(screen.queryByTestId('project-library-drag-handle')).toBeNull()
+    expect(screen.getByTestId('project-library-type')).toHaveAttribute(
+      'aria-label',
+      'Library type: Directory'
+    )
+    expect(screen.getByTestId('project-directory-input')).toHaveTextContent(
+      '/projects'
+    )
   })
 
   test('shows library type as an icon button with icon and label options', () => {

--- a/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.spec.tsx
+++ b/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.spec.tsx
@@ -1,11 +1,11 @@
+import type { ProjectLibrarySetting } from '@src/lib/projectLibraries'
 import {
   DirectoryProjectLibrarySettingsDetails,
   filterProjectLibraryTypeOptionsForSettings,
   ProjectLibrariesSettingInput,
-  projectLibraryTypeOptionsFromContributions,
   type ProjectLibraryTypeOption,
+  projectLibraryTypeOptionsFromContributions,
 } from '@src/lib/projectLibraries/settings/ProjectLibrariesSettingInput'
-import type { ProjectLibrarySetting } from '@src/lib/projectLibraries'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
 
@@ -222,7 +222,11 @@ describe('ProjectLibrariesSettingInput', () => {
         value={defaultLibraries}
         updateValue={updateValue}
         libraryTypeOptions={libraryTypeOptions}
-        canManageLibraries={false}
+        canAddLibraries={false}
+        canReorderLibraries={false}
+        canChangeLibraryType={false}
+        canEditLibraryDetails={false}
+        canRemoveLibrary={() => false}
       />
     )
 
@@ -236,6 +240,48 @@ describe('ProjectLibrariesSettingInput', () => {
     expect(screen.getByTestId('project-directory-input')).toHaveTextContent(
       '/projects'
     )
+  })
+
+  test('allows directory library removal without enabling web library management', () => {
+    const updateValue = vi.fn()
+    const cloudLibrary: ProjectLibrarySetting = {
+      title: 'Personal Cloud',
+      path: '/personal',
+      type: 'cloud',
+    }
+
+    render(
+      <ProjectLibrariesSettingInput
+        value={[...defaultLibraries, cloudLibrary]}
+        updateValue={updateValue}
+        libraryTypeOptions={multipleLibraryTypeOptions}
+        selectableLibraryTypeOptions={multipleLibraryTypeOptions.filter(
+          (option) => option.value !== 'directory'
+        )}
+        canAddLibraries={false}
+        canReorderLibraries={false}
+        canChangeLibraryType={false}
+        canEditLibraryDetails={false}
+        canRemoveLibrary={(library) => library.type === 'directory'}
+      />
+    )
+
+    expect(screen.queryByTestId('project-library-add')).toBeNull()
+    expect(screen.queryByTestId('project-library-drag-handle')).toBeNull()
+    const libraryTypes = screen.getAllByTestId('project-library-type')
+    expect(libraryTypes).toHaveLength(2)
+    expect(libraryTypes[0]).toHaveAttribute(
+      'aria-label',
+      'Library type: Directory'
+    )
+    expect(libraryTypes[1]).toHaveAttribute('aria-label', 'Library type: Cloud')
+
+    const removeButtons = screen.getAllByTestId('project-library-remove')
+    expect(removeButtons).toHaveLength(1)
+
+    fireEvent.click(removeButtons[0])
+
+    expect(updateValue).toHaveBeenLastCalledWith([cloudLibrary])
   })
 
   test('shows library type as an icon button with icon and label options', () => {

--- a/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.tsx
+++ b/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.tsx
@@ -177,7 +177,7 @@ function ProjectLibraryTypeSelect({
     <Listbox value={value} onChange={onChange}>
       <div className="relative self-start">
         <Listbox.Button
-          className="relative flex h-8 w-8 items-center justify-center rounded-sm border border-chalkboard-30 text-chalkboard-70 hover:bg-chalkboard-10 dark:border-chalkboard-70 dark:text-chalkboard-30 dark:hover:bg-chalkboard-90"
+          className="relative flex h-8 w-8 p-0 items-center justify-center rounded-sm border border-chalkboard-30 text-chalkboard-70 hover:bg-chalkboard-10 dark:border-chalkboard-70 dark:text-chalkboard-30 dark:hover:bg-chalkboard-90"
           data-testid="project-library-type"
           aria-label={`Library type: ${selectedOption?.label ?? value}`}
           title={selectedOption?.label ?? value}

--- a/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.tsx
+++ b/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.tsx
@@ -34,6 +34,8 @@ interface ProjectLibrariesSettingInputProps {
   value: ProjectLibrarySetting[]
   updateValue: (value: ProjectLibrarySetting[]) => void
   libraryTypeOptions?: readonly ProjectLibraryTypeOption[]
+  selectableLibraryTypeOptions?: readonly ProjectLibraryTypeOption[]
+  canManageLibraries?: boolean
 }
 
 export interface ProjectLibraryTypeOption {
@@ -43,6 +45,7 @@ export interface ProjectLibraryTypeOption {
   defaultLibrary: ProjectLibrarySetting
   newLibrary: ProjectLibrarySetting
   settingsDetails: ComponentType<ProjectLibrarySettingsDetailsProps>
+  hideInSettingsOnPlatform?: ProjectLibraryTypeContribution['hideInSettingsOnPlatform']
 }
 
 const defaultProjectLibraryTypeIcon: CustomIconName = 'folder'
@@ -85,8 +88,24 @@ export function projectLibraryTypeOptionsFromContributions(
         newLibrary: libraryType.newLibrarySetting ?? fallbackLibrary,
         settingsDetails:
           libraryType.settingsDetails ?? DefaultProjectLibrarySettingsDetails,
+        hideInSettingsOnPlatform: libraryType.hideInSettingsOnPlatform,
       }
     })
+}
+
+export function filterProjectLibraryTypeOptionsForSettings(
+  libraryTypeOptions: readonly ProjectLibraryTypeOption[],
+  options: { isDesktop?: boolean } = {}
+): ProjectLibraryTypeOption[] {
+  const isCurrentPlatformDesktop = options.isDesktop ?? true
+
+  return libraryTypeOptions.filter((libraryType) => {
+    const hidden = libraryType.hideInSettingsOnPlatform
+    return !(
+      hidden === 'both' ||
+      hidden === (isCurrentPlatformDesktop ? 'desktop' : 'web')
+    )
+  })
 }
 
 function defaultLibraryForType(
@@ -126,10 +145,12 @@ function ProjectLibraryTypeSelect({
   value,
   options,
   onChange,
+  readOnly = false,
 }: {
   value: ProjectLibraryType
   options: readonly ProjectLibraryTypeOption[]
   onChange: (value: ProjectLibraryType) => void
+  readOnly?: boolean
 }) {
   const selectOptions = options.some((option) => option.value === value)
     ? options
@@ -156,7 +177,7 @@ function ProjectLibraryTypeSelect({
   const selectedOption =
     selectOptions.find((option) => option.value === value) ?? selectOptions[0]
 
-  if (selectOptions.length <= 1) {
+  if (readOnly || selectOptions.length <= 1) {
     return (
       <span
         className="relative flex h-8 w-8 items-center justify-center rounded-sm border border-chalkboard-30 text-chalkboard-70 dark:border-chalkboard-70 dark:text-chalkboard-30"
@@ -225,6 +246,7 @@ export function DirectoryProjectLibrarySettingsDetails({
   index,
   updateLibrary,
   commitLibrary,
+  readOnly = false,
   chooseDirectory,
 }: ProjectLibrarySettingsDetailsProps) {
   async function chooseLibraryPath() {
@@ -246,7 +268,17 @@ export function DirectoryProjectLibrarySettingsDetails({
     })
   }
 
-  return (
+  return readOnly ? (
+    <p
+      className="min-w-0 truncate rounded-sm border border-chalkboard-30 bg-transparent p-1 text-sm dark:border-chalkboard-70"
+      data-testid={
+        index === 0 ? 'project-directory-input' : 'project-library-path'
+      }
+      title={library.path}
+    >
+      {library.path}
+    </p>
+  ) : (
     <div className="flex min-w-0 gap-1">
       <input
         value={library.path}
@@ -290,6 +322,8 @@ export function ProjectLibrariesSettingInput({
   value,
   updateValue,
   libraryTypeOptions = [],
+  selectableLibraryTypeOptions = libraryTypeOptions,
+  canManageLibraries = true,
 }: ProjectLibrariesSettingInputProps) {
   const electron = typeof window === 'undefined' ? undefined : window.electron
   const [draftLibraries, setDraftLibraries] =
@@ -395,7 +429,7 @@ export function ProjectLibrariesSettingInput({
   }
 
   async function addLibrary() {
-    const libraryTypeOption = libraryTypeOptions[0]
+    const libraryTypeOption = selectableLibraryTypeOptions[0]
     if (!libraryTypeOption) {
       return
     }
@@ -480,32 +514,47 @@ export function ProjectLibrariesSettingInput({
             return (
               <li
                 key={`${index}-${library.type}`}
-                className={`grid gap-2 rounded-sm border p-2 pl-1 dark:border-chalkboard-80 md:grid-cols-[auto_auto_minmax(10rem,1fr)_minmax(12rem,1.5fr)_auto] ${
+                className={`grid gap-2 rounded-sm border p-2 dark:border-chalkboard-80 ${
+                  canManageLibraries
+                    ? 'pl-1 md:grid-cols-[auto_auto_minmax(10rem,1fr)_minmax(12rem,1.5fr)_auto]'
+                    : 'md:grid-cols-[auto_minmax(10rem,1fr)_minmax(12rem,1.5fr)]'
+                } ${
                   dragOverLibraryIndex === index
                     ? 'border-primary bg-primary/5 dark:border-primary'
                     : 'border-chalkboard-30'
                 } ${draggedLibraryIndex === index ? 'opacity-60' : ''}`}
-                onDragOver={(event) => handleDragOver(event, index)}
-                onDrop={(event) => handleDrop(event, index)}
+                onDragOver={
+                  canManageLibraries
+                    ? (event) => handleDragOver(event, index)
+                    : undefined
+                }
+                onDrop={
+                  canManageLibraries
+                    ? (event) => handleDrop(event, index)
+                    : undefined
+                }
                 data-testid="project-library-row"
               >
-                <button
-                  type="button"
-                  draggable
-                  aria-label={`Reorder ${library.title || 'project library'}`}
-                  aria-grabbed={draggedLibraryIndex === index}
-                  className="flex p-0 cursor-grab items-center justify-center self-stretch rounded-sm border !border-transparent text-2 !bg-transparent active:cursor-grabbing"
-                  data-testid="project-library-drag-handle"
-                  onDragStart={(event) => handleDragStart(event, index)}
-                  onDragEnd={handleDragEnd}
-                >
-                  <CustomIcon name="sixDots" className="h-4 w-4" />
-                  <Tooltip position="top-right">Reorder library</Tooltip>
-                </button>
+                {canManageLibraries && (
+                  <button
+                    type="button"
+                    draggable
+                    aria-label={`Reorder ${library.title || 'project library'}`}
+                    aria-grabbed={draggedLibraryIndex === index}
+                    className="flex p-0 cursor-grab items-center justify-center self-stretch rounded-sm border !border-transparent text-2 !bg-transparent active:cursor-grabbing"
+                    data-testid="project-library-drag-handle"
+                    onDragStart={(event) => handleDragStart(event, index)}
+                    onDragEnd={handleDragEnd}
+                  >
+                    <CustomIcon name="sixDots" className="h-4 w-4" />
+                    <Tooltip position="top-right">Reorder library</Tooltip>
+                  </button>
+                )}
                 <ProjectLibraryTypeSelect
                   value={library.type}
-                  options={libraryTypeOptions}
+                  options={selectableLibraryTypeOptions}
                   onChange={(type) => updateLibraryType(index, type)}
+                  readOnly={!canManageLibraries}
                 />
                 <input
                   value={library.title}
@@ -539,43 +588,50 @@ export function ProjectLibrariesSettingInput({
                         : draftLibraries
                     )
                   }
-                  chooseDirectory={electron ? chooseDirectory : undefined}
+                  readOnly={!canManageLibraries}
+                  chooseDirectory={
+                    electron && canManageLibraries ? chooseDirectory : undefined
+                  }
                 />
-                <ActionButton
-                  Element="button"
-                  type="button"
-                  tabIndex={0}
-                  onClick={() => removeLibrary(index)}
-                  className="justify-self-start !p-0 md:justify-self-end"
-                  iconStart={{
-                    icon: 'trash',
-                    bgClassName: '!bg-transparent',
-                    iconClassName: 'dark:!text-chalkboard-30',
-                  }}
-                  data-testid="project-library-remove"
-                >
-                  <Tooltip position="top-right">Remove library</Tooltip>
-                </ActionButton>
+                {canManageLibraries && (
+                  <ActionButton
+                    Element="button"
+                    type="button"
+                    tabIndex={0}
+                    onClick={() => removeLibrary(index)}
+                    className="justify-self-start !p-0 md:justify-self-end"
+                    iconStart={{
+                      icon: 'trash',
+                      bgClassName: '!bg-transparent',
+                      iconClassName: 'dark:!text-chalkboard-30',
+                    }}
+                    data-testid="project-library-remove"
+                  >
+                    <Tooltip position="top-right">Remove library</Tooltip>
+                  </ActionButton>
+                )}
               </li>
             )
           })}
         </ul>
       )}
-      <ActionButton
-        Element="button"
-        type="button"
-        tabIndex={0}
-        onClick={toSync(addLibrary, reportRejection)}
-        disabled={libraryTypeOptions.length === 0}
-        className="self-start disabled:cursor-not-allowed disabled:opacity-60"
-        iconStart={{
-          icon: 'plus',
-          bgClassName: '!bg-transparent',
-        }}
-        data-testid="project-library-add"
-      >
-        Add library
-      </ActionButton>
+      {canManageLibraries && (
+        <ActionButton
+          Element="button"
+          type="button"
+          tabIndex={0}
+          onClick={toSync(addLibrary, reportRejection)}
+          disabled={selectableLibraryTypeOptions.length === 0}
+          className="self-start disabled:cursor-not-allowed disabled:opacity-60"
+          iconStart={{
+            icon: 'plus',
+            bgClassName: '!bg-transparent',
+          }}
+          data-testid="project-library-add"
+        >
+          Add library
+        </ActionButton>
+      )}
     </div>
   )
 }

--- a/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.tsx
+++ b/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.tsx
@@ -2,15 +2,15 @@ import { Listbox } from '@headlessui/react'
 import { ActionButton } from '@src/components/ActionButton'
 import {
   CustomIcon,
-  isCustomIconName,
   type CustomIconName,
+  isCustomIconName,
 } from '@src/components/CustomIcon'
 import Tooltip from '@src/components/Tooltip'
 import { removeDragPreviewElement, setDragPreview } from '@src/lib/dragPreview'
 import {
-  NEW_PROJECT_LIBRARY_TITLE,
   areProjectLibrarySettingsEqual,
   moveProjectLibrarySetting,
+  NEW_PROJECT_LIBRARY_TITLE,
   normalizeProjectLibrarySetting,
   type ProjectLibrarySetting,
   type ProjectLibraryType,
@@ -35,7 +35,11 @@ interface ProjectLibrariesSettingInputProps {
   updateValue: (value: ProjectLibrarySetting[]) => void
   libraryTypeOptions?: readonly ProjectLibraryTypeOption[]
   selectableLibraryTypeOptions?: readonly ProjectLibraryTypeOption[]
-  canManageLibraries?: boolean
+  canAddLibraries?: boolean
+  canReorderLibraries?: boolean
+  canChangeLibraryType?: boolean
+  canEditLibraryDetails?: boolean
+  canRemoveLibrary?: (library: ProjectLibrarySetting) => boolean
 }
 
 export interface ProjectLibraryTypeOption {
@@ -323,7 +327,11 @@ export function ProjectLibrariesSettingInput({
   updateValue,
   libraryTypeOptions = [],
   selectableLibraryTypeOptions = libraryTypeOptions,
-  canManageLibraries = true,
+  canAddLibraries = true,
+  canReorderLibraries = true,
+  canChangeLibraryType = true,
+  canEditLibraryDetails = true,
+  canRemoveLibrary = () => true,
 }: ProjectLibrariesSettingInputProps) {
   const electron = typeof window === 'undefined' ? undefined : window.electron
   const [draftLibraries, setDraftLibraries] =
@@ -510,32 +518,38 @@ export function ProjectLibrariesSettingInput({
             const SettingsDetails =
               libraryTypeOptionForType(library.type, libraryTypeOptions)
                 ?.settingsDetails ?? DefaultProjectLibrarySettingsDetails
+            const canRemoveCurrentLibrary = canRemoveLibrary(library)
+            const showRemoveColumn = draftLibraries.some(canRemoveLibrary)
 
             return (
               <li
                 key={`${index}-${library.type}`}
                 className={`grid gap-2 rounded-sm border p-2 dark:border-chalkboard-80 ${
-                  canManageLibraries
+                  canReorderLibraries && showRemoveColumn
                     ? 'pl-1 md:grid-cols-[auto_auto_minmax(10rem,1fr)_minmax(12rem,1.5fr)_auto]'
-                    : 'md:grid-cols-[auto_minmax(10rem,1fr)_minmax(12rem,1.5fr)]'
+                    : canReorderLibraries
+                      ? 'pl-1 md:grid-cols-[auto_auto_minmax(10rem,1fr)_minmax(12rem,1.5fr)]'
+                      : showRemoveColumn
+                        ? 'md:grid-cols-[auto_minmax(10rem,1fr)_minmax(12rem,1.5fr)_auto]'
+                        : 'md:grid-cols-[auto_minmax(10rem,1fr)_minmax(12rem,1.5fr)]'
                 } ${
                   dragOverLibraryIndex === index
                     ? 'border-primary bg-primary/5 dark:border-primary'
                     : 'border-chalkboard-30'
                 } ${draggedLibraryIndex === index ? 'opacity-60' : ''}`}
                 onDragOver={
-                  canManageLibraries
+                  canReorderLibraries
                     ? (event) => handleDragOver(event, index)
                     : undefined
                 }
                 onDrop={
-                  canManageLibraries
+                  canReorderLibraries
                     ? (event) => handleDrop(event, index)
                     : undefined
                 }
                 data-testid="project-library-row"
               >
-                {canManageLibraries && (
+                {canReorderLibraries && (
                   <button
                     type="button"
                     draggable
@@ -552,9 +566,13 @@ export function ProjectLibrariesSettingInput({
                 )}
                 <ProjectLibraryTypeSelect
                   value={library.type}
-                  options={selectableLibraryTypeOptions}
+                  options={
+                    canChangeLibraryType
+                      ? selectableLibraryTypeOptions
+                      : libraryTypeOptions
+                  }
                   onChange={(type) => updateLibraryType(index, type)}
-                  readOnly={!canManageLibraries}
+                  readOnly={!canChangeLibraryType}
                 />
                 <input
                   value={library.title}
@@ -588,34 +606,39 @@ export function ProjectLibrariesSettingInput({
                         : draftLibraries
                     )
                   }
-                  readOnly={!canManageLibraries}
+                  readOnly={!canEditLibraryDetails}
                   chooseDirectory={
-                    electron && canManageLibraries ? chooseDirectory : undefined
+                    electron && canEditLibraryDetails
+                      ? chooseDirectory
+                      : undefined
                   }
                 />
-                {canManageLibraries && (
-                  <ActionButton
-                    Element="button"
-                    type="button"
-                    tabIndex={0}
-                    onClick={() => removeLibrary(index)}
-                    className="justify-self-start !p-0 md:justify-self-end"
-                    iconStart={{
-                      icon: 'trash',
-                      bgClassName: '!bg-transparent',
-                      iconClassName: 'dark:!text-chalkboard-30',
-                    }}
-                    data-testid="project-library-remove"
-                  >
-                    <Tooltip position="top-right">Remove library</Tooltip>
-                  </ActionButton>
-                )}
+                {showRemoveColumn &&
+                  (canRemoveCurrentLibrary ? (
+                    <ActionButton
+                      Element="button"
+                      type="button"
+                      tabIndex={0}
+                      onClick={() => removeLibrary(index)}
+                      className="justify-self-start !p-0 md:justify-self-end"
+                      iconStart={{
+                        icon: 'trash',
+                        bgClassName: '!bg-transparent',
+                        iconClassName: 'dark:!text-chalkboard-30',
+                      }}
+                      data-testid="project-library-remove"
+                    >
+                      <Tooltip position="top-right">Remove library</Tooltip>
+                    </ActionButton>
+                  ) : (
+                    <span aria-hidden="true" />
+                  ))}
               </li>
             )
           })}
         </ul>
       )}
-      {canManageLibraries && (
+      {canAddLibraries && (
         <ActionButton
           Element="button"
           type="button"

--- a/src/lib/routeLoaders.ts
+++ b/src/lib/routeLoaders.ts
@@ -40,7 +40,10 @@ import type {
   IndexLoaderData,
 } from '@src/lib/types'
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
-import { projectLibrarySettingDefaultsValueSpec } from '@src/registry/contracts/projectLibraries'
+import {
+  projectLibrarySettingDefaultPoliciesValueSpec,
+  projectLibrarySettingDefaultsValueSpec,
+} from '@src/registry/contracts/projectLibraries'
 import { settingsValueSpec } from '@src/registry/contracts/settings'
 import type { LoaderFunction } from 'react-router-dom'
 import { redirect } from 'react-router-dom'
@@ -62,6 +65,9 @@ function loadRouteSettings(
   return loadAndValidateSettings(wasmInstance, {
     defaultProjectLibraries: app.registry.get(
       projectLibrarySettingDefaultsValueSpec
+    ),
+    projectLibrarySettingDefaultPolicies: app.registry.get(
+      projectLibrarySettingDefaultPoliciesValueSpec
     ),
     extensionSettings: app.registry.get(settingsValueSpec),
     projectPath,

--- a/src/lib/settings/settingsUtils.ts
+++ b/src/lib/settings/settingsUtils.ts
@@ -30,11 +30,12 @@ import {
 } from '@src/lib/layout/utils'
 import {
   getDefaultDirectoryProjectLibraryPath,
-  getDefaultProjectLibrarySettings,
   isProjectLibrarySettings,
   mergeProjectLibrarySettings,
   type ProjectLibrarySetting,
 } from '@src/lib/projectLibraries'
+import type { ProjectLibrarySettingDefaultPolicy } from '@src/registry/contracts/projectLibraries'
+import { resolveProjectLibrarySettingDefaults } from '@src/registry/contracts/projectLibraries'
 import type { ResolvedExtensionSettings } from '@src/lib/settings/extensionSettings'
 import {
   Setting,
@@ -958,6 +959,7 @@ export async function loadAndValidateSettings(
     | string
     | {
         defaultProjectLibraries?: readonly ProjectLibrarySetting[]
+        projectLibrarySettingDefaultPolicies?: readonly ProjectLibrarySettingDefaultPolicy[]
         extensionSettings?: ResolvedExtensionSettings
         projectPath?: string
       }
@@ -969,6 +971,7 @@ export async function loadAndValidateSettings(
       : projectPathOrOptions
   const {
     defaultProjectLibraries = [],
+    projectLibrarySettingDefaultPolicies = [],
     extensionSettings = {},
     projectPath,
   } = options
@@ -991,14 +994,21 @@ export async function loadAndValidateSettings(
     typeof appSettings.app?.projectDirectory === 'string'
       ? appSettings.app.projectDirectory
       : undefined
-  const defaultDirectoryLibraryPath =
-    legacyProjectDirectory ?? initialDefaultDir
+
+  const policyDefaultProjectLibraries = resolveProjectLibrarySettingDefaults(
+    projectLibrarySettingDefaultPolicies,
+    {
+      initialDefaultDir,
+      legacyProjectDirectory,
+      isDesktop: isDesktop(),
+    }
+  )
 
   let settingsNext = createSettings(extensionSettings)
   settingsNext.app.projectDirectory.default = initialDefaultDir
   if (settingsNext.app.libraries) {
     settingsNext.app.libraries.default = mergeProjectLibrarySettings(
-      getDefaultProjectLibrarySettings(defaultDirectoryLibraryPath),
+      policyDefaultProjectLibraries,
       defaultProjectLibraries
     )
   }

--- a/src/machines/settingsMachine.ts
+++ b/src/machines/settingsMachine.ts
@@ -21,6 +21,7 @@ import type { Project } from '@src/lib/project'
 import type { ProjectLibrarySetting } from '@src/lib/projectLibraries'
 import type { ResolvedExtensionSettings } from '@src/lib/settings/extensionSettings'
 import type { SettingsType } from '@src/lib/settings/initialSettings'
+import type { ProjectLibrarySettingDefaultPolicy } from '@src/registry/contracts/projectLibraries'
 import { createSettings } from '@src/lib/settings/initialSettings'
 import type {
   BaseUnit,
@@ -48,6 +49,7 @@ export type SettingsActorDepsType = {
   currentProject?: Project
   commandBarActor: ActorRefFrom<typeof commandBarMachine>
   defaultProjectLibraries: readonly ProjectLibrarySetting[]
+  projectLibrarySettingDefaultPolicies: readonly ProjectLibrarySettingDefaultPolicy[]
   extensionSettings: ResolvedExtensionSettings
   wasmInstancePromise: Promise<ModuleType>
 }
@@ -125,6 +127,7 @@ export const settingsMachine = setup({
       SettingsType,
       {
         defaultProjectLibraries: readonly ProjectLibrarySetting[]
+        projectLibrarySettingDefaultPolicies: readonly ProjectLibrarySettingDefaultPolicy[]
         extensionSettings: ResolvedExtensionSettings
         wasmInstancePromise: Promise<ModuleType>
       }
@@ -133,6 +136,8 @@ export const settingsMachine = setup({
         input.wasmInstancePromise,
         {
           defaultProjectLibraries: input.defaultProjectLibraries,
+          projectLibrarySettingDefaultPolicies:
+            input.projectLibrarySettingDefaultPolicies,
           extensionSettings: input.extensionSettings,
         }
       )
@@ -142,6 +147,7 @@ export const settingsMachine = setup({
       SettingsType,
       {
         defaultProjectLibraries: readonly ProjectLibrarySetting[]
+        projectLibrarySettingDefaultPolicies: readonly ProjectLibrarySettingDefaultPolicy[]
         extensionSettings: ResolvedExtensionSettings
         project: Project
         settings: SettingsType
@@ -152,6 +158,8 @@ export const settingsMachine = setup({
         input.wasmInstancePromise,
         {
           defaultProjectLibraries: input.defaultProjectLibraries,
+          projectLibrarySettingDefaultPolicies:
+            input.projectLibrarySettingDefaultPolicies,
           extensionSettings: input.extensionSettings,
           projectPath: input.project.path,
         }
@@ -163,6 +171,7 @@ export const settingsMachine = setup({
       {
         currentProject?: Project
         defaultProjectLibraries: readonly ProjectLibrarySetting[]
+        projectLibrarySettingDefaultPolicies: readonly ProjectLibrarySettingDefaultPolicy[]
         extensionSettings: ResolvedExtensionSettings
         wasmInstancePromise: Promise<ModuleType>
       }
@@ -171,6 +180,8 @@ export const settingsMachine = setup({
         input.wasmInstancePromise,
         {
           defaultProjectLibraries: input.defaultProjectLibraries,
+          projectLibrarySettingDefaultPolicies:
+            input.projectLibrarySettingDefaultPolicies,
           extensionSettings: input.extensionSettings,
           projectPath: input.currentProject?.path,
         }
@@ -577,6 +588,8 @@ export const settingsMachine = setup({
         input: ({ context }) => ({
           currentProject: context.currentProject,
           defaultProjectLibraries: context.defaultProjectLibraries,
+          projectLibrarySettingDefaultPolicies:
+            context.projectLibrarySettingDefaultPolicies,
           extensionSettings: context.extensionSettings,
           wasmInstancePromise: context.wasmInstancePromise,
         }),
@@ -627,6 +640,8 @@ export const settingsMachine = setup({
         src: 'loadUserSettings',
         input: ({ context }) => ({
           defaultProjectLibraries: context.defaultProjectLibraries,
+          projectLibrarySettingDefaultPolicies:
+            context.projectLibrarySettingDefaultPolicies,
           extensionSettings: context.extensionSettings,
           wasmInstancePromise: context.wasmInstancePromise,
         }),
@@ -677,6 +692,8 @@ export const settingsMachine = setup({
           assertEvent(event, 'load.project')
           return {
             defaultProjectLibraries: context.defaultProjectLibraries,
+            projectLibrarySettingDefaultPolicies:
+              context.projectLibrarySettingDefaultPolicies,
             extensionSettings: context.extensionSettings,
             settings: getOnlySettingsFromContext(context),
             project: event.project,
@@ -695,6 +712,7 @@ export function getOnlySettingsFromContext(
     currentProject: _c,
     commandBarActor: _cba,
     defaultProjectLibraries: _defaultProjectLibraries,
+    projectLibrarySettingDefaultPolicies: _projectLibrarySettingDefaultPolicies,
     extensionSettings: _extensionSettings,
     wasmInstancePromise: _w,
     ...settings

--- a/src/registry/contracts/projectLibraries.spec.ts
+++ b/src/registry/contracts/projectLibraries.spec.ts
@@ -1,9 +1,11 @@
 import {
+  combineProjectLibrarySettingDefaultPolicies,
   combineProjectLibrarySettingDefaults,
   combineProjectLibraryTypes,
   combineProjectLibraries,
   getHomeProjectEntriesForLibrary,
   getProjectLibraryOperation,
+  resolveProjectLibrarySettingDefaults,
 } from '@src/registry/contracts/projectLibraries'
 import {
   DEFAULT_PROJECT_LIBRARY_ID,
@@ -300,6 +302,51 @@ describe('combineProjectLibraries', () => {
         id: 'external',
         title: 'External Projects',
       }),
+    ])
+  })
+})
+
+describe('project library default policies', () => {
+  test('resolves the highest-priority default library policy', () => {
+    const directoryPolicy = {
+      id: 'directory',
+      priority: 0,
+      getDefaultLibraries: () => [
+        {
+          title: 'Projects',
+          path: '/projects',
+          type: 'directory',
+        },
+      ],
+    }
+    const cloudPolicy = {
+      id: 'cloud',
+      priority: 10,
+      getDefaultLibraries: () => [
+        {
+          title: 'Personal Cloud',
+          path: '/personal',
+          type: 'cloud',
+        },
+      ],
+    }
+
+    const policies = combineProjectLibrarySettingDefaultPolicies([
+      directoryPolicy,
+      cloudPolicy,
+    ])
+
+    expect(
+      resolveProjectLibrarySettingDefaults(policies, {
+        initialDefaultDir: '/projects',
+        isDesktop: false,
+      })
+    ).toEqual([
+      {
+        title: 'Personal Cloud',
+        path: '/personal',
+        type: 'cloud',
+      },
     ])
   })
 })

--- a/src/registry/contracts/projectLibraries.spec.ts
+++ b/src/registry/contracts/projectLibraries.spec.ts
@@ -6,7 +6,10 @@ import {
   getProjectLibraryOperation,
 } from '@src/registry/contracts/projectLibraries'
 import {
+  CLOUD_PROJECT_LIBRARY_ID,
+  DEFAULT_CLOUD_PROJECT_LIBRARY_PATH,
   DEFAULT_PROJECT_LIBRARY_ID,
+  getDefaultCloudProjectLibrarySetting,
   areProjectLibrarySettingsEqual,
   getContainingDirectoryProjectLibraryPath,
   getDefaultDirectoryProjectLibrarySetting,
@@ -51,6 +54,18 @@ describe('project library settings', () => {
     ).toEqual(
       expect.objectContaining({
         id: DEFAULT_PROJECT_LIBRARY_ID,
+      })
+    )
+  })
+
+  test('maps the default cloud library to the stable cloud library id', () => {
+    expect(
+      projectLibraryFromSetting(getDefaultCloudProjectLibrarySetting())
+    ).toEqual(
+      expect.objectContaining({
+        id: CLOUD_PROJECT_LIBRARY_ID,
+        path: DEFAULT_CLOUD_PROJECT_LIBRARY_PATH,
+        type: 'cloud',
       })
     )
   })

--- a/src/registry/contracts/projectLibraries.spec.ts
+++ b/src/registry/contracts/projectLibraries.spec.ts
@@ -6,9 +6,9 @@ import {
   getProjectLibraryOperation,
 } from '@src/registry/contracts/projectLibraries'
 import {
-  CLOUD_PROJECT_LIBRARY_ID,
-  DEFAULT_CLOUD_PROJECT_LIBRARY_PATH,
   DEFAULT_PROJECT_LIBRARY_ID,
+  DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH,
+  PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
   getDefaultCloudProjectLibrarySetting,
   areProjectLibrarySettingsEqual,
   getContainingDirectoryProjectLibraryPath,
@@ -63,8 +63,8 @@ describe('project library settings', () => {
       projectLibraryFromSetting(getDefaultCloudProjectLibrarySetting())
     ).toEqual(
       expect.objectContaining({
-        id: CLOUD_PROJECT_LIBRARY_ID,
-        path: DEFAULT_CLOUD_PROJECT_LIBRARY_PATH,
+        id: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+        path: DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH,
         type: 'cloud',
       })
     )

--- a/src/registry/contracts/projectLibraries.ts
+++ b/src/registry/contracts/projectLibraries.ts
@@ -11,6 +11,7 @@ import type {
   ProjectLibraryType,
 } from '@src/lib/projectLibraries'
 import { mergeProjectLibrarySettings } from '@src/lib/projectLibraries'
+import type { HideOnPlatformValue } from '@src/lib/settings/settingsTypes'
 import { isArray } from '@src/lib/utils'
 import type { ComponentType } from 'react'
 
@@ -21,6 +22,24 @@ export type ProjectLibraryContribution =
 export type ProjectLibrarySettingDefaultContribution =
   | ProjectLibrarySetting
   | readonly ProjectLibrarySetting[]
+
+export interface ProjectLibrarySettingDefaultPolicyInput {
+  initialDefaultDir: string
+  legacyProjectDirectory?: string
+  isDesktop: boolean
+}
+
+export interface ProjectLibrarySettingDefaultPolicy {
+  id: string
+  priority?: number
+  getDefaultLibraries: (
+    input: ProjectLibrarySettingDefaultPolicyInput
+  ) => readonly ProjectLibrarySetting[] | undefined
+}
+
+export type ProjectLibrarySettingDefaultPolicyContribution =
+  | ProjectLibrarySettingDefaultPolicy
+  | readonly ProjectLibrarySettingDefaultPolicy[]
 
 export interface ProjectLibraryOperation<
   Input extends { library: ProjectLibrary },
@@ -68,6 +87,7 @@ export interface ProjectLibrarySettingsDetailsProps {
   index: number
   updateLibrary: (library: ProjectLibrarySetting) => void
   commitLibrary: (library?: ProjectLibrarySetting) => void
+  readOnly?: boolean
   chooseDirectory?: (input: {
     defaultPath?: string
     title?: string
@@ -85,6 +105,8 @@ export interface ProjectLibraryTypeContribution {
   newLibrarySetting?: ProjectLibrarySetting
   /** Optional detail cell rendered in the project libraries settings row. */
   settingsDetails?: ComponentType<ProjectLibrarySettingsDetailsProps>
+  /** Hide this type from creation/editing UI while keeping runtime support. */
+  hideInSettingsOnPlatform?: HideOnPlatformValue
   operations?: ProjectLibraryTypeOperations
   readEntries?: (input: {
     library: ProjectLibrary
@@ -180,6 +202,33 @@ export function combineProjectLibrarySettingDefaults(
   )
 }
 
+export function combineProjectLibrarySettingDefaultPolicies(
+  contributions: readonly ProjectLibrarySettingDefaultPolicyContribution[]
+) {
+  return contributions
+    .flatMap((contribution) =>
+      isArray(contribution) ? contribution : [contribution]
+    )
+    .toSorted((a, b) => {
+      const priorityDiff = (b.priority ?? 0) - (a.priority ?? 0)
+      return priorityDiff === 0 ? a.id.localeCompare(b.id) : priorityDiff
+    })
+}
+
+export function resolveProjectLibrarySettingDefaults(
+  policies: readonly ProjectLibrarySettingDefaultPolicy[],
+  input: ProjectLibrarySettingDefaultPolicyInput
+) {
+  for (const policy of policies) {
+    const defaults = policy.getDefaultLibraries(input)
+    if (defaults && defaults.length > 0) {
+      return mergeProjectLibrarySettings(defaults)
+    }
+  }
+
+  return []
+}
+
 export const projectLibrariesContract = defineContract({
   projectLibrariesValueSpec: defineValueSpec<
     ProjectLibraryContribution,
@@ -205,10 +254,19 @@ export const projectLibrariesContract = defineContract({
     defaultValue: [],
     combine: combineProjectLibrarySettingDefaults,
   }),
+  projectLibrarySettingDefaultPoliciesValueSpec: defineValueSpec<
+    ProjectLibrarySettingDefaultPolicyContribution,
+    ProjectLibrarySettingDefaultPolicy[]
+  >({
+    name: 'project-library-setting-default-policies',
+    defaultValue: [],
+    combine: combineProjectLibrarySettingDefaultPolicies,
+  }),
 })
 
 export const {
   projectLibrariesValueSpec,
   projectLibraryTypesValueSpec,
   projectLibrarySettingDefaultsValueSpec,
+  projectLibrarySettingDefaultPoliciesValueSpec,
 } = projectLibrariesContract

--- a/src/registry/createZdsPlugin.ts
+++ b/src/registry/createZdsPlugin.ts
@@ -6,6 +6,7 @@ import {
   defineRegistryItem,
   provide,
 } from '@kittycad/registry'
+import type { Feature } from '@kittycad/lib'
 import { defineBooleanExtensionSetting } from '@src/lib/settings/extensionSettings'
 import type {
   HideOnPlatformValue,
@@ -39,6 +40,13 @@ type ZdsPluginActivationSettingSpec = {
    * the app runtime; this only removes the settings control.
    */
   hideOnPlatform?: HideOnPlatformValue
+  /**
+   * Hide the activation toggle unless the user has this feature flag. Lets a
+   * feature-gated plugin (e.g. cloud sync) drop out of the settings panel,
+   * command bar, and plugins list through the same settings config rather than
+   * a bespoke check per surface.
+   */
+  hideWithoutFeature?: Feature
   userToml?: { sectionKey: string; tomlKey: string }
   projectToml?: { sectionKey: string; tomlKey: string }
 }
@@ -95,6 +103,7 @@ export function createZdsPlugin({
             commandConfig: activationSetting.commandConfig,
             hideOnLevel: activationSetting.hideOnLevel,
             hideOnPlatform: activationSetting.hideOnPlatform,
+            hideWithoutFeature: activationSetting.hideWithoutFeature,
             userToml: activationSetting.userToml,
             projectToml: activationSetting.projectToml,
           }),

--- a/src/registry/createZdsPlugin.ts
+++ b/src/registry/createZdsPlugin.ts
@@ -7,7 +7,10 @@ import {
   provide,
 } from '@kittycad/registry'
 import { defineBooleanExtensionSetting } from '@src/lib/settings/extensionSettings'
-import type { SettingsLevel } from '@src/lib/settings/settingsTypes'
+import type {
+  HideOnPlatformValue,
+  SettingsLevel,
+} from '@src/lib/settings/settingsTypes'
 import { settingsValueSpec } from '@src/registry/contracts/settings'
 
 type ZdsPluginDefault = 'core' | 'off'
@@ -29,6 +32,13 @@ type ZdsPluginActivationSettingSpec = {
   description?: string
   commandConfig?: { inputType: 'boolean' }
   hideOnLevel?: SettingsLevel
+  /**
+   * Hide the activation toggle on a platform. Used to make a plugin
+   * non-optional there (e.g. cloud sync on web, where it is the storage layer).
+   * Enforcement that the value cannot be turned off is handled separately in
+   * the app runtime; this only removes the settings control.
+   */
+  hideOnPlatform?: HideOnPlatformValue
   userToml?: { sectionKey: string; tomlKey: string }
   projectToml?: { sectionKey: string; tomlKey: string }
 }
@@ -84,6 +94,7 @@ export function createZdsPlugin({
             description: activationSetting.description,
             commandConfig: activationSetting.commandConfig,
             hideOnLevel: activationSetting.hideOnLevel,
+            hideOnPlatform: activationSetting.hideOnPlatform,
             userToml: activationSetting.userToml,
             projectToml: activationSetting.projectToml,
           }),

--- a/src/registry/extensions/cloudSyncLibrary/index.ts
+++ b/src/registry/extensions/cloudSyncLibrary/index.ts
@@ -1,0 +1,6 @@
+// The `cloud` project-library type handler is always-on infrastructure, kept
+// separate from the toggle-able cloud-sync plugin so that disabling cloud sync
+// never removes the ability to browse or create projects in the Personal Cloud
+// folder (on web that folder is the canonical project storage). See
+// cloudSyncProjectLibraryType in @src/lib/cloudSync/registry/plugin.
+export { cloudSyncProjectLibraryType as default } from '@src/lib/cloudSync/registry/plugin'

--- a/src/registry/extensions/homeProjects/index.ts
+++ b/src/registry/extensions/homeProjects/index.ts
@@ -6,6 +6,7 @@ import {
   provideService,
 } from '@kittycad/registry'
 import { computed, effect, signal } from '@preact/signals-core'
+import { getDefaultCloudProjectDirectoryPath } from '@src/lib/cloudSync/paths'
 import {
   getProjectInfo,
   writeProjectTitleToProjectToml,
@@ -173,7 +174,8 @@ const homeProjectActions = defineRegistryItemFactory((ctx) => {
       }
 
       const syncedProject = await cloudSync.value?.ensureProjectLocallySynced(
-        project.remoteProjectId
+        project.remoteProjectId,
+        await getDefaultCloudProjectDirectoryPath()
       )
       if (!syncedProject) {
         return undefined

--- a/src/registry/extensions/homeProjects/index.ts
+++ b/src/registry/extensions/homeProjects/index.ts
@@ -17,18 +17,18 @@ import {
   homeProjectEntryFromProject,
 } from '@src/lib/homeProjects'
 import type { Project } from '@src/lib/project'
-import { readProjectsFromProjectDirectory } from '@src/lib/projectLibraries/directoryScanner'
-import { createProjectInLocalDirectory } from '@src/lib/projectLibraries/operations'
 import {
   DEFAULT_PROJECT_LIBRARY_ID,
   DEFAULT_PROJECT_LIBRARY_TITLE,
   DIRECTORY_PROJECT_LIBRARY_TYPE,
-  NEW_PROJECT_LIBRARY_TITLE,
   getDefaultDirectoryProjectLibraryPath,
   getDefaultProjectLibrarySettings,
+  NEW_PROJECT_LIBRARY_TITLE,
   type ProjectLibrary,
   projectLibraryFromSetting,
 } from '@src/lib/projectLibraries'
+import { readProjectsFromProjectDirectory } from '@src/lib/projectLibraries/directoryScanner'
+import { createProjectInLocalDirectory } from '@src/lib/projectLibraries/operations'
 import { DirectoryProjectLibrarySettingsDetails } from '@src/lib/projectLibraries/settings/ProjectLibrariesSettingInput'
 import { reportRejection } from '@src/lib/trap'
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
@@ -42,10 +42,10 @@ import {
 } from '@src/registry/contracts/homeProjects'
 import {
   getProjectLibraryOperation,
+  type ProjectLibraryTypeOperations,
   projectLibrariesValueSpec,
   projectLibrarySettingDefaultPoliciesValueSpec,
   projectLibraryTypesValueSpec,
-  type ProjectLibraryTypeOperations,
 } from '@src/registry/contracts/projectLibraries'
 import { settingsService } from '@src/registry/contracts/settings'
 import { systemIOService } from '@src/registry/contracts/systemIO'
@@ -54,7 +54,7 @@ import toast from 'react-hot-toast'
 
 const configuredProjectLibraryEntriesInvalidation = signal(0)
 
-function invalidateConfiguredProjectLibraryEntries() {
+export function invalidateConfiguredProjectLibraryEntries() {
   configuredProjectLibraryEntriesInvalidation.value += 1
 }
 
@@ -148,17 +148,17 @@ const homeProjectActions = defineRegistryItemFactory((ctx) => {
           getProjectOperation(project, 'openProject')) ||
           project.remoteProjectId
       ),
+    // A local materialization is not required: cloud library operations can act
+    // on a remote-only project directly. Each library type's operation guards
+    // its own local-vs-remote handling, so the shared capability check only
+    // needs write access plus a registered operation.
     canRename: (project) =>
       Boolean(
-        project.localProjectPath &&
-          project.readWriteAccess &&
-          getProjectOperation(project, 'renameProject')
+        project.readWriteAccess && getProjectOperation(project, 'renameProject')
       ),
     canDelete: (project) =>
       Boolean(
-        project.localProjectPath &&
-          project.readWriteAccess &&
-          getProjectOperation(project, 'deleteProject')
+        project.readWriteAccess && getProjectOperation(project, 'deleteProject')
       ),
     open: async (project) => {
       const openProject = getProjectOperation(project, 'openProject')

--- a/src/registry/extensions/homeProjects/index.ts
+++ b/src/registry/extensions/homeProjects/index.ts
@@ -24,6 +24,7 @@ import {
   DIRECTORY_PROJECT_LIBRARY_TYPE,
   NEW_PROJECT_LIBRARY_TITLE,
   getDefaultDirectoryProjectLibraryPath,
+  getDefaultProjectLibrarySettings,
   type ProjectLibrary,
   projectLibraryFromSetting,
 } from '@src/lib/projectLibraries'
@@ -41,6 +42,7 @@ import {
 import {
   getProjectLibraryOperation,
   projectLibrariesValueSpec,
+  projectLibrarySettingDefaultPoliciesValueSpec,
   projectLibraryTypesValueSpec,
   type ProjectLibraryTypeOperations,
 } from '@src/registry/contracts/projectLibraries'
@@ -349,6 +351,7 @@ const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
             type: DIRECTORY_PROJECT_LIBRARY_TYPE,
           },
           settingsDetails: DirectoryProjectLibrarySettingsDetails,
+          hideInSettingsOnPlatform: 'web',
           readEntries: async ({ library, signal }) => {
             const projects = await readProjectsFromProjectDirectory({
               projectDirectoryPath: library.path,
@@ -425,6 +428,26 @@ const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
     }),
   }
 }, 'home-projects.directory-library-type')
+
+const directoryProjectLibraryDefaultPolicy = defineRegistryItem({
+  id: 'home-projects.directory-library-default-policy',
+  provides: [
+    provide(projectLibrarySettingDefaultPoliciesValueSpec, {
+      id: 'home-projects.directory-library-default-policy',
+      priority: 0,
+      /**
+       * Product policy: the directory library owns the legacy default project
+       * directory fallback. Other library systems can contribute
+       * higher-priority policies without `loadAndValidateSettings()` knowing
+       * about their storage type.
+       */
+      getDefaultLibraries: ({ legacyProjectDirectory, initialDefaultDir }) =>
+        getDefaultProjectLibrarySettings(
+          legacyProjectDirectory ?? initialDefaultDir
+        ),
+    }),
+  ],
+})
 
 const configuredProjectLibraryEntries = defineRegistryItemFactory((ctx) => {
   const settings = ctx.services.signal(settingsService)
@@ -538,6 +561,7 @@ const homeProjectsExtension = defineRegistryItem({
   uses: [
     configuredProjectLibraries,
     configuredProjectLibraryEntries,
+    directoryProjectLibraryDefaultPolicy,
     directoryProjectLibraryType,
     homeProjectActions,
     systemIOLocalHomeProjectEntries,

--- a/src/registry/extensions/homeProjects/index.ts
+++ b/src/registry/extensions/homeProjects/index.ts
@@ -456,6 +456,11 @@ const configuredProjectLibraryEntries = defineRegistryItemFactory((ctx) => {
   const libraryTypes = ctx.valueSpecs.signal(projectLibraryTypesValueSpec)
   const entries = signal<HomeProjectEntryContribution[]>([])
   const entriesByLibraryId = new Map<string, HomeProjectEntryContribution[]>()
+  // Diagnostic dedupe: a configured library whose type has no registered
+  // handler cannot be listed and would silently vanish from Home. This should
+  // not happen (the cloud and directory types are always-on), so warn once per
+  // library rather than swallowing it.
+  const warnedMissingTypeLibraryIds = new Set<string>()
   let abortController: AbortController | undefined
   let disposeConfiguredProjectLibraryEntriesEffect: (() => void) | undefined
   let disposed = false
@@ -505,6 +510,12 @@ const configuredProjectLibraryEntries = defineRegistryItemFactory((ctx) => {
       for (const library of configuredLibraries) {
         const readEntries = typeById.get(library.type)?.readEntries
         if (!readEntries) {
+          if (!warnedMissingTypeLibraryIds.has(library.id)) {
+            warnedMissingTypeLibraryIds.add(library.id)
+            console.warn(
+              `Configured project library "${library.title}" (${library.id}) has no registered "${library.type}" type handler; its projects cannot be listed.`
+            )
+          }
           continue
         }
 

--- a/src/registry/extensions/settings/index.ts
+++ b/src/registry/extensions/settings/index.ts
@@ -20,7 +20,10 @@ import {
   settingsService,
   settingsValueSpec,
 } from '@src/registry/contracts/settings'
-import { projectLibrarySettingDefaultsValueSpec } from '@src/registry/contracts/projectLibraries'
+import {
+  projectLibrarySettingDefaultPoliciesValueSpec,
+  projectLibrarySettingDefaultsValueSpec,
+} from '@src/registry/contracts/projectLibraries'
 import { statusBarGlobalItemsValueSpec } from '@src/registry/contracts/statusBar'
 import { wasmPromiseValueSpec } from '@src/registry/contracts/wasm'
 import { useSelector } from '@xstate/react'
@@ -45,11 +48,15 @@ export const settingsExtension = defineRegistryItemFactory((ctx) => {
     const defaultProjectLibraries = ctx.valueSpecs.get(
       projectLibrarySettingDefaultsValueSpec
     )
+    const projectLibrarySettingDefaultPolicies = ctx.valueSpecs.get(
+      projectLibrarySettingDefaultPoliciesValueSpec
+    )
     const actor = createActor(settingsMachine, {
       input: {
         ...createSettings(extensionSettings),
         commandBarActor: commands.actor,
         defaultProjectLibraries,
+        projectLibrarySettingDefaultPolicies,
         extensionSettings,
         wasmInstancePromise: getWasmPromise(),
       },

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -566,6 +566,7 @@ const Home = () => {
             projectActions={homeProjectActions}
             showCloudSyncUi={hasCloudSyncFeature}
             showSourceStatusBadges={false}
+            projectLibraryEmptyTestId="project-library-empty"
             className="flex-1 col-start-2 -col-end-1 overflow-y-auto pr-2 pb-24"
           />
         ) : (
@@ -947,6 +948,7 @@ interface ProjectGridProps extends HTMLProps<HTMLDivElement> {
   projectActions: HomeProjectActionsService
   showCloudSyncUi: boolean
   showSourceStatusBadges?: boolean
+  projectLibraryEmptyTestId?: string
 }
 
 function ProjectGrid({
@@ -959,6 +961,7 @@ function ProjectGrid({
   projectActions,
   showCloudSyncUi,
   showSourceStatusBadges = true,
+  projectLibraryEmptyTestId,
   ...rest
 }: ProjectGridProps) {
   const state = useSystemIOState()
@@ -989,7 +992,9 @@ function ProjectGrid({
               data-testid="projects-none"
               className="p-4 my-8 border border-dashed rounded border-chalkboard-30 dark:border-chalkboard-70"
             >
-              No projects found
+              <span data-testid={projectLibraryEmptyTestId}>
+                No projects found
+              </span>
               {projects.length === 0
                 ? ', ready to make your first one?'
                 : ` with the search term "${query}"`}

--- a/src/unitTestUtils.ts
+++ b/src/unitTestUtils.ts
@@ -75,6 +75,7 @@ export async function buildTheWorldAndConnectToEngine() {
     input: {
       commandBarActor,
       defaultProjectLibraries: [],
+      projectLibrarySettingDefaultPolicies: [],
       extensionSettings: {},
       ...createSettings(),
       wasmInstancePromise: instancePromise,
@@ -181,6 +182,7 @@ export async function buildTheWorldAndNoEngineConnection(mockWasm = false) {
     input: {
       commandBarActor,
       defaultProjectLibraries: [],
+      projectLibrarySettingDefaultPolicies: [],
       extensionSettings: {},
       ...createSettings(),
       wasmInstancePromise: instancePromise,


### PR DESCRIPTION
## Summary
- adds the `cloud` project library type and the default `cloud-personal` Personal Cloud library
- keeps the cloud-sync plugin's static default off so registry/settings startup is deterministic
- applies the cloud-sync rollout policy from the app runtime: feature-flagged users with no explicit preference get cloud sync enabled, and toggling cloud sync on materializes the Personal Cloud library
- on web, treats Personal Cloud as the canonical project library by replacing only the recognized default directory row instead of adding a duplicate library
- keeps desktop behavior additive: directory libraries and Personal Cloud can appear side by side
- uses the existing browser project storage root as Personal Cloud's local clone folder, while desktop resolves an OS-visible `Zoo/personal` folder
- hides directory-library creation, reordering, type-switching, and path-editing controls on web while still allowing users to remove existing directory-library rows
- wires cloud-only Home entries into the Personal Cloud library

## Why
This is the Personal Cloud library PR in the project-library stack. It adds the cloud library model and default personal library without including the legacy synced-directory migration prompt.

The cloud-sync activation behavior is intentionally modeled as app product policy instead of plugin startup reconciliation. The plugin can stay statically default-off, while the settled app runtime decides when a feature-flagged user should be opted in and when the Personal Cloud library row should be added to `app.libraries`. That avoids a brittle settings mutation during registry construction and keeps user opt-outs respected.

The web policy is also intentional: OPFS is an implementation detail, so enabling Personal Cloud should not create a second visible directory-style library or physically move the browser's default project storage. Instead, the default browser project library is represented as Personal Cloud once cloud sync is enabled. Browser users also cannot create or edit directory libraries, but they can remove a directory-library row if one already exists in their settings.

## Stack
- Depends on #12579 for the settings-details contribution point.
- Follow-up #12581 adds the legacy cloud-synced directory project migration prompt.

## Validation
- `npm run test -- src/registry/contracts/projectLibraries.spec.ts src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.spec.tsx src/lib/cloudSync/registry/plugin.spec.tsx`
- `npm run test:integration -- src/lib/settings/settingsUtils.spec.ts src/lib/app.spec.ts`
- `npm run tsc -- --noEmit`
- `npm run lint -- src/lib/app.ts src/lib/app.spec.ts src/lib/cloudSync/index.test.ts src/lib/cloudSync/paths.ts src/lib/cloudSync/registry/plugin.spec.tsx src/lib/projectLibraries/settings/ProjectLibrariesSetting.tsx src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.tsx src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.spec.tsx src/lib/routeLoaders.ts src/lib/settings/settingsUtils.ts src/machines/settingsMachine.ts src/registry/contracts/projectLibraries.ts src/registry/contracts/projectLibraries.spec.ts src/registry/extensions/homeProjects/index.ts src/registry/extensions/settings/index.ts src/unitTestUtils.ts`
- `npx biome check --formatter-enabled=true --linter-enabled=false --assist-enabled=false --files-ignore-unknown=true src/lib/app.ts src/lib/app.spec.ts src/lib/cloudSync/index.test.ts src/lib/cloudSync/paths.ts src/lib/cloudSync/registry/plugin.spec.tsx src/lib/projectLibraries/settings/ProjectLibrariesSetting.tsx src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.tsx src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.spec.tsx src/lib/routeLoaders.ts src/lib/settings/settingsUtils.ts src/machines/settingsMachine.ts src/registry/contracts/projectLibraries.ts src/registry/contracts/projectLibraries.spec.ts src/registry/extensions/homeProjects/index.ts src/registry/extensions/settings/index.ts src/unitTestUtils.ts`
- `git diff --check`
