### PR TITLE
Include a display prefix on cloud library paths

### DIFF
--- a/src/lib/projectLibraries/index.ts
+++ b/src/lib/projectLibraries/index.ts
@@ -9,6 +9,17 @@ export const PERSONAL_CLOUD_PROJECT_LIBRARY_ID = 'cloud-personal'
 export const PERSONAL_CLOUD_PROJECT_LIBRARY_TITLE = 'Personal Cloud'
 export const CLOUD_PROJECT_LIBRARY_TYPE = 'cloud'
 export const DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH = '/personal'
+export const CLOUD_PROJECT_LIBRARY_PATH_DISPLAY_PREFIX = 'zoo://'
+
+export function formatProjectLibraryPathForDisplay(
+  library: Pick<ProjectLibrarySetting, 'path' | 'type'>
+) {
+  if (library.type !== CLOUD_PROJECT_LIBRARY_TYPE) {
+    return library.path
+  }
+
+  return `${CLOUD_PROJECT_LIBRARY_PATH_DISPLAY_PREFIX}${library.path.replace(/^\/+/, '')}`
+}
 
 export type ProjectLibraryType = string
 

--- a/src/registry/contracts/projectLibraries.spec.ts
+++ b/src/registry/contracts/projectLibraries.spec.ts
@@ -2,6 +2,7 @@ import {
   areProjectLibrarySettingsEqual,
   DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH,
   DEFAULT_PROJECT_LIBRARY_ID,
+  formatProjectLibraryPathForDisplay,
   getContainingDirectoryProjectLibraryPath,
   getDefaultCloudProjectLibrarySetting,
   getDefaultDirectoryProjectLibraryPath,
@@ -70,6 +71,21 @@ describe('project library settings', () => {
         type: 'cloud',
       })
     )
+  })
+
+  test('formats cloud library paths with a zoo:// display prefix', () => {
+    expect(
+      formatProjectLibraryPathForDisplay({
+        path: DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH,
+        type: 'cloud',
+      })
+    ).toBe('zoo://personal')
+    expect(
+      formatProjectLibraryPathForDisplay({
+        path: '/projects',
+        type: 'directory',
+      })
+    ).toBe('/projects')
   })
 
   test('treats the first directory library as the default local project target', () => {
@@ -330,7 +346,7 @@ describe('project library default policies', () => {
       getDefaultLibraries: () => [
         {
           title: 'Personal Cloud',
-          path: '/personal',
+          path: DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH,
           type: 'cloud',
         },
       ],
@@ -349,7 +365,7 @@ describe('project library default policies', () => {
     ).toEqual([
       {
         title: 'Personal Cloud',
-        path: '/personal',
+        path: DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH,
         type: 'cloud',
       },
     ])

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -39,6 +39,7 @@ import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
 import { PATHS } from '@src/lib/paths'
 import { markOnce } from '@src/lib/performance'
 import {
+  formatProjectLibraryPathForDisplay,
   type ProjectLibrary,
   projectLibrariesFromSettings,
 } from '@src/lib/projectLibraries'
@@ -738,9 +739,8 @@ function HomeHeader({
             to={`${PATHS.HOME + PATHS.SETTINGS_USER}#libraries`}
             className="text-chalkboard-90 dark:text-chalkboard-20 underline underline-offset-2"
           >
-            {library.path}
+            {formatProjectLibraryPathForDisplay(library)}
           </Link>
-          .
         </p>
       ) : null}
       {!readWriteProjectDir.value && (
@@ -947,7 +947,7 @@ function ProjectLibraryPreviewRow({
             {library.title}
           </span>
           <span className="block truncate text-xs text-chalkboard-70 dark:text-chalkboard-30">
-            {library.path}
+            {formatProjectLibraryPathForDisplay(library)}
           </span>
         </span>
         <span className="hidden flex-none text-xs text-chalkboard-70 dark:text-chalkboard-30 sm:block">


### PR DESCRIPTION
`/personal` looks like a root filesystem path, which is a little confusing.

I think we should display it with a pseudo-network prefix. This is a purely visual change.

---

Before:


<img width="498" height="176" alt="Screenshot 2026-07-30 at 9 28 14 PM" src="https://github.com/user-attachments/assets/b6190a44-c2eb-4b68-b7ee-2b535155172c" /><br>


After:

<img width="520" height="188" alt="Screenshot 2026-07-30 at 9 28 45 PM" src="https://github.com/user-attachments/assets/bdcc4918-ab9b-425c-a247-db4c5500278f" />


