### PR TITLE
Restrict cloud sync enrollment and scoped status

### DIFF
--- a/e2e/playwright/storageStates.ts
+++ b/e2e/playwright/storageStates.ts
@@ -1,5 +1,10 @@
 import type { SaveSettingsPayload } from '@src/lib/settings/settingsTypes'
 import { PROJECT_FOLDER } from '@src/lib/constants'
+import {
+  CLOUD_PROJECT_LIBRARY_TYPE,
+  DIRECTORY_PROJECT_LIBRARY_TYPE,
+  PERSONAL_CLOUD_PROJECT_LIBRARY_TITLE,
+} from '@src/lib/projectLibraries'
 import { Themes } from '@src/lib/theme'
 import type { DeepPartial } from '@src/lib/types'
 
@@ -10,13 +15,28 @@ export const PLAYWRIGHT_PROJECT_DIRECTORY = `/documents/${PROJECT_FOLDER}`
 export const PLAYWRIGHT_PROJECT_LIBRARY_TITLE = 'Projects'
 
 export function playwrightProjectLibraries(
-  projectDirectory: string = PLAYWRIGHT_PROJECT_DIRECTORY
+  projectDirectory: string = PLAYWRIGHT_PROJECT_DIRECTORY,
+  {
+    cloudSyncWebEnabled = false,
+  }: {
+    cloudSyncWebEnabled?: boolean
+  } = {}
 ) {
+  if (cloudSyncWebEnabled) {
+    return [
+      {
+        title: PERSONAL_CLOUD_PROJECT_LIBRARY_TITLE,
+        path: projectDirectory,
+        type: CLOUD_PROJECT_LIBRARY_TYPE,
+      },
+    ]
+  }
+
   return [
     {
       title: PLAYWRIGHT_PROJECT_LIBRARY_TITLE,
       path: projectDirectory,
-      type: 'directory',
+      type: DIRECTORY_PROJECT_LIBRARY_TYPE,
     },
   ]
 }

--- a/e2e/playwright/test-utils.ts
+++ b/e2e/playwright/test-utils.ts
@@ -940,6 +940,7 @@ export async function setup(
   testInfo?: TestInfo,
   userFeatures: readonly Feature[] = []
 ) {
+  const cloudSyncWebEnabled = userFeatures.includes(OPFS_CLOUD_FEATURE_FLAG)
   const testProjectSettings =
     TEST_SETTINGS.project &&
     typeof TEST_SETTINGS.project === 'object' &&
@@ -983,7 +984,7 @@ export async function setup(
         settings: {
           ...TEST_SETTINGS,
           plugins: playwrightPluginSettings({
-            cloudSyncEnabled: userFeatures.includes(OPFS_CLOUD_FEATURE_FLAG),
+            cloudSyncEnabled: cloudSyncWebEnabled,
           }),
           ...PLAYWRIGHT_LAYOUT_SETTINGS,
           app: {
@@ -991,7 +992,12 @@ export async function setup(
               ...TEST_SETTINGS.app?.appearance,
               theme: 'dark',
             },
-            libraries: playwrightProjectLibraries(),
+            libraries: playwrightProjectLibraries(
+              PLAYWRIGHT_PROJECT_DIRECTORY,
+              {
+                cloudSyncWebEnabled,
+              }
+            ),
             onboarding_status: 'dismissed',
           },
           project: {

--- a/src/components/OpenedProject.tsx
+++ b/src/components/OpenedProject.tsx
@@ -23,7 +23,6 @@ import {
 } from '@src/lib/autoUpdate'
 import { BillingTransition } from '@src/lib/billing'
 import { useApp, useSingletons } from '@src/lib/boot'
-import { setCloudSyncProjectScope } from '@src/lib/cloudSync'
 import {
   CHANGES_REQUESTED_TOAST_ID,
   ONBOARDING_TOAST_ID,
@@ -100,14 +99,6 @@ export function OpenedProject() {
   const projectPath = project?.path || null
 
   const systemIOState = useSelector(systemIOActor, (actor) => actor.value)
-
-  useEffect(() => {
-    setCloudSyncProjectScope(projectPath ?? undefined)
-
-    return () => {
-      setCloudSyncProjectScope(undefined)
-    }
-  }, [projectPath])
 
   // Handle our project folder disappearing (Go back to Projects listing)
   useEffect(() => {

--- a/src/hooks/useQueryParamEffects.ts
+++ b/src/hooks/useQueryParamEffects.ts
@@ -1,13 +1,7 @@
-import { useEffect } from 'react'
-import toast from 'react-hot-toast'
-import { useNavigate, useSearchParams } from 'react-router-dom'
-import { waitFor } from 'xstate'
-
 import type { KclManager } from '@src/lang/KclManager'
 import { base64ToString } from '@src/lib/base64'
 import { useApp } from '@src/lib/boot'
-import { ensureCloudProjectLocallySynced } from '@src/lib/cloudSync'
-import { getDefaultCloudProjectDirectoryPath } from '@src/lib/cloudSync/paths'
+import { getCloudProjectLibraryMaterializationDirectoryPath } from '@src/lib/cloudSync/paths'
 import type { ProjectsCommandSchema } from '@src/lib/commandBarConfigs/projectsCommandConfig'
 import {
   ASK_TO_OPEN_QUERY_PARAM,
@@ -28,7 +22,10 @@ import {
 import fsZds from '@src/lib/fs-zds'
 import { isDesktop } from '@src/lib/isDesktop'
 import { PATHS, safeEncodeForRouterPaths } from '@src/lib/paths'
-import { getDefaultDirectoryProjectLibraryPath } from '@src/lib/projectLibraries'
+import {
+  CLOUD_PROJECT_LIBRARY_TYPE,
+  getDefaultDirectoryProjectLibraryPath,
+} from '@src/lib/projectLibraries'
 import { DEFAULT_WEB_PROJECT_NAME } from '@src/lib/routeLoaders'
 import { err } from '@src/lib/trap'
 import { getAllSubDirectoriesAtProjectRoot } from '@src/machines/systemIO/snapshotContext'
@@ -37,6 +34,11 @@ import {
   SystemIOMachineStates,
   waitForIdleState,
 } from '@src/machines/systemIO/utils'
+import { cloudSyncService } from '@src/registry/contracts/cloudSync'
+import { useEffect } from 'react'
+import toast from 'react-hot-toast'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { waitFor } from 'xstate'
 
 // For initializing the command arguments, we actually want `method` to be undefined
 // so that we don't skip it in the command palette.
@@ -72,6 +74,20 @@ export function useQueryParamEffects(kclManager: KclManager) {
     !hasAskToOpen &&
     searchParams.has(CMD_NAME_QUERY_PARAM) &&
     searchParams.has(CMD_GROUP_QUERY_PARAM)
+
+  async function getDefaultCloudProjectDirectoryPath() {
+    const cloudLibrary = app.settings
+      .get()
+      .app.libraries.current.find(
+        (library) => library.type === CLOUD_PROJECT_LIBRARY_TYPE
+      )
+
+    return cloudLibrary
+      ? getCloudProjectLibraryMaterializationDirectoryPath(cloudLibrary).catch(
+          () => undefined
+        )
+      : undefined
+  }
 
   /**
    * Watches for legacy `?create-file` hook, which share links currently use.
@@ -128,10 +144,14 @@ export function useQueryParamEffects(kclManager: KclManager) {
         return
       }
 
-      const localCloudProject = await ensureCloudProjectLocallySynced(
-        projectId,
+      const targetProjectDirectoryPath =
         await getDefaultCloudProjectDirectoryPath()
-      ).catch(() => undefined)
+      const localCloudProject = targetProjectDirectoryPath
+        ? await app.registry
+            .get(cloudSyncService)
+            .ensureProjectLocallySynced(projectId, targetProjectDirectoryPath)
+            .catch(() => undefined)
+        : undefined
       if (cancelled) {
         return
       }

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -6,14 +6,15 @@ import { App } from '@src/lib/app'
 import {
   KCL_NEW_LEXER_PARSER_FEATURE_FLAG,
   OPFS_CLOUD_FEATURE_FLAG,
+  PROJECT_FOLDER,
 } from '@src/lib/constants'
 import fsZds, { moduleFsViaModuleImport, StorageName } from '@src/lib/fs-zds'
 import type { Project } from '@src/lib/project'
 import { rustContextService } from '@src/lib/rustContext/registry/contract'
 import {
+  CLOUD_PROJECT_LIBRARY_TYPE,
   DIRECTORY_PROJECT_LIBRARY_TYPE,
   PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
-  getDefaultCloudProjectLibrarySetting,
 } from '@src/lib/projectLibraries'
 import { getChangedSettingsAtLevel } from '@src/lib/settings/settingsUtils'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
@@ -227,20 +228,34 @@ function getPluginToggle(app: App, pluginId: string) {
   return app.registry.get(plugin.service)
 }
 
-function hasPersonalCloudLibrarySetting(app: App) {
-  const defaultCloudLibrary = getDefaultCloudProjectLibrarySetting()
+function getPersonalCloudLibrarySetting(app: App) {
   return app.settings
     .get()
-    .app.libraries.current.some(
+    .app.libraries.current.find(
       (library) =>
-        library.type === defaultCloudLibrary.type &&
-        library.path === defaultCloudLibrary.path &&
-        library.source === defaultCloudLibrary.source
+        library.type === CLOUD_PROJECT_LIBRARY_TYPE && !library.source
     )
 }
 
+function hasPersonalCloudLibrarySetting(app: App) {
+  return Boolean(getPersonalCloudLibrarySetting(app))
+}
+
+function getDefaultProjectDirectorySettingPath(app: App) {
+  const settings = app.settings.get()
+  const projectDirectory = settings.app.projectDirectory
+  return (
+    projectDirectory.current ||
+    projectDirectory.default ||
+    settings.app.libraries.default.find(
+      (library) => library.type === DIRECTORY_PROJECT_LIBRARY_TYPE
+    )?.path ||
+    ''
+  )
+}
+
 function hasDefaultDirectoryLibrarySetting(app: App) {
-  const projectDirectory = app.settings.get().app.projectDirectory.current
+  const projectDirectory = getDefaultProjectDirectorySettingPath(app)
   return app.settings
     .get()
     .app.libraries.current.some(
@@ -462,6 +477,7 @@ describe('project system', () => {
           current: getCloudSyncPluginSetting(app)?.current,
           user: getCloudSyncPluginSetting(app)?.user,
           hasPersonalCloudLibrarySetting: hasPersonalCloudLibrarySetting(app),
+          personalCloudLibraryPath: getPersonalCloudLibrarySetting(app)?.path,
           hasDefaultDirectoryLibrarySetting:
             hasDefaultDirectoryLibrarySetting(app),
         }))
@@ -470,6 +486,7 @@ describe('project system', () => {
           current: true,
           user: true,
           hasPersonalCloudLibrarySetting: true,
+          personalCloudLibraryPath: `/documents/${PROJECT_FOLDER}`,
           hasDefaultDirectoryLibrarySetting: false,
         })
 

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -22,18 +22,19 @@ import { layoutService } from '@src/lib/layout/registry/contract'
 import type { LayoutService } from '@src/lib/layout/types'
 import type { MachineManager } from '@src/lib/MachineManager'
 import type { Project } from '@src/lib/project'
-import type RustContext from '@src/lib/rustContext'
-import { rustContextService } from '@src/lib/rustContext/registry/contract'
 import {
   areProjectLibrarySettingsEqual,
   DIRECTORY_PROJECT_LIBRARY_TYPE,
   getDefaultCloudProjectLibrarySetting,
-  isLegacyPersonalCloudProjectLibraryPathSetting,
+  isDefaultPersonalCloudProjectLibraryPathSetting,
   isPersonalCloudProjectLibrarySetting,
   mergeProjectLibrarySettings,
-  projectLibrariesFromSettings,
+  normalizeProjectLibrarySettingPath,
   type ProjectLibrarySetting,
+  projectLibrariesFromSettings,
 } from '@src/lib/projectLibraries'
+import type RustContext from '@src/lib/rustContext'
+import { rustContextService } from '@src/lib/rustContext/registry/contract'
 import type { SaveSettingsPayload } from '@src/lib/settings/settingsTypes'
 import {
   getAllCurrentSettings,
@@ -127,10 +128,6 @@ function getZookeeperReplayFallbackFilePath(
   ].filter((path, index, paths) => paths.indexOf(path) === index)
 
   return candidates.find((path) => path && !deletedPaths.has(path))
-}
-
-function normalizeProjectLibrarySettingPath(path: string) {
-  return path.trim().replaceAll('\\', '/').replace(/\/+$/g, '')
 }
 
 // We set some of our singletons on the window for debugging and E2E tests
@@ -680,18 +677,27 @@ export class App implements AppSubsystems {
     }
 
     const currentLibraries = snapshot.context.app.libraries?.current ?? []
+    const defaultDirectoryLibraryPathCandidates = [
+      snapshot.context.app.projectDirectory?.current,
+      snapshot.context.app.projectDirectory?.default,
+      ...(snapshot.context.app.libraries?.default ?? [])
+        .filter((library) => library.type === DIRECTORY_PROJECT_LIBRARY_TYPE)
+        .map((library) => library.path),
+    ].filter((path): path is string => Boolean(path?.trim()))
     const defaultDirectoryLibraryPaths = new Set(
-      [
-        snapshot.context.app.projectDirectory?.current,
-        snapshot.context.app.projectDirectory?.default,
-        ...(snapshot.context.app.libraries?.default ?? [])
-          .filter((library) => library.type === DIRECTORY_PROJECT_LIBRARY_TYPE)
-          .map((library) => library.path),
-      ]
-        .filter((path): path is string => Boolean(path?.trim()))
-        .map(normalizeProjectLibrarySettingPath)
+      defaultDirectoryLibraryPathCandidates.map(
+        normalizeProjectLibrarySettingPath
+      )
     )
-    const defaultCloudLibrary = getDefaultCloudProjectLibrarySetting()
+    const shouldUseProjectDirectoryForPersonalCloud =
+      typeof window !== 'undefined' &&
+      !window.electron &&
+      Boolean(defaultDirectoryLibraryPathCandidates[0])
+    const defaultCloudLibrary = getDefaultCloudProjectLibrarySetting(
+      shouldUseProjectDirectoryForPersonalCloud
+        ? defaultDirectoryLibraryPathCandidates[0]
+        : undefined
+    )
     const isDefaultCloudLibrary = (library: ProjectLibrarySetting) =>
       isPersonalCloudProjectLibrarySetting(library)
     const shouldReplaceDirectoryLibraryOnWeb = (
@@ -709,17 +715,14 @@ export class App implements AppSubsystems {
       currentLibraries.flatMap((library) => {
         if (isDefaultCloudLibrary(library)) {
           hasPersonalCloudLibrary = true
-          return [
-            isLegacyPersonalCloudProjectLibraryPathSetting(library)
-              ? {
-                  ...library,
-                  path: defaultCloudLibrary.path,
-                  ...(defaultCloudLibrary.source
-                    ? { source: defaultCloudLibrary.source }
-                    : {}),
-                }
-              : library,
-          ]
+          if (
+            shouldUseProjectDirectoryForPersonalCloud &&
+            isDefaultPersonalCloudProjectLibraryPathSetting(library)
+          ) {
+            return [defaultCloudLibrary]
+          }
+
+          return [library]
         }
 
         if (shouldReplaceDirectoryLibraryOnWeb(library)) {

--- a/src/lib/cloudSync/README.md
+++ b/src/lib/cloudSync/README.md
@@ -14,7 +14,7 @@ The files under `src/registry/extensions/cloudSync`, `src/registry/plugins/cloud
 
 ## Libraries and disk persistence
 
-The cloud sync system supports syncing on a per-project basis. However, cloud sync also pairs with our project library capability to register a "cloud" library type to the application, which maps local project directories to user cloud libraries. At present, we only support a "personal" cloud library in our API (see [our docs](https://zoo.dev/docs/developer-tools/api/projects)), and the location on the disk where this library's contents are synced locally is not editable by users. The chosen locations are:
+The cloud sync system supports syncing on a per-project basis. However, cloud sync also pairs with our project library capability to register a "cloud" library type to the application, which maps local project directories to user cloud libraries. Each configured cloud-type library contributes its own local materialization path. The personal cloud library may omit that path and use the app-managed default:
 - On web: `<opfs-root>/documents/zoo-design-studio-projects`
 - Linux: `~/Zoo/personal`
 - Windows: `%USERPROFILE%\Zoo\personal`
@@ -29,12 +29,12 @@ Cloud sync is technically keyed by per-project `project.toml` IDs, but the user-
 - Directory -> Cloud: move the local project directory into the Personal Cloud storage directory. If cloud sync is enabled, explicitly enroll the moved project with `startProjectSync`. If the project already has a valid cloud project ID, the engine may bind to that remote project; otherwise the next sync creates one.
 - Cloud -> Directory: treat this as "make local-only." Before the filesystem move, run the user-initiated disconnect flow: remove the local `project.toml` cloud project ID, clear pending cloud sync work, mark the local project `syncExcluded` with `reason: "user-disconnected"`, delete the remote cloud project, and update the remote project index. If remote deletion fails, the disconnect restores the local cloud link and the move should fail rather than leaving a half-detached project.
 - Cloud -> Cloud: if we add multiple cloud-type libraries, moving between them should preserve the cloud binding. Do not disconnect unless the target library type is not cloud.
-- Directory -> Directory: leave cloud sync state alone. This preserves support for individually synced projects outside cloud-type libraries.
+- Directory -> Directory: leave existing project metadata alone, but do not auto-enroll local-only projects. Directory-type libraries may discover projects that already carry cloud metadata, but they do not own cloud sync enrollment.
 - Library move availability is a declared library-type capability. Libraries whose type does not implement `moveProjectFrom` or `moveProjectTo` must not appear as move sources or targets. Future read-only/virtual types such as "recents" should omit both capabilities.
 
 ### Deleting projects
 
-Deleting a cloud-backed project means deleting the project everywhere. This applies both to projects in cloud-type libraries and to individually synced projects shown in directory-type libraries.
+Deleting a cloud-backed project means deleting the project everywhere. This applies to projects in cloud-type libraries. Directory-type libraries can still display already-linked projects from their `project.toml` metadata, but they must not create a new cloud project for an unlinked local project.
 
 - Local materialized cloud project: remove the local project directory and delete the linked remote cloud project before reporting success. The filesystem observer may enqueue a tombstone as part of the local delete, but product actions must not rely on background sync as the only remote deletion path.
 - Remote-only cloud project: delete the remote cloud project. There is no local materialization to remove.
@@ -120,7 +120,7 @@ flowchart TD
 
 - OPFS is the user-visible source of truth for reads, writes, and deletes.
 - Cloud sync must not block local reads, local writes, local project creation, or local project open.
-- Every local mutation that affects a project persists durable metadata and an outbox entry before cloud work runs.
+- Every local mutation inside the configured cloud library persists durable metadata and an outbox entry before cloud work runs.
 - Returning to a visible browser tab schedules an immediate remote-index check, bypassing the normal remote-index throttle.
 - Remote updates must send `expected_revision`; creates and deletes are the only unguarded remote writes.
 - A remote-only project discovered from the cloud index may remain remote-only; local materialization happens when a caller explicitly opens or moves it into a local library.

--- a/src/lib/cloudSync/conflictScope.spec.ts
+++ b/src/lib/cloudSync/conflictScope.spec.ts
@@ -1,4 +1,5 @@
 import 'fake-indexeddb/auto'
+import { effect } from '@preact/signals-core'
 import {
   cloudSyncStatus,
   configureCloudSyncEngine,
@@ -23,6 +24,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const baseUrl = 'https://example.test'
 const projectDirectory = '/documents/Projects'
 const currentProjectPath = `${projectDirectory}/current`
+const currentCloudBackedProjectPath = `${projectDirectory}/current-cloud`
+const currentPersonalCloudProjectPath =
+  '/Users/frank/Library/CloudStorage/Zoo/personal/current'
 const otherProjectPath = `${projectDirectory}/other`
 const otherConflictProjectPath = `${projectDirectory}/other (cloud conflict)`
 const otherRemoteProjectId = 'other-remote-project'
@@ -36,6 +40,11 @@ describe('cloud sync conflict scoping', () => {
     await deleteCloudSyncTestDatabase()
     fetchMock.mockReset()
     vi.stubGlobal('fetch', fetchMock)
+    cloudSyncStatus.value = {
+      enabled: false,
+      state: 'disabled',
+      pendingCount: 0,
+    }
   })
 
   afterEach(async () => {
@@ -43,6 +52,11 @@ describe('cloud sync conflict scoping', () => {
     configureCloudSyncEngine({ enabled: false })
     vi.unstubAllGlobals()
     await deleteCloudSyncTestDatabase()
+    cloudSyncStatus.value = {
+      enabled: false,
+      state: 'disabled',
+      pendingCount: 0,
+    }
   })
 
   it('does not surface existing unrelated conflicts after entering a scoped project', async () => {
@@ -157,11 +171,14 @@ describe('cloud sync conflict scoping', () => {
       enabled: true,
       baseUrl,
       environmentName: 'dev.zoo.dev',
-      projectDirectoryPath: projectDirectory,
+      cloudProjectDirectoryPaths: [projectDirectory],
       autoEnrollCloudLibraryProjects: false,
     })
     await remoteIndexStarted
-    setCloudSyncProjectScope(currentProjectPath)
+    setCloudSyncProjectScope({
+      projectPath: currentProjectPath,
+      syncable: true,
+    })
     finishRemoteIndex()
 
     await vi.waitFor(async () => {
@@ -178,5 +195,166 @@ describe('cloud sync conflict scoping', () => {
       activeProjectPath: otherProjectPath,
     })
     expect(cloudSyncStatus.value.activeProjectPath).not.toBe(otherProjectPath)
+  })
+
+  it('keeps a local-only scoped project outside the cloud library quiet', async () => {
+    const files = new Map([
+      [
+        `${currentPersonalCloudProjectPath}/${PROJECT_SETTINGS_FILE_NAME}`,
+        'title = "Current"\n',
+      ],
+      [`${otherProjectPath}/main.kcl`, 'local = 2\n'],
+      [
+        `${otherProjectPath}/${PROJECT_SETTINGS_FILE_NAME}`,
+        'title = "Other"\n',
+      ],
+    ])
+    configureCloudSyncLocalFileSystem(
+      createCloudSyncTestFs(files, { projectDirectory })
+    )
+    await putProjectMetadata({
+      schemaVersion: 1,
+      localProjectPath: otherProjectPath,
+      projectName: 'other',
+      remoteProjectId: otherRemoteProjectId,
+      remoteRevision: 'rev-1',
+      baseManifest: { files: {} },
+    })
+    await appendOutboxEntry({
+      projectPath: otherProjectPath,
+      kind: 'upsert',
+      targetPath: `${otherProjectPath}/main.kcl`,
+      createdAt: '2026-07-08T12:01:00.000Z',
+    })
+
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = getFetchUrl(input)
+      const method = getFetchMethod(input, init)
+
+      if (url === `${baseUrl}/user/projects` && method === 'GET') {
+        return jsonResponse([
+          {
+            id: otherRemoteProjectId,
+            title: 'Other',
+            revision: 'rev-3',
+            updated_at: '2026-07-08T12:05:00.000Z',
+          },
+        ])
+      }
+
+      if (url === otherRemoteProjectUrl && method === 'GET') {
+        return jsonResponse({
+          id: otherRemoteProjectId,
+          title: 'Other',
+          revision: 'rev-3',
+          updated_at: '2026-07-08T12:05:00.000Z',
+        })
+      }
+
+      if (url === otherRemoteDownloadUrl && method === 'GET') {
+        return jsonResponse({
+          files: [
+            { relativePath: 'main.kcl', contents: 'remote = 3\n' },
+            {
+              relativePath: PROJECT_SETTINGS_FILE_NAME,
+              contents: 'title = "Other"\n',
+            },
+          ],
+        })
+      }
+
+      return jsonResponse(
+        { message: `Unexpected fetch: ${method} ${url}` },
+        500
+      )
+    })
+
+    configureCloudSyncEngine({
+      enabled: false,
+      baseUrl,
+      environmentName: 'dev.zoo.dev',
+      cloudProjectDirectoryPaths: [projectDirectory],
+      autoEnrollCloudLibraryProjects: false,
+    })
+    cloudSyncStatus.value = {
+      enabled: true,
+      state: 'conflict',
+      pendingCount: 1,
+      activeProjectPath: otherProjectPath,
+      lastFailure: 'Cloud sync conflict: local and remote both changed.',
+      lastFailureAt: '2026-07-08T12:02:00.000Z',
+    }
+    setCloudSyncProjectScope({
+      projectPath: currentPersonalCloudProjectPath,
+      syncable: false,
+    })
+    const syncingProjectPaths: Array<string | undefined> = []
+    const dispose = effect(() => {
+      const status = cloudSyncStatus.value
+      if (status.state === 'syncing') {
+        syncingProjectPaths.push(status.activeProjectPath)
+      }
+    })
+
+    try {
+      expect(cloudSyncStatus.value).toMatchObject({
+        state: 'idle',
+        scopedProjectPath: currentPersonalCloudProjectPath,
+        scopedProjectCloudProjectId: undefined,
+        activeProjectPath: undefined,
+        lastFailure: undefined,
+        lastFailureAt: undefined,
+      })
+
+      configureCloudSyncEngine({ enabled: true })
+
+      await vi.waitFor(() => {
+        expect(cloudSyncStatus.value).toMatchObject({
+          state: 'idle',
+          pendingCount: 0,
+        })
+      })
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(syncingProjectPaths).toEqual([])
+      expect(fetchMock).not.toHaveBeenCalled()
+      await expect(
+        getCloudSyncProjectMetadata(otherProjectPath)
+      ).resolves.not.toHaveProperty('conflict')
+      expect(cloudSyncStatus.value.activeProjectPath).not.toBe(otherProjectPath)
+    } finally {
+      dispose()
+    }
+  })
+
+  it('detects the scoped project cloud id from its project settings', async () => {
+    const files = new Map([
+      [
+        `${currentCloudBackedProjectPath}/${PROJECT_SETTINGS_FILE_NAME}`,
+        'title = "Current Cloud"\n\n[cloud."dev.zoo.dev"]\nproject_id = "current-cloud-project"\n',
+      ],
+    ])
+    configureCloudSyncLocalFileSystem(
+      createCloudSyncTestFs(files, { projectDirectory })
+    )
+    configureCloudSyncEngine({
+      enabled: false,
+      baseUrl,
+      environmentName: 'dev.zoo.dev',
+      cloudProjectDirectoryPaths: [projectDirectory],
+      autoEnrollCloudLibraryProjects: false,
+    })
+
+    setCloudSyncProjectScope({
+      projectPath: currentCloudBackedProjectPath,
+      syncable: true,
+    })
+
+    await vi.waitFor(() => {
+      expect(cloudSyncStatus.value).toMatchObject({
+        scopedProjectPath: currentCloudBackedProjectPath,
+        scopedProjectCloudProjectId: 'current-cloud-project',
+      })
+    })
   })
 })

--- a/src/lib/cloudSync/disconnect.spec.ts
+++ b/src/lib/cloudSync/disconnect.spec.ts
@@ -83,7 +83,7 @@ describe('disconnectCloudSyncProject', () => {
       enabled: true,
       baseUrl: 'https://example.test',
       environmentName: 'dev.zoo.dev',
-      projectDirectoryPath: '/documents/Projects',
+      cloudProjectDirectoryPaths: ['/documents/Projects'],
     })
   })
 
@@ -284,9 +284,12 @@ describe('cloud sync upload failures', () => {
       enabled: false,
       baseUrl: 'https://example.test',
       environmentName: 'dev.zoo.dev',
-      projectDirectoryPath: '/documents/Projects',
+      cloudProjectDirectoryPaths: ['/documents/Projects'],
     })
-    setCloudSyncProjectScope(projectPath)
+    setCloudSyncProjectScope({
+      projectPath,
+      syncable: true,
+    })
     configureCloudSyncEngine({ enabled: true })
     retryCloudSync()
     await vi.waitFor(() => {
@@ -320,7 +323,7 @@ describe('cloud sync upload failures', () => {
       enabled: true,
       baseUrl: 'https://example.test',
       environmentName: 'dev.zoo.dev',
-      projectDirectoryPath: '/documents/Projects',
+      cloudProjectDirectoryPaths: ['/documents/Projects'],
     })
 
     expect(cloudSyncStatus.value).toMatchObject({

--- a/src/lib/cloudSync/duplicateRemote.spec.ts
+++ b/src/lib/cloudSync/duplicateRemote.spec.ts
@@ -34,7 +34,7 @@ describe('duplicateRemoteCloudProject', () => {
       enabled: true,
       baseUrl,
       environmentName: 'dev.zoo.dev',
-      projectDirectoryPath: '/documents/Projects',
+      cloudProjectDirectoryPaths: ['/documents/Projects'],
     })
     vi.stubGlobal('fetch', fetchMock)
   })

--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -20,9 +20,7 @@ import {
   type ConflictInspection,
 } from '@src/lib/cloudSync/conflictInspection'
 import {
-  getCloudSyncProjectRoot,
   isCloudSyncExcludedPath,
-  isCloudSyncProjectDirectoryPath,
   isProjectRootPath,
   normalizePathForSync,
   normalizeRelativePath,
@@ -50,6 +48,7 @@ import type {
   CloudSyncConfig,
   CloudSyncLocalProject,
   CloudSyncProjectMetadataIndexEntry,
+  CloudSyncProjectScope,
   CloudSyncStatus,
   OutboxEntry,
   ProjectArchiveFile,
@@ -62,7 +61,6 @@ import type {
 } from '@src/lib/cloudSync/types'
 import {
   DUPLICATE_PROJECT_TEMPORARY_PREFIX,
-  PROJECT_FOLDER,
   PROJECT_IMAGE_NAME,
   PROJECT_SETTINGS_FILE_NAME,
 } from '@src/lib/constants'
@@ -92,7 +90,6 @@ import {
 import { isErr, reportRejection } from '@src/lib/trap'
 import { v4 } from 'uuid'
 
-export { getCloudSyncProjectRoot } from '@src/lib/cloudSync/paths'
 export {
   prepareProjectFilesForCloudUpload,
   projectManifestsEqual,
@@ -150,6 +147,7 @@ let initialLocalScanComplete = false
 let pendingStatusSyncedAt: string | undefined
 let detachVisibilityChangeListener: (() => void) | undefined
 let syncScopeProjectPath: string | undefined
+let syncScopeSyncable = false
 const scheduledProjectDirectoryNameSyncs = new Set<string>()
 
 export const cloudSyncStatus = signal<CloudSyncStatus>({
@@ -214,41 +212,115 @@ function rejectRemoteUploadFailure(error: unknown): Promise<never> {
   return Promise.reject(remoteUploadFailureFromError(error))
 }
 
-function getConfiguredProjectDirectoryPath() {
-  return normalizePathForSync(
-    config.projectDirectoryPath?.trim() ||
-      localFs.join(`${localFs.sep}documents`, PROJECT_FOLDER)
-  )
-}
-
-function getConfiguredProjectRoot(targetPath: string) {
+export function getCloudSyncProjectRootInDirectory(
+  targetPath: string,
+  projectDirectoryPath: string
+) {
   const normalizedTargetPath = normalizePathForSync(targetPath)
-  const projectDirectory = getConfiguredProjectDirectoryPath()
+  const projectDirectory = normalizePathForSync(projectDirectoryPath)
   if (normalizedTargetPath === projectDirectory) {
     return undefined
   }
 
-  const relativePath = normalizeRelativePath(
-    localFs.relative(projectDirectory, normalizedTargetPath)
-  )
-  if (
-    !relativePath ||
-    relativePath === '..' ||
-    relativePath.startsWith('../')
-  ) {
-    return getCloudSyncProjectRoot(targetPath)
+  if (!normalizedTargetPath.startsWith(`${projectDirectory}/`)) {
+    return undefined
   }
 
+  const relativePath = normalizeRelativePath(
+    normalizedTargetPath.slice(projectDirectory.length + 1)
+  )
   const [projectName] = webSafePathSplit(relativePath).filter(Boolean)
   return projectName
-    ? normalizePathForSync(localFs.join(projectDirectory, projectName))
+    ? normalizePathForSync(`${projectDirectory}/${projectName}`)
     : undefined
 }
 
-function isConfiguredProjectDirectoryPath(targetPath: string) {
+export function getCloudSyncProjectRootInDirectories(
+  targetPath: string,
+  projectDirectoryPaths: readonly string[]
+) {
+  const projectDirectories = [...projectDirectoryPaths].sort(
+    (left, right) =>
+      normalizePathForSync(right).length - normalizePathForSync(left).length
+  )
+  for (const projectDirectory of projectDirectories) {
+    const projectRoot = getCloudSyncProjectRootInDirectory(
+      targetPath,
+      projectDirectory
+    )
+    if (projectRoot) {
+      return projectRoot
+    }
+  }
+
+  return undefined
+}
+
+function normalizeCloudLibraryMaterializationPaths(
+  projectDirectoryPaths: readonly (string | undefined)[]
+) {
+  return Array.from(
+    new Set(
+      projectDirectoryPaths
+        .map((projectDirectoryPath) => projectDirectoryPath?.trim())
+        .filter((projectDirectoryPath): projectDirectoryPath is string =>
+          Boolean(projectDirectoryPath)
+        )
+        .map(normalizePathForSync)
+    )
+  )
+}
+
+function getCloudLibraryMaterializationPathsForConfig(
+  targetConfig: CloudSyncConfig
+) {
+  return normalizeCloudLibraryMaterializationPaths(
+    targetConfig.cloudProjectDirectoryPaths ?? []
+  )
+}
+
+function getCloudLibraryMaterializationPaths() {
+  return getCloudLibraryMaterializationPathsForConfig(config)
+}
+
+function getCloudLibraryMaterializationConfigKey(
+  targetConfig: CloudSyncConfig
+) {
+  return getCloudLibraryMaterializationPathsForConfig(targetConfig)
+    .sort()
+    .join('\0')
+}
+
+function getCloudLibraryProjectRoot(targetPath: string) {
+  return getCloudSyncProjectRootInDirectories(
+    targetPath,
+    getCloudLibraryMaterializationPaths()
+  )
+}
+
+function getScopedProjectRoot(targetPath: string) {
+  if (!syncScopeProjectPath || !syncScopeSyncable) {
+    return undefined
+  }
+
+  const normalizedTargetPath = normalizePathForSync(targetPath)
+  return normalizedTargetPath === syncScopeProjectPath ||
+    normalizedTargetPath.startsWith(`${syncScopeProjectPath}/`)
+    ? syncScopeProjectPath
+    : undefined
+}
+
+function getSyncPolicyProjectRoot(targetPath: string) {
   return (
-    normalizePathForSync(targetPath) === getConfiguredProjectDirectoryPath() ||
-    isCloudSyncProjectDirectoryPath(targetPath)
+    getCloudLibraryProjectRoot(targetPath) ?? getScopedProjectRoot(targetPath)
+  )
+}
+
+function isCloudLibraryMaterializationPath(targetPath: string) {
+  const normalizedTargetPath = normalizePathForSync(targetPath)
+  return getCloudLibraryMaterializationPaths().some(
+    (projectDirectoryPath) =>
+      normalizedTargetPath === normalizePathForSync(projectDirectoryPath)
   )
 }
 
@@ -275,6 +347,12 @@ function projectPathInDirectory(
     : undefined
 }
 
+function getOwningCloudLibraryMaterializationPath(projectPath: string) {
+  return getCloudLibraryMaterializationPaths().find((projectDirectoryPath) =>
+    isProjectPathInDirectory(projectPath, projectDirectoryPath)
+  )
+}
+
 function isProjectSyncExcluded(metadata: ProjectMetadata | undefined) {
   return Boolean(metadata?.syncExcluded)
 }
@@ -296,8 +374,13 @@ export function shouldAutoEnrollCloudLibraryProject({
 }
 
 function shouldSyncCloudLibraryProject(metadata: ProjectMetadata) {
+  const autoEnrollCloudLibraryProjects =
+    getOwningCloudLibraryMaterializationPath(metadata.localProjectPath)
+      ? config.autoEnrollCloudLibraryProjects
+      : false
+
   return shouldAutoEnrollCloudLibraryProject({
-    autoEnrollCloudLibraryProjects: config.autoEnrollCloudLibraryProjects,
+    autoEnrollCloudLibraryProjects,
     hasRemoteProjectId: Boolean(metadata.remoteProjectId),
     hasBaseManifest: Boolean(metadata.baseManifest),
   })
@@ -328,18 +411,22 @@ function isConfiguredForCloud() {
   return config.enabled === true
 }
 
-function getSyncScopeProjectPath(projectPath: string | undefined) {
+function normalizeCloudSyncProjectScope(
+  scope: CloudSyncProjectScope | undefined
+): CloudSyncProjectScope | undefined {
+  if (!scope) {
+    return undefined
+  }
+
+  const projectPath = scope.projectPath.trim()
   if (!projectPath) {
     return undefined
   }
 
-  const normalizedProjectPath = normalizePathForSync(projectPath)
-  return isProjectPathInDirectory(
-    normalizedProjectPath,
-    getConfiguredProjectDirectoryPath()
-  )
-    ? normalizedProjectPath
-    : undefined
+  return {
+    projectPath: normalizePathForSync(projectPath),
+    syncable: scope.syncable,
+  }
 }
 
 function projectPathMatchesSyncScope(projectPath: string) {
@@ -347,6 +434,72 @@ function projectPathMatchesSyncScope(projectPath: string) {
     !syncScopeProjectPath ||
     normalizePathForSync(projectPath) === syncScopeProjectPath
   )
+}
+
+function projectPathIsSyncScope(projectPath: string) {
+  return Boolean(
+    syncScopeProjectPath &&
+      normalizePathForSync(projectPath) === syncScopeProjectPath
+  )
+}
+
+function publishScopedProjectCloudProjectId(metadata: ProjectMetadata) {
+  if (!projectPathIsSyncScope(metadata.localProjectPath)) {
+    return
+  }
+
+  updateStatus({
+    scopedProjectCloudProjectId:
+      metadata.tombstone || isProjectSyncExcluded(metadata)
+        ? undefined
+        : metadata.remoteProjectId,
+  })
+}
+
+async function getScopedProjectCloudProjectId(projectPath: string) {
+  const metadata = await getProjectMetadata(projectPath)
+  if (metadata?.tombstone || isProjectSyncExcluded(metadata)) {
+    return undefined
+  }
+  if (metadata?.remoteProjectId) {
+    return metadata.remoteProjectId
+  }
+
+  return readProjectTomlCloudProjectId(projectPath).catch(() => undefined)
+}
+
+async function refreshScopedProjectCloudProjectId(
+  scope?: CloudSyncProjectScope
+) {
+  if (!scope) {
+    updateStatus({
+      scopedProjectPath: undefined,
+      scopedProjectCloudProjectId: undefined,
+    })
+    return
+  }
+
+  const scopedProjectPath = normalizePathForSync(scope.projectPath)
+  updateStatus({
+    scopedProjectPath,
+    scopedProjectCloudProjectId: undefined,
+  })
+  if (!scope.syncable) {
+    return
+  }
+
+  try {
+    const cloudProjectId =
+      await getScopedProjectCloudProjectId(scopedProjectPath)
+    if (syncScopeProjectPath === scopedProjectPath) {
+      updateStatus({ scopedProjectCloudProjectId: cloudProjectId })
+    }
+  } catch (error) {
+    if (syncScopeProjectPath === scopedProjectPath) {
+      updateStatus({ scopedProjectCloudProjectId: undefined })
+    }
+    reportRejection(error)
+  }
 }
 
 function outboxEntriesForProject(entries: OutboxEntry[], projectPath: string) {
@@ -370,12 +523,19 @@ export type CloudSyncScopePlan = {
 
 export function getCloudSyncScopePlan(
   entries: OutboxEntry[],
-  scopeProjectPath?: string
+  scope?: CloudSyncProjectScope
 ): CloudSyncScopePlan {
-  const normalizedScopeProjectPath = scopeProjectPath
-    ? normalizePathForSync(scopeProjectPath)
-    : undefined
+  const normalizedScope = normalizeCloudSyncProjectScope(scope)
+  const normalizedScopeProjectPath = normalizedScope?.projectPath
   if (normalizedScopeProjectPath) {
+    if (!normalizedScope.syncable) {
+      return {
+        shouldSyncRemoteIndex: false,
+        projectPaths: [],
+        pendingCount: 0,
+      }
+    }
+
     return {
       shouldSyncRemoteIndex: false,
       projectPaths: [normalizedScopeProjectPath],
@@ -886,8 +1046,15 @@ async function refreshPendingCount() {
   try {
     const entries = await getAllOutboxEntries()
     updateStatus({
-      pendingCount: getCloudSyncScopePlan(entries, syncScopeProjectPath)
-        .pendingCount,
+      pendingCount: getCloudSyncScopePlan(
+        entries,
+        syncScopeProjectPath
+          ? {
+              projectPath: syncScopeProjectPath,
+              syncable: syncScopeSyncable,
+            }
+          : undefined
+      ).pendingCount,
     })
   } catch {
     updateStatus({ pendingCount: 0 })
@@ -1303,7 +1470,7 @@ export async function deleteCloudSyncLocalProjectRealizations(
 
 async function cloneRemoteProjectToLocal(
   remoteProject: RemoteProject,
-  projectDirectory = getConfiguredProjectDirectoryPath(),
+  projectDirectory: string,
   preferredProjectPath?: string
 ): Promise<CloudSyncLocalProject> {
   await localFs.mkdir(projectDirectory, { recursive: true })
@@ -1358,13 +1525,15 @@ export async function ensureCloudProjectLocallySynced(
   const knownLocalMetadata = metadata.find(
     (entry) => entry.remoteProjectId === projectId && !entry.tombstone
   )
-  // The destination directory is the local materialization path of the
-  // project library the caller is opening this remote project from (e.g. the
-  // Personal Cloud library). Fall back to the configured directory only when
-  // the caller cannot resolve a target library.
+  // The destination directory is the local materialization path of the project
+  // library the caller is opening this remote project from (e.g. the Personal
+  // Cloud library).
   const projectDirectory = targetProjectDirectoryPath?.trim()
     ? normalizePathForSync(targetProjectDirectoryPath)
-    : getConfiguredProjectDirectoryPath()
+    : undefined
+  if (!projectDirectory) {
+    return undefined
+  }
   const knownLocalProjectPath = knownLocalMetadata
     ? projectPathInDirectory(knownLocalMetadata, projectDirectory)
     : undefined
@@ -1704,6 +1873,7 @@ async function bindRemoteProjectIdFromToml(
     remoteProjectId: cloudBinding.projectId,
   }
   await putProjectMetadata(next)
+  publishScopedProjectCloudProjectId(next)
   return next
 }
 
@@ -1722,6 +1892,7 @@ async function markProjectFailure(
     },
   }
   await putProjectMetadata(next)
+  publishScopedProjectCloudProjectId(next)
   if (projectPathMatchesSyncScope(metadata.localProjectPath)) {
     updateStatus({
       state: 'failed',
@@ -1758,7 +1929,7 @@ async function markProjectSynced(
   }
 ) {
   const syncedAt = nowIso()
-  await putProjectMetadata({
+  const nextMetadata = {
     ...metadata,
     baseManifest,
     remoteRevision: remote?.revision ?? metadata.remoteRevision,
@@ -1767,7 +1938,9 @@ async function markProjectSynced(
     conflict: undefined,
     lastFailure: undefined,
     lastSyncedAt: syncedAt,
-  })
+  }
+  await putProjectMetadata(nextMetadata)
+  publishScopedProjectCloudProjectId(nextMetadata)
   if (!projectPathMatchesSyncScope(metadata.localProjectPath)) {
     return
   }
@@ -1998,7 +2171,7 @@ async function markProjectConflict(
   const createdAt = nowIso()
   const existingConflict = metadata.conflict
 
-  await putProjectMetadata({
+  const nextMetadata = {
     ...metadata,
     remoteUpdatedAt: remoteUpdatedAt ?? metadata.remoteUpdatedAt,
     conflict: {
@@ -2013,7 +2186,9 @@ async function markProjectConflict(
       message: 'Cloud sync conflict: local and remote both changed.',
       at: createdAt,
     },
-  })
+  }
+  await putProjectMetadata(nextMetadata)
+  publishScopedProjectCloudProjectId(nextMetadata)
   reportCloudSyncConflictCopyDetected()
   if (projectPathMatchesSyncScope(metadata.localProjectPath)) {
     updateStatus({
@@ -2347,17 +2522,17 @@ async function syncProject(projectPath: string, entries: OutboxEntry[]) {
     await clearOutboxEntriesForProject(metadata.localProjectPath)
     return
   }
-  if (projectPathMatchesSyncScope(metadata.localProjectPath)) {
-    updateStatus({
-      state: 'syncing',
-      activeProjectPath: metadata.localProjectPath,
-    })
-  }
 
   try {
     metadata = await bindRemoteProjectIdFromToml(metadata, cloudBinding)
     if (!shouldSyncCloudLibraryProject(metadata) && entries.length === 0) {
       return
+    }
+    if (projectPathMatchesSyncScope(metadata.localProjectPath)) {
+      updateStatus({
+        state: 'syncing',
+        activeProjectPath: metadata.localProjectPath,
+      })
     }
 
     const latestKind = latestOutboxKind(entries)
@@ -2611,8 +2786,10 @@ async function syncRemoteIndex() {
     return
   }
 
-  const projectDirectory = getConfiguredProjectDirectoryPath()
-  await localFs.mkdir(projectDirectory, { recursive: true })
+  const projectDirectories = getCloudLibraryMaterializationPaths()
+  for (const projectDirectory of projectDirectories) {
+    await localFs.mkdir(projectDirectory, { recursive: true })
+  }
 
   const remoteProjects = await listRemoteProjects(config)
   cloudSyncRemoteProjects.value = remoteProjects
@@ -2623,6 +2800,7 @@ async function syncRemoteIndex() {
   for (const entry of await getAllProjectMetadata()) {
     if (
       isProjectSyncExcluded(entry) ||
+      !getOwningCloudLibraryMaterializationPath(entry.localProjectPath) ||
       !(await isLocalProjectEligibleForCurrentCloudEnvironment(
         entry.localProjectPath
       ))
@@ -2701,7 +2879,9 @@ async function syncRemoteIndex() {
 
     try {
       const knownLocalMetadata = metadata.find(
-        (entry) => entry.remoteProjectId === remoteProject.id
+        (entry) =>
+          entry.remoteProjectId === remoteProject.id &&
+          getOwningCloudLibraryMaterializationPath(entry.localProjectPath)
       )
       const knownLocalAction = getCloudSyncRemoteIndexAction({
         hasRemoteProjectId: Boolean(remoteProject.id),
@@ -2710,9 +2890,17 @@ async function syncRemoteIndex() {
         hasMatchingLocalProject: false,
       })
       if (knownLocalAction === 'sync-known-local' && knownLocalMetadata) {
+        const knownLocalProjectDirectory =
+          getOwningCloudLibraryMaterializationPath(
+            knownLocalMetadata.localProjectPath
+          )
+        if (!knownLocalProjectDirectory) {
+          continue
+        }
+
         const knownLocalProjectPath = projectPathInDirectory(
           knownLocalMetadata,
-          projectDirectory
+          knownLocalProjectDirectory
         )
         const knownLocalPathIsCurrent =
           knownLocalProjectPath && (await exists(knownLocalProjectPath))
@@ -2799,7 +2987,7 @@ async function syncRemoteIndex() {
         const deletedDuplicateProjectPaths =
           await cleanupDuplicateLocalRealizationsForRemoteProject({
             remoteProjectId: remoteProject.id,
-            projectDirectory,
+            projectDirectory: knownLocalProjectDirectory,
             keepProjectPath: nextLocalMetadata.localProjectPath,
           })
         for (const deletedProjectPath of deletedDuplicateProjectPaths) {
@@ -2809,12 +2997,20 @@ async function syncRemoteIndex() {
       }
 
       const projectName = localProjectNameForRemoteProject(remoteProject)
-      const existingProjectPath = await findLocalProjectPathByRemoteProjectId(
-        projectDirectory,
-        remoteProject.id,
-        projectName
-      )
-      if (existingProjectPath) {
+      let existingProjectDirectory: string | undefined
+      let existingProjectPath: string | undefined
+      for (const projectDirectory of projectDirectories) {
+        existingProjectPath = await findLocalProjectPathByRemoteProjectId(
+          projectDirectory,
+          remoteProject.id,
+          projectName
+        )
+        if (existingProjectPath) {
+          existingProjectDirectory = projectDirectory
+          break
+        }
+      }
+      if (existingProjectPath && existingProjectDirectory) {
         let nextMetadata: ProjectMetadata = {
           ...(await getOrCreateProjectMetadata(existingProjectPath)),
           remoteProjectId: remoteProject.id,
@@ -2847,7 +3043,7 @@ async function syncRemoteIndex() {
           const deletedDuplicateProjectPaths =
             await cleanupDuplicateLocalRealizationsForRemoteProject({
               remoteProjectId: remoteProject.id,
-              projectDirectory,
+              projectDirectory: existingProjectDirectory,
               keepProjectPath: nextSyncedMetadata.localProjectPath,
             })
           for (const deletedProjectPath of deletedDuplicateProjectPaths) {
@@ -2884,38 +3080,38 @@ async function enqueueExistingCloudLibraryProjectsForInitialSync() {
     return
   }
 
-  const projectDirectory = getConfiguredProjectDirectoryPath()
-  if (!(await exists(projectDirectory))) {
-    initialLocalScanComplete = true
-    return
-  }
-
-  const entries = await localFs.readdir(projectDirectory)
-  for (const entry of entries) {
-    if (entry.startsWith('.')) {
-      continue
-    }
-    const projectPath = localFs.join(projectDirectory, entry)
-    if (!(await isExistingDirectory(projectPath))) {
+  for (const projectDirectory of getCloudLibraryMaterializationPaths()) {
+    if (!(await exists(projectDirectory))) {
       continue
     }
 
-    const metadata = await getProjectMetadata(projectPath)
-    const initialSyncAction = getCloudSyncInitialLocalProjectSyncAction({
-      hasBaseManifest: Boolean(metadata?.baseManifest),
-      tombstone: Boolean(metadata?.tombstone),
-      syncExcluded: isProjectSyncExcluded(metadata),
-    })
-    if (initialSyncAction === 'skip') {
-      continue
-    }
-    if (
-      !(await isLocalProjectEligibleForCurrentCloudEnvironment(projectPath))
-    ) {
-      continue
-    }
+    const entries = await localFs.readdir(projectDirectory)
+    for (const entry of entries) {
+      if (entry.startsWith('.')) {
+        continue
+      }
+      const projectPath = localFs.join(projectDirectory, entry)
+      if (!(await isExistingDirectory(projectPath))) {
+        continue
+      }
 
-    await registerProjectMutation(projectPath, 'upsert', projectPath)
+      const metadata = await getProjectMetadata(projectPath)
+      const initialSyncAction = getCloudSyncInitialLocalProjectSyncAction({
+        hasBaseManifest: Boolean(metadata?.baseManifest),
+        tombstone: Boolean(metadata?.tombstone),
+        syncExcluded: isProjectSyncExcluded(metadata),
+      })
+      if (initialSyncAction === 'skip') {
+        continue
+      }
+      if (
+        !(await isLocalProjectEligibleForCurrentCloudEnvironment(projectPath))
+      ) {
+        continue
+      }
+
+      await registerProjectMutation(projectPath, 'upsert', projectPath)
+    }
   }
 
   initialLocalScanComplete = true
@@ -2932,15 +3128,22 @@ async function runCloudSync() {
 
   syncInProgress = true
   pendingStatusSyncedAt = undefined
-  updateStatus({ enabled: true, state: 'syncing' })
+  updateStatus({ enabled: true })
   const scopedProjectPath = syncScopeProjectPath
+  const scopedScope = scopedProjectPath
+    ? {
+        projectPath: scopedProjectPath,
+        syncable: syncScopeSyncable,
+      }
+    : undefined
   let remoteIndexFailed = false
   let remoteIndexFailureMessage: string | undefined
 
   try {
     let entries = await getAllOutboxEntries()
-    let syncScopePlan = getCloudSyncScopePlan(entries, scopedProjectPath)
+    let syncScopePlan = getCloudSyncScopePlan(entries, scopedScope)
     if (syncScopePlan.shouldSyncRemoteIndex) {
+      updateStatus({ state: 'syncing' })
       await enqueueExistingCloudLibraryProjectsForInitialSync()
       await syncRemoteIndex().catch((error) => {
         remoteIndexFailed = true
@@ -2954,7 +3157,7 @@ async function runCloudSync() {
       })
 
       entries = await getAllOutboxEntries()
-      syncScopePlan = getCloudSyncScopePlan(entries, scopedProjectPath)
+      syncScopePlan = getCloudSyncScopePlan(entries, scopedScope)
     }
 
     for (const projectPath of syncScopePlan.projectPaths) {
@@ -3006,7 +3209,7 @@ async function runCloudSync() {
       lastFailure: errorMessage(error),
       lastFailureKind: kind,
       lastFailureAt: nowIso(),
-      activeProjectPath: scopedProjectPath,
+      activeProjectPath: scopedScope?.syncable ? scopedProjectPath : undefined,
       ...(syncedAt ? { lastSyncedAt: syncedAt } : {}),
     })
     scheduleSync(SYNC_RETRY_MS)
@@ -3041,15 +3244,22 @@ function scheduleRemoteIndexSync(delay = 0) {
   scheduleSync(delay)
 }
 
-// Home syncs the full cloud index; file routes narrow status and retries to
-// the open project so unrelated project conflicts do not pollute the editor UI.
-export function setCloudSyncProjectScope(projectPath?: string) {
-  const nextSyncScopeProjectPath = getSyncScopeProjectPath(projectPath)
-  if (syncScopeProjectPath === nextSyncScopeProjectPath) {
+// Home syncs the full cloud index; file routes pass the project root selected
+// by the current library so status and retries stay limited to that project.
+export function setCloudSyncProjectScope(scope?: CloudSyncProjectScope) {
+  const nextScope = normalizeCloudSyncProjectScope(scope)
+  const nextSyncScopeProjectPath = nextScope?.projectPath
+  const nextSyncScopeSyncable = nextScope?.syncable ?? false
+  if (
+    syncScopeProjectPath === nextSyncScopeProjectPath &&
+    syncScopeSyncable === nextSyncScopeSyncable
+  ) {
     return
   }
 
   syncScopeProjectPath = nextSyncScopeProjectPath
+  syncScopeSyncable = nextSyncScopeSyncable
+  void refreshScopedProjectCloudProjectId(nextScope)
   void refreshPendingCount()
 
   const statusProjectPath = cloudSyncStatus.value.activeProjectPath
@@ -3093,7 +3303,7 @@ export async function startCloudSyncProject(projectPath: string) {
   )
 
   await clearOutboxEntriesForProject(normalizedProjectPath)
-  await putProjectMetadata({
+  const nextMetadata = {
     ...metadata,
     localProjectPath: normalizedProjectPath,
     projectName: projectNameFromPath(normalizedProjectPath),
@@ -3101,7 +3311,9 @@ export async function startCloudSyncProject(projectPath: string) {
     syncExcluded: undefined,
     conflict: undefined,
     lastFailure: undefined,
-  })
+  }
+  await putProjectMetadata(nextMetadata)
+  publishScopedProjectCloudProjectId(nextMetadata)
   await appendOutboxEntry({
     projectPath: normalizedProjectPath,
     kind: 'upsert',
@@ -3136,7 +3348,7 @@ export async function disconnectCloudSyncProject(projectPath: string) {
   const disconnectedAt = nowIso()
 
   await removeLocalProjectCloudProjectId(normalizedProjectPath)
-  await putProjectMetadata({
+  const disconnectedMetadata: ProjectMetadata = {
     ...metadata,
     localProjectPath: normalizedProjectPath,
     projectName: projectNameFromPath(normalizedProjectPath),
@@ -3153,19 +3365,23 @@ export async function disconnectCloudSyncProject(projectPath: string) {
       remoteProjectId,
       createdAt: disconnectedAt,
     },
-  })
+  }
+  await putProjectMetadata(disconnectedMetadata)
+  publishScopedProjectCloudProjectId(disconnectedMetadata)
 
   if (remoteProjectId) {
     try {
       await deleteRemoteProject(config, remoteProjectId)
     } catch (error) {
       if (!(error instanceof CloudApiError && error.status === 404)) {
-        await putProjectMetadata({
+        const restoredMetadata = {
           ...metadata,
           localProjectPath: normalizedProjectPath,
           projectName: projectNameFromPath(normalizedProjectPath),
           syncExcluded: undefined,
-        })
+        }
+        await putProjectMetadata(restoredMetadata)
+        publishScopedProjectCloudProjectId(restoredMetadata)
         await writeLocalProjectCloudProjectId(
           normalizedProjectPath,
           remoteProjectId
@@ -3177,24 +3393,8 @@ export async function disconnectCloudSyncProject(projectPath: string) {
   }
 
   await clearOutboxEntriesForProject(normalizedProjectPath)
-  await putProjectMetadata({
-    ...metadata,
-    localProjectPath: normalizedProjectPath,
-    projectName: projectNameFromPath(normalizedProjectPath),
-    remoteProjectId: undefined,
-    remoteRevision: undefined,
-    remoteUpdatedAt: undefined,
-    baseManifest: undefined,
-    tombstone: false,
-    conflict: undefined,
-    lastFailure: undefined,
-    lastSyncedAt: undefined,
-    syncExcluded: {
-      reason: 'user-disconnected',
-      remoteProjectId,
-      createdAt: disconnectedAt,
-    },
-  })
+  await putProjectMetadata(disconnectedMetadata)
+  publishScopedProjectCloudProjectId(disconnectedMetadata)
   if (remoteProjectId) {
     cloudSyncRemoteProjects.value = cloudSyncRemoteProjects.value.filter(
       (project) => project.id !== remoteProjectId
@@ -3327,6 +3527,16 @@ async function registerProjectMutation(
   ) {
     return
   }
+  const cloudBinding = await readProjectTomlCloudEnvironmentBinding(
+    normalizedProjectPath
+  ).catch(() => ({ kind: 'unbound' }) as const)
+  if (
+    !existingMetadata &&
+    !getOwningCloudLibraryMaterializationPath(normalizedProjectPath) &&
+    cloudBinding.kind !== 'current-environment'
+  ) {
+    return
+  }
   let metadata =
     existingMetadata ??
     (await getOrCreateProjectMetadata(normalizedProjectPath))
@@ -3334,9 +3544,6 @@ async function registerProjectMutation(
     await clearOutboxEntriesForProject(normalizedProjectPath)
     return
   }
-  const cloudBinding = await readProjectTomlCloudEnvironmentBinding(
-    normalizedProjectPath
-  ).catch(() => ({ kind: 'unbound' }) as const)
   if (cloudBinding.kind === 'other-environment') {
     await clearOutboxEntriesForProject(normalizedProjectPath)
     return
@@ -3372,8 +3579,8 @@ async function registerProjectRename(sourcePath: string, targetPath: string) {
     return
   }
 
-  const sourceProjectRoot = getConfiguredProjectRoot(sourcePath)
-  const targetProjectRoot = getConfiguredProjectRoot(targetPath)
+  const sourceProjectRoot = getSyncPolicyProjectRoot(sourcePath)
+  const targetProjectRoot = getSyncPolicyProjectRoot(targetPath)
   if (!targetProjectRoot) {
     return
   }
@@ -3408,9 +3615,9 @@ async function registerProjectRename(sourcePath: string, targetPath: string) {
 }
 
 async function afterWriteLikeMutation(targetPath: string) {
-  const projectRoot = getConfiguredProjectRoot(targetPath)
+  const projectRoot = getSyncPolicyProjectRoot(targetPath)
   if (!projectRoot) {
-    if (isConfiguredProjectDirectoryPath(targetPath)) {
+    if (isCloudLibraryMaterializationPath(targetPath)) {
       scheduleSync()
     }
     return
@@ -3420,7 +3627,7 @@ async function afterWriteLikeMutation(targetPath: string) {
 }
 
 async function afterRemoveMutation(targetPath: string) {
-  const projectRoot = getConfiguredProjectRoot(targetPath)
+  const projectRoot = getSyncPolicyProjectRoot(targetPath)
   if (!projectRoot) {
     return
   }
@@ -3466,7 +3673,8 @@ export function configureCloudSyncEngine(nextConfig: CloudSyncConfig) {
     previousConfig.baseUrl !== config.baseUrl ||
     previousConfig.environmentName !== config.environmentName
   const projectDirectoryChanged =
-    previousConfig.projectDirectoryPath !== config.projectDirectoryPath
+    getCloudLibraryMaterializationConfigKey(previousConfig) !==
+    getCloudLibraryMaterializationConfigKey(config)
   const autoEnrollPolicyChanged =
     previousConfig.autoEnrollCloudLibraryProjects !==
     config.autoEnrollCloudLibraryProjects
@@ -3492,6 +3700,8 @@ export function configureCloudSyncEngine(nextConfig: CloudSyncConfig) {
       enabled: false,
       state: 'disabled',
       activeProjectPath: undefined,
+      scopedProjectPath: undefined,
+      scopedProjectCloudProjectId: undefined,
       lastFailure: undefined,
       lastFailureAt: undefined,
     })
@@ -3517,6 +3727,14 @@ export function configureCloudSyncEngine(nextConfig: CloudSyncConfig) {
         }
       : {}),
   })
+  void refreshScopedProjectCloudProjectId(
+    syncScopeProjectPath
+      ? {
+          projectPath: syncScopeProjectPath,
+          syncable: syncScopeSyncable,
+        }
+      : undefined
+  )
   void refreshPendingCount()
   scheduleSync(0)
 }

--- a/src/lib/cloudSync/environmentEligibility.spec.ts
+++ b/src/lib/cloudSync/environmentEligibility.spec.ts
@@ -5,16 +5,16 @@ import {
   configureCloudSyncLocalFileSystem,
 } from '@src/lib/cloudSync'
 import {
-  deleteCloudSyncTestDatabase,
+  getAllOutboxEntries,
+  getProjectMetadata,
+} from '@src/lib/cloudSync/syncDb'
+import {
   createCloudSyncTestFs,
+  deleteCloudSyncTestDatabase,
   getFetchMethod,
   getFetchUrl,
   jsonResponse,
 } from '@src/lib/cloudSync/testUtils'
-import {
-  getAllOutboxEntries,
-  getProjectMetadata,
-} from '@src/lib/cloudSync/syncDb'
 import { PROJECT_SETTINGS_FILE_NAME } from '@src/lib/constants'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -78,7 +78,7 @@ describe('cloud sync environment eligibility', () => {
       enabled: true,
       baseUrl,
       environmentName: currentEnvironmentName,
-      projectDirectoryPath: projectDirectory,
+      cloudProjectDirectoryPaths: [projectDirectory],
       autoEnrollCloudLibraryProjects: true,
     })
 

--- a/src/lib/cloudSync/index.test.ts
+++ b/src/lib/cloudSync/index.test.ts
@@ -5,20 +5,20 @@ import {
   getCloudSyncKnownLocalRemoteIndexAction,
   getCloudSyncMissingRemoteProjectAction,
   getCloudSyncProjectModifiedTime,
-  getCloudSyncProjectRoot,
+  getCloudSyncProjectRootInDirectories,
+  getCloudSyncProjectRootInDirectory,
   getCloudSyncProjectSyncPreflightAction,
   getCloudSyncRemoteArchiveReconciliationAction,
   getCloudSyncRemoteIndexAction,
   getCloudSyncScopePlan,
-  shouldAutoEnrollCloudLibraryProject,
   type OutboxEntry,
   type ProjectArchiveFile,
   type ProjectManifest,
   prepareProjectFilesForCloudUpload,
   projectManifestsEqual,
+  shouldAutoEnrollCloudLibraryProject,
 } from '@src/lib/cloudSync'
 import {
-  DEFAULT_CLOUD_PROJECT_DIRECTORY_PATH,
   getCloudProjectLibraryMaterializationDirectoryPath,
   isCloudSyncExcludedPath,
 } from '@src/lib/cloudSync/paths'
@@ -29,13 +29,18 @@ import {
   withRemoteProjectMetadataInArchiveFiles,
 } from '@src/lib/cloudSync/projectArchive'
 import {
-  PROJECT_FOLDER,
   PROJECT_IMAGE_NAME,
   PROJECT_SETTINGS_FILE_NAME,
 } from '@src/lib/constants'
-import { describe, expect, it } from 'vitest'
+import fsZds from '@src/lib/fs-zds'
+import { INITIAL_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH_SETTING } from '@src/lib/projectLibraries'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const encoder = new TextEncoder()
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 function projectFile(relativePath: string, contents = ''): ProjectArchiveFile {
   return {
@@ -51,12 +56,6 @@ function readProjectFile(files: ProjectArchiveFile[], relativePath: string) {
 }
 
 describe('cloudSync sync helpers', () => {
-  it('uses the web project directory as the default cloud project directory fallback', () => {
-    expect(DEFAULT_CLOUD_PROJECT_DIRECTORY_PATH).toBe(
-      `/documents/${PROJECT_FOLDER}`
-    )
-  })
-
   it('uses a configured cloud library path as its materialization directory', async () => {
     await expect(
       getCloudProjectLibraryMaterializationDirectoryPath({
@@ -66,40 +65,113 @@ describe('cloudSync sync helpers', () => {
     ).resolves.toBe('/team-cloud')
   })
 
-  it('identifies project roots beneath the personal Zoo cloud directory', () => {
+  it('resolves default personal cloud library paths to the app-managed materialization directory', async () => {
+    vi.spyOn(fsZds, 'getPath').mockResolvedValue('/appData')
+    vi.spyOn(fsZds, 'join').mockImplementation((...parts) =>
+      parts.reduce((targetPath, part) => `${targetPath}/${part}`)
+    )
+
+    for (const path of [
+      undefined,
+      '',
+      INITIAL_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH_SETTING,
+    ]) {
+      await expect(
+        getCloudProjectLibraryMaterializationDirectoryPath({
+          ...(path === undefined ? {} : { path }),
+          type: 'cloud',
+        })
+      ).resolves.toBe('/appData/CloudSync/Zoo/local')
+    }
+
+    expect(fsZds.getPath).toHaveBeenCalledTimes(3)
+    expect(fsZds.getPath).toHaveBeenCalledWith('appData')
+  })
+
+  it('requires explicit paths for non-personal cloud libraries', async () => {
+    await expect(
+      getCloudProjectLibraryMaterializationDirectoryPath({
+        source: '/team',
+        type: 'cloud',
+      })
+    ).rejects.toThrow('Expected a cloud project library materialization path.')
+  })
+
+  it('rejects non-cloud libraries as cloud materialization sources', async () => {
+    await expect(
+      getCloudProjectLibraryMaterializationDirectoryPath({
+        path: '/projects',
+        type: 'directory',
+      })
+    ).rejects.toThrow('Expected a cloud project library.')
+  })
+
+  it('identifies the owning project root beneath a cloud library root', () => {
     expect(
-      getCloudSyncProjectRoot(
-        '/Users/frank/Library/CloudStorage/Zoo/personal/bracket/main.kcl'
+      getCloudSyncProjectRootInDirectory(
+        '/cloud/personal/bracket/main.kcl',
+        '/cloud/personal'
       )
-    ).toBe('/Users/frank/Library/CloudStorage/Zoo/personal/bracket')
+    ).toBe('/cloud/personal/bracket')
 
     expect(
-      getCloudSyncProjectRoot('/Users/frank/Library/CloudStorage/Zoo/personal')
+      getCloudSyncProjectRootInDirectory(
+        '/cloud/personal/bracket/nested/part.kcl',
+        '/cloud/personal'
+      )
+    ).toBe('/cloud/personal/bracket')
+
+    expect(
+      getCloudSyncProjectRootInDirectory(
+        '/cloud/personal/bracket/',
+        '/cloud/personal'
+      )
+    ).toBe('/cloud/personal/bracket')
+  })
+
+  it('does not infer project roots outside the owning cloud library root', () => {
+    expect(
+      getCloudSyncProjectRootInDirectory('/cloud/personal', '/cloud/personal')
+    ).toBeUndefined()
+
+    expect(
+      getCloudSyncProjectRootInDirectory(
+        '/cloud/personal-archive/bracket/main.kcl',
+        '/cloud/personal'
+      )
+    ).toBeUndefined()
+
+    expect(
+      getCloudSyncProjectRootInDirectory(
+        '/documents/zoo-design-studio-projects/bracket/main.kcl',
+        '/cloud/personal'
+      )
     ).toBeUndefined()
   })
 
-  it('identifies project roots beneath the OPFS project directory', () => {
+  it('normalizes path separators before finding the cloud-library project root', () => {
     expect(
-      getCloudSyncProjectRoot(`/documents/${PROJECT_FOLDER}/bracket/main.kcl`)
-    ).toBe(`/documents/${PROJECT_FOLDER}/bracket`)
-
-    expect(
-      getCloudSyncProjectRoot(
-        `/documents/${PROJECT_FOLDER}/bracket/nested/part.kcl`
+      getCloudSyncProjectRootInDirectory(
+        '\\cloud\\personal\\bracket\\main.kcl',
+        '\\cloud\\personal\\'
       )
-    ).toBe(`/documents/${PROJECT_FOLDER}/bracket`)
-
-    expect(
-      getCloudSyncProjectRoot(`/documents/${PROJECT_FOLDER}`)
-    ).toBeUndefined()
+    ).toBe('/cloud/personal/bracket')
   })
 
-  it('normalizes Windows separators when identifying project roots', () => {
+  it('uses the most specific owning cloud library root when multiple roots match', () => {
     expect(
-      getCloudSyncProjectRoot(
-        `\\documents\\${PROJECT_FOLDER}\\bracket\\main.kcl`
-      )
-    ).toBe(`/documents/${PROJECT_FOLDER}/bracket`)
+      getCloudSyncProjectRootInDirectories('/cloud/team/bracket/main.kcl', [
+        '/cloud',
+        '/cloud/team',
+      ])
+    ).toBe('/cloud/team/bracket')
+
+    expect(
+      getCloudSyncProjectRootInDirectories('/cloud/personal/bracket/main.kcl', [
+        '/cloud/team',
+        '/cloud/personal',
+      ])
+    ).toBe('/cloud/personal/bracket')
   })
 
   it('compares manifests by path, size, and content hash without depending on object key order', () => {
@@ -652,7 +724,12 @@ describe('cloudSync sync helpers', () => {
       pendingCount: 2,
     })
 
-    expect(getCloudSyncScopePlan(entries, '/projects/current')).toEqual({
+    expect(
+      getCloudSyncScopePlan(entries, {
+        projectPath: '/projects/current',
+        syncable: true,
+      })
+    ).toEqual({
       shouldSyncRemoteIndex: false,
       projectPaths: ['/projects/current'],
       pendingCount: 1,
@@ -687,7 +764,12 @@ describe('cloudSync sync helpers', () => {
       pendingCount: 2,
     })
 
-    expect(getCloudSyncScopePlan(entries, '/projects/current')).toEqual({
+    expect(
+      getCloudSyncScopePlan(entries, {
+        projectPath: '/projects/current',
+        syncable: true,
+      })
+    ).toEqual({
       shouldSyncRemoteIndex: false,
       projectPaths: ['/projects/current'],
       pendingCount: 1,
@@ -695,9 +777,36 @@ describe('cloudSync sync helpers', () => {
   })
 
   it('keeps syncing the open project even when it has no queued local edits', () => {
-    expect(getCloudSyncScopePlan([], '/projects/current')).toEqual({
+    expect(
+      getCloudSyncScopePlan([], {
+        projectPath: '/projects/current',
+        syncable: true,
+      })
+    ).toEqual({
       shouldSyncRemoteIndex: false,
       projectPaths: ['/projects/current'],
+      pendingCount: 0,
+    })
+  })
+
+  it('suppresses sync work for file-route scopes outside project libraries', () => {
+    const entries: OutboxEntry[] = [
+      {
+        projectPath: '/projects/other',
+        kind: 'upsert',
+        targetPath: '/projects/other/main.kcl',
+        createdAt: '2026-06-12T00:00:00.000Z',
+      },
+    ]
+
+    expect(
+      getCloudSyncScopePlan(entries, {
+        projectPath: '/external/random',
+        syncable: false,
+      })
+    ).toEqual({
+      shouldSyncRemoteIndex: false,
+      projectPaths: [],
       pendingCount: 0,
     })
   })

--- a/src/lib/cloudSync/index.ts
+++ b/src/lib/cloudSync/index.ts
@@ -14,6 +14,7 @@ export { retryCloudSyncEngine as retryCloudSync } from '@src/lib/cloudSync/engin
 export type {
   CloudSyncConfig,
   CloudSyncProjectMetadataIndexEntry,
+  CloudSyncProjectScope,
   CloudSyncStatus,
   ProjectMetadata as CloudSyncProjectMetadata,
   ProjectSyncFailure,

--- a/src/lib/cloudSync/liveConflicts.test.ts
+++ b/src/lib/cloudSync/liveConflicts.test.ts
@@ -194,7 +194,7 @@ describe('cloud sync live conflicts', () => {
       enabled: true,
       baseUrl,
       environmentName: 'dev.zoo.dev',
-      projectDirectoryPath: projectDirectory,
+      cloudProjectDirectoryPaths: [projectDirectory],
       autoEnrollCloudLibraryProjects: false,
     })
 
@@ -243,7 +243,7 @@ describe('cloud sync live conflicts', () => {
       enabled: true,
       baseUrl,
       environmentName: 'dev.zoo.dev',
-      projectDirectoryPath: projectDirectory,
+      cloudProjectDirectoryPaths: [projectDirectory],
       autoEnrollCloudLibraryProjects: false,
     })
 
@@ -330,7 +330,7 @@ describe('cloud sync live conflicts', () => {
       enabled: true,
       baseUrl,
       environmentName: 'dev.zoo.dev',
-      projectDirectoryPath: projectDirectory,
+      cloudProjectDirectoryPaths: [projectDirectory],
     })
 
     await vi.waitFor(async () => {
@@ -373,7 +373,7 @@ describe('cloud sync live conflicts', () => {
       enabled: false,
       baseUrl,
       environmentName: 'dev.zoo.dev',
-      projectDirectoryPath: projectDirectory,
+      cloudProjectDirectoryPaths: [projectDirectory],
       autoEnrollCloudLibraryProjects: false,
     })
 

--- a/src/lib/cloudSync/localProjectNames.spec.ts
+++ b/src/lib/cloudSync/localProjectNames.spec.ts
@@ -11,7 +11,6 @@ import {
   normalizeProjectArchiveFilesForCloudSync,
   projectManifestFromFiles,
 } from '@src/lib/cloudSync/projectArchive'
-import type { ProjectArchiveFile } from '@src/lib/cloudSync/types'
 import {
   getAllOutboxEntries,
   putProjectMetadata,
@@ -23,6 +22,7 @@ import {
   getFetchUrl,
   jsonResponse,
 } from '@src/lib/cloudSync/testUtils'
+import type { ProjectArchiveFile } from '@src/lib/cloudSync/types'
 import { PROJECT_SETTINGS_FILE_NAME } from '@src/lib/constants'
 import type * as TrapModule from '@src/lib/trap'
 import { reportRejection } from '@src/lib/trap'
@@ -94,7 +94,7 @@ function configureCloudSyncTestFs(
     enabled: true,
     baseUrl,
     environmentName: 'dev.zoo.dev',
-    projectDirectoryPath: projectDirectory,
+    cloudProjectDirectoryPaths: [projectDirectory],
     autoEnrollCloudLibraryProjects: false,
   })
 }

--- a/src/lib/cloudSync/paths.ts
+++ b/src/lib/cloudSync/paths.ts
@@ -1,20 +1,17 @@
-import { PROJECT_FOLDER } from '@src/lib/constants'
+import { webSafePathSplit } from '@src/lib/pathUtils'
 import fsZds from '@src/lib/fs-zds'
-import { webSafeJoin, webSafePathSplit } from '@src/lib/pathUtils'
 import {
   CLOUD_PROJECT_LIBRARY_TYPE,
   isDefaultPersonalCloudProjectLibraryPathSetting,
-  isLegacyPersonalCloudProjectLibraryPathSetting,
   type ProjectLibrarySetting,
 } from '@src/lib/projectLibraries'
 
+export const DEFAULT_CLOUD_PROJECT_LIBRARY_MATERIALIZATION_PATH_PARTS = [
+  'CloudSync',
+  'Zoo',
+  'local',
+] as const
 export const INTERNAL_OPFS_META_FILE = '._meta'
-export const CLOUD_PROJECT_LIBRARY_FOLDER = 'Zoo'
-export const PERSONAL_CLOUD_PROJECT_LIBRARY_FOLDER = 'personal'
-export const DEFAULT_CLOUD_PROJECT_DIRECTORY_PATH = `/${webSafeJoin([
-  'documents',
-  PROJECT_FOLDER,
-])}`
 const CLOUD_SYNC_EXCLUDED_PATH_PARTS = new Set([
   INTERNAL_OPFS_META_FILE,
   '.git',
@@ -23,54 +20,34 @@ const CLOUD_SYNC_EXCLUDED_PATH_PARTS = new Set([
   '.jj',
 ])
 
-export async function getDefaultCloudProjectDirectoryPath() {
-  if (typeof window !== 'undefined' && window.electron?.os.isMac) {
-    try {
-      return fsZds.join(
-        fsZds.dirname(await fsZds.getPath('appData')),
-        'CloudStorage',
-        CLOUD_PROJECT_LIBRARY_FOLDER,
-        PERSONAL_CLOUD_PROJECT_LIBRARY_FOLDER
-      )
-    } catch {
-      // Fall back to the shared desktop home location below.
-    }
+export async function getCloudProjectLibraryMaterializationDirectoryPath(
+  library: Pick<ProjectLibrarySetting, 'source' | 'type'> & { path?: string }
+) {
+  if (library.type !== CLOUD_PROJECT_LIBRARY_TYPE) {
+    // eslint-disable-next-line suggest-no-throw/suggest-no-throw
+    throw new Error('Expected a cloud project library.')
   }
 
-  if (typeof window !== 'undefined' && !window.electron) {
-    try {
-      return fsZds.join(await fsZds.getPath('documents'), PROJECT_FOLDER)
-    } catch {
-      return DEFAULT_CLOUD_PROJECT_DIRECTORY_PATH
-    }
+  if (isDefaultPersonalCloudProjectLibraryPathSetting(library)) {
+    return getDefaultCloudProjectLibraryMaterializationDirectoryPath()
   }
 
-  try {
-    return fsZds.join(
-      await fsZds.getPath('home'),
-      CLOUD_PROJECT_LIBRARY_FOLDER,
-      PERSONAL_CLOUD_PROJECT_LIBRARY_FOLDER
-    )
-  } catch {
-    return DEFAULT_CLOUD_PROJECT_DIRECTORY_PATH
+  const configuredPath = normalizePathForSync(library.path?.trim() ?? '')
+  if (configuredPath) {
+    return configuredPath
   }
+
+  // eslint-disable-next-line suggest-no-throw/suggest-no-throw
+  throw new Error('Expected a cloud project library materialization path.')
 }
 
-export async function getCloudProjectLibraryMaterializationDirectoryPath(
-  library: Pick<ProjectLibrarySetting, 'path' | 'source' | 'type'> | undefined
-) {
-  if (library?.type !== CLOUD_PROJECT_LIBRARY_TYPE) {
-    return getDefaultCloudProjectDirectoryPath()
-  }
-
-  if (
-    isLegacyPersonalCloudProjectLibraryPathSetting(library) ||
-    isDefaultPersonalCloudProjectLibraryPathSetting(library)
-  ) {
-    return getDefaultCloudProjectDirectoryPath()
-  }
-
-  return normalizePathForSync(library.path)
+export async function getDefaultCloudProjectLibraryMaterializationDirectoryPath() {
+  return normalizePathForSync(
+    fsZds.join(
+      await fsZds.getPath('appData'),
+      ...DEFAULT_CLOUD_PROJECT_LIBRARY_MATERIALIZATION_PATH_PARTS
+    )
+  )
 }
 
 export function normalizePathForSync(targetPath: string) {
@@ -94,54 +71,6 @@ export function isCloudSyncExcludedPath(targetPath: string) {
   )
 }
 
-function getProjectRootFromProjectDirectoryParts(
-  parts: readonly string[],
-  projectDirectoryParts: readonly string[]
-) {
-  const maxStartIndex = parts.length - projectDirectoryParts.length - 1
-  for (let index = maxStartIndex; index >= 0; index -= 1) {
-    const isMatch = projectDirectoryParts.every(
-      (part, offset) => parts[index + offset] === part
-    )
-    if (!isMatch) {
-      continue
-    }
-
-    return `/${webSafeJoin(
-      parts.slice(0, index + projectDirectoryParts.length + 1)
-    )}`
-  }
-
-  return undefined
-}
-
-export function getCloudSyncProjectRoot(
-  targetPath: string
-): string | undefined {
-  const normalized = normalizePathForSync(targetPath)
-  const parts = webSafePathSplit(normalized).filter(Boolean)
-  return (
-    getProjectRootFromProjectDirectoryParts(parts, [PROJECT_FOLDER]) ??
-    getProjectRootFromProjectDirectoryParts(parts, [
-      CLOUD_PROJECT_LIBRARY_FOLDER,
-      PERSONAL_CLOUD_PROJECT_LIBRARY_FOLDER,
-    ])
-  )
-}
-
 export function isProjectRootPath(targetPath: string, projectRoot: string) {
   return normalizePathForSync(targetPath) === normalizePathForSync(projectRoot)
-}
-
-export function isCloudSyncProjectDirectoryPath(targetPath: string) {
-  const normalized = normalizePathForSync(targetPath)
-  return (
-    normalized.endsWith(`/${PROJECT_FOLDER}`) ||
-    normalized.endsWith(
-      `/${webSafeJoin([
-        CLOUD_PROJECT_LIBRARY_FOLDER,
-        PERSONAL_CLOUD_PROJECT_LIBRARY_FOLDER,
-      ])}`
-    )
-  )
 }

--- a/src/lib/cloudSync/policy.spec.ts
+++ b/src/lib/cloudSync/policy.spec.ts
@@ -1,20 +1,22 @@
 import 'fake-indexeddb/auto'
+import type * as ClientErrorsModule from '@src/lib/clientErrors'
 import {
   configureCloudSyncEngine,
   configureCloudSyncLocalFileSystem,
   filterCloudSyncProjectFilesForSync,
+  notifyCloudSyncRenameMutation,
   notifyCloudSyncWriteLikeMutation,
+  type ProjectArchiveFile,
   retryCloudSync,
   setCloudSyncProjectScope,
-  type ProjectArchiveFile,
 } from '@src/lib/cloudSync'
+import { projectManifestFromFiles } from '@src/lib/cloudSync/projectArchive'
 import {
   appendOutboxEntry,
   getAllOutboxEntries,
   getProjectMetadata,
   putProjectMetadata,
 } from '@src/lib/cloudSync/syncDb'
-import { projectManifestFromFiles } from '@src/lib/cloudSync/projectArchive'
 import {
   createCloudSyncTestFs,
   deleteCloudSyncTestDatabase,
@@ -23,10 +25,23 @@ import {
   jsonResponse,
 } from '@src/lib/cloudSync/testUtils'
 import {
+  PROJECT_FOLDER,
   PROJECT_IMAGE_NAME,
   PROJECT_SETTINGS_FILE_NAME,
 } from '@src/lib/constants'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const clientErrorsMock = vi.hoisted(() => ({
+  reportClientError: vi.fn(),
+}))
+
+vi.mock('@src/lib/clientErrors', async (importOriginal) => {
+  const actual = await importOriginal<typeof ClientErrorsModule>()
+  return {
+    ...actual,
+    reportClientError: clientErrorsMock.reportClientError,
+  }
+})
 
 const encoder = new TextEncoder()
 const baseUrl = 'https://example.test'
@@ -64,6 +79,10 @@ function installFetchMock() {
       })
     }
 
+    if (url.endsWith('/user/client-errors') && method === 'POST') {
+      return jsonResponse({})
+    }
+
     return jsonResponse({ message: `Unexpected fetch: ${method} ${url}` }, 500)
   })
   vi.stubGlobal('fetch', fetchMock)
@@ -88,6 +107,7 @@ describe('cloud sync file policy', () => {
   afterEach(async () => {
     setCloudSyncProjectScope(undefined)
     configureCloudSyncEngine({ enabled: false })
+    clientErrorsMock.reportClientError.mockClear()
     vi.unstubAllGlobals()
     await deleteCloudSyncTestDatabase()
   })
@@ -102,13 +122,288 @@ describe('cloud sync file policy', () => {
       enabled: true,
       baseUrl,
       environmentName: 'dev.zoo.dev',
-      projectDirectoryPath: projectDirectory,
+      cloudProjectDirectoryPaths: [projectDirectory],
       autoEnrollCloudLibraryProjects: false,
     })
 
     await notifyCloudSyncWriteLikeMutation(topLevelFilePath)
 
     expect(await getProjectMetadata(topLevelFilePath)).toBeUndefined()
+    expect(await getAllOutboxEntries()).toEqual([])
+  })
+
+  it('records nested cloud-library file mutations at the owning project root', async () => {
+    const nestedFilePath = `${projectPath}/nested/part.kcl`
+    const files = new Map([
+      [`${projectPath}/${PROJECT_SETTINGS_FILE_NAME}`, `title = "Bracket"\n`],
+      [nestedFilePath, 'cube = 1\n'],
+    ])
+    configureCloudSyncLocalFileSystem(
+      createCloudSyncTestFs(files, { projectDirectory })
+    )
+    configureCloudSyncEngine({
+      enabled: true,
+      baseUrl,
+      environmentName: 'dev.zoo.dev',
+      cloudProjectDirectoryPaths: [projectDirectory],
+      autoEnrollCloudLibraryProjects: false,
+    })
+
+    await notifyCloudSyncWriteLikeMutation(nestedFilePath)
+
+    await expect(getProjectMetadata(projectPath)).resolves.toMatchObject({
+      localProjectPath: projectPath,
+      projectName: 'bracket',
+    })
+    await expect(
+      getProjectMetadata(`${projectPath}/nested`)
+    ).resolves.toBeUndefined()
+    expect(await getAllOutboxEntries()).toEqual([])
+  })
+
+  it('records nested mutations under the owning cloud library when multiple cloud libraries are configured', async () => {
+    const teamProjectDirectory = '/cloud/team'
+    const teamProjectPath = `${teamProjectDirectory}/team-bracket`
+    const nestedFilePath = `${teamProjectPath}/nested/part.kcl`
+    const files = new Map([
+      [
+        `${teamProjectPath}/${PROJECT_SETTINGS_FILE_NAME}`,
+        `title = "Team bracket"\n`,
+      ],
+      [nestedFilePath, 'cube = 1\n'],
+    ])
+    configureCloudSyncLocalFileSystem(
+      createCloudSyncTestFs(files, { projectDirectory })
+    )
+    configureCloudSyncEngine({
+      enabled: true,
+      baseUrl,
+      environmentName: 'dev.zoo.dev',
+      cloudProjectDirectoryPaths: [projectDirectory, teamProjectDirectory],
+      autoEnrollCloudLibraryProjects: false,
+    })
+
+    await notifyCloudSyncWriteLikeMutation(nestedFilePath)
+
+    await expect(getProjectMetadata(teamProjectPath)).resolves.toMatchObject({
+      localProjectPath: teamProjectPath,
+      projectName: 'team-bracket',
+    })
+    await expect(
+      getProjectMetadata(`${teamProjectPath}/nested`)
+    ).resolves.toBeUndefined()
+    expect(await getAllOutboxEntries()).toEqual([])
+  })
+
+  it('does not infer directory-library projects from legacy project folder names', async () => {
+    const cloudProjectDirectory = '/cloud/personal'
+    const directoryLibraryPath = `/documents/${PROJECT_FOLDER}`
+    const directoryProjectPath = `${directoryLibraryPath}/local-only-project`
+    const files = new Map([
+      [`${directoryProjectPath}/main.kcl`, 'cube = 1\n'],
+      [
+        `${directoryProjectPath}/${PROJECT_SETTINGS_FILE_NAME}`,
+        `title = "Local only project"\n`,
+      ],
+    ])
+    configureCloudSyncLocalFileSystem(
+      createCloudSyncTestFs(files, { projectDirectory: cloudProjectDirectory })
+    )
+    configureCloudSyncEngine({
+      enabled: true,
+      baseUrl,
+      environmentName: 'dev.zoo.dev',
+      cloudProjectDirectoryPaths: [cloudProjectDirectory],
+      autoEnrollCloudLibraryProjects: true,
+    })
+
+    await notifyCloudSyncWriteLikeMutation(`${directoryProjectPath}/main.kcl`)
+
+    expect(await getProjectMetadata(directoryProjectPath)).toBeUndefined()
+    expect(await getAllOutboxEntries()).toEqual([])
+    expect(
+      fetchMock.mock.calls.some(
+        ([input, init]) => getFetchMethod(input, init) === 'POST'
+      )
+    ).toBe(false)
+  })
+
+  it('does not create metadata for unlinked directory-library projects in a scoped file route', async () => {
+    const cloudProjectDirectory = '/cloud/personal'
+    const directoryLibraryPath = '/documents/Projects'
+    const directoryProjectPath = `${directoryLibraryPath}/local-only-project`
+    const files = new Map([
+      [`${directoryProjectPath}/main.kcl`, 'cube = 1\n'],
+      [
+        `${directoryProjectPath}/${PROJECT_SETTINGS_FILE_NAME}`,
+        `title = "Local only project"\n`,
+      ],
+    ])
+    configureCloudSyncLocalFileSystem(
+      createCloudSyncTestFs(files, { projectDirectory: cloudProjectDirectory })
+    )
+    configureCloudSyncEngine({
+      enabled: true,
+      baseUrl,
+      environmentName: 'dev.zoo.dev',
+      cloudProjectDirectoryPaths: [cloudProjectDirectory],
+      autoEnrollCloudLibraryProjects: false,
+    })
+    setCloudSyncProjectScope({
+      projectPath: directoryProjectPath,
+      syncable: true,
+    })
+
+    await notifyCloudSyncWriteLikeMutation(`${directoryProjectPath}/main.kcl`)
+
+    expect(await getProjectMetadata(directoryProjectPath)).toBeUndefined()
+    expect(await getAllOutboxEntries()).toEqual([])
+  })
+
+  it('does not sync cloud-id projects opened outside every project library', async () => {
+    const cloudProjectDirectory = '/cloud/personal'
+    const externalProjectPath = '/Users/frank/Desktop/random-project'
+    const files = new Map([
+      [`${externalProjectPath}/main.kcl`, 'cube = 1\n'],
+      [`${externalProjectPath}/${PROJECT_SETTINGS_FILE_NAME}`, projectToml],
+    ])
+    configureCloudSyncLocalFileSystem(
+      createCloudSyncTestFs(files, { projectDirectory: cloudProjectDirectory })
+    )
+    configureCloudSyncEngine({
+      enabled: true,
+      baseUrl,
+      environmentName: 'dev.zoo.dev',
+      cloudProjectDirectoryPaths: [cloudProjectDirectory],
+      autoEnrollCloudLibraryProjects: false,
+    })
+    setCloudSyncProjectScope({
+      projectPath: externalProjectPath,
+      syncable: false,
+    })
+
+    await notifyCloudSyncWriteLikeMutation(`${externalProjectPath}/main.kcl`)
+
+    expect(await getProjectMetadata(externalProjectPath)).toBeUndefined()
+    expect(await getAllOutboxEntries()).toEqual([])
+    expect(
+      fetchMock.mock.calls.some(([input]) =>
+        getFetchUrl(input).startsWith(remoteProjectUrl)
+      )
+    ).toBe(false)
+  })
+
+  it('does not treat sibling paths as cloud-library projects by prefix match', async () => {
+    const cloudProjectDirectory = '/cloud/personal'
+    const siblingProjectPath = '/cloud/personal-archive/local-only-project'
+    const files = new Map([
+      [`${siblingProjectPath}/main.kcl`, 'cube = 1\n'],
+      [
+        `${siblingProjectPath}/${PROJECT_SETTINGS_FILE_NAME}`,
+        `title = "Local only project"\n`,
+      ],
+    ])
+    configureCloudSyncLocalFileSystem(
+      createCloudSyncTestFs(files, {
+        projectDirectory: cloudProjectDirectory,
+      })
+    )
+    configureCloudSyncEngine({
+      enabled: true,
+      baseUrl,
+      environmentName: 'dev.zoo.dev',
+      cloudProjectDirectoryPaths: [cloudProjectDirectory],
+      autoEnrollCloudLibraryProjects: true,
+    })
+
+    await notifyCloudSyncWriteLikeMutation(`${siblingProjectPath}/main.kcl`)
+
+    expect(await getProjectMetadata(siblingProjectPath)).toBeUndefined()
+    expect(await getAllOutboxEntries()).toEqual([])
+  })
+
+  it('moves cloud metadata when a project root is renamed inside the cloud library', async () => {
+    const sourceProjectPath = `${projectDirectory}/old-bracket`
+    const targetProjectPath = `${projectDirectory}/new-bracket`
+    const files = new Map([
+      [`${targetProjectPath}/main.kcl`, 'cube = 1\n'],
+      [
+        `${targetProjectPath}/${PROJECT_SETTINGS_FILE_NAME}`,
+        `title = "New bracket"\n`,
+      ],
+    ])
+    configureCloudSyncLocalFileSystem(
+      createCloudSyncTestFs(files, { projectDirectory })
+    )
+    await putProjectMetadata({
+      schemaVersion: 1,
+      localProjectPath: sourceProjectPath,
+      projectName: 'old-bracket',
+      remoteRevision,
+      baseManifest: { files: {} },
+    })
+    configureCloudSyncEngine({
+      enabled: true,
+      baseUrl,
+      environmentName: 'dev.zoo.dev',
+      cloudProjectDirectoryPaths: [projectDirectory],
+      autoEnrollCloudLibraryProjects: false,
+    })
+
+    await notifyCloudSyncRenameMutation(sourceProjectPath, targetProjectPath)
+
+    await expect(getProjectMetadata(sourceProjectPath)).resolves.toBeUndefined()
+    await expect(getProjectMetadata(targetProjectPath)).resolves.toMatchObject({
+      localProjectPath: targetProjectPath,
+      projectName: 'new-bracket',
+      remoteRevision,
+      tombstone: false,
+    })
+    expect(await getAllOutboxEntries()).toMatchObject([
+      {
+        projectPath: targetProjectPath,
+        kind: 'upsert',
+        targetPath: targetProjectPath,
+        sourcePath: sourceProjectPath,
+      },
+    ])
+  })
+
+  it('ignores project root renames that land outside the cloud library', async () => {
+    const sourceProjectPath = `${projectDirectory}/old-bracket`
+    const targetProjectPath = '/outside/new-bracket'
+    const files = new Map([
+      [`${targetProjectPath}/main.kcl`, 'cube = 1\n'],
+      [
+        `${targetProjectPath}/${PROJECT_SETTINGS_FILE_NAME}`,
+        `title = "New bracket"\n`,
+      ],
+    ])
+    configureCloudSyncLocalFileSystem(
+      createCloudSyncTestFs(files, { projectDirectory })
+    )
+    await putProjectMetadata({
+      schemaVersion: 1,
+      localProjectPath: sourceProjectPath,
+      projectName: 'old-bracket',
+      remoteRevision,
+      baseManifest: { files: {} },
+    })
+    configureCloudSyncEngine({
+      enabled: true,
+      baseUrl,
+      environmentName: 'dev.zoo.dev',
+      cloudProjectDirectoryPaths: [projectDirectory],
+      autoEnrollCloudLibraryProjects: false,
+    })
+
+    await notifyCloudSyncRenameMutation(sourceProjectPath, targetProjectPath)
+
+    await expect(getProjectMetadata(sourceProjectPath)).resolves.toMatchObject({
+      localProjectPath: sourceProjectPath,
+      projectName: 'old-bracket',
+    })
+    await expect(getProjectMetadata(targetProjectPath)).resolves.toBeUndefined()
     expect(await getAllOutboxEntries()).toEqual([])
   })
 
@@ -129,7 +424,7 @@ describe('cloud sync file policy', () => {
       enabled: true,
       baseUrl,
       environmentName: 'dev.zoo.dev',
-      projectDirectoryPath: projectDirectory,
+      cloudProjectDirectoryPaths: [projectDirectory],
       autoEnrollCloudLibraryProjects: false,
     })
 
@@ -168,12 +463,15 @@ describe('cloud sync file policy', () => {
       createdAt: '2026-07-08T12:01:00.000Z',
     })
 
-    setCloudSyncProjectScope(projectPath)
+    setCloudSyncProjectScope({
+      projectPath,
+      syncable: true,
+    })
     configureCloudSyncEngine({
       enabled: true,
       baseUrl,
       environmentName: 'dev.zoo.dev',
-      projectDirectoryPath: projectDirectory,
+      cloudProjectDirectoryPaths: [projectDirectory],
       autoEnrollCloudLibraryProjects: false,
     })
     retryCloudSync()

--- a/src/lib/cloudSync/registry/contract.ts
+++ b/src/lib/cloudSync/registry/contract.ts
@@ -6,6 +6,7 @@ import type {
   CloudSyncLocalProject,
   CloudSyncProjectMetadata,
   CloudSyncProjectMetadataIndexEntry,
+  CloudSyncProjectScope,
   CloudSyncStatus,
   RemoteProjectSummary,
 } from '@src/lib/cloudSync'
@@ -16,7 +17,7 @@ export type CloudSyncRegistryService = {
   configure: (config: CloudSyncConfig) => void
   installFileSystemObserver: (activeFs?: IZooDesignStudioFS) => void
   retry: () => void
-  setProjectScope: (projectPath?: string) => void
+  setProjectScope: (scope?: CloudSyncProjectScope) => void
   /**
    * Explicitly enroll a local-only project in cloud sync, even when the global
    * policy is not auto-enrolling existing local projects.
@@ -45,8 +46,7 @@ export type CloudSyncRegistryService = {
   /**
    * Materialize a remote cloud project into the local library directory the
    * caller is opening it from. `targetProjectDirectoryPath` is the resolved
-   * local path of that library; when omitted the engine falls back to the
-   * configured project directory.
+   * local path of that owning cloud library.
    */
   ensureProjectLocallySynced: (
     remoteProjectId: string,

--- a/src/lib/cloudSync/registry/extension.test.ts
+++ b/src/lib/cloudSync/registry/extension.test.ts
@@ -61,7 +61,7 @@ describe('cloud sync extension', () => {
     cloudSyncPathMocks.getCloudProjectLibraryMaterializationDirectoryPath.mockClear()
   })
 
-  it('uses the configured cloud project library materialization directory for runtime policy', async () => {
+  it('uses cloud project library materialization directories for runtime policy', async () => {
     const settings = signal(
       createSettingsSnapshot({
         cloudSyncEnabled: true,
@@ -120,7 +120,7 @@ describe('cloud sync extension', () => {
         autoEnrollCloudLibraryProjects: true,
         baseUrl: 'https://api.dev.zoo.dev',
         environmentName: 'dev.zoo.dev',
-        projectDirectoryPath: '/cloud-personal',
+        cloudProjectDirectoryPaths: ['/cloud-personal'],
       })
     })
     const resolvedCloudLibrary =
@@ -140,7 +140,7 @@ describe('cloud sync extension', () => {
     settings.value = createSettingsSnapshot({
       cloudSyncEnabled: true,
       projectDirectoryPath: '/other-projects',
-      cloudLibraryPath: '/team-cloud',
+      cloudLibraryPaths: ['/team-cloud', '/org-cloud'],
     })
 
     await vi.waitFor(() => {
@@ -150,9 +150,17 @@ describe('cloud sync extension', () => {
         autoEnrollCloudLibraryProjects: true,
         baseUrl: 'https://api.dev.zoo.dev',
         environmentName: 'dev.zoo.dev',
-        projectDirectoryPath: '/team-cloud',
+        cloudProjectDirectoryPaths: ['/team-cloud', '/org-cloud'],
       })
     })
+    expect(
+      cloudSyncPathMocks.getCloudProjectLibraryMaterializationDirectoryPath
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/org-cloud',
+        type: 'cloud',
+      })
+    )
 
     settings.value = createSettingsSnapshot({
       cloudSyncEnabled: false,
@@ -206,13 +214,17 @@ function createSettingsSnapshot({
   cloudSyncEnabled,
   projectDirectoryPath,
   cloudLibraryPath = '/cloud-personal',
+  cloudLibraryPaths,
   cloudLibrarySource,
 }: {
   cloudSyncEnabled: boolean
   projectDirectoryPath: string
   cloudLibraryPath?: string
+  cloudLibraryPaths?: string[]
   cloudLibrarySource?: string
 }): SettingsType {
+  const resolvedCloudLibraryPaths = cloudLibraryPaths ?? [cloudLibraryPath]
+
   return {
     app: {
       libraries: {
@@ -222,12 +234,14 @@ function createSettingsSnapshot({
             path: projectDirectoryPath,
             type: 'directory',
           },
-          {
-            title: 'Personal Cloud',
-            path: cloudLibraryPath,
-            ...(cloudLibrarySource ? { source: cloudLibrarySource } : {}),
+          ...resolvedCloudLibraryPaths.map((path, index) => ({
+            title: index === 0 ? 'Personal Cloud' : `Cloud ${index + 1}`,
+            path,
+            ...(index === 0 && cloudLibrarySource
+              ? { source: cloudLibrarySource }
+              : {}),
             type: 'cloud',
-          },
+          })),
         ],
       },
       projectDirectory: {

--- a/src/lib/cloudSync/registry/extension.ts
+++ b/src/lib/cloudSync/registry/extension.ts
@@ -47,9 +47,10 @@ export const cloudSyncExtension = defineRegistryItemFactory((ctx) => {
     const currentRuntime = runtime.value?.current.value
     const cloudSyncPluginEnabled =
       currentSettings?.plugins?.[CLOUD_SYNC_PLUGIN_ID]?.current === true
-    const cloudProjectLibrary = currentSettings?.app.libraries.current.find(
-      (library) => library.type === CLOUD_PROJECT_LIBRARY_TYPE
-    )
+    const cloudProjectLibraries =
+      currentSettings?.app.libraries.current.filter(
+        (library) => library.type === CLOUD_PROJECT_LIBRARY_TYPE
+      ) ?? []
     const runtimePolicy = {
       ...runtimeConfig.value,
       enabled: runtimeConfig.value.enabled && cloudSyncPluginEnabled,
@@ -63,21 +64,33 @@ export const cloudSyncExtension = defineRegistryItemFactory((ctx) => {
       return
     }
 
-    void getCloudProjectLibraryMaterializationDirectoryPath(cloudProjectLibrary)
-      .catch(() => undefined)
-      .then((cloudProjectDirectoryPath) => {
-        if (version !== runtimePolicyVersion) {
-          return
-        }
-
-        untracked(() =>
-          configureCloudSync({
-            ...runtimePolicy,
-            projectDirectoryPath:
-              runtimePolicy.projectDirectoryPath ?? cloudProjectDirectoryPath,
-          })
+    const cloudProjectDirectoryPathsPromise = Promise.all(
+      cloudProjectLibraries.map((library) =>
+        getCloudProjectLibraryMaterializationDirectoryPath(library).catch(
+          () => undefined
         )
-      })
+      )
+    )
+
+    void cloudProjectDirectoryPathsPromise.then((resolvedProjectPaths) => {
+      if (version !== runtimePolicyVersion) {
+        return
+      }
+
+      const cloudProjectDirectoryPaths = resolvedProjectPaths.filter(
+        (projectDirectoryPath): projectDirectoryPath is string =>
+          Boolean(projectDirectoryPath)
+      )
+      const policyCloudProjectDirectoryPaths =
+        runtimePolicy.cloudProjectDirectoryPaths ?? cloudProjectDirectoryPaths
+
+      untracked(() =>
+        configureCloudSync({
+          ...runtimePolicy,
+          cloudProjectDirectoryPaths: policyCloudProjectDirectoryPaths,
+        })
+      )
+    })
   }
 
   const ensureSettingsSync = () => {

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -326,6 +326,92 @@ describe('cloud sync status presentation', () => {
   })
 })
 
+describe('cloud sync status bar contribution', () => {
+  function createStatusBarRegistry() {
+    const registry = new Registry()
+    const settings = createSettingsService({})
+    const settingsExtension = defineRegistryItem({
+      id: 'test-settings-service',
+      providesServices: [provideService(settingsService, settings.service)],
+    })
+    const userFeaturesExtension = defineRegistryItem({
+      id: 'test-user-features-service',
+      providesServices: [
+        provideService(userFeaturesService, createUserFeaturesService()),
+      ],
+    })
+
+    registry.configure([
+      settingsExtension,
+      userFeaturesExtension,
+      cloudSyncPlugin,
+    ])
+    enableCloudSyncPlugin(registry)
+
+    return registry
+  }
+
+  test('hides on file routes scoped to a local-only project', () => {
+    cloudSyncStatus.value = {
+      enabled: true,
+      state: 'idle',
+      pendingCount: 0,
+      scopedProjectPath: '/projects/local',
+    }
+    const registry = createStatusBarRegistry()
+
+    try {
+      expect(
+        registry
+          .get(statusBarGlobalItemsValueSpec)
+          .some((item) => item.id === 'cloud-sync')
+      ).toBe(false)
+    } finally {
+      registry[Symbol.dispose]()
+    }
+  })
+
+  test('shows on file routes scoped to a cloud-backed project', () => {
+    cloudSyncStatus.value = {
+      enabled: true,
+      state: 'idle',
+      pendingCount: 0,
+      scopedProjectPath: '/projects/cloud',
+      scopedProjectCloudProjectId: 'cloud-project-123',
+    }
+    const registry = createStatusBarRegistry()
+
+    try {
+      expect(
+        registry
+          .get(statusBarGlobalItemsValueSpec)
+          .some((item) => item.id === 'cloud-sync')
+      ).toBe(true)
+    } finally {
+      registry[Symbol.dispose]()
+    }
+  })
+
+  test('shows aggregate cloud status on Home', () => {
+    cloudSyncStatus.value = {
+      enabled: true,
+      state: 'idle',
+      pendingCount: 0,
+    }
+    const registry = createStatusBarRegistry()
+
+    try {
+      expect(
+        registry
+          .get(statusBarGlobalItemsValueSpec)
+          .some((item) => item.id === 'cloud-sync')
+      ).toBe(true)
+    } finally {
+      registry[Symbol.dispose]()
+    }
+  })
+})
+
 describe('cloud sync status bar conflict dialog', () => {
   test('keeps inspecting the clicked project when global conflict status changes', async () => {
     cloudConflictDialogMocks.conflict = {
@@ -484,7 +570,7 @@ describe('cloud sync project library', () => {
     }
   })
 
-  test('does not synthesize a personal cloud library row when toggled', () => {
+  test('keeps the cloud library type registered across plugin toggles', () => {
     const registry = new Registry()
     registry.configure([cloudSyncProjectLibraryType, cloudSyncPlugin])
 
@@ -826,7 +912,7 @@ describe('cloud sync project library', () => {
 
       render(
         <SettingsDetails
-          library={getDefaultCloudProjectLibrarySetting()}
+          library={getDefaultCloudProjectLibrarySetting('/cloud-local')}
           index={0}
           updateLibrary={vi.fn()}
           commitLibrary={vi.fn()}

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -374,8 +374,12 @@ const cloudSyncStatusBarItem = defineRegistryItemFactory((ctx) => {
     )
   }
 
-  const statusBarItem = computed(() =>
-    nullableStatusBarItem(
+  const statusBarItem = computed(() => {
+    const status = cloudSyncStatus.value
+    const shouldStatusItemBeVisible =
+      !status.scopedProjectPath || Boolean(status.scopedProjectCloudProjectId)
+
+    return nullableStatusBarItem(
       settings.value &&
         userFeatures.value &&
         userFeaturesContextHas(
@@ -383,7 +387,8 @@ const cloudSyncStatusBarItem = defineRegistryItemFactory((ctx) => {
           OPFS_CLOUD_FEATURE_FLAG,
           false
         ) &&
-        cloudSyncStatus.value.enabled
+        status.enabled &&
+        shouldStatusItemBeVisible
         ? {
             id: 'cloud-sync',
             component: CloudSyncStatusBarItemWithSettings,
@@ -392,7 +397,7 @@ const cloudSyncStatusBarItem = defineRegistryItemFactory((ctx) => {
           }
         : null
     )
-  )
+  })
 
   return {
     item: defineRuntimeRegistryItem({

--- a/src/lib/cloudSync/renameDeleteRemote.spec.ts
+++ b/src/lib/cloudSync/renameDeleteRemote.spec.ts
@@ -32,7 +32,7 @@ describe('renameRemoteCloudProject', () => {
       enabled: true,
       baseUrl,
       environmentName: 'dev.zoo.dev',
-      projectDirectoryPath: '/documents/Projects',
+      cloudProjectDirectoryPaths: ['/documents/Projects'],
     })
     vi.stubGlobal('fetch', fetchMock)
   })
@@ -124,7 +124,7 @@ describe('deleteRemoteCloudProject', () => {
       enabled: true,
       baseUrl,
       environmentName: 'dev.zoo.dev',
-      projectDirectoryPath: '/documents/Projects',
+      cloudProjectDirectoryPaths: ['/documents/Projects'],
     })
     vi.stubGlobal('fetch', fetchMock)
   })

--- a/src/lib/cloudSync/statusCoalescing.test.ts
+++ b/src/lib/cloudSync/statusCoalescing.test.ts
@@ -172,7 +172,7 @@ describe('cloud sync status coalescing', () => {
         enabled: true,
         baseUrl,
         environmentName,
-        projectDirectoryPath: projectDirectory,
+        cloudProjectDirectoryPaths: [projectDirectory],
         autoEnrollCloudLibraryProjects: false,
       })
 

--- a/src/lib/cloudSync/types.ts
+++ b/src/lib/cloudSync/types.ts
@@ -95,8 +95,19 @@ export type CloudSyncConfig = {
   token?: string
   baseUrl?: string
   environmentName?: string
-  projectDirectoryPath?: string
+  /** Local materialization paths for configured cloud-type project libraries. */
+  cloudProjectDirectoryPaths?: string[]
   autoEnrollCloudLibraryProjects?: boolean
+}
+
+/**
+ * File-route scope for status and retry behavior. A non-syncable scope still
+ * hides Home/global sync state while a project is open, but it cannot enqueue
+ * or retry sync work for that project.
+ */
+export type CloudSyncProjectScope = {
+  projectPath: string
+  syncable: boolean
 }
 
 /** Coarse user-visible sync state exposed to status bar consumers. */
@@ -112,6 +123,8 @@ export type CloudSyncStatus = {
   enabled: boolean
   state: CloudSyncState
   pendingCount: number
+  scopedProjectPath?: string
+  scopedProjectCloudProjectId?: string
   activeProjectPath?: string
   lastFailure?: string
   lastFailureKind?: ProjectSyncFailureKind

--- a/src/lib/projectLibraries/index.ts
+++ b/src/lib/projectLibraries/index.ts
@@ -1,4 +1,3 @@
-import { PROJECT_FOLDER } from '@src/lib/constants'
 import { hashString } from '@src/lib/stringUtils'
 import { isArray } from '@src/lib/utils'
 
@@ -9,8 +8,13 @@ export const DIRECTORY_PROJECT_LIBRARY_TYPE = 'directory'
 export const PERSONAL_CLOUD_PROJECT_LIBRARY_ID = 'cloud-personal'
 export const PERSONAL_CLOUD_PROJECT_LIBRARY_TITLE = 'Personal Cloud'
 export const CLOUD_PROJECT_LIBRARY_TYPE = 'cloud'
-export const LEGACY_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH = '/personal'
-export const DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_LOCAL_PATH = `/documents/${PROJECT_FOLDER}`
+export const DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_SOURCE = '/personal'
+export const INITIAL_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH_SETTING = '/personal'
+/**
+ * Empty is the in-memory default for the personal cloud library's local path.
+ * Serialization omits this value so settings files keep the default implicit.
+ */
+export const DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH_SETTING = ''
 export const CLOUD_PROJECT_LIBRARY_PATH_DISPLAY_PREFIX = 'zoo://'
 
 export function formatProjectLibraryPathForDisplay(
@@ -21,7 +25,7 @@ export function formatProjectLibraryPathForDisplay(
   }
 
   const cloudSource =
-    library.source?.trim() || LEGACY_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH
+    library.source?.trim() || DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_SOURCE
   return `${CLOUD_PROJECT_LIBRARY_PATH_DISPLAY_PREFIX}${cloudSource.replace(/^\/+/, '')}`
 }
 
@@ -60,11 +64,17 @@ export function getDefaultProjectLibrarySettings(
 }
 
 export function getDefaultCloudProjectLibrarySetting(
-  localMaterializationPath = DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_LOCAL_PATH
+  localMaterializationPath:
+    | string
+    | undefined = DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH_SETTING
 ): ProjectLibrarySetting {
+  const path = normalizePersonalCloudProjectLibraryPathSetting(
+    localMaterializationPath
+  )
+
   return {
     title: PERSONAL_CLOUD_PROJECT_LIBRARY_TITLE,
-    path: localMaterializationPath,
+    path,
     type: CLOUD_PROJECT_LIBRARY_TYPE,
   }
 }
@@ -97,33 +107,35 @@ export function getDefaultDirectoryProjectLibraryPath(
   return getDefaultDirectoryProjectLibrarySetting(libraries)?.path
 }
 
-function normalizeLibraryPath(path: string) {
-  return path.replaceAll('\\', '/').replace(/\/+$/g, '')
+export function normalizeProjectLibrarySettingPath(path: string | undefined) {
+  return path?.trim().replaceAll('\\', '/').replace(/\/+$/g, '') ?? ''
 }
 
 function isDefaultPersonalCloudProjectLibraryPath(path: string | undefined) {
-  const normalizedPath = normalizeLibraryPath(path ?? '')
+  const trimmedPath = path?.trim()
+  if (!trimmedPath) {
+    return true
+  }
+
   return (
-    normalizedPath ===
-      normalizeLibraryPath(LEGACY_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH) ||
-    normalizedPath ===
-      normalizeLibraryPath(DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_LOCAL_PATH)
+    trimmedPath !== '/' &&
+    normalizeProjectLibrarySettingPath(trimmedPath) ===
+      INITIAL_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH_SETTING
   )
 }
 
-export function isLegacyPersonalCloudProjectLibraryPathSetting(
-  library: Pick<ProjectLibrarySetting, 'path' | 'source' | 'type'>
+function normalizePersonalCloudProjectLibraryPathSetting(
+  path: string | undefined
 ) {
-  return (
-    library.type === CLOUD_PROJECT_LIBRARY_TYPE &&
-    !library.source?.trim() &&
-    normalizeLibraryPath(library.path) ===
-      normalizeLibraryPath(LEGACY_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH)
-  )
+  if (isDefaultPersonalCloudProjectLibraryPath(path)) {
+    return DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH_SETTING
+  }
+
+  return path?.trim() ?? DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH_SETTING
 }
 
 export function isDefaultPersonalCloudProjectLibraryPathSetting(
-  library: Pick<ProjectLibrarySetting, 'path' | 'source' | 'type'>
+  library: Pick<ProjectLibrarySetting, 'source' | 'type'> & { path?: string }
 ) {
   return (
     library.type === CLOUD_PROJECT_LIBRARY_TYPE &&
@@ -142,8 +154,8 @@ export function isPathInDirectoryProjectLibrary(
   targetPath: string,
   libraryPath: string
 ) {
-  const normalizedTargetPath = normalizeLibraryPath(targetPath)
-  const normalizedLibraryPath = normalizeLibraryPath(libraryPath)
+  const normalizedTargetPath = normalizeProjectLibrarySettingPath(targetPath)
+  const normalizedLibraryPath = normalizeProjectLibrarySettingPath(libraryPath)
 
   if (!normalizedLibraryPath) {
     return false
@@ -273,7 +285,9 @@ export function projectLibrarySettingsToSerialized(
       type: library.type,
       ...(isDefaultPersonalCloudProjectLibraryPathSetting(library)
         ? {}
-        : { path }),
+        : path
+          ? { path }
+          : {}),
       ...(source ? { source } : {}),
     }
   })
@@ -347,11 +361,17 @@ export function isProjectLibrarySetting(
   }
 
   const library = value as Record<string, unknown>
+  const isDefaultPersonalCloudLibrary =
+    library.type === CLOUD_PROJECT_LIBRARY_TYPE &&
+    typeof library.path === 'string' &&
+    library.path.length === 0 &&
+    !library.source
+
   return (
     typeof library.title === 'string' &&
     library.title.length > 0 &&
     typeof library.path === 'string' &&
-    library.path.length > 0 &&
+    (library.path.length > 0 || isDefaultPersonalCloudLibrary) &&
     typeof library.type === 'string' &&
     library.type.length > 0 &&
     (!Object.hasOwn(library, 'source') || typeof library.source === 'string')

--- a/src/lib/routeLoaders.ts
+++ b/src/lib/routeLoaders.ts
@@ -1,6 +1,7 @@
 import { projectSkeletonCreate } from '@src/lang/project'
 import { projectFsManager } from '@src/lang/std/fileSystemManager'
 import type { App } from '@src/lib/app'
+import { getCloudProjectLibraryMaterializationDirectoryPath } from '@src/lib/cloudSync/paths'
 import {
   DEFAULT_DEFAULT_LENGTH_UNIT,
   PROJECT_ENTRYPOINT,
@@ -15,11 +16,12 @@ import {
   safeEncodeForRouterPaths,
 } from '@src/lib/paths'
 import {
+  CLOUD_PROJECT_LIBRARY_TYPE,
   DEFAULT_PROJECT_LIBRARY_TITLE,
   DIRECTORY_PROJECT_LIBRARY_TYPE,
-  getDefaultDirectoryProjectLibraryPath,
   getDefaultDirectoryProjectLibrarySetting,
   isPathInDirectoryProjectLibrary,
+  normalizeProjectLibrarySettingPath,
   type ProjectLibrarySetting,
 } from '@src/lib/projectLibraries'
 import {
@@ -44,6 +46,7 @@ import { settingsValueSpec } from '@src/registry/contracts/settings'
 import type { LoaderFunction } from 'react-router-dom'
 import { redirect } from 'react-router-dom'
 import { waitFor } from 'xstate'
+import { cloudSyncService } from '@src/registry/contracts/cloudSync'
 
 export const DEFAULT_WEB_PROJECT_NAME = 'demo-project'
 
@@ -118,6 +121,61 @@ async function fileExists(filePath: string) {
   } catch {
     return false
   }
+}
+
+type ProjectLibraryPathResolution = {
+  library: ProjectLibrarySetting
+  path: string
+}
+
+async function resolveProjectLibraryLocalPath(library: ProjectLibrarySetting) {
+  if (library.type === CLOUD_PROJECT_LIBRARY_TYPE) {
+    return getCloudProjectLibraryMaterializationDirectoryPath(library).catch(
+      () => undefined
+    )
+  }
+
+  return library.path.trim() ? library.path : undefined
+}
+
+async function getContainingProjectLibraryPath(
+  libraries: readonly ProjectLibrarySetting[],
+  projectPath: string
+): Promise<ProjectLibraryPathResolution | undefined> {
+  const candidates: ProjectLibraryPathResolution[] = []
+
+  for (const library of libraries) {
+    const libraryPath = await resolveProjectLibraryLocalPath(library)
+    if (!libraryPath) {
+      continue
+    }
+
+    const normalizedProjectPath =
+      normalizeProjectLibrarySettingPath(projectPath)
+    const normalizedLibraryPath =
+      normalizeProjectLibrarySettingPath(libraryPath)
+    if (
+      normalizedProjectPath !== normalizedLibraryPath &&
+      isPathInDirectoryProjectLibrary(projectPath, libraryPath)
+    ) {
+      candidates.push({ library, path: libraryPath })
+    }
+  }
+
+  return candidates
+    .toSorted(
+      (left, right) =>
+        normalizeProjectLibrarySettingPath(right.path).length -
+        normalizeProjectLibrarySettingPath(left.path).length
+    )
+    .at(0)
+}
+
+function canProjectLibraryScopeCloudSync(library?: ProjectLibrarySetting) {
+  return (
+    library?.type === CLOUD_PROJECT_LIBRARY_TYPE ||
+    library?.type === DIRECTORY_PROJECT_LIBRARY_TYPE
+  )
 }
 
 function redirectToFile(filePath: string, routerSearch: string) {
@@ -276,6 +334,14 @@ export const fileLoader =
     const maybeProjectInfo = await getProjectInfo(projectPath, wasmInstance)
 
     const project = maybeProjectInfo ?? defaultProjectData
+    const owningProjectLibrary = await getContainingProjectLibraryPath(
+      settings.settings.app.libraries.current,
+      project.path
+    )
+    app.registry.get(cloudSyncService).setProjectScope({
+      projectPath: project.path,
+      syncable: canProjectLibraryScopeCloudSync(owningProjectLibrary?.library),
+    })
 
     // Fire off the event to load the project settings
     // once we know it's idle.
@@ -303,16 +369,8 @@ export const fileLoader =
       requestedFileName.onProjectLoaderComplete?.()
     }
 
-    const appProjectDir =
-      getDefaultDirectoryProjectLibraryPath(
-        settings.settings.app.libraries?.current
-      ) ?? ''
-    const requestedProjectDirectoryPath = isPathInDirectoryProjectLibrary(
-      project.path,
-      appProjectDir
-    )
-      ? appProjectDir
-      : getParentAbsolutePath(project.path) // Fallback to parent directory if foreign to app project dir.
+    const requestedProjectDirectoryPath =
+      owningProjectLibrary?.path ?? getParentAbsolutePath(project.path)
     app.systemIOActor.send({
       type: SystemIOMachineEvents.setProjectDirectoryPath,
       data: {
@@ -335,13 +393,15 @@ export const fileLoader =
     }
   }
 
-// Loads the settings and by extension the projects in the default directory
+// Loads the settings and by extension the configured project library entries
 // and returns them to the Home route, along with any errors that occurred
 
 // Should also clear currently loaded projects in SystemIO. They may be stale.
 export const homeLoader =
   ({ app }: { app: App }): LoaderFunction =>
   async (): Promise<HomeLoaderData | Response> => {
+    app.registry.get(cloudSyncService).setProjectScope(undefined)
+
     // If on unflagged web, bump out to root, which will redirect to a project.
     if (!window.electron && !(await webHomeRouteEnabled(app))) {
       return redirect(PATHS.INDEX)

--- a/src/lib/settings/settingsUtils.spec.ts
+++ b/src/lib/settings/settingsUtils.spec.ts
@@ -13,9 +13,9 @@ import { defaultLayoutConfig } from '@src/lib/layout/configs/default'
 import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
 import { createLayoutWithMetadata } from '@src/lib/layout/utils'
 import {
+  DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH_SETTING,
   getDefaultCloudProjectLibrarySetting,
   getDefaultProjectLibrarySettings,
-  LEGACY_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH,
 } from '@src/lib/projectLibraries'
 import { projectLibrariesSettingsContribution } from '@src/lib/projectLibraries/settings/setting'
 import { defineBooleanExtensionSetting } from '@src/lib/settings/extensionSettings'
@@ -458,7 +458,7 @@ describe('project settings serialization regression', () => {
             libraries: [
               {
                 title: 'Personal Cloud',
-                path: LEGACY_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH,
+                path: DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH_SETTING,
                 type: 'cloud',
               },
             ],

--- a/src/registry/contracts/projectLibraries.test.ts
+++ b/src/registry/contracts/projectLibraries.test.ts
@@ -1,6 +1,6 @@
 import {
   areProjectLibrarySettingsEqual,
-  DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_LOCAL_PATH,
+  DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH_SETTING,
   DEFAULT_PROJECT_LIBRARY_ID,
   formatProjectLibraryPathForDisplay,
   getContainingDirectoryProjectLibraryPath,
@@ -8,9 +8,10 @@ import {
   getDefaultDirectoryProjectLibraryPath,
   getDefaultDirectoryProjectLibrarySetting,
   getProjectLibraryIdFromSetting,
-  LEGACY_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH,
+  INITIAL_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH_SETTING,
   moveProjectLibrarySetting,
   normalizeProjectLibrarySetting,
+  normalizeProjectLibrarySettingPath,
   PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
   projectLibrariesFromSettings,
   projectLibraryFromSetting,
@@ -64,6 +65,15 @@ describe('project library settings', () => {
     )
   })
 
+  test('normalizes project library setting paths consistently', () => {
+    expect(normalizeProjectLibrarySettingPath('  \\projects\\client\\  ')).toBe(
+      '/projects/client'
+    )
+    expect(normalizeProjectLibrarySettingPath('/projects/client///')).toBe(
+      '/projects/client'
+    )
+  })
+
   test('maps the default cloud library to the stable cloud library id', () => {
     const library = projectLibraryFromSetting(
       getDefaultCloudProjectLibrarySetting()
@@ -72,18 +82,18 @@ describe('project library settings', () => {
     expect(library).toEqual(
       expect.objectContaining({
         id: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
-        path: DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_LOCAL_PATH,
+        path: DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH_SETTING,
         type: 'cloud',
       })
     )
     expect(library.source).toBeUndefined()
   })
 
-  test('maps the legacy personal cloud path to the stable cloud library id', () => {
+  test('maps an empty personal cloud path to the stable cloud library id', () => {
     expect(
       projectLibraryFromSetting({
         ...getDefaultCloudProjectLibrarySetting(),
-        path: LEGACY_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH,
+        path: '',
       })
     ).toEqual(
       expect.objectContaining({
@@ -92,12 +102,22 @@ describe('project library settings', () => {
     )
   })
 
-  test('omits the default personal cloud path when serializing project libraries', () => {
+  test('omits default personal cloud paths when serializing project libraries', () => {
     expect(
       projectLibrarySettingsToSerialized([
         {
           title: 'Personal Cloud',
-          path: LEGACY_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH,
+          path: DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH_SETTING,
+          type: 'cloud',
+        },
+        {
+          title: 'Personal Cloud',
+          path: '',
+          type: 'cloud',
+        },
+        {
+          title: 'Personal Cloud',
+          path: INITIAL_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH_SETTING,
           type: 'cloud',
         },
         {
@@ -113,6 +133,14 @@ describe('project library settings', () => {
         type: 'cloud',
       },
       {
+        title: 'Personal Cloud',
+        type: 'cloud',
+      },
+      {
+        title: 'Personal Cloud',
+        type: 'cloud',
+      },
+      {
         title: 'Team Cloud',
         path: '/team-cloud',
         source: '/team',
@@ -121,11 +149,39 @@ describe('project library settings', () => {
     ])
   })
 
-  test('fills the default personal cloud path when parsing serialized project libraries', () => {
+  test('preserves an explicit cloud root path when serializing project libraries', () => {
+    expect(
+      projectLibrarySettingsToSerialized([
+        {
+          title: 'Root Cloud',
+          path: '/',
+          type: 'cloud',
+        },
+      ])
+    ).toEqual([
+      {
+        title: 'Root Cloud',
+        path: '/',
+        type: 'cloud',
+      },
+    ])
+  })
+
+  test('normalizes default personal cloud paths to omitted path settings', () => {
     expect(
       projectLibrarySettingsFromSerialized([
         {
           title: 'Personal Cloud',
+          type: 'cloud',
+        },
+        {
+          title: 'Personal Cloud',
+          path: '',
+          type: 'cloud',
+        },
+        {
+          title: 'Personal Cloud',
+          path: INITIAL_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH_SETTING,
           type: 'cloud',
         },
         {
@@ -136,6 +192,8 @@ describe('project library settings', () => {
         },
       ])
     ).toEqual([
+      getDefaultCloudProjectLibrarySetting(),
+      getDefaultCloudProjectLibrarySetting(),
       getDefaultCloudProjectLibrarySetting(),
       {
         title: 'Team Cloud',
@@ -161,7 +219,7 @@ describe('project library settings', () => {
   test('formats cloud library paths with a zoo:// display prefix', () => {
     expect(
       formatProjectLibraryPathForDisplay({
-        path: DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_LOCAL_PATH,
+        path: DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH_SETTING,
         type: 'cloud',
       })
     ).toBe('zoo://personal')
@@ -403,7 +461,7 @@ describe('projectLibrariesFromSettings', () => {
         },
         {
           title: 'Personal Cloud',
-          path: DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_LOCAL_PATH,
+          path: DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH_SETTING,
           type: 'cloud',
         },
       ])

--- a/src/registry/extensions/homeProjects/index.spec.ts
+++ b/src/registry/extensions/homeProjects/index.spec.ts
@@ -8,7 +8,7 @@ import { signal } from '@preact/signals-core'
 import type { ProjectLibrary } from '@src/lib/projectLibraries'
 import {
   CLOUD_PROJECT_LIBRARY_TYPE,
-  DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_LOCAL_PATH,
+  DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH_SETTING,
   PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
   PERSONAL_CLOUD_PROJECT_LIBRARY_TITLE,
 } from '@src/lib/projectLibraries'
@@ -29,7 +29,7 @@ vi.mock('@src/lib/wasm_lib_wrapper', () => ({}))
 const library = {
   id: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
   title: PERSONAL_CLOUD_PROJECT_LIBRARY_TITLE,
-  path: DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_LOCAL_PATH,
+  path: DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH_SETTING,
   type: CLOUD_PROJECT_LIBRARY_TYPE,
 } satisfies ProjectLibrary
 

--- a/src/registry/extensions/homeProjects/index.test.ts
+++ b/src/registry/extensions/homeProjects/index.test.ts
@@ -38,7 +38,9 @@ const desktopMocks = vi.hoisted(() => ({
 }))
 
 const cloudSyncPathMocks = vi.hoisted(() => ({
-  getDefaultCloudProjectDirectoryPath: vi.fn(),
+  getCloudProjectLibraryMaterializationDirectoryPath: vi.fn(
+    async (library: { path: string }) => library.path
+  ),
 }))
 
 vi.mock('@src/lib/wasm_lib_wrapper', () => ({
@@ -62,8 +64,8 @@ vi.mock('@src/lib/desktop', () => {
 })
 
 vi.mock('@src/lib/cloudSync/paths', () => ({
-  getDefaultCloudProjectDirectoryPath:
-    cloudSyncPathMocks.getDefaultCloudProjectDirectoryPath,
+  getCloudProjectLibraryMaterializationDirectoryPath:
+    cloudSyncPathMocks.getCloudProjectLibraryMaterializationDirectoryPath,
 }))
 
 function createSettingsService(): SettingsRegistryService {
@@ -404,9 +406,6 @@ describe('home project actions', () => {
         remoteProjectId: 'remote-123',
       }),
     })
-    cloudSyncPathMocks.getDefaultCloudProjectDirectoryPath.mockResolvedValue(
-      '/cloud-projects'
-    )
     desktopMocks.getProjectInfo.mockResolvedValue({
       default_file: '/cloud-projects/remote-title/main.kcl',
     })
@@ -414,6 +413,7 @@ describe('home project actions', () => {
       id: 'remote:remote-123',
       source: 'remote',
       status: 'cloud-only',
+      libraryIds: [PERSONAL_CLOUD_PROJECT_LIBRARY_ID],
       name: 'remote-title',
       title: 'Remote title',
       remoteProjectId: 'remote-123',
@@ -425,7 +425,14 @@ describe('home project actions', () => {
       defineRegistryItem({
         id: 'test.settings',
         providesServices: [
-          provideService(settingsService, createSettingsService()),
+          provideService(
+            settingsService,
+            createMutableSettingsService({
+              libraries: [
+                getDefaultCloudProjectLibrarySetting('/cloud-projects'),
+              ],
+            }).service
+          ),
         ],
       }),
       defineRegistryItem({
@@ -439,6 +446,27 @@ describe('home project actions', () => {
       defineRegistryItem({
         id: 'test.wasm',
         provides: [provideWasmPromise(wasmPromise)],
+      }),
+      defineRegistryItem({
+        id: 'test.cloud-library-type',
+        provides: [
+          provide(projectLibraryTypesValueSpec, {
+            type: CLOUD_PROJECT_LIBRARY_TYPE,
+            title: 'Cloud',
+            readEntries: async () => [],
+            operations: {
+              openProject: {
+                run: ({ project }) => {
+                  if (!project.defaultFile) {
+                    return undefined
+                  }
+
+                  return { defaultFile: project.defaultFile }
+                },
+              },
+            },
+          }),
+        ],
       }),
       homeProjectsExtension,
     ])

--- a/src/registry/extensions/homeProjects/index.ts
+++ b/src/registry/extensions/homeProjects/index.ts
@@ -6,10 +6,7 @@ import {
   provideService,
 } from '@kittycad/registry'
 import { effect, signal } from '@preact/signals-core'
-import {
-  getCloudProjectLibraryMaterializationDirectoryPath,
-  getDefaultCloudProjectDirectoryPath,
-} from '@src/lib/cloudSync/paths'
+import { getCloudProjectLibraryMaterializationDirectoryPath } from '@src/lib/cloudSync/paths'
 import {
   getProjectInfo,
   writeProjectTitleToProjectToml,
@@ -291,11 +288,14 @@ const homeProjectActions = defineRegistryItemFactory((ctx) => {
         return undefined
       }
 
-      const targetProjectDirectoryPath = openProject
-        ? await getCloudProjectLibraryMaterializationDirectoryPath(
-            openProject.library
-          )
-        : await getDefaultCloudProjectDirectoryPath()
+      if (!openProject) {
+        return undefined
+      }
+
+      const targetProjectDirectoryPath =
+        await getCloudProjectLibraryMaterializationDirectoryPath(
+          openProject.library
+        )
       const syncedProject = await cloudSync.value?.ensureProjectLocallySynced(
         project.remoteProjectId,
         targetProjectDirectoryPath

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -30,7 +30,6 @@ import {
 } from '@src/lib/autoUpdate'
 import { BillingTransition } from '@src/lib/billing'
 import { useApp, useSingletons } from '@src/lib/boot'
-import { setCloudSyncProjectScope } from '@src/lib/cloudSync'
 import { createRouteCommands } from '@src/lib/commandBarConfigs/routeCommandConfig'
 import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
 import { isDesktop } from '@src/lib/isDesktop'
@@ -75,6 +74,7 @@ import {
   getHomeProjectEntriesForLibrary,
   projectLibraryTypesValueSpec,
 } from '@src/registry/contracts/projectLibraries'
+import { cloudSyncService } from '@src/registry/contracts/cloudSync'
 import {
   filterStatusBarItemsForScopes,
   statusBarGlobalItemsValueSpec,
@@ -232,8 +232,8 @@ const Home = () => {
   }, [app, selectedProjectLibraryId])
 
   useEffect(() => {
-    setCloudSyncProjectScope(undefined)
-  }, [])
+    registry.get(cloudSyncService).setProjectScope(undefined)
+  }, [registry])
 
   useEffect(() => {
     const { RouteTelemetryCommand, RouteSettingsCommand } = createRouteCommands(


### PR DESCRIPTION
Projects now derive cloud-sync behavior from configured project libraries instead of from folder-name conventions or a default project-directory fallback. Cloud-type libraries contribute explicit local materialization paths, the personal cloud library keeps its app-managed materialization default, and directory-type libraries can sync only projects that are explicitly linked by cloud metadata.

## Included

- Resolve configured cloud-type library materialization paths and pass all of them into cloud sync.
- Scope file-route cloud sync status through the registry service using the opened project and its owning library.
- Keep status hidden for file-route projects with no cloud project ID, and treat projects outside every library as non-syncable even if opened directly from disk.
- Preserve web Personal Cloud materialization by synthesizing the default project directory into the personal cloud library row when cloud sync is enabled on web.
- Remove engine fallbacks to a default project directory or an implicit first cloud library for remote materialization.
- Add focused coverage for cloud-library root inference, scoped status, directory-library linked projects, default personal cloud paths, and external project opens.

## How to test

- Open Home with cloud sync enabled and verify cloud projects appear under the Personal Cloud library.
- Open a cloud-backed project, then verify the status bar reflects only that project and opens its conflict dialog when applicable.
- Open a local-only directory-library project and verify the cloud sync status item is hidden.
- Open a random KCL file outside all configured libraries and verify it does not enqueue cloud-sync work, even if the project.toml contains a cloud project ID.

## Verification

- npm run fmt:check
- npm run tsc
- npm run lint
- npm run test:unit -- src/lib/cloudSync/index.test.ts src/lib/cloudSync/statusCoalescing.test.ts src/lib/cloudSync/liveConflicts.test.ts src/lib/cloudSync/syncDb.test.ts src/lib/cloudSync/clientErrorReporting.test.ts src/registry/extensions/homeProjects/index.test.ts
- npm run test:integration -- src/lib/app.spec.ts src/lib/settings/settingsUtils.spec.ts src/registry/contracts/projectLibraries.test.ts src/registry/extensions/homeProjects/index.spec.ts src/lib/cloudSync/registry/plugin.spec.tsx src/lib/cloudSync/registry/extension.test.ts src/lib/cloudSync/policy.spec.ts src/lib/cloudSync/conflictScope.spec.ts src/lib/cloudSync/disconnect.spec.ts src/lib/cloudSync/localProjectNames.spec.ts