### PR TITLE
feat(kcl): project enums to strings under explicit ascription

### DIFF
--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use async_recursion::async_recursion;
 use ezpz::Constraint;
@@ -72,6 +73,7 @@ use crate::execution::sketch_solve::substitute_sketch_var_in_segment;
 use crate::execution::sketch_solve::substitute_sketch_vars;
 use crate::execution::state::ModuleState;
 use crate::execution::state::SketchBlockState;
+use crate::execution::types::CoercionMode;
 use crate::execution::types::NumericTypeExt;
 use crate::execution::types::PrimitiveType;
 use crate::execution::types::RuntimeType;
@@ -1182,7 +1184,7 @@ impl ExecutorContext {
                                 })?;
 
                                 let value = KclValue::Type {
-                                    value: TypeDef::Enum(def),
+                                    value: TypeDef::Enum(Arc::new(def)),
                                     meta: vec![metadata],
                                     experimental: attrs.experimental,
                                 };
@@ -1746,7 +1748,7 @@ fn enum_named_by_segment(
     exec_state: &ExecState,
     segment: &Node<Identifier>,
     within: Option<&(EnvironmentRef, Vec<String>)>,
-) -> Option<EnumTypeDef> {
+) -> Option<Arc<EnumTypeDef>> {
     let key = format!("{}{}", memory::TYPE_PREFIX, segment.name);
     let value = match within {
         // Inside another module the enum must be exported to be reachable, and
@@ -1776,7 +1778,7 @@ fn enum_named_by_segment(
 
 /// `Red` in `Color::Red`.
 fn enum_variant_value(
-    def: &EnumTypeDef,
+    def: Arc<EnumTypeDef>,
     variant: &Node<Identifier>,
     exec_state: &mut ExecState,
 ) -> Result<KclValue, KclError> {
@@ -1803,12 +1805,12 @@ fn enum_variant_value(
     // `RuntimeType::from_alias`.
     exec_state.warn_experimental(&format!("the enum `{enum_name}`"), variant.as_source_range());
 
-    // The identity comes from the declaration and is never rebuilt from a name.
-    // A later enum v2 can then add a declaration site to `EnumTypeId` by changing
-    // this one construction, without revisiting every use.
+    // The value holds the declaration itself, so its identity is read off that
+    // declaration and can never be rebuilt from a name. A later enum v2 adding a
+    // declaration site to `EnumTypeId` therefore changes nothing here.
     Ok(KclValue::Enum {
         value: Box::new(EnumValue::new(
-            def.id().clone(),
+            def,
             variant.name.clone(),
             vec![Metadata {
                 source_range: variant.as_source_range(),
@@ -2633,7 +2635,13 @@ fn apply_ascription(
         exec_state.clear_units_warnings(&source_range);
     }
 
-    value.coerce(&ty, false, exec_state).map_err(|_| {
+    value.coerce(&ty, CoercionMode::explicit(), exec_state).map_err(|e| {
+        // A coercion that knows why it failed says so; the generic wording below
+        // would replace that with a worse description of the same failure.
+        if let Some(message) = e.message {
+            return KclError::new_semantic(KclErrorDetails::new(message, vec![source_range]));
+        }
+
         let suggestion = if ty == RuntimeType::length() {
             ", you might try coercing to a fully specified numeric type such as `mm`"
         } else if ty == RuntimeType::angle() {
@@ -2732,7 +2740,7 @@ impl Node<Name> {
                     )));
                 }
 
-                return enum_variant_value(&def, &self.name, exec_state);
+                return enum_variant_value(def, &self.name, exec_state);
             }
 
             let value = match mem_spec {

--- a/rust/kcl-lib/src/execution/fn_call.rs
+++ b/rust/kcl-lib/src/execution/fn_call.rs
@@ -28,6 +28,7 @@ use crate::execution::kcl_value::FunctionBody;
 use crate::execution::kcl_value::FunctionSource;
 use crate::execution::kcl_value::NamedParam;
 use crate::execution::memory;
+use crate::execution::types::CoercionMode;
 use crate::execution::types::RuntimeType;
 use crate::parsing::ast::types::CallExpressionKw;
 use crate::parsing::ast::types::Node;
@@ -965,18 +966,21 @@ fn type_check_params_kw(
                 // warned about once for the function definition.
                 let rty = RuntimeType::from_parsed(ty.clone(), exec_state, arg.source_range, false, true)
                     .map_err(|e| KclError::new_semantic(e.into()))?;
-                arg.value = arg.value.coerce(&rty, true, exec_state).map_err(|_| {
-                    KclError::new_argument(KclErrorDetails::new(
-                        format!(
-                            "The input argument of {} requires {}",
-                            fn_name
-                                .map(|n| format!("`{n}`"))
-                                .unwrap_or_else(|| "this function".to_owned()),
-                            type_err_str(ty, &arg.value, &arg.source_range, exec_state),
-                        ),
-                        vec![arg.source_range],
-                    ))
-                })?;
+                arg.value = arg
+                    .value
+                    .coerce(&rty, CoercionMode::implicit(), exec_state)
+                    .map_err(|_| {
+                        KclError::new_argument(KclErrorDetails::new(
+                            format!(
+                                "The input argument of {} requires {}",
+                                fn_name
+                                    .map(|n| format!("`{n}`"))
+                                    .unwrap_or_else(|| "this function".to_owned()),
+                                type_err_str(ty, &arg.value, &arg.source_range, exec_state),
+                            ),
+                            vec![arg.source_range],
+                        ))
+                    })?;
             }
             result.unlabeled = vec![(None, arg)]
         } else {
@@ -1069,7 +1073,7 @@ fn type_check_params_kw(
                                 .value
                                 .coerce(
                                     &rty,
-                                    true,
+                                    CoercionMode::implicit(),
                                     exec_state,
                                 )
                                 .map_err(|e| {
@@ -1220,7 +1224,7 @@ fn coerce_result_type(
         return Ok(None);
     };
 
-    let val = val.coerce(&ty, true, exec_state).map_err(|_| {
+    let val = val.coerce(&ty, CoercionMode::implicit(), exec_state).map_err(|_| {
         KclError::new_type(KclErrorDetails::new(
             format!(
                 "This function requires its result to be {}",

--- a/rust/kcl-lib/src/execution/kcl_value.rs
+++ b/rust/kcl-lib/src/execution/kcl_value.rs
@@ -1,9 +1,11 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use anyhow::Result;
 use indexmap::IndexMap;
 use kcl_api::UnitLength;
 use serde::Serialize;
+use serde::Serializer;
 
 use crate::CompilationIssue;
 use crate::KclError;
@@ -321,7 +323,10 @@ pub enum FunctionBody {
 pub enum TypeDef {
     RustRepr(PrimitiveType, StdFnProps),
     Alias(RuntimeType),
-    Enum(EnumTypeDef),
+    /// Shared rather than owned so that every value of the enum points at the
+    /// one declaration object, and so that reading the type out of memory,
+    /// which clones the `KclValue`, does not copy the variant list.
+    Enum(Arc<EnumTypeDef>),
 }
 
 /// The nominal identity of an enum.
@@ -416,28 +421,51 @@ impl EnumTypeDef {
 
 /// A value of an enum type, i.e. one of its variants.
 ///
-/// V1 variants are nullary, so the variant name is the entire value. A
-/// variant's representation is deliberately absent: it is secondary metadata
-/// and never participates in identity or equality.
-#[derive(Debug, Clone, PartialEq, Serialize)]
+/// V1 variants are nullary, so the variant name is the entire value. The value
+/// holds its declaration rather than only the declaration's identity, which is
+/// what lets a variant be projected to its declared representation: that
+/// representation is per-variant declaration data, and a value cannot find its
+/// declaration by name, because an import alias renames the binding and a value
+/// can reach a module that never imported the type at all. The declaration is
+/// reachable, not part of the value: identity and equality read the declaration's
+/// id and the variant name, never a representation.
+#[derive(Debug, Clone, Serialize)]
 pub struct EnumValue {
-    enum_id: EnumTypeId,
+    /// Serialized as `enum_id` so that the exposed shape stays the nominal
+    /// identity plus the variant, and no declaration data leaks into snapshots
+    /// or the memory pane.
+    #[serde(rename = "enum_id", serialize_with = "serialize_enum_def_id")]
+    def: Arc<EnumTypeDef>,
     variant: String,
     #[serde(skip)]
     meta: Vec<Metadata>,
 }
 
+fn serialize_enum_def_id<S: Serializer>(def: &Arc<EnumTypeDef>, serializer: S) -> Result<S::Ok, S::Error> {
+    def.id().serialize(serializer)
+}
+
+/// Two values are equal when they name the same variant of the same declaration.
+/// Written out rather than derived because the declaration handle is a route to
+/// the declaration and not part of the value: comparing it would, once variants
+/// carry representations, let a representation decide equality.
+impl PartialEq for EnumValue {
+    fn eq(&self, other: &Self) -> bool {
+        self.def.id() == other.def.id() && self.variant == other.variant
+    }
+}
+
 impl EnumValue {
-    pub fn new(enum_id: EnumTypeId, variant: impl Into<String>, meta: Vec<Metadata>) -> Self {
+    pub fn new(def: Arc<EnumTypeDef>, variant: impl Into<String>, meta: Vec<Metadata>) -> Self {
         Self {
-            enum_id,
+            def,
             variant: variant.into(),
             meta,
         }
     }
 
     pub fn enum_id(&self) -> &EnumTypeId {
-        &self.enum_id
+        self.def.id()
     }
 
     pub fn variant(&self) -> &str {
@@ -448,9 +476,20 @@ impl EnumValue {
         &self.meta
     }
 
+    /// The string this variant projects to under `enumValue: string`.
+    ///
+    /// The declared representation of the variant, which in V1 is always the
+    /// variant name because no variant can declare a `@repr` yet. This is the
+    /// single place that answers the question, so when `@repr` lands it reads the
+    /// declaration here rather than adding a second notion of representation at
+    /// the projection site.
+    pub fn declared_string_repr(&self) -> String {
+        self.variant.clone()
+    }
+
     /// How the value is written in KCL and shown to users, e.g. `Color::Red`.
     pub fn qualified_name(&self) -> String {
-        format!("{}::{}", self.enum_id.declared_name(), self.variant)
+        format!("{}::{}", self.def.id().declared_name(), self.variant)
     }
 }
 
@@ -1311,13 +1350,19 @@ mod tests {
         );
     }
 
+    fn color_def() -> Arc<EnumTypeDef> {
+        Arc::new(
+            EnumTypeDef::new(
+                EnumTypeId::new(ModuleId::default(), "Color"),
+                vec!["Red".to_owned(), "Green".to_owned()],
+            )
+            .unwrap(),
+        )
+    }
+
     fn color_red() -> KclValue {
         KclValue::Enum {
-            value: Box::new(EnumValue::new(
-                EnumTypeId::new(ModuleId::default(), "Color"),
-                "Red",
-                vec![],
-            )),
+            value: Box::new(EnumValue::new(color_def(), "Red", vec![])),
         }
     }
 
@@ -1352,6 +1397,24 @@ mod tests {
                 enum_name: "Color".to_owned(),
                 variant: "Red".to_owned(),
             }
+        );
+    }
+
+    /// Serialization is the third such surface, and the one that reaches
+    /// `program_memory.snap`. A value holds its whole declaration, so this pins
+    /// that only the identity and the variant are written out: the declaration
+    /// will carry `@repr` values, and those must not appear here.
+    #[test]
+    fn enum_values_serialize_as_identity_and_variant() {
+        assert_eq!(
+            serde_json::to_value(color_red()).unwrap(),
+            serde_json::json!({
+                "type": "Enum",
+                "value": {
+                    "enum_id": { "module_id": 0, "declared_name": "Color" },
+                    "variant": "Red",
+                },
+            })
         );
     }
 

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -5230,4 +5230,287 @@ type Color { | Green }
             "Redefinition of type Color."
         );
     }
+
+    /// Projection yields the variant's declared representation, which in V1 is
+    /// always the variant name. Every row binds `x` so the rows differ only in the
+    /// shape being projected, and the alias row is here because the target is
+    /// resolved before projection decides anything, so an alias must behave
+    /// exactly like the type it names.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enum_projects_to_string() {
+        let header = r#"
+            @settings(experimentalFeatures = allow)
+            type Color { | Red | Green }
+            type Label = string
+        "#;
+
+        for (case, body, expected) in [
+            ("a variant", "x = Color::Red: string", "Red"),
+            ("another variant of the same enum", "x = Color::Green: string", "Green"),
+            ("an alias of the target type", "x = Color::Red: Label", "Red"),
+            (
+                "an element of a projected array",
+                r#"
+                    pair = [Color::Red, Color::Green]: [string]
+                    x = pair[1]
+                "#,
+                "Green",
+            ),
+            (
+                "an element of a nested projected array",
+                r#"
+                    grid = [[Color::Green]]: [[string]]
+                    x = grid[0][0]
+                "#,
+                "Green",
+            ),
+            (
+                "a one-element array against a bare string",
+                "x = [Color::Red]: string",
+                "Red",
+            ),
+        ] {
+            let result = parse_execute(&format!("{header}{body}\n"))
+                .await
+                .unwrap_or_else(|err| panic!("case: {case}: {}", err.message()));
+            let KclValue::String { value, .. } = mem_get_json(result.exec_state.stack(), result.mem_env, "x") else {
+                panic!("case: {case}: `x` should hold a string");
+            };
+            assert_eq!(value, expected, "case: {case}");
+        }
+    }
+
+    /// Ascribing the enum's own type, directly or through an alias, is a check
+    /// rather than a conversion: the value stays an enum and still compares equal
+    /// to the variant it came from.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enum_ascription_keeps_the_enum() {
+        let header = r#"
+            @settings(experimentalFeatures = allow)
+            type Color { | Red | Green }
+            type Paint = Color
+        "#;
+
+        for (case, expression, expected) in [
+            ("its own type", "(Color::Red: Color) == Color::Red", true),
+            ("an alias of its own type", "(Color::Red: Paint) == Color::Red", true),
+            (
+                "the ascription does not change which variant it is",
+                "(Color::Red: Color) == Color::Green",
+                false,
+            ),
+        ] {
+            let result = parse_execute(&format!("{header}x = {expression}\n"))
+                .await
+                .unwrap_or_else(|err| panic!("case: {case}: {}", err.message()));
+            let KclValue::Bool { value, .. } = mem_get_json(result.exec_state.stack(), result.mem_env, "x") else {
+                panic!("case: {case}: `x` should hold a bool");
+            };
+            assert_eq!(value, expected, "case: {case}");
+        }
+    }
+
+    /// A boundary the user did not write must not project, or a nominal parameter
+    /// type would mean nothing. The rows are the separate coercion sites: the
+    /// unlabeled argument, a labeled argument, and the return.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enum_projection_is_not_implicit() {
+        let header = r#"
+            @settings(experimentalFeatures = allow)
+            type Color { | Red | Green }
+        "#;
+        let found = "but found a value of enum `Color` (with type `Color`).";
+
+        for (case, body, expected) in [
+            (
+                "unlabeled argument",
+                r#"
+                    fn label(@text: string) { return text }
+                    x = label(Color::Red)
+                "#,
+                format!("The input argument of `label` requires a value with type `string`, {found}"),
+            ),
+            (
+                "labeled argument",
+                r#"
+                    fn label(text: string) { return text }
+                    x = label(text = Color::Red)
+                "#,
+                format!("text requires a value with type `string`, {found}"),
+            ),
+            (
+                "return",
+                r#"
+                    fn label(): string { return Color::Red }
+                    x = label()
+                "#,
+                format!("This function requires its result to be a value with type `string`, {found}"),
+            ),
+            (
+                // The reported type is `[any; 1]` rather than `[Color; 1]` because
+                // an array literal does not infer a homogeneous element type. That
+                // is pre-existing and unrelated to enums; it is pinned here so the
+                // row is not read as an enum-specific quirk.
+                "inside an array at an argument boundary",
+                r#"
+                    fn labels(@text: [string]) { return text }
+                    x = labels([Color::Red])
+                "#,
+                "The input argument of `labels` requires an array of strings (`[string]`), but found an array of `Color` with 1 value (with type `[any; 1]`).".to_owned(),
+            ),
+        ] {
+            assert_eq!(
+                parse_execute(&format!("{header}{body}\n")).await.unwrap_err().message(),
+                expected,
+                "case: {case}"
+            );
+        }
+    }
+
+    /// What an explicit ascription refuses, and what it says about it. The numeric
+    /// rows deliberately do not name the mechanism a later version would use.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enum_ascription_rejections() {
+        let header = r#"
+            @settings(experimentalFeatures = allow)
+            type Color { | Red }
+            type Shade { | Red }
+        "#;
+        let no_number = "Cannot project enum `Color` to a number. An enum projects to `string`; projecting to a number is not supported yet.";
+
+        for (case, expression, expected) in [
+            ("a number target", "Color::Red: number(_)", no_number.to_owned()),
+            (
+                "a number target reached through an array, so the reason survives the walk",
+                "[Color::Red]: [number(_)]",
+                no_number.to_owned(),
+            ),
+            (
+                "a boolean target, which is not a projection at all",
+                "Color::Red: bool",
+                "could not coerce a value of enum `Color` (with type `Color`) to type `bool`".to_owned(),
+            ),
+            (
+                "another enum whose variants happen to match",
+                "Color::Red: Shade",
+                "could not coerce a value of enum `Color` (with type `Color`) to type `Shade`".to_owned(),
+            ),
+        ] {
+            assert_eq!(
+                parse_execute(&format!("{header}x = {expression}\n"))
+                    .await
+                    .unwrap_err()
+                    .message(),
+                expected,
+                "case: {case}"
+            );
+        }
+    }
+
+    /// The mirror of `enum_projection_is_not_implicit`: where the declared type is
+    /// the enum itself, a value flows through every boundary unchanged. Each row
+    /// binds `x` to a comparison that must hold, so a value that arrived altered
+    /// would fail rather than pass unnoticed. `Some(message)` marks a row that must
+    /// be refused instead, which is what keeps the check nominal rather than
+    /// merely permissive.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enum_flows_through_declared_types() {
+        let header = r#"
+            @settings(experimentalFeatures = allow)
+            type Color { | Red | Green }
+            type Shade { | Red }
+        "#;
+
+        for (case, body, expected) in [
+            (
+                "an unlabeled parameter",
+                r#"
+                    fn paint(@c: Color) { return c }
+                    x = paint(Color::Red) == Color::Red
+                "#,
+                None,
+            ),
+            (
+                "a labeled parameter",
+                r#"
+                    fn paint(c: Color) { return c }
+                    x = paint(c = Color::Green) == Color::Green
+                "#,
+                None,
+            ),
+            (
+                "a declared return type",
+                r#"
+                    fn pick(): Color { return Color::Red }
+                    x = pick() == Color::Red
+                "#,
+                None,
+            ),
+            (
+                "an array parameter",
+                r#"
+                    fn firstOf(@cs: [Color]) { return cs[0] }
+                    x = firstOf([Color::Red, Color::Green]) == Color::Red
+                "#,
+                None,
+            ),
+            (
+                // The field check is `has_type`, which an enum satisfies, so an
+                // object passes here while the projection row of
+                // `enum_projects_by_target_shape` fails. Both behaviors come from
+                // the same unfinished object coercion.
+                "an object field",
+                r#"
+                    fn take(@o: { c: Color }) { return o.c }
+                    x = take({ c = Color::Green }) == Color::Green
+                "#,
+                None,
+            ),
+            (
+                "a union that names the enum",
+                r#"
+                    fn either(@v: Color | string) { return v }
+                    x = either(Color::Red) == Color::Red
+                "#,
+                None,
+            ),
+            (
+                "the same union given the other member",
+                r#"
+                    fn either(@v: Color | string) { return v }
+                    x = either("plain") == "plain"
+                "#,
+                None,
+            ),
+            (
+                "another declaration at the same boundary",
+                r#"
+                    fn paint(@c: Color) { return c }
+                    x = paint(Shade::Red) == Shade::Red
+                "#,
+                Some(
+                    "The input argument of `paint` requires a value with type `Color`, but found a value of enum `Shade` (with type `Shade`).",
+                ),
+            ),
+        ] {
+            let code = format!("{header}{body}\n");
+            match expected {
+                None => {
+                    let result = parse_execute(&code)
+                        .await
+                        .unwrap_or_else(|err| panic!("case: {case}: {}", err.message()));
+                    let KclValue::Bool { value, .. } = mem_get_json(result.exec_state.stack(), result.mem_env, "x")
+                    else {
+                        panic!("case: {case}: `x` should hold a bool");
+                    };
+                    assert!(value, "case: {case}: the value did not survive the boundary");
+                }
+                Some(message) => assert_eq!(
+                    parse_execute(&code).await.unwrap_err().message(),
+                    message,
+                    "case: {case}"
+                ),
+            }
+        }
+    }
 }

--- a/rust/kcl-lib/src/execution/sketch_solve.rs
+++ b/rust/kcl-lib/src/execution/sketch_solve.rs
@@ -24,6 +24,7 @@ use crate::execution::SketchSurface;
 use crate::execution::UnsolvedExpr;
 use crate::execution::UnsolvedSegment;
 use crate::execution::UnsolvedSegmentKind;
+use crate::execution::types::CoercionMode;
 use crate::execution::types::PrimitiveType;
 use crate::execution::types::RuntimeType;
 use crate::front::Freedom;
@@ -68,17 +69,19 @@ pub(crate) fn normalize_to_solver_distance_unit(
     description: &str,
 ) -> Result<KclValue, KclError> {
     let length_ty = RuntimeType::Primitive(PrimitiveType::Number(solver_numeric_type(exec_state)));
-    value.coerce(&length_ty, true, exec_state).map_err(|_| {
-        KclError::new_semantic(KclErrorDetails::new(
-            format!(
-                "{} must be a length coercible to the module length unit {}, but found {}",
-                description,
-                length_ty.human_friendly_type(),
-                value.human_friendly_type(),
-            ),
-            vec![source_range],
-        ))
-    })
+    value
+        .coerce(&length_ty, CoercionMode::implicit(), exec_state)
+        .map_err(|_| {
+            KclError::new_semantic(KclErrorDetails::new(
+                format!(
+                    "{} must be a length coercible to the module length unit {}, but found {}",
+                    description,
+                    length_ty.human_friendly_type(),
+                    value.human_friendly_type(),
+                ),
+                vec![source_range],
+            ))
+        })
 }
 
 /// When giving input to the solver, all numbers must be given in the same
@@ -90,17 +93,19 @@ pub(crate) fn normalize_to_solver_angle_unit(
     description: &str,
 ) -> Result<KclValue, KclError> {
     let angle_ty = RuntimeType::angle();
-    value.coerce(&angle_ty, true, exec_state).map_err(|_| {
-        KclError::new_semantic(KclErrorDetails::new(
-            format!(
-                "{} must be coercible to an angle unit {}, but found {}",
-                description,
-                angle_ty.human_friendly_type(),
-                value.human_friendly_type(),
-            ),
-            vec![source_range],
-        ))
-    })
+    value
+        .coerce(&angle_ty, CoercionMode::implicit(), exec_state)
+        .map_err(|_| {
+            KclError::new_semantic(KclErrorDetails::new(
+                format!(
+                    "{} must be coercible to an angle unit {}, but found {}",
+                    description,
+                    angle_ty.human_friendly_type(),
+                    value.human_friendly_type(),
+                ),
+                vec![source_range],
+            ))
+        })
 }
 
 pub(super) fn substitute_sketch_vars(

--- a/rust/kcl-lib/src/execution/types.rs
+++ b/rust/kcl-lib/src/execution/types.rs
@@ -1280,15 +1280,74 @@ pub(super) fn angle_from_str(s: &str, source_range: SourceRange) -> Result<UnitA
     })
 }
 
+/// Which value-changing conversions a coercion is allowed to perform. Separate
+/// from the question of which types it accepts, which never varies.
+///
+/// The two constructors are the only two modes the language has: a value
+/// crossing a boundary the user did not write, and a type the user wrote down.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CoercionMode {
+    convert_units: bool,
+    project_enums: bool,
+}
+
+impl CoercionMode {
+    /// A boundary the user did not write: an argument, a return, or a
+    /// Rust-implemented function reading its arguments. Numbers convert to the
+    /// target's units. Enums do not project, because an implicit projection
+    /// would defeat nominal checking exactly where it matters.
+    pub fn implicit() -> Self {
+        CoercionMode {
+            convert_units: true,
+            project_enums: false,
+        }
+    }
+
+    /// A type the user wrote down, as in `expr: Type`. Numbers are reinterpreted
+    /// as having the target's units rather than converted, and an enum projects
+    /// to its declared representation.
+    pub fn explicit() -> Self {
+        CoercionMode {
+            convert_units: false,
+            project_enums: true,
+        }
+    }
+
+    pub(crate) fn convert_units(self) -> bool {
+        self.convert_units
+    }
+
+    pub(crate) fn project_enums(self) -> bool {
+        self.project_enums
+    }
+
+    /// The same mode with projection off, so that a union can look for an exact
+    /// match before it considers projecting.
+    pub(crate) fn without_projection(self) -> Self {
+        CoercionMode {
+            project_enums: false,
+            ..self
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct CoercionError {
     pub found: Option<RuntimeType>,
     pub explicit_coercion: Option<String>,
+    /// Set when the generic "could not coerce" wording would describe the wrong
+    /// problem, and the caller should report this instead.
+    pub message: Option<String>,
 }
 
 impl CoercionError {
     fn with_explicit(mut self, c: String) -> Self {
         self.explicit_coercion = Some(c);
+        self
+    }
+
+    fn with_message(mut self, message: String) -> Self {
+        self.message = Some(message);
         self
     }
 }
@@ -1298,6 +1357,7 @@ impl From<&'_ KclValue> for CoercionError {
         CoercionError {
             found: value.principal_type(),
             explicit_coercion: None,
+            message: None,
         }
     }
 }
@@ -1321,7 +1381,7 @@ impl KclValue {
     pub fn coerce(
         &self,
         ty: &RuntimeType,
-        convert_units: bool,
+        mode: CoercionMode,
         exec_state: &mut ExecState,
     ) -> Result<KclValue, CoercionError> {
         match self {
@@ -1329,7 +1389,7 @@ impl KclValue {
                 if value.len() == 1
                     && !matches!(ty, RuntimeType::Primitive(PrimitiveType::Any) | RuntimeType::Tuple(..)) =>
             {
-                if let Ok(coerced) = value[0].coerce(ty, convert_units, exec_state) {
+                if let Ok(coerced) = value[0].coerce(ty, mode, exec_state) {
                     return Ok(coerced);
                 }
             }
@@ -1337,7 +1397,7 @@ impl KclValue {
                 if value.len() == 1
                     && !matches!(ty, RuntimeType::Primitive(PrimitiveType::Any) | RuntimeType::Array(..)) =>
             {
-                if let Ok(coerced) = value[0].coerce(ty, convert_units, exec_state) {
+                if let Ok(coerced) = value[0].coerce(ty, mode, exec_state) {
                     return Ok(coerced);
                 }
             }
@@ -1345,12 +1405,12 @@ impl KclValue {
         }
 
         match ty {
-            RuntimeType::Primitive(ty) => self.coerce_to_primitive_type(ty, convert_units, exec_state),
-            RuntimeType::Array(ty, len) => self.coerce_to_array_type(ty, convert_units, *len, exec_state, false),
-            RuntimeType::Tuple(tys) => self.coerce_to_tuple_type(tys, convert_units, exec_state),
-            RuntimeType::Union(tys) => self.coerce_to_union_type(tys, convert_units, exec_state),
+            RuntimeType::Primitive(ty) => self.coerce_to_primitive_type(ty, mode, exec_state),
+            RuntimeType::Array(ty, len) => self.coerce_to_array_type(ty, mode, *len, exec_state, false),
+            RuntimeType::Tuple(tys) => self.coerce_to_tuple_type(tys, mode, exec_state),
+            RuntimeType::Union(tys) => self.coerce_to_union_type(tys, mode, exec_state),
             RuntimeType::Object(tys, constrainable) => {
-                self.coerce_to_object_type(tys, *constrainable, convert_units, exec_state)
+                self.coerce_to_object_type(tys, *constrainable, mode, exec_state)
             }
             RuntimeType::Enum(id) => self.coerce_to_enum_type(id),
         }
@@ -1370,7 +1430,7 @@ impl KclValue {
     fn coerce_to_primitive_type(
         &self,
         ty: &PrimitiveType,
-        convert_units: bool,
+        mode: CoercionMode,
         exec_state: &mut ExecState,
     ) -> Result<KclValue, CoercionError> {
         match ty {
@@ -1381,7 +1441,20 @@ impl KclValue {
                 _ => Err(self.into()),
             },
             PrimitiveType::Number(ty) => {
-                if convert_units {
+                // `Color::Red: number(_)` is a projection the user asked for and
+                // V1 cannot perform. Reporting the numeric "expected a number"
+                // here would describe the wrong problem: the value is a working
+                // enum, not a broken number.
+                if let KclValue::Enum { value } = self
+                    && mode.project_enums()
+                {
+                    return Err(CoercionError::from(self).with_message(format!(
+                        "Cannot project enum `{}` to a number. An enum projects to `string`; projecting to a number is not supported yet.",
+                        value.enum_id().declared_name()
+                    )));
+                }
+
+                if mode.convert_units() {
                     return ty.coerce(self);
                 }
 
@@ -1405,6 +1478,12 @@ impl KclValue {
             }
             PrimitiveType::String => match self {
                 KclValue::String { .. } => Ok(self.clone()),
+                // The one projection V1 performs, and only where the user wrote
+                // the type: see `CoercionMode`.
+                KclValue::Enum { value } if mode.project_enums() => Ok(KclValue::String {
+                    value: value.declared_string_repr(),
+                    meta: value.meta().to_vec(),
+                }),
                 _ => Err(self.into()),
             },
             PrimitiveType::Boolean => match self {
@@ -1545,22 +1624,10 @@ impl KclValue {
                     }
 
                     let origin = values.get("origin").ok_or(self.into()).and_then(|p| {
-                        p.coerce_to_array_type(
-                            &RuntimeType::length(),
-                            convert_units,
-                            ArrayLen::Known(2),
-                            exec_state,
-                            true,
-                        )
+                        p.coerce_to_array_type(&RuntimeType::length(), mode, ArrayLen::Known(2), exec_state, true)
                     })?;
                     let direction = values.get("direction").ok_or(self.into()).and_then(|p| {
-                        p.coerce_to_array_type(
-                            &RuntimeType::length(),
-                            convert_units,
-                            ArrayLen::Known(2),
-                            exec_state,
-                            true,
-                        )
+                        p.coerce_to_array_type(&RuntimeType::length(), mode, ArrayLen::Known(2), exec_state, true)
                     })?;
 
                     Ok(KclValue::Object {
@@ -1589,22 +1656,10 @@ impl KclValue {
                     }
 
                     let origin = values.get("origin").ok_or(self.into()).and_then(|p| {
-                        p.coerce_to_array_type(
-                            &RuntimeType::length(),
-                            convert_units,
-                            ArrayLen::Known(3),
-                            exec_state,
-                            true,
-                        )
+                        p.coerce_to_array_type(&RuntimeType::length(), mode, ArrayLen::Known(3), exec_state, true)
                     })?;
                     let direction = values.get("direction").ok_or(self.into()).and_then(|p| {
-                        p.coerce_to_array_type(
-                            &RuntimeType::length(),
-                            convert_units,
-                            ArrayLen::Known(3),
-                            exec_state,
-                            true,
-                        )
+                        p.coerce_to_array_type(&RuntimeType::length(), mode, ArrayLen::Known(3), exec_state, true)
                     })?;
 
                     Ok(KclValue::Object {
@@ -1634,7 +1689,7 @@ impl KclValue {
     fn coerce_to_array_type(
         &self,
         ty: &RuntimeType,
-        convert_units: bool,
+        mode: CoercionMode,
         len: ArrayLen,
         exec_state: &mut ExecState,
         allow_shrink: bool,
@@ -1663,7 +1718,7 @@ impl KclValue {
                     let value_result = value
                         .iter()
                         .take(satisfied_len)
-                        .map(|v| v.coerce(ty, convert_units, exec_state))
+                        .map(|v| v.coerce(ty, mode, exec_state))
                         .collect::<Result<Vec<_>, _>>();
 
                     if let Ok(value) = value_result {
@@ -1678,10 +1733,10 @@ impl KclValue {
                     if let KclValue::HomArray { value: inner_value, .. } = item {
                         // Flatten elements.
                         for item in inner_value {
-                            values.push(item.coerce(ty, convert_units, exec_state)?);
+                            values.push(item.coerce(ty, mode, exec_state)?);
                         }
                     } else {
-                        values.push(item.coerce(ty, convert_units, exec_state)?);
+                        values.push(item.coerce(ty, mode, exec_state)?);
                     }
                 }
 
@@ -1711,7 +1766,7 @@ impl KclValue {
                     .ok_or(CoercionError::from(self))?;
                 let value = value
                     .iter()
-                    .map(|item| item.coerce(ty, convert_units, exec_state))
+                    .map(|item| item.coerce(ty, mode, exec_state))
                     .take(len)
                     .collect::<Result<Vec<_>, _>>()?;
 
@@ -1721,7 +1776,7 @@ impl KclValue {
                 value: Vec::new(),
                 ty: ty.clone(),
             }),
-            _ if len.satisfied(1, false).is_some() => self.coerce(ty, convert_units, exec_state),
+            _ if len.satisfied(1, false).is_some() => self.coerce(ty, mode, exec_state),
             _ => Err(self.into()),
         }
     }
@@ -1729,14 +1784,14 @@ impl KclValue {
     fn coerce_to_tuple_type(
         &self,
         tys: &[RuntimeType],
-        convert_units: bool,
+        mode: CoercionMode,
         exec_state: &mut ExecState,
     ) -> Result<KclValue, CoercionError> {
         match self {
             KclValue::Tuple { value, .. } | KclValue::HomArray { value, .. } if value.len() == tys.len() => {
                 let mut result = Vec::new();
                 for (i, t) in tys.iter().enumerate() {
-                    result.push(value[i].coerce(t, convert_units, exec_state)?);
+                    result.push(value[i].coerce(t, mode, exec_state)?);
                 }
 
                 Ok(KclValue::Tuple {
@@ -1748,7 +1803,7 @@ impl KclValue {
                 value: Vec::new(),
                 meta: meta.clone(),
             }),
-            _ if tys.len() == 1 => self.coerce(&tys[0], convert_units, exec_state),
+            _ if tys.len() == 1 => self.coerce(&tys[0], mode, exec_state),
             _ => Err(self.into()),
         }
     }
@@ -1756,11 +1811,25 @@ impl KclValue {
     fn coerce_to_union_type(
         &self,
         tys: &[RuntimeType],
-        convert_units: bool,
+        mode: CoercionMode,
         exec_state: &mut ExecState,
     ) -> Result<KclValue, CoercionError> {
+        // A member that accepts the value as it is must win over one that would
+        // change it, whichever order the union was written in. Without this pass
+        // `Color::Red: Color | string` would keep the enum while
+        // `Color::Red: string | Color` would project it, making the meaning of a
+        // union depend on how the author happened to spell it.
+        if mode.project_enums() {
+            let exact = mode.without_projection();
+            for t in tys {
+                if let Ok(v) = self.coerce(t, exact, exec_state) {
+                    return Ok(v);
+                }
+            }
+        }
+
         for t in tys {
-            if let Ok(v) = self.coerce(t, convert_units, exec_state) {
+            if let Ok(v) = self.coerce(t, mode, exec_state) {
                 return Ok(v);
             }
         }
@@ -1772,7 +1841,7 @@ impl KclValue {
         &self,
         tys: &[(String, RuntimeType)],
         constrainable: bool,
-        _convert_units: bool,
+        _mode: CoercionMode,
         _exec_state: &mut ExecState,
     ) -> Result<KclValue, CoercionError> {
         match self {
@@ -1864,6 +1933,8 @@ impl KclValue {
 
 #[cfg(test)]
 mod test {
+    use std::sync::Arc;
+
     use super::*;
     use crate::ModuleId;
     use crate::execution::ExecTestResults;
@@ -1931,7 +2002,7 @@ mod test {
         exec_state: &mut ExecState,
     ) {
         let is_subtype = value == expected_value;
-        let actual = value.coerce(super_type, true, exec_state).unwrap();
+        let actual = value.coerce(super_type, CoercionMode::implicit(), exec_state).unwrap();
         assert_eq!(&actual, expected_value);
         assert_eq!(
             is_subtype,
@@ -1980,10 +2051,10 @@ mod test {
                     );
                     // Coercing an empty array to an array of length 1
                     // should fail.
-                    v.coerce(&aty1, true, &mut exec_state).unwrap_err();
+                    v.coerce(&aty1, CoercionMode::implicit(), &mut exec_state).unwrap_err();
                     // Coercing an empty array to an array that's
                     // non-empty should fail.
-                    v.coerce(&aty0, true, &mut exec_state).unwrap_err();
+                    v.coerce(&aty0, CoercionMode::implicit(), &mut exec_state).unwrap_err();
                 }
                 KclValue::Tuple { .. } => {}
                 _ => {
@@ -2000,8 +2071,12 @@ mod test {
 
         for v in &values[1..] {
             // Not a subtype
-            v.coerce(&RuntimeType::Primitive(PrimitiveType::Boolean), true, &mut exec_state)
-                .unwrap_err();
+            v.coerce(
+                &RuntimeType::Primitive(PrimitiveType::Boolean),
+                CoercionMode::implicit(),
+                &mut exec_state,
+            )
+            .unwrap_err();
         }
         ctx.close().await;
     }
@@ -2036,8 +2111,10 @@ mod test {
             },
             &mut exec_state,
         );
-        none.coerce(&aty1, true, &mut exec_state).unwrap_err();
-        none.coerce(&aty1p, true, &mut exec_state).unwrap_err();
+        none.coerce(&aty1, CoercionMode::implicit(), &mut exec_state)
+            .unwrap_err();
+        none.coerce(&aty1p, CoercionMode::implicit(), &mut exec_state)
+            .unwrap_err();
 
         let tty = RuntimeType::Tuple(vec![]);
         let tty1 = RuntimeType::Tuple(vec![RuntimeType::solid()]);
@@ -2050,7 +2127,8 @@ mod test {
             },
             &mut exec_state,
         );
-        none.coerce(&tty1, true, &mut exec_state).unwrap_err();
+        none.coerce(&tty1, CoercionMode::implicit(), &mut exec_state)
+            .unwrap_err();
 
         let oty = RuntimeType::Object(vec![], false);
         assert_coerce_results(
@@ -2131,7 +2209,8 @@ mod test {
             vec![("foo".to_owned(), RuntimeType::Primitive(PrimitiveType::Boolean))],
             false,
         );
-        obj0.coerce(&ty1, true, &mut exec_state).unwrap_err();
+        obj0.coerce(&ty1, CoercionMode::implicit(), &mut exec_state)
+            .unwrap_err();
         assert_coerce_results(&obj1, &ty1, &obj1, &mut exec_state);
         assert_coerce_results(&obj2, &ty1, &obj2, &mut exec_state);
 
@@ -2146,8 +2225,10 @@ mod test {
             ],
             false,
         );
-        obj0.coerce(&ty2, true, &mut exec_state).unwrap_err();
-        obj1.coerce(&ty2, true, &mut exec_state).unwrap_err();
+        obj0.coerce(&ty2, CoercionMode::implicit(), &mut exec_state)
+            .unwrap_err();
+        obj1.coerce(&ty2, CoercionMode::implicit(), &mut exec_state)
+            .unwrap_err();
         assert_coerce_results(&obj2, &ty2, &obj2, &mut exec_state);
 
         // field not present
@@ -2155,16 +2236,20 @@ mod test {
             vec![("qux".to_owned(), RuntimeType::Primitive(PrimitiveType::Boolean))],
             false,
         );
-        obj0.coerce(&tyq, true, &mut exec_state).unwrap_err();
-        obj1.coerce(&tyq, true, &mut exec_state).unwrap_err();
-        obj2.coerce(&tyq, true, &mut exec_state).unwrap_err();
+        obj0.coerce(&tyq, CoercionMode::implicit(), &mut exec_state)
+            .unwrap_err();
+        obj1.coerce(&tyq, CoercionMode::implicit(), &mut exec_state)
+            .unwrap_err();
+        obj2.coerce(&tyq, CoercionMode::implicit(), &mut exec_state)
+            .unwrap_err();
 
         // field with different type
         let ty1 = RuntimeType::Object(
             vec![("bar".to_owned(), RuntimeType::Primitive(PrimitiveType::Boolean))],
             false,
         );
-        obj2.coerce(&ty1, true, &mut exec_state).unwrap_err();
+        obj2.coerce(&ty1, CoercionMode::implicit(), &mut exec_state)
+            .unwrap_err();
         ctx.close().await;
     }
 
@@ -2243,8 +2328,12 @@ mod test {
         assert_coerce_results(&hom_arr, &tyh, &hom_arr, &mut exec_state);
         assert_coerce_results(&mixed1, &tym1, &mixed1, &mut exec_state);
         assert_coerce_results(&mixed2, &tym2, &mixed2, &mut exec_state);
-        mixed1.coerce(&tym2, true, &mut exec_state).unwrap_err();
-        mixed2.coerce(&tym1, true, &mut exec_state).unwrap_err();
+        mixed1
+            .coerce(&tym2, CoercionMode::implicit(), &mut exec_state)
+            .unwrap_err();
+        mixed2
+            .coerce(&tym1, CoercionMode::implicit(), &mut exec_state)
+            .unwrap_err();
 
         // Length subtyping
         let tyhn = RuntimeType::Array(
@@ -2269,17 +2358,25 @@ mod test {
         );
         assert_coerce_results(&hom_arr, &tyhn, &hom_arr, &mut exec_state);
         assert_coerce_results(&hom_arr, &tyh1, &hom_arr, &mut exec_state);
-        hom_arr.coerce(&tyh3, true, &mut exec_state).unwrap_err();
+        hom_arr
+            .coerce(&tyh3, CoercionMode::implicit(), &mut exec_state)
+            .unwrap_err();
         assert_coerce_results(&hom_arr, &tyhm3, &hom_arr, &mut exec_state);
-        hom_arr.coerce(&tyhm5, true, &mut exec_state).unwrap_err();
+        hom_arr
+            .coerce(&tyhm5, CoercionMode::implicit(), &mut exec_state)
+            .unwrap_err();
 
         let hom_arr0 = KclValue::HomArray {
             value: vec![],
             ty: RuntimeType::Primitive(PrimitiveType::Number(NumericType::count())),
         };
         assert_coerce_results(&hom_arr0, &tyhn, &hom_arr0, &mut exec_state);
-        hom_arr0.coerce(&tyh1, true, &mut exec_state).unwrap_err();
-        hom_arr0.coerce(&tyh3, true, &mut exec_state).unwrap_err();
+        hom_arr0
+            .coerce(&tyh1, CoercionMode::implicit(), &mut exec_state)
+            .unwrap_err();
+        hom_arr0
+            .coerce(&tyh3, CoercionMode::implicit(), &mut exec_state)
+            .unwrap_err();
 
         // Covariance
         // let tyh = RuntimeType::Array(Box::new(RuntimeType::Primitive(PrimitiveType::Number(NumericType::Any))), ArrayLen::Known(4));
@@ -2319,16 +2416,28 @@ mod test {
         assert_coerce_results(&mixed1, &tyhn, &hom_arr_2, &mut exec_state);
         assert_coerce_results(&mixed1, &tyh1, &hom_arr_2, &mut exec_state);
         assert_coerce_results(&mixed0, &tyhn, &hom_arr0, &mut exec_state);
-        mixed0.coerce(&tyh, true, &mut exec_state).unwrap_err();
-        mixed0.coerce(&tyh1, true, &mut exec_state).unwrap_err();
+        mixed0
+            .coerce(&tyh, CoercionMode::implicit(), &mut exec_state)
+            .unwrap_err();
+        mixed0
+            .coerce(&tyh1, CoercionMode::implicit(), &mut exec_state)
+            .unwrap_err();
 
         // Homogehous to mixed
         assert_coerce_results(&hom_arr_2, &tym1, &mixed1, &mut exec_state);
-        hom_arr.coerce(&tym1, true, &mut exec_state).unwrap_err();
-        hom_arr_2.coerce(&tym2, true, &mut exec_state).unwrap_err();
+        hom_arr
+            .coerce(&tym1, CoercionMode::implicit(), &mut exec_state)
+            .unwrap_err();
+        hom_arr_2
+            .coerce(&tym2, CoercionMode::implicit(), &mut exec_state)
+            .unwrap_err();
 
-        mixed0.coerce(&tym1, true, &mut exec_state).unwrap_err();
-        mixed0.coerce(&tym2, true, &mut exec_state).unwrap_err();
+        mixed0
+            .coerce(&tym1, CoercionMode::implicit(), &mut exec_state)
+            .unwrap_err();
+        mixed0
+            .coerce(&tym2, CoercionMode::implicit(), &mut exec_state)
+            .unwrap_err();
         ctx.close().await;
     }
 
@@ -2381,8 +2490,12 @@ mod test {
             RuntimeType::Primitive(PrimitiveType::Boolean),
             RuntimeType::Primitive(PrimitiveType::String),
         ]);
-        count.coerce(&tyb, true, &mut exec_state).unwrap_err();
-        count.coerce(&tyb2, true, &mut exec_state).unwrap_err();
+        count
+            .coerce(&tyb, CoercionMode::implicit(), &mut exec_state)
+            .unwrap_err();
+        count
+            .coerce(&tyb2, CoercionMode::implicit(), &mut exec_state)
+            .unwrap_err();
         ctx.close().await;
     }
 
@@ -2445,6 +2558,18 @@ mod test {
         RuntimeType::Enum(EnumTypeId::new(ModuleId::from_usize(module_id as usize), name))
     }
 
+    /// A value holds its declaration, so building one by hand needs a
+    /// declaration rather than just an id.
+    fn enum_def(module_id: u32, name: &str, variants: &[&str]) -> Arc<EnumTypeDef> {
+        Arc::new(
+            EnumTypeDef::new(
+                EnumTypeId::new(ModuleId::from_usize(module_id as usize), name),
+                variants.iter().map(|v| (*v).to_owned()).collect(),
+            )
+            .unwrap(),
+        )
+    }
+
     #[test]
     fn enum_subtyping_is_nominal() {
         let color = enum_ty(0, "Color");
@@ -2491,11 +2616,7 @@ mod test {
     #[test]
     fn enum_values_report_their_own_type() {
         let red = KclValue::Enum {
-            value: Box::new(EnumValue::new(
-                EnumTypeId::new(ModuleId::default(), "Color"),
-                "Red",
-                Vec::new(),
-            )),
+            value: Box::new(EnumValue::new(enum_def(0, "Color", &["Red"]), "Red", Vec::new())),
         };
 
         assert_eq!(red.principal_type(), Some(enum_ty(0, "Color")));
@@ -2534,7 +2655,7 @@ mod test {
             .add(
                 format!("{}Color", memory::TYPE_PREFIX),
                 KclValue::Type {
-                    value: TypeDef::Enum(EnumTypeDef::new(id.clone(), vec!["Red".to_owned()]).unwrap()),
+                    value: TypeDef::Enum(Arc::new(EnumTypeDef::new(id.clone(), vec!["Red".to_owned()]).unwrap())),
                     experimental: false,
                     meta: vec![],
                 },
@@ -2554,26 +2675,221 @@ mod test {
     async fn enum_coercion_requires_the_same_declaration() {
         let (ctx, mut exec_state) = new_exec_state().await;
         let red = KclValue::Enum {
-            value: Box::new(EnumValue::new(
-                EnumTypeId::new(ModuleId::default(), "Color"),
-                "Red",
-                Vec::new(),
-            )),
+            value: Box::new(EnumValue::new(enum_def(0, "Color", &["Red"]), "Red", Vec::new())),
         };
 
         // Coercing to its own type is identity-preserving.
-        assert_eq!(red.coerce(&enum_ty(0, "Color"), true, &mut exec_state).unwrap(), red);
+        assert_eq!(
+            red.coerce(&enum_ty(0, "Color"), CoercionMode::implicit(), &mut exec_state)
+                .unwrap(),
+            red
+        );
         // Everything else is rejected, including projection to string, which is
         // explicit ascription rather than coercion.
-        red.coerce(&enum_ty(0, "Shape"), true, &mut exec_state).unwrap_err();
-        red.coerce(&enum_ty(1, "Color"), true, &mut exec_state).unwrap_err();
-        red.coerce(&RuntimeType::string(), true, &mut exec_state).unwrap_err();
+        red.coerce(&enum_ty(0, "Shape"), CoercionMode::implicit(), &mut exec_state)
+            .unwrap_err();
+        red.coerce(&enum_ty(1, "Color"), CoercionMode::implicit(), &mut exec_state)
+            .unwrap_err();
+        red.coerce(&RuntimeType::string(), CoercionMode::implicit(), &mut exec_state)
+            .unwrap_err();
         // A non-enum value never satisfies an enum type.
         let string = KclValue::String {
             value: "Red".to_owned(),
             meta: Vec::new(),
         };
-        string.coerce(&enum_ty(0, "Color"), true, &mut exec_state).unwrap_err();
+        string
+            .coerce(&enum_ty(0, "Color"), CoercionMode::implicit(), &mut exec_state)
+            .unwrap_err();
+
+        ctx.close().await;
+    }
+
+    fn enum_value(module_id: u32, name: &str, variants: &[&str], variant: &str) -> KclValue {
+        KclValue::Enum {
+            value: Box::new(EnumValue::new(enum_def(module_id, name, variants), variant, Vec::new())),
+        }
+    }
+
+    fn string_value(value: &str) -> KclValue {
+        KclValue::String {
+            value: value.to_owned(),
+            meta: Vec::new(),
+        }
+    }
+
+    /// Every row states the outcome under BOTH modes, so the table pins the whole
+    /// matrix of target shape against mode rather than one half of it. `None`
+    /// means the coercion must fail.
+    ///
+    /// The pattern to read off it: projection happens wherever the type walk
+    /// reaches, and only when the user wrote the type.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enum_projects_by_target_shape() {
+        let (ctx, mut exec_state) = new_exec_state().await;
+        let variants = &["Red", "Green"];
+        let red = enum_value(0, "Color", variants, "Red");
+        let green = enum_value(0, "Color", variants, "Green");
+        let color = enum_ty(0, "Color");
+        let string = RuntimeType::string();
+        let strings = RuntimeType::Array(Box::new(string.clone()), ArrayLen::None);
+        let array = |value: Vec<KclValue>, ty: RuntimeType| KclValue::HomArray { value, ty };
+        let tuple = |value: Vec<KclValue>| KclValue::Tuple {
+            value,
+            meta: Vec::new(),
+        };
+
+        #[allow(clippy::type_complexity)]
+        let rows: Vec<(&str, KclValue, RuntimeType, Option<KclValue>, Option<KclValue>)> = vec![
+            (
+                "a bare enum",
+                red.clone(),
+                string.clone(),
+                Some(string_value("Red")),
+                None,
+            ),
+            (
+                "an array, element by element",
+                array(vec![red.clone(), green.clone()], color.clone()),
+                strings.clone(),
+                Some(array(vec![string_value("Red"), string_value("Green")], string.clone())),
+                None,
+            ),
+            (
+                "an array of arrays, so more than one level down",
+                array(vec![array(vec![green.clone()], RuntimeType::any())], RuntimeType::any()),
+                RuntimeType::Array(Box::new(strings.clone()), ArrayLen::None),
+                Some(array(
+                    vec![array(vec![string_value("Green")], string.clone())],
+                    strings.clone(),
+                )),
+                None,
+            ),
+            (
+                // KCL has no tuple type syntax, so this shape is only reachable here.
+                "a tuple, positionally, beside a value that needs nothing done",
+                tuple(vec![red.clone(), string_value("plain")]),
+                RuntimeType::Tuple(vec![string.clone(), string.clone()]),
+                Some(tuple(vec![string_value("Red"), string_value("plain")])),
+                None,
+            ),
+            (
+                // The existing singleton/array equivalence carries projection with
+                // it, the same way it carries numeric coercion.
+                "a one-element array against a bare string",
+                array(vec![red.clone()], RuntimeType::any()),
+                string.clone(),
+                Some(string_value("Red")),
+                None,
+            ),
+            (
+                // Object coercion checks fields with `has_type` and converts
+                // nothing: see the `TODO coerce fields` in `coerce_to_object_type`.
+                // Inherited behavior rather than an enum rule, so when field
+                // coercion is implemented this row should start expecting a
+                // projection instead of being deleted.
+                "an object field, which projects nothing",
+                KclValue::Object {
+                    value: HashMap::from([("c".to_owned(), red.clone())]),
+                    constrainable: false,
+                    object_kind: Default::default(),
+                    meta: Vec::new(),
+                },
+                RuntimeType::Object(vec![("c".to_owned(), string.clone())], false),
+                None,
+                None,
+            ),
+            (
+                "its own type, which is a check rather than a conversion",
+                red.clone(),
+                color.clone(),
+                Some(red.clone()),
+                Some(red.clone()),
+            ),
+            (
+                "another declaration, which projection is not a way around",
+                red.clone(),
+                enum_ty(0, "Shade"),
+                None,
+                None,
+            ),
+        ];
+
+        for (case, value, target, explicit, implicit) in rows {
+            assert_eq!(
+                value.coerce(&target, CoercionMode::explicit(), &mut exec_state).ok(),
+                explicit,
+                "explicit mode, case: {case}"
+            );
+            assert_eq!(
+                value.coerce(&target, CoercionMode::implicit(), &mut exec_state).ok(),
+                implicit,
+                "implicit mode, case: {case}"
+            );
+        }
+
+        ctx.close().await;
+    }
+
+    /// A member that accepts the value unchanged wins over one that would change
+    /// it, whichever order the union was written in. Each pair of rows below is
+    /// the same union spelled both ways, so a rule that depended on order would
+    /// fail one row of the pair.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enum_projection_ignores_the_order_a_union_was_written_in() {
+        let (ctx, mut exec_state) = new_exec_state().await;
+        let red = enum_value(0, "Color", &["Red"], "Red");
+        let string = RuntimeType::string();
+        let color = enum_ty(0, "Color");
+        let shade = enum_ty(0, "Shade");
+
+        let rows: Vec<(&str, Vec<RuntimeType>, Option<KclValue>)> = vec![
+            ("the enum first", vec![color.clone(), string.clone()], Some(red.clone())),
+            ("the enum last", vec![string.clone(), color.clone()], Some(red.clone())),
+            (
+                "no member accepts an enum, so projection is what satisfies it",
+                vec![RuntimeType::bool(), string.clone()],
+                Some(string_value("Red")),
+            ),
+            (
+                "a different enum is not a match, so this projects too",
+                vec![shade.clone(), string.clone()],
+                Some(string_value("Red")),
+            ),
+            (
+                "a different enum with no string member is unsatisfiable",
+                vec![shade, RuntimeType::bool()],
+                None,
+            ),
+        ];
+
+        for (case, tys, expected) in rows {
+            let union = RuntimeType::Union(tys);
+            assert_eq!(
+                red.coerce(&union, CoercionMode::explicit(), &mut exec_state).ok(),
+                expected,
+                "case: {case} ({union})"
+            );
+        }
+
+        ctx.close().await;
+    }
+
+    /// The numeric target reports what the user asked for and cannot have; the
+    /// implicit boundary keeps the numeric wording, because nobody asked for a
+    /// projection there.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enum_projection_to_a_number_explains_itself() {
+        let (ctx, mut exec_state) = new_exec_state().await;
+        let red = enum_value(0, "Color", &["Red"], "Red");
+        let message = "Cannot project enum `Color` to a number. An enum projects to `string`; projecting to a number is not supported yet.";
+
+        for (case, mode, expected) in [
+            ("explicit", CoercionMode::explicit(), Some(message)),
+            ("implicit", CoercionMode::implicit(), None),
+        ] {
+            let err = red.coerce(&RuntimeType::count(), mode, &mut exec_state).unwrap_err();
+            assert_eq!(err.message.as_deref(), expected, "case: {case}");
+        }
 
         ctx.close().await;
     }
@@ -2599,7 +2915,9 @@ mod test {
         assert!(RuntimeType::Union(vec![never.clone(), string.clone()]).subtype(&string));
 
         for value in values(&mut exec_state) {
-            value.coerce(&never, true, &mut exec_state).unwrap_err();
+            value
+                .coerce(&never, CoercionMode::implicit(), &mut exec_state)
+                .unwrap_err();
         }
         ctx.close().await;
     }
@@ -2720,7 +3038,8 @@ mod test {
         assert_coerce_results(&a2d, &ty2d, &a2d, &mut exec_state);
         assert_coerce_results(&a3d, &ty3d, &a3d, &mut exec_state);
         assert_coerce_results(&a3d, &ty2d, &a2d, &mut exec_state);
-        a2d.coerce(&ty3d, true, &mut exec_state).unwrap_err();
+        a2d.coerce(&ty3d, CoercionMode::implicit(), &mut exec_state)
+            .unwrap_err();
         ctx.close().await;
     }
 
@@ -2784,7 +3103,7 @@ mod test {
                         angle: UnitAngle::Degrees,
                     }
                     .into(),
-                    true,
+                    CoercionMode::implicit(),
                     &mut exec_state
                 )
                 .unwrap(),
@@ -2793,29 +3112,33 @@ mod test {
 
         // No coercion
         count
-            .coerce(&NumericType::mm().into(), true, &mut exec_state)
+            .coerce(&NumericType::mm().into(), CoercionMode::implicit(), &mut exec_state)
             .unwrap_err();
-        mm.coerce(&NumericType::count().into(), true, &mut exec_state)
-            .unwrap_err();
-        unknown
-            .coerce(&NumericType::mm().into(), true, &mut exec_state)
+        mm.coerce(&NumericType::count().into(), CoercionMode::implicit(), &mut exec_state)
             .unwrap_err();
         unknown
-            .coerce(&NumericType::default().into(), true, &mut exec_state)
+            .coerce(&NumericType::mm().into(), CoercionMode::implicit(), &mut exec_state)
+            .unwrap_err();
+        unknown
+            .coerce(
+                &NumericType::default().into(),
+                CoercionMode::implicit(),
+                &mut exec_state,
+            )
             .unwrap_err();
 
         count
-            .coerce(&NumericType::Unknown.into(), true, &mut exec_state)
+            .coerce(&NumericType::Unknown.into(), CoercionMode::implicit(), &mut exec_state)
             .unwrap_err();
-        mm.coerce(&NumericType::Unknown.into(), true, &mut exec_state)
+        mm.coerce(&NumericType::Unknown.into(), CoercionMode::implicit(), &mut exec_state)
             .unwrap_err();
         default
-            .coerce(&NumericType::Unknown.into(), true, &mut exec_state)
+            .coerce(&NumericType::Unknown.into(), CoercionMode::implicit(), &mut exec_state)
             .unwrap_err();
 
         assert_eq!(
             inches
-                .coerce(&NumericType::mm().into(), true, &mut exec_state)
+                .coerce(&NumericType::mm().into(), CoercionMode::implicit(), &mut exec_state)
                 .unwrap()
                 .as_f64()
                 .unwrap()
@@ -2825,7 +3148,7 @@ mod test {
         assert_eq!(
             rads.coerce(
                 &NumericType::Known(UnitType::Angle(UnitAngle::Degrees)).into(),
-                true,
+                CoercionMode::implicit(),
                 &mut exec_state
             )
             .unwrap()
@@ -2836,7 +3159,11 @@ mod test {
         );
         assert_eq!(
             inches
-                .coerce(&NumericType::default().into(), true, &mut exec_state)
+                .coerce(
+                    &NumericType::default().into(),
+                    CoercionMode::implicit(),
+                    &mut exec_state
+                )
                 .unwrap()
                 .as_f64()
                 .unwrap()
@@ -2844,11 +3171,15 @@ mod test {
             1.0
         );
         assert_eq!(
-            rads.coerce(&NumericType::default().into(), true, &mut exec_state)
-                .unwrap()
-                .as_f64()
-                .unwrap()
-                .round(),
+            rads.coerce(
+                &NumericType::default().into(),
+                CoercionMode::implicit(),
+                &mut exec_state
+            )
+            .unwrap()
+            .as_f64()
+            .unwrap()
+            .round(),
             1.0
         );
         ctx.close().await;

--- a/rust/kcl-lib/src/std/args.rs
+++ b/rust/kcl-lib/src/std/args.rs
@@ -36,6 +36,7 @@ use crate::execution::TagIdentifier;
 use crate::execution::annotations;
 pub use crate::execution::fn_call::Args;
 use crate::execution::kcl_value::FunctionSource;
+use crate::execution::types::CoercionMode;
 use crate::execution::types::NumericSuffixTypeConvertError;
 use crate::execution::types::NumericType;
 use crate::execution::types::NumericTypeExt;
@@ -188,7 +189,7 @@ impl Args {
             )));
         };
 
-        let arg = arg.value.coerce(ty, true, exec_state).map_err(|_| {
+        let arg = arg.value.coerce(ty, CoercionMode::implicit(), exec_state).map_err(|_| {
             let actual_type = arg.value.principal_type();
             let actual_type_name = actual_type
                 .as_ref()
@@ -310,7 +311,7 @@ impl Args {
                 vec![self.source_range],
             )))?;
 
-        let arg = arg.value.coerce(ty, true, exec_state).map_err(|_| {
+        let arg = arg.value.coerce(ty, CoercionMode::implicit(), exec_state).map_err(|_| {
             let actual_type = arg.value.principal_type();
             let actual_type_name = actual_type
                 .as_ref()

--- a/rust/kcl-lib/src/std/patterns.rs
+++ b/rust/kcl-lib/src/std/patterns.rs
@@ -37,6 +37,7 @@ use crate::execution::early_return;
 use crate::execution::fn_call::Arg;
 use crate::execution::fn_call::Args;
 use crate::execution::kcl_value::FunctionSource;
+use crate::execution::types::CoercionMode;
 use crate::execution::types::NumericType;
 use crate::execution::types::NumericTypeExt;
 use crate::execution::types::PrimitiveType;
@@ -415,7 +416,7 @@ fn array_to_point3d(
     source_ranges: Vec<SourceRange>,
     exec_state: &mut ExecState,
 ) -> Result<[TyF64; 3], KclError> {
-    val.coerce(&RuntimeType::point3d(), true, exec_state)
+    val.coerce(&RuntimeType::point3d(), CoercionMode::implicit(), exec_state)
         .map_err(|e| {
             KclError::new_semantic(KclErrorDetails::new(
                 format!(
@@ -435,7 +436,7 @@ fn array_to_point2d(
     source_ranges: Vec<SourceRange>,
     exec_state: &mut ExecState,
 ) -> Result<[TyF64; 2], KclError> {
-    val.coerce(&RuntimeType::point2d(), true, exec_state)
+    val.coerce(&RuntimeType::point2d(), CoercionMode::implicit(), exec_state)
         .map_err(|e| {
             KclError::new_semantic(KclErrorDetails::new(
                 format!(


### PR DESCRIPTION
With this part we have a minimum viable enum type in KCL. 

* Plain variants (no payload), 
* Top level definitions *only* 
* Type checks (runtime) 
* equality 
* projection to `string` through ascription (returns the Variant name as a string) 
* supports exporting from modules and maintains equality based on definition 
* coercions (follows existing rules for other types) 

This is now usable! 


Part 5 of the enum V1 series. 

- Part 1 — AST restructure for enum type declarations: [#12596](https://github.com/KittyCAD/modeling-app/pull/12596) (merged)
- Part 2 — parsing, formatting, editor grammar: [#12597](https://github.com/KittyCAD/modeling-app/pull/12597) (merged)
- Part 3 — nominal runtime representation: [#12601](https://github.com/KittyCAD/modeling-app/pull/12601) (merged)
- Part 4 — declaration and constructor evaluation: [#12684](https://github.com/KittyCAD/modeling-app/pull/12684) (merged)

This part is based on `main` rather than a parent branch, since part 4 is merged.

- carry the declaration in an enum value so projection can read it
- replace the `convert_units` bool on `coerce` with `CoercionMode`
- project to the declared representation wherever the type walk reaches
- prefer a union member that accepts the value over one that projects
- give a numeric target its own reason instead of "expected a number"
- table-driven tests over target shape, mode, boundaries and rejections
