### PR TITLE
fix(app): show enum values as Color::Red in the feature tree

### DIFF
--- a/src/lib/operations.spec.ts
+++ b/src/lib/operations.spec.ts
@@ -19,6 +19,7 @@ import {
   enterEditFlow,
   filterOperations,
   getHideOpForArtifact,
+  getOperationCalculatedDisplay,
   getOperationLabel,
   getOperationVariableName,
   groupNestedOperations,
@@ -1042,6 +1043,44 @@ ${operationName}(${targetLabel} = ${targetExpression}, tolerance = 0.1mm, datums
       }
       expect(argDefaultValues.note).toBe('Note on XY')
       expect(argDefaultValues.framePlane).toBe('XZ')
+    })
+  })
+
+  describe('getOperationCalculatedDisplay', () => {
+    const red: OpKclValue = { type: 'Enum', enum_name: 'Color', variant: 'Red' }
+    const green: OpKclValue = {
+      type: 'Enum',
+      enum_name: 'Color',
+      variant: 'Green',
+    }
+
+    // An enum reaches this function whenever an enum-valued variable appears in
+    // the feature tree: `getFeatureTreeValueDetail` passes a VariableDeclaration's
+    // value through unchanged, and the Rust side already maps `KclValue::Enum` to
+    // `OpKclValue::Enum`. Before this arm existed the switch fell through to
+    // `default`, which returned the value's type, so the tree read "Enum".
+    it.each([
+      ['a variant as its qualified name', red, 'Color::Red'],
+      [
+        'every variant of an array',
+        { type: 'Array', value: [red, green] },
+        'Color::Red, Color::Green',
+      ],
+      [
+        'a variant nested in an array of arrays',
+        { type: 'Array', value: [{ type: 'Array', value: [green] }] },
+        'Color::Green',
+      ],
+    ] as const)('renders %s', (_case, value, expected) => {
+      expect(getOperationCalculatedDisplay(value as OpKclValue)).toBe(expected)
+    })
+
+    it('still falls back to the type name for a value it cannot render', () => {
+      // Guards the arm above from being written as a catch-all: a type with no
+      // case of its own must keep the old behaviour rather than crash.
+      expect(
+        getOperationCalculatedDisplay({ type: 'Uuid', value: 'abc' })
+      ).toBe('Uuid')
     })
   })
 

--- a/src/lib/operations.ts
+++ b/src/lib/operations.ts
@@ -3868,6 +3868,10 @@ export function getOperationCalculatedDisplay(op: OpKclValue): string {
       return isNonNullable(op.value) ? op.value.toPrecision(5) : ''
     case 'String':
       return op.value
+    case 'Enum':
+      // Shown by nominal identity, the way the user writes it and the way the
+      // variables pane shows it. A variant's representation never appears here.
+      return `${op.enum_name}::${op.variant}`
     case 'Bool':
       return String(op.value)
     case 'Number':


### PR DESCRIPTION
The feature tree showed the word "Enum" for enum-valued variables:
`getOperationCalculatedDisplay` had no `Enum` arm, so those values hit
`default: return op.type`. This adds the arm, rendering `Color::Red`, which is
what the variables pane already shows (`MemoryPane.tsx:143`).

Tests cover the bare variant, an array of variants, and a nested one, plus the
type-name fallback for unhandled types. Removing the arm fails the three enum
rows.



- add the `Enum` arm to `getOperationCalculatedDisplay`
- match how the variables pane already renders enum values
- test the bare, array, and nested cases plus the type-name fallback