### PR TITLE
Move artifact graph types to kcl-api

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2356,6 +2356,7 @@ dependencies = [
  "pyo3-stub-gen",
  "schemars 0.8.22",
  "serde",
+ "serde_json",
  "ts-rs",
  "uuid",
 ]

--- a/rust/kcl-api/Cargo.toml
+++ b/rust/kcl-api/Cargo.toml
@@ -24,5 +24,8 @@ serde = { workspace = true }
 ts-rs = { version = "12.0.1", features = ["uuid-impl", "url-impl", "chrono-impl", "indexmap-impl", "no-serde-warnings", "serde-json-impl"] }
 uuid = { workspace = true, features = ["v4", "v5", "js", "serde"] }
 
+[dev-dependencies]
+serde_json = { workspace = true }
+
 [lints]
 workspace = true

--- a/rust/kcl-api/src/artifact.rs
+++ b/rust/kcl-api/src/artifact.rs
@@ -1,12 +1,17 @@
 use indexmap::IndexMap;
-use parse_display::{Display, FromStr};
+use kcl_error::SourceRange;
+use parse_display::Display;
+use parse_display::FromStr;
 use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
 use serde::ser::SerializeSeq;
-use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{ArtifactId, NodePath, ObjectId, UnitLength};
-use kcl_error::SourceRange;
+use crate::ArtifactId;
+use crate::NodePath;
+use crate::ObjectId;
+use crate::UnitLength;
 
 pub type DummyPathToNode = Vec<()>;
 

--- a/rust/kcl-api/src/artifact.rs
+++ b/rust/kcl-api/src/artifact.rs
@@ -1,0 +1,668 @@
+use indexmap::IndexMap;
+use parse_display::{Display, FromStr};
+use schemars::JsonSchema;
+use serde::ser::SerializeSeq;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{ArtifactId, NodePath, ObjectId, UnitLength};
+use kcl_error::SourceRange;
+
+pub type DummyPathToNode = Vec<()>;
+
+fn serialize_dummy_path_to_node<S>(_path_to_node: &DummyPathToNode, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let seq = serializer.serialize_seq(Some(0))?;
+    seq.end()
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct CodeRef {
+    pub range: SourceRange,
+    pub node_path: NodePath,
+    // TODO: We should implement this in Rust.
+    #[serde(default, serialize_with = "serialize_dummy_path_to_node")]
+    #[ts(type = "Array<[string | number, string]>")]
+    pub path_to_node: DummyPathToNode,
+}
+
+impl CodeRef {
+    pub fn placeholder(range: SourceRange) -> Self {
+        Self {
+            range,
+            node_path: Default::default(),
+            path_to_node: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Hash, Eq, Copy, Clone, Deserialize, Serialize, JsonSchema, PartialEq, ts_rs::TS, Display, FromStr)]
+#[ts(export)]
+#[serde(rename_all = "camelCase")]
+pub enum PlaneName {
+    /// The XY plane.
+    #[display("XY")]
+    Xy,
+    /// The opposite side of the XY plane.
+    #[display("-XY")]
+    NegXy,
+    /// The XZ plane.
+    #[display("XZ")]
+    Xz,
+    /// The opposite side of the XZ plane.
+    #[display("-XZ")]
+    NegXz,
+    /// The YZ plane.
+    #[display("YZ")]
+    Yz,
+    /// The opposite side of the YZ plane.
+    #[display("-YZ")]
+    NegYz,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Default, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+/// API-owned point data used by artifact payloads so the wire model does not
+/// depend on kcl-lib's execution geometry types.
+pub struct ArtifactPoint3d {
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+    pub units: Option<UnitLength>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+/// API-owned plane data used by artifacts. It mirrors kcl-lib's evaluated
+/// plane JSON shape while keeping kcl-api independent of execution internals.
+pub struct ArtifactPlaneInfo {
+    pub origin: ArtifactPoint3d,
+    pub x_axis: ArtifactPoint3d,
+    pub y_axis: ArtifactPoint3d,
+    pub z_axis: ArtifactPoint3d,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "snake_case")]
+/// API-owned sweep method equivalent to the engine extrusion method, avoiding
+/// a kcl-api dependency on kittycad-modeling-cmds.
+pub enum ArtifactSweepMethod {
+    New,
+    Merge,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct CompositeSolid {
+    pub id: ArtifactId,
+    /// Whether this artifact has been used in a subsequent operation
+    pub consumed: bool,
+    pub sub_type: CompositeSolidSubType,
+    /// Index of this output in the expression result, for operations that
+    /// return multiple selectable bodies from one KCL variable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_index: Option<usize>,
+    /// Constituent solids of the composite solid.
+    pub solid_ids: Vec<ArtifactId>,
+    /// Tool solids used for asymmetric operations like subtract.
+    pub tool_ids: Vec<ArtifactId>,
+    pub code_ref: CodeRef,
+    /// This is the ID of the composite solid that this is part of, if any, as a
+    /// composite solid can be used as input for another composite solid.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub composite_solid_id: Option<ArtifactId>,
+    /// Pattern operations that use this composite solid as their source.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pattern_ids: Vec<ArtifactId>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+pub enum CompositeSolidSubType {
+    Intersect,
+    Subtract,
+    Split,
+    Union,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct Plane {
+    pub id: ArtifactId,
+    pub path_ids: Vec<ArtifactId>,
+    pub code_ref: CodeRef,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct Path {
+    pub id: ArtifactId,
+    pub sub_type: PathSubType,
+    pub plane_id: ArtifactId,
+    pub seg_ids: Vec<ArtifactId>,
+    /// Whether this artifact has been used in a subsequent operation
+    pub consumed: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// The sweep, if any, that this Path serves as the base path for.
+    /// corresponds to `path_id` on the Sweep.
+    pub sweep_id: Option<ArtifactId>,
+    /// The sweep, if any, that this Path serves as the trajectory for.
+    pub trajectory_sweep_id: Option<ArtifactId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub solid2d_id: Option<ArtifactId>,
+    pub code_ref: CodeRef,
+    /// This is the ID of the composite solid that this is part of, if any, as
+    /// this can be used as input for another composite solid.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub composite_solid_id: Option<ArtifactId>,
+    /// For sketch paths, the ID of the sketch block this path was created
+    /// from. `None` for region paths and paths created in other ways.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sketch_block_id: Option<ArtifactId>,
+    /// For region paths, the ID of the sketch path this region was created
+    /// from. `None` for sketch paths.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub origin_path_id: Option<ArtifactId>,
+    /// The hole, if any, from a subtract2d() call.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inner_path_id: Option<ArtifactId>,
+    /// The `Path` that this is a hole of, if any. The inverse link of
+    /// `inner_path_id`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub outer_path_id: Option<ArtifactId>,
+    /// Pattern operations that use this path as their source.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pattern_ids: Vec<ArtifactId>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+pub enum PathSubType {
+    Sketch,
+    Region,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct Segment {
+    pub id: ArtifactId,
+    pub path_id: ArtifactId,
+    /// If this artifact is a segment in a region, the segment in the original
+    /// sketch that this was derived from.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub original_seg_id: Option<ArtifactId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub surface_id: Option<ArtifactId>,
+    pub edge_ids: Vec<ArtifactId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub edge_cut_id: Option<ArtifactId>,
+    pub code_ref: CodeRef,
+    pub common_surface_ids: Vec<ArtifactId>,
+}
+
+/// A sweep is a more generic term for extrude, revolve, loft, sweep, and blend.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct Sweep {
+    pub id: ArtifactId,
+    pub sub_type: SweepSubType,
+    pub path_id: ArtifactId,
+    pub surface_ids: Vec<ArtifactId>,
+    pub edge_ids: Vec<ArtifactId>,
+    pub code_ref: CodeRef,
+    /// ID of trajectory path for sweep, if any
+    /// Only applicable to SweepSubType::Sweep and SweepSubType::Blend, which
+    /// can use a second path-like input
+    pub trajectory_id: Option<ArtifactId>,
+    pub method: ArtifactSweepMethod,
+    /// Whether this artifact has been used in a subsequent operation
+    pub consumed: bool,
+    /// Pattern operations that use this sweep as their source.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pattern_ids: Vec<ArtifactId>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+pub enum SweepSubType {
+    Extrusion,
+    ExtrusionTwist,
+    Revolve,
+    RevolveAboutEdge,
+    Loft,
+    Blend,
+    Sweep,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct Solid2d {
+    pub id: ArtifactId,
+    pub path_id: ArtifactId,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct PrimitiveFace {
+    pub id: ArtifactId,
+    pub solid_id: ArtifactId,
+    pub code_ref: CodeRef,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct PrimitiveEdge {
+    pub id: ArtifactId,
+    pub solid_id: ArtifactId,
+    pub code_ref: CodeRef,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct PlaneOfFace {
+    pub id: ArtifactId,
+    pub face_id: ArtifactId,
+    pub code_ref: CodeRef,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct StartSketchOnFace {
+    pub id: ArtifactId,
+    pub face_id: ArtifactId,
+    pub code_ref: CodeRef,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct StartSketchOnPlane {
+    pub id: ArtifactId,
+    pub plane_id: ArtifactId,
+    pub code_ref: CodeRef,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct SketchBlock {
+    pub id: ArtifactId,
+    /// The semantic standard plane name when the sketch block is on a standard plane.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub standard_plane: Option<PlaneName>,
+    /// The concrete plane artifact ID backing the sketch block, when one is available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plane_id: Option<ArtifactId>,
+    /// The evaluated plane data backing the sketch block, when the sketch is on a plane.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plane_info: Option<ArtifactPlaneInfo>,
+    /// The path artifact ID created from the sketch block, if there is one.
+    /// There are edge cases when a path isn't created, like when there are no
+    /// segments.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path_id: Option<ArtifactId>,
+    pub code_ref: CodeRef,
+    /// The sketch ID (ObjectId) for the sketch scene object.
+    pub sketch_id: ObjectId,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+pub enum SketchBlockConstraintType {
+    Angle,
+    Coincident,
+    Distance,
+    Diameter,
+    EqualRadius,
+    Fixed,
+    HorizontalDistance,
+    VerticalDistance,
+    Horizontal,
+    LinesEqualLength,
+    Midpoint,
+    Parallel,
+    Perpendicular,
+    Radius,
+    Symmetric,
+    Tangent,
+    Vertical,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct SketchBlockConstraint {
+    pub id: ArtifactId,
+    /// The sketch ID (ObjectId) that owns this constraint.
+    pub sketch_id: ObjectId,
+    /// The constraint ID (ObjectId) for the constraint scene object.
+    pub constraint_id: ObjectId,
+    pub constraint_type: SketchBlockConstraintType,
+    pub code_ref: CodeRef,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct Wall {
+    pub id: ArtifactId,
+    pub seg_id: ArtifactId,
+    pub edge_cut_edge_ids: Vec<ArtifactId>,
+    pub sweep_id: ArtifactId,
+    pub path_ids: Vec<ArtifactId>,
+    /// This is for the sketch-on-face plane, not for the wall itself.  Traverse
+    /// to the extrude and/or segment to get the wall's code_ref.
+    pub face_code_ref: CodeRef,
+    /// The command ID that got the data for this wall. Used for stable sorting.
+    pub cmd_id: Uuid,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct Cap {
+    pub id: ArtifactId,
+    pub sub_type: CapSubType,
+    pub edge_cut_edge_ids: Vec<ArtifactId>,
+    pub sweep_id: ArtifactId,
+    pub path_ids: Vec<ArtifactId>,
+    /// This is for the sketch-on-face plane, not for the cap itself.  Traverse
+    /// to the extrude and/or segment to get the cap's code_ref.
+    pub face_code_ref: CodeRef,
+    /// The command ID that got the data for this cap. Used for stable sorting.
+    pub cmd_id: Uuid,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+pub enum CapSubType {
+    Start,
+    End,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct SweepEdge {
+    pub id: ArtifactId,
+    pub sub_type: SweepEdgeSubType,
+    pub seg_id: ArtifactId,
+    pub cmd_id: Uuid,
+    // This is only used for sorting, not for the actual artifact.
+    #[serde(skip)]
+    pub index: usize,
+    pub sweep_id: ArtifactId,
+    pub common_surface_ids: Vec<ArtifactId>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+pub enum SweepEdgeSubType {
+    Opposite,
+    Adjacent,
+    PreviousAdjacent,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct EdgeCut {
+    pub id: ArtifactId,
+    pub sub_type: EdgeCutSubType,
+    pub consumed_edge_id: ArtifactId,
+    pub edge_ids: Vec<ArtifactId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub surface_id: Option<ArtifactId>,
+    pub code_ref: CodeRef,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+pub enum EdgeCutSubType {
+    Fillet,
+    Chamfer,
+    Custom,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct EdgeCutEdge {
+    pub id: ArtifactId,
+    pub edge_cut_id: ArtifactId,
+    pub surface_id: ArtifactId,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct Helix {
+    pub id: ArtifactId,
+    /// The axis of the helix.  Currently this is always an edge ID, but we may
+    /// add axes to the graph.
+    pub axis_id: Option<ArtifactId>,
+    pub code_ref: CodeRef,
+    /// The sweep, if any, that this Helix serves as the trajectory for.
+    pub trajectory_sweep_id: Option<ArtifactId>,
+    /// Whether this artifact has been used in a subsequent operation
+    pub consumed: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct GdtAnnotationArtifact {
+    pub id: ArtifactId,
+    pub code_ref: CodeRef,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct Pattern {
+    pub id: ArtifactId,
+    pub sub_type: PatternSubType,
+    /// Geometry artifact that was the source of the pattern operation.
+    pub source_id: ArtifactId,
+    /// IDs of copied top-level objects created by the pattern operation.
+    pub copy_ids: Vec<ArtifactId>,
+    /// IDs of copied faces created by the pattern operation.
+    pub copy_face_ids: Vec<ArtifactId>,
+    /// IDs of copied edges created by the pattern operation.
+    pub copy_edge_ids: Vec<ArtifactId>,
+    pub code_ref: CodeRef,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+pub enum PatternSubType {
+    Circular,
+    Linear,
+    Transform,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum Artifact {
+    CompositeSolid(CompositeSolid),
+    Plane(Plane),
+    Path(Path),
+    Segment(Segment),
+    Solid2d(Solid2d),
+    PrimitiveFace(PrimitiveFace),
+    PrimitiveEdge(PrimitiveEdge),
+    PlaneOfFace(PlaneOfFace),
+    StartSketchOnFace(StartSketchOnFace),
+    StartSketchOnPlane(StartSketchOnPlane),
+    SketchBlock(SketchBlock),
+    SketchBlockConstraint(SketchBlockConstraint),
+    Sweep(Sweep),
+    Wall(Wall),
+    Cap(Cap),
+    SweepEdge(SweepEdge),
+    EdgeCut(EdgeCut),
+    EdgeCutEdge(EdgeCutEdge),
+    Helix(Helix),
+    GdtAnnotation(GdtAnnotationArtifact),
+    Pattern(Pattern),
+}
+
+impl Artifact {
+    pub fn id(&self) -> ArtifactId {
+        match self {
+            Self::CompositeSolid(a) => a.id,
+            Self::Plane(a) => a.id,
+            Self::Path(a) => a.id,
+            Self::Segment(a) => a.id,
+            Self::Solid2d(a) => a.id,
+            Self::PrimitiveFace(a) => a.id,
+            Self::PrimitiveEdge(a) => a.id,
+            Self::PlaneOfFace(a) => a.id,
+            Self::StartSketchOnFace(a) => a.id,
+            Self::StartSketchOnPlane(a) => a.id,
+            Self::SketchBlock(a) => a.id,
+            Self::SketchBlockConstraint(a) => a.id,
+            Self::Sweep(a) => a.id,
+            Self::Wall(a) => a.id,
+            Self::Cap(a) => a.id,
+            Self::SweepEdge(a) => a.id,
+            Self::EdgeCut(a) => a.id,
+            Self::EdgeCutEdge(a) => a.id,
+            Self::Helix(a) => a.id,
+            Self::GdtAnnotation(a) => a.id,
+            Self::Pattern(a) => a.id,
+        }
+    }
+
+    /// The [`CodeRef`] for the artifact itself. See also
+    /// [`Self::face_code_ref`].
+    pub fn code_ref(&self) -> Option<&CodeRef> {
+        match self {
+            Self::CompositeSolid(a) => Some(&a.code_ref),
+            Self::Plane(a) => Some(&a.code_ref),
+            Self::Path(a) => Some(&a.code_ref),
+            Self::Segment(a) => Some(&a.code_ref),
+            Self::Solid2d(_) => None,
+            Self::PrimitiveFace(a) => Some(&a.code_ref),
+            Self::PrimitiveEdge(a) => Some(&a.code_ref),
+            Self::PlaneOfFace(a) => Some(&a.code_ref),
+            Self::StartSketchOnFace(a) => Some(&a.code_ref),
+            Self::StartSketchOnPlane(a) => Some(&a.code_ref),
+            Self::SketchBlock(a) => Some(&a.code_ref),
+            Self::SketchBlockConstraint(a) => Some(&a.code_ref),
+            Self::Sweep(a) => Some(&a.code_ref),
+            Self::Wall(_) | Self::Cap(_) | Self::SweepEdge(_) => None,
+            Self::EdgeCut(a) => Some(&a.code_ref),
+            Self::EdgeCutEdge(_) => None,
+            Self::Helix(a) => Some(&a.code_ref),
+            Self::GdtAnnotation(a) => Some(&a.code_ref),
+            Self::Pattern(a) => Some(&a.code_ref),
+        }
+    }
+
+    /// The [`CodeRef`] referring to the face artifact that it's on, not the
+    /// artifact itself.
+    pub fn face_code_ref(&self) -> Option<&CodeRef> {
+        match self {
+            Self::PrimitiveFace(a) => Some(&a.code_ref),
+            Self::Wall(a) => Some(&a.face_code_ref),
+            Self::Cap(a) => Some(&a.face_code_ref),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema, ts_rs::TS)]
+#[ts(export_to = "Artifact.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct ArtifactGraph {
+    map: IndexMap<ArtifactId, Artifact>,
+    item_count: usize,
+}
+
+impl ArtifactGraph {
+    pub fn from_parts(map: IndexMap<ArtifactId, Artifact>, item_count: usize) -> Self {
+        Self { map, item_count }
+    }
+
+    pub fn into_parts(self) -> (IndexMap<ArtifactId, Artifact>, usize) {
+        (self.map, self.item_count)
+    }
+
+    pub fn item_count(&self) -> usize {
+        self.item_count
+    }
+
+    pub fn get(&self, id: &ArtifactId) -> Option<&Artifact> {
+        self.map.get(id)
+    }
+
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&ArtifactId, &Artifact)> {
+        self.map.iter()
+    }
+
+    pub fn values(&self) -> impl Iterator<Item = &Artifact> {
+        self.map.values()
+    }
+
+    pub fn clear(&mut self) {
+        self.map.clear();
+        self.item_count = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_artifact_graph_json_round_trip() {
+        let graph = ArtifactGraph::default();
+        let json = serde_json::to_string(&graph).unwrap();
+
+        assert_eq!(json, r#"{"map":{},"itemCount":0}"#);
+        assert_eq!(serde_json::from_str::<ArtifactGraph>(&json).unwrap(), graph);
+    }
+
+    #[test]
+    fn artifact_sweep_method_uses_engine_json_shape() {
+        assert_eq!(serde_json::to_string(&ArtifactSweepMethod::New).unwrap(), r#""new""#);
+        assert_eq!(
+            serde_json::to_string(&ArtifactSweepMethod::Merge).unwrap(),
+            r#""merge""#
+        );
+    }
+}

--- a/rust/kcl-api/src/artifact_id.rs
+++ b/rust/kcl-api/src/artifact_id.rs
@@ -1,8 +1,9 @@
+use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use uuid::Uuid;
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Ord, PartialOrd, Hash, ts_rs::TS)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Ord, PartialOrd, Hash, ts_rs::TS)]
 pub struct ArtifactId(Uuid);
 
 impl ArtifactId {

--- a/rust/kcl-api/src/ast/node_path.rs
+++ b/rust/kcl-api/src/ast/node_path.rs
@@ -1,4 +1,5 @@
-use serde::Serialize;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 /// A traversal path through the AST to a node.
 ///
@@ -7,13 +8,13 @@ use serde::Serialize;
 ///
 /// The implementation doesn't cover all parts of the tree. It currently only
 /// works on parts of the tree that the frontend uses.
-#[derive(Debug, Default, Clone, Serialize, PartialEq, Eq, Hash, ts_rs::TS)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Hash, ts_rs::TS)]
 #[ts(export_to = "NodePath.ts")]
 pub struct NodePath {
     pub steps: Vec<Step>,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq, Hash, ts_rs::TS)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Hash, ts_rs::TS)]
 #[ts(export_to = "NodePath.ts")]
 #[serde(tag = "type")]
 pub enum Step {

--- a/rust/kcl-api/src/ast/node_path.rs
+++ b/rust/kcl-api/src/ast/node_path.rs
@@ -1,5 +1,6 @@
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 
 /// A traversal path through the AST to a node.
 ///

--- a/rust/kcl-api/src/front.rs
+++ b/rust/kcl-api/src/front.rs
@@ -1,7 +1,8 @@
+use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, PartialOrd, Ord, Deserialize, Serialize, ts_rs::TS)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, PartialOrd, Ord, Deserialize, Serialize, JsonSchema, ts_rs::TS)]
 #[ts(export, export_to = "FrontendApi.ts", rename = "ApiObjectId")]
 pub struct ObjectId(pub usize);
 

--- a/rust/kcl-api/src/lib.rs
+++ b/rust/kcl-api/src/lib.rs
@@ -1,3 +1,4 @@
+pub use artifact::*;
 pub use artifact_id::ArtifactId;
 pub use ast::node_path::NodePath;
 pub use ast::node_path::Step;
@@ -9,6 +10,7 @@ pub use numeric_type::*;
 use serde::Serialize;
 pub use units::*;
 
+pub mod artifact;
 mod artifact_id;
 pub mod ast;
 mod cad_op;

--- a/rust/kcl-lib/src/engine/mod.rs
+++ b/rust/kcl-lib/src/engine/mod.rs
@@ -13,15 +13,12 @@ use std::sync::atomic::Ordering;
 
 pub use async_tasks::AsyncTasks;
 use indexmap::IndexMap;
+pub use kcl_api::PlaneName;
 use kcl_api::UnitLength;
 use kcmc::ModelingCmd;
 use kcmc::each_cmd as mcmd;
 use kcmc::websocket::WebSocketRequest;
 use kittycad_modeling_cmds::{self as kcmc};
-use parse_display::Display;
-use parse_display::FromStr;
-use serde::Deserialize;
-use serde::Serialize;
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
@@ -176,30 +173,6 @@ impl Clone for EngineStats {
             batches_sent: AtomicUsize::new(self.batches_sent.load(Ordering::Relaxed)),
         }
     }
-}
-
-#[derive(Debug, Hash, Eq, Copy, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, Display, FromStr)]
-#[ts(export)]
-#[serde(rename_all = "camelCase")]
-pub enum PlaneName {
-    /// The XY plane.
-    #[display("XY")]
-    Xy,
-    /// The opposite side of the XY plane.
-    #[display("-XY")]
-    NegXy,
-    /// The XZ plane.
-    #[display("XZ")]
-    Xz,
-    /// The opposite side of the XZ plane.
-    #[display("-XZ")]
-    NegXz,
-    /// The YZ plane.
-    #[display("YZ")]
-    Yz,
-    /// The opposite side of the YZ plane.
-    #[display("-YZ")]
-    NegYz,
 }
 
 /// Create a new zoo api client.

--- a/rust/kcl-lib/src/execution/artifact.rs
+++ b/rust/kcl-lib/src/execution/artifact.rs
@@ -2,6 +2,7 @@ use ahash::AHashMap;
 use ahash::AHashSet;
 use indexmap::IndexMap;
 use kcl_api::NodePath;
+use kcl_api::artifact::*;
 use kittycad_modeling_cmds::EnableSketchMode;
 use kittycad_modeling_cmds::FaceIsPlanar;
 use kittycad_modeling_cmds::ModelingCmd;
@@ -12,21 +13,18 @@ use kittycad_modeling_cmds::websocket::OkWebSocketResponseData;
 use kittycad_modeling_cmds::websocket::WebSocketResponse;
 use kittycad_modeling_cmds::{self as kcmc};
 use serde::Serialize;
-use serde::ser::SerializeSeq;
 use uuid::Uuid;
 
 use crate::KclError;
 use crate::ModuleId;
 use crate::NodePathExt;
 use crate::SourceRange;
-use crate::engine::PlaneName;
 use crate::errors::KclErrorDetails;
 use crate::execution::ArtifactId;
 use crate::execution::cmd_id_ref_to_artifact_id;
 use crate::execution::geometry::PlaneInfo;
 use crate::execution::state::ModuleInfoMap;
 use crate::front::Constraint;
-use crate::front::ObjectId;
 use crate::modules::ModulePath;
 use crate::parsing::ast::types::BodyItem;
 use crate::parsing::ast::types::ImportPath;
@@ -36,7 +34,7 @@ use crate::parsing::ast::types::Program;
 use crate::std::sketch::build_reverse_region_mapping;
 
 #[cfg(test)]
-mod mermaid_tests;
+pub(crate) mod mermaid_tests;
 #[cfg(test)]
 mod tests;
 
@@ -72,821 +70,196 @@ pub struct ArtifactCommand {
     pub omit_from_graph: bool,
 }
 
-pub type DummyPathToNode = Vec<()>;
-
-fn serialize_dummy_path_to_node<S>(_path_to_node: &DummyPathToNode, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    // Always output an empty array, for now.
-    let seq = serializer.serialize_seq(Some(0))?;
-    seq.end()
-}
-
-#[derive(Debug, Clone, Default, Serialize, PartialEq, Eq, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(rename_all = "camelCase")]
-pub struct CodeRef {
-    pub range: SourceRange,
-    pub node_path: NodePath,
-    // TODO: We should implement this in Rust.
-    #[serde(default, serialize_with = "serialize_dummy_path_to_node")]
-    #[ts(type = "Array<[string | number, string]>")]
-    pub path_to_node: DummyPathToNode,
-}
-
-impl CodeRef {
-    pub fn placeholder(range: SourceRange) -> Self {
-        Self {
-            range,
-            node_path: Default::default(),
-            path_to_node: Vec::new(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(rename_all = "camelCase")]
-pub struct CompositeSolid {
-    pub id: ArtifactId,
-    /// Whether this artifact has been used in a subsequent operation
-    pub consumed: bool,
-    pub sub_type: CompositeSolidSubType,
-    /// Index of this output in the expression result, for operations that
-    /// return multiple selectable bodies from one KCL variable.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub output_index: Option<usize>,
-    /// Constituent solids of the composite solid.
-    pub solid_ids: Vec<ArtifactId>,
-    /// Tool solids used for asymmetric operations like subtract.
-    pub tool_ids: Vec<ArtifactId>,
-    pub code_ref: CodeRef,
-    /// This is the ID of the composite solid that this is part of, if any, as a
-    /// composite solid can be used as input for another composite solid.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub composite_solid_id: Option<ArtifactId>,
-    /// Pattern operations that use this composite solid as their source.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub pattern_ids: Vec<ArtifactId>,
-}
-
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(rename_all = "camelCase")]
-pub enum CompositeSolidSubType {
-    Intersect,
-    Subtract,
-    Split,
-    Union,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(rename_all = "camelCase")]
-pub struct Plane {
-    pub id: ArtifactId,
-    pub path_ids: Vec<ArtifactId>,
-    pub code_ref: CodeRef,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(rename_all = "camelCase")]
-pub struct Path {
-    pub id: ArtifactId,
-    pub sub_type: PathSubType,
-    pub plane_id: ArtifactId,
-    pub seg_ids: Vec<ArtifactId>,
-    /// Whether this artifact has been used in a subsequent operation
-    pub consumed: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    /// The sweep, if any, that this Path serves as the base path for.
-    /// corresponds to `path_id` on the Sweep.
-    pub sweep_id: Option<ArtifactId>,
-    /// The sweep, if any, that this Path serves as the trajectory for.
-    pub trajectory_sweep_id: Option<ArtifactId>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub solid2d_id: Option<ArtifactId>,
-    pub code_ref: CodeRef,
-    /// This is the ID of the composite solid that this is part of, if any, as
-    /// this can be used as input for another composite solid.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub composite_solid_id: Option<ArtifactId>,
-    /// For sketch paths, the ID of the sketch block this path was created
-    /// from. `None` for region paths and paths created in other ways.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub sketch_block_id: Option<ArtifactId>,
-    /// For region paths, the ID of the sketch path this region was created
-    /// from. `None` for sketch paths.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub origin_path_id: Option<ArtifactId>,
-    /// The hole, if any, from a subtract2d() call.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub inner_path_id: Option<ArtifactId>,
-    /// The `Path` that this is a hole of, if any. The inverse link of
-    /// `inner_path_id`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub outer_path_id: Option<ArtifactId>,
-    /// Pattern operations that use this path as their source.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub pattern_ids: Vec<ArtifactId>,
-}
-
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(rename_all = "camelCase")]
-pub enum PathSubType {
-    Sketch,
-    Region,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(rename_all = "camelCase")]
-pub struct Segment {
-    pub id: ArtifactId,
-    pub path_id: ArtifactId,
-    /// If this artifact is a segment in a region, the segment in the original
-    /// sketch that this was derived from.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub original_seg_id: Option<ArtifactId>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub surface_id: Option<ArtifactId>,
-    pub edge_ids: Vec<ArtifactId>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub edge_cut_id: Option<ArtifactId>,
-    pub code_ref: CodeRef,
-    pub common_surface_ids: Vec<ArtifactId>,
-}
-
-/// A sweep is a more generic term for extrude, revolve, loft, sweep, and blend.
-#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(rename_all = "camelCase")]
-pub struct Sweep {
-    pub id: ArtifactId,
-    pub sub_type: SweepSubType,
-    pub path_id: ArtifactId,
-    pub surface_ids: Vec<ArtifactId>,
-    pub edge_ids: Vec<ArtifactId>,
-    pub code_ref: CodeRef,
-    /// ID of trajectory path for sweep, if any
-    /// Only applicable to SweepSubType::Sweep and SweepSubType::Blend, which
-    /// can use a second path-like input
-    pub trajectory_id: Option<ArtifactId>,
-    pub method: kittycad_modeling_cmds::shared::ExtrudeMethod,
-    /// Whether this artifact has been used in a subsequent operation
-    pub consumed: bool,
-    /// Pattern operations that use this sweep as their source.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub pattern_ids: Vec<ArtifactId>,
-}
-
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(rename_all = "camelCase")]
-pub enum SweepSubType {
-    Extrusion,
-    ExtrusionTwist,
-    Revolve,
-    RevolveAboutEdge,
-    Loft,
-    Blend,
-    Sweep,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(rename_all = "camelCase")]
-pub struct Solid2d {
-    pub id: ArtifactId,
-    pub path_id: ArtifactId,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(rename_all = "camelCase")]
-pub struct PrimitiveFace {
-    pub id: ArtifactId,
-    pub solid_id: ArtifactId,
-    pub code_ref: CodeRef,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(rename_all = "camelCase")]
-pub struct PrimitiveEdge {
-    pub id: ArtifactId,
-    pub solid_id: ArtifactId,
-    pub code_ref: CodeRef,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(rename_all = "camelCase")]
-pub struct PlaneOfFace {
-    pub id: ArtifactId,
-    pub face_id: ArtifactId,
-    pub code_ref: CodeRef,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(rename_all = "camelCase")]
-pub struct StartSketchOnFace {
-    pub id: ArtifactId,
-    pub face_id: ArtifactId,
-    pub code_ref: CodeRef,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(rename_all = "camelCase")]
-pub struct StartSketchOnPlane {
-    pub id: ArtifactId,
-    pub plane_id: ArtifactId,
-    pub code_ref: CodeRef,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(rename_all = "camelCase")]
-pub struct SketchBlock {
-    pub id: ArtifactId,
-    /// The semantic standard plane name when the sketch block is on a standard plane.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub standard_plane: Option<PlaneName>,
-    /// The concrete plane artifact ID backing the sketch block, when one is available.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub plane_id: Option<ArtifactId>,
-    /// The evaluated plane data backing the sketch block, when the sketch is on a plane.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub plane_info: Option<PlaneInfo>,
-    /// The path artifact ID created from the sketch block, if there is one.
-    /// There are edge cases when a path isn't created, like when there are no
-    /// segments.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub path_id: Option<ArtifactId>,
-    pub code_ref: CodeRef,
-    /// The sketch ID (ObjectId) for the sketch scene object.
-    pub sketch_id: ObjectId,
-}
-
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(rename_all = "camelCase")]
-pub enum SketchBlockConstraintType {
-    Angle,
-    Coincident,
-    Distance,
-    Diameter,
-    EqualRadius,
-    Fixed,
-    HorizontalDistance,
-    VerticalDistance,
-    Horizontal,
-    LinesEqualLength,
-    Midpoint,
-    Parallel,
-    Perpendicular,
-    Radius,
-    Symmetric,
-    Tangent,
-    Vertical,
-}
-
-impl From<&Constraint> for SketchBlockConstraintType {
-    fn from(constraint: &Constraint) -> Self {
-        match constraint {
-            Constraint::Coincident { .. } => SketchBlockConstraintType::Coincident,
-            Constraint::Distance { .. } => SketchBlockConstraintType::Distance,
-            Constraint::Diameter { .. } => SketchBlockConstraintType::Diameter,
-            Constraint::EqualRadius { .. } => SketchBlockConstraintType::EqualRadius,
-            Constraint::Fixed { .. } => SketchBlockConstraintType::Fixed,
-            Constraint::HorizontalDistance { .. } => SketchBlockConstraintType::HorizontalDistance,
-            Constraint::VerticalDistance { .. } => SketchBlockConstraintType::VerticalDistance,
-            Constraint::Horizontal { .. } => SketchBlockConstraintType::Horizontal,
-            Constraint::LinesEqualLength { .. } => SketchBlockConstraintType::LinesEqualLength,
-            Constraint::Midpoint(..) => SketchBlockConstraintType::Midpoint,
-            Constraint::Parallel { .. } => SketchBlockConstraintType::Parallel,
-            Constraint::Perpendicular { .. } => SketchBlockConstraintType::Perpendicular,
-            Constraint::Radius { .. } => SketchBlockConstraintType::Radius,
-            Constraint::Symmetric { .. } => SketchBlockConstraintType::Symmetric,
-            Constraint::Tangent { .. } => SketchBlockConstraintType::Tangent,
-            Constraint::Vertical { .. } => SketchBlockConstraintType::Vertical,
-            Constraint::Angle(..) => SketchBlockConstraintType::Angle,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(rename_all = "camelCase")]
-pub struct SketchBlockConstraint {
-    pub id: ArtifactId,
-    /// The sketch ID (ObjectId) that owns this constraint.
-    pub sketch_id: ObjectId,
-    /// The constraint ID (ObjectId) for the constraint scene object.
-    pub constraint_id: ObjectId,
-    pub constraint_type: SketchBlockConstraintType,
-    pub code_ref: CodeRef,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(rename_all = "camelCase")]
-pub struct Wall {
-    pub id: ArtifactId,
-    pub seg_id: ArtifactId,
-    pub edge_cut_edge_ids: Vec<ArtifactId>,
-    pub sweep_id: ArtifactId,
-    pub path_ids: Vec<ArtifactId>,
-    /// This is for the sketch-on-face plane, not for the wall itself.  Traverse
-    /// to the extrude and/or segment to get the wall's code_ref.
-    pub face_code_ref: CodeRef,
-    /// The command ID that got the data for this wall. Used for stable sorting.
-    pub cmd_id: uuid::Uuid,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(rename_all = "camelCase")]
-pub struct Cap {
-    pub id: ArtifactId,
-    pub sub_type: CapSubType,
-    pub edge_cut_edge_ids: Vec<ArtifactId>,
-    pub sweep_id: ArtifactId,
-    pub path_ids: Vec<ArtifactId>,
-    /// This is for the sketch-on-face plane, not for the cap itself.  Traverse
-    /// to the extrude and/or segment to get the cap's code_ref.
-    pub face_code_ref: CodeRef,
-    /// The command ID that got the data for this cap. Used for stable sorting.
-    pub cmd_id: uuid::Uuid,
-}
-
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(rename_all = "camelCase")]
-pub enum CapSubType {
-    Start,
-    End,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(rename_all = "camelCase")]
-pub struct SweepEdge {
-    pub id: ArtifactId,
-    pub sub_type: SweepEdgeSubType,
-    pub seg_id: ArtifactId,
-    pub cmd_id: uuid::Uuid,
-    // This is only used for sorting, not for the actual artifact.
-    #[serde(skip)]
-    pub index: usize,
-    pub sweep_id: ArtifactId,
-    pub common_surface_ids: Vec<ArtifactId>,
-}
-
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(rename_all = "camelCase")]
-pub enum SweepEdgeSubType {
-    Opposite,
-    Adjacent,
-    PreviousAdjacent,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(rename_all = "camelCase")]
-pub struct EdgeCut {
-    pub id: ArtifactId,
-    pub sub_type: EdgeCutSubType,
-    pub consumed_edge_id: ArtifactId,
-    pub edge_ids: Vec<ArtifactId>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub surface_id: Option<ArtifactId>,
-    pub code_ref: CodeRef,
-}
-
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(rename_all = "camelCase")]
-pub enum EdgeCutSubType {
-    Fillet,
-    Chamfer,
-    Custom,
-}
-
-impl From<kcmc::shared::CutType> for EdgeCutSubType {
-    fn from(cut_type: kcmc::shared::CutType) -> Self {
-        match cut_type {
-            kcmc::shared::CutType::Fillet => EdgeCutSubType::Fillet,
-            kcmc::shared::CutType::Chamfer => EdgeCutSubType::Chamfer,
-        }
-    }
-}
-
-impl From<kcmc::shared::CutTypeV2> for EdgeCutSubType {
-    fn from(cut_type: kcmc::shared::CutTypeV2) -> Self {
-        match cut_type {
-            kcmc::shared::CutTypeV2::Fillet { .. } => EdgeCutSubType::Fillet,
-            kcmc::shared::CutTypeV2::Chamfer { .. } => EdgeCutSubType::Chamfer,
-            kcmc::shared::CutTypeV2::Custom { .. } => EdgeCutSubType::Custom,
-            // Modeling API has added something we're not aware of.
-            _other => EdgeCutSubType::Custom,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(rename_all = "camelCase")]
-pub struct EdgeCutEdge {
-    pub id: ArtifactId,
-    pub edge_cut_id: ArtifactId,
-    pub surface_id: ArtifactId,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(rename_all = "camelCase")]
-pub struct Helix {
-    pub id: ArtifactId,
-    /// The axis of the helix.  Currently this is always an edge ID, but we may
-    /// add axes to the graph.
-    pub axis_id: Option<ArtifactId>,
-    pub code_ref: CodeRef,
-    /// The sweep, if any, that this Helix serves as the trajectory for.
-    pub trajectory_sweep_id: Option<ArtifactId>,
-    /// Whether this artifact has been used in a subsequent operation
-    pub consumed: bool,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, Eq, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(rename_all = "camelCase")]
-pub struct GdtAnnotationArtifact {
-    pub id: ArtifactId,
-    pub code_ref: CodeRef,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(rename_all = "camelCase")]
-pub struct Pattern {
-    pub id: ArtifactId,
-    pub sub_type: PatternSubType,
-    /// Geometry artifact that was the source of the pattern operation.
-    pub source_id: ArtifactId,
-    /// IDs of copied top-level objects created by the pattern operation.
-    pub copy_ids: Vec<ArtifactId>,
-    /// IDs of copied faces created by the pattern operation.
-    pub copy_face_ids: Vec<ArtifactId>,
-    /// IDs of copied edges created by the pattern operation.
-    pub copy_edge_ids: Vec<ArtifactId>,
-    pub code_ref: CodeRef,
-}
-
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(rename_all = "camelCase")]
-pub enum PatternSubType {
-    Circular,
-    Linear,
-    Transform,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(tag = "type", rename_all = "camelCase")]
-pub enum Artifact {
-    CompositeSolid(CompositeSolid),
-    Plane(Plane),
-    Path(Path),
-    Segment(Segment),
-    Solid2d(Solid2d),
-    PrimitiveFace(PrimitiveFace),
-    PrimitiveEdge(PrimitiveEdge),
-    PlaneOfFace(PlaneOfFace),
-    StartSketchOnFace(StartSketchOnFace),
-    StartSketchOnPlane(StartSketchOnPlane),
-    SketchBlock(SketchBlock),
-    SketchBlockConstraint(SketchBlockConstraint),
-    Sweep(Sweep),
-    Wall(Wall),
-    Cap(Cap),
-    SweepEdge(SweepEdge),
-    EdgeCut(EdgeCut),
-    EdgeCutEdge(EdgeCutEdge),
-    Helix(Helix),
-    GdtAnnotation(GdtAnnotationArtifact),
-    Pattern(Pattern),
-}
-
-impl Artifact {
-    pub(crate) fn id(&self) -> ArtifactId {
-        match self {
-            Artifact::CompositeSolid(a) => a.id,
-            Artifact::Plane(a) => a.id,
-            Artifact::Path(a) => a.id,
-            Artifact::Segment(a) => a.id,
-            Artifact::Solid2d(a) => a.id,
-            Artifact::PrimitiveFace(a) => a.id,
-            Artifact::PrimitiveEdge(a) => a.id,
-            Artifact::StartSketchOnFace(a) => a.id,
-            Artifact::StartSketchOnPlane(a) => a.id,
-            Artifact::SketchBlock(a) => a.id,
-            Artifact::SketchBlockConstraint(a) => a.id,
-            Artifact::PlaneOfFace(a) => a.id,
-            Artifact::Sweep(a) => a.id,
-            Artifact::Wall(a) => a.id,
-            Artifact::Cap(a) => a.id,
-            Artifact::SweepEdge(a) => a.id,
-            Artifact::EdgeCut(a) => a.id,
-            Artifact::EdgeCutEdge(a) => a.id,
-            Artifact::Helix(a) => a.id,
-            Artifact::GdtAnnotation(a) => a.id,
-            Artifact::Pattern(a) => a.id,
+pub(super) fn artifact_plane_info(info: &PlaneInfo) -> ArtifactPlaneInfo {
+    fn point(point: crate::execution::Point3d) -> ArtifactPoint3d {
+        ArtifactPoint3d {
+            x: point.x,
+            y: point.y,
+            z: point.z,
+            units: point.units,
         }
     }
 
-    /// The [`CodeRef`] for the artifact itself. See also
-    /// [`Self::face_code_ref`].
-    pub fn code_ref(&self) -> Option<&CodeRef> {
-        match self {
-            Artifact::CompositeSolid(a) => Some(&a.code_ref),
-            Artifact::Plane(a) => Some(&a.code_ref),
-            Artifact::Path(a) => Some(&a.code_ref),
-            Artifact::Segment(a) => Some(&a.code_ref),
-            Artifact::Solid2d(_) => None,
-            Artifact::PrimitiveFace(a) => Some(&a.code_ref),
-            Artifact::PrimitiveEdge(a) => Some(&a.code_ref),
-            Artifact::StartSketchOnFace(a) => Some(&a.code_ref),
-            Artifact::StartSketchOnPlane(a) => Some(&a.code_ref),
-            Artifact::SketchBlock(a) => Some(&a.code_ref),
-            Artifact::SketchBlockConstraint(a) => Some(&a.code_ref),
-            Artifact::PlaneOfFace(a) => Some(&a.code_ref),
-            Artifact::Sweep(a) => Some(&a.code_ref),
-            Artifact::Wall(_) => None,
-            Artifact::Cap(_) => None,
-            Artifact::SweepEdge(_) => None,
-            Artifact::EdgeCut(a) => Some(&a.code_ref),
-            Artifact::EdgeCutEdge(_) => None,
-            Artifact::Helix(a) => Some(&a.code_ref),
-            Artifact::GdtAnnotation(a) => Some(&a.code_ref),
-            Artifact::Pattern(a) => Some(&a.code_ref),
-        }
-    }
-
-    /// The [`CodeRef`] referring to the face artifact that it's on, not the
-    /// artifact itself.
-    pub fn face_code_ref(&self) -> Option<&CodeRef> {
-        match self {
-            Artifact::CompositeSolid(_)
-            | Artifact::Plane(_)
-            | Artifact::Path(_)
-            | Artifact::Segment(_)
-            | Artifact::Solid2d(_)
-            | Artifact::PrimitiveEdge(_)
-            | Artifact::StartSketchOnFace(_)
-            | Artifact::PlaneOfFace(_)
-            | Artifact::StartSketchOnPlane(_)
-            | Artifact::SketchBlock(_)
-            | Artifact::SketchBlockConstraint(_)
-            | Artifact::Sweep(_) => None,
-            Artifact::PrimitiveFace(a) => Some(&a.code_ref),
-            Artifact::Wall(a) => Some(&a.face_code_ref),
-            Artifact::Cap(a) => Some(&a.face_code_ref),
-            Artifact::SweepEdge(_)
-            | Artifact::EdgeCut(_)
-            | Artifact::EdgeCutEdge(_)
-            | Artifact::Helix(_)
-            | Artifact::GdtAnnotation(_)
-            | Artifact::Pattern(_) => None,
-        }
-    }
-
-    /// Merge the new artifact into self.  If it can't because it's a different
-    /// type, return the new artifact which should be used as a replacement.
-    fn merge(&mut self, new: Artifact) -> Option<Artifact> {
-        match self {
-            Artifact::CompositeSolid(a) => a.merge(new),
-            Artifact::Plane(a) => a.merge(new),
-            Artifact::Path(a) => a.merge(new),
-            Artifact::Segment(a) => a.merge(new),
-            Artifact::Solid2d(_) => Some(new),
-            Artifact::PrimitiveFace(_) => Some(new),
-            Artifact::PrimitiveEdge(_) => Some(new),
-            Artifact::StartSketchOnFace { .. } => Some(new),
-            Artifact::StartSketchOnPlane { .. } => Some(new),
-            Artifact::SketchBlock { .. } => Some(new),
-            Artifact::SketchBlockConstraint { .. } => Some(new),
-            Artifact::PlaneOfFace { .. } => Some(new),
-            Artifact::Sweep(a) => a.merge(new),
-            Artifact::Wall(a) => a.merge(new),
-            Artifact::Cap(a) => a.merge(new),
-            Artifact::SweepEdge(_) => Some(new),
-            Artifact::EdgeCut(a) => a.merge(new),
-            Artifact::EdgeCutEdge(_) => Some(new),
-            Artifact::Helix(a) => a.merge(new),
-            Artifact::GdtAnnotation(a) => a.merge(new),
-            Artifact::Pattern(a) => a.merge(new),
-        }
+    ArtifactPlaneInfo {
+        origin: point(info.origin),
+        x_axis: point(info.x_axis),
+        y_axis: point(info.y_axis),
+        z_axis: point(info.z_axis),
     }
 }
 
-impl CompositeSolid {
-    fn merge(&mut self, new: Artifact) -> Option<Artifact> {
-        let Artifact::CompositeSolid(new) = new else {
-            return Some(new);
-        };
-        merge_ids(&mut self.solid_ids, new.solid_ids);
-        merge_ids(&mut self.tool_ids, new.tool_ids);
-        merge_opt_id(&mut self.composite_solid_id, new.composite_solid_id);
-        merge_ids(&mut self.pattern_ids, new.pattern_ids);
-        self.output_index = new.output_index;
-        self.consumed = new.consumed;
-
-        None
+fn artifact_sweep_method(method: kcmc::shared::ExtrudeMethod) -> ArtifactSweepMethod {
+    match method {
+        kcmc::shared::ExtrudeMethod::New => ArtifactSweepMethod::New,
+        kcmc::shared::ExtrudeMethod::Merge => ArtifactSweepMethod::Merge,
+        _ => ArtifactSweepMethod::Merge,
     }
 }
 
-impl Plane {
-    fn merge(&mut self, new: Artifact) -> Option<Artifact> {
-        let Artifact::Plane(new) = new else {
-            return Some(new);
-        };
-        merge_ids(&mut self.path_ids, new.path_ids);
-
-        None
+fn edge_cut_sub_type(cut_type: kcmc::shared::CutType) -> EdgeCutSubType {
+    match cut_type {
+        kcmc::shared::CutType::Fillet => EdgeCutSubType::Fillet,
+        kcmc::shared::CutType::Chamfer => EdgeCutSubType::Chamfer,
     }
 }
 
-impl Path {
-    fn merge(&mut self, new: Artifact) -> Option<Artifact> {
-        let Artifact::Path(new) = new else {
-            return Some(new);
-        };
-        merge_opt_id(&mut self.sweep_id, new.sweep_id);
-        merge_opt_id(&mut self.trajectory_sweep_id, new.trajectory_sweep_id);
-        merge_ids(&mut self.seg_ids, new.seg_ids);
-        merge_opt_id(&mut self.solid2d_id, new.solid2d_id);
-        merge_opt_id(&mut self.composite_solid_id, new.composite_solid_id);
-        merge_opt_id(&mut self.sketch_block_id, new.sketch_block_id);
-        merge_opt_id(&mut self.origin_path_id, new.origin_path_id);
-        merge_opt_id(&mut self.inner_path_id, new.inner_path_id);
-        merge_opt_id(&mut self.outer_path_id, new.outer_path_id);
-        merge_ids(&mut self.pattern_ids, new.pattern_ids);
-        self.consumed = new.consumed;
-
-        None
+fn edge_cut_sub_type_v2(cut_type: kcmc::shared::CutTypeV2) -> EdgeCutSubType {
+    match cut_type {
+        kcmc::shared::CutTypeV2::Fillet { .. } => EdgeCutSubType::Fillet,
+        kcmc::shared::CutTypeV2::Chamfer { .. } => EdgeCutSubType::Chamfer,
+        kcmc::shared::CutTypeV2::Custom { .. } => EdgeCutSubType::Custom,
+        _ => EdgeCutSubType::Custom,
     }
 }
 
-impl Segment {
-    fn merge(&mut self, new: Artifact) -> Option<Artifact> {
-        let Artifact::Segment(new) = new else {
-            return Some(new);
-        };
-        merge_opt_id(&mut self.original_seg_id, new.original_seg_id);
-        merge_opt_id(&mut self.surface_id, new.surface_id);
-        merge_ids(&mut self.edge_ids, new.edge_ids);
-        merge_opt_id(&mut self.edge_cut_id, new.edge_cut_id);
-        merge_ids(&mut self.common_surface_ids, new.common_surface_ids);
-
-        None
+pub(crate) fn sketch_block_constraint_type(constraint: &Constraint) -> SketchBlockConstraintType {
+    match constraint {
+        Constraint::Coincident { .. } => SketchBlockConstraintType::Coincident,
+        Constraint::Distance { .. } => SketchBlockConstraintType::Distance,
+        Constraint::Diameter { .. } => SketchBlockConstraintType::Diameter,
+        Constraint::EqualRadius { .. } => SketchBlockConstraintType::EqualRadius,
+        Constraint::Fixed { .. } => SketchBlockConstraintType::Fixed,
+        Constraint::HorizontalDistance { .. } => SketchBlockConstraintType::HorizontalDistance,
+        Constraint::VerticalDistance { .. } => SketchBlockConstraintType::VerticalDistance,
+        Constraint::Horizontal { .. } => SketchBlockConstraintType::Horizontal,
+        Constraint::LinesEqualLength { .. } => SketchBlockConstraintType::LinesEqualLength,
+        Constraint::Midpoint(..) => SketchBlockConstraintType::Midpoint,
+        Constraint::Parallel { .. } => SketchBlockConstraintType::Parallel,
+        Constraint::Perpendicular { .. } => SketchBlockConstraintType::Perpendicular,
+        Constraint::Radius { .. } => SketchBlockConstraintType::Radius,
+        Constraint::Symmetric { .. } => SketchBlockConstraintType::Symmetric,
+        Constraint::Tangent { .. } => SketchBlockConstraintType::Tangent,
+        Constraint::Vertical { .. } => SketchBlockConstraintType::Vertical,
+        Constraint::Angle(..) => SketchBlockConstraintType::Angle,
     }
 }
 
-impl Sweep {
-    fn merge(&mut self, new: Artifact) -> Option<Artifact> {
-        let Artifact::Sweep(new) = new else {
-            return Some(new);
-        };
-        merge_ids(&mut self.surface_ids, new.surface_ids);
-        merge_ids(&mut self.edge_ids, new.edge_ids);
-        merge_opt_id(&mut self.trajectory_id, new.trajectory_id);
-        merge_ids(&mut self.pattern_ids, new.pattern_ids);
-        self.consumed = new.consumed;
-
-        None
+/// Merge the new artifact into the old one, returning a replacement when the
+/// artifact types differ.
+fn merge_artifacts(old: &mut Artifact, new: Artifact) -> Option<Artifact> {
+    match old {
+        Artifact::CompositeSolid(a) => merge_composite_solid(a, new),
+        Artifact::Plane(a) => merge_plane(a, new),
+        Artifact::Path(a) => merge_path(a, new),
+        Artifact::Segment(a) => merge_segment(a, new),
+        Artifact::Solid2d(_) => Some(new),
+        Artifact::PrimitiveFace(_) => Some(new),
+        Artifact::PrimitiveEdge(_) => Some(new),
+        Artifact::StartSketchOnFace { .. } => Some(new),
+        Artifact::StartSketchOnPlane { .. } => Some(new),
+        Artifact::SketchBlock { .. } => Some(new),
+        Artifact::SketchBlockConstraint { .. } => Some(new),
+        Artifact::PlaneOfFace { .. } => Some(new),
+        Artifact::Sweep(a) => merge_sweep(a, new),
+        Artifact::Wall(a) => merge_wall(a, new),
+        Artifact::Cap(a) => merge_cap(a, new),
+        Artifact::SweepEdge(_) => Some(new),
+        Artifact::EdgeCut(a) => merge_edge_cut(a, new),
+        Artifact::EdgeCutEdge(_) => Some(new),
+        Artifact::Helix(a) => merge_helix(a, new),
+        Artifact::GdtAnnotation(a) => merge_gdt_annotation(a, new),
+        Artifact::Pattern(a) => merge_pattern(a, new),
     }
 }
 
-impl Wall {
-    fn merge(&mut self, new: Artifact) -> Option<Artifact> {
-        let Artifact::Wall(new) = new else {
-            return Some(new);
-        };
-        merge_ids(&mut self.edge_cut_edge_ids, new.edge_cut_edge_ids);
-        merge_ids(&mut self.path_ids, new.path_ids);
-
-        None
-    }
+fn merge_composite_solid(old: &mut CompositeSolid, new: Artifact) -> Option<Artifact> {
+    let Artifact::CompositeSolid(new) = new else {
+        return Some(new);
+    };
+    merge_ids(&mut old.solid_ids, new.solid_ids);
+    merge_ids(&mut old.tool_ids, new.tool_ids);
+    merge_opt_id(&mut old.composite_solid_id, new.composite_solid_id);
+    merge_ids(&mut old.pattern_ids, new.pattern_ids);
+    old.output_index = new.output_index;
+    old.consumed = new.consumed;
+    None
 }
 
-impl Cap {
-    fn merge(&mut self, new: Artifact) -> Option<Artifact> {
-        let Artifact::Cap(new) = new else {
-            return Some(new);
-        };
-        merge_ids(&mut self.edge_cut_edge_ids, new.edge_cut_edge_ids);
-        merge_ids(&mut self.path_ids, new.path_ids);
-
-        None
-    }
+fn merge_plane(old: &mut Plane, new: Artifact) -> Option<Artifact> {
+    let Artifact::Plane(new) = new else { return Some(new) };
+    merge_ids(&mut old.path_ids, new.path_ids);
+    None
 }
 
-impl EdgeCut {
-    fn merge(&mut self, new: Artifact) -> Option<Artifact> {
-        let Artifact::EdgeCut(new) = new else {
-            return Some(new);
-        };
-        merge_opt_id(&mut self.surface_id, new.surface_id);
-        merge_ids(&mut self.edge_ids, new.edge_ids);
-
-        None
-    }
+fn merge_path(old: &mut Path, new: Artifact) -> Option<Artifact> {
+    let Artifact::Path(new) = new else { return Some(new) };
+    merge_opt_id(&mut old.sweep_id, new.sweep_id);
+    merge_opt_id(&mut old.trajectory_sweep_id, new.trajectory_sweep_id);
+    merge_ids(&mut old.seg_ids, new.seg_ids);
+    merge_opt_id(&mut old.solid2d_id, new.solid2d_id);
+    merge_opt_id(&mut old.composite_solid_id, new.composite_solid_id);
+    merge_opt_id(&mut old.sketch_block_id, new.sketch_block_id);
+    merge_opt_id(&mut old.origin_path_id, new.origin_path_id);
+    merge_opt_id(&mut old.inner_path_id, new.inner_path_id);
+    merge_opt_id(&mut old.outer_path_id, new.outer_path_id);
+    merge_ids(&mut old.pattern_ids, new.pattern_ids);
+    old.consumed = new.consumed;
+    None
 }
 
-impl Helix {
-    fn merge(&mut self, new: Artifact) -> Option<Artifact> {
-        let Artifact::Helix(new) = new else {
-            return Some(new);
-        };
-        merge_opt_id(&mut self.axis_id, new.axis_id);
-        merge_opt_id(&mut self.trajectory_sweep_id, new.trajectory_sweep_id);
-        self.consumed = new.consumed;
-
-        None
-    }
+fn merge_segment(old: &mut Segment, new: Artifact) -> Option<Artifact> {
+    let Artifact::Segment(new) = new else { return Some(new) };
+    merge_opt_id(&mut old.original_seg_id, new.original_seg_id);
+    merge_opt_id(&mut old.surface_id, new.surface_id);
+    merge_ids(&mut old.edge_ids, new.edge_ids);
+    merge_opt_id(&mut old.edge_cut_id, new.edge_cut_id);
+    merge_ids(&mut old.common_surface_ids, new.common_surface_ids);
+    None
 }
 
-impl GdtAnnotationArtifact {
-    fn merge(&mut self, new: Artifact) -> Option<Artifact> {
-        let Artifact::GdtAnnotation(new) = new else {
-            return Some(new);
-        };
-        self.code_ref = new.code_ref;
-
-        None
-    }
+fn merge_sweep(old: &mut Sweep, new: Artifact) -> Option<Artifact> {
+    let Artifact::Sweep(new) = new else { return Some(new) };
+    merge_ids(&mut old.surface_ids, new.surface_ids);
+    merge_ids(&mut old.edge_ids, new.edge_ids);
+    merge_opt_id(&mut old.trajectory_id, new.trajectory_id);
+    merge_ids(&mut old.pattern_ids, new.pattern_ids);
+    old.consumed = new.consumed;
+    None
 }
 
-impl Pattern {
-    fn merge(&mut self, new: Artifact) -> Option<Artifact> {
-        let Artifact::Pattern(new) = new else {
-            return Some(new);
-        };
-        merge_ids(&mut self.copy_ids, new.copy_ids);
-        merge_ids(&mut self.copy_face_ids, new.copy_face_ids);
-        merge_ids(&mut self.copy_edge_ids, new.copy_edge_ids);
-
-        None
-    }
+fn merge_wall(old: &mut Wall, new: Artifact) -> Option<Artifact> {
+    let Artifact::Wall(new) = new else { return Some(new) };
+    merge_ids(&mut old.edge_cut_edge_ids, new.edge_cut_edge_ids);
+    merge_ids(&mut old.path_ids, new.path_ids);
+    None
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Serialize, ts_rs::TS)]
-#[ts(export_to = "Artifact.ts")]
-#[serde(rename_all = "camelCase")]
-pub struct ArtifactGraph {
-    map: IndexMap<ArtifactId, Artifact>,
-    pub(super) item_count: usize,
+fn merge_cap(old: &mut Cap, new: Artifact) -> Option<Artifact> {
+    let Artifact::Cap(new) = new else { return Some(new) };
+    merge_ids(&mut old.edge_cut_edge_ids, new.edge_cut_edge_ids);
+    merge_ids(&mut old.path_ids, new.path_ids);
+    None
 }
 
-impl ArtifactGraph {
-    pub fn get(&self, id: &ArtifactId) -> Option<&Artifact> {
-        self.map.get(id)
-    }
+fn merge_edge_cut(old: &mut EdgeCut, new: Artifact) -> Option<Artifact> {
+    let Artifact::EdgeCut(new) = new else { return Some(new) };
+    merge_opt_id(&mut old.surface_id, new.surface_id);
+    merge_ids(&mut old.edge_ids, new.edge_ids);
+    None
+}
 
-    pub fn len(&self) -> usize {
-        self.map.len()
-    }
+fn merge_helix(old: &mut Helix, new: Artifact) -> Option<Artifact> {
+    let Artifact::Helix(new) = new else { return Some(new) };
+    merge_opt_id(&mut old.axis_id, new.axis_id);
+    merge_opt_id(&mut old.trajectory_sweep_id, new.trajectory_sweep_id);
+    old.consumed = new.consumed;
+    None
+}
 
-    pub fn is_empty(&self) -> bool {
-        self.map.is_empty()
-    }
+fn merge_gdt_annotation(old: &mut GdtAnnotationArtifact, new: Artifact) -> Option<Artifact> {
+    let Artifact::GdtAnnotation(new) = new else {
+        return Some(new);
+    };
+    old.code_ref = new.code_ref;
+    None
+}
 
-    #[cfg(test)]
-    pub(crate) fn iter(&self) -> impl Iterator<Item = (&ArtifactId, &Artifact)> {
-        self.map.iter()
-    }
-
-    pub fn values(&self) -> impl Iterator<Item = &Artifact> {
-        self.map.values()
-    }
-
-    pub fn clear(&mut self) {
-        self.map.clear();
-        self.item_count = 0;
-    }
-
-    /// Consume the artifact graph and return the map of artifacts.
-    fn into_map(self) -> IndexMap<ArtifactId, Artifact> {
-        self.map
-    }
+fn merge_pattern(old: &mut Pattern, new: Artifact) -> Option<Artifact> {
+    let Artifact::Pattern(new) = new else { return Some(new) };
+    merge_ids(&mut old.copy_ids, new.copy_ids);
+    merge_ids(&mut old.copy_face_ids, new.copy_face_ids);
+    merge_ids(&mut old.copy_edge_ids, new.copy_edge_ids);
+    None
 }
 
 #[derive(Debug, Clone)]
@@ -967,8 +340,7 @@ pub(super) fn build_artifact_graph(
     programs: &crate::execution::ProgramLookup,
     module_infos: &ModuleInfoMap,
 ) -> Result<ArtifactGraph, KclError> {
-    let item_count = initial_graph.item_count;
-    let mut map = initial_graph.into_map();
+    let (mut map, item_count) = initial_graph.into_parts();
 
     let mut path_to_plane_id_map = AHashMap::default();
     let mut current_plane_id = None;
@@ -1025,10 +397,7 @@ pub(super) fn build_artifact_graph(
         merge_artifact_into_map(&mut map, exec_artifact.clone());
     }
 
-    Ok(ArtifactGraph {
-        map,
-        item_count: item_count + ast.body.len(),
-    })
+    Ok(ArtifactGraph::from_parts(map, item_count + ast.body.len()))
 }
 
 /// These may have been created with placeholder `CodeRef`s because we didn't
@@ -1204,7 +573,7 @@ fn merge_artifact_into_map(map: &mut IndexMap<ArtifactId, Artifact>, new_artifac
         return;
     }
 
-    if let Some(replacement) = old_artifact.merge(new_artifact) {
+    if let Some(replacement) = merge_artifacts(old_artifact, new_artifact) {
         *old_artifact = replacement;
     }
 }
@@ -2226,6 +1595,7 @@ fn artifacts_to_update(
                 }
                 _ => kittycad_modeling_cmds::shared::ExtrudeMethod::Merge,
             };
+            let method = artifact_sweep_method(method);
             let sub_type = match cmd {
                 ModelingCmd::Extrude(_) => SweepSubType::Extrusion,
                 ModelingCmd::ExtrudeToReference(_) => SweepSubType::Extrusion,
@@ -2266,7 +1636,7 @@ fn artifacts_to_update(
         }
         ModelingCmd::Sweep(kcmc::Sweep { target, trajectory, .. }) => {
             // Determine the resulting method from the specific command, if provided
-            let method = kittycad_modeling_cmds::shared::ExtrudeMethod::Merge;
+            let method = ArtifactSweepMethod::Merge;
             let sub_type = SweepSubType::Sweep;
             let mut return_arr = Vec::new();
             let target = cmd_id_ref_to_artifact_id(target);
@@ -2352,7 +1722,7 @@ fn artifacts_to_update(
                 edge_ids: Vec::new(),
                 code_ref,
                 trajectory_id,
-                method: kittycad_modeling_cmds::shared::ExtrudeMethod::New,
+                method: ArtifactSweepMethod::New,
                 consumed: false,
                 pattern_ids: Vec::new(),
             })];
@@ -2378,7 +1748,7 @@ fn artifacts_to_update(
                 edge_ids: Vec::new(),
                 code_ref,
                 trajectory_id: None,
-                method: kittycad_modeling_cmds::shared::ExtrudeMethod::Merge,
+                method: ArtifactSweepMethod::Merge,
                 consumed: false,
                 pattern_ids: Vec::new(),
             }));
@@ -2697,7 +2067,7 @@ fn artifacts_to_update(
             };
             return_arr.push(Artifact::EdgeCut(EdgeCut {
                 id,
-                sub_type: cmd.cut_type.into(),
+                sub_type: edge_cut_sub_type(cmd.cut_type),
                 consumed_edge_id: edge_id,
                 edge_ids: Vec::new(),
                 surface_id: None,
@@ -2722,7 +2092,7 @@ fn artifacts_to_update(
             };
             return_arr.push(Artifact::EdgeCut(EdgeCut {
                 id,
-                sub_type: cmd.cut_type.into(),
+                sub_type: edge_cut_sub_type_v2(cmd.cut_type),
                 consumed_edge_id: edge_id,
                 edge_ids: Vec::new(),
                 surface_id: None,

--- a/rust/kcl-lib/src/execution/artifact/mermaid_tests.rs
+++ b/rust/kcl-lib/src/execution/artifact/mermaid_tests.rs
@@ -186,10 +186,15 @@ fn canonicalize_duplicate_edge_pairings(
     }
 }
 
-impl Artifact {
+trait ArtifactMermaidExt {
+    fn back_edges(&self) -> Vec<ArtifactId>;
+    fn child_ids(&self) -> Vec<ArtifactId>;
+}
+
+impl ArtifactMermaidExt for Artifact {
     /// The IDs pointing back to prior nodes in a depth-first traversal of
     /// the graph.  This should be disjoint with `child_ids`.
-    pub(crate) fn back_edges(&self) -> Vec<ArtifactId> {
+    fn back_edges(&self) -> Vec<ArtifactId> {
         match self {
             Artifact::CompositeSolid(a) => {
                 let mut ids = a.solid_ids.clone();
@@ -248,7 +253,7 @@ impl Artifact {
 
     /// The child IDs of this artifact, used to do a depth-first traversal of
     /// the graph.
-    pub(crate) fn child_ids(&self) -> Vec<ArtifactId> {
+    fn child_ids(&self) -> Vec<ArtifactId> {
         match self {
             Artifact::CompositeSolid(a) => {
                 // Note: Don't include these since they're parents: solid_ids,
@@ -395,9 +400,34 @@ impl Artifact {
     }
 }
 
-impl ArtifactGraph {
+pub(crate) trait ArtifactGraphMermaidExt {
+    fn to_mermaid_flowchart(&self) -> Result<String, std::fmt::Error>;
+    fn flowchart_nodes<W: Write>(
+        &self,
+        output: &mut W,
+        stable_id_map: &AHashMap<ArtifactId, NodeId>,
+        prefix: &str,
+    ) -> std::fmt::Result;
+    fn flowchart_node<W: Write>(
+        &self,
+        output: &mut W,
+        artifact: &Artifact,
+        id: NodeId,
+        prefix: &str,
+    ) -> std::fmt::Result;
+    fn flowchart_duplicate_segment_key(artifact: &Artifact) -> Option<String>;
+    fn flowchart_basic_sort_key(artifact: &Artifact) -> String;
+    fn flowchart_edges<W: Write>(
+        &self,
+        output: &mut W,
+        stable_id_map: &AHashMap<ArtifactId, NodeId>,
+        prefix: &str,
+    ) -> Result<(), std::fmt::Error>;
+}
+
+impl ArtifactGraphMermaidExt for ArtifactGraph {
     /// Output the Mermaid flowchart for the artifact graph.
-    pub(crate) fn to_mermaid_flowchart(&self) -> Result<String, std::fmt::Error> {
+    fn to_mermaid_flowchart(&self) -> Result<String, std::fmt::Error> {
         let mut output = String::new();
         output.push_str("```mermaid\n");
         output.push_str("flowchart LR\n");
@@ -405,7 +435,7 @@ impl ArtifactGraph {
         let mut next_id = 1_u32;
         let mut stable_id_map = AHashMap::default();
 
-        for id in self.map.keys() {
+        for (id, _) in self.iter() {
             stable_id_map.insert(*id, next_id);
             next_id = next_id.checked_add(1).unwrap();
         }
@@ -433,7 +463,7 @@ impl ArtifactGraph {
         let mut groups = IndexMap::new();
         let mut ungrouped = Vec::new();
 
-        for artifact in self.map.values() {
+        for artifact in self.values() {
             let id = artifact.id();
 
             let grouped = match artifact {
@@ -479,7 +509,7 @@ impl ArtifactGraph {
             writeln!(output, "{prefix}subgraph path{group_id} [Path]")?;
             let indented = format!("{prefix}  ");
             for artifact_id in artifact_ids {
-                let artifact = self.map.get(&artifact_id).unwrap();
+                let artifact = self.get(&artifact_id).unwrap();
                 let id = *stable_id_map.get(&artifact_id).unwrap();
                 self.flowchart_node(output, artifact, id, &indented)?;
             }
@@ -487,7 +517,7 @@ impl ArtifactGraph {
         }
 
         for artifact_id in ungrouped {
-            let artifact = self.map.get(&artifact_id).unwrap();
+            let artifact = self.get(&artifact_id).unwrap();
             let id = *stable_id_map.get(&artifact_id).unwrap();
             self.flowchart_node(output, artifact, id, prefix)?;
         }
@@ -818,7 +848,7 @@ impl ArtifactGraph {
         // edge under a canonical `(min, max)` key and merges duplicates; Mermaid
         // would otherwise render `a --- b` and `b --- a` as two edges.
         let mut edges = IndexMap::default();
-        for artifact in self.map.values() {
+        for artifact in self.values() {
             let source_id = *stable_id_map.get(&artifact.id()).unwrap();
             // In Mermaid, the textual order defines the rank, even though the
             // edge arrow can go in either direction.
@@ -836,7 +866,7 @@ impl ArtifactGraph {
                         .zip(std::iter::repeat(EdgeFlow::SourceToTarget)),
                 )
             {
-                let Some(target) = self.map.get(&target_id) else {
+                let Some(target) = self.get(&target_id) else {
                     continue;
                 };
                 let edge_kind = match (artifact, target) {
@@ -894,7 +924,7 @@ impl ArtifactGraph {
         let node_key = |node_id: NodeId| {
             reverse_stable_id_map
                 .get(&node_id)
-                .and_then(|artifact_id| self.map.get(artifact_id))
+                .and_then(|artifact_id| self.get(artifact_id))
                 .and_then(Self::flowchart_duplicate_segment_key)
                 .unwrap_or_else(|| format!("Node:{node_id}"))
         };
@@ -909,7 +939,7 @@ impl ArtifactGraph {
         let signature_node_key = |node_id: NodeId| {
             reverse_stable_id_map
                 .get(&node_id)
-                .and_then(|artifact_id| self.map.get(artifact_id))
+                .and_then(|artifact_id| self.get(artifact_id))
                 .map(Self::flowchart_basic_sort_key)
                 .unwrap_or_else(|| format!("Node:{node_id}"))
         };

--- a/rust/kcl-lib/src/execution/artifact/tests.rs
+++ b/rust/kcl-lib/src/execution/artifact/tests.rs
@@ -45,7 +45,7 @@ fn entity_clone_remaps_sweep_ids() {
             edge_ids: vec![source_edge_id],
             code_ref: CodeRef::placeholder(SourceRange::synthetic()),
             trajectory_id: Some(source_trajectory_id),
-            method: kittycad_modeling_cmds::shared::ExtrudeMethod::New,
+            method: ArtifactSweepMethod::New,
             consumed: true,
             pattern_ids: Vec::new(),
         }),
@@ -92,7 +92,7 @@ fn entity_clone_remaps_sweep_ids() {
     assert_eq!(clone_sweep.id, ArtifactId::new(cmd_id));
     assert_eq!(clone_sweep.sub_type, SweepSubType::Revolve);
     assert_eq!(clone_sweep.path_id, cloned_path_id);
-    assert_eq!(clone_sweep.method, kittycad_modeling_cmds::shared::ExtrudeMethod::New);
+    assert_eq!(clone_sweep.method, ArtifactSweepMethod::New);
     assert_eq!(clone_sweep.surface_ids, vec![cloned_surface_id]);
     assert_eq!(clone_sweep.edge_ids, vec![cloned_edge_id]);
     assert_eq!(clone_sweep.trajectory_id, Some(cloned_trajectory_id));
@@ -390,7 +390,7 @@ fn entity_clone_clones_mapped_child_artifacts() {
             edge_ids: Vec::new(),
             code_ref: CodeRef::placeholder(SourceRange::synthetic()),
             trajectory_id: None,
-            method: kittycad_modeling_cmds::shared::ExtrudeMethod::Merge,
+            method: ArtifactSweepMethod::Merge,
             consumed: true,
             pattern_ids: Vec::new(),
         }),
@@ -572,7 +572,7 @@ fn surface_blend_creates_blend_sweep_artifact() {
             edge_ids: Vec::new(),
             code_ref: source_code_ref.clone(),
             trajectory_id: None,
-            method: kittycad_modeling_cmds::shared::ExtrudeMethod::Merge,
+            method: ArtifactSweepMethod::Merge,
             consumed: false,
             pattern_ids: Vec::new(),
         }),
@@ -587,7 +587,7 @@ fn surface_blend_creates_blend_sweep_artifact() {
             edge_ids: Vec::new(),
             code_ref: source_code_ref,
             trajectory_id: None,
-            method: kittycad_modeling_cmds::shared::ExtrudeMethod::Merge,
+            method: ArtifactSweepMethod::Merge,
             consumed: false,
             pattern_ids: Vec::new(),
         }),
@@ -651,7 +651,7 @@ fn surface_blend_creates_blend_sweep_artifact() {
     assert_eq!(blend_sweep.sub_type, SweepSubType::Blend);
     assert_eq!(blend_sweep.path_id, path_one_id);
     assert_eq!(blend_sweep.trajectory_id, Some(path_two_id));
-    assert_eq!(blend_sweep.method, kittycad_modeling_cmds::shared::ExtrudeMethod::New);
+    assert_eq!(blend_sweep.method, ArtifactSweepMethod::New);
     assert!(!blend_sweep.consumed);
 }
 
@@ -778,7 +778,7 @@ fn pattern_artifact_links_to_source_geometry() {
             edge_ids: Vec::new(),
             code_ref: code_ref.clone(),
             trajectory_id: None,
-            method: kittycad_modeling_cmds::shared::ExtrudeMethod::Merge,
+            method: ArtifactSweepMethod::Merge,
             consumed: false,
             pattern_ids: Vec::new(),
         }),
@@ -923,7 +923,7 @@ fn mirror_3d_artifacts_include_mirrored_body_with_face_and_edge_ids() {
             edge_ids: Vec::new(),
             code_ref,
             trajectory_id: None,
-            method: kittycad_modeling_cmds::shared::ExtrudeMethod::Merge,
+            method: ArtifactSweepMethod::Merge,
             consumed: false,
             pattern_ids: Vec::new(),
         }),

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -1654,7 +1654,7 @@ impl Node<SketchBlock> {
             // Get the plane artifact ID so that we can do an exclusive borrow.
             let plane_artifact_id = on_object.map(|object| object.artifact_id);
             let plane_info = match &sketch_surface {
-                SketchSurface::Plane(plane) => Some(plane.info.clone()),
+                SketchSurface::Plane(plane) => Some(super::artifact::artifact_plane_info(&plane.info)),
                 SketchSurface::Face(_) => None,
             };
 
@@ -3856,7 +3856,6 @@ impl Node<BinaryExpression> {
                             use crate::execution::Artifact;
                             use crate::execution::CodeRef;
                             use crate::execution::SketchBlockConstraint;
-                            use crate::execution::SketchBlockConstraintType;
                             use crate::front::Angle;
                             use crate::front::SourceRef;
 
@@ -3878,7 +3877,7 @@ impl Node<BinaryExpression> {
                                 id: artifact_id,
                                 sketch_id,
                                 constraint_id,
-                                constraint_type: SketchBlockConstraintType::from(&sketch_constraint),
+                                constraint_type: super::artifact::sketch_block_constraint_type(&sketch_constraint),
                                 code_ref: CodeRef::placeholder(range),
                             }));
                             exec_state.add_scene_object(
@@ -3986,7 +3985,6 @@ impl Node<BinaryExpression> {
                             use crate::execution::Artifact;
                             use crate::execution::CodeRef;
                             use crate::execution::SketchBlockConstraint;
-                            use crate::execution::SketchBlockConstraintType;
                             use crate::front::Distance;
                             use crate::front::SourceRef;
                             use crate::frontend::sketch::ConstraintSegment;
@@ -4027,7 +4025,7 @@ impl Node<BinaryExpression> {
                                 id: artifact_id,
                                 sketch_id,
                                 constraint_id,
-                                constraint_type: SketchBlockConstraintType::from(&sketch_constraint),
+                                constraint_type: super::artifact::sketch_block_constraint_type(&sketch_constraint),
                                 code_ref: CodeRef::placeholder(range),
                             }));
                             exec_state.add_scene_object(
@@ -4133,7 +4131,6 @@ impl Node<BinaryExpression> {
                             use crate::execution::Artifact;
                             use crate::execution::CodeRef;
                             use crate::execution::SketchBlockConstraint;
-                            use crate::execution::SketchBlockConstraintType;
                             use crate::front::Distance;
                             use crate::front::SourceRef;
                             use crate::frontend::sketch::ConstraintSegment;
@@ -4161,7 +4158,7 @@ impl Node<BinaryExpression> {
                                 id: artifact_id,
                                 sketch_id,
                                 constraint_id,
-                                constraint_type: SketchBlockConstraintType::from(&sketch_constraint),
+                                constraint_type: super::artifact::sketch_block_constraint_type(&sketch_constraint),
                                 code_ref: CodeRef::placeholder(range),
                             }));
                             exec_state.add_scene_object(
@@ -4277,7 +4274,6 @@ impl Node<BinaryExpression> {
                             use crate::execution::Artifact;
                             use crate::execution::CodeRef;
                             use crate::execution::SketchBlockConstraint;
-                            use crate::execution::SketchBlockConstraintType;
                             use crate::front::Distance;
                             use crate::front::SourceRef;
                             use crate::frontend::sketch::ConstraintSegment;
@@ -4301,7 +4297,7 @@ impl Node<BinaryExpression> {
                                 id: artifact_id,
                                 sketch_id,
                                 constraint_id,
-                                constraint_type: SketchBlockConstraintType::from(&sketch_constraint),
+                                constraint_type: super::artifact::sketch_block_constraint_type(&sketch_constraint),
                                 code_ref: CodeRef::placeholder(range),
                             }));
                             exec_state.add_scene_object(
@@ -4373,7 +4369,6 @@ impl Node<BinaryExpression> {
                             use crate::execution::Artifact;
                             use crate::execution::CodeRef;
                             use crate::execution::SketchBlockConstraint;
-                            use crate::execution::SketchBlockConstraintType;
                             use crate::front::Distance;
                             use crate::front::SourceRef;
                             use crate::frontend::sketch::ConstraintSegment;
@@ -4401,7 +4396,7 @@ impl Node<BinaryExpression> {
                                 id: artifact_id,
                                 sketch_id,
                                 constraint_id,
-                                constraint_type: SketchBlockConstraintType::from(&sketch_constraint),
+                                constraint_type: super::artifact::sketch_block_constraint_type(&sketch_constraint),
                                 code_ref: CodeRef::placeholder(range),
                             }));
                             exec_state.add_scene_object(
@@ -4513,7 +4508,6 @@ impl Node<BinaryExpression> {
                             use crate::execution::Artifact;
                             use crate::execution::CodeRef;
                             use crate::execution::SketchBlockConstraint;
-                            use crate::execution::SketchBlockConstraintType;
                             use crate::front::Distance;
                             use crate::front::SourceRef;
                             use crate::frontend::sketch::ConstraintSegment;
@@ -4537,7 +4531,7 @@ impl Node<BinaryExpression> {
                                 id: artifact_id,
                                 sketch_id,
                                 constraint_id,
-                                constraint_type: SketchBlockConstraintType::from(&sketch_constraint),
+                                constraint_type: super::artifact::sketch_block_constraint_type(&sketch_constraint),
                                 code_ref: CodeRef::placeholder(range),
                             }));
                             exec_state.add_scene_object(
@@ -4696,7 +4690,6 @@ impl Node<BinaryExpression> {
                             use crate::execution::Artifact;
                             use crate::execution::CodeRef;
                             use crate::execution::SketchBlockConstraint;
-                            use crate::execution::SketchBlockConstraintType;
                             use crate::front::Distance;
                             use crate::front::SourceRef;
                             use crate::frontend::sketch::ConstraintSegment;
@@ -4720,7 +4713,7 @@ impl Node<BinaryExpression> {
                                 id: artifact_id,
                                 sketch_id,
                                 constraint_id,
-                                constraint_type: SketchBlockConstraintType::from(&sketch_constraint),
+                                constraint_type: super::artifact::sketch_block_constraint_type(&sketch_constraint),
                                 code_ref: CodeRef::placeholder(range),
                             }));
                             exec_state.add_scene_object(
@@ -4921,7 +4914,6 @@ impl Node<BinaryExpression> {
                             use crate::execution::Artifact;
                             use crate::execution::CodeRef;
                             use crate::execution::SketchBlockConstraint;
-                            use crate::execution::SketchBlockConstraintType;
                             use crate::front::SourceRef;
                             let segment_object_id = match target_segment {
                                 CircularSegmentConstraintTarget::Arc { object_id, .. }
@@ -4960,7 +4952,7 @@ impl Node<BinaryExpression> {
                                 id: artifact_id,
                                 sketch_id,
                                 constraint_id,
-                                constraint_type: SketchBlockConstraintType::from(&constraint),
+                                constraint_type: super::artifact::sketch_block_constraint_type(&constraint),
                                 code_ref: CodeRef::placeholder(range),
                             }));
                             exec_state.add_scene_object(
@@ -5034,7 +5026,6 @@ impl Node<BinaryExpression> {
                             use crate::execution::Artifact;
                             use crate::execution::CodeRef;
                             use crate::execution::SketchBlockConstraint;
-                            use crate::execution::SketchBlockConstraintType;
                             use crate::front::Distance;
                             use crate::front::SourceRef;
                             use crate::frontend::sketch::ConstraintSegment;
@@ -5075,7 +5066,7 @@ impl Node<BinaryExpression> {
                                 id: artifact_id,
                                 sketch_id,
                                 constraint_id,
-                                constraint_type: SketchBlockConstraintType::from(&constraint),
+                                constraint_type: super::artifact::sketch_block_constraint_type(&constraint),
                                 code_ref: CodeRef::placeholder(range),
                             }));
                             exec_state.add_scene_object(
@@ -5147,7 +5138,6 @@ impl Node<BinaryExpression> {
                             use crate::execution::Artifact;
                             use crate::execution::CodeRef;
                             use crate::execution::SketchBlockConstraint;
-                            use crate::execution::SketchBlockConstraintType;
                             use crate::front::Distance;
                             use crate::front::SourceRef;
                             use crate::frontend::sketch::ConstraintSegment;
@@ -5188,7 +5178,7 @@ impl Node<BinaryExpression> {
                                 id: artifact_id,
                                 sketch_id,
                                 constraint_id,
-                                constraint_type: SketchBlockConstraintType::from(&constraint),
+                                constraint_type: super::artifact::sketch_block_constraint_type(&constraint),
                                 code_ref: CodeRef::placeholder(range),
                             }));
                             exec_state.add_scene_object(

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -4,17 +4,8 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use anyhow::Result;
-pub use artifact::Artifact;
 pub use artifact::ArtifactCommand;
-pub use artifact::ArtifactGraph;
-pub use artifact::CapSubType;
-pub use artifact::CodeRef;
-pub use artifact::GdtAnnotationArtifact;
-pub use artifact::SketchBlock;
-pub use artifact::SketchBlockConstraint;
-pub use artifact::SketchBlockConstraintType;
-pub use artifact::StartSketchOnFace;
-pub use artifact::StartSketchOnPlane;
+pub(crate) use artifact::sketch_block_constraint_type;
 use cache::GlobalState;
 pub use cache::bust_cache;
 pub use cache::clear_mem_cache;
@@ -23,6 +14,17 @@ pub use id_generator::IdGenerator;
 pub(crate) use import::PreImportedGeometry;
 use indexmap::IndexMap;
 pub use kcl_api::Operation;
+pub use kcl_api::artifact::Artifact;
+pub use kcl_api::artifact::ArtifactGraph;
+pub use kcl_api::artifact::CapSubType;
+pub use kcl_api::artifact::CodeRef;
+pub use kcl_api::artifact::GdtAnnotationArtifact;
+pub use kcl_api::artifact::SketchBlock;
+pub use kcl_api::artifact::SketchBlockConstraint;
+#[allow(unused_imports)]
+pub use kcl_api::artifact::SketchBlockConstraintType;
+pub use kcl_api::artifact::StartSketchOnFace;
+pub use kcl_api::artifact::StartSketchOnPlane;
 use kcl_api::ast::node_path::NodePath;
 pub use kcl_value::KclObjectFields;
 pub use kcl_value::KclObjectKind;
@@ -140,6 +142,8 @@ impl OperationsByModule {
 
 pub(crate) mod annotations;
 mod artifact;
+#[cfg(test)]
+pub(crate) use artifact::mermaid_tests::ArtifactGraphMermaidExt;
 pub(crate) mod cache;
 mod cad_op;
 mod exec_ast;

--- a/rust/kcl-lib/src/execution/state.rs
+++ b/rust/kcl-lib/src/execution/state.rs
@@ -1240,7 +1240,7 @@ impl GlobalState {
 
 impl ArtifactState {
     pub fn cached_body_items(&self) -> usize {
-        self.graph.item_count
+        self.graph.item_count()
     }
 
     pub(crate) fn clear(&mut self) {

--- a/rust/kcl-lib/src/simulation_tests.rs
+++ b/rust/kcl-lib/src/simulation_tests.rs
@@ -14,6 +14,7 @@ use crate::ExecutorContext;
 use crate::ModuleId;
 use crate::errors::KclError;
 use crate::execution::ArtifactGraph;
+use crate::execution::ArtifactGraphMermaidExt;
 use crate::execution::EnvironmentRef;
 use crate::execution::KclValueView;
 use crate::execution::ModuleArtifactState;

--- a/rust/kcl-lib/src/std/constraints.rs
+++ b/rust/kcl-lib/src/std/constraints.rs
@@ -26,7 +26,6 @@ use crate::execution::ExecState;
 use crate::execution::KclValue;
 use crate::execution::SegmentRepr;
 use crate::execution::SketchBlockConstraint;
-use crate::execution::SketchBlockConstraintType;
 use crate::execution::SketchConstraint;
 use crate::execution::SketchConstraintKind;
 use crate::execution::SketchVarId;
@@ -2408,7 +2407,7 @@ fn track_constraint(constraint_id: ObjectId, constraint: Constraint, exec_state:
         id: artifact_id,
         sketch_id,
         constraint_id,
-        constraint_type: SketchBlockConstraintType::from(&constraint),
+        constraint_type: crate::execution::sketch_block_constraint_type(&constraint),
         code_ref: CodeRef::placeholder(args.source_range),
     }));
     exec_state.add_scene_object(


### PR DESCRIPTION
After talking with @jtran about well-typing `artifact_graph` on `ExecKclProjectOk` output, this PR pulls `ArtifactGraph` into `kcl-api`. Original catalyst: https://github.com/KittyCAD/modeling-api/pull/1295/changes#r3658712629

We could've left it as a blob, but eventually we'd need to bite the bullet. Also a rich structure like this is prone to error if there are any changes around it and isn't well typed in some situations.