### PR TITLE
Ignore VCS metadata in cloud sync

### DIFF
--- a/src/components/CloudConflictDialog.spec.tsx
+++ b/src/components/CloudConflictDialog.spec.tsx
@@ -106,10 +106,22 @@ describe('CloudConflictDialog', () => {
   test('shows changed files with expanded diffs and resolution actions', async () => {
     vi.mocked(fsZds.readdir).mockImplementation(async (path) => {
       if (path === '/projects/local') {
-        return ['main.kcl', 'local-only.txt', 'thumbnail.png', 'project.toml']
+        return [
+          'main.kcl',
+          'local-only.txt',
+          'thumbnail.png',
+          'project.toml',
+          '.git',
+        ]
       }
       if (path === '/projects/local (cloud conflict)') {
-        return ['main.kcl', 'cloud-only.txt', 'thumbnail.png', 'project.toml']
+        return [
+          'main.kcl',
+          'cloud-only.txt',
+          'thumbnail.png',
+          'project.toml',
+          '.git',
+        ]
       }
       return []
     })
@@ -169,6 +181,7 @@ describe('CloudConflictDialog', () => {
     expect(screen.getAllByText('local-only.txt')).not.toHaveLength(0)
     expect(screen.getAllByText('cloud-only.txt')).not.toHaveLength(0)
     expect(screen.getByText('thumbnail.png')).toBeInTheDocument()
+    expect(screen.queryByText('.git')).not.toBeInTheDocument()
     expect(screen.getAllByTestId('mock-merge-view')).toHaveLength(3)
     expect(
       screen.queryByText('Diff unavailable: Binary or non-UTF-8 file.')
@@ -198,5 +211,9 @@ describe('CloudConflictDialog', () => {
     )
 
     expect(getCloudSyncProjectMetadata).toHaveBeenCalledWith('/projects/local')
+    expect(fsZds.stat).not.toHaveBeenCalledWith('/projects/local/.git')
+    expect(fsZds.stat).not.toHaveBeenCalledWith(
+      '/projects/local (cloud conflict)/.git'
+    )
   })
 })

--- a/src/lib/cloudSync/conflictInspection.ts
+++ b/src/lib/cloudSync/conflictInspection.ts
@@ -1,5 +1,5 @@
 import {
-  INTERNAL_OPFS_META_FILE,
+  isCloudSyncExcludedPath,
   normalizeRelativePath,
 } from '@src/lib/cloudSync/paths'
 import { getCloudSyncProjectMetadata } from '@src/lib/cloudSync/syncDb'
@@ -139,7 +139,7 @@ async function scanProjectFiles(projectRoot: string) {
     const entries = (await fsZds.readdir(currentPath)).toSorted()
 
     for (const entry of entries) {
-      if (entry === INTERNAL_OPFS_META_FILE) {
+      if (isCloudSyncExcludedPath(entry)) {
         continue
       }
 

--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -12,7 +12,7 @@ import {
 } from '@src/lib/cloudSync/cloudApi'
 import {
   getCloudSyncProjectRoot,
-  INTERNAL_OPFS_META_FILE,
+  isCloudSyncExcludedPath,
   isCloudSyncProjectDirectoryPath,
   isProjectRootPath,
   normalizePathForSync,
@@ -379,13 +379,8 @@ export function filterCloudSyncProjectFilesForSync(
 
   return normalizedFiles.filter(
     (file) =>
+      !isCloudSyncExcludedPath(file.relativePath) &&
       !isPathIgnoredByGitignore(gitignoreStack, file.relativePath, false)
-  )
-}
-
-function isInternalOpfsPath(targetPath: string) {
-  return webSafePathSplit(normalizePathForSync(targetPath)).includes(
-    INTERNAL_OPFS_META_FILE
   )
 }
 
@@ -879,7 +874,7 @@ async function collectLocalProjectFiles(projectRoot: string) {
   ) => {
     const entries = await localFs.readdir(currentPath)
     for (const entry of entries) {
-      if (entry === INTERNAL_OPFS_META_FILE) {
+      if (isCloudSyncExcludedPath(entry)) {
         continue
       }
 
@@ -2773,7 +2768,7 @@ async function registerProjectMutation(
   targetPath: string,
   sourcePath?: string
 ) {
-  if (!isConfiguredForCloud() || isInternalOpfsPath(targetPath)) {
+  if (!isConfiguredForCloud() || isCloudSyncExcludedPath(targetPath)) {
     return
   }
 

--- a/src/lib/cloudSync/index.test.ts
+++ b/src/lib/cloudSync/index.test.ts
@@ -18,7 +18,10 @@ import {
   projectManifestsEqual,
   shouldCloudSyncAutoSyncLocalProject,
 } from '@src/lib/cloudSync'
-import { DEFAULT_CLOUD_PROJECT_DIRECTORY_PATH } from '@src/lib/cloudSync/paths'
+import {
+  DEFAULT_CLOUD_PROJECT_DIRECTORY_PATH,
+  isCloudSyncExcludedPath,
+} from '@src/lib/cloudSync/paths'
 import {
   normalizeProjectArchiveFilesForCloudSync,
   projectManifestFromFiles,
@@ -243,6 +246,31 @@ describe('cloudSync sync helpers', () => {
       '.gitignore',
       'nested/.gitignore',
       'nested/part.kcl',
+    ])
+  })
+
+  it('excludes VCS metadata from cloud sync manifests without .gitignore entries', () => {
+    expect(isCloudSyncExcludedPath('.git')).toBe(true)
+    expect(isCloudSyncExcludedPath('.git/objects/pack.idx')).toBe(true)
+    expect(isCloudSyncExcludedPath('nested/.git/HEAD')).toBe(true)
+    expect(isCloudSyncExcludedPath('.gitignore')).toBe(false)
+    expect(isCloudSyncExcludedPath('.github/workflows/test.yml')).toBe(false)
+
+    const files = filterCloudSyncProjectFilesForSync([
+      projectFile('main.kcl', 'cube = 1'),
+      projectFile('.git/HEAD', 'ref: refs/heads/main\n'),
+      projectFile('.git/objects/pack/pack-123.idx', 'pack index'),
+      projectFile('.gitignore', 'dist/\n'),
+      projectFile('.github/workflows/test.yml', 'name: test\n'),
+      projectFile('.hg/store/data', 'hg data'),
+      projectFile('.svn/entries', 'svn entries'),
+      projectFile('.jj/repo/store/git/HEAD', 'jj data'),
+    ])
+
+    expect(files.map((file) => file.relativePath)).toEqual([
+      'main.kcl',
+      '.gitignore',
+      '.github/workflows/test.yml',
     ])
   })
 

--- a/src/lib/cloudSync/paths.ts
+++ b/src/lib/cloudSync/paths.ts
@@ -9,6 +9,13 @@ export const DEFAULT_CLOUD_PROJECT_DIRECTORY_PATH = `/${webSafeJoin([
   'documents',
   PROJECT_FOLDER,
 ])}`
+const CLOUD_SYNC_EXCLUDED_PATH_PARTS = new Set([
+  INTERNAL_OPFS_META_FILE,
+  '.git',
+  '.hg',
+  '.svn',
+  '.jj',
+])
 
 export async function getDefaultCloudProjectDirectoryPath() {
   if (typeof window !== 'undefined' && window.electron?.os.isMac) {
@@ -56,6 +63,12 @@ export function normalizeRelativePath(relativePath: string) {
     .replaceAll('\\', '/')
     .replace(/^\/+/g, '')
     .replace(/^(?:\.\/)+/g, '')
+}
+
+export function isCloudSyncExcludedPath(targetPath: string) {
+  return webSafePathSplit(normalizePathForSync(targetPath)).some((part) =>
+    CLOUD_SYNC_EXCLUDED_PATH_PARTS.has(part)
+  )
 }
 
 function getProjectRootFromProjectDirectoryParts(


### PR DESCRIPTION
## Summary

- Add a shared cloud sync path exclusion for VCS metadata directories (`.git`, `.hg`, `.svn`, `.jj`) while preserving normal dotfiles like `.gitignore` and `.github`.
- Apply the exclusion to manifest/archive filtering, local project scanning, mutation enqueueing, and conflict inspection.
- Cover the behavior with focused cloud sync helper and conflict dialog tests.

## Root cause

Cloud sync already honors project `.gitignore` files, but Git metadata lives in `.git/`, which Git does not require users to list in `.gitignore`. Those frequently changing files could make a cloud-backed project appear locally dirty or show irrelevant conflict details.