### PR TITLE
Send cross-service correlation IDs

### DIFF
--- a/src/lib/engineConnection/connection.ts
+++ b/src/lib/engineConnection/connection.ts
@@ -63,6 +63,7 @@ export class Connection extends EventTarget {
   unreliableDataChannel: RTCDataChannel | undefined
   mediaStream: MediaStream | undefined
   websocket: WebSocket | undefined
+  apiCallId: string | undefined
   sdpAnswer: RTCSessionDescriptionInit | undefined
 
   // Promises to write sync code and await the multiple levels of
@@ -619,6 +620,9 @@ export class Connection extends EventTarget {
       webrtcStatsCollector: () => this.webrtcStatsCollector?.bind(this),
       sdpAnswerResolve: this.deferredSdpAnswer.resolve,
       sdpAnswerReject: this.deferredSdpAnswer.reject,
+      setApiCallId: (apiCallId) => {
+        this.apiCallId = apiCallId
+      },
     })
     const onWebSocketClose = createOnWebSocketClose({
       websocket: this.websocket,

--- a/src/lib/engineConnection/connectionManager.ts
+++ b/src/lib/engineConnection/connectionManager.ts
@@ -97,6 +97,10 @@ export class ConnectionManager extends EventTarget {
   commandLogs: CommandLog[] = []
 
   connection: Connection | undefined
+
+  get apiCallId(): string | undefined {
+    return this.connection?.apiCallId
+  }
   private readonly systemDeps: ConnectionSystemDeps
 
   streamDimensions = {

--- a/src/lib/engineConnection/websocketConnection.ts
+++ b/src/lib/engineConnection/websocketConnection.ts
@@ -96,6 +96,7 @@ export const createOnWebSocketMessage = ({
   webrtcStatsCollector,
   sdpAnswerResolve,
   sdpAnswerReject,
+  setApiCallId,
 }: {
   disconnectAll: () => void
   setPong: (pong: number) => void
@@ -110,6 +111,7 @@ export const createOnWebSocketMessage = ({
   webrtcStatsCollector: () => (() => Promise<ClientMetrics>) | undefined
   sdpAnswerResolve: (value: any) => void
   sdpAnswerReject: (value: any) => void
+  setApiCallId: (apiCallId: string) => void
 }) => {
   const onWebSocketMessage = (event: MessageEvent<any>) => {
     // In the EngineConnection, we're looking for messages to/from
@@ -180,6 +182,7 @@ export const createOnWebSocketMessage = ({
         break
       case 'modeling_session_data':
         const apiCallId = resp.data.session.api_call_id
+        setApiCallId(apiCallId)
         mark('code/apiCallId', {
           name: 'code/apiCallId',
           startTime: performance.now(),

--- a/src/lib/zookeeper/mlEphantManagerMachine.test.ts
+++ b/src/lib/zookeeper/mlEphantManagerMachine.test.ts
@@ -3,6 +3,7 @@ import { resetReportedClientErrorsForTests } from '@src/lib/clientErrors'
 import type { FileMeta } from '@src/lib/types'
 import {
   type Conversation,
+  createZookeeperTurnCorrelation,
   type MlCopilotModeOption,
   MlEphantConversationToMarkdown,
   type MlEphantManagerContext,
@@ -113,6 +114,26 @@ type SetupActorInput = {
 }
 
 const completedConversationStartedAt = new Date('2026-07-15T12:00:00.000Z')
+
+describe('createZookeeperTurnCorrelation', () => {
+  it('creates a unique turn ID and includes the Engine API call ID', () => {
+    const first = createZookeeperTurnCorrelation('engine-api-call-id')
+    const second = createZookeeperTurnCorrelation('engine-api-call-id')
+
+    expect(first.turn_id).not.toBe(second.turn_id)
+    expect(first.turn_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+    )
+    expect(first.engine_api_call_id).toBe('engine-api-call-id')
+  })
+
+  it('omits the Engine API call ID before an Engine session exists', () => {
+    expect(createZookeeperTurnCorrelation(undefined)).not.toHaveProperty(
+      'engine_api_call_id'
+    )
+  })
+})
+
 const completedConversation: Conversation = {
   exchanges: [
     {

--- a/src/lib/zookeeper/mlEphantManagerMachine.test.ts
+++ b/src/lib/zookeeper/mlEphantManagerMachine.test.ts
@@ -3,7 +3,7 @@ import { resetReportedClientErrorsForTests } from '@src/lib/clientErrors'
 import type { FileMeta } from '@src/lib/types'
 import {
   type Conversation,
-  createZookeeperTurnCorrelation,
+  createZookeeperCorrelation,
   type MlCopilotModeOption,
   MlEphantConversationToMarkdown,
   type MlEphantManagerContext,
@@ -115,20 +115,20 @@ type SetupActorInput = {
 
 const completedConversationStartedAt = new Date('2026-07-15T12:00:00.000Z')
 
-describe('createZookeeperTurnCorrelation', () => {
-  it('creates a unique turn ID and includes the Engine API call ID', () => {
-    const first = createZookeeperTurnCorrelation('engine-api-call-id')
-    const second = createZookeeperTurnCorrelation('engine-api-call-id')
+describe('createZookeeperCorrelation', () => {
+  it('creates a unique correlation ID and includes the Engine API call ID', () => {
+    const first = createZookeeperCorrelation('engine-api-call-id')
+    const second = createZookeeperCorrelation('engine-api-call-id')
 
-    expect(first.turn_id).not.toBe(second.turn_id)
-    expect(first.turn_id).toMatch(
+    expect(first.correlation_id).not.toBe(second.correlation_id)
+    expect(first.correlation_id).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
     )
     expect(first.engine_api_call_id).toBe('engine-api-call-id')
   })
 
   it('omits the Engine API call ID before an Engine session exists', () => {
-    expect(createZookeeperTurnCorrelation(undefined)).not.toHaveProperty(
+    expect(createZookeeperCorrelation(undefined)).not.toHaveProperty(
       'engine_api_call_id'
     )
   })

--- a/src/lib/zookeeper/mlEphantManagerMachine.ts
+++ b/src/lib/zookeeper/mlEphantManagerMachine.ts
@@ -61,14 +61,14 @@ type MlCopilotUserRequest = Omit<
   // but mode discovery intentionally treats the backend-provided id as opaque.
   mode?: MlCopilotModeId
   active_file?: string
-  turn_id?: string
+  correlation_id?: string
   engine_api_call_id?: string
 }
 
-export const createZookeeperTurnCorrelation = (
+export const createZookeeperCorrelation = (
   engineApiCallId: string | undefined
 ) => ({
-  turn_id: uuidv4(),
+  correlation_id: uuidv4(),
   ...(engineApiCallId ? { engine_api_call_id: engineApiCallId } : {}),
 })
 
@@ -1290,7 +1290,7 @@ export const mlEphantManagerMachine = setup({
 
       const request: MlCopilotUserRequest = {
         type: 'user',
-        ...createZookeeperTurnCorrelation(event.engineCommandManager.apiCallId),
+        ...createZookeeperCorrelation(event.engineCommandManager.apiCallId),
         content: requestData.body.prompt ?? '',
         project_name: requestData.body.project_name,
         ...(requestData.body.source_ranges !== undefined

--- a/src/lib/zookeeper/mlEphantManagerMachine.ts
+++ b/src/lib/zookeeper/mlEphantManagerMachine.ts
@@ -17,7 +17,7 @@ import {
 
 import { ClientErrorCode, reportClientError } from '@src/lib/clientErrors'
 import { isErr } from '@src/lib/trap'
-import { isArray } from '@src/lib/utils'
+import { isArray, uuidv4 } from '@src/lib/utils'
 
 import { getKclVersion } from '@src/lib/kclVersion'
 import { S, transitions, xstateEventError } from '@src/machines/utils'
@@ -61,7 +61,16 @@ type MlCopilotUserRequest = Omit<
   // but mode discovery intentionally treats the backend-provided id as opaque.
   mode?: MlCopilotModeId
   active_file?: string
+  turn_id?: string
+  engine_api_call_id?: string
 }
+
+export const createZookeeperTurnCorrelation = (
+  engineApiCallId: string | undefined
+) => ({
+  turn_id: uuidv4(),
+  ...(engineApiCallId ? { engine_api_call_id: engineApiCallId } : {}),
+})
 
 type MlCopilotProjectContextRequest = Extract<
   MlCopilotClientMessage,
@@ -1281,6 +1290,7 @@ export const mlEphantManagerMachine = setup({
 
       const request: MlCopilotUserRequest = {
         type: 'user',
+        ...createZookeeperTurnCorrelation(event.engineCommandManager.apiCallId),
         content: requestData.body.prompt ?? '',
         project_name: requestData.body.project_name,
         ...(requestData.body.source_ranges !== undefined


### PR DESCRIPTION
- retain the Engine modeling-session API call ID received over the websocket
- generate a unique `correlation_id` for every Zookeeper user request
- send both IDs with the request so downstream services can correlate a user turn, Zookeeper trace, and Engine session

Incident Slack [Thread](https://kittycadworkspace.slack.com/archives/C0BLVAR0KUM)
Discussion [thread](https://kittycadworkspace.slack.com/archives/C0BLVAR0KUM/p1785949574632399)