### PR TITLE
Deduplicate local cloud project realizations

### DIFF
--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -999,10 +999,25 @@ async function findLocalProjectPathByRemoteProjectId(
   remoteProjectId: string,
   preferredProjectName?: string
 ) {
+  return (
+    await findLocalProjectPathsByRemoteProjectId(
+      projectDirectory,
+      remoteProjectId,
+      preferredProjectName
+    )
+  )[0]
+}
+
+async function findLocalProjectPathsByRemoteProjectId(
+  projectDirectory: string,
+  remoteProjectId: string,
+  preferredProjectName?: string
+) {
   const candidateNames = new Set<string>()
   if (preferredProjectName) {
     candidateNames.add(preferredProjectName)
   }
+  const projectPaths: string[] = []
 
   const entries = await localFs.readdir(projectDirectory).catch((error) => {
     if (error === 'ENOENT') {
@@ -1030,11 +1045,192 @@ async function findLocalProjectPathByRemoteProjectId(
       candidatePath
     ).catch(() => undefined)
     if (candidateRemoteProjectId === remoteProjectId) {
-      return candidatePath
+      projectPaths.push(normalizePathForSync(candidatePath))
     }
   }
 
-  return undefined
+  return projectPaths
+}
+
+type LocalProjectRealizationCandidate = {
+  projectPath: string
+  metadata?: ProjectMetadata
+  manifest?: ProjectManifest
+}
+
+async function getLocalProjectRealizationCandidatesByRemoteProjectId(
+  projectDirectory: string,
+  remoteProjectId: string,
+  preferredProjectName?: string
+): Promise<LocalProjectRealizationCandidate[]> {
+  const paths = await findLocalProjectPathsByRemoteProjectId(
+    projectDirectory,
+    remoteProjectId,
+    preferredProjectName
+  )
+
+  return Promise.all(
+    paths.map(async (projectPath) => ({
+      projectPath,
+      metadata: await getProjectMetadata(projectPath),
+      manifest: await collectLocalProjectFiles(projectPath)
+        .then(projectManifestFromFiles)
+        .catch(() => undefined),
+    }))
+  )
+}
+
+function canDeleteDuplicateLocalRealization({
+  candidate,
+  baseManifest,
+  pendingProjectPaths,
+}: {
+  candidate: LocalProjectRealizationCandidate
+  baseManifest: ProjectManifest
+  pendingProjectPaths: ReadonlySet<string>
+}) {
+  const normalizedProjectPath = normalizePathForSync(candidate.projectPath)
+  return Boolean(
+    candidate.manifest &&
+      !pendingProjectPaths.has(normalizedProjectPath) &&
+      !candidate.metadata?.tombstone &&
+      !candidate.metadata?.conflict &&
+      !isProjectSyncExcluded(candidate.metadata) &&
+      projectManifestsEqual(candidate.manifest, baseManifest)
+  )
+}
+
+async function deleteLocalProjectRealization(projectPath: string) {
+  await clearOutboxEntriesForProject(projectPath)
+  if (await exists(projectPath)) {
+    await localFs.rm(projectPath, { recursive: true })
+  }
+  await deleteProjectMetadata(projectPath)
+}
+
+async function detachLocalProjectRealization(projectPath: string) {
+  await clearOutboxEntriesForProject(projectPath)
+  if (await exists(projectPath).catch(() => false)) {
+    await removeLocalProjectCloudProjectId(projectPath)
+  }
+  await deleteProjectMetadata(projectPath)
+}
+
+async function cleanupDuplicateLocalRealizationsForRemoteProject({
+  remoteProjectId,
+  projectDirectory,
+  keepProjectPath,
+}: {
+  remoteProjectId: string
+  projectDirectory: string
+  keepProjectPath: string
+}) {
+  const normalizedKeepProjectPath = normalizePathForSync(keepProjectPath)
+  const pendingProjectPaths = new Set(
+    (await getAllOutboxEntries()).map((entry) =>
+      normalizePathForSync(entry.projectPath)
+    )
+  )
+  const candidates =
+    await getLocalProjectRealizationCandidatesByRemoteProjectId(
+      projectDirectory,
+      remoteProjectId
+    )
+  const keepCandidate = candidates.find(
+    (candidate) =>
+      normalizePathForSync(candidate.projectPath) === normalizedKeepProjectPath
+  )
+
+  if (
+    !keepCandidate?.metadata?.baseManifest ||
+    !keepCandidate.manifest ||
+    !projectManifestsEqual(
+      keepCandidate.manifest,
+      keepCandidate.metadata.baseManifest
+    )
+  ) {
+    return []
+  }
+
+  const deletedProjectPaths: string[] = []
+  for (const candidate of candidates) {
+    const normalizedProjectPath = normalizePathForSync(candidate.projectPath)
+    if (normalizedProjectPath === normalizedKeepProjectPath) {
+      continue
+    }
+    if (
+      !canDeleteDuplicateLocalRealization({
+        candidate,
+        baseManifest: keepCandidate.manifest,
+        pendingProjectPaths,
+      })
+    ) {
+      continue
+    }
+
+    await deleteLocalProjectRealization(candidate.projectPath)
+    deletedProjectPaths.push(candidate.projectPath)
+  }
+
+  return deletedProjectPaths
+}
+
+export async function deleteCloudSyncLocalProjectRealizations(
+  remoteProjectId: string,
+  selectedProjectPath: string
+) {
+  if (!isConfiguredForCloud()) {
+    return
+  }
+
+  const projectId = remoteProjectId.trim()
+  const normalizedSelectedProjectPath =
+    normalizePathForSync(selectedProjectPath)
+  if (!projectId || !normalizedSelectedProjectPath) {
+    return
+  }
+
+  const pendingProjectPaths = new Set(
+    (await getAllOutboxEntries()).map((entry) =>
+      normalizePathForSync(entry.projectPath)
+    )
+  )
+  const projectDirectory = localFs.dirname(normalizedSelectedProjectPath)
+  const candidates =
+    await getLocalProjectRealizationCandidatesByRemoteProjectId(
+      projectDirectory,
+      projectId
+    )
+  const selectedCandidate = candidates.find(
+    (candidate) =>
+      normalizePathForSync(candidate.projectPath) ===
+      normalizedSelectedProjectPath
+  )
+  const selectedManifest = selectedCandidate?.manifest
+
+  for (const candidate of candidates) {
+    const normalizedProjectPath = normalizePathForSync(candidate.projectPath)
+    if (normalizedProjectPath === normalizedSelectedProjectPath) {
+      await deleteLocalProjectRealization(candidate.projectPath)
+      continue
+    }
+
+    if (
+      selectedManifest &&
+      canDeleteDuplicateLocalRealization({
+        candidate,
+        baseManifest: selectedManifest,
+        pendingProjectPaths,
+      })
+    ) {
+      await deleteLocalProjectRealization(candidate.projectPath)
+      continue
+    }
+
+    await detachLocalProjectRealization(candidate.projectPath)
+  }
+
+  await refreshPendingCount()
 }
 
 async function cloneRemoteProjectToLocal(
@@ -1128,9 +1324,19 @@ export async function ensureCloudProjectLocallySynced(
       normalizePathForSync(nextMetadata.localProjectPath) !==
         normalizePathForSync(metadataBeforeDirectorySync.localProjectPath)
     ) {
+      await cleanupDuplicateLocalRealizationsForRemoteProject({
+        remoteProjectId: projectId,
+        projectDirectory,
+        keepProjectPath: nextMetadata.localProjectPath,
+      })
       scheduleSync(0)
       return localProjectFromMetadata(nextMetadata)
     }
+    await cleanupDuplicateLocalRealizationsForRemoteProject({
+      remoteProjectId: projectId,
+      projectDirectory,
+      keepProjectPath: knownLocalMetadata.localProjectPath,
+    })
     scheduleSync(0)
     return localProjectFromMetadata(knownLocalMetadata)
   }
@@ -1162,6 +1368,11 @@ export async function ensureCloudProjectLocallySynced(
       metadata: nextMetadata,
       title: await readLocalProjectTitle(nextMetadata.localProjectPath),
       pendingProjectPaths: new Set(),
+    })
+    await cleanupDuplicateLocalRealizationsForRemoteProject({
+      remoteProjectId: projectId,
+      projectDirectory,
+      keepProjectPath: nextMetadata.localProjectPath,
     })
     scheduleSync(0)
     return localProjectFromMetadata(nextMetadata)
@@ -1260,8 +1471,7 @@ export async function deleteRemoteCloudProject(
 
   for (const metadata of await getAllProjectMetadata()) {
     if (metadata.remoteProjectId === projectId) {
-      await clearOutboxEntriesForProject(metadata.localProjectPath)
-      await deleteProjectMetadata(metadata.localProjectPath)
+      await detachLocalProjectRealization(metadata.localProjectPath)
     }
   }
 
@@ -2354,6 +2564,15 @@ async function syncRemoteIndex() {
           }
           upsertMetadata(indexedMetadata)
         }
+        const deletedDuplicateProjectPaths =
+          await cleanupDuplicateLocalRealizationsForRemoteProject({
+            remoteProjectId: remoteProject.id,
+            projectDirectory,
+            keepProjectPath: nextLocalMetadata.localProjectPath,
+          })
+        for (const deletedProjectPath of deletedDuplicateProjectPaths) {
+          removeMetadata(deletedProjectPath)
+        }
         continue
       }
 
@@ -2393,6 +2612,15 @@ async function syncRemoteIndex() {
           (await getProjectMetadata(nextMetadata.localProjectPath))
         if (nextSyncedMetadata) {
           upsertMetadata(nextSyncedMetadata)
+          const deletedDuplicateProjectPaths =
+            await cleanupDuplicateLocalRealizationsForRemoteProject({
+              remoteProjectId: remoteProject.id,
+              projectDirectory,
+              keepProjectPath: nextSyncedMetadata.localProjectPath,
+            })
+          for (const deletedProjectPath of deletedDuplicateProjectPaths) {
+            removeMetadata(deletedProjectPath)
+          }
         }
       }
     } catch (error) {

--- a/src/lib/cloudSync/localProjectNames.spec.ts
+++ b/src/lib/cloudSync/localProjectNames.spec.ts
@@ -2,10 +2,16 @@ import 'fake-indexeddb/auto'
 import {
   configureCloudSyncEngine,
   configureCloudSyncLocalFileSystem,
+  deleteCloudSyncLocalProjectRealizations,
   ensureCloudProjectLocallySynced,
   getCloudSyncProjectMetadata,
   scheduleCloudProjectDirectoryNameSyncFromTitles,
 } from '@src/lib/cloudSync'
+import {
+  normalizeProjectArchiveFilesForCloudSync,
+  projectManifestFromFiles,
+} from '@src/lib/cloudSync/projectArchive'
+import type { ProjectArchiveFile } from '@src/lib/cloudSync/types'
 import {
   getAllOutboxEntries,
   putProjectMetadata,
@@ -37,6 +43,8 @@ const remoteProjectTitle = 'Café Bracket / v2'
 const expectedProjectName = 'cafe-bracket-v2'
 const idProjectPath = `${projectDirectory}/${remoteProjectId}`
 const titleProjectPath = `${projectDirectory}/${expectedProjectName}`
+const duplicateTitleProjectPath = `${projectDirectory}/${expectedProjectName}-2`
+const dirtyTitleProjectPath = `${projectDirectory}/${expectedProjectName}-dirty`
 const remoteProjectUrl = `${baseUrl}/user/projects/${remoteProjectId}`
 const remoteProjectDownloadUrl = `${remoteProjectUrl}/download?format=zip`
 
@@ -49,7 +57,13 @@ function installFetchMock() {
     const method = getFetchMethod(input, init)
 
     if (url === `${baseUrl}/user/projects` && method === 'GET') {
-      return jsonResponse([])
+      return jsonResponse([
+        {
+          id: remoteProjectId,
+          title: remoteProjectTitle,
+          revision: 'rev-1',
+        },
+      ])
     }
     if (url === remoteProjectUrl && method === 'GET') {
       return jsonResponse({
@@ -95,12 +109,54 @@ function createIdBasedCloudProjectFiles() {
   ])
 }
 
+function cloudProjectToml() {
+  return `title = "${remoteProjectTitle}"\n\n[cloud."dev.zoo.dev"]\nproject_id = "${remoteProjectId}"\n`
+}
+
+function cloudProjectArchiveFiles(mainKcl = 'x = 1'): ProjectArchiveFile[] {
+  const encoder = new TextEncoder()
+  return normalizeProjectArchiveFilesForCloudSync([
+    {
+      relativePath: 'main.kcl',
+      data: encoder.encode(mainKcl),
+    },
+    {
+      relativePath: PROJECT_SETTINGS_FILE_NAME,
+      data: encoder.encode(cloudProjectToml()),
+    },
+  ])
+}
+
+function addCloudProjectFiles(
+  files: Map<string, string>,
+  projectPath: string,
+  mainKcl = 'x = 1'
+) {
+  files.set(`${projectPath}/main.kcl`, mainKcl)
+  files.set(`${projectPath}/${PROJECT_SETTINGS_FILE_NAME}`, cloudProjectToml())
+}
+
+async function cleanCloudProjectManifest() {
+  return projectManifestFromFiles(cloudProjectArchiveFiles())
+}
+
 async function seedIdBasedCloudProjectMetadata() {
   await putProjectMetadata({
     schemaVersion: 1,
     localProjectPath: idProjectPath,
     projectName: remoteProjectId,
     remoteProjectId,
+  })
+}
+
+async function seedCleanTitleCloudProjectMetadata() {
+  await putProjectMetadata({
+    schemaVersion: 1,
+    localProjectPath: titleProjectPath,
+    projectName: expectedProjectName,
+    remoteProjectId,
+    remoteRevision: 'rev-1',
+    baseManifest: await cleanCloudProjectManifest(),
   })
 }
 
@@ -182,6 +238,69 @@ describe('cloud sync local project names', () => {
     })
     expect(await getAllOutboxEntries()).toEqual([])
     expect(onProjectDirectoriesRenamed).toHaveBeenCalledTimes(1)
+  })
+
+  it('removes exact duplicate local realizations when syncing a known clean cloud project', async () => {
+    const files = new Map<string, string>()
+    addCloudProjectFiles(files, titleProjectPath)
+    addCloudProjectFiles(files, duplicateTitleProjectPath)
+    configureCloudSyncTestFs(files)
+    await seedCleanTitleCloudProjectMetadata()
+
+    await expect(
+      ensureCloudProjectLocallySynced(remoteProjectId, projectDirectory)
+    ).resolves.toMatchObject({
+      projectPath: titleProjectPath,
+      projectName: expectedProjectName,
+      remoteProjectId,
+    })
+
+    expect(files.get(`${titleProjectPath}/main.kcl`)).toBe('x = 1')
+    expect(files.has(`${duplicateTitleProjectPath}/main.kcl`)).toBe(false)
+    expect(await getCloudSyncProjectMetadata(titleProjectPath)).toMatchObject({
+      localProjectPath: titleProjectPath,
+      remoteProjectId,
+    })
+    expect(
+      await getCloudSyncProjectMetadata(duplicateTitleProjectPath)
+    ).toBeUndefined()
+  })
+
+  it('deletes selected and exact duplicate local realizations while detaching divergent copies', async () => {
+    const files = new Map<string, string>()
+    addCloudProjectFiles(files, titleProjectPath)
+    addCloudProjectFiles(files, duplicateTitleProjectPath)
+    addCloudProjectFiles(files, dirtyTitleProjectPath, 'x = 2')
+    configureCloudSyncTestFs(files)
+    await seedCleanTitleCloudProjectMetadata()
+    await putProjectMetadata({
+      schemaVersion: 1,
+      localProjectPath: dirtyTitleProjectPath,
+      projectName: `${expectedProjectName}-dirty`,
+      remoteProjectId,
+      remoteRevision: 'rev-1',
+      baseManifest: await cleanCloudProjectManifest(),
+    })
+
+    await deleteCloudSyncLocalProjectRealizations(
+      remoteProjectId,
+      titleProjectPath
+    )
+
+    expect(files.has(`${titleProjectPath}/main.kcl`)).toBe(false)
+    expect(files.has(`${duplicateTitleProjectPath}/main.kcl`)).toBe(false)
+    expect(files.get(`${dirtyTitleProjectPath}/main.kcl`)).toBe('x = 2')
+    expect(
+      files.get(`${dirtyTitleProjectPath}/${PROJECT_SETTINGS_FILE_NAME}`)
+    ).not.toContain(`project_id = "${remoteProjectId}"`)
+    expect(await getCloudSyncProjectMetadata(titleProjectPath)).toBeUndefined()
+    expect(
+      await getCloudSyncProjectMetadata(duplicateTitleProjectPath)
+    ).toBeUndefined()
+    expect(
+      await getCloudSyncProjectMetadata(dirtyTitleProjectPath)
+    ).toBeUndefined()
+    expect(await getAllOutboxEntries()).toEqual([])
   })
 
   it('leaves data and metadata in place when a cloud project directory rename fails', async () => {

--- a/src/lib/cloudSync/registry/contract.ts
+++ b/src/lib/cloudSync/registry/contract.ts
@@ -34,6 +34,15 @@ export type CloudSyncRegistryService = {
    */
   deleteRemoteProject: (remoteProjectId: string) => Promise<void>
   /**
+   * Remove the selected local materialization of a cloud project plus exact
+   * duplicate local copies. Divergent local copies are detached from the cloud
+   * project instead of being silently deleted.
+   */
+  deleteLocalProjectRealizations: (
+    remoteProjectId: string,
+    selectedProjectPath: string
+  ) => Promise<void>
+  /**
    * Materialize a remote cloud project into the local library directory the
    * caller is opening it from. `targetProjectDirectoryPath` is the resolved
    * local path of that library; when omitted the engine falls back to the

--- a/src/lib/cloudSync/registry/extension.test.ts
+++ b/src/lib/cloudSync/registry/extension.test.ts
@@ -23,6 +23,7 @@ const cloudSyncMocks = vi.hoisted(() => ({
 vi.mock('@src/lib/cloudSync', () => ({
   cloudSyncStatus: cloudSyncMocks.cloudSyncStatus,
   configureCloudSync: cloudSyncMocks.configureCloudSync,
+  deleteCloudSyncLocalProjectRealizations: vi.fn(),
   deleteRemoteCloudProject: vi.fn(),
   ensureCloudProjectLocallySynced: vi.fn(),
   startCloudSyncProject: vi.fn(),

--- a/src/lib/cloudSync/registry/extension.ts
+++ b/src/lib/cloudSync/registry/extension.ts
@@ -7,6 +7,7 @@ import { effect, signal, untracked } from '@preact/signals-core'
 import {
   cloudSyncStatus,
   configureCloudSync,
+  deleteCloudSyncLocalProjectRealizations,
   deleteRemoteCloudProject,
   disconnectCloudSyncProject,
   ensureCloudProjectLocallySynced,
@@ -76,6 +77,7 @@ export const cloudSyncExtension = defineRegistryItemFactory((ctx) => {
     startProjectSync: startCloudSyncProject,
     disconnectProjectSync: disconnectCloudSyncProject,
     deleteRemoteProject: deleteRemoteCloudProject,
+    deleteLocalProjectRealizations: deleteCloudSyncLocalProjectRealizations,
     ensureProjectLocallySynced: ensureCloudProjectLocallySynced,
     getProjectMetadata: getCloudSyncProjectMetadata,
     getProjectMetadataIndex: getCloudSyncProjectMetadataIndex,

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -122,6 +122,7 @@ function createCloudSyncService(): CloudSyncRegistryService {
     startProjectSync: vi.fn().mockResolvedValue(undefined),
     disconnectProjectSync: vi.fn().mockResolvedValue(undefined),
     deleteRemoteProject: vi.fn().mockResolvedValue(undefined),
+    deleteLocalProjectRealizations: vi.fn().mockResolvedValue(undefined),
     ensureProjectLocallySynced: vi.fn().mockResolvedValue(undefined),
     getRemoteProjectThumbnailUrl: vi.fn().mockResolvedValue(undefined),
     getProjectMetadata: vi.fn().mockResolvedValue(undefined),
@@ -512,9 +513,6 @@ describe('cloud sync project library', () => {
       pendingCount: 0,
     }
     const cloudSync = createCloudSyncService()
-    const removeProjectDirectory = vi
-      .spyOn(fsZds, 'rm')
-      .mockResolvedValue(undefined)
     const registry = new Registry()
     const cloudSyncServiceExtension = defineRegistryItem({
       id: 'test-cloud-sync-service',
@@ -553,11 +551,15 @@ describe('cloud sync project library', () => {
         },
       })
 
-      expect(removeProjectDirectory).toHaveBeenCalledWith('/cloud/bracket', {
-        recursive: true,
-      })
+      expect(cloudSync.deleteLocalProjectRealizations).toHaveBeenCalledWith(
+        'remote-123',
+        '/cloud/bracket'
+      )
       expect(cloudSync.deleteRemoteProject).toHaveBeenCalledWith('remote-123')
-      expect(removeProjectDirectory.mock.invocationCallOrder[0]).toBeLessThan(
+      expect(
+        vi.mocked(cloudSync.deleteLocalProjectRealizations).mock
+          .invocationCallOrder[0]
+      ).toBeLessThan(
         vi.mocked(cloudSync.deleteRemoteProject).mock.invocationCallOrder[0]
       )
     } finally {
@@ -615,6 +617,7 @@ describe('cloud sync project library', () => {
       ).rejects.toThrow('Cloud sync is not enabled.')
 
       expect(removeProjectDirectory).not.toHaveBeenCalled()
+      expect(cloudSync.deleteLocalProjectRealizations).not.toHaveBeenCalled()
       expect(cloudSync.deleteRemoteProject).not.toHaveBeenCalled()
     } finally {
       registry[Symbol.dispose]()

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -927,7 +927,14 @@ export const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
           }
 
           if (project.localProjectPath && project.readWriteAccess) {
-            await fsZds.rm(project.localProjectPath, { recursive: true })
+            if (remoteProjectId) {
+              await cloudSyncActions?.deleteLocalProjectRealizations(
+                remoteProjectId,
+                project.localProjectPath
+              )
+            } else {
+              await fsZds.rm(project.localProjectPath, { recursive: true })
+            }
             // Cloud-backed deletes are explicit local + remote product
             // actions, not just local tombstones for background sync.
             if (remoteProjectId) {


### PR DESCRIPTION
## Summary
- Add cloud sync engine cleanup for duplicate local materializations that point at the same `remoteProjectId`.
- Opportunistically remove exact clean duplicate local folders when a clean representative is known during local materialization or remote index sync.
- Route Personal Cloud delete through the engine so a coalesced cloud project delete removes the selected local realization plus exact duplicates; divergent local copies are preserved and detached from the deleted cloud project.
- Detach surviving local metadata/project.toml references when the remote project is deleted so preserved folders do not rebind to a stale remote id.

## Root Cause
Home coalesces local and remote project contributions by cloud project id. That makes duplicate local folders for the same cloud project appear as a single card. Deleting the visible card removed only the current representative, so the next hidden local folder with the same cloud id became visible afterward.

## User Impact
Deleting a coalesced Personal Cloud project no longer reveals a decrementing sequence of duplicate local folders. Clean duplicates are cleaned up automatically; divergent copies are kept as local-only data instead of being silently deleted.

## Validation
- `npm run test:integration -- src/lib/cloudSync/localProjectNames.spec.ts src/lib/cloudSync/registry/plugin.spec.tsx src/lib/cloudSync/renameDeleteRemote.spec.ts`
- `npm run tsc -- --noEmit`
- `npx biome check --formatter-enabled=true --linter-enabled=false --assist-enabled=false --files-ignore-unknown=true src/lib/cloudSync/engine.ts src/lib/cloudSync/localProjectNames.spec.ts src/lib/cloudSync/registry/contract.ts src/lib/cloudSync/registry/extension.ts src/lib/cloudSync/registry/plugin.tsx src/lib/cloudSync/registry/plugin.spec.tsx src/lib/cloudSync/renameDeleteRemote.spec.ts`