### PR TITLE
docs: Add docs for order of points for horizontalDistance and verticalDistance

### DIFF
--- a/docs/kcl-std/functions/std-solver-angle.md
+++ b/docs/kcl-std/functions/std-solver-angle.md
@@ -11,13 +11,17 @@ Constrain lines to meet at a given angle.
 solver::angle(@input: [Segment; 2])
 ```
 
-
+The angle is measured counterclockwise from the first line to the second
+line, modulo 180 degrees, so the order of the lines matters:
+`angle([a, b]) == 30deg` is equivalent to `angle([b, a]) == 150deg`.
+Because the angle is measured modulo 180 degrees, it does not matter
+which end of each line segment is its start or end.
 
 ### Arguments
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `input` | [[`Segment`](/docs/kcl-std/types/std-types-Segment); 2] | The two line segments whose relative angle should match the value set with `==`. | Yes |
+| `input` | [[`Segment`](/docs/kcl-std/types/std-types-Segment); 2] | The two line segments whose relative angle should match the value set with `==`, measured counterclockwise from the first line to the second, modulo 180 degrees. The order of the lines matters. | Yes |
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-solver-distance.md
+++ b/docs/kcl-std/functions/std-solver-distance.md
@@ -1,11 +1,11 @@
 ---
 title: "solver::distance"
 subtitle: "Function in std::solver"
-excerpt: "Constrain the distance between two points."
+excerpt: "Constrain the distance between two sketch entities."
 layout: manual
 ---
 
-Constrain the distance between two points.
+Constrain the distance between two sketch entities.
 
 ```kcl
 solver::distance(
@@ -14,13 +14,34 @@ solver::distance(
 )
 ```
 
+The distance is always non-negative, and the order of the two entities
+does not matter: `distance([a, b]) == 5mm` and `distance([b, a]) == 5mm`
+are the same constraint. This differs from `horizontalDistance` and
+`verticalDistance`, which are signed and order-sensitive.
 
+Supported entity pairs (in either order):
+
+- Two points: the straight-line distance between them.
+- Point and line: the perpendicular distance from the point to the
+  infinite line through the line segment.
+- Two lines: constrains the lines to be parallel and separated by the
+  given perpendicular distance.
+- Point and circle: the gap between the point and the nearest point on
+  the circle's perimeter, with the point kept outside the circle.
+- Line and circle: the gap between the circle's perimeter and the
+  infinite line through the line segment, with the circle kept to one
+  side of the line.
+- Two circles: the gap between the two perimeters, with each circle kept
+  outside the other.
+
+A point may be `ORIGIN`, and arcs are treated as the full circle through
+them.
 
 ### Arguments
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `points` | [[`Segment`](/docs/kcl-std/types/std-types-Segment) or [`Point2d`](/docs/kcl-std/types/std-types-Point2d); 2] | Two sketch points, or one sketch point and `ORIGIN`, whose separation should match the value set with `==`. | Yes |
+| `points` | [[`Segment`](/docs/kcl-std/types/std-types-Segment) or [`Point2d`](/docs/kcl-std/types/std-types-Point2d); 2] | Two sketch entities, or one sketch entity and `ORIGIN`, whose separation should match the value set with `==`. The order of the entities does not matter. | Yes |
 | `labelPosition` | [`Point2d`](/docs/kcl-std/types/std-types-Point2d) | Optional position for the displayed constraint label in the sketch's local 2D coordinate system. | No |
 
 

--- a/docs/kcl-std/functions/std-solver-horizontalDistance.md
+++ b/docs/kcl-std/functions/std-solver-horizontalDistance.md
@@ -14,13 +14,18 @@ solver::horizontalDistance(
 )
 ```
 
-
+The distance is signed, so the order of the points matters: the value set
+with `==` equals the second point's X coordinate minus the first point's
+X coordinate. A positive value places the second point at a greater X
+than the first, and swapping the points negates the sign. For example,
+`horizontalDistance([ORIGIN, point]) == 5mm` places `point` at X = 5mm,
+while `horizontalDistance([point, ORIGIN]) == 5mm` places it at X = -5mm.
 
 ### Arguments
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `points` | [[`Segment`](/docs/kcl-std/types/std-types-Segment) or [`Point2d`](/docs/kcl-std/types/std-types-Point2d); 2] | Two sketch points, or one sketch point and `ORIGIN`, whose X-axis separation should match the value set with `==`. | Yes |
+| `points` | [[`Segment`](/docs/kcl-std/types/std-types-Segment) or [`Point2d`](/docs/kcl-std/types/std-types-Point2d); 2] | Two sketch points, or one sketch point and `ORIGIN`. The value set with `==` equals the second point's X coordinate minus the first point's X coordinate, so the order of the points determines the sign. | Yes |
 | `labelPosition` | [`Point2d`](/docs/kcl-std/types/std-types-Point2d) | Optional position for the displayed constraint label in the sketch's local 2D coordinate system. | No |
 
 

--- a/docs/kcl-std/functions/std-solver-verticalDistance.md
+++ b/docs/kcl-std/functions/std-solver-verticalDistance.md
@@ -14,13 +14,18 @@ solver::verticalDistance(
 )
 ```
 
-
+The distance is signed, so the order of the points matters: the value set
+with `==` equals the second point's Y coordinate minus the first point's
+Y coordinate. A positive value places the second point at a greater Y
+than the first, and swapping the points negates the sign. For example,
+`verticalDistance([ORIGIN, point]) == 5mm` places `point` at Y = 5mm,
+while `verticalDistance([point, ORIGIN]) == 5mm` places it at Y = -5mm.
 
 ### Arguments
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `points` | [[`Segment`](/docs/kcl-std/types/std-types-Segment) or [`Point2d`](/docs/kcl-std/types/std-types-Point2d); 2] | Two sketch points, or one sketch point and `ORIGIN`, whose Y-axis separation should match the value set with `==`. | Yes |
+| `points` | [[`Segment`](/docs/kcl-std/types/std-types-Segment) or [`Point2d`](/docs/kcl-std/types/std-types-Point2d); 2] | Two sketch points, or one sketch point and `ORIGIN`. The value set with `==` equals the second point's Y coordinate minus the first point's Y coordinate, so the order of the points determines the sign. | Yes |
 | `labelPosition` | [`Point2d`](/docs/kcl-std/types/std-types-Point2d) | Optional position for the displayed constraint label in the sketch's local 2D coordinate system. | No |
 
 

--- a/rust/kcl-lib/std/solver.kcl
+++ b/rust/kcl-lib/std/solver.kcl
@@ -290,6 +290,13 @@ export fn diameter(
 
 /// Constrain the horizontal distance between two points.
 ///
+/// The distance is signed, so the order of the points matters: the value set
+/// with `==` equals the second point's X coordinate minus the first point's
+/// X coordinate. A positive value places the second point at a greater X
+/// than the first, and swapping the points negates the sign. For example,
+/// `horizontalDistance([ORIGIN, point]) == 5mm` places `point` at X = 5mm,
+/// while `horizontalDistance([point, ORIGIN]) == 5mm` places it at X = -5mm.
+///
 /// ```kcl,sketchSolve
 /// profile = sketch(on = XY) {
 ///   edge1 = line(start = [var 0mm, var 0mm], end = [var 6mm, var 0mm])
@@ -307,13 +314,22 @@ export fn diameter(
 /// ```
 @(impl = std_rust_constraint, feature_tree = true)
 export fn horizontalDistance(
-  /// Two sketch points, or one sketch point and `ORIGIN`, whose X-axis separation should match the value set with `==`.
+  /// Two sketch points, or one sketch point and `ORIGIN`. The value set with
+  /// `==` equals the second point's X coordinate minus the first point's X
+  /// coordinate, so the order of the points determines the sign.
   @points: [Segment | Point2d; 2],
   /// Optional position for the displayed constraint label in the sketch's local 2D coordinate system.
   labelPosition?: Point2d,
 ) {}
 
 /// Constrain the vertical distance between two points.
+///
+/// The distance is signed, so the order of the points matters: the value set
+/// with `==` equals the second point's Y coordinate minus the first point's
+/// Y coordinate. A positive value places the second point at a greater Y
+/// than the first, and swapping the points negates the sign. For example,
+/// `verticalDistance([ORIGIN, point]) == 5mm` places `point` at Y = 5mm,
+/// while `verticalDistance([point, ORIGIN]) == 5mm` places it at Y = -5mm.
 ///
 /// ```kcl,sketchSolve
 /// profile = sketch(on = XY) {
@@ -332,7 +348,9 @@ export fn horizontalDistance(
 /// ```
 @(impl = std_rust_constraint, feature_tree = true)
 export fn verticalDistance(
-  /// Two sketch points, or one sketch point and `ORIGIN`, whose Y-axis separation should match the value set with `==`.
+  /// Two sketch points, or one sketch point and `ORIGIN`. The value set with
+  /// `==` equals the second point's Y coordinate minus the first point's Y
+  /// coordinate, so the order of the points determines the sign.
   @points: [Segment | Point2d; 2],
   /// Optional position for the displayed constraint label in the sketch's local 2D coordinate system.
   labelPosition?: Point2d,

--- a/rust/kcl-lib/std/solver.kcl
+++ b/rust/kcl-lib/std/solver.kcl
@@ -212,7 +212,30 @@ export fn coincident(
   @points: [Segment | Point2d; 2+],
 ) {}
 
-/// Constrain the distance between two points.
+/// Constrain the distance between two sketch entities.
+///
+/// The distance is always non-negative, and the order of the two entities
+/// does not matter: `distance([a, b]) == 5mm` and `distance([b, a]) == 5mm`
+/// are the same constraint. This differs from `horizontalDistance` and
+/// `verticalDistance`, which are signed and order-sensitive.
+///
+/// Supported entity pairs (in either order):
+///
+/// - Two points: the straight-line distance between them.
+/// - Point and line: the perpendicular distance from the point to the
+///   infinite line through the line segment.
+/// - Two lines: constrains the lines to be parallel and separated by the
+///   given perpendicular distance.
+/// - Point and circle: the gap between the point and the nearest point on
+///   the circle's perimeter, with the point kept outside the circle.
+/// - Line and circle: the gap between the circle's perimeter and the
+///   infinite line through the line segment, with the circle kept to one
+///   side of the line.
+/// - Two circles: the gap between the two perimeters, with each circle kept
+///   outside the other.
+///
+/// A point may be `ORIGIN`, and arcs are treated as the full circle through
+/// them.
 ///
 /// ```kcl,sketchSolve
 /// profile = sketch(on = XY) {
@@ -231,7 +254,9 @@ export fn coincident(
 /// ```
 @(impl = std_rust_constraint, feature_tree = true)
 export fn distance(
-  /// Two sketch points, or one sketch point and `ORIGIN`, whose separation should match the value set with `==`.
+  /// Two sketch entities, or one sketch entity and `ORIGIN`, whose separation
+  /// should match the value set with `==`. The order of the entities does not
+  /// matter.
   @points: [Segment | Point2d; 2],
   /// Optional position for the displayed constraint label in the sketch's local 2D coordinate system.
   labelPosition?: Point2d,
@@ -447,6 +472,12 @@ export fn perpendicular(
 
 /// Constrain lines to meet at a given angle.
 ///
+/// The angle is measured counterclockwise from the first line to the second
+/// line, modulo 180 degrees, so the order of the lines matters:
+/// `angle([a, b]) == 30deg` is equivalent to `angle([b, a]) == 150deg`.
+/// Because the angle is measured modulo 180 degrees, it does not matter
+/// which end of each line segment is its start or end.
+///
 /// ```kcl,sketchSolve
 /// profile = sketch(on = XY) {
 ///   line1 = line(start = [var 0mm, var 0mm], end = [var 4mm, var 0mm])
@@ -462,7 +493,9 @@ export fn perpendicular(
 /// ```
 @(impl = std_rust_constraint, feature_tree = true)
 export fn angle(
-  /// The two line segments whose relative angle should match the value set with `==`.
+  /// The two line segments whose relative angle should match the value set
+  /// with `==`, measured counterclockwise from the first line to the second,
+  /// modulo 180 degrees. The order of the lines matters.
   @input: [Segment; 2],
 ) {}
 


### PR DESCRIPTION
Resolves #12724.

This also updates `distance()` and `angle()` docs to clarify this.