### PR TITLE
Simplify cloud sync file policies

### DIFF
--- a/src/components/CloudConflictDialog.spec.tsx
+++ b/src/components/CloudConflictDialog.spec.tsx
@@ -173,7 +173,7 @@ describe('CloudConflictDialog', () => {
     expect(screen.getAllByText('main.kcl')).not.toHaveLength(0)
     expect(screen.getAllByText('local-only.txt')).not.toHaveLength(0)
     expect(screen.getAllByText('cloud-only.txt')).not.toHaveLength(0)
-    expect(screen.getByText('thumbnail.png')).toBeInTheDocument()
+    expect(screen.queryByText('thumbnail.png')).not.toBeInTheDocument()
     expect(screen.queryByText('.git')).not.toBeInTheDocument()
     expect(screen.getAllByTestId('mock-merge-view')).toHaveLength(3)
     expect(
@@ -184,13 +184,6 @@ describe('CloudConflictDialog', () => {
 
     fireEvent.click(screen.getByTestId('cloud-conflict-file-toggle-main.kcl'))
     expect(screen.getAllByTestId('mock-merge-view')).toHaveLength(2)
-
-    fireEvent.click(
-      screen.getByTestId('cloud-conflict-file-toggle-thumbnail.png')
-    )
-    expect(
-      screen.getByText('Diff unavailable: Binary or non-UTF-8 file.')
-    ).toBeInTheDocument()
 
     fireEvent.click(screen.getByTestId('cloud-conflict-close-button'))
     expect(onDismiss).toHaveBeenCalledTimes(1)

--- a/src/components/CloudConflictDialog.spec.tsx
+++ b/src/components/CloudConflictDialog.spec.tsx
@@ -27,16 +27,6 @@ const cloudConflictDialogSpecMocks = vi.hoisted(() => {
     }
   }
 
-  function inspectedBinaryFile(relativePath: string, modifiedAtMs: number) {
-    return {
-      absolutePath: relativePath,
-      data: new Uint8Array([0, 1, 2]),
-      modifiedAtMs,
-      relativePath,
-      size: 3,
-    }
-  }
-
   return {
     inspection: {
       projectTitle: 'User-facing project title',
@@ -66,13 +56,6 @@ const cloudConflictDialogSpecMocks = vi.hoisted(() => {
           cloud: inspectedFile('cloud-only.txt', 'cloud\n', cloudSavedAtMs),
           localText: '',
           cloudText: 'cloud\n',
-        },
-        {
-          status: 'changed',
-          relativePath: 'thumbnail.png',
-          local: inspectedBinaryFile('thumbnail.png', localSavedAtMs),
-          cloud: inspectedBinaryFile('thumbnail.png', cloudSavedAtMs),
-          textUnavailableReason: 'Binary or non-UTF-8 file.',
         },
       ],
     },

--- a/src/lib/cloudSync/cloudApi.ts
+++ b/src/lib/cloudSync/cloudApi.ts
@@ -355,12 +355,14 @@ export async function updateRemoteProject({
   projectId,
   files,
   expectedRevision,
+  entrypointPath,
 }: {
   config: CloudSyncConfig
   projectPath: string
   projectId: string
   files: ProjectArchiveFile[]
   expectedRevision?: Revision
+  entrypointPath?: string
 }) {
   return cloudJson<RemoteProject>(
     config,
@@ -370,20 +372,30 @@ export async function updateRemoteProject({
     ),
     {
       method: 'PUT',
-      body: buildProjectFormData(projectPath, files, expectedRevision),
+      body: buildProjectFormData(projectPath, files, {
+        expectedRevision,
+        entrypointPath,
+      }),
     }
   )
+}
+
+type BuildProjectFormDataOptions = {
+  expectedRevision?: Revision
+  entrypointPath?: string
 }
 
 function buildProjectFormData(
   projectPath: string,
   files: ProjectArchiveFile[],
-  expectedRevision?: Revision
+  options?: Revision | BuildProjectFormDataOptions
 ) {
+  const uploadOptions =
+    typeof options === 'string' ? { expectedRevision: options } : options
   const uploadPayload = prepareProjectFilesForCloudUpload(
     projectPath,
     files,
-    expectedRevision
+    uploadOptions
   )
 
   const formData = new FormData()

--- a/src/lib/cloudSync/conflictInspection.ts
+++ b/src/lib/cloudSync/conflictInspection.ts
@@ -7,7 +7,10 @@ import type {
   ProjectMetadata,
   Revision,
 } from '@src/lib/cloudSync/types'
-import { PROJECT_SETTINGS_FILE_NAME } from '@src/lib/constants'
+import {
+  PROJECT_IMAGE_NAME,
+  PROJECT_SETTINGS_FILE_NAME,
+} from '@src/lib/constants'
 import fsZds from '@src/lib/fs-zds'
 import { fsZdsConstants } from '@src/lib/fs-zds/constants'
 import type { IZooDesignStudioFS } from '@src/lib/fs-zds/interface'
@@ -162,6 +165,9 @@ async function scanProjectFiles(
       const relativePath = normalizeRelativePath(
         fileSystem.relative(projectRoot, absolutePath) ?? ''
       )
+      if (relativePath === PROJECT_IMAGE_NAME) {
+        continue
+      }
       const data = Uint8Array.from(await fileSystem.readFile(absolutePath))
       files.set(relativePath, {
         absolutePath,
@@ -185,6 +191,9 @@ function projectArchiveFilesToScannedFiles(
 
   for (const file of files) {
     const relativePath = normalizeRelativePath(file.relativePath)
+    if (relativePath === PROJECT_IMAGE_NAME) {
+      continue
+    }
     scannedFiles.set(relativePath, {
       absolutePath: relativePath,
       data: file.data,

--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -1319,8 +1319,7 @@ async function cloneRemoteProjectToLocal(
       await parseProjectArchive(archive),
       remoteProject.title,
       remoteProject.id,
-      getEnvironmentName(),
-      getRemoteProjectEntrypointPath(remoteProject)
+      getEnvironmentName()
     )
   )
   const nextMetadata = {
@@ -1487,8 +1486,7 @@ export async function renameRemoteCloudProject(
     ),
     title,
     projectId,
-    getEnvironmentName(),
-    getRemoteProjectEntrypointPath(remoteProject)
+    getEnvironmentName()
   )
   const updated = await updateRemoteProject({
     config,
@@ -1496,6 +1494,7 @@ export async function renameRemoteCloudProject(
     projectId,
     files,
     expectedRevision: getRevision(remoteProject),
+    entrypointPath: getRemoteProjectEntrypointPath(remoteProject),
   }).catch(rejectRemoteUploadFailure)
 
   // Reflect the new title in the in-memory remote index immediately so Home
@@ -2427,8 +2426,7 @@ async function syncProject(projectPath: string, entries: OutboxEntry[]) {
         await parseProjectArchive(remoteArchive),
         remoteProject.title,
         remoteProjectId,
-        getEnvironmentName(),
-        getRemoteProjectEntrypointPath(remoteProject)
+        getEnvironmentName()
       )
     )
     const remoteManifest = await projectManifestFromFiles(remoteFiles)

--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -521,8 +521,7 @@ async function downloadRemoteProjectSnapshot({
     parsedArchive,
     project.title,
     projectId,
-    getEnvironmentName(),
-    getRemoteProjectEntrypointPath(project)
+    getEnvironmentName()
   )
   const files = filterCloudSyncProjectFilesForSync(filesWithMetadata)
 
@@ -1860,6 +1859,7 @@ async function applyLocalDataForConflict(
     projectId: metadata.remoteProjectId,
     files: localFiles,
     expectedRevision,
+    entrypointPath: getRemoteProjectEntrypointPath(remoteProject),
   }).catch(rejectRemoteUploadFailure)
   await clearOutboxEntriesForProject(metadata.localProjectPath)
   await deleteLegacyConflictCopy(conflict)
@@ -2407,6 +2407,7 @@ async function syncProject(projectPath: string, entries: OutboxEntry[]) {
         projectId: remoteProjectId,
         files: localFiles,
         expectedRevision: metadata.remoteRevision,
+        entrypointPath: getRemoteProjectEntrypointPath(remoteProject),
       }).catch(rejectRemoteUploadFailure)
       await clearOutboxEntriesForProject(metadata.localProjectPath)
       await markProjectSynced(

--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -63,6 +63,7 @@ import type {
 import {
   DUPLICATE_PROJECT_TEMPORARY_PREFIX,
   PROJECT_FOLDER,
+  PROJECT_IMAGE_NAME,
   PROJECT_SETTINGS_FILE_NAME,
 } from '@src/lib/constants'
 import type { IStat, IZooDesignStudioFS } from '@src/lib/fs-zds/interface'
@@ -318,6 +319,7 @@ export function filterCloudSyncProjectFilesForSync(
   return normalizedFiles.filter(
     (file) =>
       !isCloudSyncExcludedPath(file.relativePath) &&
+      !isCloudSyncGeneratedArtifactPath(file.relativePath) &&
       !isPathIgnoredByGitignore(gitignoreStack, file.relativePath, false)
   )
 }
@@ -3104,6 +3106,62 @@ function attachVisibilityChangeListener() {
   }
 }
 
+function isCloudSyncGeneratedArtifactPath(relativePath: string) {
+  return normalizeRelativePath(relativePath) === PROJECT_IMAGE_NAME
+}
+
+async function createGitignoreStackForMutationTarget(
+  projectRoot: string,
+  relativeTargetPath: string
+) {
+  let gitignoreStack = await createInitialGitignoreStackWithFs(
+    localFs,
+    projectRoot
+  )
+  const parentParts = webSafePathSplit(relativeTargetPath)
+    .filter(Boolean)
+    .slice(0, -1)
+  let currentDirectory = projectRoot
+
+  for (const part of parentParts) {
+    currentDirectory = localFs.join(currentDirectory, part)
+    gitignoreStack = await appendGitignoreForDirectoryWithFs(
+      localFs,
+      gitignoreStack,
+      currentDirectory,
+      projectRoot
+    )
+  }
+
+  return gitignoreStack
+}
+
+async function isCloudSyncIgnoredMutationTarget(
+  projectRoot: string,
+  targetPath: string
+) {
+  const relativeTargetPath = normalizeRelativePath(
+    localFs.relative(projectRoot, targetPath)
+  )
+  if (!relativeTargetPath) {
+    return false
+  }
+  if (isCloudSyncGeneratedArtifactPath(relativeTargetPath)) {
+    return true
+  }
+
+  const gitignoreStack = await createGitignoreStackForMutationTarget(
+    projectRoot,
+    relativeTargetPath
+  )
+  const stat = await localFs.stat(targetPath).catch(() => undefined)
+  return isPathIgnoredByGitignore(
+    gitignoreStack,
+    relativeTargetPath,
+    stat ? statIsDirectory(stat) : false
+  )
+}
+
 async function registerProjectMutation(
   projectPath: string,
   kind: OutboxEntry['kind'],
@@ -3122,6 +3180,7 @@ async function registerProjectMutation(
   ) {
     return
   }
+  const normalizedTargetPath = normalizePathForSync(targetPath)
   const existingMetadata = await getProjectMetadata(normalizedProjectPath)
   if (kind === 'delete') {
     if (
@@ -3134,6 +3193,14 @@ async function registerProjectMutation(
     return
   }
 
+  if (
+    await isCloudSyncIgnoredMutationTarget(
+      normalizedProjectPath,
+      normalizedTargetPath
+    )
+  ) {
+    return
+  }
   let metadata =
     existingMetadata ??
     (await getOrCreateProjectMetadata(normalizedProjectPath))
@@ -3167,7 +3234,7 @@ async function registerProjectMutation(
   await appendOutboxEntry({
     projectPath: normalizedProjectPath,
     kind,
-    targetPath: normalizePathForSync(targetPath),
+    targetPath: normalizedTargetPath,
     sourcePath: sourcePath ? normalizePathForSync(sourcePath) : undefined,
     createdAt: nowIso(),
   })

--- a/src/lib/cloudSync/index.test.ts
+++ b/src/lib/cloudSync/index.test.ts
@@ -188,20 +188,18 @@ describe('cloudSync sync helpers', () => {
     expect(projectToml).toContain('title = "bracket"')
   })
 
-  it('normalizes project.toml table order before cloud sync upload and manifest hashing', async () => {
+  it('preserves project.toml bytes before cloud sync upload and manifest hashing', async () => {
+    const localProjectToml =
+      'title = "demo-project"\ndefault_file = "main.kcl"\n\n[settings.meta]\nid = "settings-id"\n\n[settings.app]\n[settings.modeling]\n[cloud."dev.zoo.dev"]\nproject_id = "project-123"\n'
+    const cloudProjectToml =
+      'default_file = "main.kcl"\ntitle = "demo-project"\n\n[cloud."dev.zoo.dev"]\nproject_id = "project-123"\n\n[settings.app]\n[settings.meta]\nid = "settings-id"\n\n[settings.modeling]\n'
     const localOrderFiles = normalizeProjectArchiveFilesForCloudSync([
       projectFile('main.kcl', 'cube = 1'),
-      projectFile(
-        PROJECT_SETTINGS_FILE_NAME,
-        'title = "demo-project"\ndefault_file = "main.kcl"\n\n[settings.meta]\nid = "settings-id"\n\n[settings.app]\n[settings.modeling]\n[cloud."dev.zoo.dev"]\nproject_id = "project-123"\n'
-      ),
+      projectFile(PROJECT_SETTINGS_FILE_NAME, localProjectToml),
     ])
     const cloudOrderFiles = normalizeProjectArchiveFilesForCloudSync([
       projectFile('main.kcl', 'cube = 1'),
-      projectFile(
-        PROJECT_SETTINGS_FILE_NAME,
-        'default_file = "main.kcl"\ntitle = "demo-project"\n\n[cloud."dev.zoo.dev"]\nproject_id = "project-123"\n\n[settings.app]\n[settings.meta]\nid = "settings-id"\n\n[settings.modeling]\n'
-      ),
+      projectFile(PROJECT_SETTINGS_FILE_NAME, cloudProjectToml),
     ])
     const uploadPayload = prepareProjectFilesForCloudUpload(
       '/projects/demo-project',
@@ -209,17 +207,17 @@ describe('cloudSync sync helpers', () => {
     )
 
     expect(readProjectFile(localOrderFiles, PROJECT_SETTINGS_FILE_NAME)).toBe(
-      readProjectFile(cloudOrderFiles, PROJECT_SETTINGS_FILE_NAME)
+      localProjectToml
     )
     expect(
       readProjectFile(uploadPayload.files, PROJECT_SETTINGS_FILE_NAME)
-    ).toBe(readProjectFile(localOrderFiles, PROJECT_SETTINGS_FILE_NAME))
+    ).toBe(cloudProjectToml)
     expect(
       projectManifestsEqual(
         await projectManifestFromFiles(localOrderFiles),
         await projectManifestFromFiles(cloudOrderFiles)
       )
-    ).toBe(true)
+    ).toBe(false)
   })
 
   it('adds an Untitled project.toml title when remote project metadata has no title', () => {
@@ -278,6 +276,15 @@ describe('cloudSync sync helpers', () => {
       'nested/.gitignore',
       'nested/part.kcl',
     ])
+  })
+
+  it('excludes generated thumbnails from cloud sync manifests and uploads', () => {
+    const files = filterCloudSyncProjectFilesForSync([
+      projectFile('main.kcl', 'cube = 1'),
+      projectFile(PROJECT_IMAGE_NAME, 'generated image'),
+    ])
+
+    expect(files.map((file) => file.relativePath)).toEqual(['main.kcl'])
   })
 
   it('excludes VCS metadata from cloud sync manifests without .gitignore entries', () => {

--- a/src/lib/cloudSync/index.test.ts
+++ b/src/lib/cloudSync/index.test.ts
@@ -22,6 +22,7 @@ import {
   isCloudSyncExcludedPath,
 } from '@src/lib/cloudSync/paths'
 import {
+  getProjectArchiveEntrypointPath,
   normalizeProjectArchiveFilesForCloudSync,
   projectManifestFromFiles,
   withRemoteProjectMetadataInArchiveFiles,
@@ -145,10 +146,15 @@ describe('cloudSync sync helpers', () => {
     ])
   })
 
-  it('adds a project.toml upload file when local project settings are missing', () => {
+  it('adds a project.toml upload file without default_file when local project settings are missing', () => {
     const payload = prepareProjectFilesForCloudUpload('/projects/bracket', [
       projectFile('main.kcl'),
     ])
+    const projectToml = new TextDecoder().decode(
+      payload.files.find(
+        (file) => file.relativePath === PROJECT_SETTINGS_FILE_NAME
+      )?.data
+    )
 
     expect(payload.body.entrypoint_path).toBe('main.kcl')
     expect(payload.body.project_toml_path).toBe(PROJECT_SETTINGS_FILE_NAME)
@@ -156,20 +162,8 @@ describe('cloudSync sync helpers', () => {
       'main.kcl',
       PROJECT_SETTINGS_FILE_NAME,
     ])
-    expect(
-      new TextDecoder().decode(
-        payload.files.find(
-          (file) => file.relativePath === PROJECT_SETTINGS_FILE_NAME
-        )?.data
-      )
-    ).toContain('default_file = "main.kcl"')
-    expect(
-      new TextDecoder().decode(
-        payload.files.find(
-          (file) => file.relativePath === PROJECT_SETTINGS_FILE_NAME
-        )?.data
-      )
-    ).toContain('title = "bracket"')
+    expect(projectToml).toContain('title = "bracket"')
+    expect(projectToml).not.toContain('default_file')
   })
 
   it('adds the upload title to project.toml when local project settings have no title', () => {
@@ -186,6 +180,27 @@ describe('cloudSync sync helpers', () => {
     expect(payload.body.title).toBe('bracket')
     expect(projectToml).toContain('default_file = "main.kcl"')
     expect(projectToml).toContain('title = "bracket"')
+  })
+
+  it('uses API entrypoint metadata for uploads without writing default_file into project.toml', () => {
+    const payload = prepareProjectFilesForCloudUpload(
+      '/projects/bracket',
+      [
+        projectFile('main.kcl'),
+        projectFile('nested/part.kcl'),
+        projectFile(PROJECT_SETTINGS_FILE_NAME, 'title = "Bracket"\n'),
+      ],
+      { entrypointPath: 'nested/part.kcl' }
+    )
+    const projectToml = new TextDecoder().decode(
+      payload.files.find(
+        (file) => file.relativePath === PROJECT_SETTINGS_FILE_NAME
+      )?.data
+    )
+
+    expect(payload.body.entrypoint_path).toBe('nested/part.kcl')
+    expect(projectToml).toContain('title = "Bracket"')
+    expect(projectToml).not.toContain('default_file')
   })
 
   it('preserves project.toml bytes before cloud sync upload and manifest hashing', async () => {
@@ -233,11 +248,11 @@ describe('cloudSync sync helpers', () => {
     )
 
     expect(projectToml).toContain('title = "Untitled"')
-    expect(projectToml).toContain('default_file = "main.kcl"')
+    expect(projectToml).not.toContain('default_file')
     expect(projectToml).toContain('project_id = "remote-project-123"')
   })
 
-  it('adds project.toml default_file from remote entrypoint metadata', () => {
+  it('does not write project.toml default_file from remote entrypoint metadata', () => {
     const files = withRemoteProjectMetadataInArchiveFiles(
       [
         projectFile('main.kcl'),
@@ -246,16 +261,18 @@ describe('cloudSync sync helpers', () => {
       ],
       'Bracket',
       'remote-project-123',
-      'dev.zoo.dev',
-      'nested/part.kcl'
+      'dev.zoo.dev'
     )
     const projectToml = new TextDecoder().decode(
       files.find((file) => file.relativePath === PROJECT_SETTINGS_FILE_NAME)
         ?.data
     )
 
+    expect(getProjectArchiveEntrypointPath(files, 'nested/part.kcl')).toBe(
+      'nested/part.kcl'
+    )
     expect(projectToml).toContain('title = "Bracket"')
-    expect(projectToml).toContain('default_file = "nested/part.kcl"')
+    expect(projectToml).not.toContain('default_file')
     expect(projectToml).toContain('project_id = "remote-project-123"')
   })
 

--- a/src/lib/cloudSync/liveConflicts.test.ts
+++ b/src/lib/cloudSync/liveConflicts.test.ts
@@ -21,7 +21,10 @@ import {
   getFetchUrl,
   jsonResponse,
 } from '@src/lib/cloudSync/testUtils'
-import { PROJECT_SETTINGS_FILE_NAME } from '@src/lib/constants'
+import {
+  PROJECT_IMAGE_NAME,
+  PROJECT_SETTINGS_FILE_NAME,
+} from '@src/lib/constants'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const clientErrorsMock = vi.hoisted(() => ({
@@ -71,6 +74,7 @@ function remoteArchivePayload(contents = 'remote = 2\n') {
         relativePath: PROJECT_SETTINGS_FILE_NAME,
         contents: 'title = "Demo"\n',
       },
+      { relativePath: PROJECT_IMAGE_NAME, contents: 'remote thumbnail' },
     ],
   }
 }
@@ -138,6 +142,7 @@ describe('cloud sync live conflicts', () => {
     const files = new Map([
       [`${projectPath}/main.kcl`, 'local = 2\n'],
       [`${projectPath}/${PROJECT_SETTINGS_FILE_NAME}`, 'title = "Demo"\n'],
+      [`${projectPath}/${PROJECT_IMAGE_NAME}`, 'local thumbnail'],
     ])
     configureCloudSyncLocalFileSystem(
       createCloudSyncTestFs(files, { projectDirectory })
@@ -232,6 +237,11 @@ describe('cloud sync live conflicts', () => {
           localText: 'local = 2\n',
           cloudText: 'remote = 3\n',
         }),
+      ])
+    )
+    expect(inspection.changedFiles).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ relativePath: PROJECT_IMAGE_NAME }),
       ])
     )
   })

--- a/src/lib/cloudSync/policy.spec.ts
+++ b/src/lib/cloudSync/policy.spec.ts
@@ -130,7 +130,7 @@ describe('cloud sync file policy', () => {
       baseUrl,
       environmentName: 'dev.zoo.dev',
       projectDirectoryPath: projectDirectory,
-      syncExistingLocalProjects: false,
+      autoEnrollCloudLibraryProjects: false,
     })
 
     await notifyCloudSyncWriteLikeMutation(`${projectPath}/scratch.txt`)
@@ -174,7 +174,7 @@ describe('cloud sync file policy', () => {
       baseUrl,
       environmentName: 'dev.zoo.dev',
       projectDirectoryPath: projectDirectory,
-      syncExistingLocalProjects: false,
+      autoEnrollCloudLibraryProjects: false,
     })
     retryCloudSync()
 

--- a/src/lib/cloudSync/policy.spec.ts
+++ b/src/lib/cloudSync/policy.spec.ts
@@ -2,28 +2,93 @@ import 'fake-indexeddb/auto'
 import {
   configureCloudSyncEngine,
   configureCloudSyncLocalFileSystem,
+  filterCloudSyncProjectFilesForSync,
   notifyCloudSyncWriteLikeMutation,
+  retryCloudSync,
+  setCloudSyncProjectScope,
+  type ProjectArchiveFile,
 } from '@src/lib/cloudSync'
 import {
+  appendOutboxEntry,
   getAllOutboxEntries,
   getProjectMetadata,
+  putProjectMetadata,
 } from '@src/lib/cloudSync/syncDb'
+import { projectManifestFromFiles } from '@src/lib/cloudSync/projectArchive'
 import {
   createCloudSyncTestFs,
   deleteCloudSyncTestDatabase,
+  getFetchMethod,
+  getFetchUrl,
+  jsonResponse,
 } from '@src/lib/cloudSync/testUtils'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  PROJECT_IMAGE_NAME,
+  PROJECT_SETTINGS_FILE_NAME,
+} from '@src/lib/constants'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+const encoder = new TextEncoder()
 const baseUrl = 'https://example.test'
 const projectDirectory = '/documents/Projects'
+const projectPath = `${projectDirectory}/bracket`
+const remoteProjectId = 'remote-project-123'
+const remoteRevision = 'revision-123'
+const remoteProjectUrl = `${baseUrl}/user/projects/${remoteProjectId}`
+const projectToml = `title = "Bracket"\n\n[cloud."dev.zoo.dev"]\nproject_id = "${remoteProjectId}"\n`
+
+const fetchMock = vi.fn<typeof fetch>()
+
+function projectFile(relativePath: string, contents = ''): ProjectArchiveFile {
+  return {
+    relativePath,
+    data: encoder.encode(contents),
+  }
+}
+
+function installFetchMock() {
+  fetchMock.mockReset()
+  fetchMock.mockImplementation(async (input, init) => {
+    const url = getFetchUrl(input)
+    const method = getFetchMethod(input, init)
+
+    if (url === `${baseUrl}/user/projects` && method === 'GET') {
+      return jsonResponse([])
+    }
+
+    if (url === remoteProjectUrl && method === 'GET') {
+      return jsonResponse({
+        id: remoteProjectId,
+        title: 'Bracket',
+        revision: remoteRevision,
+      })
+    }
+
+    return jsonResponse({ message: `Unexpected fetch: ${method} ${url}` }, 500)
+  })
+  vi.stubGlobal('fetch', fetchMock)
+}
+
+async function cleanBaseManifest() {
+  return projectManifestFromFiles(
+    filterCloudSyncProjectFilesForSync([
+      projectFile('main.kcl', 'cube = 1\n'),
+      projectFile(PROJECT_SETTINGS_FILE_NAME, projectToml),
+      projectFile('.gitignore', 'scratch.txt\nnested/local.txt\n'),
+    ])
+  )
+}
 
 describe('cloud sync file policy', () => {
   beforeEach(async () => {
     await deleteCloudSyncTestDatabase()
+    installFetchMock()
   })
 
   afterEach(async () => {
+    setCloudSyncProjectScope(undefined)
     configureCloudSyncEngine({ enabled: false })
+    vi.unstubAllGlobals()
     await deleteCloudSyncTestDatabase()
   })
 
@@ -45,5 +110,81 @@ describe('cloud sync file policy', () => {
 
     expect(await getProjectMetadata(topLevelFilePath)).toBeUndefined()
     expect(await getAllOutboxEntries()).toEqual([])
+  })
+
+  it('does not enqueue mutations for ignored files or generated thumbnails', async () => {
+    const files = new Map([
+      [`${projectPath}/main.kcl`, 'cube = 1\n'],
+      [`${projectPath}/${PROJECT_SETTINGS_FILE_NAME}`, `title = "Bracket"\n`],
+      [`${projectPath}/.gitignore`, 'scratch.txt\n'],
+      [`${projectPath}/scratch.txt`, 'ignored local note\n'],
+      [`${projectPath}/nested/.gitignore`, 'local.txt\n'],
+      [`${projectPath}/nested/local.txt`, 'ignored nested note\n'],
+      [`${projectPath}/${PROJECT_IMAGE_NAME}`, 'generated thumbnail\n'],
+    ])
+    configureCloudSyncLocalFileSystem(
+      createCloudSyncTestFs(files, { projectDirectory })
+    )
+    configureCloudSyncEngine({
+      enabled: true,
+      baseUrl,
+      environmentName: 'dev.zoo.dev',
+      projectDirectoryPath: projectDirectory,
+      syncExistingLocalProjects: false,
+    })
+
+    await notifyCloudSyncWriteLikeMutation(`${projectPath}/scratch.txt`)
+    await notifyCloudSyncWriteLikeMutation(`${projectPath}/nested/local.txt`)
+    await notifyCloudSyncWriteLikeMutation(
+      `${projectPath}/${PROJECT_IMAGE_NAME}`
+    )
+
+    expect(await getAllOutboxEntries()).toEqual([])
+  })
+
+  it('clears ignored-file-only pending work without uploading a new revision', async () => {
+    const files = new Map([
+      [`${projectPath}/main.kcl`, 'cube = 1\n'],
+      [`${projectPath}/${PROJECT_SETTINGS_FILE_NAME}`, projectToml],
+      [`${projectPath}/.gitignore`, 'scratch.txt\nnested/local.txt\n'],
+      [`${projectPath}/scratch.txt`, 'ignored local note changed\n'],
+    ])
+    configureCloudSyncLocalFileSystem(
+      createCloudSyncTestFs(files, { projectDirectory })
+    )
+    await putProjectMetadata({
+      schemaVersion: 1,
+      localProjectPath: projectPath,
+      projectName: 'bracket',
+      remoteProjectId,
+      remoteRevision,
+      remoteUpdatedAt: '2026-07-08T12:00:00.000Z',
+      baseManifest: await cleanBaseManifest(),
+    })
+    await appendOutboxEntry({
+      projectPath,
+      kind: 'upsert',
+      targetPath: `${projectPath}/scratch.txt`,
+      createdAt: '2026-07-08T12:01:00.000Z',
+    })
+
+    setCloudSyncProjectScope(projectPath)
+    configureCloudSyncEngine({
+      enabled: true,
+      baseUrl,
+      environmentName: 'dev.zoo.dev',
+      projectDirectoryPath: projectDirectory,
+      syncExistingLocalProjects: false,
+    })
+    retryCloudSync()
+
+    await vi.waitFor(async () => {
+      expect(await getAllOutboxEntries()).toEqual([])
+    })
+    expect(
+      fetchMock.mock.calls.some(
+        ([input, init]) => getFetchMethod(input, init) === 'PUT'
+      )
+    ).toBe(false)
   })
 })

--- a/src/lib/cloudSync/projectArchive.ts
+++ b/src/lib/cloudSync/projectArchive.ts
@@ -15,7 +15,6 @@ import {
   getProjectDefaultFileFromProjectTomlContents,
   getProjectTitleFromProjectTomlContents,
   setCloudProjectIdInProjectTomlContents,
-  setProjectDefaultFileInProjectTomlContents,
   setProjectTitleInProjectTomlContents,
 } from '@src/lib/projectTomlMetadata'
 import { isArray } from '@src/lib/utils'
@@ -28,17 +27,48 @@ export function getRemoteProjectTitleForProjectToml(title?: string) {
   return title?.trim() || CLOUD_SYNC_UNTITLED_PROJECT_TITLE
 }
 
+type PrepareProjectFilesForCloudUploadOptions = {
+  expectedRevision?: Revision
+  entrypointPath?: string
+}
+
 export function prepareProjectFilesForCloudUpload(
   projectPath: string,
   files: ProjectArchiveFile[],
   expectedRevision?: Revision
+): {
+  body: ProjectUploadBody
+  files: ProjectArchiveFile[]
+}
+export function prepareProjectFilesForCloudUpload(
+  projectPath: string,
+  files: ProjectArchiveFile[],
+  options?: PrepareProjectFilesForCloudUploadOptions
+): {
+  body: ProjectUploadBody
+  files: ProjectArchiveFile[]
+}
+export function prepareProjectFilesForCloudUpload(
+  projectPath: string,
+  files: ProjectArchiveFile[],
+  optionsOrExpectedRevision?:
+    | Revision
+    | PrepareProjectFilesForCloudUploadOptions
 ) {
+  const expectedRevision =
+    typeof optionsOrExpectedRevision === 'string'
+      ? optionsOrExpectedRevision
+      : optionsOrExpectedRevision?.expectedRevision
+  const preferredEntrypointPath =
+    typeof optionsOrExpectedRevision === 'string'
+      ? undefined
+      : optionsOrExpectedRevision?.entrypointPath
   const normalizedFiles = normalizeProjectArchiveFilesForCloudSync(files)
-  const entrypointPath = getUploadEntrypointPath(normalizedFiles)
-  const projectTomlPath = ensureProjectTomlUploadFile(
+  const entrypointPath = getUploadEntrypointPath(
     normalizedFiles,
-    entrypointPath
+    preferredEntrypointPath
   )
+  const projectTomlPath = ensureProjectTomlUploadFile(normalizedFiles)
   const projectTitle =
     getProjectTomlTitle(normalizedFiles) ||
     localFs.basename(projectPath.replaceAll('\\', '/').replace(/\/+$/g, ''))
@@ -73,10 +103,7 @@ export function normalizeProjectArchiveFilesForCloudSync(
   })
 }
 
-function ensureProjectTomlUploadFile(
-  files: ProjectArchiveFile[],
-  entrypointPath: string
-) {
+function ensureProjectTomlUploadFile(files: ProjectArchiveFile[]) {
   const projectTomlFile = files.find(
     (file) => file.relativePath === PROJECT_SETTINGS_FILE_NAME
   )
@@ -86,9 +113,7 @@ function ensureProjectTomlUploadFile(
 
   files.push({
     relativePath: PROJECT_SETTINGS_FILE_NAME,
-    data: new TextEncoder().encode(
-      `default_file = ${JSON.stringify(entrypointPath)}\n`
-    ),
+    data: new Uint8Array(),
   })
   return PROJECT_SETTINGS_FILE_NAME
 }
@@ -131,14 +156,17 @@ export function getProjectArchiveEntrypointPath(
   files: ProjectArchiveFile[],
   preferredEntrypointPath?: string
 ) {
+  const filePaths = new Set(files.map((file) => file.relativePath))
   const normalizedPreferredEntrypointPath = preferredEntrypointPath
     ? normalizeRelativePath(preferredEntrypointPath)
     : undefined
-  if (normalizedPreferredEntrypointPath) {
+  if (
+    normalizedPreferredEntrypointPath &&
+    filePaths.has(normalizedPreferredEntrypointPath)
+  ) {
     return normalizedPreferredEntrypointPath
   }
 
-  const filePaths = new Set(files.map((file) => file.relativePath))
   const projectTomlDefaultFile = getProjectTomlDefaultFile(files)
   if (projectTomlDefaultFile && filePaths.has(projectTomlDefaultFile)) {
     return projectTomlDefaultFile
@@ -160,8 +188,14 @@ export function getProjectArchiveEntrypointPath(
   return undefined
 }
 
-function getUploadEntrypointPath(files: ProjectArchiveFile[]) {
-  const entrypointPath = getProjectArchiveEntrypointPath(files)
+function getUploadEntrypointPath(
+  files: ProjectArchiveFile[],
+  preferredEntrypointPath?: string
+) {
+  const entrypointPath = getProjectArchiveEntrypointPath(
+    files,
+    preferredEntrypointPath
+  )
   if (entrypointPath) {
     return entrypointPath
   }
@@ -227,19 +261,6 @@ export function withProjectCloudProjectIdInArchiveFiles(
   )
 }
 
-export function withProjectDefaultFileInArchiveFiles(
-  files: ProjectArchiveFile[],
-  defaultFile?: string
-) {
-  if (!defaultFile) {
-    return files
-  }
-
-  return withUpdatedProjectTomlInArchiveFiles(files, (contents) =>
-    setProjectDefaultFileInProjectTomlContents(contents, defaultFile)
-  )
-}
-
 export function withUpdatedProjectTomlInArchiveFiles(
   files: ProjectArchiveFile[],
   update: (contents: string) => string
@@ -282,20 +303,15 @@ export function withRemoteProjectMetadataInArchiveFiles(
   files: ProjectArchiveFile[],
   title: string | undefined,
   projectId: string,
-  environmentName?: string,
-  entrypointPath?: string
+  environmentName?: string
 ) {
-  const filesWithMetadata = withProjectCloudProjectIdInArchiveFiles(
+  return withProjectCloudProjectIdInArchiveFiles(
     withProjectTitleInArchiveFiles(
       files,
       getRemoteProjectTitleForProjectToml(title)
     ),
     projectId,
     environmentName
-  )
-  return withProjectDefaultFileInArchiveFiles(
-    filesWithMetadata,
-    getProjectArchiveEntrypointPath(filesWithMetadata, entrypointPath)
   )
 }
 

--- a/src/lib/cloudSync/projectArchive.ts
+++ b/src/lib/cloudSync/projectArchive.ts
@@ -14,7 +14,6 @@ import { webSafePathSplit } from '@src/lib/pathUtils'
 import {
   getProjectDefaultFileFromProjectTomlContents,
   getProjectTitleFromProjectTomlContents,
-  normalizeProjectTomlContents,
   setCloudProjectIdInProjectTomlContents,
   setProjectDefaultFileInProjectTomlContents,
   setProjectTitleInProjectTomlContents,
@@ -69,12 +68,7 @@ export function normalizeProjectArchiveFilesForCloudSync(
     return {
       ...file,
       relativePath,
-      data:
-        relativePath === PROJECT_SETTINGS_FILE_NAME
-          ? new TextEncoder().encode(
-              normalizeProjectTomlContents(new TextDecoder().decode(file.data))
-            )
-          : file.data,
+      data: file.data,
     }
   })
 }

--- a/src/lib/cloudSync/renameDeleteRemote.spec.ts
+++ b/src/lib/cloudSync/renameDeleteRemote.spec.ts
@@ -45,6 +45,7 @@ describe('renameRemoteCloudProject', () => {
 
   it('re-uploads the remote project archive with the new title', async () => {
     let uploadedTitle: string | undefined
+    let uploadedEntrypointPath: string | undefined
     fetchMock.mockImplementation(async (input, init) => {
       const url = getFetchUrl(input)
       const method = getFetchMethod(input, init)
@@ -54,21 +55,23 @@ describe('renameRemoteCloudProject', () => {
           id: remoteProjectId,
           title: 'Bracket',
           revision: 'rev-1',
+          entrypoint_path: 'nested/part.kcl',
         })
       }
       if (url === remoteProjectDownloadUrl && method === 'GET') {
         return jsonResponse({
           files: [
             { relativePath: 'main.kcl', contents: 'foo = 1' },
+            { relativePath: 'nested/part.kcl', contents: 'bar = 2' },
             { relativePath: 'project.toml', contents: 'title = "Bracket"\n' },
           ],
         })
       }
       if (url.startsWith(remoteProjectUrl) && method === 'PUT') {
         const body = init?.body as FormData
-        uploadedTitle = JSON.parse(
-          await (body.get('body') as Blob).text()
-        ).title
+        const uploadedBody = JSON.parse(await (body.get('body') as Blob).text())
+        uploadedTitle = uploadedBody.title
+        uploadedEntrypointPath = uploadedBody.entrypoint_path
         return jsonResponse({
           id: remoteProjectId,
           title: 'Housing',
@@ -85,6 +88,7 @@ describe('renameRemoteCloudProject', () => {
     await renameRemoteCloudProject(remoteProjectId, 'Housing')
 
     expect(uploadedTitle).toBe('Housing')
+    expect(uploadedEntrypointPath).toBe('nested/part.kcl')
     expect(fetchMock).toHaveBeenCalledWith(
       remoteProjectDownloadUrl,
       expect.objectContaining({ credentials: 'include' })


### PR DESCRIPTION
## Summary

- remove automatic `project.toml` normalization/reordering from cloud sync manifests and uploads
- stop cloud sync from writing `default_file` into synthesized upload TOML or remote-downloaded TOML
- preserve existing user-authored `default_file` values only as an entrypoint fallback, while sending API-owned entrypoints through `entrypoint_path`
- exclude ignored/generated files from sync manifests so local generated artifacts do not create false conflict pressure

## Why

Cloud sync was treating app/API metadata drift as real project file drift. In particular, `default_file` could be reintroduced into `project.toml` even though the API already owns entrypoint metadata as `entrypoint_path`, creating a path for false-positive project differences and conflict noise.