### PR TITLE
Materialize cloud project default file

### DIFF
--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -924,6 +924,20 @@ async function collectLocalProjectFiles(projectRoot: string) {
   )
 }
 
+function getRemoteProjectEntrypointPath(remoteProject: RemoteProject) {
+  const candidates = [
+    remoteProject.entrypoint_path,
+    remoteProject.entrypointPath,
+    remoteProject.entrypoint,
+  ]
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim()) {
+      return normalizeRelativePath(candidate)
+    }
+  }
+  return undefined
+}
+
 async function replaceLocalProjectWithFiles(
   projectPath: string,
   files: ProjectArchiveFile[]
@@ -1257,7 +1271,8 @@ async function cloneRemoteProjectToLocal(
       await parseProjectArchive(archive),
       remoteProject.title,
       remoteProject.id,
-      getEnvironmentName()
+      getEnvironmentName(),
+      getRemoteProjectEntrypointPath(remoteProject)
     )
   )
   const nextMetadata = {
@@ -1424,7 +1439,8 @@ export async function renameRemoteCloudProject(
     ),
     title,
     projectId,
-    getEnvironmentName()
+    getEnvironmentName(),
+    getRemoteProjectEntrypointPath(remoteProject)
   )
   const updated = await updateRemoteProject({
     config,
@@ -2337,7 +2353,8 @@ async function syncProject(projectPath: string, entries: OutboxEntry[]) {
         await parseProjectArchive(remoteArchive),
         remoteProject.title,
         remoteProjectId,
-        getEnvironmentName()
+        getEnvironmentName(),
+        getRemoteProjectEntrypointPath(remoteProject)
       )
     )
     const remoteManifest = await projectManifestFromFiles(remoteFiles)

--- a/src/lib/cloudSync/index.test.ts
+++ b/src/lib/cloudSync/index.test.ts
@@ -227,6 +227,29 @@ describe('cloudSync sync helpers', () => {
     )
 
     expect(projectToml).toContain('title = "Untitled"')
+    expect(projectToml).toContain('default_file = "main.kcl"')
+    expect(projectToml).toContain('project_id = "remote-project-123"')
+  })
+
+  it('adds project.toml default_file from remote entrypoint metadata', () => {
+    const files = withRemoteProjectMetadataInArchiveFiles(
+      [
+        projectFile('main.kcl'),
+        projectFile('nested/part.kcl'),
+        projectFile(PROJECT_SETTINGS_FILE_NAME, 'title = "Bracket"\n'),
+      ],
+      'Bracket',
+      'remote-project-123',
+      'dev.zoo.dev',
+      'nested/part.kcl'
+    )
+    const projectToml = new TextDecoder().decode(
+      files.find((file) => file.relativePath === PROJECT_SETTINGS_FILE_NAME)
+        ?.data
+    )
+
+    expect(projectToml).toContain('title = "Bracket"')
+    expect(projectToml).toContain('default_file = "nested/part.kcl"')
     expect(projectToml).toContain('project_id = "remote-project-123"')
   })
 

--- a/src/lib/cloudSync/projectArchive.ts
+++ b/src/lib/cloudSync/projectArchive.ts
@@ -12,9 +12,11 @@ import {
 import opfs from '@src/lib/fs-zds/opfs'
 import { webSafePathSplit } from '@src/lib/pathUtils'
 import {
+  getProjectDefaultFileFromProjectTomlContents,
   getProjectTitleFromProjectTomlContents,
   normalizeProjectTomlContents,
   setCloudProjectIdInProjectTomlContents,
+  setProjectDefaultFileInProjectTomlContents,
   setProjectTitleInProjectTomlContents,
 } from '@src/lib/projectTomlMetadata'
 import { isArray } from '@src/lib/utils'
@@ -131,7 +133,17 @@ function getProjectTomlTitle(files: ProjectArchiveFile[]) {
   )
 }
 
-function getUploadEntrypointPath(files: ProjectArchiveFile[]) {
+export function getProjectArchiveEntrypointPath(
+  files: ProjectArchiveFile[],
+  preferredEntrypointPath?: string
+) {
+  const normalizedPreferredEntrypointPath = preferredEntrypointPath
+    ? normalizeRelativePath(preferredEntrypointPath)
+    : undefined
+  if (normalizedPreferredEntrypointPath) {
+    return normalizedPreferredEntrypointPath
+  }
+
   const filePaths = new Set(files.map((file) => file.relativePath))
   const projectTomlDefaultFile = getProjectTomlDefaultFile(files)
   if (projectTomlDefaultFile && filePaths.has(projectTomlDefaultFile)) {
@@ -151,6 +163,15 @@ function getUploadEntrypointPath(files: ProjectArchiveFile[]) {
     return fallbackKclFile
   }
 
+  return undefined
+}
+
+function getUploadEntrypointPath(files: ProjectArchiveFile[]) {
+  const entrypointPath = getProjectArchiveEntrypointPath(files)
+  if (entrypointPath) {
+    return entrypointPath
+  }
+
   // eslint-disable-next-line suggest-no-throw/suggest-no-throw
   throw new Error('Cloud sync needs at least one KCL file to upload a project.')
 }
@@ -163,11 +184,9 @@ function getProjectTomlDefaultFile(files: ProjectArchiveFile[]) {
     return undefined
   }
 
-  const projectToml = new TextDecoder().decode(projectTomlFile.data)
-  const defaultFile = projectToml.match(
-    /^\s*default_file\s*=\s*["']([^"']+)["']/m
-  )?.[1]
-  return defaultFile ? normalizeRelativePath(defaultFile) : undefined
+  return getProjectDefaultFileFromProjectTomlContents(
+    new TextDecoder().decode(projectTomlFile.data)
+  )
 }
 
 export function getMimeType(fileName: string) {
@@ -214,6 +233,19 @@ export function withProjectCloudProjectIdInArchiveFiles(
   )
 }
 
+export function withProjectDefaultFileInArchiveFiles(
+  files: ProjectArchiveFile[],
+  defaultFile?: string
+) {
+  if (!defaultFile) {
+    return files
+  }
+
+  return withProjectTomlArchiveFile(files, (contents) =>
+    setProjectDefaultFileInProjectTomlContents(contents, defaultFile)
+  )
+}
+
 function withProjectTomlArchiveFile(
   files: ProjectArchiveFile[],
   update: (contents: string) => string
@@ -244,15 +276,20 @@ export function withRemoteProjectMetadataInArchiveFiles(
   files: ProjectArchiveFile[],
   title: string | undefined,
   projectId: string,
-  environmentName?: string
+  environmentName?: string,
+  entrypointPath?: string
 ) {
-  return withProjectCloudProjectIdInArchiveFiles(
+  const filesWithMetadata = withProjectCloudProjectIdInArchiveFiles(
     withProjectTitleInArchiveFiles(
       files,
       getRemoteProjectTitleForProjectToml(title)
     ),
     projectId,
     environmentName
+  )
+  return withProjectDefaultFileInArchiveFiles(
+    filesWithMetadata,
+    getProjectArchiveEntrypointPath(filesWithMetadata, entrypointPath)
   )
 }
 

--- a/src/lib/projectTomlMetadata.ts
+++ b/src/lib/projectTomlMetadata.ts
@@ -36,6 +36,13 @@ const ROOT_TABLE_KEY_ORDER = ['settings', 'cloud']
 const SETTINGS_TABLE_KEY_ORDER = ['app', 'meta', 'modeling']
 const CLOUD_ENVIRONMENT_SCALAR_KEY_ORDER = ['project_id']
 
+function normalizeProjectTomlPath(path: string) {
+  return path
+    .replaceAll('\\', '/')
+    .replace(/^\/+/g, '')
+    .replace(/^(?:\.\/)+/g, '')
+}
+
 function orderedKeys(keys: string[], preferredKeys: string[]) {
   return [
     ...preferredKeys.filter((key) => keys.includes(key)),
@@ -110,6 +117,16 @@ export function normalizeProjectTomlContents(contents: string) {
   return stringifyProjectToml(table)
 }
 
+export function getProjectDefaultFileFromProjectTomlContents(contents: string) {
+  const table = parseProjectToml(contents)
+  if (!table) {
+    return undefined
+  }
+
+  const defaultFile = getNonEmptyString(table.default_file)
+  return defaultFile ? normalizeProjectTomlPath(defaultFile) : undefined
+}
+
 export function getProjectTitleFromProjectTomlContents(contents: string) {
   const table = parseProjectToml(contents)
   if (!table) {
@@ -125,6 +142,15 @@ export function setProjectTitleInProjectTomlContents(
 ) {
   const table = parseProjectToml(contents) ?? {}
   table.title = title
+  return stringifyProjectToml(table)
+}
+
+export function setProjectDefaultFileInProjectTomlContents(
+  contents: string,
+  defaultFile: string
+) {
+  const table = parseProjectToml(contents) ?? {}
+  table.default_file = normalizeProjectTomlPath(defaultFile)
   return stringifyProjectToml(table)
 }
 


### PR DESCRIPTION
## Summary

Hydrates cloud project archives with a local `project.toml` `default_file` entry when the cloud archive/backend omits it but the project entrypoint is known.

## Why

The app writes and expects `default_file` locally, while cloud uploads also send the entrypoint as API metadata. If the backend stores the entrypoint separately and returns a canonicalized `project.toml` without `default_file`, the local materialization can immediately look different from the cloud archive and contribute to widespread sync conflicts.

## Changes

- Add structured `project.toml` helpers for reading and setting `default_file`.
- Teach remote cloud archive metadata enrichment to write `default_file` using the remote entrypoint metadata when available, or the existing archive fallback (`main.kcl` / first KCL file).
- Pass remote entrypoint fields through cloud project clone, rename, and sync hydration paths.
- Add regression coverage for default-file materialization, including a nested entrypoint.

## Validation

- `npx tsc --noEmit`
- `npx vitest run src/lib/cloudSync`
- `node --require ./scripts/register-typescript-eslint-typescript.cjs ./node_modules/eslint/bin/eslint.js --max-warnings 0 src/lib/cloudSync/engine.ts src/lib/cloudSync/index.test.ts src/lib/cloudSync/projectArchive.ts src/lib/projectTomlMetadata.ts`