### PR TITLE
Improve the reliability of command bar tests

### DIFF
--- a/e2e/playwright/command-bar-tests.spec.ts
+++ b/e2e/playwright/command-bar-tests.spec.ts
@@ -115,8 +115,8 @@ test.describe('Command bar tests', { tag: '@desktop' }, () => {
     await expect(cmdSearchBar).not.toBeVisible()
 
     // Now try the same, but with the keyboard shortcut, check focus
-    await page.keyboard.press('ControlOrMeta+K')
-    await expect(cmdSearchBar).toBeVisible()
+    await commandBarButton.focus()
+    await cmdBar.openCmdBarViaHotkey()
     await expect(cmdSearchBar).toBeFocused()
 
     await test.step(`Pressing backspace in the command selection step does not dismiss`, async () => {
@@ -179,13 +179,14 @@ test.describe('Command bar tests', { tag: '@desktop' }, () => {
     await scene.settled()
 
     // Put the cursor in the code editor
-    await page.locator('.cm-content').click()
+    const codeEditor = page.locator('.cm-content')
+    await codeEditor.click()
+    await expect(codeEditor).toBeFocused()
 
     // Now try the same, but with the keyboard shortcut, check focus
-    await page.keyboard.press('ControlOrMeta+K')
+    await cmdBar.openCmdBarViaHotkey()
 
     let cmdSearchBar = page.getByPlaceholder('Search commands')
-    await expect(cmdSearchBar).toBeVisible()
     await expect(cmdSearchBar).toBeFocused()
 
     // Try typing in the command bar
@@ -242,7 +243,7 @@ test.describe('Command bar tests', { tag: '@desktop' }, () => {
     await scene.settled()
 
     let cmdSearchBar = page.getByPlaceholder('Search commands')
-    await page.keyboard.press('ControlOrMeta+K')
+    await cmdBar.openCmdBarViaHotkey()
     await expect(cmdSearchBar).toBeVisible()
 
     // Search for extrude command and choose it

--- a/e2e/playwright/fixtures/cmdBarFixture.ts
+++ b/e2e/playwright/fixtures/cmdBarFixture.ts
@@ -274,8 +274,8 @@ export class CmdBarFixture {
       if (!(await cmdSearchBar.isVisible())) {
         await this.page.keyboard.press('ControlOrMeta+K')
       }
-      await expect(cmdSearchBar).toBeVisible({ timeout: 2_000 })
-    }).toPass({ timeout: 12_000 })
+      await expect(cmdSearchBar).toBeVisible()
+    }).toPass({ timeout: 15_000 })
   }
 
   closeCmdBar = async () => {

--- a/e2e/playwright/fixtures/cmdBarFixture.ts
+++ b/e2e/playwright/fixtures/cmdBarFixture.ts
@@ -268,6 +268,16 @@ export class CmdBarFixture {
     await expect(this.page.getByPlaceholder('Search commands')).toBeVisible()
   }
 
+  openCmdBarViaHotkey = async () => {
+    const cmdSearchBar = this.page.getByPlaceholder('Search commands')
+    await expect(async () => {
+      if (!(await cmdSearchBar.isVisible())) {
+        await this.page.keyboard.press('ControlOrMeta+K')
+      }
+      await expect(cmdSearchBar).toBeVisible({ timeout: 2_000 })
+    }).toPass({ timeout: 12_000 })
+  }
+
   closeCmdBar = async () => {
     const cmdBarCloseBtn = this.page.getByTestId('command-bar-close-button')
     await cmdBarCloseBtn.click()


### PR DESCRIPTION
These tests were failing about half the time:

https://test-analysis-bot.corp.zoo.dev/projects/KittyCAD/modeling-app/tests/197?branch=improve-command-bar-tests

https://test-analysis-bot.corp.zoo.dev/projects/KittyCAD/modeling-app/tests/210?branch=improve-command-bar-tests