### PR TITLE
Preserve cloud project outside cloud library delete

### DIFF
--- a/src/components/AppProjectCard/AppProjectCard.spec.tsx
+++ b/src/components/AppProjectCard/AppProjectCard.spec.tsx
@@ -1,5 +1,6 @@
 import AppProjectCard from '@src/components/AppProjectCard/AppProjectCard'
 import fsZds from '@src/lib/fs-zds'
+import { DIRECTORY_PROJECT_LIBRARY_TYPE } from '@src/lib/projectLibraries'
 import type {
   HomeProjectActionsService,
   HomeProjectEntry,
@@ -311,6 +312,25 @@ describe('ProjectCard', () => {
     fireEvent.click(screen.getByTestId('project-card-context-move-to-library'))
 
     expect(onMoveToLibrary).toHaveBeenCalledWith(cloudProject)
+  })
+
+  test('clarifies that deleting a cloud-backed directory project keeps the cloud version', () => {
+    renderProjectCard({
+      project: {
+        ...cloudProject,
+        libraryPath: '/projects',
+        libraryType: DIRECTORY_PROJECT_LIBRARY_TYPE,
+      },
+    })
+
+    fireEvent.contextMenu(screen.getByTestId('project-link'))
+    fireEvent.click(screen.getByTestId('project-card-context-delete'))
+
+    expect(
+      screen.getByText(
+        'This will delete the local copy of "Old cloud title". The cloud version will not be deleted.'
+      )
+    ).toBeInTheDocument()
   })
 
   test('selects the project title when opening rename from the context menu', async () => {

--- a/src/components/AppProjectCard/AppProjectCard.spec.tsx
+++ b/src/components/AppProjectCard/AppProjectCard.spec.tsx
@@ -314,7 +314,7 @@ describe('ProjectCard', () => {
     expect(onMoveToLibrary).toHaveBeenCalledWith(cloudProject)
   })
 
-  test('clarifies that deleting a cloud-backed directory project keeps the cloud version', () => {
+  test('clarifies that deleting a cloud-backed non-cloud library project keeps the cloud version', () => {
     renderProjectCard({
       project: {
         ...cloudProject,

--- a/src/components/AppProjectCard/AppProjectCard.tsx
+++ b/src/components/AppProjectCard/AppProjectCard.tsx
@@ -8,7 +8,11 @@ import { DeleteConfirmationDialog } from '@src/components/DeleteProjectDialog'
 import Tooltip from '@src/components/Tooltip'
 import type { ProjectStatus } from '@src/hooks/useProjectStatus'
 import fsZds from '@src/lib/fs-zds'
-import { getHomeProjectDisplayName } from '@src/lib/homeProjects'
+import {
+  getHomeProjectDeleteWarningMessage,
+  getHomeProjectDisplayName,
+  shouldPreserveRemoteOnHomeProjectDelete,
+} from '@src/lib/homeProjects'
 import { PATHS } from '@src/lib/paths'
 import { reportRejection, trap } from '@src/lib/trap'
 import { toSync } from '@src/lib/utils'
@@ -240,6 +244,16 @@ function AppProjectCard({
   const canMoveToLibrary = Boolean(
     onMoveToLibrary && projectActions.canMoveToLibrary(project)
   )
+  const deleteProjectDisplayName = projectName || 'this file'
+  const deleteWarningMessage = getHomeProjectDeleteWarningMessage(
+    project,
+    deleteProjectDisplayName
+  )
+  const deleteConfirmationMessage = shouldPreserveRemoteOnHomeProjectDelete(
+    project
+  )
+    ? `Are you sure you want to delete the local copy of "${deleteProjectDisplayName}"? This action cannot be undone.`
+    : `Are you sure you want to delete "${deleteProjectDisplayName}"? This action cannot be undone.`
   const openHref =
     project.readWriteAccess && project.defaultFile
       ? `${PATHS.FILE}/${encodeURIComponent(project.defaultFile)}`
@@ -329,13 +343,9 @@ function AppProjectCard({
           }, reportRejection)}
           onDismiss={() => setIsConfirmingDelete(false)}
         >
+          <p className="my-4 text-wrap break-words">{deleteWarningMessage}</p>
           <p className="my-4 text-wrap break-words">
-            This will permanently delete "{projectName || 'this file'}
-            ".
-          </p>
-          <p className="my-4 text-wrap break-words">
-            Are you sure you want to delete "{projectName || 'this file'}
-            "? This action cannot be undone.
+            {deleteConfirmationMessage}
           </p>
         </DeleteConfirmationDialog>
       )}

--- a/src/lib/cloudSync/README.md
+++ b/src/lib/cloudSync/README.md
@@ -34,12 +34,13 @@ Cloud sync is technically keyed by per-project `project.toml` IDs, but the user-
 
 ### Deleting projects
 
-Deleting a cloud-backed project means deleting the project everywhere. This applies to projects in cloud-type libraries. Directory-type libraries can still display already-linked projects from their `project.toml` metadata, but they must not create a new cloud project for an unlinked local project.
+Deleting a cloud-backed project follows the library that owns the local project path. Cloud-type library deletes are delete-everywhere actions. Directory-type libraries can still display already-linked projects from their `project.toml` metadata, but deleting them removes only the local realization and leaves the remote cloud project in place. Directory-type libraries must not create a new cloud project for an unlinked local project.
 
-- Local materialized cloud project: remove the local project directory and delete the linked remote cloud project before reporting success. The filesystem observer may enqueue a tombstone as part of the local delete, but product actions must not rely on background sync as the only remote deletion path.
+- Local materialized cloud-library project: remove the local project directory and delete the linked remote cloud project before reporting success. The filesystem observer may enqueue a tombstone as part of the local delete, but product actions must not rely on background sync as the only remote deletion path.
+- Local materialized directory-library project with a cloud project ID: remove the local realization and clear local cloud sync state/outbox without deleting the linked remote cloud project.
 - Remote-only cloud project: delete the remote cloud project. There is no local materialization to remove.
 - Local-only directory project: remove only the local project directory.
-- If the remote delete fails for a cloud-backed project, the delete action should fail rather than show success while the cloud project can still reappear from the remote index.
+- If the remote delete fails for a cloud-library or remote-only cloud project, the delete action should fail rather than show success while the cloud project can still reappear from the remote index.
 
 ## Sync Flows
 
@@ -130,7 +131,7 @@ flowchart TD
 - Sync failures must preserve outbox and dirty metadata.
 - Cloud project title is user-facing metadata; the OPFS folder name is an implementation detail that may be uniquified.
 - Home rename of a cloud project acts on the local materialization when one exists and acts directly on the remote project when the project is still remote-only. Because the cloud API has no title-only update, a remote-only rename re-uploads the downloaded project archive with the new title under `expected_revision`.
-- Home delete of a cloud-backed project must remove both the local materialization, when present, and the linked remote project before reporting success.
+- Home delete of a cloud-library or remote-only cloud project must remove both the local materialization, when present, and the linked remote project before reporting success. Home delete of a directory-library project with a cloud project ID removes only the local realization.
 
 ## Persistent State
 

--- a/src/lib/cloudSync/README.md
+++ b/src/lib/cloudSync/README.md
@@ -34,13 +34,13 @@ Cloud sync is technically keyed by per-project `project.toml` IDs, but the user-
 
 ### Deleting projects
 
-Deleting a cloud-backed project follows the library that owns the local project path. Cloud-type library deletes are delete-everywhere actions. Directory-type libraries can still display already-linked projects from their `project.toml` metadata, but deleting them removes only the local realization and leaves the remote cloud project in place. Directory-type libraries must not create a new cloud project for an unlinked local project.
+Only delete the remote version of a project if that project is within a cloud-type library. Directory-type libraries can still display already-linked projects from their `project.toml` metadata, but deleting them removes only the local realization and leaves the remote cloud project in place. Directory-type libraries must not create a new cloud project for an unlinked local project.
 
 - Local materialized cloud-library project: remove the local project directory and delete the linked remote cloud project before reporting success. The filesystem observer may enqueue a tombstone as part of the local delete, but product actions must not rely on background sync as the only remote deletion path.
 - Local materialized directory-library project with a cloud project ID: remove the local realization and clear local cloud sync state/outbox without deleting the linked remote cloud project.
 - Remote-only cloud project: delete the remote cloud project. There is no local materialization to remove.
 - Local-only directory project: remove only the local project directory.
-- If the remote delete fails for a cloud-library or remote-only cloud project, the delete action should fail rather than show success while the cloud project can still reappear from the remote index.
+- If the remote delete fails for a project within a cloud-type library, the delete action should fail rather than show success while the cloud project can still reappear from the remote index.
 
 ## Sync Flows
 
@@ -131,7 +131,7 @@ flowchart TD
 - Sync failures must preserve outbox and dirty metadata.
 - Cloud project title is user-facing metadata; the OPFS folder name is an implementation detail that may be uniquified.
 - Home rename of a cloud project acts on the local materialization when one exists and acts directly on the remote project when the project is still remote-only. Because the cloud API has no title-only update, a remote-only rename re-uploads the downloaded project archive with the new title under `expected_revision`.
-- Home delete of a cloud-library or remote-only cloud project must remove both the local materialization, when present, and the linked remote project before reporting success. Home delete of a directory-library project with a cloud project ID removes only the local realization.
+- Home delete must delete the linked remote project only when the project is within a cloud-type library. Home delete of a directory-library project with a cloud project ID removes only the local realization.
 
 ## Persistent State
 

--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -74,12 +74,12 @@ import {
   isPathIgnoredByGitignore,
 } from '@src/lib/gitignore'
 import { webSafePathSplit } from '@src/lib/pathUtils'
+import { CLOUD_PROJECT_LIBRARY_TYPE } from '@src/lib/projectLibraries'
 import {
   getProjectDirectoryNameFromTitle,
   getUniqueDuplicateProjectName,
   sanitizeProjectName,
 } from '@src/lib/projectName'
-import { CLOUD_PROJECT_LIBRARY_TYPE } from '@src/lib/projectLibraries'
 import {
   getCloudProjectIdFromProjectTomlContents,
   getProjectTitleFromProjectTomlContents,
@@ -1311,6 +1311,18 @@ type LocalProjectRealizationCandidate = {
   manifest?: ProjectManifest
 }
 
+async function localProjectRealizationCandidate(
+  projectPath: string
+): Promise<LocalProjectRealizationCandidate> {
+  return {
+    projectPath,
+    metadata: await getProjectMetadata(projectPath),
+    manifest: await collectLocalProjectFiles(projectPath)
+      .then(projectManifestFromFiles)
+      .catch(() => undefined),
+  }
+}
+
 async function getLocalProjectRealizationCandidatesByRemoteProjectId(
   projectDirectory: string,
   remoteProjectId: string,
@@ -1322,15 +1334,7 @@ async function getLocalProjectRealizationCandidatesByRemoteProjectId(
     preferredProjectName
   )
 
-  return Promise.all(
-    paths.map(async (projectPath) => ({
-      projectPath,
-      metadata: await getProjectMetadata(projectPath),
-      manifest: await collectLocalProjectFiles(projectPath)
-        .then(projectManifestFromFiles)
-        .catch(() => undefined),
-    }))
-  )
+  return Promise.all(paths.map(localProjectRealizationCandidate))
 }
 
 function canDeleteDuplicateLocalRealization({
@@ -1454,11 +1458,20 @@ export async function deleteCloudSyncLocalProjectRealizations(
       projectDirectory,
       projectId
     )
-  const selectedCandidate = candidates.find(
+  let selectedCandidate = candidates.find(
     (candidate) =>
       normalizePathForSync(candidate.projectPath) ===
       normalizedSelectedProjectPath
   )
+  if (
+    !selectedCandidate &&
+    (await exists(normalizedSelectedProjectPath).catch(() => false))
+  ) {
+    selectedCandidate = await localProjectRealizationCandidate(
+      normalizedSelectedProjectPath
+    )
+    candidates.unshift(selectedCandidate)
+  }
   const selectedManifest = selectedCandidate?.manifest
 
   for (const candidate of candidates) {

--- a/src/lib/cloudSync/localProjectNames.spec.ts
+++ b/src/lib/cloudSync/localProjectNames.spec.ts
@@ -303,6 +303,28 @@ describe('cloud sync local project names', () => {
     expect(await getAllOutboxEntries()).toEqual([])
   })
 
+  it('deletes the selected local realization even when project.toml lookup cannot rediscover it', async () => {
+    const files = new Map([[`${titleProjectPath}/main.kcl`, 'x = 1']])
+    configureCloudSyncTestFs(files)
+    await putProjectMetadata({
+      schemaVersion: 1,
+      localProjectPath: titleProjectPath,
+      projectName: expectedProjectName,
+      remoteProjectId,
+      remoteRevision: 'rev-1',
+      baseManifest: await cleanCloudProjectManifest(),
+    })
+
+    await deleteCloudSyncLocalProjectRealizations(
+      remoteProjectId,
+      titleProjectPath
+    )
+
+    expect(files.has(`${titleProjectPath}/main.kcl`)).toBe(false)
+    expect(await getCloudSyncProjectMetadata(titleProjectPath)).toBeUndefined()
+    expect(await getAllOutboxEntries()).toEqual([])
+  })
+
   it('leaves data and metadata in place when a cloud project directory rename fails', async () => {
     const files = createIdBasedCloudProjectFiles()
     configureCloudSyncTestFs(files, { failRenames: true })

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -517,7 +517,12 @@ function homeProjectEntryCloudSyncFields(
   metadata: CloudSyncProjectMetadataIndexEntry | undefined
 ): Pick<
   HomeProjectEntryContribution,
-  'conflict' | 'libraryId' | 'localProjectPath' | 'status' | 'syncFailure'
+  | 'conflict'
+  | 'libraryId'
+  | 'libraryType'
+  | 'localProjectPath'
+  | 'status'
+  | 'syncFailure'
 > {
   const syncFailure =
     metadata?.lastFailure?.kind === 'remote-upload-forbidden'
@@ -526,6 +531,7 @@ function homeProjectEntryCloudSyncFields(
   if (!metadata?.conflict) {
     return {
       libraryId: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+      libraryType: CLOUD_PROJECT_LIBRARY_TYPE,
       status: 'cloud-only',
       ...(syncFailure
         ? { syncFailure, localProjectPath: metadata?.localProjectPath }
@@ -535,6 +541,7 @@ function homeProjectEntryCloudSyncFields(
 
   return {
     libraryId: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+    libraryType: CLOUD_PROJECT_LIBRARY_TYPE,
     status: 'conflicted',
     conflict: metadata.conflict,
     localProjectPath: metadata.localProjectPath,

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -1021,9 +1021,10 @@ export const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
         return Promise.reject(wasmInstancePromise)
       }
 
+      const projectDirectoryPath =
+        await getCloudProjectLibraryMaterializationDirectoryPath(library)
       const projects = await readProjectsFromProjectDirectory({
-        projectDirectoryPath:
-          await getCloudProjectLibraryMaterializationDirectoryPath(library),
+        projectDirectoryPath,
         wasmInstancePromise,
         signal,
       })
@@ -1038,6 +1039,8 @@ export const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
       return projects.map((project) => ({
         ...homeProjectEntryFromProject(project),
         libraryId: library.id,
+        libraryPath: projectDirectoryPath,
+        libraryType: library.type,
       }))
     },
   }

--- a/src/lib/commandBarConfigs/projectsCommandConfig.spec.ts
+++ b/src/lib/commandBarConfigs/projectsCommandConfig.spec.ts
@@ -1,7 +1,10 @@
 import { createProjectCommands } from '@src/lib/commandBarConfigs/projectsCommandConfig'
 import type { CommandArgumentOption } from '@src/lib/commandTypes'
 import type { Project } from '@src/lib/project'
-import type { ProjectLibrary } from '@src/lib/projectLibraries'
+import {
+  DIRECTORY_PROJECT_LIBRARY_TYPE,
+  type ProjectLibrary,
+} from '@src/lib/projectLibraries'
 import type { commandBarMachine } from '@src/machines/commandBarMachine'
 import type { systemIOMachine } from '@src/machines/systemIO/systemIOMachine'
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
@@ -9,6 +12,7 @@ import type {
   HomeProjectActionsService,
   HomeProjectEntry,
 } from '@src/registry/contracts/homeProjects'
+import { render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import type { ActorRefFrom, ContextFrom } from 'xstate'
 
@@ -524,6 +528,51 @@ describe('project command config', () => {
     } finally {
       window.location.hash = ''
     }
+  })
+
+  it('clarifies command-bar deletion for cloud-backed directory projects', () => {
+    const homeProject = {
+      ...createHomeProject({
+        id: 'remote:remote-123',
+        title: 'Client Bracket',
+        localProjectName: 'bracket',
+        localProjectPath: '/client-projects/bracket',
+        libraryIds: ['client-projects'],
+      }),
+      source: 'both',
+      status: 'synced',
+      libraryPath: '/client-projects',
+      libraryType: DIRECTORY_PROJECT_LIBRARY_TYPE,
+      remoteProjectId: 'remote-123',
+    } satisfies HomeProjectEntry
+    const commands = createProjectCommands({
+      systemIOActor: createSystemIOActor(),
+      enableProjectDirectoryCommands: true,
+      getHomeProjectActions: () => createHomeProjectActions(),
+      getHomeProjectEntries: () => [homeProject],
+    })
+    const deleteCommand = commands.find(
+      (command) => command.name === 'Delete project'
+    )
+    const reviewMessage = deleteCommand?.reviewMessage
+    expect(typeof reviewMessage).toBe('function')
+    if (typeof reviewMessage !== 'function') {
+      return
+    }
+
+    render(
+      reviewMessage({
+        argumentsToSubmit: {
+          name: homeProject.id,
+        },
+      } as unknown as ContextFrom<typeof commandBarMachine>)
+    )
+
+    expect(
+      screen.getByText(
+        'This will delete the local copy of "Client Bracket". The cloud version will not be deleted.'
+      )
+    ).toBeInTheDocument()
   })
 
   it('moves home project entries to a selected library through project actions', async () => {

--- a/src/lib/commandBarConfigs/projectsCommandConfig.spec.ts
+++ b/src/lib/commandBarConfigs/projectsCommandConfig.spec.ts
@@ -530,7 +530,7 @@ describe('project command config', () => {
     }
   })
 
-  it('clarifies command-bar deletion for cloud-backed directory projects', () => {
+  it('clarifies command-bar deletion for cloud-backed non-cloud library projects', () => {
     const homeProject = {
       ...createHomeProject({
         id: 'remote:remote-123',

--- a/src/lib/commandBarConfigs/projectsCommandConfig.ts
+++ b/src/lib/commandBarConfigs/projectsCommandConfig.ts
@@ -1,7 +1,10 @@
 import { CommandBarOverwriteWarning } from '@src/components/CommandBarOverwriteWarning'
 import type { Command, CommandArgumentOption } from '@src/lib/commandTypes'
 import { MAX_PROJECT_NAME_LENGTH } from '@src/lib/constants'
-import { getHomeProjectDisplayName } from '@src/lib/homeProjects'
+import {
+  getHomeProjectDeleteWarningMessage,
+  getHomeProjectDisplayName,
+} from '@src/lib/homeProjects'
 import { isDesktop } from '@src/lib/isDesktop'
 import { PATHS } from '@src/lib/paths'
 import type { Project } from '@src/lib/project'
@@ -491,14 +494,23 @@ export function createProjectCommands({
         })
       }
     },
-    reviewMessage: ({ argumentsToSubmit }) =>
-      CommandBarOverwriteWarning({
+    reviewMessage: ({ argumentsToSubmit }) => {
+      const target = selectedHomeProjectTarget(argumentsToSubmit.name, 'delete')
+      const projectDisplayName = projectDisplayNameFromCommandValue(
+        argumentsToSubmit.name,
+        'delete'
+      )
+
+      return CommandBarOverwriteWarning({
         heading: 'Are you sure you want to delete?',
-        message: `This will permanently delete the project "${projectDisplayNameFromCommandValue(
-          argumentsToSubmit.name,
-          'delete'
-        )}" and all its contents.`,
-      }),
+        message: target
+          ? getHomeProjectDeleteWarningMessage(
+              target.project,
+              projectDisplayName
+            )
+          : `This will permanently delete the project "${projectDisplayName}" and all its contents.`,
+      })
+    },
     args: {
       name: {
         inputType: 'options',

--- a/src/lib/homeProjects.test.ts
+++ b/src/lib/homeProjects.test.ts
@@ -1,5 +1,13 @@
-import { homeProjectEntryFromProject } from '@src/lib/homeProjects'
+import {
+  homeProjectEntryFromProject,
+  shouldDeleteRemoteOnHomeProjectDelete,
+  shouldPreserveRemoteOnHomeProjectDelete,
+} from '@src/lib/homeProjects'
 import type { FileMetadata, Project } from '@src/lib/project'
+import {
+  CLOUD_PROJECT_LIBRARY_TYPE,
+  DIRECTORY_PROJECT_LIBRARY_TYPE,
+} from '@src/lib/projectLibraries'
 import { describe, expect, test } from 'vitest'
 
 function metadata(modified: number): FileMetadata {
@@ -35,5 +43,50 @@ describe('homeProjectEntryFromProject', () => {
     } satisfies Project
 
     expect(homeProjectEntryFromProject(project).modified).toBe(50)
+  })
+})
+
+describe('Home project deletion policy', () => {
+  test('deletes the remote version only for projects in cloud-type libraries', () => {
+    expect(
+      shouldDeleteRemoteOnHomeProjectDelete({
+        libraryType: CLOUD_PROJECT_LIBRARY_TYPE,
+        remoteProjectId: 'remote-123',
+      })
+    ).toBe(true)
+    expect(
+      shouldDeleteRemoteOnHomeProjectDelete({
+        libraryType: DIRECTORY_PROJECT_LIBRARY_TYPE,
+        remoteProjectId: 'remote-123',
+      })
+    ).toBe(false)
+    expect(
+      shouldDeleteRemoteOnHomeProjectDelete({
+        libraryType: 'custom-library',
+        remoteProjectId: 'remote-123',
+      })
+    ).toBe(false)
+    expect(
+      shouldDeleteRemoteOnHomeProjectDelete({
+        remoteProjectId: 'remote-123',
+      })
+    ).toBe(false)
+  })
+
+  test('preserves the remote version when deleting a local copy outside a cloud-type library', () => {
+    expect(
+      shouldPreserveRemoteOnHomeProjectDelete({
+        libraryType: DIRECTORY_PROJECT_LIBRARY_TYPE,
+        localProjectPath: '/projects/bracket',
+        remoteProjectId: 'remote-123',
+      })
+    ).toBe(true)
+    expect(
+      shouldPreserveRemoteOnHomeProjectDelete({
+        libraryType: CLOUD_PROJECT_LIBRARY_TYPE,
+        localProjectPath: '/cloud/bracket',
+        remoteProjectId: 'remote-123',
+      })
+    ).toBe(false)
   })
 })

--- a/src/lib/homeProjects.ts
+++ b/src/lib/homeProjects.ts
@@ -2,7 +2,7 @@ import { FILE_EXT, PROJECT_IMAGE_NAME } from '@src/lib/constants'
 import fsZds from '@src/lib/fs-zds'
 import type { FileEntry, Project } from '@src/lib/project'
 import { getProjectDisplayName } from '@src/lib/projectDisplayName'
-import { DIRECTORY_PROJECT_LIBRARY_TYPE } from '@src/lib/projectLibraries'
+import { CLOUD_PROJECT_LIBRARY_TYPE } from '@src/lib/projectLibraries'
 import type {
   HomeProjectEntry,
   HomeProjectEntryContribution,
@@ -13,23 +13,25 @@ export function getHomeProjectDisplayName(project: HomeProjectEntry) {
   return (project.title || project.name).replace(FILE_EXT, '')
 }
 
+export function shouldDeleteRemoteOnHomeProjectDelete(
+  project: Pick<HomeProjectEntry, 'libraryType' | 'remoteProjectId'>
+) {
+  return Boolean(
+    project.remoteProjectId &&
+      project.libraryType === CLOUD_PROJECT_LIBRARY_TYPE
+  )
+}
+
 export function shouldPreserveRemoteOnHomeProjectDelete(
   project: Pick<
     HomeProjectEntry,
     'libraryType' | 'localProjectPath' | 'remoteProjectId'
   >
-): project is Pick<
-  HomeProjectEntry,
-  'libraryType' | 'localProjectPath' | 'remoteProjectId'
-> & {
-  libraryType: typeof DIRECTORY_PROJECT_LIBRARY_TYPE
-  localProjectPath: string
-  remoteProjectId: string
-} {
+): boolean {
   return Boolean(
     project.localProjectPath &&
       project.remoteProjectId &&
-      project.libraryType === DIRECTORY_PROJECT_LIBRARY_TYPE
+      !shouldDeleteRemoteOnHomeProjectDelete(project)
   )
 }
 

--- a/src/lib/homeProjects.ts
+++ b/src/lib/homeProjects.ts
@@ -2,6 +2,7 @@ import { FILE_EXT, PROJECT_IMAGE_NAME } from '@src/lib/constants'
 import fsZds from '@src/lib/fs-zds'
 import type { FileEntry, Project } from '@src/lib/project'
 import { getProjectDisplayName } from '@src/lib/projectDisplayName'
+import { DIRECTORY_PROJECT_LIBRARY_TYPE } from '@src/lib/projectLibraries'
 import type {
   HomeProjectEntry,
   HomeProjectEntryContribution,
@@ -10,6 +11,37 @@ import type {
 
 export function getHomeProjectDisplayName(project: HomeProjectEntry) {
   return (project.title || project.name).replace(FILE_EXT, '')
+}
+
+export function shouldPreserveRemoteOnHomeProjectDelete(
+  project: Pick<
+    HomeProjectEntry,
+    'libraryType' | 'localProjectPath' | 'remoteProjectId'
+  >
+): project is Pick<
+  HomeProjectEntry,
+  'libraryType' | 'localProjectPath' | 'remoteProjectId'
+> & {
+  libraryType: typeof DIRECTORY_PROJECT_LIBRARY_TYPE
+  localProjectPath: string
+  remoteProjectId: string
+} {
+  return Boolean(
+    project.localProjectPath &&
+      project.remoteProjectId &&
+      project.libraryType === DIRECTORY_PROJECT_LIBRARY_TYPE
+  )
+}
+
+export function getHomeProjectDeleteWarningMessage(
+  project: HomeProjectEntry,
+  projectDisplayName = getHomeProjectDisplayName(project)
+) {
+  if (shouldPreserveRemoteOnHomeProjectDelete(project)) {
+    return `This will delete the local copy of "${projectDisplayName}". The cloud version will not be deleted.`
+  }
+
+  return `This will permanently delete the project "${projectDisplayName}" and all its contents.`
 }
 
 function getLatestModifiedTime(entry: FileEntry): number | undefined {
@@ -53,6 +85,8 @@ export function homeProjectEntryFromProject(
     title: getProjectDisplayName(project),
     localProjectPath: project.path,
     localProjectName: project.name,
+    libraryPath: project.libraryPath,
+    libraryType: project.libraryType,
     remoteProjectId: project.cloudProjectId,
     modified,
     defaultFile: project.default_file,

--- a/src/registry/contracts/homeProjects.spec.ts
+++ b/src/registry/contracts/homeProjects.spec.ts
@@ -1,3 +1,9 @@
+import {
+  CLOUD_PROJECT_LIBRARY_TYPE,
+  DEFAULT_PROJECT_LIBRARY_ID,
+  DIRECTORY_PROJECT_LIBRARY_TYPE,
+  PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+} from '@src/lib/projectLibraries'
 import { coalesceHomeProjectEntries } from '@src/registry/contracts/homeProjects'
 import { describe, expect, test } from 'vitest'
 
@@ -91,6 +97,8 @@ describe('coalesceHomeProjectEntries', () => {
           title: 'Local title',
           localProjectPath: '/projects/local-name',
           localProjectName: 'local-name',
+          libraryPath: '/projects',
+          libraryType: DIRECTORY_PROJECT_LIBRARY_TYPE,
           remoteProjectId: 'remote-123',
           modified: 10,
           readWriteAccess: true,
@@ -105,6 +113,8 @@ describe('coalesceHomeProjectEntries', () => {
         title: 'Local title',
         modified: 20,
         localProjectPath: '/projects/local-name',
+        libraryPath: '/projects',
+        libraryType: DIRECTORY_PROJECT_LIBRARY_TYPE,
         remoteProjectId: 'remote-123',
       }),
     ])
@@ -150,6 +160,48 @@ describe('coalesceHomeProjectEntries', () => {
         conflict: {
           conflictProjectPath: '/projects/local-name (cloud conflict)',
         },
+      }),
+    ])
+  })
+
+  test('keeps configured library ownership over the default local fallback', () => {
+    expect(
+      coalesceHomeProjectEntries([
+        {
+          source: 'local',
+          status: 'synced',
+          libraryId: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+          name: 'cloud-name',
+          localProjectPath: '/cloud/cloud-name',
+          localProjectName: 'cloud-name',
+          libraryPath: '/cloud',
+          libraryType: CLOUD_PROJECT_LIBRARY_TYPE,
+          remoteProjectId: 'remote-123',
+          modified: 20,
+          readWriteAccess: true,
+        },
+        {
+          source: 'local',
+          status: 'synced',
+          libraryId: DEFAULT_PROJECT_LIBRARY_ID,
+          name: 'cloud-name',
+          localProjectPath: '/cloud/cloud-name',
+          localProjectName: 'cloud-name',
+          libraryPath: '/cloud',
+          libraryType: DIRECTORY_PROJECT_LIBRARY_TYPE,
+          remoteProjectId: 'remote-123',
+          modified: 10,
+          readWriteAccess: true,
+        },
+      ])
+    ).toEqual([
+      expect.objectContaining({
+        libraryIds: [
+          PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+          DEFAULT_PROJECT_LIBRARY_ID,
+        ],
+        libraryPath: '/cloud',
+        libraryType: CLOUD_PROJECT_LIBRARY_TYPE,
       }),
     ])
   })

--- a/src/registry/contracts/homeProjects.ts
+++ b/src/registry/contracts/homeProjects.ts
@@ -3,7 +3,11 @@ import {
   defineService,
   defineValueSpec,
 } from '@kittycad/registry'
-import type { ProjectLibrary } from '@src/lib/projectLibraries'
+import type {
+  ProjectLibrary,
+  ProjectLibraryType,
+} from '@src/lib/projectLibraries'
+import { DEFAULT_PROJECT_LIBRARY_ID } from '@src/lib/projectLibraries'
 import { uniqueStrings } from '@src/lib/stringUtils'
 import { isArray } from '@src/lib/utils'
 
@@ -41,6 +45,8 @@ export interface HomeProjectEntry {
   title?: string
   localProjectPath?: string
   localProjectName?: string
+  libraryPath?: string
+  libraryType?: ProjectLibraryType
   remoteProjectId?: string
   modified?: number
   defaultFile?: string
@@ -188,9 +194,16 @@ function mergeSameSourceHomeProjectEntries(
     return next
   }
 
+  const nextIsDefaultFallback =
+    next.libraryIds?.length === 1 &&
+    next.libraryIds[0] === DEFAULT_PROJECT_LIBRARY_ID
+  const ownership = nextIsDefaultFallback ? existing : next
+
   return {
     ...existing,
     ...next,
+    libraryPath: ownership.libraryPath,
+    libraryType: ownership.libraryType,
     modified: Math.max(existing.modified ?? 0, next.modified ?? 0) || undefined,
     thumbnail: existing.thumbnail ?? next.thumbnail,
     libraryIds: uniqueStrings([

--- a/src/registry/extensions/homeProjects/index.test.ts
+++ b/src/registry/extensions/homeProjects/index.test.ts
@@ -567,7 +567,7 @@ describe('home project actions', () => {
     expect(systemIO.send).not.toHaveBeenCalled()
   })
 
-  it('deletes only local state for a cloud-backed directory project', async () => {
+  it('deletes only local state for a cloud-backed project outside a cloud-type library', async () => {
     const systemIO = createSystemIOService()
     const cloudSync = createCloudSyncService()
     const removeProjectDirectory = vi

--- a/src/registry/extensions/homeProjects/index.test.ts
+++ b/src/registry/extensions/homeProjects/index.test.ts
@@ -5,10 +5,12 @@ import {
   Registry,
 } from '@kittycad/registry'
 import { signal } from '@preact/signals-core'
+import fsZds from '@src/lib/fs-zds'
 import type { Project } from '@src/lib/project'
 import {
   CLOUD_PROJECT_LIBRARY_TYPE,
   DEFAULT_PROJECT_LIBRARY_ID,
+  DIRECTORY_PROJECT_LIBRARY_TYPE,
   getDefaultCloudProjectLibrarySetting,
   PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
   type ProjectLibrary,
@@ -563,5 +565,158 @@ describe('home project actions', () => {
     expect(cloudSync.ensureProjectLocallySynced).not.toHaveBeenCalled()
     expect(desktopMocks.getProjectInfo).not.toHaveBeenCalled()
     expect(systemIO.send).not.toHaveBeenCalled()
+  })
+
+  it('deletes only local state for a cloud-backed directory project', async () => {
+    const systemIO = createSystemIOService()
+    const cloudSync = createCloudSyncService()
+    const removeProjectDirectory = vi
+      .spyOn(fsZds, 'rm')
+      .mockResolvedValue(undefined)
+
+    registry = new Registry()
+    registry.configure([
+      defineRegistryItem({
+        id: 'test.settings',
+        providesServices: [
+          provideService(
+            settingsService,
+            createMutableSettingsService({
+              libraries: [
+                {
+                  title: 'Projects',
+                  path: '/projects',
+                  type: DIRECTORY_PROJECT_LIBRARY_TYPE,
+                },
+              ],
+            }).service
+          ),
+        ],
+      }),
+      defineRegistryItem({
+        id: 'test.system-io',
+        providesServices: [provideService(systemIOService, systemIO.service)],
+      }),
+      defineRegistryItem({
+        id: 'test.cloud-sync',
+        providesServices: [provideService(cloudSyncService, cloudSync)],
+      }),
+      homeProjectsExtension,
+    ])
+
+    const directoryLibraryType = registry
+      .get(projectLibraryTypesValueSpec)
+      .get(DIRECTORY_PROJECT_LIBRARY_TYPE)
+    const deleteProject = directoryLibraryType?.operations?.deleteProject
+    expect(deleteProject).toBeDefined()
+    if (!deleteProject) {
+      return
+    }
+
+    await deleteProject.run({
+      library: {
+        id: DEFAULT_PROJECT_LIBRARY_ID,
+        title: 'Projects',
+        path: '/projects',
+        type: DIRECTORY_PROJECT_LIBRARY_TYPE,
+      },
+      project: {
+        id: 'local:/projects/bracket',
+        source: 'both',
+        status: 'synced',
+        libraryIds: [DEFAULT_PROJECT_LIBRARY_ID],
+        name: 'bracket',
+        localProjectPath: '/projects/bracket',
+        localProjectName: 'bracket',
+        remoteProjectId: 'remote-123',
+        defaultFile: '/projects/bracket/main.kcl',
+        readWriteAccess: true,
+      },
+    })
+
+    expect(cloudSync.deleteLocalProjectRealizations).toHaveBeenCalledWith(
+      'remote-123',
+      '/projects/bracket'
+    )
+    expect(cloudSync.deleteRemoteProject).not.toHaveBeenCalled()
+    expect(removeProjectDirectory).not.toHaveBeenCalled()
+  })
+
+  it('uses the owning directory library when a local project is merged with its cloud entry', async () => {
+    const systemIO = createSystemIOService()
+    const cloudSync = createCloudSyncService()
+    const deleteCloudProject = vi.fn().mockResolvedValue(undefined)
+
+    registry = new Registry()
+    registry.configure([
+      defineRegistryItem({
+        id: 'test.settings',
+        providesServices: [
+          provideService(
+            settingsService,
+            createMutableSettingsService({
+              libraries: [
+                getDefaultCloudProjectLibrarySetting('/cloud-projects'),
+                {
+                  title: 'Projects',
+                  path: '/projects',
+                  type: DIRECTORY_PROJECT_LIBRARY_TYPE,
+                },
+              ],
+            }).service
+          ),
+        ],
+      }),
+      defineRegistryItem({
+        id: 'test.system-io',
+        providesServices: [provideService(systemIOService, systemIO.service)],
+      }),
+      defineRegistryItem({
+        id: 'test.cloud-sync',
+        providesServices: [provideService(cloudSyncService, cloudSync)],
+      }),
+      defineRegistryItem({
+        id: 'test.cloud-library-type',
+        provides: [
+          provide(projectLibraryTypesValueSpec, {
+            type: CLOUD_PROJECT_LIBRARY_TYPE,
+            title: 'Cloud',
+            readEntries: async () => [],
+            operations: {
+              deleteProject: {
+                run: deleteCloudProject,
+              },
+            },
+          }),
+        ],
+      }),
+      homeProjectsExtension,
+    ])
+
+    await registry.get(homeProjectActionsService).delete({
+      id: 'remote:remote-123',
+      source: 'both',
+      status: 'synced',
+      libraryIds: [
+        PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+        DEFAULT_PROJECT_LIBRARY_ID,
+      ],
+      name: 'bracket',
+      title: 'Bracket',
+      localProjectPath: '/projects/bracket',
+      localProjectName: 'bracket',
+      libraryPath: '/projects',
+      libraryType: DIRECTORY_PROJECT_LIBRARY_TYPE,
+      remoteProjectId: 'remote-123',
+      defaultFile: '/projects/bracket/main.kcl',
+      readWriteAccess: true,
+    })
+
+    expect(deleteCloudProject).not.toHaveBeenCalled()
+    expect(cloudSync.deleteLocalProjectRealizations).toHaveBeenCalledWith(
+      'remote-123',
+      '/projects/bracket'
+    )
+    expect(cloudSync.deleteRemoteProject).not.toHaveBeenCalled()
   })
 })

--- a/src/registry/extensions/homeProjects/index.ts
+++ b/src/registry/extensions/homeProjects/index.ts
@@ -76,12 +76,18 @@ function readConfiguredProjectLibraryEntriesInvalidation() {
 
 function localHomeProjectEntriesFromProjects(
   projects: readonly Project[] | undefined,
-  libraryId?: string
+  library?: Pick<ProjectLibrary, 'id' | 'path' | 'type'>
 ): HomeProjectEntryContribution[] {
   return (
     projects?.map((project) => ({
       ...homeProjectEntryFromProject(project),
-      libraryId,
+      ...(library
+        ? {
+            libraryId: library.id,
+            libraryPath: library.path,
+            libraryType: library.type,
+          }
+        : {}),
     })) ?? []
   )
 }
@@ -142,7 +148,24 @@ const homeProjectActions = defineRegistryItemFactory((ctx) => {
     }
 
     const libraryTypes = ctx.valueSpecs.get(projectLibraryTypesValueSpec)
-    for (const library of getConfiguredProjectLibraries()) {
+    const configuredLibraries = getConfiguredProjectLibraries()
+    const orderedLibraries =
+      project.libraryType !== undefined
+        ? [
+            ...configuredLibraries.filter(
+              (library) =>
+                projectLibraryIds.has(library.id) &&
+                library.type === project.libraryType
+            ),
+            ...configuredLibraries.filter(
+              (library) =>
+                projectLibraryIds.has(library.id) &&
+                library.type !== project.libraryType
+            ),
+          ]
+        : configuredLibraries
+
+    for (const library of orderedLibraries) {
       if (!projectLibraryIds.has(library.id)) {
         continue
       }
@@ -456,10 +479,11 @@ const systemIOLocalHomeProjectEntries = defineRegistryItemFactory((ctx) => {
         const context = snapshot.context
         const projects = context.folders
         if (projects !== undefined) {
-          entries.value = localHomeProjectEntriesFromProjects(
-            projects,
-            DEFAULT_PROJECT_LIBRARY_ID
-          )
+          entries.value = localHomeProjectEntriesFromProjects(projects, {
+            id: DEFAULT_PROJECT_LIBRARY_ID,
+            path: context.projectDirectoryPath,
+            type: DIRECTORY_PROJECT_LIBRARY_TYPE,
+          })
         }
 
         if (
@@ -573,7 +597,7 @@ const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
               })
             }
 
-            return localHomeProjectEntriesFromProjects(projects, library.id)
+            return localHomeProjectEntriesFromProjects(projects, library)
           },
           operations: {
             createProject: {
@@ -667,15 +691,15 @@ const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
                   return Promise.reject(new Error('Cloud sync is not enabled.'))
                 }
 
-                await fsZds.rm(project.localProjectPath, {
-                  recursive: true,
-                })
-                // Individually synced directory projects follow the same
-                // delete-everywhere policy as cloud-library projects.
                 if (project.remoteProjectId) {
-                  await cloudSyncActions?.deleteRemoteProject(
-                    project.remoteProjectId
+                  await cloudSyncActions?.deleteLocalProjectRealizations(
+                    project.remoteProjectId,
+                    project.localProjectPath
                   )
+                } else {
+                  await fsZds.rm(project.localProjectPath, {
+                    recursive: true,
+                  })
                 }
                 refreshLocalProjectEntries()
               },


### PR DESCRIPTION
Closes #12804 by updating cloud sync's "delete remote" policy only apply when the project in a cloud-type library. So deleting a cloud-synced project inside of a directory-type library, or no library for that matter, can be safely done without attempting to delete the remote too, which would probably be an unpleasant surprise for users.

## What changed

- Only delete the remote cloud project when the Home project is within a cloud-type library.
- Preserve the cloud version when deleting a cloud-backed local copy from a non-cloud library, while cleaning local cloud sync state/outbox.
- Carry local library ownership through Home project entries so merged local/remote cards choose the correct delete operation. I'm going to remove the "merged cards" idea entirely in #12805
- Add delete-dialog copy for this case so users know the cloud version will not be deleted.


## How to test

Try deleting a cloud-backed project from a normal directory library and confirm the local copy disappears while the cloud project remains. Also delete a project from the Personal Cloud library and confirm the remote delete behavior is unchanged.