### PR TITLE
Let project library types render settings details

### DIFF
--- a/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.spec.tsx
+++ b/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.spec.tsx
@@ -1,4 +1,5 @@
 import {
+  DirectoryProjectLibrarySettingsDetails,
   ProjectLibrariesSettingInput,
   projectLibraryTypeOptionsFromContributions,
   type ProjectLibraryTypeOption,
@@ -30,6 +31,7 @@ const libraryTypeOptions: ProjectLibraryTypeOption[] = [
       path: 'projects',
       type: 'directory',
     },
+    settingsDetails: DirectoryProjectLibrarySettingsDetails,
   },
 ]
 
@@ -49,6 +51,7 @@ const multipleLibraryTypeOptions: ProjectLibraryTypeOption[] = [
       path: 'zoo-cloud',
       type: 'cloud',
     },
+    settingsDetails: () => <></>,
   },
 ]
 
@@ -84,6 +87,34 @@ describe('ProjectLibrariesSettingInput', () => {
     fireEvent.blur(screen.getByTestId('project-directory-input'))
 
     expect(updateValue).not.toHaveBeenCalled()
+  })
+
+  test('does not render implicit details for library types without a settings details contribution', () => {
+    const updateValue = vi.fn()
+    render(
+      <ProjectLibrariesSettingInput
+        value={defaultLibraries}
+        updateValue={updateValue}
+        libraryTypeOptions={projectLibraryTypeOptionsFromContributions(
+          new Map([
+            [
+              'directory',
+              {
+                type: 'directory',
+                title: 'Directory',
+                defaultSetting: {
+                  title: 'Default Projects Directory',
+                  path: 'projects',
+                  type: 'directory',
+                },
+              },
+            ],
+          ])
+        )}
+      />
+    )
+
+    expect(screen.queryByTestId('project-directory-input')).toBeNull()
   })
 
   test('does not update project libraries when normalization matches the current value', () => {

--- a/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.tsx
+++ b/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.tsx
@@ -19,10 +19,16 @@ import {
 import { reportRejection } from '@src/lib/trap'
 import { toSync } from '@src/lib/utils'
 import type {
+  ProjectLibrarySettingsDetailsProps,
   ProjectLibraryTypeContribution,
-  ProjectLibraryTypePathInput,
 } from '@src/registry/contracts/projectLibraries'
-import { type DragEvent, useEffect, useRef, useState } from 'react'
+import {
+  type ComponentType,
+  type DragEvent,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 
 interface ProjectLibrariesSettingInputProps {
   value: ProjectLibrarySetting[]
@@ -36,12 +42,7 @@ export interface ProjectLibraryTypeOption {
   value: ProjectLibraryType
   defaultLibrary: ProjectLibrarySetting
   newLibrary: ProjectLibrarySetting
-  pathInput?: ProjectLibraryTypeOptionPathInput
-}
-
-interface ProjectLibraryTypeOptionPathInput
-  extends Omit<ProjectLibraryTypePathInput, 'icon'> {
-  icon: CustomIconName
+  settingsDetails: ComponentType<ProjectLibrarySettingsDetailsProps>
 }
 
 const defaultProjectLibraryTypeIcon: CustomIconName = 'folder'
@@ -56,19 +57,8 @@ function libraryTypeIconFromContribution(
   return defaultProjectLibraryTypeIcon
 }
 
-function libraryTypePathInputFromContribution(
-  pathInput: ProjectLibraryTypePathInput | undefined
-): ProjectLibraryTypeOptionPathInput | undefined {
-  if (!pathInput) {
-    return undefined
-  }
-
-  return {
-    ...pathInput,
-    icon: isCustomIconName(pathInput.icon)
-      ? pathInput.icon
-      : defaultProjectLibraryTypeIcon,
-  }
+function DefaultProjectLibrarySettingsDetails() {
+  return <></>
 }
 
 export function projectLibraryTypeOptionsFromContributions(
@@ -93,7 +83,8 @@ export function projectLibraryTypeOptionsFromContributions(
         value: libraryType.type,
         defaultLibrary: libraryType.defaultSetting ?? fallbackLibrary,
         newLibrary: libraryType.newLibrarySetting ?? fallbackLibrary,
-        pathInput: libraryTypePathInputFromContribution(libraryType.pathInput),
+        settingsDetails:
+          libraryType.settingsDetails ?? DefaultProjectLibrarySettingsDetails,
       }
     })
 }
@@ -158,6 +149,7 @@ function ProjectLibraryTypeSelect({
             path: 'projects',
             type: value,
           },
+          settingsDetails: DefaultProjectLibrarySettingsDetails,
         },
       ]
 
@@ -225,6 +217,72 @@ function ProjectLibraryTypeSelect({
         </Listbox.Options>
       </div>
     </Listbox>
+  )
+}
+
+export function DirectoryProjectLibrarySettingsDetails({
+  library,
+  index,
+  updateLibrary,
+  commitLibrary,
+  chooseDirectory,
+}: ProjectLibrarySettingsDetailsProps) {
+  async function chooseLibraryPath() {
+    if (!chooseDirectory) {
+      return
+    }
+
+    const selectedPath = await chooseDirectory({
+      defaultPath: library.path,
+      title: 'Choose a project library folder',
+    })
+    if (!selectedPath) {
+      return
+    }
+
+    commitLibrary({
+      ...library,
+      path: selectedPath,
+    })
+  }
+
+  return (
+    <div className="flex min-w-0 gap-1">
+      <input
+        value={library.path}
+        onChange={(event) =>
+          updateLibrary({
+            ...library,
+            path: event.target.value,
+          })
+        }
+        onBlur={() => commitLibrary()}
+        className="min-w-0 flex-1 rounded-sm border border-chalkboard-30 bg-transparent p-1 text-sm dark:border-chalkboard-70"
+        data-testid={
+          index === 0 ? 'project-directory-input' : 'project-library-path'
+        }
+      />
+      {chooseDirectory && (
+        <ActionButton
+          Element="button"
+          type="button"
+          tabIndex={0}
+          onClick={toSync(chooseLibraryPath, reportRejection)}
+          className="!p-0"
+          iconStart={{
+            icon: 'folder',
+            bgClassName: '!bg-transparent',
+          }}
+          data-testid={
+            index === 0
+              ? 'project-directory-button'
+              : 'project-library-folder-button'
+          }
+        >
+          <Tooltip position="top-right">Choose folder</Tooltip>
+        </ActionButton>
+      )}
+    </div>
   )
 }
 
@@ -316,18 +374,17 @@ export function ProjectLibrariesSettingInput({
     )
   }
 
-  async function choosePathWithInput(
-    pathInput: ProjectLibraryTypeOptionPathInput,
+  async function chooseDirectory({
+    defaultPath,
+    title,
+  }: {
     defaultPath?: string
-  ) {
-    if (pathInput.kind !== 'directory') {
-      return defaultPath
-    }
-
+    title?: string
+  }) {
     const result = await electron?.open({
       properties: ['openDirectory', 'createDirectory'],
       defaultPath,
-      title: pathInput.dialogTitle ?? 'Choose a project library path',
+      title: title ?? 'Choose a project library folder',
     })
 
     if (!result || result.canceled) {
@@ -344,25 +401,7 @@ export function ProjectLibrariesSettingInput({
     }
 
     const newLibrary = libraryTypeOption.newLibrary
-    const selectedPath =
-      electron && libraryTypeOption.pathInput
-        ? await choosePathWithInput(
-            libraryTypeOption.pathInput,
-            newLibrary.path
-          )
-        : newLibrary.path
-
-    if (!selectedPath) {
-      return
-    }
-
-    commit([
-      ...draftLibraries,
-      {
-        ...newLibrary,
-        path: selectedPath,
-      },
-    ])
+    commit([...draftLibraries, newLibrary])
   }
 
   function removeLibrary(index: number) {
@@ -426,33 +465,6 @@ export function ProjectLibrariesSettingInput({
     dragPreviewIdRef.current = null
   }
 
-  async function chooseLibraryPath(index: number) {
-    const library = draftLibraries[index]
-    if (!library) {
-      return
-    }
-
-    const pathInput = libraryTypeOptionForType(
-      library.type,
-      libraryTypeOptions
-    )?.pathInput
-    if (!pathInput) {
-      return
-    }
-
-    const selectedPath = await choosePathWithInput(pathInput, library.path)
-    if (!selectedPath) {
-      return
-    }
-
-    commit(
-      updateProjectLibrarySettingAt(draftLibraries, index, (library) => ({
-        ...library,
-        path: selectedPath,
-      }))
-    )
-  }
-
   return (
     <div
       className="flex flex-col gap-3"
@@ -461,10 +473,9 @@ export function ProjectLibrariesSettingInput({
       {draftLibraries.length > 0 && (
         <ul className="flex flex-col gap-2">
           {draftLibraries.map((library, index) => {
-            const pathInput = libraryTypeOptionForType(
-              library.type,
-              libraryTypeOptions
-            )?.pathInput
+            const SettingsDetails =
+              libraryTypeOptionForType(library.type, libraryTypeOptions)
+                ?.settingsDetails ?? DefaultProjectLibrarySettingsDetails
 
             return (
               <li
@@ -505,46 +516,31 @@ export function ProjectLibrariesSettingInput({
                   className="min-w-0 rounded-sm border border-chalkboard-30 bg-transparent p-1 text-sm dark:border-chalkboard-70"
                   data-testid="project-library-title"
                 />
-                <div className="flex min-w-0 gap-1">
-                  <input
-                    value={library.path}
-                    onChange={(event) =>
-                      updateDraftField(index, 'path', event.target.value)
-                    }
-                    onBlur={() => commitDraftLibrary(index)}
-                    className="min-w-0 flex-1 rounded-sm border border-chalkboard-30 bg-transparent p-1 text-sm dark:border-chalkboard-70"
-                    data-testid={
-                      index === 0
-                        ? 'project-directory-input'
-                        : 'project-library-path'
-                    }
-                  />
-                  {electron && pathInput && (
-                    <ActionButton
-                      Element="button"
-                      type="button"
-                      tabIndex={0}
-                      onClick={toSync(
-                        () => chooseLibraryPath(index),
-                        reportRejection
-                      )}
-                      className="!p-0"
-                      iconStart={{
-                        icon: pathInput.icon,
-                        bgClassName: '!bg-transparent',
-                      }}
-                      data-testid={
-                        index === 0
-                          ? 'project-directory-button'
-                          : 'project-library-folder-button'
-                      }
-                    >
-                      <Tooltip position="top-right">
-                        {pathInput.buttonLabel ?? 'Choose path'}
-                      </Tooltip>
-                    </ActionButton>
-                  )}
-                </div>
+                <SettingsDetails
+                  library={library}
+                  index={index}
+                  updateLibrary={(nextLibrary) =>
+                    setDraftLibraries((libraries) =>
+                      updateProjectLibrarySettingAt(
+                        libraries,
+                        index,
+                        () => nextLibrary
+                      )
+                    )
+                  }
+                  commitLibrary={(nextLibrary) =>
+                    commit(
+                      nextLibrary
+                        ? updateProjectLibrarySettingAt(
+                            draftLibraries,
+                            index,
+                            () => nextLibrary
+                          )
+                        : draftLibraries
+                    )
+                  }
+                  chooseDirectory={electron ? chooseDirectory : undefined}
+                />
                 <ActionButton
                   Element="button"
                   type="button"

--- a/src/registry/contracts/projectLibraries.ts
+++ b/src/registry/contracts/projectLibraries.ts
@@ -12,6 +12,7 @@ import type {
 } from '@src/lib/projectLibraries'
 import { mergeProjectLibrarySettings } from '@src/lib/projectLibraries'
 import { isArray } from '@src/lib/utils'
+import type { ComponentType } from 'react'
 
 export type ProjectLibraryContribution =
   | ProjectLibrary
@@ -62,11 +63,15 @@ export interface ProjectLibraryTypeOperations {
   deleteProject?: ProjectLibraryOperation<ProjectLibraryDeleteProjectInput>
 }
 
-export interface ProjectLibraryTypePathInput {
-  kind: 'directory'
-  icon?: string
-  dialogTitle?: string
-  buttonLabel?: string
+export interface ProjectLibrarySettingsDetailsProps {
+  library: ProjectLibrarySetting
+  index: number
+  updateLibrary: (library: ProjectLibrarySetting) => void
+  commitLibrary: (library?: ProjectLibrarySetting) => void
+  chooseDirectory?: (input: {
+    defaultPath?: string
+    title?: string
+  }) => Promise<string | undefined>
 }
 
 export interface ProjectLibraryTypeContribution {
@@ -78,8 +83,8 @@ export interface ProjectLibraryTypeContribution {
   defaultSetting?: ProjectLibrarySetting
   /** Template used when a user manually adds a new library of this type. */
   newLibrarySetting?: ProjectLibrarySetting
-  /** Optional UI behavior for editing the library path in settings. */
-  pathInput?: ProjectLibraryTypePathInput
+  /** Optional detail cell rendered in the project libraries settings row. */
+  settingsDetails?: ComponentType<ProjectLibrarySettingsDetailsProps>
   operations?: ProjectLibraryTypeOperations
   readEntries?: (input: {
     library: ProjectLibrary

--- a/src/registry/extensions/homeProjects/index.ts
+++ b/src/registry/extensions/homeProjects/index.ts
@@ -27,6 +27,7 @@ import {
   type ProjectLibrary,
   projectLibraryFromSetting,
 } from '@src/lib/projectLibraries'
+import { DirectoryProjectLibrarySettingsDetails } from '@src/lib/projectLibraries/settings/ProjectLibrariesSettingInput'
 import { reportRejection } from '@src/lib/trap'
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
 import { cloudSyncService } from '@src/registry/contracts/cloudSync'
@@ -347,12 +348,7 @@ const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
             path: 'projects',
             type: DIRECTORY_PROJECT_LIBRARY_TYPE,
           },
-          pathInput: {
-            kind: 'directory',
-            icon: 'folder',
-            dialogTitle: 'Choose a project library folder',
-            buttonLabel: 'Choose folder',
-          },
+          settingsDetails: DirectoryProjectLibrarySettingsDetails,
           readEntries: async ({ library, signal }) => {
             const projects = await readProjectsFromProjectDirectory({
               projectDirectoryPath: library.path,


### PR DESCRIPTION
## Summary
- adds a `settingsDetails` contribution point for project library types
- moves the directory library path picker into an explicit directory-type settings detail component
- keeps the shared library settings row responsible for ordering, type, title, and removal

## Why
The directory and cloud library types need different location/details UI. This keeps the common row shell consistent while letting each library type describe and edit its own storage details.

## Validation
- `npm run test:integration -- src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.spec.tsx`
- `npm run tsc -- --noEmit`
