### PR TITLE
Keep Zookeeper prompts resilient to missing selection files

### DIFF
--- a/src/lib/zookeeper/zookeeperPromptRequest.test.ts
+++ b/src/lib/zookeeper/zookeeperPromptRequest.test.ts
@@ -363,25 +363,52 @@ describe('constructZookeeperUserPromptRequest', () => {
     )
   })
 
-  it('returns an error instead of sending empty source ranges for stale graph selections', async () => {
-    const request = await makeRequest({
-      code: 'width = 5\n',
-      selections: {
-        otherSelections: [],
-        graphSelections: [
-          {
-            codeRef: {
-              range: [0, 5, 42],
-              pathToNode: [],
+  it('reports and omits graph selections when their source file cannot be mapped', async () => {
+    const code = 'width = 5\n'
+    const reportSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    try {
+      const request = await constructZookeeperUserPromptRequest({
+        prompt: userPrompt,
+        selections: {
+          otherSelections: [],
+          graphSelections: [
+            {
+              codeRef: {
+                range: [0, 5, 0],
+                pathToNode: [],
+              },
             },
+          ],
+        },
+        projectFiles: [
+          {
+            type: 'kcl',
+            relPath: 'main.kcl',
+            absPath: '/projects/zoo-project/main.kcl',
+            fileContents: code,
+            execStateFileNamesIndex: undefined as unknown as number,
           },
         ],
-      },
-    })
+        applicationProjectDirectory: '/projects',
+        artifactGraph: new Map(),
+        projectName: 'zoo-project',
+        currentFile: { entry: currentFileEntry, content: code },
+        kclVersion: '1.0.0',
+        ...unusedSelectionReferenceDependencies,
+      })
 
-    expect(isErr(request)).toBe(true)
-    if (!isErr(request)) return
+      expect(isErr(request)).toBe(false)
+      if (isErr(request)) return
 
-    expect(request.message).toMatch(/no KCL file found/)
+      expect(request.activeFile).toBe('main.kcl')
+      expect(request.body.prompt).toBe(userPrompt)
+      expect(request.body.source_ranges).toStrictEqual([])
+      expect(reportSpy).toHaveBeenCalledWith(
+        expect.stringContaining('no KCL file found')
+      )
+    } finally {
+      reportSpy.mockRestore()
+    }
   })
 })

--- a/src/lib/zookeeper/zookeeperPromptRequest.ts
+++ b/src/lib/zookeeper/zookeeperPromptRequest.ts
@@ -15,7 +15,7 @@ import {
   type SelectionReference,
 } from '@src/lib/selections'
 import type { FileMeta } from '@src/lib/types'
-import { isErr } from '@src/lib/trap'
+import { isErr, reportRejection } from '@src/lib/trap'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type {
   EnginePrimitiveSelection,
@@ -369,7 +369,7 @@ export function buildZookeeperSourceRangePromptsForSelection({
   selection: Selection
   artifactGraph: ArtifactGraph
   kclFilesMap: KclFileMetaMap
-}): SourceRangePrompt[] | Error {
+}): SourceRangePrompt[] {
   const promptDrafts: SourceRangePromptDraft[] = selection.artifact
     ? zookeeperArtifactSelectionPromptHandlers[selection.artifact.type]({
         selection: selection as Selection & { artifact: Artifact },
@@ -391,18 +391,15 @@ export function buildZookeeperSourceRangePromptsForSelection({
       required: promptDraft.required ?? true,
     })
     if (prompt instanceof Error) {
-      return prompt
+      reportRejection(prompt.message)
+      continue
     }
     if (prompt !== null) {
       prompts.push(prompt)
     }
   }
 
-  return prompts.length > 0
-    ? prompts
-    : new Error(
-        'Could not send Zookeeper selection: no selected source ranges could be serialized.'
-      )
+  return prompts
 }
 
 function isReferenceableEnginePrimitiveSelection(
@@ -517,7 +514,9 @@ export async function constructZookeeperUserPromptRequest({
     if (file.type === 'other') {
       data = file.data
     } else {
-      kclFilesMap[file.execStateFileNamesIndex] = file
+      if (Number.isInteger(file.execStateFileNamesIndex)) {
+        kclFilesMap[file.execStateFileNamesIndex] = file
+      }
       data = new Blob([file.fileContents], { type: 'text/kcl' })
     }
     files.push({
@@ -577,9 +576,6 @@ export async function constructZookeeperUserPromptRequest({
       artifactGraph,
       kclFilesMap,
     })
-    if (selectionPrompts instanceof Error) {
-      return selectionPrompts
-    }
     ranges.push(...selectionPrompts)
   }
 

--- a/src/machines/systemIO/utils.spec.ts
+++ b/src/machines/systemIO/utils.spec.ts
@@ -330,6 +330,49 @@ describe('System IO Utils', () => {
     }
   })
 
+  it('uses exec state index 0 for the selected project file when exec filenames are unavailable', async () => {
+    const projectPath = `/tmp/opencode/zookeeper-project-${crypto.randomUUID()}`
+    const mainPath = fsZds.join(projectPath, 'main.kcl')
+    await fsZds.mkdir(projectPath, { recursive: true })
+    await fsZds.writeFile(
+      mainPath,
+      new TextEncoder().encode('boxHeight = 50mm')
+    )
+
+    try {
+      const projectFiles = await collectProjectFiles({
+        selectedFileContents: 'boxHeight = 500mm',
+        selectedFilePath: mainPath,
+        fileNames: {},
+        projectContext: {
+          name: 'zookeeper-project',
+          path: projectPath,
+          children: [
+            {
+              name: 'main.kcl',
+              path: mainPath,
+              children: null,
+            },
+          ],
+          metadata: null,
+          kcl_file_count: 1,
+          directory_count: 0,
+          default_file: mainPath,
+          readWriteAccess: true,
+        },
+      })
+
+      const mainFile = projectFiles.find((file) => file.relPath === 'main.kcl')
+      expect(mainFile).toMatchObject({
+        type: 'kcl',
+        fileContents: 'boxHeight = 500mm',
+        execStateFileNamesIndex: 0,
+      })
+    } finally {
+      await fsZds.rm(projectPath, { recursive: true, force: true })
+    }
+  })
+
   it('keeps the currently focused file as the navigation target after project-wide edits', () => {
     const preparedPayload = prepareMlEphantNewFileRequest({
       projectNameCurrentlyOpened: 'some-project',

--- a/src/machines/systemIO/utils.ts
+++ b/src/machines/systemIO/utils.ts
@@ -256,16 +256,29 @@ export const collectProjectFiles = async (args: {
       execStateFileNamesIndex: 0,
     },
   ]
-  const execStateNameToIndexMap: { [fileName: string]: number } = {}
-  Object.entries(args.fileNames).forEach(([index, val]) => {
-    if (val?.type === 'Local') {
-      execStateNameToIndexMap[val.value] = Number(index)
-    }
-  })
   let basePath = ''
   if (args.projectContext) {
     // Use the entire project directory as the basePath for prompt to edit, do not use relative subdir paths
     basePath = args.projectContext?.path
+    const execStateNameToIndexMap: { [fileName: string]: number } = {}
+    const setExecStateFileIndex = (fileName: string, index: number) => {
+      const normalizedFileName = normalizeRelativePath(fileName)
+      execStateNameToIndexMap[fileName] = index
+      execStateNameToIndexMap[normalizedFileName] = index
+      execStateNameToIndexMap[normalizePathForComparison(fileName)] = index
+
+      const projectRelativePath = normalizeRelativePath(
+        fsZds.relative(basePath, fileName) ?? ''
+      )
+      if (projectRelativePath && !projectRelativePath.startsWith('..')) {
+        execStateNameToIndexMap[projectRelativePath] = index
+      }
+    }
+    Object.entries(args.fileNames).forEach(([index, val]) => {
+      if (val?.type === 'Local') {
+        setExecStateFileIndex(val.value, Number(index))
+      }
+    })
     const selectedAbsolutePath = args.selectedFilePath
       ? normalizePathForComparison(args.selectedFilePath)
       : undefined
@@ -283,6 +296,16 @@ export const collectProjectFiles = async (args: {
           selectedRelativePath
       )
     }
+    const execStateFileIndexForKclFile = (
+      absolutePathToFileNameWithExtension: string,
+      fileNameWithExtension: string
+    ) =>
+      execStateNameToIndexMap[absolutePathToFileNameWithExtension] ??
+      execStateNameToIndexMap[
+        normalizePathForComparison(absolutePathToFileNameWithExtension)
+      ] ??
+      execStateNameToIndexMap[fileNameWithExtension] ??
+      (isSelectedFilePath(absolutePathToFileNameWithExtension) ? 0 : undefined)
     const filePromises: Promise<FileMeta | null>[] = []
     let uploadSize = 0
     const pushFilePromise = (absolutePathToFileNameWithExtension: string) => {
@@ -311,8 +334,10 @@ export const collectProjectFiles = async (args: {
                 absPath: absolutePathToFileNameWithExtension,
                 relPath: fileNameWithExtension,
                 fileContents: decoder.decode(file),
-                execStateFileNamesIndex:
-                  execStateNameToIndexMap[absolutePathToFileNameWithExtension],
+                execStateFileNamesIndex: execStateFileIndexForKclFile(
+                  absolutePathToFileNameWithExtension,
+                  fileNameWithExtension
+                ),
               }
             }
             const blob = new Blob([new Uint8Array(file)], {


### PR DESCRIPTION
## Summary

This fixes a release-blocking Zookeeper prompt submission failure when a selected source range refers to an exec-state file index that is not present in the collected KCL file metadata.

This is no longer possible:
<img width="1160" height="907" alt="Screenshot 2026-07-31 at 4 57 20 PM" src="https://github.com/user-attachments/assets/d5ef1f85-f58b-4d73-a274-d94841efe748" />

## What changed

1. Zookeeper request construction now reports and omits unmappable graph-selection source ranges instead of returning an error that blocks prompt submission.
2. KCL file upload/index mapping now ignores invalid `execStateFileNamesIndex` values rather than indexing files under an `undefined` key.
3. `collectProjectFiles` now builds a more tolerant exec-state filename lookup using original, normalized, resolved, and project-relative path keys.
4. If the active editor KCL file is present but `execState.filenames` is unavailable or stale, `collectProjectFiles` preserves that selected file as exec-state index `0`.
5. Regression tests cover both the Zookeeper request fallback and the active-file collection fallback.

## Why this is needed

After prompting a model, making point-and-click sketch edits, exiting sketch mode, and submitting a prompt with a face selection, ZDS could show:

> Could not send Zookeeper selection: no KCL file found for source range file index 0.

The app still had the active project and active file. The submit path passes `theProject`, `loaderFile`, live editor code, and `kclManager.path` into project file collection. The missing piece was the numeric exec-state filename mapping: the selection range still pointed at file index `0`, but the collected `main.kcl` metadata could arrive without a usable `execStateFileNamesIndex`.

## What this should prevent

Users should no longer be blocked from submitting a Zookeeper prompt because local selection serialization cannot map a stale or missing source-range file index. In that case, ZDS reports the serialization problem, sends the prompt, and leaves Zookeeper to handle the request without that bad selection source range.

## Validation

- `npm run test:unit -- src/lib/zookeeper/zookeeperPromptRequest.test.ts`
- `npm run test:integration -- src/machines/systemIO/utils.spec.ts`
- `npm run tsc`
- `npm run lint`
- `npm run fmt:check`