### PR TITLE
Cloud sync: derive Home from explicit relationships

### DIFF
--- a/src/components/AppProjectCard/AppProjectCard.spec.tsx
+++ b/src/components/AppProjectCard/AppProjectCard.spec.tsx
@@ -1,6 +1,5 @@
 import AppProjectCard from '@src/components/AppProjectCard/AppProjectCard'
 import fsZds from '@src/lib/fs-zds'
-import { DIRECTORY_PROJECT_LIBRARY_TYPE } from '@src/lib/projectLibraries'
 import type {
   HomeProjectActionsService,
   HomeProjectEntry,
@@ -251,17 +250,6 @@ describe('ProjectCard', () => {
     )
   })
 
-  test('does not show status badges for cards with both local and remote sources', () => {
-    renderProjectCard({
-      project: {
-        ...cloudProject,
-        source: 'both',
-      },
-    })
-
-    expect(screen.queryByTestId('project-status-badge')).not.toBeInTheDocument()
-  })
-
   test('hides cloud sync project chips when cloud sync UI is disabled', () => {
     renderProjectCard({
       showCloudSyncUi: false,
@@ -318,8 +306,7 @@ describe('ProjectCard', () => {
     renderProjectCard({
       project: {
         ...cloudProject,
-        libraryPath: '/projects',
-        libraryType: DIRECTORY_PROJECT_LIBRARY_TYPE,
+        deleteRemoteOnDelete: false,
       },
     })
 
@@ -354,7 +341,6 @@ describe('ProjectCard', () => {
     renderProjectCard({
       project: {
         ...cloudProject,
-        source: 'both',
         syncFailure: {
           kind: 'remote-upload-forbidden',
           message: 'Cloud sync cannot upload local changes.',
@@ -366,14 +352,15 @@ describe('ProjectCard', () => {
     expect(screen.getByTestId('cloud-sync-blocked-badge')).toHaveTextContent(
       'Cloud sync blocked'
     )
-    expect(screen.queryByTestId('project-status-badge')).not.toBeInTheDocument()
+    expect(screen.getByTestId('project-status-badge')).toHaveTextContent(
+      'Synced'
+    )
   })
 
   test('shows cloud sync blocked badge for upload permission failures', () => {
     renderProjectCard({
       project: {
         ...cloudProject,
-        source: 'both',
         syncFailure: {
           kind: 'remote-upload-forbidden',
           message: 'Cloud sync cannot upload local changes.',
@@ -385,7 +372,9 @@ describe('ProjectCard', () => {
     expect(screen.getByTestId('cloud-sync-blocked-badge')).toHaveTextContent(
       'Cloud sync blocked'
     )
-    expect(screen.queryByTestId('project-status-badge')).not.toBeInTheDocument()
+    expect(screen.getByTestId('project-status-badge')).toHaveTextContent(
+      'Synced'
+    )
   })
 
   test('keeps local thumbnail object URLs stable when the project object changes', async () => {

--- a/src/components/AppProjectCard/AppProjectCard.tsx
+++ b/src/components/AppProjectCard/AppProjectCard.tsx
@@ -259,7 +259,7 @@ function AppProjectCard({
       ? `${PATHS.FILE}/${encodeURIComponent(project.defaultFile)}`
       : ''
   const statusBadgeLabel =
-    !showCloudSyncUi || !showSourceStatusBadges || project.source === 'both'
+    !showCloudSyncUi || !showSourceStatusBadges
       ? undefined
       : homeProjectStatusBadgeLabels[project.status]
 

--- a/src/lib/cloudSync/localManifest.ts
+++ b/src/lib/cloudSync/localManifest.ts
@@ -1,0 +1,99 @@
+import {
+  isCloudSyncExcludedPath,
+  normalizeRelativePath,
+} from '@src/lib/cloudSync/paths'
+import {
+  normalizeProjectArchiveFilesForCloudSync,
+  projectManifestFromFiles,
+  projectManifestsEqual,
+} from '@src/lib/cloudSync/projectArchive'
+import type {
+  ProjectArchiveFile,
+  ProjectManifest,
+} from '@src/lib/cloudSync/types'
+import type { IStat, IZooDesignStudioFS } from '@src/lib/fs-zds/interface'
+import {
+  appendGitignoreForDirectoryWithFs,
+  createInitialGitignoreStackWithFs,
+  type GitignoreStackEntry,
+  isPathIgnoredByGitignore,
+} from '@src/lib/gitignore'
+
+function statIsDirectory(stat: IStat) {
+  return Boolean(stat.mode & 0o040000)
+}
+
+export async function collectLocalProjectFilesForCloudSync({
+  localFs,
+  projectRoot,
+}: {
+  localFs: IZooDesignStudioFS
+  projectRoot: string
+}) {
+  const files: ProjectArchiveFile[] = []
+
+  const walk = async (
+    currentPath: string,
+    gitignoreStack: GitignoreStackEntry[]
+  ) => {
+    const entries = await localFs.readdir(currentPath)
+    for (const entry of entries) {
+      if (isCloudSyncExcludedPath(entry)) {
+        continue
+      }
+
+      const absolutePath = localFs.join(currentPath, entry)
+      const stat = await localFs.stat(absolutePath)
+      const relativePath = normalizeRelativePath(
+        localFs.relative(projectRoot, absolutePath)
+      )
+      const isDirectory = statIsDirectory(stat)
+      if (isPathIgnoredByGitignore(gitignoreStack, relativePath, isDirectory)) {
+        continue
+      }
+
+      if (statIsDirectory(stat)) {
+        const childGitignoreStack = await appendGitignoreForDirectoryWithFs(
+          localFs,
+          gitignoreStack,
+          absolutePath,
+          projectRoot
+        )
+        await walk(absolutePath, childGitignoreStack)
+        continue
+      }
+
+      const data = await localFs.readFile(absolutePath)
+      files.push({
+        relativePath,
+        data: Uint8Array.from(data),
+      })
+    }
+  }
+
+  const gitignoreStack = await createInitialGitignoreStackWithFs(
+    localFs,
+    projectRoot
+  )
+  await walk(projectRoot, gitignoreStack)
+  return normalizeProjectArchiveFilesForCloudSync(files).sort((a, b) =>
+    a.relativePath.localeCompare(b.relativePath)
+  )
+}
+
+export async function localProjectManifestMatchesBase({
+  baseManifest,
+  localFs,
+  projectRoot,
+}: {
+  baseManifest: ProjectManifest
+  localFs: IZooDesignStudioFS
+  projectRoot: string
+}) {
+  const localManifest = await collectLocalProjectFilesForCloudSync({
+    localFs,
+    projectRoot,
+  }).then(projectManifestFromFiles)
+
+  return projectManifestsEqual(localManifest, baseManifest)
+}

--- a/src/lib/cloudSync/localManifest.ts
+++ b/src/lib/cloudSync/localManifest.ts
@@ -11,6 +11,7 @@ import type {
   ProjectArchiveFile,
   ProjectManifest,
 } from '@src/lib/cloudSync/types'
+import { fsZdsConstants } from '@src/lib/fs-zds/constants'
 import type { IStat, IZooDesignStudioFS } from '@src/lib/fs-zds/interface'
 import {
   appendGitignoreForDirectoryWithFs,
@@ -20,9 +21,15 @@ import {
 } from '@src/lib/gitignore'
 
 function statIsDirectory(stat: IStat) {
-  return Boolean(stat.mode & 0o040000)
+  return Boolean(stat.mode & fsZdsConstants.S_IFDIR)
 }
 
+/**
+ * Collects the files from `projectRoot` that cloud sync would include in an
+ * upload archive. The walk uses the caller's filesystem, skips cloud-sync
+ * internal paths, respects `.gitignore` rules, and returns normalized files in
+ * stable relative-path order.
+ */
 export async function collectLocalProjectFilesForCloudSync({
   localFs,
   projectRoot,
@@ -52,7 +59,7 @@ export async function collectLocalProjectFilesForCloudSync({
         continue
       }
 
-      if (statIsDirectory(stat)) {
+      if (isDirectory) {
         const childGitignoreStack = await appendGitignoreForDirectoryWithFs(
           localFs,
           gitignoreStack,
@@ -81,6 +88,11 @@ export async function collectLocalProjectFilesForCloudSync({
   )
 }
 
+/**
+ * Builds the current syncable manifest for a local project folder and compares
+ * it with a stored clean base manifest. Duplicate classification uses this to
+ * distinguish exact duplicate realizations from divergent local copies.
+ */
 export async function localProjectManifestMatchesBase({
   baseManifest,
   localFs,

--- a/src/lib/cloudSync/registry/contract.ts
+++ b/src/lib/cloudSync/registry/contract.ts
@@ -1,4 +1,8 @@
-import { defineContract, defineService } from '@kittycad/registry'
+import {
+  defineContract,
+  defineService,
+  defineValueSpec,
+} from '@kittycad/registry'
 import type { ReadonlySignal } from '@preact/signals-core'
 import type {
   CloudSyncConfig,
@@ -11,6 +15,61 @@ import type {
   RemoteProjectSummary,
 } from '@src/lib/cloudSync'
 import type { IZooDesignStudioFS } from '@src/lib/fs-zds/interface'
+import { isArray } from '@src/lib/utils'
+import type { ProjectLibraryRealization } from '@src/registry/contracts/projectLibraries'
+
+export type CloudProjectDuplicateRisk =
+  | 'exact'
+  | 'divergent'
+  | 'pending'
+  | 'conflicted'
+  | 'unreadable'
+  | 'tombstoned'
+  | 'sync-excluded'
+  | 'unknown'
+
+export type CloudProjectRealizationRole = 'canonical' | 'duplicate'
+
+export interface CloudProjectRelationshipRealization {
+  role: CloudProjectRealizationRole
+  realization: ProjectLibraryRealization
+  duplicateRisk: CloudProjectDuplicateRisk
+  autoCleanupEligible: boolean
+}
+
+/**
+ * A remote project is the cloud-side project record identified by cloud project
+ * ID. A cloud relationship explicitly binds that remote project to zero or
+ * more local realizations.
+ *
+ * The canonical realization is the preferred local folder for the
+ * relationship. Duplicate realizations are non-canonical local folders bound to
+ * the same remote project. Home renders these relationships; it does not infer
+ * them from provider entries.
+ */
+export interface CloudProjectRelationship {
+  id: string
+  remoteProjectId: string
+  remoteProject?: RemoteProjectSummary
+  canonicalRealization?: CloudProjectRelationshipRealization
+  duplicateRealizations: readonly CloudProjectRelationshipRealization[]
+  localRealizations: readonly CloudProjectRelationshipRealization[]
+  title?: string
+  name: string
+  modified?: number
+  remoteThumbnailUrl?: string
+  defaultFile?: string
+  conflict?: unknown
+  syncFailure?: {
+    message: string
+    at?: string
+    kind?: string
+  }
+}
+
+export type CloudProjectRelationshipContribution =
+  | CloudProjectRelationship
+  | readonly CloudProjectRelationship[]
 
 export type CloudSyncRegistryService = {
   status: ReadonlySignal<CloudSyncStatus>
@@ -76,6 +135,18 @@ export type CloudSyncRegistryService = {
 export const cloudSyncContract = defineContract({
   cloudSyncService:
     defineService<CloudSyncRegistryService>('cloud-sync.service'),
+  cloudProjectRelationshipsValueSpec: defineValueSpec<
+    CloudProjectRelationshipContribution,
+    CloudProjectRelationship[]
+  >({
+    name: 'cloud-project-relationships',
+    defaultValue: [],
+    combine: (contributions) =>
+      contributions.flatMap((contribution) =>
+        isArray(contribution) ? contribution : [contribution]
+      ),
+  }),
 })
 
-export const { cloudSyncService } = cloudSyncContract
+export const { cloudSyncService, cloudProjectRelationshipsValueSpec } =
+  cloudSyncContract

--- a/src/lib/cloudSync/registry/contract.ts
+++ b/src/lib/cloudSync/registry/contract.ts
@@ -1,8 +1,4 @@
-import {
-  defineContract,
-  defineService,
-  defineValueSpec,
-} from '@kittycad/registry'
+import { defineContract, defineService } from '@kittycad/registry'
 import type { ReadonlySignal } from '@preact/signals-core'
 import type {
   CloudSyncConfig,
@@ -15,7 +11,6 @@ import type {
   RemoteProjectSummary,
 } from '@src/lib/cloudSync'
 import type { IZooDesignStudioFS } from '@src/lib/fs-zds/interface'
-import { isArray } from '@src/lib/utils'
 import type { ProjectLibraryRealization } from '@src/registry/contracts/projectLibraries'
 
 export type CloudProjectDuplicateRisk =
@@ -64,9 +59,14 @@ export interface CloudProjectRelationship {
   }
 }
 
-export type CloudProjectRelationshipContribution =
-  | CloudProjectRelationship
-  | readonly CloudProjectRelationship[]
+export type CloudProjectRelationshipsRegistryService = {
+  /**
+   * cloudSync-owned relationship state. This is a singleton service signal,
+   * not a ValueSpec, because cloud identity resolution is not an extension
+   * contribution surface.
+   */
+  relationships: ReadonlySignal<CloudProjectRelationship[]>
+}
 
 export type CloudSyncRegistryService = {
   status: ReadonlySignal<CloudSyncStatus>
@@ -132,18 +132,11 @@ export type CloudSyncRegistryService = {
 export const cloudSyncContract = defineContract({
   cloudSyncService:
     defineService<CloudSyncRegistryService>('cloud-sync.service'),
-  cloudProjectRelationshipsValueSpec: defineValueSpec<
-    CloudProjectRelationshipContribution,
-    CloudProjectRelationship[]
-  >({
-    name: 'cloud-project-relationships',
-    defaultValue: [],
-    combine: (contributions) =>
-      contributions.flatMap((contribution) =>
-        isArray(contribution) ? contribution : [contribution]
-      ),
-  }),
+  cloudProjectRelationshipsService:
+    defineService<CloudProjectRelationshipsRegistryService>(
+      'cloud-project-relationships.service'
+    ),
 })
 
-export const { cloudSyncService, cloudProjectRelationshipsValueSpec } =
+export const { cloudSyncService, cloudProjectRelationshipsService } =
   cloudSyncContract

--- a/src/lib/cloudSync/registry/contract.ts
+++ b/src/lib/cloudSync/registry/contract.ts
@@ -54,11 +54,8 @@ export interface CloudProjectRelationship {
   canonicalRealization?: CloudProjectRelationshipRealization
   duplicateRealizations: readonly CloudProjectRelationshipRealization[]
   localRealizations: readonly CloudProjectRelationshipRealization[]
-  title?: string
-  name: string
   modified?: number
   remoteThumbnailUrl?: string
-  defaultFile?: string
   conflict?: unknown
   syncFailure?: {
     message: string

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -30,7 +30,7 @@ import {
 import { Themes } from '@src/lib/theme'
 import type { CloudSyncRegistryService } from '@src/registry/contracts/cloudSync'
 import {
-  cloudProjectRelationshipsValueSpec,
+  cloudProjectRelationshipsService,
   cloudSyncService,
 } from '@src/registry/contracts/cloudSync'
 import type { HomeProjectEntry } from '@src/registry/contracts/homeProjects'
@@ -986,7 +986,9 @@ describe('cloud sync project relationships', () => {
 
     try {
       await waitFor(() =>
-        expect(registry.get(cloudProjectRelationshipsValueSpec)).toEqual([])
+        expect(
+          registry.get(cloudProjectRelationshipsService).relationships.value
+        ).toEqual([])
       )
     } finally {
       registry[Symbol.dispose]()
@@ -1022,7 +1024,9 @@ describe('cloud sync project relationships', () => {
 
     try {
       await waitFor(() =>
-        expect(registry.get(cloudProjectRelationshipsValueSpec)).toEqual([
+        expect(
+          registry.get(cloudProjectRelationshipsService).relationships.value
+        ).toEqual([
           expect.objectContaining({
             remoteProjectId: 'remote-123',
             remoteThumbnailUrl: 'https://example.test/remote-123-thumbnail.png',
@@ -1083,7 +1087,9 @@ describe('cloud sync project relationships', () => {
 
     try {
       await waitFor(() =>
-        expect(registry.get(cloudProjectRelationshipsValueSpec)).toEqual([
+        expect(
+          registry.get(cloudProjectRelationshipsService).relationships.value
+        ).toEqual([
           expect.objectContaining({
             remoteProjectId: 'remote-123',
             canonicalRealization: undefined,
@@ -1147,7 +1153,9 @@ describe('cloud sync project relationships', () => {
 
     try {
       await waitFor(() =>
-        expect(registry.get(cloudProjectRelationshipsValueSpec)).toEqual([
+        expect(
+          registry.get(cloudProjectRelationshipsService).relationships.value
+        ).toEqual([
           expect.objectContaining({
             remoteProjectId: 'remote-123',
             canonicalRealization: undefined,

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -2,6 +2,7 @@ import type { Feature } from '@kittycad/lib'
 import {
   defineRegistryItem,
   pluginsValueSpec,
+  provide,
   provideService,
   Registry,
 } from '@kittycad/registry'
@@ -18,6 +19,7 @@ import {
 import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
 import fsZds from '@src/lib/fs-zds'
 import { homeProjectEntryFromProject } from '@src/lib/homeProjects'
+import { localProjectManifestMatchesBase } from '@src/lib/cloudSync/localManifest'
 import type { Project } from '@src/lib/project'
 import {
   CLOUD_PROJECT_LIBRARY_TYPE,
@@ -36,8 +38,10 @@ import {
 import type { HomeProjectEntry } from '@src/registry/contracts/homeProjects'
 import {
   getProjectLibraryCreateProjectOperation,
+  projectLibraryRealizationsValueSpec,
   projectLibrarySettingDefaultPoliciesValueSpec,
   projectLibraryTypesValueSpec,
+  type ProjectLibraryRealization,
 } from '@src/registry/contracts/projectLibraries'
 import {
   type SettingsRegistryService,
@@ -72,6 +76,10 @@ vi.mock('@src/components/CloudConflictDialog', () => ({
 
 vi.mock('@src/lib/desktop', () => ({
   writeProjectTitleToProjectToml: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@src/lib/cloudSync/localManifest', () => ({
+  localProjectManifestMatchesBase: vi.fn().mockResolvedValue(true),
 }))
 
 vi.mock('react-hot-toast', () => ({
@@ -150,6 +158,39 @@ function createCloudSyncService(): CloudSyncRegistryService {
     getProjectMetadataIndex: vi.fn().mockResolvedValue(new Map()),
     getProjectModifiedTime: vi.fn((_metadata, localModified) => localModified),
     resolveProjectConflict: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+function projectLibraryRealization({
+  libraryType,
+  localProjectPath,
+  modified = 1,
+}: {
+  libraryType: string
+  localProjectPath: string
+  modified?: number
+}): ProjectLibraryRealization {
+  const localProjectName = localProjectPath.slice(
+    localProjectPath.lastIndexOf('/') + 1
+  )
+
+  return {
+    id: `local:${localProjectPath}`,
+    libraryIds: [`${libraryType}-library`],
+    libraryRefs: [
+      {
+        id: `${libraryType}-library`,
+        title: libraryType === CLOUD_PROJECT_LIBRARY_TYPE ? 'Cloud' : 'Folder',
+        path: libraryType === CLOUD_PROJECT_LIBRARY_TYPE ? '/cloud' : '/files',
+        type: libraryType,
+      },
+    ],
+    localProjectPath,
+    localProjectName,
+    name: localProjectName,
+    cloudProjectId: 'remote-123',
+    modified,
+    readWriteAccess: true,
   }
 }
 
@@ -1035,6 +1076,199 @@ describe('cloud sync project relationships', () => {
           }),
         ])
       )
+    } finally {
+      registry[Symbol.dispose]()
+    }
+  })
+
+  test('compares manifests for cloud-library duplicate cleanup candidates', async () => {
+    cloudSyncStatus.value = {
+      enabled: true,
+      state: 'idle',
+      pendingCount: 0,
+    }
+    vi.mocked(localProjectManifestMatchesBase).mockClear()
+    vi.mocked(localProjectManifestMatchesBase).mockResolvedValue(true)
+    const cloudSync = createCloudSyncService()
+    vi.mocked(cloudSync.getProjectMetadataIndex).mockResolvedValue(
+      new Map([
+        [
+          '/cloud/bracket',
+          {
+            schemaVersion: 1,
+            localProjectPath: '/cloud/bracket',
+            projectName: 'bracket',
+            remoteProjectId: 'remote-123',
+            hasPendingChanges: false,
+            baseManifest: { files: {} },
+          },
+        ],
+        [
+          '/cloud/bracket-copy',
+          {
+            schemaVersion: 1,
+            localProjectPath: '/cloud/bracket-copy',
+            projectName: 'bracket-copy',
+            remoteProjectId: 'remote-123',
+            hasPendingChanges: false,
+            baseManifest: { files: {} },
+          },
+        ],
+      ])
+    )
+    const registry = new Registry()
+    const cloudSyncServiceExtension = defineRegistryItem({
+      id: 'test-cloud-sync-service',
+      providesServices: [provideService(cloudSyncService, cloudSync)],
+    })
+    const projectRealizationsExtension = defineRegistryItem({
+      id: 'test-project-library-realizations',
+      provides: [
+        provide(projectLibraryRealizationsValueSpec, [
+          projectLibraryRealization({
+            libraryType: CLOUD_PROJECT_LIBRARY_TYPE,
+            localProjectPath: '/cloud/bracket',
+            modified: 20,
+          }),
+          projectLibraryRealization({
+            libraryType: CLOUD_PROJECT_LIBRARY_TYPE,
+            localProjectPath: '/cloud/bracket-copy',
+            modified: 10,
+          }),
+        ]),
+      ],
+    })
+
+    registry.configure([
+      cloudSyncServiceExtension,
+      projectRealizationsExtension,
+      cloudSyncPlugin,
+    ])
+    enableCloudSyncPlugin(registry)
+
+    try {
+      await waitFor(() =>
+        expect(
+          registry.get(cloudProjectRelationshipsService).relationships.value[0]
+            ?.duplicateRealizations
+        ).toEqual([
+          expect.objectContaining({
+            autoCleanupEligible: true,
+            duplicateRisk: 'exact',
+            realization: expect.objectContaining({
+              localProjectPath: '/cloud/bracket-copy',
+            }),
+          }),
+        ])
+      )
+      expect(localProjectManifestMatchesBase).toHaveBeenCalledTimes(1)
+      expect(localProjectManifestMatchesBase).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectRoot: '/cloud/bracket-copy',
+        })
+      )
+    } finally {
+      registry[Symbol.dispose]()
+    }
+  })
+
+  test('does not eagerly compare directory-library duplicate manifests', async () => {
+    cloudSyncStatus.value = {
+      enabled: true,
+      state: 'idle',
+      pendingCount: 0,
+    }
+    cloudSyncRemoteProjects.value = [
+      {
+        id: 'remote-123',
+        title: 'Remote title',
+        revision: 'remote-rev-1',
+      },
+    ]
+    vi.mocked(localProjectManifestMatchesBase).mockClear()
+    vi.mocked(localProjectManifestMatchesBase).mockResolvedValue(true)
+    const cloudSync = createCloudSyncService()
+    vi.mocked(cloudSync.getRemoteProjectThumbnailUrl).mockResolvedValue(
+      'https://example.test/remote-123-thumbnail.png'
+    )
+    vi.mocked(cloudSync.getProjectMetadataIndex).mockResolvedValue(
+      new Map([
+        [
+          '/cloud/bracket',
+          {
+            schemaVersion: 1,
+            localProjectPath: '/cloud/bracket',
+            projectName: 'bracket',
+            remoteProjectId: 'remote-123',
+            hasPendingChanges: false,
+            baseManifest: { files: {} },
+          },
+        ],
+        [
+          '/files/bracket-copy',
+          {
+            schemaVersion: 1,
+            localProjectPath: '/files/bracket-copy',
+            projectName: 'bracket-copy',
+            remoteProjectId: 'remote-123',
+            hasPendingChanges: false,
+            baseManifest: { files: {} },
+          },
+        ],
+      ])
+    )
+    const registry = new Registry()
+    const cloudSyncServiceExtension = defineRegistryItem({
+      id: 'test-cloud-sync-service',
+      providesServices: [provideService(cloudSyncService, cloudSync)],
+    })
+    const projectRealizationsExtension = defineRegistryItem({
+      id: 'test-project-library-realizations',
+      provides: [
+        provide(projectLibraryRealizationsValueSpec, [
+          projectLibraryRealization({
+            libraryType: CLOUD_PROJECT_LIBRARY_TYPE,
+            localProjectPath: '/cloud/bracket',
+            modified: 20,
+          }),
+          projectLibraryRealization({
+            libraryType: DIRECTORY_PROJECT_LIBRARY_TYPE,
+            localProjectPath: '/files/bracket-copy',
+            modified: 10,
+          }),
+        ]),
+      ],
+    })
+
+    registry.configure([
+      cloudSyncServiceExtension,
+      projectRealizationsExtension,
+      cloudSyncPlugin,
+    ])
+    enableCloudSyncPlugin(registry)
+
+    try {
+      await waitFor(() =>
+        expect(
+          registry.get(cloudProjectRelationshipsService).relationships.value[0]
+            ?.remoteThumbnailUrl
+        ).toBe('https://example.test/remote-123-thumbnail.png')
+      )
+      await Promise.resolve()
+      await Promise.resolve()
+      expect(
+        registry.get(cloudProjectRelationshipsService).relationships.value[0]
+          ?.duplicateRealizations
+      ).toEqual([
+        expect.objectContaining({
+          autoCleanupEligible: false,
+          duplicateRisk: 'unknown',
+          realization: expect.objectContaining({
+            localProjectPath: '/files/bracket-copy',
+          }),
+        }),
+      ])
+      expect(localProjectManifestMatchesBase).not.toHaveBeenCalled()
     } finally {
       registry[Symbol.dispose]()
     }

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -30,11 +30,11 @@ import {
 } from '@src/lib/projectLibraries'
 import { Themes } from '@src/lib/theme'
 import type { CloudSyncRegistryService } from '@src/registry/contracts/cloudSync'
-import { cloudSyncService } from '@src/registry/contracts/cloudSync'
 import {
-  type HomeProjectEntry,
-  homeProjectEntriesValueSpec,
-} from '@src/registry/contracts/homeProjects'
+  cloudProjectRelationshipsValueSpec,
+  cloudSyncService,
+} from '@src/registry/contracts/cloudSync'
+import type { HomeProjectEntry } from '@src/registry/contracts/homeProjects'
 import {
   getProjectLibraryCreateProjectOperation,
   projectLibrarySettingDefaultPoliciesValueSpec,
@@ -624,9 +624,9 @@ describe('cloud sync project library', () => {
         ...getDefaultCloudProjectLibrarySetting(),
         id: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
       }
-      // readEntries and createProject stay available even though cloud sync is
+      // readRealizations and createProject stay available even though cloud sync is
       // off, so a web user who is not actively syncing can still list/create.
-      expect(cloudLibraryType.readEntries).toBeDefined()
+      expect(cloudLibraryType.readRealizations).toBeDefined()
       expect(
         getProjectLibraryCreateProjectOperation(cloudLibraryType, cloudLibrary)
       ).toBeDefined()
@@ -743,7 +743,7 @@ describe('cloud sync project library', () => {
         },
         project: {
           id: 'local:/cloud/bracket',
-          source: 'both',
+          source: 'local',
           status: 'synced',
           libraryIds: [PERSONAL_CLOUD_PROJECT_LIBRARY_ID],
           name: 'bracket',
@@ -807,7 +807,7 @@ describe('cloud sync project library', () => {
           },
           project: {
             id: 'local:/cloud/bracket',
-            source: 'both',
+            source: 'local',
             status: 'synced',
             libraryIds: [PERSONAL_CLOUD_PROJECT_LIBRARY_ID],
             name: 'bracket',
@@ -954,8 +954,8 @@ describe('cloud sync project library', () => {
   })
 })
 
-describe('cloud sync home project entries', () => {
-  test('preserves the moved local default file while waiting for a remote id', async () => {
+describe('cloud sync project relationships', () => {
+  test('does not manufacture a relationship while waiting for a remote id', async () => {
     cloudSyncStatus.value = {
       enabled: true,
       state: 'idle',
@@ -992,25 +992,14 @@ describe('cloud sync home project entries', () => {
 
     try {
       await waitFor(() =>
-        expect(registry.get(homeProjectEntriesValueSpec)).toEqual([
-          expect.objectContaining({
-            source: 'remote',
-            status: 'cloud-only',
-            libraryIds: [PERSONAL_CLOUD_PROJECT_LIBRARY_ID],
-            name: 'Moved project',
-            title: 'Moved project',
-            localProjectPath: movedProjectPath,
-            defaultFile: movedDefaultFile,
-            readWriteAccess: true,
-          }),
-        ])
+        expect(registry.get(cloudProjectRelationshipsValueSpec)).toEqual([])
       )
     } finally {
       registry[Symbol.dispose]()
     }
   })
 
-  test('contributes remote thumbnails for cloud-only home entries', async () => {
+  test('contributes remote thumbnails for remote-only cloud relationships', async () => {
     cloudSyncStatus.value = {
       enabled: true,
       state: 'idle',
@@ -1039,18 +1028,14 @@ describe('cloud sync home project entries', () => {
 
     try {
       await waitFor(() =>
-        expect(registry.get(homeProjectEntriesValueSpec)).toEqual([
+        expect(registry.get(cloudProjectRelationshipsValueSpec)).toEqual([
           expect.objectContaining({
-            source: 'remote',
-            status: 'cloud-only',
-            libraryIds: [PERSONAL_CLOUD_PROJECT_LIBRARY_ID],
             name: 'Remote title',
             title: 'Remote title',
             remoteProjectId: 'remote-123',
-            thumbnail: {
-              type: 'remote',
-              url: 'https://example.test/remote-123-thumbnail.png',
-            },
+            remoteThumbnailUrl: 'https://example.test/remote-123-thumbnail.png',
+            canonicalRealization: undefined,
+            duplicateRealizations: [],
           }),
         ])
       )
@@ -1059,7 +1044,7 @@ describe('cloud sync home project entries', () => {
     }
   })
 
-  test('marks home entries with both sources as conflicted from cloud sync metadata', async () => {
+  test('marks cloud relationships as conflicted from cloud sync metadata', async () => {
     cloudSyncStatus.value = {
       enabled: true,
       state: 'conflict',
@@ -1106,14 +1091,12 @@ describe('cloud sync home project entries', () => {
 
     try {
       await waitFor(() =>
-        expect(registry.get(homeProjectEntriesValueSpec)).toEqual([
+        expect(registry.get(cloudProjectRelationshipsValueSpec)).toEqual([
           expect.objectContaining({
-            source: 'remote',
-            status: 'conflicted',
             name: 'Local project',
             title: 'Local project',
             remoteProjectId: 'remote-123',
-            localProjectPath: '/some/path/local-project',
+            canonicalRealization: undefined,
             conflict: expect.objectContaining({
               conflictProjectPath: '/some/path/local-project (cloud conflict)',
             }),
@@ -1174,14 +1157,12 @@ describe('cloud sync home project entries', () => {
 
     try {
       await waitFor(() =>
-        expect(registry.get(homeProjectEntriesValueSpec)).toEqual([
+        expect(registry.get(cloudProjectRelationshipsValueSpec)).toEqual([
           expect.objectContaining({
-            source: 'remote',
-            status: 'cloud-only',
             name: 'Local project',
             title: 'Local project',
             remoteProjectId: 'remote-123',
-            localProjectPath: '/some/path/local-project',
+            canonicalRealization: undefined,
             syncFailure: expect.objectContaining({
               kind: 'remote-upload-forbidden',
               message: 'Cloud sync cannot upload local changes.',

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -14,7 +14,6 @@ import {
   cloudSyncPlugin,
   cloudSyncProjectLibraryType,
   getCloudSyncStatusBarPresentation,
-  preserveCloudProjectDefaultFile,
 } from '@src/lib/cloudSync/registry/plugin'
 import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
 import fsZds from '@src/lib/fs-zds'
@@ -962,11 +961,6 @@ describe('cloud sync project relationships', () => {
       pendingCount: 1,
     }
     const movedProjectPath = '/some/path/moved-project'
-    const movedDefaultFile = `${movedProjectPath}/main.kcl`
-    preserveCloudProjectDefaultFile({
-      localProjectPath: movedProjectPath,
-      defaultFile: movedDefaultFile,
-    })
     const cloudSync = createCloudSyncService()
     vi.mocked(cloudSync.getProjectMetadataIndex).mockResolvedValue(
       new Map([
@@ -1030,8 +1024,6 @@ describe('cloud sync project relationships', () => {
       await waitFor(() =>
         expect(registry.get(cloudProjectRelationshipsValueSpec)).toEqual([
           expect.objectContaining({
-            name: 'Remote title',
-            title: 'Remote title',
             remoteProjectId: 'remote-123',
             remoteThumbnailUrl: 'https://example.test/remote-123-thumbnail.png',
             canonicalRealization: undefined,
@@ -1093,8 +1085,6 @@ describe('cloud sync project relationships', () => {
       await waitFor(() =>
         expect(registry.get(cloudProjectRelationshipsValueSpec)).toEqual([
           expect.objectContaining({
-            name: 'Local project',
-            title: 'Local project',
             remoteProjectId: 'remote-123',
             canonicalRealization: undefined,
             conflict: expect.objectContaining({
@@ -1159,8 +1149,6 @@ describe('cloud sync project relationships', () => {
       await waitFor(() =>
         expect(registry.get(cloudProjectRelationshipsValueSpec)).toEqual([
           expect.objectContaining({
-            name: 'Local project',
-            title: 'Local project',
             remoteProjectId: 'remote-123',
             canonicalRealization: undefined,
             syncFailure: expect.objectContaining({

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -26,9 +26,11 @@ import Tooltip from '@src/components/Tooltip'
 import {
   type CloudSyncProjectMetadataIndexEntry,
   type CloudSyncStatus,
+  type ProjectManifest,
   cloudSyncRemoteProjects,
   cloudSyncStatus,
   duplicateRemoteCloudProject,
+  getCloudSyncProjectModifiedTime,
   type RemoteProjectSummary,
   renameRemoteCloudProject,
   retryCloudSync,
@@ -38,26 +40,29 @@ import {
   getCloudProjectLibraryMaterializationDirectoryPath,
   normalizePathForSync,
 } from '@src/lib/cloudSync/paths'
+import { localProjectManifestMatchesBase } from '@src/lib/cloudSync/localManifest'
+import {
+  type CloudProjectLocalManifestComparison,
+  deriveCloudProjectRelationships,
+} from '@src/lib/cloudSync/relationships'
 import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
 import { writeProjectTitleToProjectToml } from '@src/lib/desktop'
 import fsZds from '@src/lib/fs-zds'
-import {
-  getHomeProjectDisplayName,
-  homeProjectEntryFromProject,
-} from '@src/lib/homeProjects'
+import { getHomeProjectDisplayName } from '@src/lib/homeProjects'
 import { PATHS } from '@src/lib/paths'
 import { getProjectDisplayName } from '@src/lib/projectDisplayName'
 import { duplicateProjectInDirectory } from '@src/lib/projectDuplication'
 import {
   CLOUD_PROJECT_LIBRARY_TYPE,
   getDefaultCloudProjectLibrarySetting,
-  PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
 } from '@src/lib/projectLibraries'
 import { readProjectsFromProjectDirectory } from '@src/lib/projectLibraries/directoryScanner'
 import {
   createProjectInLocalDirectory,
   moveProjectIntoLocalDirectory,
 } from '@src/lib/projectLibraries/operations'
+import { projectLibraryRealizationFromProject } from '@src/lib/projectLibraries/realizations'
+import { invalidateProjectLibraryRealizations } from '@src/lib/projectLibraries/registry/invalidation'
 import {
   canRevealInFileExplorer,
   revealInFileExplorer,
@@ -66,18 +71,19 @@ import { getResolvedTheme, type ResolvedTheme } from '@src/lib/theme'
 import { reportRejection } from '@src/lib/trap'
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
 import { userFeaturesContextHas } from '@src/machines/userFeaturesMachine'
-import { cloudSyncService } from '@src/registry/contracts/cloudSync'
 import {
-  type HomeProjectEntryContribution,
-  homeProjectEntriesValueSpec,
-} from '@src/registry/contracts/homeProjects'
+  cloudProjectRelationshipsValueSpec,
+  cloudSyncService,
+} from '@src/registry/contracts/cloudSync'
 import {
   type ProjectExplorerProjectMenuItemComponentProps,
   projectExplorerProjectMenuItemsValueSpec,
 } from '@src/registry/contracts/projectExplorer'
 import {
   type ProjectLibrarySettingsDetailsProps,
+  type ProjectLibraryRealization,
   type ProjectLibraryTypeContribution,
+  projectLibraryRealizationsValueSpec,
   projectLibrarySettingDefaultPoliciesValueSpec,
   projectLibraryTypesValueSpec,
 } from '@src/registry/contracts/projectLibraries'
@@ -90,7 +96,6 @@ import { systemIOService } from '@src/registry/contracts/systemIO'
 import { userFeaturesService } from '@src/registry/contracts/userFeatures'
 import { wasmPromiseValueSpec } from '@src/registry/contracts/wasm'
 import { createZdsPlugin } from '@src/registry/createZdsPlugin'
-import { invalidateConfiguredProjectLibraryEntries } from '@src/registry/extensions/homeProjects'
 import { Fragment, useEffect, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 
@@ -133,16 +138,6 @@ export function preserveCloudProjectDefaultFile({
   const nextDefaultFiles = new Map(preservedCloudProjectDefaultFiles.value)
   nextDefaultFiles.set(normalizePathForSync(localProjectPath), defaultFile)
   preservedCloudProjectDefaultFiles.value = nextDefaultFiles
-}
-
-function getPreservedCloudProjectDefaultFile(
-  metadata: CloudSyncProjectMetadataIndexEntry | undefined
-) {
-  return metadata
-    ? preservedCloudProjectDefaultFiles.value.get(
-        normalizePathForSync(metadata.localProjectPath)
-      )
-    : undefined
 }
 
 function CloudProjectLibrarySettingsDetails({
@@ -500,65 +495,6 @@ const cloudConflictProjectMenuItem = defineRegistryItemFactory(() => {
   }
 }, 'cloud-sync.conflict-project-menu-item')
 
-function getCloudSyncHomeProjectModifiedTime(
-  project: { updated_at?: string },
-  metadata?: CloudSyncProjectMetadataIndexEntry
-) {
-  const modified = metadata?.remoteUpdatedAt
-    ? Date.parse(metadata.remoteUpdatedAt)
-    : project.updated_at
-      ? Date.parse(project.updated_at)
-      : NaN
-
-  return Number.isNaN(modified) ? undefined : modified
-}
-
-function homeProjectEntryCloudSyncFields(
-  metadata: CloudSyncProjectMetadataIndexEntry | undefined
-): Pick<
-  HomeProjectEntryContribution,
-  | 'conflict'
-  | 'libraryId'
-  | 'libraryType'
-  | 'localProjectPath'
-  | 'status'
-  | 'syncFailure'
-> {
-  const syncFailure =
-    metadata?.lastFailure?.kind === 'remote-upload-forbidden'
-      ? metadata.lastFailure
-      : undefined
-  if (!metadata?.conflict) {
-    return {
-      libraryId: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
-      libraryType: CLOUD_PROJECT_LIBRARY_TYPE,
-      status: 'cloud-only',
-      ...(syncFailure
-        ? { syncFailure, localProjectPath: metadata?.localProjectPath }
-        : {}),
-    }
-  }
-
-  return {
-    libraryId: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
-    libraryType: CLOUD_PROJECT_LIBRARY_TYPE,
-    status: 'conflicted',
-    conflict: metadata.conflict,
-    localProjectPath: metadata.localProjectPath,
-    ...(syncFailure ? { syncFailure } : {}),
-  }
-}
-
-function shouldContributeCloudSyncMetadata(
-  metadata: CloudSyncProjectMetadataIndexEntry
-) {
-  return (
-    Boolean(metadata.conflict) ||
-    metadata.lastFailure?.kind === 'remote-upload-forbidden' ||
-    Boolean(getPreservedCloudProjectDefaultFile(metadata))
-  )
-}
-
 function remoteThumbnailCacheKey(project: RemoteProjectSummary) {
   return [
     project.id,
@@ -606,185 +542,251 @@ function pruneRemoteThumbnailState({
   }
 }
 
-const cloudSyncRemoteHomeProjectEntryContribution = defineRegistryItemFactory(
-  (ctx) => {
-    const cloudSync = ctx.services.signal(cloudSyncService)
-    const cloudSyncMetadata = signal<CloudSyncProjectMetadataIndexEntry[]>([])
-    const remoteThumbnailUrls = signal<Map<string, string>>(new Map())
-    const requestedThumbnailKeys = new Map<string, string>()
-    let disposed = false
-    let disposeEffect: (() => void) | undefined
-    let loadId = 0
+function groupedMetadataByRemoteProjectId(
+  metadata: readonly CloudSyncProjectMetadataIndexEntry[]
+) {
+  const groups = new Map<string, CloudSyncProjectMetadataIndexEntry[]>()
+  for (const entry of metadata) {
+    if (!entry.remoteProjectId) {
+      continue
+    }
 
-    const cloudSyncHomeProjectEntries = computed<
-      HomeProjectEntryContribution[]
-    >(() => {
-      if (!cloudSyncStatus.value.enabled) {
-        return []
-      }
+    groups.set(entry.remoteProjectId, [
+      ...(groups.get(entry.remoteProjectId) ?? []),
+      entry,
+    ])
+  }
+  return groups
+}
 
-      const cloudSyncMetadataByRemoteProjectId = new Map(
-        cloudSyncMetadata.value.flatMap((metadata) =>
-          metadata.remoteProjectId
-            ? ([[metadata.remoteProjectId, metadata]] as const)
-            : []
-        )
-      )
-      const remoteProjectIds = new Set(
-        cloudSyncRemoteProjects.value.map((project) => project.id)
-      )
-      const remoteProjectEntries = cloudSyncRemoteProjects.value.map(
-        (project) => {
-          const metadata = cloudSyncMetadataByRemoteProjectId.get(project.id)
-          const name = metadata?.projectName || project.title || project.id
-          const thumbnailUrl = remoteThumbnailUrls.value.get(project.id)
-          const defaultFile = getPreservedCloudProjectDefaultFile(metadata)
+function firstCleanBaseManifest(
+  metadataEntries: readonly CloudSyncProjectMetadataIndexEntry[] | undefined
+): ProjectManifest | undefined {
+  return metadataEntries?.find(
+    (entry) => entry.baseManifest && !entry.tombstone && !entry.syncExcluded
+  )?.baseManifest
+}
 
-          return {
-            source: 'remote',
-            ...homeProjectEntryCloudSyncFields(metadata),
-            name,
-            title: metadata?.projectName || project.title,
-            remoteProjectId: project.id,
-            modified: getCloudSyncHomeProjectModifiedTime(project, metadata),
-            readWriteAccess: true,
-            ...(defaultFile ? { defaultFile } : {}),
-            ...(thumbnailUrl
-              ? {
-                  thumbnail: {
-                    type: 'remote',
-                    url: thumbnailUrl,
-                  },
-                }
-              : {}),
-          } satisfies HomeProjectEntryContribution
+async function readLocalManifestComparisons({
+  metadata,
+  realizations,
+}: {
+  metadata: readonly CloudSyncProjectMetadataIndexEntry[]
+  realizations: readonly ProjectLibraryRealization[]
+}) {
+  const comparisons = new Map<string, CloudProjectLocalManifestComparison>()
+  const metadataByPath = new Map(
+    metadata.map((entry) => [
+      normalizePathForSync(entry.localProjectPath),
+      entry,
+    ])
+  )
+  const metadataByRemoteProjectId = groupedMetadataByRemoteProjectId(metadata)
+  const realizationsByRemoteProjectId = new Map<
+    string,
+    ProjectLibraryRealization[]
+  >()
+
+  for (const realization of realizations) {
+    const remoteProjectId = realization.cloudProjectId?.trim()
+    if (!remoteProjectId) {
+      continue
+    }
+
+    realizationsByRemoteProjectId.set(remoteProjectId, [
+      ...(realizationsByRemoteProjectId.get(remoteProjectId) ?? []),
+      realization,
+    ])
+  }
+
+  await Promise.all(
+    Array.from(realizationsByRemoteProjectId.entries()).flatMap(
+      ([remoteProjectId, remoteRealizations]) => {
+        if (remoteRealizations.length < 2) {
+          return []
         }
-      )
-      const localOnlyCloudSyncEntries = cloudSyncMetadata.value
-        .filter(
-          (metadata) =>
-            !metadata.remoteProjectId ||
-            !remoteProjectIds.has(metadata.remoteProjectId)
-        )
-        .map((metadata) => {
-          const defaultFile = getPreservedCloudProjectDefaultFile(metadata)
 
-          return {
-            source: 'remote',
-            ...homeProjectEntryCloudSyncFields(metadata),
-            name: metadata.projectName,
-            title: metadata.projectName,
-            localProjectPath: metadata.localProjectPath,
-            remoteProjectId: metadata.remoteProjectId,
-            modified: getCloudSyncHomeProjectModifiedTime({}, metadata),
-            readWriteAccess: true,
-            ...(defaultFile ? { defaultFile } : {}),
-          } satisfies HomeProjectEntryContribution
+        return remoteRealizations.map(async (realization) => {
+          const normalizedLocalProjectPath = normalizePathForSync(
+            realization.localProjectPath
+          )
+          const baseManifest =
+            metadataByPath.get(normalizedLocalProjectPath)?.baseManifest ??
+            firstCleanBaseManifest(
+              metadataByRemoteProjectId.get(remoteProjectId)
+            )
+
+          if (!baseManifest) {
+            return
+          }
+
+          try {
+            comparisons.set(normalizedLocalProjectPath, {
+              localMatchesBase: await localProjectManifestMatchesBase({
+                baseManifest,
+                localFs: fsZds,
+                projectRoot: realization.localProjectPath,
+              }),
+            })
+          } catch {
+            comparisons.set(normalizedLocalProjectPath, {
+              manifestReadable: false,
+            })
+          }
         })
+      }
+    )
+  )
 
-      return [...remoteProjectEntries, ...localOnlyCloudSyncEntries]
+  return comparisons
+}
+
+const cloudSyncCloudProjectRelationships = defineRegistryItemFactory((ctx) => {
+  const cloudSync = ctx.services.signal(cloudSyncService)
+  const projectLibraryRealizations = ctx.valueSpecs.signal(
+    projectLibraryRealizationsValueSpec
+  )
+  const cloudSyncMetadata = signal<CloudSyncProjectMetadataIndexEntry[]>([])
+  const localManifestComparisons = signal<
+    Map<string, CloudProjectLocalManifestComparison>
+  >(new Map())
+  const remoteThumbnailUrls = signal<Map<string, string>>(new Map())
+  const requestedThumbnailKeys = new Map<string, string>()
+  let disposed = false
+  let disposeEffect: (() => void) | undefined
+  let loadId = 0
+
+  const cloudProjectRelationships = computed(() => {
+    if (!cloudSyncStatus.value.enabled) {
+      return []
+    }
+
+    return deriveCloudProjectRelationships({
+      realizations: projectLibraryRealizations.value,
+      remoteProjects: cloudSyncRemoteProjects.value,
+      metadata: cloudSyncMetadata.value,
+      localManifestComparisons: localManifestComparisons.value,
+      remoteThumbnailUrls: remoteThumbnailUrls.value,
+      preservedDefaultFiles: preservedCloudProjectDefaultFiles.value,
+      getModifiedTime: getCloudSyncProjectModifiedTime,
     })
+  })
 
-    // Defer because `effect` runs immediately, and service reads are blocked
-    // while the registry graph is still being built.
-    queueMicrotask(() => {
-      if (disposed) {
+  // Defer because `effect` runs immediately, and service reads are blocked
+  // while the registry graph is still being built.
+  queueMicrotask(() => {
+    if (disposed) {
+      return
+    }
+
+    // Keep Home cloud sync badges in sync with cloud sync metadata, even
+    // before System IO rereads local project folders.
+    disposeEffect = effect(() => {
+      const service = cloudSync.value
+      const status = cloudSyncStatus.value
+      const nextLoadId = ++loadId
+
+      if (!service || !status.enabled) {
+        cloudSyncMetadata.value = []
+        localManifestComparisons.value = new Map()
+        remoteThumbnailUrls.value = new Map()
+        requestedThumbnailKeys.clear()
         return
       }
 
-      // Keep Home cloud sync badges in sync with cloud sync metadata, even
-      // before System IO rereads local project folders.
-      disposeEffect = effect(() => {
-        const service = cloudSync.value
-        const status = cloudSyncStatus.value
-        const nextLoadId = ++loadId
+      const remoteProjects = cloudSyncRemoteProjects.value
+      const realizations = projectLibraryRealizations.value
+      pruneRemoteThumbnailState({
+        remoteProjects,
+        requestedThumbnailKeys,
+        thumbnailUrls: remoteThumbnailUrls,
+      })
 
-        if (!service || !status.enabled) {
-          cloudSyncMetadata.value = []
-          remoteThumbnailUrls.value = new Map()
-          requestedThumbnailKeys.clear()
-          return
+      for (const remoteProject of remoteProjects) {
+        const cacheKey = remoteThumbnailCacheKey(remoteProject)
+        if (requestedThumbnailKeys.get(remoteProject.id) === cacheKey) {
+          continue
         }
 
-        const remoteProjects = cloudSyncRemoteProjects.value
-        pruneRemoteThumbnailState({
-          remoteProjects,
-          requestedThumbnailKeys,
-          thumbnailUrls: remoteThumbnailUrls,
-        })
-
-        for (const remoteProject of remoteProjects) {
-          const cacheKey = remoteThumbnailCacheKey(remoteProject)
-          if (requestedThumbnailKeys.get(remoteProject.id) === cacheKey) {
-            continue
-          }
-
-          requestedThumbnailKeys.set(remoteProject.id, cacheKey)
-          service
-            .getRemoteProjectThumbnailUrl(remoteProject)
-            .then((thumbnailUrl) => {
-              if (
-                disposed ||
-                requestedThumbnailKeys.get(remoteProject.id) !== cacheKey ||
-                !thumbnailUrl
-              ) {
-                return
-              }
-
-              setRemoteThumbnailUrl(
-                remoteThumbnailUrls,
-                remoteProject.id,
-                thumbnailUrl
-              )
-            })
-            .catch((error: unknown) => {
-              if (requestedThumbnailKeys.get(remoteProject.id) === cacheKey) {
-                requestedThumbnailKeys.delete(remoteProject.id)
-              }
-              reportRejection(error)
-            })
-        }
-
+        requestedThumbnailKeys.set(remoteProject.id, cacheKey)
         service
-          .getProjectMetadataIndex()
-          .then((metadataIndex) => {
-            if (disposed || nextLoadId !== loadId) {
+          .getRemoteProjectThumbnailUrl(remoteProject)
+          .then((thumbnailUrl) => {
+            if (
+              disposed ||
+              requestedThumbnailKeys.get(remoteProject.id) !== cacheKey ||
+              !thumbnailUrl
+            ) {
               return
             }
 
-            cloudSyncMetadata.value = Array.from(metadataIndex.values()).filter(
-              (metadata) =>
-                shouldContributeCloudSyncMetadata(metadata) &&
-                !metadata.tombstone &&
-                !metadata.syncExcluded
+            setRemoteThumbnailUrl(
+              remoteThumbnailUrls,
+              remoteProject.id,
+              thumbnailUrl
             )
           })
           .catch((error: unknown) => {
-            if (!disposed && nextLoadId === loadId) {
-              cloudSyncMetadata.value = []
+            if (requestedThumbnailKeys.get(remoteProject.id) === cacheKey) {
+              requestedThumbnailKeys.delete(remoteProject.id)
             }
             reportRejection(error)
           })
-      })
-    })
+      }
 
-    return {
-      item: defineRuntimeRegistryItem({
-        id: 'cloud-sync.remote-home-project-entries',
-        provides: [
-          provide(homeProjectEntriesValueSpec, cloudSyncHomeProjectEntries, {
-            key: 'cloud-sync.remote-home-project-entries',
-          }),
-        ],
-        dispose: () => {
-          disposed = true
-          disposeEffect?.()
-        },
-      }),
-    }
-  },
-  'cloud-sync.remote-home-project-entries'
-)
+      service
+        .getProjectMetadataIndex()
+        .then((metadataIndex) => {
+          if (disposed || nextLoadId !== loadId) {
+            return
+          }
+
+          const metadata = Array.from(metadataIndex.values())
+          cloudSyncMetadata.value = metadata
+
+          readLocalManifestComparisons({
+            metadata,
+            realizations,
+          })
+            .then((comparisons) => {
+              if (disposed || nextLoadId !== loadId) {
+                return
+              }
+
+              localManifestComparisons.value = comparisons
+            })
+            .catch((error: unknown) => {
+              if (!disposed && nextLoadId === loadId) {
+                localManifestComparisons.value = new Map()
+              }
+              reportRejection(error)
+            })
+        })
+        .catch((error: unknown) => {
+          if (!disposed && nextLoadId === loadId) {
+            cloudSyncMetadata.value = []
+            localManifestComparisons.value = new Map()
+          }
+          reportRejection(error)
+        })
+    })
+  })
+
+  return {
+    item: defineRuntimeRegistryItem({
+      id: 'cloud-sync.cloud-project-relationships',
+      provides: [
+        provide(cloudProjectRelationshipsValueSpec, cloudProjectRelationships, {
+          key: 'cloud-sync.cloud-project-relationships',
+        }),
+      ],
+      dispose: () => {
+        disposed = true
+        disposeEffect?.()
+      },
+    }),
+  }
+}, 'cloud-sync.cloud-project-relationships')
 
 /**
  * The `cloud` project-library *type* handler (browse/create in the local
@@ -809,7 +811,7 @@ export const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
     systemIO.value?.actor.send({
       type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
     })
-    invalidateConfiguredProjectLibraryEntries()
+    invalidateProjectLibraryRealizations()
   }
 
   const cloudLibraryType: ProjectLibraryTypeContribution = {
@@ -1022,33 +1024,28 @@ export const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
         },
       },
     },
-    readEntries: async ({ library, signal }) => {
+    readRealizations: async ({ library, signal }) => {
       const wasmInstancePromise = getWasmPromise()
       if (wasmInstancePromise instanceof Error) {
         return Promise.reject(wasmInstancePromise)
       }
 
-      const projectDirectoryPath =
-        await getCloudProjectLibraryMaterializationDirectoryPath(library)
       const projects = await readProjectsFromProjectDirectory({
-        projectDirectoryPath,
+        projectDirectoryPath:
+          await getCloudProjectLibraryMaterializationDirectoryPath(library),
         wasmInstancePromise,
         signal,
       })
       if (!signal.aborted) {
         scheduleCloudProjectDirectoryNameSyncFromTitles({
           projects,
-          onProjectDirectoriesRenamed:
-            invalidateConfiguredProjectLibraryEntries,
+          onProjectDirectoriesRenamed: invalidateProjectLibraryRealizations,
         })
       }
 
-      return projects.map((project) => ({
-        ...homeProjectEntryFromProject(project),
-        libraryId: library.id,
-        libraryPath: projectDirectoryPath,
-        libraryType: library.type,
-      }))
+      return projects.map((project) =>
+        projectLibraryRealizationFromProject(project, library)
+      )
     },
   }
 
@@ -1085,7 +1082,7 @@ export const cloudSyncPlugin = createZdsPlugin({
   items: [
     cloudConflictProjectMenuItem,
     cloudSyncStatusBarItemContribution,
-    cloudSyncRemoteHomeProjectEntryContribution,
+    cloudSyncCloudProjectRelationships,
   ],
   defaultSetting: 'off',
   // On web, cloud sync is the project storage layer rather than an optional

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -44,6 +44,7 @@ import {
 import { localProjectManifestMatchesBase } from '@src/lib/cloudSync/localManifest'
 import {
   type CloudProjectLocalManifestComparison,
+  classifyCloudProjectDuplicateRisk,
   deriveCloudProjectRelationships,
 } from '@src/lib/cloudSync/relationships'
 import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
@@ -550,6 +551,79 @@ function firstCleanBaseManifest(
   )?.baseManifest
 }
 
+function realizationIsOnlyInCloudLibraries(
+  realization: ProjectLibraryRealization
+) {
+  return (
+    realization.libraryRefs.length > 0 &&
+    realization.libraryRefs.every(
+      (library) => library.type === CLOUD_PROJECT_LIBRARY_TYPE
+    )
+  )
+}
+
+function realizationIsInCloudLibrary(realization: ProjectLibraryRealization) {
+  return realization.libraryRefs.some(
+    (library) => library.type === CLOUD_PROJECT_LIBRARY_TYPE
+  )
+}
+
+function cheapDuplicateRiskIsClean(
+  realization: ProjectLibraryRealization,
+  metadata: CloudSyncProjectMetadataIndexEntry | undefined
+) {
+  return (
+    classifyCloudProjectDuplicateRisk({
+      hasPendingChanges: metadata?.hasPendingChanges,
+      hasConflict: Boolean(metadata?.conflict || realization.conflict),
+      readWriteAccess: realization.readWriteAccess,
+      tombstone: metadata?.tombstone,
+      syncExcluded: Boolean(metadata?.syncExcluded),
+    }) === 'unknown'
+  )
+}
+
+function manifestComparisonCanonicalKey({
+  metadata,
+  realization,
+}: {
+  metadata: CloudSyncProjectMetadataIndexEntry | undefined
+  realization: ProjectLibraryRealization
+}) {
+  const clean = cheapDuplicateRiskIsClean(realization, metadata)
+  const cloudLibrary = realizationIsInCloudLibrary(realization)
+  const modified = String(realization.modified ?? 0).padStart(16, '0')
+
+  return [
+    clean && cloudLibrary ? '2' : clean ? '1' : '0',
+    modified,
+    realization.localProjectPath,
+  ].join(':')
+}
+
+function selectManifestComparisonCanonical({
+  metadataByPath,
+  realizations,
+}: {
+  metadataByPath: ReadonlyMap<string, CloudSyncProjectMetadataIndexEntry>
+  realizations: readonly ProjectLibraryRealization[]
+}) {
+  return realizations.toSorted((left, right) => {
+    const leftKey = manifestComparisonCanonicalKey({
+      metadata: metadataByPath.get(normalizePathForSync(left.localProjectPath)),
+      realization: left,
+    })
+    const rightKey = manifestComparisonCanonicalKey({
+      metadata: metadataByPath.get(
+        normalizePathForSync(right.localProjectPath)
+      ),
+      realization: right,
+    })
+
+    return rightKey.localeCompare(leftKey)
+  })[0]
+}
+
 async function readLocalManifestComparisons({
   metadata,
   realizations,
@@ -589,12 +663,35 @@ async function readLocalManifestComparisons({
           return []
         }
 
+        const canonical = selectManifestComparisonCanonical({
+          metadataByPath,
+          realizations: remoteRealizations,
+        })
+        const canonicalPath = canonical
+          ? normalizePathForSync(canonical.localProjectPath)
+          : undefined
+
         return remoteRealizations.map(async (realization) => {
           const normalizedLocalProjectPath = normalizePathForSync(
             realization.localProjectPath
           )
+          const realizationMetadata = metadataByPath.get(
+            normalizedLocalProjectPath
+          )
+
+          // Manifest comparison walks and hashes project files. Only pay that
+          // cost for non-canonical cloud-library copies that could become
+          // exact, silently removable duplicates.
+          if (
+            normalizedLocalProjectPath === canonicalPath ||
+            !realizationIsOnlyInCloudLibraries(realization) ||
+            !cheapDuplicateRiskIsClean(realization, realizationMetadata)
+          ) {
+            return
+          }
+
           const baseManifest =
-            metadataByPath.get(normalizedLocalProjectPath)?.baseManifest ??
+            realizationMetadata?.baseManifest ??
             firstCleanBaseManifest(
               metadataByRemoteProjectId.get(remoteProjectId)
             )

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -122,24 +122,6 @@ function openCloudConflictDialog(request: CloudConflictDialogRequest) {
   cloudConflictDialogRequest.value = request
 }
 
-const preservedCloudProjectDefaultFiles = signal<Map<string, string>>(new Map())
-
-export function preserveCloudProjectDefaultFile({
-  localProjectPath,
-  defaultFile,
-}: {
-  localProjectPath?: string
-  defaultFile?: string
-}) {
-  if (!localProjectPath || !defaultFile) {
-    return
-  }
-
-  const nextDefaultFiles = new Map(preservedCloudProjectDefaultFiles.value)
-  nextDefaultFiles.set(normalizePathForSync(localProjectPath), defaultFile)
-  preservedCloudProjectDefaultFiles.value = nextDefaultFiles
-}
-
 function CloudProjectLibrarySettingsDetails({
   library,
 }: ProjectLibrarySettingsDetailsProps) {
@@ -667,7 +649,6 @@ const cloudSyncCloudProjectRelationships = defineRegistryItemFactory((ctx) => {
       metadata: cloudSyncMetadata.value,
       localManifestComparisons: localManifestComparisons.value,
       remoteThumbnailUrls: remoteThumbnailUrls.value,
-      preservedDefaultFiles: preservedCloudProjectDefaultFiles.value,
       getModifiedTime: getCloudSyncProjectModifiedTime,
     })
   })
@@ -1005,11 +986,6 @@ export const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
             sourceProjectPath: source.localProjectPath,
             sourceProjectName: source.localProjectName,
             defaultFile: source.defaultFile,
-          })
-
-          preserveCloudProjectDefaultFile({
-            localProjectPath: result.localProjectPath,
-            defaultFile: result.defaultFile,
           })
 
           if (cloudSyncStatus.value.enabled) {

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -4,6 +4,7 @@ import {
   defineRegistryItemFactory,
   defineRuntimeRegistryItem,
   provide,
+  provideService,
 } from '@kittycad/registry'
 import {
   computed,
@@ -72,7 +73,7 @@ import { reportRejection } from '@src/lib/trap'
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
 import { userFeaturesContextHas } from '@src/machines/userFeaturesMachine'
 import {
-  cloudProjectRelationshipsValueSpec,
+  cloudProjectRelationshipsService,
   cloudSyncService,
 } from '@src/registry/contracts/cloudSync'
 import {
@@ -756,9 +757,9 @@ const cloudSyncCloudProjectRelationships = defineRegistryItemFactory((ctx) => {
   return {
     item: defineRuntimeRegistryItem({
       id: 'cloud-sync.cloud-project-relationships',
-      provides: [
-        provide(cloudProjectRelationshipsValueSpec, cloudProjectRelationships, {
-          key: 'cloud-sync.cloud-project-relationships',
+      providesServices: [
+        provideService(cloudProjectRelationshipsService, {
+          relationships: cloudProjectRelationships,
         }),
       ],
       dispose: () => {

--- a/src/lib/cloudSync/relationships.test.ts
+++ b/src/lib/cloudSync/relationships.test.ts
@@ -202,7 +202,6 @@ describe('deriveCloudProjectRelationships', () => {
     ).toEqual([
       expect.objectContaining({
         remoteProjectId: 'remote-only',
-        name: 'Remote Only',
         canonicalRealization: undefined,
         duplicateRealizations: [],
         localRealizations: [],

--- a/src/lib/cloudSync/relationships.test.ts
+++ b/src/lib/cloudSync/relationships.test.ts
@@ -1,0 +1,228 @@
+import {
+  classifyCloudProjectDuplicateRisk,
+  deriveCloudProjectRelationships,
+} from '@src/lib/cloudSync/relationships'
+import type { CloudSyncProjectMetadataIndexEntry } from '@src/lib/cloudSync/types'
+import type { ProjectLibraryRealization } from '@src/registry/contracts/projectLibraries'
+import { describe, expect, test } from 'vitest'
+
+function projectNameFromPath(projectPath: string) {
+  return projectPath.slice(projectPath.lastIndexOf('/') + 1)
+}
+
+function realization(
+  overrides: Partial<ProjectLibraryRealization> & {
+    localProjectPath: string
+    libraryType: string
+  }
+): ProjectLibraryRealization {
+  const { libraryType, localProjectPath, ...rest } = overrides
+  const localProjectName = projectNameFromPath(localProjectPath)
+
+  return {
+    id: `local:${localProjectPath}`,
+    libraryIds: [`${libraryType}-library`],
+    libraryRefs: [
+      {
+        id: `${libraryType}-library`,
+        title: libraryType === 'cloud' ? 'Personal Cloud' : 'Projects',
+        path: libraryType === 'cloud' ? '/cloud' : '/projects',
+        type: libraryType,
+      },
+    ],
+    localProjectPath,
+    localProjectName,
+    name: localProjectName,
+    cloudProjectId: 'remote-123',
+    modified: 1,
+    readWriteAccess: true,
+    ...rest,
+  }
+}
+
+function metadata(
+  overrides: Partial<CloudSyncProjectMetadataIndexEntry> & {
+    localProjectPath: string
+  }
+): CloudSyncProjectMetadataIndexEntry {
+  const { localProjectPath, ...rest } = overrides
+  const projectName = projectNameFromPath(localProjectPath)
+
+  return {
+    schemaVersion: 1,
+    localProjectPath,
+    projectName,
+    remoteProjectId: 'remote-123',
+    hasPendingChanges: false,
+    baseManifest: { files: {} },
+    ...rest,
+  }
+}
+
+describe('deriveCloudProjectRelationships', () => {
+  test('groups local realizations by remote project id and prefers a clean cloud-library canonical', () => {
+    const relationships = deriveCloudProjectRelationships({
+      realizations: [
+        realization({
+          localProjectPath: '/projects/bracket',
+          libraryType: 'directory',
+          modified: 20,
+        }),
+        realization({
+          localProjectPath: '/cloud/bracket',
+          libraryType: 'cloud',
+          modified: 10,
+        }),
+        realization({
+          localProjectPath: '/cloud/bracket-copy',
+          libraryType: 'cloud',
+          modified: 5,
+        }),
+      ],
+      remoteProjects: [{ id: 'remote-123', title: 'Remote Bracket' }],
+      metadata: [
+        metadata({ localProjectPath: '/projects/bracket' }),
+        metadata({ localProjectPath: '/cloud/bracket' }),
+        metadata({ localProjectPath: '/cloud/bracket-copy' }),
+      ],
+    })
+
+    expect(relationships).toEqual([
+      expect.objectContaining({
+        remoteProjectId: 'remote-123',
+        canonicalRealization: expect.objectContaining({
+          role: 'canonical',
+          realization: expect.objectContaining({
+            localProjectPath: '/cloud/bracket',
+          }),
+        }),
+        duplicateRealizations: [
+          expect.objectContaining({
+            duplicateRisk: 'unknown',
+            autoCleanupEligible: false,
+            realization: expect.objectContaining({
+              localProjectPath: '/projects/bracket',
+            }),
+          }),
+          expect.objectContaining({
+            duplicateRisk: 'unknown',
+            autoCleanupEligible: false,
+            realization: expect.objectContaining({
+              localProjectPath: '/cloud/bracket-copy',
+            }),
+          }),
+        ],
+      }),
+    ])
+  })
+
+  test('prefers the newest clean synced realization when no cloud-library realization exists', () => {
+    const relationships = deriveCloudProjectRelationships({
+      realizations: [
+        realization({
+          localProjectPath: '/archive/bracket',
+          libraryType: 'directory',
+          modified: 10,
+        }),
+        realization({
+          localProjectPath: '/projects/bracket',
+          libraryType: 'directory',
+          modified: 20,
+        }),
+      ],
+      remoteProjects: [{ id: 'remote-123', title: 'Remote Bracket' }],
+      metadata: [
+        metadata({ localProjectPath: '/archive/bracket' }),
+        metadata({ localProjectPath: '/projects/bracket' }),
+      ],
+    })
+
+    expect(
+      relationships[0]?.canonicalRealization?.realization.localProjectPath
+    ).toBe('/projects/bracket')
+  })
+
+  test('uses local manifest comparisons to classify exact and divergent duplicates', () => {
+    const relationships = deriveCloudProjectRelationships({
+      realizations: [
+        realization({
+          localProjectPath: '/projects/bracket',
+          libraryType: 'directory',
+          modified: 20,
+        }),
+        realization({
+          localProjectPath: '/cloud/bracket',
+          libraryType: 'cloud',
+          modified: 10,
+        }),
+        realization({
+          localProjectPath: '/cloud/bracket-copy',
+          libraryType: 'cloud',
+          modified: 5,
+        }),
+      ],
+      remoteProjects: [{ id: 'remote-123', title: 'Remote Bracket' }],
+      metadata: [
+        metadata({ localProjectPath: '/projects/bracket' }),
+        metadata({ localProjectPath: '/cloud/bracket' }),
+        metadata({ localProjectPath: '/cloud/bracket-copy' }),
+      ],
+      localManifestComparisons: new Map([
+        ['/projects/bracket', { localMatchesBase: false }],
+        ['/cloud/bracket', { localMatchesBase: true }],
+        ['/cloud/bracket-copy', { localMatchesBase: true }],
+      ]),
+    })
+
+    expect(relationships[0]?.duplicateRealizations).toEqual([
+      expect.objectContaining({
+        duplicateRisk: 'divergent',
+        autoCleanupEligible: false,
+        realization: expect.objectContaining({
+          localProjectPath: '/projects/bracket',
+        }),
+      }),
+      expect.objectContaining({
+        duplicateRisk: 'exact',
+        autoCleanupEligible: true,
+        realization: expect.objectContaining({
+          localProjectPath: '/cloud/bracket-copy',
+        }),
+      }),
+    ])
+  })
+
+  test('creates remote-only relationships from remote projects', () => {
+    expect(
+      deriveCloudProjectRelationships({
+        realizations: [],
+        remoteProjects: [{ id: 'remote-only', title: 'Remote Only' }],
+        metadata: [],
+      })
+    ).toEqual([
+      expect.objectContaining({
+        remoteProjectId: 'remote-only',
+        name: 'Remote Only',
+        canonicalRealization: undefined,
+        duplicateRealizations: [],
+        localRealizations: [],
+      }),
+    ])
+  })
+})
+
+describe('classifyCloudProjectDuplicateRisk', () => {
+  test.each([
+    ['tombstoned', { tombstone: true }],
+    ['sync-excluded', { syncExcluded: true }],
+    ['conflicted', { hasConflict: true }],
+    ['pending', { hasPendingChanges: true }],
+    ['unreadable', { readWriteAccess: false }],
+    ['unreadable', { manifestReadable: false }],
+    ['divergent', { localMatchesBase: false }],
+    ['exact', { hasBaseManifest: true, localMatchesBase: true }],
+    ['unknown', {}],
+  ] as const)('classifies %s duplicate realizations', (expected, input) => {
+    expect(classifyCloudProjectDuplicateRisk(input)).toBe(expected)
+  })
+})

--- a/src/lib/cloudSync/relationships.ts
+++ b/src/lib/cloudSync/relationships.ts
@@ -1,0 +1,350 @@
+import { normalizePathForSync } from '@src/lib/cloudSync/paths'
+import type {
+  CloudSyncProjectMetadataIndexEntry,
+  RemoteProjectSummary,
+} from '@src/lib/cloudSync/types'
+import { CLOUD_PROJECT_LIBRARY_TYPE } from '@src/lib/projectLibraries'
+import type {
+  CloudProjectDuplicateRisk,
+  CloudProjectRelationship,
+  CloudProjectRelationshipRealization,
+} from '@src/registry/contracts/cloudSync'
+import type { ProjectLibraryRealization } from '@src/registry/contracts/projectLibraries'
+
+export type DeriveCloudProjectRelationshipsInput = {
+  realizations: readonly ProjectLibraryRealization[]
+  remoteProjects: readonly RemoteProjectSummary[]
+  metadata: readonly CloudSyncProjectMetadataIndexEntry[]
+  localManifestComparisons?: ReadonlyMap<
+    string,
+    CloudProjectLocalManifestComparison
+  >
+  remoteThumbnailUrls?: ReadonlyMap<string, string>
+  preservedDefaultFiles?: ReadonlyMap<string, string>
+  getModifiedTime?: (
+    metadata: CloudSyncProjectMetadataIndexEntry | undefined,
+    localModified: number | null | undefined
+  ) => number | null
+}
+
+export type ClassifyCloudProjectDuplicateRiskInput = {
+  hasBaseManifest?: boolean
+  hasPendingChanges?: boolean
+  hasConflict?: boolean
+  readWriteAccess?: boolean
+  tombstone?: boolean
+  syncExcluded?: boolean
+  localMatchesBase?: boolean
+  manifestReadable?: boolean
+}
+
+export type CloudProjectLocalManifestComparison = {
+  localMatchesBase?: boolean
+  manifestReadable?: boolean
+}
+
+function cloudProjectRelationshipId(remoteProjectId: string) {
+  return `cloud:${remoteProjectId}`
+}
+
+function realizationIsInCloudLibrary(realization: ProjectLibraryRealization) {
+  return realization.libraryRefs.some(
+    (library) => library.type === CLOUD_PROJECT_LIBRARY_TYPE
+  )
+}
+
+function realizationIsOnlyInCloudLibraries(
+  realization: ProjectLibraryRealization
+) {
+  return (
+    realization.libraryRefs.length > 0 &&
+    realization.libraryRefs.every(
+      (library) => library.type === CLOUD_PROJECT_LIBRARY_TYPE
+    )
+  )
+}
+
+/**
+ * Exact/divergent are reserved for callers that have compared the current
+ * local manifest with the relationship's clean base. Metadata alone can only
+ * classify known policy states such as pending, conflicted, tombstoned, or
+ * sync-excluded.
+ */
+export function classifyCloudProjectDuplicateRisk({
+  hasBaseManifest,
+  hasPendingChanges,
+  hasConflict,
+  readWriteAccess = true,
+  tombstone,
+  syncExcluded,
+  localMatchesBase,
+  manifestReadable = true,
+}: ClassifyCloudProjectDuplicateRiskInput): CloudProjectDuplicateRisk {
+  if (tombstone) {
+    return 'tombstoned'
+  }
+  if (syncExcluded) {
+    return 'sync-excluded'
+  }
+  if (hasConflict) {
+    return 'conflicted'
+  }
+  if (hasPendingChanges) {
+    return 'pending'
+  }
+  if (!readWriteAccess || !manifestReadable) {
+    return 'unreadable'
+  }
+  if (localMatchesBase === false) {
+    return 'divergent'
+  }
+  if (hasBaseManifest && localMatchesBase === true) {
+    return 'exact'
+  }
+
+  return 'unknown'
+}
+
+function classifyDuplicateRisk({
+  localManifestComparison,
+  realization,
+  metadata,
+}: {
+  localManifestComparison?: CloudProjectLocalManifestComparison
+  realization: ProjectLibraryRealization
+  metadata: CloudSyncProjectMetadataIndexEntry | undefined
+}): CloudProjectDuplicateRisk {
+  return classifyCloudProjectDuplicateRisk({
+    hasBaseManifest: Boolean(
+      metadata?.baseManifest ||
+        localManifestComparison?.localMatchesBase !== undefined
+    ),
+    hasPendingChanges: metadata?.hasPendingChanges,
+    hasConflict: Boolean(metadata?.conflict || realization.conflict),
+    readWriteAccess: realization.readWriteAccess,
+    tombstone: metadata?.tombstone,
+    syncExcluded: Boolean(metadata?.syncExcluded),
+    localMatchesBase: localManifestComparison?.localMatchesBase,
+    manifestReadable: localManifestComparison?.manifestReadable,
+  })
+}
+
+function duplicateRiskIsClean(risk: CloudProjectDuplicateRisk) {
+  return risk === 'exact' || risk === 'unknown'
+}
+
+function canonicalPreferenceKey(
+  relationshipRealization: CloudProjectRelationshipRealization
+) {
+  const { realization, duplicateRisk } = relationshipRealization
+  const clean = duplicateRiskIsClean(duplicateRisk)
+  const cloudLibrary = realizationIsInCloudLibrary(realization)
+  const modified = String(realization.modified ?? 0).padStart(16, '0')
+
+  return [
+    clean && cloudLibrary ? '2' : clean ? '1' : '0',
+    modified,
+    realization.localProjectPath,
+  ].join(':')
+}
+
+function selectCanonicalRealization(
+  realizations: readonly CloudProjectRelationshipRealization[]
+) {
+  return realizations.toSorted((a, b) =>
+    canonicalPreferenceKey(b).localeCompare(canonicalPreferenceKey(a))
+  )[0]
+}
+
+function relationshipTitle({
+  canonical,
+  remoteProject,
+  metadata,
+}: {
+  canonical: CloudProjectRelationshipRealization | undefined
+  remoteProject: RemoteProjectSummary | undefined
+  metadata: CloudSyncProjectMetadataIndexEntry | undefined
+}) {
+  return (
+    canonical?.realization.title ||
+    metadata?.projectName ||
+    remoteProject?.title ||
+    remoteProject?.id
+  )
+}
+
+function relationshipName({
+  canonical,
+  remoteProject,
+  metadata,
+  remoteProjectId,
+}: {
+  canonical: CloudProjectRelationshipRealization | undefined
+  remoteProject: RemoteProjectSummary | undefined
+  metadata: CloudSyncProjectMetadataIndexEntry | undefined
+  remoteProjectId: string
+}) {
+  return (
+    canonical?.realization.name ||
+    metadata?.projectName ||
+    remoteProject?.title ||
+    remoteProjectId
+  )
+}
+
+function remoteModifiedTime(remoteProject: RemoteProjectSummary | undefined) {
+  const modified = remoteProject?.updated_at
+    ? Date.parse(remoteProject.updated_at)
+    : NaN
+
+  return Number.isNaN(modified) ? undefined : modified
+}
+
+export function deriveCloudProjectRelationships({
+  localManifestComparisons = new Map(),
+  realizations,
+  remoteProjects,
+  metadata,
+  remoteThumbnailUrls = new Map(),
+  preservedDefaultFiles = new Map(),
+  getModifiedTime,
+}: DeriveCloudProjectRelationshipsInput): CloudProjectRelationship[] {
+  const remoteProjectsById = new Map(
+    remoteProjects.map((project) => [project.id, project])
+  )
+  const metadataByPath = new Map(
+    metadata.map((entry) => [
+      normalizePathForSync(entry.localProjectPath),
+      entry,
+    ])
+  )
+  const metadataByRemoteProjectId = new Map<
+    string,
+    CloudSyncProjectMetadataIndexEntry[]
+  >()
+  const realizationsByRemoteProjectId = new Map<
+    string,
+    ProjectLibraryRealization[]
+  >()
+  const remoteProjectIds = new Set(remoteProjects.map((project) => project.id))
+
+  for (const entry of metadata) {
+    if (!entry.remoteProjectId) {
+      continue
+    }
+    if (
+      !entry.tombstone &&
+      !entry.syncExcluded &&
+      (entry.conflict || entry.lastFailure)
+    ) {
+      remoteProjectIds.add(entry.remoteProjectId)
+    }
+    const entries = metadataByRemoteProjectId.get(entry.remoteProjectId) ?? []
+    entries.push(entry)
+    metadataByRemoteProjectId.set(entry.remoteProjectId, entries)
+  }
+
+  for (const realization of realizations) {
+    const remoteProjectId = realization.cloudProjectId?.trim()
+    if (!remoteProjectId) {
+      continue
+    }
+    remoteProjectIds.add(remoteProjectId)
+    const groupedRealizations =
+      realizationsByRemoteProjectId.get(remoteProjectId) ?? []
+    groupedRealizations.push(realization)
+    realizationsByRemoteProjectId.set(remoteProjectId, groupedRealizations)
+  }
+
+  return Array.from(remoteProjectIds)
+    .toSorted((a, b) => a.localeCompare(b))
+    .map((remoteProjectId) => {
+      const remoteProject = remoteProjectsById.get(remoteProjectId)
+      const relationshipMetadata =
+        metadataByRemoteProjectId.get(remoteProjectId) ?? []
+      const firstMetadata = relationshipMetadata[0]
+      const relationshipRealizations = (
+        realizationsByRemoteProjectId.get(remoteProjectId) ?? []
+      ).map((realization): CloudProjectRelationshipRealization => {
+        const localMetadata = metadataByPath.get(
+          normalizePathForSync(realization.localProjectPath)
+        )
+        const localManifestComparison = localManifestComparisons.get(
+          normalizePathForSync(realization.localProjectPath)
+        )
+        const duplicateRisk = classifyDuplicateRisk({
+          localManifestComparison,
+          realization,
+          metadata: localMetadata,
+        })
+
+        return {
+          role: 'duplicate',
+          realization,
+          duplicateRisk,
+          autoCleanupEligible:
+            duplicateRisk === 'exact' &&
+            realizationIsOnlyInCloudLibraries(realization),
+        }
+      })
+      const canonical = selectCanonicalRealization(relationshipRealizations)
+      const localRealizations = relationshipRealizations.map((entry) =>
+        entry === canonical
+          ? {
+              ...entry,
+              role: 'canonical' as const,
+              autoCleanupEligible: false,
+            }
+          : entry
+      )
+      const canonicalRealization = localRealizations.find(
+        (entry) => entry.role === 'canonical'
+      )
+      const duplicateRealizations = localRealizations.filter(
+        (entry) => entry.role === 'duplicate'
+      )
+      const preservedDefaultFile = firstMetadata
+        ? preservedDefaultFiles.get(
+            normalizePathForSync(firstMetadata.localProjectPath)
+          )
+        : undefined
+      const modified =
+        getModifiedTime?.(
+          firstMetadata,
+          canonicalRealization?.realization.modified ??
+            remoteModifiedTime(remoteProject)
+        ) ??
+        canonicalRealization?.realization.modified ??
+        remoteModifiedTime(remoteProject)
+
+      return {
+        id: cloudProjectRelationshipId(remoteProjectId),
+        remoteProjectId,
+        remoteProject,
+        canonicalRealization,
+        duplicateRealizations,
+        localRealizations,
+        name: relationshipName({
+          canonical: canonicalRealization,
+          remoteProject,
+          metadata: firstMetadata,
+          remoteProjectId,
+        }),
+        title: relationshipTitle({
+          canonical: canonicalRealization,
+          remoteProject,
+          metadata: firstMetadata,
+        }),
+        modified: modified ?? undefined,
+        remoteThumbnailUrl: remoteThumbnailUrls.get(remoteProjectId),
+        defaultFile:
+          canonicalRealization?.realization.defaultFile ?? preservedDefaultFile,
+        conflict:
+          canonicalRealization?.realization.conflict ?? firstMetadata?.conflict,
+        syncFailure:
+          firstMetadata?.lastFailure?.kind === 'remote-upload-forbidden'
+            ? firstMetadata.lastFailure
+            : undefined,
+      }
+    })
+}

--- a/src/lib/cloudSync/relationships.ts
+++ b/src/lib/cloudSync/relationships.ts
@@ -11,6 +11,14 @@ import type {
 } from '@src/registry/contracts/cloudSync'
 import type { ProjectLibraryRealization } from '@src/registry/contracts/projectLibraries'
 
+/**
+ * Inputs for the pure cloud-relationship derivation pass.
+ *
+ * projectLibraries contributes local realizations. cloudSync adds cloud-side
+ * project records, sync metadata, manifest comparisons, and remote artifacts.
+ * Callers must gather those observations before calling this module; derivation
+ * itself must not touch disk, network, or service methods.
+ */
 export type DeriveCloudProjectRelationshipsInput = {
   realizations: readonly ProjectLibraryRealization[]
   remoteProjects: readonly RemoteProjectSummary[]
@@ -26,6 +34,11 @@ export type DeriveCloudProjectRelationshipsInput = {
   ) => number | null
 }
 
+/**
+ * Facts used to classify cleanup risk for one local realization. Missing facts
+ * deliberately degrade to `unknown` instead of pretending a folder is safe to
+ * delete.
+ */
 export type ClassifyCloudProjectDuplicateRiskInput = {
   hasBaseManifest?: boolean
   hasPendingChanges?: boolean
@@ -37,11 +50,19 @@ export type ClassifyCloudProjectDuplicateRiskInput = {
   manifestReadable?: boolean
 }
 
+/**
+ * Result of comparing the current local project manifest against the clean base
+ * manifest stored for the cloud relationship.
+ */
 export type CloudProjectLocalManifestComparison = {
   localMatchesBase?: boolean
   manifestReadable?: boolean
 }
 
+/**
+ * Lookup tables built once per derivation so later helpers can operate on one
+ * remote project ID at a time without repeating grouping or path normalization.
+ */
 type RelationshipInputIndex = {
   getModifiedTime?: DeriveCloudProjectRelationshipsInput['getModifiedTime']
   localManifestComparisons: ReadonlyMap<
@@ -62,6 +83,7 @@ type RelationshipInputIndex = {
   remoteThumbnailUrls: ReadonlyMap<string, string>
 }
 
+/** The complete local, remote, and metadata context for one remote project ID. */
 type RelationshipContext = {
   metadata: readonly CloudSyncProjectMetadataIndexEntry[]
   remoteProject?: RemoteProjectSummary
@@ -159,6 +181,12 @@ function duplicateRiskIsClean(risk: CloudProjectDuplicateRisk) {
   return risk === 'exact' || risk === 'unknown'
 }
 
+/**
+ * Canonical selection policy:
+ * 1. Prefer a clean realization in a cloud library.
+ * 2. Otherwise prefer any clean synced realization.
+ * 3. Otherwise keep the newest local realization as a display-only fallback.
+ */
 function canonicalPreferenceKey(
   relationshipRealization: CloudProjectRelationshipRealization
 ) {
@@ -196,6 +224,10 @@ function groupedMapSet<K, V>(map: Map<K, V[]>, key: K, value: V) {
   map.set(key, values)
 }
 
+/**
+ * Metadata can preserve a relationship even without a listed remote project or
+ * readable local realization. This keeps conflicts and sync failures visible.
+ */
 function relationshipShouldExistForMetadata(
   metadata: CloudSyncProjectMetadataIndexEntry
 ) {
@@ -206,6 +238,7 @@ function relationshipShouldExistForMetadata(
   )
 }
 
+/** Groups every relationship input by normalized path and remote project ID. */
 function indexRelationshipInputs({
   getModifiedTime,
   localManifestComparisons = new Map(),
@@ -279,6 +312,11 @@ function relationshipContexts(
     }))
 }
 
+/**
+ * Converts one local realization into relationship state. It starts as a
+ * duplicate candidate; canonical selection happens only after all realizations
+ * for the remote project ID are visible.
+ */
 function relationshipRealizationFromLocal(
   index: RelationshipInputIndex,
   realization: ProjectLibraryRealization
@@ -304,6 +342,7 @@ function relationshipRealizationFromLocal(
   }
 }
 
+/** Marks one local realization canonical and leaves the rest as duplicates. */
 function localRealizationsFromContext(
   index: RelationshipInputIndex,
   context: RelationshipContext
@@ -362,6 +401,11 @@ function relationshipSyncFailure(context: RelationshipContext) {
     : undefined
 }
 
+/**
+ * Builds the public cloud relationship for one remote project ID. Display-only
+ * fields such as Home card name/title/default file are intentionally omitted;
+ * Home derives them from the relationship plus canonical realization.
+ */
 function relationshipFromContext(
   index: RelationshipInputIndex,
   context: RelationshipContext
@@ -393,6 +437,12 @@ function relationshipFromContext(
   }
 }
 
+/**
+ * Derives explicit remote-project-to-local-realization relationships. This is
+ * where cloud identity resolution, canonical selection, and duplicate
+ * classification happen; Home receives the result as already-resolved domain
+ * state.
+ */
 export function deriveCloudProjectRelationships(
   input: DeriveCloudProjectRelationshipsInput
 ): CloudProjectRelationship[] {

--- a/src/lib/cloudSync/relationships.ts
+++ b/src/lib/cloudSync/relationships.ts
@@ -20,7 +20,6 @@ export type DeriveCloudProjectRelationshipsInput = {
     CloudProjectLocalManifestComparison
   >
   remoteThumbnailUrls?: ReadonlyMap<string, string>
-  preservedDefaultFiles?: ReadonlyMap<string, string>
   getModifiedTime?: (
     metadata: CloudSyncProjectMetadataIndexEntry | undefined,
     localModified: number | null | undefined
@@ -41,6 +40,33 @@ export type ClassifyCloudProjectDuplicateRiskInput = {
 export type CloudProjectLocalManifestComparison = {
   localMatchesBase?: boolean
   manifestReadable?: boolean
+}
+
+type RelationshipInputIndex = {
+  getModifiedTime?: DeriveCloudProjectRelationshipsInput['getModifiedTime']
+  localManifestComparisons: ReadonlyMap<
+    string,
+    CloudProjectLocalManifestComparison
+  >
+  metadataByPath: ReadonlyMap<string, CloudSyncProjectMetadataIndexEntry>
+  metadataByRemoteProjectId: ReadonlyMap<
+    string,
+    readonly CloudSyncProjectMetadataIndexEntry[]
+  >
+  realizationsByRemoteProjectId: ReadonlyMap<
+    string,
+    readonly ProjectLibraryRealization[]
+  >
+  remoteProjectIds: ReadonlySet<string>
+  remoteProjectsById: ReadonlyMap<string, RemoteProjectSummary>
+  remoteThumbnailUrls: ReadonlyMap<string, string>
+}
+
+type RelationshipContext = {
+  metadata: readonly CloudSyncProjectMetadataIndexEntry[]
+  remoteProject?: RemoteProjectSummary
+  remoteProjectId: string
+  realizations: readonly ProjectLibraryRealization[]
 }
 
 function cloudProjectRelationshipId(remoteProjectId: string) {
@@ -156,42 +182,6 @@ function selectCanonicalRealization(
   )[0]
 }
 
-function relationshipTitle({
-  canonical,
-  remoteProject,
-  metadata,
-}: {
-  canonical: CloudProjectRelationshipRealization | undefined
-  remoteProject: RemoteProjectSummary | undefined
-  metadata: CloudSyncProjectMetadataIndexEntry | undefined
-}) {
-  return (
-    canonical?.realization.title ||
-    metadata?.projectName ||
-    remoteProject?.title ||
-    remoteProject?.id
-  )
-}
-
-function relationshipName({
-  canonical,
-  remoteProject,
-  metadata,
-  remoteProjectId,
-}: {
-  canonical: CloudProjectRelationshipRealization | undefined
-  remoteProject: RemoteProjectSummary | undefined
-  metadata: CloudSyncProjectMetadataIndexEntry | undefined
-  remoteProjectId: string
-}) {
-  return (
-    canonical?.realization.name ||
-    metadata?.projectName ||
-    remoteProject?.title ||
-    remoteProjectId
-  )
-}
-
 function remoteModifiedTime(remoteProject: RemoteProjectSummary | undefined) {
   const modified = remoteProject?.updated_at
     ? Date.parse(remoteProject.updated_at)
@@ -200,15 +190,30 @@ function remoteModifiedTime(remoteProject: RemoteProjectSummary | undefined) {
   return Number.isNaN(modified) ? undefined : modified
 }
 
-export function deriveCloudProjectRelationships({
+function groupedMapSet<K, V>(map: Map<K, V[]>, key: K, value: V) {
+  const values = map.get(key) ?? []
+  values.push(value)
+  map.set(key, values)
+}
+
+function relationshipShouldExistForMetadata(
+  metadata: CloudSyncProjectMetadataIndexEntry
+) {
+  return (
+    !metadata.tombstone &&
+    !metadata.syncExcluded &&
+    (metadata.conflict || metadata.lastFailure)
+  )
+}
+
+function indexRelationshipInputs({
+  getModifiedTime,
   localManifestComparisons = new Map(),
   realizations,
   remoteProjects,
   metadata,
   remoteThumbnailUrls = new Map(),
-  preservedDefaultFiles = new Map(),
-  getModifiedTime,
-}: DeriveCloudProjectRelationshipsInput): CloudProjectRelationship[] {
+}: DeriveCloudProjectRelationshipsInput): RelationshipInputIndex {
   const remoteProjectsById = new Map(
     remoteProjects.map((project) => [project.id, project])
   )
@@ -232,16 +237,11 @@ export function deriveCloudProjectRelationships({
     if (!entry.remoteProjectId) {
       continue
     }
-    if (
-      !entry.tombstone &&
-      !entry.syncExcluded &&
-      (entry.conflict || entry.lastFailure)
-    ) {
+
+    if (relationshipShouldExistForMetadata(entry)) {
       remoteProjectIds.add(entry.remoteProjectId)
     }
-    const entries = metadataByRemoteProjectId.get(entry.remoteProjectId) ?? []
-    entries.push(entry)
-    metadataByRemoteProjectId.set(entry.remoteProjectId, entries)
+    groupedMapSet(metadataByRemoteProjectId, entry.remoteProjectId, entry)
   }
 
   for (const realization of realizations) {
@@ -250,101 +250,154 @@ export function deriveCloudProjectRelationships({
       continue
     }
     remoteProjectIds.add(remoteProjectId)
-    const groupedRealizations =
-      realizationsByRemoteProjectId.get(remoteProjectId) ?? []
-    groupedRealizations.push(realization)
-    realizationsByRemoteProjectId.set(remoteProjectId, groupedRealizations)
+    groupedMapSet(realizationsByRemoteProjectId, remoteProjectId, realization)
   }
 
-  return Array.from(remoteProjectIds)
+  return {
+    getModifiedTime,
+    localManifestComparisons,
+    metadataByPath,
+    metadataByRemoteProjectId,
+    realizationsByRemoteProjectId,
+    remoteProjectIds,
+    remoteProjectsById,
+    remoteThumbnailUrls,
+  }
+}
+
+function relationshipContexts(
+  index: RelationshipInputIndex
+): RelationshipContext[] {
+  return Array.from(index.remoteProjectIds)
     .toSorted((a, b) => a.localeCompare(b))
-    .map((remoteProjectId) => {
-      const remoteProject = remoteProjectsById.get(remoteProjectId)
-      const relationshipMetadata =
-        metadataByRemoteProjectId.get(remoteProjectId) ?? []
-      const firstMetadata = relationshipMetadata[0]
-      const relationshipRealizations = (
-        realizationsByRemoteProjectId.get(remoteProjectId) ?? []
-      ).map((realization): CloudProjectRelationshipRealization => {
-        const localMetadata = metadataByPath.get(
-          normalizePathForSync(realization.localProjectPath)
-        )
-        const localManifestComparison = localManifestComparisons.get(
-          normalizePathForSync(realization.localProjectPath)
-        )
-        const duplicateRisk = classifyDuplicateRisk({
-          localManifestComparison,
-          realization,
-          metadata: localMetadata,
-        })
+    .map((remoteProjectId) => ({
+      metadata: index.metadataByRemoteProjectId.get(remoteProjectId) ?? [],
+      remoteProject: index.remoteProjectsById.get(remoteProjectId),
+      remoteProjectId,
+      realizations:
+        index.realizationsByRemoteProjectId.get(remoteProjectId) ?? [],
+    }))
+}
 
-        return {
-          role: 'duplicate',
-          realization,
-          duplicateRisk,
-          autoCleanupEligible:
-            duplicateRisk === 'exact' &&
-            realizationIsOnlyInCloudLibraries(realization),
+function relationshipRealizationFromLocal(
+  index: RelationshipInputIndex,
+  realization: ProjectLibraryRealization
+): CloudProjectRelationshipRealization {
+  const normalizedProjectPath = normalizePathForSync(
+    realization.localProjectPath
+  )
+  const duplicateRisk = classifyDuplicateRisk({
+    localManifestComparison: index.localManifestComparisons.get(
+      normalizedProjectPath
+    ),
+    realization,
+    metadata: index.metadataByPath.get(normalizedProjectPath),
+  })
+
+  return {
+    role: 'duplicate',
+    realization,
+    duplicateRisk,
+    autoCleanupEligible:
+      duplicateRisk === 'exact' &&
+      realizationIsOnlyInCloudLibraries(realization),
+  }
+}
+
+function localRealizationsFromContext(
+  index: RelationshipInputIndex,
+  context: RelationshipContext
+) {
+  const relationshipRealizations = context.realizations.map((realization) =>
+    relationshipRealizationFromLocal(index, realization)
+  )
+  const canonical = selectCanonicalRealization(relationshipRealizations)
+
+  return relationshipRealizations.map((entry) =>
+    entry === canonical
+      ? {
+          ...entry,
+          role: 'canonical' as const,
+          autoCleanupEligible: false,
         }
-      })
-      const canonical = selectCanonicalRealization(relationshipRealizations)
-      const localRealizations = relationshipRealizations.map((entry) =>
-        entry === canonical
-          ? {
-              ...entry,
-              role: 'canonical' as const,
-              autoCleanupEligible: false,
-            }
-          : entry
-      )
-      const canonicalRealization = localRealizations.find(
-        (entry) => entry.role === 'canonical'
-      )
-      const duplicateRealizations = localRealizations.filter(
-        (entry) => entry.role === 'duplicate'
-      )
-      const preservedDefaultFile = firstMetadata
-        ? preservedDefaultFiles.get(
-            normalizePathForSync(firstMetadata.localProjectPath)
-          )
-        : undefined
-      const modified =
-        getModifiedTime?.(
-          firstMetadata,
-          canonicalRealization?.realization.modified ??
-            remoteModifiedTime(remoteProject)
-        ) ??
-        canonicalRealization?.realization.modified ??
-        remoteModifiedTime(remoteProject)
+      : entry
+  )
+}
 
-      return {
-        id: cloudProjectRelationshipId(remoteProjectId),
-        remoteProjectId,
-        remoteProject,
-        canonicalRealization,
-        duplicateRealizations,
-        localRealizations,
-        name: relationshipName({
-          canonical: canonicalRealization,
-          remoteProject,
-          metadata: firstMetadata,
-          remoteProjectId,
-        }),
-        title: relationshipTitle({
-          canonical: canonicalRealization,
-          remoteProject,
-          metadata: firstMetadata,
-        }),
-        modified: modified ?? undefined,
-        remoteThumbnailUrl: remoteThumbnailUrls.get(remoteProjectId),
-        defaultFile:
-          canonicalRealization?.realization.defaultFile ?? preservedDefaultFile,
-        conflict:
-          canonicalRealization?.realization.conflict ?? firstMetadata?.conflict,
-        syncFailure:
-          firstMetadata?.lastFailure?.kind === 'remote-upload-forbidden'
-            ? firstMetadata.lastFailure
-            : undefined,
-      }
-    })
+function relationshipModifiedTime({
+  canonicalRealization,
+  context,
+  index,
+}: {
+  canonicalRealization?: CloudProjectRelationshipRealization
+  context: RelationshipContext
+  index: RelationshipInputIndex
+}) {
+  const localOrRemoteModified =
+    canonicalRealization?.realization.modified ??
+    remoteModifiedTime(context.remoteProject)
+
+  return (
+    index.getModifiedTime?.(context.metadata[0], localOrRemoteModified) ??
+    localOrRemoteModified
+  )
+}
+
+function relationshipConflict({
+  canonicalRealization,
+  context,
+}: {
+  canonicalRealization?: CloudProjectRelationshipRealization
+  context: RelationshipContext
+}) {
+  return (
+    canonicalRealization?.realization.conflict ?? context.metadata[0]?.conflict
+  )
+}
+
+function relationshipSyncFailure(context: RelationshipContext) {
+  const lastFailure = context.metadata[0]?.lastFailure
+  return lastFailure?.kind === 'remote-upload-forbidden'
+    ? lastFailure
+    : undefined
+}
+
+function relationshipFromContext(
+  index: RelationshipInputIndex,
+  context: RelationshipContext
+): CloudProjectRelationship {
+  const localRealizations = localRealizationsFromContext(index, context)
+  const canonicalRealization = localRealizations.find(
+    (entry) => entry.role === 'canonical'
+  )
+  const duplicateRealizations = localRealizations.filter(
+    (entry) => entry.role === 'duplicate'
+  )
+  const modified = relationshipModifiedTime({
+    canonicalRealization,
+    context,
+    index,
+  })
+
+  return {
+    id: cloudProjectRelationshipId(context.remoteProjectId),
+    remoteProjectId: context.remoteProjectId,
+    remoteProject: context.remoteProject,
+    canonicalRealization,
+    duplicateRealizations,
+    localRealizations,
+    modified: modified ?? undefined,
+    remoteThumbnailUrl: index.remoteThumbnailUrls.get(context.remoteProjectId),
+    conflict: relationshipConflict({ canonicalRealization, context }),
+    syncFailure: relationshipSyncFailure(context),
+  }
+}
+
+export function deriveCloudProjectRelationships(
+  input: DeriveCloudProjectRelationshipsInput
+): CloudProjectRelationship[] {
+  const index = indexRelationshipInputs(input)
+  return relationshipContexts(index).map((context) =>
+    relationshipFromContext(index, context)
+  )
 }

--- a/src/lib/commandBarConfigs/projectsCommandConfig.spec.ts
+++ b/src/lib/commandBarConfigs/projectsCommandConfig.spec.ts
@@ -1,10 +1,7 @@
 import { createProjectCommands } from '@src/lib/commandBarConfigs/projectsCommandConfig'
 import type { CommandArgumentOption } from '@src/lib/commandTypes'
 import type { Project } from '@src/lib/project'
-import {
-  DIRECTORY_PROJECT_LIBRARY_TYPE,
-  type ProjectLibrary,
-} from '@src/lib/projectLibraries'
+import type { ProjectLibrary } from '@src/lib/projectLibraries'
 import type { commandBarMachine } from '@src/machines/commandBarMachine'
 import type { systemIOMachine } from '@src/machines/systemIO/systemIOMachine'
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
@@ -539,11 +536,10 @@ describe('project command config', () => {
         localProjectPath: '/client-projects/bracket',
         libraryIds: ['client-projects'],
       }),
-      source: 'both',
+      source: 'local',
       status: 'synced',
-      libraryPath: '/client-projects',
-      libraryType: DIRECTORY_PROJECT_LIBRARY_TYPE,
       remoteProjectId: 'remote-123',
+      deleteRemoteOnDelete: false,
     } satisfies HomeProjectEntry
     const commands = createProjectCommands({
       systemIOActor: createSystemIOActor(),

--- a/src/lib/homeProjects.test.ts
+++ b/src/lib/homeProjects.test.ts
@@ -4,10 +4,7 @@ import {
   shouldPreserveRemoteOnHomeProjectDelete,
 } from '@src/lib/homeProjects'
 import type { FileMetadata, Project } from '@src/lib/project'
-import {
-  CLOUD_PROJECT_LIBRARY_TYPE,
-  DIRECTORY_PROJECT_LIBRARY_TYPE,
-} from '@src/lib/projectLibraries'
+import { CLOUD_PROJECT_LIBRARY_TYPE } from '@src/lib/projectLibraries'
 import { describe, expect, test } from 'vitest'
 
 function metadata(modified: number): FileMetadata {
@@ -44,48 +41,65 @@ describe('homeProjectEntryFromProject', () => {
 
     expect(homeProjectEntryFromProject(project).modified).toBe(50)
   })
+
+  test('marks cloud-type project snapshots as remote-deleting Home cards', () => {
+    const project = {
+      name: 'project',
+      path: '/projects/project',
+      default_file: '/projects/project/main.kcl',
+      readWriteAccess: true,
+      metadata: metadata(10),
+      kcl_file_count: 1,
+      directory_count: 0,
+      children: [],
+      cloudProjectId: 'remote-123',
+      libraryType: CLOUD_PROJECT_LIBRARY_TYPE,
+    } satisfies Project
+
+    expect(homeProjectEntryFromProject(project).deleteRemoteOnDelete).toBe(true)
+  })
 })
 
 describe('Home project deletion policy', () => {
-  test('deletes the remote version only for projects in cloud-type libraries', () => {
+  test('deletes the remote version only when the Home entry says delete removes the remote project', () => {
     expect(
       shouldDeleteRemoteOnHomeProjectDelete({
-        libraryType: CLOUD_PROJECT_LIBRARY_TYPE,
         remoteProjectId: 'remote-123',
+        deleteRemoteOnDelete: true,
       })
     ).toBe(true)
     expect(
       shouldDeleteRemoteOnHomeProjectDelete({
-        libraryType: DIRECTORY_PROJECT_LIBRARY_TYPE,
         remoteProjectId: 'remote-123',
-      })
-    ).toBe(false)
-    expect(
-      shouldDeleteRemoteOnHomeProjectDelete({
-        libraryType: 'custom-library',
-        remoteProjectId: 'remote-123',
+        deleteRemoteOnDelete: false,
       })
     ).toBe(false)
     expect(
       shouldDeleteRemoteOnHomeProjectDelete({
         remoteProjectId: 'remote-123',
+        deleteRemoteOnDelete: undefined,
+      })
+    ).toBe(false)
+    expect(
+      shouldDeleteRemoteOnHomeProjectDelete({
+        deleteRemoteOnDelete: true,
       })
     ).toBe(false)
   })
 
-  test('preserves the remote version when deleting a local copy outside a cloud-type library', () => {
+  test('preserves the remote version when deleting a local cloud-backed copy that does not delete remote', () => {
     expect(
       shouldPreserveRemoteOnHomeProjectDelete({
-        libraryType: DIRECTORY_PROJECT_LIBRARY_TYPE,
         localProjectPath: '/projects/bracket',
         remoteProjectId: 'remote-123',
+        deleteRemoteOnDelete: false,
       })
     ).toBe(true)
     expect(
       shouldPreserveRemoteOnHomeProjectDelete({
-        libraryType: CLOUD_PROJECT_LIBRARY_TYPE,
         localProjectPath: '/cloud/bracket',
         remoteProjectId: 'remote-123',
+        deleteRemoteOnDelete: true,
       })
     ).toBe(false)
   })

--- a/src/lib/homeProjects.ts
+++ b/src/lib/homeProjects.ts
@@ -14,18 +14,15 @@ export function getHomeProjectDisplayName(project: HomeProjectEntry) {
 }
 
 export function shouldDeleteRemoteOnHomeProjectDelete(
-  project: Pick<HomeProjectEntry, 'libraryType' | 'remoteProjectId'>
+  project: Pick<HomeProjectEntry, 'deleteRemoteOnDelete' | 'remoteProjectId'>
 ) {
-  return Boolean(
-    project.remoteProjectId &&
-      project.libraryType === CLOUD_PROJECT_LIBRARY_TYPE
-  )
+  return Boolean(project.remoteProjectId && project.deleteRemoteOnDelete)
 }
 
 export function shouldPreserveRemoteOnHomeProjectDelete(
   project: Pick<
     HomeProjectEntry,
-    'libraryType' | 'localProjectPath' | 'remoteProjectId'
+    'deleteRemoteOnDelete' | 'localProjectPath' | 'remoteProjectId'
   >
 ): boolean {
   return Boolean(
@@ -87,9 +84,11 @@ export function homeProjectEntryFromProject(
     title: getProjectDisplayName(project),
     localProjectPath: project.path,
     localProjectName: project.name,
-    libraryPath: project.libraryPath,
-    libraryType: project.libraryType,
     remoteProjectId: project.cloudProjectId,
+    deleteRemoteOnDelete: Boolean(
+      project.cloudProjectId &&
+        project.libraryType === CLOUD_PROJECT_LIBRARY_TYPE
+    ),
     modified,
     defaultFile: project.default_file,
     kclFileCount: project.kcl_file_count,

--- a/src/lib/projectLibraries/registry/index.ts
+++ b/src/lib/projectLibraries/registry/index.ts
@@ -37,9 +37,16 @@ import { DirectoryProjectLibrarySettingsDetails } from '@src/lib/projectLibrarie
 import { projectLibrariesSettingsContribution } from '@src/lib/projectLibraries/settings/setting'
 import { reportRejection } from '@src/lib/trap'
 import { uuidv4 } from '@src/lib/utils'
+import {
+  ExpectedSystemIOError,
+  reportSystemIOError,
+  type SystemIOErrorRisk,
+} from '@src/machines/systemIO/errorReporting'
+import { SystemIOMachineActors } from '@src/machines/systemIO/utils'
 import { cloudSyncService } from '@src/registry/contracts/cloudSync'
 import type { HomeProjectEntry } from '@src/registry/contracts/homeProjects'
 import {
+  type ProjectLibraryOperation,
   type ProjectLibraryRealizationContribution,
   type ProjectLibraryRealizationsService,
   type ProjectLibraryTypeContribution,
@@ -513,11 +520,108 @@ function getProjectMoveSource({ project }: { project: HomeProjectEntry }) {
   }
 }
 
+type DirectoryProjectOperationReport = {
+  operation: string
+  risk: SystemIOErrorRisk
+}
+
+async function runReportedDirectoryProjectOperation<T>({
+  run,
+  ...report
+}: DirectoryProjectOperationReport & {
+  run: () => Promise<T> | T
+}): Promise<T> {
+  try {
+    return await run()
+  } catch (error) {
+    reportSystemIOError({
+      error,
+      source: 'DirectoryProjectLibrary',
+      ...report,
+    })
+    return Promise.reject(error)
+  }
+}
+
+function withReportedDirectoryProjectOperation<
+  Input extends { library: ProjectLibrary },
+  Result,
+>(
+  operation: ProjectLibraryOperation<Input, Result>,
+  report: DirectoryProjectOperationReport
+): ProjectLibraryOperation<Input, Result> {
+  return {
+    ...operation,
+    run: (input) =>
+      runReportedDirectoryProjectOperation({
+        ...report,
+        run: () => operation.run(input),
+      }),
+  }
+}
+
+function withReportedDirectoryProjectOperations(
+  operations: ProjectLibraryTypeOperations
+): ProjectLibraryTypeOperations {
+  const report = <Input extends { library: ProjectLibrary }, Result>(
+    operation: ProjectLibraryOperation<Input, Result> | undefined,
+    metadata: DirectoryProjectOperationReport
+  ) =>
+    operation
+      ? withReportedDirectoryProjectOperation(operation, metadata)
+      : undefined
+
+  return {
+    ...operations,
+    createProject: report(operations.createProject, {
+      operation: SystemIOMachineActors.createProject,
+      risk: 'write',
+    }),
+    duplicateProject: report(operations.duplicateProject, {
+      operation: SystemIOMachineActors.duplicateProject,
+      risk: 'write',
+    }),
+    renameProject: report(operations.renameProject, {
+      operation: SystemIOMachineActors.renameProject,
+      risk: 'write',
+    }),
+    deleteProject: report(operations.deleteProject, {
+      operation: SystemIOMachineActors.deleteProject,
+      risk: 'destructive',
+    }),
+    moveProjectTo: report(operations.moveProjectTo, {
+      operation: SystemIOMachineActors.moveRecursive,
+      risk: 'destructive',
+    }),
+  }
+}
+
+function reportDirectoryProjectStatFailures({
+  error,
+  count,
+}: {
+  error: unknown
+  count: number
+}) {
+  reportSystemIOError({
+    error,
+    operation: SystemIOMachineActors.readFoldersFromProjectDirectory,
+    risk: 'read',
+    source: 'DirectoryProjectLibrary',
+    dedupeKey:
+      'SystemIO:DirectoryProjectLibrary:read folders from project directory:stat_project',
+    extra: {
+      phase: 'stat_project',
+      skippedProjectCount: count,
+    },
+  })
+}
+
 const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
   const cloudSync = ctx.services.signal(cloudSyncService)
   const getWasmPromise = () =>
     ctx.valueSpecs.get(wasmPromiseValueSpec) ??
-    new Error('Missing WASM promise registry value.')
+    new ExpectedSystemIOError('Missing WASM promise registry value.')
   /**
    * Directory operations know the configured library they changed, so they
    * refresh that library's local realization discovery directly.
@@ -609,7 +713,9 @@ const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
           project.remoteProjectId &&
           cloudSyncActions?.status.value.enabled !== true
         ) {
-          return Promise.reject(new Error('Cloud sync is not enabled.'))
+          return Promise.reject(
+            new ExpectedSystemIOError('Cloud sync is not enabled.')
+          )
         }
 
         await fsZds.rm(project.localProjectPath, {
@@ -673,26 +779,33 @@ const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
               return Promise.reject(wasmInstancePromise)
             }
 
-            const projects = await readProjectsFromProjectDirectory({
-              projectDirectoryPath: library.path,
-              wasmInstancePromise,
-              signal,
-            })
-            if (!signal.aborted) {
-              scheduleProjectDirectoryNameSyncFromTitles({
-                projects,
-                onProjectDirectoriesRenamed: () =>
-                  invalidateProjectLibraryRealizations({
-                    libraryId: library.id,
-                  }),
-              })
-            }
+            return runReportedDirectoryProjectOperation({
+              operation: SystemIOMachineActors.readFoldersFromProjectDirectory,
+              risk: 'read',
+              run: async () => {
+                const projects = await readProjectsFromProjectDirectory({
+                  projectDirectoryPath: library.path,
+                  wasmInstancePromise,
+                  signal,
+                  onProjectStatFailures: reportDirectoryProjectStatFailures,
+                })
+                if (!signal.aborted) {
+                  scheduleProjectDirectoryNameSyncFromTitles({
+                    projects,
+                    onProjectDirectoriesRenamed: () =>
+                      invalidateProjectLibraryRealizations({
+                        libraryId: library.id,
+                      }),
+                  })
+                }
 
-            return projects.map((project) =>
-              projectLibraryRealizationFromProject(project, library)
-            )
+                return projects.map((project) =>
+                  projectLibraryRealizationFromProject(project, library)
+                )
+              },
+            })
           },
-          operations,
+          operations: withReportedDirectoryProjectOperations(operations),
         }),
       ],
     }),

--- a/src/lib/projectLibraries/registry/index.ts
+++ b/src/lib/projectLibraries/registry/index.ts
@@ -718,11 +718,15 @@ const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
           )
         }
 
-        await fsZds.rm(project.localProjectPath, {
-          recursive: true,
-        })
         if (project.remoteProjectId) {
-          await cloudSyncActions?.deleteRemoteProject(project.remoteProjectId)
+          await cloudSyncActions?.deleteLocalProjectRealizations(
+            project.remoteProjectId,
+            project.localProjectPath
+          )
+        } else {
+          await fsZds.rm(project.localProjectPath, {
+            recursive: true,
+          })
         }
         refreshLocalProjectRealizations(library)
       },

--- a/src/registry/contracts/cloudSync.ts
+++ b/src/registry/contracts/cloudSync.ts
@@ -1,5 +1,13 @@
-export type { CloudSyncRegistryService } from '@src/lib/cloudSync/registry/contract'
+export type {
+  CloudProjectDuplicateRisk,
+  CloudProjectRealizationRole,
+  CloudProjectRelationship,
+  CloudProjectRelationshipContribution,
+  CloudProjectRelationshipRealization,
+  CloudSyncRegistryService,
+} from '@src/lib/cloudSync/registry/contract'
 export {
+  cloudProjectRelationshipsValueSpec,
   cloudSyncContract,
   cloudSyncService,
 } from '@src/lib/cloudSync/registry/contract'

--- a/src/registry/contracts/cloudSync.ts
+++ b/src/registry/contracts/cloudSync.ts
@@ -2,12 +2,12 @@ export type {
   CloudProjectDuplicateRisk,
   CloudProjectRealizationRole,
   CloudProjectRelationship,
-  CloudProjectRelationshipContribution,
   CloudProjectRelationshipRealization,
+  CloudProjectRelationshipsRegistryService,
   CloudSyncRegistryService,
 } from '@src/lib/cloudSync/registry/contract'
 export {
-  cloudProjectRelationshipsValueSpec,
+  cloudProjectRelationshipsService,
   cloudSyncContract,
   cloudSyncService,
 } from '@src/lib/cloudSync/registry/contract'

--- a/src/registry/contracts/homeProjects.spec.ts
+++ b/src/registry/contracts/homeProjects.spec.ts
@@ -1,16 +1,10 @@
-import {
-  CLOUD_PROJECT_LIBRARY_TYPE,
-  DEFAULT_PROJECT_LIBRARY_ID,
-  DIRECTORY_PROJECT_LIBRARY_TYPE,
-  PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
-} from '@src/lib/projectLibraries'
-import { coalesceHomeProjectEntries } from '@src/registry/contracts/homeProjects'
+import { combineHomeProjectEntryContributions } from '@src/registry/contracts/homeProjects'
 import { describe, expect, test } from 'vitest'
 
-describe('coalesceHomeProjectEntries', () => {
+describe('combineHomeProjectEntryContributions', () => {
   test('keeps local-only projects as local entries', () => {
     expect(
-      coalesceHomeProjectEntries([
+      combineHomeProjectEntryContributions([
         {
           source: 'local',
           status: 'local',
@@ -33,7 +27,7 @@ describe('coalesceHomeProjectEntries', () => {
 
   test('keeps cloud-only projects as remote entries', () => {
     expect(
-      coalesceHomeProjectEntries([
+      combineHomeProjectEntryContributions([
         {
           source: 'remote',
           status: 'cloud-only',
@@ -56,7 +50,7 @@ describe('coalesceHomeProjectEntries', () => {
 
   test('keeps cloud-linked local projects keyed by local path', () => {
     expect(
-      coalesceHomeProjectEntries([
+      combineHomeProjectEntryContributions([
         {
           source: 'local',
           status: 'synced',
@@ -78,9 +72,9 @@ describe('coalesceHomeProjectEntries', () => {
     ])
   })
 
-  test('merges local and remote entries with the same cloud project id', () => {
+  test('does not merge local and remote entries with the same cloud project id', () => {
     expect(
-      coalesceHomeProjectEntries([
+      combineHomeProjectEntryContributions([
         {
           source: 'remote',
           status: 'cloud-only',
@@ -97,8 +91,6 @@ describe('coalesceHomeProjectEntries', () => {
           title: 'Local title',
           localProjectPath: '/projects/local-name',
           localProjectName: 'local-name',
-          libraryPath: '/projects',
-          libraryType: DIRECTORY_PROJECT_LIBRARY_TYPE,
           remoteProjectId: 'remote-123',
           modified: 10,
           readWriteAccess: true,
@@ -106,23 +98,29 @@ describe('coalesceHomeProjectEntries', () => {
       ])
     ).toEqual([
       expect.objectContaining({
+        id: 'remote:remote-123',
+        source: 'remote',
+        status: 'cloud-only',
+        name: 'remote-name',
+        modified: 20,
+        remoteProjectId: 'remote-123',
+      }),
+      expect.objectContaining({
         id: 'local:/projects/local-name',
-        source: 'both',
+        source: 'local',
         status: 'synced',
         name: 'local-name',
         title: 'Local title',
-        modified: 20,
+        modified: 10,
         localProjectPath: '/projects/local-name',
-        libraryPath: '/projects',
-        libraryType: DIRECTORY_PROJECT_LIBRARY_TYPE,
         remoteProjectId: 'remote-123',
       }),
     ])
   })
 
-  test('preserves remote conflict metadata when the local project snapshot is stale', () => {
+  test('keeps stale remote conflict metadata as its own explicit entry', () => {
     expect(
-      coalesceHomeProjectEntries([
+      combineHomeProjectEntryContributions([
         {
           source: 'remote',
           status: 'conflicted',
@@ -150,58 +148,101 @@ describe('coalesceHomeProjectEntries', () => {
       ])
     ).toEqual([
       expect.objectContaining({
-        id: 'local:/projects/local-name',
-        source: 'both',
+        id: 'remote:remote-123',
+        source: 'remote',
         status: 'conflicted',
-        name: 'local-name',
-        title: 'Local title',
+        name: 'remote-name',
+        title: 'Remote title',
         localProjectPath: '/projects/local-name',
         remoteProjectId: 'remote-123',
         conflict: {
           conflictProjectPath: '/projects/local-name (cloud conflict)',
         },
       }),
+      expect.objectContaining({
+        id: 'local:/projects/local-name',
+        source: 'local',
+        status: 'synced',
+        name: 'local-name',
+        title: 'Local title',
+        localProjectPath: '/projects/local-name',
+        remoteProjectId: 'remote-123',
+      }),
     ])
   })
 
-  test('keeps configured library ownership over the default local fallback', () => {
+  test('does not collapse local-only projects with the same path', () => {
     expect(
-      coalesceHomeProjectEntries([
+      combineHomeProjectEntryContributions([
         {
           source: 'local',
-          status: 'synced',
-          libraryId: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
-          name: 'cloud-name',
-          localProjectPath: '/cloud/cloud-name',
-          localProjectName: 'cloud-name',
-          libraryPath: '/cloud',
-          libraryType: CLOUD_PROJECT_LIBRARY_TYPE,
-          remoteProjectId: 'remote-123',
-          modified: 20,
+          status: 'local',
+          libraryId: 'parent-library',
+          name: 'shared-project',
+          localProjectPath: '/projects/shared-project',
+          localProjectName: 'shared-project',
+          modified: 10,
           readWriteAccess: true,
         },
         {
           source: 'local',
-          status: 'synced',
-          libraryId: DEFAULT_PROJECT_LIBRARY_ID,
-          name: 'cloud-name',
-          localProjectPath: '/cloud/cloud-name',
-          localProjectName: 'cloud-name',
-          libraryPath: '/cloud',
-          libraryType: DIRECTORY_PROJECT_LIBRARY_TYPE,
-          remoteProjectId: 'remote-123',
+          status: 'local',
+          libraryId: 'child-library',
+          name: 'shared-project',
+          localProjectPath: '/projects/shared-project',
+          localProjectName: 'shared-project',
           modified: 10,
           readWriteAccess: true,
         },
       ])
     ).toEqual([
       expect.objectContaining({
-        libraryIds: [
-          PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
-          DEFAULT_PROJECT_LIBRARY_ID,
-        ],
-        libraryPath: '/cloud',
-        libraryType: CLOUD_PROJECT_LIBRARY_TYPE,
+        libraryIds: ['parent-library'],
+      }),
+      expect.objectContaining({
+        libraryIds: ['child-library'],
+      }),
+    ])
+  })
+
+  test('does not deduplicate local entries with the same cloud project id', () => {
+    expect(
+      combineHomeProjectEntryContributions([
+        {
+          source: 'local',
+          status: 'synced',
+          libraryId: 'directory-library',
+          name: 'older-project',
+          localProjectPath: '/projects/older-project',
+          localProjectName: 'older-project',
+          remoteProjectId: 'remote-123',
+          modified: 10,
+          readWriteAccess: true,
+        },
+        {
+          source: 'local',
+          status: 'synced',
+          libraryId: 'cloud-library',
+          name: 'newer-project',
+          localProjectPath: '/cloud/newer-project',
+          localProjectName: 'newer-project',
+          remoteProjectId: 'remote-123',
+          modified: 20,
+          readWriteAccess: true,
+        },
+      ])
+    ).toEqual([
+      expect.objectContaining({
+        id: 'local:/projects/older-project',
+        name: 'older-project',
+        libraryIds: ['directory-library'],
+        remoteProjectId: 'remote-123',
+      }),
+      expect.objectContaining({
+        id: 'local:/cloud/newer-project',
+        name: 'newer-project',
+        libraryIds: ['cloud-library'],
+        remoteProjectId: 'remote-123',
       }),
     ])
   })

--- a/src/registry/contracts/homeProjects.ts
+++ b/src/registry/contracts/homeProjects.ts
@@ -3,15 +3,12 @@ import {
   defineService,
   defineValueSpec,
 } from '@kittycad/registry'
-import type {
-  ProjectLibrary,
-  ProjectLibraryType,
-} from '@src/lib/projectLibraries'
-import { DEFAULT_PROJECT_LIBRARY_ID } from '@src/lib/projectLibraries'
+import type { ProjectLibrary } from '@src/lib/projectLibraries'
 import { uniqueStrings } from '@src/lib/stringUtils'
 import { isArray } from '@src/lib/utils'
+import type { CloudProjectDuplicateRisk } from '@src/registry/contracts/cloudSync'
 
-export type HomeProjectSource = 'local' | 'remote' | 'both'
+export type HomeProjectSource = 'local' | 'remote'
 
 export type HomeProjectStatus =
   | 'local'
@@ -36,6 +33,24 @@ export type HomeProjectSyncFailure = {
   kind?: string
 }
 
+export interface HomeProjectDuplicateRealization {
+  remoteProjectId: string
+  canonicalProjectPath?: string
+  localProjectPath: string
+  localProjectName?: string
+  title?: string
+  libraryIds: readonly string[]
+  libraryTitles: readonly string[]
+  duplicateRisk: CloudProjectDuplicateRisk
+  autoCleanupEligible: boolean
+}
+
+/**
+ * Home project view model: UI-ready card data derived from project-library
+ * realizations and cloudSync relationships. Home entries are presentation
+ * models only; Home must not infer cloud identity, merge providers by cloud ID,
+ * or manufacture a combined local/remote source.
+ */
 export interface HomeProjectEntry {
   id: string
   source: HomeProjectSource
@@ -45,9 +60,13 @@ export interface HomeProjectEntry {
   title?: string
   localProjectPath?: string
   localProjectName?: string
-  libraryPath?: string
-  libraryType?: ProjectLibraryType
   remoteProjectId?: string
+  /**
+   * Delete confirmation wording is derived from explicit action semantics rather
+   * than from library identity. A local cloud relationship may either delete only
+   * its local realization or delete the backing remote project as well.
+   */
+  deleteRemoteOnDelete?: boolean
   modified?: number
   defaultFile?: string
   kclFileCount?: number
@@ -56,16 +75,17 @@ export interface HomeProjectEntry {
   thumbnail?: HomeProjectThumbnail
   conflict?: unknown
   syncFailure?: HomeProjectSyncFailure
+  cloudRelationshipId?: string
+  duplicateRealizations?: readonly HomeProjectDuplicateRealization[]
 }
 
 export type HomeProjectEntryContribution = Omit<
   HomeProjectEntry,
-  'id' | 'libraryIds' | 'source'
+  'id' | 'libraryIds'
 > & {
   id?: string
   libraryId?: string
   libraryIds?: readonly string[]
-  source: Exclude<HomeProjectSource, 'both'>
 }
 
 export type HomeProjectEntryContributionGroup =
@@ -102,17 +122,10 @@ export interface HomeProjectActionsService {
   ) => Promise<HomeProjectOpenResult | undefined>
 }
 
-function contributionBucketKey(entry: HomeProjectEntryContribution) {
-  if (entry.remoteProjectId) {
+function contributionStableId(entry: HomeProjectEntryContribution) {
+  if (entry.source === 'remote' && entry.remoteProjectId) {
     return `remote:${entry.remoteProjectId}`
   }
-  if (entry.localProjectPath) {
-    return `local:${entry.localProjectPath}`
-  }
-  return `${entry.source}:${entry.id ?? entry.name}`
-}
-
-function contributionStableId(entry: HomeProjectEntryContribution) {
   if (entry.localProjectPath) {
     return `local:${entry.localProjectPath}`
   }
@@ -142,113 +155,19 @@ function entryFromContribution(
   }
 }
 
-function mergeHomeProjectEntries(
-  local: HomeProjectEntry | undefined,
-  remote: HomeProjectEntry | undefined
-): HomeProjectEntry | undefined {
-  if (!local && !remote) {
-    return undefined
-  }
-  if (!local) {
-    return remote
-  }
-  if (!remote) {
-    return local
-  }
-
-  const conflict = local.conflict ?? remote.conflict
-  const syncFailure = local.syncFailure ?? remote.syncFailure
-
-  return {
-    ...remote,
-    ...local,
-    id: local.id || remote.id,
-    source: 'both',
-    status: conflict
-      ? 'conflicted'
-      : remote.status === 'syncing'
-        ? 'syncing'
-        : 'synced',
-    conflict,
-    syncFailure,
-    modified: Math.max(local.modified ?? 0, remote.modified ?? 0) || undefined,
-    thumbnail: local.thumbnail ?? remote.thumbnail,
-    readWriteAccess: local.readWriteAccess,
-    libraryIds: uniqueStrings([
-      ...(local.libraryIds ?? []),
-      ...(remote.libraryIds ?? []),
-    ]),
-  }
-}
-
 /**
- * Same-source entries can overlap when multiple libraries point at the same
- * local or remote project. Keep the newest display data while preserving every
- * library membership so library-filtered views can still find the project.
+ * Home entry contributions are flattened only. Identity resolution lives in
+ * cloudSync relationships, and local realization path membership lives in
+ * projectLibraries.
  */
-function mergeSameSourceHomeProjectEntries(
-  existing: HomeProjectEntry | undefined,
-  next: HomeProjectEntry
-): HomeProjectEntry {
-  if (!existing) {
-    return next
-  }
-
-  const nextIsDefaultFallback =
-    next.libraryIds?.length === 1 &&
-    next.libraryIds[0] === DEFAULT_PROJECT_LIBRARY_ID
-  const ownership = nextIsDefaultFallback ? existing : next
-
-  return {
-    ...existing,
-    ...next,
-    libraryPath: ownership.libraryPath,
-    libraryType: ownership.libraryType,
-    modified: Math.max(existing.modified ?? 0, next.modified ?? 0) || undefined,
-    thumbnail: existing.thumbnail ?? next.thumbnail,
-    libraryIds: uniqueStrings([
-      ...(existing.libraryIds ?? []),
-      ...(next.libraryIds ?? []),
-    ]),
-  }
-}
-
-/**
- * Coalesce independently contributed local and remote entries so Home renders a
- * single card for projects that are present in both places.
- */
-export function coalesceHomeProjectEntries(
+export function combineHomeProjectEntryContributions(
   contributionGroups: readonly HomeProjectEntryContributionGroup[]
 ) {
-  const contributions = contributionGroups.flatMap((contribution) =>
-    isArray(contribution) ? contribution : [contribution]
-  )
-  const buckets = new Map<
-    string,
-    {
-      local?: HomeProjectEntry
-      remote?: HomeProjectEntry
-    }
-  >()
-
-  for (const contribution of contributions) {
-    const key = contributionBucketKey(contribution)
-    const entry = entryFromContribution(contribution)
-    const bucket = buckets.get(key) ?? {}
-
-    if (contribution.source === 'local') {
-      bucket.local = mergeSameSourceHomeProjectEntries(bucket.local, entry)
-    } else {
-      bucket.remote = mergeSameSourceHomeProjectEntries(bucket.remote, entry)
-    }
-
-    buckets.set(key, bucket)
-  }
-
-  return Array.from(buckets.values()).flatMap(({ local, remote }) => {
-    const entry = mergeHomeProjectEntries(local, remote)
-    return entry ? [entry] : []
-  })
+  return contributionGroups
+    .flatMap((contribution) =>
+      isArray(contribution) ? contribution : [contribution]
+    )
+    .map(entryFromContribution)
 }
 
 export const homeProjectsContract = defineContract({
@@ -261,7 +180,7 @@ export const homeProjectsContract = defineContract({
   >({
     name: 'home-project-entries',
     defaultValue: [],
-    combine: coalesceHomeProjectEntries,
+    combine: combineHomeProjectEntryContributions,
   }),
 })
 

--- a/src/registry/contracts/projectLibraries.ts
+++ b/src/registry/contracts/projectLibraries.ts
@@ -18,7 +18,6 @@ import type { HideOnPlatformValue } from '@src/lib/settings/settingsTypes'
 import { isArray } from '@src/lib/utils'
 import type {
   HomeProjectEntry,
-  HomeProjectEntryContribution,
   HomeProjectOpenResult,
 } from '@src/registry/contracts/homeProjects'
 import type { ComponentType } from 'react'
@@ -244,10 +243,6 @@ export interface ProjectLibraryTypeContribution {
   /** Hide this type from creation/editing UI while keeping runtime support. */
   hideInSettingsOnPlatform?: HideOnPlatformValue
   operations?: ProjectLibraryTypeOperations
-  readEntries?: (input: {
-    library: ProjectLibrary
-    signal: AbortSignal
-  }) => Promise<HomeProjectEntryContribution[]>
   /**
    * Discover local project folders for one configured library. Implementations
    * return observations only; identity resolution across cloud project IDs is not

--- a/src/registry/extensions/homeProjects/index.test.ts
+++ b/src/registry/extensions/homeProjects/index.test.ts
@@ -281,7 +281,6 @@ function cloudRelationship(
     remoteProjectId,
     duplicateRealizations: [],
     localRealizations: [],
-    name: remoteProjectId,
     ...rest,
   }
 }
@@ -316,8 +315,10 @@ describe('deriveHomeProjectEntryContributions', () => {
         cloudRelationships: [
           cloudRelationship({
             remoteProjectId: 'remote-123',
-            name: 'Remote Project',
-            title: 'Remote Project',
+            remoteProject: {
+              id: 'remote-123',
+              title: 'Remote Project',
+            },
           }),
         ],
       })
@@ -326,6 +327,8 @@ describe('deriveHomeProjectEntryContributions', () => {
         id: 'cloud:remote-123',
         source: 'remote',
         status: 'cloud-only',
+        name: 'Remote Project',
+        title: 'Remote Project',
         libraryIds: [PERSONAL_CLOUD_PROJECT_LIBRARY_ID],
         remoteProjectId: 'remote-123',
       }),

--- a/src/registry/extensions/homeProjects/index.test.ts
+++ b/src/registry/extensions/homeProjects/index.test.ts
@@ -7,12 +7,14 @@ import {
 import { signal } from '@preact/signals-core'
 import type * as ClientErrors from '@src/lib/clientErrors'
 import fsZds from '@src/lib/fs-zds'
+import { fsZdsConstants } from '@src/lib/fs-zds/constants'
 import type { Project } from '@src/lib/project'
 import {
   CLOUD_PROJECT_LIBRARY_TYPE,
   DEFAULT_PROJECT_LIBRARY_ID,
   DIRECTORY_PROJECT_LIBRARY_TYPE,
   getDefaultCloudProjectLibrarySetting,
+  getDefaultProjectLibrarySettings,
   PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
   type ProjectLibrary,
 } from '@src/lib/projectLibraries'
@@ -71,6 +73,48 @@ vi.mock('@src/lib/clientErrors', async (importOriginal) => {
   }
 })
 
+const fsZdsMocks = vi.hoisted(() => {
+  const join = (...parts: string[]) => {
+    let joinedPath = ''
+    for (const part of parts) {
+      if (!part) {
+        continue
+      }
+      if (!joinedPath) {
+        joinedPath = part
+        continue
+      }
+      joinedPath = `${joinedPath.replace(/\/+$/g, '')}/${part.replace(
+        /^\/+/g,
+        ''
+      )}`
+    }
+
+    return joinedPath.replace(/\/$/g, '')
+  }
+  const dirname = (path: string) => {
+    const normalizedPath = path.replace(/\/+$/g, '')
+    const lastSeparatorIndex = normalizedPath.lastIndexOf('/')
+
+    if (lastSeparatorIndex <= 0) {
+      return '/'
+    }
+
+    return normalizedPath.slice(0, lastSeparatorIndex)
+  }
+
+  return {
+    basename: vi.fn((path: string) => path.slice(path.lastIndexOf('/') + 1)),
+    dirname: vi.fn(dirname),
+    join: vi.fn(join),
+    readdir: vi.fn(),
+    rename: vi.fn(),
+    rm: vi.fn(),
+    sep: '/',
+    stat: vi.fn(),
+  }
+})
+
 vi.mock('@src/lib/wasm_lib_wrapper', () => ({
   getModule: vi.fn(),
   init: vi.fn(),
@@ -96,27 +140,9 @@ vi.mock('@src/lib/cloudSync/paths', () => ({
     cloudSyncPathMocks.getCloudProjectLibraryMaterializationDirectoryPath,
 }))
 
-function createSettingsService(): SettingsRegistryService {
-  const current = signal({
-    app: {
-      libraries: {
-        current: [],
-      },
-    },
-  })
-
-  return {
-    actor: {
-      getSnapshot: () => ({
-        matches: (state: string) => state === 'idle',
-      }),
-    },
-    current,
-    get: () => current.value,
-    send: vi.fn(),
-    useSettings: () => current.value,
-  } as unknown as SettingsRegistryService
-}
+vi.mock('@src/lib/fs-zds', () => ({
+  default: fsZdsMocks,
+}))
 
 function createMutableSettingsService({
   libraries,
@@ -169,54 +195,6 @@ function createSystemIOService() {
       },
     } as unknown as SystemIORegistryService,
     send,
-  }
-}
-
-function createMutableSystemIOService({
-  folders,
-}: {
-  folders: Project[] | undefined
-}) {
-  const send = vi.fn()
-  const subscribers = new Set<() => void>()
-  let snapshot = {
-    context: {
-      folders,
-      requestedProjectName: {
-        name: 'active-project',
-      },
-    },
-    matches: (state: string) => state === 'idle',
-  }
-
-  return {
-    service: {
-      actor: {
-        send,
-        getSnapshot: () => snapshot,
-        subscribe: vi.fn((callback: () => void) => {
-          subscribers.add(callback)
-          return {
-            unsubscribe: () => {
-              subscribers.delete(callback)
-            },
-          }
-        }),
-      },
-    } as unknown as SystemIORegistryService,
-    send,
-    setFolders: (foldersNext: Project[] | undefined) => {
-      snapshot = {
-        ...snapshot,
-        context: {
-          ...snapshot.context,
-          folders: foldersNext,
-        },
-      }
-      for (const subscriber of subscribers) {
-        subscriber()
-      }
-    },
   }
 }
 
@@ -453,7 +431,8 @@ describe('home project actions', () => {
     vi.restoreAllMocks()
   })
 
-  it('keeps default directory entries while System IO folders are temporarily unset', async () => {
+  it('discovers default directory entries through project library scanning', async () => {
+    const wasmPromise = Promise.resolve({} as never)
     const project = {
       name: 'local-project',
       title: 'Local Project',
@@ -472,18 +451,23 @@ describe('home project actions', () => {
       directory_count: 0,
       readWriteAccess: true,
     } satisfies Project
-    const systemIO = createMutableSystemIOService({
-      folders: [project],
+    const settings = createMutableSettingsService({
+      libraries: getDefaultProjectLibrarySettings('/projects'),
     })
+    const systemIO = createSystemIOService()
     const cloudSync = createCloudSyncService()
+    fsZdsMocks.readdir.mockResolvedValue(['local-project'])
+    fsZdsMocks.stat.mockResolvedValue({
+      mode: fsZdsConstants.S_IFDIR,
+      mtimeMs: 100,
+    })
+    desktopMocks.getProjectInfo.mockResolvedValue(project)
 
     registry = new Registry()
     registry.configure([
       defineRegistryItem({
         id: 'test.settings',
-        providesServices: [
-          provideService(settingsService, createSettingsService()),
-        ],
+        providesServices: [provideService(settingsService, settings.service)],
       }),
       defineRegistryItem({
         id: 'test.system-io',
@@ -492,6 +476,10 @@ describe('home project actions', () => {
       defineRegistryItem({
         id: 'test.cloud-sync',
         providesServices: [provideService(cloudSyncService, cloudSync)],
+      }),
+      defineRegistryItem({
+        id: 'test.wasm',
+        provides: [provideWasmPromise(wasmPromise)],
       }),
       projectLibrariesExtension,
       homeProjectsExtension,
@@ -505,21 +493,9 @@ describe('home project actions', () => {
         }),
       ])
     )
-
-    systemIO.setFolders(undefined)
-    await Promise.resolve()
-    await Promise.resolve()
-
-    expect(registry.get(homeProjectEntriesValueSpec)).toEqual([
-      expect.objectContaining({
-        name: 'local-project',
-        libraryIds: [DEFAULT_PROJECT_LIBRARY_ID],
-      }),
-    ])
-
-    systemIO.setFolders([])
-    await waitFor(() =>
-      expect(registry?.get(homeProjectEntriesValueSpec)).toEqual([])
+    expect(desktopMocks.getProjectInfo).toHaveBeenCalledWith(
+      '/projects/local-project',
+      await wasmPromise
     )
   })
 
@@ -551,7 +527,18 @@ describe('home project actions', () => {
       defineRegistryItem({
         id: 'test.settings',
         providesServices: [
-          provideService(settingsService, createSettingsService()),
+          provideService(
+            settingsService,
+            createMutableSettingsService({
+              libraries: [
+                {
+                  title: library.title,
+                  path: library.path,
+                  type: library.type,
+                },
+              ],
+            }).service
+          ),
         ],
       }),
       defineRegistryItem({
@@ -566,6 +553,7 @@ describe('home project actions', () => {
         id: 'test.wasm',
         provides: [provideWasmPromise(Promise.resolve({} as never))],
       }),
+      projectLibrariesExtension,
       homeProjectsExtension,
     ])
 
@@ -613,7 +601,18 @@ describe('home project actions', () => {
       defineRegistryItem({
         id: 'test.settings',
         providesServices: [
-          provideService(settingsService, createSettingsService()),
+          provideService(
+            settingsService,
+            createMutableSettingsService({
+              libraries: [
+                {
+                  title: library.title,
+                  path: library.path,
+                  type: library.type,
+                },
+              ],
+            }).service
+          ),
         ],
       }),
       defineRegistryItem({
@@ -624,6 +623,7 @@ describe('home project actions', () => {
         id: 'test.cloud-sync',
         providesServices: [provideService(cloudSyncService, cloudSync)],
       }),
+      projectLibrariesExtension,
       homeProjectsExtension,
     ])
 
@@ -963,7 +963,7 @@ describe('home project actions', () => {
       },
       project: {
         id: 'local:/projects/bracket',
-        source: 'both',
+        source: 'local',
         status: 'synced',
         libraryIds: [DEFAULT_PROJECT_LIBRARY_ID],
         name: 'bracket',
@@ -981,83 +981,5 @@ describe('home project actions', () => {
     )
     expect(cloudSync.deleteRemoteProject).not.toHaveBeenCalled()
     expect(removeProjectDirectory).not.toHaveBeenCalled()
-  })
-
-  it('uses the owning directory library when a local project is merged with its cloud entry', async () => {
-    const systemIO = createSystemIOService()
-    const cloudSync = createCloudSyncService()
-    const deleteCloudProject = vi.fn().mockResolvedValue(undefined)
-
-    registry = new Registry()
-    registry.configure([
-      defineRegistryItem({
-        id: 'test.settings',
-        providesServices: [
-          provideService(
-            settingsService,
-            createMutableSettingsService({
-              libraries: [
-                getDefaultCloudProjectLibrarySetting('/cloud-projects'),
-                {
-                  title: 'Projects',
-                  path: '/projects',
-                  type: DIRECTORY_PROJECT_LIBRARY_TYPE,
-                },
-              ],
-            }).service
-          ),
-        ],
-      }),
-      defineRegistryItem({
-        id: 'test.system-io',
-        providesServices: [provideService(systemIOService, systemIO.service)],
-      }),
-      defineRegistryItem({
-        id: 'test.cloud-sync',
-        providesServices: [provideService(cloudSyncService, cloudSync)],
-      }),
-      defineRegistryItem({
-        id: 'test.cloud-library-type',
-        provides: [
-          provide(projectLibraryTypesValueSpec, {
-            type: CLOUD_PROJECT_LIBRARY_TYPE,
-            title: 'Cloud',
-            readEntries: async () => [],
-            operations: {
-              deleteProject: {
-                run: deleteCloudProject,
-              },
-            },
-          }),
-        ],
-      }),
-      homeProjectsExtension,
-    ])
-
-    await registry.get(homeProjectActionsService).delete({
-      id: 'remote:remote-123',
-      source: 'both',
-      status: 'synced',
-      libraryIds: [
-        PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
-        DEFAULT_PROJECT_LIBRARY_ID,
-      ],
-      name: 'bracket',
-      title: 'Bracket',
-      localProjectPath: '/projects/bracket',
-      localProjectName: 'bracket',
-      libraryPath: '/projects',
-      libraryType: DIRECTORY_PROJECT_LIBRARY_TYPE,
-      remoteProjectId: 'remote-123',
-      defaultFile: '/projects/bracket/main.kcl',
-      readWriteAccess: true,
-    })
-
-    expect(deleteCloudProject).not.toHaveBeenCalled()
-    expect(cloudSync.deleteLocalProjectRealizations).toHaveBeenCalledWith(
-      'remote-123',
-      '/projects/bracket'
-    )
-    expect(cloudSync.deleteRemoteProject).not.toHaveBeenCalled()
   })
 })

--- a/src/registry/extensions/homeProjects/index.test.ts
+++ b/src/registry/extensions/homeProjects/index.test.ts
@@ -16,15 +16,22 @@ import {
   PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
   type ProjectLibrary,
 } from '@src/lib/projectLibraries'
-import type { CloudSyncRegistryService } from '@src/registry/contracts/cloudSync'
+import projectLibrariesExtension from '@src/lib/projectLibraries/registry'
+import type {
+  CloudProjectRelationship,
+  CloudSyncRegistryService,
+} from '@src/registry/contracts/cloudSync'
 import { cloudSyncService } from '@src/registry/contracts/cloudSync'
 import {
   type HomeProjectEntry,
-  type HomeProjectEntryContribution,
   homeProjectActionsService,
   homeProjectEntriesValueSpec,
 } from '@src/registry/contracts/homeProjects'
-import { projectLibraryTypesValueSpec } from '@src/registry/contracts/projectLibraries'
+import {
+  type ProjectLibraryRealization,
+  type ProjectLibraryRealizationContribution,
+  projectLibraryTypesValueSpec,
+} from '@src/registry/contracts/projectLibraries'
 import type { SettingsRegistryService } from '@src/registry/contracts/settings'
 import { settingsService } from '@src/registry/contracts/settings'
 import {
@@ -32,9 +39,15 @@ import {
   systemIOService,
 } from '@src/registry/contracts/systemIO'
 import { provideWasmPromise } from '@src/registry/contracts/wasm'
-import homeProjectsExtension from '@src/registry/extensions/homeProjects'
+import homeProjectsExtension, {
+  deriveHomeProjectEntryContributions,
+} from '@src/registry/extensions/homeProjects'
 import { waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+function projectNameFromPath(projectPath: string) {
+  return projectPath.slice(projectPath.lastIndexOf('/') + 1)
+}
 
 const desktopMocks = vi.hoisted(() => ({
   getProjectInfo: vi.fn(),
@@ -234,6 +247,196 @@ function createCloudSyncService(
   }
 }
 
+function realization(
+  overrides: Partial<ProjectLibraryRealization> & { localProjectPath: string }
+): ProjectLibraryRealization {
+  const { localProjectPath, ...rest } = overrides
+  const localProjectName = projectNameFromPath(localProjectPath)
+
+  return {
+    id: `local:${localProjectPath}`,
+    libraryIds: ['default-project-directory'],
+    libraryRefs: [
+      {
+        id: 'default-project-directory',
+        title: 'Projects',
+        path: '/projects',
+        type: 'directory',
+      },
+    ],
+    localProjectPath,
+    localProjectName,
+    name: localProjectName,
+    readWriteAccess: true,
+    ...rest,
+  }
+}
+
+function cloudRelationship(
+  overrides: Partial<CloudProjectRelationship> & { remoteProjectId: string }
+): CloudProjectRelationship {
+  const { remoteProjectId, ...rest } = overrides
+  return {
+    id: `cloud:${remoteProjectId}`,
+    remoteProjectId,
+    duplicateRealizations: [],
+    localRealizations: [],
+    name: remoteProjectId,
+    ...rest,
+  }
+}
+
+describe('deriveHomeProjectEntryContributions', () => {
+  it('derives local-only realization cards', () => {
+    expect(
+      deriveHomeProjectEntryContributions({
+        realizations: [
+          realization({
+            localProjectPath: '/projects/local-project',
+            title: 'Local Project',
+          }),
+        ],
+        cloudRelationships: [],
+      })
+    ).toEqual([
+      expect.objectContaining({
+        source: 'local',
+        status: 'local',
+        name: 'local-project',
+        title: 'Local Project',
+        localProjectPath: '/projects/local-project',
+      }),
+    ])
+  })
+
+  it('derives remote-only cloud relationship cards', () => {
+    expect(
+      deriveHomeProjectEntryContributions({
+        realizations: [],
+        cloudRelationships: [
+          cloudRelationship({
+            remoteProjectId: 'remote-123',
+            name: 'Remote Project',
+            title: 'Remote Project',
+          }),
+        ],
+      })
+    ).toEqual([
+      expect.objectContaining({
+        id: 'cloud:remote-123',
+        source: 'remote',
+        status: 'cloud-only',
+        libraryIds: [PERSONAL_CLOUD_PROJECT_LIBRARY_ID],
+        remoteProjectId: 'remote-123',
+      }),
+    ])
+  })
+
+  it('derives one canonical relationship card with duplicate metadata attached', () => {
+    const canonical = realization({
+      localProjectPath: '/cloud/bracket',
+      cloudProjectId: 'remote-123',
+      libraryIds: [PERSONAL_CLOUD_PROJECT_LIBRARY_ID],
+      libraryRefs: [
+        {
+          id: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+          title: 'Personal Cloud',
+          path: '/cloud',
+          type: CLOUD_PROJECT_LIBRARY_TYPE,
+        },
+      ],
+    })
+    const duplicate = realization({
+      localProjectPath: '/projects/bracket-copy',
+      cloudProjectId: 'remote-123',
+    })
+
+    expect(
+      deriveHomeProjectEntryContributions({
+        realizations: [canonical, duplicate],
+        cloudRelationships: [
+          cloudRelationship({
+            remoteProjectId: 'remote-123',
+            canonicalRealization: {
+              role: 'canonical',
+              realization: canonical,
+              duplicateRisk: 'exact',
+              autoCleanupEligible: false,
+            },
+            duplicateRealizations: [
+              {
+                role: 'duplicate',
+                realization: duplicate,
+                duplicateRisk: 'exact',
+                autoCleanupEligible: false,
+              },
+            ],
+            localRealizations: [
+              {
+                role: 'canonical',
+                realization: canonical,
+                duplicateRisk: 'exact',
+                autoCleanupEligible: false,
+              },
+              {
+                role: 'duplicate',
+                realization: duplicate,
+                duplicateRisk: 'exact',
+                autoCleanupEligible: false,
+              },
+            ],
+          }),
+        ],
+      })
+    ).toEqual([
+      expect.objectContaining({
+        id: 'cloud:remote-123',
+        source: 'local',
+        status: 'synced',
+        libraryIds: [
+          PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+          DEFAULT_PROJECT_LIBRARY_ID,
+        ],
+        localProjectPath: '/cloud/bracket',
+        remoteProjectId: 'remote-123',
+        duplicateRealizations: [
+          expect.objectContaining({
+            localProjectPath: '/projects/bracket-copy',
+            duplicateRisk: 'exact',
+          }),
+        ],
+      }),
+    ])
+  })
+
+  it('keeps duplicate realizations as separate cards without an explicit cloud relationship', () => {
+    expect(
+      deriveHomeProjectEntryContributions({
+        realizations: [
+          realization({
+            localProjectPath: '/projects/bracket',
+            cloudProjectId: 'remote-123',
+          }),
+          realization({
+            localProjectPath: '/cloud/bracket',
+            cloudProjectId: 'remote-123',
+          }),
+        ],
+        cloudRelationships: [],
+      })
+    ).toEqual([
+      expect.objectContaining({
+        localProjectPath: '/projects/bracket',
+        remoteProjectId: 'remote-123',
+      }),
+      expect.objectContaining({
+        localProjectPath: '/cloud/bracket',
+        remoteProjectId: 'remote-123',
+      }),
+    ])
+  })
+})
+
 describe('home project actions', () => {
   let registry: Registry | undefined
 
@@ -287,6 +490,7 @@ describe('home project actions', () => {
         id: 'test.cloud-sync',
         providesServices: [provideService(cloudSyncService, cloudSync)],
       }),
+      projectLibrariesExtension,
       homeProjectsExtension,
     ])
 
@@ -449,17 +653,15 @@ describe('home project actions', () => {
     })
     const systemIO = createSystemIOService()
     const cloudSync = createCloudSyncService()
-    const readEntries = vi.fn(({ library }: { library: ProjectLibrary }) =>
+    const readRealizations = vi.fn(({ library }: { library: ProjectLibrary }) =>
       Promise.resolve([
         {
-          source: 'local',
-          status: 'synced',
-          libraryId: library.id,
+          library,
           name: 'untitled-43',
           title: 'untitled-43',
           localProjectPath: '/custom-cloud/untitled-43',
           localProjectName: 'untitled-43',
-          remoteProjectId: 'remote-123',
+          cloudProjectId: 'remote-123',
           defaultFile: '/custom-cloud/untitled-43/main.kcl',
           readWriteAccess: true,
           thumbnail: {
@@ -467,7 +669,7 @@ describe('home project actions', () => {
             path: '/custom-cloud/untitled-43/thumbnail.png',
           },
         },
-      ] satisfies HomeProjectEntryContribution[])
+      ] satisfies ProjectLibraryRealizationContribution[])
     )
 
     registry = new Registry()
@@ -490,10 +692,11 @@ describe('home project actions', () => {
           provide(projectLibraryTypesValueSpec, {
             type: 'custom-cloud',
             title: 'Custom Cloud',
-            readEntries,
+            readRealizations,
           }),
         ],
       }),
+      projectLibrariesExtension,
       homeProjectsExtension,
     ])
 
@@ -509,7 +712,7 @@ describe('home project actions', () => {
       ])
     )
 
-    readEntries.mockClear()
+    readRealizations.mockClear()
     settings.current.value = {
       ...settings.current.value,
       unrelated: {
@@ -519,7 +722,7 @@ describe('home project actions', () => {
     await Promise.resolve()
     await Promise.resolve()
 
-    expect(readEntries).not.toHaveBeenCalled()
+    expect(readRealizations).not.toHaveBeenCalled()
     expect(registry.get(homeProjectEntriesValueSpec)).toEqual([
       expect.objectContaining({
         name: 'untitled-43',
@@ -589,7 +792,7 @@ describe('home project actions', () => {
           provide(projectLibraryTypesValueSpec, {
             type: CLOUD_PROJECT_LIBRARY_TYPE,
             title: 'Cloud',
-            readEntries: async () => [],
+            readRealizations: async () => [],
             operations: {
               openProject: {
                 run: ({ project }) => {
@@ -630,7 +833,7 @@ describe('home project actions', () => {
     const cloudSync = createCloudSyncService()
     const localCloudProject = {
       id: 'remote:remote-123',
-      source: 'both',
+      source: 'local',
       status: 'synced',
       libraryIds: [PERSONAL_CLOUD_PROJECT_LIBRARY_ID],
       name: 'remote-title',
@@ -673,7 +876,7 @@ describe('home project actions', () => {
           provide(projectLibraryTypesValueSpec, {
             type: CLOUD_PROJECT_LIBRARY_TYPE,
             title: 'Cloud',
-            readEntries: async () => [],
+            readRealizations: async () => [],
             operations: {
               openProject: {
                 run: ({ project }) => {
@@ -735,6 +938,7 @@ describe('home project actions', () => {
         id: 'test.cloud-sync',
         providesServices: [provideService(cloudSyncService, cloudSync)],
       }),
+      projectLibrariesExtension,
       homeProjectsExtension,
     ])
 

--- a/src/registry/extensions/homeProjects/index.ts
+++ b/src/registry/extensions/homeProjects/index.ts
@@ -123,6 +123,30 @@ function libraryIdsFromRelationship(
   return Array.from(new Set(libraryIds))
 }
 
+function homeProjectNameFromCloudRelationship({
+  canonical,
+  relationship,
+}: {
+  canonical?: ProjectLibraryRealization
+  relationship: CloudProjectRelationship
+}) {
+  return (
+    canonical?.name ??
+    relationship.remoteProject?.title ??
+    relationship.remoteProjectId
+  )
+}
+
+function homeProjectTitleFromCloudRelationship({
+  canonical,
+  relationship,
+}: {
+  canonical?: ProjectLibraryRealization
+  relationship: CloudProjectRelationship
+}) {
+  return canonical?.title ?? relationship.remoteProject?.title
+}
+
 function homeProjectDuplicateRealizationFromRelationship(
   relationship: CloudProjectRelationship,
   duplicate: CloudProjectRelationshipRealization
@@ -175,8 +199,8 @@ function homeProjectEntryFromCloudRelationship(
       relationshipLibraryIds.length > 0
         ? relationshipLibraryIds
         : [PERSONAL_CLOUD_PROJECT_LIBRARY_ID],
-    name: canonical?.name ?? relationship.name,
-    title: canonical?.title ?? relationship.title,
+    name: homeProjectNameFromCloudRelationship({ canonical, relationship }),
+    title: homeProjectTitleFromCloudRelationship({ canonical, relationship }),
     localProjectPath: canonical?.localProjectPath,
     localProjectName: canonical?.localProjectName,
     remoteProjectId: relationship.remoteProjectId,
@@ -185,7 +209,7 @@ function homeProjectEntryFromCloudRelationship(
         (!canonical || realizationDeletesRemoteOnDelete(canonical))
     ),
     modified: relationship.modified ?? canonical?.modified,
-    defaultFile: relationship.defaultFile ?? canonical?.defaultFile,
+    defaultFile: canonical?.defaultFile,
     kclFileCount: canonical?.kclFileCount,
     directoryCount: canonical?.directoryCount,
     readWriteAccess: canonical?.readWriteAccess ?? true,

--- a/src/registry/extensions/homeProjects/index.ts
+++ b/src/registry/extensions/homeProjects/index.ts
@@ -74,6 +74,11 @@ function homeProjectStatusFromRealization(
   return 'local'
 }
 
+/**
+ * Delete semantics come from the operation-owning library type, not Home's
+ * identity model. Cloud-library realizations delete the remote project; directory
+ * realizations with cloud metadata delete only the local folder.
+ */
 function realizationDeletesRemoteOnDelete(
   realization: ProjectLibraryRealization | undefined
 ) {
@@ -114,6 +119,7 @@ function homeProjectEntryFromRealization(
   }
 }
 
+/** Local library membership is copied from relationship realizations. */
 function libraryIdsFromRelationship(
   relationship: CloudProjectRelationship
 ): readonly string[] {
@@ -167,6 +173,11 @@ function homeProjectDuplicateRealizationFromRelationship(
   }
 }
 
+/**
+ * Converts one explicit cloud relationship into one Home card. Home can choose
+ * display fallbacks, badges, and actions from the relationship, but it must not
+ * merge arbitrary provider entries or decide which local folders are duplicates.
+ */
 function homeProjectEntryFromCloudRelationship(
   relationship: CloudProjectRelationship
 ): HomeProjectEntryContribution {
@@ -221,6 +232,11 @@ function homeProjectEntryFromCloudRelationship(
   }
 }
 
+/**
+ * Builds Home project cards from explicit inputs:
+ * - one card for each cloud relationship;
+ * - one local-only card for each realization not claimed by a relationship.
+ */
 export function deriveHomeProjectEntryContributions({
   realizations,
   cloudRelationships,
@@ -247,6 +263,10 @@ export function deriveHomeProjectEntryContributions({
   return [...relationshipEntries, ...localOnlyEntries]
 }
 
+/**
+ * UI adapter for Home project commands. Storage behavior stays with project
+ * library operations, and cloud duplicate cleanup stays with cloudSync.
+ */
 const homeProjectActions = defineRegistryItemFactory((ctx) => {
   const settings = ctx.services.signal(settingsService)
   const cloudSync = ctx.services.signal(cloudSyncService)
@@ -255,6 +275,10 @@ const homeProjectActions = defineRegistryItemFactory((ctx) => {
     ctx.valueSpecs.get(wasmPromiseValueSpec) ??
     new Error('Missing WASM promise registry value.')
 
+  /**
+   * Selects the first configured library containing the Home card that supports
+   * the requested operation. Multi-library membership is explicit on the card.
+   */
   const getProjectOperation = <
     OperationName extends keyof ProjectLibraryTypeOperations,
   >(
@@ -559,6 +583,11 @@ const homeProjectActions = defineRegistryItemFactory((ctx) => {
   }
 }, 'home-projects.actions')
 
+/**
+ * Sole Home entry producer for project cards. External extensions contribute
+ * local realizations or cloud relationships; Home derives view models from
+ * those explicit domain models.
+ */
 const homeProjectEntryViewModels = defineRegistryItemFactory((ctx) => {
   const projectLibraryRealizations = ctx.valueSpecs.signal(
     projectLibraryRealizationsValueSpec

--- a/src/registry/extensions/homeProjects/index.ts
+++ b/src/registry/extensions/homeProjects/index.ts
@@ -15,11 +15,10 @@ import {
   type ProjectLibrary,
   projectLibrariesFromSettings,
 } from '@src/lib/projectLibraries'
-import { invalidateProjectLibraryRealizations } from '@src/lib/projectLibraries/registry/invalidation'
 import {
   type CloudProjectRelationship,
   type CloudProjectRelationshipRealization,
-  cloudProjectRelationshipsValueSpec,
+  cloudProjectRelationshipsService,
   cloudSyncService,
 } from '@src/registry/contracts/cloudSync'
 import { commandSystemService } from '@src/registry/contracts/commands'
@@ -585,20 +584,21 @@ const homeProjectActions = defineRegistryItemFactory((ctx) => {
 
 /**
  * Sole Home entry producer for project cards. External extensions contribute
- * local realizations or cloud relationships; Home derives view models from
- * those explicit domain models.
+ * local realizations, and cloudSync publishes explicit relationships through
+ * its singleton service. Home derives view models from those domain models.
  */
 const homeProjectEntryViewModels = defineRegistryItemFactory((ctx) => {
   const projectLibraryRealizations = ctx.valueSpecs.signal(
     projectLibraryRealizationsValueSpec
   )
-  const cloudProjectRelationships = ctx.valueSpecs.signal(
-    cloudProjectRelationshipsValueSpec
+  const cloudProjectRelationships = ctx.services.signal(
+    cloudProjectRelationshipsService
   )
   const entries = computed(() =>
     deriveHomeProjectEntryContributions({
       realizations: projectLibraryRealizations.value,
-      cloudRelationships: cloudProjectRelationships.value,
+      cloudRelationships:
+        cloudProjectRelationships.value?.relationships.value ?? [],
     })
   )
 

--- a/src/registry/extensions/homeProjects/index.ts
+++ b/src/registry/extensions/homeProjects/index.ts
@@ -5,53 +5,27 @@ import {
   provide,
   provideService,
 } from '@kittycad/registry'
-import { effect, signal } from '@preact/signals-core'
+import { computed } from '@preact/signals-core'
 import { getCloudProjectLibraryMaterializationDirectoryPath } from '@src/lib/cloudSync/paths'
+import { getProjectInfo } from '@src/lib/desktop'
+import { getHomeProjectDisplayName } from '@src/lib/homeProjects'
 import {
-  getProjectInfo,
-  writeProjectTitleToProjectToml,
-} from '@src/lib/desktop'
-import fsZds from '@src/lib/fs-zds'
-import {
-  getHomeProjectDisplayName,
-  homeProjectEntryFromProject,
-} from '@src/lib/homeProjects'
-import type { Project } from '@src/lib/project'
-import { duplicateProjectInDirectory } from '@src/lib/projectDuplication'
-import {
-  DEFAULT_PROJECT_LIBRARY_ID,
-  DEFAULT_PROJECT_LIBRARY_TITLE,
-  DIRECTORY_PROJECT_LIBRARY_TYPE,
-  getDefaultProjectLibrarySettings,
-  NEW_PROJECT_LIBRARY_TITLE,
+  CLOUD_PROJECT_LIBRARY_TYPE,
+  PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
   type ProjectLibrary,
   projectLibrariesFromSettings,
 } from '@src/lib/projectLibraries'
+import { invalidateProjectLibraryRealizations } from '@src/lib/projectLibraries/registry/invalidation'
 import {
-  readProjectsFromProjectDirectory,
-  scheduleProjectDirectoryNameSyncFromTitles,
-} from '@src/lib/projectLibraries/directoryScanner'
-import {
-  createProjectInLocalDirectory,
-  moveProjectIntoLocalDirectory,
-} from '@src/lib/projectLibraries/operations'
-import { DirectoryProjectLibrarySettingsDetails } from '@src/lib/projectLibraries/settings/ProjectLibrariesSettingInput'
-import { reportRejection } from '@src/lib/trap'
-import {
-  ExpectedSystemIOError,
-  reportSystemIOError,
-  type SystemIOErrorRisk,
-} from '@src/machines/systemIO/errorReporting'
-import {
-  NO_PROJECT_DIRECTORY,
-  SystemIOMachineActors,
-  SystemIOMachineEvents,
-  SystemIOMachineStates,
-} from '@src/machines/systemIO/utils'
-import { cloudSyncService } from '@src/registry/contracts/cloudSync'
+  type CloudProjectRelationship,
+  type CloudProjectRelationshipRealization,
+  cloudProjectRelationshipsValueSpec,
+  cloudSyncService,
+} from '@src/registry/contracts/cloudSync'
 import { commandSystemService } from '@src/registry/contracts/commands'
 import {
   type HomeProjectActionsService,
+  type HomeProjectDuplicateRealization,
   type HomeProjectEntry,
   type HomeProjectEntryContribution,
   type HomeProjectMoveToLibraryTarget,
@@ -61,140 +35,14 @@ import {
 import { projectExplorerProjectMenuItemsValueSpec } from '@src/registry/contracts/projectExplorer'
 import {
   getProjectLibraryOperation,
-  type ProjectLibraryOperation,
+  type ProjectLibraryRealization,
   type ProjectLibraryTypeOperations,
-  projectLibrarySettingDefaultPoliciesValueSpec,
+  projectLibraryRealizationsValueSpec,
   projectLibraryTypesValueSpec,
 } from '@src/registry/contracts/projectLibraries'
 import { settingsService } from '@src/registry/contracts/settings'
-import { systemIOService } from '@src/registry/contracts/systemIO'
 import { wasmPromiseValueSpec } from '@src/registry/contracts/wasm'
 import toast from 'react-hot-toast'
-
-const configuredProjectLibraryEntriesInvalidation = signal(0)
-
-type DirectoryProjectOperationReport = {
-  operation: string
-  risk: SystemIOErrorRisk
-}
-
-async function runReportedDirectoryProjectOperation<T>({
-  run,
-  ...report
-}: DirectoryProjectOperationReport & {
-  run: () => Promise<T> | T
-}): Promise<T> {
-  try {
-    return await run()
-  } catch (error) {
-    reportSystemIOError({
-      error,
-      source: 'DirectoryProjectLibrary',
-      ...report,
-    })
-    return Promise.reject(error)
-  }
-}
-
-function withReportedDirectoryProjectOperation<
-  Input extends { library: ProjectLibrary },
-  Result,
->(
-  operation: ProjectLibraryOperation<Input, Result>,
-  report: DirectoryProjectOperationReport
-): ProjectLibraryOperation<Input, Result> {
-  return {
-    ...operation,
-    run: (input) =>
-      runReportedDirectoryProjectOperation({
-        ...report,
-        run: () => operation.run(input),
-      }),
-  }
-}
-
-function withReportedDirectoryProjectOperations(
-  operations: ProjectLibraryTypeOperations
-): ProjectLibraryTypeOperations {
-  const report = <Input extends { library: ProjectLibrary }, Result>(
-    operation: ProjectLibraryOperation<Input, Result> | undefined,
-    metadata: DirectoryProjectOperationReport
-  ) =>
-    operation
-      ? withReportedDirectoryProjectOperation(operation, metadata)
-      : undefined
-
-  return {
-    ...operations,
-    createProject: report(operations.createProject, {
-      operation: SystemIOMachineActors.createProject,
-      risk: 'write',
-    }),
-    duplicateProject: report(operations.duplicateProject, {
-      operation: SystemIOMachineActors.duplicateProject,
-      risk: 'write',
-    }),
-    renameProject: report(operations.renameProject, {
-      operation: SystemIOMachineActors.renameProject,
-      risk: 'write',
-    }),
-    deleteProject: report(operations.deleteProject, {
-      operation: SystemIOMachineActors.deleteProject,
-      risk: 'destructive',
-    }),
-    moveProjectTo: report(operations.moveProjectTo, {
-      operation: SystemIOMachineActors.moveRecursive,
-      risk: 'destructive',
-    }),
-  }
-}
-
-function reportDirectoryProjectStatFailures({
-  error,
-  count,
-}: {
-  error: unknown
-  count: number
-}) {
-  reportSystemIOError({
-    error,
-    operation: SystemIOMachineActors.readFoldersFromProjectDirectory,
-    risk: 'read',
-    source: 'DirectoryProjectLibrary',
-    dedupeKey:
-      'SystemIO:DirectoryProjectLibrary:read folders from project directory:stat_project',
-    extra: {
-      phase: 'stat_project',
-      skippedProjectCount: count,
-    },
-  })
-}
-
-export function invalidateConfiguredProjectLibraryEntries() {
-  configuredProjectLibraryEntriesInvalidation.value += 1
-}
-
-function readConfiguredProjectLibraryEntriesInvalidation() {
-  return configuredProjectLibraryEntriesInvalidation.value
-}
-
-function localHomeProjectEntriesFromProjects(
-  projects: readonly Project[] | undefined,
-  library?: Pick<ProjectLibrary, 'id' | 'path' | 'type'>
-): HomeProjectEntryContribution[] {
-  return (
-    projects?.map((project) => ({
-      ...homeProjectEntryFromProject(project),
-      ...(library
-        ? {
-            libraryId: library.id,
-            libraryPath: library.path,
-            libraryType: library.type,
-          }
-        : {}),
-    })) ?? []
-  )
-}
 
 function homeProjectDisplayNameExists({
   entries,
@@ -214,17 +62,165 @@ function homeProjectDisplayNameExists({
   )
 }
 
-function getProjectMoveSource({ project }: { project: HomeProjectEntry }) {
-  if (!project.localProjectPath || !project.readWriteAccess) {
-    return undefined
+function homeProjectStatusFromRealization(
+  realization: ProjectLibraryRealization
+): HomeProjectEntryContribution['status'] {
+  if (realization.conflict) {
+    return 'conflicted'
   }
+  if (realization.cloudProjectId) {
+    return 'synced'
+  }
+  return 'local'
+}
+
+function realizationDeletesRemoteOnDelete(
+  realization: ProjectLibraryRealization | undefined
+) {
+  return Boolean(
+    realization?.cloudProjectId &&
+      realization.libraryRefs.some(
+        (library) => library.type === CLOUD_PROJECT_LIBRARY_TYPE
+      )
+  )
+}
+
+/**
+ * Converts a local realization that is not part of a cloud relationship into a
+ * Home card. This path must stay local-only; cloud ID observations on the
+ * realization are not enough for Home to infer relationship identity.
+ */
+function homeProjectEntryFromRealization(
+  realization: ProjectLibraryRealization
+): HomeProjectEntryContribution {
+  return {
+    source: 'local',
+    status: homeProjectStatusFromRealization(realization),
+    libraryIds: realization.libraryIds,
+    name: realization.name,
+    title: realization.title,
+    localProjectPath: realization.localProjectPath,
+    localProjectName: realization.localProjectName,
+    remoteProjectId: realization.cloudProjectId,
+    deleteRemoteOnDelete: realizationDeletesRemoteOnDelete(realization),
+    modified: realization.modified,
+    defaultFile: realization.defaultFile,
+    kclFileCount: realization.kclFileCount,
+    directoryCount: realization.directoryCount,
+    readWriteAccess: realization.readWriteAccess,
+    thumbnail: realization.thumbnail,
+    conflict: realization.conflict,
+    syncFailure: realization.syncFailure,
+  }
+}
+
+function libraryIdsFromRelationship(
+  relationship: CloudProjectRelationship
+): readonly string[] {
+  const libraryIds = relationship.localRealizations.flatMap(
+    ({ realization }) => realization.libraryIds
+  )
+  return Array.from(new Set(libraryIds))
+}
+
+function homeProjectDuplicateRealizationFromRelationship(
+  relationship: CloudProjectRelationship,
+  duplicate: CloudProjectRelationshipRealization
+): HomeProjectDuplicateRealization {
+  return {
+    remoteProjectId: relationship.remoteProjectId,
+    canonicalProjectPath:
+      relationship.canonicalRealization?.realization.localProjectPath,
+    localProjectPath: duplicate.realization.localProjectPath,
+    localProjectName: duplicate.realization.localProjectName,
+    title: duplicate.realization.title,
+    libraryIds: duplicate.realization.libraryIds,
+    libraryTitles: duplicate.realization.libraryRefs.map(
+      (library) => library.title
+    ),
+    duplicateRisk: duplicate.duplicateRisk,
+    autoCleanupEligible: duplicate.autoCleanupEligible,
+  }
+}
+
+function homeProjectEntryFromCloudRelationship(
+  relationship: CloudProjectRelationship
+): HomeProjectEntryContribution {
+  const canonical = relationship.canonicalRealization?.realization
+  const duplicateRealizations = relationship.duplicateRealizations.map(
+    (duplicate) =>
+      homeProjectDuplicateRealizationFromRelationship(relationship, duplicate)
+  )
+  const relationshipLibraryIds = libraryIdsFromRelationship(relationship)
+  const source = canonical ? 'local' : 'remote'
+  const thumbnail = canonical?.thumbnail
+    ? canonical.thumbnail
+    : relationship.remoteThumbnailUrl
+      ? {
+          type: 'remote' as const,
+          url: relationship.remoteThumbnailUrl,
+        }
+      : undefined
 
   return {
-    localProjectPath: project.localProjectPath,
-    localProjectName:
-      project.localProjectName ?? fsZds.basename(project.localProjectPath),
-    defaultFile: project.defaultFile,
+    id: relationship.id,
+    cloudRelationshipId: relationship.id,
+    source,
+    status: relationship.conflict
+      ? 'conflicted'
+      : canonical
+        ? 'synced'
+        : 'cloud-only',
+    libraryIds:
+      relationshipLibraryIds.length > 0
+        ? relationshipLibraryIds
+        : [PERSONAL_CLOUD_PROJECT_LIBRARY_ID],
+    name: canonical?.name ?? relationship.name,
+    title: canonical?.title ?? relationship.title,
+    localProjectPath: canonical?.localProjectPath,
+    localProjectName: canonical?.localProjectName,
+    remoteProjectId: relationship.remoteProjectId,
+    deleteRemoteOnDelete: Boolean(
+      relationship.remoteProjectId &&
+        (!canonical || realizationDeletesRemoteOnDelete(canonical))
+    ),
+    modified: relationship.modified ?? canonical?.modified,
+    defaultFile: relationship.defaultFile ?? canonical?.defaultFile,
+    kclFileCount: canonical?.kclFileCount,
+    directoryCount: canonical?.directoryCount,
+    readWriteAccess: canonical?.readWriteAccess ?? true,
+    thumbnail,
+    conflict: relationship.conflict ?? canonical?.conflict,
+    syncFailure: relationship.syncFailure ?? canonical?.syncFailure,
+    duplicateRealizations:
+      duplicateRealizations.length > 0 ? duplicateRealizations : undefined,
   }
+}
+
+export function deriveHomeProjectEntryContributions({
+  realizations,
+  cloudRelationships,
+}: {
+  realizations: readonly ProjectLibraryRealization[]
+  cloudRelationships: readonly CloudProjectRelationship[]
+}): HomeProjectEntryContribution[] {
+  const relationshipLocalPaths = new Set(
+    cloudRelationships.flatMap((relationship) =>
+      relationship.localRealizations.map(
+        ({ realization }) => realization.localProjectPath
+      )
+    )
+  )
+  const relationshipEntries = cloudRelationships.map(
+    homeProjectEntryFromCloudRelationship
+  )
+  const localOnlyEntries = realizations
+    .filter(
+      (realization) => !relationshipLocalPaths.has(realization.localProjectPath)
+    )
+    .map(homeProjectEntryFromRealization)
+
+  return [...relationshipEntries, ...localOnlyEntries]
 }
 
 const homeProjectActions = defineRegistryItemFactory((ctx) => {
@@ -252,24 +248,7 @@ const homeProjectActions = defineRegistryItemFactory((ctx) => {
     }
 
     const libraryTypes = ctx.valueSpecs.get(projectLibraryTypesValueSpec)
-    const configuredLibraries = getConfiguredProjectLibraries()
-    const orderedLibraries =
-      project.libraryType !== undefined
-        ? [
-            ...configuredLibraries.filter(
-              (library) =>
-                projectLibraryIds.has(library.id) &&
-                library.type === project.libraryType
-            ),
-            ...configuredLibraries.filter(
-              (library) =>
-                projectLibraryIds.has(library.id) &&
-                library.type !== project.libraryType
-            ),
-          ]
-        : configuredLibraries
-
-    for (const library of orderedLibraries) {
+    for (const library of getConfiguredProjectLibraries()) {
       if (!projectLibraryIds.has(library.id)) {
         continue
       }
@@ -556,440 +535,31 @@ const homeProjectActions = defineRegistryItemFactory((ctx) => {
   }
 }, 'home-projects.actions')
 
-const systemIOLocalHomeProjectEntries = defineRegistryItemFactory((ctx) => {
-  const entries = signal<HomeProjectEntryContribution[]>([])
-  const systemIO = ctx.services.signal(systemIOService)
-  let systemIOSubscription: { unsubscribe: () => void } | undefined
-  let disposeSystemIOEffect: (() => void) | undefined
-  let disposed = false
-
-  queueMicrotask(() => {
-    if (disposed) {
-      return
-    }
-
-    disposeSystemIOEffect = effect(() => {
-      const service = systemIO.value
-      systemIOSubscription?.unsubscribe()
-      systemIOSubscription = undefined
-      entries.value = []
-
-      if (!service) {
-        return
-      }
-
-      const updateEntries = () => {
-        const snapshot = service.actor.getSnapshot()
-        const context = snapshot.context
-        const projects = context.folders
-        if (projects !== undefined) {
-          entries.value = localHomeProjectEntriesFromProjects(projects, {
-            id: DEFAULT_PROJECT_LIBRARY_ID,
-            path: context.projectDirectoryPath,
-            type: DIRECTORY_PROJECT_LIBRARY_TYPE,
-          })
-        }
-
-        if (
-          projects &&
-          snapshot.matches(SystemIOMachineStates.idle) &&
-          context.requestedProjectName.name === NO_PROJECT_DIRECTORY
-        ) {
-          scheduleProjectDirectoryNameSyncFromTitles({
-            projects,
-            onProjectDirectoriesRenamed: () => {
-              service.actor.send({
-                type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
-              })
-            },
-          })
-        }
-      }
-
-      updateEntries()
-      systemIOSubscription = service.actor.subscribe(updateEntries)
-    })
-  })
-
-  return {
-    item: defineRuntimeRegistryItem({
-      id: 'home-projects.system-io-local-projects',
-      provides: [
-        provide(homeProjectEntriesValueSpec, entries, {
-          key: 'home-projects.system-io-local-projects',
-        }),
-      ],
-      dispose: () => {
-        disposed = true
-        disposeSystemIOEffect?.()
-        systemIOSubscription?.unsubscribe()
-      },
-    }),
-  }
-}, 'home-projects.system-io-local-projects')
-
-function areProjectLibrariesEqual(
-  left: readonly ProjectLibrary[],
-  right: readonly ProjectLibrary[]
-) {
-  return (
-    left.length === right.length &&
-    left.every((library, index) => {
-      const otherLibrary = right[index]
-      return (
-        otherLibrary !== undefined &&
-        library.id === otherLibrary.id &&
-        library.title === otherLibrary.title &&
-        library.path === otherLibrary.path &&
-        library.type === otherLibrary.type &&
-        library.order === otherLibrary.order
-      )
+const homeProjectEntryViewModels = defineRegistryItemFactory((ctx) => {
+  const projectLibraryRealizations = ctx.valueSpecs.signal(
+    projectLibraryRealizationsValueSpec
+  )
+  const cloudProjectRelationships = ctx.valueSpecs.signal(
+    cloudProjectRelationshipsValueSpec
+  )
+  const entries = computed(() =>
+    deriveHomeProjectEntryContributions({
+      realizations: projectLibraryRealizations.value,
+      cloudRelationships: cloudProjectRelationships.value,
     })
   )
-}
-
-const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
-  const systemIO = ctx.services.signal(systemIOService)
-  const cloudSync = ctx.services.signal(cloudSyncService)
-  const getWasmPromise = () =>
-    ctx.valueSpecs.get(wasmPromiseValueSpec) ??
-    new ExpectedSystemIOError('Missing WASM promise registry value.')
-  const refreshLocalProjectEntries = () => {
-    systemIO.value?.actor.send({
-      type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
-    })
-    invalidateConfiguredProjectLibraryEntries()
-  }
 
   return {
     item: defineRuntimeRegistryItem({
-      id: 'home-projects.directory-library-type',
-      provides: [
-        provide(projectLibraryTypesValueSpec, {
-          type: DIRECTORY_PROJECT_LIBRARY_TYPE,
-          title: 'Directory',
-          icon: 'folder',
-          order: 0,
-          defaultSetting: {
-            title: DEFAULT_PROJECT_LIBRARY_TITLE,
-            path: 'projects',
-            type: DIRECTORY_PROJECT_LIBRARY_TYPE,
-          },
-          newLibrarySetting: {
-            title: NEW_PROJECT_LIBRARY_TITLE,
-            path: 'projects',
-            type: DIRECTORY_PROJECT_LIBRARY_TYPE,
-          },
-          settingsDetails: DirectoryProjectLibrarySettingsDetails,
-          hideInSettingsOnPlatform: 'web',
-          readEntries: async ({ library, signal }) => {
-            const wasmInstancePromise = getWasmPromise()
-            if (wasmInstancePromise instanceof Error) {
-              return Promise.reject(wasmInstancePromise)
-            }
-
-            return runReportedDirectoryProjectOperation({
-              operation: SystemIOMachineActors.readFoldersFromProjectDirectory,
-              risk: 'read',
-              run: async () => {
-                const projects = await readProjectsFromProjectDirectory({
-                  projectDirectoryPath: library.path,
-                  wasmInstancePromise,
-                  signal,
-                  onProjectStatFailures: reportDirectoryProjectStatFailures,
-                })
-                if (!signal.aborted) {
-                  scheduleProjectDirectoryNameSyncFromTitles({
-                    projects,
-                    onProjectDirectoriesRenamed:
-                      invalidateConfiguredProjectLibraryEntries,
-                  })
-                }
-
-                return localHomeProjectEntriesFromProjects(projects, library)
-              },
-            })
-          },
-          operations: withReportedDirectoryProjectOperations({
-            createProject: {
-              run: async ({
-                library,
-                requestedProjectName,
-                requestedProjectTitle,
-              }) => {
-                const wasmInstancePromise = getWasmPromise()
-                if (wasmInstancePromise instanceof Error) {
-                  return Promise.reject(wasmInstancePromise)
-                }
-
-                const project = await createProjectInLocalDirectory({
-                  projectDirectoryPath: library.path,
-                  requestedProjectName,
-                  requestedProjectTitle,
-                  wasmInstancePromise,
-                })
-                systemIO.value?.actor.send({
-                  type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
-                })
-                invalidateConfiguredProjectLibraryEntries()
-
-                return project
-              },
-            },
-            openProject: {
-              run: ({ project }) => {
-                if (!project.readWriteAccess || !project.defaultFile) {
-                  return undefined
-                }
-
-                return { defaultFile: project.defaultFile }
-              },
-            },
-            duplicateProject: {
-              run: async ({ library, project }) => {
-                if (!project.localProjectName || !project.localProjectPath) {
-                  return undefined
-                }
-                const wasmInstancePromise = getWasmPromise()
-                if (wasmInstancePromise instanceof Error) {
-                  return Promise.reject(wasmInstancePromise)
-                }
-
-                const result = await duplicateProjectInDirectory({
-                  source: {
-                    directoryName: project.localProjectName,
-                    displayName: getHomeProjectDisplayName(project),
-                    path: project.localProjectPath,
-                  },
-                  projectDirectoryPath: library.path,
-                  requestedProjectTitle: getHomeProjectDisplayName(project),
-                  wasmInstance: await wasmInstancePromise,
-                })
-                systemIO.value?.actor.send({
-                  type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
-                })
-                invalidateConfiguredProjectLibraryEntries()
-
-                return result
-              },
-            },
-            renameProject: {
-              run: async ({ project, requestedName }) => {
-                if (!project.localProjectPath || !project.readWriteAccess) {
-                  return
-                }
-
-                await writeProjectTitleToProjectToml(
-                  project.localProjectPath,
-                  requestedName
-                )
-                refreshLocalProjectEntries()
-              },
-            },
-            deleteProject: {
-              run: async ({ project }) => {
-                if (!project.localProjectPath || !project.readWriteAccess) {
-                  return
-                }
-
-                const cloudSyncActions = project.remoteProjectId
-                  ? cloudSync.value
-                  : undefined
-                if (
-                  project.remoteProjectId &&
-                  cloudSyncActions?.status.value.enabled !== true
-                ) {
-                  return Promise.reject(
-                    new ExpectedSystemIOError('Cloud sync is not enabled.')
-                  )
-                }
-
-                if (project.remoteProjectId) {
-                  await cloudSyncActions?.deleteLocalProjectRealizations(
-                    project.remoteProjectId,
-                    project.localProjectPath
-                  )
-                } else {
-                  await fsZds.rm(project.localProjectPath, {
-                    recursive: true,
-                  })
-                }
-                refreshLocalProjectEntries()
-              },
-            },
-            moveProjectFrom: {
-              canMoveProject: ({ project }) =>
-                Boolean(project.localProjectPath && project.readWriteAccess),
-              run: ({ project }) => getProjectMoveSource({ project }),
-            },
-            moveProjectTo: {
-              run: async ({ library, source }) => {
-                const result = await moveProjectIntoLocalDirectory({
-                  projectDirectoryPath: library.path,
-                  sourceProjectPath: source.localProjectPath,
-                  sourceProjectName: source.localProjectName,
-                  defaultFile: source.defaultFile,
-                })
-                refreshLocalProjectEntries()
-
-                return result
-              },
-            },
-          }),
-        }),
-      ],
-    }),
-  }
-}, 'home-projects.directory-library-type')
-
-const directoryProjectLibraryDefaultPolicy = defineRegistryItem({
-  id: 'home-projects.directory-library-default-policy',
-  provides: [
-    provide(projectLibrarySettingDefaultPoliciesValueSpec, {
-      id: 'home-projects.directory-library-default-policy',
-      priority: 0,
-      /**
-       * Product policy: the directory library owns the legacy default project
-       * directory fallback. Other library systems can contribute
-       * higher-priority policies without `loadAndValidateSettings()` knowing
-       * about their storage type.
-       */
-      getDefaultLibraries: ({ legacyProjectDirectory, initialDefaultDir }) =>
-        getDefaultProjectLibrarySettings(
-          legacyProjectDirectory ?? initialDefaultDir
-        ),
-    }),
-  ],
-})
-
-const configuredProjectLibraryEntries = defineRegistryItemFactory((ctx) => {
-  const settings = ctx.services.signal(settingsService)
-  const libraryTypes = ctx.valueSpecs.signal(projectLibraryTypesValueSpec)
-  const entries = signal<HomeProjectEntryContribution[]>([])
-  const entriesByLibraryId = new Map<string, HomeProjectEntryContribution[]>()
-  // Diagnostic dedupe: a configured library whose type has no registered
-  // handler cannot be listed and would silently vanish from Home. This should
-  // not happen (the cloud and directory types are always-on), so warn once per
-  // library rather than swallowing it.
-  const warnedMissingTypeLibraryIds = new Set<string>()
-  let abortController: AbortController | undefined
-  let disposeConfiguredProjectLibraryEntriesEffect: (() => void) | undefined
-  let disposed = false
-  let loadId = 0
-  let lastScannedConfiguredLibraries: ProjectLibrary[] | undefined
-  let lastScannedLibraryTypes: typeof libraryTypes.value | undefined
-  let lastScannedInvalidation = -1
-
-  const updateEntries = () => {
-    entries.value = Array.from(entriesByLibraryId.values()).flat()
-  }
-
-  // Defer because `effect` runs immediately, and service reads are blocked
-  // while the registry graph is still being built.
-  queueMicrotask(() => {
-    if (disposed) {
-      return
-    }
-
-    disposeConfiguredProjectLibraryEntriesEffect = effect(() => {
-      const currentSettings = settings.value?.current.value
-      const typeById = libraryTypes.value
-      // Directory library operations mutate the filesystem without changing
-      // settings or library type registrations. Read this signal so known
-      // mutations can invalidate and rescan configured library entries.
-      const invalidation = readConfiguredProjectLibraryEntriesInvalidation()
-
-      const configuredLibraries =
-        currentSettings !== undefined
-          ? projectLibrariesFromSettings(
-              currentSettings.app.libraries.current
-            ).filter((library) => library.id !== DEFAULT_PROJECT_LIBRARY_ID)
-          : []
-
-      if (
-        lastScannedLibraryTypes === typeById &&
-        lastScannedInvalidation === invalidation &&
-        lastScannedConfiguredLibraries &&
-        areProjectLibrariesEqual(
-          lastScannedConfiguredLibraries,
-          configuredLibraries
-        )
-      ) {
-        return
-      }
-
-      lastScannedLibraryTypes = typeById
-      lastScannedInvalidation = invalidation
-      lastScannedConfiguredLibraries = configuredLibraries
-      const nextLoadId = ++loadId
-
-      abortController?.abort()
-      const loadController = new AbortController()
-      abortController = loadController
-      entriesByLibraryId.clear()
-      entries.value = []
-
-      for (const library of configuredLibraries) {
-        const readEntries = typeById.get(library.type)?.readEntries
-        if (!readEntries) {
-          if (!warnedMissingTypeLibraryIds.has(library.id)) {
-            warnedMissingTypeLibraryIds.add(library.id)
-            console.warn(
-              `Configured project library "${library.title}" (${library.id}) has no registered "${library.type}" type handler; its projects cannot be listed.`
-            )
-          }
-          continue
-        }
-
-        readEntries({
-          library,
-          signal: loadController.signal,
-        })
-          .then((libraryEntries) => {
-            if (
-              disposed ||
-              loadController.signal.aborted ||
-              nextLoadId !== loadId
-            ) {
-              return
-            }
-
-            entriesByLibraryId.set(library.id, libraryEntries)
-            updateEntries()
-          })
-          .catch((error: unknown) => {
-            if (
-              disposed ||
-              loadController.signal.aborted ||
-              nextLoadId !== loadId
-            ) {
-              return
-            }
-
-            entriesByLibraryId.delete(library.id)
-            updateEntries()
-            reportRejection(error)
-          })
-      }
-    })
-  })
-
-  return {
-    item: defineRuntimeRegistryItem({
-      id: 'home-projects.configured-project-library-entries',
+      id: 'home-projects.view-models',
       provides: [
         provide(homeProjectEntriesValueSpec, entries, {
-          key: 'home-projects.configured-project-library-entries',
+          key: 'home-projects.view-models',
         }),
       ],
-      dispose: () => {
-        disposed = true
-        abortController?.abort()
-        disposeConfiguredProjectLibraryEntriesEffect?.()
-      },
     }),
   }
-}, 'home-projects.configured-project-library-entries')
+}, 'home-projects.view-models')
 
 function findHomeProjectEntryByProjectPath(
   entries: readonly HomeProjectEntry[],
@@ -1051,12 +621,9 @@ const moveProjectToLibraryProjectMenuItem = defineRegistryItemFactory((ctx) => {
 const homeProjectsExtension = defineRegistryItem({
   id: 'home-projects',
   uses: [
-    configuredProjectLibraryEntries,
-    directoryProjectLibraryDefaultPolicy,
-    directoryProjectLibraryType,
     homeProjectActions,
+    homeProjectEntryViewModels,
     moveProjectToLibraryProjectMenuItem,
-    systemIOLocalHomeProjectEntries,
   ],
 })
 


### PR DESCRIPTION
Addresses #12805 by removing Home project coalescing from the display pipeline.

A "Project" is really an ideal, and it can have zero or more "realizations" on the disk: cloud library projects that have never been opened on the device have zero, and multiple project folders on disk could share a common cloud ID. We needed one layer of indirection to break the coupling between folders on disk and the projects they represent, and this many-to-one mapping does just that.

## Important Changes
1. Adds `CloudProjectRelationship` derivation so cloudSync owns remote identity, canonical local realization selection, and duplicate metadata.
2. Publishes cloud relationships through a singleton `cloudProjectRelationshipsService` signal instead of a ValueSpec contribution surface.
3. Compares duplicate local realization manifests only for non-canonical cloud-library copies that could become exact, silently removable duplicates.
4. Replaces Home provider coalescing with derived Home view models from `projectLibraryRealizationsValueSpec` plus `cloudProjectRelationshipsService`.
5. Removes `source: 'both'`; local-plus-remote projects appear as one card only when cloudSync emits an explicit relationship.

## Manifest Comparison Note
To prove that two local folders are exactly the same cloud project copy, cloudSync has to read the syncable files in the folder and compare that content to the last clean cloud-sync snapshot. That can be expensive for large projects, so this PR avoids doing it during normal Home refresh for directory-library copies. Directory-library duplicates are still shown as duplicate copies, but their risk stays `unknown` until explicit review. The eager content comparison is reserved for cloud-library duplicate copies where an exact match could allow safe automatic cleanup.

## Feature Flag / Ungated Impact
This PR touches ungated Home rendering and cloudSync relationship derivation code. Users without the cloud sync feature flag should still see local projects from the default project directory and configured directory libraries through the realization pipeline introduced by #12849 and refreshed by #12854. They should not see cloud relationship behavior, duplicate-copy badges, or duplicate-review actions without the cloud sync UI flag.

## How To Test
Start without the cloud sync feature flag. Home should continue to show projects from the default project directory and configured directory libraries, and ordinary actions such as open, rename, duplicate, delete, and move-to-library should still work where they did before.

Then enable cloud sync and compare the core card states: local-only directory projects should remain local-only cards; remote-only cloud projects should render as cloud-only cards; synced projects should render through a cloud relationship instead of `homeProjects` coalescing separate local and remote contributions. This is still a form of "silent coalescing" that we are trying to address with #12805 but this is a refactor that enables the last PR to provide UI to handle duplicate project realizations.

For duplicate reproduction, copy a synced cloud project's local folder into a configured directory library using Finder or another file explorer. Home should keep relationship identity explicit: the canonical cloud relationship card should carry duplicate metadata, and local folders should not be hidden merely because they share a cloud project ID unless cloudSync emitted that relationship. Directory-library copies should appear as duplicate copies without requiring Home to scan their file contents eagerly; cloud-library duplicate copies can still be classified as `exact` when they are safe automatic cleanup candidates.

## Stack
This is PR 4 of 5.

1. #12843: project-library realization model and domain documentation.
2. #12849: configured project-library realization discovery.
3. #12854: project-library realization freshness without System IO.
4. This PR: cloud relationships and Home derivation without coalescing.
5. #12841: duplicate-copy review and cleanup UI.