### PR TITLE
Use committed bindings for Vercel deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ node_modules
 
 # production
 build
+*.log
 
 # misc
 .DS_Store

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -7,7 +7,11 @@ rm -rf rust/kcl-lib/bindings
 
 cd rust
 wasm-pack build kcl-wasm-lib --release --target web --out-dir pkg --scope kittycad
-cargo test -p kcl-lib --features artifact-graph export_bindings
+if [ -n "${VERCEL:-}" ]; then
+  cp -R kcl-lib/expected-bindings/ts-rs kcl-lib/bindings
+else
+  cargo test -p kcl-lib --features artifact-graph export_bindings
+fi
 cd ..
 
 cp rust/kcl-wasm-lib/README.md rust/kcl-wasm-lib/pkg/README.md


### PR DESCRIPTION
This should save ~4 minutes on the preview deployments. If bindings actually need to be regenerated, that should happen in another CI step, which will result in a new commit that triggers a new deployment.