### PR TITLE
Preserve mixed inline loft inputs during point-and-click edits

### DIFF
--- a/src/lang/modifyAst.test.ts
+++ b/src/lang/modifyAst.test.ts
@@ -82,4 +82,15 @@ describe('editing calls in place', () => {
 
     expect(pathsReferToSamePipe(first, second)).toBe(false)
   })
+
+  it('rejects identical paths that are not inside a pipe', () => {
+    const path: PathToNode = [
+      ['body', ''],
+      [0, 'index'],
+      ['declaration', 'VariableDeclaration'],
+      ['init', 'VariableDeclarator'],
+    ]
+
+    expect(pathsReferToSamePipe(path, path)).toBe(false)
+  })
 })

--- a/src/lang/modifyAst.ts
+++ b/src/lang/modifyAst.ts
@@ -1289,10 +1289,6 @@ export function pathsReferToSamePipe(
   first: PathToNode,
   second: PathToNode
 ): boolean {
-  if (stringifyPathToNode(first) === stringifyPathToNode(second)) {
-    return true
-  }
-
   const firstPipe = splitPathAtPipeExpression(first)
   const secondPipe = splitPathAtPipeExpression(second)
   return (
@@ -1331,9 +1327,10 @@ export function setCallInAst({
   let pathToNode: PathToNode | undefined
   if (pathToEdit) {
     if (pathIfNewPipe && !pathsReferToSamePipe(pathIfNewPipe, pathToEdit)) {
-      return new Error(
-        'Cannot edit the call in place because its reconstructed input belongs to a different pipe'
-      )
+      // A pipe substitution reconstructed outside the edited call's pipe is
+      // invalid. Discard the reconstruction so replaceCallInPlace preserves
+      // the existing unlabeled argument and applies only the labeled edits.
+      call.unlabeled = null
     }
 
     const result = getNodeFromPath<CallExpressionKw>(

--- a/src/lang/modifyAst/sweeps.spec.ts
+++ b/src/lang/modifyAst/sweeps.spec.ts
@@ -2254,6 +2254,59 @@ loft001 = loft([region001, region002])`
       await enginelessExecutor(result.modifiedAst, rustContextInThisFile)
     })
 
+    it('should preserve mixed named and inline regions when editing a loft', async () => {
+      const code = `lowerSketch = sketch(on = XY) {
+  lower = circle(center = [0mm, 0mm], start = [10mm, 0mm])
+}
+lowerRegion = region(point = [5mm, 0mm], sketch = lowerSketch)
+upperSketch = sketch(on = offsetPlane(XY, offset = 20mm)) {
+  upper = circle(center = [0mm, 0mm], start = [6mm, 0mm])
+}
+mixedLoft = loft(
+  [
+    lowerRegion,
+    region(point = [3mm, 0mm], sketch = upperSketch),
+  ],
+  vDegree = 2,
+)`
+      const { ast, artifactGraph } = await getAstAndArtifactGraphEngineless(
+        code,
+        instanceInThisFile,
+        rustContextInThisFile
+      )
+      const regions = [...artifactGraph.values()].filter(
+        (artifact) => artifact.type === 'path' && artifact.subType === 'region'
+      )
+      expect(regions).toHaveLength(2)
+      const sketches = createSelectionFromArtifacts(regions, artifactGraph)
+      const vDegree = await getKclCommandValue(
+        '3',
+        instanceInThisFile,
+        rustContextInThisFile
+      )
+
+      const result = addLoft({
+        ast,
+        artifactGraph,
+        sketches,
+        vDegree,
+        nodeToEdit: createPathToNodeForLastVariable(ast),
+        wasmInstance: instanceInThisFile,
+      })
+      if (err(result)) throw result
+
+      const newCode = recast(result.modifiedAst, instanceInThisFile)
+      expect(newCode).toContain(`mixedLoft = loft(
+  [
+    lowerRegion,
+    region(point = [3mm, 0mm], sketch = upperSketch)
+  ],
+  vDegree = 3,
+)`)
+      expect(newCode).not.toContain('%')
+      await enginelessExecutor(result.modifiedAst, rustContextInThisFile)
+    })
+
     it('should add a basic loft call with surface bodyType', async () => {
       const { ast, artifactGraph, sketches } = await getAstAndSketchSelections(
         twoCirclesCode,


### PR DESCRIPTION
Addresses #2 from https://github.com/KittyCAD/modeling-app/pull/12541#pullrequestreview-4759458256

Thanks @Irev-Dev!