### PR TITLE
No idle when waiting on ZK

### DIFF
--- a/src/hooks/network/useOnPageIdle.spec.tsx
+++ b/src/hooks/network/useOnPageIdle.spec.tsx
@@ -42,6 +42,7 @@ vi.mock('@src/hooks/useModelingContext', () => ({
 }))
 
 import { useOnPageIdle } from '@src/hooks/network/useOnPageIdle'
+import { zookeeperPromptRunningSignal } from '@src/lib/zookeeper/zookeeperPromptState'
 
 async function advance(ms: number) {
   await act(async () => {
@@ -54,6 +55,7 @@ describe('useOnPageIdle', () => {
     vi.useFakeTimers()
     hookMocks.state.streamIdleMode = 5_000
     hookMocks.state.modelingValue = 'idle'
+    zookeeperPromptRunningSignal.value = false
     hookMocks.state.kclManager = {
       isExecuting: false,
       sceneInfra: {
@@ -70,6 +72,7 @@ describe('useOnPageIdle', () => {
   })
 
   afterEach(() => {
+    zookeeperPromptRunningSignal.value = false
     vi.runOnlyPendingTimers()
     vi.useRealTimers()
   })
@@ -137,6 +140,79 @@ describe('useOnPageIdle', () => {
       hookMocks.state.kclManager.engineCommandManager.tearDown
     ).toHaveBeenCalledTimes(1)
     expect(idleCallback).toHaveBeenCalledTimes(1)
+
+    unmount()
+  })
+
+  test('does not disconnect while a Zookeeper prompt is running', async () => {
+    zookeeperPromptRunningSignal.value = true
+
+    const idleCallback = vi.fn()
+    const { unmount } = renderHook(() =>
+      useOnPageIdle({
+        startCallback: vi.fn(),
+        idleCallback,
+      })
+    )
+
+    await advance(30_000)
+
+    expect(
+      hookMocks.state.kclManager.sceneInfra.camControls.saveRemoteCameraState
+    ).not.toHaveBeenCalled()
+    expect(
+      hookMocks.state.kclManager.engineCommandManager.tearDown
+    ).not.toHaveBeenCalled()
+    expect(idleCallback).not.toHaveBeenCalled()
+
+    zookeeperPromptRunningSignal.value = false
+    await advance(5_000)
+    expect(
+      hookMocks.state.kclManager.engineCommandManager.tearDown
+    ).not.toHaveBeenCalled()
+
+    await advance(1_000)
+    expect(
+      hookMocks.state.kclManager.engineCommandManager.tearDown
+    ).toHaveBeenCalledTimes(1)
+    expect(idleCallback).toHaveBeenCalledTimes(1)
+
+    unmount()
+  })
+
+  test('does not disconnect when a Zookeeper prompt starts during idle teardown', async () => {
+    let finishSavingCameraState: () => void = () => undefined
+    hookMocks.state.kclManager.sceneInfra.camControls.saveRemoteCameraState =
+      vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            finishSavingCameraState = resolve
+          })
+      )
+
+    const idleCallback = vi.fn()
+    const { unmount } = renderHook(() =>
+      useOnPageIdle({
+        startCallback: vi.fn(),
+        idleCallback,
+      })
+    )
+
+    await advance(5_000)
+    expect(
+      hookMocks.state.kclManager.sceneInfra.camControls.saveRemoteCameraState
+    ).toHaveBeenCalledTimes(1)
+
+    zookeeperPromptRunningSignal.value = true
+    await act(async () => {
+      finishSavingCameraState()
+      await Promise.resolve()
+    })
+
+    expect(
+      hookMocks.state.kclManager.engineCommandManager.tearDown
+    ).not.toHaveBeenCalled()
+    expect(idleCallback).not.toHaveBeenCalled()
 
     unmount()
   })

--- a/src/hooks/network/useOnPageIdle.tsx
+++ b/src/hooks/network/useOnPageIdle.tsx
@@ -1,6 +1,7 @@
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import { useApp, useSingletons } from '@src/lib/boot'
 import { EngineDebugger } from '@src/lib/debugger'
+import { zookeeperPromptRunningSignal } from '@src/lib/zookeeper/zookeeperPromptState'
 import { useEffect, useRef } from 'react'
 
 export const useOnPageIdle = ({
@@ -66,7 +67,8 @@ export const useOnPageIdle = ({
 
         const isBusy =
           kclManager.isExecuting ||
-          !modelingMachineStateRef.current.matches('idle')
+          !modelingMachineStateRef.current.matches('idle') ||
+          zookeeperPromptRunningSignal.value
 
         // Only start the idle timer once KCL execution and other modeling
         // interactions have fully finished.
@@ -91,6 +93,11 @@ export const useOnPageIdle = ({
             } catch (e) {
               console.warn('unable to save old camera state on idle', e)
               kclManager.sceneInfra.camControls.clearOldCameraState()
+            }
+            // A prompt may have started while the camera state was being saved.
+            if (zookeeperPromptRunningSignal.value) {
+              wasBusyRef.current = true
+              return
             }
             console.log(kclManager.sceneInfra.camControls.oldCameraState)
             console.warn('detected idle, tearing down connection.')
@@ -121,7 +128,8 @@ export const useOnPageIdle = ({
       startCallbackRef.current()
       timeoutStart.current =
         kclManager.isExecuting ||
-        !modelingMachineStateRef.current.matches('idle')
+        !modelingMachineStateRef.current.matches('idle') ||
+        zookeeperPromptRunningSignal.value
           ? null
           : Date.now()
     }
@@ -130,7 +138,9 @@ export const useOnPageIdle = ({
     // all, meaning the timer is not reset to run. We need to set it every
     // time our effect dependencies change then.
     timeoutStart.current =
-      kclManager.isExecuting || !modelingMachineStateRef.current.matches('idle')
+      kclManager.isExecuting ||
+      !modelingMachineStateRef.current.matches('idle') ||
+      zookeeperPromptRunningSignal.value
         ? null
         : Date.now()
 

--- a/src/lib/zookeeper/components/MlEphantConversationPaneWrapper.tsx
+++ b/src/lib/zookeeper/components/MlEphantConversationPaneWrapper.tsx
@@ -33,6 +33,7 @@ import {
   type ZookeeperEditPatch,
   type ZookeeperEditPatchFile,
 } from '@src/lib/zookeeper/zookeeperEditPatch'
+import { zookeeperPromptRunningSignal } from '@src/lib/zookeeper/zookeeperPromptState'
 import {
   normalizeKCLFileDeletePath,
   prepareMlEphantNewFileRequest,
@@ -119,6 +120,22 @@ function MlEphantConversationPaneInner(props: AreaTypeComponentProps) {
   } = useModelingContext()
   const loaderFile = project?.executingFileEntry.value
   const mlEphantManagerActor = MlEphantManagerReactContext.useActorRef()
+
+  useEffect(() => {
+    const updatePromptRunning = (
+      snapshot: ReturnType<typeof mlEphantManagerActor.getSnapshot>
+    ) => {
+      zookeeperPromptRunningSignal.value = snapshot.context.awaitingResponse
+    }
+
+    updatePromptRunning(mlEphantManagerActor.getSnapshot())
+    const subscription = mlEphantManagerActor.subscribe(updatePromptRunning)
+
+    return () => {
+      subscription.unsubscribe()
+      zookeeperPromptRunningSignal.value = false
+    }
+  }, [mlEphantManagerActor])
 
   useEffect(() => {
     if (!IS_STAGING_OR_DEBUG) return

--- a/src/lib/zookeeper/zookeeperPromptState.ts
+++ b/src/lib/zookeeper/zookeeperPromptState.ts
@@ -1,0 +1,7 @@
+import { signal } from '@preact/signals-core'
+
+/**
+ * Shared prompt state for app-wide behavior that must remain active while
+ * Zookeeper is waiting for a response.
+ */
+export const zookeeperPromptRunningSignal = signal(false)


### PR DESCRIPTION
## Summary

Prevent the engine connection from entering idle mode while a Zookeeper prompt is running.

- Exposes Zookeeper’s `awaitingResponse` state to the engine idle handler.
- Suspends the idle countdown for the duration of a prompt.
- Restarts the full idle countdown after the prompt completes.
- Handles the race where a prompt begins while idle teardown is saving camera state.

Context: https://kittycadworkspace.slack.com/archives/C07A80B83FS/p1785417786760909