### PR TITLE
Adapt kcl-lib to optional extrude reference target

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -112,12 +112,7 @@
 
           src = ./rust;
 
-          cargoLock = {
-            lockFile = ./rust/Cargo.lock;
-            outputHashes = {
-              "kittycad-modeling-cmds-0.2.218" = "sha256-Nse9v4pcpBREAnfMx+nvdW2v1zjNWGiRO6BvSbVBQMU=";
-            };
-          };
+          cargoLock.lockFile = ./rust/Cargo.lock;
           cargoBuildFlags = [
             "-p"
             "kcl-language-server"

--- a/flake.nix
+++ b/flake.nix
@@ -112,7 +112,12 @@
 
           src = ./rust;
 
-          cargoLock.lockFile = ./rust/Cargo.lock;
+          cargoLock = {
+            lockFile = ./rust/Cargo.lock;
+            outputHashes = {
+              "kittycad-modeling-cmds-0.2.218" = "sha256-Nse9v4pcpBREAnfMx+nvdW2v1zjNWGiRO6BvSbVBQMU=";
+            };
+          };
           cargoBuildFlags = [
             "-p"
             "kcl-language-server"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -332,7 +332,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -1159,7 +1159,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2250,7 +2250,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2653,9 +2653,8 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.217"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13fa97ccecf077d08e26a6c4ddc311a9d21547676341fcd1cf6a4fbfb23adf2a"
+version = "0.2.218"
+source = "git+https://github.com/KittyCAD/modeling-api.git?branch=kurt-extrude-to-reference-edge-specifier-api#b7574555e10e2c22ec36f4b66894726fc6579f35"
 dependencies = [
  "anyhow",
  "bon",
@@ -2686,8 +2685,7 @@ dependencies = [
 [[package]]
 name = "kittycad-modeling-cmds-macros"
 version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb4ba190f74f6d32f4607ecac4bdebd4a935d4943b8ca8369305e6e7a59b5976"
+source = "git+https://github.com/KittyCAD/modeling-api.git?branch=kurt-extrude-to-reference-edge-specifier-api#b7574555e10e2c22ec36f4b66894726fc6579f35"
 dependencies = [
  "kittycad-modeling-cmds-macros-impl",
  "proc-macro2",
@@ -2698,8 +2696,7 @@ dependencies = [
 [[package]]
 name = "kittycad-modeling-cmds-macros-impl"
 version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743b6533d1848de67e3455a28614a2b7896807ab0d3358ccd3ea1863de3c4e6b"
+source = "git+https://github.com/KittyCAD/modeling-api.git?branch=kurt-extrude-to-reference-edge-specifier-api#b7574555e10e2c22ec36f4b66894726fc6579f35"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4023,7 +4020,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4405,7 +4402,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5211,7 +5208,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6244,7 +6241,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -332,7 +332,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -1159,7 +1159,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2250,7 +2250,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2653,8 +2653,9 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.218"
-source = "git+https://github.com/KittyCAD/modeling-api.git?branch=kurt-extrude-to-reference-edge-specifier-api#b7574555e10e2c22ec36f4b66894726fc6579f35"
+version = "0.2.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79add5ae11c20a108795061d5d49c020893ad04d6b5791846024f73e255d2c85"
 dependencies = [
  "anyhow",
  "bon",
@@ -2685,7 +2686,8 @@ dependencies = [
 [[package]]
 name = "kittycad-modeling-cmds-macros"
 version = "0.1.13"
-source = "git+https://github.com/KittyCAD/modeling-api.git?branch=kurt-extrude-to-reference-edge-specifier-api#b7574555e10e2c22ec36f4b66894726fc6579f35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb4ba190f74f6d32f4607ecac4bdebd4a935d4943b8ca8369305e6e7a59b5976"
 dependencies = [
  "kittycad-modeling-cmds-macros-impl",
  "proc-macro2",
@@ -2696,7 +2698,8 @@ dependencies = [
 [[package]]
 name = "kittycad-modeling-cmds-macros-impl"
 version = "0.1.14"
-source = "git+https://github.com/KittyCAD/modeling-api.git?branch=kurt-extrude-to-reference-edge-specifier-api#b7574555e10e2c22ec36f4b66894726fc6579f35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743b6533d1848de67e3455a28614a2b7896807ab0d3358ccd3ea1863de3c4e6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3154,7 +3157,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4020,7 +4023,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4402,7 +4405,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5208,7 +5211,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5217,7 +5220,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6241,7 +6244,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -95,7 +95,7 @@ insta = { opt-level = 3 }
 debug = "line-tables-only"
 
 #Example: how to point modeling-app at a different repo (e.g. a branch or a local clone)
-# [patch.crates-io]
+[patch.crates-io]
 # ezpz = { git = "https://github.com/KittyCAD/ezpz.git", branch = "david/circle-circle-tangent" }
-# kittycad-modeling-cmds = { git = "https://github.com/KittyCAD/modeling-api.git", branch = "main" }
+kittycad-modeling-cmds = { git = "https://github.com/KittyCAD/modeling-api.git", branch = "kurt-extrude-to-reference-edge-specifier-api" }
 # kittycad-modeling-cmds = { path = "../../modeling-api/modeling-cmds" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -95,6 +95,6 @@ insta = { opt-level = 3 }
 debug = "line-tables-only"
 
 #Example: how to point modeling-app at a different repo (e.g. a branch or a local clone)
-[patch.crates-io]
+# [patch.crates-io]
 # ezpz = { git = "https://github.com/KittyCAD/ezpz.git", branch = "david/circle-circle-tangent" }
 # kittycad-modeling-cmds = { path = "../../modeling-api/modeling-cmds" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -29,7 +29,7 @@ kittycad = { version = "0.4.13", default-features = false, features = [
   "js",
   "requests",
 ] }
-kittycad-modeling-cmds = { version = "0.2.216", features = [
+kittycad-modeling-cmds = { version = "0.2.219", features = [
   "ts-rs",
   "websocket",
 ] }
@@ -97,5 +97,4 @@ debug = "line-tables-only"
 #Example: how to point modeling-app at a different repo (e.g. a branch or a local clone)
 [patch.crates-io]
 # ezpz = { git = "https://github.com/KittyCAD/ezpz.git", branch = "david/circle-circle-tangent" }
-kittycad-modeling-cmds = { git = "https://github.com/KittyCAD/modeling-api.git", branch = "kurt-extrude-to-reference-edge-specifier-api" }
 # kittycad-modeling-cmds = { path = "../../modeling-api/modeling-cmds" }

--- a/rust/kcl-lib/src/execution/artifact.rs
+++ b/rust/kcl-lib/src/execution/artifact.rs
@@ -2206,9 +2206,14 @@ fn artifacts_to_update(
                 ModelingCmd::Extrude(kcmc::Extrude { target: None, .. }) => return Ok(Vec::new()),
                 ModelingCmd::TwistExtrude(kcmc::TwistExtrude { target, .. })
                 | ModelingCmd::Revolve(kcmc::Revolve { target, .. })
-                | ModelingCmd::RevolveAboutEdge(kcmc::RevolveAboutEdge { target, .. })
-                | ModelingCmd::ExtrudeToReference(kcmc::ExtrudeToReference { target, .. }) => {
+                | ModelingCmd::RevolveAboutEdge(kcmc::RevolveAboutEdge { target, .. }) => {
                     cmd_id_ref_to_artifact_id(target)
+                }
+                ModelingCmd::ExtrudeToReference(kcmc::ExtrudeToReference {
+                    target: Some(target), ..
+                }) => cmd_id_ref_to_artifact_id(target),
+                ModelingCmd::ExtrudeToReference(kcmc::ExtrudeToReference { target: None, .. }) => {
+                    return Ok(Vec::new());
                 }
                 _ => internal_error!(range, "Sweep-like command variant not handled: id={id:?}, cmd={cmd:?}"),
             };


### PR DESCRIPTION
This is a small compatibility fix for edge extrudes using `to`. We already support edge specifier payloads for edge extrude in the length-based path, but the `to` path still required a concrete edge UUID, so this shape could not work: `extrude({ sideFaces = [region001.tags.line1, endCap] }, to = offsetPlane(XY, offset = 10), bodyType = SURFACE, method = NEW)`. We split this into four PRs so the API/KCL/engine compatibility can land safely without blocking PR3 for the broader face API point-and-click work.

In `modeling-api`, [KittyCAD/modeling-api#1306](https://github.com/KittyCAD/modeling-api/pull/1306) updates `ExtrudeToReference` so the source can be either the existing legacy `target` UUID or a new `target_reference` edge specifier payload. `target` is now optional, `target_reference` is optional, and callers are expected to provide one of them. The OpenAPI output has been regenerated from the Rust schema.

## This PR

In the small `modeling-app` compatibility PR, [KittyCAD/modeling-app#12615](https://github.com/KittyCAD/modeling-app/pull/12615) updates `kcl-lib` to compile against that new command shape without changing user-facing KCL behavior. Existing `ExtrudeToReference { target: Some(...) }` artifact handling stays the same, and `target: None` is tolerated as a no-op for artifact graph updates. The old KCL semantic restriction still remains here, so this is intentionally just a bridge PR for dependency ordering.

In `engine`, [KittyCAD/engine#4828](https://github.com/KittyCAD/engine/pull/4828) resolves `target_reference` through the same single-edge face API resolver used by the other edge-specifier endpoints, then passes the resolved edge UUID into the existing extrude-to-reference bridge call. If neither `target` nor `target_reference` is provided, the command now returns a clear request error instead of relying on malformed input.

A second `modeling-app` PR, and this one is user-facing, [KittyCAD/modeling-app#12616](https://github.com/KittyCAD/modeling-app/pull/12616) allows the KCL stdlib to send `target_reference` for edge-specifier source targets when `to` is used, and Z0006 is un-nerfed for `extrude(..., to = ...)`. `twistAngle` is still intentionally left out because that path still needs a concrete twist-extrudable target. This was found working on [PR3 of the face-api work](https://github.com/KittyCAD/modeling-app/pull/10607) but decided to keep it separate from PR3 so the broader face API stack is not held up by this more fringe kwarg combination work.

These PRs need to merge in this order:

- Modeling-api PR
- First no-op modeling-app PR
- Engine PR
- Second modeling-app PR

Several of the branches are patched to point at each other's branches. They need to be unpatched as the dependencies land in the order above.

TODO:

- [ ] Unpatch from the modeling-api branch after KittyCAD/modeling-api#1306 has merged and `kittycad-modeling-cmds` is available from the normal dependency source.
