### PR TITLE
Coalesce cloud sync outbox work

### DIFF
--- a/src/lib/cloudSync/disconnect.spec.ts
+++ b/src/lib/cloudSync/disconnect.spec.ts
@@ -295,5 +295,19 @@ describe('cloud sync upload failures', () => {
       lastFailureKind: 'remote-upload-forbidden',
       lastFailure: expect.stringContaining('does not have edit access'),
     })
+
+    configureCloudSyncEngine({
+      enabled: true,
+      baseUrl: 'https://example.test',
+      environmentName: 'dev.zoo.dev',
+      projectDirectoryPath: '/documents/Projects',
+    })
+
+    expect(cloudSyncStatus.value).toMatchObject({
+      state: 'failed',
+      activeProjectPath: projectPath,
+      lastFailureKind: 'remote-upload-forbidden',
+      lastFailure: expect.stringContaining('does not have edit access'),
+    })
   })
 })

--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -416,6 +416,12 @@ function outboxEntriesForProject(entries: OutboxEntry[], projectPath: string) {
   )
 }
 
+function outboxProjectPaths(entries: OutboxEntry[]) {
+  return Array.from(
+    new Set(entries.map((entry) => normalizePathForSync(entry.projectPath)))
+  )
+}
+
 export type CloudSyncScopePlan = {
   shouldSyncRemoteIndex: boolean
   projectPaths: string[]
@@ -434,16 +440,17 @@ export function getCloudSyncScopePlan(
       shouldSyncRemoteIndex: false,
       projectPaths: [normalizedScopeProjectPath],
       pendingCount: outboxEntriesForProject(entries, normalizedScopeProjectPath)
-        .length,
+        .length
+        ? 1
+        : 0,
     }
   }
 
+  const projectPaths = outboxProjectPaths(entries)
   return {
     shouldSyncRemoteIndex: true,
-    projectPaths: Array.from(
-      new Set(entries.map((entry) => normalizePathForSync(entry.projectPath)))
-    ),
-    pendingCount: entries.length,
+    projectPaths,
+    pendingCount: projectPaths.length,
   }
 }
 
@@ -2933,12 +2940,24 @@ export function configureCloudSyncEngine(nextConfig: CloudSyncConfig) {
     return
   }
 
+  const shouldResetEnabledStatus =
+    !previousConfig.enabled ||
+    cloudIdentityChanged ||
+    projectDirectoryChanged ||
+    syncPolicyChanged ||
+    cloudSyncStatus.value.state === 'disabled'
+
   attachVisibilityChangeListener()
   updateStatus({
     enabled: true,
-    state: 'idle',
-    lastFailure: undefined,
-    lastFailureAt: undefined,
+    ...(shouldResetEnabledStatus
+      ? {
+          state: 'idle',
+          activeProjectPath: undefined,
+          lastFailure: undefined,
+          lastFailureAt: undefined,
+        }
+      : {}),
   })
   void refreshPendingCount()
   scheduleSync(0)

--- a/src/lib/cloudSync/index.test.ts
+++ b/src/lib/cloudSync/index.test.ts
@@ -606,6 +606,41 @@ describe('cloudSync sync helpers', () => {
     })
   })
 
+  it('counts pending cloud sync work by project instead of raw outbox rows', () => {
+    const entries: OutboxEntry[] = [
+      {
+        projectPath: '/projects/current',
+        kind: 'upsert',
+        targetPath: '/projects/current/main.kcl',
+        createdAt: '2026-06-12T00:00:00.000Z',
+      },
+      {
+        projectPath: '/projects/current',
+        kind: 'upsert',
+        targetPath: '/projects/current/project.toml',
+        createdAt: '2026-06-12T00:00:01.000Z',
+      },
+      {
+        projectPath: '/projects/other',
+        kind: 'upsert',
+        targetPath: '/projects/other/main.kcl',
+        createdAt: '2026-06-12T00:00:02.000Z',
+      },
+    ]
+
+    expect(getCloudSyncScopePlan(entries)).toEqual({
+      shouldSyncRemoteIndex: true,
+      projectPaths: ['/projects/current', '/projects/other'],
+      pendingCount: 2,
+    })
+
+    expect(getCloudSyncScopePlan(entries, '/projects/current')).toEqual({
+      shouldSyncRemoteIndex: false,
+      projectPaths: ['/projects/current'],
+      pendingCount: 1,
+    })
+  })
+
   it('keeps syncing the open project even when it has no queued local edits', () => {
     expect(getCloudSyncScopePlan([], '/projects/current')).toEqual({
       shouldSyncRemoteIndex: false,

--- a/src/lib/cloudSync/syncDb.test.ts
+++ b/src/lib/cloudSync/syncDb.test.ts
@@ -50,4 +50,52 @@ describe('cloud sync outbox persistence', () => {
       },
     ])
   })
+
+  it('keeps existing project upload work when a duplicate upsert is registered', async () => {
+    await appendOutboxEntry({
+      projectPath: '/projects/bracket',
+      kind: 'upsert',
+      targetPath: '/projects/bracket/main.kcl',
+      createdAt: '2026-07-28T12:00:00.000Z',
+    })
+    await appendOutboxEntry({
+      projectPath: '/projects/bracket',
+      kind: 'upsert',
+      targetPath: '/projects/bracket',
+      createdAt: '2026-07-28T12:01:00.000Z',
+    })
+
+    await expect(getAllOutboxEntries()).resolves.toMatchObject([
+      {
+        projectPath: '/projects/bracket',
+        kind: 'upsert',
+        targetPath: '/projects/bracket/main.kcl',
+        createdAt: '2026-07-28T12:00:00.000Z',
+      },
+    ])
+  })
+
+  it('keeps project delete work when a later upsert is registered for the tombstoned project', async () => {
+    await appendOutboxEntry({
+      projectPath: '/projects/bracket',
+      kind: 'delete',
+      targetPath: '/projects/bracket',
+      createdAt: '2026-07-28T12:00:00.000Z',
+    })
+    await appendOutboxEntry({
+      projectPath: '/projects/bracket',
+      kind: 'upsert',
+      targetPath: '/projects/bracket/main.kcl',
+      createdAt: '2026-07-28T12:01:00.000Z',
+    })
+
+    await expect(getAllOutboxEntries()).resolves.toMatchObject([
+      {
+        projectPath: '/projects/bracket',
+        kind: 'delete',
+        targetPath: '/projects/bracket',
+        createdAt: '2026-07-28T12:00:00.000Z',
+      },
+    ])
+  })
 })

--- a/src/lib/cloudSync/syncDb.test.ts
+++ b/src/lib/cloudSync/syncDb.test.ts
@@ -1,0 +1,53 @@
+import 'fake-indexeddb/auto'
+import {
+  appendOutboxEntry,
+  getAllOutboxEntries,
+} from '@src/lib/cloudSync/syncDb'
+import { deleteCloudSyncTestDatabase } from '@src/lib/cloudSync/testUtils'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+describe('cloud sync outbox persistence', () => {
+  beforeEach(async () => {
+    await deleteCloudSyncTestDatabase()
+  })
+
+  afterEach(async () => {
+    await deleteCloudSyncTestDatabase()
+  })
+
+  it('coalesces queued work for the same project to the latest entry', async () => {
+    await appendOutboxEntry({
+      projectPath: '/projects/bracket',
+      kind: 'upsert',
+      targetPath: '/projects/bracket/main.kcl',
+      createdAt: '2026-07-28T12:00:00.000Z',
+    })
+    await appendOutboxEntry({
+      projectPath: '/projects/bracket',
+      kind: 'delete',
+      targetPath: '/projects/bracket',
+      createdAt: '2026-07-28T12:01:00.000Z',
+    })
+    await appendOutboxEntry({
+      projectPath: '/projects/other',
+      kind: 'upsert',
+      targetPath: '/projects/other/main.kcl',
+      createdAt: '2026-07-28T12:02:00.000Z',
+    })
+
+    await expect(getAllOutboxEntries()).resolves.toMatchObject([
+      {
+        projectPath: '/projects/bracket',
+        kind: 'delete',
+        targetPath: '/projects/bracket',
+        createdAt: '2026-07-28T12:01:00.000Z',
+      },
+      {
+        projectPath: '/projects/other',
+        kind: 'upsert',
+        targetPath: '/projects/other/main.kcl',
+        createdAt: '2026-07-28T12:02:00.000Z',
+      },
+    ])
+  })
+})

--- a/src/lib/cloudSync/syncDb.ts
+++ b/src/lib/cloudSync/syncDb.ts
@@ -141,19 +141,52 @@ export async function getAllProjectMetadata() {
 
 export async function appendOutboxEntry(entry: Omit<OutboxEntry, 'id'>) {
   const normalizedProjectPath = normalizePathForSync(entry.projectPath)
+  const nextEntry = {
+    ...entry,
+    projectPath: normalizedProjectPath,
+  }
   const db = await openSyncDb()
   await new Promise<void>((resolve, reject) => {
     const transaction = db.transaction(OUTBOX_STORE, 'readwrite')
     const store = transaction.objectStore(OUTBOX_STORE)
     const request = store.openCursor()
+    const matchingDeleteEntryKeys: IDBValidKey[] = []
+    const matchingUpsertEntryKeys: IDBValidKey[] = []
 
     request.onsuccess = () => {
       const cursor = request.result
       if (!cursor) {
-        store.add({
-          ...entry,
-          projectPath: normalizedProjectPath,
-        })
+        if (nextEntry.kind === 'delete') {
+          for (const key of [
+            ...matchingDeleteEntryKeys,
+            ...matchingUpsertEntryKeys,
+          ]) {
+            store.delete(key)
+          }
+          store.add(nextEntry)
+          return
+        }
+
+        const retainedDeleteEntryKey = matchingDeleteEntryKeys[0]
+        if (retainedDeleteEntryKey !== undefined) {
+          for (const key of [
+            ...matchingDeleteEntryKeys.slice(1),
+            ...matchingUpsertEntryKeys,
+          ]) {
+            store.delete(key)
+          }
+          return
+        }
+
+        const retainedUpsertEntryKey = matchingUpsertEntryKeys[0]
+        if (retainedUpsertEntryKey !== undefined) {
+          for (const key of matchingUpsertEntryKeys.slice(1)) {
+            store.delete(key)
+          }
+          return
+        }
+
+        store.add(nextEntry)
         return
       }
 
@@ -162,7 +195,11 @@ export async function appendOutboxEntry(entry: Omit<OutboxEntry, 'id'>) {
         normalizePathForSync(existingEntry.projectPath) ===
         normalizedProjectPath
       ) {
-        cursor.delete()
+        if (existingEntry.kind === 'delete') {
+          matchingDeleteEntryKeys.push(cursor.primaryKey)
+        } else {
+          matchingUpsertEntryKeys.push(cursor.primaryKey)
+        }
       }
       cursor.continue()
     }

--- a/src/lib/cloudSync/syncDb.ts
+++ b/src/lib/cloudSync/syncDb.ts
@@ -140,9 +140,40 @@ export async function getAllProjectMetadata() {
 }
 
 export async function appendOutboxEntry(entry: Omit<OutboxEntry, 'id'>) {
-  await withStore<IDBValidKey>(OUTBOX_STORE, 'readwrite', (store) =>
-    store.add(entry)
-  )
+  const normalizedProjectPath = normalizePathForSync(entry.projectPath)
+  const db = await openSyncDb()
+  await new Promise<void>((resolve, reject) => {
+    const transaction = db.transaction(OUTBOX_STORE, 'readwrite')
+    const store = transaction.objectStore(OUTBOX_STORE)
+    const request = store.openCursor()
+
+    request.onsuccess = () => {
+      const cursor = request.result
+      if (!cursor) {
+        store.add({
+          ...entry,
+          projectPath: normalizedProjectPath,
+        })
+        return
+      }
+
+      const existingEntry = cursor.value as OutboxEntry
+      if (
+        normalizePathForSync(existingEntry.projectPath) ===
+        normalizedProjectPath
+      ) {
+        cursor.delete()
+      }
+      cursor.continue()
+    }
+    request.onerror = () => reject(request.error)
+    transaction.onerror = () => reject(transaction.error)
+    transaction.onabort = () => reject(transaction.error)
+    transaction.oncomplete = () => {
+      db.close()
+      resolve()
+    }
+  })
 }
 
 export async function getAllOutboxEntries() {


### PR DESCRIPTION
## Summary
- Coalesce durable cloud sync outbox entries by local project path so repeated startup/enrollment writes cannot grow duplicate pending rows indefinitely.
- Count pending sync work by distinct project operations instead of raw outbox rows, including scoped project status.
- Preserve visible failed cloud sync state when the same enabled runtime policy is reapplied, so upload failures do not regress to misleading pending/idle UI.

## Root Cause
Home sync can enqueue project-level work repeatedly while the outbox remains uncleared. The sync engine processes and clears work at project granularity, but the durable outbox and status count were tracking every raw queued row. Reapplying the cloud sync runtime config could also reset an actual failure back to idle, leaving users seeing only pending work.

## Validation
- `npm run test:unit -- src/lib/cloudSync/index.test.ts src/lib/cloudSync/syncDb.test.ts`
- `npm run test:integration -- src/lib/cloudSync/cloudApi.spec.ts src/lib/cloudSync/disconnect.spec.ts src/lib/cloudSync/localProjectNames.spec.ts src/lib/cloudSync/renameDeleteRemote.spec.ts`
- `npx biome check --formatter-enabled=true --linter-enabled=false --assist-enabled=false --files-ignore-unknown=true src/lib/cloudSync/engine.ts src/lib/cloudSync/syncDb.ts src/lib/cloudSync/index.test.ts src/lib/cloudSync/syncDb.test.ts src/lib/cloudSync/disconnect.spec.ts`