### PR TITLE
Sync project directory names from project titles

### DIFF
--- a/src/lib/cloudSync/disconnect.spec.ts
+++ b/src/lib/cloudSync/disconnect.spec.ts
@@ -1,7 +1,7 @@
 import 'fake-indexeddb/auto'
 import {
-  cloudSyncStatus,
   cloudSyncRemoteProjects,
+  cloudSyncStatus,
   configureCloudSyncEngine,
   configureCloudSyncLocalFileSystem,
   disconnectCloudSyncProject,
@@ -14,12 +14,17 @@ import {
   getAllOutboxEntries,
   putProjectMetadata,
 } from '@src/lib/cloudSync/syncDb'
+import {
+  createCloudSyncTestFs,
+  deleteCloudSyncTestDatabase,
+  getFetchMethod,
+  getFetchUrl,
+  jsonResponse,
+} from '@src/lib/cloudSync/testUtils'
 import { PROJECT_SETTINGS_FILE_NAME } from '@src/lib/constants'
-import type { IStat, IZooDesignStudioFS } from '@src/lib/fs-zds/interface'
-import { webSafeJoin, webSafePathSplit } from '@src/lib/pathUtils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const syncDatabaseName = 'zds-opfs-cloud-sync'
+const projectDirectory = '/documents/Projects'
 const projectPath = '/documents/Projects/bracket'
 const projectTomlPath = `${projectPath}/${PROJECT_SETTINGS_FILE_NAME}`
 const remoteProjectId = 'remote-project-123'
@@ -30,72 +35,6 @@ let deleteProjectFetch: typeof fetch = async () =>
   new Response(null, { status: 204 })
 
 const fetchMock = vi.fn<typeof fetch>()
-
-function normalizePath(path: string) {
-  return path.replace(/\/+/g, '/')
-}
-
-function joinPaths(...parts: string[]) {
-  return normalizePath(webSafeJoin(parts))
-}
-
-function dirname(path: string) {
-  return webSafeJoin(webSafePathSplit(path).slice(0, -1)) || '/'
-}
-
-function basename(path: string) {
-  return webSafePathSplit(path).at(-1) || ''
-}
-
-function getFetchUrl(input: Parameters<typeof fetch>[0]) {
-  if (typeof input === 'string') {
-    return input
-  }
-  if (input instanceof URL) {
-    return input.toString()
-  }
-  return input.url
-}
-
-function getFetchMethod(
-  input: Parameters<typeof fetch>[0],
-  init?: Parameters<typeof fetch>[1]
-) {
-  if (init?.method) {
-    return init.method
-  }
-  if (typeof input === 'object' && 'method' in input) {
-    return input.method
-  }
-  return 'GET'
-}
-
-async function deleteSyncDatabase() {
-  if (typeof indexedDB === 'undefined') {
-    return Promise.reject(
-      new Error('IndexedDB is unavailable in this test environment.')
-    )
-  }
-
-  await new Promise<void>((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      reject(new Error(`IndexedDB database ${syncDatabaseName} is blocked.`))
-    }, 1000)
-    const request = indexedDB.deleteDatabase(syncDatabaseName)
-    request.onerror = () => {
-      clearTimeout(timeout)
-      reject(
-        request.error ??
-          new Error(`Failed to delete IndexedDB database ${syncDatabaseName}.`)
-      )
-    }
-    request.onblocked = () => undefined
-    request.onsuccess = () => {
-      clearTimeout(timeout)
-      resolve()
-    }
-  })
-}
 
 function installFetchMock() {
   deleteProjectFetch = async () => new Response(null, { status: 204 })
@@ -109,129 +48,12 @@ function installFetchMock() {
     }
 
     if (url === 'https://example.test/user/projects' && method === 'GET') {
-      return new Response(JSON.stringify([]), {
-        status: 200,
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      })
+      return jsonResponse([])
     }
 
-    return new Response(
-      JSON.stringify({ message: `Unexpected fetch: ${method} ${url}` }),
-      {
-        status: 500,
-        statusText: 'Unexpected fetch',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      }
-    )
+    return jsonResponse({ message: `Unexpected fetch: ${method} ${url}` }, 500)
   })
   vi.stubGlobal('fetch', fetchMock)
-}
-
-function createStat(mode: number, size = 0): IStat {
-  const date = new Date(0)
-  return {
-    dev: 0,
-    ino: 0,
-    mode,
-    nlink: 0,
-    uid: 0,
-    gid: 0,
-    rdev: 0,
-    size,
-    blksize: 0,
-    blocks: 0,
-    atimeMs: 0,
-    mtimeMs: 0,
-    ctimeMs: 0,
-    birthtimeMs: 0,
-    atime: date,
-    mtime: date,
-    ctime: date,
-    birthtime: date,
-  }
-}
-
-function createTestFs(files: Map<string, string>) {
-  const directories = new Set([
-    '/documents',
-    '/documents/Projects',
-    projectPath,
-  ])
-  return {
-    resolve: joinPaths,
-    join: joinPaths,
-    relative: (from: string, to: string) =>
-      normalizePath(to).replace(`${normalizePath(from)}/`, ''),
-    extname: (path: string) => {
-      const fileName = basename(path)
-      const extensionStart = fileName.lastIndexOf('.')
-      return extensionStart === -1 ? '' : fileName.slice(extensionStart)
-    },
-    sep: '/',
-    basename,
-    dirname,
-    getPath: async () => '/documents',
-    access: async (path: string) => {
-      const normalizedPath = normalizePath(path)
-      if (!files.has(normalizedPath) && !directories.has(normalizedPath)) {
-        return Promise.reject('ENOENT')
-      }
-    },
-    cp: async () => undefined,
-    readFile: async (
-      path: string,
-      options?: { encoding?: string } | string
-    ) => {
-      const normalizedPath = normalizePath(path)
-      const contents = files.get(normalizedPath)
-      if (contents === undefined) {
-        return Promise.reject('ENOENT')
-      }
-      if (
-        options === 'utf8' ||
-        (typeof options === 'object' && options.encoding === 'utf-8')
-      ) {
-        return contents
-      }
-      return new TextEncoder().encode(contents)
-    },
-    rename: async () => undefined,
-    writeFile: async (path: string, data: Uint8Array<ArrayBuffer>) => {
-      files.set(normalizePath(path), new TextDecoder().decode(data))
-    },
-    readdir: async (path: string) => {
-      const normalizedPath = normalizePath(path)
-      return [...directories, ...files.keys()]
-        .filter((entry) => dirname(entry) === normalizedPath)
-        .map(basename)
-    },
-    stat: async (path: string) => {
-      const normalizedPath = normalizePath(path)
-      if (directories.has(normalizedPath)) {
-        return createStat(0o040000)
-      }
-      const contents = files.get(normalizedPath)
-      if (contents !== undefined) {
-        return createStat(0o100000, contents.length)
-      }
-      return Promise.reject('ENOENT')
-    },
-    mkdir: async (path: string) => {
-      directories.add(normalizePath(path))
-      return undefined
-    },
-    rm: async (path: string) => {
-      const normalizedPath = normalizePath(path)
-      directories.delete(normalizedPath)
-      files.delete(normalizedPath)
-    },
-    detach: async () => undefined,
-    attach: async () => undefined,
-  } as IZooDesignStudioFS
 }
 
 async function seedLinkedProject() {
@@ -250,7 +72,7 @@ async function seedLinkedProject() {
 
 describe('disconnectCloudSyncProject', () => {
   beforeEach(async () => {
-    await deleteSyncDatabase()
+    await deleteCloudSyncTestDatabase()
     installFetchMock()
     cloudSyncRemoteProjects.value = [{ id: remoteProjectId }]
     configureCloudSyncEngine({
@@ -264,7 +86,7 @@ describe('disconnectCloudSyncProject', () => {
   afterEach(async () => {
     configureCloudSyncEngine({ enabled: false })
     vi.unstubAllGlobals()
-    await deleteSyncDatabase()
+    await deleteCloudSyncTestDatabase()
   })
 
   it('detaches local sync metadata before deleting the remote project', async () => {
@@ -274,7 +96,9 @@ describe('disconnectCloudSyncProject', () => {
         `title = "Bracket"\n\n[cloud."dev.zoo.dev"]\nproject_id = "${remoteProjectId}"\n`,
       ],
     ])
-    configureCloudSyncLocalFileSystem(createTestFs(files))
+    configureCloudSyncLocalFileSystem(
+      createCloudSyncTestFs(files, { projectDirectory })
+    )
     await seedLinkedProject()
     await appendOutboxEntry({
       projectPath,
@@ -339,7 +163,9 @@ describe('disconnectCloudSyncProject', () => {
         `title = "Bracket"\n\n[cloud."dev.zoo.dev"]\nproject_id = "${remoteProjectId}"\n`,
       ],
     ])
-    configureCloudSyncLocalFileSystem(createTestFs(files))
+    configureCloudSyncLocalFileSystem(
+      createCloudSyncTestFs(files, { projectDirectory })
+    )
     await seedLinkedProject()
     deleteProjectFetch = async () =>
       new Response(JSON.stringify({ message: 'Remote delete failed.' }), {
@@ -374,7 +200,7 @@ describe('disconnectCloudSyncProject', () => {
 
 describe('cloud sync upload failures', () => {
   beforeEach(async () => {
-    await deleteSyncDatabase()
+    await deleteCloudSyncTestDatabase()
     installFetchMock()
   })
 
@@ -382,7 +208,7 @@ describe('cloud sync upload failures', () => {
     setCloudSyncProjectScope(undefined)
     configureCloudSyncEngine({ enabled: false })
     vi.unstubAllGlobals()
-    await deleteSyncDatabase()
+    await deleteCloudSyncTestDatabase()
   })
 
   it('records a blocked upload failure when the remote project is readable but not writable', async () => {
@@ -393,7 +219,9 @@ describe('cloud sync upload failures', () => {
         `title = "Bracket"\n\n[cloud."dev.zoo.dev"]\nproject_id = "${remoteProjectId}"\n`,
       ],
     ])
-    configureCloudSyncLocalFileSystem(createTestFs(files))
+    configureCloudSyncLocalFileSystem(
+      createCloudSyncTestFs(files, { projectDirectory })
+    )
     await seedLinkedProject()
     await appendOutboxEntry({
       projectPath,
@@ -406,19 +234,11 @@ describe('cloud sync upload failures', () => {
       const method = getFetchMethod(input, init)
 
       if (url === remoteProjectUrl && method === 'GET') {
-        return new Response(
-          JSON.stringify({
-            id: remoteProjectId,
-            title: 'Bracket',
-            revision: remoteRevision,
-          }),
-          {
-            status: 200,
-            headers: {
-              'Content-Type': 'application/json',
-            },
-          }
-        )
+        return jsonResponse({
+          id: remoteProjectId,
+          title: 'Bracket',
+          revision: remoteRevision,
+        })
       }
 
       if (
@@ -434,15 +254,9 @@ describe('cloud sync upload failures', () => {
         })
       }
 
-      return new Response(
-        JSON.stringify({ message: `Unexpected fetch: ${method} ${url}` }),
-        {
-          status: 500,
-          statusText: 'Unexpected fetch',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        }
+      return jsonResponse(
+        { message: `Unexpected fetch: ${method} ${url}` },
+        500
       )
     })
 

--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -1153,7 +1153,7 @@ export async function ensureCloudProjectLocallySynced(
     projectName
   )
   if (existingProjectPath) {
-    let nextMetadata = {
+    let nextMetadata: ProjectMetadata = {
       ...(await getOrCreateProjectMetadata(existingProjectPath)),
       remoteProjectId: projectId,
       tombstone: false,
@@ -2367,7 +2367,7 @@ async function syncRemoteIndex() {
         projectName
       )
       if (existingProjectPath) {
-        let nextMetadata = {
+        let nextMetadata: ProjectMetadata = {
           ...(await getOrCreateProjectMetadata(existingProjectPath)),
           remoteProjectId: remoteProject.id,
           remoteUpdatedAt: getRemoteUpdatedAt(remoteProject),

--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -62,7 +62,10 @@ import {
   isPathIgnoredByGitignore,
 } from '@src/lib/gitignore'
 import { webSafePathSplit } from '@src/lib/pathUtils'
-import { sanitizeProjectName } from '@src/lib/projectName'
+import {
+  getProjectDirectoryNameFromTitle,
+  sanitizeProjectName,
+} from '@src/lib/projectName'
 import {
   getCloudProjectIdFromProjectTomlContents,
   getProjectTitleFromProjectTomlContents,
@@ -70,6 +73,7 @@ import {
   setCloudProjectIdInProjectTomlContents,
   setProjectTitleInProjectTomlContents,
 } from '@src/lib/projectTomlMetadata'
+import { reportRejection } from '@src/lib/trap'
 
 export { getCloudSyncProjectRoot } from '@src/lib/cloudSync/paths'
 export {
@@ -113,6 +117,7 @@ let conflictCopyRepairComplete = false
 let pendingStatusSyncedAt: string | undefined
 let detachVisibilityChangeListener: (() => void) | undefined
 let syncScopeProjectPath: string | undefined
+const scheduledProjectDirectoryNameSyncs = new Set<string>()
 
 export const cloudSyncStatus = signal<CloudSyncStatus>({
   enabled: false,
@@ -123,8 +128,8 @@ export const cloudSyncRemoteProjects = signal<RemoteProjectSummary[]>([])
 
 function updateStatus(next: Partial<CloudSyncStatus>) {
   const shouldClearFailureKind =
-    Object.prototype.hasOwnProperty.call(next, 'lastFailure') &&
-    !Object.prototype.hasOwnProperty.call(next, 'lastFailureKind')
+    Object.hasOwn(next, 'lastFailure') &&
+    !Object.hasOwn(next, 'lastFailureKind')
   cloudSyncStatus.value = {
     ...cloudSyncStatus.value,
     ...next,
@@ -474,8 +479,18 @@ function getRemoteUpdatedAt(project: RemoteProject | undefined) {
   return project.updated_at
 }
 
+function cloudProjectDirectoryNameFromTitle(
+  title: string | undefined,
+  fallback: string
+) {
+  return title?.trim()
+    ? getProjectDirectoryNameFromTitle(title, fallback)
+    : fallback
+}
+
 function localProjectNameForRemoteProject(remoteProject: RemoteProject) {
-  return sanitizeProjectName(remoteProject.id, 'cloud-project')
+  const fallback = sanitizeProjectName(remoteProject.id, 'cloud-project')
+  return cloudProjectDirectoryNameFromTitle(remoteProject.title, fallback)
 }
 
 function remoteSyncMetadata(
@@ -577,6 +592,187 @@ async function readLocalProjectTitle(projectPath: string) {
   return getProjectTitleFromProjectTomlContents(
     await localFs.readFile(projectTomlPath, { encoding: 'utf-8' })
   )
+}
+
+type CloudProjectDirectoryNameSyncCandidate = {
+  path: string
+  name: string
+  title?: string
+  readWriteAccess?: boolean
+}
+
+function projectsByDirectory(
+  projects: readonly CloudProjectDirectoryNameSyncCandidate[]
+) {
+  const projectsByDirectoryPath = new Map<
+    string,
+    CloudProjectDirectoryNameSyncCandidate[]
+  >()
+  for (const project of projects) {
+    const projectDirectoryPath = localFs.dirname(project.path)
+    projectsByDirectoryPath.set(projectDirectoryPath, [
+      ...(projectsByDirectoryPath.get(projectDirectoryPath) ?? []),
+      project,
+    ])
+  }
+
+  return projectsByDirectoryPath
+}
+
+async function syncCloudProjectDirectoryNameFromTitle({
+  metadata,
+  title,
+  pendingProjectPaths,
+}: {
+  metadata: ProjectMetadata
+  title?: string
+  pendingProjectPaths: ReadonlySet<string>
+}) {
+  const sourceProjectPath = normalizePathForSync(metadata.localProjectPath)
+  if (
+    !metadata.remoteProjectId ||
+    metadata.tombstone ||
+    isProjectSyncExcluded(metadata) ||
+    pendingProjectPaths.has(sourceProjectPath) ||
+    !(await exists(sourceProjectPath))
+  ) {
+    return metadata
+  }
+
+  const projectTitle =
+    title?.trim() || (await readLocalProjectTitle(sourceProjectPath))
+  if (!projectTitle?.trim()) {
+    return metadata
+  }
+
+  const currentProjectName = projectNameFromPath(sourceProjectPath)
+  const preferredProjectName = cloudProjectDirectoryNameFromTitle(
+    projectTitle,
+    currentProjectName
+  )
+  if (preferredProjectName === currentProjectName) {
+    if (metadata.projectName === currentProjectName) {
+      return metadata
+    }
+
+    const nextMetadata = {
+      ...metadata,
+      localProjectPath: sourceProjectPath,
+      projectName: currentProjectName,
+    }
+    await putProjectMetadata(nextMetadata)
+    return nextMetadata
+  }
+
+  const targetProjectPath = normalizePathForSync(
+    await uniqueUnixProjectPath(
+      localFs.dirname(sourceProjectPath),
+      preferredProjectName,
+      sourceProjectPath
+    )
+  )
+  if (targetProjectPath === sourceProjectPath) {
+    return metadata
+  }
+
+  await localFs.rename(sourceProjectPath, targetProjectPath)
+  const nextMetadata = {
+    ...metadata,
+    localProjectPath: targetProjectPath,
+    projectName: projectNameFromPath(targetProjectPath),
+    tombstone: false,
+  }
+  await deleteProjectMetadata(sourceProjectPath)
+  await putProjectMetadata(nextMetadata)
+
+  if (normalizePathForSync(syncScopeProjectPath ?? '') === sourceProjectPath) {
+    syncScopeProjectPath = targetProjectPath
+  }
+  if (
+    normalizePathForSync(cloudSyncStatus.value.activeProjectPath ?? '') ===
+    sourceProjectPath
+  ) {
+    updateStatus({ activeProjectPath: targetProjectPath })
+  }
+
+  return nextMetadata
+}
+
+export function scheduleCloudProjectDirectoryNameSyncFromTitles({
+  projects,
+  onProjectDirectoriesRenamed,
+}: {
+  projects: readonly CloudProjectDirectoryNameSyncCandidate[]
+  onProjectDirectoriesRenamed?: () => void
+}) {
+  if (!isConfiguredForCloud()) {
+    return
+  }
+
+  const syncGroups = Array.from(projectsByDirectory(projects)).filter(
+    ([projectDirectoryPath]) => {
+      if (scheduledProjectDirectoryNameSyncs.has(projectDirectoryPath)) {
+        return false
+      }
+
+      scheduledProjectDirectoryNameSyncs.add(projectDirectoryPath)
+      return true
+    }
+  )
+
+  if (syncGroups.length === 0) {
+    return
+  }
+
+  queueMicrotask(() => {
+    void (async () => {
+      let renamed = false
+      const pendingProjectPaths = new Set(
+        (await getAllOutboxEntries()).map((entry) =>
+          normalizePathForSync(entry.projectPath)
+        )
+      )
+
+      for (const [, directoryProjects] of syncGroups) {
+        for (const project of directoryProjects) {
+          if (!project.readWriteAccess) {
+            continue
+          }
+
+          try {
+            const metadata = await getProjectMetadata(project.path)
+            if (!metadata) {
+              continue
+            }
+
+            const nextMetadata = await syncCloudProjectDirectoryNameFromTitle({
+              metadata,
+              title: project.title,
+              pendingProjectPaths,
+            })
+            if (
+              normalizePathForSync(nextMetadata.localProjectPath) !==
+              normalizePathForSync(metadata.localProjectPath)
+            ) {
+              renamed = true
+            }
+          } catch (error) {
+            reportRejection(error)
+          }
+        }
+      }
+
+      if (renamed) {
+        onProjectDirectoriesRenamed?.()
+      }
+    })()
+      .catch(reportRejection)
+      .finally(() => {
+        for (const [projectDirectoryPath] of syncGroups) {
+          scheduledProjectDirectoryNameSyncs.delete(projectDirectoryPath)
+        }
+      })
+  })
 }
 
 async function writeLocalProjectCloudProjectId(
@@ -765,6 +961,29 @@ async function uniqueProjectPath(
   return candidate
 }
 
+async function uniqueUnixProjectPath(
+  projectDirectory: string,
+  projectName: string,
+  ignoredProjectPath?: string
+) {
+  const ignored = ignoredProjectPath
+    ? normalizePathForSync(ignoredProjectPath)
+    : undefined
+  let index = 0
+
+  while (true) {
+    const candidateName = index === 0 ? projectName : `${projectName}-${index}`
+    const candidate = localFs.join(projectDirectory, candidateName)
+    if (
+      normalizePathForSync(candidate) === ignored ||
+      !(await exists(candidate))
+    ) {
+      return candidate
+    }
+    index += 1
+  }
+}
+
 function localProjectFromMetadata(
   metadata: ProjectMetadata
 ): CloudSyncLocalProject | undefined {
@@ -895,16 +1114,27 @@ export async function ensureCloudProjectLocallySynced(
     knownLocalProjectPath &&
     (await exists(knownLocalProjectPath))
   ) {
+    let nextMetadata = knownLocalMetadata
     if (!(await readLocalProjectTitle(knownLocalProjectPath))) {
       const remoteProject = await getRemoteProject(config, projectId)
-      const nextMetadata = await hydrateCleanLocalProjectTitle(
+      nextMetadata = await hydrateCleanLocalProjectTitle(
         knownLocalMetadata,
         getRemoteProjectTitleForProjectToml(remoteProject.title)
       )
-      if (nextMetadata !== knownLocalMetadata) {
-        scheduleSync(0)
-        return localProjectFromMetadata(nextMetadata)
-      }
+    }
+    const metadataBeforeDirectorySync = nextMetadata
+    nextMetadata = await syncCloudProjectDirectoryNameFromTitle({
+      metadata: nextMetadata,
+      title: await readLocalProjectTitle(nextMetadata.localProjectPath),
+      pendingProjectPaths: new Set(),
+    })
+    if (
+      nextMetadata !== knownLocalMetadata ||
+      normalizePathForSync(nextMetadata.localProjectPath) !==
+        normalizePathForSync(metadataBeforeDirectorySync.localProjectPath)
+    ) {
+      scheduleSync(0)
+      return localProjectFromMetadata(nextMetadata)
     }
     scheduleSync(0)
     return localProjectFromMetadata(knownLocalMetadata)
@@ -923,7 +1153,7 @@ export async function ensureCloudProjectLocallySynced(
     projectName
   )
   if (existingProjectPath) {
-    const nextMetadata = {
+    let nextMetadata = {
       ...(await getOrCreateProjectMetadata(existingProjectPath)),
       remoteProjectId: projectId,
       tombstone: false,
@@ -933,6 +1163,11 @@ export async function ensureCloudProjectLocallySynced(
       getRemoteProjectTitleForProjectToml(remoteProject.title)
     )
     await putProjectMetadata(nextMetadata)
+    nextMetadata = await syncCloudProjectDirectoryNameFromTitle({
+      metadata: nextMetadata,
+      title: await readLocalProjectTitle(nextMetadata.localProjectPath),
+      pendingProjectPaths: new Set(),
+    })
     scheduleSync(0)
     return localProjectFromMetadata(nextMetadata)
   }
@@ -1788,6 +2023,13 @@ async function syncProject(projectPath: string, entries: OutboxEntry[]) {
         ? getRemoteProjectTitleForProjectToml(remoteProject.title)
         : metadata.projectName
     )
+    if (entries.length === 0) {
+      metadata = await syncCloudProjectDirectoryNameFromTitle({
+        metadata,
+        title: await readLocalProjectTitle(metadata.localProjectPath),
+        pendingProjectPaths: new Set(),
+      })
+    }
     const localFiles = await collectLocalProjectFiles(metadata.localProjectPath)
     const localManifest = await projectManifestFromFiles(localFiles)
 
@@ -2044,12 +2286,27 @@ async function syncRemoteIndex() {
         const hasPendingLocalChanges = pendingProjectPaths.has(
           normalizePathForSync(knownLocalMetadata.localProjectPath)
         )
-        const nextLocalMetadata = hasPendingLocalChanges
+        let nextLocalMetadata = hasPendingLocalChanges
           ? knownLocalMetadata
           : await hydrateCleanLocalProjectTitle(
               knownLocalMetadata,
               remoteProject.title
             )
+        if (!hasPendingLocalChanges) {
+          nextLocalMetadata = await syncCloudProjectDirectoryNameFromTitle({
+            metadata: nextLocalMetadata,
+            title: await readLocalProjectTitle(
+              nextLocalMetadata.localProjectPath
+            ),
+            pendingProjectPaths,
+          })
+          if (
+            normalizePathForSync(nextLocalMetadata.localProjectPath) !==
+            normalizePathForSync(knownLocalMetadata.localProjectPath)
+          ) {
+            removeMetadata(knownLocalMetadata.localProjectPath)
+          }
+        }
         const remoteRevision = getRevision(remoteProject)
         const hasUnqueuedLocalChanges =
           !hasPendingLocalChanges &&
@@ -2110,17 +2367,35 @@ async function syncRemoteIndex() {
         projectName
       )
       if (existingProjectPath) {
-        const nextMetadata = {
+        let nextMetadata = {
           ...(await getOrCreateProjectMetadata(existingProjectPath)),
           remoteProjectId: remoteProject.id,
           remoteUpdatedAt: getRemoteUpdatedAt(remoteProject),
         }
+        await ensureLocalProjectTitle(
+          existingProjectPath,
+          getRemoteProjectTitleForProjectToml(remoteProject.title)
+        )
         await putProjectMetadata(nextMetadata)
+        nextMetadata = await syncCloudProjectDirectoryNameFromTitle({
+          metadata: nextMetadata,
+          title: await readLocalProjectTitle(nextMetadata.localProjectPath),
+          pendingProjectPaths,
+        })
+        if (
+          normalizePathForSync(nextMetadata.localProjectPath) !==
+          normalizePathForSync(existingProjectPath)
+        ) {
+          removeMetadata(existingProjectPath)
+        }
         upsertMetadata(nextMetadata)
-        await syncProject(existingProjectPath, [])
+        await syncProject(nextMetadata.localProjectPath, [])
         const syncedMetadata = await getProjectMetadata(existingProjectPath)
-        if (syncedMetadata) {
-          upsertMetadata(syncedMetadata)
+        const nextSyncedMetadata =
+          syncedMetadata ??
+          (await getProjectMetadata(nextMetadata.localProjectPath))
+        if (nextSyncedMetadata) {
+          upsertMetadata(nextSyncedMetadata)
         }
       }
     } catch (error) {

--- a/src/lib/cloudSync/localProjectNames.spec.ts
+++ b/src/lib/cloudSync/localProjectNames.spec.ts
@@ -10,9 +10,14 @@ import {
   getAllOutboxEntries,
   putProjectMetadata,
 } from '@src/lib/cloudSync/syncDb'
+import {
+  createCloudSyncTestFs,
+  deleteCloudSyncTestDatabase,
+  getFetchMethod,
+  getFetchUrl,
+  jsonResponse,
+} from '@src/lib/cloudSync/testUtils'
 import { PROJECT_SETTINGS_FILE_NAME } from '@src/lib/constants'
-import type { IStat, IZooDesignStudioFS } from '@src/lib/fs-zds/interface'
-import { webSafeJoin, webSafePathSplit } from '@src/lib/pathUtils'
 import type * as TrapModule from '@src/lib/trap'
 import { reportRejection } from '@src/lib/trap'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -25,256 +30,17 @@ vi.mock('@src/lib/trap', async (importOriginal) => {
   }
 })
 
-const syncDatabaseName = 'zds-opfs-cloud-sync'
 const baseUrl = 'https://example.test'
 const projectDirectory = '/documents/Projects'
 const remoteProjectId = 'remote-project-123'
+const remoteProjectTitle = 'Café Bracket / v2'
+const expectedProjectName = 'cafe-bracket-v2'
+const idProjectPath = `${projectDirectory}/${remoteProjectId}`
+const titleProjectPath = `${projectDirectory}/${expectedProjectName}`
 const remoteProjectUrl = `${baseUrl}/user/projects/${remoteProjectId}`
 const remoteProjectDownloadUrl = `${remoteProjectUrl}/download?format=zip`
 
 const fetchMock = vi.fn<typeof fetch>()
-
-function normalizePath(path: string) {
-  const normalized = path.replace(/\/+/g, '/')
-  if (!normalized || normalized === '/') {
-    return '/'
-  }
-  return normalized.startsWith('/') ? normalized : `/${normalized}`
-}
-
-function joinPaths(...parts: string[]) {
-  return normalizePath(webSafeJoin(parts))
-}
-
-function dirname(path: string) {
-  const parts = webSafePathSplit(normalizePath(path)).filter(Boolean)
-  return parts.length <= 1 ? '/' : joinPaths(...parts.slice(0, -1))
-}
-
-function basename(path: string) {
-  return webSafePathSplit(normalizePath(path)).filter(Boolean).at(-1) || ''
-}
-
-function createStat(mode: number, size = 0): IStat {
-  const date = new Date(0)
-  return {
-    dev: 0,
-    ino: 0,
-    mode,
-    nlink: 0,
-    uid: 0,
-    gid: 0,
-    rdev: 0,
-    size,
-    blksize: 0,
-    blocks: 0,
-    atimeMs: 0,
-    mtimeMs: 0,
-    ctimeMs: 0,
-    birthtimeMs: 0,
-    atime: date,
-    mtime: date,
-    ctime: date,
-    birthtime: date,
-  }
-}
-
-function pathNotFound() {
-  return Promise.reject('ENOENT')
-}
-
-function createTestFs(
-  files: Map<string, string>,
-  options: { failRenames?: boolean } = {}
-) {
-  const directories = new Set<string>()
-  const addDirectory = (path: string) => {
-    const parts = webSafePathSplit(normalizePath(path)).filter(Boolean)
-    directories.add('/')
-    for (let index = 0; index < parts.length; index += 1) {
-      directories.add(joinPaths(...parts.slice(0, index + 1)))
-    }
-  }
-
-  addDirectory(projectDirectory)
-  for (const path of files.keys()) {
-    addDirectory(dirname(path))
-  }
-
-  const movePath = (path: string, source: string, target: string) =>
-    path === source
-      ? target
-      : path.startsWith(`${source}/`)
-        ? `${target}${path.slice(source.length)}`
-        : path
-
-  return {
-    resolve: joinPaths,
-    join: joinPaths,
-    relative: (from: string, to: string) => {
-      const normalizedFrom = normalizePath(from)
-      const normalizedTo = normalizePath(to)
-      return normalizedTo === normalizedFrom
-        ? ''
-        : normalizedTo.replace(`${normalizedFrom}/`, '')
-    },
-    extname: (path: string) => {
-      const fileName = basename(path)
-      const extensionStart = fileName.lastIndexOf('.')
-      return extensionStart === -1 ? '' : fileName.slice(extensionStart)
-    },
-    sep: '/',
-    basename,
-    dirname,
-    getPath: async () => '/documents',
-    access: async (path: string) => {
-      const normalizedPath = normalizePath(path)
-      if (!files.has(normalizedPath) && !directories.has(normalizedPath)) {
-        return pathNotFound()
-      }
-    },
-    cp: async () => undefined,
-    readFile: async (
-      path: string,
-      options?: { encoding?: string } | string
-    ) => {
-      const contents = files.get(normalizePath(path))
-      if (contents === undefined) {
-        return pathNotFound()
-      }
-      if (
-        options === 'utf8' ||
-        (typeof options === 'object' && options.encoding === 'utf-8')
-      ) {
-        return contents
-      }
-      return new TextEncoder().encode(contents)
-    },
-    rename: async (sourcePath: string, targetPath: string) => {
-      if (options.failRenames) {
-        throw new Error('rename failed')
-      }
-
-      const source = normalizePath(sourcePath)
-      const target = normalizePath(targetPath)
-      if (directories.has(source)) {
-        const movedDirectories = [...directories]
-          .filter((path) => path === source || path.startsWith(`${source}/`))
-          .map((path) => [path, movePath(path, source, target)] as const)
-        const movedFiles = [...files.entries()]
-          .filter(([path]) => path === source || path.startsWith(`${source}/`))
-          .map(
-            ([path, contents]) =>
-              [path, movePath(path, source, target), contents] as const
-          )
-
-        for (const [path] of movedDirectories) {
-          directories.delete(path)
-        }
-        for (const [path] of movedFiles) {
-          files.delete(path)
-        }
-        for (const [, nextPath] of movedDirectories) {
-          directories.add(nextPath)
-        }
-        for (const [, nextPath, contents] of movedFiles) {
-          files.set(nextPath, contents)
-        }
-        return
-      }
-
-      const contents = files.get(source)
-      if (contents === undefined) {
-        return pathNotFound()
-      }
-      files.delete(source)
-      files.set(target, contents)
-    },
-    writeFile: async (path: string, data: Uint8Array | string) => {
-      files.set(
-        normalizePath(path),
-        typeof data === 'string' ? data : new TextDecoder().decode(data)
-      )
-    },
-    readdir: async (path: string) => {
-      const normalizedPath = normalizePath(path)
-      if (!directories.has(normalizedPath)) {
-        return pathNotFound()
-      }
-
-      const children = new Set<string>()
-      for (const entry of [...directories, ...files.keys()]) {
-        if (entry !== normalizedPath && dirname(entry) === normalizedPath) {
-          children.add(basename(entry))
-        }
-      }
-      return [...children]
-    },
-    stat: async (path: string) => {
-      const normalizedPath = normalizePath(path)
-      if (directories.has(normalizedPath)) {
-        return createStat(0o040000)
-      }
-
-      const contents = files.get(normalizedPath)
-      if (contents !== undefined) {
-        return createStat(0o100000, contents.length)
-      }
-      return pathNotFound()
-    },
-    mkdir: async (path: string) => {
-      addDirectory(path)
-    },
-    rm: async (path: string) => {
-      const normalizedPath = normalizePath(path)
-      for (const directory of [...directories]) {
-        if (
-          directory === normalizedPath ||
-          directory.startsWith(`${normalizedPath}/`)
-        ) {
-          directories.delete(directory)
-        }
-      }
-      for (const file of [...files.keys()]) {
-        if (file === normalizedPath || file.startsWith(`${normalizedPath}/`)) {
-          files.delete(file)
-        }
-      }
-    },
-    detach: async () => undefined,
-    attach: async () => undefined,
-  } as IZooDesignStudioFS
-}
-
-function getFetchUrl(input: Parameters<typeof fetch>[0]) {
-  if (typeof input === 'string') {
-    return input
-  }
-  if (input instanceof URL) {
-    return input.toString()
-  }
-  return input.url
-}
-
-function getFetchMethod(
-  input: Parameters<typeof fetch>[0],
-  init?: Parameters<typeof fetch>[1]
-) {
-  if (init?.method) {
-    return init.method
-  }
-  if (typeof input === 'object' && 'method' in input) {
-    return input.method
-  }
-  return 'GET'
-}
-
-function jsonResponse(value: unknown, status = 200) {
-  return new Response(JSON.stringify(value), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
-}
 
 function installFetchMock() {
   fetchMock.mockReset()
@@ -288,7 +54,7 @@ function installFetchMock() {
     if (url === remoteProjectUrl && method === 'GET') {
       return jsonResponse({
         id: remoteProjectId,
-        title: 'Café Bracket / v2',
+        title: remoteProjectTitle,
         revision: 'rev-1',
       })
     }
@@ -303,113 +69,104 @@ function installFetchMock() {
   vi.stubGlobal('fetch', fetchMock)
 }
 
-async function deleteSyncDatabase() {
-  await new Promise<void>((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      reject(new Error(`IndexedDB database ${syncDatabaseName} is blocked.`))
-    }, 1000)
-    const request = indexedDB.deleteDatabase(syncDatabaseName)
-    request.onerror = () => {
-      clearTimeout(timeout)
-      reject(
-        request.error ??
-          new Error(`Failed to delete IndexedDB database ${syncDatabaseName}.`)
-      )
-    }
-    request.onblocked = () => undefined
-    request.onsuccess = () => {
-      clearTimeout(timeout)
-      resolve()
-    }
+function configureCloudSyncTestFs(
+  files: Map<string, string>,
+  options: { failRenames?: boolean } = {}
+) {
+  configureCloudSyncLocalFileSystem(
+    createCloudSyncTestFs(files, { projectDirectory, ...options })
+  )
+  configureCloudSyncEngine({
+    enabled: true,
+    baseUrl,
+    environmentName: 'dev.zoo.dev',
+    projectDirectoryPath: projectDirectory,
+    syncExistingLocalProjects: false,
   })
+}
+
+function createIdBasedCloudProjectFiles() {
+  return new Map([
+    [`${idProjectPath}/main.kcl`, 'x = 1'],
+    [
+      `${idProjectPath}/${PROJECT_SETTINGS_FILE_NAME}`,
+      `title = "${remoteProjectTitle}"\n\n[cloud."dev.zoo.dev"]\nproject_id = "${remoteProjectId}"\n`,
+    ],
+  ])
+}
+
+async function seedIdBasedCloudProjectMetadata() {
+  await putProjectMetadata({
+    schemaVersion: 1,
+    localProjectPath: idProjectPath,
+    projectName: remoteProjectId,
+    remoteProjectId,
+  })
+}
+
+function scheduleIdBasedProjectDirectorySync() {
+  const onProjectDirectoriesRenamed = vi.fn()
+  scheduleCloudProjectDirectoryNameSyncFromTitles({
+    projects: [
+      {
+        path: idProjectPath,
+        name: remoteProjectId,
+        title: remoteProjectTitle,
+        readWriteAccess: true,
+      },
+    ],
+    onProjectDirectoriesRenamed,
+  })
+  return onProjectDirectoriesRenamed
 }
 
 describe('cloud sync local project names', () => {
   beforeEach(async () => {
-    await deleteSyncDatabase()
+    await deleteCloudSyncTestDatabase()
     installFetchMock()
     vi.mocked(reportRejection).mockClear()
   })
 
   afterEach(async () => {
     configureCloudSyncEngine({ enabled: false })
-    configureCloudSyncLocalFileSystem(createTestFs(new Map()))
+    configureCloudSyncLocalFileSystem(
+      createCloudSyncTestFs(new Map(), { projectDirectory })
+    )
     vi.unstubAllGlobals()
-    await deleteSyncDatabase()
+    await deleteCloudSyncTestDatabase()
   })
 
   it('materializes remote projects with a Unix-friendly directory name from the title', async () => {
     const files = new Map<string, string>()
-    configureCloudSyncLocalFileSystem(createTestFs(files))
-    configureCloudSyncEngine({
-      enabled: true,
-      baseUrl,
-      environmentName: 'dev.zoo.dev',
-      projectDirectoryPath: projectDirectory,
-      syncExistingLocalProjects: false,
-    })
+    configureCloudSyncTestFs(files)
 
     const project = await ensureCloudProjectLocallySynced(
       remoteProjectId,
       projectDirectory
     )
 
-    const expectedProjectPath = `${projectDirectory}/cafe-bracket-v2`
     expect(project).toMatchObject({
-      projectPath: expectedProjectPath,
-      projectName: 'cafe-bracket-v2',
+      projectPath: titleProjectPath,
+      projectName: expectedProjectName,
       remoteProjectId,
     })
-    expect(files.get(`${expectedProjectPath}/main.kcl`)).toBe('x = 1')
+    expect(files.get(`${titleProjectPath}/main.kcl`)).toBe('x = 1')
     expect(
-      files.get(`${expectedProjectPath}/${PROJECT_SETTINGS_FILE_NAME}`)
+      files.get(`${titleProjectPath}/${PROJECT_SETTINGS_FILE_NAME}`)
     ).toContain(`project_id = "${remoteProjectId}"`)
-    expect(
-      await getCloudSyncProjectMetadata(expectedProjectPath)
-    ).toMatchObject({
-      localProjectPath: expectedProjectPath,
-      projectName: 'cafe-bracket-v2',
+    expect(await getCloudSyncProjectMetadata(titleProjectPath)).toMatchObject({
+      localProjectPath: titleProjectPath,
+      projectName: expectedProjectName,
       remoteProjectId,
     })
   })
 
   it('renames existing ID-based cloud project folders and rekeys metadata', async () => {
-    const idProjectPath = `${projectDirectory}/${remoteProjectId}`
-    const titleProjectPath = `${projectDirectory}/cafe-bracket-v2`
-    const files = new Map([
-      [`${idProjectPath}/main.kcl`, 'x = 1'],
-      [
-        `${idProjectPath}/${PROJECT_SETTINGS_FILE_NAME}`,
-        `title = "Café Bracket / v2"\n\n[cloud."dev.zoo.dev"]\nproject_id = "${remoteProjectId}"\n`,
-      ],
-    ])
-    configureCloudSyncLocalFileSystem(createTestFs(files))
-    configureCloudSyncEngine({
-      enabled: true,
-      baseUrl,
-      environmentName: 'dev.zoo.dev',
-      projectDirectoryPath: projectDirectory,
-      syncExistingLocalProjects: false,
-    })
-    await putProjectMetadata({
-      schemaVersion: 1,
-      localProjectPath: idProjectPath,
-      projectName: remoteProjectId,
-      remoteProjectId,
-    })
-    const onProjectDirectoriesRenamed = vi.fn()
+    const files = createIdBasedCloudProjectFiles()
+    configureCloudSyncTestFs(files)
+    await seedIdBasedCloudProjectMetadata()
 
-    scheduleCloudProjectDirectoryNameSyncFromTitles({
-      projects: [
-        {
-          path: idProjectPath,
-          name: remoteProjectId,
-          title: 'Café Bracket / v2',
-          readWriteAccess: true,
-        },
-      ],
-      onProjectDirectoriesRenamed,
-    })
+    const onProjectDirectoriesRenamed = scheduleIdBasedProjectDirectorySync()
 
     await vi.waitFor(() =>
       expect(onProjectDirectoriesRenamed).toHaveBeenCalled()
@@ -420,7 +177,7 @@ describe('cloud sync local project names', () => {
     expect(await getCloudSyncProjectMetadata(idProjectPath)).toBeUndefined()
     expect(await getCloudSyncProjectMetadata(titleProjectPath)).toMatchObject({
       localProjectPath: titleProjectPath,
-      projectName: 'cafe-bracket-v2',
+      projectName: expectedProjectName,
       remoteProjectId,
     })
     expect(await getAllOutboxEntries()).toEqual([])
@@ -428,44 +185,11 @@ describe('cloud sync local project names', () => {
   })
 
   it('leaves data and metadata in place when a cloud project directory rename fails', async () => {
-    const idProjectPath = `${projectDirectory}/${remoteProjectId}`
-    const titleProjectPath = `${projectDirectory}/cafe-bracket-v2`
-    const files = new Map([
-      [`${idProjectPath}/main.kcl`, 'x = 1'],
-      [
-        `${idProjectPath}/${PROJECT_SETTINGS_FILE_NAME}`,
-        `title = "Café Bracket / v2"\n\n[cloud."dev.zoo.dev"]\nproject_id = "${remoteProjectId}"\n`,
-      ],
-    ])
-    configureCloudSyncLocalFileSystem(
-      createTestFs(files, { failRenames: true })
-    )
-    configureCloudSyncEngine({
-      enabled: true,
-      baseUrl,
-      environmentName: 'dev.zoo.dev',
-      projectDirectoryPath: projectDirectory,
-      syncExistingLocalProjects: false,
-    })
-    await putProjectMetadata({
-      schemaVersion: 1,
-      localProjectPath: idProjectPath,
-      projectName: remoteProjectId,
-      remoteProjectId,
-    })
-    const onProjectDirectoriesRenamed = vi.fn()
+    const files = createIdBasedCloudProjectFiles()
+    configureCloudSyncTestFs(files, { failRenames: true })
+    await seedIdBasedCloudProjectMetadata()
 
-    scheduleCloudProjectDirectoryNameSyncFromTitles({
-      projects: [
-        {
-          path: idProjectPath,
-          name: remoteProjectId,
-          title: 'Café Bracket / v2',
-          readWriteAccess: true,
-        },
-      ],
-      onProjectDirectoriesRenamed,
-    })
+    const onProjectDirectoriesRenamed = scheduleIdBasedProjectDirectorySync()
 
     await new Promise((resolve) => setTimeout(resolve, 0))
 

--- a/src/lib/cloudSync/localProjectNames.spec.ts
+++ b/src/lib/cloudSync/localProjectNames.spec.ts
@@ -1,0 +1,483 @@
+import 'fake-indexeddb/auto'
+import {
+  configureCloudSyncEngine,
+  configureCloudSyncLocalFileSystem,
+  ensureCloudProjectLocallySynced,
+  getCloudSyncProjectMetadata,
+  scheduleCloudProjectDirectoryNameSyncFromTitles,
+} from '@src/lib/cloudSync'
+import {
+  getAllOutboxEntries,
+  putProjectMetadata,
+} from '@src/lib/cloudSync/syncDb'
+import { PROJECT_SETTINGS_FILE_NAME } from '@src/lib/constants'
+import type { IStat, IZooDesignStudioFS } from '@src/lib/fs-zds/interface'
+import { webSafeJoin, webSafePathSplit } from '@src/lib/pathUtils'
+import type * as TrapModule from '@src/lib/trap'
+import { reportRejection } from '@src/lib/trap'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@src/lib/trap', async (importOriginal) => {
+  const actual = await importOriginal<typeof TrapModule>()
+  return {
+    ...actual,
+    reportRejection: vi.fn(),
+  }
+})
+
+const syncDatabaseName = 'zds-opfs-cloud-sync'
+const baseUrl = 'https://example.test'
+const projectDirectory = '/documents/Projects'
+const remoteProjectId = 'remote-project-123'
+const remoteProjectUrl = `${baseUrl}/user/projects/${remoteProjectId}`
+const remoteProjectDownloadUrl = `${remoteProjectUrl}/download?format=zip`
+
+const fetchMock = vi.fn<typeof fetch>()
+
+function normalizePath(path: string) {
+  const normalized = path.replace(/\/+/g, '/')
+  if (!normalized || normalized === '/') {
+    return '/'
+  }
+  return normalized.startsWith('/') ? normalized : `/${normalized}`
+}
+
+function joinPaths(...parts: string[]) {
+  return normalizePath(webSafeJoin(parts))
+}
+
+function dirname(path: string) {
+  const parts = webSafePathSplit(normalizePath(path)).filter(Boolean)
+  return parts.length <= 1 ? '/' : joinPaths(...parts.slice(0, -1))
+}
+
+function basename(path: string) {
+  return webSafePathSplit(normalizePath(path)).filter(Boolean).at(-1) || ''
+}
+
+function createStat(mode: number, size = 0): IStat {
+  const date = new Date(0)
+  return {
+    dev: 0,
+    ino: 0,
+    mode,
+    nlink: 0,
+    uid: 0,
+    gid: 0,
+    rdev: 0,
+    size,
+    blksize: 0,
+    blocks: 0,
+    atimeMs: 0,
+    mtimeMs: 0,
+    ctimeMs: 0,
+    birthtimeMs: 0,
+    atime: date,
+    mtime: date,
+    ctime: date,
+    birthtime: date,
+  }
+}
+
+function pathNotFound() {
+  return Promise.reject('ENOENT')
+}
+
+function createTestFs(
+  files: Map<string, string>,
+  options: { failRenames?: boolean } = {}
+) {
+  const directories = new Set<string>()
+  const addDirectory = (path: string) => {
+    const parts = webSafePathSplit(normalizePath(path)).filter(Boolean)
+    directories.add('/')
+    for (let index = 0; index < parts.length; index += 1) {
+      directories.add(joinPaths(...parts.slice(0, index + 1)))
+    }
+  }
+
+  addDirectory(projectDirectory)
+  for (const path of files.keys()) {
+    addDirectory(dirname(path))
+  }
+
+  const movePath = (path: string, source: string, target: string) =>
+    path === source
+      ? target
+      : path.startsWith(`${source}/`)
+        ? `${target}${path.slice(source.length)}`
+        : path
+
+  return {
+    resolve: joinPaths,
+    join: joinPaths,
+    relative: (from: string, to: string) => {
+      const normalizedFrom = normalizePath(from)
+      const normalizedTo = normalizePath(to)
+      return normalizedTo === normalizedFrom
+        ? ''
+        : normalizedTo.replace(`${normalizedFrom}/`, '')
+    },
+    extname: (path: string) => {
+      const fileName = basename(path)
+      const extensionStart = fileName.lastIndexOf('.')
+      return extensionStart === -1 ? '' : fileName.slice(extensionStart)
+    },
+    sep: '/',
+    basename,
+    dirname,
+    getPath: async () => '/documents',
+    access: async (path: string) => {
+      const normalizedPath = normalizePath(path)
+      if (!files.has(normalizedPath) && !directories.has(normalizedPath)) {
+        return pathNotFound()
+      }
+    },
+    cp: async () => undefined,
+    readFile: async (
+      path: string,
+      options?: { encoding?: string } | string
+    ) => {
+      const contents = files.get(normalizePath(path))
+      if (contents === undefined) {
+        return pathNotFound()
+      }
+      if (
+        options === 'utf8' ||
+        (typeof options === 'object' && options.encoding === 'utf-8')
+      ) {
+        return contents
+      }
+      return new TextEncoder().encode(contents)
+    },
+    rename: async (sourcePath: string, targetPath: string) => {
+      if (options.failRenames) {
+        throw new Error('rename failed')
+      }
+
+      const source = normalizePath(sourcePath)
+      const target = normalizePath(targetPath)
+      if (directories.has(source)) {
+        const movedDirectories = [...directories]
+          .filter((path) => path === source || path.startsWith(`${source}/`))
+          .map((path) => [path, movePath(path, source, target)] as const)
+        const movedFiles = [...files.entries()]
+          .filter(([path]) => path === source || path.startsWith(`${source}/`))
+          .map(
+            ([path, contents]) =>
+              [path, movePath(path, source, target), contents] as const
+          )
+
+        for (const [path] of movedDirectories) {
+          directories.delete(path)
+        }
+        for (const [path] of movedFiles) {
+          files.delete(path)
+        }
+        for (const [, nextPath] of movedDirectories) {
+          directories.add(nextPath)
+        }
+        for (const [, nextPath, contents] of movedFiles) {
+          files.set(nextPath, contents)
+        }
+        return
+      }
+
+      const contents = files.get(source)
+      if (contents === undefined) {
+        return pathNotFound()
+      }
+      files.delete(source)
+      files.set(target, contents)
+    },
+    writeFile: async (path: string, data: Uint8Array | string) => {
+      files.set(
+        normalizePath(path),
+        typeof data === 'string' ? data : new TextDecoder().decode(data)
+      )
+    },
+    readdir: async (path: string) => {
+      const normalizedPath = normalizePath(path)
+      if (!directories.has(normalizedPath)) {
+        return pathNotFound()
+      }
+
+      const children = new Set<string>()
+      for (const entry of [...directories, ...files.keys()]) {
+        if (entry !== normalizedPath && dirname(entry) === normalizedPath) {
+          children.add(basename(entry))
+        }
+      }
+      return [...children]
+    },
+    stat: async (path: string) => {
+      const normalizedPath = normalizePath(path)
+      if (directories.has(normalizedPath)) {
+        return createStat(0o040000)
+      }
+
+      const contents = files.get(normalizedPath)
+      if (contents !== undefined) {
+        return createStat(0o100000, contents.length)
+      }
+      return pathNotFound()
+    },
+    mkdir: async (path: string) => {
+      addDirectory(path)
+    },
+    rm: async (path: string) => {
+      const normalizedPath = normalizePath(path)
+      for (const directory of [...directories]) {
+        if (
+          directory === normalizedPath ||
+          directory.startsWith(`${normalizedPath}/`)
+        ) {
+          directories.delete(directory)
+        }
+      }
+      for (const file of [...files.keys()]) {
+        if (file === normalizedPath || file.startsWith(`${normalizedPath}/`)) {
+          files.delete(file)
+        }
+      }
+    },
+    detach: async () => undefined,
+    attach: async () => undefined,
+  } as IZooDesignStudioFS
+}
+
+function getFetchUrl(input: Parameters<typeof fetch>[0]) {
+  if (typeof input === 'string') {
+    return input
+  }
+  if (input instanceof URL) {
+    return input.toString()
+  }
+  return input.url
+}
+
+function getFetchMethod(
+  input: Parameters<typeof fetch>[0],
+  init?: Parameters<typeof fetch>[1]
+) {
+  if (init?.method) {
+    return init.method
+  }
+  if (typeof input === 'object' && 'method' in input) {
+    return input.method
+  }
+  return 'GET'
+}
+
+function jsonResponse(value: unknown, status = 200) {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function installFetchMock() {
+  fetchMock.mockReset()
+  fetchMock.mockImplementation(async (input, init) => {
+    const url = getFetchUrl(input)
+    const method = getFetchMethod(input, init)
+
+    if (url === `${baseUrl}/user/projects` && method === 'GET') {
+      return jsonResponse([])
+    }
+    if (url === remoteProjectUrl && method === 'GET') {
+      return jsonResponse({
+        id: remoteProjectId,
+        title: 'Café Bracket / v2',
+        revision: 'rev-1',
+      })
+    }
+    if (url === remoteProjectDownloadUrl && method === 'GET') {
+      return jsonResponse({
+        files: [{ relativePath: 'main.kcl', contents: 'x = 1' }],
+      })
+    }
+
+    return jsonResponse({ message: `Unexpected fetch: ${method} ${url}` }, 500)
+  })
+  vi.stubGlobal('fetch', fetchMock)
+}
+
+async function deleteSyncDatabase() {
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`IndexedDB database ${syncDatabaseName} is blocked.`))
+    }, 1000)
+    const request = indexedDB.deleteDatabase(syncDatabaseName)
+    request.onerror = () => {
+      clearTimeout(timeout)
+      reject(
+        request.error ??
+          new Error(`Failed to delete IndexedDB database ${syncDatabaseName}.`)
+      )
+    }
+    request.onblocked = () => undefined
+    request.onsuccess = () => {
+      clearTimeout(timeout)
+      resolve()
+    }
+  })
+}
+
+describe('cloud sync local project names', () => {
+  beforeEach(async () => {
+    await deleteSyncDatabase()
+    installFetchMock()
+    vi.mocked(reportRejection).mockClear()
+  })
+
+  afterEach(async () => {
+    configureCloudSyncEngine({ enabled: false })
+    configureCloudSyncLocalFileSystem(createTestFs(new Map()))
+    vi.unstubAllGlobals()
+    await deleteSyncDatabase()
+  })
+
+  it('materializes remote projects with a Unix-friendly directory name from the title', async () => {
+    const files = new Map<string, string>()
+    configureCloudSyncLocalFileSystem(createTestFs(files))
+    configureCloudSyncEngine({
+      enabled: true,
+      baseUrl,
+      environmentName: 'dev.zoo.dev',
+      projectDirectoryPath: projectDirectory,
+      syncExistingLocalProjects: false,
+    })
+
+    const project = await ensureCloudProjectLocallySynced(
+      remoteProjectId,
+      projectDirectory
+    )
+
+    const expectedProjectPath = `${projectDirectory}/cafe-bracket-v2`
+    expect(project).toMatchObject({
+      projectPath: expectedProjectPath,
+      projectName: 'cafe-bracket-v2',
+      remoteProjectId,
+    })
+    expect(files.get(`${expectedProjectPath}/main.kcl`)).toBe('x = 1')
+    expect(
+      files.get(`${expectedProjectPath}/${PROJECT_SETTINGS_FILE_NAME}`)
+    ).toContain(`project_id = "${remoteProjectId}"`)
+    expect(
+      await getCloudSyncProjectMetadata(expectedProjectPath)
+    ).toMatchObject({
+      localProjectPath: expectedProjectPath,
+      projectName: 'cafe-bracket-v2',
+      remoteProjectId,
+    })
+  })
+
+  it('renames existing ID-based cloud project folders and rekeys metadata', async () => {
+    const idProjectPath = `${projectDirectory}/${remoteProjectId}`
+    const titleProjectPath = `${projectDirectory}/cafe-bracket-v2`
+    const files = new Map([
+      [`${idProjectPath}/main.kcl`, 'x = 1'],
+      [
+        `${idProjectPath}/${PROJECT_SETTINGS_FILE_NAME}`,
+        `title = "Café Bracket / v2"\n\n[cloud."dev.zoo.dev"]\nproject_id = "${remoteProjectId}"\n`,
+      ],
+    ])
+    configureCloudSyncLocalFileSystem(createTestFs(files))
+    configureCloudSyncEngine({
+      enabled: true,
+      baseUrl,
+      environmentName: 'dev.zoo.dev',
+      projectDirectoryPath: projectDirectory,
+      syncExistingLocalProjects: false,
+    })
+    await putProjectMetadata({
+      schemaVersion: 1,
+      localProjectPath: idProjectPath,
+      projectName: remoteProjectId,
+      remoteProjectId,
+    })
+    const onProjectDirectoriesRenamed = vi.fn()
+
+    scheduleCloudProjectDirectoryNameSyncFromTitles({
+      projects: [
+        {
+          path: idProjectPath,
+          name: remoteProjectId,
+          title: 'Café Bracket / v2',
+          readWriteAccess: true,
+        },
+      ],
+      onProjectDirectoriesRenamed,
+    })
+
+    await vi.waitFor(() =>
+      expect(onProjectDirectoriesRenamed).toHaveBeenCalled()
+    )
+
+    expect(files.get(`${titleProjectPath}/main.kcl`)).toBe('x = 1')
+    expect(files.has(`${idProjectPath}/main.kcl`)).toBe(false)
+    expect(await getCloudSyncProjectMetadata(idProjectPath)).toBeUndefined()
+    expect(await getCloudSyncProjectMetadata(titleProjectPath)).toMatchObject({
+      localProjectPath: titleProjectPath,
+      projectName: 'cafe-bracket-v2',
+      remoteProjectId,
+    })
+    expect(await getAllOutboxEntries()).toEqual([])
+    expect(onProjectDirectoriesRenamed).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves data and metadata in place when a cloud project directory rename fails', async () => {
+    const idProjectPath = `${projectDirectory}/${remoteProjectId}`
+    const titleProjectPath = `${projectDirectory}/cafe-bracket-v2`
+    const files = new Map([
+      [`${idProjectPath}/main.kcl`, 'x = 1'],
+      [
+        `${idProjectPath}/${PROJECT_SETTINGS_FILE_NAME}`,
+        `title = "Café Bracket / v2"\n\n[cloud."dev.zoo.dev"]\nproject_id = "${remoteProjectId}"\n`,
+      ],
+    ])
+    configureCloudSyncLocalFileSystem(
+      createTestFs(files, { failRenames: true })
+    )
+    configureCloudSyncEngine({
+      enabled: true,
+      baseUrl,
+      environmentName: 'dev.zoo.dev',
+      projectDirectoryPath: projectDirectory,
+      syncExistingLocalProjects: false,
+    })
+    await putProjectMetadata({
+      schemaVersion: 1,
+      localProjectPath: idProjectPath,
+      projectName: remoteProjectId,
+      remoteProjectId,
+    })
+    const onProjectDirectoriesRenamed = vi.fn()
+
+    scheduleCloudProjectDirectoryNameSyncFromTitles({
+      projects: [
+        {
+          path: idProjectPath,
+          name: remoteProjectId,
+          title: 'Café Bracket / v2',
+          readWriteAccess: true,
+        },
+      ],
+      onProjectDirectoriesRenamed,
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(files.get(`${idProjectPath}/main.kcl`)).toBe('x = 1')
+    expect(files.has(`${titleProjectPath}/main.kcl`)).toBe(false)
+    expect(await getCloudSyncProjectMetadata(idProjectPath)).toMatchObject({
+      localProjectPath: idProjectPath,
+      projectName: remoteProjectId,
+      remoteProjectId,
+    })
+    expect(await getCloudSyncProjectMetadata(titleProjectPath)).toBeUndefined()
+    expect(onProjectDirectoriesRenamed).not.toHaveBeenCalled()
+    expect(reportRejection).toHaveBeenCalledWith(expect.any(Error))
+  })
+})

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -33,6 +33,7 @@ import {
   type RemoteProjectSummary,
   renameRemoteCloudProject,
   retryCloudSync,
+  scheduleCloudProjectDirectoryNameSyncFromTitles,
 } from '@src/lib/cloudSync'
 import { getDefaultCloudProjectDirectoryPath } from '@src/lib/cloudSync/paths'
 import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
@@ -70,7 +71,6 @@ import {
   projectExplorerProjectMenuItemsValueSpec,
 } from '@src/registry/contracts/projectExplorer'
 import {
-  type ProjectLibrarySettingsDetailsProps,
   type ProjectLibraryTypeContribution,
   projectLibrariesValueSpec,
   projectLibraryTypesValueSpec,
@@ -99,9 +99,7 @@ type CloudSyncStatusBarPresentation = {
   tooltip: string
 }
 
-function CloudProjectLibrarySettingsDetails({
-  library,
-}: ProjectLibrarySettingsDetailsProps) {
+function CloudProjectLibrarySettingsDetails() {
   const [storagePath, setStoragePath] = useState<string>()
 
   useEffect(() => {
@@ -629,7 +627,9 @@ const cloudSyncStatusBarItem = defineRegistryItemFactory((ctx) => {
   const settings = ctx.services.signal(settingsService)
   const userFeatures = ctx.services.signal(userFeaturesService)
   function CloudSyncStatusBarItemWithSettings() {
-    const settingsValues = settings.value!.useSettings()
+    const settingsValues = (
+      settings.value as NonNullable<typeof settings.value>
+    ).useSettings()
     return (
       <CloudSyncStatusBarItem
         resolvedTheme={getResolvedTheme(settingsValues.app.theme.current)}
@@ -1115,6 +1115,13 @@ export const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
         wasmInstancePromise: getWasmPromise(),
         signal,
       })
+      if (!signal.aborted) {
+        scheduleCloudProjectDirectoryNameSyncFromTitles({
+          projects,
+          onProjectDirectoriesRenamed:
+            invalidateConfiguredProjectLibraryEntries,
+        })
+      }
 
       return projects.map((project) => ({
         ...homeProjectEntryFromProject(project),

--- a/src/lib/cloudSync/renameDeleteRemote.spec.ts
+++ b/src/lib/cloudSync/renameDeleteRemote.spec.ts
@@ -7,9 +7,14 @@ import {
   renameRemoteCloudProject,
 } from '@src/lib/cloudSync'
 import { putProjectMetadata } from '@src/lib/cloudSync/syncDb'
+import {
+  deleteCloudSyncTestDatabase,
+  getFetchMethod,
+  getFetchUrl,
+  jsonResponse,
+} from '@src/lib/cloudSync/testUtils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const syncDatabaseName = 'zds-opfs-cloud-sync'
 const projectPath = '/documents/Projects/bracket'
 const remoteProjectId = 'remote-project-123'
 const baseUrl = 'https://example.test'
@@ -18,60 +23,9 @@ const remoteProjectDownloadUrl = `${remoteProjectUrl}/download?format=zip`
 
 const fetchMock = vi.fn<typeof fetch>()
 
-function getFetchUrl(input: Parameters<typeof fetch>[0]) {
-  if (typeof input === 'string') {
-    return input
-  }
-  if (input instanceof URL) {
-    return input.toString()
-  }
-  return input.url
-}
-
-function getFetchMethod(
-  input: Parameters<typeof fetch>[0],
-  init?: Parameters<typeof fetch>[1]
-) {
-  if (init?.method) {
-    return init.method
-  }
-  if (typeof input === 'object' && 'method' in input) {
-    return input.method
-  }
-  return 'GET'
-}
-
-function jsonResponse(value: unknown, status = 200) {
-  return new Response(JSON.stringify(value), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
-}
-
-async function deleteSyncDatabase() {
-  await new Promise<void>((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      reject(new Error(`IndexedDB database ${syncDatabaseName} is blocked.`))
-    }, 1000)
-    const request = indexedDB.deleteDatabase(syncDatabaseName)
-    request.onerror = () => {
-      clearTimeout(timeout)
-      reject(
-        request.error ??
-          new Error(`Failed to delete IndexedDB database ${syncDatabaseName}.`)
-      )
-    }
-    request.onblocked = () => undefined
-    request.onsuccess = () => {
-      clearTimeout(timeout)
-      resolve()
-    }
-  })
-}
-
 describe('renameRemoteCloudProject', () => {
   beforeEach(async () => {
-    await deleteSyncDatabase()
+    await deleteCloudSyncTestDatabase()
     fetchMock.mockReset()
     cloudSyncRemoteProjects.value = [{ id: remoteProjectId, title: 'Bracket' }]
     configureCloudSyncEngine({
@@ -86,7 +40,7 @@ describe('renameRemoteCloudProject', () => {
   afterEach(async () => {
     configureCloudSyncEngine({ enabled: false })
     vi.unstubAllGlobals()
-    await deleteSyncDatabase()
+    await deleteCloudSyncTestDatabase()
   })
 
   it('re-uploads the remote project archive with the new title', async () => {
@@ -156,7 +110,7 @@ describe('renameRemoteCloudProject', () => {
 
 describe('deleteRemoteCloudProject', () => {
   beforeEach(async () => {
-    await deleteSyncDatabase()
+    await deleteCloudSyncTestDatabase()
     fetchMock.mockReset()
     cloudSyncRemoteProjects.value = [
       { id: remoteProjectId },
@@ -174,7 +128,7 @@ describe('deleteRemoteCloudProject', () => {
   afterEach(async () => {
     configureCloudSyncEngine({ enabled: false })
     vi.unstubAllGlobals()
-    await deleteSyncDatabase()
+    await deleteCloudSyncTestDatabase()
   })
 
   it('deletes the remote project and clears any lingering local metadata', async () => {

--- a/src/lib/cloudSync/testUtils.ts
+++ b/src/lib/cloudSync/testUtils.ts
@@ -1,0 +1,282 @@
+import type { IStat, IZooDesignStudioFS } from '@src/lib/fs-zds/interface'
+import { webSafeJoin, webSafePathSplit } from '@src/lib/pathUtils'
+
+const SYNC_DATABASE_NAME = 'zds-opfs-cloud-sync'
+
+export type CloudSyncTestFsOptions = {
+  projectDirectory?: string
+  failRenames?: boolean
+}
+
+export function normalizeTestPath(path: string) {
+  const normalized = path.replace(/\/+/g, '/')
+  if (!normalized || normalized === '/') {
+    return '/'
+  }
+
+  return normalized.startsWith('/') ? normalized : `/${normalized}`
+}
+
+function joinTestPaths(...parts: string[]) {
+  return normalizeTestPath(webSafeJoin(parts))
+}
+
+function dirname(path: string) {
+  const parts = webSafePathSplit(normalizeTestPath(path)).filter(Boolean)
+  return parts.length <= 1 ? '/' : joinTestPaths(...parts.slice(0, -1))
+}
+
+function basename(path: string) {
+  return webSafePathSplit(normalizeTestPath(path)).filter(Boolean).at(-1) || ''
+}
+
+function createStat(mode: number, size = 0): IStat {
+  const date = new Date(0)
+  return {
+    dev: 0,
+    ino: 0,
+    mode,
+    nlink: 0,
+    uid: 0,
+    gid: 0,
+    rdev: 0,
+    size,
+    blksize: 0,
+    blocks: 0,
+    atimeMs: 0,
+    mtimeMs: 0,
+    ctimeMs: 0,
+    birthtimeMs: 0,
+    atime: date,
+    mtime: date,
+    ctime: date,
+    birthtime: date,
+  }
+}
+
+function pathNotFound() {
+  return Promise.reject('ENOENT')
+}
+
+export function createCloudSyncTestFs(
+  files: Map<string, string>,
+  options: CloudSyncTestFsOptions = {}
+) {
+  const projectDirectory = options.projectDirectory ?? '/documents/Projects'
+  const directories = new Set<string>()
+  const addDirectory = (path: string) => {
+    const parts = webSafePathSplit(normalizeTestPath(path)).filter(Boolean)
+    directories.add('/')
+    for (let index = 0; index < parts.length; index += 1) {
+      directories.add(joinTestPaths(...parts.slice(0, index + 1)))
+    }
+  }
+
+  addDirectory(projectDirectory)
+  for (const path of files.keys()) {
+    addDirectory(dirname(path))
+  }
+
+  const movePath = (path: string, source: string, target: string) =>
+    path === source
+      ? target
+      : path.startsWith(`${source}/`)
+        ? `${target}${path.slice(source.length)}`
+        : path
+
+  return {
+    resolve: joinTestPaths,
+    join: joinTestPaths,
+    relative: (from: string, to: string) => {
+      const normalizedFrom = normalizeTestPath(from)
+      const normalizedTo = normalizeTestPath(to)
+      return normalizedTo === normalizedFrom
+        ? ''
+        : normalizedTo.replace(`${normalizedFrom}/`, '')
+    },
+    extname: (path: string) => {
+      const fileName = basename(path)
+      const extensionStart = fileName.lastIndexOf('.')
+      return extensionStart === -1 ? '' : fileName.slice(extensionStart)
+    },
+    sep: '/',
+    basename,
+    dirname,
+    getPath: async () => '/documents',
+    access: async (path: string) => {
+      const normalizedPath = normalizeTestPath(path)
+      if (!files.has(normalizedPath) && !directories.has(normalizedPath)) {
+        return pathNotFound()
+      }
+    },
+    cp: async () => undefined,
+    readFile: async (
+      path: string,
+      options?: { encoding?: string } | string
+    ) => {
+      const contents = files.get(normalizeTestPath(path))
+      if (contents === undefined) {
+        return pathNotFound()
+      }
+      if (
+        options === 'utf8' ||
+        (typeof options === 'object' && options.encoding === 'utf-8')
+      ) {
+        return contents
+      }
+      return new TextEncoder().encode(contents)
+    },
+    rename: async (sourcePath: string, targetPath: string) => {
+      if (options.failRenames) {
+        return Promise.reject(new Error('rename failed'))
+      }
+
+      const source = normalizeTestPath(sourcePath)
+      const target = normalizeTestPath(targetPath)
+      if (directories.has(source)) {
+        const movedDirectories = [...directories]
+          .filter((path) => path === source || path.startsWith(`${source}/`))
+          .map((path) => [path, movePath(path, source, target)] as const)
+        const movedFiles = [...files.entries()]
+          .filter(([path]) => path === source || path.startsWith(`${source}/`))
+          .map(
+            ([path, contents]) =>
+              [path, movePath(path, source, target), contents] as const
+          )
+
+        for (const [path] of movedDirectories) {
+          directories.delete(path)
+        }
+        for (const [path] of movedFiles) {
+          files.delete(path)
+        }
+        for (const [, nextPath] of movedDirectories) {
+          directories.add(nextPath)
+        }
+        for (const [, nextPath, contents] of movedFiles) {
+          files.set(nextPath, contents)
+        }
+        return
+      }
+
+      const contents = files.get(source)
+      if (contents === undefined) {
+        return pathNotFound()
+      }
+      files.delete(source)
+      files.set(target, contents)
+    },
+    writeFile: async (path: string, data: Uint8Array | string) => {
+      files.set(
+        normalizeTestPath(path),
+        typeof data === 'string' ? data : new TextDecoder().decode(data)
+      )
+    },
+    readdir: async (path: string) => {
+      const normalizedPath = normalizeTestPath(path)
+      if (!directories.has(normalizedPath)) {
+        return pathNotFound()
+      }
+
+      const children = new Set<string>()
+      for (const entry of [...directories, ...files.keys()]) {
+        if (entry !== normalizedPath && dirname(entry) === normalizedPath) {
+          children.add(basename(entry))
+        }
+      }
+      return [...children]
+    },
+    stat: async (path: string) => {
+      const normalizedPath = normalizeTestPath(path)
+      if (directories.has(normalizedPath)) {
+        return createStat(0o040000)
+      }
+
+      const contents = files.get(normalizedPath)
+      if (contents !== undefined) {
+        return createStat(0o100000, contents.length)
+      }
+      return pathNotFound()
+    },
+    mkdir: async (path: string) => {
+      addDirectory(path)
+    },
+    rm: async (path: string) => {
+      const normalizedPath = normalizeTestPath(path)
+      for (const directory of [...directories]) {
+        if (
+          directory === normalizedPath ||
+          directory.startsWith(`${normalizedPath}/`)
+        ) {
+          directories.delete(directory)
+        }
+      }
+      for (const file of [...files.keys()]) {
+        if (file === normalizedPath || file.startsWith(`${normalizedPath}/`)) {
+          files.delete(file)
+        }
+      }
+    },
+    detach: async () => undefined,
+    attach: async () => undefined,
+  } as IZooDesignStudioFS
+}
+
+export function getFetchUrl(input: Parameters<typeof fetch>[0]) {
+  if (typeof input === 'string') {
+    return input
+  }
+  if (input instanceof URL) {
+    return input.toString()
+  }
+  return input.url
+}
+
+export function getFetchMethod(
+  input: Parameters<typeof fetch>[0],
+  init?: Parameters<typeof fetch>[1]
+) {
+  if (init?.method) {
+    return init.method
+  }
+  if (typeof input === 'object' && 'method' in input) {
+    return input.method
+  }
+  return 'GET'
+}
+
+export function jsonResponse(value: unknown, status = 200) {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+export async function deleteCloudSyncTestDatabase() {
+  if (typeof indexedDB === 'undefined') {
+    return Promise.reject(
+      new Error('IndexedDB is unavailable in this test environment.')
+    )
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`IndexedDB database ${SYNC_DATABASE_NAME} is blocked.`))
+    }, 1000)
+    const request = indexedDB.deleteDatabase(SYNC_DATABASE_NAME)
+    request.onerror = () => {
+      clearTimeout(timeout)
+      reject(
+        request.error ??
+          new Error(
+            `Failed to delete IndexedDB database ${SYNC_DATABASE_NAME}.`
+          )
+      )
+    }
+    request.onblocked = () => undefined
+    request.onsuccess = () => {
+      clearTimeout(timeout)
+      resolve()
+    }
+  })
+}

--- a/src/lib/projectLibraries/directoryScanner.spec.ts
+++ b/src/lib/projectLibraries/directoryScanner.spec.ts
@@ -1,0 +1,346 @@
+import { fsZdsConstants } from '@src/lib/fs-zds/constants'
+import type { Project } from '@src/lib/project'
+import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+  const pathNotFound = () =>
+    Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+  const join = (...parts: string[]) => {
+    let joinedPath = ''
+    for (const part of parts) {
+      if (!part) {
+        continue
+      }
+      if (!joinedPath) {
+        joinedPath = part
+        continue
+      }
+      joinedPath = `${joinedPath.replace(/\/+$/g, '')}/${part.replace(
+        /^\/+/g,
+        ''
+      )}`
+    }
+
+    return joinedPath.replace(/\/$/g, '')
+  }
+  const dirname = (path: string) => {
+    const normalizedPath = path.replace(/\/+$/g, '')
+    const lastSeparatorIndex = normalizedPath.lastIndexOf('/')
+
+    if (lastSeparatorIndex <= 0) {
+      return '/'
+    }
+
+    return normalizedPath.slice(0, lastSeparatorIndex)
+  }
+
+  return {
+    pathNotFound,
+    desktop: {
+      canReadWriteDirectory: vi.fn(),
+      getProjectInfo: vi.fn(),
+      isPathNotFoundError: vi.fn((error: unknown) => {
+        return (
+          error === 'ENOENT' ||
+          (typeof error === 'object' &&
+            error !== null &&
+            'code' in error &&
+            error.code === 'ENOENT')
+        )
+      }),
+      mkdirOrNOOP: vi.fn(),
+    },
+    fsZds: {
+      cp: vi.fn(),
+      dirname: vi.fn(dirname),
+      join: vi.fn(join),
+      readdir: vi.fn(),
+      rename: vi.fn(),
+      rm: vi.fn(),
+      stat: vi.fn(),
+      writeFile: vi.fn(),
+    },
+    trap: {
+      reportRejection: vi.fn(),
+    },
+  }
+})
+
+vi.mock('@src/lib/cloudSync', () => ({
+  cloudSyncStatus: { value: { enabled: false } },
+  getCloudSyncProjectMetadataIndex: vi.fn(async () => new Map()),
+  getCloudSyncProjectModifiedTime: vi.fn(
+    (_metadata: unknown, modified: number | null) => modified
+  ),
+}))
+
+vi.mock('@src/lib/desktop', () => mocks.desktop)
+
+vi.mock('@src/lib/fs-zds', () => ({
+  default: mocks.fsZds,
+}))
+
+vi.mock('@src/lib/trap', () => mocks.trap)
+
+import {
+  readProjectsFromProjectDirectory,
+  scheduleProjectDirectoryNameSyncFromTitles,
+  syncProjectDirectoryNameFromTitle,
+} from '@src/lib/projectLibraries/directoryScanner'
+
+function dirStat(ino: number) {
+  const date = new Date(0)
+  return {
+    dev: 1,
+    ino,
+    mode: fsZdsConstants.S_IFDIR,
+    nlink: 1,
+    uid: 1,
+    gid: 1,
+    rdev: 1,
+    size: 1,
+    blksize: 1,
+    blocks: 1,
+    atimeMs: 1,
+    mtimeMs: 1,
+    ctimeMs: 1,
+    birthtimeMs: 1,
+    atime: date,
+    mtime: date,
+    ctime: date,
+    birthtime: date,
+  }
+}
+
+function createProject(overrides: Partial<Project> = {}): Project {
+  const name = overrides.name ?? 'stale-id'
+  const path = overrides.path ?? `/projects/${name}`
+  return {
+    name,
+    path,
+    title: 'My Cool Project',
+    children: [],
+    default_file: `${path}/main.kcl`,
+    directory_count: 0,
+    kcl_file_count: 1,
+    metadata: null,
+    readWriteAccess: true,
+    ...overrides,
+  }
+}
+
+describe('directory project scanner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.desktop.canReadWriteDirectory.mockResolvedValue({
+      value: true,
+      error: undefined,
+    })
+    mocks.desktop.mkdirOrNOOP.mockResolvedValue(undefined)
+    mocks.fsZds.rename.mockResolvedValue(undefined)
+  })
+
+  it('schedules stale project directory name syncs after the scan returns', async () => {
+    const project = createProject()
+    let finishRename: () => void = () => undefined
+
+    mocks.fsZds.readdir.mockResolvedValue(['stale-id'])
+    mocks.fsZds.stat.mockImplementation(async (path: string) => {
+      if (path === '/projects/stale-id') {
+        return dirStat(1)
+      }
+      throw mocks.pathNotFound()
+    })
+    mocks.fsZds.rename.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishRename = resolve
+        })
+    )
+    mocks.desktop.getProjectInfo.mockResolvedValue(project)
+    const onProjectDirectoriesRenamed = vi.fn()
+
+    const projects = await readProjectsFromProjectDirectory({
+      projectDirectoryPath: '/projects',
+      wasmInstancePromise: Promise.resolve({} as ModuleType),
+    })
+
+    expect(projects).toEqual([project])
+    expect(mocks.fsZds.rename).not.toHaveBeenCalled()
+
+    scheduleProjectDirectoryNameSyncFromTitles({
+      projects,
+      onProjectDirectoriesRenamed,
+    })
+
+    await vi.waitFor(() =>
+      expect(mocks.fsZds.rename).toHaveBeenCalledWith(
+        '/projects/stale-id',
+        '/projects/my-cool-project'
+      )
+    )
+    expect(onProjectDirectoriesRenamed).not.toHaveBeenCalled()
+
+    finishRename()
+
+    await vi.waitFor(() =>
+      expect(onProjectDirectoriesRenamed).toHaveBeenCalledTimes(1)
+    )
+  })
+
+  it('batches scheduled directory name sync refreshes', async () => {
+    const onProjectDirectoriesRenamed = vi.fn()
+    const projects = [
+      createProject({
+        name: 'stale-one',
+        path: '/projects/stale-one',
+        title: 'First Project',
+      }),
+      createProject({
+        name: 'stale-two',
+        path: '/projects/stale-two',
+        title: 'Second Project',
+      }),
+    ]
+
+    mocks.fsZds.readdir.mockResolvedValue(['stale-one', 'stale-two'])
+    mocks.fsZds.stat.mockImplementation(async (path: string) => {
+      if (path === '/projects/stale-one') {
+        return dirStat(1)
+      }
+      if (path === '/projects/stale-two') {
+        return dirStat(2)
+      }
+      throw mocks.pathNotFound()
+    })
+
+    scheduleProjectDirectoryNameSyncFromTitles({
+      projects,
+      onProjectDirectoriesRenamed,
+    })
+
+    await vi.waitFor(() => expect(mocks.fsZds.rename).toHaveBeenCalledTimes(2))
+    expect(mocks.fsZds.rename).toHaveBeenCalledWith(
+      '/projects/stale-one',
+      '/projects/first-project'
+    )
+    expect(mocks.fsZds.rename).toHaveBeenCalledWith(
+      '/projects/stale-two',
+      '/projects/second-project'
+    )
+    await vi.waitFor(() =>
+      expect(onProjectDirectoriesRenamed).toHaveBeenCalledTimes(1)
+    )
+  })
+
+  it('reports rename failures without stopping the batch or risking project data', async () => {
+    const renameFailure = new Error('Permission denied')
+    const onProjectDirectoriesRenamed = vi.fn()
+    const projects = [
+      createProject({
+        name: 'stale-one',
+        path: '/projects/stale-one',
+        title: 'First Project',
+      }),
+      createProject({
+        name: 'stale-two',
+        path: '/projects/stale-two',
+        title: 'Second Project',
+      }),
+    ]
+
+    mocks.fsZds.readdir.mockResolvedValue(['stale-one', 'stale-two'])
+    mocks.fsZds.stat.mockImplementation(async (path: string) => {
+      if (path === '/projects/stale-one') {
+        return dirStat(1)
+      }
+      if (path === '/projects/stale-two') {
+        return dirStat(2)
+      }
+      throw mocks.pathNotFound()
+    })
+    mocks.fsZds.rename.mockImplementation(async (sourcePath: string) => {
+      if (sourcePath === '/projects/stale-one') {
+        throw renameFailure
+      }
+    })
+
+    scheduleProjectDirectoryNameSyncFromTitles({
+      projects,
+      onProjectDirectoriesRenamed,
+    })
+
+    await vi.waitFor(() => expect(mocks.fsZds.rename).toHaveBeenCalledTimes(2))
+    expect(mocks.trap.reportRejection).toHaveBeenCalledWith(renameFailure)
+    expect(mocks.fsZds.rename).toHaveBeenCalledWith(
+      '/projects/stale-one',
+      '/projects/first-project'
+    )
+    expect(mocks.fsZds.rename).toHaveBeenCalledWith(
+      '/projects/stale-two',
+      '/projects/second-project'
+    )
+    expect(onProjectDirectoriesRenamed).toHaveBeenCalledTimes(1)
+    expect(mocks.fsZds.cp).not.toHaveBeenCalled()
+    expect(mocks.fsZds.rm).not.toHaveBeenCalled()
+    expect(mocks.fsZds.writeFile).not.toHaveBeenCalled()
+  })
+
+  it('uses a unique unix-friendly directory name when the title slug is occupied', async () => {
+    mocks.fsZds.stat.mockImplementation(async (path: string) => {
+      if (path === '/projects/stale-id') {
+        return dirStat(1)
+      }
+      if (path === '/projects/my-cool-project-1') {
+        throw mocks.pathNotFound()
+      }
+      return dirStat(2)
+    })
+
+    const targetProjectDirectoryName = await syncProjectDirectoryNameFromTitle({
+      project: createProject(),
+      projectDirectoryEntryNames: ['stale-id', 'my-cool-project'],
+    })
+
+    expect(targetProjectDirectoryName).toBe('my-cool-project-1')
+    expect(mocks.fsZds.rename).toHaveBeenCalledWith(
+      '/projects/stale-id',
+      '/projects/my-cool-project-1'
+    )
+  })
+
+  it('falls back to the default project directory name when the title cannot be slugged', async () => {
+    mocks.fsZds.stat.mockImplementation(async (path: string) => {
+      if (path === '/projects/stale-id') {
+        return dirStat(1)
+      }
+      throw mocks.pathNotFound()
+    })
+
+    const targetProjectDirectoryName = await syncProjectDirectoryNameFromTitle({
+      project: createProject({ title: '!!!' }),
+      projectDirectoryEntryNames: ['stale-id'],
+    })
+
+    expect(targetProjectDirectoryName).toBe('untitled')
+    expect(mocks.fsZds.rename).toHaveBeenCalledWith(
+      '/projects/stale-id',
+      '/projects/untitled'
+    )
+  })
+
+  it('does not rename when the project directory already matches the title', async () => {
+    const targetProjectDirectoryName = await syncProjectDirectoryNameFromTitle({
+      project: createProject({
+        name: 'my-cool-project',
+        path: '/projects/my-cool-project',
+      }),
+      projectDirectoryEntryNames: ['my-cool-project'],
+    })
+
+    expect(targetProjectDirectoryName).toBeUndefined()
+    expect(mocks.fsZds.rename).not.toHaveBeenCalled()
+    expect(mocks.fsZds.stat).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/projectLibraries/directoryScanner.ts
+++ b/src/lib/projectLibraries/directoryScanner.ts
@@ -3,14 +3,19 @@ import {
   getCloudSyncProjectMetadataIndex,
   getCloudSyncProjectModifiedTime,
 } from '@src/lib/cloudSync'
+import { DEFAULT_PROJECT_NAME } from '@src/lib/constants'
 import {
   canReadWriteDirectory,
   getProjectInfo,
+  isPathNotFoundError,
   mkdirOrNOOP,
 } from '@src/lib/desktop'
+import { getUniqueProjectName } from '@src/lib/desktopFS'
 import fsZds from '@src/lib/fs-zds'
 import { fsZdsConstants } from '@src/lib/fs-zds/constants'
 import type { Project } from '@src/lib/project'
+import { getProjectDirectoryNameFromTitle } from '@src/lib/projectName'
+import { reportRejection } from '@src/lib/trap'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 
 const PROJECT_FOLDER_PROGRESS_CHUNK_SIZE = 12
@@ -19,6 +24,176 @@ type ProjectDirectoryEntry = {
   name: string
   path: string
   modified: number
+}
+
+const scheduledProjectDirectoryNameSyncs = new Set<string>()
+
+function projectDirectoryEntryNamesToProjects(
+  projectDirectoryPath: string,
+  names: Iterable<string>
+) {
+  return Array.from(names, (name) => ({
+    name,
+    path: fsZds.join(projectDirectoryPath, name),
+    children: [],
+  }))
+}
+
+function sameFilesystemEntry(
+  left: Awaited<ReturnType<typeof fsZds.stat>>,
+  right: Awaited<ReturnType<typeof fsZds.stat>>
+) {
+  if (
+    (left.dev === 0 && left.ino === 0) ||
+    (right.dev === 0 && right.ino === 0)
+  ) {
+    return false
+  }
+
+  return left.dev === right.dev && left.ino === right.ino
+}
+
+async function canRenameProjectDirectoryTo({
+  projectPath,
+  targetPath,
+}: {
+  projectPath: string
+  targetPath: string
+}) {
+  const projectStat = await fsZds.stat(projectPath)
+
+  try {
+    const targetStat = await fsZds.stat(targetPath)
+    return sameFilesystemEntry(projectStat, targetStat)
+  } catch (error) {
+    if (isPathNotFoundError(error)) {
+      return true
+    }
+    return Promise.reject(error)
+  }
+}
+
+export async function syncProjectDirectoryNameFromTitle({
+  project,
+  projectDirectoryEntryNames,
+}: {
+  project: Project
+  projectDirectoryEntryNames: Iterable<string>
+}) {
+  const title = project.title?.trim()
+  if (!title || !project.readWriteAccess) {
+    return undefined
+  }
+
+  const preferredProjectDirectoryName = getProjectDirectoryNameFromTitle(
+    title,
+    DEFAULT_PROJECT_NAME
+  )
+  const projectDirectoryPath = fsZds.dirname(project.path)
+  const siblingNames = new Set(projectDirectoryEntryNames)
+  siblingNames.delete(project.name)
+  const targetProjectDirectoryName = getUniqueProjectName(
+    preferredProjectDirectoryName,
+    projectDirectoryEntryNamesToProjects(projectDirectoryPath, siblingNames)
+  )
+
+  if (targetProjectDirectoryName === project.name) {
+    return undefined
+  }
+
+  const targetPath = fsZds.join(
+    projectDirectoryPath,
+    targetProjectDirectoryName
+  )
+  if (
+    !(await canRenameProjectDirectoryTo({
+      projectPath: project.path,
+      targetPath,
+    }))
+  ) {
+    return undefined
+  }
+
+  await fsZds.rename(project.path, targetPath)
+  return targetProjectDirectoryName
+}
+
+function projectsByDirectory(projects: readonly Project[]) {
+  const projectsByDirectoryPath = new Map<string, Project[]>()
+  for (const project of projects) {
+    const projectDirectoryPath = fsZds.dirname(project.path)
+    projectsByDirectoryPath.set(projectDirectoryPath, [
+      ...(projectsByDirectoryPath.get(projectDirectoryPath) ?? []),
+      project,
+    ])
+  }
+
+  return projectsByDirectoryPath
+}
+
+export function scheduleProjectDirectoryNameSyncFromTitles({
+  projects,
+  onProjectDirectoriesRenamed,
+}: {
+  projects: readonly Project[]
+  onProjectDirectoriesRenamed?: () => void
+}) {
+  const projectsGroupedByDirectory = projectsByDirectory(projects).entries()
+  const syncGroups = Array.from(projectsGroupedByDirectory).filter(
+    ([projectDirectoryPath]) => {
+      if (scheduledProjectDirectoryNameSyncs.has(projectDirectoryPath)) {
+        return false
+      }
+
+      scheduledProjectDirectoryNameSyncs.add(projectDirectoryPath)
+      return true
+    }
+  )
+
+  if (syncGroups.length === 0) {
+    return
+  }
+
+  queueMicrotask(() => {
+    void (async () => {
+      let renamed = false
+      for (const [projectDirectoryPath, directoryProjects] of syncGroups) {
+        const currentProjectDirectoryEntryNames = new Set(
+          await fsZds.readdir(projectDirectoryPath)
+        )
+
+        for (const project of directoryProjects) {
+          let targetProjectDirectoryName: string | undefined
+          try {
+            targetProjectDirectoryName =
+              await syncProjectDirectoryNameFromTitle({
+                project,
+                projectDirectoryEntryNames: currentProjectDirectoryEntryNames,
+              })
+          } catch (error) {
+            reportRejection(error)
+            continue
+          }
+
+          if (targetProjectDirectoryName) {
+            currentProjectDirectoryEntryNames.delete(project.name)
+            currentProjectDirectoryEntryNames.add(targetProjectDirectoryName)
+            renamed = true
+          }
+        }
+      }
+
+      if (renamed) {
+        onProjectDirectoriesRenamed?.()
+      }
+    })()
+      .catch(reportRejection)
+      .finally(() => {
+        for (const [projectDirectoryPath] of syncGroups) {
+          scheduledProjectDirectoryNameSyncs.delete(projectDirectoryPath)
+        }
+      })
+  })
 }
 
 export function sortProjectDirectoryEntriesByModifiedDesc(

--- a/src/machines/systemIO/systemIOMachineImpl.ts
+++ b/src/machines/systemIO/systemIOMachineImpl.ts
@@ -26,8 +26,11 @@ import {
   parentPathRelativeToProject,
 } from '@src/lib/paths'
 import type { FileEntry } from '@src/lib/project'
-import { readProjectsFromProjectDirectory } from '@src/lib/projectLibraries/directoryScanner'
 import { getProjectDisplayName } from '@src/lib/projectDisplayName'
+import {
+  readProjectsFromProjectDirectory,
+  scheduleProjectDirectoryNameSyncFromTitles,
+} from '@src/lib/projectLibraries/directoryScanner'
 import { getProjectTitleFromUniqueDirectoryName } from '@src/lib/projectName'
 import { err, isErr } from '@src/lib/trap'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
@@ -410,7 +413,7 @@ export const systemIOMachineImpl = systemIOMachine.provide({
           return []
         }
 
-        return readProjectsFromProjectDirectory({
+        const projects = await readProjectsFromProjectDirectory({
           projectDirectoryPath,
           wasmInstancePromise: context.wasmInstancePromise,
           previousProjects: context.folders,
@@ -422,6 +425,19 @@ export const systemIOMachineImpl = systemIOMachine.provide({
             })
           },
         })
+
+        if (!signal.aborted) {
+          scheduleProjectDirectoryNameSyncFromTitles({
+            projects,
+            onProjectDirectoriesRenamed: () => {
+              context.app.systemIOActor.send({
+                type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
+              })
+            },
+          })
+        }
+
+        return projects
       }
     ),
     [SystemIOMachineActors.createProject]: fromPromise(

--- a/src/machines/systemIO/systemIOMachineImpl.ts
+++ b/src/machines/systemIO/systemIOMachineImpl.ts
@@ -426,7 +426,10 @@ export const systemIOMachineImpl = systemIOMachine.provide({
           },
         })
 
-        if (!signal.aborted) {
+        if (
+          !signal.aborted &&
+          context.requestedProjectName.name === NO_PROJECT_DIRECTORY
+        ) {
           scheduleProjectDirectoryNameSyncFromTitles({
             projects,
             onProjectDirectoriesRenamed: () => {

--- a/src/machines/systemIO/systemIOMachineImpl.ts
+++ b/src/machines/systemIO/systemIOMachineImpl.ts
@@ -27,10 +27,7 @@ import {
 } from '@src/lib/paths'
 import type { FileEntry } from '@src/lib/project'
 import { getProjectDisplayName } from '@src/lib/projectDisplayName'
-import {
-  readProjectsFromProjectDirectory,
-  scheduleProjectDirectoryNameSyncFromTitles,
-} from '@src/lib/projectLibraries/directoryScanner'
+import { readProjectsFromProjectDirectory } from '@src/lib/projectLibraries/directoryScanner'
 import { getProjectTitleFromUniqueDirectoryName } from '@src/lib/projectName'
 import { err, isErr } from '@src/lib/trap'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
@@ -425,20 +422,6 @@ export const systemIOMachineImpl = systemIOMachine.provide({
             })
           },
         })
-
-        if (
-          !signal.aborted &&
-          context.requestedProjectName.name === NO_PROJECT_DIRECTORY
-        ) {
-          scheduleProjectDirectoryNameSyncFromTitles({
-            projects,
-            onProjectDirectoriesRenamed: () => {
-              context.app.systemIOActor.send({
-                type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
-              })
-            },
-          })
-        }
 
         return projects
       }

--- a/src/registry/extensions/homeProjects/index.ts
+++ b/src/registry/extensions/homeProjects/index.ts
@@ -34,7 +34,11 @@ import {
 import { createProjectInLocalDirectory } from '@src/lib/projectLibraries/operations'
 import { DirectoryProjectLibrarySettingsDetails } from '@src/lib/projectLibraries/settings/ProjectLibrariesSettingInput'
 import { reportRejection } from '@src/lib/trap'
-import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
+import {
+  NO_PROJECT_DIRECTORY,
+  SystemIOMachineEvents,
+  SystemIOMachineStates,
+} from '@src/machines/systemIO/utils'
 import { cloudSyncService } from '@src/registry/contracts/cloudSync'
 import {
   type HomeProjectActionsService,
@@ -269,10 +273,28 @@ const systemIOLocalHomeProjectEntries = defineRegistryItemFactory((ctx) => {
       }
 
       const updateEntries = () => {
+        const snapshot = service.actor.getSnapshot()
+        const context = snapshot.context
+        const projects = context.folders
         entries.value = localHomeProjectEntriesFromProjects(
-          service.actor.getSnapshot().context.folders,
+          projects,
           DEFAULT_PROJECT_LIBRARY_ID
         )
+
+        if (
+          projects &&
+          snapshot.matches(SystemIOMachineStates.idle) &&
+          context.requestedProjectName.name === NO_PROJECT_DIRECTORY
+        ) {
+          scheduleProjectDirectoryNameSyncFromTitles({
+            projects,
+            onProjectDirectoriesRenamed: () => {
+              service.actor.send({
+                type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
+              })
+            },
+          })
+        }
       }
 
       updateEntries()

--- a/src/registry/extensions/homeProjects/index.ts
+++ b/src/registry/extensions/homeProjects/index.ts
@@ -27,7 +27,10 @@ import {
   type ProjectLibrary,
   projectLibraryFromSetting,
 } from '@src/lib/projectLibraries'
-import { readProjectsFromProjectDirectory } from '@src/lib/projectLibraries/directoryScanner'
+import {
+  readProjectsFromProjectDirectory,
+  scheduleProjectDirectoryNameSyncFromTitles,
+} from '@src/lib/projectLibraries/directoryScanner'
 import { createProjectInLocalDirectory } from '@src/lib/projectLibraries/operations'
 import { DirectoryProjectLibrarySettingsDetails } from '@src/lib/projectLibraries/settings/ProjectLibrariesSettingInput'
 import { reportRejection } from '@src/lib/trap'
@@ -360,6 +363,13 @@ const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
               wasmInstancePromise: getWasmPromise(),
               signal,
             })
+            if (!signal.aborted) {
+              scheduleProjectDirectoryNameSyncFromTitles({
+                projects,
+                onProjectDirectoriesRenamed:
+                  invalidateConfiguredProjectLibraryEntries,
+              })
+            }
 
             return localHomeProjectEntriesFromProjects(projects, library.id)
           },


### PR DESCRIPTION
## Summary

- Schedule passive directory-name maintenance after directory library scans instead of making the scan function mutate directly.
- Rename local project directories to Unix-friendly slugs derived from `project.toml` titles, with uniqueness suffixes when needed.
- Batch maintenance refreshes so a scan pass triggers at most one follow-up refresh, and report rename failures without stopping the rest of the batch or using destructive fallback operations.

Closes #12490.

## Demo

https://github.com/user-attachments/assets/3a46fd33-8b1a-4c9d-bb77-7d82efba68e2

## Validation

- `node --require ./scripts/register-typescript-eslint-typescript.cjs ./node_modules/eslint/bin/eslint.js src/lib/projectLibraries/directoryScanner.ts src/lib/projectLibraries/directoryScanner.spec.ts src/machines/systemIO/systemIOMachineImpl.ts src/registry/extensions/homeProjects/index.ts`
- `./node_modules/.bin/biome check src/lib/projectLibraries/directoryScanner.ts src/lib/projectLibraries/directoryScanner.spec.ts src/machines/systemIO/systemIOMachineImpl.ts src/registry/extensions/homeProjects/index.ts`
- `npx vitest run --mode=development --project=integration src/lib/projectLibraries/directoryScanner.spec.ts`
- `npx vitest run --mode=development --project=unit src/lib/projectName.test.ts`