### PR TITLE
Fix ZK selection bug

### DIFF
--- a/src/lib/selections.ts
+++ b/src/lib/selections.ts
@@ -12,6 +12,7 @@ import type { Object3D } from 'three'
 import { Mesh } from 'three'
 
 import type { Node } from '@rust/kcl-lib/bindings/Node'
+import type { Operation } from '@rust/kcl-lib/bindings/Operation'
 import type { PlaneName } from '@rust/kcl-lib/bindings/PlaneName'
 
 import {
@@ -304,9 +305,14 @@ export type SelectionReference = {
   id: string
   label: string
   code: string
+  moduleId: number
   graphSelection?: Selection
   enginePrimitiveSelection?: EnginePrimitiveSelection
 }
+
+export type SelectionReferenceAstResolver = (
+  sourceRange: SourceRange
+) => Node<Program> | undefined
 
 type ReferenceablePrimitiveSelection = EnginePrimitiveSelection & {
   primitiveType: 'face' | 'edge'
@@ -457,12 +463,57 @@ export function getBodySelectionFromPrimitiveParentEntityId(
   }
 }
 
+/**
+ * Resolves an imported body's code reference from the import statement to the
+ * matching operation in the imported module. The returned selection's
+ * `codeRef.range` contains the imported module ID at index 2.
+ */
+function resolveImportedBodySourceRange(
+  bodySelection: Selection,
+  kclManager: KclManager
+): Selection | null {
+  const sourceBodyId = bodySelection.artifact?.id
+  if (!sourceBodyId) return null
+
+  const importRange = bodySelection.codeRef.range
+  const moduleInstance = kclManager.operationsByModule.map[
+    importRange[2]
+  ]?.find(
+    (operation): operation is Extract<Operation, { type: 'ModuleInstance' }> =>
+      operation.type === 'ModuleInstance' &&
+      operation.sourceRange.every(
+        (value, index) => value === importRange[index]
+      )
+  )
+  if (!moduleInstance) return null
+
+  const operations =
+    kclManager.operationsByModule.map[moduleInstance.moduleId] ?? []
+  const matchingOperation = operations.findLast(
+    (operation): operation is Extract<Operation, { type: 'StdLibCall' }> =>
+      operation.type === 'StdLibCall' &&
+      operation.unlabeledArg?.value.type === 'Solid' &&
+      operation.unlabeledArg.value.value.artifactId === sourceBodyId
+  )
+  if (!matchingOperation) return null
+
+  return {
+    ...bodySelection,
+    codeRef: {
+      ...bodySelection.codeRef,
+      range: matchingOperation.sourceRange,
+    },
+  }
+}
+
 type SelectionExpressionBuilderContext = {
   primitiveSelection: ReferenceablePrimitiveSelection
+  bodySelection: Selection | null
   artifactGraph: ArtifactGraph
   kclManager: KclManager
   wasmInstance: ModuleType
   engineCommandManager: ConnectionManager
+  resolveAstForSourceRange?: SelectionReferenceAstResolver
 }
 
 type SelectionExpressionValidationContext =
@@ -796,31 +847,33 @@ async function validateAvailableReferenceExpr({
 
 function createPrimitiveIndexReferenceExpr({
   primitiveSelection,
+  bodySelection,
   artifactGraph,
   kclManager,
   wasmInstance,
+  resolveAstForSourceRange,
 }: SelectionExpressionBuilderContext): Expr | null {
-  if (!primitiveSelection.parentEntityId) {
-    return null
-  }
-
-  const bodySelection = getBodySelectionFromPrimitiveParentEntityId(
-    primitiveSelection.parentEntityId,
-    artifactGraph,
-    {
-      bodyArtifactTypes: BODY_REFERENCE_ARTIFACT_TYPES,
-      codeRefLookup: 'first',
-      lookUpPatternCopies: true,
-    }
-  )
   if (!bodySelection) {
     return null
   }
 
+  const ast = resolveAstForSourceRange
+    ? resolveAstForSourceRange(bodySelection.codeRef.range)
+    : kclManager.ast
+  if (!ast) return null
+
+  const bodySelectionForAst: Selection = {
+    ...bodySelection,
+    codeRef: {
+      ...bodySelection.codeRef,
+      pathToNode: getNodePathFromSourceRange(ast, bodySelection.codeRef.range),
+    },
+  }
+
   const bodyVariables = getVariableExprsFromSelection(
-    { graphSelections: [bodySelection], otherSelections: [] },
+    { graphSelections: [bodySelectionForAst], otherSelections: [] },
     artifactGraph,
-    kclManager.ast,
+    ast,
     wasmInstance,
     undefined,
     {
@@ -833,6 +886,7 @@ function createPrimitiveIndexReferenceExpr({
   }
 
   const bodyExpr = bodyVariables.exprs[0]
+  if (bodyExpr.type === 'PipeSubstitution') return null
   const functionName =
     primitiveSelection.primitiveType === 'face' ? 'faceId' : 'edgeId'
   return createCallExpressionStdLibKw(functionName, structuredClone(bodyExpr), [
@@ -923,6 +977,7 @@ function createExpressionReferences({
         id: `${label}:${selection.artifact?.id || selection.engineEntityId || code}:${code}`,
         label,
         code,
+        moduleId: selection.codeRef.range[2],
         graphSelection: selection,
       },
     ]
@@ -936,6 +991,7 @@ export async function getSelectionReferences({
   engineCommandManager,
   kclManager,
   wasmInstance,
+  resolveAstForSourceRange,
 }: {
   graphSelections: Selection[]
   enginePrimitives: EnginePrimitiveSelection[]
@@ -943,6 +999,7 @@ export async function getSelectionReferences({
   engineCommandManager: ConnectionManager
   kclManager: KclManager
   wasmInstance: ModuleType
+  resolveAstForSourceRange?: SelectionReferenceAstResolver
 }): Promise<SelectionReference[]> {
   const references: SelectionReference[] = []
   const primitiveSelections: ReferenceablePrimitiveSelection[] = []
@@ -1028,12 +1085,37 @@ export async function getSelectionReferences({
   ]
 
   for (const primitiveSelection of dedupedPrimitiveSelections) {
+    const graphBodySelection = primitiveSelection.parentEntityId
+      ? getBodySelectionFromPrimitiveParentEntityId(
+          primitiveSelection.parentEntityId,
+          artifactGraph,
+          {
+            bodyArtifactTypes: BODY_REFERENCE_ARTIFACT_TYPES,
+            codeRefLookup: 'first',
+            lookUpPatternCopies: true,
+          }
+        )
+      : null
+    const bodySelection =
+      resolveAstForSourceRange && graphBodySelection
+        ? (resolveImportedBodySourceRange(graphBodySelection, kclManager) ??
+          graphBodySelection)
+        : graphBodySelection
+    const sourceRange =
+      bodySelection?.codeRef.range ??
+      primitiveSelection.graphSelection?.codeRef.range
+    if (!sourceRange) {
+      continue
+    }
+
     const code = await createPrimitiveReferenceCode({
       primitiveSelection,
+      bodySelection,
       artifactGraph,
       engineCommandManager,
       kclManager,
       wasmInstance,
+      resolveAstForSourceRange,
     })
     if (!code) {
       continue
@@ -1043,6 +1125,7 @@ export async function getSelectionReferences({
       id: `${primitiveSelection.primitiveType}:${primitiveSelection.entityId}`,
       label: primitiveSelection.primitiveType === 'face' ? 'Face' : 'Edge',
       code,
+      moduleId: sourceRange[2],
       graphSelection: primitiveSelection.graphSelection,
       enginePrimitiveSelection: primitiveSelection.enginePrimitiveSelection,
     })
@@ -1051,7 +1134,7 @@ export async function getSelectionReferences({
   return [
     ...new Map(
       references.map((reference) => [
-        `${reference.label}:${reference.code}`,
+        `${reference.moduleId}:${reference.label}:${reference.code}`,
         reference,
       ])
     ).values(),

--- a/src/lib/zookeeper/zookeeperPromptRequest.integration.spec.ts
+++ b/src/lib/zookeeper/zookeeperPromptRequest.integration.spec.ts
@@ -125,9 +125,11 @@ describe('Zookeeper prompt selections from modelingMachine', () => {
   async function sendZookeeperMessage({
     code,
     selections,
+    projectFiles: providedProjectFiles,
   }: {
     code: string
     selections: Selections | null
+    projectFiles?: FileMeta[]
   }) {
     const ws: TestWebSocket = new TestSocket() as TestWebSocket
     const conversation: Conversation = { exchanges: [] }
@@ -144,7 +146,7 @@ describe('Zookeeper prompt selections from modelingMachine', () => {
       },
     })
     const actor = createActor(machine, { input: { apiToken: '' } }).start()
-    const projectFiles: FileMeta[] = [
+    const projectFiles: FileMeta[] = providedProjectFiles ?? [
       {
         type: 'kcl',
         relPath: 'main.kcl',
@@ -196,10 +198,14 @@ describe('Zookeeper prompt selections from modelingMachine', () => {
     return ws.sentPayloads.map((payload) => JSON.parse(payload))
   }
 
-  function sourceRangeForSnippet(code: string, snippet: string): SourceRange {
+  function sourceRangeForSnippet(
+    code: string,
+    snippet: string,
+    moduleId = 0
+  ): SourceRange {
     const start = code.indexOf(snippet)
     expect(start).toBeGreaterThanOrEqual(0)
-    return [start, start + snippet.length, 0]
+    return [start, start + snippet.length, moduleId]
   }
 
   function selectedIdentifierRange(
@@ -427,6 +433,141 @@ cfdBoundingHollowCylinder = subtract(outerBody, tools = innerBody)
     expect(userPayload?.source_ranges).toHaveLength(1)
     expect(userPayload?.source_ranges?.[0].prompt).toContain(
       'Face: `faceId(cfdBoundingHollowCylinder, index = 5)`'
+    )
+  })
+
+  it('resolves imported primitive faces against the imported file AST', async () => {
+    const code = `import "imported.kcl"
+
+activeRegion = region(segments = [])
+activeExtrude = extrude(activeRegion, length = 10mm)
+activeShell = shell(activeExtrude, faces = [], thickness = 1mm)
+`
+    const importedCode = `alignmentMarker = 0
+
+importedRegion = region(segments = [])
+importedExtrude = extrude(importedRegion, length = 10mm)
+importedShell = shell(importedExtrude, faces = [], thickness = 1mm)
+`
+    const activeAst = assertParse(code, world.instance)
+    const importedShellSnippet =
+      'importedShell = shell(importedExtrude, faces = [], thickness = 1mm)'
+    const importedShellRange = sourceRangeForSnippet(
+      importedCode,
+      importedShellSnippet,
+      1
+    )
+    const importRange = sourceRangeForSnippet(code, 'import "imported.kcl"')
+    const importedShell: Artifact = {
+      type: 'sweep',
+      id: 'imported-shell-id',
+      subType: 'extrusion',
+      pathId: 'imported-region-id',
+      surfaceIds: [],
+      edgeIds: [],
+      trajectoryId: null,
+      method: 'new',
+      consumed: false,
+      codeRef: {
+        range: importRange,
+        nodePath: defaultNodePath(),
+        pathToNode: getNodePathFromSourceRange(activeAst, importRange),
+      },
+    }
+    const importedPath: Artifact = {
+      type: 'path',
+      id: 'imported-path-id',
+      subType: 'region',
+      planeId: 'imported-plane-id',
+      segIds: [],
+      consumed: true,
+      sweepId: importedShell.id,
+      trajectorySweepId: null,
+      codeRef: importedShell.codeRef,
+    }
+    const artifactGraph: ArtifactGraph = new Map<string, Artifact>([
+      [importedShell.id, importedShell],
+      [importedPath.id, importedPath],
+    ])
+    const faceSelection: EnginePrimitiveSelection = {
+      type: 'enginePrimitive',
+      entityId: 'selected-imported-shell-face',
+      parentEntityId: importedPath.id,
+      primitiveIndex: 3,
+      primitiveType: 'face',
+    }
+    const modelingSelections = setupModelingSelection({
+      code,
+      artifactGraph,
+      selection: {
+        selectionType: 'enginePrimitiveSelection',
+        selection: faceSelection,
+      },
+    })
+    const previousOperations = world.kclManager.execState.operations
+    world.kclManager.execState.operations = {
+      map: {
+        0: [
+          {
+            type: 'ModuleInstance',
+            name: 'imported',
+            moduleId: 1,
+            glob: false,
+            nodePath: defaultNodePath(),
+            sourceRange: importRange,
+          },
+        ],
+        1: [
+          {
+            type: 'StdLibCall',
+            name: 'shell',
+            unlabeledArg: {
+              value: {
+                type: 'Solid',
+                value: { artifactId: importedShell.id },
+              },
+              sourceRange: importedShellRange,
+            },
+            labeledArgs: {},
+            nodePath: defaultNodePath(),
+            sourceRange: importedShellRange,
+          },
+        ],
+      },
+    }
+    const projectFiles: FileMeta[] = [
+      {
+        type: 'kcl',
+        relPath: 'main.kcl',
+        absPath: currentFileEntry.path,
+        fileContents: code,
+        execStateFileNamesIndex: 0,
+      },
+      {
+        type: 'kcl',
+        relPath: 'imported.kcl',
+        absPath: '/projects/zoo-project/imported.kcl',
+        fileContents: importedCode,
+        execStateFileNamesIndex: 1,
+      },
+    ]
+
+    const sentPayloads = await sendZookeeperMessage({
+      code,
+      selections: modelingSelections,
+      projectFiles,
+    }).finally(() => {
+      world.kclManager.execState.operations = previousOperations
+    })
+    const userPayload = sentPayloads.find((payload) => payload.type === 'user')
+
+    expect(userPayload?.source_ranges).toHaveLength(1)
+    expect(userPayload?.source_ranges?.[0].file).toBe('imported.kcl')
+    expect(userPayload?.source_ranges?.[0].prompt).toContain(
+      'Face: `faceId(importedShell, index = 3)`'
+    )
+    expect(userPayload?.source_ranges?.[0].prompt).not.toContain(
+      'faceId(activeExtrude'
     )
   })
 

--- a/src/lib/zookeeper/zookeeperPromptRequest.test.ts
+++ b/src/lib/zookeeper/zookeeperPromptRequest.test.ts
@@ -244,6 +244,7 @@ describe('constructZookeeperUserPromptRequest', () => {
         id: 'face:cubeRegion.tags.right',
         label: 'Face',
         code: 'cubeRegion.tags.right',
+        moduleId: 0,
       },
     ])
 
@@ -303,6 +304,7 @@ describe('constructZookeeperUserPromptRequest', () => {
         id: 'face:cubeRegion.tags.right',
         label: 'Face',
         code: 'cubeRegion.tags.right',
+        moduleId: 0,
       },
     ])
 

--- a/src/lib/zookeeper/zookeeperPromptRequest.ts
+++ b/src/lib/zookeeper/zookeeperPromptRequest.ts
@@ -6,6 +6,7 @@ import type {
 import type { KclManager } from '@src/lang/KclManager'
 import { getArtifactOfTypes } from '@src/lang/std/artifactGraph'
 import type { Artifact, ArtifactGraph, SourceRange } from '@src/lang/wasm'
+import { parse, resultIsOk } from '@src/lang/wasm'
 import type { ConnectionManager } from '@src/lib/engineConnection/connectionManager'
 import { parentPathRelativeToProject, toWebSafePath } from '@src/lib/paths'
 import type { FileEntry } from '@src/lib/project'
@@ -13,6 +14,7 @@ import {
   getSelectionReferences,
   isEnginePrimitiveSelection,
   type SelectionReference,
+  type SelectionReferenceAstResolver,
 } from '@src/lib/selections'
 import type { FileMeta } from '@src/lib/types'
 import { isErr, reportRejection } from '@src/lib/trap'
@@ -435,19 +437,21 @@ function appendSelectionReferenceSourceRangePrompt({
     : prompt
 }
 
-async function buildSelectionReferencePrompt({
+async function buildSelectionReferences({
   selections,
   artifactGraph,
   kclManager,
   engineCommandManager,
   wasmInstance,
+  resolveAstForSourceRange,
 }: {
   selections: Selections
   artifactGraph: ArtifactGraph
   kclManager: KclManager
   engineCommandManager: ConnectionManager
   wasmInstance: ModuleType
-}): Promise<string | Error | null> {
+  resolveAstForSourceRange: SelectionReferenceAstResolver
+}): Promise<SelectionReference[] | Error> {
   const enginePrimitives = selections.otherSelections.filter(
     isEnginePrimitiveSelection
   )
@@ -462,7 +466,7 @@ async function buildSelectionReferencePrompt({
     !hasReferenceableGraphSelections &&
     referenceableEnginePrimitives.length === 0
   ) {
-    return null
+    return []
   }
 
   const references = await getSelectionReferences({
@@ -472,6 +476,7 @@ async function buildSelectionReferencePrompt({
     engineCommandManager,
     kclManager,
     wasmInstance,
+    resolveAstForSourceRange,
   })
 
   const unresolvedSelections = referenceableEnginePrimitives.filter(
@@ -487,7 +492,61 @@ async function buildSelectionReferencePrompt({
     )
   }
 
-  return formatSelectionReferencePrompt(references)
+  return references
+}
+
+function buildSelectionReferenceSourceRangePrompts({
+  references,
+  currentFilePrompt,
+  currentFileEntry,
+  kclFilesMap,
+}: {
+  references: SelectionReference[]
+  currentFilePrompt: SourceRangePrompt
+  currentFileEntry: FileEntry
+  kclFilesMap: KclFileMetaMap
+}): SourceRangePrompt[] | Error {
+  const referencesByModuleId = new Map<number, SelectionReference[]>()
+
+  for (const reference of references) {
+    const moduleId = reference.moduleId
+    const moduleReferences = referencesByModuleId.get(moduleId) ?? []
+    moduleReferences.push(reference)
+    referencesByModuleId.set(moduleId, moduleReferences)
+  }
+
+  const prompts: SourceRangePrompt[] = []
+  for (const [moduleId, moduleReferences] of referencesByModuleId) {
+    const file = kclFilesMap[moduleId]
+    if (!file) {
+      return new Error(
+        `Could not send Zookeeper selection: no KCL file found for generated reference file index ${moduleId}.`
+      )
+    }
+
+    const isCurrentFile = file.absPath === currentFileEntry.path
+    const carrierPrompt = isCurrentFile
+      ? currentFilePrompt
+      : {
+          file: file.relPath,
+          range: convertAppRangeToApiRange(
+            [0, file.fileContents.length, moduleId],
+            file.fileContents
+          ),
+          prompt: 'This file contains geometry selected by the user.',
+        }
+
+    prompts.push({
+      ...carrierPrompt,
+      prompt: appendSelectionReferenceSourceRangePrompt({
+        prompt: carrierPrompt.prompt,
+        selectionReferencePrompt:
+          formatSelectionReferencePrompt(moduleReferences),
+      }),
+    })
+  }
+
+  return prompts
 }
 
 export async function constructZookeeperUserPromptRequest({
@@ -559,15 +618,32 @@ export async function constructZookeeperUserPromptRequest({
   }
 
   const ranges: SourceRangePrompt[] = []
-  const selectionReferencePrompt = await buildSelectionReferencePrompt({
+  const resolveAstForSourceRange: SelectionReferenceAstResolver = (
+    sourceRange
+  ) => {
+    const moduleId = sourceRange[2]
+    if (moduleId === currentKclFile?.execStateFileNamesIndex) {
+      return kclManager.ast
+    }
+
+    const file = kclFilesMap[moduleId]
+    if (!file) return undefined
+
+    const parseResult = parse(file.fileContents, wasmInstance)
+    return !isErr(parseResult) && resultIsOk(parseResult)
+      ? parseResult.program
+      : undefined
+  }
+  const selectionReferences = await buildSelectionReferences({
     selections,
     artifactGraph,
     kclManager,
     engineCommandManager,
     wasmInstance,
+    resolveAstForSourceRange,
   })
-  if (selectionReferencePrompt instanceof Error) {
-    return selectionReferencePrompt
+  if (selectionReferences instanceof Error) {
+    return selectionReferences
   }
 
   for (const selection of selections.graphSelections) {
@@ -579,15 +655,17 @@ export async function constructZookeeperUserPromptRequest({
     ranges.push(...selectionPrompts)
   }
 
-  if (selectionReferencePrompt !== null) {
-    ranges.push({
-      ...currentFilePrompt,
-      prompt: appendSelectionReferenceSourceRangePrompt({
-        prompt: currentFilePrompt.prompt,
-        selectionReferencePrompt,
-      }),
-    })
+  const selectionReferencePrompts = buildSelectionReferenceSourceRangePrompts({
+    references: selectionReferences,
+    currentFilePrompt,
+    currentFileEntry: currentFile.entry,
+    kclFilesMap,
+  })
+  if (selectionReferencePrompts instanceof Error) {
+    return selectionReferencePrompts
   }
+
+  ranges.push(...selectionReferencePrompts)
 
   return {
     body: {


### PR DESCRIPTION
I found this issue while testing https://github.com/KittyCAD/modeling-app/pull/12720

Steps:

main.kcl
```
import "imported.kcl"

activeSketch = sketch(on = XY) {
  circle1 = circle(start = [var -15mm, var 0mm], center = [var -25mm, var 0mm])
  horizontal([circle1.start, circle1.center])
  horizontalDistance([ORIGIN, circle1.center]) == -25mm
  verticalDistance([ORIGIN, circle1.center]) == 0mm
  radius(circle1) == 10mm
}
activeRegion = region(segments = [activeSketch.circle1])
activeExtrude = extrude(activeRegion, length = 10mm, tagEnd = $activeEnd)
activeShell = shell(activeExtrude, faces = activeEnd, thickness = 1mm)
```

imported.kcl
```
alignmentMarker = 0

importedSketch = sketch(on = XY) {
  circle1 = circle(start = [35mm, 0mm], center = [25mm, 0mm])
}
importedRegion = region(segments = [importedSketch.circle1])
importedExtrude = extrude(importedRegion, length = 10mm, tagEnd = $importedEnd)
importedShell = shell(importedExtrude, faces = importedEnd, thickness = 1mm)
```

Select a face of the imported geometry (right side):
<img width="411" height="315" alt="Screenshot 2026-08-03 at 19 17 03" src="https://github.com/user-attachments/assets/e8ede553-285d-4f07-9ff6-abff96c5d5a2" />

Ask ZK to "delete the selected face"

Expected:
the face from `imported.kcl` gets deleted:
```
importedShellWithFaceDeleted = deleteFace(importedShell, faces = [faceId(importedShell, index = 3)])
```

Actual:
the face from `main.kcl` gets deleted:
```
activeShellWithFaceDeleted = deleteFace(activeShell, faces = [faceId(activeShell, index = 3)])
```

This is because imported selections are resolved using the active file’s AST because their artifact code references the import statement in main.kcl. So the generated selection reference is associated with main.kcl instead of the imported file, causing ZK to edit the wrong file.

I'm keeping this PR as draft as I'm not too happy with it, but it's a proof of concept for how to fix it: basically find the correct moduleId and send the correct one in the selection context that is sent to ZK.

What I don't like is the optional `resolveAstForSourceRange` but I also didn't want to put that into `KclManager` as that would introduce rare races. I think we could have an "execution snapshot" per execution but that is a bigger and unrelated refactor, plus @franknoirot might already have plans for something like that.

So for now I'm parking this to think about it a bit more.