### PR TITLE
Pin the 'ruff' version for determinism

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -20,4 +20,5 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.0
       - uses: astral-sh/ruff-action@v4.1.0
-
+        with:
+          version: 0.15.22


### PR DESCRIPTION
We should only see new type warnings after explicitly upgrading.