### PR TITLE
Fix default setting value for `app.libraries`

### DIFF
--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -1,10 +1,10 @@
+import type { Feature } from '@kittycad/lib'
 import {
   defineRegistryItem,
   pluginsValueSpec,
   provideService,
   Registry,
 } from '@kittycad/registry'
-import type { Feature } from '@kittycad/lib'
 import { signal } from '@preact/signals-core'
 import ProjectSidebarMenu from '@src/components/ProjectSidebarMenu'
 import type { App } from '@src/lib/app'
@@ -25,8 +25,8 @@ import {
   DIRECTORY_PROJECT_LIBRARY_TYPE,
   getDefaultCloudProjectLibrarySetting,
   PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
-  projectLibrariesFromSettings,
   type ProjectLibrarySetting,
+  projectLibrariesFromSettings,
 } from '@src/lib/projectLibraries'
 import { Themes } from '@src/lib/theme'
 import type { CloudSyncRegistryService } from '@src/registry/contracts/cloudSync'
@@ -37,6 +37,7 @@ import {
 } from '@src/registry/contracts/homeProjects'
 import {
   getProjectLibraryCreateProjectOperation,
+  projectLibrarySettingDefaultPoliciesValueSpec,
   projectLibraryTypesValueSpec,
 } from '@src/registry/contracts/projectLibraries'
 import {
@@ -479,6 +480,36 @@ describe('cloud sync project library', () => {
           project,
         })
       ).toEqual({ defaultFile: projectWellFormed.default_file })
+    } finally {
+      registry[Symbol.dispose]()
+    }
+  })
+
+  test('uses Personal Cloud as the web project library default', () => {
+    const registry = new Registry()
+    registry.configure([cloudSyncProjectLibraryType])
+
+    try {
+      const defaultPolicies = registry.get(
+        projectLibrarySettingDefaultPoliciesValueSpec
+      )
+      const personalCloudPolicy = defaultPolicies.find(
+        (policy) =>
+          policy.id === 'cloud-sync.personal-cloud-library-default-policy'
+      )
+
+      expect(
+        personalCloudPolicy?.getDefaultLibraries({
+          initialDefaultDir: '/projects',
+          isDesktop: false,
+        })
+      ).toEqual([getDefaultCloudProjectLibrarySetting()])
+      expect(
+        personalCloudPolicy?.getDefaultLibraries({
+          initialDefaultDir: '/projects',
+          isDesktop: true,
+        })
+      ).toBeUndefined()
     } finally {
       registry[Symbol.dispose]()
     }

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -218,9 +218,11 @@ function createSettingsService({
   }
 }
 
-function createUserFeaturesService(): UserFeaturesRegistryService {
+function createUserFeaturesService(
+  featureIds: Set<Feature> = new Set([OPFS_CLOUD_FEATURE_FLAG])
+): UserFeaturesRegistryService {
   const context = signal({
-    featureIds: new Set([OPFS_CLOUD_FEATURE_FLAG]),
+    featureIds,
   })
 
   return {
@@ -487,7 +489,13 @@ describe('cloud sync project library', () => {
 
   test('uses Personal Cloud as the web project library default', () => {
     const registry = new Registry()
-    registry.configure([cloudSyncProjectLibraryType])
+    const userFeaturesExtension = defineRegistryItem({
+      id: 'test-user-features-service',
+      providesServices: [
+        provideService(userFeaturesService, createUserFeaturesService()),
+      ],
+    })
+    registry.configure([userFeaturesExtension, cloudSyncProjectLibraryType])
 
     try {
       const defaultPolicies = registry.get(
@@ -504,6 +512,45 @@ describe('cloud sync project library', () => {
           isDesktop: false,
         })
       ).toEqual([getDefaultCloudProjectLibrarySetting()])
+      expect(
+        personalCloudPolicy?.getDefaultLibraries({
+          initialDefaultDir: '/projects',
+          isDesktop: true,
+        })
+      ).toBeUndefined()
+    } finally {
+      registry[Symbol.dispose]()
+    }
+  })
+
+  test('keeps the cloud project library default gated by feature flag and platform', () => {
+    const registry = new Registry()
+    const userFeaturesExtension = defineRegistryItem({
+      id: 'test-user-features-service',
+      providesServices: [
+        provideService(
+          userFeaturesService,
+          createUserFeaturesService(new Set())
+        ),
+      ],
+    })
+    registry.configure([userFeaturesExtension, cloudSyncProjectLibraryType])
+
+    try {
+      const defaultPolicies = registry.get(
+        projectLibrarySettingDefaultPoliciesValueSpec
+      )
+      const personalCloudPolicy = defaultPolicies.find(
+        (policy) =>
+          policy.id === 'cloud-sync.personal-cloud-library-default-policy'
+      )
+
+      expect(
+        personalCloudPolicy?.getDefaultLibraries({
+          initialDefaultDir: '/projects',
+          isDesktop: false,
+        })
+      ).toBeUndefined()
       expect(
         personalCloudPolicy?.getDefaultLibraries({
           initialDefaultDir: '/projects',

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -76,8 +76,9 @@ import {
   projectExplorerProjectMenuItemsValueSpec,
 } from '@src/registry/contracts/projectExplorer'
 import {
-  type ProjectLibraryTypeContribution,
   type ProjectLibrarySettingsDetailsProps,
+  type ProjectLibraryTypeContribution,
+  projectLibrarySettingDefaultPoliciesValueSpec,
   projectLibraryTypesValueSpec,
 } from '@src/registry/contracts/projectLibraries'
 import { settingsService } from '@src/registry/contracts/settings'
@@ -1044,6 +1045,12 @@ export const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
     item: defineRuntimeRegistryItem({
       id: 'cloud-sync.project-library-type',
       provides: [
+        provide(projectLibrarySettingDefaultPoliciesValueSpec, {
+          id: 'cloud-sync.personal-cloud-library-default-policy',
+          priority: 10,
+          getDefaultLibraries: ({ isDesktop }) =>
+            isDesktop ? undefined : [getDefaultCloudProjectLibrarySetting()],
+        }),
         provide(projectLibraryTypesValueSpec, cloudLibraryType, {
           key: 'cloud-sync.project-library-type',
         }),

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -789,6 +789,7 @@ const cloudSyncRemoteHomeProjectEntryContribution = defineRegistryItemFactory(
  */
 export const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
   const systemIO = ctx.services.signal(systemIOService)
+  const userFeatures = ctx.services.signal(userFeaturesService)
   const getWasmPromise = () =>
     ctx.valueSpecs.get(wasmPromiseValueSpec) ??
     new Error('Missing WASM promise registry value.')
@@ -1049,7 +1050,15 @@ export const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
           id: 'cloud-sync.personal-cloud-library-default-policy',
           priority: 10,
           getDefaultLibraries: ({ isDesktop }) =>
-            isDesktop ? undefined : [getDefaultCloudProjectLibrarySetting()],
+            !isDesktop &&
+            userFeatures.value &&
+            userFeaturesContextHas(
+              userFeatures.value.context.value,
+              OPFS_CLOUD_FEATURE_FLAG,
+              false
+            )
+              ? [getDefaultCloudProjectLibrarySetting()]
+              : undefined,
         }),
         provide(projectLibraryTypesValueSpec, cloudLibraryType, {
           key: 'cloud-sync.project-library-type',

--- a/src/lib/settings/settingsUtils.spec.ts
+++ b/src/lib/settings/settingsUtils.spec.ts
@@ -9,10 +9,11 @@ import {
   serializeProjectConfiguration,
 } from '@src/lang/wasm'
 import { loadAndInitialiseWasmInstance } from '@src/lang/wasmUtilsNode'
-import { defaultLayoutConfig } from '@src/lib/layout/configs/default'
 import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
+import { defaultLayoutConfig } from '@src/lib/layout/configs/default'
 import { createLayoutWithMetadata } from '@src/lib/layout/utils'
 import {
+  DEFAULT_PROJECT_LIBRARY_TITLE,
   getDefaultCloudProjectLibrarySetting,
   getDefaultProjectLibrarySettings,
   LEGACY_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH,
@@ -21,6 +22,7 @@ import { projectLibrariesSettingsContribution } from '@src/lib/projectLibraries/
 import { defineBooleanExtensionSetting } from '@src/lib/settings/extensionSettings'
 import { createSettings, type Setting } from '@src/lib/settings/initialSettings'
 import {
+  clearSettingsAtLevel,
   configurationToSettingsPayload,
   formatSettingsLabel,
   getAllCurrentSettings,
@@ -122,7 +124,7 @@ describe('testing settings initialization', () => {
 
     expect(settings.app.libraries.current).toEqual([
       {
-        title: 'Default Projects Directory',
+        title: DEFAULT_PROJECT_LIBRARY_TITLE,
         path: '/tmp/projects',
         type: 'directory',
       },
@@ -137,6 +139,31 @@ describe('testing settings initialization', () => {
     expect(settings.app.libraries.current).toEqual([])
     expect(getChangedSettingsAtLevel(settings, 'user').app?.libraries).toEqual(
       []
+    )
+  })
+
+  it('falls back to default project libraries after clearing user-level libraries', () => {
+    const settings = createSettingsWithProjectLibraries()
+    settings.app.libraries.default =
+      getDefaultProjectLibrarySettings('/tmp/projects')
+
+    setSettingsAtLevel(settings, 'user', {
+      app: {
+        libraries: [getDefaultCloudProjectLibrarySetting()],
+      },
+    })
+
+    clearSettingsAtLevel(settings, 'user')
+
+    expect(settings.app.libraries.current).toEqual([
+      {
+        title: DEFAULT_PROJECT_LIBRARY_TITLE,
+        path: '/tmp/projects',
+        type: 'directory',
+      },
+    ])
+    expect(getChangedSettingsAtLevel(settings, 'user').app?.libraries).toBe(
+      undefined
     )
   })
 })
@@ -280,7 +307,7 @@ describe('project settings serialization regression', () => {
             projectDirectory: '/tmp/projects',
             libraries: [
               {
-                title: 'Default Projects Directory',
+                title: DEFAULT_PROJECT_LIBRARY_TITLE,
                 path: '/tmp/projects',
                 type: 'directory',
               },
@@ -368,7 +395,7 @@ describe('project settings serialization regression', () => {
     expect(parsedPayload.app?.projectDirectory).toBe('/tmp/projects')
     expect(parsedPayload.app?.libraries).toEqual([
       {
-        title: 'Default Projects Directory',
+        title: DEFAULT_PROJECT_LIBRARY_TITLE,
         path: '/tmp/projects',
         type: 'directory',
       },


### PR DESCRIPTION
Closes #12801. We just weren't setting this value properly on each platform, pretty simple.