### PR TITLE
Auto-reconcile independent cloud sync changes

### DIFF
--- a/src/lib/cloudSync/README.md
+++ b/src/lib/cloudSync/README.md
@@ -90,11 +90,13 @@ flowchart TD
   CompareBase -->|"Local changed, remote unchanged"| PushGuarded["Upload with expected_revision"]
   CompareBase -->|"Local clean, remote changed"| PullRemote["Hydrate OPFS from remote archive"]
   CompareBase -->|"Both unchanged or manifests equal"| MarkSynced["Clear outbox and update base"]
-  CompareBase -->|"Both changed differently"| Conflict["Keep local primary and record conflict"]
+  CompareBase -->|"Both changed on independent files"| AutoReconcile["Upload merged archive with latest expected_revision"]
+  CompareBase -->|"Both changed same files differently"| Conflict["Keep local primary and record conflict"]
   DeleteRemote --> Done["Done"]
   ForgetLocal --> Done
   CreateRemote --> MarkSynced
   PushGuarded --> MarkSynced
+  AutoReconcile --> MarkSynced
   PullRemote --> MarkSynced
   Conflict --> Blocked["Persist conflict status"]
 ```
@@ -124,7 +126,7 @@ flowchart TD
 - A remote-only project discovered from the cloud index may remain remote-only; local materialization happens when a caller explicitly opens or moves it into a local library.
 - A remotely deleted project may remove the local OPFS mirror only when that local mirror still matches the last synced base.
 - Remote hydration may replace OPFS only when local is clean relative to the last synced base.
-- If local and remote both changed differently, local remains primary and the conflict stores the remote revision/update metadata. The cloud archive is fetched on demand for inspection or resolution.
+- If local and remote both changed differently but only on independent file paths, cloud sync may upload a merged archive under the latest remote `expected_revision`. If both sides changed the same path differently, local remains primary and the conflict stores the remote revision/update metadata. The cloud archive is fetched on demand for inspection or resolution.
 - Sync failures must preserve outbox and dirty metadata.
 - Cloud project title is user-facing metadata; the OPFS folder name is an implementation detail that may be uniquified.
 - Home rename of a cloud project acts on the local materialization when one exists and acts directly on the remote project when the project is still remote-only. Because the cloud API has no title-only update, a remote-only rename re-uploads the downloaded project archive with the new title under `expected_revision`.
@@ -159,8 +161,8 @@ Remote deletes are intentionally not revision-guarded. A project-root `rm` recor
 
 If a remote project disappears from the cloud index, the local mirror is removed only when its manifest still matches `ProjectMetadata.baseManifest` and it has no pending local outbox work. Dirty or unverifiable local projects are detached from the missing remote id and queued as local-first projects so user data is preserved and the stale id does not keep retrying a 404.
 
-Remote hydration is only allowed to replace OPFS when the local project is clean relative to `baseManifest`, or when the caller explicitly materializes a remote-only project into a local library. If both local and remote changed since the base, the local project remains primary and the remote archive is fetched live when the user inspects or resolves the conflict.
+Remote hydration is only allowed to replace OPFS when the local project is clean relative to `baseManifest`, or when the caller explicitly materializes a remote-only project into a local library. If both local and remote changed since the base, the engine may auto-reconcile changes that touch independent file paths. Same-path divergent changes keep the local project primary and fetch the remote archive live when the user inspects or resolves the conflict.
 
-This implementation is whole-project archive based. It does not attempt file-level merging because the cloud API does not expose file-level revisions. A remote revision must therefore change on every successful project archive update; otherwise a remote change can be missed.
+This implementation is whole-project archive based. It can auto-reconcile independent file-level changes by comparing local and remote manifests to `baseManifest`, but it does not attempt same-file line or syntax merges because the base stores file fingerprints instead of file contents. A remote revision must therefore change on every successful project archive update; otherwise a remote change can be missed.
 
 When a cloud title changes, the title is written into `project.toml` only when that can be done without overwriting local edits. The local project directory name is treated as an implementation detail and may differ from the cloud title when uniqueness requires it.

--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -2030,6 +2030,89 @@ function latestOutboxKind(entries: OutboxEntry[]) {
   return entries.toSorted((a, b) => (a.id ?? 0) - (b.id ?? 0)).at(-1)?.kind
 }
 
+function projectManifestEntryEqual(
+  left: ProjectManifest['files'][string] | undefined,
+  right: ProjectManifest['files'][string] | undefined
+) {
+  if (!left || !right) {
+    return left === right
+  }
+
+  return left.byteSize === right.byteSize && left.sha256 === right.sha256
+}
+
+function projectArchiveFileMap(files: ProjectArchiveFile[]) {
+  const filesByPath = new Map<string, ProjectArchiveFile>()
+  for (const file of files) {
+    const relativePath = normalizeRelativePath(file.relativePath)
+    filesByPath.set(relativePath, {
+      ...file,
+      relativePath,
+    })
+  }
+  return filesByPath
+}
+
+/**
+ * Builds a whole-project snapshot when local and remote changed independent
+ * paths from the last synced base. This is intentionally file-level only: when
+ * both sides changed the same path differently, the user-facing conflict flow
+ * remains responsible for choosing the winner.
+ */
+export function getCloudSyncAutoReconciledProjectFiles({
+  baseManifest,
+  localFiles,
+  localManifest,
+  remoteFiles,
+  remoteManifest,
+}: {
+  baseManifest: ProjectManifest
+  localFiles: ProjectArchiveFile[]
+  localManifest: ProjectManifest
+  remoteFiles: ProjectArchiveFile[]
+  remoteManifest: ProjectManifest
+}) {
+  const localFilesByPath = projectArchiveFileMap(localFiles)
+  const remoteFilesByPath = projectArchiveFileMap(remoteFiles)
+  const relativePaths = Array.from(
+    new Set([
+      ...Object.keys(baseManifest.files),
+      ...Object.keys(localManifest.files),
+      ...Object.keys(remoteManifest.files),
+    ])
+  ).sort((left, right) => left.localeCompare(right))
+  const mergedFiles: ProjectArchiveFile[] = []
+
+  for (const relativePath of relativePaths) {
+    const baseEntry = baseManifest.files[relativePath]
+    const localEntry = localManifest.files[relativePath]
+    const remoteEntry = remoteManifest.files[relativePath]
+    const localChanged = !projectManifestEntryEqual(localEntry, baseEntry)
+    const remoteChanged = !projectManifestEntryEqual(remoteEntry, baseEntry)
+
+    if (projectManifestEntryEqual(localEntry, remoteEntry)) {
+      const file = localFilesByPath.get(relativePath)
+      if (file) {
+        mergedFiles.push(file)
+      }
+      continue
+    }
+
+    if (localChanged && remoteChanged) {
+      return undefined
+    }
+
+    const selectedFile = remoteChanged
+      ? remoteFilesByPath.get(relativePath)
+      : localFilesByPath.get(relativePath)
+    if (selectedFile) {
+      mergedFiles.push(selectedFile)
+    }
+  }
+
+  return mergedFiles
+}
+
 export type CloudSyncProjectSyncPreflightAction =
   | 'delete-remote'
   | 'forget-missing-local'
@@ -2076,16 +2159,19 @@ export function getCloudSyncProjectSyncPreflightAction({
 export type CloudSyncRemoteArchiveReconciliationAction =
   | 'mark-synced'
   | 'hydrate-clean-local'
+  | 'auto-reconcile'
   | 'mark-conflict'
 
 export function getCloudSyncRemoteArchiveReconciliationAction({
   hasBaseManifest,
   localMatchesRemote,
   localClean,
+  canAutoReconcile,
 }: {
   hasBaseManifest: boolean
   localMatchesRemote: boolean
   localClean: boolean
+  canAutoReconcile?: boolean
 }): CloudSyncRemoteArchiveReconciliationAction {
   if (!hasBaseManifest && localMatchesRemote) {
     return 'mark-synced'
@@ -2095,6 +2181,9 @@ export function getCloudSyncRemoteArchiveReconciliationAction({
   }
   if (localMatchesRemote) {
     return 'mark-synced'
+  }
+  if (canAutoReconcile) {
+    return 'auto-reconcile'
   }
   return 'mark-conflict'
 }
@@ -2436,13 +2525,28 @@ async function syncProject(projectPath: string, entries: OutboxEntry[]) {
       localManifest,
       remoteManifest
     )
+    const localClean = Boolean(
+      metadata.baseManifest &&
+        projectManifestsEqual(localManifest, metadata.baseManifest)
+    )
+    const autoReconciledFiles =
+      metadata.baseManifest &&
+      remoteRevision &&
+      !localMatchesRemote &&
+      !localClean
+        ? getCloudSyncAutoReconciledProjectFiles({
+            baseManifest: metadata.baseManifest,
+            localFiles,
+            localManifest,
+            remoteFiles,
+            remoteManifest,
+          })
+        : undefined
     const reconciliationAction = getCloudSyncRemoteArchiveReconciliationAction({
       hasBaseManifest: Boolean(metadata.baseManifest),
       localMatchesRemote,
-      localClean: Boolean(
-        metadata.baseManifest &&
-          projectManifestsEqual(localManifest, metadata.baseManifest)
-      ),
+      localClean,
+      canAutoReconcile: Boolean(autoReconciledFiles),
     })
 
     if (reconciliationAction === 'mark-synced') {
@@ -2462,6 +2566,29 @@ async function syncProject(projectPath: string, entries: OutboxEntry[]) {
         metadata,
         remoteManifest,
         remoteSyncMetadata(remoteProject)
+      )
+      return
+    }
+
+    if (reconciliationAction === 'auto-reconcile' && autoReconciledFiles) {
+      const autoReconciledManifest =
+        await projectManifestFromFiles(autoReconciledFiles)
+      const updated = await updateRemoteProject({
+        config,
+        projectPath: metadata.localProjectPath,
+        projectId: remoteProjectId,
+        files: autoReconciledFiles,
+        expectedRevision: remoteRevision,
+      }).catch(rejectRemoteUploadFailure)
+      await replaceLocalProjectWithFiles(
+        metadata.localProjectPath,
+        autoReconciledFiles
+      )
+      await clearOutboxEntriesForProject(metadata.localProjectPath)
+      await markProjectSynced(
+        metadata,
+        autoReconciledManifest,
+        remoteSyncMetadata(updated, { useNowAsUpdatedAtFallback: true })
       )
       return
     }

--- a/src/lib/cloudSync/index.test.ts
+++ b/src/lib/cloudSync/index.test.ts
@@ -1,5 +1,6 @@
 import {
   filterCloudSyncProjectFilesForSync,
+  getCloudSyncAutoReconciledProjectFiles,
   getCloudSyncInitialLocalProjectSyncAction,
   getCloudSyncKnownLocalRemoteIndexAction,
   getCloudSyncMissingRemoteProjectAction,
@@ -124,6 +125,56 @@ describe('cloudSync sync helpers', () => {
     expect(projectManifestsEqual(left, right)).toBe(true)
     expect(projectManifestsEqual(left, changed)).toBe(false)
     expect(projectManifestsEqual(left, undefined)).toBe(false)
+  })
+
+  it('auto-reconciles independent local and remote file changes from the sync base', async () => {
+    const baseFiles = [
+      projectFile('main.kcl', 'base = 1\n'),
+      projectFile('obsolete.kcl', 'delete me\n'),
+      projectFile(PROJECT_SETTINGS_FILE_NAME, 'title = "Demo"\n'),
+    ]
+    const localFiles = [
+      projectFile('main.kcl', 'local = 2\n'),
+      projectFile(PROJECT_SETTINGS_FILE_NAME, 'title = "Demo"\n'),
+    ]
+    const remoteFiles = [
+      projectFile('main.kcl', 'base = 1\n'),
+      projectFile('obsolete.kcl', 'delete me\n'),
+      projectFile('remote.kcl', 'cloud = 2\n'),
+      projectFile(PROJECT_SETTINGS_FILE_NAME, 'title = "Demo"\n'),
+    ]
+
+    const mergedFiles = getCloudSyncAutoReconciledProjectFiles({
+      baseManifest: await projectManifestFromFiles(baseFiles),
+      localFiles,
+      localManifest: await projectManifestFromFiles(localFiles),
+      remoteFiles,
+      remoteManifest: await projectManifestFromFiles(remoteFiles),
+    })
+
+    expect(mergedFiles?.map((file) => file.relativePath)).toEqual([
+      'main.kcl',
+      'project.toml',
+      'remote.kcl',
+    ])
+    expect(readProjectFile(mergedFiles ?? [], 'main.kcl')).toBe('local = 2\n')
+    expect(readProjectFile(mergedFiles ?? [], 'remote.kcl')).toBe('cloud = 2\n')
+  })
+
+  it('keeps same-path divergent local and remote changes in the conflict flow', async () => {
+    const baseFiles = [projectFile('main.kcl', 'base = 1\n')]
+    const localFiles = [projectFile('main.kcl', 'local = 2\n')]
+    const remoteFiles = [projectFile('main.kcl', 'cloud = 2\n')]
+
+    expect(
+      getCloudSyncAutoReconciledProjectFiles({
+        baseManifest: await projectManifestFromFiles(baseFiles),
+        localFiles,
+        localManifest: await projectManifestFromFiles(localFiles),
+        remoteFiles,
+        remoteManifest: await projectManifestFromFiles(remoteFiles),
+      })
+    ).toBeUndefined()
   })
 
   it('includes API-required entrypoint and project.toml paths in project upload metadata', () => {
@@ -545,6 +596,17 @@ describe('cloudSync sync helpers', () => {
         localClean: false,
       })
     ).toBe('mark-conflict')
+  })
+
+  it('auto-reconciles when local and remote archive changes are independent', () => {
+    expect(
+      getCloudSyncRemoteArchiveReconciliationAction({
+        hasBaseManifest: true,
+        localMatchesRemote: false,
+        localClean: false,
+        canAutoReconcile: true,
+      })
+    ).toBe('auto-reconcile')
   })
 
   it('uses remote updated_at for clean cloud projects and local mtime for pending edits', () => {

--- a/src/lib/cloudSync/liveConflicts.test.ts
+++ b/src/lib/cloudSync/liveConflicts.test.ts
@@ -9,7 +9,10 @@ import {
   type ProjectArchiveFile,
   resolveCloudSyncProjectConflict,
 } from '@src/lib/cloudSync'
-import { projectManifestFromFiles } from '@src/lib/cloudSync/projectArchive'
+import {
+  normalizeProjectArchiveFilesForCloudSync,
+  projectManifestFromFiles,
+} from '@src/lib/cloudSync/projectArchive'
 import {
   appendOutboxEntry,
   putProjectMetadata,
@@ -66,9 +69,17 @@ function remoteProjectPayload(revision = 'rev-2') {
   }
 }
 
-function remoteArchivePayload(contents = 'remote = 2\n') {
+type RemoteArchivePayloadFile = {
+  relativePath: string
+  contents: string
+}
+
+function remoteArchivePayload(
+  contents = 'remote = 2\n',
+  files?: RemoteArchivePayloadFile[]
+) {
   return {
-    files: [
+    files: files ?? [
       { relativePath: 'main.kcl', contents },
       {
         relativePath: PROJECT_SETTINGS_FILE_NAME,
@@ -82,9 +93,18 @@ function remoteArchivePayload(contents = 'remote = 2\n') {
 function installFetchMock({
   remoteRevision = 'rev-2',
   remoteContents = 'remote = 2\n',
+  remoteFiles,
+  updatedRevision = 'rev-3',
+  onUpdate,
 }: {
   remoteRevision?: string
   remoteContents?: string
+  remoteFiles?: RemoteArchivePayloadFile[]
+  updatedRevision?: string
+  onUpdate?: (
+    input: Parameters<typeof fetch>[0],
+    init?: Parameters<typeof fetch>[1]
+  ) => void | Promise<void>
 } = {}) {
   fetchMock.mockImplementation(async (input, init) => {
     const url = getFetchUrl(input)
@@ -99,7 +119,12 @@ function installFetchMock({
     }
 
     if (url === remoteDownloadUrl && method === 'GET') {
-      return jsonResponse(remoteArchivePayload(remoteContents))
+      return jsonResponse(remoteArchivePayload(remoteContents, remoteFiles))
+    }
+
+    if (url.startsWith(remoteProjectUrl) && method === 'PUT') {
+      await onUpdate?.(input, init)
+      return jsonResponse(remoteProjectPayload(updatedRevision))
     }
 
     return jsonResponse({ message: `Unexpected fetch: ${method} ${url}` }, 500)
@@ -243,6 +268,94 @@ describe('cloud sync live conflicts', () => {
       expect.arrayContaining([
         expect.objectContaining({ relativePath: PROJECT_IMAGE_NAME }),
       ])
+    )
+  })
+
+  it('auto-reconciles independent local and remote archive changes', async () => {
+    const projectToml =
+      'title = "Demo"\ndefault_file = "main.kcl"\n\n[cloud."dev.zoo.dev"]\nproject_id = "remote-123"\n'
+    const files = new Map([
+      [`${projectPath}/main.kcl`, 'local = 2\n'],
+      [`${projectPath}/${PROJECT_SETTINGS_FILE_NAME}`, projectToml],
+    ])
+    const updatePayloads: Array<{
+      expectedRevision?: string
+      main?: string
+      remote?: string
+    }> = []
+    configureCloudSyncLocalFileSystem(
+      createCloudSyncTestFs(files, { projectDirectory })
+    )
+    await putProjectMetadata({
+      schemaVersion: 1,
+      localProjectPath: projectPath,
+      projectName: 'demo',
+      remoteProjectId,
+      remoteRevision: 'rev-1',
+      baseManifest: await projectManifestFromFiles(
+        normalizeProjectArchiveFilesForCloudSync([
+          projectFile('main.kcl', 'base = 1\n'),
+          projectFile(PROJECT_SETTINGS_FILE_NAME, projectToml),
+        ])
+      ),
+    })
+    await appendOutboxEntry({
+      projectPath,
+      kind: 'upsert',
+      targetPath: `${projectPath}/main.kcl`,
+      createdAt: '2026-07-17T12:02:00.000Z',
+    })
+    installFetchMock({
+      remoteFiles: [
+        { relativePath: 'main.kcl', contents: 'base = 1\n' },
+        { relativePath: 'remote.kcl', contents: 'cloud = 2\n' },
+        {
+          relativePath: PROJECT_SETTINGS_FILE_NAME,
+          contents: 'title = "Demo"\n',
+        },
+      ],
+      onUpdate: async (_input, init) => {
+        const formData = init?.body as FormData
+        const body = JSON.parse(
+          await (formData.get('body') as Blob).text()
+        ) as { expected_revision?: string }
+        updatePayloads.push({
+          expectedRevision: body.expected_revision,
+          main: await (formData.get('main.kcl') as Blob).text(),
+          remote: await (formData.get('remote.kcl') as Blob).text(),
+        })
+      },
+    })
+    configureCloudSyncEngine({
+      enabled: true,
+      baseUrl,
+      environmentName: 'dev.zoo.dev',
+      projectDirectoryPath: projectDirectory,
+    })
+
+    await vi.waitFor(async () => {
+      await expect(
+        getCloudSyncProjectMetadata(projectPath)
+      ).resolves.toMatchObject({
+        remoteRevision: 'rev-3',
+        conflict: undefined,
+        lastFailure: undefined,
+      })
+    })
+
+    expect(updatePayloads).toEqual([
+      {
+        expectedRevision: 'rev-2',
+        main: 'local = 2\n',
+        remote: 'cloud = 2\n',
+      },
+    ])
+    expect(files.get(`${projectPath}/main.kcl`)).toBe('local = 2\n')
+    expect(files.get(`${projectPath}/remote.kcl`)).toBe('cloud = 2\n')
+    expect(clientErrorsMock.reportClientError).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'cloud_sync_conflict_copy_detected',
+      })
     )
   })
 


### PR DESCRIPTION
## Summary

Adds a conservative cloud sync auto-reconciliation path for projects where local and remote have both changed since the last synced base, but only on independent file paths.

The sync worker now compares local and remote manifests against `baseManifest`; if no path was changed differently on both sides, it builds a merged whole-project archive, uploads it with the latest remote `expected_revision`, then updates the local project and marks the project synced. Same-path divergent changes still use the existing conflict flow.

## Why

Cloud sync is not intended to replace version control, but users should not have to manually resolve trivial cloud/local conflicts when the engine can prove the changes compose safely.

## Validation

- `npx vitest run --mode=development --project=unit src/lib/cloudSync/index.test.ts src/lib/cloudSync/liveConflicts.test.ts`
- `npm run tsc -- --noEmit`
- `npx vitest run --mode=development --project=unit src/lib/cloudSync`
- `npx vitest run --mode=development --project=integration src/lib/cloudSync`