### PR TITLE
feat(kcl): evaluate enum declarations and resolve variant constructors

### DIFF
--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -1634,8 +1634,6 @@ impl ExecutorContext {
     }
 }
 
-/// When executing in sketch mode, whether we should skip executing this
-/// expression.
 /// The head of a `Color::Red` path is looked up both as a module and as an enum,
 /// so one scope must not bind a module and an enum under the same name. Reporting
 /// the clash where the second name is introduced keeps every `X::y` use site
@@ -1846,6 +1844,8 @@ fn reject_glob_import_clash(
     Ok(())
 }
 
+/// When executing in sketch mode, whether we should skip executing this
+/// expression.
 fn sketch_mode_should_skip(expr: &Expr) -> bool {
     match expr {
         Expr::SketchBlock(sketch_block) => !sketch_block.is_being_edited,

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -52,6 +52,9 @@ use crate::execution::early_return;
 use crate::execution::fn_call::Arg;
 use crate::execution::fn_call::Args;
 use crate::execution::fn_call::unexpected_kw_arg_message;
+use crate::execution::kcl_value::EnumTypeDef;
+use crate::execution::kcl_value::EnumTypeId;
+use crate::execution::kcl_value::EnumValue;
 use crate::execution::kcl_value::FunctionSource;
 use crate::execution::kcl_value::KclFunctionSourceParams;
 use crate::execution::kcl_value::KclObjectKind;
@@ -91,6 +94,7 @@ use crate::parsing::ast::types::BinaryPart;
 use crate::parsing::ast::types::BodyItem;
 use crate::parsing::ast::types::CodeBlock;
 use crate::parsing::ast::types::Expr;
+use crate::parsing::ast::types::Identifier;
 use crate::parsing::ast::types::IfExpression;
 use crate::parsing::ast::types::ImportPath;
 use crate::parsing::ast::types::ImportSelector;
@@ -840,6 +844,19 @@ impl ExecutorContext {
 
                                 if let Ok(ty) = ty {
                                     let ty_name = format!("{}{}", memory::TYPE_PREFIX, import_item.identifier());
+                                    if matches!(
+                                        &ty,
+                                        KclValue::Type {
+                                            value: TypeDef::Enum(_),
+                                            ..
+                                        }
+                                    ) {
+                                        reject_enum_clashing_with_module(
+                                            exec_state,
+                                            import_item.identifier(),
+                                            SourceRange::from(&import_item.name),
+                                        )?;
+                                    }
                                     exec_state.mut_stack().add(
                                         ty_name.clone(),
                                         ty,
@@ -853,6 +870,11 @@ impl ExecutorContext {
 
                                 if let Ok(mod_value) = mod_value {
                                     let mod_name = format!("{}{}", memory::MODULE_PREFIX, import_item.identifier());
+                                    reject_module_clashing_with_enum(
+                                        exec_state,
+                                        import_item.identifier(),
+                                        SourceRange::from(&import_item.name),
+                                    )?;
                                     exec_state.mut_stack().add(
                                         mod_name.clone(),
                                         mod_value,
@@ -879,6 +901,7 @@ impl ExecutorContext {
                                             source_range,
                                         )
                                     })?;
+                                reject_glob_import_clash(exec_state, name, &item, source_range)?;
                                 exec_state.mut_stack().add(name.to_owned(), item, source_range)?;
 
                                 if let ItemVisibility::Export = import_stmt.visibility {
@@ -888,6 +911,7 @@ impl ExecutorContext {
                         }
                         ImportSelector::None { .. } => {
                             let name = import_stmt.module_name().unwrap();
+                            reject_module_clashing_with_enum(exec_state, &name, source_range)?;
                             let item = KclValue::Module {
                                 value: module_id,
                                 meta: vec![source_range.into()],
@@ -1125,11 +1149,57 @@ impl ExecutorContext {
                                     vec![metadata.source_range],
                                 )));
                             }
-                            TypeDeclarationDefinition::Enum(_) => {
-                                return Err(KclError::new_semantic(KclErrorDetails::new(
-                                    "Enum declarations are not yet supported.".to_owned(),
-                                    vec![metadata.source_range],
-                                )));
+                            TypeDeclarationDefinition::Enum(decl) => {
+                                // Identity is module plus declared name, so `type Color` in
+                                // two function bodies of one file would be one type with two
+                                // variant sets. A V1 limitation, liftable in enum v2 by
+                                // giving `EnumTypeId` a declaration site.
+                                if !matches!(body_type, BodyType::Root) {
+                                    return Err(KclError::new_semantic(KclErrorDetails::new(
+                                        format!(
+                                            "Enum declarations are only supported at the top-level of a file. Move `type {}` to the top-level.",
+                                            ty.name.name
+                                        ),
+                                        vec![metadata.source_range],
+                                    )));
+                                }
+
+                                reject_enum_clashing_with_module(exec_state, &ty.name.name, metadata.source_range)?;
+
+                                let variants = decl.variants.iter().map(|v| v.name.name.clone()).collect();
+                                let id = EnumTypeId::new(metadata.source_range.module_id(), ty.name.name.clone());
+                                // Constructing the definition is the validation step: nothing
+                                // below runs, so nothing reaches memory, unless every variant
+                                // name is distinct.
+                                let def = EnumTypeDef::new(id, variants).map_err(|duplicate| {
+                                    KclError::new_semantic(KclErrorDetails::new(
+                                        format!("Duplicate variant `{}` in enum `{}`.", duplicate.name, ty.name.name),
+                                        vec![
+                                            decl.variants[duplicate.first_index].as_source_range(),
+                                            decl.variants[duplicate.duplicate_index].as_source_range(),
+                                        ],
+                                    ))
+                                })?;
+
+                                let value = KclValue::Type {
+                                    value: TypeDef::Enum(def),
+                                    meta: vec![metadata],
+                                    experimental: attrs.experimental,
+                                };
+                                let name_in_mem = format!("{}{}", memory::TYPE_PREFIX, ty.name.name);
+                                exec_state
+                                    .mut_stack()
+                                    .add(name_in_mem.clone(), value, metadata.source_range)
+                                    .map_err(|_| {
+                                        KclError::new_semantic(KclErrorDetails::new(
+                                            format!("Redefinition of type {}.", ty.name.name),
+                                            vec![metadata.source_range],
+                                        ))
+                                    })?;
+
+                                if let ItemVisibility::Export = ty.visibility {
+                                    exec_state.mod_local.module_exports.push(name_in_mem);
+                                }
                             }
                         },
                     }
@@ -1566,6 +1636,216 @@ impl ExecutorContext {
 
 /// When executing in sketch mode, whether we should skip executing this
 /// expression.
+/// The head of a `Color::Red` path is looked up both as a module and as an enum,
+/// so one scope must not bind a module and an enum under the same name. Reporting
+/// the clash where the second name is introduced keeps every `X::y` use site
+/// unambiguous, so no check is needed at the use site.
+///
+/// Type aliases and bare types are exempt, since neither can head a `::` path.
+/// They may continue to share a name with a module.
+fn module_enum_clash(name: &str, source_range: SourceRange) -> KclError {
+    KclError::new_semantic(KclErrorDetails::new(
+        format!(
+            "An enum and a module cannot share the name `{name}` in the same scope, because `{name}::x` would be ambiguous. Rename one of them."
+        ),
+        vec![source_range],
+    ))
+}
+
+/// Call before binding an enum under `name`.
+fn reject_enum_clashing_with_module(
+    exec_state: &ExecState,
+    name: &str,
+    source_range: SourceRange,
+) -> Result<(), KclError> {
+    if exec_state
+        .stack()
+        .get(&format!("{}{}", memory::MODULE_PREFIX, name), source_range)
+        .is_err()
+    {
+        return Ok(());
+    }
+
+    Err(module_enum_clash(name, source_range))
+}
+
+/// Call before binding a module under `name`. The mirror of
+/// [`reject_enum_clashing_with_module`].
+fn reject_module_clashing_with_enum(
+    exec_state: &ExecState,
+    name: &str,
+    source_range: SourceRange,
+) -> Result<(), KclError> {
+    let Ok(KclValue::Type {
+        value: TypeDef::Enum(_),
+        ..
+    }) = exec_state
+        .stack()
+        .get(&format!("{}{}", memory::TYPE_PREFIX, name), source_range)
+    else {
+        return Ok(());
+    };
+
+    Err(module_enum_clash(name, source_range))
+}
+
+/// Builds the error for comparing values of two different enum types.
+fn different_enums_err(left: &EnumValue, right: &EnumValue, source_range: SourceRange) -> KclError {
+    let left_name = left.enum_id().declared_name();
+    let right_name = right.enum_id().declared_name();
+
+    let message = if left_name == right_name {
+        // Identity is the declaration, so two enums can share a name and still be
+        // different types. Naming both would read as a mistake in the message.
+        format!(
+            "Cannot compare two different enums that are both named `{left_name}`. They come from separate declarations."
+        )
+    } else {
+        format!("Cannot compare enum `{left_name}` with enum `{right_name}`. They are different types.")
+    };
+
+    KclError::new_semantic(KclErrorDetails::new(message, vec![source_range]))
+}
+
+/// Builds the error for a name that resolves to a type where a value is needed,
+/// such as `x = Color`.
+///
+/// Returns `None` when no type of that name is in scope, which leaves the
+/// caller's "is not defined" error in place.
+fn type_used_as_value(exec_state: &ExecState, name: &Node<Identifier>) -> Option<KclError> {
+    let key = format!("{}{}", memory::TYPE_PREFIX, name.name);
+    let KclValue::Type { value: def, .. } = exec_state.stack().get(&key, name.as_source_range()).ok()? else {
+        return None;
+    };
+
+    // The suggestion uses the name as written, which may be an import alias, so
+    // that it can be pasted into the file that produced the error.
+    let suggestion = match &def {
+        TypeDef::Enum(def) => def
+            .variants()
+            .first()
+            .map(|variant| format!(" Use one of its variants, such as `{}::{variant}`.", name.name))
+            .unwrap_or_default(),
+        _ => String::new(),
+    };
+
+    Some(KclError::new_semantic(KclErrorDetails::new(
+        format!("`{}` is a type, not a value.{suggestion}", name.name),
+        name.as_source_ranges(),
+    )))
+}
+
+/// Looks up the enum named by a `::` path segment: `Color` in both `Color::Red`
+/// and `colors::Color::Red`.
+///
+/// Returns `None` when the segment does not name an enum, including when it
+/// names a type alias, since only an enum can head a `::` path. The caller then
+/// resolves the segment as a module instead.
+///
+/// This is the only place that builds a `__ty_` memory key, so the deferred
+/// typed-key refactor has one site to change.
+fn enum_named_by_segment(
+    exec_state: &ExecState,
+    segment: &Node<Identifier>,
+    within: Option<&(EnvironmentRef, Vec<String>)>,
+) -> Option<EnumTypeDef> {
+    let key = format!("{}{}", memory::TYPE_PREFIX, segment.name);
+    let value = match within {
+        // Inside another module the enum must be exported to be reachable, and
+        // exports record the prefixed key rather than the bare name.
+        Some((env, exports)) => {
+            if !exports.contains(&key) {
+                return None;
+            }
+
+            exec_state
+                .stack()
+                .memory
+                .get_from_owned(&key, *env, segment.as_source_range(), 0)
+                .ok()?
+        }
+        None => exec_state.stack().get(&key, segment.as_source_range()).ok()?,
+    };
+
+    match value {
+        KclValue::Type {
+            value: TypeDef::Enum(def),
+            ..
+        } => Some(def),
+        _ => None,
+    }
+}
+
+/// `Red` in `Color::Red`.
+fn enum_variant_value(
+    def: &EnumTypeDef,
+    variant: &Node<Identifier>,
+    exec_state: &mut ExecState,
+) -> Result<KclValue, KclError> {
+    let enum_name = def.id().declared_name();
+
+    if !def.has_variant(&variant.name) {
+        let known = if def.variants().is_empty() {
+            format!("Enum `{enum_name}` has no variants")
+        } else {
+            format!("Its variants are: {}", def.variants().join(", "))
+        };
+
+        return Err(KclError::new_semantic(KclErrorDetails::new(
+            format!("`{}` is not a variant of enum `{enum_name}`. {known}.", variant.name),
+            variant.as_source_ranges(),
+        )));
+    }
+
+    // Every V1 enum is experimental, not only those with an annotation, so this
+    // call is unconditional. `warn_experimental` reads the setting of the module
+    // being executed and does nothing when that setting is `allow`, so an enum
+    // imported from a permissive module is still reported in a consumer that has
+    // not opted in. Declarations are gated during parsing; type positions by
+    // `RuntimeType::from_alias`.
+    exec_state.warn_experimental(&format!("the enum `{enum_name}`"), variant.as_source_range());
+
+    // The identity comes from the declaration and is never rebuilt from a name.
+    // A later enum v2 can then add a declaration site to `EnumTypeId` by changing
+    // this one construction, without revisiting every use.
+    Ok(KclValue::Enum {
+        value: Box::new(EnumValue::new(
+            def.id().clone(),
+            variant.name.clone(),
+            vec![Metadata {
+                source_range: variant.as_source_range(),
+            }],
+        )),
+    })
+}
+
+/// Glob imports copy exported keys verbatim, prefix included, so which namespace
+/// an incoming key lands in has to be read back off the key itself.
+fn reject_glob_import_clash(
+    exec_state: &ExecState,
+    key: &str,
+    item: &KclValue,
+    source_range: SourceRange,
+) -> Result<(), KclError> {
+    if let Some(name) = key.strip_prefix(memory::MODULE_PREFIX) {
+        return reject_module_clashing_with_enum(exec_state, name, source_range);
+    }
+
+    if let Some(name) = key.strip_prefix(memory::TYPE_PREFIX)
+        && matches!(
+            item,
+            KclValue::Type {
+                value: TypeDef::Enum(_),
+                ..
+            }
+        )
+    {
+        return reject_enum_clashing_with_module(exec_state, name, source_range);
+    }
+
+    Ok(())
+}
+
 fn sketch_mode_should_skip(expr: &Expr) -> bool {
     match expr {
         Expr::SketchBlock(sketch_block) => !sketch_block.is_being_edited,
@@ -2426,11 +2706,35 @@ impl Node<Name> {
             if let Ok(item_value) = exec_state.stack().get(&self.name.name, self.into()) {
                 return Ok(item_value);
             }
-            return exec_state.stack().get(&mod_name, self.into());
+
+            let not_defined = match exec_state.stack().get(&mod_name, self.into()) {
+                Ok(module) => return Ok(module),
+                Err(err) => err,
+            };
+
+            // No value and no module of this name exists. If a type does, report
+            // that instead: "is not defined" would point away from the mistake.
+            return Err(type_used_as_value(exec_state, &self.name).unwrap_or(not_defined));
         }
 
         let mut mem_spec: Option<(EnvironmentRef, Vec<String>)> = None;
-        for p in &self.path {
+        for (index, p) in self.path.iter().enumerate() {
+            // Only the last segment can name an enum, because what follows an
+            // enum is a variant rather than something to traverse into.
+            if let Some(def) = enum_named_by_segment(exec_state, p, mem_spec.as_ref()) {
+                if let Some(next) = self.path.get(index + 1) {
+                    return Err(KclError::new_semantic(KclErrorDetails::new(
+                        format!(
+                            "`{}` is an enum, so only a variant name can follow it. There is nothing to reach through `{}::{}`.",
+                            p.name, p.name, next.name
+                        ),
+                        p.as_source_ranges(),
+                    )));
+                }
+
+                return enum_variant_value(&def, &self.name, exec_state);
+            }
+
             let value = match mem_spec {
                 Some((env, exports)) => {
                     if !exports.contains(&p.name) {
@@ -5222,6 +5526,38 @@ impl Node<BinaryExpression> {
                 !is_equal
             };
             return Ok(KclValue::Bool { value, meta });
+        }
+
+        // Enums compare by declaration and variant. This has to precede
+        // `number_as_f64` below, which would otherwise reject an enum with
+        // "expected a number" and describe the wrong problem.
+        if matches!(self.operator, BinaryOperator::Eq | BinaryOperator::Neq) {
+            match (&left_value, &right_value) {
+                (KclValue::Enum { value: left }, KclValue::Enum { value: right }) => {
+                    if left.enum_id() != right.enum_id() {
+                        return Err(different_enums_err(left, right, self.as_source_range()));
+                    }
+
+                    let is_equal = left.variant() == right.variant();
+                    let value = if self.operator == BinaryOperator::Eq {
+                        is_equal
+                    } else {
+                        !is_equal
+                    };
+                    return Ok(KclValue::Bool { value, meta });
+                }
+                (KclValue::Enum { value }, other) | (other, KclValue::Enum { value }) => {
+                    return Err(KclError::new_semantic(KclErrorDetails::new(
+                        format!(
+                            "Cannot compare enum `{}` with {}.",
+                            value.qualified_name(),
+                            other.human_friendly_type()
+                        ),
+                        vec![self.as_source_range()],
+                    )));
+                }
+                _ => {}
+            }
         }
 
         let left = number_as_f64(&left_value, self.left.clone().into())?;

--- a/rust/kcl-lib/src/execution/kcl_value.rs
+++ b/rust/kcl-lib/src/execution/kcl_value.rs
@@ -363,9 +363,42 @@ pub struct EnumTypeDef {
     variants: Vec<String>,
 }
 
+/// Two variants of one enum declared under the same name, e.g.
+/// `type Color { | Red | Red }`.
+///
+/// Carries indices into the variant list rather than source ranges so that
+/// `EnumTypeDef` stays independent of the AST and of diagnostic types. The
+/// caller holds the declaration, so it can turn an index back into the range it
+/// needs for the error it reports.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DuplicateVariant {
+    /// The name declared twice.
+    pub name: String,
+    /// Where the name was first declared.
+    pub first_index: usize,
+    /// Where it was declared again. Always greater than `first_index`.
+    pub duplicate_index: usize,
+}
+
 impl EnumTypeDef {
-    pub fn new(id: EnumTypeId, variants: Vec<String>) -> Self {
-        Self { id, variants }
+    /// Variant names must be unique, so this is the only way to build an
+    /// `EnumTypeDef` and it rejects a repeat rather than dropping it. Silently
+    /// collapsing duplicates would deny the user a diagnostic naming the variant
+    /// they typed twice.
+    ///
+    /// Reports the earliest repeat when a declaration contains several.
+    pub fn new(id: EnumTypeId, variants: Vec<String>) -> Result<Self, DuplicateVariant> {
+        for (duplicate_index, variant) in variants.iter().enumerate() {
+            if let Some(first_index) = variants[..duplicate_index].iter().position(|v| v == variant) {
+                return Err(DuplicateVariant {
+                    name: variant.clone(),
+                    first_index,
+                    duplicate_index,
+                });
+            }
+        }
+
+        Ok(Self { id, variants })
     }
 
     pub fn id(&self) -> &EnumTypeId {
@@ -1327,7 +1360,8 @@ mod tests {
         let def = EnumTypeDef::new(
             EnumTypeId::new(ModuleId::default(), "Color"),
             vec!["Red".to_owned(), "Green".to_owned()],
-        );
+        )
+        .unwrap();
 
         assert_eq!(def.variants(), ["Red", "Green"]);
         assert!(def.has_variant("Red"));
@@ -1340,7 +1374,47 @@ mod tests {
                 EnumTypeId::new(ModuleId::from_usize(1), "Color"),
                 vec!["Red".to_owned(), "Green".to_owned()],
             )
+            .unwrap()
             .id()
         );
+    }
+
+    #[test]
+    fn enum_rejects_duplicate_variant() {
+        let err = EnumTypeDef::new(
+            EnumTypeId::new(ModuleId::default(), "Color"),
+            vec!["Red".to_owned(), "Green".to_owned(), "Red".to_owned()],
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            err,
+            DuplicateVariant {
+                name: "Red".to_owned(),
+                first_index: 0,
+                duplicate_index: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn enum_reports_earliest_duplicate() {
+        // `Green` repeats at index 3 and `Red` at index 4. The caller reports one
+        // duplicate, so it must be the one the user reads first.
+        let err = EnumTypeDef::new(
+            EnumTypeId::new(ModuleId::default(), "Color"),
+            vec![
+                "Red".to_owned(),
+                "Green".to_owned(),
+                "Blue".to_owned(),
+                "Green".to_owned(),
+                "Red".to_owned(),
+            ],
+        )
+        .unwrap_err();
+
+        assert_eq!(err.name, "Green");
+        assert_eq!(err.first_index, 1);
+        assert_eq!(err.duplicate_index, 3);
     }
 }

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -4687,24 +4687,547 @@ s2 = sketch(on = XZ) {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_enum_declaration_execution_not_yet_supported() {
-        // Enums parse but do not execute until their runtime representation
-        // lands; until then execution reports a graceful error.
+    async fn enum_declaration_registers_type() {
+        // Plain and exported declarations both execute. Nothing references the
+        // enum yet, so this only asserts that declaring one is no longer an
+        // error; constructor use is exercised separately.
         let code = r#"@settings(experimentalFeatures = allow)
-type Color { | Red }
+type Color { | Red | Green }
+"#;
+        parse_execute(code).await.unwrap();
+
+        let code = r#"@settings(experimentalFeatures = allow)
+export type Color { | Red | Green }
+"#;
+        parse_execute(code).await.unwrap();
+
+        // A zero-variant enum is a valid declaration.
+        let code = r#"@settings(experimentalFeatures = allow)
+type Empty { | }
+"#;
+        parse_execute(code).await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enum_declaration_rejects_nested_scope() {
+        // Identity is (module, declared name), so two same-named declarations in
+        // one file would collide. The parser and formatter accept this shape, so
+        // execution is the only thing that can reject it.
+        //
+        // The rule is about nesting, not about one kind of block, so both routes
+        // to `BodyType::Block` are covered here.
+        let allow = "@settings(experimentalFeatures = allow)\n";
+        for (case, code) in [
+            (
+                "function body",
+                format!("{allow}fn palette() {{\n  type Color {{ | Red }}\n  return 0\n}}\npalette()\n"),
+            ),
+            (
+                "sketch block",
+                format!(
+                    "{allow}sketch(on = XY) {{\n  type Color {{ | Red }}\n  l1 = line(start = [var 0mm, var 0mm], end = [var 10mm, var 0mm])\n}}\n"
+                ),
+            ),
+        ] {
+            assert_eq!(
+                parse_execute(&code).await.unwrap_err().message(),
+                "Enum declarations are only supported at the top-level of a file. Move `type Color` to the top-level.",
+                "case: {case}"
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enum_alone_is_restricted_to_top_level() {
+        // Pins the asymmetry the rule above creates: a type alias may be declared
+        // in any block, an enum may not. The difference is required by enum
+        // identity rather than chosen -- two nested aliases shadow each other
+        // harmlessly, while two nested `type Color` declarations would be one type
+        // with two variant sets. Tightening aliases to match, or relaxing enums,
+        // has to break this test first.
+        let allow = "@settings(experimentalFeatures = allow)\n";
+        for (case, code) in [
+            (
+                "function body",
+                format!("{allow}fn f() {{\n  type Temperature = number(_)\n  return 0\n}}\nx = f()\n"),
+            ),
+            (
+                "sketch block",
+                format!(
+                    "{allow}sketch(on = XY) {{\n  type Temperature = number(_)\n  l1 = line(start = [var 0mm, var 0mm], end = [var 10mm, var 0mm])\n}}\n"
+                ),
+            ),
+        ] {
+            parse_execute(&code)
+                .await
+                .unwrap_or_else(|err| panic!("a type alias should be allowed in a {case}: {}", err.message()));
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enum_declaration_rejects_duplicate() {
+        let code = r#"@settings(experimentalFeatures = allow)
+type Color { | Red | Green | Red }
 "#;
         assert_eq!(
             parse_execute(code).await.unwrap_err().message(),
-            "Enum declarations are not yet supported."
+            "Duplicate variant `Red` in enum `Color`."
+        );
+    }
+
+    /// Runs `main` with `modules` written beside it, so import paths resolve.
+    async fn execute_with_modules(main: &str, modules: &[(&str, &str)]) -> Result<ExecTestResults, KclError> {
+        let tmpdir = tempfile::TempDir::with_prefix("zma_kcl_enum_clash").unwrap();
+        for (name, source) in modules {
+            tokio::fs::write(tmpdir.path().join(name), source).await.unwrap();
+        }
+
+        parse_execute_with_project_dir(main, Some(crate::TypedPath(tmpdir.path().into()))).await
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enum_rejects_name_clash_with_module() {
+        // One rule reached four ways: by declaring the enum second, by importing
+        // the module second, and by importing the enum itself either by name or
+        // through a glob, which arrive by different code paths because a glob
+        // copies exported keys with their namespace prefix intact.
+        let plain_module = ("Color.kcl", "export x = 1\n");
+        let enum_module = (
+            "enums.kcl",
+            "@settings(experimentalFeatures = allow)\nexport type Color { | Red }\n",
         );
 
-        // Exported enums take the same path.
+        for (case, main, modules) in [
+            (
+                "module then enum",
+                "@settings(experimentalFeatures = allow)\nimport \"Color.kcl\"\ntype Color { | Red }\n",
+                vec![plain_module],
+            ),
+            (
+                "enum then module",
+                "@settings(experimentalFeatures = allow)\ntype Color { | Red }\nimport \"Color.kcl\"\n",
+                vec![plain_module],
+            ),
+            (
+                "named import of an enum",
+                "@settings(experimentalFeatures = allow)\nimport \"Color.kcl\"\nimport Color from 'enums.kcl'\n",
+                vec![plain_module, enum_module],
+            ),
+            (
+                "glob import of an enum",
+                "@settings(experimentalFeatures = allow)\nimport \"Color.kcl\"\nimport * from 'enums.kcl'\n",
+                vec![plain_module, enum_module],
+            ),
+        ] {
+            let err = execute_with_modules(main, &modules).await.unwrap_err();
+            assert_eq!(
+                err.message(),
+                "An enum and a module cannot share the name `Color` in the same scope, because `Color::x` would be ambiguous. Rename one of them.",
+                "case: {case}"
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enum_constructs_variant() {
+        let allow = "@settings(experimentalFeatures = allow)\n";
+        let colors = (
+            "colors.kcl",
+            "@settings(experimentalFeatures = allow)\nexport type Color { | Red | Green }\n",
+        );
+
+        for (case, main, modules) in [
+            (
+                "declared locally",
+                format!("{allow}type Color {{ | Red | Green }}\nx = Color::Red\n"),
+                vec![],
+            ),
+            (
+                // Also the regression test for the export check: a module's exports
+                // record the prefixed key `__ty_Color`, not the bare name.
+                "reached through a module path",
+                format!("{allow}import \"colors.kcl\"\nx = colors::Color::Red\n"),
+                vec![colors],
+            ),
+            (
+                "imported by name",
+                format!("{allow}import Color from 'colors.kcl'\nx = Color::Red\n"),
+                vec![colors],
+            ),
+            (
+                // An import alias renames the binding, not the type, so identity
+                // and therefore the reported name stay those of the declaration.
+                "imported under an alias",
+                format!("{allow}import Color as Shade from 'colors.kcl'\nx = Shade::Red\n"),
+                vec![colors],
+            ),
+        ] {
+            let result = execute_with_modules(&main, &modules)
+                .await
+                .unwrap_or_else(|err| panic!("case: {case}: {}", err.message()));
+            let KclValue::Enum { value } = mem_get_json(result.exec_state.stack(), result.mem_env, "x") else {
+                panic!("case: {case}: `x` should hold an enum value");
+            };
+            assert_eq!(value.qualified_name(), "Color::Red", "case: {case}");
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enum_rejects_bad_variant_paths() {
+        let allow = "@settings(experimentalFeatures = allow)\n";
+
+        for (case, main, modules, message) in [
+            (
+                "unknown variant",
+                format!("{allow}type Color {{ | Red | Green }}\nx = Color::Blue\n"),
+                vec![],
+                "`Blue` is not a variant of enum `Color`. Its variants are: Red, Green.",
+            ),
+            (
+                "enum with no variants",
+                format!("{allow}type Empty {{ | }}\nx = Empty::Red\n"),
+                vec![],
+                "`Red` is not a variant of enum `Empty`. Enum `Empty` has no variants.",
+            ),
+            (
+                "path continues past the enum",
+                format!("{allow}type Color {{ | Red }}\nx = Color::Red::more\n"),
+                vec![],
+                "`Color` is an enum, so only a variant name can follow it. There is nothing to reach through `Color::Red`.",
+            ),
+            (
+                "variant name is case sensitive",
+                format!("{allow}type Color {{ | Red }}\nx = Color::red\n"),
+                vec![],
+                "`red` is not a variant of enum `Color`. Its variants are: Red.",
+            ),
+            (
+                "enum not exported from its module",
+                format!("{allow}import \"colors.kcl\"\nx = colors::Color::Red\n"),
+                vec![(
+                    "colors.kcl",
+                    "@settings(experimentalFeatures = allow)\ntype Color { | Red }\n",
+                )],
+                "Item Color not found in module's exported items",
+            ),
+            (
+                // The alias exemption seen from the use site: a type alias is not
+                // an enum, so the segment is resolved as a module and fails.
+                "a type alias cannot head a path",
+                format!("{allow}type T = number(_)\nx = T::foo\n"),
+                vec![],
+                "`T` is not defined",
+            ),
+            (
+                // The other half of allowing a value and an enum to share a name:
+                // a value on its own can never head a path.
+                "a value cannot head a path",
+                "Color = 5\nx = Color::Red\n".to_owned(),
+                vec![],
+                "`Color` is not defined",
+            ),
+        ] {
+            let err = execute_with_modules(&main, &modules).await.unwrap_err();
+            assert_eq!(err.message(), message, "case: {case}");
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enum_compares_by_variant() {
         let code = r#"@settings(experimentalFeatures = allow)
-export type Color { | Red }
+type Color { | Red | Green }
+sameEq = Color::Red == Color::Red
+sameNeq = Color::Red != Color::Red
+otherEq = Color::Red == Color::Green
+otherNeq = Color::Red != Color::Green
+"#;
+        let result = parse_execute(code).await.unwrap();
+
+        for (name, expected) in [
+            ("sameEq", true),
+            ("sameNeq", false),
+            ("otherEq", false),
+            ("otherNeq", true),
+        ] {
+            let KclValue::Bool { value, .. } = mem_get_json(result.exec_state.stack(), result.mem_env, name) else {
+                panic!("`{name}` should hold a bool");
+            };
+            assert_eq!(value, expected, "variable: {name}");
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enum_usable_inside_sketch_block() {
+        // Only enum declarations are restricted to the top level; uses are not
+        // restricted at all. A sketch block executes its body with sketch-mode
+        // skipping turned off, and memory lookups walk outward, so the enum
+        // declared above resolves inside the block.
+        //
+        // `assertIs` runs inside the block because block-local bindings live in a
+        // child scope that the root environment cannot read afterwards. A wrong
+        // comparison therefore fails this test instead of passing unnoticed.
+        let code = r#"@settings(experimentalFeatures = allow)
+type Color { | Red | Green }
+sketch(on = XY) {
+  c = Color::Red
+  assertIs(Color::Red != Color::Green)
+  assertIs(!(Color::Red != Color::Red))
+  l1 = line(start = [var 0mm, var 0mm], end = [var 10mm, var 0mm])
+}
+"#;
+        parse_execute(code)
+            .await
+            .unwrap_or_else(|err| panic!("enum use inside a sketch block should work: {}", err.message()));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enum_eq_reserved_inside_sketch_block() {
+        // Inside a sketch block, `==` declares an equivalence constraint, so it is
+        // not available for ordinary comparison. Enums are not singled out: the
+        // interception happens before any value-comparison arm is reached, and
+        // strings and numbers are refused in the same words. The string and number
+        // rows are here to keep that visible -- if a later change makes enums
+        // report something different from the other types, this test says so.
+        //
+        // `!=` is deliberately absent: the interception tests `Eq` only, so `!=`
+        // still compares, which `enum_usable_inside_sketch_block` covers.
+        let allow = "@settings(experimentalFeatures = allow)\n";
+        let tail = "  l1 = line(start = [var 0mm, var 0mm], end = [var 10mm, var 0mm])\n}\n";
+        for (case, declaration, comparison, types) in [
+            (
+                "enums",
+                "type Color { | Red | Green }\n",
+                "Color::Red == Color::Green",
+                "a value of enum `Color` and a value of enum `Color`",
+            ),
+            ("strings", "", "\"a\" == \"b\"", "a string and a string"),
+            ("numbers", "", "1 == 2", "a number and a number"),
+        ] {
+            let code = format!("{allow}{declaration}sketch(on = XY) {{\n  x = {comparison}\n{tail}");
+            assert_eq!(
+                parse_execute(&code).await.unwrap_err().message(),
+                format!("Cannot create an equivalence constraint between values of these types: {types}"),
+                "case: {case}"
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enum_same_file_imported_twice_is_one_type() {
+        // Two names for one declaration, so they are the same type and compare
+        // equal. Identity is the declaration, not the binding, which is what makes
+        // this different from two files that each declare a `Color`.
+        let main = r#"@settings(experimentalFeatures = allow)
+import Color as A from 'colors.kcl'
+import Color as B from 'colors.kcl'
+x = A::Red == B::Red
+y = A::Red == B::Green
+"#;
+        let result = execute_with_modules(
+            main,
+            &[(
+                "colors.kcl",
+                "@settings(experimentalFeatures = allow)\nexport type Color { | Red | Green }\n",
+            )],
+        )
+        .await
+        .unwrap();
+
+        for (name, expected) in [("x", true), ("y", false)] {
+            let KclValue::Bool { value, .. } = mem_get_json(result.exec_state.stack(), result.mem_env, name) else {
+                panic!("`{name}` should hold a bool");
+            };
+            assert_eq!(value, expected, "variable: {name}");
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enum_rejects_comparison_across_types() {
+        let allow = "@settings(experimentalFeatures = allow)\n";
+        let color = (
+            "a.kcl",
+            "@settings(experimentalFeatures = allow)\nexport type Color { | Red }\n",
+        );
+        let other_color = (
+            "b.kcl",
+            "@settings(experimentalFeatures = allow)\nexport type Color { | Red }\n",
+        );
+
+        for (case, main, modules, message) in [
+            (
+                "two enums declared separately",
+                format!("{allow}type Color {{ | Red }}\ntype Shade {{ | Red }}\nx = Color::Red == Shade::Red\n"),
+                vec![],
+                "Cannot compare enum `Color` with enum `Shade`. They are different types.",
+            ),
+            (
+                // Identity is the declaration, not the name, so two enums that
+                // share a name are still different types. Pins that the message
+                // says so rather than naming `Color` twice.
+                "two enums sharing a name",
+                format!(
+                    "{allow}import Color as A from 'a.kcl'\nimport Color as B from 'b.kcl'\nx = A::Red == B::Red\n"
+                ),
+                vec![color, other_color],
+                "Cannot compare two different enums that are both named `Color`. They come from separate declarations.",
+            ),
+            (
+                "an enum and a number",
+                format!("{allow}type Color {{ | Red }}\nx = Color::Red == 5\n"),
+                vec![],
+                "Cannot compare enum `Color::Red` with a number.",
+            ),
+            (
+                "a number and an enum, in that order",
+                format!("{allow}type Color {{ | Red }}\nx = 5 == Color::Red\n"),
+                vec![],
+                "Cannot compare enum `Color::Red` with a number.",
+            ),
+            (
+                "an enum and a string",
+                format!("{allow}type Color {{ | Red }}\nx = Color::Red == \"Red\"\n"),
+                vec![],
+                "Cannot compare enum `Color::Red` with a string.",
+            ),
+        ] {
+            let err = execute_with_modules(&main, &modules).await.unwrap_err();
+            assert_eq!(err.message(), message, "case: {case}");
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enum_rejects_bare_type_name_as_value() {
+        let allow = "@settings(experimentalFeatures = allow)\n";
+        let colors = (
+            "colors.kcl",
+            "@settings(experimentalFeatures = allow)\nexport type Color { | Red | Green }\n",
+        );
+
+        for (case, main, modules, message) in [
+            (
+                "enum suggests a variant",
+                format!("{allow}type Color {{ | Red | Green }}\nx = Color\n"),
+                vec![],
+                "`Color` is a type, not a value. Use one of its variants, such as `Color::Red`.",
+            ),
+            (
+                // The suggestion has to be pasteable into the file that produced
+                // the error, so it uses the local name rather than the declared one.
+                "suggestion uses the import alias",
+                format!("{allow}import Color as Shade from 'colors.kcl'\nx = Shade\n"),
+                vec![colors],
+                "`Shade` is a type, not a value. Use one of its variants, such as `Shade::Red`.",
+            ),
+            (
+                "enum with no variants suggests nothing",
+                format!("{allow}type Empty {{ | }}\nx = Empty\n"),
+                vec![],
+                "`Empty` is a type, not a value.",
+            ),
+            (
+                "a type alias reports the same way",
+                format!("{allow}type T = number(_)\nx = T\n"),
+                vec![],
+                "`T` is a type, not a value.",
+            ),
+            (
+                // Unchanged behavior: with no type of that name, the old message
+                // is still the right one.
+                "an unknown name is still undefined",
+                "x = Nope\n".to_owned(),
+                vec![],
+                "`Nope` is not defined",
+            ),
+        ] {
+            let err = execute_with_modules(&main, &modules).await.unwrap_err();
+            assert_eq!(err.message(), message, "case: {case}");
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enum_use_gated_by_consuming_module() {
+        // The declaring module allows experimental features; the consuming one
+        // does not, so using the imported enum is what trips the gate. Pins that
+        // the gate follows the consumer's settings rather than the declaration's.
+        //
+        // Experimental use is reported as a compilation issue rather than by
+        // aborting the run, which is how `RuntimeType::from_alias` reports it too,
+        // so execution succeeds and the diagnostic is what carries the complaint.
+        let main = r#"import "colors.kcl"
+x = colors::Color::Red
+"#;
+        let result = execute_with_modules(
+            main,
+            &[(
+                "colors.kcl",
+                "@settings(experimentalFeatures = allow)\nexport type Color { | Red }\n",
+            )],
+        )
+        .await
+        .unwrap();
+
+        let issues = &result.exec_state.global.issues;
+        assert_eq!(issues.len(), 1, "issues: {issues:?}");
+        assert_eq!(
+            issues[0].message,
+            "Use of the enum `Color` is experimental and may change or be removed."
+        );
+        assert_eq!(issues[0].severity, Severity::Error);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enum_use_not_gated_when_consumer_allows_it() {
+        // The other half of the gate: with the setting present, using an enum
+        // raises nothing at all.
+        let code = r#"@settings(experimentalFeatures = allow)
+type Color { | Red }
+x = Color::Red
+"#;
+        let result = parse_execute(code).await.unwrap();
+        assert!(
+            result.exec_state.global.issues.is_empty(),
+            "issues: {:?}",
+            result.exec_state.global.issues
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enum_allows_name_sharing_outside_modules() {
+        // Pins two deliberate exemptions from the clash rule above, so that
+        // tightening it later has to be a decision rather than an accident.
+        //
+        // Only an enum or a module can head a `Color::Red` path, so only those two
+        // can be ambiguous. A type alias cannot head a `::` path, and an ordinary
+        // value is never looked up for a path head at all.
+        for (case, main, modules) in [
+            (
+                // The module arrives second, which is the path carrying the
+                // "only `TypeDef::Enum` conflicts" guard.
+                "an alias may share a name with a module",
+                "@settings(experimentalFeatures = allow)\ntype Temperature = number(_)\nimport \"Temperature.kcl\"\n",
+                vec![("Temperature.kcl", "export x = 1\n")],
+            ),
+            (
+                "a value may share a name with an enum",
+                "@settings(experimentalFeatures = allow)\ntype Color { | Red }\nColor = 5\n",
+                vec![],
+            ),
+        ] {
+            if let Err(err) = execute_with_modules(main, &modules).await {
+                panic!("case: {case}: {}", err.message());
+            }
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enum_declaration_rejects_redefinition() {
+        let code = r#"@settings(experimentalFeatures = allow)
+type Color { | Red }
+type Color { | Green }
 "#;
         assert_eq!(
             parse_execute(code).await.unwrap_err().message(),
-            "Enum declarations are not yet supported."
+            "Redefinition of type Color."
         );
     }
 }

--- a/rust/kcl-lib/src/execution/types.rs
+++ b/rust/kcl-lib/src/execution/types.rs
@@ -2534,7 +2534,7 @@ mod test {
             .add(
                 format!("{}Color", memory::TYPE_PREFIX),
                 KclValue::Type {
-                    value: TypeDef::Enum(EnumTypeDef::new(id.clone(), vec!["Red".to_owned()])),
+                    value: TypeDef::Enum(EnumTypeDef::new(id.clone(), vec!["Red".to_owned()]).unwrap()),
                     experimental: false,
                     meta: vec![],
                 },


### PR DESCRIPTION
**Part 4 of KCL enum types.** 

* Part 1 (#12596) -- merged
* Part 2 (#12597) -- merged 
* Part 3 (#12601) -- in review, and this PR is stacked on it: the base is `tsk-kcl-enum-part3`, so it will be re-anchored onto `main` once part 3 merges.

Adds:
- Enum declarations register a type under the `__ty_` prefix, reusing the existing type export and import path. All variants are checked before anything is written to memory.
- `EnumTypeDef::new` now returns an error on a repeated variant, so no caller can build an enum with duplicates. The first duplicate is reported at both of its occurrences.
- `Color::Red` and `colors::Color::Red` resolve. The cross-module lookup compares the prefixed name against the module's exports, in a single helper.
- `==` and `!=` compare by declaration and variant, ahead of the numeric fallback, so `Color::Red == 5` is a type error instead of "expected a number".
- A bare `Color` where a value is expected now says the name is a type and suggests a variant.
- An enum and a module cannot share a name in one scope. This is checked where the second name is introduced: declaration, plain import, named import, and glob import.
- Constructor use warns according to the consuming module's `experimentalFeatures` setting rather than the declaring module's.

Invariant:
- Read an enum's identity from its declaration. Never rebuild it as `EnumTypeId::new(module_id, name)`. A later version can then add a declaration site to `EnumTypeId` by changing one place instead of every use.

Limitations by design for V1:
- Declarations must be at the top level of a file. Uses are unrestricted. Identity is the module plus the declared name, which is unique only because type names are unique per module; two `type Color` declarations in one file would otherwise be one type with two sets of variants. The check rejects any non-root body, so function bodies and if blocks are refused as well.
- Type aliases have no such restriction, so enums are stricter than aliases about where they can be declared.
- An import alias renames the binding, not the type. One file imported twice under two names is one type. Two files that each declare `type Color` are two types, and comparing them is an error.
- A value and an enum may share a name. Only modules and enums can start a `::` path, so this is never ambiguous.
- Only the first duplicate variant is reported.
- Inside a sketch block, `==` declares an equivalence constraint, so comparing enums with `==` fails there while `!=` works. This is not specific to enums; strings, numbers and bools behave the same way. Left unchanged.

The bare-name error text also changes for type aliases. Tests are mock execution only.
