### PR TITLE
Remove unnecessary reconnect toasts

### DIFF
--- a/src/hooks/network/useTryConnect.tsx
+++ b/src/hooks/network/useTryConnect.tsx
@@ -15,7 +15,6 @@ import type { SettingsActorType } from '@src/machines/settingsMachine'
 import type { ConnectionManager } from '@src/lib/engineConnection/connectionManager'
 import { getDimensions } from '@src/lib/engineConnection/utils'
 import { useRef } from 'react'
-import toast from 'react-hot-toast'
 
 /**
  * Helper function, do not call this directly. Use tryConnecting instead.
@@ -215,8 +214,6 @@ async function tryConnecting({
         return resolve('connecting')
       }
 
-      let toastId: string | null = null
-
       isConnecting.current = true
 
       async function attempt() {
@@ -269,9 +266,6 @@ async function tryConnecting({
             label: 'tryConnecting',
             message: 'setAppState({ isStreamAcceptingInput: true })',
           })
-          if (toastId) {
-            toast.dismiss(toastId)
-          }
           resolve('connected')
         } catch (e) {
           isConnecting.current = false
@@ -283,28 +277,9 @@ async function tryConnecting({
           engineCommandManager.tearDown()
           if (numberOfConnectionAttempts.current >= NUMBER_OF_ENGINE_RETRIES) {
             numberOfConnectionAttempts.current = 0
-            if (toastId) {
-              toast.dismiss(toastId)
-            }
             return reject(e)
           }
           attempt().catch(reportRejection)
-          if (toastId) {
-            toast.error(
-              `Engine connection lost, reconnecting... Attempt ${numberOfConnectionAttempts.current}/${NUMBER_OF_ENGINE_RETRIES}.`,
-              {
-                duration: Number.POSITIVE_INFINITY,
-                id: toastId,
-              }
-            )
-          } else {
-            toastId = toast.error(
-              `Engine connection lost, reconnecting... Attempt ${numberOfConnectionAttempts.current}/${NUMBER_OF_ENGINE_RETRIES}.`,
-              {
-                duration: Number.POSITIVE_INFINITY,
-              }
-            )
-          }
         }
       }
       await attempt()


### PR DESCRIPTION
These are not actionable error messages and do not reassure the user that the system is recovering. I have a strong suspicion that these actually cause a loss of trust by exposing internal error states directly to the user. Most apps to not behave this way.

---

Contributes to https://github.com/KittyCAD/modeling-app/issues/9967
Closes https://github.com/KittyCAD/modeling-app/issues/12173 (indirectly)