### PR TITLE
Limit optimization to staging/production Vercel builds

### DIFF
--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -6,7 +6,11 @@ mkdir -p rust/kcl-wasm-lib/pkg
 rm -rf rust/kcl-lib/bindings
 
 cd rust
-wasm-pack build kcl-wasm-lib --release --target web --out-dir pkg --scope kittycad
+wasm_pack_args=(build kcl-wasm-lib --release --target web --out-dir pkg --scope kittycad)
+if [ "${VERCEL_ENV:-}" = "preview" ]; then
+  wasm_pack_args+=(--no-opt)
+fi
+wasm-pack "${wasm_pack_args[@]}"
 if [ -n "${VERCEL:-}" ]; then
   cp -R kcl-lib/expected-bindings/ts-rs kcl-lib/bindings
 else

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -6,18 +6,18 @@ mkdir -p rust/kcl-wasm-lib/pkg
 rm -rf rust/kcl-lib/bindings
 
 cd rust
-wasm_pack_args=(build kcl-wasm-lib --release --target web --out-dir pkg --scope kittycad)
+
+wasm_pack_args=(build kcl-wasm-lib --release --target=web --out-dir=pkg --scope=kittycad)
 if [ "${VERCEL_ENV:-}" = "preview" ]; then
   wasm_pack_args+=(--no-opt)
 fi
 wasm-pack "${wasm_pack_args[@]}"
+
 if [ -n "${VERCEL:-}" ]; then
   cp -R kcl-lib/expected-bindings/ts-rs kcl-lib/bindings
 else
-  cargo test -p kcl-lib --features artifact-graph export_bindings
+  cargo test --package=kcl-lib --features=artifact-graph export_bindings
 fi
-cd ..
 
-cp rust/kcl-wasm-lib/README.md rust/kcl-wasm-lib/pkg/README.md
-cp rust/kcl-wasm-lib/pkg/kcl_wasm_lib_bg.wasm public
-npm run fmt
+cp kcl-wasm-lib/pkg/kcl_wasm_lib_bg.wasm ../public
+cp kcl-wasm-lib/README.md kcl-wasm-lib/pkg/README.md


### PR DESCRIPTION
This should save 1-3 minutes on the preview deployments. I think this slight deviation from staging/production is worth reducing the feedback cycle on PRs. Staging will still be an optimized build that we run end-to-end tests against.