### PR TITLE
Clear sketch selection after tool completion

### DIFF
--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -75,6 +75,7 @@ After reviewing, tell the human what should be smoke tested and whether the PR's
 ## Tests
 
 - Unit tests use `*.test.ts` or `*.test.tsx` and run with `npm run test:unit`.
+- Never import `wasm-lib` in unit tests.
 - Integration tests use `*.spec.ts` or `*.spec.tsx` and run with `npm run test:integration`.
 - Prefer targeted Vitest runs while iterating, for example `npm run test:unit -- src/path/to/file.spec.tsx`.
 - Component tests should prefer user-visible queries (`screen.getByRole`, `screen.getByText`) when practical. `data-testid` is fine for controls or generated content without a stable accessible label.

--- a/src/machines/sketchSolve/sketchSolveDiagram.spec.ts
+++ b/src/machines/sketchSolve/sketchSolveDiagram.spec.ts
@@ -1,0 +1,124 @@
+import { SKETCH_SOLVE_GROUP } from '@src/clientSideScene/sceneUtils'
+import type { KclManager } from '@src/lang/KclManager'
+import { Themes } from '@src/lib/theme'
+import { sketchSolveMachine } from '@src/machines/sketchSolve/sketchSolveDiagram'
+import { CHILD_TOOL_DONE_EVENT } from '@src/machines/sketchSolve/sketchSolveImpl'
+import {
+  createMockRustContext,
+  createSceneGraphDelta,
+} from '@src/machines/sketchSolve/tools/sketchToolTestUtils'
+import { Group } from 'three'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createActor } from 'xstate'
+
+const startedActors: Array<{ stop: () => void }> = []
+
+afterEach(() => {
+  for (const actor of startedActors) {
+    actor.stop()
+  }
+  startedActors.length = 0
+  vi.restoreAllMocks()
+})
+
+function createSketchSolveHarness() {
+  const scene = new Group()
+  const sketchSolveGroup = new Group()
+  sketchSolveGroup.name = SKETCH_SOLVE_GROUP
+  scene.add(sketchSolveGroup)
+
+  const sceneInfra = {
+    scene,
+    setCallbacks: vi.fn(),
+    setOnBeforeRender: vi.fn(),
+    getClientSceneScaleFactor: vi.fn(() => 1),
+    getPlaneIntersectPoint: vi.fn(() => null),
+    isAreaSelectActive: false,
+    theme: Themes.Light,
+  }
+  const rustContext = createMockRustContext()
+  const kclManager = {
+    code: 'sketch001 = startSketchOn(XY)',
+    editorView: {
+      dispatch: vi.fn(),
+    },
+    fileSettings: {
+      defaultLengthUnit: 'Mm',
+    },
+    sceneInfra,
+    sceneEntitiesManager: {
+      initSketchSolveEntityOrientation: vi.fn(),
+    },
+    rustContext,
+    setHighlightRange: vi.fn(),
+    setSketchSolveDiagnostics: vi.fn(),
+    syncSketchSolveOutcome: vi.fn(),
+    updateCodeEditor: vi.fn(),
+    wasmInstancePromise: Promise.resolve({}),
+    systemDeps: {
+      settings: {},
+    },
+  }
+
+  const actor = createActor(
+    sketchSolveMachine.provide({
+      actions: {
+        'send tool equipped to parent': () => {},
+        'send tool unequipped to parent': () => {},
+      },
+    }),
+    {
+      input: {
+        kclManager: kclManager as unknown as KclManager,
+        initialSketchSolvePlane: null,
+        sketchId: 0,
+        initialSceneGraphDelta: createSceneGraphDelta([]),
+      },
+    }
+  ).start()
+  startedActors.push(actor)
+
+  return { actor }
+}
+
+describe('sketchSolveMachine selection clearing', () => {
+  it('clears the selection when an equipped child tool completes', () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    const { actor } = createSketchSolveHarness()
+
+    actor.send({ type: 'equip tool', data: { tool: 'dimensionTool' } })
+    expect(actor.getSnapshot().matches('using tool')).toBe(true)
+
+    actor.send({
+      type: 'update selected ids',
+      data: { selectedIds: [10], duringAreaSelectIds: [11] },
+    })
+    expect(actor.getSnapshot().context.selectedIds).toEqual([10])
+    expect(actor.getSnapshot().context.duringAreaSelectIds).toEqual([11])
+
+    actor.send({ type: CHILD_TOOL_DONE_EVENT })
+
+    expect(actor.getSnapshot().matches('move and select')).toBe(true)
+    expect(actor.getSnapshot().context.selectedIds).toEqual([])
+    expect(actor.getSnapshot().context.duringAreaSelectIds).toEqual([])
+  })
+
+  it('clears the selection when constraint editing stops', () => {
+    const { actor } = createSketchSolveHarness()
+
+    actor.send({
+      type: 'update selected ids',
+      data: { selectedIds: [12], duringAreaSelectIds: [13] },
+    })
+    actor.send({
+      type: 'start editing constraint',
+      data: { constraintId: 12 },
+    })
+
+    actor.send({ type: 'stop editing constraint' })
+
+    expect(actor.getSnapshot().context.editingConstraintId).toBeUndefined()
+    expect(actor.getSnapshot().context.selectedIds).toEqual([])
+    expect(actor.getSnapshot().context.duringAreaSelectIds).toEqual([])
+  })
+})

--- a/src/machines/sketchSolve/sketchSolveDiagram.test.ts
+++ b/src/machines/sketchSolve/sketchSolveDiagram.test.ts
@@ -1,7 +1,4 @@
 import type { ApiObject } from '@rust/kcl-lib/bindings/FrontendApi'
-import { SKETCH_SOLVE_GROUP } from '@src/clientSideScene/sceneUtils'
-import type { KclManager } from '@src/lang/KclManager'
-import { Themes } from '@src/lib/theme'
 import {
   buildAngleConstraintInput,
   buildCircularSizeDimensionConstraintInput,
@@ -11,19 +8,13 @@ import {
   buildSymmetricConstraintInputWithExplicitAxis,
   buildTangentConstraintInput,
 } from '@src/machines/sketchSolve/constraints/constraintUtils'
-import { sketchSolveMachine } from '@src/machines/sketchSolve/sketchSolveDiagram'
-import { CHILD_TOOL_DONE_EVENT } from '@src/machines/sketchSolve/sketchSolveImpl'
 import {
   createArcApiObject,
   createCircleApiObject,
   createLineApiObject,
-  createMockRustContext,
   createPointApiObject,
-  createSceneGraphDelta,
 } from '@src/machines/sketchSolve/tools/sketchToolTestUtils'
-import { Group } from 'three'
-import { afterEach, describe, expect, it, vi } from 'vitest'
-import { createActor } from 'xstate'
+import { describe, expect, it } from 'vitest'
 
 function createObjectsArray(objects: ApiObject[]) {
   const array: ApiObject[] = []
@@ -32,118 +23,6 @@ function createObjectsArray(objects: ApiObject[]) {
   }
   return array
 }
-
-const startedActors: Array<{ stop: () => void }> = []
-
-afterEach(() => {
-  for (const actor of startedActors) {
-    actor.stop()
-  }
-  startedActors.length = 0
-  vi.restoreAllMocks()
-})
-
-function createSketchSolveHarness() {
-  const scene = new Group()
-  const sketchSolveGroup = new Group()
-  sketchSolveGroup.name = SKETCH_SOLVE_GROUP
-  scene.add(sketchSolveGroup)
-
-  const sceneInfra = {
-    scene,
-    setCallbacks: vi.fn(),
-    setOnBeforeRender: vi.fn(),
-    getClientSceneScaleFactor: vi.fn(() => 1),
-    getPlaneIntersectPoint: vi.fn(() => null),
-    isAreaSelectActive: false,
-    theme: Themes.Light,
-  }
-  const rustContext = createMockRustContext()
-  const kclManager = {
-    code: 'sketch001 = startSketchOn(XY)',
-    editorView: {
-      dispatch: vi.fn(),
-    },
-    fileSettings: {
-      defaultLengthUnit: 'Mm',
-    },
-    sceneInfra,
-    sceneEntitiesManager: {
-      initSketchSolveEntityOrientation: vi.fn(),
-    },
-    rustContext,
-    setHighlightRange: vi.fn(),
-    setSketchSolveDiagnostics: vi.fn(),
-    syncSketchSolveOutcome: vi.fn(),
-    updateCodeEditor: vi.fn(),
-    wasmInstancePromise: Promise.resolve({}),
-    systemDeps: {
-      settings: {},
-    },
-  }
-
-  const actor = createActor(
-    sketchSolveMachine.provide({
-      actions: {
-        'send tool equipped to parent': () => {},
-        'send tool unequipped to parent': () => {},
-      },
-    }),
-    {
-      input: {
-        kclManager: kclManager as unknown as KclManager,
-        initialSketchSolvePlane: null,
-        sketchId: 0,
-        initialSceneGraphDelta: createSceneGraphDelta([]),
-      },
-    }
-  ).start()
-  startedActors.push(actor)
-
-  return { actor }
-}
-
-describe('sketchSolveMachine selection clearing', () => {
-  it('clears the selection when an equipped child tool completes', () => {
-    vi.spyOn(console, 'log').mockImplementation(() => undefined)
-    const { actor } = createSketchSolveHarness()
-
-    actor.send({ type: 'equip tool', data: { tool: 'dimensionTool' } })
-    expect(actor.getSnapshot().matches('using tool')).toBe(true)
-
-    actor.send({
-      type: 'update selected ids',
-      data: { selectedIds: [10], duringAreaSelectIds: [11] },
-    })
-    expect(actor.getSnapshot().context.selectedIds).toEqual([10])
-    expect(actor.getSnapshot().context.duringAreaSelectIds).toEqual([11])
-
-    actor.send({ type: CHILD_TOOL_DONE_EVENT })
-
-    expect(actor.getSnapshot().matches('move and select')).toBe(true)
-    expect(actor.getSnapshot().context.selectedIds).toEqual([])
-    expect(actor.getSnapshot().context.duringAreaSelectIds).toEqual([])
-  })
-
-  it('clears the selection when constraint editing stops', () => {
-    const { actor } = createSketchSolveHarness()
-
-    actor.send({
-      type: 'update selected ids',
-      data: { selectedIds: [12], duringAreaSelectIds: [13] },
-    })
-    actor.send({
-      type: 'start editing constraint',
-      data: { constraintId: 12 },
-    })
-
-    actor.send({ type: 'stop editing constraint' })
-
-    expect(actor.getSnapshot().context.editingConstraintId).toBeUndefined()
-    expect(actor.getSnapshot().context.selectedIds).toEqual([])
-    expect(actor.getSnapshot().context.duringAreaSelectIds).toEqual([])
-  })
-})
 
 describe('buildAngleConstraintInput', () => {
   it('builds a 45deg angle constraint for lines (0,0)->(0,10) and (0,0)->(10,10)', () => {

--- a/src/machines/sketchSolve/sketchSolveDiagram.test.ts
+++ b/src/machines/sketchSolve/sketchSolveDiagram.test.ts
@@ -1,4 +1,7 @@
 import type { ApiObject } from '@rust/kcl-lib/bindings/FrontendApi'
+import { SKETCH_SOLVE_GROUP } from '@src/clientSideScene/sceneUtils'
+import type { KclManager } from '@src/lang/KclManager'
+import { Themes } from '@src/lib/theme'
 import {
   buildAngleConstraintInput,
   buildCircularSizeDimensionConstraintInput,
@@ -8,13 +11,19 @@ import {
   buildSymmetricConstraintInputWithExplicitAxis,
   buildTangentConstraintInput,
 } from '@src/machines/sketchSolve/constraints/constraintUtils'
+import { sketchSolveMachine } from '@src/machines/sketchSolve/sketchSolveDiagram'
+import { CHILD_TOOL_DONE_EVENT } from '@src/machines/sketchSolve/sketchSolveImpl'
 import {
   createArcApiObject,
   createCircleApiObject,
   createLineApiObject,
+  createMockRustContext,
   createPointApiObject,
+  createSceneGraphDelta,
 } from '@src/machines/sketchSolve/tools/sketchToolTestUtils'
-import { describe, expect, it } from 'vitest'
+import { Group } from 'three'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createActor } from 'xstate'
 
 function createObjectsArray(objects: ApiObject[]) {
   const array: ApiObject[] = []
@@ -23,6 +32,118 @@ function createObjectsArray(objects: ApiObject[]) {
   }
   return array
 }
+
+const startedActors: Array<{ stop: () => void }> = []
+
+afterEach(() => {
+  for (const actor of startedActors) {
+    actor.stop()
+  }
+  startedActors.length = 0
+  vi.restoreAllMocks()
+})
+
+function createSketchSolveHarness() {
+  const scene = new Group()
+  const sketchSolveGroup = new Group()
+  sketchSolveGroup.name = SKETCH_SOLVE_GROUP
+  scene.add(sketchSolveGroup)
+
+  const sceneInfra = {
+    scene,
+    setCallbacks: vi.fn(),
+    setOnBeforeRender: vi.fn(),
+    getClientSceneScaleFactor: vi.fn(() => 1),
+    getPlaneIntersectPoint: vi.fn(() => null),
+    isAreaSelectActive: false,
+    theme: Themes.Light,
+  }
+  const rustContext = createMockRustContext()
+  const kclManager = {
+    code: 'sketch001 = startSketchOn(XY)',
+    editorView: {
+      dispatch: vi.fn(),
+    },
+    fileSettings: {
+      defaultLengthUnit: 'Mm',
+    },
+    sceneInfra,
+    sceneEntitiesManager: {
+      initSketchSolveEntityOrientation: vi.fn(),
+    },
+    rustContext,
+    setHighlightRange: vi.fn(),
+    setSketchSolveDiagnostics: vi.fn(),
+    syncSketchSolveOutcome: vi.fn(),
+    updateCodeEditor: vi.fn(),
+    wasmInstancePromise: Promise.resolve({}),
+    systemDeps: {
+      settings: {},
+    },
+  }
+
+  const actor = createActor(
+    sketchSolveMachine.provide({
+      actions: {
+        'send tool equipped to parent': () => {},
+        'send tool unequipped to parent': () => {},
+      },
+    }),
+    {
+      input: {
+        kclManager: kclManager as unknown as KclManager,
+        initialSketchSolvePlane: null,
+        sketchId: 0,
+        initialSceneGraphDelta: createSceneGraphDelta([]),
+      },
+    }
+  ).start()
+  startedActors.push(actor)
+
+  return { actor }
+}
+
+describe('sketchSolveMachine selection clearing', () => {
+  it('clears the selection when an equipped child tool completes', () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    const { actor } = createSketchSolveHarness()
+
+    actor.send({ type: 'equip tool', data: { tool: 'dimensionTool' } })
+    expect(actor.getSnapshot().matches('using tool')).toBe(true)
+
+    actor.send({
+      type: 'update selected ids',
+      data: { selectedIds: [10], duringAreaSelectIds: [11] },
+    })
+    expect(actor.getSnapshot().context.selectedIds).toEqual([10])
+    expect(actor.getSnapshot().context.duringAreaSelectIds).toEqual([11])
+
+    actor.send({ type: CHILD_TOOL_DONE_EVENT })
+
+    expect(actor.getSnapshot().matches('move and select')).toBe(true)
+    expect(actor.getSnapshot().context.selectedIds).toEqual([])
+    expect(actor.getSnapshot().context.duringAreaSelectIds).toEqual([])
+  })
+
+  it('clears the selection when constraint editing stops', () => {
+    const { actor } = createSketchSolveHarness()
+
+    actor.send({
+      type: 'update selected ids',
+      data: { selectedIds: [12], duringAreaSelectIds: [13] },
+    })
+    actor.send({
+      type: 'start editing constraint',
+      data: { constraintId: 12 },
+    })
+
+    actor.send({ type: 'stop editing constraint' })
+
+    expect(actor.getSnapshot().context.editingConstraintId).toBeUndefined()
+    expect(actor.getSnapshot().context.selectedIds).toEqual([])
+    expect(actor.getSnapshot().context.duringAreaSelectIds).toEqual([])
+  })
+})
 
 describe('buildAngleConstraintInput', () => {
   it('builds a 45deg angle constraint for lines (0,0)->(0,10) and (0,0)->(10,10)', () => {

--- a/src/machines/sketchSolve/sketchSolveDiagram.ts
+++ b/src/machines/sketchSolve/sketchSolveDiagram.ts
@@ -29,13 +29,8 @@ import {
 } from '@src/machines/sketchSolve/constraints/constraintUtils'
 import { toastSketchSolveError } from '@src/machines/sketchSolve/sketchSolveErrors'
 import {
-  CHILD_TOOL_DONE_EVENT,
-  ORIGIN_TARGET,
-  type SketchSolveContext,
-  type SketchSolveMachineEvent,
-  type SolveActionArgs,
-  type SpawnToolActor,
   buildSegmentCtorFromObject,
+  CHILD_TOOL_DONE_EVENT,
   cleanupSketchSolveGroup,
   clearDraftEntities,
   clearHoverCallbacks,
@@ -45,8 +40,13 @@ import {
   getObjectSelectionIds,
   initializeInitialSceneGraph,
   initializeIntersectionPlane,
+  ORIGIN_TARGET,
   refreshSelectionStyling,
   refreshSketchSolveScale,
+  type SketchSolveContext,
+  type SketchSolveMachineEvent,
+  type SolveActionArgs,
+  type SpawnToolActor,
   sendToActorIfActive,
   setDraftEntities,
   spawnTool,
@@ -57,12 +57,12 @@ import {
   updateSelectedIdsFromCodeSelection,
   updateSketchOutcome,
 } from '@src/machines/sketchSolve/sketchSolveImpl'
+import { applyOrEquipConstraintToolFromToolbar } from '@src/machines/sketchSolve/tools/constraintToolbarAction'
 import { getConstraintToolPreparedApply } from '@src/machines/sketchSolve/tools/constraintToolHelpers'
 import {
   type ConstraintToolName,
   constraintToolNames,
 } from '@src/machines/sketchSolve/tools/constraintToolModel'
-import { applyOrEquipConstraintToolFromToolbar } from '@src/machines/sketchSolve/tools/constraintToolbarAction'
 import { setUpOnDragAndSelectionClickCallbacks } from '@src/machines/sketchSolve/tools/moveTool/moveTool'
 import type { ConstraintSegment } from '@src/machines/sketchSolve/types'
 import { assertEvent, assign, createMachine, sendParent, setup } from 'xstate'
@@ -397,7 +397,7 @@ export const sketchSolveMachine = setup({
     'send escape to tool': ({ context }) => {
       sendToActorIfActive(context.childTool, { type: 'escape' })
     },
-    'store pending tool': assign(({ event, system }) => {
+    'store pending tool': assign(({ event }) => {
       assertEvent(event, 'equip tool')
       return { pendingToolName: event.data.tool }
     }),
@@ -1001,6 +1001,9 @@ export const sketchSolveMachine = setup({
         assign({
           editingConstraintId: undefined,
         }),
+        'clear selection',
+        'update selected code highlight',
+        'refresh selection styling',
       ],
     },
   },
@@ -1075,7 +1078,13 @@ export const sketchSolveMachine = setup({
         },
         [CHILD_TOOL_DONE_EVENT]: {
           target: 'move and select',
-          actions: ['clear child tool', 'send tool unequipped to parent'],
+          actions: [
+            'clear selection',
+            'update selected code highlight',
+            'refresh selection styling',
+            'clear child tool',
+            'send tool unequipped to parent',
+          ],
         },
         escape: {
           // Forward escape to child tool only when tool is active
@@ -1098,7 +1107,11 @@ export const sketchSolveMachine = setup({
       on: {
         [CHILD_TOOL_DONE_EVENT]: {
           target: 'using tool',
-          actions: [],
+          actions: [
+            'clear selection',
+            'update selected code highlight',
+            'refresh selection styling',
+          ],
         },
       },
 
@@ -1145,7 +1158,7 @@ export const sketchSolveMachine = setup({
             ({ event }) => {
               toastSketchSolveError(event, 'Failed to exit sketch cleanly')
             },
-            ({ event, context, self }) => {
+            ({ self }) => {
               // Clear draft entities even on error to allow exit to continue
               sendToActorIfActive(self, { type: 'clear draft entities' })
             },
@@ -1165,7 +1178,13 @@ export const sketchSolveMachine = setup({
       on: {
         [CHILD_TOOL_DONE_EVENT]: {
           target: 'move and select',
-          actions: ['clear child tool', 'send tool unequipped to parent'],
+          actions: [
+            'clear selection',
+            'update selected code highlight',
+            'refresh selection styling',
+            'clear child tool',
+            'send tool unequipped to parent',
+          ],
         },
       },
 


### PR DESCRIPTION
## Summary

Clear sketchSolve selection state whenever a child tool completes, whether the tool finishes normally, during an explicit unequip, or while switching to another tool. Also clear selection when constraint editing stops so editing a dimension value leaves the sketch in the same deselected state as other completed operations.

## Why

Tool completion paths were inconsistent: toolbar constraint operations generally cleared selection, but child tool completion and dimension-value edits could leave the previous sketch selection active. That made subsequent sketch actions operate on stale-looking selections.

Basically, make sure this UX can't happen anymore:

https://github.com/user-attachments/assets/0a059831-4fa9-40d0-9231-f70b48a55c1d

The machine-level regression coverage now lives in an integration spec instead of a unit test because importing `sketchSolveMachine` pulls in Wasm-backed tool modules. `src/AGENTS.md` now also documents that unit tests must not import `wasm-lib`.

## Validation

- `npx biome check src/AGENTS.md src/machines/sketchSolve/sketchSolveDiagram.ts src/machines/sketchSolve/sketchSolveDiagram.test.ts src/machines/sketchSolve/sketchSolveDiagram.spec.ts`
- `npx vitest run --mode=development --project=unit src/machines/sketchSolve/sketchSolveDiagram.test.ts`
- `npx vitest run --mode=development --project=integration src/machines/sketchSolve/sketchSolveDiagram.spec.ts`
- `npx vitest run --mode=development --project=unit src/machines/sketchSolve`
- `npm run tsc -- --noEmit` currently fails on unrelated `src/machines/modelingMachine.ts:3442` because `primitiveFace` is not a known `ApiPlane` property

Note: the broader `npx vitest run --mode=development --project=integration src/machines/sketchSolve` command previously printed pass lines for all sketchSolve integration/spec files but did not exit after teardown; I interrupted it after it remained running with no new output.