### PR TITLE
Stabilize Home project refreshes

### DIFF
--- a/src/registry/extensions/homeProjects/index.test.ts
+++ b/src/registry/extensions/homeProjects/index.test.ts
@@ -7,10 +7,12 @@ import {
 import { signal } from '@preact/signals-core'
 import { cloudSyncProjectLibraryType } from '@src/lib/cloudSync/registry/plugin'
 import {
+  DEFAULT_PROJECT_LIBRARY_ID,
   getDefaultCloudProjectLibrarySetting,
   PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
   type ProjectLibrary,
 } from '@src/lib/projectLibraries'
+import type { Project } from '@src/lib/project'
 import type { CloudSyncRegistryService } from '@src/registry/contracts/cloudSync'
 import { cloudSyncService } from '@src/registry/contracts/cloudSync'
 import {
@@ -143,6 +145,54 @@ function createSystemIOService() {
   }
 }
 
+function createMutableSystemIOService({
+  folders,
+}: {
+  folders: Project[] | undefined
+}) {
+  const send = vi.fn()
+  const subscribers = new Set<() => void>()
+  let snapshot = {
+    context: {
+      folders,
+      requestedProjectName: {
+        name: 'active-project',
+      },
+    },
+    matches: (state: string) => state === 'idle',
+  }
+
+  return {
+    service: {
+      actor: {
+        send,
+        getSnapshot: () => snapshot,
+        subscribe: vi.fn((callback: () => void) => {
+          subscribers.add(callback)
+          return {
+            unsubscribe: () => {
+              subscribers.delete(callback)
+            },
+          }
+        }),
+      },
+    } as unknown as SystemIORegistryService,
+    send,
+    setFolders: (foldersNext: Project[] | undefined) => {
+      snapshot = {
+        ...snapshot,
+        context: {
+          ...snapshot.context,
+          folders: foldersNext,
+        },
+      }
+      for (const subscriber of subscribers) {
+        subscriber()
+      }
+    },
+  }
+}
+
 function createCloudSyncService(
   overrides: Partial<CloudSyncRegistryService> = {}
 ): CloudSyncRegistryService {
@@ -179,6 +229,75 @@ describe('home project actions', () => {
     registry?.[Symbol.dispose]()
     registry = undefined
     vi.restoreAllMocks()
+  })
+
+  it('keeps default directory entries while System IO folders are temporarily unset', async () => {
+    const project = {
+      name: 'local-project',
+      title: 'Local Project',
+      path: '/projects/local-project',
+      default_file: '/projects/local-project/main.kcl',
+      children: [],
+      metadata: {
+        accessed: null,
+        created: null,
+        modified: 100,
+        permission: null,
+        size: 1,
+        type: 'directory',
+      },
+      kcl_file_count: 1,
+      directory_count: 0,
+      readWriteAccess: true,
+    } satisfies Project
+    const systemIO = createMutableSystemIOService({
+      folders: [project],
+    })
+    const cloudSync = createCloudSyncService()
+
+    registry = new Registry()
+    registry.configure([
+      defineRegistryItem({
+        id: 'test.settings',
+        providesServices: [
+          provideService(settingsService, createSettingsService()),
+        ],
+      }),
+      defineRegistryItem({
+        id: 'test.system-io',
+        providesServices: [provideService(systemIOService, systemIO.service)],
+      }),
+      defineRegistryItem({
+        id: 'test.cloud-sync',
+        providesServices: [provideService(cloudSyncService, cloudSync)],
+      }),
+      homeProjectsExtension,
+    ])
+
+    await waitFor(() =>
+      expect(registry?.get(homeProjectEntriesValueSpec)).toEqual([
+        expect.objectContaining({
+          name: 'local-project',
+          libraryIds: [DEFAULT_PROJECT_LIBRARY_ID],
+        }),
+      ])
+    )
+
+    systemIO.setFolders(undefined)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(registry.get(homeProjectEntriesValueSpec)).toEqual([
+      expect.objectContaining({
+        name: 'local-project',
+        libraryIds: [DEFAULT_PROJECT_LIBRARY_ID],
+      }),
+    ])
+
+    systemIO.setFolders([])
+    await waitFor(() =>
+      expect(registry?.get(homeProjectEntriesValueSpec)).toEqual([])
+    )
   })
 
   it('does not clear configured library entries for unrelated settings updates', async () => {

--- a/src/registry/extensions/homeProjects/index.test.ts
+++ b/src/registry/extensions/homeProjects/index.test.ts
@@ -28,6 +28,12 @@ const cloudSyncPathMocks = vi.hoisted(() => ({
   getDefaultCloudProjectDirectoryPath: vi.fn(),
 }))
 
+vi.mock('@src/lib/wasm_lib_wrapper', () => ({
+  getModule: vi.fn(),
+  init: vi.fn(),
+  reloadModule: vi.fn(),
+}))
+
 vi.mock('@src/lib/desktop', () => {
   return {
     canReadWriteDirectory: vi.fn().mockResolvedValue({
@@ -126,10 +132,8 @@ describe('home project actions', () => {
   })
 
   it('opens remote-only cloud projects without forcing a full folder rescan', async () => {
-    const wasmInstance = {}
-    const wasmPromise = Promise.resolve(wasmInstance) as Parameters<
-      typeof provideWasmPromise
-    >[0]
+    const wasmInstance = {} as never
+    const wasmPromise = Promise.resolve(wasmInstance)
     const systemIO = createSystemIOService()
     const cloudSync = createCloudSyncService({
       ensureProjectLocallySynced: vi.fn().mockResolvedValue({

--- a/src/registry/extensions/homeProjects/index.test.ts
+++ b/src/registry/extensions/homeProjects/index.test.ts
@@ -1,0 +1,188 @@
+import {
+  defineRegistryItem,
+  provideService,
+  Registry,
+} from '@kittycad/registry'
+import { signal } from '@preact/signals-core'
+import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
+import type { CloudSyncRegistryService } from '@src/registry/contracts/cloudSync'
+import { cloudSyncService } from '@src/registry/contracts/cloudSync'
+import {
+  type HomeProjectEntry,
+  homeProjectActionsService,
+} from '@src/registry/contracts/homeProjects'
+import type { SettingsRegistryService } from '@src/registry/contracts/settings'
+import { settingsService } from '@src/registry/contracts/settings'
+import {
+  type SystemIORegistryService,
+  systemIOService,
+} from '@src/registry/contracts/systemIO'
+import { provideWasmPromise } from '@src/registry/contracts/wasm'
+import homeProjectsExtension from '@src/registry/extensions/homeProjects'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const desktopMocks = vi.hoisted(() => ({
+  getProjectInfo: vi.fn(),
+}))
+
+const cloudSyncPathMocks = vi.hoisted(() => ({
+  getDefaultCloudProjectDirectoryPath: vi.fn(),
+}))
+
+vi.mock('@src/lib/desktop', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@src/lib/desktop')>()
+  return {
+    ...actual,
+    getProjectInfo: desktopMocks.getProjectInfo,
+  }
+})
+
+vi.mock('@src/lib/cloudSync/paths', () => ({
+  getDefaultCloudProjectDirectoryPath:
+    cloudSyncPathMocks.getDefaultCloudProjectDirectoryPath,
+}))
+
+function createSettingsService(): SettingsRegistryService {
+  const current = signal({
+    app: {
+      libraries: {
+        current: [],
+      },
+    },
+  })
+
+  return {
+    actor: {
+      getSnapshot: () => ({
+        matches: (state: string) => state === 'idle',
+      }),
+    },
+    current,
+    get: () => current.value,
+    send: vi.fn(),
+    useSettings: () => current.value,
+  } as unknown as SettingsRegistryService
+}
+
+function createSystemIOService() {
+  const send = vi.fn()
+
+  return {
+    service: {
+      actor: {
+        send,
+        getSnapshot: () => ({
+          context: {
+            folders: undefined,
+          },
+          matches: (state: string) => state === 'idle',
+        }),
+        subscribe: vi.fn(() => ({
+          unsubscribe: vi.fn(),
+        })),
+      },
+    } as unknown as SystemIORegistryService,
+    send,
+  }
+}
+
+function createCloudSyncService(
+  overrides: Partial<CloudSyncRegistryService> = {}
+): CloudSyncRegistryService {
+  return {
+    status: signal({
+      enabled: true,
+      state: 'idle',
+      pendingCount: 0,
+    }),
+    configure: vi.fn(),
+    installFileSystemObserver: vi.fn(),
+    retry: vi.fn(),
+    setProjectScope: vi.fn(),
+    startProjectSync: vi.fn().mockResolvedValue(undefined),
+    disconnectProjectSync: vi.fn().mockResolvedValue(undefined),
+    ensureProjectLocallySynced: vi.fn().mockResolvedValue(undefined),
+    getRemoteProjectThumbnailUrl: vi.fn().mockResolvedValue(undefined),
+    getProjectMetadata: vi.fn().mockResolvedValue(undefined),
+    getProjectMetadataIndex: vi.fn().mockResolvedValue(new Map()),
+    getProjectModifiedTime: vi.fn((_metadata, localModified) => localModified),
+    resolveProjectConflict: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  }
+}
+
+describe('home project actions', () => {
+  let registry: Registry | undefined
+
+  afterEach(() => {
+    registry?.[Symbol.dispose]()
+    registry = undefined
+    vi.restoreAllMocks()
+  })
+
+  it('opens remote-only cloud projects without forcing a full folder rescan', async () => {
+    const wasmInstance = {} as ModuleType
+    const wasmPromise = Promise.resolve(wasmInstance)
+    const systemIO = createSystemIOService()
+    const cloudSync = createCloudSyncService({
+      ensureProjectLocallySynced: vi.fn().mockResolvedValue({
+        projectPath: '/cloud-projects/remote-title',
+        projectName: 'remote-title',
+        remoteProjectId: 'remote-123',
+      }),
+    })
+    cloudSyncPathMocks.getDefaultCloudProjectDirectoryPath.mockResolvedValue(
+      '/cloud-projects'
+    )
+    desktopMocks.getProjectInfo.mockResolvedValue({
+      default_file: '/cloud-projects/remote-title/main.kcl',
+    })
+    const remoteOnlyProject = {
+      id: 'remote:remote-123',
+      source: 'remote',
+      status: 'cloud-only',
+      name: 'remote-title',
+      title: 'Remote title',
+      remoteProjectId: 'remote-123',
+      readWriteAccess: true,
+    } satisfies HomeProjectEntry
+
+    registry = new Registry()
+    registry.configure([
+      defineRegistryItem({
+        id: 'test.settings',
+        providesServices: [
+          provideService(settingsService, createSettingsService()),
+        ],
+      }),
+      defineRegistryItem({
+        id: 'test.system-io',
+        providesServices: [provideService(systemIOService, systemIO.service)],
+      }),
+      defineRegistryItem({
+        id: 'test.cloud-sync',
+        providesServices: [provideService(cloudSyncService, cloudSync)],
+      }),
+      defineRegistryItem({
+        id: 'test.wasm',
+        provides: [provideWasmPromise(wasmPromise)],
+      }),
+      homeProjectsExtension,
+    ])
+
+    await expect(
+      registry.get(homeProjectActionsService).open(remoteOnlyProject)
+    ).resolves.toEqual({
+      defaultFile: '/cloud-projects/remote-title/main.kcl',
+    })
+    expect(cloudSync.ensureProjectLocallySynced).toHaveBeenCalledWith(
+      'remote-123',
+      '/cloud-projects'
+    )
+    expect(desktopMocks.getProjectInfo).toHaveBeenCalledWith(
+      '/cloud-projects/remote-title',
+      wasmInstance
+    )
+    expect(systemIO.send).not.toHaveBeenCalled()
+  })
+})

--- a/src/registry/extensions/homeProjects/index.test.ts
+++ b/src/registry/extensions/homeProjects/index.test.ts
@@ -1,15 +1,22 @@
 import {
   defineRegistryItem,
+  provide,
   provideService,
   Registry,
 } from '@kittycad/registry'
 import { signal } from '@preact/signals-core'
+import { cloudSyncProjectLibraryType } from '@src/lib/cloudSync/registry/plugin'
+import {
+  getDefaultCloudProjectLibrarySetting,
+  PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+} from '@src/lib/projectLibraries'
 import type { CloudSyncRegistryService } from '@src/registry/contracts/cloudSync'
 import { cloudSyncService } from '@src/registry/contracts/cloudSync'
 import {
   type HomeProjectEntry,
   homeProjectActionsService,
 } from '@src/registry/contracts/homeProjects'
+import { projectLibrariesValueSpec } from '@src/registry/contracts/projectLibraries'
 import type { SettingsRegistryService } from '@src/registry/contracts/settings'
 import { settingsService } from '@src/registry/contracts/settings'
 import {
@@ -18,7 +25,7 @@ import {
 } from '@src/registry/contracts/systemIO'
 import { provideWasmPromise } from '@src/registry/contracts/wasm'
 import homeProjectsExtension from '@src/registry/extensions/homeProjects'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const desktopMocks = vi.hoisted(() => ({
   getProjectInfo: vi.fn(),
@@ -125,6 +132,10 @@ function createCloudSyncService(
 describe('home project actions', () => {
   let registry: Registry | undefined
 
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   afterEach(() => {
     registry?.[Symbol.dispose]()
     registry = undefined
@@ -194,6 +205,68 @@ describe('home project actions', () => {
       '/cloud-projects/remote-title',
       wasmInstance
     )
+    expect(systemIO.send).not.toHaveBeenCalled()
+  })
+
+  it('opens locally materialized cloud library projects without re-syncing them first', async () => {
+    const wasmInstance = {} as never
+    const wasmPromise = Promise.resolve(wasmInstance)
+    const systemIO = createSystemIOService()
+    const cloudSync = createCloudSyncService()
+    const localCloudProject = {
+      id: 'remote:remote-123',
+      source: 'both',
+      status: 'synced',
+      libraryIds: [PERSONAL_CLOUD_PROJECT_LIBRARY_ID],
+      name: 'remote-title',
+      title: 'Remote title',
+      localProjectPath: '/cloud-projects/remote-title',
+      localProjectName: 'remote-title',
+      remoteProjectId: 'remote-123',
+      defaultFile: '/cloud-projects/remote-title/main.kcl',
+      readWriteAccess: true,
+    } satisfies HomeProjectEntry
+
+    registry = new Registry()
+    registry.configure([
+      defineRegistryItem({
+        id: 'test.settings',
+        providesServices: [
+          provideService(settingsService, createSettingsService()),
+        ],
+      }),
+      defineRegistryItem({
+        id: 'test.cloud-library',
+        provides: [
+          provide(projectLibrariesValueSpec, {
+            ...getDefaultCloudProjectLibrarySetting(),
+            id: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+          }),
+        ],
+      }),
+      defineRegistryItem({
+        id: 'test.system-io',
+        providesServices: [provideService(systemIOService, systemIO.service)],
+      }),
+      defineRegistryItem({
+        id: 'test.cloud-sync',
+        providesServices: [provideService(cloudSyncService, cloudSync)],
+      }),
+      defineRegistryItem({
+        id: 'test.wasm',
+        provides: [provideWasmPromise(wasmPromise)],
+      }),
+      cloudSyncProjectLibraryType,
+      homeProjectsExtension,
+    ])
+
+    await expect(
+      registry.get(homeProjectActionsService).open(localCloudProject)
+    ).resolves.toEqual({
+      defaultFile: '/cloud-projects/remote-title/main.kcl',
+    })
+    expect(cloudSync.ensureProjectLocallySynced).not.toHaveBeenCalled()
+    expect(desktopMocks.getProjectInfo).not.toHaveBeenCalled()
     expect(systemIO.send).not.toHaveBeenCalled()
   })
 })

--- a/src/registry/extensions/homeProjects/index.test.ts
+++ b/src/registry/extensions/homeProjects/index.test.ts
@@ -5,26 +5,23 @@ import {
   Registry,
 } from '@kittycad/registry'
 import { signal } from '@preact/signals-core'
-import { cloudSyncProjectLibraryType } from '@src/lib/cloudSync/registry/plugin'
+import type { Project } from '@src/lib/project'
 import {
+  CLOUD_PROJECT_LIBRARY_TYPE,
   DEFAULT_PROJECT_LIBRARY_ID,
   getDefaultCloudProjectLibrarySetting,
   PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
   type ProjectLibrary,
 } from '@src/lib/projectLibraries'
-import type { Project } from '@src/lib/project'
 import type { CloudSyncRegistryService } from '@src/registry/contracts/cloudSync'
 import { cloudSyncService } from '@src/registry/contracts/cloudSync'
 import {
   type HomeProjectEntry,
   type HomeProjectEntryContribution,
-  homeProjectEntriesValueSpec,
   homeProjectActionsService,
+  homeProjectEntriesValueSpec,
 } from '@src/registry/contracts/homeProjects'
-import {
-  projectLibrariesValueSpec,
-  projectLibraryTypesValueSpec,
-} from '@src/registry/contracts/projectLibraries'
+import { projectLibraryTypesValueSpec } from '@src/registry/contracts/projectLibraries'
 import type { SettingsRegistryService } from '@src/registry/contracts/settings'
 import { settingsService } from '@src/registry/contracts/settings'
 import {
@@ -208,6 +205,8 @@ function createCloudSyncService(
     setProjectScope: vi.fn(),
     startProjectSync: vi.fn().mockResolvedValue(undefined),
     disconnectProjectSync: vi.fn().mockResolvedValue(undefined),
+    deleteRemoteProject: vi.fn().mockResolvedValue(undefined),
+    deleteLocalProjectRealizations: vi.fn().mockResolvedValue(undefined),
     ensureProjectLocallySynced: vi.fn().mockResolvedValue(undefined),
     getRemoteProjectThumbnailUrl: vi.fn().mockResolvedValue(undefined),
     getProjectMetadata: vi.fn().mockResolvedValue(undefined),
@@ -484,16 +483,12 @@ describe('home project actions', () => {
       defineRegistryItem({
         id: 'test.settings',
         providesServices: [
-          provideService(settingsService, createSettingsService()),
-        ],
-      }),
-      defineRegistryItem({
-        id: 'test.cloud-library',
-        provides: [
-          provide(projectLibrariesValueSpec, {
-            ...getDefaultCloudProjectLibrarySetting(),
-            id: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
-          }),
+          provideService(
+            settingsService,
+            createMutableSettingsService({
+              libraries: [getDefaultCloudProjectLibrarySetting()],
+            }).service
+          ),
         ],
       }),
       defineRegistryItem({
@@ -508,7 +503,27 @@ describe('home project actions', () => {
         id: 'test.wasm',
         provides: [provideWasmPromise(wasmPromise)],
       }),
-      cloudSyncProjectLibraryType,
+      defineRegistryItem({
+        id: 'test.cloud-library-type',
+        provides: [
+          provide(projectLibraryTypesValueSpec, {
+            type: CLOUD_PROJECT_LIBRARY_TYPE,
+            title: 'Cloud',
+            readEntries: async () => [],
+            operations: {
+              openProject: {
+                run: ({ project }) => {
+                  if (!project.defaultFile) {
+                    return undefined
+                  }
+
+                  return { defaultFile: project.defaultFile }
+                },
+              },
+            },
+          }),
+        ],
+      }),
       homeProjectsExtension,
     ])
 

--- a/src/registry/extensions/homeProjects/index.test.ts
+++ b/src/registry/extensions/homeProjects/index.test.ts
@@ -9,14 +9,20 @@ import { cloudSyncProjectLibraryType } from '@src/lib/cloudSync/registry/plugin'
 import {
   getDefaultCloudProjectLibrarySetting,
   PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+  type ProjectLibrary,
 } from '@src/lib/projectLibraries'
 import type { CloudSyncRegistryService } from '@src/registry/contracts/cloudSync'
 import { cloudSyncService } from '@src/registry/contracts/cloudSync'
 import {
   type HomeProjectEntry,
+  type HomeProjectEntryContribution,
+  homeProjectEntriesValueSpec,
   homeProjectActionsService,
 } from '@src/registry/contracts/homeProjects'
-import { projectLibrariesValueSpec } from '@src/registry/contracts/projectLibraries'
+import {
+  projectLibrariesValueSpec,
+  projectLibraryTypesValueSpec,
+} from '@src/registry/contracts/projectLibraries'
 import type { SettingsRegistryService } from '@src/registry/contracts/settings'
 import { settingsService } from '@src/registry/contracts/settings'
 import {
@@ -25,6 +31,7 @@ import {
 } from '@src/registry/contracts/systemIO'
 import { provideWasmPromise } from '@src/registry/contracts/wasm'
 import homeProjectsExtension from '@src/registry/extensions/homeProjects'
+import { waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const desktopMocks = vi.hoisted(() => ({
@@ -80,6 +87,38 @@ function createSettingsService(): SettingsRegistryService {
     send: vi.fn(),
     useSettings: () => current.value,
   } as unknown as SettingsRegistryService
+}
+
+function createMutableSettingsService({
+  libraries,
+}: {
+  libraries: { title: string; path: string; type: string }[]
+}) {
+  const current = signal({
+    app: {
+      libraries: {
+        current: libraries,
+      },
+    },
+    unrelated: {
+      value: 0,
+    },
+  })
+
+  return {
+    current,
+    service: {
+      actor: {
+        getSnapshot: () => ({
+          matches: (state: string) => state === 'idle',
+        }),
+      },
+      current,
+      get: () => current.value,
+      send: vi.fn(),
+      useSettings: () => current.value,
+    } as unknown as SettingsRegistryService,
+  }
 }
 
 function createSystemIOService() {
@@ -140,6 +179,100 @@ describe('home project actions', () => {
     registry?.[Symbol.dispose]()
     registry = undefined
     vi.restoreAllMocks()
+  })
+
+  it('does not clear configured library entries for unrelated settings updates', async () => {
+    const settings = createMutableSettingsService({
+      libraries: [
+        {
+          title: 'Custom Cloud',
+          path: '/custom-cloud',
+          type: 'custom-cloud',
+        },
+      ],
+    })
+    const systemIO = createSystemIOService()
+    const cloudSync = createCloudSyncService()
+    const readEntries = vi.fn(({ library }: { library: ProjectLibrary }) =>
+      Promise.resolve([
+        {
+          source: 'local',
+          status: 'synced',
+          libraryId: library.id,
+          name: 'untitled-43',
+          title: 'untitled-43',
+          localProjectPath: '/custom-cloud/untitled-43',
+          localProjectName: 'untitled-43',
+          remoteProjectId: 'remote-123',
+          defaultFile: '/custom-cloud/untitled-43/main.kcl',
+          readWriteAccess: true,
+          thumbnail: {
+            type: 'local',
+            path: '/custom-cloud/untitled-43/thumbnail.png',
+          },
+        },
+      ] satisfies HomeProjectEntryContribution[])
+    )
+
+    registry = new Registry()
+    registry.configure([
+      defineRegistryItem({
+        id: 'test.settings',
+        providesServices: [provideService(settingsService, settings.service)],
+      }),
+      defineRegistryItem({
+        id: 'test.system-io',
+        providesServices: [provideService(systemIOService, systemIO.service)],
+      }),
+      defineRegistryItem({
+        id: 'test.cloud-sync',
+        providesServices: [provideService(cloudSyncService, cloudSync)],
+      }),
+      defineRegistryItem({
+        id: 'test.custom-library-type',
+        provides: [
+          provide(projectLibraryTypesValueSpec, {
+            type: 'custom-cloud',
+            title: 'Custom Cloud',
+            readEntries,
+          }),
+        ],
+      }),
+      homeProjectsExtension,
+    ])
+
+    await waitFor(() =>
+      expect(registry?.get(homeProjectEntriesValueSpec)).toEqual([
+        expect.objectContaining({
+          name: 'untitled-43',
+          thumbnail: {
+            type: 'local',
+            path: '/custom-cloud/untitled-43/thumbnail.png',
+          },
+        }),
+      ])
+    )
+
+    readEntries.mockClear()
+    settings.current.value = {
+      ...settings.current.value,
+      unrelated: {
+        value: 1,
+      },
+    }
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(readEntries).not.toHaveBeenCalled()
+    expect(registry.get(homeProjectEntriesValueSpec)).toEqual([
+      expect.objectContaining({
+        name: 'untitled-43',
+        thumbnail: {
+          type: 'local',
+          path: '/custom-cloud/untitled-43/thumbnail.png',
+        },
+      }),
+    ])
   })
 
   it('opens remote-only cloud projects without forcing a full folder rescan', async () => {

--- a/src/registry/extensions/homeProjects/index.test.ts
+++ b/src/registry/extensions/homeProjects/index.test.ts
@@ -4,7 +4,6 @@ import {
   Registry,
 } from '@kittycad/registry'
 import { signal } from '@preact/signals-core'
-import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { CloudSyncRegistryService } from '@src/registry/contracts/cloudSync'
 import { cloudSyncService } from '@src/registry/contracts/cloudSync'
 import {
@@ -29,11 +28,17 @@ const cloudSyncPathMocks = vi.hoisted(() => ({
   getDefaultCloudProjectDirectoryPath: vi.fn(),
 }))
 
-vi.mock('@src/lib/desktop', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@src/lib/desktop')>()
+vi.mock('@src/lib/desktop', () => {
   return {
-    ...actual,
+    canReadWriteDirectory: vi.fn().mockResolvedValue({
+      value: true,
+      error: undefined,
+    }),
+    createNewProjectDirectory: vi.fn(),
     getProjectInfo: desktopMocks.getProjectInfo,
+    isPathNotFoundError: vi.fn(() => false),
+    mkdirOrNOOP: vi.fn().mockResolvedValue(undefined),
+    writeProjectTitleToProjectToml: vi.fn().mockResolvedValue(undefined),
   }
 })
 
@@ -121,8 +126,10 @@ describe('home project actions', () => {
   })
 
   it('opens remote-only cloud projects without forcing a full folder rescan', async () => {
-    const wasmInstance = {} as ModuleType
-    const wasmPromise = Promise.resolve(wasmInstance)
+    const wasmInstance = {}
+    const wasmPromise = Promise.resolve(wasmInstance) as Parameters<
+      typeof provideWasmPromise
+    >[0]
     const systemIO = createSystemIOService()
     const cloudSync = createCloudSyncService({
       ensureProjectLocallySynced: vi.fn().mockResolvedValue({

--- a/src/registry/extensions/homeProjects/index.ts
+++ b/src/registry/extensions/homeProjects/index.ts
@@ -301,9 +301,6 @@ const homeProjectActions = defineRegistryItemFactory((ctx) => {
         syncedProject.projectPath,
         await getWasmPromise()
       )
-      systemIO.value?.actor.send({
-        type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
-      })
       return { defaultFile: projectInfo.default_file }
     },
     duplicate: async (project) => {

--- a/src/registry/extensions/homeProjects/index.ts
+++ b/src/registry/extensions/homeProjects/index.ts
@@ -5,7 +5,7 @@ import {
   provide,
   provideService,
 } from '@kittycad/registry'
-import { effect, signal } from '@preact/signals-core'
+import { computed, effect, signal } from '@preact/signals-core'
 import { getDefaultCloudProjectDirectoryPath } from '@src/lib/cloudSync/paths'
 import {
   getProjectInfo,
@@ -22,9 +22,11 @@ import {
   DEFAULT_PROJECT_LIBRARY_ID,
   DEFAULT_PROJECT_LIBRARY_TITLE,
   DIRECTORY_PROJECT_LIBRARY_TYPE,
+  getDefaultDirectoryProjectLibraryPath,
   getDefaultProjectLibrarySettings,
   NEW_PROJECT_LIBRARY_TITLE,
   type ProjectLibrary,
+  projectLibraryFromSetting,
   projectLibrariesFromSettings,
 } from '@src/lib/projectLibraries'
 import {
@@ -56,6 +58,7 @@ import { projectExplorerProjectMenuItemsValueSpec } from '@src/registry/contract
 import {
   getProjectLibraryOperation,
   type ProjectLibraryTypeOperations,
+  projectLibrariesValueSpec,
   projectLibrarySettingDefaultPoliciesValueSpec,
   projectLibraryTypesValueSpec,
 } from '@src/registry/contracts/projectLibraries'
@@ -486,6 +489,59 @@ const systemIOLocalHomeProjectEntries = defineRegistryItemFactory((ctx) => {
   }
 }, 'home-projects.system-io-local-projects')
 
+const configuredProjectLibraries = defineRegistryItemFactory((ctx) => {
+  const settings = ctx.services.signal(settingsService)
+  const libraries = computed<ProjectLibrary[]>(() => {
+    const currentSettings = settings.value?.current.value
+    if (!currentSettings) {
+      return []
+    }
+
+    const defaultProjectDirectory = getDefaultDirectoryProjectLibraryPath(
+      currentSettings.app.libraries.current
+    )
+
+    return currentSettings.app.libraries.current.map((library, index) => ({
+      ...projectLibraryFromSetting(library, index, {
+        defaultProjectDirectory,
+      }),
+      icon: 'folder',
+      order: index,
+    }))
+  })
+
+  return {
+    item: defineRuntimeRegistryItem({
+      id: 'home-projects.configured-project-libraries',
+      provides: [
+        provide(projectLibrariesValueSpec, libraries, {
+          key: 'home-projects.configured-project-libraries',
+        }),
+      ],
+    }),
+  }
+}, 'home-projects.configured-project-libraries')
+
+function areProjectLibrariesEqual(
+  left: readonly ProjectLibrary[],
+  right: readonly ProjectLibrary[]
+) {
+  return (
+    left.length === right.length &&
+    left.every((library, index) => {
+      const otherLibrary = right[index]
+      return (
+        otherLibrary !== undefined &&
+        library.id === otherLibrary.id &&
+        library.title === otherLibrary.title &&
+        library.path === otherLibrary.path &&
+        library.type === otherLibrary.type &&
+        library.order === otherLibrary.order
+      )
+    })
+  )
+}
+
 const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
   const systemIO = ctx.services.signal(systemIOService)
   const cloudSync = ctx.services.signal(cloudSyncService)
@@ -691,6 +747,9 @@ const configuredProjectLibraryEntries = defineRegistryItemFactory((ctx) => {
   let disposeConfiguredProjectLibraryEntriesEffect: (() => void) | undefined
   let disposed = false
   let loadId = 0
+  let lastScannedConfiguredLibraries: ProjectLibrary[] | undefined
+  let lastScannedLibraryTypes: typeof libraryTypes.value | undefined
+  let lastScannedInvalidation = -1
 
   const updateEntries = () => {
     entries.value = Array.from(entriesByLibraryId.values()).flat()
@@ -709,7 +768,35 @@ const configuredProjectLibraryEntries = defineRegistryItemFactory((ctx) => {
       // Directory library operations mutate the filesystem without changing
       // settings or library type registrations. Read this signal so known
       // mutations can invalidate and rescan configured library entries.
-      readConfiguredProjectLibraryEntriesInvalidation()
+      const invalidation = readConfiguredProjectLibraryEntriesInvalidation()
+
+      const defaultProjectDirectory = getDefaultDirectoryProjectLibraryPath(
+        currentSettings?.app.libraries.current
+      )
+      const configuredLibraries =
+        currentSettings?.app.libraries.current
+          .map((library, index) =>
+            projectLibraryFromSetting(library, index, {
+              defaultProjectDirectory,
+            })
+          )
+          .filter((library) => library.id !== DEFAULT_PROJECT_LIBRARY_ID) ?? []
+
+      if (
+        lastScannedLibraryTypes === typeById &&
+        lastScannedInvalidation === invalidation &&
+        lastScannedConfiguredLibraries &&
+        areProjectLibrariesEqual(
+          lastScannedConfiguredLibraries,
+          configuredLibraries
+        )
+      ) {
+        return
+      }
+
+      lastScannedLibraryTypes = typeById
+      lastScannedInvalidation = invalidation
+      lastScannedConfiguredLibraries = configuredLibraries
       const nextLoadId = ++loadId
 
       abortController?.abort()
@@ -717,14 +804,6 @@ const configuredProjectLibraryEntries = defineRegistryItemFactory((ctx) => {
       abortController = loadController
       entriesByLibraryId.clear()
       entries.value = []
-
-      if (!currentSettings) {
-        return
-      }
-
-      const configuredLibraries = projectLibrariesFromSettings(
-        currentSettings.app.libraries.current
-      ).filter((library) => library.id !== DEFAULT_PROJECT_LIBRARY_ID)
 
       for (const library of configuredLibraries) {
         const readEntries = typeById.get(library.type)?.readEntries
@@ -848,6 +927,7 @@ const moveProjectToLibraryProjectMenuItem = defineRegistryItemFactory((ctx) => {
 const homeProjectsExtension = defineRegistryItem({
   id: 'home-projects',
   uses: [
+    configuredProjectLibraries,
     configuredProjectLibraryEntries,
     directoryProjectLibraryDefaultPolicy,
     directoryProjectLibraryType,

--- a/src/registry/extensions/homeProjects/index.ts
+++ b/src/registry/extensions/homeProjects/index.ts
@@ -446,10 +446,12 @@ const systemIOLocalHomeProjectEntries = defineRegistryItemFactory((ctx) => {
         const snapshot = service.actor.getSnapshot()
         const context = snapshot.context
         const projects = context.folders
-        entries.value = localHomeProjectEntriesFromProjects(
-          projects,
-          DEFAULT_PROJECT_LIBRARY_ID
-        )
+        if (projects !== undefined) {
+          entries.value = localHomeProjectEntriesFromProjects(
+            projects,
+            DEFAULT_PROJECT_LIBRARY_ID
+          )
+        }
 
         if (
           projects &&

--- a/src/registry/extensions/homeProjects/index.ts
+++ b/src/registry/extensions/homeProjects/index.ts
@@ -5,7 +5,7 @@ import {
   provide,
   provideService,
 } from '@kittycad/registry'
-import { computed, effect, signal } from '@preact/signals-core'
+import { effect, signal } from '@preact/signals-core'
 import { getDefaultCloudProjectDirectoryPath } from '@src/lib/cloudSync/paths'
 import {
   getProjectInfo,
@@ -22,11 +22,9 @@ import {
   DEFAULT_PROJECT_LIBRARY_ID,
   DEFAULT_PROJECT_LIBRARY_TITLE,
   DIRECTORY_PROJECT_LIBRARY_TYPE,
-  getDefaultDirectoryProjectLibraryPath,
   getDefaultProjectLibrarySettings,
   NEW_PROJECT_LIBRARY_TITLE,
   type ProjectLibrary,
-  projectLibraryFromSetting,
   projectLibrariesFromSettings,
 } from '@src/lib/projectLibraries'
 import {
@@ -58,7 +56,6 @@ import { projectExplorerProjectMenuItemsValueSpec } from '@src/registry/contract
 import {
   getProjectLibraryOperation,
   type ProjectLibraryTypeOperations,
-  projectLibrariesValueSpec,
   projectLibrarySettingDefaultPoliciesValueSpec,
   projectLibraryTypesValueSpec,
 } from '@src/registry/contracts/projectLibraries'
@@ -122,7 +119,6 @@ function getProjectMoveSource({ project }: { project: HomeProjectEntry }) {
 
 const homeProjectActions = defineRegistryItemFactory((ctx) => {
   const settings = ctx.services.signal(settingsService)
-  const systemIO = ctx.services.signal(systemIOService)
   const cloudSync = ctx.services.signal(cloudSyncService)
 
   const getWasmPromise = () =>
@@ -491,39 +487,6 @@ const systemIOLocalHomeProjectEntries = defineRegistryItemFactory((ctx) => {
   }
 }, 'home-projects.system-io-local-projects')
 
-const configuredProjectLibraries = defineRegistryItemFactory((ctx) => {
-  const settings = ctx.services.signal(settingsService)
-  const libraries = computed<ProjectLibrary[]>(() => {
-    const currentSettings = settings.value?.current.value
-    if (!currentSettings) {
-      return []
-    }
-
-    const defaultProjectDirectory = getDefaultDirectoryProjectLibraryPath(
-      currentSettings.app.libraries.current
-    )
-
-    return currentSettings.app.libraries.current.map((library, index) => ({
-      ...projectLibraryFromSetting(library, index, {
-        defaultProjectDirectory,
-      }),
-      icon: 'folder',
-      order: index,
-    }))
-  })
-
-  return {
-    item: defineRuntimeRegistryItem({
-      id: 'home-projects.configured-project-libraries',
-      provides: [
-        provide(projectLibrariesValueSpec, libraries, {
-          key: 'home-projects.configured-project-libraries',
-        }),
-      ],
-    }),
-  }
-}, 'home-projects.configured-project-libraries')
-
 function areProjectLibrariesEqual(
   left: readonly ProjectLibrary[],
   right: readonly ProjectLibrary[]
@@ -772,17 +735,12 @@ const configuredProjectLibraryEntries = defineRegistryItemFactory((ctx) => {
       // mutations can invalidate and rescan configured library entries.
       const invalidation = readConfiguredProjectLibraryEntriesInvalidation()
 
-      const defaultProjectDirectory = getDefaultDirectoryProjectLibraryPath(
-        currentSettings?.app.libraries.current
-      )
       const configuredLibraries =
-        currentSettings?.app.libraries.current
-          .map((library, index) =>
-            projectLibraryFromSetting(library, index, {
-              defaultProjectDirectory,
-            })
-          )
-          .filter((library) => library.id !== DEFAULT_PROJECT_LIBRARY_ID) ?? []
+        currentSettings !== undefined
+          ? projectLibrariesFromSettings(
+              currentSettings.app.libraries.current
+            ).filter((library) => library.id !== DEFAULT_PROJECT_LIBRARY_ID)
+          : []
 
       if (
         lastScannedLibraryTypes === typeById &&
@@ -929,7 +887,6 @@ const moveProjectToLibraryProjectMenuItem = defineRegistryItemFactory((ctx) => {
 const homeProjectsExtension = defineRegistryItem({
   id: 'home-projects',
   uses: [
-    configuredProjectLibraries,
     configuredProjectLibraryEntries,
     directoryProjectLibraryDefaultPolicy,
     directoryProjectLibraryType,

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -1,5 +1,4 @@
 import { BillingDialog } from '@kittycad/ui-components'
-import { effect as createSignalEffect } from '@preact/signals-core'
 import { useSignals } from '@preact/signals-react/runtime'
 import { ActionButton } from '@src/components/ActionButton'
 import { Announcements } from '@src/components/Announcements'
@@ -31,7 +30,7 @@ import {
 } from '@src/lib/autoUpdate'
 import { BillingTransition } from '@src/lib/billing'
 import { useApp, useSingletons } from '@src/lib/boot'
-import { cloudSyncStatus, setCloudSyncProjectScope } from '@src/lib/cloudSync'
+import { setCloudSyncProjectScope } from '@src/lib/cloudSync'
 import { createRouteCommands } from '@src/lib/commandBarConfigs/routeCommandConfig'
 import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
 import { isDesktop } from '@src/lib/isDesktop'
@@ -55,10 +54,7 @@ import {
   useFolders,
   useState as useSystemIOState,
 } from '@src/machines/systemIO/hooks'
-import {
-  SystemIOMachineEvents,
-  SystemIOMachineStates,
-} from '@src/machines/systemIO/utils'
+import { SystemIOMachineStates } from '@src/machines/systemIO/utils'
 import type { WebContentSendPayload } from '@src/menu/channels'
 import {
   type HomeProjectActionsService,
@@ -98,7 +94,6 @@ import {
   useParams,
   useSearchParams,
 } from 'react-router-dom'
-import { waitFor } from 'xstate'
 
 type ReadWriteProjectState = {
   value: boolean
@@ -281,37 +276,6 @@ const Home = () => {
   const autoUpdateReady = autoUpdateReadySignal.value
   const machineApiEnabled = settingsValues.app.machineApi.current
   const onboardingStatus = settingsValues.app.onboardingStatus.current
-
-  useEffect(() => {
-    let disposed = false
-    let lastHandledSyncedAt: string | undefined
-
-    const disposeCloudSyncRefreshEffect = createSignalEffect(() => {
-      const syncedAt = cloudSyncStatus.value.lastSyncedAt
-      if (!syncedAt || syncedAt === lastHandledSyncedAt) {
-        return
-      }
-
-      lastHandledSyncedAt = syncedAt
-      void waitFor(systemIOActor, (state) =>
-        state.matches(SystemIOMachineStates.idle)
-      )
-        .then(() => {
-          if (disposed || lastHandledSyncedAt !== syncedAt) {
-            return
-          }
-          systemIOActor.send({
-            type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
-          })
-        })
-        .catch(reportRejection)
-    })
-
-    return () => {
-      disposed = true
-      disposeCloudSyncRefreshEffect()
-    }
-  }, [systemIOActor])
 
   // Menu listeners
   const cb = (data: WebContentSendPayload) => {


### PR DESCRIPTION
## Summary

- Remove the Home-level cloud sync `lastSyncedAt` listener that forced full folder rescans after sync completion; #12699 now separately coalesces sync status and suppresses background loading UI.
- Open cloud projects through project-library operations so locally materialized cloud projects and newly materialized remote projects navigate without sending an extra System IO folder read.
- Preserve Home project entries while System IO folders are temporarily unset, and skip configured-library rescans when settings, library types, and invalidation state have not changed.
- Rebase onto current `main` by reading configured Home libraries from `app.libraries` settings and dropping the stale configured-library value provider.

## Why

After #12699, this PR is no longer the only fix for the visible status/loading flutter. Its remaining value is removing redundant Home/project-library refreshes that can still reshuffle entries or add latency around cloud project opens and background registry updates.

## Validation

- `npm run tsc`
- `npm run lint`
- `./node_modules/.bin/vitest run --mode=development --project=unit src/registry/extensions/homeProjects/index.test.ts`
- `./node_modules/.bin/biome check src/routes/Home.tsx src/registry/extensions/homeProjects/index.ts src/registry/extensions/homeProjects/index.test.ts`