### PR TITLE
Ask user to pick a directory on local library creation

### DIFF
--- a/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.spec.tsx
+++ b/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.spec.tsx
@@ -178,7 +178,8 @@ describe('ProjectLibrariesSettingInput', () => {
       canceled: false,
       filePaths: ['/client-projects'],
     })
-    window.electron = { open } as unknown as Window['electron']
+    const getPath = vi.fn().mockResolvedValue('/documents')
+    window.electron = { getPath, open } as unknown as Window['electron']
 
     render(
       <ProjectLibrariesSettingInput
@@ -219,9 +220,10 @@ describe('ProjectLibrariesSettingInput', () => {
     )
     expect(open).toHaveBeenCalledWith({
       properties: ['openDirectory', 'createDirectory'],
-      defaultPath: '/projects',
+      defaultPath: '/documents',
       title: 'Choose a project library folder',
     })
+    expect(getPath).toHaveBeenCalledWith('documents')
 
     fireEvent.click(screen.getAllByTestId('project-library-remove')[1])
 

--- a/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.spec.tsx
+++ b/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.spec.tsx
@@ -6,8 +6,14 @@ import {
   type ProjectLibraryTypeOption,
   projectLibraryTypeOptionsFromContributions,
 } from '@src/lib/projectLibraries/settings/ProjectLibrariesSettingInput'
-import { fireEvent, render, screen } from '@testing-library/react'
-import { describe, expect, test, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+const originalElectron = window.electron
+
+afterEach(() => {
+  window.electron = originalElectron
+})
 
 const defaultLibraries: ProjectLibrarySetting[] = [
   {
@@ -166,8 +172,14 @@ describe('ProjectLibrariesSettingInput', () => {
     expect(updateValue).not.toHaveBeenCalled()
   })
 
-  test('edits, adds, and removes project libraries', () => {
+  test('edits, adds, and removes project libraries', async () => {
     const updateValue = vi.fn()
+    const open = vi.fn().mockResolvedValue({
+      canceled: false,
+      filePaths: ['/client-projects'],
+    })
+    window.electron = { open } as unknown as Window['electron']
+
     render(
       <ProjectLibrariesSettingInput
         value={defaultLibraries}
@@ -191,18 +203,25 @@ describe('ProjectLibrariesSettingInput', () => {
 
     fireEvent.click(screen.getByTestId('project-library-add'))
 
-    expect(updateValue).toHaveBeenLastCalledWith([
-      {
-        title: 'Client Projects',
-        path: '/projects',
-        type: 'directory',
-      },
-      {
-        title: 'Project Library',
-        path: 'projects',
-        type: 'directory',
-      },
-    ])
+    await waitFor(() =>
+      expect(updateValue).toHaveBeenLastCalledWith([
+        {
+          title: 'Client Projects',
+          path: '/projects',
+          type: 'directory',
+        },
+        {
+          title: 'Project Library',
+          path: '/client-projects',
+          type: 'directory',
+        },
+      ])
+    )
+    expect(open).toHaveBeenCalledWith({
+      properties: ['openDirectory', 'createDirectory'],
+      defaultPath: '/projects',
+      title: 'Choose a project library folder',
+    })
 
     fireEvent.click(screen.getAllByTestId('project-library-remove')[1])
 

--- a/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.tsx
+++ b/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.tsx
@@ -9,6 +9,8 @@ import Tooltip from '@src/components/Tooltip'
 import { removeDragPreviewElement, setDragPreview } from '@src/lib/dragPreview'
 import {
   areProjectLibrarySettingsEqual,
+  DIRECTORY_PROJECT_LIBRARY_TYPE,
+  getDefaultDirectoryProjectLibraryPath,
   moveProjectLibrarySetting,
   NEW_PROJECT_LIBRARY_TITLE,
   normalizeProjectLibrarySetting,
@@ -443,7 +445,19 @@ export function ProjectLibrariesSettingInput({
     }
 
     const newLibrary = libraryTypeOption.newLibrary
-    commit([...draftLibraries, newLibrary])
+    if (newLibrary.type !== DIRECTORY_PROJECT_LIBRARY_TYPE || !electron) {
+      commit([...draftLibraries, newLibrary])
+      return
+    }
+
+    const selectedPath = await chooseDirectory({
+      defaultPath: getDefaultDirectoryProjectLibraryPath(draftLibraries),
+    })
+    if (!selectedPath) {
+      return
+    }
+
+    commit([...draftLibraries, { ...newLibrary, path: selectedPath }])
   }
 
   function removeLibrary(index: number) {

--- a/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.tsx
+++ b/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.tsx
@@ -10,7 +10,6 @@ import { removeDragPreviewElement, setDragPreview } from '@src/lib/dragPreview'
 import {
   areProjectLibrarySettingsEqual,
   DIRECTORY_PROJECT_LIBRARY_TYPE,
-  getDefaultDirectoryProjectLibraryPath,
   moveProjectLibrarySetting,
   NEW_PROJECT_LIBRARY_TITLE,
   normalizeProjectLibrarySetting,
@@ -450,9 +449,8 @@ export function ProjectLibrariesSettingInput({
       return
     }
 
-    const selectedPath = await chooseDirectory({
-      defaultPath: getDefaultDirectoryProjectLibraryPath(draftLibraries),
-    })
+    const documentsPath = await electron.getPath('documents')
+    const selectedPath = await chooseDirectory({ defaultPath: documentsPath })
     if (!selectedPath) {
       return
     }


### PR DESCRIPTION
Fixes #12705 by forcing a directory picker, and starting it from the user’s Documents folder to avoid reselecting an existing library right away (if we had used `getDefaultDirectoryProjectLibraryPath`).

Tested on macOS and Windows.