### PR TITLE
Fix nested file route project root resolution

### DIFF
--- a/e2e/playwright/file-tree.spec.ts
+++ b/e2e/playwright/file-tree.spec.ts
@@ -1,4 +1,4 @@
-import { FILE_EXT } from '@src/lib/constants'
+import { FILE_EXT, PROJECT_SETTINGS_FILE_NAME } from '@src/lib/constants'
 import type { PromisifiedZooDesignStudioFS } from '@src/lib/fs-zds/interface'
 import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
 import * as nodeFsP from 'fs/promises'
@@ -239,6 +239,76 @@ test.describe('when using the file tree to', { tag: ['@desktop'] }, () => {
       await expect(toolbar.fileName).toHaveText('main.kcl')
     }
   )
+
+  test('opening a nested file keeps the project directory rooted at the project list', async ({
+    fs,
+    folderSetupFn,
+    page,
+    homePage,
+    scene,
+    toolbar,
+    cmdBar,
+  }, testInfo) => {
+    const projectName = 'nested-file-navigation'
+    const folderName = 'parts'
+    const nestedFileName = 'bolt.kcl'
+    let nestedDir = ''
+
+    const { dir } = await folderSetupFn(async (dir) => {
+      const projectDir = await fs.join(dir, projectName)
+      nestedDir = await fs.join(projectDir, folderName)
+      await fs.mkdir(nestedDir, { recursive: true })
+
+      const mainFileData = await nodeFsP.readFile(executorInputPath('cube.kcl'))
+      const nestedFileData = await nodeFsP.readFile(
+        executorInputPath('cylinder.kcl')
+      )
+      await fs.writeFile(
+        await fs.join(projectDir, 'main.kcl'),
+        new Uint8Array(mainFileData)
+      )
+      await fs.writeFile(
+        await fs.join(nestedDir, nestedFileName),
+        new Uint8Array(nestedFileData)
+      )
+    })
+
+    const filePaneScroll = page.getByTestId('file-pane-scroll-container')
+    const treeItem = (name: string) =>
+      filePaneScroll.getByRole('treeitem', { name, exact: true })
+    const projectDirectoryPath = () =>
+      page.evaluate(
+        () =>
+          window.app.systemIOActor.getSnapshot().context.projectDirectoryPath
+      )
+    const nestedProjectSettingsFile = async () =>
+      fs.join(nestedDir, PROJECT_SETTINGS_FILE_NAME)
+
+    await test.step('Open project and reveal nested file', async () => {
+      await homePage.openProject(projectName)
+      await scene.settled()
+      await toolbar.openPane(DefaultLayoutPaneID.Files)
+
+      await toolbar.ensureFolderOpen(treeItem(folderName), true)
+      await expect(treeItem(nestedFileName)).toBeVisible()
+      await expect.poll(projectDirectoryPath).toBe(dir)
+      expect(await exists(fs, await nestedProjectSettingsFile())).toBeFalsy()
+    })
+
+    await test.step('Open nested file without changing project directory', async () => {
+      await treeItem(nestedFileName).click()
+      await scene.settled()
+
+      await expect(toolbar.fileName).toContainText(nestedFileName)
+      await expect.poll(projectDirectoryPath).toBe(dir)
+      await toolbar.expectFileTreeState([
+        folderName,
+        nestedFileName,
+        'main.kcl',
+      ])
+      expect(await exists(fs, await nestedProjectSettingsFile())).toBeFalsy()
+    })
+  })
 
   test('deleting all files recreates a default main.kcl with no code', async ({
     page,

--- a/src/lib/routeLoaders.ts
+++ b/src/lib/routeLoaders.ts
@@ -5,17 +5,13 @@ import {
   DEFAULT_DEFAULT_LENGTH_UNIT,
   PROJECT_ENTRYPOINT,
 } from '@src/lib/constants'
-import {
-  getInitialDefaultDir,
-  getProjectInfo,
-  readAppSettingsFile,
-} from '@src/lib/desktop'
+import { getInitialDefaultDir, getProjectInfo } from '@src/lib/desktop'
 import fsZds from '@src/lib/fs-zds'
 import {
   getParentAbsolutePath,
-  getProjectMetaByRouteId,
   getRouterSearchFromRequestUrl,
   PATHS,
+  parseProjectRoute,
   safeEncodeForRouterPaths,
 } from '@src/lib/paths'
 import {
@@ -199,30 +195,27 @@ export const fileLoader =
       return redirect(PATHS.HOME)
     }
 
-    const heuristicProjectFilePath = params.id
-      ? params.id.split(fsZds.sep).slice(0, -1).join(fsZds.sep)
-      : undefined
-
     const wasmInstance = await kclManager.wasmInstancePromise
 
-    const settings = await loadRouteSettings(
-      app,
-      wasmInstance,
-      heuristicProjectFilePath
-    )
-
-    const projectPathData = await getProjectMetaByRouteId(
-      readAppSettingsFile,
-      wasmInstance,
-      params.id,
-      settings.configuration
-    )
+    // Resolve the project root before loading project settings. Loading project
+    // settings from a selected file's parent folder creates project.toml in
+    // nested folders and makes them look like project roots.
+    const appSettings = await loadRouteSettings(app, wasmInstance)
+    const projectPathData = params.id
+      ? parseProjectRoute(appSettings.configuration, params.id)
+      : undefined
 
     if (!projectPathData) {
       return Promise.reject(
         new Error('bug: projectPathData undefined, early return')
       )
     }
+
+    const settings = await loadRouteSettings(
+      app,
+      wasmInstance,
+      projectPathData.projectPath
+    )
 
     const { projectName, projectPath, currentFileName, currentFilePath } =
       projectPathData


### PR DESCRIPTION
## Summary

Fixes #12765.

Opening a KCL file inside a nested folder from the file explorer should keep the project rooted at the original project directory. This changes the file route loader to resolve the real project root from app/user settings before loading project-level settings.

## Root cause

The file loader derived a `heuristicProjectFilePath` by taking the parent directory of the requested route path. For a route like `<project>/parts/bolt.kcl`, that heuristic was `<project>/parts`. `loadAndValidateSettings()` then treated that nested folder as the project settings target and wrote a `project.toml` there when none existed. Once that happened, the nested folder could be interpreted as a project root.

## Changes

- Added a desktop Playwright regression that opens an existing nested KCL file and verifies the app project directory stays at the project list root.
- The regression also verifies that opening the nested file does not create `project.toml` inside the nested folder.
- Updated the file route loader to first load app/user settings, parse the route to the actual project root, and only then load project settings from that root.