### PR TITLE
Prompt to move legacy cloud projects into Personal Cloud

### DIFF
--- a/e2e/playwright/cloud-sync.spec.ts
+++ b/e2e/playwright/cloud-sync.spec.ts
@@ -30,6 +30,12 @@ async function expectProjectFileRoute(page: Page) {
   })
 }
 
+async function expectCloudSyncHomeReady(page: Page) {
+  await expect(
+    page.getByRole('heading', { name: /^(Project Libraries|Personal Cloud)$/ })
+  ).toBeVisible({ timeout: CLOUD_SYNC_E2E_TIMEOUT })
+}
+
 test(
   'streams remote-only projects into an empty local list and materializes opened clones',
   { tag: ['@web'] },
@@ -85,8 +91,10 @@ test(
 
     await setup(context, page, testInfo, [OPFS_CLOUD_FEATURE_FLAG])
     await page.goto('/')
-    await expect(page.getByRole('heading', { name: 'Projects' })).toBeVisible()
-    await expect(page.getByTestId('projects-none')).toBeVisible()
+    await expectCloudSyncHomeReady(page)
+    await expect(
+      page.getByTestId('project-library-empty').first()
+    ).toBeVisible()
 
     remoteListGate.release()
 
@@ -136,7 +144,7 @@ test(
     remoteListGate.hold()
 
     await page.goto('/')
-    await expect(page.getByRole('heading', { name: 'Projects' })).toBeVisible()
+    await expectCloudSyncHomeReady(page)
     await expect
       .poll(() => projectTitles(page), { timeout: CLOUD_SYNC_E2E_TIMEOUT })
       .toEqual(expect.arrayContaining(['Remote empty one']))
@@ -222,7 +230,7 @@ test(
 
     await setup(context, page, testInfo, [OPFS_CLOUD_FEATURE_FLAG])
     await page.goto('/')
-    await expect(page.getByRole('heading', { name: 'Projects' })).toBeVisible()
+    await expectCloudSyncHomeReady(page)
 
     const localOnlyFiles = {
       'main.kcl': 'localOnly = 1\n',
@@ -287,7 +295,7 @@ test(
     })
 
     await page.reload()
-    await expect(page.getByRole('heading', { name: 'Projects' })).toBeVisible()
+    await expectCloudSyncHomeReady(page)
     await expect
       .poll(() => projectTitles(page), { timeout: CLOUD_SYNC_E2E_TIMEOUT })
       .toEqual(
@@ -428,7 +436,7 @@ test(
     // project should now behave like a normal local OPFS project, so Home should
     // show it from local state without needing another remote list response.
     await page.goto('/')
-    await expect(page.getByRole('heading', { name: 'Projects' })).toBeVisible()
+    await expectCloudSyncHomeReady(page)
     await expect
       .poll(() => projectTitles(page), { timeout: CLOUD_SYNC_E2E_TIMEOUT })
       .toEqual(
@@ -465,7 +473,7 @@ test(
     // restores the Home card without restoring OPFS files until the card opens.
     remoteListGate.hold()
     await page.reload()
-    await expect(page.getByRole('heading', { name: 'Projects' })).toBeVisible()
+    await expectCloudSyncHomeReady(page)
     remoteListGate.release()
     await expect
       .poll(() => projectTitles(page), { timeout: CLOUD_SYNC_E2E_TIMEOUT })

--- a/e2e/playwright/fixtures/fixtureSetup.ts
+++ b/e2e/playwright/fixtures/fixtureSetup.ts
@@ -26,7 +26,11 @@ import { SceneFixture } from '@e2e/playwright/fixtures/sceneFixture'
 import { SignInPageFixture } from '@e2e/playwright/fixtures/signInPageFixture'
 import { ToolbarFixture } from '@e2e/playwright/fixtures/toolbarFixture'
 
-import { TEST_SETTINGS } from '@e2e/playwright/storageStates'
+import {
+  TEST_SETTINGS,
+  playwrightPluginSettings,
+  playwrightProjectLibraries,
+} from '@e2e/playwright/storageStates'
 import {
   PLAYWRIGHT_LAYOUT_SETTINGS,
   getUtils,
@@ -323,37 +327,34 @@ export class ElectronZoo {
 
     let settingsOverridesToml = ''
 
-    if (appSettings) {
-      settingsOverridesToml = settingsToToml({
-        settings: {
-          ...TEST_SETTINGS,
-          ...appSettings,
-          ...PLAYWRIGHT_LAYOUT_SETTINGS,
-          app: {
-            ...TEST_SETTINGS.app,
-            ...appSettings.app,
-          },
-          project: {
-            ...TEST_PROJECT_SETTINGS,
-            directory: this.projectDirName,
-          },
+    const appSettingsPlugins =
+      appSettings &&
+      typeof appSettings.plugins === 'object' &&
+      appSettings.plugins !== null &&
+      !isArray(appSettings.plugins)
+        ? appSettings.plugins
+        : {}
+
+    settingsOverridesToml = settingsToToml({
+      settings: {
+        ...TEST_SETTINGS,
+        ...appSettings,
+        plugins: {
+          ...playwrightPluginSettings(),
+          ...appSettingsPlugins,
         },
-      })
-    } else {
-      settingsOverridesToml = settingsToToml({
-        settings: {
-          ...TEST_SETTINGS,
-          ...PLAYWRIGHT_LAYOUT_SETTINGS,
-          app: {
-            ...TEST_SETTINGS.app,
-          },
-          project: {
-            ...TEST_PROJECT_SETTINGS,
-            directory: this.projectDirName,
-          },
+        ...PLAYWRIGHT_LAYOUT_SETTINGS,
+        app: {
+          ...TEST_SETTINGS.app,
+          libraries: playwrightProjectLibraries(this.projectDirName),
+          ...appSettings?.app,
         },
-      })
-    }
+        project: {
+          ...TEST_PROJECT_SETTINGS,
+          directory: this.projectDirName,
+        },
+      },
+    })
     await fsp.writeFile(tempSettingsFilePath, settingsOverridesToml)
   }
 }

--- a/e2e/playwright/native-file-menu.spec.ts
+++ b/e2e/playwright/native-file-menu.spec.ts
@@ -8,9 +8,6 @@ import {
 } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
 import type { Page } from '@playwright/test'
-import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
-
-test.use({ userFeatures: [OPFS_CLOUD_FEATURE_FLAG] })
 
 async function expectNewWindowMenuItem(
   nativeMenu: NativeMenuFixture,

--- a/e2e/playwright/storageStates.ts
+++ b/e2e/playwright/storageStates.ts
@@ -1,10 +1,36 @@
 import type { SaveSettingsPayload } from '@src/lib/settings/settingsTypes'
+import { PROJECT_FOLDER } from '@src/lib/constants'
 import { Themes } from '@src/lib/theme'
 import type { DeepPartial } from '@src/lib/types'
 
 import type { Settings } from '@rust/kcl-lib/bindings/Settings'
 
 export const TEST_SETTINGS_KEY = '/settings.toml'
+export const PLAYWRIGHT_PROJECT_DIRECTORY = `/documents/${PROJECT_FOLDER}`
+export const PLAYWRIGHT_PROJECT_LIBRARY_TITLE = 'Projects'
+
+export function playwrightProjectLibraries(
+  projectDirectory: string = PLAYWRIGHT_PROJECT_DIRECTORY
+) {
+  return [
+    {
+      title: PLAYWRIGHT_PROJECT_LIBRARY_TITLE,
+      path: projectDirectory,
+      type: 'directory',
+    },
+  ]
+}
+
+export function playwrightPluginSettings({
+  cloudSyncEnabled = false,
+}: {
+  cloudSyncEnabled?: boolean
+} = {}) {
+  return {
+    'cloud-sync': cloudSyncEnabled,
+  }
+}
+
 export const TEST_SETTINGS: DeepPartial<Settings> = {
   app: {
     appearance: {

--- a/e2e/playwright/test-utils.ts
+++ b/e2e/playwright/test-utils.ts
@@ -8,6 +8,7 @@ import type { Configuration } from '@src/lang/wasm'
 import {
   COOKIE_NAME_PREFIX,
   IS_PLAYWRIGHT_KEY,
+  OPFS_CLOUD_FEATURE_FLAG,
   SIDEBAR_BUTTON_SUFFIX,
   TOKEN_PERSIST_KEY,
   VERCEL_PLAYWRIGHT_TOKEN_QUERY_PARAM,
@@ -34,7 +35,13 @@ import type { ProjectConfiguration } from '@rust/kcl-lib/bindings/ProjectConfigu
 import type { CmdBarFixture } from '@e2e/playwright/fixtures/cmdBarFixture'
 import type { ElectronZoo } from '@e2e/playwright/fixtures/fixtureSetup'
 import { isErrorWhitelisted } from '@e2e/playwright/lib/console-error-whitelist'
-import { TEST_SETTINGS, TEST_SETTINGS_KEY } from '@e2e/playwright/storageStates'
+import {
+  PLAYWRIGHT_PROJECT_DIRECTORY,
+  TEST_SETTINGS,
+  TEST_SETTINGS_KEY,
+  playwrightPluginSettings,
+  playwrightProjectLibraries,
+} from '@e2e/playwright/storageStates'
 import { test } from '@e2e/playwright/zoo-test'
 import { createLayoutWithMetadata } from '@src/lib/layout'
 import { playwrightLayoutConfig } from '@src/lib/layout/configs/playwright'
@@ -975,19 +982,21 @@ export async function setup(
       settings: settingsToToml({
         settings: {
           ...TEST_SETTINGS,
+          plugins: playwrightPluginSettings({
+            cloudSyncEnabled: userFeatures.includes(OPFS_CLOUD_FEATURE_FLAG),
+          }),
           ...PLAYWRIGHT_LAYOUT_SETTINGS,
           app: {
             appearance: {
               ...TEST_SETTINGS.app?.appearance,
               theme: 'dark',
             },
+            libraries: playwrightProjectLibraries(),
             onboarding_status: 'dismissed',
           },
           project: {
             ...testProjectSettings,
-            ...(typeof testProjectSettings?.directory === 'string'
-              ? { directory: testProjectSettings.directory }
-              : {}),
+            directory: PLAYWRIGHT_PROJECT_DIRECTORY,
           },
         },
       }),

--- a/interface.d.ts
+++ b/interface.d.ts
@@ -29,6 +29,7 @@ export interface IElectronAPI {
   save: typeof dialog.showSaveDialog
   openExternal: typeof shell.openExternal
   openInNewWindow: (name: string) => void
+  openPath: typeof shell.openPath
   showInFolder: typeof shell.showItemInFolder
   pluginIpc: {
     invoke: <T>(channel: PluginIpcChannel, payload?: unknown) => Promise<T>

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -207,6 +207,7 @@ function getCloudSyncPluginSetting(app: App) {
           string,
           {
             current?: unknown
+            default?: unknown
             user?: unknown
           }
         >
@@ -439,6 +440,7 @@ describe('project system', () => {
       await expect
         .poll(() => ({
           active: getPluginToggle(app, 'cloud-sync').active.value,
+          default: getCloudSyncPluginSetting(app)?.default,
           current: getCloudSyncPluginSetting(app)?.current,
           user: getCloudSyncPluginSetting(app)?.user,
           hasPersonalCloudLibrarySetting: hasPersonalCloudLibrarySetting(app),
@@ -450,8 +452,9 @@ describe('project system', () => {
         }))
         .toEqual({
           active: true,
+          default: true,
           current: true,
-          user: true,
+          user: undefined,
           hasPersonalCloudLibrarySetting: true,
           hasPersonalCloudLibrary: true,
         })
@@ -468,6 +471,11 @@ describe('project system', () => {
       await waitForSettingsIdle(app)
       userFeatures.setFeatureIds(new Set([OPFS_CLOUD_FEATURE_FLAG]))
 
+      expect(
+        getChangedSettingsAtLevel(app.settings.get(), 'user').plugins
+      ).toEqual({
+        'cloud-sync': false,
+      })
       expect(getCloudSyncPluginSetting(app)?.current).toBe(false)
       expect(getCloudSyncPluginSetting(app)?.user).toBe(false)
       expect(getPluginToggle(app, 'cloud-sync').active.value).toBe(false)

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -500,6 +500,64 @@ describe('project system', () => {
     }
   })
 
+  it('does not recreate a deleted Personal Cloud library while cloud sync remains enabled', async () => {
+    const userFeatures = createUserFeaturesForTest(
+      new Set([OPFS_CLOUD_FEATURE_FLAG])
+    )
+    const app = createAppForTest({
+      userFeatures,
+    })
+
+    try {
+      await expect
+        .poll(() => ({
+          active: getPluginToggle(app, 'cloud-sync').active.value,
+          hasPersonalCloudLibrarySetting: hasPersonalCloudLibrarySetting(app),
+        }))
+        .toEqual({
+          active: true,
+          hasPersonalCloudLibrarySetting: true,
+        })
+
+      const defaultCloudLibrary = getDefaultCloudProjectLibrarySetting()
+      const librariesWithoutPersonalCloud = app.settings
+        .get()
+        .app.libraries.current.filter(
+          (library) =>
+            library.type !== defaultCloudLibrary.type ||
+            library.path !== defaultCloudLibrary.path
+        )
+
+      app.settings.actor.send({
+        type: 'set.app.libraries',
+        data: {
+          level: 'user',
+          value: librariesWithoutPersonalCloud,
+        },
+      })
+
+      await waitForSettingsIdle(app)
+
+      await expect
+        .poll(() => ({
+          active: getPluginToggle(app, 'cloud-sync').active.value,
+          hasPersonalCloudLibrarySetting: hasPersonalCloudLibrarySetting(app),
+          hasPersonalCloudLibrary: app.registry
+            .get(projectLibrariesValueSpec)
+            .some(
+              (library) => library.id === PERSONAL_CLOUD_PROJECT_LIBRARY_ID
+            ),
+        }))
+        .toEqual({
+          active: true,
+          hasPersonalCloudLibrarySetting: false,
+          hasPersonalCloudLibrary: false,
+        })
+    } finally {
+      app.dispose()
+    }
+  })
+
   it('selects the create project command from the app command system', async () => {
     const userFeatures = createUserFeaturesForTest(new Set())
     const app = createAppForTest({

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -229,10 +229,14 @@ function getPluginToggle(app: App, pluginId: string) {
 }
 
 function hasPersonalCloudLibrarySetting(app: App) {
+  return Boolean(getPersonalCloudLibrarySetting(app))
+}
+
+function getPersonalCloudLibrarySetting(app: App) {
   const defaultCloudLibrary = getDefaultCloudProjectLibrarySetting()
   return app.settings
     .get()
-    .app.libraries.current.some(
+    .app.libraries.current.find(
       (library) =>
         library.type === defaultCloudLibrary.type &&
         library.path === defaultCloudLibrary.path
@@ -495,6 +499,45 @@ describe('project system', () => {
       expect(getCloudSyncPluginSetting(app)?.current).toBe(false)
       expect(getCloudSyncPluginSetting(app)?.user).toBe(false)
       expect(getPluginToggle(app, 'cloud-sync').active.value).toBe(false)
+    } finally {
+      app.dispose()
+    }
+  })
+
+  it('preserves the default project library title when web materialization replaces it with Personal Cloud', async () => {
+    const userFeatures = createUserFeaturesForTest(new Set())
+    const app = createAppForTest({
+      userFeatures,
+    })
+
+    try {
+      await waitForSettingsIdle(app)
+      const projectDirectory = app.settings.get().app.projectDirectory.current
+      app.settings.actor.send({
+        type: 'set.app.libraries',
+        data: {
+          level: 'user',
+          value: [
+            {
+              title: 'Projects',
+              path: projectDirectory,
+              type: DIRECTORY_PROJECT_LIBRARY_TYPE,
+            },
+          ],
+        },
+      })
+
+      await waitForSettingsIdle(app)
+      userFeatures.setFeatureIds(new Set([OPFS_CLOUD_FEATURE_FLAG]))
+
+      await expect
+        .poll(() => getPersonalCloudLibrarySetting(app))
+        .toMatchObject({
+          title: 'Projects',
+          path: getDefaultCloudProjectLibrarySetting().path,
+          type: getDefaultCloudProjectLibrarySetting().type,
+        })
+      expect(hasDefaultDirectoryLibrarySetting(app)).toBe(false)
     } finally {
       app.dispose()
     }

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -9,6 +9,10 @@ import {
 } from '@src/lib/constants'
 import fsZds, { moduleFsViaModuleImport, StorageName } from '@src/lib/fs-zds'
 import type { Project } from '@src/lib/project'
+import {
+  PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+  getDefaultCloudProjectLibrarySetting,
+} from '@src/lib/projectLibraries'
 import { getChangedSettingsAtLevel } from '@src/lib/settings/settingsUtils'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { notifyActiveWasmInstance } from '@src/lib/wasmLifecycle'
@@ -22,6 +26,7 @@ import { commandsValueSpec } from '@src/registry/contracts/commands'
 import { engineConnectionService } from '@src/registry/contracts/engineConnection'
 import { executingEditorService } from '@src/registry/contracts/executingEditor'
 import { machineManagerService } from '@src/registry/contracts/machineManager'
+import { projectLibrariesValueSpec } from '@src/registry/contracts/projectLibraries'
 import { userFeaturesService } from '@src/registry/contracts/userFeatures'
 import { wasmPromiseValueSpec } from '@src/registry/contracts/wasm'
 import { createTestWasmRegistryItem } from '@src/unitTestUtils'
@@ -195,6 +200,43 @@ function expectedRuntimeFlags(useNewLexerParser: 'On' | 'Off') {
   })
 }
 
+function getCloudSyncPluginSetting(app: App) {
+  return (
+    app.settings.get().plugins as
+      | Record<
+          string,
+          {
+            current?: unknown
+            user?: unknown
+          }
+        >
+      | undefined
+  )?.['cloud-sync']
+}
+
+function getPluginToggle(app: App, pluginId: string) {
+  const plugin = app.registry
+    .get(pluginsValueSpec)
+    .find((plugin) => plugin.id === pluginId)
+  expect(plugin).toBeDefined()
+  if (!plugin) {
+    throw new Error(`Missing ${pluginId} plugin registry item`)
+  }
+
+  return app.registry.get(plugin.service)
+}
+
+function hasPersonalCloudLibrarySetting(app: App) {
+  const defaultCloudLibrary = getDefaultCloudProjectLibrarySetting()
+  return app.settings
+    .get()
+    .app.libraries.current.some(
+      (library) =>
+        library.type === defaultCloudLibrary.type &&
+        library.path === defaultCloudLibrary.path
+    )
+}
+
 describe('project system', () => {
   it('uses registry runtime dependencies by default', () => {
     const app = createAppForTest()
@@ -359,6 +401,78 @@ describe('project system', () => {
     } finally {
       app.dispose()
       window.electron = previousElectron
+    }
+  })
+
+  it('keeps cloud sync disabled by default without the cloud projects feature', async () => {
+    const userFeatures = createUserFeaturesForTest(new Set())
+    const app = createAppForTest({
+      userFeatures,
+    })
+
+    try {
+      await waitForSettingsIdle(app)
+
+      expect(getCloudSyncPluginSetting(app)?.current).toBe(false)
+      expect(getCloudSyncPluginSetting(app)?.user).toBeUndefined()
+      expect(getPluginToggle(app, 'cloud-sync').active.value).toBe(false)
+      expect(hasPersonalCloudLibrarySetting(app)).toBe(false)
+      expect(
+        app.registry
+          .get(projectLibrariesValueSpec)
+          .some((library) => library.id === PERSONAL_CLOUD_PROJECT_LIBRARY_ID)
+      ).toBe(false)
+    } finally {
+      app.dispose()
+    }
+  })
+
+  it('auto-enables cloud sync for feature-flagged users and materializes Personal Cloud', async () => {
+    const userFeatures = createUserFeaturesForTest(
+      new Set([OPFS_CLOUD_FEATURE_FLAG])
+    )
+    const app = createAppForTest({
+      userFeatures,
+    })
+
+    try {
+      await expect
+        .poll(() => ({
+          active: getPluginToggle(app, 'cloud-sync').active.value,
+          current: getCloudSyncPluginSetting(app)?.current,
+          user: getCloudSyncPluginSetting(app)?.user,
+          hasPersonalCloudLibrarySetting: hasPersonalCloudLibrarySetting(app),
+          hasPersonalCloudLibrary: app.registry
+            .get(projectLibrariesValueSpec)
+            .some(
+              (library) => library.id === PERSONAL_CLOUD_PROJECT_LIBRARY_ID
+            ),
+        }))
+        .toEqual({
+          active: true,
+          current: true,
+          user: true,
+          hasPersonalCloudLibrarySetting: true,
+          hasPersonalCloudLibrary: true,
+        })
+
+      app.settings.actor.send({
+        type: 'set.plugins.cloud-sync',
+        data: {
+          level: 'user',
+          value: false,
+        },
+        doNotPersist: true,
+      } as never)
+
+      await waitForSettingsIdle(app)
+      userFeatures.setFeatureIds(new Set([OPFS_CLOUD_FEATURE_FLAG]))
+
+      expect(getCloudSyncPluginSetting(app)?.current).toBe(false)
+      expect(getCloudSyncPluginSetting(app)?.user).toBe(false)
+      expect(getPluginToggle(app, 'cloud-sync').active.value).toBe(false)
+    } finally {
+      app.dispose()
     }
   })
 

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -10,6 +10,7 @@ import {
 import fsZds, { moduleFsViaModuleImport, StorageName } from '@src/lib/fs-zds'
 import type { Project } from '@src/lib/project'
 import {
+  DIRECTORY_PROJECT_LIBRARY_TYPE,
   PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
   getDefaultCloudProjectLibrarySetting,
 } from '@src/lib/projectLibraries'
@@ -238,6 +239,17 @@ function hasPersonalCloudLibrarySetting(app: App) {
     )
 }
 
+function hasDefaultDirectoryLibrarySetting(app: App) {
+  const projectDirectory = app.settings.get().app.projectDirectory.current
+  return app.settings
+    .get()
+    .app.libraries.current.some(
+      (library) =>
+        library.type === DIRECTORY_PROJECT_LIBRARY_TYPE &&
+        library.path === projectDirectory
+    )
+}
+
 describe('project system', () => {
   it('uses registry runtime dependencies by default', () => {
     const app = createAppForTest()
@@ -418,6 +430,7 @@ describe('project system', () => {
       expect(getCloudSyncPluginSetting(app)?.user).toBeUndefined()
       expect(getPluginToggle(app, 'cloud-sync').active.value).toBe(false)
       expect(hasPersonalCloudLibrarySetting(app)).toBe(false)
+      expect(hasDefaultDirectoryLibrarySetting(app)).toBe(true)
       expect(
         app.registry
           .get(projectLibrariesValueSpec)
@@ -444,6 +457,8 @@ describe('project system', () => {
           current: getCloudSyncPluginSetting(app)?.current,
           user: getCloudSyncPluginSetting(app)?.user,
           hasPersonalCloudLibrarySetting: hasPersonalCloudLibrarySetting(app),
+          hasDefaultDirectoryLibrarySetting:
+            hasDefaultDirectoryLibrarySetting(app),
           hasPersonalCloudLibrary: app.registry
             .get(projectLibrariesValueSpec)
             .some(
@@ -456,6 +471,7 @@ describe('project system', () => {
           current: true,
           user: undefined,
           hasPersonalCloudLibrarySetting: true,
+          hasDefaultDirectoryLibrarySetting: false,
           hasPersonalCloudLibrary: true,
         })
 

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -569,22 +569,26 @@ export class App implements AppSubsystems {
     return (
       snapshot.context as unknown as Record<
         string,
-        | Record<string, { current?: unknown; user?: unknown } | undefined>
+        | Record<
+            string,
+            { current?: unknown; default?: unknown; user?: unknown } | undefined
+          >
         | undefined
       >
     )[activationSetting.category]?.[activationSetting.settingName]
   }
 
   /**
-   * Product policy: Cloud sync is feature-gated, but feature-flagged users
-   * should get the plugin enabled by default until they explicitly opt out.
+   * Product policy: the cloud projects feature changes Cloud sync from opt-in
+   * to default-on for eligible users.
    *
-   * Keep the plugin's static default off so registry startup stays
-   * deterministic. Once settings and user features are both settled in the app
-   * runtime, this writes the first user-level enablement only when there is no
-   * existing user preference.
+   * This is deliberately modeled as a settings default, not as a repeated
+   * "force enable" reconciliation. With the feature flag enabled, a user who
+   * toggles Cloud sync off writes `plugins.cloud-sync = false`, which differs
+   * from the runtime default and persists through the normal settings diff
+   * path.
    */
-  private maybeEnableCloudSyncPluginForFeature = (
+  private syncCloudSyncPluginDefaultForFeature = (
     snapshot: SnapshotFrom<typeof this.settings.actor>,
     pluginActivationSettings: Map<
       string,
@@ -607,31 +611,21 @@ export class App implements AppSubsystems {
       snapshot,
       activationSetting
     )
-    if (!settingValue || settingValue.current === true) {
+    if (!settingValue || typeof settingValue.default !== 'boolean') {
       return false
     }
 
-    if (settingValue.user !== undefined) {
+    const defaultEnabled = userFeaturesContextHas(
+      this.userFeatures.actor.getSnapshot().context,
+      OPFS_CLOUD_FEATURE_FLAG,
+      false
+    )
+
+    if (settingValue.default === defaultEnabled) {
       return false
     }
 
-    if (
-      !userFeaturesContextHas(
-        this.userFeatures.actor.getSnapshot().context,
-        OPFS_CLOUD_FEATURE_FLAG,
-        false
-      )
-    ) {
-      return false
-    }
-
-    this.settings.actor.send({
-      type: `set.${activationSetting.category}.${activationSetting.settingName}`,
-      data: {
-        level: 'user',
-        value: true,
-      },
-    } as never)
+    settingValue.default = defaultEnabled
     return true
   }
 
@@ -684,7 +678,7 @@ export class App implements AppSubsystems {
    * Keep plugin runtime state aligned with the persisted settings model.
    *
    * Settings stay the source of truth. Plugin toggle services are an imperative
-   * projection of settled settings, and cloud-sync's feature-flag auto-enable
+   * projection of settled settings, and cloud-sync's feature-aware default
    * policy is applied here so plugins do not mutate settings while the registry
    * graph is being built.
    */
@@ -699,17 +693,14 @@ export class App implements AppSubsystems {
       return
     }
 
-    if (
-      this.maybeEnableCloudSyncPluginForFeature(
-        snapshot,
-        pluginActivationSettings
-      )
-    ) {
-      return
-    }
+    const cloudSyncDefaultChanged = this.syncCloudSyncPluginDefaultForFeature(
+      snapshot,
+      pluginActivationSettings
+    )
 
     const activePluginIds: string[] = []
     let shouldMaterializePersonalCloudLibrary = false
+    let shouldSyncCloudSyncRuntimePolicy = cloudSyncDefaultChanged
 
     for (const plugin of this.registry.get(pluginsValueSpec)) {
       const activationSetting = pluginActivationSettings.get(plugin.id)
@@ -747,11 +738,15 @@ export class App implements AppSubsystems {
         toggle.enable()
         if (plugin.id === CLOUD_SYNC_PLUGIN_ID && !wasActive) {
           shouldMaterializePersonalCloudLibrary = true
+          shouldSyncCloudSyncRuntimePolicy = true
         }
         continue
       }
 
       toggle.disable()
+      if (plugin.id === CLOUD_SYNC_PLUGIN_ID && wasActive) {
+        shouldSyncCloudSyncRuntimePolicy = true
+      }
     }
 
     const syncActivePlugins =
@@ -764,6 +759,9 @@ export class App implements AppSubsystems {
 
     if (shouldMaterializePersonalCloudLibrary) {
       this.materializePersonalCloudLibraryOnEnable(snapshot)
+    }
+    if (shouldSyncCloudSyncRuntimePolicy) {
+      this.syncCloudSyncRuntimePolicy()
     }
   }
 

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -24,8 +24,10 @@ import type { MachineManager } from '@src/lib/MachineManager'
 import type { Project } from '@src/lib/project'
 import {
   areProjectLibrarySettingsEqual,
+  DIRECTORY_PROJECT_LIBRARY_TYPE,
   getDefaultCloudProjectLibrarySetting,
   mergeProjectLibrarySettings,
+  type ProjectLibrarySetting,
 } from '@src/lib/projectLibraries'
 import RustContext from '@src/lib/rustContext'
 import type { SaveSettingsPayload } from '@src/lib/settings/settingsTypes'
@@ -122,6 +124,10 @@ function getZookeeperReplayFallbackFilePath(
   ].filter((path, index, paths) => paths.indexOf(path) === index)
 
   return candidates.find((path) => path && !deletedPaths.has(path))
+}
+
+function normalizeProjectLibrarySettingPath(path: string) {
+  return path.trim().replaceAll('\\', '/').replace(/\/+$/g, '')
 }
 
 // We set some of our singletons on the window for debugging and E2E tests
@@ -634,9 +640,9 @@ export class App implements AppSubsystems {
    * Cloud library row in user settings.
    *
    * This is intentionally tied to the plugin activation lifecycle instead of a
-   * plugin-side startup reconciliation pass. Users can reorder, rename, or
-   * remove the library without an always-on boot effect fighting their settings;
-   * toggling the plugin on again is the action that restores the default row.
+   * plugin-side startup reconciliation pass. Desktop keeps directory and cloud
+   * libraries side by side; web treats Personal Cloud as the canonical project
+   * library and replaces only the recognized default directory row.
    */
   private materializePersonalCloudLibraryOnEnable = (
     snapshot: SnapshotFrom<typeof this.settings.actor>
@@ -646,21 +652,54 @@ export class App implements AppSubsystems {
     }
 
     const currentLibraries = snapshot.context.app.libraries?.current ?? []
-    const defaultCloudLibrary = getDefaultCloudProjectLibrarySetting()
-    const hasDefaultCloudLibrary = currentLibraries.some(
-      (library) =>
-        library.type === defaultCloudLibrary.type &&
-        library.path === defaultCloudLibrary.path
+    const defaultDirectoryLibraryPaths = new Set(
+      [
+        snapshot.context.app.projectDirectory?.current,
+        snapshot.context.app.projectDirectory?.default,
+        ...(snapshot.context.app.libraries?.default ?? [])
+          .filter((library) => library.type === DIRECTORY_PROJECT_LIBRARY_TYPE)
+          .map((library) => library.path),
+      ]
+        .filter((path): path is string => Boolean(path?.trim()))
+        .map(normalizeProjectLibrarySettingPath)
     )
+    const defaultCloudLibrary = getDefaultCloudProjectLibrarySetting()
+    const isDefaultCloudLibrary = (library: ProjectLibrarySetting) =>
+      library.type === defaultCloudLibrary.type &&
+      library.path === defaultCloudLibrary.path
+    const shouldReplaceDirectoryLibraryOnWeb = (
+      library: ProjectLibrarySetting
+    ) =>
+      typeof window !== 'undefined' &&
+      !window.electron &&
+      library.type === DIRECTORY_PROJECT_LIBRARY_TYPE &&
+      defaultDirectoryLibraryPaths.has(
+        normalizeProjectLibrarySettingPath(library.path)
+      )
+
+    let hasPersonalCloudLibrary = false
     const nextLibraries = mergeProjectLibrarySettings(
-      currentLibraries,
-      hasDefaultCloudLibrary ? [] : [defaultCloudLibrary]
+      currentLibraries.flatMap((library) => {
+        if (isDefaultCloudLibrary(library)) {
+          hasPersonalCloudLibrary = true
+          return [library]
+        }
+
+        if (shouldReplaceDirectoryLibraryOnWeb(library)) {
+          if (hasPersonalCloudLibrary) {
+            return []
+          }
+
+          hasPersonalCloudLibrary = true
+          return [defaultCloudLibrary]
+        }
+
+        return [library]
+      }),
+      hasPersonalCloudLibrary ? [] : [defaultCloudLibrary]
     )
 
-    if (
-      hasDefaultCloudLibrary ||
-      areProjectLibrarySettingsEqual(nextLibraries, currentLibraries)
-    ) {
+    if (areProjectLibrarySettingsEqual(nextLibraries, currentLibraries)) {
       return false
     }
 

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -706,7 +706,12 @@ export class App implements AppSubsystems {
           }
 
           hasPersonalCloudLibrary = true
-          return [defaultCloudLibrary]
+          return [
+            {
+              ...defaultCloudLibrary,
+              title: library.title || defaultCloudLibrary.title,
+            },
+          ]
         }
 
         return [library]

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -229,6 +229,7 @@ export class App implements AppSubsystems {
   private lastSettings: SaveSettingsPayload
   private activeWasmInstance: ModuleType | undefined
   private unsubscribeFromActiveWasmInstance: (() => void) | undefined
+  private previousCloudSyncDesiredActive: boolean | undefined
 
   constructor(subsystems: AppSubsystems) {
     this.wasmPromise = subsystems.wasmPromise
@@ -645,13 +646,15 @@ export class App implements AppSubsystems {
    * library and replaces only the recognized default directory row.
    */
   private materializePersonalCloudLibraryOnEnable = (
-    snapshot: SnapshotFrom<typeof this.settings.actor>
+    snapshot: SnapshotFrom<typeof this.settings.actor>,
+    options: { force?: boolean } = {}
   ) => {
     if (!snapshot.matches('idle')) {
       return false
     }
 
     const currentLibraries = snapshot.context.app.libraries?.current ?? []
+    const userLibraries = snapshot.context.app.libraries?.user
     const defaultDirectoryLibraryPaths = new Set(
       [
         snapshot.context.app.projectDirectory?.current,
@@ -667,6 +670,18 @@ export class App implements AppSubsystems {
     const isDefaultCloudLibrary = (library: ProjectLibrarySetting) =>
       library.type === defaultCloudLibrary.type &&
       library.path === defaultCloudLibrary.path
+
+    if (
+      !options.force &&
+      userLibraries !== undefined &&
+      !userLibraries.some(isDefaultCloudLibrary)
+    ) {
+      // Product policy: an explicit user library list without Personal Cloud
+      // means the user removed it. Do not re-add it just because the plugin is
+      // active by default for feature-flagged users.
+      return false
+    }
+
     const shouldReplaceDirectoryLibraryOnWeb = (
       library: ProjectLibrarySetting
     ) =>
@@ -739,6 +754,7 @@ export class App implements AppSubsystems {
 
     const activePluginIds: string[] = []
     let shouldMaterializePersonalCloudLibrary = false
+    let shouldForceMaterializePersonalCloudLibrary = false
     let shouldSyncCloudSyncRuntimePolicy = cloudSyncDefaultChanged
 
     for (const plugin of this.registry.get(pluginsValueSpec)) {
@@ -763,6 +779,12 @@ export class App implements AppSubsystems {
           false
         )
       const desiredActive = settingDesiredActive && featureAllowsCloudSyncPlugin
+      if (plugin.id === CLOUD_SYNC_PLUGIN_ID) {
+        shouldForceMaterializePersonalCloudLibrary =
+          this.previousCloudSyncDesiredActive === false && desiredActive
+        this.previousCloudSyncDesiredActive = desiredActive
+      }
+
       if (desiredActive) {
         activePluginIds.push(plugin.id)
       }
@@ -797,7 +819,9 @@ export class App implements AppSubsystems {
     }
 
     if (shouldMaterializePersonalCloudLibrary) {
-      this.materializePersonalCloudLibraryOnEnable(snapshot)
+      this.materializePersonalCloudLibraryOnEnable(snapshot, {
+        force: shouldForceMaterializePersonalCloudLibrary,
+      })
     }
     if (shouldSyncCloudSyncRuntimePolicy) {
       this.syncCloudSyncRuntimePolicy()

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -22,6 +22,11 @@ import type { LayoutService } from '@src/lib/layout/types'
 import { lspService } from '@src/lang/lsp/registry/contract'
 import type { MachineManager } from '@src/lib/MachineManager'
 import type { Project } from '@src/lib/project'
+import {
+  areProjectLibrarySettingsEqual,
+  getDefaultCloudProjectLibrarySetting,
+  mergeProjectLibrarySettings,
+} from '@src/lib/projectLibraries'
 import RustContext from '@src/lib/rustContext'
 import type { SaveSettingsPayload } from '@src/lib/settings/settingsTypes'
 import {
@@ -90,6 +95,7 @@ import {
 import type { SnapshotFrom, Subscription } from 'xstate'
 import { createActor } from 'xstate'
 
+const CLOUD_SYNC_PLUGIN_ID = 'cloud-sync'
 const appCommandsSlot = new Slot()
 
 type AppRegistryOptions = {
@@ -247,6 +253,7 @@ export class App implements AppSubsystems {
     this.userFeatures.actor.subscribe(this.syncCloudSyncRuntimePolicy)
     this.userFeatures.actor.subscribe(this.syncAppCommands)
     this.userFeatures.actor.subscribe(this.syncKclRuntimeFlags)
+    this.userFeatures.actor.subscribe(this.syncPluginSettingsFromCurrent)
     this.unsubscribeFromActiveWasmInstance = onActiveWasmInstance(
       this.setActiveWasmInstance
     )
@@ -260,8 +267,9 @@ export class App implements AppSubsystems {
     this.lastSettings = getAllCurrentSettings(
       getOnlySettingsFromContext(this.settings.actor.getSnapshot().context)
     )
+    this.settings.actor.subscribe(this.syncCloudSyncRuntimePolicy)
     this.settings.actor.subscribe(this.syncPluginSettings)
-    this.syncPluginSettings(this.settings.actor.getSnapshot())
+    this.syncPluginSettingsFromCurrent()
   }
 
   /**
@@ -462,6 +470,7 @@ export class App implements AppSubsystems {
       : undefined
     const enabled =
       Boolean(token) &&
+      this.cloudSyncPluginSettingEnabled() &&
       userFeaturesContextHas(
         this.userFeatures.actor.getSnapshot().context,
         OPFS_CLOUD_FEATURE_FLAG,
@@ -473,6 +482,17 @@ export class App implements AppSubsystems {
       token,
       syncExistingLocalProjects: !window.electron,
     })
+  }
+
+  private cloudSyncPluginSettingEnabled = () => {
+    const cloudSyncSetting = (
+      this.settings.actor.getSnapshot().context as unknown as Record<
+        string,
+        Record<string, { current?: unknown } | undefined> | undefined
+      >
+    ).plugins?.[CLOUD_SYNC_PLUGIN_ID]
+
+    return cloudSyncSetting?.current === true
   }
 
   setActiveWasmInstance = (wasmInstance: ModuleType) => {
@@ -535,13 +555,138 @@ export class App implements AppSubsystems {
     ])
   }
 
+  syncPluginSettingsFromCurrent = () => {
+    this.syncPluginSettings(this.settings.actor.getSnapshot())
+  }
+
+  private getPluginActivationSettingValue = (
+    snapshot: SnapshotFrom<typeof this.settings.actor>,
+    activationSetting: {
+      category: string
+      settingName: string
+    }
+  ) => {
+    return (
+      snapshot.context as unknown as Record<
+        string,
+        | Record<string, { current?: unknown; user?: unknown } | undefined>
+        | undefined
+      >
+    )[activationSetting.category]?.[activationSetting.settingName]
+  }
+
+  /**
+   * Product policy: Cloud sync is feature-gated, but feature-flagged users
+   * should get the plugin enabled by default until they explicitly opt out.
+   *
+   * Keep the plugin's static default off so registry startup stays
+   * deterministic. Once settings and user features are both settled in the app
+   * runtime, this writes the first user-level enablement only when there is no
+   * existing user preference.
+   */
+  private maybeEnableCloudSyncPluginForFeature = (
+    snapshot: SnapshotFrom<typeof this.settings.actor>,
+    pluginActivationSettings: Map<
+      string,
+      {
+        category: string
+        settingName: string
+      }
+    >
+  ) => {
+    if (!snapshot.matches('idle')) {
+      return false
+    }
+
+    const activationSetting = pluginActivationSettings.get(CLOUD_SYNC_PLUGIN_ID)
+    if (!activationSetting) {
+      return false
+    }
+
+    const settingValue = this.getPluginActivationSettingValue(
+      snapshot,
+      activationSetting
+    )
+    if (!settingValue || settingValue.current === true) {
+      return false
+    }
+
+    if (settingValue.user !== undefined) {
+      return false
+    }
+
+    if (
+      !userFeaturesContextHas(
+        this.userFeatures.actor.getSnapshot().context,
+        OPFS_CLOUD_FEATURE_FLAG,
+        false
+      )
+    ) {
+      return false
+    }
+
+    this.settings.actor.send({
+      type: `set.${activationSetting.category}.${activationSetting.settingName}`,
+      data: {
+        level: 'user',
+        value: true,
+      },
+    } as never)
+    return true
+  }
+
+  /**
+   * Product policy: enabling Cloud sync materializes the explicit Personal
+   * Cloud library row in user settings.
+   *
+   * This is intentionally tied to the plugin activation lifecycle instead of a
+   * plugin-side startup reconciliation pass. Users can reorder, rename, or
+   * remove the library without an always-on boot effect fighting their settings;
+   * toggling the plugin on again is the action that restores the default row.
+   */
+  private materializePersonalCloudLibraryOnEnable = (
+    snapshot: SnapshotFrom<typeof this.settings.actor>
+  ) => {
+    if (!snapshot.matches('idle')) {
+      return false
+    }
+
+    const currentLibraries = snapshot.context.app.libraries?.current ?? []
+    const defaultCloudLibrary = getDefaultCloudProjectLibrarySetting()
+    const hasDefaultCloudLibrary = currentLibraries.some(
+      (library) =>
+        library.type === defaultCloudLibrary.type &&
+        library.path === defaultCloudLibrary.path
+    )
+    const nextLibraries = mergeProjectLibrarySettings(
+      currentLibraries,
+      hasDefaultCloudLibrary ? [] : [defaultCloudLibrary]
+    )
+
+    if (
+      hasDefaultCloudLibrary ||
+      areProjectLibrarySettingsEqual(nextLibraries, currentLibraries)
+    ) {
+      return false
+    }
+
+    this.settings.actor.send({
+      type: 'set.app.libraries',
+      data: {
+        level: 'user',
+        value: nextLibraries,
+      },
+    })
+    return true
+  }
+
   /**
    * Keep plugin runtime state aligned with the persisted settings model.
    *
-   * For now the settings actor is the source of truth and plugin toggle
-   * services are an imperative projection of that state. A narrower follow-up
-   * can invert this by deriving both the UI and persistence model directly from
-   * extension-owned settings state.
+   * Settings stay the source of truth. Plugin toggle services are an imperative
+   * projection of settled settings, and cloud-sync's feature-flag auto-enable
+   * policy is applied here so plugins do not mutate settings while the registry
+   * graph is being built.
    */
   syncPluginSettings = (snapshot: SnapshotFrom<typeof this.settings.actor>) => {
     const pluginActivationSettings = new Map(
@@ -549,7 +694,22 @@ export class App implements AppSubsystems {
         .get(zdsPluginActivationSettingsValueSpec)
         .map((setting) => [setting.pluginId, setting])
     )
+
+    if (!snapshot.matches('idle')) {
+      return
+    }
+
+    if (
+      this.maybeEnableCloudSyncPluginForFeature(
+        snapshot,
+        pluginActivationSettings
+      )
+    ) {
+      return
+    }
+
     const activePluginIds: string[] = []
+    let shouldMaterializePersonalCloudLibrary = false
 
     for (const plugin of this.registry.get(pluginsValueSpec)) {
       const activationSetting = pluginActivationSettings.get(plugin.id)
@@ -557,26 +717,37 @@ export class App implements AppSubsystems {
         continue
       }
 
-      const desiredActive = (
-        snapshot.context as unknown as Record<
-          string,
-          Record<string, { current: unknown } | undefined> | undefined
-        >
-      )[activationSetting.category]?.[activationSetting.settingName]?.current
-      if (typeof desiredActive !== 'boolean') {
+      const settingValue = this.getPluginActivationSettingValue(
+        snapshot,
+        activationSetting
+      )
+      const settingDesiredActive = settingValue?.current
+      if (typeof settingDesiredActive !== 'boolean') {
         continue
       }
+      const featureAllowsCloudSyncPlugin =
+        plugin.id !== CLOUD_SYNC_PLUGIN_ID ||
+        userFeaturesContextHas(
+          this.userFeatures.actor.getSnapshot().context,
+          OPFS_CLOUD_FEATURE_FLAG,
+          false
+        )
+      const desiredActive = settingDesiredActive && featureAllowsCloudSyncPlugin
       if (desiredActive) {
         activePluginIds.push(plugin.id)
       }
 
       const toggle = this.registry.get(plugin.service)
+      const wasActive = toggle.active.value
       if (toggle.active.value === desiredActive) {
         continue
       }
 
       if (desiredActive) {
         toggle.enable()
+        if (plugin.id === CLOUD_SYNC_PLUGIN_ID && !wasActive) {
+          shouldMaterializePersonalCloudLibrary = true
+        }
         continue
       }
 
@@ -589,6 +760,10 @@ export class App implements AppSubsystems {
         : undefined
     if (syncActivePlugins) {
       void syncActivePlugins(activePluginIds).catch(reportRejection)
+    }
+
+    if (shouldMaterializePersonalCloudLibrary) {
+      this.materializePersonalCloudLibraryOnEnable(snapshot)
     }
   }
 

--- a/src/lib/cloudSync/disconnect.spec.ts
+++ b/src/lib/cloudSync/disconnect.spec.ts
@@ -6,6 +6,7 @@ import {
   configureCloudSyncLocalFileSystem,
   disconnectCloudSyncProject,
   getCloudSyncProjectMetadata,
+  moveCloudSyncProjectToDirectory,
   retryCloudSync,
   setCloudSyncProjectScope,
 } from '@src/lib/cloudSync'
@@ -161,6 +162,63 @@ function createTestFs(files: Map<string, string>) {
     '/documents/Projects',
     projectPath,
   ])
+  function normalizeDirectory(path: string) {
+    const normalizedPath = normalizePath(path)
+    return normalizedPath === '/'
+      ? normalizedPath
+      : normalizedPath.replace(/\/$/g, '')
+  }
+  function copyPath(sourcePath: string, targetPath: string) {
+    const normalizedSourcePath = normalizePath(sourcePath)
+    const normalizedTargetPath = normalizePath(targetPath)
+    if (directories.has(normalizedSourcePath)) {
+      directories.add(normalizedTargetPath)
+      for (const directory of Array.from(directories)) {
+        if (!directory.startsWith(`${normalizedSourcePath}/`)) {
+          continue
+        }
+        directories.add(
+          `${normalizedTargetPath}${directory.slice(normalizedSourcePath.length)}`
+        )
+      }
+      for (const [filePath, contents] of Array.from(files)) {
+        if (!filePath.startsWith(`${normalizedSourcePath}/`)) {
+          continue
+        }
+        files.set(
+          `${normalizedTargetPath}${filePath.slice(normalizedSourcePath.length)}`,
+          contents
+        )
+      }
+      return
+    }
+
+    const contents = files.get(normalizedSourcePath)
+    if (contents === undefined) {
+      throw new Error('ENOENT')
+    }
+    directories.add(normalizeDirectory(dirname(normalizedTargetPath)))
+    files.set(normalizedTargetPath, contents)
+  }
+  function removePath(path: string) {
+    const normalizedPath = normalizePath(path)
+    for (const directory of Array.from(directories)) {
+      if (
+        directory === normalizedPath ||
+        directory.startsWith(`${normalizedPath}/`)
+      ) {
+        directories.delete(directory)
+      }
+    }
+    for (const filePath of Array.from(files.keys())) {
+      if (
+        filePath === normalizedPath ||
+        filePath.startsWith(`${normalizedPath}/`)
+      ) {
+        files.delete(filePath)
+      }
+    }
+  }
   return {
     resolve: joinPaths,
     join: joinPaths,
@@ -181,7 +239,9 @@ function createTestFs(files: Map<string, string>) {
         return Promise.reject('ENOENT')
       }
     },
-    cp: async () => undefined,
+    cp: async (sourcePath: string, targetPath: string) => {
+      copyPath(sourcePath, targetPath)
+    },
     readFile: async (
       path: string,
       options?: { encoding?: string } | string
@@ -199,7 +259,10 @@ function createTestFs(files: Map<string, string>) {
       }
       return new TextEncoder().encode(contents)
     },
-    rename: async () => undefined,
+    rename: async (sourcePath: string, targetPath: string) => {
+      copyPath(sourcePath, targetPath)
+      removePath(sourcePath)
+    },
     writeFile: async (path: string, data: Uint8Array<ArrayBuffer>) => {
       files.set(normalizePath(path), new TextDecoder().decode(data))
     },
@@ -224,11 +287,7 @@ function createTestFs(files: Map<string, string>) {
       directories.add(normalizePath(path))
       return undefined
     },
-    rm: async (path: string) => {
-      const normalizedPath = normalizePath(path)
-      directories.delete(normalizedPath)
-      files.delete(normalizedPath)
-    },
+    rm: async (path: string) => removePath(path),
     detach: async () => undefined,
     attach: async () => undefined,
   } as IZooDesignStudioFS
@@ -481,5 +540,76 @@ describe('cloud sync upload failures', () => {
       lastFailureKind: 'remote-upload-forbidden',
       lastFailure: expect.stringContaining('does not have edit access'),
     })
+  })
+})
+
+describe('moveCloudSyncProjectToDirectory', () => {
+  beforeEach(async () => {
+    await deleteSyncDatabase()
+    installFetchMock()
+    configureCloudSyncEngine({
+      enabled: true,
+      baseUrl: 'https://example.test',
+      environmentName: 'dev.zoo.dev',
+      projectDirectoryPath: '/documents/Projects',
+    })
+  })
+
+  afterEach(async () => {
+    configureCloudSyncEngine({ enabled: false })
+    vi.unstubAllGlobals()
+    await deleteSyncDatabase()
+  })
+
+  it('moves a cloud-linked local project and rewrites sync metadata', async () => {
+    const files = new Map([
+      [
+        projectTomlPath,
+        `title = "Bracket"\n\n[cloud."dev.zoo.dev"]\nproject_id = "${remoteProjectId}"\n`,
+      ],
+      [`${projectPath}/main.kcl`, 'cube(1)'],
+    ])
+    configureCloudSyncLocalFileSystem(createTestFs(files))
+    await seedLinkedProject()
+    await appendOutboxEntry({
+      projectPath,
+      kind: 'upsert',
+      targetPath: `${projectPath}/main.kcl`,
+      createdAt: '2026-07-08T12:00:00.000Z',
+    })
+
+    await expect(
+      moveCloudSyncProjectToDirectory({
+        projectPath,
+        projectDirectoryPath: '/documents/Zoo/personal',
+      })
+    ).resolves.toEqual({
+      projectPath: '/documents/Zoo/personal/bracket',
+      projectName: 'bracket',
+      remoteProjectId,
+      remoteRevision,
+    })
+
+    expect(files.has(`${projectPath}/main.kcl`)).toBe(false)
+    expect(files.get('/documents/Zoo/personal/bracket/main.kcl')).toBe(
+      'cube(1)'
+    )
+    expect(await getCloudSyncProjectMetadata(projectPath)).toBeUndefined()
+    expect(
+      await getCloudSyncProjectMetadata('/documents/Zoo/personal/bracket')
+    ).toMatchObject({
+      localProjectPath: '/documents/Zoo/personal/bracket',
+      projectName: 'bracket',
+      remoteProjectId,
+      remoteRevision,
+    })
+    expect(await getAllOutboxEntries()).toEqual([
+      expect.objectContaining({
+        projectPath: '/documents/Zoo/personal/bracket',
+        kind: 'upsert',
+        targetPath: '/documents/Zoo/personal/bracket',
+        sourcePath: projectPath,
+      }),
+    ])
   })
 })

--- a/src/lib/cloudSync/disconnect.spec.ts
+++ b/src/lib/cloudSync/disconnect.spec.ts
@@ -156,11 +156,15 @@ function createStat(mode: number, size = 0): IStat {
   }
 }
 
-function createTestFs(files: Map<string, string>) {
+function createTestFs(
+  files: Map<string, string>,
+  extraDirectories: string[] = []
+) {
   const directories = new Set([
     '/documents',
     '/documents/Projects',
     projectPath,
+    ...extraDirectories,
   ])
   function normalizeDirectory(path: string) {
     const normalizedPath = normalizePath(path)
@@ -611,5 +615,57 @@ describe('moveCloudSyncProjectToDirectory', () => {
         sourcePath: projectPath,
       }),
     ])
+  })
+
+  it('does not move a project when Personal Cloud already has the same remote project', async () => {
+    const personalCloudProjectPath = '/documents/Zoo/personal/bracket'
+    const files = new Map([
+      [
+        projectTomlPath,
+        `title = "Bracket"\n\n[cloud."dev.zoo.dev"]\nproject_id = "${remoteProjectId}"\n`,
+      ],
+      [`${projectPath}/main.kcl`, 'cube(1)'],
+      [
+        `${personalCloudProjectPath}/${PROJECT_SETTINGS_FILE_NAME}`,
+        `title = "Bracket"\n\n[cloud."dev.zoo.dev"]\nproject_id = "${remoteProjectId}"\n`,
+      ],
+      [`${personalCloudProjectPath}/main.kcl`, 'cube(2)'],
+    ])
+    configureCloudSyncLocalFileSystem(
+      createTestFs(files, [
+        '/documents/Zoo',
+        '/documents/Zoo/personal',
+        personalCloudProjectPath,
+      ])
+    )
+    await seedLinkedProject()
+    await putProjectMetadata({
+      schemaVersion: 1,
+      localProjectPath: personalCloudProjectPath,
+      projectName: 'bracket',
+      remoteProjectId,
+      remoteRevision: 'target-revision',
+      baseManifest: {
+        files: {},
+      },
+    })
+
+    await expect(
+      moveCloudSyncProjectToDirectory({
+        projectPath,
+        projectDirectoryPath: '/documents/Zoo/personal',
+      })
+    ).rejects.toThrow(
+      'Personal Cloud already has a local copy of this cloud project at /documents/Zoo/personal/bracket.'
+    )
+
+    expect(files.get(`${projectPath}/main.kcl`)).toBe('cube(1)')
+    expect(files.get(`${personalCloudProjectPath}/main.kcl`)).toBe('cube(2)')
+    expect(files.has('/documents/Zoo/personal/bracket 2/main.kcl')).toBe(false)
+    expect(await getCloudSyncProjectMetadata(projectPath)).toMatchObject({
+      localProjectPath: projectPath,
+      remoteProjectId,
+    })
+    expect(await getAllOutboxEntries()).toEqual([])
   })
 })

--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -765,6 +765,25 @@ async function uniqueProjectPath(
   return candidate
 }
 
+async function moveProjectDirectory(sourcePath: string, targetPath: string) {
+  try {
+    await localFs.rename(sourcePath, targetPath)
+    return
+  } catch (error) {
+    const code =
+      error && typeof error === 'object' && 'code' in error
+        ? error.code
+        : undefined
+    if (code !== 'EXDEV') {
+      // eslint-disable-next-line suggest-no-throw/suggest-no-throw
+      throw error
+    }
+  }
+
+  await localFs.cp(sourcePath, targetPath, { recursive: true })
+  await localFs.rm(sourcePath, { recursive: true })
+}
+
 function localProjectFromMetadata(
   metadata: ProjectMetadata
 ): CloudSyncLocalProject | undefined {
@@ -2366,6 +2385,82 @@ export async function disconnectCloudSyncProject(projectPath: string) {
     lastSyncedAt: disconnectedAt,
   })
   scheduleRemoteIndexSync(0)
+}
+
+export async function moveCloudSyncProjectToDirectory({
+  projectPath,
+  projectDirectoryPath,
+}: {
+  projectPath: string
+  projectDirectoryPath: string
+}): Promise<CloudSyncLocalProject> {
+  if (!isConfiguredForCloud()) {
+    // eslint-disable-next-line suggest-no-throw/suggest-no-throw
+    throw new Error('Cloud sync is not enabled.')
+  }
+
+  const normalizedProjectPath = normalizePathForSync(projectPath)
+  const normalizedProjectDirectoryPath =
+    normalizePathForSync(projectDirectoryPath)
+  const metadata = await bindRemoteProjectIdFromToml(
+    await getOrCreateProjectMetadata(normalizedProjectPath)
+  )
+  if (!metadata.remoteProjectId) {
+    // eslint-disable-next-line suggest-no-throw/suggest-no-throw
+    throw new Error('Only cloud-synced projects can be moved.')
+  }
+
+  if (isProjectPathInDirectory(normalizedProjectPath, projectDirectoryPath)) {
+    return {
+      projectPath: normalizedProjectPath,
+      projectName: projectNameFromPath(normalizedProjectPath),
+      remoteProjectId: metadata.remoteProjectId,
+      remoteRevision: metadata.remoteRevision,
+    }
+  }
+
+  await localFs.mkdir(normalizedProjectDirectoryPath, { recursive: true })
+  const targetProjectPath = normalizePathForSync(
+    await uniqueProjectPath(
+      normalizedProjectDirectoryPath,
+      projectNameFromPath(normalizedProjectPath)
+    )
+  )
+
+  await moveProjectDirectory(normalizedProjectPath, targetProjectPath)
+  await clearOutboxEntriesForProject(normalizedProjectPath)
+  await deleteProjectMetadata(normalizedProjectPath)
+
+  const nextMetadata = {
+    ...metadata,
+    localProjectPath: targetProjectPath,
+    projectName: projectNameFromPath(targetProjectPath),
+    tombstone: false,
+    syncExcluded: undefined,
+    lastFailure: undefined,
+  }
+  await putProjectMetadata(nextMetadata)
+  await appendOutboxEntry({
+    projectPath: targetProjectPath,
+    kind: 'upsert',
+    targetPath: targetProjectPath,
+    sourcePath: normalizedProjectPath,
+    createdAt: nowIso(),
+  })
+  updateStatus({
+    state: 'idle',
+    activeProjectPath: undefined,
+    lastFailure: undefined,
+    lastFailureAt: undefined,
+  })
+  scheduleSync(0)
+
+  return {
+    projectPath: targetProjectPath,
+    projectName: nextMetadata.projectName,
+    remoteProjectId: metadata.remoteProjectId,
+    remoteRevision: metadata.remoteRevision,
+  }
 }
 
 function attachVisibilityChangeListener() {

--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -802,12 +802,16 @@ function localProjectFromMetadata(
 async function findLocalProjectPathByRemoteProjectId(
   projectDirectory: string,
   remoteProjectId: string,
-  preferredProjectName?: string
+  preferredProjectName?: string,
+  options: { excludedProjectPath?: string } = {}
 ) {
   const candidateNames = new Set<string>()
   if (preferredProjectName) {
     candidateNames.add(preferredProjectName)
   }
+  const excludedProjectPath = options.excludedProjectPath
+    ? normalizePathForSync(options.excludedProjectPath)
+    : undefined
 
   const entries = await localFs.readdir(projectDirectory).catch((error) => {
     if (error === 'ENOENT') {
@@ -824,18 +828,31 @@ async function findLocalProjectPathByRemoteProjectId(
       continue
     }
     const candidatePath = localFs.join(projectDirectory, entry)
-    if (!(await exists(candidatePath))) {
+    const normalizedCandidatePath = normalizePathForSync(candidatePath)
+    if (normalizedCandidatePath === excludedProjectPath) {
       continue
     }
-    const candidateMetadata = await getProjectMetadata(candidatePath)
+    const stat = await localFs.stat(candidatePath).catch((error) => {
+      if (error === 'ENOENT') {
+        return undefined
+      }
+      return Promise.reject(error)
+    })
+    if (!stat || !statIsDirectory(stat)) {
+      continue
+    }
+    const candidateMetadata = await getProjectMetadata(normalizedCandidatePath)
     if (isProjectSyncExcluded(candidateMetadata)) {
       continue
     }
+    if (candidateMetadata?.remoteProjectId === remoteProjectId) {
+      return normalizedCandidatePath
+    }
     const candidateRemoteProjectId = await readProjectTomlCloudProjectId(
-      candidatePath
+      normalizedCandidatePath
     ).catch(() => undefined)
     if (candidateRemoteProjectId === remoteProjectId) {
-      return candidatePath
+      return normalizedCandidatePath
     }
   }
 
@@ -2420,6 +2437,18 @@ export async function moveCloudSyncProjectToDirectory({
   }
 
   await localFs.mkdir(normalizedProjectDirectoryPath, { recursive: true })
+  const existingTargetProjectPath = await findLocalProjectPathByRemoteProjectId(
+    normalizedProjectDirectoryPath,
+    metadata.remoteProjectId,
+    projectNameFromPath(normalizedProjectPath),
+    { excludedProjectPath: normalizedProjectPath }
+  )
+  if (existingTargetProjectPath) {
+    // eslint-disable-next-line suggest-no-throw/suggest-no-throw
+    throw new Error(
+      `Personal Cloud already has a local copy of this cloud project at ${existingTargetProjectPath}.`
+    )
+  }
   const targetProjectPath = normalizePathForSync(
     await uniqueProjectPath(
       normalizedProjectDirectoryPath,

--- a/src/lib/cloudSync/index.test.ts
+++ b/src/lib/cloudSync/index.test.ts
@@ -47,8 +47,10 @@ function readProjectFile(files: ProjectArchiveFile[], relativePath: string) {
 }
 
 describe('cloudSync sync helpers', () => {
-  it('uses a personal Zoo folder as the default cloud project directory fallback', () => {
-    expect(DEFAULT_CLOUD_PROJECT_DIRECTORY_PATH).toBe('/documents/Zoo/personal')
+  it('uses the web project directory as the default cloud project directory fallback', () => {
+    expect(DEFAULT_CLOUD_PROJECT_DIRECTORY_PATH).toBe(
+      `/documents/${PROJECT_FOLDER}`
+    )
   })
 
   it('identifies project roots beneath the personal Zoo cloud directory', () => {

--- a/src/lib/cloudSync/index.test.ts
+++ b/src/lib/cloudSync/index.test.ts
@@ -18,6 +18,7 @@ import {
   projectManifestsEqual,
   shouldCloudSyncAutoSyncLocalProject,
 } from '@src/lib/cloudSync'
+import { DEFAULT_CLOUD_PROJECT_DIRECTORY_PATH } from '@src/lib/cloudSync/paths'
 import {
   normalizeProjectArchiveFilesForCloudSync,
   projectManifestFromFiles,
@@ -46,6 +47,22 @@ function readProjectFile(files: ProjectArchiveFile[], relativePath: string) {
 }
 
 describe('cloudSync sync helpers', () => {
+  it('uses a personal Zoo folder as the default cloud project directory fallback', () => {
+    expect(DEFAULT_CLOUD_PROJECT_DIRECTORY_PATH).toBe('/documents/Zoo/personal')
+  })
+
+  it('identifies project roots beneath the personal Zoo cloud directory', () => {
+    expect(
+      getCloudSyncProjectRoot(
+        '/Users/frank/Library/CloudStorage/Zoo/personal/bracket/main.kcl'
+      )
+    ).toBe('/Users/frank/Library/CloudStorage/Zoo/personal/bracket')
+
+    expect(
+      getCloudSyncProjectRoot('/Users/frank/Library/CloudStorage/Zoo/personal')
+    ).toBeUndefined()
+  })
+
   it('identifies project roots beneath the OPFS project directory', () => {
     expect(
       getCloudSyncProjectRoot(`/documents/${PROJECT_FOLDER}/bracket/main.kcl`)

--- a/src/lib/cloudSync/legacyProjectMigration.test.ts
+++ b/src/lib/cloudSync/legacyProjectMigration.test.ts
@@ -1,4 +1,5 @@
 import {
+  getLegacyCloudProjectMigrationFailureMessage,
   getLegacyCloudLocationProjects,
   getLegacyCloudProjectMigrationSignature,
 } from '@src/lib/cloudSync/legacyProjectMigration'
@@ -77,5 +78,39 @@ describe('legacy cloud project migration helpers', () => {
         project({ remoteProjectId: 'remote-a' }),
       ])
     ).toBe('remote-a|remote-b')
+  })
+
+  it('formats single-project migration failures with the project and reason', () => {
+    expect(
+      getLegacyCloudProjectMigrationFailureMessage({
+        movedCount: 0,
+        failures: [
+          {
+            project: project({ title: 'Bracket' }),
+            reason: new Error(
+              'Personal Cloud already has a local copy of this cloud project at /documents/Zoo/personal/bracket.'
+            ),
+          },
+        ],
+      })
+    ).toBe(
+      'Could not move "Bracket" into Personal Cloud: Personal Cloud already has a local copy of this cloud project at /documents/Zoo/personal/bracket.'
+    )
+  })
+
+  it('formats partial migration failures without hiding successful moves', () => {
+    expect(
+      getLegacyCloudProjectMigrationFailureMessage({
+        movedCount: 2,
+        failures: [
+          {
+            project: project({ title: 'Bracket' }),
+            reason: 'destination already exists',
+          },
+        ],
+      })
+    ).toBe(
+      'Moved 2 cloud-synced projects, but could not move "Bracket" into Personal Cloud: destination already exists'
+    )
   })
 })

--- a/src/lib/cloudSync/legacyProjectMigration.test.ts
+++ b/src/lib/cloudSync/legacyProjectMigration.test.ts
@@ -1,0 +1,81 @@
+import {
+  getLegacyCloudLocationProjects,
+  getLegacyCloudProjectMigrationSignature,
+} from '@src/lib/cloudSync/legacyProjectMigration'
+import {
+  CLOUD_PROJECT_LIBRARY_TYPE,
+  DIRECTORY_PROJECT_LIBRARY_TYPE,
+  PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+} from '@src/lib/projectLibraries'
+import type { HomeProjectEntry } from '@src/registry/contracts/homeProjects'
+import type { ProjectLibrary } from '@src/lib/projectLibraries'
+import { describe, expect, it } from 'vitest'
+
+const libraries: ProjectLibrary[] = [
+  {
+    id: 'client-projects',
+    title: 'Client Projects',
+    path: '/projects',
+    type: DIRECTORY_PROJECT_LIBRARY_TYPE,
+  },
+  {
+    id: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+    title: 'Personal Cloud',
+    path: '/personal',
+    type: CLOUD_PROJECT_LIBRARY_TYPE,
+  },
+]
+
+function project(overrides: Partial<HomeProjectEntry> = {}): HomeProjectEntry {
+  return {
+    id: 'local:/projects/bracket',
+    source: 'both',
+    status: 'synced',
+    libraryIds: ['client-projects', PERSONAL_CLOUD_PROJECT_LIBRARY_ID],
+    name: 'bracket',
+    title: 'Bracket',
+    localProjectPath: '/projects/bracket',
+    remoteProjectId: 'remote-123',
+    readWriteAccess: true,
+    ...overrides,
+  }
+}
+
+describe('legacy cloud project migration helpers', () => {
+  it('finds cloud-linked projects inside non-cloud libraries but outside Personal Cloud', () => {
+    expect(
+      getLegacyCloudLocationProjects({
+        libraries,
+        personalCloudRoot: '/documents/Zoo/personal',
+        projects: [
+          project(),
+          project({
+            id: 'local:/documents/Zoo/personal/cloud-project',
+            localProjectPath: '/documents/Zoo/personal/cloud-project',
+            remoteProjectId: 'remote-456',
+          }),
+          project({
+            id: 'local:/projects/local-only',
+            localProjectPath: '/projects/local-only',
+            remoteProjectId: undefined,
+          }),
+          project({
+            id: 'local:/projects/conflicted',
+            localProjectPath: '/projects/conflicted',
+            remoteProjectId: 'remote-789',
+            conflict: {},
+          }),
+        ],
+      })
+    ).toEqual([project()])
+  })
+
+  it('uses remote ids to build a stable dismissal signature', () => {
+    expect(
+      getLegacyCloudProjectMigrationSignature([
+        project({ remoteProjectId: 'remote-b' }),
+        project({ remoteProjectId: 'remote-a' }),
+      ])
+    ).toBe('remote-a|remote-b')
+  })
+})

--- a/src/lib/cloudSync/legacyProjectMigration.ts
+++ b/src/lib/cloudSync/legacyProjectMigration.ts
@@ -8,6 +8,11 @@ import type { HomeProjectEntry } from '@src/registry/contracts/homeProjects'
 export const LEGACY_CLOUD_PROJECT_MIGRATION_DISMISSED_STORAGE_KEY =
   'zoo.cloudSync.legacyCloudProjectMigration.dismissed'
 
+export type LegacyCloudProjectMigrationFailure = {
+  project: Pick<HomeProjectEntry, 'localProjectPath' | 'name' | 'title'>
+  reason: unknown
+}
+
 function pathIsWithinDirectory(targetPath: string, directoryPath: string) {
   const normalizedTargetPath = normalizePathForSync(targetPath)
   const normalizedDirectoryPath = normalizePathForSync(directoryPath)
@@ -67,4 +72,76 @@ export function getLegacyCloudLocationProjects({
 
     return !pathIsWithinDirectory(project.localProjectPath, personalCloudRoot)
   })
+}
+
+function projectDisplayName(
+  project: Pick<HomeProjectEntry, 'localProjectPath' | 'name' | 'title'>
+) {
+  return project.title || project.name || project.localProjectPath || 'Project'
+}
+
+function migrationErrorMessage(error: unknown) {
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  if (typeof error === 'string') {
+    return error
+  }
+
+  if (error && typeof error === 'object') {
+    const message = (error as { message?: unknown }).message
+    if (typeof message === 'string') {
+      return message
+    }
+
+    try {
+      const serialized = JSON.stringify(error)
+      if (serialized && serialized !== '{}') {
+        return serialized
+      }
+    } catch {
+      // Fall through to the generic message for non-serializable values.
+    }
+  }
+
+  return 'Unknown error'
+}
+
+function cloudSyncedProjectCount(count: number) {
+  return `${count} cloud-synced project${count === 1 ? '' : 's'}`
+}
+
+export function getLegacyCloudProjectMigrationFailureMessage({
+  movedCount,
+  failures,
+}: {
+  movedCount: number
+  failures: readonly LegacyCloudProjectMigrationFailure[]
+}) {
+  const firstFailure = failures[0]
+  if (!firstFailure) {
+    return ''
+  }
+
+  const reason = migrationErrorMessage(firstFailure.reason)
+
+  if (failures.length === 1) {
+    const projectName = projectDisplayName(firstFailure.project)
+    if (movedCount > 0) {
+      return `Moved ${cloudSyncedProjectCount(
+        movedCount
+      )}, but could not move "${projectName}" into Personal Cloud: ${reason}`
+    }
+
+    return `Could not move "${projectName}" into Personal Cloud: ${reason}`
+  }
+
+  if (movedCount > 0) {
+    return `Moved ${cloudSyncedProjectCount(
+      movedCount
+    )}, but could not move ${failures.length} others into Personal Cloud. First failure: ${reason}`
+  }
+
+  return `Could not move ${failures.length} cloud-synced projects into Personal Cloud. First failure: ${reason}`
 }

--- a/src/lib/cloudSync/legacyProjectMigration.ts
+++ b/src/lib/cloudSync/legacyProjectMigration.ts
@@ -1,0 +1,70 @@
+import { normalizePathForSync } from '@src/lib/cloudSync/paths'
+import {
+  CLOUD_PROJECT_LIBRARY_TYPE,
+  type ProjectLibrary,
+} from '@src/lib/projectLibraries'
+import type { HomeProjectEntry } from '@src/registry/contracts/homeProjects'
+
+export const LEGACY_CLOUD_PROJECT_MIGRATION_DISMISSED_STORAGE_KEY =
+  'zoo.cloudSync.legacyCloudProjectMigration.dismissed'
+
+function pathIsWithinDirectory(targetPath: string, directoryPath: string) {
+  const normalizedTargetPath = normalizePathForSync(targetPath)
+  const normalizedDirectoryPath = normalizePathForSync(directoryPath)
+
+  return (
+    normalizedTargetPath === normalizedDirectoryPath ||
+    normalizedTargetPath.startsWith(`${normalizedDirectoryPath}/`)
+  )
+}
+
+export function getLegacyCloudProjectMigrationSignature(
+  projects: readonly HomeProjectEntry[]
+) {
+  return projects
+    .map((project) => project.remoteProjectId ?? project.localProjectPath)
+    .filter((id): id is string => Boolean(id))
+    .toSorted()
+    .join('|')
+}
+
+export function getLegacyCloudLocationProjects({
+  projects,
+  libraries,
+  personalCloudRoot,
+}: {
+  projects: readonly HomeProjectEntry[]
+  libraries: readonly ProjectLibrary[]
+  personalCloudRoot: string | undefined
+}) {
+  if (!personalCloudRoot) {
+    return []
+  }
+
+  const directoryLibraryIds = new Set(
+    libraries
+      .filter((library) => library.type !== CLOUD_PROJECT_LIBRARY_TYPE)
+      .map((library) => library.id)
+  )
+
+  return projects.filter((project) => {
+    if (
+      !project.remoteProjectId ||
+      !project.localProjectPath ||
+      project.conflict ||
+      !project.libraryIds
+    ) {
+      return false
+    }
+
+    if (
+      !project.libraryIds.some((libraryId) =>
+        directoryLibraryIds.has(libraryId)
+      )
+    ) {
+      return false
+    }
+
+    return !pathIsWithinDirectory(project.localProjectPath, personalCloudRoot)
+  })
+}

--- a/src/lib/cloudSync/paths.ts
+++ b/src/lib/cloudSync/paths.ts
@@ -7,8 +7,7 @@ export const CLOUD_PROJECT_LIBRARY_FOLDER = 'Zoo'
 export const PERSONAL_CLOUD_PROJECT_LIBRARY_FOLDER = 'personal'
 export const DEFAULT_CLOUD_PROJECT_DIRECTORY_PATH = `/${webSafeJoin([
   'documents',
-  CLOUD_PROJECT_LIBRARY_FOLDER,
-  PERSONAL_CLOUD_PROJECT_LIBRARY_FOLDER,
+  PROJECT_FOLDER,
 ])}`
 
 export async function getDefaultCloudProjectDirectoryPath() {
@@ -22,6 +21,14 @@ export async function getDefaultCloudProjectDirectoryPath() {
       )
     } catch {
       // Fall back to the cross-platform documents location below.
+    }
+  }
+
+  if (typeof window !== 'undefined' && !window.electron) {
+    try {
+      return fsZds.join(await fsZds.getPath('documents'), PROJECT_FOLDER)
+    } catch {
+      return DEFAULT_CLOUD_PROJECT_DIRECTORY_PATH
     }
   }
 

--- a/src/lib/cloudSync/paths.ts
+++ b/src/lib/cloudSync/paths.ts
@@ -3,14 +3,34 @@ import fsZds from '@src/lib/fs-zds'
 import { webSafeJoin, webSafePathSplit } from '@src/lib/pathUtils'
 
 export const INTERNAL_OPFS_META_FILE = '._meta'
+export const CLOUD_PROJECT_LIBRARY_FOLDER = 'Zoo'
+export const PERSONAL_CLOUD_PROJECT_LIBRARY_FOLDER = 'personal'
 export const DEFAULT_CLOUD_PROJECT_DIRECTORY_PATH = `/${webSafeJoin([
   'documents',
-  PROJECT_FOLDER,
+  CLOUD_PROJECT_LIBRARY_FOLDER,
+  PERSONAL_CLOUD_PROJECT_LIBRARY_FOLDER,
 ])}`
 
 export async function getDefaultCloudProjectDirectoryPath() {
+  if (typeof window !== 'undefined' && window.electron?.os.isMac) {
+    try {
+      return fsZds.join(
+        fsZds.dirname(await fsZds.getPath('appData')),
+        'CloudStorage',
+        CLOUD_PROJECT_LIBRARY_FOLDER,
+        PERSONAL_CLOUD_PROJECT_LIBRARY_FOLDER
+      )
+    } catch {
+      // Fall back to the cross-platform documents location below.
+    }
+  }
+
   try {
-    return fsZds.join(await fsZds.getPath('documents'), PROJECT_FOLDER)
+    return fsZds.join(
+      await fsZds.getPath('documents'),
+      CLOUD_PROJECT_LIBRARY_FOLDER,
+      PERSONAL_CLOUD_PROJECT_LIBRARY_FOLDER
+    )
   } catch {
     return DEFAULT_CLOUD_PROJECT_DIRECTORY_PATH
   }
@@ -31,20 +51,39 @@ export function normalizeRelativePath(relativePath: string) {
     .replace(/^(?:\.\/)+/g, '')
 }
 
+function getProjectRootFromProjectDirectoryParts(
+  parts: readonly string[],
+  projectDirectoryParts: readonly string[]
+) {
+  const maxStartIndex = parts.length - projectDirectoryParts.length - 1
+  for (let index = maxStartIndex; index >= 0; index -= 1) {
+    const isMatch = projectDirectoryParts.every(
+      (part, offset) => parts[index + offset] === part
+    )
+    if (!isMatch) {
+      continue
+    }
+
+    return `/${webSafeJoin(
+      parts.slice(0, index + projectDirectoryParts.length + 1)
+    )}`
+  }
+
+  return undefined
+}
+
 export function getCloudSyncProjectRoot(
   targetPath: string
 ): string | undefined {
   const normalized = normalizePathForSync(targetPath)
   const parts = webSafePathSplit(normalized).filter(Boolean)
-  const projectDirectoryIndex = parts.lastIndexOf(PROJECT_FOLDER)
-  if (
-    projectDirectoryIndex === -1 ||
-    parts.length <= projectDirectoryIndex + 1
-  ) {
-    return undefined
-  }
-
-  return `/${webSafeJoin(parts.slice(0, projectDirectoryIndex + 2))}`
+  return (
+    getProjectRootFromProjectDirectoryParts(parts, [PROJECT_FOLDER]) ??
+    getProjectRootFromProjectDirectoryParts(parts, [
+      CLOUD_PROJECT_LIBRARY_FOLDER,
+      PERSONAL_CLOUD_PROJECT_LIBRARY_FOLDER,
+    ])
+  )
 }
 
 export function isProjectRootPath(targetPath: string, projectRoot: string) {
@@ -53,5 +92,13 @@ export function isProjectRootPath(targetPath: string, projectRoot: string) {
 
 export function isCloudSyncProjectDirectoryPath(targetPath: string) {
   const normalized = normalizePathForSync(targetPath)
-  return normalized.endsWith(`/${PROJECT_FOLDER}`)
+  return (
+    normalized.endsWith(`/${PROJECT_FOLDER}`) ||
+    normalized.endsWith(
+      `/${webSafeJoin([
+        CLOUD_PROJECT_LIBRARY_FOLDER,
+        PERSONAL_CLOUD_PROJECT_LIBRARY_FOLDER,
+      ])}`
+    )
+  )
 }

--- a/src/lib/cloudSync/paths.ts
+++ b/src/lib/cloudSync/paths.ts
@@ -1,7 +1,20 @@
 import { PROJECT_FOLDER } from '@src/lib/constants'
+import fsZds from '@src/lib/fs-zds'
 import { webSafeJoin, webSafePathSplit } from '@src/lib/pathUtils'
 
 export const INTERNAL_OPFS_META_FILE = '._meta'
+export const DEFAULT_CLOUD_PROJECT_DIRECTORY_PATH = `/${webSafeJoin([
+  'documents',
+  PROJECT_FOLDER,
+])}`
+
+export async function getDefaultCloudProjectDirectoryPath() {
+  try {
+    return fsZds.join(await fsZds.getPath('documents'), PROJECT_FOLDER)
+  } catch {
+    return DEFAULT_CLOUD_PROJECT_DIRECTORY_PATH
+  }
+}
 
 export function normalizePathForSync(targetPath: string) {
   const normalized = targetPath.replaceAll('\\', '/')

--- a/src/lib/cloudSync/registry/contract.ts
+++ b/src/lib/cloudSync/registry/contract.ts
@@ -27,6 +27,13 @@ export type CloudSyncRegistryService = {
    * The local project is marked excluded so later edits do not recreate it.
    */
   disconnectProjectSync: (projectPath: string) => Promise<void>
+  /**
+   * Move an already cloud-linked local project into the canonical Personal
+   * Cloud library storage location.
+   */
+  moveProjectToPersonalCloudLibrary: (
+    projectPath: string
+  ) => Promise<CloudSyncLocalProject>
   ensureProjectLocallySynced: (
     remoteProjectId: string
   ) => Promise<CloudSyncLocalProject | undefined>

--- a/src/lib/cloudSync/registry/extension.ts
+++ b/src/lib/cloudSync/registry/extension.ts
@@ -14,11 +14,13 @@ import {
   getCloudSyncProjectModifiedTime,
   getCloudSyncRemoteProjectThumbnailUrl,
   installCloudSyncFileSystemObserver,
+  moveCloudSyncProjectToDirectory,
   resolveCloudSyncProjectConflict,
   retryCloudSync,
   setCloudSyncProjectScope,
   startCloudSyncProject,
 } from '@src/lib/cloudSync'
+import { getDefaultCloudProjectDirectoryPath } from '@src/lib/cloudSync/paths'
 import {
   type CloudSyncRegistryService,
   cloudSyncService,
@@ -74,6 +76,13 @@ export const cloudSyncExtension = defineRegistryItemFactory((ctx) => {
     setProjectScope: setCloudSyncProjectScope,
     startProjectSync: startCloudSyncProject,
     disconnectProjectSync: disconnectCloudSyncProject,
+    moveProjectToPersonalCloudLibrary: (projectPath) =>
+      getDefaultCloudProjectDirectoryPath().then((projectDirectoryPath) =>
+        moveCloudSyncProjectToDirectory({
+          projectPath,
+          projectDirectoryPath,
+        })
+      ),
     ensureProjectLocallySynced: ensureCloudProjectLocallySynced,
     getProjectMetadata: getCloudSyncProjectMetadata,
     getProjectMetadataIndex: getCloudSyncProjectMetadataIndex,

--- a/src/lib/cloudSync/registry/extension.ts
+++ b/src/lib/cloudSync/registry/extension.ts
@@ -38,7 +38,7 @@ export const cloudSyncExtension = defineRegistryItemFactory((ctx) => {
   const applyRuntimePolicy = () => {
     const currentSettings = settings.value?.current.value
     const cloudSyncPluginEnabled =
-      currentSettings?.plugins?.[CLOUD_SYNC_PLUGIN_ID]?.current !== false
+      currentSettings?.plugins?.[CLOUD_SYNC_PLUGIN_ID]?.current === true
     const nextConfig = {
       ...runtimeConfig.value,
       enabled: runtimeConfig.value.enabled && cloudSyncPluginEnabled,

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -76,6 +76,7 @@ const projectWellFormed = {
 } satisfies Project
 
 const CLOUD_SYNC_PLUGIN_ID = 'cloud-sync'
+const originalElectron = window.electron
 
 type TestSettings = {
   app: {
@@ -228,6 +229,7 @@ function createProjectMenuApp(cloudSync: CloudSyncRegistryService) {
 }
 
 afterEach(() => {
+  window.electron = originalElectron
   cloudSyncStatus.value = {
     enabled: false,
     state: 'disabled',
@@ -413,6 +415,54 @@ describe('cloud sync project library', () => {
           order: 1,
         }),
       ])
+    } finally {
+      registry[Symbol.dispose]()
+    }
+  })
+
+  test('reveals the resolved local storage path from settings details', async () => {
+    const registry = new Registry()
+    const showInFolder = vi.fn()
+    vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue('Electron')
+    window.electron = {
+      os: {
+        isMac: true,
+      },
+      showInFolder,
+    } as unknown as Window['electron']
+
+    registry.configure([cloudSyncPlugin])
+
+    try {
+      enableCloudSyncPlugin(registry)
+      const cloudLibraryType = registry
+        .get(projectLibraryTypesValueSpec)
+        .get(CLOUD_PROJECT_LIBRARY_TYPE)
+      expect(cloudLibraryType?.settingsDetails).toBeDefined()
+      const SettingsDetails = cloudLibraryType?.settingsDetails
+      if (!SettingsDetails) {
+        return
+      }
+
+      render(
+        <SettingsDetails
+          library={getDefaultCloudProjectLibrarySetting()}
+          index={0}
+          updateLibrary={vi.fn()}
+          commitLibrary={vi.fn()}
+        />
+      )
+
+      const revealButton = await screen.findByRole('button', {
+        name: 'Show in Finder',
+      })
+      await waitFor(() => expect(revealButton).not.toBeDisabled())
+
+      fireEvent.click(revealButton)
+
+      expect(showInFolder).toHaveBeenCalledWith(
+        expect.stringMatching(/Zoo.*personal/)
+      )
     } finally {
       registry[Symbol.dispose]()
     }

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -14,8 +14,8 @@ import {
 } from '@src/lib/cloudSync/registry/plugin'
 import type { Project } from '@src/lib/project'
 import {
-  CLOUD_PROJECT_LIBRARY_ID,
   CLOUD_PROJECT_LIBRARY_TYPE,
+  PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
   getDefaultCloudProjectLibrarySetting,
   type ProjectLibrarySetting,
 } from '@src/lib/projectLibraries'
@@ -321,8 +321,8 @@ describe('cloud sync project library', () => {
       })
       expect(registry.get(projectLibrariesValueSpec)).toEqual([
         expect.objectContaining({
-          id: CLOUD_PROJECT_LIBRARY_ID,
-          title: 'Cloud',
+          id: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+          title: 'Personal Cloud',
           path: getDefaultCloudProjectLibrarySetting().path,
           type: CLOUD_PROJECT_LIBRARY_TYPE,
           icon: 'network',
@@ -435,7 +435,7 @@ describe('cloud sync home project entries', () => {
           expect.objectContaining({
             source: 'remote',
             status: 'cloud-only',
-            libraryIds: [CLOUD_PROJECT_LIBRARY_ID],
+            libraryIds: [PERSONAL_CLOUD_PROJECT_LIBRARY_ID],
             name: 'Remote title',
             title: 'Remote title',
             remoteProjectId: 'remote-123',

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -170,6 +170,19 @@ function createSettingsService({
   }
 }
 
+function enableCloudSyncPlugin(registry: Registry) {
+  const plugin = registry
+    .get(pluginsValueSpec)
+    .find((plugin) => plugin.id === CLOUD_SYNC_PLUGIN_ID)
+  const pluginService = plugin?.service
+  expect(pluginService).toBeDefined()
+  if (!pluginService) {
+    return
+  }
+
+  registry.get(pluginService).enable()
+}
+
 function createProjectMenuApp(cloudSync: CloudSyncRegistryService) {
   const registry = new Registry()
   const cloudSyncServiceExtension = defineRegistryItem({
@@ -177,6 +190,7 @@ function createProjectMenuApp(cloudSync: CloudSyncRegistryService) {
     providesServices: [provideService(cloudSyncService, cloudSync)],
   })
   registry.configure([cloudSyncServiceExtension, cloudSyncPlugin])
+  enableCloudSyncPlugin(registry)
   const commandsActor = createActor(
     createMachine({
       context: {
@@ -310,6 +324,26 @@ describe('cloud sync project library', () => {
     registry.configure([cloudSyncPlugin])
 
     try {
+      const plugin = registry
+        .get(pluginsValueSpec)
+        .find((plugin) => plugin.id === CLOUD_SYNC_PLUGIN_ID)
+      const pluginService = plugin?.service
+      expect(pluginService).toBeDefined()
+      if (!pluginService) {
+        return
+      }
+
+      const pluginToggle = registry.get(pluginService)
+      expect(pluginToggle.active.value).toBe(false)
+      expect(
+        registry
+          .get(projectLibraryTypesValueSpec)
+          .has(CLOUD_PROJECT_LIBRARY_TYPE)
+      ).toBe(false)
+      expect(registry.get(projectLibrariesValueSpec)).toEqual([])
+
+      pluginToggle.enable()
+
       expect(
         registry
           .get(projectLibraryTypesValueSpec)
@@ -329,16 +363,7 @@ describe('cloud sync project library', () => {
         }),
       ])
 
-      const plugin = registry
-        .get(pluginsValueSpec)
-        .find((plugin) => plugin.id === CLOUD_SYNC_PLUGIN_ID)
-      const pluginService = plugin?.service
-      expect(pluginService).toBeDefined()
-      if (!pluginService) {
-        return
-      }
-
-      registry.get(pluginService).disable()
+      pluginToggle.disable()
 
       expect(
         registry
@@ -371,6 +396,17 @@ describe('cloud sync project library', () => {
     registry.configure([settingsExtension, cloudSyncPlugin])
 
     try {
+      const plugin = registry
+        .get(pluginsValueSpec)
+        .find((plugin) => plugin.id === CLOUD_SYNC_PLUGIN_ID)
+      const pluginService = plugin?.service
+      expect(pluginService).toBeDefined()
+      if (!pluginService) {
+        return
+      }
+
+      registry.get(pluginService).enable()
+
       expect(registry.get(projectLibrariesValueSpec)).toEqual([
         expect.objectContaining({
           id: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
@@ -382,7 +418,7 @@ describe('cloud sync project library', () => {
     }
   })
 
-  test('adds the default cloud library to user settings when enabled', async () => {
+  test('does not mutate project library settings from plugin activation', async () => {
     const registry = new Registry()
     const settings = createSettingsService({})
     const settingsExtension = defineRegistryItem({
@@ -393,38 +429,19 @@ describe('cloud sync project library', () => {
     registry.configure([settingsExtension, cloudSyncPlugin])
 
     try {
-      registry.get(projectLibraryTypesValueSpec)
-      await waitFor(() =>
-        expect(settings.send).toHaveBeenCalledWith({
-          type: 'set.app.libraries',
-          data: {
-            level: 'user',
-            value: [getDefaultCloudProjectLibrarySetting()],
-          },
-        })
-      )
-      expect(settings.settingsSignal.value.app.libraries.current).toEqual([
-        getDefaultCloudProjectLibrarySetting(),
-      ])
-    } finally {
-      registry[Symbol.dispose]()
-    }
-  })
+      const plugin = registry
+        .get(pluginsValueSpec)
+        .find((plugin) => plugin.id === CLOUD_SYNC_PLUGIN_ID)
+      const pluginService = plugin?.service
+      expect(pluginService).toBeDefined()
+      if (!pluginService) {
+        return
+      }
 
-  test('does not add the default cloud library when settings disable the plugin', async () => {
-    const registry = new Registry()
-    const settings = createSettingsService({ cloudSyncEnabled: false })
-    const settingsExtension = defineRegistryItem({
-      id: 'test-settings-service',
-      providesServices: [provideService(settingsService, settings.service)],
-    })
-
-    registry.configure([settingsExtension, cloudSyncPlugin])
-
-    try {
-      registry.get(projectLibraryTypesValueSpec)
+      registry.get(pluginService).enable()
       await Promise.resolve()
       await Promise.resolve()
+
       expect(settings.send).not.toHaveBeenCalled()
       expect(settings.settingsSignal.value.app.libraries.current).toEqual([])
     } finally {
@@ -459,6 +476,7 @@ describe('cloud sync home project entries', () => {
     })
 
     registry.configure([cloudSyncServiceExtension, cloudSyncPlugin])
+    enableCloudSyncPlugin(registry)
 
     try {
       await waitFor(() =>
@@ -525,6 +543,7 @@ describe('cloud sync home project entries', () => {
     })
 
     registry.configure([cloudSyncServiceExtension, cloudSyncPlugin])
+    enableCloudSyncPlugin(registry)
 
     try {
       await waitFor(() =>
@@ -592,6 +611,7 @@ describe('cloud sync home project entries', () => {
     })
 
     registry.configure([cloudSyncServiceExtension, cloudSyncPlugin])
+    enableCloudSyncPlugin(registry)
 
     try {
       await waitFor(() =>

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -424,6 +424,17 @@ describe('cloud sync project library', () => {
   test('opens the resolved local storage path from settings details', async () => {
     const registry = new Registry()
     const openPath = vi.fn().mockResolvedValue('')
+    vi.spyOn(fsZds, 'getPath').mockImplementation(async (pathType) => {
+      if (pathType === 'appData') {
+        return '/Users/frank/Library/Application Support/dev.zoo.modeling-app'
+      }
+
+      return '/documents'
+    })
+    vi.spyOn(fsZds, 'dirname').mockReturnValue('/Users/frank/Library')
+    vi.spyOn(fsZds, 'join').mockImplementation((...parts) =>
+      parts.reduce((path, part) => `${path}/${part}`)
+    )
     const mkdir = vi.spyOn(fsZds, 'mkdir').mockResolvedValue(undefined)
     vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue('Electron')
     window.electron = {

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -105,6 +105,11 @@ function createCloudSyncService(): CloudSyncRegistryService {
     setProjectScope: vi.fn(),
     startProjectSync: vi.fn().mockResolvedValue(undefined),
     disconnectProjectSync: vi.fn().mockResolvedValue(undefined),
+    moveProjectToPersonalCloudLibrary: vi.fn().mockResolvedValue({
+      projectPath: '/some/path/local-project',
+      projectName: 'local-project',
+      remoteProjectId: 'remote-123',
+    }),
     ensureProjectLocallySynced: vi.fn().mockResolvedValue(undefined),
     getRemoteProjectThumbnailUrl: vi.fn().mockResolvedValue(undefined),
     getProjectMetadata: vi.fn().mockResolvedValue(undefined),

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -361,15 +361,7 @@ describe('cloud sync project library', () => {
         icon: 'network',
         defaultSetting: getDefaultCloudProjectLibrarySetting(),
       })
-      expect(registry.get(projectLibrariesValueSpec)).toEqual([
-        expect.objectContaining({
-          id: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
-          title: 'Personal Cloud',
-          path: getDefaultCloudProjectLibrarySetting().path,
-          type: CLOUD_PROJECT_LIBRARY_TYPE,
-          icon: 'network',
-        }),
-      ])
+      expect(registry.get(projectLibrariesValueSpec)).toEqual([])
 
       pluginToggle.disable()
 
@@ -421,6 +413,46 @@ describe('cloud sync project library', () => {
           order: 1,
         }),
       ])
+    } finally {
+      registry[Symbol.dispose]()
+    }
+  })
+
+  test('does not contribute Personal Cloud after it is removed from settings', () => {
+    const registry = new Registry()
+    const settings = createSettingsService({
+      libraries: [getDefaultCloudProjectLibrarySetting()],
+    })
+    const settingsExtension = defineRegistryItem({
+      id: 'test-settings-service',
+      providesServices: [provideService(settingsService, settings.service)],
+    })
+
+    registry.configure([settingsExtension, cloudSyncPlugin])
+
+    try {
+      const plugin = registry
+        .get(pluginsValueSpec)
+        .find((plugin) => plugin.id === CLOUD_SYNC_PLUGIN_ID)
+      const pluginService = plugin?.service
+      expect(pluginService).toBeDefined()
+      if (!pluginService) {
+        return
+      }
+
+      registry.get(pluginService).enable()
+      expect(registry.get(projectLibrariesValueSpec)).toEqual([
+        expect.objectContaining({
+          id: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+        }),
+      ])
+
+      settings.send({
+        type: 'set.app.libraries',
+        data: { value: [] },
+      })
+
+      expect(registry.get(projectLibrariesValueSpec)).toEqual([])
     } finally {
       registry[Symbol.dispose]()
     }

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -12,6 +12,7 @@ import {
   cloudSyncPlugin,
   getCloudSyncStatusBarPresentation,
 } from '@src/lib/cloudSync/registry/plugin'
+import fsZds from '@src/lib/fs-zds'
 import type { Project } from '@src/lib/project'
 import {
   CLOUD_PROJECT_LIBRARY_TYPE,
@@ -420,15 +421,16 @@ describe('cloud sync project library', () => {
     }
   })
 
-  test('reveals the resolved local storage path from settings details', async () => {
+  test('opens the resolved local storage path from settings details', async () => {
     const registry = new Registry()
-    const showInFolder = vi.fn()
+    const openPath = vi.fn().mockResolvedValue('')
+    const mkdir = vi.spyOn(fsZds, 'mkdir').mockResolvedValue(undefined)
     vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue('Electron')
     window.electron = {
       os: {
         isMac: true,
       },
-      showInFolder,
+      openPath,
     } as unknown as Window['electron']
 
     registry.configure([cloudSyncPlugin])
@@ -460,8 +462,16 @@ describe('cloud sync project library', () => {
 
       fireEvent.click(revealButton)
 
-      expect(showInFolder).toHaveBeenCalledWith(
-        expect.stringMatching(/Zoo.*personal/)
+      await waitFor(() =>
+        expect(openPath).toHaveBeenCalledWith(
+          expect.stringMatching(/Zoo.*personal/)
+        )
+      )
+      expect(mkdir).toHaveBeenCalledWith(
+        expect.stringMatching(/Zoo.*personal/),
+        {
+          recursive: true,
+        }
       )
     } finally {
       registry[Symbol.dispose]()

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -351,6 +351,37 @@ describe('cloud sync project library', () => {
     }
   })
 
+  test('preserves configured personal cloud library order', () => {
+    const registry = new Registry()
+    const settings = createSettingsService({
+      libraries: [
+        {
+          title: 'Directory',
+          path: '/projects',
+          type: 'directory',
+        },
+        getDefaultCloudProjectLibrarySetting(),
+      ],
+    })
+    const settingsExtension = defineRegistryItem({
+      id: 'test-settings-service',
+      providesServices: [provideService(settingsService, settings.service)],
+    })
+
+    registry.configure([settingsExtension, cloudSyncPlugin])
+
+    try {
+      expect(registry.get(projectLibrariesValueSpec)).toEqual([
+        expect.objectContaining({
+          id: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+          order: 1,
+        }),
+      ])
+    } finally {
+      registry[Symbol.dispose]()
+    }
+  })
+
   test('adds the default cloud library to user settings when enabled', async () => {
     const registry = new Registry()
     const settings = createSettingsService({})

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -1,5 +1,6 @@
 import {
   defineRegistryItem,
+  pluginsValueSpec,
   provideService,
   Registry,
 } from '@kittycad/registry'
@@ -12,9 +13,23 @@ import {
   getCloudSyncStatusBarPresentation,
 } from '@src/lib/cloudSync/registry/plugin'
 import type { Project } from '@src/lib/project'
+import {
+  CLOUD_PROJECT_LIBRARY_ID,
+  CLOUD_PROJECT_LIBRARY_TYPE,
+  getDefaultCloudProjectLibrarySetting,
+  type ProjectLibrarySetting,
+} from '@src/lib/projectLibraries'
 import type { CloudSyncRegistryService } from '@src/registry/contracts/cloudSync'
 import { cloudSyncService } from '@src/registry/contracts/cloudSync'
 import { homeProjectEntriesValueSpec } from '@src/registry/contracts/homeProjects'
+import {
+  projectLibrariesValueSpec,
+  projectLibraryTypesValueSpec,
+} from '@src/registry/contracts/projectLibraries'
+import {
+  type SettingsRegistryService,
+  settingsService,
+} from '@src/registry/contracts/settings'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { BrowserRouter } from 'react-router-dom'
@@ -60,6 +75,21 @@ const projectWellFormed = {
   default_file: '/some/path/550e8400-e29b-41d4-a716-446655440000/main.kcl',
 } satisfies Project
 
+const CLOUD_SYNC_PLUGIN_ID = 'cloud-sync'
+
+type TestSettings = {
+  app: {
+    libraries: {
+      current: ProjectLibrarySetting[]
+    }
+  }
+  plugins: {
+    [CLOUD_SYNC_PLUGIN_ID]: {
+      current: boolean
+    }
+  }
+}
+
 function renderWithRouter(children: ReactNode) {
   return render(<BrowserRouter>{children}</BrowserRouter>)
 }
@@ -79,6 +109,64 @@ function createCloudSyncService(): CloudSyncRegistryService {
     getProjectMetadataIndex: vi.fn().mockResolvedValue(new Map()),
     getProjectModifiedTime: vi.fn((_metadata, localModified) => localModified),
     resolveProjectConflict: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+function createSettingsService({
+  cloudSyncEnabled = true,
+  libraries = [],
+}: {
+  cloudSyncEnabled?: boolean
+  libraries?: ProjectLibrarySetting[]
+}) {
+  const settingsSignal = signal<TestSettings>({
+    app: {
+      libraries: {
+        current: libraries,
+      },
+    },
+    plugins: {
+      [CLOUD_SYNC_PLUGIN_ID]: {
+        current: cloudSyncEnabled,
+      },
+    },
+  })
+  const send = vi.fn(
+    (event: {
+      type: 'set.app.libraries'
+      data: { value: ProjectLibrarySetting[] }
+    }) => {
+      if (event.type !== 'set.app.libraries') {
+        return
+      }
+
+      settingsSignal.value = {
+        ...settingsSignal.value,
+        app: {
+          ...settingsSignal.value.app,
+          libraries: {
+            current: event.data.value,
+          },
+        },
+      }
+    }
+  )
+  const service = {
+    actor: {
+      getSnapshot: () => ({
+        matches: (state: string) => state === 'idle',
+      }),
+    },
+    current: settingsSignal,
+    get: () => settingsSignal.value,
+    send,
+    useSettings: () => settingsSignal.value,
+  } as unknown as SettingsRegistryService
+
+  return {
+    service,
+    settingsSignal,
+    send,
   }
 }
 
@@ -216,6 +304,104 @@ describe('cloud sync project menu item', () => {
   })
 })
 
+describe('cloud sync project library', () => {
+  test('contributes the cloud project library type while the plugin is active', () => {
+    const registry = new Registry()
+    registry.configure([cloudSyncPlugin])
+
+    try {
+      expect(
+        registry
+          .get(projectLibraryTypesValueSpec)
+          .get(CLOUD_PROJECT_LIBRARY_TYPE)
+      ).toMatchObject({
+        title: 'Cloud',
+        icon: 'network',
+        defaultSetting: getDefaultCloudProjectLibrarySetting(),
+      })
+      expect(registry.get(projectLibrariesValueSpec)).toEqual([
+        expect.objectContaining({
+          id: CLOUD_PROJECT_LIBRARY_ID,
+          title: 'Cloud',
+          path: getDefaultCloudProjectLibrarySetting().path,
+          type: CLOUD_PROJECT_LIBRARY_TYPE,
+          icon: 'network',
+        }),
+      ])
+
+      const plugin = registry
+        .get(pluginsValueSpec)
+        .find((plugin) => plugin.id === CLOUD_SYNC_PLUGIN_ID)
+      const pluginService = plugin?.service
+      expect(pluginService).toBeDefined()
+      if (!pluginService) {
+        return
+      }
+
+      registry.get(pluginService).disable()
+
+      expect(
+        registry
+          .get(projectLibraryTypesValueSpec)
+          .has(CLOUD_PROJECT_LIBRARY_TYPE)
+      ).toBe(false)
+      expect(registry.get(projectLibrariesValueSpec)).toEqual([])
+    } finally {
+      registry[Symbol.dispose]()
+    }
+  })
+
+  test('adds the default cloud library to user settings when enabled', async () => {
+    const registry = new Registry()
+    const settings = createSettingsService({})
+    const settingsExtension = defineRegistryItem({
+      id: 'test-settings-service',
+      providesServices: [provideService(settingsService, settings.service)],
+    })
+
+    registry.configure([settingsExtension, cloudSyncPlugin])
+
+    try {
+      registry.get(projectLibraryTypesValueSpec)
+      await waitFor(() =>
+        expect(settings.send).toHaveBeenCalledWith({
+          type: 'set.app.libraries',
+          data: {
+            level: 'user',
+            value: [getDefaultCloudProjectLibrarySetting()],
+          },
+        })
+      )
+      expect(settings.settingsSignal.value.app.libraries.current).toEqual([
+        getDefaultCloudProjectLibrarySetting(),
+      ])
+    } finally {
+      registry[Symbol.dispose]()
+    }
+  })
+
+  test('does not add the default cloud library when settings disable the plugin', async () => {
+    const registry = new Registry()
+    const settings = createSettingsService({ cloudSyncEnabled: false })
+    const settingsExtension = defineRegistryItem({
+      id: 'test-settings-service',
+      providesServices: [provideService(settingsService, settings.service)],
+    })
+
+    registry.configure([settingsExtension, cloudSyncPlugin])
+
+    try {
+      registry.get(projectLibraryTypesValueSpec)
+      await Promise.resolve()
+      await Promise.resolve()
+      expect(settings.send).not.toHaveBeenCalled()
+      expect(settings.settingsSignal.value.app.libraries.current).toEqual([])
+    } finally {
+      registry[Symbol.dispose]()
+    }
+  })
+})
+
 describe('cloud sync home project entries', () => {
   test('contributes remote thumbnails for cloud-only home entries', async () => {
     cloudSyncStatus.value = {
@@ -249,6 +435,7 @@ describe('cloud sync home project entries', () => {
           expect.objectContaining({
             source: 'remote',
             status: 'cloud-only',
+            libraryIds: [CLOUD_PROJECT_LIBRARY_ID],
             name: 'Remote title',
             title: 'Remote title',
             remoteProjectId: 'remote-123',

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -32,9 +32,20 @@ import {
   type RemoteProjectSummary,
   retryCloudSync,
 } from '@src/lib/cloudSync'
+import { getDefaultCloudProjectDirectoryPath } from '@src/lib/cloudSync/paths'
 import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
 import { PATHS } from '@src/lib/paths'
 import { getProjectDisplayName } from '@src/lib/projectDisplayName'
+import {
+  CLOUD_PROJECT_LIBRARY_ID,
+  CLOUD_PROJECT_LIBRARY_TITLE,
+  CLOUD_PROJECT_LIBRARY_TYPE,
+  areProjectLibrarySettingsEqual,
+  getDefaultCloudProjectLibrarySetting,
+  mergeProjectLibrarySettings,
+  type ProjectLibrary,
+} from '@src/lib/projectLibraries'
+import { createProjectInLocalDirectory } from '@src/lib/projectLibraries/operations'
 import { getResolvedTheme, type ResolvedTheme } from '@src/lib/theme'
 import { reportRejection } from '@src/lib/trap'
 import { userFeaturesContextHas } from '@src/machines/userFeaturesMachine'
@@ -51,15 +62,23 @@ import {
   projectExplorerProjectMenuItemsValueSpec,
 } from '@src/registry/contracts/projectExplorer'
 import {
+  type ProjectLibraryTypeContribution,
+  projectLibrariesValueSpec,
+  projectLibraryTypesValueSpec,
+} from '@src/registry/contracts/projectLibraries'
+import {
   nullableStatusBarItem,
   statusBarGlobalItemsValueSpec,
 } from '@src/registry/contracts/statusBar'
 import { settingsService } from '@src/registry/contracts/settings'
 import { userFeaturesService } from '@src/registry/contracts/userFeatures'
+import { wasmPromiseValueSpec } from '@src/registry/contracts/wasm'
 import { createZdsPlugin } from '@src/registry/createZdsPlugin'
 import { Fragment, useEffect, useState } from 'react'
 import toast from 'react-hot-toast'
 import { useLocation } from 'react-router-dom'
+
+const CLOUD_SYNC_PLUGIN_ID = 'cloud-sync'
 
 type CloudSyncStatusBarPresentation = {
   label: string
@@ -884,11 +903,153 @@ const cloudSyncRemoteHomeProjectEntryContribution = defineRegistryItemFactory(
   'cloud-sync.remote-home-project-entries'
 )
 
+const cloudSyncProjectLibraryContribution = defineRegistryItemFactory((ctx) => {
+  const settings = ctx.services.signal(settingsService)
+  const library = computed<ProjectLibrary[]>(() => {
+    const defaultCloudLibrary = getDefaultCloudProjectLibrarySetting()
+    const configuredCloudLibrary =
+      settings.value?.current.value.app.libraries?.current.find(
+        (library) =>
+          library.type === defaultCloudLibrary.type &&
+          library.path === defaultCloudLibrary.path
+      )
+
+    return [
+      {
+        ...defaultCloudLibrary,
+        ...configuredCloudLibrary,
+        id: CLOUD_PROJECT_LIBRARY_ID,
+        icon: 'network',
+        order: 10,
+      },
+    ]
+  })
+
+  return {
+    item: defineRuntimeRegistryItem({
+      id: 'cloud-sync.project-library',
+      provides: [
+        provide(projectLibrariesValueSpec, library, {
+          key: 'cloud-sync.project-library',
+        }),
+      ],
+    }),
+  }
+}, 'cloud-sync.project-library')
+
+const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
+  const settings = ctx.services.signal(settingsService)
+  let disposed = false
+  let didReconcile = false
+  let disposeEffect: (() => void) | undefined
+
+  const getWasmPromise = () =>
+    ctx.valueSpecs.get(wasmPromiseValueSpec) ??
+    Promise.reject(new Error('Missing WASM promise registry value.'))
+
+  const cloudLibraryType: ProjectLibraryTypeContribution = {
+    type: CLOUD_PROJECT_LIBRARY_TYPE,
+    title: CLOUD_PROJECT_LIBRARY_TITLE,
+    icon: 'network',
+    order: 10,
+    defaultSetting: getDefaultCloudProjectLibrarySetting(),
+    newLibrarySetting: getDefaultCloudProjectLibrarySetting(),
+    operations: {
+      createProject: {
+        isAvailable: () => cloudSyncStatus.value.enabled,
+        run: async ({ requestedProjectName, requestedProjectTitle }) => {
+          if (!cloudSyncStatus.value.enabled) {
+            return Promise.reject(new Error('Cloud sync is not enabled.'))
+          }
+
+          const project = await createProjectInLocalDirectory({
+            projectDirectoryPath: await getDefaultCloudProjectDirectoryPath(),
+            requestedProjectName,
+            requestedProjectTitle,
+            wasmInstancePromise: getWasmPromise(),
+          })
+
+          await ctx.services
+            .get(cloudSyncService)
+            .startProjectSync(project.path)
+
+          return project
+        },
+      },
+    },
+  }
+
+  queueMicrotask(() => {
+    if (disposed) {
+      return
+    }
+
+    disposeEffect = effect(() => {
+      const service = settings.value
+      if (!service || didReconcile) {
+        return
+      }
+
+      const currentSettings = service.current.value
+      const cloudSyncPluginEnabled =
+        currentSettings.plugins?.[CLOUD_SYNC_PLUGIN_ID]?.current !== false
+      if (
+        !cloudSyncPluginEnabled ||
+        !service.actor.getSnapshot().matches('idle')
+      ) {
+        return
+      }
+
+      didReconcile = true
+      const currentLibraries = currentSettings.app.libraries?.current ?? []
+      const defaultCloudLibrary = getDefaultCloudProjectLibrarySetting()
+      const hasDefaultCloudLibrary = currentLibraries.some(
+        (library) =>
+          library.type === defaultCloudLibrary.type &&
+          library.path === defaultCloudLibrary.path
+      )
+      const nextLibraries = mergeProjectLibrarySettings(
+        currentLibraries,
+        hasDefaultCloudLibrary ? [] : [defaultCloudLibrary]
+      )
+
+      if (areProjectLibrarySettingsEqual(nextLibraries, currentLibraries)) {
+        return
+      }
+
+      service.send({
+        type: 'set.app.libraries',
+        data: {
+          level: 'user',
+          value: nextLibraries,
+        },
+      })
+    })
+  })
+
+  return {
+    item: defineRuntimeRegistryItem({
+      id: 'cloud-sync.project-library-type',
+      provides: [
+        provide(projectLibraryTypesValueSpec, cloudLibraryType, {
+          key: 'cloud-sync.project-library-type',
+        }),
+      ],
+      dispose: () => {
+        disposed = true
+        disposeEffect?.()
+      },
+    }),
+  }
+}, 'cloud-sync.project-library-type')
+
 export const cloudSyncPlugin = createZdsPlugin({
-  id: 'cloud-sync',
+  id: CLOUD_SYNC_PLUGIN_ID,
   title: 'Cloud sync',
   description: 'Cloud-backed project sync controls and status.',
   items: [
+    cloudSyncProjectLibraryContribution,
+    cloudSyncProjectLibraryType,
     cloudSyncStatusBarItemContribution,
     cloudSyncProjectMenuItem,
     cloudSyncRemoteHomeProjectEntryContribution,

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -37,12 +37,14 @@ import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
 import fsZds from '@src/lib/fs-zds'
 import { PATHS } from '@src/lib/paths'
 import { getProjectDisplayName } from '@src/lib/projectDisplayName'
+import { homeProjectEntryFromProject } from '@src/lib/homeProjects'
 import {
   CLOUD_PROJECT_LIBRARY_TYPE,
   PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
   getDefaultCloudProjectLibrarySetting,
   type ProjectLibrary,
 } from '@src/lib/projectLibraries'
+import { readProjectsFromProjectDirectory } from '@src/lib/projectLibraries/directoryScanner'
 import { createProjectInLocalDirectory } from '@src/lib/projectLibraries/operations'
 import {
   canOpenPathInFileExplorer,
@@ -1048,6 +1050,18 @@ const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
           return project
         },
       },
+    },
+    readEntries: async ({ signal }) => {
+      const projects = await readProjectsFromProjectDirectory({
+        projectDirectoryPath: await getDefaultCloudProjectDirectoryPath(),
+        wasmInstancePromise: getWasmPromise(),
+        signal,
+      })
+
+      return projects.map((project) => ({
+        ...homeProjectEntryFromProject(project),
+        libraryId: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+      }))
     },
   }
 

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -61,6 +61,7 @@ import {
   projectExplorerProjectMenuItemsValueSpec,
 } from '@src/registry/contracts/projectExplorer'
 import {
+  type ProjectLibrarySettingsDetailsProps,
   type ProjectLibraryTypeContribution,
   projectLibrariesValueSpec,
   projectLibraryTypesValueSpec,
@@ -85,6 +86,45 @@ type CloudSyncStatusBarPresentation = {
   iconClassName: string
   isBlocked: boolean
   tooltip: string
+}
+
+function CloudProjectLibrarySettingsDetails({
+  library,
+}: ProjectLibrarySettingsDetailsProps) {
+  const [storagePath, setStoragePath] = useState<string>()
+
+  useEffect(() => {
+    let disposed = false
+
+    getDefaultCloudProjectDirectoryPath()
+      .then((projectDirectoryPath) => {
+        if (!disposed) {
+          setStoragePath(projectDirectoryPath)
+        }
+      })
+      .catch(() => {
+        if (!disposed) {
+          setStoragePath(undefined)
+        }
+      })
+
+    return () => {
+      disposed = true
+    }
+  }, [])
+
+  return (
+    <div className="min-w-0 rounded-sm border border-chalkboard-30 bg-chalkboard-10 px-2 py-1 text-xs leading-5 dark:border-chalkboard-70 dark:bg-chalkboard-90">
+      <p className="truncate font-medium text-chalkboard-90 dark:text-chalkboard-10">
+        {library.title || 'Personal Cloud'}
+      </p>
+      <p className="truncate text-chalkboard-70 dark:text-chalkboard-30">
+        {storagePath
+          ? `Stored locally at ${storagePath}`
+          : 'Resolving local storage path...'}
+      </p>
+    </div>
+  )
 }
 
 type CloudSyncProjectMenuDialog =
@@ -962,6 +1002,7 @@ const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
     order: 10,
     defaultSetting: getDefaultCloudProjectLibrarySetting(),
     newLibrarySetting: getDefaultCloudProjectLibrarySetting(),
+    settingsDetails: CloudProjectLibrarySettingsDetails,
     operations: {
       createProject: {
         isAvailable: () => cloudSyncStatus.value.enabled,

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -991,6 +991,10 @@ const cloudSyncProjectLibraryContribution = defineRegistryItemFactory((ctx) => {
         ? undefined
         : configuredLibraries?.[configuredCloudLibraryIndex]
 
+    if (!configuredCloudLibrary) {
+      return []
+    }
+
     return [
       {
         ...defaultCloudLibrary,

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -34,6 +34,7 @@ import {
 } from '@src/lib/cloudSync'
 import { getDefaultCloudProjectDirectoryPath } from '@src/lib/cloudSync/paths'
 import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
+import fsZds from '@src/lib/fs-zds'
 import { PATHS } from '@src/lib/paths'
 import { getProjectDisplayName } from '@src/lib/projectDisplayName'
 import {
@@ -44,8 +45,8 @@ import {
 } from '@src/lib/projectLibraries'
 import { createProjectInLocalDirectory } from '@src/lib/projectLibraries/operations'
 import {
-  canRevealInFileExplorer,
-  revealInFileExplorer,
+  canOpenPathInFileExplorer,
+  openPathInFileExplorer,
 } from '@src/lib/revealInFileExplorer'
 import { getResolvedTheme, type ResolvedTheme } from '@src/lib/theme'
 import { reportRejection } from '@src/lib/trap'
@@ -94,6 +95,10 @@ function CloudProjectLibrarySettingsDetails({
   library,
 }: ProjectLibrarySettingsDetailsProps) {
   const [storagePath, setStoragePath] = useState<string>()
+  const revealLabel =
+    typeof window !== 'undefined' && window.electron?.os.isMac
+      ? 'Show in Finder'
+      : 'Show in Folder'
 
   useEffect(() => {
     let disposed = false
@@ -122,11 +127,12 @@ function CloudProjectLibrarySettingsDetails({
           ? `Stored locally at ${storagePath}`
           : 'Resolving local storage path...'}
       </p>
-      {canRevealInFileExplorer() && (
+      {canOpenPathInFileExplorer() && (
         <ActionButton
           Element="button"
           type="button"
           tabIndex={0}
+          aria-label={revealLabel}
           className="!p-0"
           iconStart={{
             icon: 'folder',
@@ -135,11 +141,14 @@ function CloudProjectLibrarySettingsDetails({
           disabled={!storagePath}
           onClick={() => {
             if (storagePath) {
-              revealInFileExplorer(storagePath)
+              void fsZds
+                .mkdir(storagePath, { recursive: true })
+                .then(() => openPathInFileExplorer(storagePath))
+                .catch(reportRejection)
             }
           }}
         >
-          <Tooltip position="top-right">Reveal in file explorer</Tooltip>
+          <Tooltip position="top-right">{revealLabel}</Tooltip>
         </ActionButton>
       )}
     </div>

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -908,12 +908,18 @@ const cloudSyncProjectLibraryContribution = defineRegistryItemFactory((ctx) => {
   const settings = ctx.services.signal(settingsService)
   const library = computed<ProjectLibrary[]>(() => {
     const defaultCloudLibrary = getDefaultCloudProjectLibrarySetting()
-    const configuredCloudLibrary =
-      settings.value?.current.value.app.libraries?.current.find(
+    const configuredLibraries =
+      settings.value?.current.value.app.libraries?.current
+    const configuredCloudLibraryIndex =
+      configuredLibraries?.findIndex(
         (library) =>
           library.type === defaultCloudLibrary.type &&
           library.path === defaultCloudLibrary.path
-      )
+      ) ?? -1
+    const configuredCloudLibrary =
+      configuredCloudLibraryIndex === -1
+        ? undefined
+        : configuredLibraries?.[configuredCloudLibraryIndex]
 
     return [
       {
@@ -921,7 +927,8 @@ const cloudSyncProjectLibraryContribution = defineRegistryItemFactory((ctx) => {
         ...configuredCloudLibrary,
         id: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
         icon: 'network',
-        order: 10,
+        order:
+          configuredCloudLibraryIndex === -1 ? 10 : configuredCloudLibraryIndex,
       },
     ]
   })

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -43,6 +43,10 @@ import {
   type ProjectLibrary,
 } from '@src/lib/projectLibraries'
 import { createProjectInLocalDirectory } from '@src/lib/projectLibraries/operations'
+import {
+  canRevealInFileExplorer,
+  revealInFileExplorer,
+} from '@src/lib/revealInFileExplorer'
 import { getResolvedTheme, type ResolvedTheme } from '@src/lib/theme'
 import { reportRejection } from '@src/lib/trap'
 import { userFeaturesContextHas } from '@src/machines/userFeaturesMachine'
@@ -112,15 +116,32 @@ function CloudProjectLibrarySettingsDetails({
   }, [])
 
   return (
-    <div className="min-w-0 rounded-sm border border-chalkboard-30 bg-chalkboard-10 px-2 py-1 text-xs leading-5 dark:border-chalkboard-70 dark:bg-chalkboard-90">
-      <p className="truncate font-medium text-chalkboard-90 dark:text-chalkboard-10">
-        {library.title || 'Personal Cloud'}
-      </p>
-      <p className="truncate text-chalkboard-70 dark:text-chalkboard-30">
+    <div className="min-w-0 text-sm m-0 flex items-stretch gap-2">
+      <p className="min-w-0 px-2 py-1 flex-1 truncate text-2">
         {storagePath
           ? `Stored locally at ${storagePath}`
           : 'Resolving local storage path...'}
       </p>
+      {canRevealInFileExplorer() && (
+        <ActionButton
+          Element="button"
+          type="button"
+          tabIndex={0}
+          className="!p-0"
+          iconStart={{
+            icon: 'folder',
+            bgClassName: '!bg-transparent',
+          }}
+          disabled={!storagePath}
+          onClick={() => {
+            if (storagePath) {
+              revealInFileExplorer(storagePath)
+            }
+          }}
+        >
+          <Tooltip position="top-right">Reveal in file explorer</Tooltip>
+        </ActionButton>
+      )}
     </div>
   )
 }

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -39,9 +39,7 @@ import { getProjectDisplayName } from '@src/lib/projectDisplayName'
 import {
   CLOUD_PROJECT_LIBRARY_TYPE,
   PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
-  areProjectLibrarySettingsEqual,
   getDefaultCloudProjectLibrarySetting,
-  mergeProjectLibrarySettings,
   type ProjectLibrary,
 } from '@src/lib/projectLibraries'
 import { createProjectInLocalDirectory } from '@src/lib/projectLibraries/operations'
@@ -986,11 +984,6 @@ const cloudSyncProjectLibraryContribution = defineRegistryItemFactory((ctx) => {
 }, 'cloud-sync.project-library')
 
 const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
-  const settings = ctx.services.signal(settingsService)
-  let disposed = false
-  let didReconcile = false
-  let disposeEffect: (() => void) | undefined
-
   const getWasmPromise = () =>
     ctx.valueSpecs.get(wasmPromiseValueSpec) ??
     Promise.reject(new Error('Missing WASM promise registry value.'))
@@ -1028,54 +1021,6 @@ const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
     },
   }
 
-  queueMicrotask(() => {
-    if (disposed) {
-      return
-    }
-
-    disposeEffect = effect(() => {
-      const service = settings.value
-      if (!service || didReconcile) {
-        return
-      }
-
-      const currentSettings = service.current.value
-      const cloudSyncPluginEnabled =
-        currentSettings.plugins?.[CLOUD_SYNC_PLUGIN_ID]?.current !== false
-      if (
-        !cloudSyncPluginEnabled ||
-        !service.actor.getSnapshot().matches('idle')
-      ) {
-        return
-      }
-
-      didReconcile = true
-      const currentLibraries = currentSettings.app.libraries?.current ?? []
-      const defaultCloudLibrary = getDefaultCloudProjectLibrarySetting()
-      const hasDefaultCloudLibrary = currentLibraries.some(
-        (library) =>
-          library.type === defaultCloudLibrary.type &&
-          library.path === defaultCloudLibrary.path
-      )
-      const nextLibraries = mergeProjectLibrarySettings(
-        currentLibraries,
-        hasDefaultCloudLibrary ? [] : [defaultCloudLibrary]
-      )
-
-      if (areProjectLibrarySettingsEqual(nextLibraries, currentLibraries)) {
-        return
-      }
-
-      service.send({
-        type: 'set.app.libraries',
-        data: {
-          level: 'user',
-          value: nextLibraries,
-        },
-      })
-    })
-  })
-
   return {
     item: defineRuntimeRegistryItem({
       id: 'cloud-sync.project-library-type',
@@ -1084,10 +1029,6 @@ const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
           key: 'cloud-sync.project-library-type',
         }),
       ],
-      dispose: () => {
-        disposed = true
-        disposeEffect?.()
-      },
     }),
   }
 }, 'cloud-sync.project-library-type')
@@ -1103,5 +1044,5 @@ export const cloudSyncPlugin = createZdsPlugin({
     cloudSyncProjectMenuItem,
     cloudSyncRemoteHomeProjectEntryContribution,
   ],
-  defaultSetting: 'core',
+  defaultSetting: 'off',
 })

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -37,9 +37,8 @@ import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
 import { PATHS } from '@src/lib/paths'
 import { getProjectDisplayName } from '@src/lib/projectDisplayName'
 import {
-  CLOUD_PROJECT_LIBRARY_ID,
-  CLOUD_PROJECT_LIBRARY_TITLE,
   CLOUD_PROJECT_LIBRARY_TYPE,
+  PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
   areProjectLibrarySettingsEqual,
   getDefaultCloudProjectLibrarySetting,
   mergeProjectLibrarySettings,
@@ -648,7 +647,7 @@ function homeProjectEntryCloudSyncFields(
   metadata: CloudSyncProjectMetadataIndexEntry | undefined
 ): Pick<
   HomeProjectEntryContribution,
-  'conflict' | 'localProjectPath' | 'status' | 'syncFailure'
+  'conflict' | 'libraryId' | 'localProjectPath' | 'status' | 'syncFailure'
 > {
   const syncFailure =
     metadata?.lastFailure?.kind === 'remote-upload-forbidden'
@@ -656,6 +655,7 @@ function homeProjectEntryCloudSyncFields(
       : undefined
   if (!metadata?.conflict) {
     return {
+      libraryId: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
       status: 'cloud-only',
       ...(syncFailure
         ? { syncFailure, localProjectPath: metadata?.localProjectPath }
@@ -664,6 +664,7 @@ function homeProjectEntryCloudSyncFields(
   }
 
   return {
+    libraryId: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
     status: 'conflicted',
     conflict: metadata.conflict,
     localProjectPath: metadata.localProjectPath,
@@ -918,7 +919,7 @@ const cloudSyncProjectLibraryContribution = defineRegistryItemFactory((ctx) => {
       {
         ...defaultCloudLibrary,
         ...configuredCloudLibrary,
-        id: CLOUD_PROJECT_LIBRARY_ID,
+        id: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
         icon: 'network',
         order: 10,
       },
@@ -949,7 +950,7 @@ const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
 
   const cloudLibraryType: ProjectLibraryTypeContribution = {
     type: CLOUD_PROJECT_LIBRARY_TYPE,
-    title: CLOUD_PROJECT_LIBRARY_TITLE,
+    title: 'Cloud',
     icon: 'network',
     order: 10,
     defaultSetting: getDefaultCloudProjectLibrarySetting(),

--- a/src/lib/projectLibraries/index.ts
+++ b/src/lib/projectLibraries/index.ts
@@ -5,10 +5,10 @@ export const DEFAULT_PROJECT_LIBRARY_ID = 'default-project-directory'
 export const DEFAULT_PROJECT_LIBRARY_TITLE = 'Default Projects Directory'
 export const NEW_PROJECT_LIBRARY_TITLE = 'Project Library'
 export const DIRECTORY_PROJECT_LIBRARY_TYPE = 'directory'
-export const CLOUD_PROJECT_LIBRARY_ID = 'cloud'
-export const CLOUD_PROJECT_LIBRARY_TITLE = 'Cloud'
+export const PERSONAL_CLOUD_PROJECT_LIBRARY_ID = 'cloud-personal'
+export const PERSONAL_CLOUD_PROJECT_LIBRARY_TITLE = 'Personal Cloud'
 export const CLOUD_PROJECT_LIBRARY_TYPE = 'cloud'
-export const DEFAULT_CLOUD_PROJECT_LIBRARY_PATH = 'zoo://user/projects'
+export const DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH = '/personal'
 
 export type ProjectLibraryType = string
 
@@ -38,8 +38,8 @@ export function getDefaultProjectLibrarySettings(
 
 export function getDefaultCloudProjectLibrarySetting(): ProjectLibrarySetting {
   return {
-    title: CLOUD_PROJECT_LIBRARY_TITLE,
-    path: DEFAULT_CLOUD_PROJECT_LIBRARY_PATH,
+    title: PERSONAL_CLOUD_PROJECT_LIBRARY_TITLE,
+    path: DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH,
     type: CLOUD_PROJECT_LIBRARY_TYPE,
   }
 }
@@ -213,8 +213,8 @@ export function projectLibraryFromSetting(
       library.path === options.defaultProjectDirectory
         ? DEFAULT_PROJECT_LIBRARY_ID
         : library.type === CLOUD_PROJECT_LIBRARY_TYPE &&
-            library.path === DEFAULT_CLOUD_PROJECT_LIBRARY_PATH
-          ? CLOUD_PROJECT_LIBRARY_ID
+            library.path === DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH
+          ? PERSONAL_CLOUD_PROJECT_LIBRARY_ID
           : getProjectLibraryIdFromSetting(library),
     order: index,
   }

--- a/src/lib/projectLibraries/index.ts
+++ b/src/lib/projectLibraries/index.ts
@@ -5,6 +5,10 @@ export const DEFAULT_PROJECT_LIBRARY_ID = 'default-project-directory'
 export const DEFAULT_PROJECT_LIBRARY_TITLE = 'Default Projects Directory'
 export const NEW_PROJECT_LIBRARY_TITLE = 'Project Library'
 export const DIRECTORY_PROJECT_LIBRARY_TYPE = 'directory'
+export const CLOUD_PROJECT_LIBRARY_ID = 'cloud'
+export const CLOUD_PROJECT_LIBRARY_TITLE = 'Cloud'
+export const CLOUD_PROJECT_LIBRARY_TYPE = 'cloud'
+export const DEFAULT_CLOUD_PROJECT_LIBRARY_PATH = 'zoo://user/projects'
 
 export type ProjectLibraryType = string
 
@@ -30,6 +34,14 @@ export function getDefaultProjectLibrarySettings(
       type: DIRECTORY_PROJECT_LIBRARY_TYPE,
     },
   ]
+}
+
+export function getDefaultCloudProjectLibrarySetting(): ProjectLibrarySetting {
+  return {
+    title: CLOUD_PROJECT_LIBRARY_TITLE,
+    path: DEFAULT_CLOUD_PROJECT_LIBRARY_PATH,
+    type: CLOUD_PROJECT_LIBRARY_TYPE,
+  }
 }
 
 export function getDefaultDirectoryProjectLibrarySetting(
@@ -200,7 +212,10 @@ export function projectLibraryFromSetting(
       library.type === DIRECTORY_PROJECT_LIBRARY_TYPE &&
       library.path === options.defaultProjectDirectory
         ? DEFAULT_PROJECT_LIBRARY_ID
-        : getProjectLibraryIdFromSetting(library),
+        : library.type === CLOUD_PROJECT_LIBRARY_TYPE &&
+            library.path === DEFAULT_CLOUD_PROJECT_LIBRARY_PATH
+          ? CLOUD_PROJECT_LIBRARY_ID
+          : getProjectLibraryIdFromSetting(library),
     order: index,
   }
 }

--- a/src/lib/projectLibraries/settings/ProjectLibrariesSetting.tsx
+++ b/src/lib/projectLibraries/settings/ProjectLibrariesSetting.tsx
@@ -1,8 +1,10 @@
 import { useSignals } from '@preact/signals-react/runtime'
+import { isDesktop } from '@src/lib/isDesktop'
 import type { ProjectLibrarySetting } from '@src/lib/projectLibraries'
 import type { SettingComponentProps } from '@src/lib/settings/settingsTypes'
 import { projectLibraryTypesValueSpec } from '@src/registry/contracts/projectLibraries'
 import {
+  filterProjectLibraryTypeOptionsForSettings,
   ProjectLibrariesSettingInput,
   projectLibraryTypeOptionsFromContributions,
 } from '@src/lib/projectLibraries/settings/ProjectLibrariesSettingInput'
@@ -13,15 +15,22 @@ export function ProjectLibrariesSetting({
   registry,
 }: SettingComponentProps<ProjectLibrarySetting[]>) {
   useSignals()
+  const canManageLibraries = isDesktop()
   const libraryTypeOptions = projectLibraryTypeOptionsFromContributions(
     registry.signal(projectLibraryTypesValueSpec).value
   )
+  const selectableLibraryTypeOptions =
+    filterProjectLibraryTypeOptionsForSettings(libraryTypeOptions, {
+      isDesktop: canManageLibraries,
+    })
 
   return (
     <ProjectLibrariesSettingInput
       value={value}
       updateValue={updateValue}
       libraryTypeOptions={libraryTypeOptions}
+      selectableLibraryTypeOptions={selectableLibraryTypeOptions}
+      canManageLibraries={canManageLibraries}
     />
   )
 }

--- a/src/lib/projectLibraries/settings/ProjectLibrariesSetting.tsx
+++ b/src/lib/projectLibraries/settings/ProjectLibrariesSetting.tsx
@@ -1,13 +1,16 @@
 import { useSignals } from '@preact/signals-react/runtime'
 import { isDesktop } from '@src/lib/isDesktop'
-import type { ProjectLibrarySetting } from '@src/lib/projectLibraries'
-import type { SettingComponentProps } from '@src/lib/settings/settingsTypes'
-import { projectLibraryTypesValueSpec } from '@src/registry/contracts/projectLibraries'
+import {
+  DIRECTORY_PROJECT_LIBRARY_TYPE,
+  type ProjectLibrarySetting,
+} from '@src/lib/projectLibraries'
 import {
   filterProjectLibraryTypeOptionsForSettings,
   ProjectLibrariesSettingInput,
   projectLibraryTypeOptionsFromContributions,
 } from '@src/lib/projectLibraries/settings/ProjectLibrariesSettingInput'
+import type { SettingComponentProps } from '@src/lib/settings/settingsTypes'
+import { projectLibraryTypesValueSpec } from '@src/registry/contracts/projectLibraries'
 
 export function ProjectLibrariesSetting({
   value,
@@ -30,7 +33,13 @@ export function ProjectLibrariesSetting({
       updateValue={updateValue}
       libraryTypeOptions={libraryTypeOptions}
       selectableLibraryTypeOptions={selectableLibraryTypeOptions}
-      canManageLibraries={canManageLibraries}
+      canAddLibraries={canManageLibraries}
+      canReorderLibraries={canManageLibraries}
+      canChangeLibraryType={canManageLibraries}
+      canEditLibraryDetails={canManageLibraries}
+      canRemoveLibrary={(library) =>
+        canManageLibraries || library.type === DIRECTORY_PROJECT_LIBRARY_TYPE
+      }
     />
   )
 }

--- a/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.spec.tsx
+++ b/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.spec.tsx
@@ -1,5 +1,6 @@
 import {
   DirectoryProjectLibrarySettingsDetails,
+  filterProjectLibraryTypeOptionsForSettings,
   ProjectLibrariesSettingInput,
   projectLibraryTypeOptionsFromContributions,
   type ProjectLibraryTypeOption,
@@ -117,6 +118,33 @@ describe('ProjectLibrariesSettingInput', () => {
     expect(screen.queryByTestId('project-directory-input')).toBeNull()
   })
 
+  test('filters library types hidden on the current platform from settings options', () => {
+    expect(
+      filterProjectLibraryTypeOptionsForSettings(
+        projectLibraryTypeOptionsFromContributions(
+          new Map([
+            [
+              'directory',
+              {
+                type: 'directory',
+                title: 'Directory',
+                hideInSettingsOnPlatform: 'web',
+              },
+            ],
+            [
+              'cloud',
+              {
+                type: 'cloud',
+                title: 'Cloud',
+              },
+            ],
+          ])
+        ),
+        { isDesktop: false }
+      ).map((option) => option.value)
+    ).toEqual(['cloud'])
+  })
+
   test('does not update project libraries when normalization matches the current value', () => {
     const updateValue = vi.fn()
     render(
@@ -185,6 +213,29 @@ describe('ProjectLibrariesSettingInput', () => {
         type: 'directory',
       },
     ])
+  })
+
+  test('hides library management controls when management is disabled', () => {
+    const updateValue = vi.fn()
+    render(
+      <ProjectLibrariesSettingInput
+        value={defaultLibraries}
+        updateValue={updateValue}
+        libraryTypeOptions={libraryTypeOptions}
+        canManageLibraries={false}
+      />
+    )
+
+    expect(screen.queryByTestId('project-library-add')).toBeNull()
+    expect(screen.queryByTestId('project-library-remove')).toBeNull()
+    expect(screen.queryByTestId('project-library-drag-handle')).toBeNull()
+    expect(screen.getByTestId('project-library-type')).toHaveAttribute(
+      'aria-label',
+      'Library type: Directory'
+    )
+    expect(screen.getByTestId('project-directory-input')).toHaveTextContent(
+      '/projects'
+    )
   })
 
   test('shows library type as an icon button with icon and label options', () => {

--- a/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.spec.tsx
+++ b/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.spec.tsx
@@ -1,11 +1,11 @@
+import type { ProjectLibrarySetting } from '@src/lib/projectLibraries'
 import {
   DirectoryProjectLibrarySettingsDetails,
   filterProjectLibraryTypeOptionsForSettings,
   ProjectLibrariesSettingInput,
-  projectLibraryTypeOptionsFromContributions,
   type ProjectLibraryTypeOption,
+  projectLibraryTypeOptionsFromContributions,
 } from '@src/lib/projectLibraries/settings/ProjectLibrariesSettingInput'
-import type { ProjectLibrarySetting } from '@src/lib/projectLibraries'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
 
@@ -222,7 +222,11 @@ describe('ProjectLibrariesSettingInput', () => {
         value={defaultLibraries}
         updateValue={updateValue}
         libraryTypeOptions={libraryTypeOptions}
-        canManageLibraries={false}
+        canAddLibraries={false}
+        canReorderLibraries={false}
+        canChangeLibraryType={false}
+        canEditLibraryDetails={false}
+        canRemoveLibrary={() => false}
       />
     )
 
@@ -236,6 +240,48 @@ describe('ProjectLibrariesSettingInput', () => {
     expect(screen.getByTestId('project-directory-input')).toHaveTextContent(
       '/projects'
     )
+  })
+
+  test('allows directory library removal without enabling web library management', () => {
+    const updateValue = vi.fn()
+    const cloudLibrary: ProjectLibrarySetting = {
+      title: 'Personal Cloud',
+      path: '/personal',
+      type: 'cloud',
+    }
+
+    render(
+      <ProjectLibrariesSettingInput
+        value={[...defaultLibraries, cloudLibrary]}
+        updateValue={updateValue}
+        libraryTypeOptions={multipleLibraryTypeOptions}
+        selectableLibraryTypeOptions={multipleLibraryTypeOptions.filter(
+          (option) => option.value !== 'directory'
+        )}
+        canAddLibraries={false}
+        canReorderLibraries={false}
+        canChangeLibraryType={false}
+        canEditLibraryDetails={false}
+        canRemoveLibrary={(library) => library.type === 'directory'}
+      />
+    )
+
+    expect(screen.queryByTestId('project-library-add')).toBeNull()
+    expect(screen.queryByTestId('project-library-drag-handle')).toBeNull()
+    const libraryTypes = screen.getAllByTestId('project-library-type')
+    expect(libraryTypes).toHaveLength(2)
+    expect(libraryTypes[0]).toHaveAttribute(
+      'aria-label',
+      'Library type: Directory'
+    )
+    expect(libraryTypes[1]).toHaveAttribute('aria-label', 'Library type: Cloud')
+
+    const removeButtons = screen.getAllByTestId('project-library-remove')
+    expect(removeButtons).toHaveLength(1)
+
+    fireEvent.click(removeButtons[0])
+
+    expect(updateValue).toHaveBeenLastCalledWith([cloudLibrary])
   })
 
   test('shows library type as an icon button with icon and label options', () => {

--- a/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.spec.tsx
+++ b/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.spec.tsx
@@ -1,4 +1,5 @@
 import {
+  DirectoryProjectLibrarySettingsDetails,
   ProjectLibrariesSettingInput,
   projectLibraryTypeOptionsFromContributions,
   type ProjectLibraryTypeOption,
@@ -30,6 +31,7 @@ const libraryTypeOptions: ProjectLibraryTypeOption[] = [
       path: 'projects',
       type: 'directory',
     },
+    settingsDetails: DirectoryProjectLibrarySettingsDetails,
   },
 ]
 
@@ -49,6 +51,7 @@ const multipleLibraryTypeOptions: ProjectLibraryTypeOption[] = [
       path: 'zoo-cloud',
       type: 'cloud',
     },
+    settingsDetails: () => <></>,
   },
 ]
 
@@ -84,6 +87,34 @@ describe('ProjectLibrariesSettingInput', () => {
     fireEvent.blur(screen.getByTestId('project-directory-input'))
 
     expect(updateValue).not.toHaveBeenCalled()
+  })
+
+  test('does not render implicit details for library types without a settings details contribution', () => {
+    const updateValue = vi.fn()
+    render(
+      <ProjectLibrariesSettingInput
+        value={defaultLibraries}
+        updateValue={updateValue}
+        libraryTypeOptions={projectLibraryTypeOptionsFromContributions(
+          new Map([
+            [
+              'directory',
+              {
+                type: 'directory',
+                title: 'Directory',
+                defaultSetting: {
+                  title: 'Default Projects Directory',
+                  path: 'projects',
+                  type: 'directory',
+                },
+              },
+            ],
+          ])
+        )}
+      />
+    )
+
+    expect(screen.queryByTestId('project-directory-input')).toBeNull()
   })
 
   test('does not update project libraries when normalization matches the current value', () => {

--- a/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.tsx
+++ b/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.tsx
@@ -177,7 +177,7 @@ function ProjectLibraryTypeSelect({
     <Listbox value={value} onChange={onChange}>
       <div className="relative self-start">
         <Listbox.Button
-          className="relative flex h-8 w-8 items-center justify-center rounded-sm border border-chalkboard-30 text-chalkboard-70 hover:bg-chalkboard-10 dark:border-chalkboard-70 dark:text-chalkboard-30 dark:hover:bg-chalkboard-90"
+          className="relative flex h-8 w-8 p-0 items-center justify-center rounded-sm border border-chalkboard-30 text-chalkboard-70 hover:bg-chalkboard-10 dark:border-chalkboard-70 dark:text-chalkboard-30 dark:hover:bg-chalkboard-90"
           data-testid="project-library-type"
           aria-label={`Library type: ${selectedOption?.label ?? value}`}
           title={selectedOption?.label ?? value}

--- a/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.tsx
+++ b/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.tsx
@@ -34,6 +34,8 @@ interface ProjectLibrariesSettingInputProps {
   value: ProjectLibrarySetting[]
   updateValue: (value: ProjectLibrarySetting[]) => void
   libraryTypeOptions?: readonly ProjectLibraryTypeOption[]
+  selectableLibraryTypeOptions?: readonly ProjectLibraryTypeOption[]
+  canManageLibraries?: boolean
 }
 
 export interface ProjectLibraryTypeOption {
@@ -43,6 +45,7 @@ export interface ProjectLibraryTypeOption {
   defaultLibrary: ProjectLibrarySetting
   newLibrary: ProjectLibrarySetting
   settingsDetails: ComponentType<ProjectLibrarySettingsDetailsProps>
+  hideInSettingsOnPlatform?: ProjectLibraryTypeContribution['hideInSettingsOnPlatform']
 }
 
 const defaultProjectLibraryTypeIcon: CustomIconName = 'folder'
@@ -85,8 +88,24 @@ export function projectLibraryTypeOptionsFromContributions(
         newLibrary: libraryType.newLibrarySetting ?? fallbackLibrary,
         settingsDetails:
           libraryType.settingsDetails ?? DefaultProjectLibrarySettingsDetails,
+        hideInSettingsOnPlatform: libraryType.hideInSettingsOnPlatform,
       }
     })
+}
+
+export function filterProjectLibraryTypeOptionsForSettings(
+  libraryTypeOptions: readonly ProjectLibraryTypeOption[],
+  options: { isDesktop?: boolean } = {}
+): ProjectLibraryTypeOption[] {
+  const isCurrentPlatformDesktop = options.isDesktop ?? true
+
+  return libraryTypeOptions.filter((libraryType) => {
+    const hidden = libraryType.hideInSettingsOnPlatform
+    return !(
+      hidden === 'both' ||
+      hidden === (isCurrentPlatformDesktop ? 'desktop' : 'web')
+    )
+  })
 }
 
 function defaultLibraryForType(
@@ -126,10 +145,12 @@ function ProjectLibraryTypeSelect({
   value,
   options,
   onChange,
+  readOnly = false,
 }: {
   value: ProjectLibraryType
   options: readonly ProjectLibraryTypeOption[]
   onChange: (value: ProjectLibraryType) => void
+  readOnly?: boolean
 }) {
   const selectOptions = options.some((option) => option.value === value)
     ? options
@@ -156,7 +177,7 @@ function ProjectLibraryTypeSelect({
   const selectedOption =
     selectOptions.find((option) => option.value === value) ?? selectOptions[0]
 
-  if (selectOptions.length <= 1) {
+  if (readOnly || selectOptions.length <= 1) {
     return (
       <span
         className="relative flex h-8 w-8 items-center justify-center rounded-sm border border-chalkboard-30 text-chalkboard-70 dark:border-chalkboard-70 dark:text-chalkboard-30"
@@ -225,6 +246,7 @@ export function DirectoryProjectLibrarySettingsDetails({
   index,
   updateLibrary,
   commitLibrary,
+  readOnly = false,
   chooseDirectory,
 }: ProjectLibrarySettingsDetailsProps) {
   async function chooseLibraryPath() {
@@ -246,7 +268,17 @@ export function DirectoryProjectLibrarySettingsDetails({
     })
   }
 
-  return (
+  return readOnly ? (
+    <p
+      className="min-w-0 truncate rounded-sm border border-chalkboard-30 bg-transparent p-1 text-sm dark:border-chalkboard-70"
+      data-testid={
+        index === 0 ? 'project-directory-input' : 'project-library-path'
+      }
+      title={library.path}
+    >
+      {library.path}
+    </p>
+  ) : (
     <div className="flex min-w-0 gap-1">
       <input
         value={library.path}
@@ -290,6 +322,8 @@ export function ProjectLibrariesSettingInput({
   value,
   updateValue,
   libraryTypeOptions = [],
+  selectableLibraryTypeOptions = libraryTypeOptions,
+  canManageLibraries = true,
 }: ProjectLibrariesSettingInputProps) {
   const electron = typeof window === 'undefined' ? undefined : window.electron
   const [draftLibraries, setDraftLibraries] =
@@ -395,7 +429,7 @@ export function ProjectLibrariesSettingInput({
   }
 
   async function addLibrary() {
-    const libraryTypeOption = libraryTypeOptions[0]
+    const libraryTypeOption = selectableLibraryTypeOptions[0]
     if (!libraryTypeOption) {
       return
     }
@@ -480,32 +514,47 @@ export function ProjectLibrariesSettingInput({
             return (
               <li
                 key={`${index}-${library.type}`}
-                className={`grid gap-2 rounded-sm border p-2 pl-1 dark:border-chalkboard-80 md:grid-cols-[auto_auto_minmax(10rem,1fr)_minmax(12rem,1.5fr)_auto] ${
+                className={`grid gap-2 rounded-sm border p-2 dark:border-chalkboard-80 ${
+                  canManageLibraries
+                    ? 'pl-1 md:grid-cols-[auto_auto_minmax(10rem,1fr)_minmax(12rem,1.5fr)_auto]'
+                    : 'md:grid-cols-[auto_minmax(10rem,1fr)_minmax(12rem,1.5fr)]'
+                } ${
                   dragOverLibraryIndex === index
                     ? 'border-primary bg-primary/5 dark:border-primary'
                     : 'border-chalkboard-30'
                 } ${draggedLibraryIndex === index ? 'opacity-60' : ''}`}
-                onDragOver={(event) => handleDragOver(event, index)}
-                onDrop={(event) => handleDrop(event, index)}
+                onDragOver={
+                  canManageLibraries
+                    ? (event) => handleDragOver(event, index)
+                    : undefined
+                }
+                onDrop={
+                  canManageLibraries
+                    ? (event) => handleDrop(event, index)
+                    : undefined
+                }
                 data-testid="project-library-row"
               >
-                <button
-                  type="button"
-                  draggable
-                  aria-label={`Reorder ${library.title || 'project library'}`}
-                  aria-grabbed={draggedLibraryIndex === index}
-                  className="flex p-0 cursor-grab items-center justify-center self-stretch rounded-sm border !border-transparent text-2 !bg-transparent active:cursor-grabbing"
-                  data-testid="project-library-drag-handle"
-                  onDragStart={(event) => handleDragStart(event, index)}
-                  onDragEnd={handleDragEnd}
-                >
-                  <CustomIcon name="sixDots" className="h-4 w-4" />
-                  <Tooltip position="top-right">Reorder library</Tooltip>
-                </button>
+                {canManageLibraries && (
+                  <button
+                    type="button"
+                    draggable
+                    aria-label={`Reorder ${library.title || 'project library'}`}
+                    aria-grabbed={draggedLibraryIndex === index}
+                    className="flex p-0 cursor-grab items-center justify-center self-stretch rounded-sm border !border-transparent text-2 !bg-transparent active:cursor-grabbing"
+                    data-testid="project-library-drag-handle"
+                    onDragStart={(event) => handleDragStart(event, index)}
+                    onDragEnd={handleDragEnd}
+                  >
+                    <CustomIcon name="sixDots" className="h-4 w-4" />
+                    <Tooltip position="top-right">Reorder library</Tooltip>
+                  </button>
+                )}
                 <ProjectLibraryTypeSelect
                   value={library.type}
-                  options={libraryTypeOptions}
+                  options={selectableLibraryTypeOptions}
                   onChange={(type) => updateLibraryType(index, type)}
+                  readOnly={!canManageLibraries}
                 />
                 <input
                   value={library.title}
@@ -539,43 +588,50 @@ export function ProjectLibrariesSettingInput({
                         : draftLibraries
                     )
                   }
-                  chooseDirectory={electron ? chooseDirectory : undefined}
+                  readOnly={!canManageLibraries}
+                  chooseDirectory={
+                    electron && canManageLibraries ? chooseDirectory : undefined
+                  }
                 />
-                <ActionButton
-                  Element="button"
-                  type="button"
-                  tabIndex={0}
-                  onClick={() => removeLibrary(index)}
-                  className="justify-self-start !p-0 md:justify-self-end"
-                  iconStart={{
-                    icon: 'trash',
-                    bgClassName: '!bg-transparent',
-                    iconClassName: 'dark:!text-chalkboard-30',
-                  }}
-                  data-testid="project-library-remove"
-                >
-                  <Tooltip position="top-right">Remove library</Tooltip>
-                </ActionButton>
+                {canManageLibraries && (
+                  <ActionButton
+                    Element="button"
+                    type="button"
+                    tabIndex={0}
+                    onClick={() => removeLibrary(index)}
+                    className="justify-self-start !p-0 md:justify-self-end"
+                    iconStart={{
+                      icon: 'trash',
+                      bgClassName: '!bg-transparent',
+                      iconClassName: 'dark:!text-chalkboard-30',
+                    }}
+                    data-testid="project-library-remove"
+                  >
+                    <Tooltip position="top-right">Remove library</Tooltip>
+                  </ActionButton>
+                )}
               </li>
             )
           })}
         </ul>
       )}
-      <ActionButton
-        Element="button"
-        type="button"
-        tabIndex={0}
-        onClick={toSync(addLibrary, reportRejection)}
-        disabled={libraryTypeOptions.length === 0}
-        className="self-start disabled:cursor-not-allowed disabled:opacity-60"
-        iconStart={{
-          icon: 'plus',
-          bgClassName: '!bg-transparent',
-        }}
-        data-testid="project-library-add"
-      >
-        Add library
-      </ActionButton>
+      {canManageLibraries && (
+        <ActionButton
+          Element="button"
+          type="button"
+          tabIndex={0}
+          onClick={toSync(addLibrary, reportRejection)}
+          disabled={selectableLibraryTypeOptions.length === 0}
+          className="self-start disabled:cursor-not-allowed disabled:opacity-60"
+          iconStart={{
+            icon: 'plus',
+            bgClassName: '!bg-transparent',
+          }}
+          data-testid="project-library-add"
+        >
+          Add library
+        </ActionButton>
+      )}
     </div>
   )
 }

--- a/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.tsx
+++ b/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.tsx
@@ -2,15 +2,15 @@ import { Listbox } from '@headlessui/react'
 import { ActionButton } from '@src/components/ActionButton'
 import {
   CustomIcon,
-  isCustomIconName,
   type CustomIconName,
+  isCustomIconName,
 } from '@src/components/CustomIcon'
 import Tooltip from '@src/components/Tooltip'
 import { removeDragPreviewElement, setDragPreview } from '@src/lib/dragPreview'
 import {
-  NEW_PROJECT_LIBRARY_TITLE,
   areProjectLibrarySettingsEqual,
   moveProjectLibrarySetting,
+  NEW_PROJECT_LIBRARY_TITLE,
   normalizeProjectLibrarySetting,
   type ProjectLibrarySetting,
   type ProjectLibraryType,
@@ -35,7 +35,11 @@ interface ProjectLibrariesSettingInputProps {
   updateValue: (value: ProjectLibrarySetting[]) => void
   libraryTypeOptions?: readonly ProjectLibraryTypeOption[]
   selectableLibraryTypeOptions?: readonly ProjectLibraryTypeOption[]
-  canManageLibraries?: boolean
+  canAddLibraries?: boolean
+  canReorderLibraries?: boolean
+  canChangeLibraryType?: boolean
+  canEditLibraryDetails?: boolean
+  canRemoveLibrary?: (library: ProjectLibrarySetting) => boolean
 }
 
 export interface ProjectLibraryTypeOption {
@@ -323,7 +327,11 @@ export function ProjectLibrariesSettingInput({
   updateValue,
   libraryTypeOptions = [],
   selectableLibraryTypeOptions = libraryTypeOptions,
-  canManageLibraries = true,
+  canAddLibraries = true,
+  canReorderLibraries = true,
+  canChangeLibraryType = true,
+  canEditLibraryDetails = true,
+  canRemoveLibrary = () => true,
 }: ProjectLibrariesSettingInputProps) {
   const electron = typeof window === 'undefined' ? undefined : window.electron
   const [draftLibraries, setDraftLibraries] =
@@ -510,32 +518,38 @@ export function ProjectLibrariesSettingInput({
             const SettingsDetails =
               libraryTypeOptionForType(library.type, libraryTypeOptions)
                 ?.settingsDetails ?? DefaultProjectLibrarySettingsDetails
+            const canRemoveCurrentLibrary = canRemoveLibrary(library)
+            const showRemoveColumn = draftLibraries.some(canRemoveLibrary)
 
             return (
               <li
                 key={`${index}-${library.type}`}
                 className={`grid gap-2 rounded-sm border p-2 dark:border-chalkboard-80 ${
-                  canManageLibraries
+                  canReorderLibraries && showRemoveColumn
                     ? 'pl-1 md:grid-cols-[auto_auto_minmax(10rem,1fr)_minmax(12rem,1.5fr)_auto]'
-                    : 'md:grid-cols-[auto_minmax(10rem,1fr)_minmax(12rem,1.5fr)]'
+                    : canReorderLibraries
+                      ? 'pl-1 md:grid-cols-[auto_auto_minmax(10rem,1fr)_minmax(12rem,1.5fr)]'
+                      : showRemoveColumn
+                        ? 'md:grid-cols-[auto_minmax(10rem,1fr)_minmax(12rem,1.5fr)_auto]'
+                        : 'md:grid-cols-[auto_minmax(10rem,1fr)_minmax(12rem,1.5fr)]'
                 } ${
                   dragOverLibraryIndex === index
                     ? 'border-primary bg-primary/5 dark:border-primary'
                     : 'border-chalkboard-30'
                 } ${draggedLibraryIndex === index ? 'opacity-60' : ''}`}
                 onDragOver={
-                  canManageLibraries
+                  canReorderLibraries
                     ? (event) => handleDragOver(event, index)
                     : undefined
                 }
                 onDrop={
-                  canManageLibraries
+                  canReorderLibraries
                     ? (event) => handleDrop(event, index)
                     : undefined
                 }
                 data-testid="project-library-row"
               >
-                {canManageLibraries && (
+                {canReorderLibraries && (
                   <button
                     type="button"
                     draggable
@@ -552,9 +566,13 @@ export function ProjectLibrariesSettingInput({
                 )}
                 <ProjectLibraryTypeSelect
                   value={library.type}
-                  options={selectableLibraryTypeOptions}
+                  options={
+                    canChangeLibraryType
+                      ? selectableLibraryTypeOptions
+                      : libraryTypeOptions
+                  }
                   onChange={(type) => updateLibraryType(index, type)}
-                  readOnly={!canManageLibraries}
+                  readOnly={!canChangeLibraryType}
                 />
                 <input
                   value={library.title}
@@ -588,34 +606,39 @@ export function ProjectLibrariesSettingInput({
                         : draftLibraries
                     )
                   }
-                  readOnly={!canManageLibraries}
+                  readOnly={!canEditLibraryDetails}
                   chooseDirectory={
-                    electron && canManageLibraries ? chooseDirectory : undefined
+                    electron && canEditLibraryDetails
+                      ? chooseDirectory
+                      : undefined
                   }
                 />
-                {canManageLibraries && (
-                  <ActionButton
-                    Element="button"
-                    type="button"
-                    tabIndex={0}
-                    onClick={() => removeLibrary(index)}
-                    className="justify-self-start !p-0 md:justify-self-end"
-                    iconStart={{
-                      icon: 'trash',
-                      bgClassName: '!bg-transparent',
-                      iconClassName: 'dark:!text-chalkboard-30',
-                    }}
-                    data-testid="project-library-remove"
-                  >
-                    <Tooltip position="top-right">Remove library</Tooltip>
-                  </ActionButton>
-                )}
+                {showRemoveColumn &&
+                  (canRemoveCurrentLibrary ? (
+                    <ActionButton
+                      Element="button"
+                      type="button"
+                      tabIndex={0}
+                      onClick={() => removeLibrary(index)}
+                      className="justify-self-start !p-0 md:justify-self-end"
+                      iconStart={{
+                        icon: 'trash',
+                        bgClassName: '!bg-transparent',
+                        iconClassName: 'dark:!text-chalkboard-30',
+                      }}
+                      data-testid="project-library-remove"
+                    >
+                      <Tooltip position="top-right">Remove library</Tooltip>
+                    </ActionButton>
+                  ) : (
+                    <span aria-hidden="true" />
+                  ))}
               </li>
             )
           })}
         </ul>
       )}
-      {canManageLibraries && (
+      {canAddLibraries && (
         <ActionButton
           Element="button"
           type="button"

--- a/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.tsx
+++ b/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.tsx
@@ -19,10 +19,16 @@ import {
 import { reportRejection } from '@src/lib/trap'
 import { toSync } from '@src/lib/utils'
 import type {
+  ProjectLibrarySettingsDetailsProps,
   ProjectLibraryTypeContribution,
-  ProjectLibraryTypePathInput,
 } from '@src/registry/contracts/projectLibraries'
-import { type DragEvent, useEffect, useRef, useState } from 'react'
+import {
+  type ComponentType,
+  type DragEvent,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 
 interface ProjectLibrariesSettingInputProps {
   value: ProjectLibrarySetting[]
@@ -36,12 +42,7 @@ export interface ProjectLibraryTypeOption {
   value: ProjectLibraryType
   defaultLibrary: ProjectLibrarySetting
   newLibrary: ProjectLibrarySetting
-  pathInput?: ProjectLibraryTypeOptionPathInput
-}
-
-interface ProjectLibraryTypeOptionPathInput
-  extends Omit<ProjectLibraryTypePathInput, 'icon'> {
-  icon: CustomIconName
+  settingsDetails: ComponentType<ProjectLibrarySettingsDetailsProps>
 }
 
 const defaultProjectLibraryTypeIcon: CustomIconName = 'folder'
@@ -56,19 +57,8 @@ function libraryTypeIconFromContribution(
   return defaultProjectLibraryTypeIcon
 }
 
-function libraryTypePathInputFromContribution(
-  pathInput: ProjectLibraryTypePathInput | undefined
-): ProjectLibraryTypeOptionPathInput | undefined {
-  if (!pathInput) {
-    return undefined
-  }
-
-  return {
-    ...pathInput,
-    icon: isCustomIconName(pathInput.icon)
-      ? pathInput.icon
-      : defaultProjectLibraryTypeIcon,
-  }
+function DefaultProjectLibrarySettingsDetails() {
+  return <></>
 }
 
 export function projectLibraryTypeOptionsFromContributions(
@@ -93,7 +83,8 @@ export function projectLibraryTypeOptionsFromContributions(
         value: libraryType.type,
         defaultLibrary: libraryType.defaultSetting ?? fallbackLibrary,
         newLibrary: libraryType.newLibrarySetting ?? fallbackLibrary,
-        pathInput: libraryTypePathInputFromContribution(libraryType.pathInput),
+        settingsDetails:
+          libraryType.settingsDetails ?? DefaultProjectLibrarySettingsDetails,
       }
     })
 }
@@ -158,6 +149,7 @@ function ProjectLibraryTypeSelect({
             path: 'projects',
             type: value,
           },
+          settingsDetails: DefaultProjectLibrarySettingsDetails,
         },
       ]
 
@@ -225,6 +217,72 @@ function ProjectLibraryTypeSelect({
         </Listbox.Options>
       </div>
     </Listbox>
+  )
+}
+
+export function DirectoryProjectLibrarySettingsDetails({
+  library,
+  index,
+  updateLibrary,
+  commitLibrary,
+  chooseDirectory,
+}: ProjectLibrarySettingsDetailsProps) {
+  async function chooseLibraryPath() {
+    if (!chooseDirectory) {
+      return
+    }
+
+    const selectedPath = await chooseDirectory({
+      defaultPath: library.path,
+      title: 'Choose a project library folder',
+    })
+    if (!selectedPath) {
+      return
+    }
+
+    commitLibrary({
+      ...library,
+      path: selectedPath,
+    })
+  }
+
+  return (
+    <div className="flex min-w-0 gap-1">
+      <input
+        value={library.path}
+        onChange={(event) =>
+          updateLibrary({
+            ...library,
+            path: event.target.value,
+          })
+        }
+        onBlur={() => commitLibrary()}
+        className="min-w-0 flex-1 rounded-sm border border-chalkboard-30 bg-transparent p-1 text-sm dark:border-chalkboard-70"
+        data-testid={
+          index === 0 ? 'project-directory-input' : 'project-library-path'
+        }
+      />
+      {chooseDirectory && (
+        <ActionButton
+          Element="button"
+          type="button"
+          tabIndex={0}
+          onClick={toSync(chooseLibraryPath, reportRejection)}
+          className="!p-0"
+          iconStart={{
+            icon: 'folder',
+            bgClassName: '!bg-transparent',
+          }}
+          data-testid={
+            index === 0
+              ? 'project-directory-button'
+              : 'project-library-folder-button'
+          }
+        >
+          <Tooltip position="top-right">Choose folder</Tooltip>
+        </ActionButton>
+      )}
+    </div>
   )
 }
 
@@ -316,18 +374,17 @@ export function ProjectLibrariesSettingInput({
     )
   }
 
-  async function choosePathWithInput(
-    pathInput: ProjectLibraryTypeOptionPathInput,
+  async function chooseDirectory({
+    defaultPath,
+    title,
+  }: {
     defaultPath?: string
-  ) {
-    if (pathInput.kind !== 'directory') {
-      return defaultPath
-    }
-
+    title?: string
+  }) {
     const result = await electron?.open({
       properties: ['openDirectory', 'createDirectory'],
       defaultPath,
-      title: pathInput.dialogTitle ?? 'Choose a project library path',
+      title: title ?? 'Choose a project library folder',
     })
 
     if (!result || result.canceled) {
@@ -344,25 +401,7 @@ export function ProjectLibrariesSettingInput({
     }
 
     const newLibrary = libraryTypeOption.newLibrary
-    const selectedPath =
-      electron && libraryTypeOption.pathInput
-        ? await choosePathWithInput(
-            libraryTypeOption.pathInput,
-            newLibrary.path
-          )
-        : newLibrary.path
-
-    if (!selectedPath) {
-      return
-    }
-
-    commit([
-      ...draftLibraries,
-      {
-        ...newLibrary,
-        path: selectedPath,
-      },
-    ])
+    commit([...draftLibraries, newLibrary])
   }
 
   function removeLibrary(index: number) {
@@ -426,33 +465,6 @@ export function ProjectLibrariesSettingInput({
     dragPreviewIdRef.current = null
   }
 
-  async function chooseLibraryPath(index: number) {
-    const library = draftLibraries[index]
-    if (!library) {
-      return
-    }
-
-    const pathInput = libraryTypeOptionForType(
-      library.type,
-      libraryTypeOptions
-    )?.pathInput
-    if (!pathInput) {
-      return
-    }
-
-    const selectedPath = await choosePathWithInput(pathInput, library.path)
-    if (!selectedPath) {
-      return
-    }
-
-    commit(
-      updateProjectLibrarySettingAt(draftLibraries, index, (library) => ({
-        ...library,
-        path: selectedPath,
-      }))
-    )
-  }
-
   return (
     <div
       className="flex flex-col gap-3"
@@ -461,10 +473,9 @@ export function ProjectLibrariesSettingInput({
       {draftLibraries.length > 0 && (
         <ul className="flex flex-col gap-2">
           {draftLibraries.map((library, index) => {
-            const pathInput = libraryTypeOptionForType(
-              library.type,
-              libraryTypeOptions
-            )?.pathInput
+            const SettingsDetails =
+              libraryTypeOptionForType(library.type, libraryTypeOptions)
+                ?.settingsDetails ?? DefaultProjectLibrarySettingsDetails
 
             return (
               <li
@@ -505,46 +516,31 @@ export function ProjectLibrariesSettingInput({
                   className="min-w-0 rounded-sm border border-chalkboard-30 bg-transparent p-1 text-sm dark:border-chalkboard-70"
                   data-testid="project-library-title"
                 />
-                <div className="flex min-w-0 gap-1">
-                  <input
-                    value={library.path}
-                    onChange={(event) =>
-                      updateDraftField(index, 'path', event.target.value)
-                    }
-                    onBlur={() => commitDraftLibrary(index)}
-                    className="min-w-0 flex-1 rounded-sm border border-chalkboard-30 bg-transparent p-1 text-sm dark:border-chalkboard-70"
-                    data-testid={
-                      index === 0
-                        ? 'project-directory-input'
-                        : 'project-library-path'
-                    }
-                  />
-                  {electron && pathInput && (
-                    <ActionButton
-                      Element="button"
-                      type="button"
-                      tabIndex={0}
-                      onClick={toSync(
-                        () => chooseLibraryPath(index),
-                        reportRejection
-                      )}
-                      className="!p-0"
-                      iconStart={{
-                        icon: pathInput.icon,
-                        bgClassName: '!bg-transparent',
-                      }}
-                      data-testid={
-                        index === 0
-                          ? 'project-directory-button'
-                          : 'project-library-folder-button'
-                      }
-                    >
-                      <Tooltip position="top-right">
-                        {pathInput.buttonLabel ?? 'Choose path'}
-                      </Tooltip>
-                    </ActionButton>
-                  )}
-                </div>
+                <SettingsDetails
+                  library={library}
+                  index={index}
+                  updateLibrary={(nextLibrary) =>
+                    setDraftLibraries((libraries) =>
+                      updateProjectLibrarySettingAt(
+                        libraries,
+                        index,
+                        () => nextLibrary
+                      )
+                    )
+                  }
+                  commitLibrary={(nextLibrary) =>
+                    commit(
+                      nextLibrary
+                        ? updateProjectLibrarySettingAt(
+                            draftLibraries,
+                            index,
+                            () => nextLibrary
+                          )
+                        : draftLibraries
+                    )
+                  }
+                  chooseDirectory={electron ? chooseDirectory : undefined}
+                />
                 <ActionButton
                   Element="button"
                   type="button"

--- a/src/lib/revealInFileExplorer.test.ts
+++ b/src/lib/revealInFileExplorer.test.ts
@@ -1,5 +1,7 @@
 import {
+  canOpenPathInFileExplorer,
   canRevealInFileExplorer,
+  openPathInFileExplorer,
   revealInFileExplorer,
 } from '@src/lib/revealInFileExplorer'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -32,6 +34,20 @@ describe('revealInFileExplorer', () => {
     expect(showInFolder).toHaveBeenCalledWith('/project/main.kcl')
   })
 
+  it('uses the Electron folder open bridge', () => {
+    vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue('Electron')
+    const openPath = vi.fn()
+    window.electron = {
+      openPath,
+    } as unknown as Window['electron']
+
+    expect(canOpenPathInFileExplorer()).toBe(true)
+
+    openPathInFileExplorer('/project-library')
+
+    expect(openPath).toHaveBeenCalledWith('/project-library')
+  })
+
   it('hides reveal support outside the desktop app', () => {
     const showInFolder = vi.fn()
     window.electron = {
@@ -39,5 +55,6 @@ describe('revealInFileExplorer', () => {
     } as unknown as Window['electron']
 
     expect(canRevealInFileExplorer()).toBe(false)
+    expect(canOpenPathInFileExplorer()).toBe(false)
   })
 })

--- a/src/lib/revealInFileExplorer.ts
+++ b/src/lib/revealInFileExplorer.ts
@@ -9,6 +9,14 @@ export function canRevealInFileExplorer() {
   )
 }
 
+export function canOpenPathInFileExplorer() {
+  return (
+    isDesktop() &&
+    typeof window !== 'undefined' &&
+    typeof window.electron?.openPath === 'function'
+  )
+}
+
 export function revealInFileExplorer(path: string) {
   const electron = typeof window === 'undefined' ? undefined : window.electron
   const showInFolder = electron?.showInFolder
@@ -18,6 +26,24 @@ export function revealInFileExplorer(path: string) {
 
   try {
     void Promise.resolve(showInFolder(path)).catch(reportRejection)
+  } catch (error) {
+    reportRejection(error)
+  }
+}
+
+export function openPathInFileExplorer(path: string) {
+  const electron = typeof window === 'undefined' ? undefined : window.electron
+  const openPath = electron?.openPath
+  if (typeof openPath !== 'function') {
+    return
+  }
+
+  try {
+    void Promise.resolve(openPath(path)).then((errorMessage) => {
+      if (typeof errorMessage === 'string' && errorMessage.length > 0) {
+        reportRejection(new Error(errorMessage))
+      }
+    }, reportRejection)
   } catch (error) {
     reportRejection(error)
   }

--- a/src/lib/routeLoaders.ts
+++ b/src/lib/routeLoaders.ts
@@ -40,7 +40,10 @@ import type {
   IndexLoaderData,
 } from '@src/lib/types'
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
-import { projectLibrarySettingDefaultsValueSpec } from '@src/registry/contracts/projectLibraries'
+import {
+  projectLibrarySettingDefaultPoliciesValueSpec,
+  projectLibrarySettingDefaultsValueSpec,
+} from '@src/registry/contracts/projectLibraries'
 import { settingsValueSpec } from '@src/registry/contracts/settings'
 import type { LoaderFunction } from 'react-router-dom'
 import { redirect } from 'react-router-dom'
@@ -62,6 +65,9 @@ function loadRouteSettings(
   return loadAndValidateSettings(wasmInstance, {
     defaultProjectLibraries: app.registry.get(
       projectLibrarySettingDefaultsValueSpec
+    ),
+    projectLibrarySettingDefaultPolicies: app.registry.get(
+      projectLibrarySettingDefaultPoliciesValueSpec
     ),
     extensionSettings: app.registry.get(settingsValueSpec),
     projectPath,

--- a/src/lib/settings/settingsUtils.ts
+++ b/src/lib/settings/settingsUtils.ts
@@ -30,11 +30,12 @@ import {
 } from '@src/lib/layout/utils'
 import {
   getDefaultDirectoryProjectLibraryPath,
-  getDefaultProjectLibrarySettings,
   isProjectLibrarySettings,
   mergeProjectLibrarySettings,
   type ProjectLibrarySetting,
 } from '@src/lib/projectLibraries'
+import type { ProjectLibrarySettingDefaultPolicy } from '@src/registry/contracts/projectLibraries'
+import { resolveProjectLibrarySettingDefaults } from '@src/registry/contracts/projectLibraries'
 import type { ResolvedExtensionSettings } from '@src/lib/settings/extensionSettings'
 import {
   Setting,
@@ -958,6 +959,7 @@ export async function loadAndValidateSettings(
     | string
     | {
         defaultProjectLibraries?: readonly ProjectLibrarySetting[]
+        projectLibrarySettingDefaultPolicies?: readonly ProjectLibrarySettingDefaultPolicy[]
         extensionSettings?: ResolvedExtensionSettings
         projectPath?: string
       }
@@ -969,6 +971,7 @@ export async function loadAndValidateSettings(
       : projectPathOrOptions
   const {
     defaultProjectLibraries = [],
+    projectLibrarySettingDefaultPolicies = [],
     extensionSettings = {},
     projectPath,
   } = options
@@ -991,14 +994,21 @@ export async function loadAndValidateSettings(
     typeof appSettings.app?.projectDirectory === 'string'
       ? appSettings.app.projectDirectory
       : undefined
-  const defaultDirectoryLibraryPath =
-    legacyProjectDirectory ?? initialDefaultDir
+
+  const policyDefaultProjectLibraries = resolveProjectLibrarySettingDefaults(
+    projectLibrarySettingDefaultPolicies,
+    {
+      initialDefaultDir,
+      legacyProjectDirectory,
+      isDesktop: isDesktop(),
+    }
+  )
 
   let settingsNext = createSettings(extensionSettings)
   settingsNext.app.projectDirectory.default = initialDefaultDir
   if (settingsNext.app.libraries) {
     settingsNext.app.libraries.default = mergeProjectLibrarySettings(
-      getDefaultProjectLibrarySettings(defaultDirectoryLibraryPath),
+      policyDefaultProjectLibraries,
       defaultProjectLibraries
     )
   }

--- a/src/lib/trap.test.ts
+++ b/src/lib/trap.test.ts
@@ -1,0 +1,28 @@
+import { formatRejectionReason, reportRejection } from '@src/lib/trap'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('reportRejection', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('reports Error messages instead of stringifying them as empty objects', () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+
+    reportRejection(new Error('Personal Cloud already has a local copy.'))
+
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('Personal Cloud already has a local copy.')
+    )
+  })
+})
+
+describe('formatRejectionReason', () => {
+  it('serializes non-error objects when possible', () => {
+    expect(formatRejectionReason({ reason: 'blocked' })).toBe(`{
+  "reason": "blocked"
+}`)
+  })
+})

--- a/src/lib/trap.ts
+++ b/src/lib/trap.ts
@@ -74,12 +74,37 @@ export function report(
  * Promise.prototype.catch.
  */
 export function reportRejection(reason: any): undefined {
-  report(
-    (
-      (reason instanceof Object ? JSON.stringify(reason, null, 2) : reason) ??
-      'Unknown promise rejection'
-    ).toString()
-  )
+  report(formatRejectionReason(reason))
+}
+
+export function formatRejectionReason(reason: unknown) {
+  if (reason instanceof Error) {
+    return reason.stack || reason.message
+  }
+
+  if (typeof reason === 'string') {
+    return reason
+  }
+
+  if (reason && typeof reason === 'object') {
+    const message = (reason as { message?: unknown }).message
+    if (typeof message === 'string') {
+      return message
+    }
+
+    try {
+      const serialized = JSON.stringify(reason, null, 2)
+      if (serialized && serialized !== '{}') {
+        return serialized
+      }
+    } catch {
+      // Fall through to Object.prototype.toString for non-serializable values.
+    }
+
+    return Object.prototype.toString.call(reason)
+  }
+
+  return (reason ?? 'Unknown promise rejection').toString()
 }
 
 /**

--- a/src/machines/settingsMachine.ts
+++ b/src/machines/settingsMachine.ts
@@ -21,6 +21,7 @@ import type { Project } from '@src/lib/project'
 import type { ProjectLibrarySetting } from '@src/lib/projectLibraries'
 import type { ResolvedExtensionSettings } from '@src/lib/settings/extensionSettings'
 import type { SettingsType } from '@src/lib/settings/initialSettings'
+import type { ProjectLibrarySettingDefaultPolicy } from '@src/registry/contracts/projectLibraries'
 import { createSettings } from '@src/lib/settings/initialSettings'
 import type {
   BaseUnit,
@@ -48,6 +49,7 @@ export type SettingsActorDepsType = {
   currentProject?: Project
   commandBarActor: ActorRefFrom<typeof commandBarMachine>
   defaultProjectLibraries: readonly ProjectLibrarySetting[]
+  projectLibrarySettingDefaultPolicies: readonly ProjectLibrarySettingDefaultPolicy[]
   extensionSettings: ResolvedExtensionSettings
   wasmInstancePromise: Promise<ModuleType>
 }
@@ -125,6 +127,7 @@ export const settingsMachine = setup({
       SettingsType,
       {
         defaultProjectLibraries: readonly ProjectLibrarySetting[]
+        projectLibrarySettingDefaultPolicies: readonly ProjectLibrarySettingDefaultPolicy[]
         extensionSettings: ResolvedExtensionSettings
         wasmInstancePromise: Promise<ModuleType>
       }
@@ -133,6 +136,8 @@ export const settingsMachine = setup({
         input.wasmInstancePromise,
         {
           defaultProjectLibraries: input.defaultProjectLibraries,
+          projectLibrarySettingDefaultPolicies:
+            input.projectLibrarySettingDefaultPolicies,
           extensionSettings: input.extensionSettings,
         }
       )
@@ -142,6 +147,7 @@ export const settingsMachine = setup({
       SettingsType,
       {
         defaultProjectLibraries: readonly ProjectLibrarySetting[]
+        projectLibrarySettingDefaultPolicies: readonly ProjectLibrarySettingDefaultPolicy[]
         extensionSettings: ResolvedExtensionSettings
         project: Project
         settings: SettingsType
@@ -152,6 +158,8 @@ export const settingsMachine = setup({
         input.wasmInstancePromise,
         {
           defaultProjectLibraries: input.defaultProjectLibraries,
+          projectLibrarySettingDefaultPolicies:
+            input.projectLibrarySettingDefaultPolicies,
           extensionSettings: input.extensionSettings,
           projectPath: input.project.path,
         }
@@ -163,6 +171,7 @@ export const settingsMachine = setup({
       {
         currentProject?: Project
         defaultProjectLibraries: readonly ProjectLibrarySetting[]
+        projectLibrarySettingDefaultPolicies: readonly ProjectLibrarySettingDefaultPolicy[]
         extensionSettings: ResolvedExtensionSettings
         wasmInstancePromise: Promise<ModuleType>
       }
@@ -171,6 +180,8 @@ export const settingsMachine = setup({
         input.wasmInstancePromise,
         {
           defaultProjectLibraries: input.defaultProjectLibraries,
+          projectLibrarySettingDefaultPolicies:
+            input.projectLibrarySettingDefaultPolicies,
           extensionSettings: input.extensionSettings,
           projectPath: input.currentProject?.path,
         }
@@ -577,6 +588,8 @@ export const settingsMachine = setup({
         input: ({ context }) => ({
           currentProject: context.currentProject,
           defaultProjectLibraries: context.defaultProjectLibraries,
+          projectLibrarySettingDefaultPolicies:
+            context.projectLibrarySettingDefaultPolicies,
           extensionSettings: context.extensionSettings,
           wasmInstancePromise: context.wasmInstancePromise,
         }),
@@ -627,6 +640,8 @@ export const settingsMachine = setup({
         src: 'loadUserSettings',
         input: ({ context }) => ({
           defaultProjectLibraries: context.defaultProjectLibraries,
+          projectLibrarySettingDefaultPolicies:
+            context.projectLibrarySettingDefaultPolicies,
           extensionSettings: context.extensionSettings,
           wasmInstancePromise: context.wasmInstancePromise,
         }),
@@ -677,6 +692,8 @@ export const settingsMachine = setup({
           assertEvent(event, 'load.project')
           return {
             defaultProjectLibraries: context.defaultProjectLibraries,
+            projectLibrarySettingDefaultPolicies:
+              context.projectLibrarySettingDefaultPolicies,
             extensionSettings: context.extensionSettings,
             settings: getOnlySettingsFromContext(context),
             project: event.project,
@@ -695,6 +712,7 @@ export function getOnlySettingsFromContext(
     currentProject: _c,
     commandBarActor: _cba,
     defaultProjectLibraries: _defaultProjectLibraries,
+    projectLibrarySettingDefaultPolicies: _projectLibrarySettingDefaultPolicies,
     extensionSettings: _extensionSettings,
     wasmInstancePromise: _w,
     ...settings

--- a/src/main.ts
+++ b/src/main.ts
@@ -582,6 +582,10 @@ ipcMain.handle('shell.showItemInFolder', (event, data) => {
   return shell.showItemInFolder(data)
 })
 
+ipcMain.handle('shell.openPath', (_event, data) => {
+  return shell.openPath(data)
+})
+
 ipcMain.handle('shell.openExternal', (_event, data) => {
   const allowedURL = getAllowedExternalURL(data)
   if (allowedURL instanceof Error) {

--- a/src/preload.test.ts
+++ b/src/preload.test.ts
@@ -40,7 +40,7 @@ vi.mock('chokidar', () => ({
   },
 }))
 
-import { move, openExternal } from '@src/preload'
+import { move, openExternal, openPath } from '@src/preload'
 
 describe('move', () => {
   beforeEach(() => {
@@ -143,5 +143,22 @@ describe('openExternal', () => {
     )
 
     expect(ipcRendererMock.invoke).not.toHaveBeenCalled()
+  })
+})
+
+describe('openPath', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('invokes the main process folder open channel', async () => {
+    ipcRendererMock.invoke.mockResolvedValue('')
+
+    await expect(openPath('/project-library')).resolves.toBe('')
+
+    expect(ipcRendererMock.invoke).toHaveBeenCalledWith(
+      'shell.openPath',
+      '/project-library'
+    )
   })
 })

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -36,6 +36,8 @@ export const openExternal = (url: unknown) => {
   return ipcRenderer.invoke('shell.openExternal', allowedURL)
 }
 const openInNewWindow = (url: any) => ipcRenderer.invoke('openInNewWindow', url)
+export const openPath = (path: string) =>
+  ipcRenderer.invoke('shell.openPath', path)
 const showInFolder = (path: string) =>
   ipcRenderer.invoke('shell.showItemInFolder', path)
 const pluginIpc = {
@@ -336,6 +338,7 @@ contextBridge.exposeInMainWorld('electron', {
   // opens the URL
   openExternal,
   openInNewWindow,
+  openPath,
   showInFolder,
   pluginIpc,
   getPath,

--- a/src/registry/contracts/projectLibraries.spec.ts
+++ b/src/registry/contracts/projectLibraries.spec.ts
@@ -1,9 +1,11 @@
 import {
+  combineProjectLibrarySettingDefaultPolicies,
   combineProjectLibrarySettingDefaults,
   combineProjectLibraryTypes,
   combineProjectLibraries,
   getHomeProjectEntriesForLibrary,
   getProjectLibraryOperation,
+  resolveProjectLibrarySettingDefaults,
 } from '@src/registry/contracts/projectLibraries'
 import {
   DEFAULT_PROJECT_LIBRARY_ID,
@@ -300,6 +302,51 @@ describe('combineProjectLibraries', () => {
         id: 'external',
         title: 'External Projects',
       }),
+    ])
+  })
+})
+
+describe('project library default policies', () => {
+  test('resolves the highest-priority default library policy', () => {
+    const directoryPolicy = {
+      id: 'directory',
+      priority: 0,
+      getDefaultLibraries: () => [
+        {
+          title: 'Projects',
+          path: '/projects',
+          type: 'directory',
+        },
+      ],
+    }
+    const cloudPolicy = {
+      id: 'cloud',
+      priority: 10,
+      getDefaultLibraries: () => [
+        {
+          title: 'Personal Cloud',
+          path: '/personal',
+          type: 'cloud',
+        },
+      ],
+    }
+
+    const policies = combineProjectLibrarySettingDefaultPolicies([
+      directoryPolicy,
+      cloudPolicy,
+    ])
+
+    expect(
+      resolveProjectLibrarySettingDefaults(policies, {
+        initialDefaultDir: '/projects',
+        isDesktop: false,
+      })
+    ).toEqual([
+      {
+        title: 'Personal Cloud',
+        path: '/personal',
+        type: 'cloud',
+      },
     ])
   })
 })

--- a/src/registry/contracts/projectLibraries.spec.ts
+++ b/src/registry/contracts/projectLibraries.spec.ts
@@ -6,7 +6,10 @@ import {
   getProjectLibraryOperation,
 } from '@src/registry/contracts/projectLibraries'
 import {
+  CLOUD_PROJECT_LIBRARY_ID,
+  DEFAULT_CLOUD_PROJECT_LIBRARY_PATH,
   DEFAULT_PROJECT_LIBRARY_ID,
+  getDefaultCloudProjectLibrarySetting,
   areProjectLibrarySettingsEqual,
   getContainingDirectoryProjectLibraryPath,
   getDefaultDirectoryProjectLibrarySetting,
@@ -51,6 +54,18 @@ describe('project library settings', () => {
     ).toEqual(
       expect.objectContaining({
         id: DEFAULT_PROJECT_LIBRARY_ID,
+      })
+    )
+  })
+
+  test('maps the default cloud library to the stable cloud library id', () => {
+    expect(
+      projectLibraryFromSetting(getDefaultCloudProjectLibrarySetting())
+    ).toEqual(
+      expect.objectContaining({
+        id: CLOUD_PROJECT_LIBRARY_ID,
+        path: DEFAULT_CLOUD_PROJECT_LIBRARY_PATH,
+        type: 'cloud',
       })
     )
   })

--- a/src/registry/contracts/projectLibraries.spec.ts
+++ b/src/registry/contracts/projectLibraries.spec.ts
@@ -6,9 +6,9 @@ import {
   getProjectLibraryOperation,
 } from '@src/registry/contracts/projectLibraries'
 import {
-  CLOUD_PROJECT_LIBRARY_ID,
-  DEFAULT_CLOUD_PROJECT_LIBRARY_PATH,
   DEFAULT_PROJECT_LIBRARY_ID,
+  DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH,
+  PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
   getDefaultCloudProjectLibrarySetting,
   areProjectLibrarySettingsEqual,
   getContainingDirectoryProjectLibraryPath,
@@ -63,8 +63,8 @@ describe('project library settings', () => {
       projectLibraryFromSetting(getDefaultCloudProjectLibrarySetting())
     ).toEqual(
       expect.objectContaining({
-        id: CLOUD_PROJECT_LIBRARY_ID,
-        path: DEFAULT_CLOUD_PROJECT_LIBRARY_PATH,
+        id: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+        path: DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH,
         type: 'cloud',
       })
     )

--- a/src/registry/contracts/projectLibraries.ts
+++ b/src/registry/contracts/projectLibraries.ts
@@ -12,6 +12,7 @@ import type {
 } from '@src/lib/projectLibraries'
 import { mergeProjectLibrarySettings } from '@src/lib/projectLibraries'
 import { isArray } from '@src/lib/utils'
+import type { ComponentType } from 'react'
 
 export type ProjectLibraryContribution =
   | ProjectLibrary
@@ -62,11 +63,15 @@ export interface ProjectLibraryTypeOperations {
   deleteProject?: ProjectLibraryOperation<ProjectLibraryDeleteProjectInput>
 }
 
-export interface ProjectLibraryTypePathInput {
-  kind: 'directory'
-  icon?: string
-  dialogTitle?: string
-  buttonLabel?: string
+export interface ProjectLibrarySettingsDetailsProps {
+  library: ProjectLibrarySetting
+  index: number
+  updateLibrary: (library: ProjectLibrarySetting) => void
+  commitLibrary: (library?: ProjectLibrarySetting) => void
+  chooseDirectory?: (input: {
+    defaultPath?: string
+    title?: string
+  }) => Promise<string | undefined>
 }
 
 export interface ProjectLibraryTypeContribution {
@@ -78,8 +83,8 @@ export interface ProjectLibraryTypeContribution {
   defaultSetting?: ProjectLibrarySetting
   /** Template used when a user manually adds a new library of this type. */
   newLibrarySetting?: ProjectLibrarySetting
-  /** Optional UI behavior for editing the library path in settings. */
-  pathInput?: ProjectLibraryTypePathInput
+  /** Optional detail cell rendered in the project libraries settings row. */
+  settingsDetails?: ComponentType<ProjectLibrarySettingsDetailsProps>
   operations?: ProjectLibraryTypeOperations
   readEntries?: (input: {
     library: ProjectLibrary

--- a/src/registry/contracts/projectLibraries.ts
+++ b/src/registry/contracts/projectLibraries.ts
@@ -11,6 +11,7 @@ import type {
   ProjectLibraryType,
 } from '@src/lib/projectLibraries'
 import { mergeProjectLibrarySettings } from '@src/lib/projectLibraries'
+import type { HideOnPlatformValue } from '@src/lib/settings/settingsTypes'
 import { isArray } from '@src/lib/utils'
 import type { ComponentType } from 'react'
 
@@ -21,6 +22,24 @@ export type ProjectLibraryContribution =
 export type ProjectLibrarySettingDefaultContribution =
   | ProjectLibrarySetting
   | readonly ProjectLibrarySetting[]
+
+export interface ProjectLibrarySettingDefaultPolicyInput {
+  initialDefaultDir: string
+  legacyProjectDirectory?: string
+  isDesktop: boolean
+}
+
+export interface ProjectLibrarySettingDefaultPolicy {
+  id: string
+  priority?: number
+  getDefaultLibraries: (
+    input: ProjectLibrarySettingDefaultPolicyInput
+  ) => readonly ProjectLibrarySetting[] | undefined
+}
+
+export type ProjectLibrarySettingDefaultPolicyContribution =
+  | ProjectLibrarySettingDefaultPolicy
+  | readonly ProjectLibrarySettingDefaultPolicy[]
 
 export interface ProjectLibraryOperation<
   Input extends { library: ProjectLibrary },
@@ -68,6 +87,7 @@ export interface ProjectLibrarySettingsDetailsProps {
   index: number
   updateLibrary: (library: ProjectLibrarySetting) => void
   commitLibrary: (library?: ProjectLibrarySetting) => void
+  readOnly?: boolean
   chooseDirectory?: (input: {
     defaultPath?: string
     title?: string
@@ -85,6 +105,8 @@ export interface ProjectLibraryTypeContribution {
   newLibrarySetting?: ProjectLibrarySetting
   /** Optional detail cell rendered in the project libraries settings row. */
   settingsDetails?: ComponentType<ProjectLibrarySettingsDetailsProps>
+  /** Hide this type from creation/editing UI while keeping runtime support. */
+  hideInSettingsOnPlatform?: HideOnPlatformValue
   operations?: ProjectLibraryTypeOperations
   readEntries?: (input: {
     library: ProjectLibrary
@@ -180,6 +202,33 @@ export function combineProjectLibrarySettingDefaults(
   )
 }
 
+export function combineProjectLibrarySettingDefaultPolicies(
+  contributions: readonly ProjectLibrarySettingDefaultPolicyContribution[]
+) {
+  return contributions
+    .flatMap((contribution) =>
+      isArray(contribution) ? contribution : [contribution]
+    )
+    .toSorted((a, b) => {
+      const priorityDiff = (b.priority ?? 0) - (a.priority ?? 0)
+      return priorityDiff === 0 ? a.id.localeCompare(b.id) : priorityDiff
+    })
+}
+
+export function resolveProjectLibrarySettingDefaults(
+  policies: readonly ProjectLibrarySettingDefaultPolicy[],
+  input: ProjectLibrarySettingDefaultPolicyInput
+) {
+  for (const policy of policies) {
+    const defaults = policy.getDefaultLibraries(input)
+    if (defaults && defaults.length > 0) {
+      return mergeProjectLibrarySettings(defaults)
+    }
+  }
+
+  return []
+}
+
 export const projectLibrariesContract = defineContract({
   projectLibrariesValueSpec: defineValueSpec<
     ProjectLibraryContribution,
@@ -205,10 +254,19 @@ export const projectLibrariesContract = defineContract({
     defaultValue: [],
     combine: combineProjectLibrarySettingDefaults,
   }),
+  projectLibrarySettingDefaultPoliciesValueSpec: defineValueSpec<
+    ProjectLibrarySettingDefaultPolicyContribution,
+    ProjectLibrarySettingDefaultPolicy[]
+  >({
+    name: 'project-library-setting-default-policies',
+    defaultValue: [],
+    combine: combineProjectLibrarySettingDefaultPolicies,
+  }),
 })
 
 export const {
   projectLibrariesValueSpec,
   projectLibraryTypesValueSpec,
   projectLibrarySettingDefaultsValueSpec,
+  projectLibrarySettingDefaultPoliciesValueSpec,
 } = projectLibrariesContract

--- a/src/registry/extensions/homeProjects/index.ts
+++ b/src/registry/extensions/homeProjects/index.ts
@@ -53,7 +53,7 @@ import toast from 'react-hot-toast'
 
 const configuredProjectLibraryEntriesInvalidation = signal(0)
 
-function invalidateConfiguredProjectLibraryEntries() {
+export function invalidateConfiguredProjectLibraryEntries() {
   configuredProjectLibraryEntriesInvalidation.value += 1
 }
 

--- a/src/registry/extensions/homeProjects/index.ts
+++ b/src/registry/extensions/homeProjects/index.ts
@@ -24,6 +24,7 @@ import {
   DIRECTORY_PROJECT_LIBRARY_TYPE,
   NEW_PROJECT_LIBRARY_TITLE,
   getDefaultDirectoryProjectLibraryPath,
+  getDefaultProjectLibrarySettings,
   type ProjectLibrary,
   projectLibraryFromSetting,
 } from '@src/lib/projectLibraries'
@@ -41,6 +42,7 @@ import {
 import {
   getProjectLibraryOperation,
   projectLibrariesValueSpec,
+  projectLibrarySettingDefaultPoliciesValueSpec,
   projectLibraryTypesValueSpec,
   type ProjectLibraryTypeOperations,
 } from '@src/registry/contracts/projectLibraries'
@@ -349,6 +351,7 @@ const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
             type: DIRECTORY_PROJECT_LIBRARY_TYPE,
           },
           settingsDetails: DirectoryProjectLibrarySettingsDetails,
+          hideInSettingsOnPlatform: 'web',
           readEntries: async ({ library, signal }) => {
             const projects = await readProjectsFromProjectDirectory({
               projectDirectoryPath: library.path,
@@ -425,6 +428,26 @@ const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
     }),
   }
 }, 'home-projects.directory-library-type')
+
+const directoryProjectLibraryDefaultPolicy = defineRegistryItem({
+  id: 'home-projects.directory-library-default-policy',
+  provides: [
+    provide(projectLibrarySettingDefaultPoliciesValueSpec, {
+      id: 'home-projects.directory-library-default-policy',
+      priority: 0,
+      /**
+       * Product policy: the directory library owns the legacy default project
+       * directory fallback. Other library systems can contribute
+       * higher-priority policies without `loadAndValidateSettings()` knowing
+       * about their storage type.
+       */
+      getDefaultLibraries: ({ legacyProjectDirectory, initialDefaultDir }) =>
+        getDefaultProjectLibrarySettings(
+          legacyProjectDirectory ?? initialDefaultDir
+        ),
+    }),
+  ],
+})
 
 const configuredProjectLibraryEntries = defineRegistryItemFactory((ctx) => {
   const settings = ctx.services.signal(settingsService)
@@ -538,6 +561,7 @@ const homeProjectsExtension = defineRegistryItem({
   uses: [
     configuredProjectLibraries,
     configuredProjectLibraryEntries,
+    directoryProjectLibraryDefaultPolicy,
     directoryProjectLibraryType,
     homeProjectActions,
     systemIOLocalHomeProjectEntries,

--- a/src/registry/extensions/homeProjects/index.ts
+++ b/src/registry/extensions/homeProjects/index.ts
@@ -27,6 +27,7 @@ import {
   type ProjectLibrary,
   projectLibraryFromSetting,
 } from '@src/lib/projectLibraries'
+import { DirectoryProjectLibrarySettingsDetails } from '@src/lib/projectLibraries/settings/ProjectLibrariesSettingInput'
 import { reportRejection } from '@src/lib/trap'
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
 import { cloudSyncService } from '@src/registry/contracts/cloudSync'
@@ -347,12 +348,7 @@ const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
             path: 'projects',
             type: DIRECTORY_PROJECT_LIBRARY_TYPE,
           },
-          pathInput: {
-            kind: 'directory',
-            icon: 'folder',
-            dialogTitle: 'Choose a project library folder',
-            buttonLabel: 'Choose folder',
-          },
+          settingsDetails: DirectoryProjectLibrarySettingsDetails,
           readEntries: async ({ library, signal }) => {
             const projects = await readProjectsFromProjectDirectory({
               projectDirectoryPath: library.path,

--- a/src/registry/extensions/settings/index.ts
+++ b/src/registry/extensions/settings/index.ts
@@ -20,7 +20,10 @@ import {
   settingsService,
   settingsValueSpec,
 } from '@src/registry/contracts/settings'
-import { projectLibrarySettingDefaultsValueSpec } from '@src/registry/contracts/projectLibraries'
+import {
+  projectLibrarySettingDefaultPoliciesValueSpec,
+  projectLibrarySettingDefaultsValueSpec,
+} from '@src/registry/contracts/projectLibraries'
 import { statusBarGlobalItemsValueSpec } from '@src/registry/contracts/statusBar'
 import { wasmPromiseValueSpec } from '@src/registry/contracts/wasm'
 import { useSelector } from '@xstate/react'
@@ -45,11 +48,15 @@ export const settingsExtension = defineRegistryItemFactory((ctx) => {
     const defaultProjectLibraries = ctx.valueSpecs.get(
       projectLibrarySettingDefaultsValueSpec
     )
+    const projectLibrarySettingDefaultPolicies = ctx.valueSpecs.get(
+      projectLibrarySettingDefaultPoliciesValueSpec
+    )
     const actor = createActor(settingsMachine, {
       input: {
         ...createSettings(extensionSettings),
         commandBarActor: commands.actor,
         defaultProjectLibraries,
+        projectLibrarySettingDefaultPolicies,
         extensionSettings,
         wasmInstancePromise: getWasmPromise(),
       },

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -566,6 +566,7 @@ const Home = () => {
             projectActions={homeProjectActions}
             showCloudSyncUi={hasCloudSyncFeature}
             showSourceStatusBadges={false}
+            projectLibraryEmptyTestId="project-library-empty"
             className="flex-1 col-start-2 -col-end-1 overflow-y-auto pr-2 pb-24"
           />
         ) : (
@@ -947,6 +948,7 @@ interface ProjectGridProps extends HTMLProps<HTMLDivElement> {
   projectActions: HomeProjectActionsService
   showCloudSyncUi: boolean
   showSourceStatusBadges?: boolean
+  projectLibraryEmptyTestId?: string
 }
 
 function ProjectGrid({
@@ -959,6 +961,7 @@ function ProjectGrid({
   projectActions,
   showCloudSyncUi,
   showSourceStatusBadges = true,
+  projectLibraryEmptyTestId,
   ...rest
 }: ProjectGridProps) {
   const state = useSystemIOState()
@@ -989,7 +992,9 @@ function ProjectGrid({
               data-testid="projects-none"
               className="p-4 my-8 border border-dashed rounded border-chalkboard-30 dark:border-chalkboard-70"
             >
-              No projects found
+              <span data-testid={projectLibraryEmptyTestId}>
+                No projects found
+              </span>
               {projects.length === 0
                 ? ', ready to make your first one?'
                 : ` with the search term "${query}"`}

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -32,6 +32,12 @@ import {
 import { BillingTransition } from '@src/lib/billing'
 import { useApp, useSingletons } from '@src/lib/boot'
 import { cloudSyncStatus, setCloudSyncProjectScope } from '@src/lib/cloudSync'
+import { getDefaultCloudProjectDirectoryPath } from '@src/lib/cloudSync/paths'
+import {
+  LEGACY_CLOUD_PROJECT_MIGRATION_DISMISSED_STORAGE_KEY,
+  getLegacyCloudLocationProjects,
+  getLegacyCloudProjectMigrationSignature,
+} from '@src/lib/cloudSync/legacyProjectMigration'
 import { createRouteCommands } from '@src/lib/commandBarConfigs/routeCommandConfig'
 import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
 import { isDesktop } from '@src/lib/isDesktop'
@@ -79,7 +85,9 @@ import {
   statusBarGlobalItemsValueSpec,
   statusBarLocalItemsValueSpec,
 } from '@src/registry/contracts/statusBar'
+import { cloudSyncService } from '@src/registry/contracts/cloudSync'
 import { APP_COMMAND_IDS } from '@src/registry/extensions/commands/appCommands'
+import { invalidateConfiguredProjectLibraryEntries } from '@src/registry/extensions/homeProjects'
 import {
   acceptOnboarding,
   needsToOnboard,
@@ -88,6 +96,7 @@ import {
 import type { HTMLProps } from 'react'
 import { useEffect, useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
+import toast from 'react-hot-toast'
 import {
   Link,
   useLocation,
@@ -103,6 +112,27 @@ type ReadWriteProjectState = {
 }
 
 const PROJECT_LIBRARY_PREVIEW_LIMIT = 6
+
+function getStoredLegacyCloudProjectMigrationDismissal() {
+  try {
+    return (
+      window.localStorage?.getItem(
+        LEGACY_CLOUD_PROJECT_MIGRATION_DISMISSED_STORAGE_KEY
+      ) ?? ''
+    )
+  } catch {
+    return ''
+  }
+}
+
+function storeLegacyCloudProjectMigrationDismissal(signature: string) {
+  try {
+    window.localStorage?.setItem(
+      LEGACY_CLOUD_PROJECT_MIGRATION_DISMISSED_STORAGE_KEY,
+      signature
+    )
+  } catch {}
+}
 
 // This route only opens in the desktop context for now,
 // as defined in Router.tsx, so we can use the desktop APIs and types.
@@ -151,10 +181,19 @@ const Home = () => {
   const homeProjectEntries = registry.signal(homeProjectEntriesValueSpec).value
   const projectLibraries = registry.signal(projectLibrariesValueSpec).value
   const homeProjectActions = registry.get(homeProjectActionsService)
+  const cloudSync = registry.optional(cloudSyncService)
+  const cloudSyncEnabled = cloudSync?.status.value.enabled === true
   const hasCloudSyncFeature = userFeatures.useHas(
     OPFS_CLOUD_FEATURE_FLAG,
     false
   )
+  const [personalCloudRoot, setPersonalCloudRoot] = useState<string>()
+  const [
+    dismissedLegacyCloudProjectMigrationSignature,
+    setDismissedLegacyCloudProjectMigrationSignature,
+  ] = useState(getStoredLegacyCloudProjectMigrationDismissal)
+  const [isMigratingLegacyCloudProjects, setIsMigratingLegacyCloudProjects] =
+    useState(false)
   const { libraryId } = useParams()
   const routeSelectedProjectLibrary = libraryId
     ? projectLibraries.find((library) => library.id === libraryId)
@@ -178,6 +217,20 @@ const Home = () => {
   const { searchResults, query, setQuery } = useProjectSearch(
     scopedHomeProjectEntries
   )
+  const legacyCloudLocationProjects = getLegacyCloudLocationProjects({
+    projects: homeProjectEntries,
+    libraries: projectLibraries,
+    personalCloudRoot,
+  })
+  const legacyCloudLocationProjectSignature =
+    getLegacyCloudProjectMigrationSignature(legacyCloudLocationProjects)
+  const showLegacyCloudProjectMigrationPrompt =
+    hasCloudSyncFeature &&
+    cloudSyncEnabled &&
+    !selectedProjectLibrary &&
+    legacyCloudLocationProjects.length > 0 &&
+    legacyCloudLocationProjectSignature !==
+      dismissedLegacyCloudProjectMigrationSignature
   const projectSearchKeybinding = keymapKeystrokesDisplay(
     keymap
       ? findKeymapItemForCommand(
@@ -208,6 +261,75 @@ const Home = () => {
   useEffect(() => {
     setCloudSyncProjectScope(undefined)
   }, [])
+
+  useEffect(() => {
+    if (!hasCloudSyncFeature || !cloudSyncEnabled) {
+      setPersonalCloudRoot(undefined)
+      return
+    }
+
+    let disposed = false
+    getDefaultCloudProjectDirectoryPath()
+      .then((path) => {
+        if (!disposed) {
+          setPersonalCloudRoot(path)
+        }
+      })
+      .catch(reportRejection)
+
+    return () => {
+      disposed = true
+    }
+  }, [hasCloudSyncFeature, cloudSyncEnabled])
+
+  async function migrateLegacyCloudProjectsToPersonalCloud() {
+    if (!cloudSync || legacyCloudLocationProjects.length === 0) {
+      return
+    }
+
+    setIsMigratingLegacyCloudProjects(true)
+    try {
+      await Promise.all(
+        legacyCloudLocationProjects.map((project) =>
+          project.localProjectPath
+            ? cloudSync.moveProjectToPersonalCloudLibrary(
+                project.localProjectPath
+              )
+            : Promise.resolve()
+        )
+      )
+      systemIOActor.send({
+        type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
+      })
+      invalidateConfiguredProjectLibraryEntries()
+      const count = legacyCloudLocationProjects.length
+      storeLegacyCloudProjectMigrationDismissal(
+        legacyCloudLocationProjectSignature
+      )
+      setDismissedLegacyCloudProjectMigrationSignature(
+        legacyCloudLocationProjectSignature
+      )
+      toast.success(
+        `Moved ${count} cloud-synced project${
+          count === 1 ? '' : 's'
+        } into Personal Cloud.`
+      )
+    } catch (error) {
+      toast.error('Failed to move cloud-synced projects into Personal Cloud.')
+      reportRejection(error)
+    } finally {
+      setIsMigratingLegacyCloudProjects(false)
+    }
+  }
+
+  function dismissLegacyCloudProjectMigrationPrompt() {
+    storeLegacyCloudProjectMigrationDismissal(
+      legacyCloudLocationProjectSignature
+    )
+    setDismissedLegacyCloudProjectMigrationSignature(
+      legacyCloudLocationProjectSignature
+    )
+  }
 
   useEffect(() => {
     const { RouteTelemetryCommand, RouteSettingsCommand } = createRouteCommands(
@@ -406,6 +528,16 @@ const Home = () => {
           projectSearchKeybinding={projectSearchKeybinding}
           className="col-start-2 -col-end-1"
         />
+        {showLegacyCloudProjectMigrationPrompt && (
+          <LegacyCloudProjectMigrationBanner
+            projects={legacyCloudLocationProjects}
+            personalCloudRoot={personalCloudRoot}
+            isMigrating={isMigratingLegacyCloudProjects}
+            onMigrate={() => void migrateLegacyCloudProjectsToPersonalCloud()}
+            onDismiss={dismissLegacyCloudProjectMigrationPrompt}
+            className="col-start-2 -col-end-1"
+          />
+        )}
         <aside
           data-testid="home-sidebar"
           className="lg:row-start-1 -row-end-1 grid sm:grid-cols-2 md:mb-12 lg:flex flex-col justify-between"
@@ -730,6 +862,117 @@ function HomeHeader({
           </div>
         </section>
       )}
+    </section>
+  )
+}
+
+interface LegacyCloudProjectMigrationBannerProps
+  extends HTMLProps<HTMLDivElement> {
+  projects: readonly HomeProjectEntry[]
+  personalCloudRoot?: string
+  isMigrating: boolean
+  onMigrate: () => void
+  onDismiss: () => void
+}
+
+function LegacyCloudProjectMigrationBanner({
+  projects,
+  personalCloudRoot,
+  isMigrating,
+  onMigrate,
+  onDismiss,
+  className = '',
+  ...rest
+}: LegacyCloudProjectMigrationBannerProps) {
+  const [isReviewing, setIsReviewing] = useState(false)
+  const count = projects.length
+
+  return (
+    <section
+      data-testid="legacy-cloud-project-migration-banner"
+      className={`my-4 rounded-sm border border-primary/30 bg-primary/5 p-3 text-sm dark:border-primary/40 dark:bg-chalkboard-90 ${className}`}
+      {...rest}
+    >
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start gap-2">
+            <span className="mt-0.5 grid h-6 w-6 flex-none place-content-center rounded-sm bg-primary/10 text-primary dark:bg-chalkboard-80">
+              <CustomIcon name="network" className="h-4 w-4" />
+            </span>
+            <div className="min-w-0">
+              <p className="font-semibold text-chalkboard-100 dark:text-chalkboard-10">
+                Move cloud-synced projects into Personal Cloud
+              </p>
+              <p className="mt-1 text-chalkboard-80 dark:text-chalkboard-30">
+                {count} cloud-synced project{count === 1 ? ' is' : 's are'}{' '}
+                stored outside Personal Cloud. Moving{' '}
+                {count === 1 ? 'it' : 'them'} avoids duplicate library listings.
+              </p>
+              {personalCloudRoot ? (
+                <p className="mt-1 truncate text-xs text-chalkboard-70 dark:text-chalkboard-40">
+                  Personal Cloud stores projects at {personalCloudRoot}.
+                </p>
+              ) : null}
+            </div>
+          </div>
+          {isReviewing && (
+            <ul className="mt-3 flex max-h-36 flex-col gap-1 overflow-y-auto rounded-sm border border-chalkboard-20 bg-chalkboard-10 p-2 text-xs dark:border-chalkboard-80 dark:bg-chalkboard-100">
+              {projects.map((project) => (
+                <li
+                  key={project.id}
+                  className="grid gap-1 text-chalkboard-80 dark:text-chalkboard-30 sm:grid-cols-[minmax(8rem,14rem)_minmax(0,1fr)]"
+                >
+                  <span className="truncate font-medium">
+                    {project.title || project.name}
+                  </span>
+                  <span className="truncate">{project.localProjectPath}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <div className="flex flex-wrap gap-2 lg:justify-end">
+          <ActionButton
+            Element="button"
+            type="button"
+            onClick={() => setIsReviewing((value) => !value)}
+            disabled={isMigrating}
+            iconStart={{
+              icon: isReviewing ? 'arrowUp' : 'arrowDown',
+              bgClassName: '!bg-transparent',
+            }}
+            data-testid="legacy-cloud-project-migration-review"
+          >
+            {isReviewing ? 'Hide' : 'Review'}
+          </ActionButton>
+          <ActionButton
+            Element="button"
+            type="button"
+            onClick={onMigrate}
+            disabled={isMigrating}
+            iconStart={{
+              icon: 'network',
+              bgClassName: '!bg-transparent',
+            }}
+            data-testid="legacy-cloud-project-migration-move"
+          >
+            {isMigrating ? 'Moving...' : 'Move to Personal Cloud'}
+          </ActionButton>
+          <ActionButton
+            Element="button"
+            type="button"
+            onClick={onDismiss}
+            disabled={isMigrating}
+            iconStart={{
+              icon: 'close',
+              bgClassName: '!bg-transparent',
+            }}
+            data-testid="legacy-cloud-project-migration-dismiss"
+          >
+            Dismiss
+          </ActionButton>
+        </div>
+      </div>
     </section>
   )
 }

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -35,7 +35,9 @@ import { cloudSyncStatus, setCloudSyncProjectScope } from '@src/lib/cloudSync'
 import { getDefaultCloudProjectDirectoryPath } from '@src/lib/cloudSync/paths'
 import {
   LEGACY_CLOUD_PROJECT_MIGRATION_DISMISSED_STORAGE_KEY,
+  type LegacyCloudProjectMigrationFailure,
   getLegacyCloudLocationProjects,
+  getLegacyCloudProjectMigrationFailureMessage,
   getLegacyCloudProjectMigrationSignature,
 } from '@src/lib/cloudSync/legacyProjectMigration'
 import { createRouteCommands } from '@src/lib/commandBarConfigs/routeCommandConfig'
@@ -289,31 +291,69 @@ const Home = () => {
 
     setIsMigratingLegacyCloudProjects(true)
     try {
-      await Promise.all(
-        legacyCloudLocationProjects.map((project) =>
-          project.localProjectPath
-            ? cloudSync.moveProjectToPersonalCloudLibrary(
-                project.localProjectPath
-              )
-            : Promise.resolve()
+      const moveRequests = legacyCloudLocationProjects.flatMap((project) =>
+        project.localProjectPath
+          ? [
+              {
+                project,
+                promise: cloudSync.moveProjectToPersonalCloudLibrary(
+                  project.localProjectPath
+                ),
+              },
+            ]
+          : []
+      )
+
+      if (moveRequests.length === 0) {
+        return
+      }
+
+      const moveResults = await Promise.allSettled(
+        moveRequests.map(({ promise }) => promise)
+      )
+
+      const failures: LegacyCloudProjectMigrationFailure[] =
+        moveResults.flatMap((result, index) =>
+          result.status === 'rejected'
+            ? [
+                {
+                  project: moveRequests[index].project,
+                  reason: result.reason,
+                },
+              ]
+            : []
         )
+      const movedCount = moveResults.length - failures.length
+
+      if (movedCount > 0) {
+        systemIOActor.send({
+          type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
+        })
+        invalidateConfiguredProjectLibraryEntries()
+      }
+
+      if (failures.length === 0) {
+        storeLegacyCloudProjectMigrationDismissal(
+          legacyCloudLocationProjectSignature
+        )
+        setDismissedLegacyCloudProjectMigrationSignature(
+          legacyCloudLocationProjectSignature
+        )
+        toast.success(
+          `Moved ${movedCount} cloud-synced project${
+            movedCount === 1 ? '' : 's'
+          } into Personal Cloud.`
+        )
+        return
+      }
+
+      toast.error(
+        getLegacyCloudProjectMigrationFailureMessage({
+          movedCount,
+          failures,
+        })
       )
-      systemIOActor.send({
-        type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
-      })
-      invalidateConfiguredProjectLibraryEntries()
-      const count = legacyCloudLocationProjects.length
-      storeLegacyCloudProjectMigrationDismissal(
-        legacyCloudLocationProjectSignature
-      )
-      setDismissedLegacyCloudProjectMigrationSignature(
-        legacyCloudLocationProjectSignature
-      )
-      toast.success(
-        `Moved ${count} cloud-synced project${
-          count === 1 ? '' : 's'
-        } into Personal Cloud.`
-      )
+      reportRejection(failures[0].reason)
     } catch (error) {
       toast.error('Failed to move cloud-synced projects into Personal Cloud.')
       reportRejection(error)

--- a/src/unitTestUtils.ts
+++ b/src/unitTestUtils.ts
@@ -75,6 +75,7 @@ export async function buildTheWorldAndConnectToEngine() {
     input: {
       commandBarActor,
       defaultProjectLibraries: [],
+      projectLibrarySettingDefaultPolicies: [],
       extensionSettings: {},
       ...createSettings(),
       wasmInstancePromise: instancePromise,
@@ -181,6 +182,7 @@ export async function buildTheWorldAndNoEngineConnection(mockWasm = false) {
     input: {
       commandBarActor,
       defaultProjectLibraries: [],
+      projectLibrarySettingDefaultPolicies: [],
       extensionSettings: {},
       ...createSettings(),
       wasmInstancePromise: instancePromise,


### PR DESCRIPTION
## Summary
- detects cloud-synced projects that still live in non-cloud directory libraries
- shows a non-blocking Home migration prompt to move those projects into Personal Cloud
- adds `moveCloudSyncProjectToDirectory` to move local storage and rewrite cloud sync metadata/outbox paths
- blocks the move when Personal Cloud already contains a project with the same remote project id

## Why
Internal users may already have cloud-synced projects stored inside normal directory libraries. Once Personal Cloud is displayed as its own library, those projects can appear in confusing duplicate locations. This PR keeps existing sync behavior working while offering an explicit, reviewable move into the canonical Personal Cloud local storage root.

This stays separate from #12574's default-library policy. #12574 handles the normal Personal Cloud library lifecycle, including the web behavior where the existing browser project storage is represented as Personal Cloud without a physical OPFS move. This PR only handles the explicit legacy duplicate-location case.

## Stack
- Depends on #12574 for the Personal Cloud project library and web default-library policy.
- #12574 depends on #12579 for project-library settings details.

## Validation
- `npm run test -- src/lib/cloudSync/legacyProjectMigration.test.ts src/lib/cloudSync/disconnect.spec.ts src/lib/cloudSync/registry/plugin.spec.tsx`
- `npm run tsc -- --noEmit`
- `npm run lint -- src/lib/cloudSync/disconnect.spec.ts src/lib/cloudSync/engine.ts src/lib/cloudSync/legacyProjectMigration.test.ts src/lib/cloudSync/legacyProjectMigration.ts src/lib/cloudSync/registry/contract.ts src/lib/cloudSync/registry/extension.ts src/lib/cloudSync/registry/plugin.spec.tsx src/registry/extensions/homeProjects/index.ts src/routes/Home.tsx`
- `git diff --check codex/cloud-project-library...HEAD`
