### PR TITLE
Project libraries: add local realizations

### DIFF
--- a/src/lib/cloudSync/README.md
+++ b/src/lib/cloudSync/README.md
@@ -20,9 +20,29 @@ The cloud sync system supports syncing on a per-project basis. However, cloud sy
 - Windows: `%USERPROFILE%\Zoo\personal`
 - macOS: `~/Library/CloudStorage/Zoo/personal`, by macOS convention
 
+## Project identity terms
+
+- Project library: a configured source that can discover and operate on project storage.
+- Local realization: one concrete project folder on disk. One folder can belong to more than one library when library paths overlap.
+- Remote project: a cloud-side project record identified by its cloud project ID.
+- Cloud relationship: cloudSync-owned relationship between one remote project and zero or more local realizations.
+- Canonical realization: the preferred local folder for a cloud relationship.
+- Duplicate realization: a non-canonical local folder bound to the same remote project.
+- Home project view model: UI-ready card data derived from project-library realizations and cloudSync relationships.
+
+`projectLibraries` owns local realization discovery and library membership. It combines duplicate discovery results only by normalized local path so one folder can retain all of its library memberships. It must not combine different folders by cloud project ID.
+
+`cloudSync` owns cloud identity resolution, remote-project relationships, canonical selection, duplicate detection, and duplicate cleanup policy. Home renders these explicit relationships and available actions; Home must not infer identity, merge providers, or manufacture a combined local/remote project entry.
+
 ## Product Policies
 
 Cloud sync is technically keyed by per-project `project.toml` IDs, but the user-facing model is library membership. A project is normally made cloud-backed by moving it into a cloud-type project library, and made local-only by moving it out of a cloud-type project library.
+
+### Duplicate local realizations
+
+Duplicate cleanup operates on local realizations, not Home entries. A local realization is eligible for silent deletion only when cloudSync can prove it is an exact non-canonical duplicate in a cloud-type library. Directory-library copies are never silently deleted. Pending, conflicted, unreadable, tombstoned, sync-excluded, or divergent realizations must remain visible for user review.
+
+Canonical selection prefers a clean cloud-library realization, then the newest clean synced realization, then a display-only fallback when every local realization is risky or incomplete. User-confirmed duplicate cleanup may delete selected duplicate paths, including risky ones, but must ignore the canonical path even if a caller includes it.
 
 ### Moving projects between libraries
 

--- a/src/lib/projectLibraries/index.ts
+++ b/src/lib/projectLibraries/index.ts
@@ -97,7 +97,7 @@ export function getDefaultDirectoryProjectLibraryPath(
   return getDefaultDirectoryProjectLibrarySetting(libraries)?.path
 }
 
-function normalizeLibraryPath(path: string) {
+export function normalizeLibraryPath(path: string) {
   return path.replaceAll('\\', '/').replace(/\/+$/g, '')
 }
 

--- a/src/lib/projectLibraries/realizations.ts
+++ b/src/lib/projectLibraries/realizations.ts
@@ -1,0 +1,54 @@
+import { PROJECT_IMAGE_NAME } from '@src/lib/constants'
+import fsZds from '@src/lib/fs-zds'
+import type { FileEntry, Project } from '@src/lib/project'
+import { getProjectDisplayName } from '@src/lib/projectDisplayName'
+import type { ProjectLibrary } from '@src/lib/projectLibraries'
+import type { ProjectLibraryRealizationContribution } from '@src/registry/contracts/projectLibraries'
+
+function getLatestModifiedTime(entry: FileEntry): number | undefined {
+  const ownModified = entry.metadata?.modified ?? undefined
+  const childModified =
+    entry.children
+      ?.map(getLatestModifiedTime)
+      .filter((modified): modified is number => modified !== undefined)
+      .toSorted((a, b) => b - a)[0] ?? undefined
+
+  if (ownModified === undefined) {
+    return childModified
+  }
+  if (childModified === undefined) {
+    return ownModified
+  }
+  return Math.max(ownModified, childModified)
+}
+
+/**
+ * Converts one concrete project folder into a local realization. Cloud project
+ * IDs are copied as observations only; identity resolution and duplicate
+ * policy are owned by cloudSync.
+ */
+export function projectLibraryRealizationFromProject(
+  project: Project,
+  library?: ProjectLibrary
+): ProjectLibraryRealizationContribution {
+  const modified = getLatestModifiedTime(project)
+
+  return {
+    ...(library ? { library } : {}),
+    name: project.name,
+    title: getProjectDisplayName(project),
+    localProjectPath: project.path,
+    localProjectName: project.name,
+    cloudProjectId: project.cloudProjectId,
+    modified,
+    defaultFile: project.default_file,
+    kclFileCount: project.kcl_file_count,
+    directoryCount: project.directory_count,
+    readWriteAccess: project.readWriteAccess,
+    thumbnail: {
+      type: 'local',
+      path: fsZds.join(project.path, PROJECT_IMAGE_NAME),
+    },
+    conflict: project.cloudConflict,
+  }
+}

--- a/src/lib/projectLibraries/registry/invalidation.ts
+++ b/src/lib/projectLibraries/registry/invalidation.ts
@@ -1,0 +1,11 @@
+import { signal } from '@preact/signals-core'
+
+const projectLibraryRealizationsInvalidation = signal(0)
+
+export function invalidateProjectLibraryRealizations() {
+  projectLibraryRealizationsInvalidation.value += 1
+}
+
+export function readProjectLibraryRealizationsInvalidation() {
+  return projectLibraryRealizationsInvalidation.value
+}

--- a/src/registry/contracts/projectLibraries.test.ts
+++ b/src/registry/contracts/projectLibraries.test.ts
@@ -20,6 +20,7 @@ import {
   updateProjectLibrarySettingAt,
 } from '@src/lib/projectLibraries'
 import {
+  combineProjectLibraryRealizationContributions,
   combineProjectLibrarySettingDefaultPolicies,
   combineProjectLibrarySettingDefaults,
   combineProjectLibraryTypes,
@@ -478,7 +479,7 @@ describe('project library default policies', () => {
 
 describe('combineProjectLibraryTypes', () => {
   test('merges duplicate library type contributions by type', () => {
-    const readEntries = async () => []
+    const readRealizations = async () => []
     const createProject = {
       run: async () => undefined,
     }
@@ -510,7 +511,7 @@ describe('combineProjectLibraryTypes', () => {
         {
           type: 'directory',
           title: 'Folder',
-          readEntries,
+          readRealizations,
           operations: {
             renameProject,
             deleteProject,
@@ -528,7 +529,7 @@ describe('combineProjectLibraryTypes', () => {
         renameProject,
         deleteProject,
       },
-      readEntries,
+      readRealizations,
     })
   })
 
@@ -599,7 +600,7 @@ describe('getHomeProjectEntriesForLibrary', () => {
           },
           {
             id: 'local:/projects/shared-bracket',
-            source: 'both',
+            source: 'local',
             status: 'synced',
             libraryIds: ['default-project-directory', 'external'],
             name: 'shared-bracket',
@@ -611,6 +612,83 @@ describe('getHomeProjectEntriesForLibrary', () => {
     ).toEqual([
       expect.objectContaining({
         id: 'local:/projects/shared-bracket',
+      }),
+    ])
+  })
+})
+
+describe('combineProjectLibraryRealizationContributions', () => {
+  test('combines realizations by normalized local path and preserves library membership', () => {
+    expect(
+      combineProjectLibraryRealizationContributions([
+        {
+          library: {
+            id: 'parent-library',
+            title: 'Parent',
+            path: '/projects',
+            type: 'directory',
+          },
+          name: 'bracket',
+          localProjectPath: '/projects/bracket/',
+          localProjectName: 'bracket',
+          readWriteAccess: true,
+        },
+        {
+          library: {
+            id: 'child-library',
+            title: 'Child',
+            path: '/projects/bracket',
+            type: 'directory',
+          },
+          name: 'bracket',
+          localProjectPath: '/projects/bracket',
+          localProjectName: 'bracket',
+          readWriteAccess: true,
+        },
+      ])
+    ).toEqual([
+      expect.objectContaining({
+        id: 'local:/projects/bracket',
+        localProjectPath: '/projects/bracket',
+        libraryIds: ['parent-library', 'child-library'],
+        libraryRefs: [
+          expect.objectContaining({ id: 'parent-library' }),
+          expect.objectContaining({ id: 'child-library' }),
+        ],
+      }),
+    ])
+  })
+
+  test('does not combine different local paths with the same cloud project id', () => {
+    expect(
+      combineProjectLibraryRealizationContributions([
+        {
+          libraryId: 'directory-library',
+          name: 'directory-copy',
+          localProjectPath: '/projects/directory-copy',
+          localProjectName: 'directory-copy',
+          cloudProjectId: 'remote-123',
+          readWriteAccess: true,
+        },
+        {
+          libraryId: 'cloud-library',
+          name: 'cloud-copy',
+          localProjectPath: '/cloud/cloud-copy',
+          localProjectName: 'cloud-copy',
+          cloudProjectId: 'remote-123',
+          readWriteAccess: true,
+        },
+      ])
+    ).toEqual([
+      expect.objectContaining({
+        id: 'local:/projects/directory-copy',
+        libraryIds: ['directory-library'],
+        cloudProjectId: 'remote-123',
+      }),
+      expect.objectContaining({
+        id: 'local:/cloud/cloud-copy',
+        libraryIds: ['cloud-library'],
+        cloudProjectId: 'remote-123',
       }),
     ])
   })

--- a/src/registry/contracts/projectLibraries.ts
+++ b/src/registry/contracts/projectLibraries.ts
@@ -6,7 +6,10 @@ import type {
   ProjectLibrarySetting,
   ProjectLibraryType,
 } from '@src/lib/projectLibraries'
-import { mergeProjectLibrarySettings } from '@src/lib/projectLibraries'
+import {
+  mergeProjectLibrarySettings,
+  normalizeLibraryPath,
+} from '@src/lib/projectLibraries'
 import type { HideOnPlatformValue } from '@src/lib/settings/settingsTypes'
 import { isArray } from '@src/lib/utils'
 import type {
@@ -37,6 +40,66 @@ export interface ProjectLibrarySettingDefaultPolicy {
 export type ProjectLibrarySettingDefaultPolicyContribution =
   | ProjectLibrarySettingDefaultPolicy
   | readonly ProjectLibrarySettingDefaultPolicy[]
+
+export type ProjectLibraryRealizationThumbnail = {
+  type: 'local'
+  path: string
+}
+
+export type ProjectLibraryRealizationSyncFailure = {
+  message: string
+  at?: string
+  kind?: string
+}
+
+export type ProjectLibraryRealizationLibraryRef = Pick<
+  ProjectLibrary,
+  'id' | 'title' | 'path' | 'type' | 'order'
+>
+
+/**
+ * A project library is a configured source that can discover and operate on
+ * project storage.
+ *
+ * A local realization is one concrete project folder on disk. The same local
+ * realization may be visible through multiple libraries when library paths
+ * overlap, but cloud identity is not resolved here. If two local realizations
+ * point at the same cloud project ID, they remain two realizations so cloudSync
+ * can classify and clean them up with full disk/metadata context.
+ */
+export interface ProjectLibraryRealization {
+  id: string
+  libraryIds: readonly string[]
+  libraryRefs: readonly ProjectLibraryRealizationLibraryRef[]
+  localProjectPath: string
+  localProjectName: string
+  name: string
+  title?: string
+  cloudProjectId?: string
+  modified?: number
+  defaultFile?: string
+  kclFileCount?: number
+  directoryCount?: number
+  readWriteAccess: boolean
+  thumbnail?: ProjectLibraryRealizationThumbnail
+  conflict?: unknown
+  syncFailure?: ProjectLibraryRealizationSyncFailure
+}
+
+export type ProjectLibraryRealizationContribution = Omit<
+  ProjectLibraryRealization,
+  'id' | 'libraryIds' | 'libraryRefs'
+> & {
+  id?: string
+  library?: ProjectLibrary
+  libraryId?: string
+  libraryIds?: readonly string[]
+  libraryRefs?: readonly ProjectLibraryRealizationLibraryRef[]
+}
+
+export type ProjectLibraryRealizationContributionGroup =
+  | ProjectLibraryRealizationContribution
+  | readonly ProjectLibraryRealizationContribution[]
 
 export interface ProjectLibraryOperation<
   Input extends { library: ProjectLibrary },
@@ -157,6 +220,19 @@ export interface ProjectLibraryTypeContribution {
     library: ProjectLibrary
     signal: AbortSignal
   }) => Promise<HomeProjectEntryContribution[]>
+  readRealizations?: (input: {
+    library: ProjectLibrary
+    signal: AbortSignal
+  }) => Promise<ProjectLibraryRealizationContribution[]>
+}
+
+export function getProjectLibraryRealizationsForLibrary(
+  realizations: readonly ProjectLibraryRealization[],
+  libraryId: string
+) {
+  return realizations.filter((realization) =>
+    realization.libraryIds.includes(libraryId)
+  )
 }
 
 export function getHomeProjectEntriesForLibrary(
@@ -253,6 +329,112 @@ export function resolveProjectLibrarySettingDefaults(
   return []
 }
 
+function projectLibraryRealizationStableId(
+  realization: ProjectLibraryRealizationContribution
+) {
+  return `local:${normalizeLibraryPath(realization.localProjectPath)}`
+}
+
+function projectLibraryRealizationLibraryIds(
+  realization: ProjectLibraryRealizationContribution
+) {
+  return Array.from(
+    new Set(
+      [
+        realization.library?.id,
+        realization.libraryId,
+        ...(realization.libraryIds ?? []),
+        ...(realization.libraryRefs?.map((library) => library.id) ?? []),
+      ].filter((libraryId): libraryId is string => Boolean(libraryId))
+    )
+  )
+}
+
+function projectLibraryRealizationLibraryRefs(
+  realization: ProjectLibraryRealizationContribution
+) {
+  const refsById = new Map<string, ProjectLibraryRealizationLibraryRef>()
+
+  for (const ref of realization.libraryRefs ?? []) {
+    refsById.set(ref.id, ref)
+  }
+  if (realization.library) {
+    refsById.set(realization.library.id, {
+      id: realization.library.id,
+      title: realization.library.title,
+      path: realization.library.path,
+      type: realization.library.type,
+      order: realization.library.order,
+    })
+  } else if (realization.libraryId) {
+    refsById.set(realization.libraryId, {
+      id: realization.libraryId,
+      title: realization.libraryId,
+      path: '',
+      type: '',
+    })
+  }
+
+  return Array.from(refsById.values())
+}
+
+function projectLibraryRealizationFromContribution(
+  contribution: ProjectLibraryRealizationContribution
+): ProjectLibraryRealization {
+  const {
+    id,
+    library: _library,
+    libraryId: _libraryId,
+    libraryIds: _libraryIds,
+    libraryRefs: _libraryRefs,
+    localProjectPath,
+    ...realization
+  } = contribution
+
+  return {
+    ...realization,
+    id: id ?? projectLibraryRealizationStableId(contribution),
+    libraryIds: projectLibraryRealizationLibraryIds(contribution),
+    libraryRefs: projectLibraryRealizationLibraryRefs(contribution),
+    localProjectPath: normalizeLibraryPath(localProjectPath),
+  }
+}
+
+export function combineProjectLibraryRealizationContributions(
+  contributionGroups: readonly ProjectLibraryRealizationContributionGroup[]
+) {
+  const realizationsByPath = new Map<string, ProjectLibraryRealization>()
+
+  for (const contribution of contributionGroups.flatMap((group) =>
+    isArray(group) ? group : [group]
+  )) {
+    const realization = projectLibraryRealizationFromContribution(contribution)
+    const pathKey = normalizeLibraryPath(realization.localProjectPath)
+    const existing = realizationsByPath.get(pathKey)
+    realizationsByPath.set(
+      pathKey,
+      existing
+        ? {
+            ...existing,
+            ...realization,
+            libraryIds: Array.from(
+              new Set([...existing.libraryIds, ...realization.libraryIds])
+            ),
+            libraryRefs: Array.from(
+              new Map(
+                [...existing.libraryRefs, ...realization.libraryRefs].map(
+                  (library) => [library.id, library]
+                )
+              ).values()
+            ),
+          }
+        : realization
+    )
+  }
+
+  return Array.from(realizationsByPath.values())
+}
+
 export const projectLibrariesContract = defineContract({
   projectLibraryTypesValueSpec: defineValueSpec<
     ProjectLibraryTypeContribution,
@@ -278,10 +460,19 @@ export const projectLibrariesContract = defineContract({
     defaultValue: [],
     combine: combineProjectLibrarySettingDefaultPolicies,
   }),
+  projectLibraryRealizationsValueSpec: defineValueSpec<
+    ProjectLibraryRealizationContributionGroup,
+    ProjectLibraryRealization[]
+  >({
+    name: 'project-library-realizations',
+    defaultValue: [],
+    combine: combineProjectLibraryRealizationContributions,
+  }),
 })
 
 export const {
   projectLibraryTypesValueSpec,
   projectLibrarySettingDefaultsValueSpec,
   projectLibrarySettingDefaultPoliciesValueSpec,
+  projectLibraryRealizationsValueSpec,
 } = projectLibrariesContract


### PR DESCRIPTION
Addresses #12805 by adding the vocabulary and local discovery primitive that lets later PRs stop treating Home entries as the identity layer. I've invented the term "realization" to mean the durable external state that a project in the app is associated with, a folder. Cloud sync has "local realizations" after a cloud project is opened, and directory projects are based directly on the "realizations" of the file system.

## Stack
This is PR 1 of 5.

1. This PR: project-library realization model and domain documentation.
2. #12849: configured project-library realization discovery.
3. #12854: project-library realization freshness without System IO.
4. #12844: cloud relationships and Home derivation without coalescing.
5. #12841: duplicate-copy review and cleanup UI.

## Important Changes
1. Adds `ProjectLibraryRealization` so projectLibraries can represent one concrete project folder and the libraries that discovered it.
2. Adds path-only realization combining, preserving library membership while avoiding any cloud-ID identity resolution in projectLibraries.
3. Adds realization invalidation support for later scanner ownership changes.
4. Documents the core domain terms near cloudSync: project library, local realization, remote project, cloud relationship, canonical realization, duplicate realization, and Home project view model.

## Feature Flag / Ungated Impact
This PR touches shared projectLibraries contracts/helpers and cloudSync documentation, but it does not yet move active Home discovery or rendering onto the new realization source. Users without the cloud sync feature flag should see no visible behavior change from this PR by itself.

## How To Test
Start by smoke-testing the existing Home project list with local projects present in the default project directory. The visible behavior should be unchanged at this layer.

For the new model behavior, configure overlapping project-library paths or inspect the new contract tests: the same normalized local path should become one realization with multiple library memberships, while projects that merely share a cloud ID are not merged here.