### PR TITLE
Disable the ability to remove cloud libraries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32473,7 +32473,7 @@
         "vscode-uri": "^3.1.0"
       },
       "devDependencies": {
-        "@types/node": "^24.12.4",
+        "@types/node": "^26.1.1",
         "ts-node": "^10.9.2"
       }
     },
@@ -32697,7 +32697,7 @@
         "@tsconfig/strictest": "^2.0.6",
         "@types/glob": "^9.0.0",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^24.12.4",
+        "@types/node": "^26.1.1",
         "@types/vscode": "^1.120.0",
         "@typescript-eslint/eslint-plugin": "^8.27.0",
         "@typescript-eslint/parser": "^8.27.0",

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -180,7 +180,7 @@ function CloudProjectLibrarySettingsDetails() {
           tabIndex={0}
           className="!p-0"
           iconStart={{
-            icon: 'folder',
+            icon: 'folderOpen',
             bgClassName: '!bg-transparent',
           }}
           disabled={!storagePath}

--- a/src/lib/projectLibraries/index.ts
+++ b/src/lib/projectLibraries/index.ts
@@ -44,6 +44,20 @@ export function getDefaultCloudProjectLibrarySetting(): ProjectLibrarySetting {
   }
 }
 
+export function canRemoveProjectLibrary(
+  library: Pick<ProjectLibrarySetting, 'type'>,
+  options: { canManageLibraries: boolean }
+) {
+  if (library.type === CLOUD_PROJECT_LIBRARY_TYPE) {
+    return false
+  }
+
+  return (
+    options.canManageLibraries ||
+    library.type === DIRECTORY_PROJECT_LIBRARY_TYPE
+  )
+}
+
 export function getDefaultDirectoryProjectLibrarySetting(
   libraries: readonly ProjectLibrarySetting[] | undefined
 ) {

--- a/src/lib/projectLibraries/settings/ProjectLibrariesSetting.tsx
+++ b/src/lib/projectLibraries/settings/ProjectLibrariesSetting.tsx
@@ -1,7 +1,7 @@
 import { useSignals } from '@preact/signals-react/runtime'
 import { isDesktop } from '@src/lib/isDesktop'
 import {
-  DIRECTORY_PROJECT_LIBRARY_TYPE,
+  canRemoveProjectLibrary,
   type ProjectLibrarySetting,
 } from '@src/lib/projectLibraries'
 import {
@@ -38,7 +38,7 @@ export function ProjectLibrariesSetting({
       canChangeLibraryType={canManageLibraries}
       canEditLibraryDetails={canManageLibraries}
       canRemoveLibrary={(library) =>
-        canManageLibraries || library.type === DIRECTORY_PROJECT_LIBRARY_TYPE
+        canRemoveProjectLibrary(library, { canManageLibraries })
       }
     />
   )

--- a/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.tsx
+++ b/src/lib/projectLibraries/settings/ProjectLibrariesSettingInput.tsx
@@ -316,7 +316,7 @@ export function DirectoryProjectLibrarySettingsDetails({
               : 'project-library-folder-button'
           }
         >
-          <Tooltip position="top-right">Choose folder</Tooltip>
+          <Tooltip position="top-right">Change location</Tooltip>
         </ActionButton>
       )}
     </div>


### PR DESCRIPTION
At least until we support multiple cloud libraries, I don't think the Personal Cloud library should be removable. It seems to be restored in settings upon app restart anyway so the button wasn't doing anything.