### PR TITLE
Update disabled test artifacts

### DIFF
--- a/rust/kcl-lib/tests/kcl_samples/fun-stacker-toy/program_memory.snap
+++ b/rust/kcl-lib/tests/kcl_samples/fun-stacker-toy/program_memory.snap
@@ -874,126 +874,6 @@ description: Variables in memory after executing fun-stacker-toy.kcl
             "id": "[uuid]",
             "sourceRange": []
           },
-          "from": [
-            2.009923430760289,
-            11.489955800482061
-          ],
-          "tag": {
-            "commentStart": 797,
-            "end": 802,
-            "moduleId": 0,
-            "start": 797,
-            "type": "TagDeclarator",
-            "value": "line4"
-          },
-          "to": [
-            2.0099234307599305,
-            10.989955800482019
-          ],
-          "type": "ToPoint",
-          "units": "in"
-        },
-        {
-          "__geoMeta": {
-            "id": "[uuid]",
-            "sourceRange": []
-          },
-          "from": [
-            2.009923430760289,
-            11.489955800482061
-          ],
-          "tag": {
-            "commentStart": 797,
-            "end": 802,
-            "moduleId": 0,
-            "start": 797,
-            "type": "TagDeclarator",
-            "value": "line4"
-          },
-          "to": [
-            2.0099234307599305,
-            10.989955800482019
-          ],
-          "type": "ToPoint",
-          "units": "in"
-        },
-        {
-          "__geoMeta": {
-            "id": "[uuid]",
-            "sourceRange": []
-          },
-          "from": [
-            2.009923430760289,
-            11.489955800482061
-          ],
-          "tag": {
-            "commentStart": 797,
-            "end": 802,
-            "moduleId": 0,
-            "start": 797,
-            "type": "TagDeclarator",
-            "value": "line4"
-          },
-          "to": [
-            2.0099234307599305,
-            10.989955800482019
-          ],
-          "type": "ToPoint",
-          "units": "in"
-        },
-        {
-          "__geoMeta": {
-            "id": "[uuid]",
-            "sourceRange": []
-          },
-          "from": [
-            2.009923430760289,
-            11.489955800482061
-          ],
-          "tag": {
-            "commentStart": 797,
-            "end": 802,
-            "moduleId": 0,
-            "start": 797,
-            "type": "TagDeclarator",
-            "value": "line4"
-          },
-          "to": [
-            2.0099234307599305,
-            10.989955800482019
-          ],
-          "type": "ToPoint",
-          "units": "in"
-        },
-        {
-          "__geoMeta": {
-            "id": "[uuid]",
-            "sourceRange": []
-          },
-          "from": [
-            2.009923430760289,
-            11.489955800482061
-          ],
-          "tag": {
-            "commentStart": 797,
-            "end": 802,
-            "moduleId": 0,
-            "start": 797,
-            "type": "TagDeclarator",
-            "value": "line4"
-          },
-          "to": [
-            2.0099234307599305,
-            10.989955800482019
-          ],
-          "type": "ToPoint",
-          "units": "in"
-        },
-        {
-          "__geoMeta": {
-            "id": "[uuid]",
-            "sourceRange": []
-          },
           "ccw": true,
           "center": [
             51.329941511783794,
@@ -1244,36 +1124,6 @@ description: Variables in memory after executing fun-stacker-toy.kcl
           ],
           "type": "Circle",
           "units": "in"
-        },
-        {
-          "__geoMeta": {
-            "id": "[uuid]",
-            "sourceRange": []
-          },
-          "ccw": true,
-          "center": [
-            3.681017808436987,
-            2.9649261449819755
-          ],
-          "from": [
-            4.603706583252062,
-            2.5793805253291127
-          ],
-          "radius": 1.0000000000016267,
-          "tag": {
-            "commentStart": 1251,
-            "end": 1258,
-            "moduleId": 0,
-            "start": 1251,
-            "type": "TagDeclarator",
-            "value": "circle2"
-          },
-          "to": [
-            4.603706583252062,
-            2.5793805253291127
-          ],
-          "type": "Circle",
-          "units": "in"
         }
       ],
       "on": {
@@ -1497,36 +1347,6 @@ description: Variables in memory after executing fun-stacker-toy.kcl
           "to": [
             4.385503969985048,
             5.035580773114644
-          ],
-          "type": "Circle",
-          "units": "in"
-        },
-        {
-          "__geoMeta": {
-            "id": "[uuid]",
-            "sourceRange": []
-          },
-          "ccw": true,
-          "center": [
-            3.389735024163931,
-            4.9436010398528785
-          ],
-          "from": [
-            4.3855113053204695,
-            5.035413881471218
-          ],
-          "radius": 0.9999999999999901,
-          "tag": {
-            "commentStart": 1371,
-            "end": 1378,
-            "moduleId": 0,
-            "start": 1371,
-            "type": "TagDeclarator",
-            "value": "circle3"
-          },
-          "to": [
-            4.3855113053204695,
-            5.035413881471218
           ],
           "type": "Circle",
           "units": "in"
@@ -1756,36 +1576,6 @@ description: Variables in memory after executing fun-stacker-toy.kcl
           ],
           "type": "Circle",
           "units": "in"
-        },
-        {
-          "__geoMeta": {
-            "id": "[uuid]",
-            "sourceRange": []
-          },
-          "ccw": true,
-          "center": [
-            3.180583006507501,
-            6.932634833813235
-          ],
-          "from": [
-            4.170310052184412,
-            6.7896649941230365
-          ],
-          "radius": 1.0000000000026934,
-          "tag": {
-            "commentStart": 1491,
-            "end": 1498,
-            "moduleId": 0,
-            "start": 1491,
-            "type": "TagDeclarator",
-            "value": "circle4"
-          },
-          "to": [
-            4.170310052184412,
-            6.7896649941230365
-          ],
-          "type": "Circle",
-          "units": "in"
         }
       ],
       "on": {
@@ -2012,36 +1802,6 @@ description: Variables in memory after executing fun-stacker-toy.kcl
           ],
           "type": "Circle",
           "units": "in"
-        },
-        {
-          "__geoMeta": {
-            "id": "[uuid]",
-            "sourceRange": []
-          },
-          "ccw": true,
-          "center": [
-            3.053920073115579,
-            8.928619929276255
-          ],
-          "from": [
-            3.9548465360984797,
-            9.362591712127168
-          ],
-          "radius": 1.0000000000068396,
-          "tag": {
-            "commentStart": 1611,
-            "end": 1618,
-            "moduleId": 0,
-            "start": 1611,
-            "type": "TagDeclarator",
-            "value": "circle5"
-          },
-          "to": [
-            3.9548465360984797,
-            9.362591712127168
-          ],
-          "type": "Circle",
-          "units": "in"
         }
       ],
       "on": {
@@ -2235,36 +1995,6 @@ description: Variables in memory after executing fun-stacker-toy.kcl
           "to": [
             1.5000000000001186,
             12.000000001439652
-          ],
-          "type": "Arc",
-          "units": "in"
-        },
-        {
-          "__geoMeta": {
-            "id": "[uuid]",
-            "sourceRange": []
-          },
-          "ccw": true,
-          "center": [
-            1.4999234319334465,
-            11.490000003408142
-          ],
-          "from": [
-            2.009923430100516,
-            11.489955800482123
-          ],
-          "radius": 0.5100000000826567,
-          "tag": {
-            "commentStart": 2038,
-            "end": 2042,
-            "moduleId": 0,
-            "start": 2038,
-            "type": "TagDeclarator",
-            "value": "arc2"
-          },
-          "to": [
-            1.4999999999983171,
-            11.999999997743084
           ],
           "type": "Arc",
           "units": "in"
@@ -2917,126 +2647,6 @@ description: Variables in memory after executing fun-stacker-toy.kcl
               "id": "[uuid]",
               "sourceRange": []
             },
-            "from": [
-              2.009923430760289,
-              11.489955800482061
-            ],
-            "tag": {
-              "commentStart": 797,
-              "end": 802,
-              "moduleId": 0,
-              "start": 797,
-              "type": "TagDeclarator",
-              "value": "line4"
-            },
-            "to": [
-              2.0099234307599305,
-              10.989955800482019
-            ],
-            "type": "ToPoint",
-            "units": "in"
-          },
-          {
-            "__geoMeta": {
-              "id": "[uuid]",
-              "sourceRange": []
-            },
-            "from": [
-              2.009923430760289,
-              11.489955800482061
-            ],
-            "tag": {
-              "commentStart": 797,
-              "end": 802,
-              "moduleId": 0,
-              "start": 797,
-              "type": "TagDeclarator",
-              "value": "line4"
-            },
-            "to": [
-              2.0099234307599305,
-              10.989955800482019
-            ],
-            "type": "ToPoint",
-            "units": "in"
-          },
-          {
-            "__geoMeta": {
-              "id": "[uuid]",
-              "sourceRange": []
-            },
-            "from": [
-              2.009923430760289,
-              11.489955800482061
-            ],
-            "tag": {
-              "commentStart": 797,
-              "end": 802,
-              "moduleId": 0,
-              "start": 797,
-              "type": "TagDeclarator",
-              "value": "line4"
-            },
-            "to": [
-              2.0099234307599305,
-              10.989955800482019
-            ],
-            "type": "ToPoint",
-            "units": "in"
-          },
-          {
-            "__geoMeta": {
-              "id": "[uuid]",
-              "sourceRange": []
-            },
-            "from": [
-              2.009923430760289,
-              11.489955800482061
-            ],
-            "tag": {
-              "commentStart": 797,
-              "end": 802,
-              "moduleId": 0,
-              "start": 797,
-              "type": "TagDeclarator",
-              "value": "line4"
-            },
-            "to": [
-              2.0099234307599305,
-              10.989955800482019
-            ],
-            "type": "ToPoint",
-            "units": "in"
-          },
-          {
-            "__geoMeta": {
-              "id": "[uuid]",
-              "sourceRange": []
-            },
-            "from": [
-              2.009923430760289,
-              11.489955800482061
-            ],
-            "tag": {
-              "commentStart": 797,
-              "end": 802,
-              "moduleId": 0,
-              "start": 797,
-              "type": "TagDeclarator",
-              "value": "line4"
-            },
-            "to": [
-              2.0099234307599305,
-              10.989955800482019
-            ],
-            "type": "ToPoint",
-            "units": "in"
-          },
-          {
-            "__geoMeta": {
-              "id": "[uuid]",
-              "sourceRange": []
-            },
             "ccw": true,
             "center": [
               51.329941511783794,
@@ -3341,36 +2951,6 @@ description: Variables in memory after executing fun-stacker-toy.kcl
             ],
             "type": "Circle",
             "units": "in"
-          },
-          {
-            "__geoMeta": {
-              "id": "[uuid]",
-              "sourceRange": []
-            },
-            "ccw": true,
-            "center": [
-              3.681017808436987,
-              2.9649261449819755
-            ],
-            "from": [
-              4.603706583252062,
-              2.5793805253291127
-            ],
-            "radius": 1.0000000000016267,
-            "tag": {
-              "commentStart": 1251,
-              "end": 1258,
-              "moduleId": 0,
-              "start": 1251,
-              "type": "TagDeclarator",
-              "value": "circle2"
-            },
-            "to": [
-              4.603706583252062,
-              2.5793805253291127
-            ],
-            "type": "Circle",
-            "units": "in"
           }
         ],
         "on": {
@@ -3662,36 +3242,6 @@ description: Variables in memory after executing fun-stacker-toy.kcl
             "to": [
               4.385503969985048,
               5.035580773114644
-            ],
-            "type": "Circle",
-            "units": "in"
-          },
-          {
-            "__geoMeta": {
-              "id": "[uuid]",
-              "sourceRange": []
-            },
-            "ccw": true,
-            "center": [
-              3.389735024163931,
-              4.9436010398528785
-            ],
-            "from": [
-              4.3855113053204695,
-              5.035413881471218
-            ],
-            "radius": 0.9999999999999901,
-            "tag": {
-              "commentStart": 1371,
-              "end": 1378,
-              "moduleId": 0,
-              "start": 1371,
-              "type": "TagDeclarator",
-              "value": "circle3"
-            },
-            "to": [
-              4.3855113053204695,
-              5.035413881471218
             ],
             "type": "Circle",
             "units": "in"
@@ -3989,36 +3539,6 @@ description: Variables in memory after executing fun-stacker-toy.kcl
             ],
             "type": "Circle",
             "units": "in"
-          },
-          {
-            "__geoMeta": {
-              "id": "[uuid]",
-              "sourceRange": []
-            },
-            "ccw": true,
-            "center": [
-              3.180583006507501,
-              6.932634833813235
-            ],
-            "from": [
-              4.170310052184412,
-              6.7896649941230365
-            ],
-            "radius": 1.0000000000026934,
-            "tag": {
-              "commentStart": 1491,
-              "end": 1498,
-              "moduleId": 0,
-              "start": 1491,
-              "type": "TagDeclarator",
-              "value": "circle4"
-            },
-            "to": [
-              4.170310052184412,
-              6.7896649941230365
-            ],
-            "type": "Circle",
-            "units": "in"
           }
         ],
         "on": {
@@ -4313,36 +3833,6 @@ description: Variables in memory after executing fun-stacker-toy.kcl
             ],
             "type": "Circle",
             "units": "in"
-          },
-          {
-            "__geoMeta": {
-              "id": "[uuid]",
-              "sourceRange": []
-            },
-            "ccw": true,
-            "center": [
-              3.053920073115579,
-              8.928619929276255
-            ],
-            "from": [
-              3.9548465360984797,
-              9.362591712127168
-            ],
-            "radius": 1.0000000000068396,
-            "tag": {
-              "commentStart": 1611,
-              "end": 1618,
-              "moduleId": 0,
-              "start": 1611,
-              "type": "TagDeclarator",
-              "value": "circle5"
-            },
-            "to": [
-              3.9548465360984797,
-              9.362591712127168
-            ],
-            "type": "Circle",
-            "units": "in"
           }
         ],
         "on": {
@@ -4590,36 +4080,6 @@ description: Variables in memory after executing fun-stacker-toy.kcl
             "to": [
               1.5000000000001186,
               12.000000001439652
-            ],
-            "type": "Arc",
-            "units": "in"
-          },
-          {
-            "__geoMeta": {
-              "id": "[uuid]",
-              "sourceRange": []
-            },
-            "ccw": true,
-            "center": [
-              1.4999234319334465,
-              11.490000003408142
-            ],
-            "from": [
-              2.009923430100516,
-              11.489955800482123
-            ],
-            "radius": 0.5100000000826567,
-            "tag": {
-              "commentStart": 2038,
-              "end": 2042,
-              "moduleId": 0,
-              "start": 2038,
-              "type": "TagDeclarator",
-              "value": "arc2"
-            },
-            "to": [
-              1.4999999999983171,
-              11.999999997743084
             ],
             "type": "Arc",
             "units": "in"


### PR DESCRIPTION
Updates snap for `fun-stacker-toy` test which is currently disabled. To be re-enabled once this merges.

Context: this test was only re-enabled in `engine` after #12702 so it was still being ignored in `modeling-app` for #12431 which caused the diff.