### PR TITLE
Reduce cloud sync Home flutter

### DIFF
--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -1819,7 +1819,6 @@ async function markProjectSynced(
   if (syncInProgress) {
     pendingStatusSyncedAt = syncedAt
     updateStatus({
-      lastSyncedAt: syncedAt,
       lastFailure: undefined,
       lastFailureAt: undefined,
     })
@@ -2834,6 +2833,9 @@ async function runCloudSync() {
 
     await refreshPendingCount()
     const syncedAt = pendingStatusSyncedAt
+    if (syncedAt && cloudSyncStatus.value.state === 'conflict') {
+      updateStatus({ lastSyncedAt: syncedAt })
+    }
     if (cloudSyncStatus.value.state !== 'conflict' && remoteIndexFailed) {
       updateStatus({
         state: 'failed',

--- a/src/lib/cloudSync/statusCoalescing.test.ts
+++ b/src/lib/cloudSync/statusCoalescing.test.ts
@@ -1,0 +1,190 @@
+import 'fake-indexeddb/auto'
+import { effect } from '@preact/signals-core'
+import {
+  cloudSyncStatus,
+  configureCloudSyncEngine,
+  configureCloudSyncLocalFileSystem,
+} from '@src/lib/cloudSync'
+import { projectManifestFromFiles } from '@src/lib/cloudSync/projectArchive'
+import {
+  appendOutboxEntry,
+  putProjectMetadata,
+} from '@src/lib/cloudSync/syncDb'
+import {
+  createCloudSyncTestFs,
+  deleteCloudSyncTestDatabase,
+  getFetchMethod,
+  getFetchUrl,
+  jsonResponse,
+} from '@src/lib/cloudSync/testUtils'
+import type { ProjectArchiveFile } from '@src/lib/cloudSync/types'
+import { PROJECT_SETTINGS_FILE_NAME } from '@src/lib/constants'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const baseUrl = 'https://example.test'
+const projectDirectory = '/documents/Projects'
+const environmentName = 'dev.zoo.dev'
+const encoder = new TextEncoder()
+
+type TestProject = {
+  path: string
+  name: string
+  title: string
+  remoteProjectId: string
+  remoteRevision: string
+  mainKcl: string
+}
+
+const projects: TestProject[] = [
+  {
+    path: `${projectDirectory}/one`,
+    name: 'one',
+    title: 'One',
+    remoteProjectId: 'remote-one',
+    remoteRevision: 'rev-1',
+    mainKcl: 'one = 1\n',
+  },
+  {
+    path: `${projectDirectory}/two`,
+    name: 'two',
+    title: 'Two',
+    remoteProjectId: 'remote-two',
+    remoteRevision: 'rev-2',
+    mainKcl: 'two = 2\n',
+  },
+]
+
+const fetchMock = vi.fn<typeof fetch>()
+
+function projectToml(project: TestProject) {
+  return `title = "${project.title}"\n\n[cloud."${environmentName}"]\nproject_id = "${project.remoteProjectId}"\n`
+}
+
+function projectFiles(project: TestProject): ProjectArchiveFile[] {
+  return [
+    {
+      relativePath: 'main.kcl',
+      data: encoder.encode(project.mainKcl),
+    },
+    {
+      relativePath: PROJECT_SETTINGS_FILE_NAME,
+      data: encoder.encode(projectToml(project)),
+    },
+  ]
+}
+
+async function seedSyncedProjectMetadata(project: TestProject) {
+  await putProjectMetadata({
+    schemaVersion: 1,
+    localProjectPath: project.path,
+    projectName: project.name,
+    remoteProjectId: project.remoteProjectId,
+    remoteRevision: project.remoteRevision,
+    baseManifest: await projectManifestFromFiles(projectFiles(project)),
+  })
+  await appendOutboxEntry({
+    projectPath: project.path,
+    kind: 'upsert',
+    targetPath: `${project.path}/main.kcl`,
+    createdAt: '2026-07-30T12:00:00.000Z',
+  })
+}
+
+describe('cloud sync status coalescing', () => {
+  beforeEach(async () => {
+    await deleteCloudSyncTestDatabase()
+    fetchMock.mockReset()
+    vi.stubGlobal('fetch', fetchMock)
+    cloudSyncStatus.value = {
+      enabled: false,
+      state: 'disabled',
+      pendingCount: 0,
+    }
+  })
+
+  afterEach(async () => {
+    configureCloudSyncEngine({ enabled: false })
+    vi.unstubAllGlobals()
+    await deleteCloudSyncTestDatabase()
+    cloudSyncStatus.value = {
+      enabled: false,
+      state: 'disabled',
+      pendingCount: 0,
+    }
+  })
+
+  it('does not publish per-project lastSyncedAt updates while a sync run is active', async () => {
+    const files = new Map<string, string>()
+    for (const project of projects) {
+      files.set(`${project.path}/main.kcl`, project.mainKcl)
+      files.set(
+        `${project.path}/${PROJECT_SETTINGS_FILE_NAME}`,
+        projectToml(project)
+      )
+      await seedSyncedProjectMetadata(project)
+    }
+
+    configureCloudSyncLocalFileSystem(
+      createCloudSyncTestFs(files, { projectDirectory })
+    )
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = getFetchUrl(input)
+      const method = getFetchMethod(input, init)
+      if (url === `${baseUrl}/user/projects` && method === 'GET') {
+        return jsonResponse(
+          projects.map((project) => ({
+            id: project.remoteProjectId,
+            title: project.title,
+            revision: project.remoteRevision,
+          }))
+        )
+      }
+
+      const project = projects.find(
+        (candidate) =>
+          url === `${baseUrl}/user/projects/${candidate.remoteProjectId}` &&
+          method === 'GET'
+      )
+      if (project) {
+        return jsonResponse({
+          id: project.remoteProjectId,
+          title: project.title,
+          revision: project.remoteRevision,
+        })
+      }
+
+      return jsonResponse(
+        { message: `Unexpected fetch: ${method} ${url}` },
+        500
+      )
+    })
+
+    const syncingSyncedAtUpdates: string[] = []
+    const dispose = effect(() => {
+      const status = cloudSyncStatus.value
+      if (status.state === 'syncing' && status.lastSyncedAt) {
+        syncingSyncedAtUpdates.push(status.lastSyncedAt)
+      }
+    })
+
+    try {
+      configureCloudSyncEngine({
+        enabled: true,
+        baseUrl,
+        environmentName,
+        projectDirectoryPath: projectDirectory,
+        syncExistingLocalProjects: false,
+      })
+
+      await vi.waitFor(() => {
+        expect(cloudSyncStatus.value.state).toBe('idle')
+        expect(cloudSyncStatus.value.pendingCount).toBe(0)
+        expect(cloudSyncStatus.value.lastSyncedAt).toBeDefined()
+      })
+
+      expect(syncingSyncedAtUpdates).toEqual([])
+    } finally {
+      dispose()
+    }
+  })
+})

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -792,6 +792,15 @@ function projectCountLabel(count: number) {
   return `${count} project${count === 1 ? '' : 's'}`
 }
 
+function shouldShowLoadingMoreProjects(
+  state: ReturnType<typeof useSystemIOState>
+) {
+  return (
+    state.matches(SystemIOMachineStates.readingFolders) &&
+    !state.context.hasListedProjects
+  )
+}
+
 function ProjectLibraryOverview({
   libraries,
   searchResults,
@@ -806,7 +815,6 @@ function ProjectLibraryOverview({
   ...rest
 }: ProjectLibraryOverviewProps) {
   const state = useSystemIOState()
-  const isReadingFolders = state.matches(SystemIOMachineStates.readingFolders)
   const libraryRows = libraries
     .map((library) => ({
       library,
@@ -816,7 +824,7 @@ function ProjectLibraryOverview({
       ).toSorted(getSortFunction(sort)),
     }))
     .filter(({ projects }) => query.length === 0 || projects.length > 0)
-  const loadingMore = isReadingFolders ? (
+  const loadingMore = shouldShowLoadingMoreProjects(state) ? (
     <div className="py-4">
       <Loading isDummy={true}>Loading more projects...</Loading>
     </div>
@@ -1002,9 +1010,8 @@ function ProjectGrid({
   ...rest
 }: ProjectGridProps) {
   const state = useSystemIOState()
-  const isReadingFolders = state.matches(SystemIOMachineStates.readingFolders)
   const sortedSearchResults = searchResults.toSorted(getSortFunction(sort))
-  const loadingMore = isReadingFolders ? (
+  const loadingMore = shouldShowLoadingMoreProjects(state) ? (
     <div className="py-4">
       <Loading isDummy={true}>Loading more projects...</Loading>
     </div>


### PR DESCRIPTION
## Summary

This PR addresses the contained flutter issue reported on Home when cloud sync and project-library reloads overlap, which was reported by @cgoates via Slack while user-testing cloud sync in Staging.

- Coalesces cloud sync completion status so `lastSyncedAt` is published at the end of a sync run instead of mid-run while other projects are still pending.
- Suppresses the "Loading more projects..." indicator during background folder rereads after projects have already been listed.
- Adds a regression test that watches cloud sync status and verifies mid-sync `lastSyncedAt` updates are not emitted.

## Root Cause

Cloud sync could publish a fresh `lastSyncedAt` while `syncInProgress` was still true and more project work remained. The Home/projects layer treats cloud sync status changes as part of its refresh surface, so that mid-run status churn could combine with background folder rereads and make the bottom status plus project-loading indicator flutter.

Separately, Home displayed "Loading more projects..." whenever the system IO machine was in `readingFolders`, including background rereads after the first project list was already available.

## Validation

- `./node_modules/.bin/vitest run --mode=development --project=unit src/lib/cloudSync/statusCoalescing.test.ts`
- `./node_modules/.bin/biome check src/lib/cloudSync/engine.ts src/lib/cloudSync/statusCoalescing.test.ts src/routes/Home.tsx`