### PR TITLE
Make cloud sync compare project snapshots

### DIFF
--- a/src/lib/cloudSync/diagnostics.ts
+++ b/src/lib/cloudSync/diagnostics.ts
@@ -1,0 +1,65 @@
+export type CloudSyncDiagnosticEvent = {
+  id: number
+  at: string
+  type: string
+  [key: string]: unknown
+}
+
+export type CloudSyncDiagnosticEventInput = {
+  type: string
+  [key: string]: unknown
+}
+
+type CloudSyncDiagnosticsGlobal = {
+  dump: () => CloudSyncDiagnosticEvent[]
+  clear: () => void
+}
+
+const MAX_CLOUD_SYNC_DIAGNOSTIC_EVENTS = 500
+const cloudSyncDiagnosticEvents: CloudSyncDiagnosticEvent[] = []
+let nextCloudSyncDiagnosticEventId = 1
+let installedDiagnosticsGlobal = false
+
+declare global {
+  interface Window {
+    __zdsCloudSyncDiagnostics?: CloudSyncDiagnosticsGlobal
+  }
+}
+
+function installCloudSyncDiagnosticsGlobal() {
+  if (installedDiagnosticsGlobal || typeof window === 'undefined') {
+    return
+  }
+
+  window.__zdsCloudSyncDiagnostics = {
+    dump: getCloudSyncDiagnosticEvents,
+    clear: clearCloudSyncDiagnosticEvents,
+  }
+  installedDiagnosticsGlobal = true
+}
+
+export function recordCloudSyncDiagnosticEvent(
+  event: CloudSyncDiagnosticEventInput
+) {
+  const diagnosticEvent: CloudSyncDiagnosticEvent = {
+    id: nextCloudSyncDiagnosticEventId++,
+    at: new Date().toISOString(),
+    ...event,
+  }
+  cloudSyncDiagnosticEvents.push(diagnosticEvent)
+  if (cloudSyncDiagnosticEvents.length > MAX_CLOUD_SYNC_DIAGNOSTIC_EVENTS) {
+    cloudSyncDiagnosticEvents.splice(
+      0,
+      cloudSyncDiagnosticEvents.length - MAX_CLOUD_SYNC_DIAGNOSTIC_EVENTS
+    )
+  }
+  installCloudSyncDiagnosticsGlobal()
+}
+
+export function getCloudSyncDiagnosticEvents() {
+  return [...cloudSyncDiagnosticEvents]
+}
+
+export function clearCloudSyncDiagnosticEvents() {
+  cloudSyncDiagnosticEvents.length = 0
+}

--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -20,15 +20,22 @@ import {
 } from '@src/lib/cloudSync/paths'
 import {
   getRemoteProjectTitleForProjectToml,
-  normalizeProjectArchiveFilesForCloudSync,
   parseProjectArchive,
-  projectManifestFromFiles,
   projectManifestsEqual,
   toArrayBuffer,
   withProjectTitleInArchiveFiles,
   withRemoteProjectMetadataInArchiveFiles,
   withUpdatedProjectTomlInArchiveFiles,
 } from '@src/lib/cloudSync/projectArchive'
+import { recordCloudSyncDiagnosticEvent } from '@src/lib/cloudSync/diagnostics'
+import {
+  createCloudSyncProjectSnapshot,
+  filterCloudSyncProjectFilesForSync,
+  isCloudSyncGeneratedArtifactRelativePath,
+  isCloudSyncGeneratedThumbnailGitignoreContents,
+  getProjectManifestChangedPaths,
+  type CloudSyncProjectSnapshot,
+} from '@src/lib/cloudSync/projectSnapshot'
 import {
   appendOutboxEntry as appendSyncDbOutboxEntry,
   clearOutboxEntriesForProject as clearSyncDbOutboxEntriesForProject,
@@ -61,7 +68,6 @@ import type { IStat, IZooDesignStudioFS } from '@src/lib/fs-zds/interface'
 import opfs from '@src/lib/fs-zds/opfs'
 import {
   appendGitignoreForDirectoryWithFs,
-  createGitignoreStackFromFiles,
   createInitialGitignoreStackWithFs,
   type GitignoreStackEntry,
   isPathIgnoredByGitignore,
@@ -88,6 +94,7 @@ export {
   prepareProjectFilesForCloudUpload,
   projectManifestsEqual,
 } from '@src/lib/cloudSync/projectArchive'
+export { filterCloudSyncProjectFilesForSync } from '@src/lib/cloudSync/projectSnapshot'
 export {
   getCloudSyncProjectMetadata,
   getCloudSyncProjectMetadataIndex,
@@ -370,26 +377,6 @@ export function getCloudSyncConflictCopyCleanupPlan(
     excludeProjectPaths,
     deleteProjectPaths,
   }
-}
-
-export function filterCloudSyncProjectFilesForSync(
-  files: ProjectArchiveFile[]
-) {
-  const normalizedFiles = normalizeProjectArchiveFilesForCloudSync(files)
-  const gitignoreStack = createGitignoreStackFromFiles(
-    normalizedFiles
-      .filter((file) => projectNameFromPath(file.relativePath) === '.gitignore')
-      .map((file) => ({
-        relativePath: file.relativePath,
-        contents: new TextDecoder().decode(file.data),
-      }))
-  )
-
-  return normalizedFiles.filter(
-    (file) =>
-      !isCloudSyncExcludedPath(file.relativePath) &&
-      !isPathIgnoredByGitignore(gitignoreStack, file.relativePath, false)
-  )
 }
 
 function isConfiguredForCloud() {
@@ -927,7 +914,7 @@ async function collectLocalProjectFiles(projectRoot: string) {
     projectRoot
   )
   await walk(projectRoot, gitignoreStack)
-  return normalizeProjectArchiveFilesForCloudSync(files).sort((a, b) =>
+  return filterCloudSyncProjectFilesForSync(files).sort((a, b) =>
     a.relativePath.localeCompare(b.relativePath)
   )
 }
@@ -944,6 +931,54 @@ function getRemoteProjectEntrypointPath(remoteProject: RemoteProject) {
     }
   }
   return undefined
+}
+
+async function snapshotProjectFilesForSync({
+  files,
+  source,
+  projectPath,
+  remoteProjectId,
+  entrypointPath,
+}: {
+  files: ProjectArchiveFile[]
+  source: 'local' | 'remote' | 'upload' | 'conflict'
+  projectPath?: string
+  remoteProjectId?: string
+  entrypointPath?: string
+}) {
+  return createCloudSyncProjectSnapshot(files, {
+    source,
+    projectPath,
+    remoteProjectId,
+    entrypointPath,
+  })
+}
+
+async function snapshotLocalProjectForSync(projectPath: string) {
+  const files = await collectLocalProjectFiles(projectPath)
+  return snapshotProjectFilesForSync({
+    files,
+    source: 'local',
+    projectPath,
+  })
+}
+
+async function snapshotRemoteProjectForSync({
+  remoteProject,
+  files,
+  projectPath,
+}: {
+  remoteProject: RemoteProject
+  files: ProjectArchiveFile[]
+  projectPath?: string
+}) {
+  return snapshotProjectFilesForSync({
+    files,
+    source: 'remote',
+    projectPath,
+    remoteProjectId: remoteProject.id,
+    entrypointPath: getRemoteProjectEntrypointPath(remoteProject),
+  })
 }
 
 async function replaceLocalProjectWithFiles(
@@ -1102,8 +1137,8 @@ async function getLocalProjectRealizationCandidatesByRemoteProjectId(
     paths.map(async (projectPath) => ({
       projectPath,
       metadata: await getProjectMetadata(projectPath),
-      manifest: await collectLocalProjectFiles(projectPath)
-        .then(projectManifestFromFiles)
+      manifest: await snapshotLocalProjectForSync(projectPath)
+        .then((snapshot) => snapshot.manifest)
         .catch(() => undefined),
     }))
   )
@@ -1169,6 +1204,22 @@ async function cleanupDuplicateLocalRealizationsForRemoteProject({
     (candidate) =>
       normalizePathForSync(candidate.projectPath) === normalizedKeepProjectPath
   )
+  recordCloudSyncDiagnosticEvent({
+    type: 'duplicate-realization-inventory',
+    remoteProjectId,
+    projectDirectory,
+    keepProjectPath: normalizedKeepProjectPath,
+    candidateCount: candidates.length,
+    candidates: candidates.map((candidate) => ({
+      projectPath: candidate.projectPath,
+      hasMetadata: Boolean(candidate.metadata),
+      hasBaseManifest: Boolean(candidate.metadata?.baseManifest),
+      hasManifest: Boolean(candidate.manifest),
+      tombstone: Boolean(candidate.metadata?.tombstone),
+      conflict: Boolean(candidate.metadata?.conflict),
+      syncExcluded: isProjectSyncExcluded(candidate.metadata),
+    })),
+  })
 
   if (
     !keepCandidate?.metadata?.baseManifest ||
@@ -1283,6 +1334,11 @@ async function cloneRemoteProjectToLocal(
       getRemoteProjectEntrypointPath(remoteProject)
     )
   )
+  const snapshot = await snapshotRemoteProjectForSync({
+    remoteProject,
+    files,
+    projectPath,
+  })
   const nextMetadata = {
     ...metadataForProject(projectPath),
     remoteProjectId: remoteProject.id,
@@ -1291,7 +1347,7 @@ async function cloneRemoteProjectToLocal(
   await replaceLocalProjectWithFiles(projectPath, files)
   await markProjectSynced(
     nextMetadata,
-    await projectManifestFromFiles(files),
+    snapshot.manifest,
     remoteSyncMetadata(remoteProject)
   )
 
@@ -1651,8 +1707,8 @@ async function repairExistingConflictCopies() {
     const remoteProjectId = await readProjectTomlCloudProjectId(
       projectPath
     ).catch(() => undefined)
-    const manifest = await collectLocalProjectFiles(projectPath)
-      .then(projectManifestFromFiles)
+    const manifest = await snapshotLocalProjectForSync(projectPath)
+      .then((snapshot) => snapshot.manifest)
       .catch(() => undefined)
 
     candidates.push({
@@ -1852,11 +1908,16 @@ async function applyCloudDataForConflict(metadata: ProjectMetadata) {
   const remoteFiles = await collectLocalProjectFiles(
     conflict.conflictProjectPath
   )
-  const remoteManifest = await projectManifestFromFiles(remoteFiles)
+  const remoteSnapshot = await snapshotProjectFilesForSync({
+    files: remoteFiles,
+    source: 'conflict',
+    projectPath: conflict.conflictProjectPath,
+    remoteProjectId: metadata.remoteProjectId,
+  })
   await replaceLocalProjectWithFiles(metadata.localProjectPath, remoteFiles)
   await clearOutboxEntriesForProject(metadata.localProjectPath)
   await deleteConflictCopy(conflict.conflictProjectPath)
-  await markProjectSynced(metadata, remoteManifest, {
+  await markProjectSynced(metadata, remoteSnapshot.manifest, {
     revision: conflict.remoteRevision,
   })
 }
@@ -1870,7 +1931,12 @@ async function applyLocalDataForConflict(metadata: ProjectMetadata) {
   }
 
   const localFiles = await collectLocalProjectFiles(metadata.localProjectPath)
-  const localManifest = await projectManifestFromFiles(localFiles)
+  const localSnapshot = await snapshotProjectFilesForSync({
+    files: localFiles,
+    source: 'local',
+    projectPath: metadata.localProjectPath,
+    remoteProjectId: metadata.remoteProjectId,
+  })
   const updated = await updateRemoteProject({
     config,
     projectPath: metadata.localProjectPath,
@@ -1882,7 +1948,7 @@ async function applyLocalDataForConflict(metadata: ProjectMetadata) {
   await deleteConflictCopy(conflict.conflictProjectPath)
   await markProjectSynced(
     metadata,
-    localManifest,
+    localSnapshot.manifest,
     remoteSyncMetadata(updated, { useNowAsUpdatedAtFallback: true })
   )
 }
@@ -1928,10 +1994,15 @@ async function hydrateCleanLocalProjectTitle(
   }
 
   const beforeFiles = await collectLocalProjectFiles(metadata.localProjectPath)
-  const beforeManifest = await projectManifestFromFiles(beforeFiles)
+  const beforeSnapshot = await snapshotProjectFilesForSync({
+    files: beforeFiles,
+    source: 'local',
+    projectPath: metadata.localProjectPath,
+    remoteProjectId: metadata.remoteProjectId,
+  })
   const localClean =
     !metadata.baseManifest ||
-    projectManifestsEqual(beforeManifest, metadata.baseManifest)
+    projectManifestsEqual(beforeSnapshot.manifest, metadata.baseManifest)
   if (!localClean) {
     return metadata
   }
@@ -1945,9 +2016,15 @@ async function hydrateCleanLocalProjectTitle(
   }
 
   const afterFiles = await collectLocalProjectFiles(metadata.localProjectPath)
+  const afterSnapshot = await snapshotProjectFilesForSync({
+    files: afterFiles,
+    source: 'local',
+    projectPath: metadata.localProjectPath,
+    remoteProjectId: metadata.remoteProjectId,
+  })
   const nextMetadata = {
     ...metadata,
-    baseManifest: await projectManifestFromFiles(afterFiles),
+    baseManifest: afterSnapshot.manifest,
   }
   await putProjectMetadata(nextMetadata)
   return nextMetadata
@@ -1957,9 +2034,34 @@ async function markProjectConflict(
   metadata: ProjectMetadata,
   remoteRevision: Revision | undefined,
   remoteFiles: ProjectArchiveFile[],
-  remoteTitle?: string
+  remoteTitle?: string,
+  diagnostics?: {
+    localSnapshot: CloudSyncProjectSnapshot
+    remoteSnapshot: CloudSyncProjectSnapshot
+    baseManifest?: ProjectManifest
+  }
 ) {
   const createdAt = nowIso()
+  recordCloudSyncDiagnosticEvent({
+    type: 'conflict-created',
+    projectPath: metadata.localProjectPath,
+    remoteProjectId: metadata.remoteProjectId,
+    remoteRevision,
+    baseLocalDiff: getProjectManifestChangedPaths(
+      diagnostics?.baseManifest,
+      diagnostics?.localSnapshot.manifest
+    ),
+    baseRemoteDiff: getProjectManifestChangedPaths(
+      diagnostics?.baseManifest,
+      diagnostics?.remoteSnapshot.manifest
+    ),
+    localRemoteDiff: getProjectManifestChangedPaths(
+      diagnostics?.localSnapshot.manifest,
+      diagnostics?.remoteSnapshot.manifest
+    ),
+    localAnnotations: diagnostics?.localSnapshot.annotations,
+    remoteAnnotations: diagnostics?.remoteSnapshot.annotations,
+  })
   const existingConflict = metadata.conflict
   const existingConflictProjectPath = existingConflict?.conflictProjectPath
   if (
@@ -2194,9 +2296,7 @@ async function reconcileMissingRemoteProject(
     !options.hasPendingLocalChanges
   ) {
     localMatchesBase = projectManifestsEqual(
-      await collectLocalProjectFiles(metadata.localProjectPath).then(
-        projectManifestFromFiles
-      ),
+      (await snapshotLocalProjectForSync(metadata.localProjectPath)).manifest,
       metadata.baseManifest
     )
   }
@@ -2253,10 +2353,10 @@ async function localProjectChangedFromSyncBase(metadata: ProjectMetadata) {
     return true
   }
 
-  const localManifest = await collectLocalProjectFiles(
+  const localSnapshot = await snapshotLocalProjectForSync(
     metadata.localProjectPath
-  ).then(projectManifestFromFiles)
-  return !projectManifestsEqual(localManifest, metadata.baseManifest)
+  )
+  return !projectManifestsEqual(localSnapshot.manifest, metadata.baseManifest)
 }
 
 async function syncProject(projectPath: string, entries: OutboxEntry[]) {
@@ -2341,7 +2441,13 @@ async function syncProject(projectPath: string, entries: OutboxEntry[]) {
       })
     }
     const localFiles = await collectLocalProjectFiles(metadata.localProjectPath)
-    const localManifest = await projectManifestFromFiles(localFiles)
+    const localSnapshot = await snapshotProjectFilesForSync({
+      files: localFiles,
+      source: 'local',
+      projectPath: metadata.localProjectPath,
+      remoteProjectId: metadata.remoteProjectId,
+    })
+    const localManifest = localSnapshot.manifest
 
     if (metadata.remoteProjectId) {
       remoteChanged =
@@ -2361,6 +2467,18 @@ async function syncProject(projectPath: string, entries: OutboxEntry[]) {
       remoteChanged,
       hasRemoteRevision: Boolean(metadata.remoteRevision),
     })
+    recordCloudSyncDiagnosticEvent({
+      type: 'sync-preflight-decision',
+      projectPath: metadata.localProjectPath,
+      remoteProjectId: metadata.remoteProjectId,
+      latestKind,
+      localProjectExists,
+      hasRemoteProjectId: Boolean(metadata.remoteProjectId),
+      hasBaseManifest: Boolean(metadata.baseManifest),
+      localChanged,
+      remoteChanged,
+      action: preflightAction,
+    })
 
     if (preflightAction === 'create-remote') {
       const created = await createRemoteProject(
@@ -2375,13 +2493,19 @@ async function syncProject(projectPath: string, entries: OutboxEntry[]) {
       const nextLocalFiles = await collectLocalProjectFiles(
         metadata.localProjectPath
       )
+      const nextLocalSnapshot = await snapshotProjectFilesForSync({
+        files: nextLocalFiles,
+        source: 'local',
+        projectPath: metadata.localProjectPath,
+        remoteProjectId: created.id,
+      })
       await clearOutboxEntriesForProject(metadata.localProjectPath)
       await markProjectSynced(
         {
           ...metadata,
           remoteProjectId: created.id,
         },
-        await projectManifestFromFiles(nextLocalFiles),
+        nextLocalSnapshot.manifest,
         remoteSyncMetadata(created, { useNowAsUpdatedAtFallback: true })
       )
       return
@@ -2437,7 +2561,12 @@ async function syncProject(projectPath: string, entries: OutboxEntry[]) {
         getRemoteProjectEntrypointPath(remoteProject)
       )
     )
-    const remoteManifest = await projectManifestFromFiles(remoteFiles)
+    const remoteSnapshot = await snapshotRemoteProjectForSync({
+      remoteProject,
+      files: remoteFiles,
+      projectPath: metadata.localProjectPath,
+    })
+    const remoteManifest = remoteSnapshot.manifest
 
     const localMatchesRemote = projectManifestsEqual(
       localManifest,
@@ -2450,6 +2579,37 @@ async function syncProject(projectPath: string, entries: OutboxEntry[]) {
         metadata.baseManifest &&
           projectManifestsEqual(localManifest, metadata.baseManifest)
       ),
+    })
+    recordCloudSyncDiagnosticEvent({
+      type: 'manifest-compared',
+      projectPath: metadata.localProjectPath,
+      remoteProjectId,
+      localChangedFromBase: Boolean(
+        metadata.baseManifest &&
+          !projectManifestsEqual(localManifest, metadata.baseManifest)
+      ),
+      remoteChangedFromBase: remoteChanged,
+      localMatchesRemote,
+      localBaseDiff: getProjectManifestChangedPaths(
+        metadata.baseManifest,
+        localManifest
+      ),
+      localRemoteDiff: getProjectManifestChangedPaths(
+        localManifest,
+        remoteManifest
+      ),
+    })
+    recordCloudSyncDiagnosticEvent({
+      type: 'remote-reconciliation-decision',
+      projectPath: metadata.localProjectPath,
+      remoteProjectId,
+      hasBaseManifest: Boolean(metadata.baseManifest),
+      localMatchesRemote,
+      localClean: Boolean(
+        metadata.baseManifest &&
+          projectManifestsEqual(localManifest, metadata.baseManifest)
+      ),
+      action: reconciliationAction,
     })
 
     if (reconciliationAction === 'mark-synced') {
@@ -2477,7 +2637,12 @@ async function syncProject(projectPath: string, entries: OutboxEntry[]) {
       metadata,
       remoteRevision,
       remoteFiles,
-      remoteProject?.title
+      remoteProject?.title,
+      {
+        localSnapshot,
+        remoteSnapshot,
+        baseManifest: metadata.baseManifest,
+      }
     )
   } catch (error) {
     await markProjectFailure(metadata, error)
@@ -3102,7 +3267,7 @@ async function registerProjectMutation(
   targetPath: string,
   sourcePath?: string
 ) {
-  if (!isConfiguredForCloud() || isCloudSyncExcludedPath(targetPath)) {
+  if (!isConfiguredForCloud()) {
     return
   }
 
@@ -3114,14 +3279,84 @@ async function registerProjectMutation(
   ) {
     return
   }
+  const normalizedTargetPath = normalizePathForSync(targetPath)
+  const normalizedSourcePath = sourcePath
+    ? normalizePathForSync(sourcePath)
+    : undefined
+  const relativeTargetPath = normalizeRelativePath(
+    localFs.relative(normalizedProjectPath, normalizedTargetPath)
+  )
+  if (isCloudSyncExcludedPath(targetPath)) {
+    recordCloudSyncDiagnosticEvent({
+      type: 'mutation-observed',
+      projectPath: normalizedProjectPath,
+      targetPath: normalizedTargetPath,
+      sourcePath: normalizedSourcePath,
+      kind,
+      action: 'ignored',
+      reason: 'excluded-path',
+    })
+    return
+  }
+  if (isCloudSyncGeneratedArtifactRelativePath(relativeTargetPath)) {
+    recordCloudSyncDiagnosticEvent({
+      type: 'mutation-observed',
+      projectPath: normalizedProjectPath,
+      targetPath: normalizedTargetPath,
+      sourcePath: normalizedSourcePath,
+      kind,
+      action: 'ignored',
+      reason: 'generated-artifact',
+    })
+    return
+  }
+  if (relativeTargetPath === '.gitignore') {
+    const gitignoreContents = await localFs
+      .readFile(normalizedTargetPath, { encoding: 'utf-8' })
+      .catch(() => undefined)
+    if (
+      typeof gitignoreContents === 'string' &&
+      isCloudSyncGeneratedThumbnailGitignoreContents(gitignoreContents)
+    ) {
+      recordCloudSyncDiagnosticEvent({
+        type: 'mutation-observed',
+        projectPath: normalizedProjectPath,
+        targetPath: normalizedTargetPath,
+        sourcePath: normalizedSourcePath,
+        kind,
+        action: 'ignored',
+        reason: 'generated-gitignore',
+      })
+      return
+    }
+  }
+
   let metadata = await getOrCreateProjectMetadata(normalizedProjectPath)
   if (isProjectSyncExcluded(metadata)) {
     await clearOutboxEntriesForProject(normalizedProjectPath)
+    recordCloudSyncDiagnosticEvent({
+      type: 'mutation-observed',
+      projectPath: normalizedProjectPath,
+      targetPath: normalizedTargetPath,
+      sourcePath: normalizedSourcePath,
+      kind,
+      action: 'ignored',
+      reason: 'sync-excluded-project',
+    })
     return
   }
   metadata = await bindRemoteProjectIdFromToml(metadata)
   if (!shouldAutoSyncLocalProject(metadata)) {
     await putProjectMetadata(metadata)
+    recordCloudSyncDiagnosticEvent({
+      type: 'mutation-observed',
+      projectPath: normalizedProjectPath,
+      targetPath: normalizedTargetPath,
+      sourcePath: normalizedSourcePath,
+      kind,
+      action: 'metadata-only',
+      reason: 'auto-sync-disabled',
+    })
     return
   }
 
@@ -3138,9 +3373,19 @@ async function registerProjectMutation(
   await appendOutboxEntry({
     projectPath: normalizedProjectPath,
     kind,
-    targetPath: normalizePathForSync(targetPath),
-    sourcePath: sourcePath ? normalizePathForSync(sourcePath) : undefined,
+    targetPath: normalizedTargetPath,
+    sourcePath: normalizedSourcePath,
     createdAt: nowIso(),
+  })
+  recordCloudSyncDiagnosticEvent({
+    type: 'mutation-observed',
+    projectPath: normalizedProjectPath,
+    targetPath: normalizedTargetPath,
+    sourcePath: normalizedSourcePath,
+    kind,
+    action: 'enqueued',
+    remoteProjectId: metadata.remoteProjectId,
+    hasBaseManifest: Boolean(metadata.baseManifest),
   })
   scheduleSync()
 }

--- a/src/lib/cloudSync/index.test.ts
+++ b/src/lib/cloudSync/index.test.ts
@@ -27,6 +27,7 @@ import {
   projectManifestFromFiles,
   withRemoteProjectMetadataInArchiveFiles,
 } from '@src/lib/cloudSync/projectArchive'
+import { createCloudSyncProjectSnapshot } from '@src/lib/cloudSync/projectSnapshot'
 import {
   PROJECT_FOLDER,
   PROJECT_IMAGE_NAME,
@@ -251,6 +252,97 @@ describe('cloudSync sync helpers', () => {
     expect(projectToml).toContain('title = "Bracket"')
     expect(projectToml).toContain('default_file = "nested/part.kcl"')
     expect(projectToml).toContain('project_id = "remote-project-123"')
+  })
+
+  it('compares project.toml default_file against the effective cloud entrypoint', async () => {
+    const localSnapshot = await createCloudSyncProjectSnapshot(
+      [
+        projectFile('main.kcl', 'cube = 1'),
+        projectFile(
+          PROJECT_SETTINGS_FILE_NAME,
+          'title = "Bracket"\ndefault_file = "main.kcl"\n'
+        ),
+      ],
+      { source: 'test', projectPath: '/projects/bracket' }
+    )
+    const remoteSnapshot = await createCloudSyncProjectSnapshot(
+      [
+        projectFile('main.kcl', 'cube = 1'),
+        projectFile(PROJECT_SETTINGS_FILE_NAME, 'title = "Bracket"\n'),
+      ],
+      {
+        source: 'test',
+        projectPath: '/projects/bracket',
+        entrypointPath: 'main.kcl',
+      }
+    )
+
+    expect(
+      projectManifestsEqual(localSnapshot.manifest, remoteSnapshot.manifest)
+    ).toBe(true)
+    expect(
+      readProjectFile(remoteSnapshot.syncFiles, PROJECT_SETTINGS_FILE_NAME)
+    ).toContain('default_file = "main.kcl"')
+  })
+
+  it('keeps real project.toml entrypoint changes meaningful', async () => {
+    const baseSnapshot = await createCloudSyncProjectSnapshot(
+      [
+        projectFile('main.kcl', 'cube = 1'),
+        projectFile('nested/part.kcl', 'part = 1'),
+        projectFile(
+          PROJECT_SETTINGS_FILE_NAME,
+          'title = "Bracket"\ndefault_file = "main.kcl"\n'
+        ),
+      ],
+      { source: 'test', projectPath: '/projects/bracket' }
+    )
+    const changedSnapshot = await createCloudSyncProjectSnapshot(
+      [
+        projectFile('main.kcl', 'cube = 1'),
+        projectFile('nested/part.kcl', 'part = 1'),
+        projectFile(
+          PROJECT_SETTINGS_FILE_NAME,
+          'title = "Bracket"\ndefault_file = "nested/part.kcl"\n'
+        ),
+      ],
+      { source: 'test', projectPath: '/projects/bracket' }
+    )
+
+    expect(
+      projectManifestsEqual(baseSnapshot.manifest, changedSnapshot.manifest)
+    ).toBe(false)
+  })
+
+  it('excludes generated thumbnails and exact generated .gitignore files', () => {
+    const files = filterCloudSyncProjectFilesForSync([
+      projectFile('main.kcl', 'cube = 1'),
+      projectFile('.gitignore', `${PROJECT_IMAGE_NAME}\n`),
+      projectFile(PROJECT_IMAGE_NAME, 'generated image'),
+    ])
+
+    expect(files.map((file) => file.relativePath)).toEqual(['main.kcl'])
+  })
+
+  it('neutralizes generated thumbnail .gitignore rules in snapshots', async () => {
+    const localSnapshot = await createCloudSyncProjectSnapshot(
+      [
+        projectFile('main.kcl', 'cube = 1'),
+        projectFile('.gitignore', `${PROJECT_IMAGE_NAME}\ndist/\n`),
+      ],
+      { source: 'test', projectPath: '/projects/bracket' }
+    )
+    const remoteSnapshot = await createCloudSyncProjectSnapshot(
+      [
+        projectFile('main.kcl', 'cube = 1'),
+        projectFile('.gitignore', 'dist/\n'),
+      ],
+      { source: 'test', projectPath: '/projects/bracket' }
+    )
+
+    expect(
+      projectManifestsEqual(localSnapshot.manifest, remoteSnapshot.manifest)
+    ).toBe(true)
   })
 
   it('excludes files ignored by project .gitignore from cloud sync manifests and uploads', () => {

--- a/src/lib/cloudSync/localProjectNames.spec.ts
+++ b/src/lib/cloudSync/localProjectNames.spec.ts
@@ -7,10 +7,8 @@ import {
   getCloudSyncProjectMetadata,
   scheduleCloudProjectDirectoryNameSyncFromTitles,
 } from '@src/lib/cloudSync'
-import {
-  normalizeProjectArchiveFilesForCloudSync,
-  projectManifestFromFiles,
-} from '@src/lib/cloudSync/projectArchive'
+import { normalizeProjectArchiveFilesForCloudSync } from '@src/lib/cloudSync/projectArchive'
+import { createCloudSyncProjectSnapshot } from '@src/lib/cloudSync/projectSnapshot'
 import type { ProjectArchiveFile } from '@src/lib/cloudSync/types'
 import {
   getAllOutboxEntries,
@@ -137,7 +135,13 @@ function addCloudProjectFiles(
 }
 
 async function cleanCloudProjectManifest() {
-  return projectManifestFromFiles(cloudProjectArchiveFiles())
+  return (
+    await createCloudSyncProjectSnapshot(cloudProjectArchiveFiles(), {
+      source: 'test',
+      projectPath: titleProjectPath,
+      remoteProjectId,
+    })
+  ).manifest
 }
 
 async function seedIdBasedCloudProjectMetadata() {

--- a/src/lib/cloudSync/projectSnapshot.ts
+++ b/src/lib/cloudSync/projectSnapshot.ts
@@ -1,0 +1,405 @@
+import {
+  isCloudSyncExcludedPath,
+  normalizeRelativePath,
+} from '@src/lib/cloudSync/paths'
+import {
+  normalizeProjectArchiveFilesForCloudSync,
+  projectManifestFromFiles,
+} from '@src/lib/cloudSync/projectArchive'
+import { recordCloudSyncDiagnosticEvent } from '@src/lib/cloudSync/diagnostics'
+import type {
+  ProjectArchiveFile,
+  ProjectManifest,
+} from '@src/lib/cloudSync/types'
+import {
+  PROJECT_ENTRYPOINT,
+  PROJECT_IMAGE_NAME,
+  PROJECT_SETTINGS_FILE_NAME,
+} from '@src/lib/constants'
+import {
+  createGitignoreStackFromFiles,
+  isPathIgnoredByGitignore,
+} from '@src/lib/gitignore'
+import {
+  getProjectDefaultFileFromProjectTomlContents,
+  normalizeProjectTomlContentsForCloudSyncSnapshot,
+} from '@src/lib/projectTomlMetadata'
+import { webSafePathSplit } from '@src/lib/pathUtils'
+
+export type CloudSyncSnapshotAnnotationKind =
+  | 'excluded-generated-thumbnail'
+  | 'excluded-generated-gitignore'
+  | 'ignored-by-gitignore'
+  | 'normalized-project-toml'
+  | 'neutralized-generated-gitignore'
+  | 'synthesized-default-file'
+  | 'remote-entrypoint-equivalent'
+
+export type CloudSyncSnapshotAnnotation = {
+  path: string
+  kind: CloudSyncSnapshotAnnotationKind
+  detail?: string
+}
+
+export type CloudSyncProjectSnapshot = {
+  rawFiles: ProjectArchiveFile[]
+  uploadFiles: ProjectArchiveFile[]
+  syncFiles: ProjectArchiveFile[]
+  manifest: ProjectManifest
+  annotations: CloudSyncSnapshotAnnotation[]
+  projectToml?: {
+    rawText?: string
+    canonicalText?: string
+    defaultFile?: string
+    effectiveEntrypoint?: string
+    defaultFileEquivalentToEntrypoint: boolean
+  }
+}
+
+export type CloudSyncProjectSnapshotOptions = {
+  source: 'local' | 'remote' | 'upload' | 'conflict' | 'test'
+  projectPath?: string
+  remoteProjectId?: string
+  entrypointPath?: string
+}
+
+export type ProjectManifestChangedPath = {
+  path: string
+  status: 'changed' | 'left-only' | 'right-only'
+}
+
+const textDecoder = new TextDecoder()
+const textEncoder = new TextEncoder()
+
+function fileNameFromRelativePath(relativePath: string) {
+  return webSafePathSplit(normalizeRelativePath(relativePath)).at(-1) || ''
+}
+
+function isGeneratedThumbnailPath(relativePath: string) {
+  return normalizeRelativePath(relativePath) === PROJECT_IMAGE_NAME
+}
+
+export function isCloudSyncGeneratedArtifactRelativePath(relativePath: string) {
+  return isGeneratedThumbnailPath(relativePath)
+}
+
+function isGeneratedThumbnailGitignore(contents: string) {
+  return contents.replace(/\r\n/g, '\n').trim() === PROJECT_IMAGE_NAME
+}
+
+export function isCloudSyncGeneratedThumbnailGitignoreContents(
+  contents: string
+) {
+  return isGeneratedThumbnailGitignore(contents)
+}
+
+function normalizeGitignoreContentsForSnapshot(contents: string) {
+  const nextLines = contents
+    .split(/\r?\n/g)
+    .filter((line) => line.trim() !== PROJECT_IMAGE_NAME)
+  const normalized = nextLines.join('\n').trim()
+
+  return normalized ? `${normalized}\n` : ''
+}
+
+function getProjectTomlDefaultFile(files: ProjectArchiveFile[]) {
+  const projectTomlFile = files.find(
+    (file) => file.relativePath === PROJECT_SETTINGS_FILE_NAME
+  )
+  if (!projectTomlFile) {
+    return undefined
+  }
+
+  return getProjectDefaultFileFromProjectTomlContents(
+    textDecoder.decode(projectTomlFile.data)
+  )
+}
+
+export function getCloudSyncProjectEntrypointPath(
+  files: ProjectArchiveFile[],
+  preferredEntrypointPath?: string
+) {
+  const normalizedPreferredEntrypointPath = preferredEntrypointPath
+    ? normalizeRelativePath(preferredEntrypointPath)
+    : undefined
+  if (normalizedPreferredEntrypointPath) {
+    return normalizedPreferredEntrypointPath
+  }
+
+  const normalizedFiles = normalizeProjectArchiveFilesForCloudSync(files)
+  const filePaths = new Set(normalizedFiles.map((file) => file.relativePath))
+  const projectTomlDefaultFile = getProjectTomlDefaultFile(normalizedFiles)
+  if (projectTomlDefaultFile && filePaths.has(projectTomlDefaultFile)) {
+    return projectTomlDefaultFile
+  }
+  if (filePaths.has(PROJECT_ENTRYPOINT)) {
+    return PROJECT_ENTRYPOINT
+  }
+
+  return normalizedFiles
+    .map((file) => file.relativePath)
+    .filter((relativePath) => relativePath.toLowerCase().endsWith('.kcl'))
+    .toSorted((a, b) => a.localeCompare(b))[0]
+}
+
+function cloudSyncProjectFilesForUpload(files: ProjectArchiveFile[]) {
+  const normalizedFiles = normalizeProjectArchiveFilesForCloudSync(files)
+  const annotations: CloudSyncSnapshotAnnotation[] = []
+  const gitignoreStack = createGitignoreStackFromFiles(
+    normalizedFiles
+      .filter(
+        (file) => fileNameFromRelativePath(file.relativePath) === '.gitignore'
+      )
+      .map((file) => ({
+        relativePath: file.relativePath,
+        contents: textDecoder.decode(file.data),
+      }))
+  )
+  const uploadFiles: ProjectArchiveFile[] = []
+
+  for (const file of normalizedFiles) {
+    if (isCloudSyncExcludedPath(file.relativePath)) {
+      continue
+    }
+    if (isGeneratedThumbnailPath(file.relativePath)) {
+      annotations.push({
+        path: file.relativePath,
+        kind: 'excluded-generated-thumbnail',
+      })
+      continue
+    }
+    if (
+      fileNameFromRelativePath(file.relativePath) === '.gitignore' &&
+      isGeneratedThumbnailGitignore(textDecoder.decode(file.data))
+    ) {
+      annotations.push({
+        path: file.relativePath,
+        kind: 'excluded-generated-gitignore',
+      })
+      continue
+    }
+    if (isPathIgnoredByGitignore(gitignoreStack, file.relativePath, false)) {
+      annotations.push({
+        path: file.relativePath,
+        kind: 'ignored-by-gitignore',
+      })
+      continue
+    }
+
+    uploadFiles.push(file)
+  }
+
+  return {
+    uploadFiles,
+    rawFiles: normalizedFiles,
+    annotations,
+  }
+}
+
+export function filterCloudSyncProjectFilesForSync(
+  files: ProjectArchiveFile[]
+) {
+  return cloudSyncProjectFilesForUpload(files).uploadFiles
+}
+
+function addOrReplaceFile(
+  files: ProjectArchiveFile[],
+  relativePath: string,
+  contents: string
+) {
+  const normalizedRelativePath = normalizeRelativePath(relativePath)
+  const file = {
+    relativePath: normalizedRelativePath,
+    data: textEncoder.encode(contents),
+  }
+  const existingIndex = files.findIndex(
+    (candidate) => candidate.relativePath === normalizedRelativePath
+  )
+  if (existingIndex === -1) {
+    files.push(file)
+  } else {
+    files[existingIndex] = file
+  }
+}
+
+function canonicalizeProjectTomlFile({
+  file,
+  effectiveEntrypoint,
+  annotations,
+}: {
+  file: ProjectArchiveFile
+  effectiveEntrypoint?: string
+  annotations: CloudSyncSnapshotAnnotation[]
+}) {
+  const rawText = textDecoder.decode(file.data)
+  const normalized = normalizeProjectTomlContentsForCloudSyncSnapshot(rawText, {
+    entrypointPath: effectiveEntrypoint,
+  })
+  if (normalized.contents !== rawText) {
+    annotations.push({
+      path: file.relativePath,
+      kind: 'normalized-project-toml',
+    })
+  }
+  if (normalized.defaultFileSynthesized) {
+    annotations.push({
+      path: file.relativePath,
+      kind: 'synthesized-default-file',
+      detail: normalized.effectiveEntrypointPath,
+    })
+  } else if (normalized.defaultFileMatchesEffectiveEntrypoint) {
+    annotations.push({
+      path: file.relativePath,
+      kind: 'remote-entrypoint-equivalent',
+      detail: normalized.effectiveEntrypointPath,
+    })
+  }
+
+  return {
+    file: {
+      ...file,
+      data: textEncoder.encode(normalized.contents),
+    },
+    projectToml: {
+      rawText,
+      canonicalText: normalized.contents,
+      defaultFile: normalized.defaultFile,
+      effectiveEntrypoint: normalized.effectiveEntrypointPath,
+      defaultFileEquivalentToEntrypoint:
+        normalized.defaultFileMatchesEffectiveEntrypoint,
+    },
+  }
+}
+
+function canonicalizeGitignoreFile(
+  file: ProjectArchiveFile,
+  annotations: CloudSyncSnapshotAnnotation[]
+) {
+  const rawText = textDecoder.decode(file.data)
+  const normalizedText = normalizeGitignoreContentsForSnapshot(rawText)
+  if (normalizedText === rawText) {
+    return file
+  }
+  annotations.push({
+    path: file.relativePath,
+    kind: 'neutralized-generated-gitignore',
+  })
+  if (!normalizedText) {
+    return undefined
+  }
+  return {
+    ...file,
+    data: textEncoder.encode(normalizedText),
+  }
+}
+
+export async function createCloudSyncProjectSnapshot(
+  files: ProjectArchiveFile[],
+  options: CloudSyncProjectSnapshotOptions
+): Promise<CloudSyncProjectSnapshot> {
+  const { rawFiles, uploadFiles, annotations } =
+    cloudSyncProjectFilesForUpload(files)
+  const effectiveEntrypoint = getCloudSyncProjectEntrypointPath(
+    uploadFiles,
+    options.entrypointPath
+  )
+  const syncFiles: ProjectArchiveFile[] = []
+  let projectToml: CloudSyncProjectSnapshot['projectToml']
+
+  for (const file of uploadFiles) {
+    if (file.relativePath === PROJECT_SETTINGS_FILE_NAME) {
+      const canonicalized = canonicalizeProjectTomlFile({
+        file,
+        effectiveEntrypoint,
+        annotations,
+      })
+      syncFiles.push(canonicalized.file)
+      projectToml = canonicalized.projectToml
+      continue
+    }
+    if (fileNameFromRelativePath(file.relativePath) === '.gitignore') {
+      const canonicalized = canonicalizeGitignoreFile(file, annotations)
+      if (canonicalized) {
+        syncFiles.push(canonicalized)
+      }
+      continue
+    }
+
+    syncFiles.push(file)
+  }
+
+  if (!projectToml && effectiveEntrypoint) {
+    const normalized = normalizeProjectTomlContentsForCloudSyncSnapshot('', {
+      entrypointPath: effectiveEntrypoint,
+    })
+    addOrReplaceFile(syncFiles, PROJECT_SETTINGS_FILE_NAME, normalized.contents)
+    annotations.push({
+      path: PROJECT_SETTINGS_FILE_NAME,
+      kind: 'synthesized-default-file',
+      detail: effectiveEntrypoint,
+    })
+    projectToml = {
+      rawText: undefined,
+      canonicalText: normalized.contents,
+      defaultFile: undefined,
+      effectiveEntrypoint: normalized.effectiveEntrypointPath,
+      defaultFileEquivalentToEntrypoint: false,
+    }
+  }
+
+  syncFiles.sort((a, b) => a.relativePath.localeCompare(b.relativePath))
+  const manifest = await projectManifestFromFiles(syncFiles)
+  recordCloudSyncDiagnosticEvent({
+    type: 'snapshot-built',
+    source: options.source,
+    projectPath: options.projectPath,
+    remoteProjectId: options.remoteProjectId,
+    rawFileCount: rawFiles.length,
+    uploadFileCount: uploadFiles.length,
+    syncFileCount: syncFiles.length,
+    effectiveEntrypoint,
+    annotations,
+  })
+
+  return {
+    rawFiles,
+    uploadFiles,
+    syncFiles,
+    manifest,
+    annotations,
+    projectToml,
+  }
+}
+
+export function getProjectManifestChangedPaths(
+  left: ProjectManifest | undefined,
+  right: ProjectManifest | undefined
+): ProjectManifestChangedPath[] {
+  if (!left || !right) {
+    return []
+  }
+
+  const paths = new Set([
+    ...Object.keys(left.files),
+    ...Object.keys(right.files),
+  ])
+  return Array.from(paths)
+    .toSorted((a, b) => a.localeCompare(b))
+    .flatMap((path): ProjectManifestChangedPath[] => {
+      const leftEntry = left.files[path]
+      const rightEntry = right.files[path]
+      if (!leftEntry) {
+        return [{ path, status: 'right-only' }]
+      }
+      if (!rightEntry) {
+        return [{ path, status: 'left-only' }]
+      }
+      if (
+        leftEntry.byteSize === rightEntry.byteSize &&
+        leftEntry.sha256 === rightEntry.sha256
+      ) {
+        return []
+      }
+      return [{ path, status: 'changed' }]
+    })
+}

--- a/src/lib/projectTomlMetadata.ts
+++ b/src/lib/projectTomlMetadata.ts
@@ -117,6 +117,14 @@ export function normalizeProjectTomlContents(contents: string) {
   return stringifyProjectToml(table)
 }
 
+export type CloudSyncProjectTomlNormalization = {
+  contents: string
+  defaultFile?: string
+  effectiveEntrypointPath?: string
+  defaultFileSynthesized: boolean
+  defaultFileMatchesEffectiveEntrypoint: boolean
+}
+
 export function getProjectDefaultFileFromProjectTomlContents(contents: string) {
   const table = parseProjectToml(contents)
   if (!table) {
@@ -125,6 +133,51 @@ export function getProjectDefaultFileFromProjectTomlContents(contents: string) {
 
   const defaultFile = getNonEmptyString(table.default_file)
   return defaultFile ? normalizeProjectTomlPath(defaultFile) : undefined
+}
+
+export function normalizeProjectTomlContentsForCloudSyncSnapshot(
+  contents: string,
+  options: { entrypointPath?: string } = {}
+): CloudSyncProjectTomlNormalization {
+  const table = parseProjectToml(contents)
+  if (!table) {
+    return {
+      contents,
+      defaultFile: undefined,
+      effectiveEntrypointPath: options.entrypointPath
+        ? normalizeProjectTomlPath(options.entrypointPath)
+        : undefined,
+      defaultFileSynthesized: false,
+      defaultFileMatchesEffectiveEntrypoint: false,
+    }
+  }
+
+  const defaultFile = getNonEmptyString(table.default_file)
+  const normalizedDefaultFile = defaultFile
+    ? normalizeProjectTomlPath(defaultFile)
+    : undefined
+  const entrypointPath = options.entrypointPath
+    ? normalizeProjectTomlPath(options.entrypointPath)
+    : undefined
+  const effectiveEntrypointPath = entrypointPath ?? normalizedDefaultFile
+
+  if (effectiveEntrypointPath) {
+    table.default_file = effectiveEntrypointPath
+  }
+
+  return {
+    contents: stringifyProjectToml(table),
+    defaultFile: normalizedDefaultFile,
+    effectiveEntrypointPath,
+    defaultFileSynthesized: Boolean(
+      effectiveEntrypointPath && !normalizedDefaultFile
+    ),
+    defaultFileMatchesEffectiveEntrypoint: Boolean(
+      normalizedDefaultFile &&
+        effectiveEntrypointPath &&
+        normalizedDefaultFile === effectiveEntrypointPath
+    ),
+  }
 }
 
 export function getProjectTitleFromProjectTomlContents(contents: string) {


### PR DESCRIPTION
## Summary

- Adds `CloudSyncProjectSnapshot` so cloud sync reconciliation compares semantic sync manifests instead of raw archive manifests.
- Normalizes `project.toml` around the effective cloud entrypoint/default file so backend canonicalization does not create conflicts.
- Filters generated `thumbnail.png` and generated thumbnail-only `.gitignore` artifacts out of sync comparisons and mutation enqueueing.
- Adds a bounded `window.__zdsCloudSyncDiagnostics` ring buffer to inspect snapshot/reconciliation decisions while debugging.

## Validation

- `npx vitest run src/lib/cloudSync`
- `npx tsc --noEmit`
- `node --require ./scripts/register-typescript-eslint-typescript.cjs ./node_modules/eslint/bin/eslint.js --max-warnings 0 src/lib/cloudSync/diagnostics.ts src/lib/cloudSync/engine.ts src/lib/cloudSync/index.test.ts src/lib/cloudSync/localProjectNames.spec.ts src/lib/cloudSync/projectSnapshot.ts src/lib/projectTomlMetadata.ts`
- `git diff --check --cached`