### PR TITLE
chore(gitignore): ignore common OS/editor metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,22 @@ venv
 .cursor
 
 SPECIFICATION.txt
+
+# OS metadata
+.DS_Store
+._*
+.Spotlight-V100
+.Trashes
+.AppleDouble
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+Desktop.ini
+$RECYCLE.BIN/
+*.lnk
+
+# Editor / IDE
+.idea/
+.vscode/
+*.swp
+*.swo


### PR DESCRIPTION
The existing `.gitignore` doesn't cover macOS `.DS_Store`, Windows `Thumbs.db`, and JetBrains/VS Code project folders. Contributors on those platforms occasionally end up committing them by accident.

Appending standard entries so this doesn't happen.