### PR TITLE
Fix cloud conflict dialog project scoping

### DIFF
--- a/e2e/playwright/testing-samples-loading.spec.ts
+++ b/e2e/playwright/testing-samples-loading.spec.ts
@@ -101,15 +101,25 @@ test.describe('Testing loading external models', { tag: '@desktop' }, () => {
       folderName1: 'ball-bearing-1',
     }
     const projectCard = page.getByRole('link', { name: 'bracket' })
+    const loadSampleFromToolbar = async () => {
+      await toolbar.loadButton.click()
+      await cmdBar.expectCommandName('Add file to project')
+      await expect(page.getByTestId('cmd-bar-arg-name')).toHaveText('source')
+      await expect(page.getByTestId('cmd-bar-arg-value')).toHaveAttribute(
+        'placeholder',
+        'KCL Samples'
+      )
+      await page.keyboard.press('Enter')
+      await expect(page.getByTestId('cmd-bar-arg-name')).toHaveText('sample')
+      await cmdBar.selectOption({ name: sampleOne.title }).click()
+    }
 
     await page.setBodyDimensions({ width: 1200, height: 500 })
     await projectCard.click()
     await scene.settled()
 
     await test.step('Load a KCL sample with the command palette', async () => {
-      await toolbar.loadButton.click()
-      await cmdBar.selectOption({ name: 'KCL Samples' }).click()
-      await cmdBar.selectOption({ name: sampleOne.title }).click()
+      await loadSampleFromToolbar()
     })
 
     await test.step('Ensure we made and opened a new file', async () => {
@@ -120,9 +130,7 @@ test.describe('Testing loading external models', { tag: '@desktop' }, () => {
     })
 
     await test.step('Load a KCL sample with the command palette', async () => {
-      await toolbar.loadButton.click()
-      await cmdBar.selectOption({ name: 'KCL Samples' }).click()
-      await cmdBar.selectOption({ name: sampleOne.title }).click()
+      await loadSampleFromToolbar()
     })
 
     await test.step('Ensure we made and opened a new file with a unique name', async () => {

--- a/src/lib/cloudSync/conflictScope.spec.ts
+++ b/src/lib/cloudSync/conflictScope.spec.ts
@@ -1,0 +1,182 @@
+import 'fake-indexeddb/auto'
+import {
+  cloudSyncStatus,
+  configureCloudSyncEngine,
+  configureCloudSyncLocalFileSystem,
+  getCloudSyncProjectMetadata,
+  setCloudSyncProjectScope,
+} from '@src/lib/cloudSync'
+import {
+  appendOutboxEntry,
+  putProjectMetadata,
+} from '@src/lib/cloudSync/syncDb'
+import {
+  createCloudSyncTestFs,
+  deleteCloudSyncTestDatabase,
+  getFetchMethod,
+  getFetchUrl,
+  jsonResponse,
+} from '@src/lib/cloudSync/testUtils'
+import { PROJECT_SETTINGS_FILE_NAME } from '@src/lib/constants'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const baseUrl = 'https://example.test'
+const projectDirectory = '/documents/Projects'
+const currentProjectPath = `${projectDirectory}/current`
+const otherProjectPath = `${projectDirectory}/other`
+const otherConflictProjectPath = `${projectDirectory}/other (cloud conflict)`
+const otherRemoteProjectId = 'other-remote-project'
+const otherRemoteProjectUrl = `${baseUrl}/user/projects/${otherRemoteProjectId}`
+const otherRemoteDownloadUrl = `${otherRemoteProjectUrl}/download?format=zip`
+
+const fetchMock = vi.fn<typeof fetch>()
+
+describe('cloud sync conflict scoping', () => {
+  beforeEach(async () => {
+    await deleteCloudSyncTestDatabase()
+    fetchMock.mockReset()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(async () => {
+    setCloudSyncProjectScope(undefined)
+    configureCloudSyncEngine({ enabled: false })
+    vi.unstubAllGlobals()
+    await deleteCloudSyncTestDatabase()
+  })
+
+  it('does not surface existing unrelated conflicts after entering a scoped project', async () => {
+    const files = new Map([
+      [
+        `${currentProjectPath}/${PROJECT_SETTINGS_FILE_NAME}`,
+        'title = "Current"\n',
+      ],
+      [`${otherProjectPath}/main.kcl`, 'local = 2\n'],
+      [
+        `${otherProjectPath}/${PROJECT_SETTINGS_FILE_NAME}`,
+        'title = "Other"\n',
+      ],
+      [`${otherConflictProjectPath}/main.kcl`, 'cloud = 2\n'],
+      [
+        `${otherConflictProjectPath}/${PROJECT_SETTINGS_FILE_NAME}`,
+        'title = "Other"\n',
+      ],
+    ])
+    configureCloudSyncLocalFileSystem(
+      createCloudSyncTestFs(files, { projectDirectory })
+    )
+    await putProjectMetadata({
+      schemaVersion: 1,
+      localProjectPath: otherProjectPath,
+      projectName: 'other',
+      remoteProjectId: otherRemoteProjectId,
+      remoteRevision: 'rev-1',
+      baseManifest: { files: {} },
+      conflict: {
+        conflictProjectPath: otherConflictProjectPath,
+        createdAt: '2026-07-08T12:00:00.000Z',
+        remoteRevision: 'rev-2',
+      },
+    })
+    await putProjectMetadata({
+      schemaVersion: 1,
+      localProjectPath: otherConflictProjectPath,
+      projectName: 'other (cloud conflict)',
+      remoteProjectId: otherRemoteProjectId,
+      remoteRevision: 'rev-2',
+      syncExcluded: {
+        reason: 'conflict-copy',
+        sourceProjectPath: otherProjectPath,
+        remoteProjectId: otherRemoteProjectId,
+        createdAt: '2026-07-08T12:00:00.000Z',
+      },
+    })
+    await appendOutboxEntry({
+      projectPath: otherProjectPath,
+      kind: 'upsert',
+      targetPath: `${otherProjectPath}/main.kcl`,
+      createdAt: '2026-07-08T12:01:00.000Z',
+    })
+
+    let resolveRemoteIndexStarted!: () => void
+    const remoteIndexStarted = new Promise<void>((resolve) => {
+      resolveRemoteIndexStarted = resolve
+    })
+    let finishRemoteIndex!: () => void
+    const remoteIndexResponse = new Promise<Response>((resolve) => {
+      finishRemoteIndex = () => {
+        resolve(
+          jsonResponse([
+            {
+              id: otherRemoteProjectId,
+              title: 'Other',
+              revision: 'rev-3',
+              updated_at: '2026-07-08T12:05:00.000Z',
+            },
+          ])
+        )
+      }
+    })
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = getFetchUrl(input)
+      const method = getFetchMethod(input, init)
+
+      if (url === `${baseUrl}/user/projects` && method === 'GET') {
+        resolveRemoteIndexStarted()
+        return remoteIndexResponse
+      }
+
+      if (url === otherRemoteProjectUrl && method === 'GET') {
+        return jsonResponse({
+          id: otherRemoteProjectId,
+          title: 'Other',
+          revision: 'rev-3',
+          updated_at: '2026-07-08T12:05:00.000Z',
+        })
+      }
+
+      if (url === otherRemoteDownloadUrl && method === 'GET') {
+        return jsonResponse({
+          files: [
+            { relativePath: 'main.kcl', contents: 'remote = 3\n' },
+            {
+              relativePath: PROJECT_SETTINGS_FILE_NAME,
+              contents: 'title = "Other"\n',
+            },
+          ],
+        })
+      }
+
+      return jsonResponse(
+        { message: `Unexpected fetch: ${method} ${url}` },
+        500
+      )
+    })
+
+    configureCloudSyncEngine({
+      enabled: true,
+      baseUrl,
+      environmentName: 'dev.zoo.dev',
+      projectDirectoryPath: projectDirectory,
+      syncExistingLocalProjects: false,
+    })
+    await remoteIndexStarted
+    setCloudSyncProjectScope(currentProjectPath)
+    finishRemoteIndex()
+
+    await vi.waitFor(async () => {
+      await expect(
+        getCloudSyncProjectMetadata(otherProjectPath)
+      ).resolves.toMatchObject({
+        conflict: {
+          remoteRevision: 'rev-3',
+        },
+      })
+    })
+    expect(cloudSyncStatus.value).not.toMatchObject({
+      state: 'conflict',
+      activeProjectPath: otherProjectPath,
+    })
+    expect(cloudSyncStatus.value.activeProjectPath).not.toBe(otherProjectPath)
+  })
+})

--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -1979,12 +1979,14 @@ async function markProjectConflict(
         at: createdAt,
       },
     })
-    updateStatus({
-      state: 'conflict',
-      activeProjectPath: metadata.localProjectPath,
-      lastFailure: 'Cloud sync conflict: local and remote both changed.',
-      lastFailureAt: createdAt,
-    })
+    if (projectPathMatchesSyncScope(metadata.localProjectPath)) {
+      updateStatus({
+        state: 'conflict',
+        activeProjectPath: metadata.localProjectPath,
+        lastFailure: 'Cloud sync conflict: local and remote both changed.',
+        lastFailureAt: createdAt,
+      })
+    }
     return
   }
 

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -4,17 +4,19 @@ import {
   provideService,
   Registry,
 } from '@kittycad/registry'
+import type { Feature } from '@kittycad/lib'
 import { signal } from '@preact/signals-core'
 import ProjectSidebarMenu from '@src/components/ProjectSidebarMenu'
 import type { App } from '@src/lib/app'
 import { cloudSyncRemoteProjects, cloudSyncStatus } from '@src/lib/cloudSync'
 import {
-  CloudConflictProjectMenuDialogHost,
+  CloudConflictDialogHost,
   cloudSyncPlugin,
   cloudSyncProjectLibraryType,
   getCloudSyncStatusBarPresentation,
   preserveCloudProjectDefaultFile,
 } from '@src/lib/cloudSync/registry/plugin'
+import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
 import fsZds from '@src/lib/fs-zds'
 import { homeProjectEntryFromProject } from '@src/lib/homeProjects'
 import type { Project } from '@src/lib/project'
@@ -41,20 +43,35 @@ import {
   type SettingsRegistryService,
   settingsService,
 } from '@src/registry/contracts/settings'
+import { statusBarGlobalItemsValueSpec } from '@src/registry/contracts/statusBar'
+import {
+  type UserFeaturesRegistryService,
+  userFeaturesService,
+} from '@src/registry/contracts/userFeatures'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { BrowserRouter } from 'react-router-dom'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { createActor, createMachine } from 'xstate'
 
-const cloudConflictDialogMocks: { conflict: unknown } = vi.hoisted(() => ({
-  conflict: undefined,
-}))
+const cloudConflictDialogMocks = vi.hoisted(
+  (): { conflict: unknown; dialogProjectPaths: string[] } => ({
+    conflict: undefined,
+    dialogProjectPaths: [],
+  })
+)
 
 vi.mock('@src/components/CloudConflictDialog', () => ({
-  CloudConflictDialog: () => <div data-testid="cloud-conflict-dialog" />,
+  CloudConflictDialog: ({ projectPath }: { projectPath: string }) => {
+    cloudConflictDialogMocks.dialogProjectPaths.push(projectPath)
+    return <div data-testid="cloud-conflict-dialog">{projectPath}</div>
+  },
   useCloudSyncProjectConflict: () => cloudConflictDialogMocks.conflict,
   useCloudSyncProjectConflicts: () => [],
+}))
+
+vi.mock('@src/lib/desktop', () => ({
+  writeProjectTitleToProjectToml: vi.fn().mockResolvedValue(undefined),
 }))
 
 vi.mock('react-hot-toast', () => ({
@@ -200,6 +217,23 @@ function createSettingsService({
   }
 }
 
+function createUserFeaturesService(): UserFeaturesRegistryService {
+  const context = signal({
+    featureIds: new Set([OPFS_CLOUD_FEATURE_FLAG]),
+  })
+
+  return {
+    context,
+    contextSignal: context,
+    ready: signal(true),
+    has: (featureFlagId: Feature, defaultValue: boolean) =>
+      context.value.featureIds.has(featureFlagId) ? true : defaultValue,
+    useContext: () => context.value,
+    useHas: (featureFlagId: Feature, defaultValue: boolean) =>
+      context.value.featureIds.has(featureFlagId) ? true : defaultValue,
+  } as unknown as UserFeaturesRegistryService
+}
+
 function createProjectMenuApp(cloudSync: CloudSyncRegistryService) {
   const registry = new Registry()
   const settings = createSettingsService({})
@@ -263,6 +297,7 @@ function enableCloudSyncPlugin(registry: Registry) {
 afterEach(() => {
   window.electron = originalElectron
   cloudConflictDialogMocks.conflict = undefined
+  cloudConflictDialogMocks.dialogProjectPaths = []
   cloudSyncStatus.value = {
     enabled: false,
     state: 'disabled',
@@ -291,6 +326,84 @@ describe('cloud sync status presentation', () => {
   })
 })
 
+describe('cloud sync status bar conflict dialog', () => {
+  test('keeps inspecting the clicked project when global conflict status changes', async () => {
+    cloudConflictDialogMocks.conflict = {
+      conflict: {
+        conflictProjectPath: '/projects/current (cloud conflict)',
+        remoteRevision: 'remote-rev-2',
+        createdAt: new Date(now).toISOString(),
+      },
+    }
+    cloudSyncStatus.value = {
+      enabled: true,
+      state: 'conflict',
+      pendingCount: 0,
+      activeProjectPath: '/projects/current',
+      lastFailure: 'Cloud sync conflict: local and remote both changed.',
+      lastFailureAt: new Date(now).toISOString(),
+    }
+    const registry = new Registry()
+    const settings = createSettingsService({})
+    const settingsExtension = defineRegistryItem({
+      id: 'test-settings-service',
+      providesServices: [provideService(settingsService, settings.service)],
+    })
+    const userFeaturesExtension = defineRegistryItem({
+      id: 'test-user-features-service',
+      providesServices: [
+        provideService(userFeaturesService, createUserFeaturesService()),
+      ],
+    })
+
+    registry.configure([
+      settingsExtension,
+      userFeaturesExtension,
+      cloudSyncPlugin,
+    ])
+    enableCloudSyncPlugin(registry)
+
+    try {
+      const statusItem = registry
+        .get(statusBarGlobalItemsValueSpec)
+        .find((item) => item.id === 'cloud-sync')
+      expect(statusItem).toBeDefined()
+      if (!statusItem || !('component' in statusItem)) {
+        return
+      }
+
+      const StatusBarItem = statusItem.component
+      window.history.pushState({}, '', '/file/%2Fprojects%2Fcurrent%2Fmain.kcl')
+      renderWithRouter(<StatusBarItem />)
+
+      fireEvent.click(screen.getByTestId('cloud-sync-status'))
+      expect(
+        await screen.findByTestId('cloud-conflict-dialog')
+      ).toHaveTextContent('/projects/current')
+
+      cloudSyncStatus.value = {
+        ...cloudSyncStatus.value,
+        activeProjectPath: '/projects/other',
+        lastFailureAt: new Date(now + 1).toISOString(),
+      }
+
+      await waitFor(() =>
+        expect(screen.getByTestId('cloud-conflict-dialog')).toHaveTextContent(
+          '/projects/current'
+        )
+      )
+      expect(screen.getByTestId('cloud-conflict-dialog')).not.toHaveTextContent(
+        '/projects/other'
+      )
+      expect(cloudConflictDialogMocks.dialogProjectPaths).not.toContain(
+        '/projects/other'
+      )
+    } finally {
+      registry[Symbol.dispose]()
+    }
+  })
+})
+
 describe('cloud sync conflict project menu item', () => {
   test('opens conflict resolution from the project sidebar menu', async () => {
     cloudConflictDialogMocks.conflict = {
@@ -311,7 +424,7 @@ describe('cloud sync conflict project menu item', () => {
             enableMenu
             project={projectWellFormed}
           />
-          <CloudConflictProjectMenuDialogHost resolvedTheme={Themes.Dark} />
+          <CloudConflictDialogHost resolvedTheme={Themes.Dark} />
         </>
       )
 
@@ -320,7 +433,9 @@ describe('cloud sync conflict project menu item', () => {
         await screen.findByTestId('project-sidebar-inspect-cloud-conflicts')
       )
 
-      expect(await screen.findByTestId('cloud-conflict-dialog')).toBeVisible()
+      expect(
+        await screen.findByTestId('cloud-conflict-dialog')
+      ).toHaveTextContent(projectWellFormed.path)
       expect(cloudSync.startProjectSync).not.toHaveBeenCalled()
       expect(cloudSync.disconnectProjectSync).not.toHaveBeenCalled()
     } finally {

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -24,7 +24,6 @@ import type { CustomIconName } from '@src/components/CustomIcon'
 import { defaultStatusBarItemClassNames } from '@src/components/StatusBar/StatusBar'
 import Tooltip from '@src/components/Tooltip'
 import {
-  type CloudSyncProjectMetadata,
   type CloudSyncProjectMetadataIndexEntry,
   type CloudSyncStatus,
   cloudSyncRemoteProjects,
@@ -103,13 +102,18 @@ type CloudSyncStatusBarPresentation = {
   tooltip: string
 }
 
-type CloudConflictProjectMenuDialog = {
+type CloudConflictDialogRequest = {
   projectPath: string
-  projectName: string
+  projectName?: string
 }
 
-const cloudConflictProjectMenuDialog =
-  signal<CloudConflictProjectMenuDialog | null>(null)
+const cloudConflictDialogRequest = signal<CloudConflictDialogRequest | null>(
+  null
+)
+
+function openCloudConflictDialog(request: CloudConflictDialogRequest) {
+  cloudConflictDialogRequest.value = request
+}
 
 const preservedCloudProjectDefaultFiles = signal<Map<string, string>>(new Map())
 
@@ -243,12 +247,9 @@ function CloudSyncStatusBarItem({
   useSignals()
   const location = useLocation()
   const status = cloudSyncStatus.value
-  const conflictMetadata = useCloudSyncProjectConflict(status.activeProjectPath)
+  const activeProjectPath = status.activeProjectPath
+  const conflictMetadata = useCloudSyncProjectConflict(activeProjectPath)
   const conflictMetadataList = useCloudSyncProjectConflicts()
-  const [isInspectingConflict, setIsInspectingConflict] = useState(false)
-  const [selectedConflict, setSelectedConflict] = useState<
-    CloudSyncProjectMetadata | undefined
-  >()
   if (!status.enabled) {
     return null
   }
@@ -259,9 +260,8 @@ function CloudSyncStatusBarItem({
   const canInspectConflict =
     status.state === 'conflict' &&
     isFileRoute &&
-    status.activeProjectPath &&
+    activeProjectPath &&
     conflictMetadata?.conflict
-  const selectedConflictProjectPath = selectedConflict?.localProjectPath
   const shouldListConflicts = status.state === 'conflict' && isHomeRoute
 
   const statusBarButtonContent = (
@@ -316,7 +316,12 @@ function CloudSyncStatusBarItem({
                     key={metadata.localProjectPath}
                     type="button"
                     className="rounded px-2 py-1 text-left text-chalkboard-100 hover:bg-chalkboard-20 focus:bg-chalkboard-20 focus:outline-none dark:text-chalkboard-10 dark:hover:bg-chalkboard-80 dark:focus:bg-chalkboard-80"
-                    onClick={() => setSelectedConflict(metadata)}
+                    onClick={() =>
+                      openCloudConflictDialog({
+                        projectPath: metadata.localProjectPath,
+                        projectName: metadata.projectName,
+                      })
+                    }
                   >
                     {metadata.projectName}
                   </button>
@@ -335,8 +340,10 @@ function CloudSyncStatusBarItem({
           className={statusBarClassName}
           data-testid="cloud-sync-status"
           onClick={() => {
-            if (canInspectConflict) {
-              setIsInspectingConflict(true)
+            if (canInspectConflict && activeProjectPath) {
+              openCloudConflictDialog({
+                projectPath: activeProjectPath,
+              })
               return
             }
             retryCloudSync()
@@ -345,23 +352,7 @@ function CloudSyncStatusBarItem({
           {statusBarButtonContent}
         </button>
       )}
-      {isInspectingConflict && status.activeProjectPath && (
-        <CloudConflictDialog
-          projectPath={status.activeProjectPath}
-          resolvedTheme={resolvedTheme}
-          onDismiss={() => setIsInspectingConflict(false)}
-          onResolved={() => setIsInspectingConflict(false)}
-        />
-      )}
-      {selectedConflictProjectPath && (
-        <CloudConflictDialog
-          projectPath={selectedConflictProjectPath}
-          resolvedTheme={resolvedTheme}
-          onDismiss={() => setSelectedConflict(undefined)}
-          onResolved={() => setSelectedConflict(undefined)}
-        />
-      )}
-      <CloudConflictProjectMenuDialogHost resolvedTheme={resolvedTheme} />
+      <CloudConflictDialogHost resolvedTheme={resolvedTheme} />
     </>
   )
 }
@@ -435,10 +426,10 @@ function CloudConflictProjectMenuItem({
         }}
         className={`${className}bg-warn-10/50 text-warn-90 hover:!bg-warn-20 focus:!bg-warn-20 dark:bg-warn-80/20 dark:text-warn-10 dark:hover:!bg-warn-80/30 dark:focus:!bg-warn-80/30`}
         onClick={() => {
-          cloudConflictProjectMenuDialog.value = {
+          openCloudConflictDialog({
             projectPath: context.projectPath,
             projectName: getProjectDisplayName(context.project),
-          }
+          })
           close()
         }}
       >
@@ -453,17 +444,17 @@ function CloudConflictProjectMenuItem({
   )
 }
 
-export function CloudConflictProjectMenuDialogHost({
+export function CloudConflictDialogHost({
   resolvedTheme,
 }: {
   resolvedTheme: ResolvedTheme
 }) {
   useSignals()
-  const dialog = cloudConflictProjectMenuDialog.value
+  const dialog = cloudConflictDialogRequest.value
 
   useEffect(() => {
     return () => {
-      cloudConflictProjectMenuDialog.value = null
+      cloudConflictDialogRequest.value = null
     }
   }, [])
 
@@ -477,10 +468,10 @@ export function CloudConflictProjectMenuDialogHost({
       projectName={dialog.projectName}
       resolvedTheme={resolvedTheme}
       onDismiss={() => {
-        cloudConflictProjectMenuDialog.value = null
+        cloudConflictDialogRequest.value = null
       }}
       onResolved={() => {
-        cloudConflictProjectMenuDialog.value = null
+        cloudConflictDialogRequest.value = null
       }}
     />
   )


### PR DESCRIPTION
## Summary

Fixes cloud conflict dialog flicker where conflict details could switch between unrelated projects while a user was inspecting conflicts inside a project.

## Root Cause

The cloud sync engine correctly scoped newly-created conflict status updates to the active file-route project, but the existing-conflict-copy path updated global `cloudSyncStatus.activeProjectPath` unconditionally. If a full sync started before file-route scoping settled, revisiting an unrelated existing conflict could briefly point the status-bar dialog at that other project.

The status-bar dialog also used the live global active project path after it opened, so any later global status churn could swap the dialog's `projectPath` prop.

The failing desktop E2E was also racing Headless UI's option remount for the default `KCL Samples` source selection.

## Changes

- Guard existing-conflict status updates with `projectPathMatchesSyncScope`.
- Route status-bar, Home conflict-list, and project-sidebar conflict inspection through one shared `CloudConflictDialogHost` opener.
- Preserve the clicked project path in the shared dialog request so later global status changes cannot swap dialog content.
- Add engine and UI regressions covering unrelated conflict churn and sidebar conflict opening.
- Stabilize the sample-loading E2E by submitting the current `KCL Samples` source argument instead of clicking a transient option element.

## Validation

- `npm run tsc`
- `npm run lint`
- `npm run test:integration -- src/lib/cloudSync/conflictScope.spec.ts src/lib/cloudSync/registry/plugin.spec.tsx src/components/CloudConflictDialog.spec.tsx`
- `npm run tronb:vite:dev`
- `npm run test:e2e:desktop -- e2e/playwright/testing-samples-loading.spec.ts --grep "should create new file by default"`