### PR TITLE
Codex: Fix unreliable autocomplete in CommandBar

### DIFF
--- a/e2e/playwright/point-click.spec.ts
+++ b/e2e/playwright/point-click.spec.ts
@@ -454,7 +454,6 @@ sketch001 = extrude(region001, length = -12)`
   })
 
   test(`Offset plane point-and-click`, async ({
-    context,
     page,
     homePage,
     scene,
@@ -462,8 +461,11 @@ sketch001 = extrude(region001, length = -12)`
     toolbar,
     cmdBar,
   }) => {
-    const expectedOutput = `plane001 = offsetPlane(XZ, offset = 5)`
+    const initialCode = `offsetDistance = 5`
+    const expectedOutput = `plane001 = offsetPlane(XZ, offset = offsetDistance)`
     await homePage.goToModelingScene()
+    await editor.replaceCode('', initialCode)
+    await editor.expectEditor.toContain(initialCode)
     await scene.settled()
 
     await test.step(`Go through the command bar flow`, async () => {
@@ -489,6 +491,15 @@ sketch001 = extrude(region001, length = -12)`
         highlightedHeaderArg: 'offset',
         commandName: 'Offset plane',
       })
+      const offsetInput = cmdBar.currentArgumentInput.locator('.cm-content')
+      await offsetInput.fill('offsetD')
+      await expect(
+        page.locator('.cm-tooltip-autocomplete .cm-completionLabel', {
+          hasText: /^offsetDistance$/,
+        })
+      ).toBeVisible()
+      await offsetInput.press('Enter')
+      await expect(offsetInput).toHaveText('offsetDistance')
       await cmdBar.progressCmdBar()
       await cmdBar.expectState({
         stage: 'review',
@@ -505,6 +516,20 @@ sketch001 = extrude(region001, length = -12)`
         activeLines: [expectedOutput],
         highlightedCode: '',
       })
+    })
+
+    await test.step('Autocomplete still works after reopening the command', async () => {
+      await toolbar.offsetPlaneButton.click()
+      await toolbar.selectDefaultPlane('Front plane')
+      await cmdBar.progressCmdBar()
+      const offsetInput = cmdBar.currentArgumentInput.locator('.cm-content')
+      await offsetInput.fill('offsetD')
+      await expect(
+        page.locator('.cm-tooltip-autocomplete .cm-completionLabel', {
+          hasText: /^offsetDistance$/,
+        })
+      ).toBeVisible()
+      await cmdBar.closeCmdBar()
     })
 
     await test.step('Delete offset plane via feature tree selection', async () => {

--- a/e2e/playwright/point-click.spec.ts
+++ b/e2e/playwright/point-click.spec.ts
@@ -461,11 +461,8 @@ sketch001 = extrude(region001, length = -12)`
     toolbar,
     cmdBar,
   }) => {
-    const initialCode = `offsetDistance = 5`
-    const expectedOutput = `plane001 = offsetPlane(XZ, offset = offsetDistance)`
+    const expectedOutput = `plane001 = offsetPlane(XZ, offset = 5)`
     await homePage.goToModelingScene()
-    await editor.replaceCode('', initialCode)
-    await editor.expectEditor.toContain(initialCode)
     await scene.settled()
 
     await test.step(`Go through the command bar flow`, async () => {
@@ -491,15 +488,6 @@ sketch001 = extrude(region001, length = -12)`
         highlightedHeaderArg: 'offset',
         commandName: 'Offset plane',
       })
-      const offsetInput = cmdBar.currentArgumentInput.locator('.cm-content')
-      await offsetInput.fill('offsetD')
-      await expect(
-        page.locator('.cm-tooltip-autocomplete .cm-completionLabel', {
-          hasText: /^offsetDistance$/,
-        })
-      ).toBeVisible()
-      await offsetInput.press('Enter')
-      await expect(offsetInput).toHaveText('offsetDistance')
       await cmdBar.progressCmdBar()
       await cmdBar.expectState({
         stage: 'review',
@@ -518,7 +506,59 @@ sketch001 = extrude(region001, length = -12)`
       })
     })
 
-    await test.step('Autocomplete still works after reopening the command', async () => {
+    await test.step('Delete offset plane via feature tree selection', async () => {
+      await editor.closePane()
+      const operationButton = await toolbar.getFeatureTreeOperation(
+        'plane001',
+        0
+      )
+      await operationButton.click({ button: 'left' })
+      await page.keyboard.press('Delete')
+    })
+  })
+
+  test(`Offset plane autocomplete works after reopening`, async ({
+    page,
+    homePage,
+    scene,
+    editor,
+    toolbar,
+    cmdBar,
+  }) => {
+    const initialCode = `offsetDistance = 5`
+    const expectedOutput = `plane001 = offsetPlane(XZ, offset = offsetDistance)`
+    await homePage.goToModelingScene()
+    await editor.replaceCode('', initialCode)
+    await editor.expectEditor.toContain(initialCode)
+    await scene.settled()
+
+    await test.step('Accept variable autocomplete', async () => {
+      await toolbar.offsetPlaneButton.click()
+      await expect
+        .poll(() => page.getByText('Please select one').count())
+        .toBe(1)
+      await toolbar.selectDefaultPlane('Front plane')
+      await cmdBar.progressCmdBar()
+      const offsetInput = cmdBar.currentArgumentInput.locator('.cm-content')
+      await offsetInput.fill('offsetD')
+      await expect(
+        page.locator('.cm-tooltip-autocomplete .cm-completionLabel', {
+          hasText: /^offsetDistance$/,
+        })
+      ).toBeVisible()
+      await offsetInput.press('Enter')
+      await expect(offsetInput).toHaveText('offsetDistance')
+      await cmdBar.progressCmdBar()
+      await cmdBar.expectState({
+        stage: 'review',
+        headerArguments: { Plane: '1 plane', Offset: '5' },
+        commandName: 'Offset plane',
+      })
+      await cmdBar.submit()
+      await editor.expectEditor.toContain(expectedOutput)
+    })
+
+    await test.step('Accept variable autocomplete after reopening', async () => {
       await toolbar.offsetPlaneButton.click()
       await toolbar.selectDefaultPlane('Front plane')
       await cmdBar.progressCmdBar()
@@ -529,17 +569,9 @@ sketch001 = extrude(region001, length = -12)`
           hasText: /^offsetDistance$/,
         })
       ).toBeVisible()
+      await offsetInput.press('Enter')
+      await expect(offsetInput).toHaveText('offsetDistance')
       await cmdBar.closeCmdBar()
-    })
-
-    await test.step('Delete offset plane via feature tree selection', async () => {
-      await editor.closePane()
-      const operationButton = await toolbar.getFeatureTreeOperation(
-        'plane001',
-        0
-      )
-      await operationButton.click({ button: 'left' })
-      await page.keyboard.press('Delete')
     })
   })
 

--- a/src/components/CommandBar/CommandBarKclInput.tsx
+++ b/src/components/CommandBar/CommandBarKclInput.tsx
@@ -1,39 +1,42 @@
 import type { Completion } from '@codemirror/autocomplete'
 import { closeBrackets, closeBracketsKeymap } from '@codemirror/autocomplete'
-import { Compartment, EditorState } from '@codemirror/state'
 import type { ViewUpdate } from '@codemirror/view'
 import { EditorView, keymap } from '@codemirror/view'
+import useHotkeyWrapper from '@src/lib/hotkeyWrapper'
+import { useSelector } from '@xstate/react'
+import { use, useEffect, useMemo, useRef, useState } from 'react'
+import toast from 'react-hot-toast'
+import type { AnyStateMachine, SnapshotFrom } from 'xstate'
+
 import type { Node } from '@rust/kcl-lib/bindings/Node'
+
 import {
   createCommandBarKclInputKeymap,
   createCommandBarKclInputPendingEnterExtension,
 } from '@src/components/CommandBar/commandBarKclInputKeymap'
 import { CustomIcon } from '@src/components/CustomIcon'
 import { Spinner } from '@src/components/Spinner'
-import { editorTheme } from '@src/editor/plugins/theme'
-import { useModelingContext } from '@src/hooks/useModelingContext'
 import { createLocalName, createVariableDeclaration } from '@src/lang/create'
-import type { KclManager } from '@src/lang/KclManager'
 import { getNodeFromPath } from '@src/lang/queryAst'
 import type { SourceRange, VariableDeclarator } from '@src/lang/wasm'
 import { formatNumberValue, isPathToNode } from '@src/lang/wasm'
-import {
-  noAutofillFormProps,
-  noAutofillInputProps,
-  setNoAutofillAttributes,
-} from '@src/lib/autofill'
 import { useApp } from '@src/lib/boot'
 import type { CommandArgument, KclCommandValue } from '@src/lib/commandTypes'
-import useHotkeyWrapper from '@src/lib/hotkeyWrapper'
 import { getResolvedTheme } from '@src/lib/theme'
 import { err } from '@src/lib/trap'
 import { useCalculateKclExpression } from '@src/lib/useCalculateKclExpression'
 import { roundOff, roundOffWithUnits } from '@src/lib/utils'
 import { varMentions } from '@src/lib/varCompletionExtension'
-import { useSelector } from '@xstate/react'
-import { use, useEffect, useMemo, useRef, useState } from 'react'
-import toast from 'react-hot-toast'
-import type { AnyStateMachine, SnapshotFrom } from 'xstate'
+
+import { Compartment, EditorState } from '@codemirror/state'
+import { editorTheme } from '@src/editor/plugins/theme'
+import { useModelingContext } from '@src/hooks/useModelingContext'
+import type { KclManager } from '@src/lang/KclManager'
+import {
+  noAutofillFormProps,
+  noAutofillInputProps,
+  setNoAutofillAttributes,
+} from '@src/lib/autofill'
 import styles from './CommandBarKclInput.module.css'
 
 // TODO: remove the need for this selector once we decouple all actors from React

--- a/src/components/CommandBar/CommandBarKclInput.tsx
+++ b/src/components/CommandBar/CommandBarKclInput.tsx
@@ -1,68 +1,41 @@
 import type { Completion } from '@codemirror/autocomplete'
-import {
-  closeBrackets,
-  closeBracketsKeymap,
-  completionKeymap,
-  completionStatus,
-} from '@codemirror/autocomplete'
+import { closeBrackets, closeBracketsKeymap } from '@codemirror/autocomplete'
+import { Compartment, EditorState } from '@codemirror/state'
 import type { ViewUpdate } from '@codemirror/view'
 import { EditorView, keymap } from '@codemirror/view'
-import useHotkeyWrapper from '@src/lib/hotkeyWrapper'
-import { useSelector } from '@xstate/react'
-import { use, useEffect, useMemo, useRef, useState } from 'react'
-import toast from 'react-hot-toast'
-import type { AnyStateMachine, SnapshotFrom } from 'xstate'
-
 import type { Node } from '@rust/kcl-lib/bindings/Node'
-
+import { createCommandBarKclInputKeymap } from '@src/components/CommandBar/commandBarKclInputKeymap'
 import { CustomIcon } from '@src/components/CustomIcon'
 import { Spinner } from '@src/components/Spinner'
+import { editorTheme } from '@src/editor/plugins/theme'
+import { useModelingContext } from '@src/hooks/useModelingContext'
 import { createLocalName, createVariableDeclaration } from '@src/lang/create'
+import type { KclManager } from '@src/lang/KclManager'
 import { getNodeFromPath } from '@src/lang/queryAst'
 import type { SourceRange, VariableDeclarator } from '@src/lang/wasm'
 import { formatNumberValue, isPathToNode } from '@src/lang/wasm'
-import { useApp } from '@src/lib/boot'
-import type { CommandArgument, KclCommandValue } from '@src/lib/commandTypes'
-import { getResolvedTheme } from '@src/lib/theme'
-import { err } from '@src/lib/trap'
-import { useCalculateKclExpression } from '@src/lib/useCalculateKclExpression'
-import { roundOff, roundOffWithUnits } from '@src/lib/utils'
-import { varMentions } from '@src/lib/varCompletionExtension'
-
-import { Compartment, EditorState } from '@codemirror/state'
-import { editorTheme, themeCompartment } from '@src/editor/plugins/theme'
-import { useModelingContext } from '@src/hooks/useModelingContext'
-import type { KclManager } from '@src/lang/KclManager'
 import {
   noAutofillFormProps,
   noAutofillInputProps,
   setNoAutofillAttributes,
 } from '@src/lib/autofill'
+import { useApp } from '@src/lib/boot'
+import type { CommandArgument, KclCommandValue } from '@src/lib/commandTypes'
+import useHotkeyWrapper from '@src/lib/hotkeyWrapper'
+import { getResolvedTheme } from '@src/lib/theme'
+import { err } from '@src/lib/trap'
+import { useCalculateKclExpression } from '@src/lib/useCalculateKclExpression'
+import { roundOff, roundOffWithUnits } from '@src/lib/utils'
+import { varMentions } from '@src/lib/varCompletionExtension'
+import { useSelector } from '@xstate/react'
+import { use, useEffect, useMemo, useRef, useState } from 'react'
+import toast from 'react-hot-toast'
+import type { AnyStateMachine, SnapshotFrom } from 'xstate'
 import styles from './CommandBarKclInput.module.css'
 
 // TODO: remove the need for this selector once we decouple all actors from React
 const machineContextSelector = (snapshot?: SnapshotFrom<AnyStateMachine>) =>
   snapshot?.context
-
-const varMentionsCompartment = new Compartment()
-const setValueCompartment = new Compartment()
-const keymapCompartment = new Compartment()
-const kclLspCompartment = new Compartment()
-const kclAutocompleteCompartment = new Compartment()
-const miniEditor = new EditorView({
-  state: EditorState.create({
-    extensions: [
-      themeCompartment.of([]),
-      varMentionsCompartment.of([]),
-      setValueCompartment.of([]),
-      kclLspCompartment.of([]),
-      kclAutocompleteCompartment.of([]),
-      closeBrackets(),
-      keymap.of([...closeBracketsKeymap, ...completionKeymap]),
-      keymapCompartment.of([]),
-    ],
-  }),
-})
 
 function CommandBarKclInput({
   arg,
@@ -171,6 +144,15 @@ function CommandBarKclInput({
     { enableOnFormTags: true, enableOnContentEditable: true }
   )
   const editorRef = useRef<HTMLDivElement>(null)
+  const miniEditorRef = useRef<EditorView | null>(null)
+  const editorCompartments = useMemo(
+    () => ({
+      keymap: new Compartment(),
+      theme: new Compartment(),
+      varMentions: new Compartment(),
+    }),
+    []
+  )
 
   const allowArrays = arg.allowArrays ?? false
   const allowStringArrays = arg.allowStringArrays ?? false
@@ -200,94 +182,118 @@ function CommandBarKclInput({
     options,
   })
 
-  const varMentionData: Completion[] = prevVariables.map((v) => {
-    const roundedWithUnits = (() => {
-      if (typeof v.value !== 'number' || !v.ty) {
-        return undefined
-      }
-      const numWithUnits = formatNumberValue(v.value, v.ty, wasmInstance)
-      if (err(numWithUnits)) {
-        return undefined
-      }
-      return roundOffWithUnits(numWithUnits)
-    })()
-    return {
-      label: v.key,
-      detail: roundedWithUnits ?? String(roundOff(Number(v.value))),
-    }
-  })
-  const varMentionsExtension = varMentions(varMentionData)
+  const varMentionData = useMemo<Completion[]>(
+    () =>
+      prevVariables.map((v) => {
+        const roundedWithUnits = (() => {
+          if (typeof v.value !== 'number' || !v.ty) {
+            return undefined
+          }
+          const numWithUnits = formatNumberValue(v.value, v.ty, wasmInstance)
+          if (err(numWithUnits)) {
+            return undefined
+          }
+          return roundOffWithUnits(numWithUnits)
+        })()
+        return {
+          label: v.key,
+          detail: roundedWithUnits ?? String(roundOff(Number(v.value))),
+        }
+      }),
+    [prevVariables, wasmInstance]
+  )
+  const varMentionsExtension = useMemo(
+    () =>
+      varMentions(varMentionData, {
+        activateOnTypingDelay: 0,
+        interactionDelay: 0,
+      }),
+    [varMentionData]
+  )
 
   useEffect(() => {
+    if (!editorRef.current) return
+    const miniEditor = new EditorView({
+      state: EditorState.create({
+        extensions: [
+          editorCompartments.theme.of([]),
+          editorCompartments.varMentions.of([]),
+          closeBrackets(),
+          keymap.of(closeBracketsKeymap),
+          editorCompartments.keymap.of([]),
+          EditorView.updateListener.of((vu: ViewUpdate) => {
+            if (vu.docChanged) {
+              setValue(vu.state.doc.toString())
+            }
+          }),
+        ],
+      }),
+      parent: editorRef.current,
+    })
+    miniEditorRef.current = miniEditor
+    setNoAutofillAttributes(editorRef.current)
+    setNoAutofillAttributes(miniEditor.dom)
+    setNoAutofillAttributes(miniEditor.contentDOM)
+
+    return () => {
+      miniEditor.destroy()
+      miniEditorRef.current = null
+    }
+  }, [editorCompartments])
+
+  useEffect(() => {
+    const miniEditor = miniEditorRef.current
+    if (!miniEditor) return
     miniEditor.dispatch({
       effects: [
-        keymapCompartment.reconfigure(
-          keymap.of([
-            {
-              key: 'Enter',
-              run: (editor) => {
-                // Only submit if there is no completion active
-                if (completionStatus(editor.state) !== null) return false
-                handleSubmit()
-                return true
-              },
-            },
-            {
-              key: 'Meta-Backspace',
-              run: () => {
-                stepBack()
-                return true
-              },
-            },
-          ])
+        editorCompartments.keymap.reconfigure(
+          keymap.of(
+            createCommandBarKclInputKeymap({
+              onSubmit: handleSubmit,
+              stepBack,
+            })
+          )
         ),
       ],
     })
   })
 
   useEffect(() => {
+    const miniEditor = miniEditorRef.current
+    if (!miniEditor) return
     miniEditor.dispatch({
-      effects: [varMentionsCompartment.reconfigure(varMentionsExtension)],
+      effects: [
+        editorCompartments.varMentions.reconfigure(varMentionsExtension),
+      ],
     })
-  }, [varMentionsExtension])
+  }, [editorCompartments.varMentions, varMentionsExtension])
 
   useEffect(() => {
+    const miniEditor = miniEditorRef.current
+    if (!miniEditor) return
     miniEditor.dispatch({
-      effects: themeCompartment.reconfigure(
+      effects: editorCompartments.theme.reconfigure(
         editorTheme[getResolvedTheme(settingsValues.app.theme.current)]
       ),
     })
-  }, [settingsValues.app.theme])
+  }, [editorCompartments.theme, settingsValues.app.theme])
 
   useEffect(() => {
-    if (editorRef.current) {
-      setNoAutofillAttributes(editorRef.current)
-      setNoAutofillAttributes(miniEditor.dom)
-      setNoAutofillAttributes(miniEditor.contentDOM)
-      miniEditor.dispatch({
-        changes: {
-          from: 0,
-          to: miniEditor.state.doc.length,
-          insert: initialValue,
-        },
-        selection: {
-          anchor: 0,
-          head: initialValue.length,
-        },
-      })
-      editorRef.current.appendChild(miniEditor.dom)
-      miniEditor.focus()
-    }
+    const miniEditor = miniEditorRef.current
+    if (!miniEditor) return
     miniEditor.dispatch({
-      effects: setValueCompartment.reconfigure(
-        EditorView.updateListener.of((vu: ViewUpdate) => {
-          if (vu.docChanged) {
-            setValue(vu.state.doc.toString())
-          }
-        })
-      ),
+      changes: {
+        from: 0,
+        to: miniEditor.state.doc.length,
+        insert: initialValue,
+      },
+      selection: {
+        anchor: 0,
+        head: initialValue.length,
+      },
     })
-  }, [arg, editorRef, initialValue])
+    miniEditor.focus()
+  }, [arg, initialValue])
 
   useEffect(() => {
     const canUseUncalculatedValue =

--- a/src/components/CommandBar/CommandBarKclInput.tsx
+++ b/src/components/CommandBar/CommandBarKclInput.tsx
@@ -4,7 +4,10 @@ import { Compartment, EditorState } from '@codemirror/state'
 import type { ViewUpdate } from '@codemirror/view'
 import { EditorView, keymap } from '@codemirror/view'
 import type { Node } from '@rust/kcl-lib/bindings/Node'
-import { createCommandBarKclInputKeymap } from '@src/components/CommandBar/commandBarKclInputKeymap'
+import {
+  createCommandBarKclInputKeymap,
+  createCommandBarKclInputPendingEnterExtension,
+} from '@src/components/CommandBar/commandBarKclInputKeymap'
 import { CustomIcon } from '@src/components/CustomIcon'
 import { Spinner } from '@src/components/Spinner'
 import { editorTheme } from '@src/editor/plugins/theme'
@@ -145,6 +148,8 @@ function CommandBarKclInput({
   )
   const editorRef = useRef<HTMLDivElement>(null)
   const miniEditorRef = useRef<EditorView | null>(null)
+  const handleSubmitRef = useRef(handleSubmit)
+  handleSubmitRef.current = handleSubmit
   const editorCompartments = useMemo(
     () => ({
       keymap: new Compartment(),
@@ -221,6 +226,9 @@ function CommandBarKclInput({
           closeBrackets(),
           keymap.of(closeBracketsKeymap),
           editorCompartments.keymap.of([]),
+          createCommandBarKclInputPendingEnterExtension({
+            onSubmit: () => handleSubmitRef.current(),
+          }),
           EditorView.updateListener.of((vu: ViewUpdate) => {
             if (vu.docChanged) {
               setValue(vu.state.doc.toString())

--- a/src/components/CommandBar/commandBarKclInputKeymap.test.ts
+++ b/src/components/CommandBar/commandBarKclInputKeymap.test.ts
@@ -1,0 +1,52 @@
+import {
+  autocompletion,
+  completionStatus,
+  startCompletion,
+} from '@codemirror/autocomplete'
+import { EditorState } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
+import { createCommandBarKclInputKeymap } from '@src/components/CommandBar/commandBarKclInputKeymap'
+import { describe, expect, it, vi } from 'vitest'
+
+describe('command bar KCL input keymap', () => {
+  it('submits when autocomplete is inactive', () => {
+    const onSubmit = vi.fn()
+    const view = new EditorView({
+      state: EditorState.create(),
+    })
+    const [enter] = createCommandBarKclInputKeymap({
+      onSubmit,
+      stepBack: vi.fn(),
+    })
+
+    expect(enter.run?.(view)).toBe(true)
+    expect(enter.preventDefault).toBe(true)
+    expect(onSubmit).toHaveBeenCalledOnce()
+    view.destroy()
+  })
+
+  it('consumes Enter without submitting while autocomplete is pending', () => {
+    const onSubmit = vi.fn()
+    const view = new EditorView({
+      state: EditorState.create({
+        doc: 'wid',
+        extensions: [
+          autocompletion({
+            override: [() => new Promise(() => {})],
+          }),
+        ],
+      }),
+    })
+    const [enter] = createCommandBarKclInputKeymap({
+      onSubmit,
+      stepBack: vi.fn(),
+    })
+
+    expect(startCompletion(view)).toBe(true)
+    expect(completionStatus(view.state)).toBe('pending')
+    expect(enter.run?.(view)).toBe(true)
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(view.state.doc.toString()).toBe('wid')
+    view.destroy()
+  })
+})

--- a/src/components/CommandBar/commandBarKclInputKeymap.test.ts
+++ b/src/components/CommandBar/commandBarKclInputKeymap.test.ts
@@ -5,7 +5,10 @@ import {
 } from '@codemirror/autocomplete'
 import { EditorState } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
-import { createCommandBarKclInputKeymap } from '@src/components/CommandBar/commandBarKclInputKeymap'
+import {
+  createCommandBarKclInputKeymap,
+  createCommandBarKclInputPendingEnterExtension,
+} from '@src/components/CommandBar/commandBarKclInputKeymap'
 import { describe, expect, it, vi } from 'vitest'
 
 describe('command bar KCL input keymap', () => {
@@ -25,15 +28,27 @@ describe('command bar KCL input keymap', () => {
     view.destroy()
   })
 
-  it('consumes Enter without submitting while autocomplete is pending', () => {
+  it('accepts autocomplete after Enter is pressed while it is pending', async () => {
     const onSubmit = vi.fn()
+    let resolveCompletion:
+      | ((result: { from: number; options: { label: string }[] }) => void)
+      | undefined
+    const pendingCompletion = new Promise<{
+      from: number
+      options: { label: string }[]
+    }>((resolve) => {
+      resolveCompletion = resolve
+    })
     const view = new EditorView({
       state: EditorState.create({
         doc: 'wid',
+        selection: { anchor: 3 },
         extensions: [
           autocompletion({
-            override: [() => new Promise(() => {})],
+            interactionDelay: 0,
+            override: [() => pendingCompletion],
           }),
+          createCommandBarKclInputPendingEnterExtension({ onSubmit }),
         ],
       }),
     })
@@ -45,8 +60,53 @@ describe('command bar KCL input keymap', () => {
     expect(startCompletion(view)).toBe(true)
     expect(completionStatus(view.state)).toBe('pending')
     expect(enter.run?.(view)).toBe(true)
+    expect(enter.run?.(view)).toBe(true)
     expect(onSubmit).not.toHaveBeenCalled()
     expect(view.state.doc.toString()).toBe('wid')
+
+    resolveCompletion?.({
+      from: 0,
+      options: [{ label: 'width' }],
+    })
+    await vi.waitFor(() => {
+      expect(view.state.doc.toString()).toBe('width')
+    })
+    expect(onSubmit).not.toHaveBeenCalled()
+    view.destroy()
+  })
+
+  it('submits once if pending autocomplete finds no suggestions', async () => {
+    const onSubmit = vi.fn()
+    let resolveCompletion: ((result: null) => void) | undefined
+    const pendingCompletion = new Promise<null>((resolve) => {
+      resolveCompletion = resolve
+    })
+    const view = new EditorView({
+      state: EditorState.create({
+        doc: 'wid',
+        selection: { anchor: 3 },
+        extensions: [
+          autocompletion({
+            interactionDelay: 0,
+            override: [() => pendingCompletion],
+          }),
+          createCommandBarKclInputPendingEnterExtension({ onSubmit }),
+        ],
+      }),
+    })
+    const [enter] = createCommandBarKclInputKeymap({
+      onSubmit,
+      stepBack: vi.fn(),
+    })
+
+    expect(startCompletion(view)).toBe(true)
+    expect(enter.run?.(view)).toBe(true)
+    expect(enter.run?.(view)).toBe(true)
+    resolveCompletion?.(null)
+
+    await vi.waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledOnce()
+    })
     view.destroy()
   })
 })

--- a/src/components/CommandBar/commandBarKclInputKeymap.ts
+++ b/src/components/CommandBar/commandBarKclInputKeymap.ts
@@ -1,0 +1,34 @@
+import { completionStatus } from '@codemirror/autocomplete'
+import type { KeyBinding } from '@codemirror/view'
+
+export function createCommandBarKclInputKeymap({
+  onSubmit,
+  stepBack,
+}: {
+  onSubmit: () => void
+  stepBack: () => void
+}): KeyBinding[] {
+  return [
+    {
+      key: 'Enter',
+      preventDefault: true,
+      run: (editor) => {
+        // The autocomplete keymap has higher precedence and accepts an active
+        // completion first. While completions are still pending, consume Enter
+        // so the single-line field can never fall through to a native newline.
+        if (completionStatus(editor.state) !== null) {
+          return true
+        }
+        onSubmit()
+        return true
+      },
+    },
+    {
+      key: 'Meta-Backspace',
+      run: () => {
+        stepBack()
+        return true
+      },
+    },
+  ]
+}

--- a/src/components/CommandBar/commandBarKclInputKeymap.ts
+++ b/src/components/CommandBar/commandBarKclInputKeymap.ts
@@ -1,5 +1,67 @@
-import { completionStatus } from '@codemirror/autocomplete'
-import type { KeyBinding } from '@codemirror/view'
+import { acceptCompletion, completionStatus } from '@codemirror/autocomplete'
+import { StateEffect } from '@codemirror/state'
+import type { Extension } from '@codemirror/state'
+import type { EditorView, KeyBinding, ViewUpdate } from '@codemirror/view'
+import { ViewPlugin } from '@codemirror/view'
+
+const queuePendingEnter = StateEffect.define()
+
+export function createCommandBarKclInputPendingEnterExtension({
+  onSubmit,
+}: {
+  onSubmit: () => void
+}): Extension {
+  return ViewPlugin.fromClass(
+    class {
+      private enterQueued = false
+      private replayScheduled = false
+      private destroyed = false
+
+      constructor(private readonly view: EditorView) {}
+
+      update(update: ViewUpdate) {
+        if (
+          update.transactions.some((transaction) =>
+            transaction.effects.some((effect) => effect.is(queuePendingEnter))
+          )
+        ) {
+          this.enterQueued = true
+        }
+
+        this.scheduleReplay()
+      }
+
+      private scheduleReplay() {
+        if (
+          !this.enterQueued ||
+          this.replayScheduled ||
+          completionStatus(this.view.state) === 'pending'
+        ) {
+          return
+        }
+
+        this.replayScheduled = true
+        queueMicrotask(() => {
+          this.replayScheduled = false
+          if (this.destroyed || !this.enterQueued) return
+
+          const status = completionStatus(this.view.state)
+          if (status === 'pending') return
+
+          this.enterQueued = false
+          if (status === 'active' && acceptCompletion(this.view)) return
+
+          onSubmit()
+        })
+      }
+
+      destroy() {
+        this.destroyed = true
+        this.enterQueued = false
+      }
+    }
+  )
+}
 
 export function createCommandBarKclInputKeymap({
   onSubmit,
@@ -14,9 +76,14 @@ export function createCommandBarKclInputKeymap({
       preventDefault: true,
       run: (editor) => {
         // The autocomplete keymap has higher precedence and accepts an active
-        // completion first. While completions are still pending, consume Enter
-        // so the single-line field can never fall through to a native newline.
-        if (completionStatus(editor.state) !== null) {
+        // completion first. If it is still pending, defer this Enter until the
+        // completion finishes so a fast keypress is not lost.
+        const status = completionStatus(editor.state)
+        if (status === 'pending') {
+          editor.dispatch({ effects: queuePendingEnter.of(null) })
+          return true
+        }
+        if (status === 'active') {
           return true
         }
         onSubmit()

--- a/src/lang/queryAst.test.ts
+++ b/src/lang/queryAst.test.ts
@@ -1,0 +1,57 @@
+import { findAllPreviousVariables } from '@src/lang/queryAst'
+import type { Program, VariableMap } from '@src/lang/wasm'
+import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
+import { describe, expect, it } from 'vitest'
+
+describe('findAllPreviousVariables without a source range', () => {
+  it('returns every top-level variable of the requested type', () => {
+    const ast = {
+      body: [
+        {
+          type: 'VariableDeclaration',
+          start: 0,
+          end: 12,
+          declaration: { id: { name: 'width' } },
+        },
+        {
+          type: 'VariableDeclaration',
+          start: 13,
+          end: 28,
+          declaration: { id: { name: 'description' } },
+        },
+        {
+          type: 'VariableDeclaration',
+          start: 29,
+          end: 40,
+          declaration: { id: { name: 'height' } },
+        },
+      ],
+    } as unknown as Program
+    const defaultType = {
+      type: 'Default',
+      angle: 'degrees',
+      len: 'mm',
+    } as const
+    const variables = {
+      width: { type: 'Number', value: 10, ty: defaultType },
+      description: { type: 'String', value: 'bracket' },
+      height: { type: 'Number', value: 20, ty: defaultType },
+    } as unknown as VariableMap
+
+    expect(
+      findAllPreviousVariables(
+        ast,
+        variables,
+        undefined,
+        null as unknown as ModuleType
+      )
+    ).toEqual({
+      variables: [
+        { key: 'width', value: 10, ty: defaultType },
+        { key: 'height', value: 20, ty: defaultType },
+      ],
+      bodyPath: [['body', '']],
+      insertIndex: 3,
+    })
+  })
+})

--- a/src/lang/queryAst.ts
+++ b/src/lang/queryAst.ts
@@ -444,14 +444,39 @@ export interface PrevVariable<T> {
   ty: NumericType | undefined
 }
 
-export function findAllPreviousVariablesPath(
+function previousVariablesFromBody<T extends 'number' | 'string'>(
+  bodyItems: Program['body'],
+  memVars: VariableMap,
+  type: T,
+  before: number = Number.POSITIVE_INFINITY
+): PrevVariable<T extends 'number' ? number : string>[] {
+  const variables: PrevVariable<T extends 'number' ? number : string>[] = []
+  bodyItems.forEach((item) => {
+    if (item.type !== 'VariableDeclaration' || item.end > before) return
+    const varName = item.declaration.id.name
+    const varValue = memVars[varName]
+    if (!varValue || !('value' in varValue) || typeof varValue.value !== type) {
+      return
+    }
+    variables.push({
+      key: varName,
+      value: varValue.value as T extends 'number' ? number : string,
+      ty: varValue.type === 'Number' ? varValue.ty : undefined,
+    })
+  })
+  return variables
+}
+
+export function findAllPreviousVariablesPath<
+  T extends 'number' | 'string' = 'number',
+>(
   ast: Program,
   memVars: VariableMap,
   path: PathToNode,
   wasmInstance: ModuleType,
-  type: 'number' | 'string' = 'number'
+  type: T = 'number' as T
 ): {
-  variables: PrevVariable<typeof type extends 'number' ? number : string>[]
+  variables: PrevVariable<T extends 'number' ? number : string>[]
   bodyPath: PathToNode
   insertIndex: number
 } {
@@ -481,20 +506,12 @@ export function findAllPreviousVariablesPath(
   }
   const { node: bodyItems } = _node2
 
-  const variables: PrevVariable<any>[] = []
-  bodyItems?.forEach?.((item) => {
-    if (item.type !== 'VariableDeclaration' || item.end > startRange) return
-    const varName = item.declaration.id.name
-    const varValue = memVars[varName]
-    if (!varValue || !('value' in varValue) || typeof varValue.value !== type) {
-      return
-    }
-    variables.push({
-      key: varName,
-      value: varValue.value,
-      ty: varValue.type === 'Number' ? varValue.ty : undefined,
-    })
-  })
+  const variables = previousVariablesFromBody(
+    bodyItems,
+    memVars,
+    type,
+    startRange
+  )
 
   return {
     insertIndex,
@@ -503,17 +520,26 @@ export function findAllPreviousVariablesPath(
   }
 }
 
-export function findAllPreviousVariables(
+export function findAllPreviousVariables<
+  T extends 'number' | 'string' = 'number',
+>(
   ast: Program,
   memVars: VariableMap,
-  sourceRange: SourceRange,
+  sourceRange: SourceRange | undefined,
   wasmInstance: ModuleType,
-  type: 'number' | 'string' = 'number'
+  type: T = 'number' as T
 ): {
-  variables: PrevVariable<typeof type extends 'number' ? number : string>[]
+  variables: PrevVariable<T extends 'number' ? number : string>[]
   bodyPath: PathToNode
   insertIndex: number
 } {
+  if (!sourceRange) {
+    return {
+      variables: previousVariablesFromBody(ast.body, memVars, type),
+      bodyPath: [['body', '']],
+      insertIndex: ast.body.length,
+    }
+  }
   const path = getNodePathFromSourceRange(ast, sourceRange)
   return findAllPreviousVariablesPath(ast, memVars, path, wasmInstance, type)
 }

--- a/src/lib/useCalculateKclExpression.ts
+++ b/src/lib/useCalculateKclExpression.ts
@@ -55,15 +55,13 @@ export function useCalculateKclExpression({
   // is asynchronous. Use this state variable to track if execution
   // has completed
   const [isExecuting, setIsExecuting] = useState(false)
-  // If there is no selection, use the end of the code
-  // so all variables are available
   const selectionRange: SourceRange | undefined =
     selectionRanges.graphSelections[0]?.codeRef?.range
-  // If there is no selection, use the end of the code
-  // If we don't memoize this, we risk an infinite set/read state loop
-  const endingSourceRange = useMemo(
-    () => sourceRange || selectionRange || [code.length, code.length],
-    [code, selectionRange, sourceRange]
+  // An undefined range means the new expression will be inserted at the end
+  // of the program, where every top-level variable is available.
+  const previousVariablesSourceRange = useMemo(
+    () => sourceRange || selectionRange,
+    [selectionRange, sourceRange]
   )
   const inputRef = useRef<HTMLInputElement>(null)
   const [availableVarInfo, setAvailableVarInfo] = useState<
@@ -129,12 +127,12 @@ export function useCalculateKclExpression({
     const varInfo = findAllPreviousVariables(
       ast,
       variables,
-      endingSourceRange,
+      previousVariablesSourceRange,
       wasmInstance
     )
     setAvailableVarInfo(varInfo)
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
-  }, [ast, variables, endingSourceRange])
+  }, [ast, variables, previousVariablesSourceRange])
 
   useEffect(() => {
     const execAstAndSetResult = async () => {

--- a/src/lib/usePreviousVarMentions.ts
+++ b/src/lib/usePreviousVarMentions.ts
@@ -15,7 +15,6 @@ export function usePreviousVarMentions(
   const { kclManager } = useSingletons()
   const wasmInstance = use(kclManager.wasmInstancePromise)
   const previousVariables = usePreviousVariables({
-    code: context.view?.state.doc.toString() || '',
     ast,
     variables,
     wasmInstance,

--- a/src/lib/usePreviousVariables.ts
+++ b/src/lib/usePreviousVariables.ts
@@ -1,8 +1,9 @@
+import { useEffect, useState } from 'react'
+
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import { findAllPreviousVariables } from '@src/lang/queryAst'
 import type { Program, VariableMap } from '@src/lang/wasm'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
-import { useEffect, useState } from 'react'
 
 export function usePreviousVariables({
   ast,

--- a/src/lib/usePreviousVariables.ts
+++ b/src/lib/usePreviousVariables.ts
@@ -1,28 +1,21 @@
-import { useEffect, useMemo, useState } from 'react'
-
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import { findAllPreviousVariables } from '@src/lang/queryAst'
 import type { Program, VariableMap } from '@src/lang/wasm'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
+import { useEffect, useState } from 'react'
 
 export function usePreviousVariables({
-  code,
   ast,
   variables,
   wasmInstance,
 }: {
-  code: string
   ast: Program
   variables: VariableMap
   wasmInstance: ModuleType
 }) {
   const { context } = useModelingContext()
-  const selectionFromContext =
+  const selectionRange =
     context.selectionRanges.graphSelections[0]?.codeRef?.range
-  const selectionRange = useMemo(
-    () => selectionFromContext || [code.length, code.length],
-    [selectionFromContext, code]
-  )
   const [previousVariablesInfo, setPreviousVariablesInfo] = useState<
     ReturnType<typeof findAllPreviousVariables>
   >({
@@ -32,7 +25,7 @@ export function usePreviousVariables({
   })
 
   useEffect(() => {
-    if (!variables || !selectionRange) return
+    if (!variables) return
     const varInfo = findAllPreviousVariables(
       ast,
       variables,

--- a/src/lib/varCompletionExtension.ts
+++ b/src/lib/varCompletionExtension.ts
@@ -2,10 +2,19 @@ import type { Completion, CompletionContext } from '@codemirror/autocomplete'
 import { autocompletion } from '@codemirror/autocomplete'
 import type { Extension } from '@codemirror/state'
 
+type VarMentionsConfig = {
+  activateOnTypingDelay?: number
+  interactionDelay?: number
+}
+
 /// Basically a fork of the `mentions` extension https://github.com/uiwjs/react-codemirror/blob/master/extensions/mentions/src/index.ts
 /// But it matches on any word, not just the `@` symbol
-export function varMentions(data: Completion[] = []): Extension {
+export function varMentions(
+  data: Completion[] = [],
+  config: VarMentionsConfig = {}
+): Extension {
   return autocompletion({
+    ...config,
     override: [
       (context: CompletionContext) => {
         let word = context.matchBefore(/(\w+)?/)


### PR DESCRIPTION
Closes #7409.

## Root cause

- When the command bar had no modeling selection, autocomplete substituted an end-of-file source range (`[code.length, code.length]`). That range does not correspond to an AST node, so `getNodePathFromSourceRange` returned no usable path and `findAllPreviousVariables` returned an empty variable list.
- Command-bar KCL fields shared a module-level CodeMirror editor and compartments. Completion state could therefore leak or become stale when moving between arguments, reopening commands, or entering sketch mode.
- If Enter was pressed while CodeMirror was still resolving completions, the completion keymap could not accept anything yet and the event could fall through to the editor, inserting a newline.

## Solution

- Treat an undefined source range explicitly as insertion at the end of the program and return all compatible top-level variables.
- Give each mounted command-bar KCL field its own CodeMirror editor and compartments, and destroy that editor on unmount.
- Start local variable completion immediately and defer Enter while completion is pending. Once it resolves, accept the suggestion—or submit once if there is no suggestion—without inserting a newline or requiring a second keypress.

## Regression coverage

- Unit coverage for no-selection variable discovery and pending-Enter behavior, including duplicate rapid Enter presses and no-result fallback.
- Separate Playwright scenarios preserve the empty-AST offset-plane flow and verify autocomplete before and after reopening the command.