### PR TITLE
Make it more obvious when a non-standard environment is used

### DIFF
--- a/src/components/environment/Environment.tsx
+++ b/src/components/environment/Environment.tsx
@@ -1,22 +1,24 @@
 import { ActionButton } from '@src/components/ActionButton'
+import {
+  getEnvironmentLabel,
+  isNonStandardEnvironment,
+} from '@src/components/environment/utils'
 import env from '@src/env'
 import { useApp } from '@src/lib/boot'
+import { IS_STAGING_OR_DEBUG } from '@src/routes/utils'
 
 export function EnvironmentChip() {
-  let label = env().VITE_ZOO_BASE_DOMAIN
-  const urls = [
+  const label = getEnvironmentLabel(env().VITE_ZOO_BASE_DOMAIN, [
     new URL(env().VITE_KITTYCAD_WEBSOCKET_URL ?? ''),
     new URL(env().VITE_MLEPHANT_WEBSOCKET_URL ?? ''),
-  ]
-  for (const url of urls) {
-    if (['localhost', '127.0.0.1', '0.0.0.0'].includes(url.hostname)) {
-      label = `${label} + local`
-    } else if (url.search) {
-      label = `${label} + ${url.search.substring(1)}`
-    }
-  }
+  ])
+  const textClassName = isNonStandardEnvironment(label, !IS_STAGING_OR_DEBUG)
+    ? 'text-destroy-80 dark:text-destroy-20 hover:text-destroy-90 dark:hover:text-destroy-10 focus:text-destroy-90 dark:focus:text-destroy-10'
+    : 'text-chalkboard-80 dark:text-chalkboard-30 hover:text-chalkboard-100 dark:hover:text-chalkboard-10 focus:text-chalkboard-100 dark:focus:text-chalkboard-10'
   return (
-    <div className="flex items-center px-2 py-1 text-xs text-chalkboard-80 dark:text-chalkboard-30 rounded-none border-none hover:bg-chalkboard-30 dark:hover:bg-chalkboard-80 focus:bg-chalkboard-30 dark:focus:bg-chalkboard-80 hover:text-chalkboard-100 dark:hover:text-chalkboard-10 focus:text-chalkboard-100 dark:focus:text-chalkboard-10  focus:outline-none focus-visible:ring-2 focus:ring-primary focus:ring-opacity-50">
+    <div
+      className={`flex items-center px-2 py-1 text-xs rounded-none border-none hover:bg-chalkboard-30 dark:hover:bg-chalkboard-80 focus:bg-chalkboard-30 dark:focus:bg-chalkboard-80 focus:outline-none focus-visible:ring-2 focus:ring-primary focus:ring-opacity-50 ${textClassName}`}
+    >
       <span className="">{label}</span>
     </div>
   )

--- a/src/components/environment/utils.test.ts
+++ b/src/components/environment/utils.test.ts
@@ -1,0 +1,55 @@
+import {
+  getEnvironmentLabel,
+  isNonStandardEnvironment,
+} from '@src/components/environment/utils'
+import { describe, expect, it } from 'vitest'
+
+describe('getEnvironmentLabel', () => {
+  it('returns the domain when urls have no overrides', () => {
+    expect(
+      getEnvironmentLabel('dev.zoo.dev', [
+        new URL('wss://api.dev.zoo.dev/ws/modeling/commands'),
+        new URL('wss://api.dev.zoo.dev/ws/ml/copilot'),
+      ])
+    ).toBe('dev.zoo.dev')
+  })
+
+  it('appends local for localhost hosts', () => {
+    expect(
+      getEnvironmentLabel('dev.zoo.dev', [
+        new URL('ws://localhost:8080/ws/modeling/commands'),
+      ])
+    ).toBe('dev.zoo.dev + local')
+  })
+
+  it('appends search params for non-local overrides', () => {
+    expect(
+      getEnvironmentLabel('dev.zoo.dev', [
+        new URL('wss://api.dev.zoo.dev/ws/modeling/commands?pr=1234'),
+      ])
+    ).toBe('dev.zoo.dev + pr=1234')
+  })
+})
+
+describe('isNonStandardEnvironment', () => {
+  it('is non-standard when non-production points at zoo.dev', () => {
+    expect(isNonStandardEnvironment('zoo.dev', false)).toBe(true)
+  })
+
+  it('is standard when non-production points at dev.zoo.dev', () => {
+    expect(isNonStandardEnvironment('dev.zoo.dev', false)).toBe(false)
+  })
+
+  it('is non-standard when production points at dev.zoo.dev', () => {
+    expect(isNonStandardEnvironment('dev.zoo.dev', true)).toBe(true)
+  })
+
+  it('is standard when production points at zoo.dev', () => {
+    expect(isNonStandardEnvironment('zoo.dev', true)).toBe(false)
+  })
+
+  it('is always non-standard with preview parameters', () => {
+    expect(isNonStandardEnvironment('dev.zoo.dev + pr=1234', false)).toBe(true)
+    expect(isNonStandardEnvironment('zoo.dev + local', true)).toBe(true)
+  })
+})

--- a/src/components/environment/utils.ts
+++ b/src/components/environment/utils.ts
@@ -1,0 +1,33 @@
+export function getEnvironmentLabel(
+  domain: string | undefined,
+  urls: URL[]
+): string | undefined {
+  let label = domain
+  for (const url of urls) {
+    if (['localhost', '127.0.0.1', '0.0.0.0'].includes(url.hostname)) {
+      label = `${label} + local`
+    } else if (url.search) {
+      label = `${label} + ${url.search.substring(1)}`
+    }
+  }
+  return label
+}
+
+export function isNonStandardEnvironment(
+  label: string | undefined,
+  production: boolean
+): boolean {
+  if (!label) {
+    return false
+  }
+  if (label.includes('+')) {
+    return true
+  }
+  if (!production && label === 'zoo.dev') {
+    return true
+  }
+  if (production && label === 'dev.zoo.dev') {
+    return true
+  }
+  return false
+}

--- a/src/components/environment/utils.ts
+++ b/src/components/environment/utils.ts
@@ -1,10 +1,14 @@
+import { ZOO_DOMAIN_STAGING, ZOO_DOMAIN_PRODUCTION } from '@src/lib/constants'
+
+const LOCAL_HOSTNAMES = ['localhost', '127.0.0.1', '0.0.0.0']
+
 export function getEnvironmentLabel(
   domain: string | undefined,
   urls: URL[]
 ): string | undefined {
   let label = domain
   for (const url of urls) {
-    if (['localhost', '127.0.0.1', '0.0.0.0'].includes(url.hostname)) {
+    if (LOCAL_HOSTNAMES.includes(url.hostname)) {
       label = `${label} + local`
     } else if (url.search) {
       label = `${label} + ${url.search.substring(1)}`
@@ -14,19 +18,19 @@ export function getEnvironmentLabel(
 }
 
 export function isNonStandardEnvironment(
-  label: string | undefined,
-  production: boolean
+  environmentLabel: string | undefined,
+  productionApp: boolean
 ): boolean {
-  if (!label) {
+  if (!environmentLabel) {
     return false
   }
-  if (label.includes('+')) {
+  if (environmentLabel.includes('+')) {
     return true
   }
-  if (!production && label === 'zoo.dev') {
+  if (productionApp && environmentLabel === ZOO_DOMAIN_STAGING) {
     return true
   }
-  if (production && label === 'dev.zoo.dev') {
+  if (!productionApp && environmentLabel === ZOO_DOMAIN_PRODUCTION) {
     return true
   }
   return false

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -173,6 +173,11 @@ export const TELEMETRY_FILE_NAME = 'boot.txt'
 export const TELEMETRY_RAW_FILE_NAME = 'raw-metrics.txt'
 export const ENVIRONMENT_FILE_NAME = 'environment.txt'
 
+/** Predefined Zoo environment base domains */
+export const ZOO_DOMAIN_STAGING = 'dev.zoo.dev'
+export const ZOO_DOMAIN_PRODUCTION = 'zoo.dev'
+export const ZOO_DOMAIN_REGULATED = 'zoogov.dev'
+
 /** Custom error message to match when rejectAllModelCommands is called
  * allows us to match if the execution of executeAst was interrupted
  * This needs to be of type WebsocketResponse, so that we can parse it back out

--- a/src/machines/authMachine.ts
+++ b/src/machines/authMachine.ts
@@ -13,6 +13,8 @@ import {
   OAUTH2_DEVICE_CLIENT_ID,
   TOKEN_PERSIST_KEY,
   VERCEL_PLAYWRIGHT_TOKEN_QUERY_PARAM,
+  ZOO_DOMAIN_REGULATED,
+  ZOO_DOMAIN_PRODUCTION,
 } from '@src/lib/constants'
 import {
   ClientErrorCode,
@@ -336,7 +338,10 @@ export function getCookie(): string | null {
   }
 
   const baseDomain = env().VITE_ZOO_BASE_DOMAIN
-  if (baseDomain === 'zoo.dev' || baseDomain === 'zoogov.dev') {
+  if (
+    baseDomain === ZOO_DOMAIN_PRODUCTION ||
+    baseDomain === ZOO_DOMAIN_REGULATED
+  ) {
     return getCookieByName(LEGACY_COOKIE_NAME)
   } else {
     return getCookieByName(COOKIE_NAME_PREFIX + baseDomain)

--- a/src/routes/AdvancedSignInOptions.tsx
+++ b/src/routes/AdvancedSignInOptions.tsx
@@ -2,6 +2,11 @@ import { Combobox, Popover, RadioGroup, Transition } from '@headlessui/react'
 import { ActionButton } from '@src/components/ActionButton'
 import { CustomIcon } from '@src/components/CustomIcon'
 import { noAutofillInputProps } from '@src/lib/autofill'
+import {
+  ZOO_DOMAIN_STAGING,
+  ZOO_DOMAIN_REGULATED,
+  ZOO_DOMAIN_PRODUCTION,
+} from '@src/lib/constants'
 import { isDesktop } from '@src/lib/isDesktop'
 import { Fragment, useState } from 'react'
 
@@ -87,13 +92,13 @@ export const AdvancedSignInOptions = ({
 }) => {
   const domains: Domain[] = [
     {
-      name: 'zoo.dev',
+      name: ZOO_DOMAIN_PRODUCTION,
     },
     {
-      name: 'zoogov.dev',
+      name: ZOO_DOMAIN_REGULATED,
     },
     {
-      name: 'dev.zoo.dev',
+      name: ZOO_DOMAIN_STAGING,
     },
   ]
   const [showCustomInput, setShowCustomInput] = useState(false)


### PR DESCRIPTION
Internal users can connect ZDS to multiple environment for various integration testing scenarios. While it's fully possible to connect staging builds to production infrastructure and production builds to staging infrastructure, this is a non-standard setup and deviation should be obvious in screenshots and videos.