### PR TITLE
Home duplicates: add review cleanup

### DIFF
--- a/src/components/AppProjectCard/AppProjectCard.spec.tsx
+++ b/src/components/AppProjectCard/AppProjectCard.spec.tsx
@@ -4,7 +4,13 @@ import type {
   HomeProjectActionsService,
   HomeProjectEntry,
 } from '@src/registry/contracts/homeProjects'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react'
 import toast from 'react-hot-toast'
 import { BrowserRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
@@ -54,6 +60,8 @@ function createProjectActions({
     canRename: () => true,
     canDelete: () => true,
     canMoveToLibrary: () => true,
+    canReviewDuplicateRealizations: (project) =>
+      Boolean(project.duplicateRealizations?.length),
     open: vi.fn().mockResolvedValue({
       defaultFile: '/projects/old-cloud-title/main.kcl',
     }),
@@ -62,6 +70,7 @@ function createProjectActions({
     delete: vi.fn().mockResolvedValue(undefined),
     getMoveToLibraryTargets: vi.fn(() => []),
     moveToLibrary: vi.fn().mockResolvedValue(undefined),
+    deleteDuplicateRealizations: vi.fn().mockResolvedValue(undefined),
   }
 }
 
@@ -250,6 +259,71 @@ describe('ProjectCard', () => {
     )
   })
 
+  test('shows duplicate copies badge and review action', async () => {
+    const deleteDuplicateRealizations = vi.fn().mockResolvedValue(undefined)
+    const projectActions = createProjectActions()
+    projectActions.deleteDuplicateRealizations = deleteDuplicateRealizations
+    renderProjectCard({
+      projectActions,
+      project: {
+        ...cloudProject,
+        duplicateRealizations: [
+          {
+            remoteProjectId: 'project-123',
+            canonicalProjectPath: '/projects/old-cloud-title',
+            localProjectPath: '/cloud/old-cloud-title-copy',
+            localProjectName: 'old-cloud-title-copy',
+            title: 'Old cloud title copy',
+            libraryIds: ['cloud-personal'],
+            libraryTitles: ['Personal Cloud'],
+            duplicateRisk: 'exact',
+            autoCleanupEligible: true,
+          },
+          {
+            remoteProjectId: 'project-123',
+            canonicalProjectPath: '/projects/old-cloud-title',
+            localProjectPath: '/files/old-cloud-title-copy',
+            localProjectName: 'old-cloud-title-copy',
+            title: 'Old cloud title directory copy',
+            libraryIds: ['directory-projects'],
+            libraryTitles: ['Projects'],
+            duplicateRisk: 'unknown',
+            autoCleanupEligible: false,
+          },
+        ],
+      },
+    })
+
+    expect(
+      screen.getByTestId('project-duplicate-copies-badge')
+    ).toHaveTextContent('Duplicate copies')
+
+    fireEvent.contextMenu(screen.getByTestId('project-link'))
+    expect(
+      within(
+        screen.getByTestId('project-card-context-review-duplicate-copies')
+      ).getByLabelText('glasses')
+    ).toBeInTheDocument()
+    fireEvent.click(
+      screen.getByTestId('project-card-context-review-duplicate-copies')
+    )
+    expect(screen.getByText('/cloud/old-cloud-title-copy')).toBeInTheDocument()
+    expect(screen.getByText('/files/old-cloud-title-copy')).toBeInTheDocument()
+
+    const checkboxes = screen.getAllByRole('checkbox')
+    expect(checkboxes).toHaveLength(2)
+    fireEvent.click(checkboxes[0])
+
+    fireEvent.click(screen.getByTestId('delete-confirmation'))
+
+    await waitFor(() =>
+      expect(deleteDuplicateRealizations).toHaveBeenCalledWith(
+        expect.objectContaining({ id: cloudProject.id }),
+        ['/files/old-cloud-title-copy']
+      )
+    )
+  })
+
   test('hides cloud sync project chips when cloud sync UI is disabled', () => {
     renderProjectCard({
       showCloudSyncUi: false,
@@ -282,6 +356,9 @@ describe('ProjectCard', () => {
     expect(screen.getByTestId('project-card-context-delete')).toHaveTextContent(
       'Delete project'
     )
+    expect(
+      screen.queryByTestId('project-card-context-review-duplicate-copies')
+    ).not.toBeInTheDocument()
   })
 
   test('opens move to library from the card context menu', () => {

--- a/src/components/AppProjectCard/AppProjectCard.tsx
+++ b/src/components/AppProjectCard/AppProjectCard.tsx
@@ -149,6 +149,10 @@ function AppProjectCard({
   useHotkeys('esc', () => setIsEditing(false))
   const [isEditing, setIsEditing] = useState(false)
   const [isConfirmingDelete, setIsConfirmingDelete] = useState(false)
+  const [isReviewingDuplicates, setIsReviewingDuplicates] = useState(false)
+  const [selectedDuplicatePaths, setSelectedDuplicatePaths] = useState<
+    Set<string>
+  >(new Set())
   const hasChangesRequested =
     projectStatus?.publicationStatus === 'changes_requested'
   const hasCloudConflict = Boolean(
@@ -241,6 +245,11 @@ function AppProjectCard({
   const canRename = projectActions.canRename(project)
   const canDelete = projectActions.canDelete(project)
   const canOpen = projectActions.canOpen(project)
+  const canReviewDuplicateRealizations =
+    showCloudSyncUi && projectActions.canReviewDuplicateRealizations(project)
+  const duplicateRealizations = project.duplicateRealizations ?? []
+  const hasDuplicateRealizations =
+    showCloudSyncUi && duplicateRealizations.length > 0
   const canMoveToLibrary = Boolean(
     onMoveToLibrary && projectActions.canMoveToLibrary(project)
   )
@@ -266,7 +275,8 @@ function AppProjectCard({
   const badges = (statusBadgeLabel ||
     hasCloudConflict ||
     hasCloudSyncFailure ||
-    hasChangesRequested) && (
+    hasChangesRequested ||
+    hasDuplicateRealizations) && (
     <>
       {statusBadgeLabel && (
         <span
@@ -299,6 +309,14 @@ function AppProjectCard({
           data-testid="changes-requested-badge"
         >
           Changes requested
+        </span>
+      )}
+      {hasDuplicateRealizations && (
+        <span
+          className="rounded bg-chalkboard-20 px-1.5 py-0.5 text-[10px] font-medium text-chalkboard-90 dark:bg-chalkboard-80 dark:text-chalkboard-10"
+          data-testid="project-duplicate-copies-badge"
+        >
+          Duplicate copies
         </span>
       )}
     </>
@@ -349,6 +367,69 @@ function AppProjectCard({
           </p>
         </DeleteConfirmationDialog>
       )}
+      {isReviewingDuplicates && (
+        <DeleteConfirmationDialog
+          title="Review Duplicate Copies"
+          onConfirm={toSync(async () => {
+            await projectActions.deleteDuplicateRealizations(
+              project,
+              Array.from(selectedDuplicatePaths)
+            )
+            setIsReviewingDuplicates(false)
+          }, reportRejection)}
+          onDismiss={() => setIsReviewingDuplicates(false)}
+        >
+          <p className="my-4 text-wrap break-words">
+            Select duplicate local project folders to permanently delete. The
+            canonical folder will be kept.
+          </p>
+          <ul className="my-4 flex max-h-72 flex-col gap-2 overflow-y-auto text-sm">
+            {duplicateRealizations.map((duplicate) => (
+              <li key={duplicate.localProjectPath}>
+                <label className="flex items-start gap-2 rounded border border-chalkboard-30 p-2 dark:border-chalkboard-80">
+                  <span className="sr-only">Select duplicate copy</span>
+                  <input
+                    type="checkbox"
+                    className="mt-1"
+                    checked={selectedDuplicatePaths.has(
+                      duplicate.localProjectPath
+                    )}
+                    onChange={(event) => {
+                      const checked = event.currentTarget.checked
+                      const duplicatePath = duplicate.localProjectPath
+                      setSelectedDuplicatePaths((paths) => {
+                        const nextPaths = new Set(paths)
+                        if (checked) {
+                          nextPaths.add(duplicatePath)
+                        } else {
+                          nextPaths.delete(duplicatePath)
+                        }
+                        return nextPaths
+                      })
+                    }}
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="block break-words font-medium">
+                      {duplicate.title ||
+                        duplicate.localProjectName ||
+                        duplicate.localProjectPath}
+                    </span>
+                    <span className="block break-all text-chalkboard-60 text-xs">
+                      {duplicate.localProjectPath}
+                    </span>
+                    <span className="block text-chalkboard-60 text-xs">
+                      {duplicate.duplicateRisk}
+                      {duplicate.libraryTitles.length > 0
+                        ? ` in ${duplicate.libraryTitles.join(', ')}`
+                        : ''}
+                    </span>
+                  </span>
+                </label>
+              </li>
+            ))}
+          </ul>
+        </DeleteConfirmationDialog>
+      )}
     </>
   )
 
@@ -395,6 +476,28 @@ function AppProjectCard({
             >
               Move to library
             </ContextMenuItem>,
+            ...(hasDuplicateRealizations
+              ? [
+                  <ContextMenuItem
+                    key="review-duplicate-copies"
+                    icon="glasses"
+                    disabled={!canReviewDuplicateRealizations}
+                    data-testid="project-card-context-review-duplicate-copies"
+                    onClick={() => {
+                      setSelectedDuplicatePaths(
+                        new Set(
+                          duplicateRealizations.map(
+                            (duplicate) => duplicate.localProjectPath
+                          )
+                        )
+                      )
+                      setIsReviewingDuplicates(true)
+                    }}
+                  >
+                    Review duplicate copies
+                  </ContextMenuItem>,
+                ]
+              : []),
             <ContextMenuItem
               key="delete"
               icon="trash"

--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -1499,6 +1499,53 @@ export async function deleteCloudSyncLocalProjectRealizations(
   await refreshPendingCount()
 }
 
+export async function deleteCloudSyncDuplicateProjectRealizations({
+  remoteProjectId,
+  canonicalProjectPath,
+  duplicateProjectPaths,
+}: {
+  remoteProjectId: string
+  canonicalProjectPath?: string
+  duplicateProjectPaths: readonly string[]
+}) {
+  if (!isConfiguredForCloud()) {
+    return
+  }
+
+  const projectId = remoteProjectId.trim()
+  const normalizedCanonicalProjectPath = canonicalProjectPath
+    ? normalizePathForSync(canonicalProjectPath)
+    : undefined
+  if (!projectId) {
+    return
+  }
+
+  const selectedProjectPaths = Array.from(
+    new Set(duplicateProjectPaths.map(normalizePathForSync).filter(Boolean))
+  )
+
+  for (const projectPath of selectedProjectPaths) {
+    if (projectPath === normalizedCanonicalProjectPath) {
+      continue
+    }
+
+    const metadata = await getProjectMetadata(projectPath)
+    const projectTomlCloudProjectId = await readProjectTomlCloudProjectId(
+      projectPath
+    ).catch(() => undefined)
+    if (
+      metadata?.remoteProjectId !== projectId &&
+      projectTomlCloudProjectId !== projectId
+    ) {
+      continue
+    }
+
+    await deleteLocalProjectRealization(projectPath)
+  }
+
+  await refreshPendingCount()
+}
+
 async function cloneRemoteProjectToLocal(
   remoteProject: RemoteProject,
   projectDirectory: string,

--- a/src/lib/cloudSync/localProjectNames.spec.ts
+++ b/src/lib/cloudSync/localProjectNames.spec.ts
@@ -2,6 +2,7 @@ import 'fake-indexeddb/auto'
 import {
   configureCloudSyncEngine,
   configureCloudSyncLocalFileSystem,
+  deleteCloudSyncDuplicateProjectRealizations,
   deleteCloudSyncLocalProjectRealizations,
   ensureCloudProjectLocallySynced,
   getCloudSyncProjectMetadata,
@@ -323,6 +324,33 @@ describe('cloud sync local project names', () => {
     expect(files.has(`${titleProjectPath}/main.kcl`)).toBe(false)
     expect(await getCloudSyncProjectMetadata(titleProjectPath)).toBeUndefined()
     expect(await getAllOutboxEntries()).toEqual([])
+  })
+
+  it('deletes selected duplicate local realizations without deleting the canonical path', async () => {
+    const files = new Map<string, string>()
+    addCloudProjectFiles(files, titleProjectPath)
+    addCloudProjectFiles(files, duplicateTitleProjectPath)
+    addCloudProjectFiles(files, dirtyTitleProjectPath, 'x = 2')
+    configureCloudSyncTestFs(files)
+    await seedCleanTitleCloudProjectMetadata()
+
+    await deleteCloudSyncDuplicateProjectRealizations({
+      remoteProjectId,
+      canonicalProjectPath: titleProjectPath,
+      duplicateProjectPaths: [
+        titleProjectPath,
+        duplicateTitleProjectPath,
+        dirtyTitleProjectPath,
+      ],
+    })
+
+    expect(files.get(`${titleProjectPath}/main.kcl`)).toBe('x = 1')
+    expect(files.has(`${duplicateTitleProjectPath}/main.kcl`)).toBe(false)
+    expect(files.has(`${dirtyTitleProjectPath}/main.kcl`)).toBe(false)
+    expect(await getCloudSyncProjectMetadata(titleProjectPath)).toMatchObject({
+      localProjectPath: titleProjectPath,
+      remoteProjectId,
+    })
   })
 
   it('leaves data and metadata in place when a cloud project directory rename fails', async () => {

--- a/src/lib/cloudSync/registry/contract.ts
+++ b/src/lib/cloudSync/registry/contract.ts
@@ -25,6 +25,12 @@ export type CloudProjectDuplicateRisk =
 
 export type CloudProjectRealizationRole = 'canonical' | 'duplicate'
 
+export type CloudProjectDuplicateCleanupInput = {
+  remoteProjectId: string
+  canonicalProjectPath?: string
+  duplicateProjectPaths: readonly string[]
+}
+
 export interface CloudProjectRelationshipRealization {
   role: CloudProjectRealizationRole
   realization: ProjectLibraryRealization
@@ -98,6 +104,14 @@ export type CloudSyncRegistryService = {
   deleteLocalProjectRealizations: (
     remoteProjectId: string,
     selectedProjectPath: string
+  ) => Promise<void>
+  /**
+   * Delete user-confirmed duplicate local realizations for a cloud
+   * relationship. Implementations must ignore the canonical realization even if
+   * a caller includes it in the selected duplicate paths.
+   */
+  deleteDuplicateProjectRealizations: (
+    input: CloudProjectDuplicateCleanupInput
   ) => Promise<void>
   /**
    * Materialize a remote cloud project into the local library directory the

--- a/src/lib/cloudSync/registry/extension.test.ts
+++ b/src/lib/cloudSync/registry/extension.test.ts
@@ -31,6 +31,7 @@ const cloudSyncPathMocks = vi.hoisted(() => ({
 vi.mock('@src/lib/cloudSync', () => ({
   cloudSyncStatus: cloudSyncMocks.cloudSyncStatus,
   configureCloudSync: cloudSyncMocks.configureCloudSync,
+  deleteCloudSyncDuplicateProjectRealizations: vi.fn(),
   deleteCloudSyncLocalProjectRealizations: vi.fn(),
   deleteRemoteCloudProject: vi.fn(),
   ensureCloudProjectLocallySynced: vi.fn(),

--- a/src/lib/cloudSync/registry/extension.ts
+++ b/src/lib/cloudSync/registry/extension.ts
@@ -7,6 +7,7 @@ import { effect, signal, untracked } from '@preact/signals-core'
 import {
   cloudSyncStatus,
   configureCloudSync,
+  deleteCloudSyncDuplicateProjectRealizations,
   deleteCloudSyncLocalProjectRealizations,
   deleteRemoteCloudProject,
   disconnectCloudSyncProject,
@@ -117,6 +118,8 @@ export const cloudSyncExtension = defineRegistryItemFactory((ctx) => {
     disconnectProjectSync: disconnectCloudSyncProject,
     deleteRemoteProject: deleteRemoteCloudProject,
     deleteLocalProjectRealizations: deleteCloudSyncLocalProjectRealizations,
+    deleteDuplicateProjectRealizations:
+      deleteCloudSyncDuplicateProjectRealizations,
     ensureProjectLocallySynced: ensureCloudProjectLocallySynced,
     getProjectMetadata: getCloudSyncProjectMetadata,
     getProjectMetadataIndex: getCloudSyncProjectMetadataIndex,

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -152,6 +152,7 @@ function createCloudSyncService(): CloudSyncRegistryService {
     disconnectProjectSync: vi.fn().mockResolvedValue(undefined),
     deleteRemoteProject: vi.fn().mockResolvedValue(undefined),
     deleteLocalProjectRealizations: vi.fn().mockResolvedValue(undefined),
+    deleteDuplicateProjectRealizations: vi.fn().mockResolvedValue(undefined),
     ensureProjectLocallySynced: vi.fn().mockResolvedValue(undefined),
     getRemoteProjectThumbnailUrl: vi.fn().mockResolvedValue(undefined),
     getProjectMetadata: vi.fn().mockResolvedValue(undefined),

--- a/src/lib/commandBarConfigs/projectsCommandConfig.spec.ts
+++ b/src/lib/commandBarConfigs/projectsCommandConfig.spec.ts
@@ -94,6 +94,7 @@ function createHomeProjectActions(
     canRename: vi.fn(() => true),
     canDelete: vi.fn(() => true),
     canMoveToLibrary: vi.fn(() => false),
+    canReviewDuplicateRealizations: vi.fn(() => false),
     open: vi.fn(async (project) => ({
       defaultFile: project.defaultFile ?? '',
     })),
@@ -102,6 +103,7 @@ function createHomeProjectActions(
     delete: vi.fn(async () => undefined),
     getMoveToLibraryTargets: vi.fn(() => []),
     moveToLibrary: vi.fn(async () => undefined),
+    deleteDuplicateRealizations: vi.fn(async () => undefined),
     ...overrides,
   }
 }

--- a/src/registry/contracts/cloudSync.ts
+++ b/src/registry/contracts/cloudSync.ts
@@ -1,4 +1,5 @@
 export type {
+  CloudProjectDuplicateCleanupInput,
   CloudProjectDuplicateRisk,
   CloudProjectRealizationRole,
   CloudProjectRelationship,

--- a/src/registry/contracts/homeProjects.ts
+++ b/src/registry/contracts/homeProjects.ts
@@ -107,6 +107,7 @@ export interface HomeProjectActionsService {
   canRename: (project: HomeProjectEntry) => boolean
   canDelete: (project: HomeProjectEntry) => boolean
   canMoveToLibrary: (project: HomeProjectEntry) => boolean
+  canReviewDuplicateRealizations: (project: HomeProjectEntry) => boolean
   open: (
     project: HomeProjectEntry
   ) => Promise<HomeProjectOpenResult | undefined>
@@ -120,6 +121,10 @@ export interface HomeProjectActionsService {
     project: HomeProjectEntry,
     targetLibraryId: string
   ) => Promise<HomeProjectOpenResult | undefined>
+  deleteDuplicateRealizations: (
+    project: HomeProjectEntry,
+    duplicateProjectPaths: readonly string[]
+  ) => Promise<void>
 }
 
 function contributionStableId(entry: HomeProjectEntryContribution) {

--- a/src/registry/extensions/homeProjects/index.test.ts
+++ b/src/registry/extensions/homeProjects/index.test.ts
@@ -215,6 +215,7 @@ function createCloudSyncService(
     disconnectProjectSync: vi.fn().mockResolvedValue(undefined),
     deleteRemoteProject: vi.fn().mockResolvedValue(undefined),
     deleteLocalProjectRealizations: vi.fn().mockResolvedValue(undefined),
+    deleteDuplicateProjectRealizations: vi.fn().mockResolvedValue(undefined),
     ensureProjectLocallySynced: vi.fn().mockResolvedValue(undefined),
     getRemoteProjectThumbnailUrl: vi.fn().mockResolvedValue(undefined),
     getProjectMetadata: vi.fn().mockResolvedValue(undefined),

--- a/src/registry/extensions/homeProjects/index.ts
+++ b/src/registry/extensions/homeProjects/index.ts
@@ -15,6 +15,7 @@ import {
   type ProjectLibrary,
   projectLibrariesFromSettings,
 } from '@src/lib/projectLibraries'
+import { invalidateProjectLibraryRealizations } from '@src/lib/projectLibraries/registry/invalidation'
 import {
   type CloudProjectRelationship,
   type CloudProjectRelationshipRealization,
@@ -428,6 +429,8 @@ const homeProjectActions = defineRegistryItemFactory((ctx) => {
         project.readWriteAccess && getProjectOperation(project, 'deleteProject')
       ),
     canMoveToLibrary: (project) => getMoveToLibraryTargets(project).length > 0,
+    canReviewDuplicateRealizations: (project) =>
+      Boolean(project.duplicateRealizations?.length),
     open: async (project) => {
       const openProject = getProjectOperation(project, 'openProject')
       if (openProject && project.readWriteAccess && project.defaultFile) {
@@ -569,6 +572,19 @@ const homeProjectActions = defineRegistryItemFactory((ctx) => {
             defaultFile: result.defaultFile,
           }
         : undefined
+    },
+    deleteDuplicateRealizations: async (project, duplicateProjectPaths) => {
+      if (!project.remoteProjectId || duplicateProjectPaths.length === 0) {
+        return
+      }
+
+      await cloudSync.value?.deleteDuplicateProjectRealizations({
+        remoteProjectId: project.remoteProjectId,
+        canonicalProjectPath: project.localProjectPath,
+        duplicateProjectPaths,
+      })
+      invalidateProjectLibraryRealizations()
+      toast.success('Deleted duplicate project copies.')
     },
   }
 


### PR DESCRIPTION
Closes #12805 and #12837. Builds on #12844 by adding the user-facing duplicate-copy review and cleanup path on top of explicit cloud relationships.

## Stack
This is PR 5 of 5.

1. #12843: project-library realization model and domain documentation.
2. #12849: configured project-library realization discovery.
3. #12854: project-library realization freshness without System IO.
4. #12844: cloud relationships and Home derivation without coalescing.
5. This PR: duplicate-copy badge, review dialog, and selected cleanup.

## Important Changes
1. Adds the cloudSync duplicate cleanup service method for deleting selected non-canonical local realizations tied to a remote project.
2. Keeps the canonical realization protected: the cleanup service ignores the canonical path even if a caller passes it.
3. Adds Home action adaptation that calls cloudSync cleanup, refreshes project-library realizations, and reports success.
4. Adds a `Duplicate copies` badge and a `Review duplicate copies` context-menu action using the `glasses` icon.
5. Hides the review action entirely for project cards that do not have duplicate realization metadata.

## Feature Flag / Ungated Impact
This PR touches shared card/action code, but the duplicate badge, review action, and review dialog are gated behind the cloud sync UI flag and duplicate relationship metadata. Users without the cloud sync feature flag should not see these new controls. The broader ungated Home discovery behavior changed in #12844; this top PR should only add duplicate review behavior for flagged cloudSync users with duplicate relationship metadata.

## How To Test
Start with a no-duplicate smoke test. With cloud sync enabled, open Home and right-click local-only, remote-only, and synced cloud project cards that have no duplicate copies. `Review duplicate copies` should not appear. The existing `Duplicate project` action should still use the clone icon; the duplicate-copy review action should use the glasses icon only when it appears.

To reproduce the main duplicate case, create or sync a cloud project and wait for it to become clean. Using Finder or another file explorer, copy that cloud project's local realization folder into a configured directory-type project library. This reproduces the old duplicate realization state even though the UI no longer offers per-project directory sync opt-in. Refresh Home or restart the app if needed. The canonical cloud relationship card should show a `Duplicate copies` badge, and the copied directory-library folder should be listed in the review dialog rather than silently hidden by Home coalescing.

From that canonical card, right-click and choose `Review duplicate copies`. The dialog should list the duplicate folder path, its duplicate risk, and the library title. A clean copied folder should show `exact`. Confirming with the duplicate selected should delete the selected duplicate folder from disk, keep the canonical folder, refresh Home, and remove the badge if there are no remaining duplicates.

For a safety pass, repeat the file-explorer copy and modify a file in the copied directory-library folder before refreshing Home. The copy should not be silently deleted. It should remain reviewable, should show `divergent` when cloudSync can compare it with the clean base manifest, and deletion should require the explicit confirmation dialog. The canonical folder should never appear as a selectable duplicate.

Finally, disable the cloud sync feature flag and smoke-test Home again. Local projects from the default project directory and configured directory libraries should still appear, and no duplicate-copy badge or review action should be visible.