### PR TITLE
Face api PR3 plane selection fixes

### DIFF
--- a/src/lib/selections.spec.ts
+++ b/src/lib/selections.spec.ts
@@ -1769,6 +1769,38 @@ describe('pattern copy selection highlighting', () => {
   })
 })
 
+describe('default plane selection synchronization', () => {
+  test('selects the plane in the engine and clears the code selection', () => {
+    const code = 'body001 = extrude(region001, length = 10)'
+    const result = handleSelectionBatch({
+      selections: {
+        graphSelections: [],
+        otherSelections: [{ name: 'XY', id: 'xy-plane-id' }],
+      },
+      artifactGraph: new Map(),
+      code,
+      ast: {} as any,
+      systemDeps: {
+        engineCommandManager: {
+          connection: { pingIntervalId: 1 },
+        } as any,
+        sceneEntitiesManager: { activeSegments: {} } as any,
+        wasmInstance: {} as any,
+      },
+    })
+
+    expect(
+      result.engineEvents.map((event) =>
+        event.type === 'modeling_cmd_req' ? event.cmd : undefined
+      )
+    ).toEqual([
+      { type: 'select_clear' },
+      { type: 'select_add', entities: ['xy-plane-id'] },
+    ])
+    expect(result.codeMirrorSelection.main.head).toBe(code.length)
+  })
+})
+
 describe('mixed entity-reference selection highlighting', () => {
   test('keeps engine primitive selections when graph selections use entity references', () => {
     const graphFaceId = 'graph-face-id'

--- a/src/lib/selections.ts
+++ b/src/lib/selections.ts
@@ -1942,6 +1942,12 @@ export function handleSelectionBatch({
               range: defaultSourceRange(),
             }
           }
+          if (isDefaultPlaneSelection(selection)) {
+            return {
+              id: selection.id,
+              range: defaultSourceRange(),
+            }
+          }
           return undefined
         })
         .filter(isNonNullable),
@@ -1975,6 +1981,14 @@ export function handleSelectionBatch({
       }
 
       if (isEngineRegionSelection(other)) {
+        selectionToEngine.push({
+          id: other.id,
+          range: defaultSourceRange(),
+        })
+        continue
+      }
+
+      if (isDefaultPlaneSelection(other)) {
         selectionToEngine.push({
           id: other.id,
           range: defaultSourceRange(),

--- a/src/machines/modelingMachine.spec.ts
+++ b/src/machines/modelingMachine.spec.ts
@@ -1556,6 +1556,43 @@ p3 = [342.51, 216.38],
           ]
         )
 
+        sendSceneCommand.mockClear()
+
+        actor.send({
+          type: 'Set selection',
+          data: {
+            selectionType: 'singleCodeCursor',
+            selection: {
+              entityRef: { type: 'solid3d', solid3d_id: 'body-id' },
+              codeRef: {
+                range: [0, code.length, 0],
+                pathToNode: [],
+              },
+            },
+          },
+        })
+
+        expect(actor.getSnapshot().context.selectionRanges).toEqual({
+          graphSelections: [
+            {
+              entityRef: { type: 'solid3d', solid3d_id: 'body-id' },
+              codeRef: {
+                range: [0, code.length, 0],
+                pathToNode: [],
+              },
+            },
+          ],
+          otherSelections: [],
+        })
+        expect(sendSceneCommand.mock.calls.map(([event]) => event.cmd)).toEqual(
+          [
+            {
+              type: 'select_entity',
+              entities: [{ type: 'solid3d', solid3d_id: 'body-id' }],
+            },
+          ]
+        )
+
         actor.stop()
       })
     })

--- a/src/machines/modelingMachine.spec.ts
+++ b/src/machines/modelingMachine.spec.ts
@@ -53,6 +53,7 @@ let machineManagerInThisFile: MachineManager = null!
 
 const TESTS_WITHOUT_ENGINE_WORLD = [
   'routes a cursor inside a sketch block segment to sketch solve edit',
+  'synchronizes default plane selection with the engine and editor',
   'shows default planes again when canceling sketch plane selection on a blank scene',
   'hides default planes when canceling sketch plane selection with geometry present',
 ]
@@ -1484,6 +1485,79 @@ p3 = [342.51, 216.38],
           }, 10_000)
         }
       )
+    })
+
+    describe('selection synchronization', () => {
+      it('synchronizes default plane selection with the engine and editor', () => {
+        const code = 'body001 = extrude(region001, length = 10)'
+        const dispatch = vi.fn()
+        const sendSceneCommand = vi.fn().mockResolvedValue(undefined)
+        const context = {
+          ...modelingMachineInitialInternalContext,
+          selectionRanges: {
+            graphSelections: [
+              {
+                entityRef: { type: 'solid3d', solid3d_id: 'body-id' },
+                codeRef: { range: [0, code.length, 0], pathToNode: [] },
+              },
+            ],
+            otherSelections: [],
+          },
+          kclManager: {
+            artifactGraph: new Map(),
+            ast: { body: [] },
+            code,
+            editorView: { dispatch },
+            hidePlanes: vi.fn(),
+            isShiftDown: false,
+            sceneEntitiesManager: { activeSegments: {} },
+            sceneInfra: {
+              resetMouseListeners: vi.fn(),
+              setCallbacks: vi.fn(),
+              camControls: {
+                enablePan: true,
+                enableRotate: true,
+                syncDirection: 'engineToClient',
+              },
+            },
+          },
+          rustContext: {},
+          engineCommandManager: {
+            connection: { pingIntervalId: 1 },
+            sendSceneCommand,
+          },
+          wasmInstance: {},
+          commandBarActor: {},
+          machineManager: {},
+        } as any
+        const actor = createActor(modelingMachine, { input: context }).start()
+
+        actor.send({
+          type: 'Set selection',
+          data: {
+            selectionType: 'defaultPlaneSelection',
+            selection: { name: 'XY', id: 'xy-plane-id' },
+          },
+        })
+
+        expect(actor.getSnapshot().context.selectionRanges).toEqual({
+          graphSelections: [],
+          otherSelections: [{ name: 'XY', id: 'xy-plane-id' }],
+        })
+        expect(dispatch).toHaveBeenCalledWith({
+          selection: expect.objectContaining({
+            main: expect.objectContaining({ head: code.length }),
+          }),
+        })
+        expect(sendSceneCommand.mock.calls.map(([event]) => event.cmd)).toEqual(
+          [
+            { type: 'select_clear' },
+            { type: 'select_add', entities: ['xy-plane-id'] },
+          ]
+        )
+
+        actor.stop()
+      })
     })
 
     describe('modelingMachine sketch entry', () => {

--- a/src/machines/modelingMachine.ts
+++ b/src/machines/modelingMachine.ts
@@ -1767,7 +1767,7 @@ export const modelingMachine = setup({
           } else if (!isEmpty && !kclManager.isShiftDown) {
             selections = {
               graphSelections: [sel],
-              otherSelections: selectionRanges.otherSelections || [],
+              otherSelections: [],
             }
           } else if (!isEmpty && kclManager.isShiftDown) {
             // Handle Shift key – compare V2 to V2 via selectionV2Equals

--- a/src/machines/modelingMachine.ts
+++ b/src/machines/modelingMachine.ts
@@ -1943,6 +1943,31 @@ export const modelingMachine = setup({
               otherSelections: [setSelections.selection],
             }
           }
+
+          if (setSelections.selectionType === 'defaultPlaneSelection') {
+            const { engineEvents, codeMirrorSelection } = handleSelectionBatch({
+              selections,
+              artifactGraph: kclManager.artifactGraph,
+              code: kclManager.code,
+              ast: kclManager.ast,
+              systemDeps: {
+                engineCommandManager,
+                sceneEntitiesManager: kclManager.sceneEntitiesManager,
+                wasmInstance,
+              },
+            })
+
+            kclManager.editorView.dispatch({
+              selection: codeMirrorSelection,
+            })
+
+            engineEvents.forEach((event) => {
+              engineCommandManager
+                .sendSceneCommand(event)
+                .catch(reportRejection)
+            })
+          }
+
           return {
             selectionRanges: selections,
           }


### PR DESCRIPTION
Fixes 2 regressions:
- clicking a plane (without shift) doesn't clear previous selection
- clicking a body doesn't clear previous plane selection