### PR TITLE
Report cloud sync conflicts and failures

### DIFF
--- a/src/lib/clientErrors.ts
+++ b/src/lib/clientErrors.ts
@@ -20,6 +20,8 @@ export enum ClientErrorCode {
   AuthLogoutTokenReadError = 'auth_logout_token_read_error',
   AuthTokenRevokeError = 'auth_token_revoke_error',
   AuthTokenSyncError = 'auth_token_sync_error',
+  CloudSyncConflict = 'cloud_sync_conflict',
+  CloudSyncFailure = 'cloud_sync_failure',
   EngineDisconnect = 'engine_disconnect',
   UserFeaturesFetchError = 'user_features_fetch_error',
   ZookeeperActorError = 'zookeeper_actor_error',

--- a/src/lib/cloudSync/clientErrorReporting.test.ts
+++ b/src/lib/cloudSync/clientErrorReporting.test.ts
@@ -1,0 +1,110 @@
+import { CloudApiError } from '@src/lib/cloudSync/cloudApi'
+import type * as ClientErrorsModule from '@src/lib/clientErrors'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  reportClientError: vi.fn<typeof ClientErrorsModule.reportClientError>(
+    async () => undefined
+  ),
+  reportRejection: vi.fn(),
+}))
+
+vi.mock('@src/lib/clientErrors', () => ({
+  ClientErrorCode: {
+    CloudSyncConflict: 'cloud_sync_conflict',
+    CloudSyncFailure: 'cloud_sync_failure',
+  },
+  reportClientError: mocks.reportClientError,
+}))
+
+vi.mock('@src/lib/trap', () => ({
+  reportRejection: mocks.reportRejection,
+}))
+
+import {
+  reportCloudSyncConflict,
+  reportCloudSyncFailure,
+} from '@src/lib/cloudSync/clientErrorReporting'
+
+describe('cloud sync client error reporting', () => {
+  beforeEach(() => {
+    mocks.reportClientError.mockReset()
+    mocks.reportClientError.mockResolvedValue(undefined)
+    mocks.reportRejection.mockClear()
+  })
+
+  it('reports conflicts without project details', () => {
+    reportCloudSyncConflict()
+
+    expect(mocks.reportClientError).toHaveBeenCalledWith({
+      code: 'cloud_sync_conflict',
+      errorName: 'CloudSyncConflict',
+      message: 'Cloud sync conflict: local and remote both changed.',
+      route: '/cloud-sync',
+      extra: {
+        source: 'CloudSyncEngine',
+        operation: 'reconcile-project',
+      },
+    })
+  })
+
+  it('reports privacy-safe failure categories', () => {
+    const firstError = new Error('ENOENT: /projects/one/main.kcl')
+    firstError.name = '/projects/private-error-name'
+    reportCloudSyncFailure('sync', firstError)
+    reportCloudSyncFailure('sync', new Error('ENOENT: /projects/two/main.kcl'))
+    reportCloudSyncFailure(
+      'sync',
+      Object.assign(new Error('Forbidden'), {
+        kind: 'remote-upload-forbidden',
+      })
+    )
+    reportCloudSyncFailure(
+      'remote-index',
+      new Error('Remote index failed', {
+        cause: new CloudApiError(503, 'Remote index is unavailable'),
+      })
+    )
+
+    const [first, second, third, fourth] =
+      mocks.reportClientError.mock.calls.map(([report]) => report)
+    expect(first.dedupeKey).toBe('CloudSync:failure:sync:Error:none:unknown')
+    expect(second.dedupeKey).toBe(first.dedupeKey)
+    expect(third).toMatchObject({
+      dedupeKey: 'CloudSync:failure:sync:Error:none:remote-upload-forbidden',
+      extra: {
+        operation: 'sync',
+        errorType: 'Error',
+        failureKind: 'remote-upload-forbidden',
+      },
+    })
+    expect(fourth).toMatchObject({
+      code: 'cloud_sync_failure',
+      dedupeKey: 'CloudSync:failure:remote-index:CloudApiError:503:unknown',
+      extra: {
+        operation: 'remote-index',
+        errorType: 'CloudApiError',
+        cloudApiStatus: 503,
+      },
+    })
+    expect(fourth.dedupeKey).not.toBe(first.dedupeKey)
+    expect(JSON.stringify([first, second, third, fourth])).not.toContain(
+      '/projects/'
+    )
+    expect(JSON.stringify([first, second, third, fourth])).not.toContain(
+      'Remote index is unavailable'
+    )
+  })
+
+  it('does not propagate reporting failures', async () => {
+    const rejection = new Error('Client error endpoint unavailable')
+    mocks.reportClientError.mockRejectedValueOnce(rejection)
+
+    expect(reportCloudSyncFailure('sync', new Error('Sync failed'))).toBe(
+      undefined
+    )
+    await vi.waitFor(() => {
+      expect(mocks.reportRejection).toHaveBeenCalledWith(rejection)
+    })
+  })
+})

--- a/src/lib/cloudSync/clientErrorReporting.ts
+++ b/src/lib/cloudSync/clientErrorReporting.ts
@@ -1,0 +1,68 @@
+import { ClientErrorCode, reportClientError } from '@src/lib/clientErrors'
+import { CloudApiError } from '@src/lib/cloudSync/cloudApi'
+import { reportRejection } from '@src/lib/trap'
+
+const route = '/cloud-sync'
+
+function submit(params: Parameters<typeof reportClientError>[0]) {
+  void reportClientError(params).catch(reportRejection)
+}
+
+export function reportCloudSyncConflict() {
+  submit({
+    code: ClientErrorCode.CloudSyncConflict,
+    errorName: 'CloudSyncConflict',
+    message: 'Cloud sync conflict: local and remote both changed.',
+    route,
+    extra: {
+      source: 'CloudSyncEngine',
+      operation: 'reconcile-project',
+    },
+  })
+}
+
+export type CloudSyncFailureOperation =
+  | 'conflict-resolution'
+  | 'mutation'
+  | 'remote-index'
+  | 'sync'
+
+export function reportCloudSyncFailure(
+  operation: CloudSyncFailureOperation,
+  error: unknown
+) {
+  const categoryError =
+    error instanceof Error && error.cause !== undefined ? error.cause : error
+  const failureKind =
+    typeof categoryError === 'object' &&
+    categoryError !== null &&
+    'kind' in categoryError &&
+    categoryError.kind === 'remote-upload-forbidden'
+      ? categoryError.kind
+      : undefined
+  const errorType =
+    categoryError instanceof CloudApiError
+      ? 'CloudApiError'
+      : categoryError instanceof TypeError
+        ? 'TypeError'
+        : categoryError instanceof Error
+          ? 'Error'
+          : typeof categoryError
+  const cloudApiStatus =
+    categoryError instanceof CloudApiError ? categoryError.status : undefined
+
+  submit({
+    code: ClientErrorCode.CloudSyncFailure,
+    errorName: 'CloudSyncFailure',
+    message: `Cloud sync failed during ${operation}.`,
+    route,
+    dedupeKey: `CloudSync:failure:${operation}:${errorType}:${cloudApiStatus ?? 'none'}:${failureKind ?? 'unknown'}`,
+    extra: {
+      source: 'CloudSyncEngine',
+      operation,
+      errorType,
+      cloudApiStatus,
+      failureKind,
+    },
+  })
+}

--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -1,6 +1,10 @@
 import { signal } from '@preact/signals-core'
 import env, { getEnvironmentNameFromEnv } from '@src/env'
 import {
+  reportCloudSyncConflict,
+  reportCloudSyncFailure,
+} from '@src/lib/cloudSync/clientErrorReporting'
+import {
   CloudApiError,
   createRemoteProject,
   deleteRemoteProject,
@@ -1783,6 +1787,7 @@ function markCloudMetadataFailure(error: unknown) {
     return
   }
 
+  reportCloudSyncFailure('mutation', error)
   initialLocalScanComplete = false
   updateStatus({
     enabled: true,
@@ -1904,6 +1909,7 @@ export async function resolveCloudSyncProjectConflict(
     await refreshPendingCount()
     scheduleSync(0)
   } catch (error) {
+    reportCloudSyncFailure('conflict-resolution', error)
     await markProjectFailure(metadata, error)
     // eslint-disable-next-line suggest-no-throw/suggest-no-throw
     throw error
@@ -2037,6 +2043,7 @@ async function markProjectConflict(
       lastFailureAt: nowIso(),
     })
   }
+  reportCloudSyncConflict()
 }
 
 function latestOutboxKind(entries: OutboxEntry[]) {
@@ -2736,7 +2743,8 @@ async function syncRemoteIndex() {
       new Error(
         `Cloud sync failed for ${failures.length} remote project${
           failures.length === 1 ? '' : 's'
-        }: ${errorMessage(failures.at(-1))}`
+        }: ${errorMessage(failures.at(-1))}`,
+        { cause: failures.at(-1) }
       )
     )
   }
@@ -2813,6 +2821,7 @@ async function runCloudSync() {
       await syncRemoteIndex().catch((error) => {
         remoteIndexFailed = true
         remoteIndexFailureMessage = errorMessage(error)
+        reportCloudSyncFailure('remote-index', error)
         updateStatus({
           state: 'failed',
           lastFailure: remoteIndexFailureMessage,
@@ -2867,6 +2876,7 @@ async function runCloudSync() {
   } catch (error) {
     const syncedAt = pendingStatusSyncedAt
     const kind = projectFailureKind(error)
+    reportCloudSyncFailure('sync', error)
     updateStatus({
       state: 'failed',
       lastFailure: errorMessage(error),


### PR DESCRIPTION
Closes #12696.

- Reports newly created cloud-sync conflicts after they are persisted.
- Reports failures from sync, remote indexing, conflict resolution, and mutation bookkeeping.
- Sends categorical error metadata without project details, raw messages, or stacks.
- Deduplicates repeated failure categories and keeps reporting fire-and-forget.

To test, get a preview from this branch in a conflict and run:

```
['dev-kubernetes']
| where message contains "client_error_reported" and message contains "cloud_sync"
| project _time, ['kubernetes.container_name'], message
| order by _time desc
```