### PR TITLE
Fix test that was meant to fail so that it fails again

### DIFF
--- a/rust/kcl-lib/tests/error_large_fillet_radius/artifact_commands.snap
+++ b/rust/kcl-lib/tests/error_large_fillet_radius/artifact_commands.snap
@@ -265,7 +265,7 @@ description: Artifact commands error_large_fillet_radius.kcl
         ],
         "cut_type": {
           "fillet": {
-            "radius": 5.0,
+            "radius": 13.0,
             "second_length": null
           }
         },

--- a/rust/kcl-lib/tests/error_large_fillet_radius/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/error_large_fillet_radius/artifact_graph_flowchart.snap.md
@@ -48,7 +48,7 @@ flowchart LR
   24["SweepEdge Adjacent"]
   25["SweepEdge Opposite"]
   26["SweepEdge Adjacent"]
-  27["EdgeCut Fillet<br>[860, 955, 0]"]
+  27["EdgeCut Fillet<br>[860, 956, 0]"]
     %% [ProgramBodyItem { index: 4 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   28["SketchBlock<br>[65, 690, 0]"]
     %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit]

--- a/rust/kcl-lib/tests/error_large_fillet_radius/ast.snap
+++ b/rust/kcl-lib/tests/error_large_fillet_radius/ast.snap
@@ -2164,12 +2164,12 @@ description: Result of parsing error_large_fillet_radius.kcl
                   "commentStart": 0,
                   "end": 0,
                   "moduleId": 0,
-                  "raw": "5",
+                  "raw": "13",
                   "start": 0,
                   "type": "Literal",
                   "type": "Literal",
                   "value": {
-                    "value": 5.0,
+                    "value": 13.0,
                     "suffix": "None"
                   }
                 }

--- a/rust/kcl-lib/tests/error_large_fillet_radius/execution_error.snap
+++ b/rust/kcl-lib/tests/error_large_fillet_radius/execution_error.snap
@@ -4,10 +4,12 @@ description: Error from executing error_large_fillet_radius.kcl
 ---
 KCL Engine error
 
-  × engine: Edge cut failed
+  × engine: The Zoo engine cannot handle this 3D subtraction yet.  Please
+  │ report this as an issue
+  │ Edge cut failed
     ╭─[21:13]
  20 │ extrude001 = extrude(region001, length = 5, tagEnd = $capEnd001)
- 21 │ fillet001 = fillet(extrude001, tags = getCommonEdge(faces = [region001.tags.line1, capEnd001]), radius = 5)
-    ·             ───────────────────────────────────────────────┬───────────────────────────────────────────────
-    ·                                                            ╰── tests/error_large_fillet_radius/input.kcl
+ 21 │ fillet001 = fillet(extrude001, tags = getCommonEdge(faces = [region001.tags.line1, capEnd001]), radius = 13)
+    ·             ────────────────────────────────────────────────┬───────────────────────────────────────────────
+    ·                                                             ╰── tests/error_large_fillet_radius/input.kcl
     ╰────

--- a/rust/kcl-lib/tests/error_large_fillet_radius/input.kcl
+++ b/rust/kcl-lib/tests/error_large_fillet_radius/input.kcl
@@ -18,4 +18,4 @@ sketch001 = sketch(on = XY) {
 hidden001 = hide(sketch001)
 region001 = region(point = [0mm, 0.0025mm], sketch = sketch001)
 extrude001 = extrude(region001, length = 5, tagEnd = $capEnd001)
-fillet001 = fillet(extrude001, tags = getCommonEdge(faces = [region001.tags.line1, capEnd001]), radius = 5)
+fillet001 = fillet(extrude001, tags = getCommonEdge(faces = [region001.tags.line1, capEnd001]), radius = 13)

--- a/rust/kcl-lib/tests/error_large_fillet_radius/ops.snap
+++ b/rust/kcl-lib/tests/error_large_fillet_radius/ops.snap
@@ -962,7 +962,7 @@ description: Operations executed error_large_fillet_radius.kcl
         "radius": {
           "value": {
             "type": "Number",
-            "value": 5.0,
+            "value": 13.0,
             "ty": {
               "type": "Default",
               "len": "mm",

--- a/rust/kcl-lib/tests/error_large_fillet_radius/program_memory.snap
+++ b/rust/kcl-lib/tests/error_large_fillet_radius/program_memory.snap
@@ -573,7 +573,7 @@ description: Variables in memory after executing error_large_fillet_radius.kcl
           "type": "fillet",
           "id": "[uuid]",
           "radius": {
-            "n": 5.0,
+            "n": 13.0,
             "ty": {
               "type": "Default",
               "len": "mm",

--- a/rust/kcl-lib/tests/error_large_fillet_radius/unparsed.snap
+++ b/rust/kcl-lib/tests/error_large_fillet_radius/unparsed.snap
@@ -22,4 +22,4 @@ sketch001 = sketch(on = XY) {
 hidden001 = hide(sketch001)
 region001 = region(point = [0mm, 0.0025mm], sketch = sketch001)
 extrude001 = extrude(region001, length = 5, tagEnd = $capEnd001)
-fillet001 = fillet(extrude001, tags = getCommonEdge(faces = [region001.tags.line1, capEnd001]), radius = 5)
+fillet001 = fillet(extrude001, tags = getCommonEdge(faces = [region001.tags.line1, capEnd001]), radius = 13)


### PR DESCRIPTION
This test that was supposed to fail succeeds after https://github.com/KittyCAD/engine/pull/4814. Upping the radius until it fails because the fillet cuts away the whole solid.