### PR TITLE
Expose view commands in the command palette

### DIFF
--- a/src/registry/extensions/commands/appCommands.ts
+++ b/src/registry/extensions/commands/appCommands.ts
@@ -70,11 +70,15 @@ function sendModelingEvent(
 function createAppCommand({
   id,
   displayName,
+  description,
+  icon,
   hideFromSearch = true,
   onSubmit,
 }: {
   id: string
   displayName: string
+  description?: Command['description']
+  icon?: Command['icon']
   hideFromSearch?: boolean
   onSubmit: Command['onSubmit']
 }): Command {
@@ -83,6 +87,8 @@ function createAppCommand({
     name: id,
     groupId: APP_COMMAND_GROUP_ID,
     displayName,
+    description,
+    icon,
     hideFromSearch,
     needsReview: false,
     onSubmit,
@@ -222,6 +228,8 @@ export const appCommands: readonly Command[] = [
   createAppCommand({
     id: APP_COMMAND_IDS.modeling.centerCameraOnSelection,
     displayName: 'Center camera on selection',
+    description: 'Center the camera on the current selection.',
+    icon: 'camera',
     hideFromSearch: false,
     onSubmit: (input) =>
       sendModelingEvent(input, { type: 'Center camera on selection' }),
@@ -239,6 +247,8 @@ export const appCommands: readonly Command[] = [
   createAppCommand({
     id: APP_COMMAND_IDS.view.reset,
     displayName: 'Reset view',
+    description: 'Restore the default camera position and view.',
+    icon: 'refresh',
     hideFromSearch: false,
     onSubmit: resetView,
   }),

--- a/src/registry/extensions/commands/appCommands.ts
+++ b/src/registry/extensions/commands/appCommands.ts
@@ -70,10 +70,12 @@ function sendModelingEvent(
 function createAppCommand({
   id,
   displayName,
+  hideFromSearch = true,
   onSubmit,
 }: {
   id: string
   displayName: string
+  hideFromSearch?: boolean
   onSubmit: Command['onSubmit']
 }): Command {
   return {
@@ -81,7 +83,7 @@ function createAppCommand({
     name: id,
     groupId: APP_COMMAND_GROUP_ID,
     displayName,
-    hideFromSearch: true,
+    hideFromSearch,
     needsReview: false,
     onSubmit,
   }
@@ -220,6 +222,7 @@ export const appCommands: readonly Command[] = [
   createAppCommand({
     id: APP_COMMAND_IDS.modeling.centerCameraOnSelection,
     displayName: 'Center camera on selection',
+    hideFromSearch: false,
     onSubmit: (input) =>
       sendModelingEvent(input, { type: 'Center camera on selection' }),
   }),
@@ -236,6 +239,7 @@ export const appCommands: readonly Command[] = [
   createAppCommand({
     id: APP_COMMAND_IDS.view.reset,
     displayName: 'Reset view',
+    hideFromSearch: false,
     onSubmit: resetView,
   }),
   createAppCommand({

--- a/src/registry/extensions/commands/index.spec.ts
+++ b/src/registry/extensions/commands/index.spec.ts
@@ -102,15 +102,28 @@ describe('commands extension', () => {
     )
   })
 
-  it('exposes view commands in command palette search', () => {
-    const searchableAppCommandIds = appCommands
-      .filter((command) => command.hideFromSearch !== true)
-      .map((command) => command.id)
+  it('exposes view commands with command palette metadata', () => {
+    const searchableAppCommands = appCommands.filter(
+      (command) => command.hideFromSearch !== true
+    )
 
-    expect(searchableAppCommandIds).toEqual([
-      APP_COMMAND_IDS.modeling.centerCameraOnSelection,
-      APP_COMMAND_IDS.view.reset,
-    ])
+    expect(searchableAppCommands).toHaveLength(2)
+    expect(searchableAppCommands).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: APP_COMMAND_IDS.modeling.centerCameraOnSelection,
+          displayName: 'Center camera on selection',
+          description: 'Center the camera on the current selection.',
+          icon: 'camera',
+        }),
+        expect.objectContaining({
+          id: APP_COMMAND_IDS.view.reset,
+          displayName: 'Reset view',
+          description: 'Restore the default camera position and view.',
+          icon: 'refresh',
+        }),
+      ])
+    )
   })
 
   it('runs toolbar commands against the KclManager from command input', () => {

--- a/src/registry/extensions/commands/index.spec.ts
+++ b/src/registry/extensions/commands/index.spec.ts
@@ -102,6 +102,17 @@ describe('commands extension', () => {
     )
   })
 
+  it('exposes view commands in command palette search', () => {
+    const searchableAppCommandIds = appCommands
+      .filter((command) => command.hideFromSearch !== true)
+      .map((command) => command.id)
+
+    expect(searchableAppCommandIds).toEqual([
+      APP_COMMAND_IDS.modeling.centerCameraOnSelection,
+      APP_COMMAND_IDS.view.reset,
+    ])
+  })
+
   it('runs toolbar commands against the KclManager from command input', () => {
     const sentEvents: unknown[] = []
     const kclManager = {


### PR DESCRIPTION
## Problem

People can run **Reset view** and **Center camera on selection** from menus and shortcuts, but those commands are missing from command palette search. Their results also need the visual metadata used by neighboring commands.

## Solution

Make **Reset view** and **Center camera on selection** searchable and runnable from the command palette, with distinct icons and concise descriptions.

## Follow-ups

- [Scope command availability by app context (#12815)](https://github.com/KittyCAD/modeling-app/issues/12815): define one typed context contract so command-palette results and shortcuts use the same scope rules.
- [Add dedicated icons for view commands (#12814)](https://github.com/KittyCAD/modeling-app/issues/12814): replace the generic settings icon used by standard and named view commands with dedicated view-direction and camera icons.
- [Prioritize command-palette results by usage (#12818)](https://github.com/KittyCAD/modeling-app/issues/12818): remember successful selections and boost recently or frequently used commands among relevant matches.

Closes #4189
Closes #4190
