### PR TITLE
Document solver sketch workflow and region selection

### DIFF
--- a/docs/kcl-lang/functions.md
+++ b/docs/kcl-lang/functions.md
@@ -44,6 +44,20 @@ two = increment(1)
 three = add(1, delta = 2)
 ```
 
+## Point-and-click editability
+
+Custom functions are useful when the same parameterized feature needs to be
+reused with different inputs. However, Zoo Design Studio's point-and-click
+tools cannot currently edit sketches inside a custom function body.
+
+Keep sketches at the top level when point-and-click editing is important. Use a
+custom function when reuse is more important than point-and-click access to its
+internal sketches. Repeating an identical body usually does not require a
+custom function; use [`clone`](/docs/kcl-std/functions/std-clone),
+[`patternLinear3d`](/docs/kcl-std/functions/std-solid-patternLinear3d), or
+[`patternCircular3d`](/docs/kcl-std/functions/std-solid-patternCircular3d)
+instead.
+
 Below shows how a custom function must be called if it has a labeled argument, and another example with an unlabeled argument:
 
 ```

--- a/docs/kcl-lang/index.md
+++ b/docs/kcl-lang/index.md
@@ -13,6 +13,7 @@ things in a more tutorial fashion. See also our documentation of the [standard l
 * [Arithmetic and logic](/docs/kcl-lang/arithmetic)
 * [Values and types](/docs/kcl-lang/types)
 * [Numeric types and units](/docs/kcl-lang/numeric)
+* [Sketch blocks and constraints](/docs/kcl-lang/sketches)
 * [Functions](/docs/kcl-lang/functions)
 * [Arrays and ranges](/docs/kcl-lang/arrays)
 * [Enums](/docs/kcl-lang/enums)

--- a/docs/kcl-lang/sketches.md
+++ b/docs/kcl-lang/sketches.md
@@ -42,12 +42,15 @@ A value introduced with `var` is a coordinate or size that the solver may
 change. It is an initial guess, not a fixed dimension. Initial guesses must be
 numeric literals, with a unit where applicable:
 
-```kcl,norun
-// Valid initial guesses
-start = [var 0mm, var -3mm]
+```kcl
+exampleSketch = sketch(on = XY) {
+  // Valid initial guesses
+  samplePoint = point(at = [var 0mm, var -3mm])
+  coincident([samplePoint, [0mm, -3mm]])
 
-// Invalid: identifiers and expressions cannot follow `var`
-// start = [var width, var (height / 2)]
+  // Invalid: identifiers and expressions cannot follow `var`
+  // samplePoint = point(at = [var width, var (height / 2)])
+}
 ```
 
 Put identifiers and expressions in constraints when they must drive the solved
@@ -102,8 +105,16 @@ boundary.
 If segment tracing cannot identify the intended boundary, use a point strictly
 inside the region and provide its sketch:
 
-```kcl,norun
-profileRegion = region(point = [20mm, 12mm], sketch = profile)
+```kcl
+fallbackProfile = sketch(on = XY) {
+  perimeter = circle(start = [var 10mm, var 0mm], center = [var 0mm, var 0mm])
+  coincident([perimeter.center, ORIGIN])
+  radius(perimeter) == 10mm
+  horizontal([perimeter.center, perimeter.start])
+}
+
+fallbackRegion = region(point = [0mm, 0mm], sketch = fallbackProfile)
+fallbackBody = extrude(fallbackRegion, length = 5mm)
 ```
 
 ## Control arc direction

--- a/docs/kcl-lang/sketches.md
+++ b/docs/kcl-lang/sketches.md
@@ -1,0 +1,114 @@
+---
+title: "Sketch Blocks and Constraints"
+excerpt: "Write constrained, editable sketches with KCL sketch blocks."
+layout: manual
+---
+
+KCL sketch blocks define 2D geometry and the relationships that control it.
+Start a block on a base plane or supported face, add sketch geometry inside the
+braces, then apply constraints to express design intent.
+
+```kcl
+width = 40mm
+height = 24mm
+
+profile = sketch(on = XY) {
+  bottom = line(start = [var 0mm, var 0mm], end = [var 40mm, var 0mm])
+  right = line(start = [var 40mm, var 0mm], end = [var 40mm, var 24mm])
+  top = line(start = [var 40mm, var 24mm], end = [var 0mm, var 24mm])
+  left = line(start = [var 0mm, var 24mm], end = [var 0mm, var 0mm])
+
+  coincident([bottom.end, right.start])
+  coincident([right.end, top.start])
+  coincident([top.end, left.start])
+  coincident([left.end, bottom.start])
+  horizontal(bottom)
+  horizontal(top)
+  vertical(right)
+  vertical(left)
+  horizontalDistance([bottom.start, bottom.end]) == width
+  verticalDistance([bottom.start, left.start]) == height
+  coincident([bottom.start, ORIGIN])
+}
+```
+
+Inside a sketch block, the [solver module](/docs/kcl-std/modules/std-solver)
+is automatically in scope. Call `line`, `arc`, `circle`, `coincident`, and
+other solver functions without a `solver::` prefix.
+
+## `var` values are initial guesses
+
+A value introduced with `var` is a coordinate or size that the solver may
+change. It is an initial guess, not a fixed dimension. Initial guesses must be
+numeric literals, with a unit where applicable:
+
+```kcl,norun
+// Valid initial guesses
+start = [var 0mm, var -3mm]
+
+// Invalid: identifiers and expressions cannot follow `var`
+// start = [var width, var (height / 2)]
+```
+
+Put identifiers and expressions in constraints when they must drive the solved
+result. For example, use `horizontalDistance([edge.start, edge.end]) == width`
+rather than `end = [var width, var 0mm]`.
+
+## Fully constrain the sketch
+
+A fully constrained sketch has no unintended degrees of freedom. Use geometric
+constraints such as `coincident`, `horizontal`, `vertical`, `parallel`,
+`perpendicular`, `equalLength`, `tangent`, and `symmetric` to describe
+relationships. Use dimensional constraints such as `distance`,
+`horizontalDistance`, `verticalDistance`, `angle`, `radius`, and `diameter` for
+driving values.
+
+Anchor the profile once, then constrain the rest of the geometry relative to
+that frame. Repeatedly fixing absolute points makes sketches harder to edit and
+can over-constrain them. An under-constrained sketch can move in unintended
+ways; an over-constrained sketch contains redundant or conflicting
+relationships.
+
+See the [constraint reference](/docs/kcl-std/modules/std-solver) for the full
+API and the [sketching guide](/docs/zoo-design-studio/features/3d-design/parametric-modeling/sketching)
+for the point-and-click workflow.
+
+## Create a region from a closed profile
+
+Most solid features consume a [region](/docs/kcl-std/functions/std-sketch-region)
+created from a closed sketch boundary.
+
+For one closed segment, such as a circle, pass that segment by itself. Omit
+`intersectionIndex` and `direction`; they are unnecessary for one loop and are
+intended to disambiguate a boundary traced from multiple segments.
+
+```kcl
+roundProfile = sketch(on = XY) {
+  perimeter = circle(start = [var 10mm, var 0mm], center = [var 0mm, var 0mm])
+  coincident([perimeter.center, ORIGIN])
+  radius(perimeter) == 10mm
+  horizontal([perimeter.center, perimeter.start])
+}
+
+roundRegion = region(segments = [roundProfile.perimeter])
+roundBody = extrude(roundRegion, length = 5mm)
+```
+
+For a boundary traced from multiple intersecting segments, pass the first two
+segments. Use `intersectionIndex` only when they intersect more than once, and
+use `direction = CW` when the default counterclockwise trace selects the wrong
+boundary.
+
+If segment tracing cannot identify the intended boundary, use a point strictly
+inside the region and provide its sketch:
+
+```kcl,norun
+profileRegion = region(point = [20mm, 12mm], sketch = profile)
+```
+
+## Control arc direction
+
+An [arc](/docs/kcl-std/functions/std-solver-arc) sweeps counterclockwise from
+its start point to its end point by default. If it takes the long or opposite
+path, set `direction = CW`. Changing the direction is clearer than swapping
+endpoints and then repairing every dependent constraint.

--- a/docs/kcl-std/functions/std-sketch-region.md
+++ b/docs/kcl-std/functions/std-sketch-region.md
@@ -22,6 +22,10 @@ segment from its start point to the intersection with the second segment,
 then turning at each intersection using `direction` until returning to the
 first segment.
 
+For a single closed segment such as a circle, pass only that segment.
+`intersectionIndex` and `direction` are unnecessary for one loop; use them
+to disambiguate a boundary traced from multiple segments.
+
 As a fallback, use the `point` parameter to select the closed boundary that
 contains a given point. When using a 2D point rather than a point from the
 sketch, provide the `sketch` parameter to specify which sketch the region is
@@ -37,8 +41,8 @@ refer to that point to create the region.
 |----------|------|-------------|----------|
 | `point` | [`Point2d`](/docs/kcl-std/types/std-types-Point2d) or [`Segment`](/docs/kcl-std/types/std-types-Segment) | A fallback point that is within the region's boundary. | No |
 | `segments` | [[`Segment`](/docs/kcl-std/types/std-types-Segment); 1+] | The first two segments that form the region's boundary. In case of a circle, the one circle segment that forms the region. This is the preferred way to create a region. | No |
-| `intersectionIndex` | [`number(_)`](/docs/kcl-std/types/std-types-number) | Index of the intersection of the first segment with the second segment to use as the region's boundary. The default is `-1`, which uses the last intersection. This is only used when the `segments` argument is provided. | No |
-| `direction` | [`string`](/docs/kcl-std/types/std-types-string) | `CCW` for counterclockwise, `CW` for clockwise. Default is `CCW`. This is only used when the `segments` argument is provided. | No |
+| `intersectionIndex` | [`number(_)`](/docs/kcl-std/types/std-types-number) | Index of the intersection of the first segment with the second segment to use as the region's boundary. The default is `-1`, which uses the last intersection. This is usually only needed when two or more `segments` are provided. | No |
+| `direction` | [`string`](/docs/kcl-std/types/std-types-string) | `CCW` for counterclockwise, `CW` for clockwise. Default is `CCW`. This is usually only needed when two or more `segments` are provided. | No |
 | `sketch` | [`any`](/docs/kcl-std/types/std-types-any) | The sketch that the region is from. This is required when point is a [`Point2d`](/docs/kcl-std/types/std-types-Point2d). | No |
 
 ### Returns

--- a/rust/kcl-lib/expected-bindings/ts-rs/StdLibCommands.ts
+++ b/rust/kcl-lib/expected-bindings/ts-rs/StdLibCommands.ts
@@ -6509,7 +6509,7 @@ export default {
       {
         "name": "intersectionIndex",
         "ty": "number(_)",
-        "docs": "Index of the intersection of the first segment with the second segment to use as the region's boundary. The default is `-1`, which uses the last intersection. This is only used when the `segments` argument is provided.",
+        "docs": "Index of the intersection of the first segment with the second segment to use as the region's boundary. The default is `-1`, which uses the last intersection. This is usually only needed when two or more `segments` are provided.",
         "required": false,
         "special": false,
         "experimental": false,
@@ -6519,7 +6519,7 @@ export default {
       {
         "name": "direction",
         "ty": "string",
-        "docs": "`CCW` for counterclockwise, `CW` for clockwise. Default is `CCW`. This is only used when the `segments` argument is provided.",
+        "docs": "`CCW` for counterclockwise, `CW` for clockwise. Default is `CCW`. This is usually only needed when two or more `segments` are provided.",
         "required": false,
         "special": false,
         "experimental": false,

--- a/rust/kcl-lib/std/sketch.kcl
+++ b/rust/kcl-lib/std/sketch.kcl
@@ -3334,6 +3334,10 @@ export fn faceOf(
 /// then turning at each intersection using `direction` until returning to the
 /// first segment.
 ///
+/// For a single closed segment such as a circle, pass only that segment.
+/// `intersectionIndex` and `direction` are unnecessary for one loop; use them
+/// to disambiguate a boundary traced from multiple segments.
+///
 /// As a fallback, use the `point` parameter to select the closed boundary that
 /// contains a given point. When using a 2D point rather than a point from the
 /// sketch, provide the `sketch` parameter to specify which sketch the region is
@@ -3404,10 +3408,11 @@ export fn region(
   segments?: [Segment; 1+],
   /// Index of the intersection of the first segment with the second segment to
   /// use as the region's boundary. The default is `-1`, which uses the last
-  /// intersection. This is only used when the `segments` argument is provided.
+  /// intersection. This is usually only needed when two or more `segments` are
+  /// provided.
   intersectionIndex?: number(Count),
   /// `CCW` for counterclockwise, `CW` for clockwise. Default is `CCW`. This is
-  /// only used when the `segments` argument is provided.
+  /// usually only needed when two or more `segments` are provided.
   direction?: string = "ccw",
   /// The sketch that the region is from. This is required when point is a `Point2d`.
   sketch?: any,


### PR DESCRIPTION
## Summary
- add a consolidated KCL guide for solver sketch blocks, literal var initial guesses, constraint strategy, regions, and arc direction
- make every KCL fence in the new guide a standalone program executed by the docs harness
- document the point-and-click editability tradeoff for custom functions
- clarify single-loop region selection in the stdlib source and regenerate its reference page

## Source ownership
KCL language guides and stdlib reference sources are owned by modeling-app. The existing generate-website-docs workflow will mirror these changes into KittyCAD/documentation after merge.

Companion changes: KittyCAD/documentation#974 documents Zookeeper project instructions and generated-source ownership; KittyCAD/text-to-cad#3988 adds the prompt-review guardrail.

Part of #3955.

## Validation
- PATH=/run/current-system/sw/bin:/Users/jessfraz/.cargo/bin:$PATH just redo-kcl-stdlib-docs-no-imgs, 1 passed
- zoo kcl lint on all four fenced guide examples, passed
- docs::gen_std_tests::test_code_in_topics selects all four examples; local live execution is blocked for all topic examples because ZOO_API_TOKEN is unavailable
- new-head GitHub Actions live engine execution pending
- four-view Zoo CLI snapshots were likewise blocked by missing Zoo authentication
- git diff --check
- independent correctness, architecture, and test reviews