### PR TITLE
Release kcl-api 171 -- only kcl-api and kcl-error

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2344,10 +2344,10 @@ dependencies = [
 
 [[package]]
 name = "kcl-api"
-version = "0.2.170"
+version = "0.2.171"
 dependencies = [
  "indexmap 2.14.0",
- "kcl-error 0.2.170",
+ "kcl-error 0.2.171",
  "kittycad-measurements",
  "kittycad-unit-conversion-derive",
  "parse-display 0.11.0",
@@ -2363,7 +2363,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-bumper"
-version = "0.1.170"
+version = "0.1.171"
 dependencies = [
  "anyhow",
  "clap",
@@ -2374,7 +2374,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-derive-docs"
-version = "0.2.170"
+version = "0.2.171"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2383,25 +2383,12 @@ dependencies = [
 
 [[package]]
 name = "kcl-directory-test-macro"
-version = "0.1.170"
+version = "0.1.171"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
-]
-
-[[package]]
-name = "kcl-error"
-version = "0.2.170"
-dependencies = [
- "miette",
- "pyo3",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "thiserror 2.0.19",
- "ts-rs",
 ]
 
 [[package]]
@@ -2419,8 +2406,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "kcl-error"
+version = "0.2.171"
+dependencies = [
+ "miette",
+ "pyo3",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "ts-rs",
+]
+
+[[package]]
 name = "kcl-language-server"
-version = "0.2.170"
+version = "0.2.171"
 dependencies = [
  "anyhow",
  "clap",
@@ -2441,7 +2441,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-language-server-release"
-version = "0.1.170"
+version = "0.1.171"
 dependencies = [
  "anyhow",
  "clap",
@@ -2461,7 +2461,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-lib"
-version = "0.2.170"
+version = "0.2.171"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2498,7 +2498,7 @@ dependencies = [
  "kcl-api",
  "kcl-derive-docs",
  "kcl-directory-test-macro",
- "kcl-error 0.2.170",
+ "kcl-error 0.2.171",
  "kcl-syntax",
  "kittycad",
  "kittycad-modeling-cmds",
@@ -2551,7 +2551,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-python-bindings"
-version = "0.3.170"
+version = "0.3.171"
 dependencies = [
  "anyhow",
  "kcl-api",
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-syntax"
-version = "0.2.170"
+version = "0.2.171"
 dependencies = [
  "logos",
  "proptest",
@@ -2576,7 +2576,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-test-server"
-version = "0.2.170"
+version = "0.2.171"
 dependencies = [
  "anyhow",
  "hyper 0.14.32",
@@ -2589,7 +2589,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-wasm-lib"
-version = "0.1.170"
+version = "0.1.171"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -2678,7 +2678,7 @@ dependencies = [
  "enum-iterator-derive",
  "euler",
  "http 1.4.2",
- "kcl-error 0.2.170 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kcl-error 0.2.170",
  "kittycad-measurements",
  "kittycad-modeling-cmds-macros",
  "kittycad-unit-conversion-derive",

--- a/rust/kcl-api/Cargo.toml
+++ b/rust/kcl-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-api"
-version = "0.2.170"
+version = "0.2.171"
 edition = "2024"
 description = "KCL API"
 license = "MIT"
@@ -12,7 +12,7 @@ pyo3 = ["dep:pyo3", "dep:pyo3-stub-gen"]
 [dependencies]
 indexmap = { workspace = true, features = ["serde", "rayon"] }
 kittycad-unit-conversion-derive = "0.1.0"
-kcl-error = { version = "=0.2.170", path = "../kcl-error" }
+kcl-error = { version = "=0.2.171", path = "../kcl-error" }
 # Fork of <crates.io/crates/measurements>
 measurements = { package = "kittycad-measurements", version = "0.11.2" }
 parse-display = "0.11.0"

--- a/rust/kcl-bumper/Cargo.toml
+++ b/rust/kcl-bumper/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "kcl-bumper"
-version = "0.1.170"
+version = "0.1.171"
 edition = "2024"
 repository = "https://github.com/KittyCAD/modeling-api"
 description = "Bumps versions in Cargo.toml"

--- a/rust/kcl-derive-docs/Cargo.toml
+++ b/rust/kcl-derive-docs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-derive-docs"
 description = "A tool for generating documentation from Rust derive macros"
-version = "0.2.170"
+version = "0.2.171"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/rust/kcl-directory-test-macro/Cargo.toml
+++ b/rust/kcl-directory-test-macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-directory-test-macro"
 description = "A tool for generating tests from a directory of kcl files"
-version = "0.1.170"
+version = "0.1.171"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/rust/kcl-error/Cargo.toml
+++ b/rust/kcl-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-error"
-version = "0.2.170"
+version = "0.2.171"
 edition = "2024"
 description = "KCL error definitions"
 license = "MIT"

--- a/rust/kcl-language-server-release/Cargo.toml
+++ b/rust/kcl-language-server-release/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-language-server-release"
-version = "0.1.170"
+version = "0.1.171"
 edition = "2024"
 authors = ["KittyCAD Inc <kcl@kittycad.io>"]
 publish = false

--- a/rust/kcl-language-server/Cargo.toml
+++ b/rust/kcl-language-server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kcl-language-server"
 description = "A language server for KCL."
 authors = ["KittyCAD Inc <kcl@kittycad.io>"]
-version = "0.2.170"
+version = "0.2.171"
 edition = "2024"
 license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust/kcl-lib/Cargo.toml
+++ b/rust/kcl-lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-lib"
 description = "KittyCAD Language implementation and tools"
-version = "0.2.170"
+version = "0.2.171"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"
@@ -69,10 +69,10 @@ image = { version = "0.25.10", default-features = false, features = ["png"] }
 image-compare = "0.5.0"
 indexmap = { workspace = true, features = ["serde", "rayon"] }
 itertools = "0.15.0"
-kcl-api = { version = "=0.2.170", path = "../kcl-api" }
-kcl-derive-docs = { version = "=0.2.170", path = "../kcl-derive-docs" }
-kcl-error = { version = "=0.2.170", path = "../kcl-error" }
-kcl-syntax = { version = "=0.2.170", path = "../kcl-syntax" }
+kcl-api = { version = "=0.2.171", path = "../kcl-api" }
+kcl-derive-docs = { version = "=0.2.171", path = "../kcl-derive-docs" }
+kcl-error = { version = "=0.2.171", path = "../kcl-error" }
+kcl-syntax = { version = "=0.2.171", path = "../kcl-syntax" }
 ezpz = { workspace = true }
 kittycad = { workspace = true }
 kittycad-modeling-cmds = { workspace = true }

--- a/rust/kcl-python-bindings/Cargo.toml
+++ b/rust/kcl-python-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-python-bindings"
-version = "0.3.170"
+version = "0.3.171"
 edition = "2024"
 repository = "https://github.com/kittycad/modeling-app"
 exclude = ["tests/*", "files/*", "venv/*"]

--- a/rust/kcl-syntax/Cargo.toml
+++ b/rust/kcl-syntax/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-syntax"
 description = "Lossless syntax trees for KCL"
-version = "0.2.170"
+version = "0.2.171"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/rust/kcl-test-server/Cargo.toml
+++ b/rust/kcl-test-server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-test-server"
 description = "A test server for KCL"
-version = "0.2.170"
+version = "0.2.171"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"
@@ -12,7 +12,7 @@ bench = false
 [dependencies]
 anyhow = "1.0.102"
 hyper = { version = "0.14.29", features = ["http1", "server", "tcp"] }
-kcl-lib = { version = "=0.2.170", path = "../kcl-lib" }
+kcl-lib = { version = "=0.2.171", path = "../kcl-lib" }
 pico-args = "0.5.0"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/rust/kcl-wasm-lib/Cargo.toml
+++ b/rust/kcl-wasm-lib/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kcl-wasm-lib"
 description = "KittyCAD Language wasm bindings"
 license = "MIT"
-version = "0.1.170"
+version = "0.1.171"
 edition = "2024"
 repository = "https://github.com/KittyCAD/modeling-app"
 publish = false


### PR DESCRIPTION
@lee-at-zoo-corp needs a `kcl-api` release. The other crates are bumped only so that they match on the next release. Only `kcl-api` and `kcl-error` will be published.