### PR TITLE
Fix tooltip popover positioning

### DIFF
--- a/e2e/playwright/tooltip-position.spec.ts
+++ b/e2e/playwright/tooltip-position.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from '@e2e/playwright/zoo-test'
+
+test(
+  'Tooltip popovers stay anchored when native CSS anchor positioning is unavailable',
+  { tag: '@web' },
+  async ({ page }) => {
+    await page.setBodyDimensions({ width: 1200, height: 500 })
+
+    await page.evaluate(() => {
+      const nativeSupports = CSS.supports.bind(CSS)
+      Object.defineProperty(CSS, 'supports', {
+        configurable: true,
+        value: (property: string, value?: string) => {
+          const declaration =
+            value === undefined ? property : `${property}: ${value}`
+          if (
+            declaration.includes('position-anchor') ||
+            declaration.includes('anchor(')
+          ) {
+            return false
+          }
+          return value === undefined
+            ? nativeSupports(property)
+            : nativeSupports(property, value)
+        },
+      })
+    })
+    await page.addStyleTag({
+      content:
+        '[role="tooltip"][popover] { position-anchor: none !important; }',
+    })
+
+    const helpButton = page.getByRole('button', {
+      name: 'Help and resources',
+    })
+    await expect(helpButton).toBeVisible()
+
+    await helpButton.hover()
+
+    const tooltip = page
+      .getByRole('tooltip')
+      .filter({ hasText: 'Help and resources' })
+    await expect(tooltip).toBeVisible()
+
+    const boxes = await Promise.all([
+      helpButton.boundingBox(),
+      tooltip.boundingBox(),
+    ])
+    const [triggerBox, tooltipBox] = boxes
+
+    expect(triggerBox).not.toBeNull()
+    expect(tooltipBox).not.toBeNull()
+    if (!triggerBox || !tooltipBox) return
+
+    expect(
+      Math.abs(
+        tooltipBox.x + tooltipBox.width - (triggerBox.x + triggerBox.width)
+      )
+    ).toBeLessThanOrEqual(2)
+    expect(
+      Math.abs(tooltipBox.y + tooltipBox.height - triggerBox.y)
+    ).toBeLessThanOrEqual(2)
+  }
+)

--- a/src/components/Tooltip.module.css
+++ b/src/components/Tooltip.module.css
@@ -15,6 +15,7 @@
   pointer-events: none;
   user-select: none;
   position: absolute;
+  position-anchor: auto;
   inset: unset;
   background-color: transparent;
   border: none;

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -19,6 +19,73 @@ export interface TooltipProps extends React.HTMLProps<HTMLDivElement> {
   inert?: boolean
 }
 
+function supportsNativeAnchorPositioning() {
+  return (
+    typeof CSS !== 'undefined' &&
+    CSS.supports('position-anchor', 'auto') &&
+    CSS.supports('top', 'anchor(bottom)')
+  )
+}
+
+// Browser-native anchor positioning is still uneven, so keep a direct
+// rectangle-based fallback for popover tooltips.
+function positionTooltipFromTrigger(
+  tooltip: HTMLElement,
+  trigger: HTMLElement,
+  position: TooltipPosition
+) {
+  const triggerBox = trigger.getBoundingClientRect()
+  const tooltipBox = tooltip.getBoundingClientRect()
+
+  let left = triggerBox.left
+  let top = triggerBox.top
+
+  switch (position) {
+    case 'top':
+      left = triggerBox.left + triggerBox.width / 2 - tooltipBox.width / 2
+      top = triggerBox.top - tooltipBox.height
+      break
+    case 'top-left':
+      left = triggerBox.left
+      top = triggerBox.top - tooltipBox.height
+      break
+    case 'top-right':
+      left = triggerBox.right - tooltipBox.width
+      top = triggerBox.top - tooltipBox.height
+      break
+    case 'right':
+      left = triggerBox.right
+      top = triggerBox.top + triggerBox.height / 2 - tooltipBox.height / 2
+      break
+    case 'bottom':
+      left = triggerBox.left + triggerBox.width / 2 - tooltipBox.width / 2
+      top = triggerBox.bottom
+      break
+    case 'bottom-left':
+      left = triggerBox.left
+      top = triggerBox.bottom
+      break
+    case 'bottom-right':
+      left = triggerBox.right - tooltipBox.width
+      top = triggerBox.bottom
+      break
+    case 'left':
+      left = triggerBox.left - tooltipBox.width
+      top = triggerBox.top + triggerBox.height / 2 - tooltipBox.height / 2
+      break
+  }
+
+  Object.assign(tooltip.style, {
+    bottom: 'auto',
+    inset: 'auto',
+    left: `${left}px`,
+    position: 'fixed',
+    right: 'auto',
+    top: `${top}px`,
+    transform: 'none',
+  })
+}
+
 export default function Tooltip({
   children,
   position = 'top',
@@ -40,9 +107,29 @@ export default function Tooltip({
       return
     }
 
-    // @ts-ignore-next-line -- React is not up to date about the options that can be passed
-    const show = () => tooltip.current?.showPopover({ source: parent })
-    const hide = () => tooltip.current?.hidePopover()
+    const updateFallbackPosition = () => {
+      if (tooltip.current && !supportsNativeAnchorPositioning()) {
+        positionTooltipFromTrigger(tooltip.current, parent, position)
+      }
+    }
+
+    const show = () => {
+      const currentTooltip = tooltip.current
+      if (!currentTooltip) return
+
+      currentTooltip.showPopover({ source: parent })
+      updateFallbackPosition()
+
+      if (!supportsNativeAnchorPositioning()) {
+        window.addEventListener('resize', updateFallbackPosition)
+        window.addEventListener('scroll', updateFallbackPosition, true)
+      }
+    }
+    const hide = () => {
+      window.removeEventListener('resize', updateFallbackPosition)
+      window.removeEventListener('scroll', updateFallbackPosition, true)
+      tooltip.current?.hidePopover()
+    }
 
     parent.addEventListener('mouseenter', show)
     parent.addEventListener('mouseleave', hide)
@@ -54,8 +141,10 @@ export default function Tooltip({
       parent.removeEventListener('mouseleave', hide)
       parent.removeEventListener('focus', show)
       parent.removeEventListener('blur', hide)
+      window.removeEventListener('resize', updateFallbackPosition)
+      window.removeEventListener('scroll', updateFallbackPosition, true)
     }
-  }, [])
+  }, [position])
   return (
     <div
       popover="hint"


### PR DESCRIPTION
## Summary

- Add an explicit `position-anchor: auto` opt-in for popover-based tooltips.
- Add a rectangle-based fallback so tooltips remain attached to their trigger when native CSS anchor positioning is unavailable or not resolving the implicit popover anchor.
- Add a web Playwright regression for the `Help and resources` tooltip that disables native anchor positioning and verifies the tooltip stays top-right anchored to the trigger.

## Root Cause

`Tooltip` relied entirely on native popover implicit anchor positioning through `showPopover({ source })` and CSS `anchor()` values. When that native anchor path is unavailable or stops resolving, the absolute popover falls back toward the viewport origin, which made unrelated tooltips appear in the top-left of the app.

## Validation

- `npx biome check --formatter-enabled=true --linter-enabled=false --assist-enabled=false --files-ignore-unknown=true src/components/Tooltip.tsx src/components/Tooltip.module.css e2e/playwright/tooltip-position.spec.ts`
- `npx tsc --noEmit --pretty false`
- `node --require ./scripts/register-typescript-eslint-typescript.cjs ./node_modules/eslint/bin/eslint.js --max-warnings 0 src/components/Tooltip.tsx e2e/playwright/tooltip-position.spec.ts`
- `TARGET=web NODE_ENV=development npx playwright test --config=playwright.config.ts e2e/playwright/tooltip-position.spec.ts --project="Google Chrome" --grep="@web"`