### PR TITLE
Superseded: Scope cloud sync status to cloud-backed projects

### DIFF
--- a/src/lib/cloudSync/conflictScope.spec.ts
+++ b/src/lib/cloudSync/conflictScope.spec.ts
@@ -1,4 +1,5 @@
 import 'fake-indexeddb/auto'
+import { effect } from '@preact/signals-core'
 import {
   cloudSyncStatus,
   configureCloudSyncEngine,
@@ -23,6 +24,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const baseUrl = 'https://example.test'
 const projectDirectory = '/documents/Projects'
 const currentProjectPath = `${projectDirectory}/current`
+const currentCloudBackedProjectPath = `${projectDirectory}/current-cloud`
+const currentPersonalCloudProjectPath =
+  '/Users/frank/Library/CloudStorage/Zoo/personal/current'
 const otherProjectPath = `${projectDirectory}/other`
 const otherConflictProjectPath = `${projectDirectory}/other (cloud conflict)`
 const otherRemoteProjectId = 'other-remote-project'
@@ -36,6 +40,11 @@ describe('cloud sync conflict scoping', () => {
     await deleteCloudSyncTestDatabase()
     fetchMock.mockReset()
     vi.stubGlobal('fetch', fetchMock)
+    cloudSyncStatus.value = {
+      enabled: false,
+      state: 'disabled',
+      pendingCount: 0,
+    }
   })
 
   afterEach(async () => {
@@ -43,6 +52,11 @@ describe('cloud sync conflict scoping', () => {
     configureCloudSyncEngine({ enabled: false })
     vi.unstubAllGlobals()
     await deleteCloudSyncTestDatabase()
+    cloudSyncStatus.value = {
+      enabled: false,
+      state: 'disabled',
+      pendingCount: 0,
+    }
   })
 
   it('does not surface existing unrelated conflicts after entering a scoped project', async () => {
@@ -178,5 +192,160 @@ describe('cloud sync conflict scoping', () => {
       activeProjectPath: otherProjectPath,
     })
     expect(cloudSyncStatus.value.activeProjectPath).not.toBe(otherProjectPath)
+  })
+
+  it('keeps a local-only scoped project outside the cloud library quiet', async () => {
+    const files = new Map([
+      [
+        `${currentPersonalCloudProjectPath}/${PROJECT_SETTINGS_FILE_NAME}`,
+        'title = "Current"\n',
+      ],
+      [`${otherProjectPath}/main.kcl`, 'local = 2\n'],
+      [
+        `${otherProjectPath}/${PROJECT_SETTINGS_FILE_NAME}`,
+        'title = "Other"\n',
+      ],
+    ])
+    configureCloudSyncLocalFileSystem(
+      createCloudSyncTestFs(files, { projectDirectory })
+    )
+    await putProjectMetadata({
+      schemaVersion: 1,
+      localProjectPath: otherProjectPath,
+      projectName: 'other',
+      remoteProjectId: otherRemoteProjectId,
+      remoteRevision: 'rev-1',
+      baseManifest: { files: {} },
+    })
+    await appendOutboxEntry({
+      projectPath: otherProjectPath,
+      kind: 'upsert',
+      targetPath: `${otherProjectPath}/main.kcl`,
+      createdAt: '2026-07-08T12:01:00.000Z',
+    })
+
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = getFetchUrl(input)
+      const method = getFetchMethod(input, init)
+
+      if (url === `${baseUrl}/user/projects` && method === 'GET') {
+        return jsonResponse([
+          {
+            id: otherRemoteProjectId,
+            title: 'Other',
+            revision: 'rev-3',
+            updated_at: '2026-07-08T12:05:00.000Z',
+          },
+        ])
+      }
+
+      if (url === otherRemoteProjectUrl && method === 'GET') {
+        return jsonResponse({
+          id: otherRemoteProjectId,
+          title: 'Other',
+          revision: 'rev-3',
+          updated_at: '2026-07-08T12:05:00.000Z',
+        })
+      }
+
+      if (url === otherRemoteDownloadUrl && method === 'GET') {
+        return jsonResponse({
+          files: [
+            { relativePath: 'main.kcl', contents: 'remote = 3\n' },
+            {
+              relativePath: PROJECT_SETTINGS_FILE_NAME,
+              contents: 'title = "Other"\n',
+            },
+          ],
+        })
+      }
+
+      return jsonResponse(
+        { message: `Unexpected fetch: ${method} ${url}` },
+        500
+      )
+    })
+
+    configureCloudSyncEngine({
+      enabled: false,
+      baseUrl,
+      environmentName: 'dev.zoo.dev',
+      projectDirectoryPath: projectDirectory,
+      autoEnrollCloudLibraryProjects: false,
+    })
+    cloudSyncStatus.value = {
+      enabled: true,
+      state: 'conflict',
+      pendingCount: 1,
+      activeProjectPath: otherProjectPath,
+      lastFailure: 'Cloud sync conflict: local and remote both changed.',
+      lastFailureAt: '2026-07-08T12:02:00.000Z',
+    }
+    setCloudSyncProjectScope(currentPersonalCloudProjectPath)
+    const syncingProjectPaths: Array<string | undefined> = []
+    const dispose = effect(() => {
+      const status = cloudSyncStatus.value
+      if (status.state === 'syncing') {
+        syncingProjectPaths.push(status.activeProjectPath)
+      }
+    })
+
+    try {
+      expect(cloudSyncStatus.value).toMatchObject({
+        state: 'idle',
+        scopedProjectPath: currentPersonalCloudProjectPath,
+        scopedProjectCloudProjectId: undefined,
+        activeProjectPath: undefined,
+        lastFailure: undefined,
+        lastFailureAt: undefined,
+      })
+
+      configureCloudSyncEngine({ enabled: true })
+
+      await vi.waitFor(() => {
+        expect(cloudSyncStatus.value).toMatchObject({
+          state: 'idle',
+          pendingCount: 0,
+        })
+      })
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(syncingProjectPaths).toEqual([])
+      expect(fetchMock).not.toHaveBeenCalled()
+      await expect(
+        getCloudSyncProjectMetadata(otherProjectPath)
+      ).resolves.not.toHaveProperty('conflict')
+      expect(cloudSyncStatus.value.activeProjectPath).not.toBe(otherProjectPath)
+    } finally {
+      dispose()
+    }
+  })
+
+  it('detects the scoped project cloud id from its project settings', async () => {
+    const files = new Map([
+      [
+        `${currentCloudBackedProjectPath}/${PROJECT_SETTINGS_FILE_NAME}`,
+        'title = "Current Cloud"\n\n[cloud."dev.zoo.dev"]\nproject_id = "current-cloud-project"\n',
+      ],
+    ])
+    configureCloudSyncLocalFileSystem(
+      createCloudSyncTestFs(files, { projectDirectory })
+    )
+    configureCloudSyncEngine({
+      enabled: false,
+      baseUrl,
+      environmentName: 'dev.zoo.dev',
+      projectDirectoryPath: projectDirectory,
+      autoEnrollCloudLibraryProjects: false,
+    })
+
+    setCloudSyncProjectScope(currentCloudBackedProjectPath)
+
+    await vi.waitFor(() => {
+      expect(cloudSyncStatus.value).toMatchObject({
+        scopedProjectPath: currentCloudBackedProjectPath,
+        scopedProjectCloudProjectId: 'current-cloud-project',
+      })
+    })
   })
 })

--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -227,7 +227,6 @@ function getConfiguredProjectRoot(targetPath: string) {
   if (normalizedTargetPath === projectDirectory) {
     return undefined
   }
-
   const relativePath = normalizeRelativePath(
     localFs.relative(projectDirectory, normalizedTargetPath)
   )
@@ -296,8 +295,15 @@ export function shouldAutoEnrollCloudLibraryProject({
 }
 
 function shouldSyncCloudLibraryProject(metadata: ProjectMetadata) {
+  const autoEnrollCloudLibraryProjects = projectPathInDirectory(
+    metadata,
+    getConfiguredProjectDirectoryPath()
+  )
+    ? config.autoEnrollCloudLibraryProjects
+    : false
+
   return shouldAutoEnrollCloudLibraryProject({
-    autoEnrollCloudLibraryProjects: config.autoEnrollCloudLibraryProjects,
+    autoEnrollCloudLibraryProjects,
     hasRemoteProjectId: Boolean(metadata.remoteProjectId),
     hasBaseManifest: Boolean(metadata.baseManifest),
   })
@@ -329,17 +335,12 @@ function isConfiguredForCloud() {
 }
 
 function getSyncScopeProjectPath(projectPath: string | undefined) {
-  if (!projectPath) {
+  const nextProjectPath = projectPath?.trim()
+  if (!nextProjectPath) {
     return undefined
   }
 
-  const normalizedProjectPath = normalizePathForSync(projectPath)
-  return isProjectPathInDirectory(
-    normalizedProjectPath,
-    getConfiguredProjectDirectoryPath()
-  )
-    ? normalizedProjectPath
-    : undefined
+  return normalizePathForSync(nextProjectPath)
 }
 
 function projectPathMatchesSyncScope(projectPath: string) {
@@ -347,6 +348,67 @@ function projectPathMatchesSyncScope(projectPath: string) {
     !syncScopeProjectPath ||
     normalizePathForSync(projectPath) === syncScopeProjectPath
   )
+}
+
+function projectPathIsSyncScope(projectPath: string) {
+  return Boolean(
+    syncScopeProjectPath &&
+      normalizePathForSync(projectPath) === syncScopeProjectPath
+  )
+}
+
+function publishScopedProjectCloudProjectId(metadata: ProjectMetadata) {
+  if (!projectPathIsSyncScope(metadata.localProjectPath)) {
+    return
+  }
+
+  updateStatus({
+    scopedProjectCloudProjectId:
+      metadata.tombstone || isProjectSyncExcluded(metadata)
+        ? undefined
+        : metadata.remoteProjectId,
+  })
+}
+
+async function getScopedProjectCloudProjectId(projectPath: string) {
+  const metadata = await getProjectMetadata(projectPath)
+  if (metadata?.tombstone || isProjectSyncExcluded(metadata)) {
+    return undefined
+  }
+  if (metadata?.remoteProjectId) {
+    return metadata.remoteProjectId
+  }
+
+  return readProjectTomlCloudProjectId(projectPath).catch(() => undefined)
+}
+
+async function refreshScopedProjectCloudProjectId(projectPath?: string) {
+  if (!projectPath) {
+    updateStatus({
+      scopedProjectPath: undefined,
+      scopedProjectCloudProjectId: undefined,
+    })
+    return
+  }
+
+  const scopedProjectPath = normalizePathForSync(projectPath)
+  updateStatus({
+    scopedProjectPath,
+    scopedProjectCloudProjectId: undefined,
+  })
+
+  try {
+    const cloudProjectId =
+      await getScopedProjectCloudProjectId(scopedProjectPath)
+    if (syncScopeProjectPath === scopedProjectPath) {
+      updateStatus({ scopedProjectCloudProjectId: cloudProjectId })
+    }
+  } catch (error) {
+    if (syncScopeProjectPath === scopedProjectPath) {
+      updateStatus({ scopedProjectCloudProjectId: undefined })
+    }
+    reportRejection(error)
+  }
 }
 
 function outboxEntriesForProject(entries: OutboxEntry[], projectPath: string) {
@@ -1704,6 +1766,7 @@ async function bindRemoteProjectIdFromToml(
     remoteProjectId: cloudBinding.projectId,
   }
   await putProjectMetadata(next)
+  publishScopedProjectCloudProjectId(next)
   return next
 }
 
@@ -1722,6 +1785,7 @@ async function markProjectFailure(
     },
   }
   await putProjectMetadata(next)
+  publishScopedProjectCloudProjectId(next)
   if (projectPathMatchesSyncScope(metadata.localProjectPath)) {
     updateStatus({
       state: 'failed',
@@ -1758,7 +1822,7 @@ async function markProjectSynced(
   }
 ) {
   const syncedAt = nowIso()
-  await putProjectMetadata({
+  const nextMetadata = {
     ...metadata,
     baseManifest,
     remoteRevision: remote?.revision ?? metadata.remoteRevision,
@@ -1767,7 +1831,9 @@ async function markProjectSynced(
     conflict: undefined,
     lastFailure: undefined,
     lastSyncedAt: syncedAt,
-  })
+  }
+  await putProjectMetadata(nextMetadata)
+  publishScopedProjectCloudProjectId(nextMetadata)
   if (!projectPathMatchesSyncScope(metadata.localProjectPath)) {
     return
   }
@@ -1998,7 +2064,7 @@ async function markProjectConflict(
   const createdAt = nowIso()
   const existingConflict = metadata.conflict
 
-  await putProjectMetadata({
+  const nextMetadata = {
     ...metadata,
     remoteUpdatedAt: remoteUpdatedAt ?? metadata.remoteUpdatedAt,
     conflict: {
@@ -2013,7 +2079,9 @@ async function markProjectConflict(
       message: 'Cloud sync conflict: local and remote both changed.',
       at: createdAt,
     },
-  })
+  }
+  await putProjectMetadata(nextMetadata)
+  publishScopedProjectCloudProjectId(nextMetadata)
   reportCloudSyncConflictCopyDetected()
   if (projectPathMatchesSyncScope(metadata.localProjectPath)) {
     updateStatus({
@@ -2258,17 +2326,17 @@ async function syncProject(projectPath: string, entries: OutboxEntry[]) {
     await clearOutboxEntriesForProject(metadata.localProjectPath)
     return
   }
-  if (projectPathMatchesSyncScope(metadata.localProjectPath)) {
-    updateStatus({
-      state: 'syncing',
-      activeProjectPath: metadata.localProjectPath,
-    })
-  }
 
   try {
     metadata = await bindRemoteProjectIdFromToml(metadata, cloudBinding)
     if (!shouldSyncCloudLibraryProject(metadata) && entries.length === 0) {
       return
+    }
+    if (projectPathMatchesSyncScope(metadata.localProjectPath)) {
+      updateStatus({
+        state: 'syncing',
+        activeProjectPath: metadata.localProjectPath,
+      })
     }
 
     const latestKind = latestOutboxKind(entries)
@@ -2805,7 +2873,7 @@ async function runCloudSync() {
 
   syncInProgress = true
   pendingStatusSyncedAt = undefined
-  updateStatus({ enabled: true, state: 'syncing' })
+  updateStatus({ enabled: true })
   const scopedProjectPath = syncScopeProjectPath
   let remoteIndexFailed = false
   let remoteIndexFailureMessage: string | undefined
@@ -2814,6 +2882,7 @@ async function runCloudSync() {
     let entries = await getAllOutboxEntries()
     let syncScopePlan = getCloudSyncScopePlan(entries, scopedProjectPath)
     if (syncScopePlan.shouldSyncRemoteIndex) {
+      updateStatus({ state: 'syncing' })
       await enqueueExistingCloudLibraryProjectsForInitialSync()
       await syncRemoteIndex().catch((error) => {
         remoteIndexFailed = true
@@ -2914,8 +2983,8 @@ function scheduleRemoteIndexSync(delay = 0) {
   scheduleSync(delay)
 }
 
-// Home syncs the full cloud index; file routes narrow status and retries to
-// the open project so unrelated project conflicts do not pollute the editor UI.
+// Home syncs the full cloud index; file routes pass the project root selected
+// by the current library so status and retries stay limited to that project.
 export function setCloudSyncProjectScope(projectPath?: string) {
   const nextSyncScopeProjectPath = getSyncScopeProjectPath(projectPath)
   if (syncScopeProjectPath === nextSyncScopeProjectPath) {
@@ -2923,6 +2992,7 @@ export function setCloudSyncProjectScope(projectPath?: string) {
   }
 
   syncScopeProjectPath = nextSyncScopeProjectPath
+  void refreshScopedProjectCloudProjectId(nextSyncScopeProjectPath)
   void refreshPendingCount()
 
   const statusProjectPath = cloudSyncStatus.value.activeProjectPath
@@ -2966,7 +3036,7 @@ export async function startCloudSyncProject(projectPath: string) {
   )
 
   await clearOutboxEntriesForProject(normalizedProjectPath)
-  await putProjectMetadata({
+  const nextMetadata = {
     ...metadata,
     localProjectPath: normalizedProjectPath,
     projectName: projectNameFromPath(normalizedProjectPath),
@@ -2974,7 +3044,9 @@ export async function startCloudSyncProject(projectPath: string) {
     syncExcluded: undefined,
     conflict: undefined,
     lastFailure: undefined,
-  })
+  }
+  await putProjectMetadata(nextMetadata)
+  publishScopedProjectCloudProjectId(nextMetadata)
   await appendOutboxEntry({
     projectPath: normalizedProjectPath,
     kind: 'upsert',
@@ -3009,7 +3081,7 @@ export async function disconnectCloudSyncProject(projectPath: string) {
   const disconnectedAt = nowIso()
 
   await removeLocalProjectCloudProjectId(normalizedProjectPath)
-  await putProjectMetadata({
+  const disconnectedMetadata = {
     ...metadata,
     localProjectPath: normalizedProjectPath,
     projectName: projectNameFromPath(normalizedProjectPath),
@@ -3026,19 +3098,23 @@ export async function disconnectCloudSyncProject(projectPath: string) {
       remoteProjectId,
       createdAt: disconnectedAt,
     },
-  })
+  }
+  await putProjectMetadata(disconnectedMetadata)
+  publishScopedProjectCloudProjectId(disconnectedMetadata)
 
   if (remoteProjectId) {
     try {
       await deleteRemoteProject(config, remoteProjectId)
     } catch (error) {
       if (!(error instanceof CloudApiError && error.status === 404)) {
-        await putProjectMetadata({
+        const restoredMetadata = {
           ...metadata,
           localProjectPath: normalizedProjectPath,
           projectName: projectNameFromPath(normalizedProjectPath),
           syncExcluded: undefined,
-        })
+        }
+        await putProjectMetadata(restoredMetadata)
+        publishScopedProjectCloudProjectId(restoredMetadata)
         await writeLocalProjectCloudProjectId(
           normalizedProjectPath,
           remoteProjectId
@@ -3050,24 +3126,8 @@ export async function disconnectCloudSyncProject(projectPath: string) {
   }
 
   await clearOutboxEntriesForProject(normalizedProjectPath)
-  await putProjectMetadata({
-    ...metadata,
-    localProjectPath: normalizedProjectPath,
-    projectName: projectNameFromPath(normalizedProjectPath),
-    remoteProjectId: undefined,
-    remoteRevision: undefined,
-    remoteUpdatedAt: undefined,
-    baseManifest: undefined,
-    tombstone: false,
-    conflict: undefined,
-    lastFailure: undefined,
-    lastSyncedAt: undefined,
-    syncExcluded: {
-      reason: 'user-disconnected',
-      remoteProjectId,
-      createdAt: disconnectedAt,
-    },
-  })
+  await putProjectMetadata(disconnectedMetadata)
+  publishScopedProjectCloudProjectId(disconnectedMetadata)
   if (remoteProjectId) {
     cloudSyncRemoteProjects.value = cloudSyncRemoteProjects.value.filter(
       (project) => project.id !== remoteProjectId
@@ -3365,6 +3425,8 @@ export function configureCloudSyncEngine(nextConfig: CloudSyncConfig) {
       enabled: false,
       state: 'disabled',
       activeProjectPath: undefined,
+      scopedProjectPath: undefined,
+      scopedProjectCloudProjectId: undefined,
       lastFailure: undefined,
       lastFailureAt: undefined,
     })
@@ -3390,6 +3452,7 @@ export function configureCloudSyncEngine(nextConfig: CloudSyncConfig) {
         }
       : {}),
   })
+  void refreshScopedProjectCloudProjectId(syncScopeProjectPath)
   void refreshPendingCount()
   scheduleSync(0)
 }

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -326,6 +326,92 @@ describe('cloud sync status presentation', () => {
   })
 })
 
+describe('cloud sync status bar contribution', () => {
+  function createStatusBarRegistry() {
+    const registry = new Registry()
+    const settings = createSettingsService({})
+    const settingsExtension = defineRegistryItem({
+      id: 'test-settings-service',
+      providesServices: [provideService(settingsService, settings.service)],
+    })
+    const userFeaturesExtension = defineRegistryItem({
+      id: 'test-user-features-service',
+      providesServices: [
+        provideService(userFeaturesService, createUserFeaturesService()),
+      ],
+    })
+
+    registry.configure([
+      settingsExtension,
+      userFeaturesExtension,
+      cloudSyncPlugin,
+    ])
+    enableCloudSyncPlugin(registry)
+
+    return registry
+  }
+
+  test('hides on file routes scoped to a local-only project', () => {
+    cloudSyncStatus.value = {
+      enabled: true,
+      state: 'idle',
+      pendingCount: 0,
+      scopedProjectPath: '/projects/local',
+    }
+    const registry = createStatusBarRegistry()
+
+    try {
+      expect(
+        registry
+          .get(statusBarGlobalItemsValueSpec)
+          .some((item) => item.id === 'cloud-sync')
+      ).toBe(false)
+    } finally {
+      registry[Symbol.dispose]()
+    }
+  })
+
+  test('shows on file routes scoped to a cloud-backed project', () => {
+    cloudSyncStatus.value = {
+      enabled: true,
+      state: 'idle',
+      pendingCount: 0,
+      scopedProjectPath: '/projects/cloud',
+      scopedProjectCloudProjectId: 'cloud-project-123',
+    }
+    const registry = createStatusBarRegistry()
+
+    try {
+      expect(
+        registry
+          .get(statusBarGlobalItemsValueSpec)
+          .some((item) => item.id === 'cloud-sync')
+      ).toBe(true)
+    } finally {
+      registry[Symbol.dispose]()
+    }
+  })
+
+  test('shows aggregate cloud status on Home', () => {
+    cloudSyncStatus.value = {
+      enabled: true,
+      state: 'idle',
+      pendingCount: 0,
+    }
+    const registry = createStatusBarRegistry()
+
+    try {
+      expect(
+        registry
+          .get(statusBarGlobalItemsValueSpec)
+          .some((item) => item.id === 'cloud-sync')
+      ).toBe(true)
+    } finally {
+      registry[Symbol.dispose]()
+    }
+  })
+})
+
 describe('cloud sync status bar conflict dialog', () => {
   test('keeps inspecting the clicked project when global conflict status changes', async () => {
     cloudConflictDialogMocks.conflict = {

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -374,8 +374,12 @@ const cloudSyncStatusBarItem = defineRegistryItemFactory((ctx) => {
     )
   }
 
-  const statusBarItem = computed(() =>
-    nullableStatusBarItem(
+  const statusBarItem = computed(() => {
+    const status = cloudSyncStatus.value
+    const scopedProjectVisible =
+      !status.scopedProjectPath || Boolean(status.scopedProjectCloudProjectId)
+
+    return nullableStatusBarItem(
       settings.value &&
         userFeatures.value &&
         userFeaturesContextHas(
@@ -383,7 +387,8 @@ const cloudSyncStatusBarItem = defineRegistryItemFactory((ctx) => {
           OPFS_CLOUD_FEATURE_FLAG,
           false
         ) &&
-        cloudSyncStatus.value.enabled
+        status.enabled &&
+        scopedProjectVisible
         ? {
             id: 'cloud-sync',
             component: CloudSyncStatusBarItemWithSettings,
@@ -392,7 +397,7 @@ const cloudSyncStatusBarItem = defineRegistryItemFactory((ctx) => {
           }
         : null
     )
-  )
+  })
 
   return {
     item: defineRuntimeRegistryItem({

--- a/src/lib/cloudSync/types.ts
+++ b/src/lib/cloudSync/types.ts
@@ -112,6 +112,8 @@ export type CloudSyncStatus = {
   enabled: boolean
   state: CloudSyncState
   pendingCount: number
+  scopedProjectPath?: string
+  scopedProjectCloudProjectId?: string
   activeProjectPath?: string
   lastFailure?: string
   lastFailureKind?: ProjectSyncFailureKind

--- a/src/lib/routeLoaders.ts
+++ b/src/lib/routeLoaders.ts
@@ -1,6 +1,7 @@
 import { projectSkeletonCreate } from '@src/lang/project'
 import { projectFsManager } from '@src/lang/std/fileSystemManager'
 import type { App } from '@src/lib/app'
+import { setCloudSyncProjectScope } from '@src/lib/cloudSync'
 import {
   DEFAULT_DEFAULT_LENGTH_UNIT,
   PROJECT_ENTRYPOINT,
@@ -276,6 +277,7 @@ export const fileLoader =
     const maybeProjectInfo = await getProjectInfo(projectPath, wasmInstance)
 
     const project = maybeProjectInfo ?? defaultProjectData
+    setCloudSyncProjectScope(project.path)
 
     // Fire off the event to load the project settings
     // once we know it's idle.
@@ -342,6 +344,8 @@ export const fileLoader =
 export const homeLoader =
   ({ app }: { app: App }): LoaderFunction =>
   async (): Promise<HomeLoaderData | Response> => {
+    setCloudSyncProjectScope(undefined)
+
     // If on unflagged web, bump out to root, which will redirect to a project.
     if (!window.electron && !(await webHomeRouteEnabled(app))) {
       return redirect(PATHS.INDEX)


### PR DESCRIPTION
Superseded by #12788, which combines the cloud sync enrollment policy fix with the scoped status/status-bar changes.