### PR TITLE
feat(kcl): render enum variants in generated type docs

### DIFF
--- a/rust/kcl-lib/src/docs/gen_std_tests.rs
+++ b/rust/kcl-lib/src/docs/gen_std_tests.rs
@@ -301,16 +301,34 @@ fn generate_type_from_kcl(ty: &TyData, file_name: String, example_name: String, 
         .filter_map(|(index, example)| generate_example(index, &example.0, &example.1, &example_name))
         .collect();
 
+    let definition = if let Some(t) = ty.alias.as_ref() {
+        Some(format!("type {} = {t}", ty.preferred_name))
+    } else if !ty.variants.is_empty() {
+        let arms = ty
+            .variants
+            .iter()
+            .map(|v| format!("  | {}", v.name))
+            .collect::<Vec<_>>()
+            .join("\n");
+        Some(format!("type {} {{\n{arms}\n}}", ty.name))
+    } else {
+        None
+    };
+
     let data = json!({
         "name": ty.preferred_name,
         "module": mod_name_std(&ty.module_name),
-        "definition": ty.alias.as_ref().map(|t| format!("type {} = {t}", ty.preferred_name)),
+        "definition": definition,
         "summary": ty.summary.clone(),
         "description": ty.description.clone(),
         "deprecated": ty.properties.deprecated,
         "deprecated_since": ty.properties.deprecated_since.as_ref().map(ToString::to_string),
         "experimental": ty.properties.experimental,
         "examples": examples,
+        "variants": ty.variants.iter().map(|v| json!({
+            "name": v.name,
+            "docs": v.docs,
+        })).collect::<Vec<_>>(),
     });
 
     let output = hbs.render("kclType", &data)?;

--- a/rust/kcl-lib/src/docs/gen_std_tests.rs
+++ b/rust/kcl-lib/src/docs/gen_std_tests.rs
@@ -285,11 +285,11 @@ fn generate_example(index: usize, src: &str, props: &ExampleProperties, file_nam
     }))
 }
 
-fn generate_type_from_kcl(ty: &TyData, file_name: String, example_name: String, kcl_std: &ModData) -> Result<()> {
-    if ty.properties.doc_hidden {
-        return Ok(());
-    }
-
+/// Renders a type's documentation page to markdown, without resolving type
+/// links against the stdlib and without writing output. Split from
+/// `generate_type_from_kcl` so the rendering can be unit tested with a
+/// synthetic `TyData`.
+fn render_type_page(ty: &TyData, example_name: &str) -> Result<String> {
     check_deprecation_attrs(&ty.qual_name, &ty.properties)?;
 
     let hbs = init_handlebars()?;
@@ -298,7 +298,7 @@ fn generate_type_from_kcl(ty: &TyData, file_name: String, example_name: String, 
         .examples
         .iter()
         .enumerate()
-        .filter_map(|(index, example)| generate_example(index, &example.0, &example.1, &example_name))
+        .filter_map(|(index, example)| generate_example(index, &example.0, &example.1, example_name))
         .collect();
 
     let definition = if let Some(t) = ty.alias.as_ref() {
@@ -331,7 +331,15 @@ fn generate_type_from_kcl(ty: &TyData, file_name: String, example_name: String, 
         })).collect::<Vec<_>>(),
     });
 
-    let output = hbs.render("kclType", &data)?;
+    Ok(hbs.render("kclType", &data)?)
+}
+
+fn generate_type_from_kcl(ty: &TyData, file_name: String, example_name: String, kcl_std: &ModData) -> Result<()> {
+    if ty.properties.doc_hidden {
+        return Ok(());
+    }
+
+    let output = render_type_page(ty, &example_name)?;
     let output = cleanup_types(&output, kcl_std);
     write_doc_output(&file_name, &output)?;
 
@@ -637,6 +645,65 @@ fn cleanup_type_string(input: &str, fmt_for_text: bool, kcl_std: &ModData) -> St
     } else {
         fmtd
     }
+}
+
+/// Renders a synthetic enum type, constructed directly rather than parsed
+/// from a std file, so the variant rendering is covered even while std
+/// declares no enums.
+#[test]
+fn test_render_type_page_enum_variants() {
+    let mut ty = TyData {
+        name: "Direction".to_owned(),
+        preferred_name: "turns::Direction".to_owned(),
+        qual_name: "std::turns::Direction".to_owned(),
+        properties: Properties {
+            deprecated: false,
+            deprecated_since: None,
+            experimental: true,
+            doc_hidden: false,
+            exported: true,
+            impl_kind: crate::execution::annotations::Impl::Kcl,
+            doc_category: None,
+        },
+        alias: None,
+        variants: vec![
+            super::kcl_doc::TyVariantData {
+                name: "Clockwise".to_owned(),
+                docs: Some("Turns in the direction of a clock's hands.".to_owned()),
+            },
+            super::kcl_doc::TyVariantData {
+                name: "Counterclockwise".to_owned(),
+                docs: None,
+            },
+        ],
+        summary: Some("The direction of rotation.".to_owned()),
+        description: None,
+        examples: Vec::new(),
+        module_name: "turns".to_owned(),
+    };
+
+    let page = render_type_page(&ty, "std-turns-Direction").unwrap();
+
+    assert!(page.lines().count() > 10, "expected a full page, got:\n{page}");
+    assert!(page.contains("The direction of rotation."));
+    assert!(page.contains("**WARNING:** This type is experimental"));
+    assert!(
+        page.contains("type Direction {\n  | Clockwise\n  | Counterclockwise\n}"),
+        "expected the enum definition block, got:\n{page}"
+    );
+    assert!(page.contains("### Variants"));
+    assert!(
+        page.contains("| `Clockwise` | Turns in the direction of a clock's hands. |"),
+        "expected a table row with the variant's docs, got:\n{page}"
+    );
+    assert!(page.contains("| `Counterclockwise` |"));
+
+    // A type without variants must not render the section. The exact
+    // whitespace of real pages is pinned by test_generate_stdlib_markdown_docs.
+    ty.variants.clear();
+    let page = render_type_page(&ty, "std-turns-Direction").unwrap();
+    assert!(!page.contains("### Variants"));
+    assert!(!page.contains("Clockwise"));
 }
 
 #[test]

--- a/rust/kcl-lib/src/docs/kcl_doc.rs
+++ b/rust/kcl-lib/src/docs/kcl_doc.rs
@@ -1087,6 +1087,9 @@ pub struct TyData {
     pub qual_name: String,
     pub properties: Properties,
     pub alias: Option<String>,
+    /// The variants of an enum type, in declaration order. Empty for
+    /// non-enum types.
+    pub variants: Vec<TyVariantData>,
 
     /// The summary of the function.
     pub summary: Option<String>,
@@ -1097,6 +1100,29 @@ pub struct TyData {
     pub examples: Vec<(String, ExampleProperties)>,
 
     pub module_name: String,
+}
+
+/// One variant of an enum type, with the doc comment attached to it in the
+/// declaration, e.g. `/// The standard three-quarter view.` above
+/// `| Isometric`.
+#[derive(Debug, Clone)]
+pub struct TyVariantData {
+    pub name: String,
+    pub docs: Option<String>,
+}
+
+/// The doc comment attached to one enum variant: the `///` lines among its
+/// pre-comments, markers stripped, joined into one string.
+fn variant_docs(pre_comments: &[String]) -> Option<String> {
+    let lines: Vec<&str> = pre_comments
+        .iter()
+        .filter(|l| l.starts_with("///"))
+        .map(|l| l.strip_prefix("/// ").unwrap_or(&l[3..]).trim_end())
+        .collect();
+    if lines.is_empty() {
+        return None;
+    }
+    Some(lines.join(" "))
 }
 
 impl TyData {
@@ -1126,6 +1152,17 @@ impl TyData {
                 TypeDeclarationDefinition::Alias { ty } => Some(ty.to_string()),
                 TypeDeclarationDefinition::Bare | TypeDeclarationDefinition::Enum(_) => None,
             },
+            variants: match &ty.definition {
+                TypeDeclarationDefinition::Enum(decl) => decl
+                    .variants
+                    .iter()
+                    .map(|variant| TyVariantData {
+                        name: variant.name.name.clone(),
+                        docs: variant_docs(&variant.pre_comments),
+                    })
+                    .collect(),
+                TypeDeclarationDefinition::Bare | TypeDeclarationDefinition::Alias { .. } => Vec::new(),
+            },
             summary: None,
             description: None,
             examples: Vec::new(),
@@ -1152,22 +1189,45 @@ impl TyData {
     fn to_completion_item(&self) -> CompletionItem {
         CompletionItem {
             label: self.preferred_name.clone(),
-            label_details: self.alias.as_ref().map(|t| CompletionItemLabelDetails {
-                detail: Some(format!("type {} = {t}", self.name)),
-                description: None,
-            }),
+            label_details: self
+                .alias
+                .as_ref()
+                .map(|t| CompletionItemLabelDetails {
+                    detail: Some(format!("type {} = {t}", self.name)),
+                    description: None,
+                })
+                .or_else(|| {
+                    if self.variants.is_empty() {
+                        return None;
+                    }
+                    let arms = self.variants.iter().map(|v| v.name.as_str()).collect::<Vec<_>>();
+                    Some(CompletionItemLabelDetails {
+                        detail: Some(format!("type {} {{ | {} }}", self.name, arms.join(" | "))),
+                        description: None,
+                    })
+                }),
             kind: self
                 .properties
                 .doc_category
                 .map(DocCategory::to_completion_item_kind)
                 .or(Some(CompletionItemKind::STRUCT)),
             detail: Some(self.qual_name().to_owned()),
-            documentation: self.short_docs().map(|s| {
-                Documentation::MarkupContent(MarkupContent {
+            documentation: {
+                let mut value = self.short_docs().map(|s| remove_md_links(&s)).unwrap_or_default();
+                for variant in &self.variants {
+                    value.push_str(if value.is_empty() { "- `" } else { "\n- `" });
+                    value.push_str(&variant.name);
+                    value.push('`');
+                    if let Some(docs) = &variant.docs {
+                        value.push_str(": ");
+                        value.push_str(&remove_md_links(docs));
+                    }
+                }
+                (!value.is_empty()).then_some(Documentation::MarkupContent(MarkupContent {
                     kind: MarkupKind::Markdown,
-                    value: remove_md_links(&s),
-                })
-            }),
+                    value,
+                }))
+            },
             deprecated: Some(self.properties.deprecated),
             preselect: None,
             sort_text: None,

--- a/rust/kcl-lib/src/docs/templates/kclType.hbs
+++ b/rust/kcl-lib/src/docs/templates/kclType.hbs
@@ -28,6 +28,16 @@ layout: manual
 {{{description}}}
 
 
+{{#if variants}}
+### Variants
+
+| Variant | Description |
+|---------|-------------|
+{{#each variants}}
+| `{{name}}` | {{{docs}}} |
+{{/each}}
+
+{{/if}}
 {{#if examples}}
 ### Examples
 


### PR DESCRIPTION
- extract each variant's name and its /// pre-comments into TyData
- type pages gain the enum definition block and a Variants table
- LSP completion for an enum type shows the declaration one-liner and per-variant docs
- no generated-docs diff in this change: std declares no enums yet