### PR TITLE
Revert "Update CODEOWNERS for rust directory ownership (#12529)"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 /src/                             @KittyCAD/frontend
 
 # KCL
-/rust/                            @KittyCAD/kcl @KittyCAD/frontend
+/rust/                            @KittyCAD/kcl
 
 # ZDS-KCL bridge
 /rust/**/frontend.rs              @KittyCAD/frontend @KittyCAD/kcl


### PR DESCRIPTION
This reverts commit 7b3b9e572bdf208d16bd6bfb1239bf309abc035a.