### PR TITLE
Allow horizontally/vertically constraint current draft line with hotkey

### DIFF
--- a/e2e/playwright/sketch-solve-edit.spec.ts
+++ b/e2e/playwright/sketch-solve-edit.spec.ts
@@ -481,6 +481,85 @@ test.describe('Sketch solve edit tests', { tag: '@desktop' }, () => {
     })
   })
 
+  test('horizontal and vertical hotkeys constrain the draft line while drawing', async ({
+    page,
+    context,
+    homePage,
+    scene,
+    editor,
+    toolbar,
+  }) => {
+    await test.step('Set up the app and enter sketch solve mode', async () => {
+      await context.addInitScript(() => {
+        localStorage.setItem('persistCode', '')
+      })
+
+      await page.setBodyDimensions({ width: 1200, height: 500 })
+      await homePage.goToModelingScene()
+      await scene.settled()
+
+      await toolbar.startSketchOnDefaultPlane('Top plane')
+      await editor.expectEditor.toContain('sketch(on = XY) {')
+      await toolbar.expectToolbarMode.toBe('sketchSolve')
+      await scene.clickNoWhere()
+    })
+
+    const [lineStart] = scene.makeMouseHelpers(0.35, 0.45, {
+      format: 'ratio',
+    })
+    const [line1EndClick, moveToLine1End] = scene.makeMouseHelpers(0.55, 0.6, {
+      format: 'ratio',
+    })
+    const [line2EndClick, moveToLine2End] = scene.makeMouseHelpers(0.75, 0.4, {
+      format: 'ratio',
+    })
+
+    await test.step('Draw a draft line and constrain it vertically with the hotkey', async () => {
+      await page.keyboard.press('l')
+      await expect(toolbar.lineBtn).toHaveAttribute('aria-pressed', 'true')
+
+      let previousCode = await editor.getCurrentCode()
+      await lineStart()
+      previousCode = await waitForCodeChange(page, previousCode)
+      await moveToLine1End()
+      previousCode = await waitForCodeChange(page, previousCode)
+
+      await page.keyboard.press('v')
+      await editor.expectEditor.toContain('vertical(line1)')
+
+      // The line tool must stay equipped so drawing can continue
+      await expect(toolbar.lineBtn).toHaveAttribute('aria-pressed', 'true')
+
+      previousCode = await editor.getCurrentCode()
+      await line1EndClick()
+      await waitForCodeChange(page, previousCode)
+      await editor.expectEditor.toContain('vertical(line1)')
+    })
+
+    await test.step('Constrain the chained draft line horizontally with the hotkey', async () => {
+      let previousCode = await editor.getCurrentCode()
+      await moveToLine2End()
+      previousCode = await waitForCodeChange(page, previousCode)
+
+      await page.keyboard.press('h')
+      await editor.expectEditor.toContain('horizontal(line2)')
+      await expect(toolbar.lineBtn).toHaveAttribute('aria-pressed', 'true')
+
+      previousCode = await editor.getCurrentCode()
+      await line2EndClick()
+      await waitForCodeChange(page, previousCode)
+    })
+
+    await test.step('Finish drawing and assert both constraints remain', async () => {
+      await page.keyboard.press('Escape')
+      await page.keyboard.press('Escape')
+      await expect(toolbar.lineBtn).toHaveAttribute('aria-pressed', 'false')
+
+      await editor.expectEditor.toContain('vertical(line1)')
+      await editor.expectEditor.toContain('horizontal(line2)')
+    })
+  })
+
   test('unequipping line tool should not drop committed segments from the scene', async ({
     page,
     context,

--- a/src/machines/sketchSolve/sketchSolveDiagram.ts
+++ b/src/machines/sketchSolve/sketchSolveDiagram.ts
@@ -59,6 +59,7 @@ import {
 } from '@src/machines/sketchSolve/sketchSolveImpl'
 import { applyOrEquipConstraintToolFromToolbar } from '@src/machines/sketchSolve/tools/constraintToolbarAction'
 import { getConstraintToolPreparedApply } from '@src/machines/sketchSolve/tools/constraintToolHelpers'
+import { buildDraftLineConstraintPlan } from '@src/machines/sketchSolve/tools/draftLineConstraint'
 import {
   type ConstraintToolName,
   constraintToolNames,
@@ -401,6 +402,24 @@ export const sketchSolveMachine = setup({
       assertEvent(event, 'equip tool')
       return { pendingToolName: event.data.tool }
     }),
+    'constrain draft line': ({ context, event }) => {
+      assertEvent(event, 'equip tool')
+      if (!context.draftEntities) {
+        return
+      }
+      const plan = buildDraftLineConstraintPlan(
+        event.data.tool,
+        context.draftEntities,
+        context.sketchExecOutcome?.sceneGraphDelta.new_graph.objects || []
+      )
+      if (!plan) {
+        return
+      }
+      sendToActorIfActive(context.childTool, {
+        type: 'constrain draft segment',
+        data: { plan, draftEntities: context.draftEntities },
+      })
+    },
     'apply current selection with equipped constraint tool': ({
       context,
       event,
@@ -1072,10 +1091,29 @@ export const sketchSolveMachine = setup({
           reenter: true,
         },
 
-        'equip tool': {
-          target: 'switching tool',
-          actions: ['send unequip to tool', 'store pending tool'],
-        },
+        'equip tool': [
+          {
+            guard: ({ context, event }) => {
+              assertEvent(event, 'equip tool')
+              return (
+                context.sketchSolveToolName === 'lineTool' &&
+                buildDraftLineConstraintPlan(
+                  event.data.tool,
+                  context.draftEntities,
+                  context.sketchExecOutcome?.sceneGraphDelta.new_graph
+                    .objects || []
+                ) !== null
+              )
+            },
+            actions: 'constrain draft line',
+            description:
+              'Pressing the horizontal/vertical constraint hotkey while drawing a line constrains the in-progress draft segment instead of switching tools.',
+          },
+          {
+            target: 'switching tool',
+            actions: ['send unequip to tool', 'store pending tool'],
+          },
+        ],
         [CHILD_TOOL_DONE_EVENT]: {
           target: 'move and select',
           actions: [

--- a/src/machines/sketchSolve/tools/draftLineConstraint.test.ts
+++ b/src/machines/sketchSolve/tools/draftLineConstraint.test.ts
@@ -1,0 +1,170 @@
+import type {
+  ApiConstraint,
+  ApiObject,
+} from '@rust/kcl-lib/bindings/FrontendApi'
+import { buildDraftLineConstraintPlan } from '@src/machines/sketchSolve/tools/draftLineConstraint'
+import {
+  createLineApiObject,
+  createPointApiObject,
+} from '@src/machines/sketchSolve/tools/sketchToolTestUtils'
+import { describe, expect, it } from 'vitest'
+
+function createConstraintApiObject(
+  id: number,
+  constraint: ApiConstraint
+): ApiObject {
+  return {
+    id,
+    kind: { type: 'Constraint', constraint },
+    label: '',
+    comments: '',
+    artifact_id: '0',
+    source: { type: 'Simple', range: [0, 0, 0], node_path: null },
+  }
+}
+
+function createObjectsArray(objects: ApiObject[]) {
+  const array: ApiObject[] = []
+  for (const object of objects) {
+    array[object.id] = object
+  }
+  return array
+}
+
+const start = createPointApiObject({ id: 1, x: 0, y: 0 })
+const end = createPointApiObject({ id: 2, x: 10, y: 5 })
+const draftLine = createLineApiObject({ id: 10, start: 1, end: 2 })
+const draftEntities = {
+  segmentIds: [1, 2, 10],
+  constraintIds: [30],
+}
+
+describe('buildDraftLineConstraintPlan', () => {
+  it('returns null for tools other than the orientation constraint tools', () => {
+    const objects = createObjectsArray([start, end, draftLine])
+
+    expect(
+      buildDraftLineConstraintPlan('lineTool', draftEntities, objects)
+    ).toBeNull()
+    expect(
+      buildDraftLineConstraintPlan(
+        'parallelConstraintTool',
+        draftEntities,
+        objects
+      )
+    ).toBeNull()
+  })
+
+  it('returns null when there are no draft entities or no draft line', () => {
+    const objects = createObjectsArray([start, end, draftLine])
+
+    expect(
+      buildDraftLineConstraintPlan('verticalConstraintTool', undefined, objects)
+    ).toBeNull()
+    expect(
+      buildDraftLineConstraintPlan(
+        'verticalConstraintTool',
+        { segmentIds: [1, 2], constraintIds: [] },
+        objects
+      )
+    ).toBeNull()
+  })
+
+  it('adds an orientation constraint to the draft line when none exists', () => {
+    const objects = createObjectsArray([start, end, draftLine])
+
+    expect(
+      buildDraftLineConstraintPlan(
+        'verticalConstraintTool',
+        draftEntities,
+        objects
+      )
+    ).toEqual({
+      deleteConstraintIds: [],
+      constraint: { type: 'Vertical', line: 10 },
+    })
+    expect(
+      buildDraftLineConstraintPlan(
+        'horizontalConstraintTool',
+        draftEntities,
+        objects
+      )
+    ).toEqual({
+      deleteConstraintIds: [],
+      constraint: { type: 'Horizontal', line: 10 },
+    })
+  })
+
+  it('toggles the constraint off when the same orientation is requested again', () => {
+    const vertical = createConstraintApiObject(20, {
+      type: 'Vertical',
+      line: 10,
+    })
+    const objects = createObjectsArray([start, end, draftLine, vertical])
+
+    expect(
+      buildDraftLineConstraintPlan(
+        'verticalConstraintTool',
+        draftEntities,
+        objects
+      )
+    ).toEqual({
+      deleteConstraintIds: [20],
+      constraint: null,
+    })
+  })
+
+  it('swaps the constraint when the opposite orientation is requested', () => {
+    const horizontal = createConstraintApiObject(20, {
+      type: 'Horizontal',
+      line: 10,
+    })
+    const objects = createObjectsArray([start, end, draftLine, horizontal])
+
+    expect(
+      buildDraftLineConstraintPlan(
+        'verticalConstraintTool',
+        draftEntities,
+        objects
+      )
+    ).toEqual({
+      deleteConstraintIds: [20],
+      constraint: { type: 'Vertical', line: 10 },
+    })
+  })
+
+  it('ignores orientation constraints on other lines and point-based ones', () => {
+    const otherStart = createPointApiObject({ id: 3, x: 20, y: 0 })
+    const otherEnd = createPointApiObject({ id: 4, x: 20, y: 10 })
+    const otherLine = createLineApiObject({ id: 11, start: 3, end: 4 })
+    const verticalOnOtherLine = createConstraintApiObject(20, {
+      type: 'Vertical',
+      line: 11,
+    })
+    const verticalOnPoints = createConstraintApiObject(21, {
+      type: 'Vertical',
+      points: [1, 'ORIGIN'],
+    })
+    const objects = createObjectsArray([
+      start,
+      end,
+      otherStart,
+      otherEnd,
+      draftLine,
+      otherLine,
+      verticalOnOtherLine,
+      verticalOnPoints,
+    ])
+
+    expect(
+      buildDraftLineConstraintPlan(
+        'verticalConstraintTool',
+        draftEntities,
+        objects
+      )
+    ).toEqual({
+      deleteConstraintIds: [],
+      constraint: { type: 'Vertical', line: 10 },
+    })
+  })
+})

--- a/src/machines/sketchSolve/tools/draftLineConstraint.ts
+++ b/src/machines/sketchSolve/tools/draftLineConstraint.ts
@@ -1,0 +1,95 @@
+import type {
+  ApiConstraint,
+  ApiObject,
+} from '@rust/kcl-lib/bindings/FrontendApi'
+import {
+  getAxisConstraintLineId,
+  isConstraint,
+  isLineSegment,
+} from '@src/machines/sketchSolve/constraints/constraintUtils'
+
+export type DraftEntities = {
+  segmentIds: Array<number>
+  constraintIds: Array<number>
+}
+
+type OrientationConstraint = Extract<
+  ApiConstraint,
+  { type: 'Horizontal' | 'Vertical' }
+>
+
+/**
+ * What to do when the user hits the horizontal/vertical constraint hotkey
+ * while rubber-banding a draft line. `deleteConstraintIds` removes a
+ * previously applied orientation constraint (swap, or toggle off when
+ * `constraint` is null), and `constraint` is the new one to add.
+ */
+export type DraftLineConstraintPlan = {
+  deleteConstraintIds: Array<number>
+  constraint: OrientationConstraint | null
+}
+
+/**
+ * Builds the plan for constraining the in-progress draft line, or returns
+ * null when the request doesn't apply (not an orientation constraint tool,
+ * or no draft line is being drawn) and normal tool switching should happen.
+ */
+export function buildDraftLineConstraintPlan(
+  toolName: string,
+  draftEntities: DraftEntities | undefined,
+  objects: readonly ApiObject[]
+): DraftLineConstraintPlan | null {
+  const orientation =
+    toolName === 'horizontalConstraintTool'
+      ? ('Horizontal' as const)
+      : toolName === 'verticalConstraintTool'
+        ? ('Vertical' as const)
+        : null
+  if (orientation === null || draftEntities === undefined) {
+    return null
+  }
+
+  const draftLineId = draftEntities.segmentIds.find((id) =>
+    isLineSegment(objects[id])
+  )
+  if (draftLineId === undefined) {
+    return null
+  }
+
+  // Find orientation constraints already applied to the draft line so
+  // repeated hotkey presses toggle/swap instead of over-constraining.
+  let sameOrientationId: number | undefined
+  let otherOrientationId: number | undefined
+  objects.forEach((obj, id) => {
+    if (!isConstraint(obj)) {
+      return
+    }
+    const constraint = obj.kind.constraint
+    if (constraint.type !== 'Horizontal' && constraint.type !== 'Vertical') {
+      return
+    }
+    if (getAxisConstraintLineId(constraint) !== draftLineId) {
+      return
+    }
+    if (constraint.type === orientation) {
+      sameOrientationId = id
+    } else {
+      otherOrientationId = id
+    }
+  })
+
+  // Same constraint selected again -> remove it
+  if (sameOrientationId !== undefined) {
+    return { deleteConstraintIds: [sameOrientationId], constraint: null }
+  }
+
+  // Other constraint selected -> remove existing one and add this one
+  return {
+    deleteConstraintIds:
+      otherOrientationId !== undefined ? [otherOrientationId] : [],
+    constraint:
+      orientation === 'Horizontal'
+        ? { type: 'Horizontal', line: draftLineId }
+        : { type: 'Vertical', line: draftLineId },
+  }
+}

--- a/src/machines/sketchSolve/tools/lineToolDiagram.ts
+++ b/src/machines/sketchSolve/tools/lineToolDiagram.ts
@@ -30,8 +30,13 @@ import {
   applyConstraintsForSnapTarget,
   getCoincidentSegmentsForSnapTarget,
 } from '@src/machines/sketchSolve/snapping'
+import type {
+  DraftEntities,
+  DraftLineConstraintPlan,
+} from '@src/machines/sketchSolve/tools/draftLineConstraint'
 import {
   type CONFIRMING_DIMENSIONS,
+  type CONSTRAINING_DRAFT_LINE,
   type TOOL_ID,
   type ToolContext,
   type ToolEvents,
@@ -39,6 +44,7 @@ import {
   addPointListener,
   animateDraftSegmentListener,
   removePointListener,
+  sendDraftConstraintOutcomeToParent,
   sendResultToParent,
   sendStoredResultToParent,
   storePendingSketchOutcome,
@@ -50,6 +56,9 @@ export const toolId: typeof TOOL_ID = 'Line tool'
 
 export const confirmingDimensions: typeof CONFIRMING_DIMENSIONS =
   'Confirming dimensions'
+
+export const constrainingDraftLine: typeof CONSTRAINING_DRAFT_LINE =
+  'Constraining draft line'
 
 export const machine = setup({
   types: {
@@ -67,6 +76,8 @@ export const machine = setup({
     'add next draft line listener': addNextDraftLineListener,
     'remove point listener': removePointListener,
     'send result to parent': assign(sendResultToParent),
+    'send draft constraint outcome to parent':
+      sendDraftConstraintOutcomeToParent,
     'toast sketch solve error': ({ event }) => {
       toastSketchSolveError(event)
     },
@@ -332,6 +343,83 @@ export const machine = setup({
           }
         } catch (error) {
           console.error('Failed to add point segment:', error)
+          return {
+            error: error instanceof Error ? error.message : 'Unknown error',
+          }
+        }
+      }
+    ),
+    constrainDraftLine: fromPromise(
+      async ({
+        input,
+      }: {
+        input: {
+          plan: DraftLineConstraintPlan
+          draftEntities: DraftEntities
+          rustContext: RustContext
+          sketchId: number
+        }
+      }): Promise<
+        | {
+            kclSource: SourceDelta
+            sceneGraphDelta: SceneGraphDelta
+            draftEntities: DraftEntities
+          }
+        | {
+            error: string
+          }
+      > => {
+        const { plan, draftEntities, rustContext, sketchId } = input
+        const settings = jsAppSettings(rustContext.settingsActor)
+
+        try {
+          let result = null
+          if (plan.deleteConstraintIds.length > 0) {
+            result = await rustContext.deleteObjects(
+              0,
+              sketchId,
+              plan.deleteConstraintIds,
+              [],
+              settings
+            )
+          }
+
+          let addedConstraintId: number | undefined
+          if (plan.constraint) {
+            const addResult = await rustContext.addConstraint(
+              0,
+              sketchId,
+              plan.constraint,
+              settings
+            )
+            addedConstraintId = addResult.sceneGraphDelta.new_objects.find(
+              (objId) =>
+                isConstraint(addResult.sceneGraphDelta.new_graph.objects[objId])
+            )
+            result = addResult
+          }
+
+          if (!result) {
+            return { error: 'No constraint change to apply to draft line.' }
+          }
+
+          const constraintIds = draftEntities.constraintIds.filter(
+            (id) => !plan.deleteConstraintIds.includes(id)
+          )
+          if (addedConstraintId !== undefined) {
+            constraintIds.push(addedConstraintId)
+          }
+
+          return {
+            kclSource: result.kclSource,
+            sceneGraphDelta: result.sceneGraphDelta,
+            draftEntities: {
+              segmentIds: draftEntities.segmentIds,
+              constraintIds,
+            },
+          }
+        } catch (error) {
+          console.error('Failed to constrain draft line:', error)
           return {
             error: error instanceof Error ? error.message : 'Unknown error',
           }
@@ -681,6 +769,7 @@ export const machine = setup({
     ShowDraftLine: {
       on: {
         'add point': 'Confirming dimensions',
+        'constrain draft segment': constrainingDraftLine,
         unequip: {
           target: 'delete draft entities on unequip',
           actions: assign({
@@ -699,6 +788,37 @@ export const machine = setup({
 
       entry: 'animate draft segment listener',
       exit: 'remove point listener', // Stop the onMove listener when leaving this state
+    },
+    [constrainingDraftLine]: {
+      invoke: {
+        src: 'constrainDraftLine',
+        input: ({ event, context }) => {
+          assertEvent(event, 'constrain draft segment')
+          return {
+            plan: event.data.plan,
+            draftEntities: event.data.draftEntities,
+            rustContext: context.rustContext,
+            sketchId: context.sketchId,
+          }
+        },
+        onDone: [
+          {
+            guard: 'invoke output has error',
+            target: 'ShowDraftLine',
+            actions: 'toast sketch solve error',
+          },
+          {
+            target: 'ShowDraftLine',
+            actions: 'send draft constraint outcome to parent',
+          },
+        ],
+        onError: {
+          target: 'ShowDraftLine',
+          actions: 'toast sketch solve error',
+        },
+      },
+      description:
+        'Applies, swaps, or removes a horizontal/vertical constraint on the draft line, then returns to rubber-banding.',
     },
     'delete draft entities on unequip': {
       entry: ({ self }) => {

--- a/src/machines/sketchSolve/tools/lineToolImpl.ts
+++ b/src/machines/sketchSolve/tools/lineToolImpl.ts
@@ -17,6 +17,10 @@ import {
 } from '@src/machines/sketchSolve/constraints/constraintUtils'
 import { toastSketchSolveError } from '@src/machines/sketchSolve/sketchSolveErrors'
 import type { SketchSolveMachineEvent } from '@src/machines/sketchSolve/sketchSolveImpl'
+import type {
+  DraftEntities,
+  DraftLineConstraintPlan,
+} from '@src/machines/sketchSolve/tools/draftLineConstraint'
 import type { BaseToolEvent } from '@src/machines/sketchSolve/tools/sharedToolTypes'
 import {
   clearToolSnappingState,
@@ -33,11 +37,19 @@ import {
 
 export const TOOL_ID = 'Line tool'
 export const CONFIRMING_DIMENSIONS = 'Confirming dimensions'
+export const CONSTRAINING_DRAFT_LINE = 'Constraining draft line'
 
 export type ToolEvents =
   | BaseToolEvent
   | { type: 'finish line chain' }
   | { type: 'start next draft line'; data: [number, number] }
+  | {
+      type: 'constrain draft segment'
+      data: {
+        plan: DraftLineConstraintPlan
+        draftEntities: DraftEntities
+      }
+    }
   | {
       type:
         | `xstate.done.actor.0.${typeof TOOL_ID}.Adding point`
@@ -46,6 +58,14 @@ export type ToolEvents =
         kclSource: SourceDelta
         sceneGraphDelta: SceneGraphDelta
         checkpointId?: number | null
+      }
+    }
+  | {
+      type: `xstate.done.actor.0.${typeof TOOL_ID}.${typeof CONSTRAINING_DRAFT_LINE}`
+      output: {
+        kclSource: SourceDelta
+        sceneGraphDelta: SceneGraphDelta
+        draftEntities: DraftEntities
       }
     }
 
@@ -435,6 +455,46 @@ export function storePendingSketchOutcome({
   }
 
   return result
+}
+
+export function sendDraftConstraintOutcomeToParent({
+  event,
+  self,
+}: ToolActionArgs) {
+  if (!('output' in event) || !event.output) {
+    return
+  }
+
+  const output = event.output as {
+    kclSource?: SourceDelta
+    sceneGraphDelta?: SceneGraphDelta
+    draftEntities?: DraftEntities
+    error?: string
+  }
+
+  if (output.error || !output.kclSource || !output.sceneGraphDelta) {
+    return
+  }
+
+  const sendData: SketchSolveMachineEvent = {
+    type: 'update sketch outcome',
+    data: {
+      sourceDelta: output.kclSource,
+      sceneGraphDelta: output.sceneGraphDelta,
+      writeToDisk: false,
+    },
+  }
+  self._parent?.send(sendData)
+
+  if (output.draftEntities) {
+    // Keep the added/removed orientation constraint tracked as a draft
+    // entity so escaping the draft line still cleans everything up.
+    const draftData: SketchSolveMachineEvent = {
+      type: 'set draft entities',
+      data: output.draftEntities,
+    }
+    self._parent?.send(draftData)
+  }
 }
 
 export function sendStoredResultToParent({ context, self }: ToolActionArgs) {


### PR DESCRIPTION
Reported by @benjamaan476 

When hitting v or h applies a real vertical(line1) / horizontal(line1).
Pressing the same key again removes the constraint, pressing the other key swaps it, and Escape still cleans up the whole draft including the constraint.


https://github.com/user-attachments/assets/41e3036e-3f1d-4d22-9150-dffee8cbc961

