### PR TITLE
Unify Home project library reads

### DIFF
--- a/src/hooks/useProjectStatus.ts
+++ b/src/hooks/useProjectStatus.ts
@@ -4,7 +4,7 @@ import type {
 } from '@kittycad/lib'
 import { projects } from '@kittycad/lib'
 import { createKCClient } from '@src/lib/kcClient'
-import type { Project } from '@src/lib/project'
+import type { HomeProjectEntry } from '@src/registry/contracts/homeProjects'
 import { useEffect, useMemo, useState } from 'react'
 
 export type ProjectStatus = {
@@ -62,7 +62,7 @@ export function useProjectStatus(
  * Uses a single `list_projects` call rather than N individual calls.
  */
 export function useProjectStatuses(
-  localProjects: Project[] | undefined,
+  homeProjects: readonly HomeProjectEntry[],
   token?: string
 ): Map<string, ProjectStatus> {
   const [remoteProjects, setRemoteProjects] = useState<
@@ -70,9 +70,8 @@ export function useProjectStatuses(
   >([])
 
   const hasCloudProjects = useMemo(() => {
-    if (!localProjects) return false
-    return localProjects.some((p) => !!p.cloudProjectId)
-  }, [localProjects])
+    return homeProjects.some((project) => !!project.remoteProjectId)
+  }, [homeProjects])
 
   useEffect(() => {
     if (!token || !hasCloudProjects) {

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -46,6 +46,7 @@ import {
   homeProjectEntryFromProject,
 } from '@src/lib/homeProjects'
 import { PATHS } from '@src/lib/paths'
+import type { Project } from '@src/lib/project'
 import { getProjectDisplayName } from '@src/lib/projectDisplayName'
 import { duplicateProjectInDirectory } from '@src/lib/projectDuplication'
 import {
@@ -64,7 +65,6 @@ import {
 } from '@src/lib/revealInFileExplorer'
 import { getResolvedTheme, type ResolvedTheme } from '@src/lib/theme'
 import { reportRejection } from '@src/lib/trap'
-import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
 import { userFeaturesContextHas } from '@src/machines/userFeaturesMachine'
 import { cloudSyncService } from '@src/registry/contracts/cloudSync'
 import {
@@ -85,7 +85,6 @@ import {
   nullableStatusBarItem,
   statusBarGlobalItemsValueSpec,
 } from '@src/registry/contracts/statusBar'
-import { systemIOService } from '@src/registry/contracts/systemIO'
 import { userFeaturesService } from '@src/registry/contracts/userFeatures'
 import { wasmPromiseValueSpec } from '@src/registry/contracts/wasm'
 import { createZdsPlugin } from '@src/registry/createZdsPlugin'
@@ -787,19 +786,11 @@ const cloudSyncRemoteHomeProjectEntryContribution = defineRegistryItemFactory(
  * sync-only surface (remote entries, status bar, project-menu sync actions).
  */
 export const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
-  const systemIO = ctx.services.signal(systemIOService)
   const getWasmPromise = () =>
     ctx.valueSpecs.get(wasmPromiseValueSpec) ??
     new Error('Missing WASM promise registry value.')
 
-  // A materialized cloud project can be listed either by System IO (when the
-  // cloud folder is the app's project directory, e.g. on web) or by the
-  // configured Personal Cloud library scan (e.g. on desktop). Refresh both so
-  // local mutations show up regardless of which surface owns the entry.
   const refreshLocalCloudProjectEntries = () => {
-    systemIO.value?.actor.send({
-      type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
-    })
     invalidateConfiguredProjectLibraryEntries()
   }
 
@@ -1013,17 +1004,26 @@ export const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
         },
       },
     },
-    readEntries: async ({ library, signal }) => {
+    readEntries: async ({ library, onProgress, previousEntries, signal }) => {
       const wasmInstancePromise = getWasmPromise()
       if (wasmInstancePromise instanceof Error) {
         return Promise.reject(wasmInstancePromise)
       }
 
+      const entriesFromProjects = (projects: readonly Project[]) =>
+        projects.map((project) => ({
+          ...homeProjectEntryFromProject(project),
+          libraryId: library.id,
+        }))
       const projects = await readProjectsFromProjectDirectory({
         projectDirectoryPath:
           await getCloudProjectLibraryMaterializationDirectoryPath(library),
         wasmInstancePromise,
+        previousProjectCount: previousEntries?.length,
         signal,
+        onProgress: (projects) => {
+          onProgress?.(entriesFromProjects(projects))
+        },
       })
       if (!signal.aborted) {
         scheduleCloudProjectDirectoryNameSyncFromTitles({
@@ -1033,10 +1033,7 @@ export const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
         })
       }
 
-      return projects.map((project) => ({
-        ...homeProjectEntryFromProject(project),
-        libraryId: library.id,
-      }))
+      return entriesFromProjects(projects)
     },
   }
 

--- a/src/lib/projectLibraries/directoryScanner.ts
+++ b/src/lib/projectLibraries/directoryScanner.ts
@@ -242,17 +242,22 @@ export async function readProjectsFromProjectDirectory({
   projectDirectoryPath,
   wasmInstancePromise,
   previousProjects,
+  previousProjectCount,
   signal,
   onProgress,
 }: {
   projectDirectoryPath: string
   wasmInstancePromise: Promise<ModuleType>
   previousProjects?: Project[]
+  previousProjectCount?: number
   signal?: AbortSignal
   onProgress?: (projects: Project[]) => void
 }) {
   const projects: Project[] = []
-  const canSendProgress = shouldSendProjectFolderReadProgress(previousProjects)
+  const canSendProgress =
+    previousProjectCount !== undefined
+      ? previousProjectCount === 0
+      : shouldSendProjectFolderReadProgress(previousProjects)
 
   const sendProgress = (folders: Project[]) => {
     if (signal?.aborted) {

--- a/src/registry/contracts/homeProjects.ts
+++ b/src/registry/contracts/homeProjects.ts
@@ -242,6 +242,11 @@ export const homeProjectsContract = defineContract({
   homeProjectActionsService: defineService<HomeProjectActionsService>(
     'home-project-actions'
   ),
+  homeProjectEntriesLoadingValueSpec: defineValueSpec<boolean, boolean>({
+    name: 'home-project-entries-loading',
+    defaultValue: false,
+    combine: (contributions) => contributions.some(Boolean),
+  }),
   homeProjectEntriesValueSpec: defineValueSpec<
     HomeProjectEntryContributionGroup,
     HomeProjectEntry[]
@@ -252,5 +257,8 @@ export const homeProjectsContract = defineContract({
   }),
 })
 
-export const { homeProjectActionsService, homeProjectEntriesValueSpec } =
-  homeProjectsContract
+export const {
+  homeProjectActionsService,
+  homeProjectEntriesLoadingValueSpec,
+  homeProjectEntriesValueSpec,
+} = homeProjectsContract

--- a/src/registry/contracts/projectLibraries.ts
+++ b/src/registry/contracts/projectLibraries.ts
@@ -156,6 +156,8 @@ export interface ProjectLibraryTypeContribution {
   readEntries?: (input: {
     library: ProjectLibrary
     signal: AbortSignal
+    previousEntries?: HomeProjectEntryContribution[]
+    onProgress?: (entries: HomeProjectEntryContribution[]) => void
   }) => Promise<HomeProjectEntryContribution[]>
 }
 

--- a/src/registry/extensions/homeProjects/index.test.ts
+++ b/src/registry/extensions/homeProjects/index.test.ts
@@ -9,9 +9,11 @@ import type { Project } from '@src/lib/project'
 import {
   CLOUD_PROJECT_LIBRARY_TYPE,
   DEFAULT_PROJECT_LIBRARY_ID,
+  DEFAULT_PROJECT_LIBRARY_TITLE,
   getDefaultCloudProjectLibrarySetting,
   PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
   type ProjectLibrary,
+  type ProjectLibrarySetting,
 } from '@src/lib/projectLibraries'
 import type { CloudSyncRegistryService } from '@src/registry/contracts/cloudSync'
 import { cloudSyncService } from '@src/registry/contracts/cloudSync'
@@ -19,6 +21,7 @@ import {
   type HomeProjectEntry,
   type HomeProjectEntryContribution,
   homeProjectActionsService,
+  homeProjectEntriesLoadingValueSpec,
   homeProjectEntriesValueSpec,
 } from '@src/registry/contracts/homeProjects'
 import { projectLibraryTypesValueSpec } from '@src/registry/contracts/projectLibraries'
@@ -29,7 +32,9 @@ import {
   systemIOService,
 } from '@src/registry/contracts/systemIO'
 import { provideWasmPromise } from '@src/registry/contracts/wasm'
-import homeProjectsExtension from '@src/registry/extensions/homeProjects'
+import homeProjectsExtension, {
+  invalidateConfiguredProjectLibraryEntries,
+} from '@src/registry/extensions/homeProjects'
 import { waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -38,7 +43,13 @@ const desktopMocks = vi.hoisted(() => ({
 }))
 
 const cloudSyncPathMocks = vi.hoisted(() => ({
+  getCloudProjectLibraryMaterializationDirectoryPath: vi.fn(),
   getDefaultCloudProjectDirectoryPath: vi.fn(),
+}))
+
+const directoryScannerMocks = vi.hoisted(() => ({
+  readProjectsFromProjectDirectory: vi.fn(),
+  scheduleProjectDirectoryNameSyncFromTitles: vi.fn(),
 }))
 
 vi.mock('@src/lib/wasm_lib_wrapper', () => ({
@@ -47,31 +58,70 @@ vi.mock('@src/lib/wasm_lib_wrapper', () => ({
   reloadModule: vi.fn(),
 }))
 
-vi.mock('@src/lib/desktop', () => {
-  return {
-    canReadWriteDirectory: vi.fn().mockResolvedValue({
-      value: true,
-      error: undefined,
-    }),
-    createNewProjectDirectory: vi.fn(),
-    getProjectInfo: desktopMocks.getProjectInfo,
-    isPathNotFoundError: vi.fn(() => false),
-    mkdirOrNOOP: vi.fn().mockResolvedValue(undefined),
-    writeProjectTitleToProjectToml: vi.fn().mockResolvedValue(undefined),
-  }
-})
+vi.mock('@src/lib/desktop', () => ({
+  canReadWriteDirectory: vi.fn().mockResolvedValue({
+    value: true,
+    error: undefined,
+  }),
+  createNewProjectDirectory: vi.fn(),
+  getProjectInfo: desktopMocks.getProjectInfo,
+  isPathNotFoundError: vi.fn(() => false),
+  mkdirOrNOOP: vi.fn().mockResolvedValue(undefined),
+  writeProjectTitleToProjectToml: vi.fn().mockResolvedValue(undefined),
+}))
 
 vi.mock('@src/lib/cloudSync/paths', () => ({
+  getCloudProjectLibraryMaterializationDirectoryPath:
+    cloudSyncPathMocks.getCloudProjectLibraryMaterializationDirectoryPath,
   getDefaultCloudProjectDirectoryPath:
     cloudSyncPathMocks.getDefaultCloudProjectDirectoryPath,
 }))
 
-function createSettingsService(): SettingsRegistryService {
+vi.mock(
+  '@src/lib/projectLibraries/directoryScanner',
+  () => directoryScannerMocks
+)
+
+function createProject({
+  name,
+  path,
+}: {
+  name: string
+  path: string
+}): Project {
+  return {
+    name,
+    title: name,
+    path,
+    default_file: `${path}/main.kcl`,
+    children: [],
+    metadata: {
+      accessed: null,
+      created: null,
+      modified: 100,
+      permission: null,
+      size: 1,
+      type: 'directory',
+    },
+    kcl_file_count: 1,
+    directory_count: 0,
+    readWriteAccess: true,
+  }
+}
+
+function createSettingsService({
+  libraries = [],
+}: {
+  libraries?: ProjectLibrarySetting[]
+} = {}): SettingsRegistryService {
   const current = signal({
     app: {
       libraries: {
-        current: [],
+        current: libraries,
       },
+    },
+    unrelated: {
+      value: 0,
     },
   })
 
@@ -91,7 +141,7 @@ function createSettingsService(): SettingsRegistryService {
 function createMutableSettingsService({
   libraries,
 }: {
-  libraries: { title: string; path: string; type: string }[]
+  libraries: ProjectLibrarySetting[]
 }) {
   const current = signal({
     app: {
@@ -129,7 +179,12 @@ function createSystemIOService() {
         send,
         getSnapshot: () => ({
           context: {
-            folders: undefined,
+            folders: [
+              createProject({
+                name: 'system-io-only-project',
+                path: '/system-io/system-io-only-project',
+              }),
+            ],
           },
           matches: (state: string) => state === 'idle',
         }),
@@ -139,54 +194,6 @@ function createSystemIOService() {
       },
     } as unknown as SystemIORegistryService,
     send,
-  }
-}
-
-function createMutableSystemIOService({
-  folders,
-}: {
-  folders: Project[] | undefined
-}) {
-  const send = vi.fn()
-  const subscribers = new Set<() => void>()
-  let snapshot = {
-    context: {
-      folders,
-      requestedProjectName: {
-        name: 'active-project',
-      },
-    },
-    matches: (state: string) => state === 'idle',
-  }
-
-  return {
-    service: {
-      actor: {
-        send,
-        getSnapshot: () => snapshot,
-        subscribe: vi.fn((callback: () => void) => {
-          subscribers.add(callback)
-          return {
-            unsubscribe: () => {
-              subscribers.delete(callback)
-            },
-          }
-        }),
-      },
-    } as unknown as SystemIORegistryService,
-    send,
-    setFolders: (foldersNext: Project[] | undefined) => {
-      snapshot = {
-        ...snapshot,
-        context: {
-          ...snapshot.context,
-          folders: foldersNext,
-        },
-      }
-      for (const subscriber of subscribers) {
-        subscriber()
-      }
-    },
   }
 }
 
@@ -217,11 +224,54 @@ function createCloudSyncService(
   }
 }
 
-describe('home project actions', () => {
+function configureHomeProjectsRegistry({
+  cloudSync = createCloudSyncService(),
+  extraItems = [],
+  settings = createSettingsService(),
+  systemIO = createSystemIOService(),
+  wasmPromise = Promise.resolve({} as never),
+}: {
+  cloudSync?: CloudSyncRegistryService
+  extraItems?: Parameters<Registry['configure']>[0]
+  settings?: SettingsRegistryService
+  systemIO?: ReturnType<typeof createSystemIOService>
+  wasmPromise?: Promise<never>
+} = {}) {
+  const registry = new Registry()
+
+  registry.configure([
+    defineRegistryItem({
+      id: 'test.settings',
+      providesServices: [provideService(settingsService, settings)],
+    }),
+    defineRegistryItem({
+      id: 'test.system-io',
+      providesServices: [provideService(systemIOService, systemIO.service)],
+    }),
+    defineRegistryItem({
+      id: 'test.cloud-sync',
+      providesServices: [provideService(cloudSyncService, cloudSync)],
+    }),
+    defineRegistryItem({
+      id: 'test.wasm',
+      provides: [provideWasmPromise(wasmPromise)],
+    }),
+    ...extraItems,
+    homeProjectsExtension,
+  ])
+
+  return {
+    registry,
+    systemIO,
+  }
+}
+
+describe('home project library entries', () => {
   let registry: Registry | undefined
 
   beforeEach(() => {
     vi.clearAllMocks()
+    directoryScannerMocks.readProjectsFromProjectDirectory.mockResolvedValue([])
   })
 
   afterEach(() => {
@@ -230,76 +280,49 @@ describe('home project actions', () => {
     vi.restoreAllMocks()
   })
 
-  it('keeps default directory entries while System IO folders are temporarily unset', async () => {
-    const project = {
-      name: 'local-project',
-      title: 'Local Project',
-      path: '/projects/local-project',
-      default_file: '/projects/local-project/main.kcl',
-      children: [],
-      metadata: {
-        accessed: null,
-        created: null,
-        modified: 100,
-        permission: null,
-        size: 1,
-        type: 'directory',
-      },
-      kcl_file_count: 1,
-      directory_count: 0,
-      readWriteAccess: true,
-    } satisfies Project
-    const systemIO = createMutableSystemIOService({
-      folders: [project],
+  it('lists the default directory through the project library reader', async () => {
+    const project = createProject({
+      name: 'library-project',
+      path: '/projects/library-project',
     })
-    const cloudSync = createCloudSyncService()
+    directoryScannerMocks.readProjectsFromProjectDirectory.mockResolvedValue([
+      project,
+    ])
 
-    registry = new Registry()
-    registry.configure([
-      defineRegistryItem({
-        id: 'test.settings',
-        providesServices: [
-          provideService(settingsService, createSettingsService()),
+    ;({ registry } = configureHomeProjectsRegistry({
+      settings: createSettingsService({
+        libraries: [
+          {
+            title: DEFAULT_PROJECT_LIBRARY_TITLE,
+            path: '/projects',
+            type: 'directory',
+          },
         ],
       }),
-      defineRegistryItem({
-        id: 'test.system-io',
-        providesServices: [provideService(systemIOService, systemIO.service)],
-      }),
-      defineRegistryItem({
-        id: 'test.cloud-sync',
-        providesServices: [provideService(cloudSyncService, cloudSync)],
-      }),
-      homeProjectsExtension,
-    ])
+    }))
 
     await waitFor(() =>
       expect(registry?.get(homeProjectEntriesValueSpec)).toEqual([
         expect.objectContaining({
-          name: 'local-project',
+          name: 'library-project',
           libraryIds: [DEFAULT_PROJECT_LIBRARY_ID],
         }),
       ])
     )
 
-    systemIO.setFolders(undefined)
-    await Promise.resolve()
-    await Promise.resolve()
-
-    expect(registry.get(homeProjectEntriesValueSpec)).toEqual([
+    expect(
+      directoryScannerMocks.readProjectsFromProjectDirectory
+    ).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: 'local-project',
-        libraryIds: [DEFAULT_PROJECT_LIBRARY_ID],
-      }),
-    ])
-
-    systemIO.setFolders([])
-    await waitFor(() =>
-      expect(registry?.get(homeProjectEntriesValueSpec)).toEqual([])
+        projectDirectoryPath: '/projects',
+      })
     )
+    expect(
+      registry.get(homeProjectEntriesValueSpec).map((entry) => entry.name)
+    ).not.toContain('system-io-only-project')
   })
 
-  it('does not clear configured library entries for unrelated settings updates', async () => {
+  it('does not clear or rescan library entries for unrelated settings updates', async () => {
     const settings = createMutableSettingsService({
       libraries: [
         {
@@ -309,8 +332,6 @@ describe('home project actions', () => {
         },
       ],
     })
-    const systemIO = createSystemIOService()
-    const cloudSync = createCloudSyncService()
     const readEntries = vi.fn(({ library }: { library: ProjectLibrary }) =>
       Promise.resolve([
         {
@@ -332,32 +353,21 @@ describe('home project actions', () => {
       ] satisfies HomeProjectEntryContribution[])
     )
 
-    registry = new Registry()
-    registry.configure([
-      defineRegistryItem({
-        id: 'test.settings',
-        providesServices: [provideService(settingsService, settings.service)],
-      }),
-      defineRegistryItem({
-        id: 'test.system-io',
-        providesServices: [provideService(systemIOService, systemIO.service)],
-      }),
-      defineRegistryItem({
-        id: 'test.cloud-sync',
-        providesServices: [provideService(cloudSyncService, cloudSync)],
-      }),
-      defineRegistryItem({
-        id: 'test.custom-library-type',
-        provides: [
-          provide(projectLibraryTypesValueSpec, {
-            type: 'custom-cloud',
-            title: 'Custom Cloud',
-            readEntries,
-          }),
-        ],
-      }),
-      homeProjectsExtension,
-    ])
+    ;({ registry } = configureHomeProjectsRegistry({
+      settings: settings.service,
+      extraItems: [
+        defineRegistryItem({
+          id: 'test.custom-library-type',
+          provides: [
+            provide(projectLibraryTypesValueSpec, {
+              type: 'custom-cloud',
+              title: 'Custom Cloud',
+              readEntries,
+            }),
+          ],
+        }),
+      ],
+    }))
 
     await waitFor(() =>
       expect(registry?.get(homeProjectEntriesValueSpec)).toEqual([
@@ -393,9 +403,125 @@ describe('home project actions', () => {
     ])
   })
 
+  it('keeps previous entries visible while a library refresh is loading', async () => {
+    let resolveFirstRead:
+      | ((entries: HomeProjectEntryContribution[]) => void)
+      | undefined
+    let resolveSecondRead:
+      | ((entries: HomeProjectEntryContribution[]) => void)
+      | undefined
+    const libraryEntry = {
+      source: 'local',
+      status: 'local',
+      libraryId: 'custom-projects',
+      name: 'stable-project',
+      localProjectPath: '/custom/stable-project',
+      localProjectName: 'stable-project',
+      defaultFile: '/custom/stable-project/main.kcl',
+      readWriteAccess: true,
+    } satisfies HomeProjectEntryContribution
+    const readEntries = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<HomeProjectEntryContribution[]>((resolve) => {
+            resolveFirstRead = resolve
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<HomeProjectEntryContribution[]>((resolve) => {
+            resolveSecondRead = resolve
+          })
+      )
+
+    ;({ registry } = configureHomeProjectsRegistry({
+      settings: createSettingsService({
+        libraries: [
+          {
+            title: 'Custom Projects',
+            path: '/custom',
+            type: 'custom',
+          },
+        ],
+      }),
+      extraItems: [
+        defineRegistryItem({
+          id: 'test.custom-library-type',
+          provides: [
+            provide(projectLibraryTypesValueSpec, {
+              type: 'custom',
+              title: 'Custom',
+              readEntries,
+            }),
+          ],
+        }),
+      ],
+    }))
+
+    await waitFor(() =>
+      expect(registry?.get(homeProjectEntriesLoadingValueSpec)).toBe(true)
+    )
+    resolveFirstRead?.([libraryEntry])
+    await waitFor(() =>
+      expect(registry?.get(homeProjectEntriesValueSpec)).toEqual([
+        expect.objectContaining({
+          name: 'stable-project',
+        }),
+      ])
+    )
+    await waitFor(() =>
+      expect(registry?.get(homeProjectEntriesLoadingValueSpec)).toBe(false)
+    )
+
+    invalidateConfiguredProjectLibraryEntries()
+    await waitFor(() => expect(readEntries).toHaveBeenCalledTimes(2))
+    await waitFor(() =>
+      expect(registry?.get(homeProjectEntriesLoadingValueSpec)).toBe(true)
+    )
+    expect(registry.get(homeProjectEntriesValueSpec)).toEqual([
+      expect.objectContaining({
+        name: 'stable-project',
+      }),
+    ])
+    expect(readEntries.mock.calls[1][0].previousEntries).toEqual([
+      expect.objectContaining({
+        name: 'stable-project',
+      }),
+    ])
+
+    resolveSecondRead?.([])
+    await waitFor(() =>
+      expect(registry?.get(homeProjectEntriesValueSpec)).toEqual([])
+    )
+    await waitFor(() =>
+      expect(registry?.get(homeProjectEntriesLoadingValueSpec)).toBe(false)
+    )
+  })
+})
+
+describe('home project actions', () => {
+  let registry: Registry | undefined
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    directoryScannerMocks.readProjectsFromProjectDirectory.mockResolvedValue([])
+    cloudSyncPathMocks.getCloudProjectLibraryMaterializationDirectoryPath.mockImplementation(
+      async (library: ProjectLibrary) => library.path
+    )
+    cloudSyncPathMocks.getDefaultCloudProjectDirectoryPath.mockResolvedValue(
+      '/cloud-projects'
+    )
+  })
+
+  afterEach(() => {
+    registry?.[Symbol.dispose]()
+    registry = undefined
+    vi.restoreAllMocks()
+  })
+
   it('opens remote-only cloud projects without forcing a full folder rescan', async () => {
     const wasmInstance = {} as never
-    const wasmPromise = Promise.resolve(wasmInstance)
     const systemIO = createSystemIOService()
     const cloudSync = createCloudSyncService({
       ensureProjectLocallySynced: vi.fn().mockResolvedValue({
@@ -404,9 +530,6 @@ describe('home project actions', () => {
         remoteProjectId: 'remote-123',
       }),
     })
-    cloudSyncPathMocks.getDefaultCloudProjectDirectoryPath.mockResolvedValue(
-      '/cloud-projects'
-    )
     desktopMocks.getProjectInfo.mockResolvedValue({
       default_file: '/cloud-projects/remote-title/main.kcl',
     })
@@ -420,28 +543,11 @@ describe('home project actions', () => {
       readWriteAccess: true,
     } satisfies HomeProjectEntry
 
-    registry = new Registry()
-    registry.configure([
-      defineRegistryItem({
-        id: 'test.settings',
-        providesServices: [
-          provideService(settingsService, createSettingsService()),
-        ],
-      }),
-      defineRegistryItem({
-        id: 'test.system-io',
-        providesServices: [provideService(systemIOService, systemIO.service)],
-      }),
-      defineRegistryItem({
-        id: 'test.cloud-sync',
-        providesServices: [provideService(cloudSyncService, cloudSync)],
-      }),
-      defineRegistryItem({
-        id: 'test.wasm',
-        provides: [provideWasmPromise(wasmPromise)],
-      }),
-      homeProjectsExtension,
-    ])
+    ;({ registry } = configureHomeProjectsRegistry({
+      cloudSync,
+      systemIO,
+      wasmPromise: Promise.resolve(wasmInstance),
+    }))
 
     await expect(
       registry.get(homeProjectActionsService).open(remoteOnlyProject)
@@ -460,8 +566,6 @@ describe('home project actions', () => {
   })
 
   it('opens locally materialized cloud library projects without re-syncing them first', async () => {
-    const wasmInstance = {} as never
-    const wasmPromise = Promise.resolve(wasmInstance)
     const systemIO = createSystemIOService()
     const cloudSync = createCloudSyncService()
     const localCloudProject = {
@@ -478,54 +582,36 @@ describe('home project actions', () => {
       readWriteAccess: true,
     } satisfies HomeProjectEntry
 
-    registry = new Registry()
-    registry.configure([
-      defineRegistryItem({
-        id: 'test.settings',
-        providesServices: [
-          provideService(
-            settingsService,
-            createMutableSettingsService({
-              libraries: [getDefaultCloudProjectLibrarySetting()],
-            }).service
-          ),
-        ],
+    ;({ registry } = configureHomeProjectsRegistry({
+      cloudSync,
+      settings: createSettingsService({
+        libraries: [getDefaultCloudProjectLibrarySetting('/cloud-projects')],
       }),
-      defineRegistryItem({
-        id: 'test.system-io',
-        providesServices: [provideService(systemIOService, systemIO.service)],
-      }),
-      defineRegistryItem({
-        id: 'test.cloud-sync',
-        providesServices: [provideService(cloudSyncService, cloudSync)],
-      }),
-      defineRegistryItem({
-        id: 'test.wasm',
-        provides: [provideWasmPromise(wasmPromise)],
-      }),
-      defineRegistryItem({
-        id: 'test.cloud-library-type',
-        provides: [
-          provide(projectLibraryTypesValueSpec, {
-            type: CLOUD_PROJECT_LIBRARY_TYPE,
-            title: 'Cloud',
-            readEntries: async () => [],
-            operations: {
-              openProject: {
-                run: ({ project }) => {
-                  if (!project.defaultFile) {
-                    return undefined
-                  }
+      extraItems: [
+        defineRegistryItem({
+          id: 'test.cloud-library-type',
+          provides: [
+            provide(projectLibraryTypesValueSpec, {
+              type: CLOUD_PROJECT_LIBRARY_TYPE,
+              title: 'Cloud',
+              readEntries: async () => [],
+              operations: {
+                openProject: {
+                  run: ({ project }) => {
+                    if (!project.defaultFile) {
+                      return undefined
+                    }
 
-                  return { defaultFile: project.defaultFile }
+                    return { defaultFile: project.defaultFile }
+                  },
                 },
               },
-            },
-          }),
-        ],
-      }),
-      homeProjectsExtension,
-    ])
+            }),
+          ],
+        }),
+      ],
+      systemIO,
+    }))
 
     await expect(
       registry.get(homeProjectActionsService).open(localCloudProject)
@@ -534,6 +620,78 @@ describe('home project actions', () => {
     })
     expect(cloudSync.ensureProjectLocallySynced).not.toHaveBeenCalled()
     expect(desktopMocks.getProjectInfo).not.toHaveBeenCalled()
+    expect(systemIO.send).not.toHaveBeenCalled()
+  })
+
+  it('materializes remote cloud library projects into their library directory', async () => {
+    const wasmInstance = {} as never
+    const systemIO = createSystemIOService()
+    const cloudSync = createCloudSyncService({
+      ensureProjectLocallySynced: vi.fn().mockResolvedValue({
+        projectPath: '/cloud-projects/remote-title',
+        projectName: 'remote-title',
+        remoteProjectId: 'remote-123',
+      }),
+    })
+    desktopMocks.getProjectInfo.mockResolvedValue({
+      default_file: '/cloud-projects/remote-title/main.kcl',
+    })
+    const remoteCloudProject = {
+      id: 'remote:remote-123',
+      source: 'remote',
+      status: 'cloud-only',
+      libraryIds: [PERSONAL_CLOUD_PROJECT_LIBRARY_ID],
+      name: 'remote-title',
+      title: 'Remote title',
+      remoteProjectId: 'remote-123',
+      readWriteAccess: true,
+    } satisfies HomeProjectEntry
+
+    ;({ registry } = configureHomeProjectsRegistry({
+      cloudSync,
+      settings: createSettingsService({
+        libraries: [getDefaultCloudProjectLibrarySetting('/cloud-projects')],
+      }),
+      extraItems: [
+        defineRegistryItem({
+          id: 'test.cloud-library-type',
+          provides: [
+            provide(projectLibraryTypesValueSpec, {
+              type: CLOUD_PROJECT_LIBRARY_TYPE,
+              title: 'Cloud',
+              readEntries: async () => [],
+              operations: {
+                openProject: {
+                  run: ({ project }) =>
+                    project.defaultFile
+                      ? { defaultFile: project.defaultFile }
+                      : undefined,
+                },
+              },
+            }),
+          ],
+        }),
+      ],
+      systemIO,
+      wasmPromise: Promise.resolve(wasmInstance),
+    }))
+
+    await expect(
+      registry.get(homeProjectActionsService).open(remoteCloudProject)
+    ).resolves.toEqual({
+      defaultFile: '/cloud-projects/remote-title/main.kcl',
+    })
+    expect(
+      cloudSyncPathMocks.getCloudProjectLibraryMaterializationDirectoryPath
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+      })
+    )
+    expect(cloudSync.ensureProjectLocallySynced).toHaveBeenCalledWith(
+      'remote-123',
+      '/cloud-projects'
+    )
     expect(systemIO.send).not.toHaveBeenCalled()
   })
 })

--- a/src/registry/extensions/homeProjects/index.ts
+++ b/src/registry/extensions/homeProjects/index.ts
@@ -22,7 +22,6 @@ import {
 import type { Project } from '@src/lib/project'
 import { duplicateProjectInDirectory } from '@src/lib/projectDuplication'
 import {
-  DEFAULT_PROJECT_LIBRARY_ID,
   DEFAULT_PROJECT_LIBRARY_TITLE,
   DIRECTORY_PROJECT_LIBRARY_TYPE,
   getDefaultProjectLibrarySettings,
@@ -40,11 +39,7 @@ import {
 } from '@src/lib/projectLibraries/operations'
 import { DirectoryProjectLibrarySettingsDetails } from '@src/lib/projectLibraries/settings/ProjectLibrariesSettingInput'
 import { reportRejection } from '@src/lib/trap'
-import {
-  NO_PROJECT_DIRECTORY,
-  SystemIOMachineEvents,
-  SystemIOMachineStates,
-} from '@src/machines/systemIO/utils'
+import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
 import { cloudSyncService } from '@src/registry/contracts/cloudSync'
 import { commandSystemService } from '@src/registry/contracts/commands'
 import {
@@ -53,6 +48,7 @@ import {
   type HomeProjectEntryContribution,
   type HomeProjectMoveToLibraryTarget,
   homeProjectActionsService,
+  homeProjectEntriesLoadingValueSpec,
   homeProjectEntriesValueSpec,
 } from '@src/registry/contracts/homeProjects'
 import { projectExplorerProjectMenuItemsValueSpec } from '@src/registry/contracts/projectExplorer'
@@ -118,6 +114,28 @@ function getProjectMoveSource({ project }: { project: HomeProjectEntry }) {
       project.localProjectName ?? fsZds.basename(project.localProjectPath),
     defaultFile: project.defaultFile,
   }
+}
+
+function areProjectLibrariesEqual(
+  left: readonly ProjectLibrary[],
+  right: readonly ProjectLibrary[]
+) {
+  return (
+    left.length === right.length &&
+    left.every((library, index) => {
+      const otherLibrary = right[index]
+      return (
+        otherLibrary !== undefined &&
+        library.id === otherLibrary.id &&
+        library.title === otherLibrary.title &&
+        library.path === otherLibrary.path &&
+        library.type === otherLibrary.type &&
+        (library.source ?? '') === (otherLibrary.source ?? '') &&
+        library.icon === otherLibrary.icon &&
+        library.order === otherLibrary.order
+      )
+    })
+  )
 }
 
 const homeProjectActions = defineRegistryItemFactory((ctx) => {
@@ -313,6 +331,7 @@ const homeProjectActions = defineRegistryItemFactory((ctx) => {
         syncedProject.projectPath,
         await wasmInstancePromise
       )
+      invalidateConfiguredProjectLibraryEntries()
       return { defaultFile: projectInfo.default_file }
     },
     duplicate: async (project) => {
@@ -429,97 +448,6 @@ const homeProjectActions = defineRegistryItemFactory((ctx) => {
   }
 }, 'home-projects.actions')
 
-const systemIOLocalHomeProjectEntries = defineRegistryItemFactory((ctx) => {
-  const entries = signal<HomeProjectEntryContribution[]>([])
-  const systemIO = ctx.services.signal(systemIOService)
-  let systemIOSubscription: { unsubscribe: () => void } | undefined
-  let disposeSystemIOEffect: (() => void) | undefined
-  let disposed = false
-
-  queueMicrotask(() => {
-    if (disposed) {
-      return
-    }
-
-    disposeSystemIOEffect = effect(() => {
-      const service = systemIO.value
-      systemIOSubscription?.unsubscribe()
-      systemIOSubscription = undefined
-      entries.value = []
-
-      if (!service) {
-        return
-      }
-
-      const updateEntries = () => {
-        const snapshot = service.actor.getSnapshot()
-        const context = snapshot.context
-        const projects = context.folders
-        if (projects !== undefined) {
-          entries.value = localHomeProjectEntriesFromProjects(
-            projects,
-            DEFAULT_PROJECT_LIBRARY_ID
-          )
-        }
-
-        if (
-          projects &&
-          snapshot.matches(SystemIOMachineStates.idle) &&
-          context.requestedProjectName.name === NO_PROJECT_DIRECTORY
-        ) {
-          scheduleProjectDirectoryNameSyncFromTitles({
-            projects,
-            onProjectDirectoriesRenamed: () => {
-              service.actor.send({
-                type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
-              })
-            },
-          })
-        }
-      }
-
-      updateEntries()
-      systemIOSubscription = service.actor.subscribe(updateEntries)
-    })
-  })
-
-  return {
-    item: defineRuntimeRegistryItem({
-      id: 'home-projects.system-io-local-projects',
-      provides: [
-        provide(homeProjectEntriesValueSpec, entries, {
-          key: 'home-projects.system-io-local-projects',
-        }),
-      ],
-      dispose: () => {
-        disposed = true
-        disposeSystemIOEffect?.()
-        systemIOSubscription?.unsubscribe()
-      },
-    }),
-  }
-}, 'home-projects.system-io-local-projects')
-
-function areProjectLibrariesEqual(
-  left: readonly ProjectLibrary[],
-  right: readonly ProjectLibrary[]
-) {
-  return (
-    left.length === right.length &&
-    left.every((library, index) => {
-      const otherLibrary = right[index]
-      return (
-        otherLibrary !== undefined &&
-        library.id === otherLibrary.id &&
-        library.title === otherLibrary.title &&
-        library.path === otherLibrary.path &&
-        library.type === otherLibrary.type &&
-        library.order === otherLibrary.order
-      )
-    })
-  )
-}
-
 const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
   const systemIO = ctx.services.signal(systemIOService)
   const cloudSync = ctx.services.signal(cloudSyncService)
@@ -554,7 +482,12 @@ const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
           },
           settingsDetails: DirectoryProjectLibrarySettingsDetails,
           hideInSettingsOnPlatform: 'web',
-          readEntries: async ({ library, signal }) => {
+          readEntries: async ({
+            library,
+            onProgress,
+            previousEntries,
+            signal,
+          }) => {
             const wasmInstancePromise = getWasmPromise()
             if (wasmInstancePromise instanceof Error) {
               return Promise.reject(wasmInstancePromise)
@@ -563,7 +496,13 @@ const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
             const projects = await readProjectsFromProjectDirectory({
               projectDirectoryPath: library.path,
               wasmInstancePromise,
+              previousProjectCount: previousEntries?.length,
               signal,
+              onProgress: (projects) => {
+                onProgress?.(
+                  localHomeProjectEntriesFromProjects(projects, library.id)
+                )
+              },
             })
             if (!signal.aborted) {
               scheduleProjectDirectoryNameSyncFromTitles({
@@ -729,8 +668,10 @@ const configuredProjectLibraryEntries = defineRegistryItemFactory((ctx) => {
   const settings = ctx.services.signal(settingsService)
   const libraryTypes = ctx.valueSpecs.signal(projectLibraryTypesValueSpec)
   const entries = signal<HomeProjectEntryContribution[]>([])
+  const loading = signal(false)
   const entriesByLibraryId = new Map<string, HomeProjectEntryContribution[]>()
-  // Diagnostic dedupe: a configured library whose type has no registered
+  const loadingLibraryIds = new Set<string>()
+  // Diagnostic dedupe: a project library whose type has no registered
   // handler cannot be listed and would silently vanish from Home. This should
   // not happen (the cloud and directory types are always-on), so warn once per
   // library rather than swallowing it.
@@ -739,12 +680,16 @@ const configuredProjectLibraryEntries = defineRegistryItemFactory((ctx) => {
   let disposeConfiguredProjectLibraryEntriesEffect: (() => void) | undefined
   let disposed = false
   let loadId = 0
-  let lastScannedConfiguredLibraries: ProjectLibrary[] | undefined
+  let lastScannedLibraries: ProjectLibrary[] | undefined
   let lastScannedLibraryTypes: typeof libraryTypes.value | undefined
   let lastScannedInvalidation = -1
 
   const updateEntries = () => {
     entries.value = Array.from(entriesByLibraryId.values()).flat()
+  }
+
+  const updateLoading = () => {
+    loading.value = loadingLibraryIds.size > 0
   }
 
   // Defer because `effect` runs immediately, and service reads are blocked
@@ -762,37 +707,44 @@ const configuredProjectLibraryEntries = defineRegistryItemFactory((ctx) => {
       // mutations can invalidate and rescan configured library entries.
       const invalidation = readConfiguredProjectLibraryEntriesInvalidation()
 
-      const configuredLibraries =
+      const projectLibraries =
         currentSettings !== undefined
-          ? projectLibrariesFromSettings(
-              currentSettings.app.libraries.current
-            ).filter((library) => library.id !== DEFAULT_PROJECT_LIBRARY_ID)
+          ? projectLibrariesFromSettings(currentSettings.app.libraries.current)
           : []
 
       if (
+        lastScannedLibraries &&
+        areProjectLibrariesEqual(lastScannedLibraries, projectLibraries) &&
         lastScannedLibraryTypes === typeById &&
-        lastScannedInvalidation === invalidation &&
-        lastScannedConfiguredLibraries &&
-        areProjectLibrariesEqual(
-          lastScannedConfiguredLibraries,
-          configuredLibraries
-        )
+        lastScannedInvalidation === invalidation
       ) {
         return
       }
 
+      lastScannedLibraries = projectLibraries.map((library) => ({
+        ...library,
+      }))
       lastScannedLibraryTypes = typeById
       lastScannedInvalidation = invalidation
-      lastScannedConfiguredLibraries = configuredLibraries
       const nextLoadId = ++loadId
 
       abortController?.abort()
       const loadController = new AbortController()
       abortController = loadController
-      entriesByLibraryId.clear()
-      entries.value = []
 
-      for (const library of configuredLibraries) {
+      loadingLibraryIds.clear()
+      const currentLibraryIds = new Set(
+        projectLibraries.map((library) => library.id)
+      )
+      for (const libraryId of entriesByLibraryId.keys()) {
+        if (!currentLibraryIds.has(libraryId)) {
+          entriesByLibraryId.delete(libraryId)
+        }
+      }
+      updateEntries()
+      updateLoading()
+
+      for (const library of projectLibraries) {
         const readEntries = typeById.get(library.type)?.readEntries
         if (!readEntries) {
           if (!warnedMissingTypeLibraryIds.has(library.id)) {
@@ -804,8 +756,24 @@ const configuredProjectLibraryEntries = defineRegistryItemFactory((ctx) => {
           continue
         }
 
+        loadingLibraryIds.add(library.id)
+        updateLoading()
+
         readEntries({
           library,
+          onProgress: (libraryEntries) => {
+            if (
+              disposed ||
+              loadController.signal.aborted ||
+              nextLoadId !== loadId
+            ) {
+              return
+            }
+
+            entriesByLibraryId.set(library.id, libraryEntries)
+            updateEntries()
+          },
+          previousEntries: entriesByLibraryId.get(library.id),
           signal: loadController.signal,
         })
           .then((libraryEntries) => {
@@ -833,6 +801,18 @@ const configuredProjectLibraryEntries = defineRegistryItemFactory((ctx) => {
             updateEntries()
             reportRejection(error)
           })
+          .finally(() => {
+            if (
+              disposed ||
+              loadController.signal.aborted ||
+              nextLoadId !== loadId
+            ) {
+              return
+            }
+
+            loadingLibraryIds.delete(library.id)
+            updateLoading()
+          })
       }
     })
   })
@@ -844,10 +824,15 @@ const configuredProjectLibraryEntries = defineRegistryItemFactory((ctx) => {
         provide(homeProjectEntriesValueSpec, entries, {
           key: 'home-projects.configured-project-library-entries',
         }),
+        provide(homeProjectEntriesLoadingValueSpec, loading, {
+          key: 'home-projects.configured-project-library-entries.loading',
+        }),
       ],
       dispose: () => {
         disposed = true
         abortController?.abort()
+        loadingLibraryIds.clear()
+        updateLoading()
         disposeConfiguredProjectLibraryEntriesEffect?.()
       },
     }),
@@ -919,7 +904,6 @@ const homeProjectsExtension = defineRegistryItem({
     directoryProjectLibraryType,
     homeProjectActions,
     moveProjectToLibraryProjectMenuItem,
-    systemIOLocalHomeProjectEntries,
   ],
 })
 

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -50,17 +50,13 @@ import {
 import { reportRejection } from '@src/lib/trap'
 import { platform } from '@src/lib/utils'
 import { withSiteBaseURL } from '@src/lib/withBaseURL'
-import {
-  useCanReadWriteProjectDirectory,
-  useFolders,
-  useState as useSystemIOState,
-} from '@src/machines/systemIO/hooks'
-import { SystemIOMachineStates } from '@src/machines/systemIO/utils'
+import { useCanReadWriteProjectDirectory } from '@src/machines/systemIO/hooks'
 import type { WebContentSendPayload } from '@src/menu/channels'
 import {
   type HomeProjectActionsService,
   type HomeProjectEntry,
   homeProjectActionsService,
+  homeProjectEntriesLoadingValueSpec,
   homeProjectEntriesValueSpec,
 } from '@src/registry/contracts/homeProjects'
 import {
@@ -145,9 +141,11 @@ const Home = () => {
   const hasUnlimitedCredits = billingContext.balance === Infinity
   const openBillingLinkExternally = openExternalBrowserIfDesktop()
 
-  const projects = useFolders()
-  const projectStatuses = useProjectStatuses(projects, apiToken)
   const homeProjectEntries = registry.signal(homeProjectEntriesValueSpec).value
+  const homeProjectEntriesLoading = registry.signal(
+    homeProjectEntriesLoadingValueSpec
+  ).value
+  const projectStatuses = useProjectStatuses(homeProjectEntries, apiToken)
   const settingsValues = settings.useSettings()
   const projectLibraryTypes = registry.signal(
     projectLibraryTypesValueSpec
@@ -551,7 +549,7 @@ const Home = () => {
           <ProjectGrid
             searchResults={searchResults ?? []}
             projects={scopedHomeProjectEntries}
-            localProjectsLoaded={projects !== undefined}
+            projectEntriesLoading={homeProjectEntriesLoading}
             query={query}
             sort={sort}
             projectStatuses={projectStatuses}
@@ -567,7 +565,7 @@ const Home = () => {
             libraries={projectLibraries}
             searchResults={searchResults ?? []}
             projects={homeProjectEntries}
-            localProjectsLoaded={projects !== undefined}
+            projectEntriesLoading={homeProjectEntriesLoading}
             query={query}
             sort={sort}
             projectStatuses={projectStatuses}
@@ -731,7 +729,7 @@ interface ProjectLibraryOverviewProps extends HTMLProps<HTMLDivElement> {
   libraries: ProjectLibrary[]
   searchResults: HomeProjectEntry[]
   projects: HomeProjectEntry[]
-  localProjectsLoaded: boolean
+  projectEntriesLoading: boolean
   query: string
   sort: string
   projectStatuses: Map<string, ProjectStatus>
@@ -760,20 +758,11 @@ function projectCountLabel(count: number) {
   return `${count} project${count === 1 ? '' : 's'}`
 }
 
-function shouldShowLoadingMoreProjects(
-  state: ReturnType<typeof useSystemIOState>
-) {
-  return (
-    state.matches(SystemIOMachineStates.readingFolders) &&
-    !state.context.hasListedProjects
-  )
-}
-
 function ProjectLibraryOverview({
   libraries,
   searchResults,
   projects,
-  localProjectsLoaded,
+  projectEntriesLoading,
   query,
   sort,
   projectStatuses,
@@ -782,7 +771,6 @@ function ProjectLibraryOverview({
   onMoveToLibrary,
   ...rest
 }: ProjectLibraryOverviewProps) {
-  const state = useSystemIOState()
   const libraryRows = libraries
     .map((library) => ({
       library,
@@ -792,11 +780,12 @@ function ProjectLibraryOverview({
       ).toSorted(getSortFunction(sort)),
     }))
     .filter(({ projects }) => query.length === 0 || projects.length > 0)
-  const loadingMore = shouldShowLoadingMoreProjects(state) ? (
-    <div className="py-4">
-      <Loading isDummy={true}>Loading more projects...</Loading>
-    </div>
-  ) : null
+  const loadingMore =
+    projectEntriesLoading && projects.length > 0 ? (
+      <div className="py-4">
+        <Loading isDummy={true}>Loading more projects...</Loading>
+      </div>
+    ) : null
 
   if (libraries.length === 0) {
     return <ProjectLibrariesEmptyState {...rest} />
@@ -804,7 +793,7 @@ function ProjectLibraryOverview({
 
   return (
     <section data-testid="home-section" {...rest}>
-      {!localProjectsLoaded && projects.length === 0 ? (
+      {projectEntriesLoading && projects.length === 0 ? (
         <Loading isDummy={true}>Loading your Projects...</Loading>
       ) : (
         <>
@@ -952,7 +941,7 @@ function ProjectLibraryPreviewRow({
 interface ProjectGridProps extends HTMLProps<HTMLDivElement> {
   searchResults: HomeProjectEntry[]
   projects: HomeProjectEntry[]
-  localProjectsLoaded: boolean
+  projectEntriesLoading: boolean
   query: string
   sort: string
   projectStatuses: Map<string, ProjectStatus>
@@ -966,7 +955,7 @@ interface ProjectGridProps extends HTMLProps<HTMLDivElement> {
 function ProjectGrid({
   searchResults,
   projects,
-  localProjectsLoaded,
+  projectEntriesLoading,
   query,
   sort,
   projectStatuses,
@@ -977,17 +966,17 @@ function ProjectGrid({
   projectLibraryEmptyTestId,
   ...rest
 }: ProjectGridProps) {
-  const state = useSystemIOState()
   const sortedSearchResults = searchResults.toSorted(getSortFunction(sort))
-  const loadingMore = shouldShowLoadingMoreProjects(state) ? (
-    <div className="py-4">
-      <Loading isDummy={true}>Loading more projects...</Loading>
-    </div>
-  ) : null
+  const loadingMore =
+    projectEntriesLoading && projects.length > 0 ? (
+      <div className="py-4">
+        <Loading isDummy={true}>Loading more projects...</Loading>
+      </div>
+    ) : null
 
   return (
     <section data-testid="home-section" {...rest}>
-      {!localProjectsLoaded && projects.length === 0 ? (
+      {projectEntriesLoading && projects.length === 0 ? (
         <Loading isDummy={true}>Loading your Projects...</Loading>
       ) : (
         <>


### PR DESCRIPTION
## Summary

- Route Home project entries through the project library reader for every configured library, including the default directory.
- Remove the separate System IO `context.folders` Home entry contribution while keeping System IO as the executor for existing local mutations.
- Preserve previous Home entries while library refreshes are in flight and expose a registry loading signal for Home loading UI.
- Keep locally materialized cloud library opens on the local default-file path without forcing cloud sync or a System IO folder rescan.

## Why

The previous split source of truth let directory entries temporarily disappear or reorder while opening cloud projects. Treating the default directory and cloud libraries through the same project-library read path makes refreshes explicit and keeps stale entries visible during async scans.

## Validation

- `npx vitest run --mode=development --project=unit src/registry/extensions/homeProjects/index.test.ts` with `rust/kcl-wasm-lib/pkg` temporarily moved aside
- `npm run lint -- src/registry/extensions/homeProjects/index.test.ts src/registry/extensions/homeProjects/index.ts src/routes/Home.tsx src/hooks/useProjectStatus.ts src/lib/cloudSync/registry/plugin.tsx src/lib/projectLibraries/directoryScanner.ts src/registry/contracts/homeProjects.ts src/registry/contracts/projectLibraries.ts`
- `npm run tsc -- --noEmit`
- `NODE_OPTIONS="--localstorage-file=/tmp/zds-vitest-localstorage" npx vitest run --mode=development --project=integration src/lib/cloudSync/registry/plugin.spec.tsx`
- `npx vitest run --mode=development --project=unit src/lib/projectLibraries/directoryScanner.test.ts`

Rebased onto `main` at `c388b0dbc`.