### PR TITLE
Project libraries: watch realization changes

### DIFF
--- a/interface.d.ts
+++ b/interface.d.ts
@@ -48,7 +48,8 @@ export interface IElectronAPI {
   watchFileOn: (
     path: string,
     key: string,
-    callback: (eventType: string, path: string) => void
+    callback: (eventType: string, path: string) => void,
+    options?: { depth?: number }
   ) => void
   readFile: typeof fs.readFile
   watchFileOff: (path: string, key: string) => void

--- a/src/lib/projectLibraries/registry/index.test.ts
+++ b/src/lib/projectLibraries/registry/index.test.ts
@@ -1,0 +1,171 @@
+import {
+  defineRegistryItem,
+  provide,
+  provideService,
+  Registry,
+} from '@kittycad/registry'
+import { signal } from '@preact/signals-core'
+import {
+  projectLibrariesFromSettings,
+  type ProjectLibrarySetting,
+} from '@src/lib/projectLibraries'
+import projectLibrariesExtension from '@src/lib/projectLibraries/registry'
+import {
+  projectLibraryRealizationsService,
+  projectLibraryRealizationsValueSpec,
+  projectLibraryTypesValueSpec,
+} from '@src/registry/contracts/projectLibraries'
+import type { SettingsRegistryService } from '@src/registry/contracts/settings'
+import { settingsService } from '@src/registry/contracts/settings'
+import { waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@src/lib/wasm_lib_wrapper', () => ({}))
+
+function createSettingsService(libraries: readonly ProjectLibrarySetting[]) {
+  const current = signal({
+    app: {
+      libraries: {
+        current: libraries,
+      },
+    },
+  })
+
+  return {
+    actor: {
+      getSnapshot: () => ({
+        matches: (state: string) => state === 'idle',
+      }),
+    },
+    current,
+    get: () => current.value,
+    send: vi.fn(),
+    useSettings: () => current.value,
+  } as unknown as SettingsRegistryService
+}
+
+describe('project library realizations registry service', () => {
+  let registry: Registry | undefined
+
+  afterEach(() => {
+    registry?.[Symbol.dispose]()
+    registry = undefined
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('invalidates only changed libraries from configured library watchers', async () => {
+    const librarySettings = [
+      {
+        title: 'Library A',
+        path: '/projects-a',
+        type: 'custom-directory',
+      },
+      {
+        title: 'Library B',
+        path: '/projects-b',
+        type: 'custom-directory',
+      },
+    ] satisfies ProjectLibrarySetting[]
+    const readRealizations = vi.fn(async () => [])
+    const registrations: {
+      path: string
+      key: string
+      callback: (eventType: string, path: string) => void
+      options?: { depth?: number }
+    }[] = []
+    const originalElectron = window.electron
+    const electronMock = {
+      ...(originalElectron ?? {}),
+      watchFileOn: vi.fn((path, key, callback, options) => {
+        registrations.push({ path, key, callback, options })
+      }),
+      watchFileOff: vi.fn(),
+    } as NonNullable<typeof window.electron>
+    Object.defineProperty(window, 'electron', {
+      configurable: true,
+      value: electronMock,
+    })
+    let dispose: (() => void) | undefined
+
+    try {
+      registry = new Registry()
+      registry.configure([
+        defineRegistryItem({
+          id: 'test.settings',
+          providesServices: [
+            provideService(
+              settingsService,
+              createSettingsService(librarySettings)
+            ),
+          ],
+        }),
+        defineRegistryItem({
+          id: 'test.custom-library-type',
+          provides: [
+            provide(projectLibraryTypesValueSpec, {
+              type: 'custom-directory',
+              title: 'Custom Directory',
+              readRealizations,
+            }),
+          ],
+        }),
+        projectLibrariesExtension,
+      ])
+      expect(
+        registry.signal(projectLibraryRealizationsValueSpec).value
+      ).toEqual([])
+
+      await waitFor(() => expect(readRealizations).toHaveBeenCalledTimes(2))
+      readRealizations.mockClear()
+
+      dispose = registry
+        .get(projectLibraryRealizationsService)
+        .watchConfiguredLibraries({
+          libraries: projectLibrariesFromSettings(librarySettings),
+        })
+      expect(electronMock.watchFileOn).toHaveBeenCalledWith(
+        '/projects-a',
+        expect.any(String),
+        expect.any(Function),
+        { depth: 0 }
+      )
+      expect(electronMock.watchFileOn).toHaveBeenCalledWith(
+        '/projects-b',
+        expect.any(String),
+        expect.any(Function),
+        { depth: 0 }
+      )
+
+      vi.useFakeTimers()
+      registrations
+        .find((registration) => registration.path === '/projects-a')
+        ?.callback('unlinkDir', '/projects-a/old-project')
+      await vi.advanceTimersByTimeAsync(750)
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(readRealizations).toHaveBeenCalledTimes(1)
+      expect(readRealizations).toHaveBeenCalledWith(
+        expect.objectContaining({
+          library: expect.objectContaining({ path: '/projects-a' }),
+        })
+      )
+      expect(readRealizations).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          library: expect.objectContaining({ path: '/projects-b' }),
+        })
+      )
+
+      dispose()
+      dispose = undefined
+      expect(electronMock.watchFileOff).toHaveBeenCalledTimes(2)
+    } finally {
+      dispose?.()
+      Object.defineProperty(window, 'electron', {
+        configurable: true,
+        value: originalElectron,
+      })
+    }
+  })
+})

--- a/src/lib/projectLibraries/registry/index.test.ts
+++ b/src/lib/projectLibraries/registry/index.test.ts
@@ -138,9 +138,17 @@ describe('project library realizations registry service', () => {
       )
 
       vi.useFakeTimers()
-      registrations
-        .find((registration) => registration.path === '/projects-a')
-        ?.callback('unlinkDir', '/projects-a/old-project')
+      const libraryAWatcher = registrations.find(
+        (registration) => registration.path === '/projects-a'
+      )
+
+      libraryAWatcher?.callback('unlinkDir', '/projects-a/old-project/main.kcl')
+      libraryAWatcher?.callback('unlinkDir', '/projects-b/old-project')
+      libraryAWatcher?.callback('ready', '/projects-a/old-project')
+      await vi.advanceTimersByTimeAsync(750)
+      expect(readRealizations).not.toHaveBeenCalled()
+
+      libraryAWatcher?.callback('unlinkDir', '/projects-a/old-project')
       await vi.advanceTimersByTimeAsync(750)
       await Promise.resolve()
       await Promise.resolve()

--- a/src/lib/projectLibraries/registry/index.ts
+++ b/src/lib/projectLibraries/registry/index.ts
@@ -172,6 +172,12 @@ type ProjectLibraryWatchTarget = {
   libraryIds: readonly string[]
 }
 
+type ProjectLibraryWatchPathScope =
+  | 'outside'
+  | 'root'
+  | 'immediate-child'
+  | 'nested-child'
+
 function normalizeProjectLibraryWatchPath(path: string) {
   return path.trim().replaceAll('\\', '/').replace(/\/+$/g, '')
 }
@@ -201,59 +207,51 @@ function projectLibraryWatchTargetsFromLibraries(
   )
 }
 
-function relativeProjectLibraryWatchPath(
+/**
+ * Classifies a file-watch event path relative to one configured library root.
+ * Discovery only needs root and immediate-child events because each direct
+ * child may be a local project realization; deeper file events belong to an
+ * already-known realization and should not trigger a full library rescan.
+ */
+function projectLibraryWatchPathScope(
   targetPath: string,
   libraryPath: string
-) {
+): ProjectLibraryWatchPathScope {
   const normalizedTargetPath = normalizeProjectLibraryWatchPath(targetPath)
   const normalizedLibraryPath = normalizeProjectLibraryWatchPath(libraryPath)
 
   if (normalizedTargetPath === normalizedLibraryPath) {
-    return ''
+    return 'root'
   }
 
   const libraryPrefix = `${normalizedLibraryPath}/`
   if (!normalizedTargetPath.startsWith(libraryPrefix)) {
-    return undefined
+    return 'outside'
   }
 
-  return normalizedTargetPath.slice(libraryPrefix.length)
+  const relativePath = normalizedTargetPath.slice(libraryPrefix.length)
+  return relativePath.includes('/') ? 'nested-child' : 'immediate-child'
 }
 
-function countNormalizedPathSegments(path: string) {
-  let count = 0
-  let inSegment = false
+const PROJECT_LIBRARY_REALIZATION_INVALIDATION_EVENT_TYPES = new Set([
+  'add',
+  'addDir',
+  'change',
+  'unlink',
+  'unlinkDir',
+])
 
-  for (const character of path) {
-    if (character === '/') {
-      inSegment = false
-      continue
-    }
-
-    if (!inSegment) {
-      count += 1
-      inSegment = true
-    }
-  }
-
-  return count
-}
-
-function isProjectLibraryRealizationBoundaryEvent(
+function shouldInvalidateProjectLibraryRealizationsForWatchEvent(
   eventType: string,
   targetPath: string,
   libraryPath: string
 ) {
-  if (!['add', 'addDir', 'change', 'unlink', 'unlinkDir'].includes(eventType)) {
+  if (!PROJECT_LIBRARY_REALIZATION_INVALIDATION_EVENT_TYPES.has(eventType)) {
     return false
   }
 
-  const relativePath = relativeProjectLibraryWatchPath(targetPath, libraryPath)
-  if (relativePath === undefined) {
-    return false
-  }
-
-  return relativePath === '' || countNormalizedPathSegments(relativePath) <= 1
+  const pathScope = projectLibraryWatchPathScope(targetPath, libraryPath)
+  return pathScope === 'root' || pathScope === 'immediate-child'
 }
 
 function watchConfiguredProjectLibraries({
@@ -305,7 +303,7 @@ function watchConfiguredProjectLibraries({
       watcherKey,
       (eventType, targetPath) => {
         if (
-          !isProjectLibraryRealizationBoundaryEvent(
+          !shouldInvalidateProjectLibraryRealizationsForWatchEvent(
             eventType,
             targetPath,
             target.path

--- a/src/lib/projectLibraries/registry/index.ts
+++ b/src/lib/projectLibraries/registry/index.ts
@@ -3,6 +3,7 @@ import {
   defineRegistryItemFactory,
   defineRuntimeRegistryItem,
   provide,
+  provideService,
 } from '@kittycad/registry'
 import { effect, signal } from '@preact/signals-core'
 import { writeProjectTitleToProjectToml } from '@src/lib/desktop'
@@ -28,18 +29,22 @@ import {
 import { projectLibraryRealizationFromProject } from '@src/lib/projectLibraries/realizations'
 import {
   invalidateProjectLibraryRealizations,
+  readProjectLibraryRealizationInvalidationForLibrary,
   readProjectLibraryRealizationsInvalidation,
+  type ProjectLibraryRealizationsInvalidationSnapshot,
 } from '@src/lib/projectLibraries/registry/invalidation'
 import { DirectoryProjectLibrarySettingsDetails } from '@src/lib/projectLibraries/settings/ProjectLibrariesSettingInput'
 import { projectLibrariesSettingsContribution } from '@src/lib/projectLibraries/settings/setting'
 import { reportRejection } from '@src/lib/trap'
-import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
+import { uuidv4 } from '@src/lib/utils'
 import { cloudSyncService } from '@src/registry/contracts/cloudSync'
 import type { HomeProjectEntry } from '@src/registry/contracts/homeProjects'
 import {
   type ProjectLibraryRealizationContribution,
+  type ProjectLibraryRealizationsService,
   type ProjectLibraryTypeContribution,
   type ProjectLibraryTypeOperations,
+  projectLibraryRealizationsService,
   projectLibraryRealizationsValueSpec,
   projectLibrarySettingDefaultPoliciesValueSpec,
   projectLibraryTypesValueSpec,
@@ -48,7 +53,6 @@ import {
   settingsService,
   settingsValueSpec,
 } from '@src/registry/contracts/settings'
-import { systemIOService } from '@src/registry/contracts/systemIO'
 import { wasmPromiseValueSpec } from '@src/registry/contracts/wasm'
 
 function areProjectLibrariesEqual(
@@ -71,71 +75,269 @@ function areProjectLibrariesEqual(
   )
 }
 
-/** Inputs whose change requires configured libraries to be rediscovered. */
-type ConfiguredProjectLibraryScanInputs = {
-  libraries: readonly ProjectLibrary[]
-  libraryTypes: ReadonlyMap<string, ProjectLibraryTypeContribution>
-  invalidation: number
+type ProjectLibraryInvalidationGeneration = {
+  global: number
+  library: number
 }
 
-/**
- * Avoids rescanning when unrelated settings updates produce new settings object
- * identities but the library list, type handlers, and invalidation token are
- * unchanged.
- */
-function configuredProjectLibraryScanInputsAreEqual(
-  left: ConfiguredProjectLibraryScanInputs | undefined,
-  right: ConfiguredProjectLibraryScanInputs
+/** Inputs whose change requires one configured library to be rediscovered. */
+type ConfiguredProjectLibraryScanInput = {
+  library: ProjectLibrary
+  libraryType?: ProjectLibraryTypeContribution
+  invalidation: ProjectLibraryInvalidationGeneration
+}
+
+type ConfiguredProjectLibraryScanState = {
+  input: ConfiguredProjectLibraryScanInput
+  abortController?: AbortController
+  realizations: ProjectLibraryRealizationContribution[]
+}
+
+function configuredProjectLibraryScanInputIsEqual(
+  left: ConfiguredProjectLibraryScanInput | undefined,
+  right: ConfiguredProjectLibraryScanInput
 ) {
   return Boolean(
     left &&
-      left.libraryTypes === right.libraryTypes &&
-      left.invalidation === right.invalidation &&
-      areProjectLibrariesEqual(left.libraries, right.libraries)
+      left.libraryType === right.libraryType &&
+      left.invalidation.global === right.invalidation.global &&
+      left.invalidation.library === right.invalidation.library &&
+      areProjectLibrariesEqual([left.library], [right.library])
+  )
+}
+
+function configuredProjectLibrarySourceIsEqual(
+  left: ConfiguredProjectLibraryScanInput | undefined,
+  right: ConfiguredProjectLibraryScanInput
+) {
+  return Boolean(
+    left &&
+      left.libraryType === right.libraryType &&
+      areProjectLibrariesEqual([left.library], [right.library])
+  )
+}
+
+function warnMissingProjectLibraryTypeHandler(
+  library: ProjectLibrary,
+  warnedMissingTypeLibraryIds: Set<string>
+) {
+  if (warnedMissingTypeLibraryIds.has(library.id)) {
+    return
+  }
+
+  warnedMissingTypeLibraryIds.add(library.id)
+  console.warn(
+    `Configured project library "${library.title}" (${library.id}) has no registered "${library.type}" type handler; its projects cannot be listed.`
   )
 }
 
 /**
- * Reads every configured library for one discovery pass. Results are flattened
- * without identity resolution; the value spec combiner later merges only
- * observations of the same normalized local path.
+ * Reads one configured library for one discovery pass. The result is still only
+ * a set of local observations; the ValueSpec combiner later merges observations
+ * of the same normalized path and cloudSync handles cloud identity.
  */
 async function readConfiguredProjectLibraryRealizations({
-  libraries,
-  libraryTypes,
+  library,
+  libraryType,
   warnedMissingTypeLibraryIds,
   signal,
 }: {
-  libraries: readonly ProjectLibrary[]
-  libraryTypes: ReadonlyMap<string, ProjectLibraryTypeContribution>
+  library: ProjectLibrary
+  libraryType?: ProjectLibraryTypeContribution
   warnedMissingTypeLibraryIds: Set<string>
   signal: AbortSignal
 }): Promise<ProjectLibraryRealizationContribution[]> {
-  const realizationGroups = await Promise.all(
-    libraries.map(async (library) => {
-      const readRealizations = libraryTypes.get(library.type)?.readRealizations
-      if (!readRealizations) {
-        if (!warnedMissingTypeLibraryIds.has(library.id)) {
-          warnedMissingTypeLibraryIds.add(library.id)
-          console.warn(
-            `Configured project library "${library.title}" (${library.id}) has no registered "${library.type}" type handler; its projects cannot be listed.`
-          )
-        }
-        return []
-      }
+  const readRealizations = libraryType?.readRealizations
+  if (!readRealizations) {
+    warnMissingProjectLibraryTypeHandler(library, warnedMissingTypeLibraryIds)
+    return []
+  }
 
-      try {
-        return await readRealizations({ library, signal })
-      } catch (error) {
-        if (!signal.aborted) {
-          reportRejection(error)
-        }
-        return []
-      }
+  try {
+    return await readRealizations({ library, signal })
+  } catch (error) {
+    if (!signal.aborted) {
+      reportRejection(error)
+    }
+    return []
+  }
+}
+
+const PROJECT_LIBRARY_WATCH_DEBOUNCE_MS = 750
+const PROJECT_LIBRARY_WATCH_SETTLED_RESCAN_MS = 3000
+
+type ProjectLibraryWatchTarget = {
+  path: string
+  normalizedPath: string
+  libraryIds: readonly string[]
+}
+
+function normalizeProjectLibraryWatchPath(path: string) {
+  return path.trim().replaceAll('\\', '/').replace(/\/+$/g, '')
+}
+
+function projectLibraryWatchTargetsFromLibraries(
+  libraries: readonly ProjectLibrary[]
+): ProjectLibraryWatchTarget[] {
+  const targetsByPath = new Map<string, ProjectLibraryWatchTarget>()
+
+  for (const library of libraries) {
+    const path = library.path.trim()
+    const normalizedPath = normalizeProjectLibraryWatchPath(path)
+    if (!path || !normalizedPath || normalizedPath === fsZds.sep) {
+      continue
+    }
+
+    const previousTarget = targetsByPath.get(normalizedPath)
+    targetsByPath.set(normalizedPath, {
+      path: previousTarget?.path ?? path,
+      normalizedPath,
+      libraryIds: [...(previousTarget?.libraryIds ?? []), library.id],
     })
-  )
+  }
 
-  return signal.aborted ? [] : realizationGroups.flat()
+  return Array.from(targetsByPath.values()).toSorted((left, right) =>
+    left.normalizedPath.localeCompare(right.normalizedPath)
+  )
+}
+
+function relativeProjectLibraryWatchPath(
+  targetPath: string,
+  libraryPath: string
+) {
+  const normalizedTargetPath = normalizeProjectLibraryWatchPath(targetPath)
+  const normalizedLibraryPath = normalizeProjectLibraryWatchPath(libraryPath)
+
+  if (normalizedTargetPath === normalizedLibraryPath) {
+    return ''
+  }
+
+  const libraryPrefix = `${normalizedLibraryPath}/`
+  if (!normalizedTargetPath.startsWith(libraryPrefix)) {
+    return undefined
+  }
+
+  return normalizedTargetPath.slice(libraryPrefix.length)
+}
+
+function countNormalizedPathSegments(path: string) {
+  let count = 0
+  let inSegment = false
+
+  for (const character of path) {
+    if (character === '/') {
+      inSegment = false
+      continue
+    }
+
+    if (!inSegment) {
+      count += 1
+      inSegment = true
+    }
+  }
+
+  return count
+}
+
+function isProjectLibraryRealizationBoundaryEvent(
+  eventType: string,
+  targetPath: string,
+  libraryPath: string
+) {
+  if (!['add', 'addDir', 'change', 'unlink', 'unlinkDir'].includes(eventType)) {
+    return false
+  }
+
+  const relativePath = relativeProjectLibraryWatchPath(targetPath, libraryPath)
+  if (relativePath === undefined) {
+    return false
+  }
+
+  return relativePath === '' || countNormalizedPathSegments(relativePath) <= 1
+}
+
+function watchConfiguredProjectLibraries({
+  libraries,
+  onInvalidateLibrary,
+}: {
+  libraries: readonly ProjectLibrary[]
+  onInvalidateLibrary: (libraryId: string) => void
+}) {
+  if (typeof window === 'undefined' || !window.electron) {
+    return () => {}
+  }
+
+  const targets = projectLibraryWatchTargetsFromLibraries(libraries)
+  const timersByLibraryId = new Map<string, ReturnType<typeof setTimeout>>()
+  const settledTimersByLibraryId = new Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >()
+  const watcherKeysByPath = new Map<string, string>()
+
+  const scheduleInvalidation = (libraryId: string) => {
+    clearTimeout(timersByLibraryId.get(libraryId))
+    timersByLibraryId.set(
+      libraryId,
+      setTimeout(() => {
+        timersByLibraryId.delete(libraryId)
+        onInvalidateLibrary(libraryId)
+      }, PROJECT_LIBRARY_WATCH_DEBOUNCE_MS)
+    )
+  }
+
+  const scheduleSettledInvalidation = (libraryId: string) => {
+    clearTimeout(settledTimersByLibraryId.get(libraryId))
+    settledTimersByLibraryId.set(
+      libraryId,
+      setTimeout(() => {
+        settledTimersByLibraryId.delete(libraryId)
+        onInvalidateLibrary(libraryId)
+      }, PROJECT_LIBRARY_WATCH_SETTLED_RESCAN_MS)
+    )
+  }
+
+  for (const target of targets) {
+    const watcherKey = `project-library-realizations:${uuidv4()}`
+    watcherKeysByPath.set(target.path, watcherKey)
+    window.electron.watchFileOn(
+      target.path,
+      watcherKey,
+      (eventType, targetPath) => {
+        if (
+          !isProjectLibraryRealizationBoundaryEvent(
+            eventType,
+            targetPath,
+            target.path
+          )
+        ) {
+          return
+        }
+
+        for (const libraryId of target.libraryIds) {
+          scheduleInvalidation(libraryId)
+          if (eventType === 'addDir') {
+            // Root-only watchers see the project folder creation, not every file
+            // copied into it. A settled follow-up catches slower external copies.
+            scheduleSettledInvalidation(libraryId)
+          }
+        }
+      },
+      { depth: 0 }
+    )
+  }
+
+  return () => {
+    for (const timer of timersByLibraryId.values()) {
+      clearTimeout(timer)
+    }
+    for (const timer of settledTimersByLibraryId.values()) {
+      clearTimeout(timer)
+    }
+    for (const [path, watcherKey] of watcherKeysByPath) {
+      window.electron?.watchFileOff(path, watcherKey)
+    }
+  }
 }
 
 /**
@@ -149,12 +351,86 @@ const configuredProjectLibraryRealizations = defineRegistryItemFactory(
     const libraryTypes = ctx.valueSpecs.signal(projectLibraryTypesValueSpec)
     const realizations = signal<ProjectLibraryRealizationContribution[]>([])
     const warnedMissingTypeLibraryIds = new Set<string>()
-    let abortController: AbortController | undefined
+    const scanStates = new Map<string, ConfiguredProjectLibraryScanState>()
     let disposeConfiguredProjectLibraryRealizationsEffect:
       | (() => void)
       | undefined
     let disposed = false
-    let lastScannedInputs: ConfiguredProjectLibraryScanInputs | undefined
+    let currentLibraryIds: readonly string[] = []
+
+    const updateRealizations = () => {
+      realizations.value = currentLibraryIds.flatMap(
+        (libraryId) => scanStates.get(libraryId)?.realizations ?? []
+      )
+    }
+
+    const scanLibrary = (
+      library: ProjectLibrary,
+      libraryType: ProjectLibraryTypeContribution | undefined,
+      invalidation: ProjectLibraryRealizationsInvalidationSnapshot
+    ) => {
+      const previousState = scanStates.get(library.id)
+      const input: ConfiguredProjectLibraryScanInput = {
+        library,
+        libraryType,
+        invalidation: readProjectLibraryRealizationInvalidationForLibrary(
+          invalidation,
+          library.id
+        ),
+      }
+
+      if (
+        configuredProjectLibraryScanInputIsEqual(previousState?.input, input)
+      ) {
+        return
+      }
+
+      previousState?.abortController?.abort()
+      const readRealizations = libraryType?.readRealizations
+      if (!readRealizations) {
+        warnMissingProjectLibraryTypeHandler(
+          library,
+          warnedMissingTypeLibraryIds
+        )
+        scanStates.set(library.id, {
+          input,
+          realizations: [],
+        })
+        return
+      }
+
+      const abortController = new AbortController()
+      const state: ConfiguredProjectLibraryScanState = {
+        input,
+        abortController,
+        realizations: configuredProjectLibrarySourceIsEqual(
+          previousState?.input,
+          input
+        )
+          ? (previousState?.realizations ?? [])
+          : [],
+      }
+      scanStates.set(library.id, state)
+
+      void readConfiguredProjectLibraryRealizations({
+        library,
+        libraryType,
+        warnedMissingTypeLibraryIds,
+        signal: abortController.signal,
+      }).then((nextRealizations) => {
+        if (
+          disposed ||
+          abortController.signal.aborted ||
+          scanStates.get(library.id) !== state
+        ) {
+          return
+        }
+
+        state.abortController = undefined
+        state.realizations = nextRealizations
+        updateRealizations()
+      })
+    }
 
     queueMicrotask(() => {
       if (disposed) {
@@ -165,44 +441,23 @@ const configuredProjectLibraryRealizations = defineRegistryItemFactory(
         const currentSettings = settings.value?.current.value
         const typeById = libraryTypes.value
         const invalidation = readProjectLibraryRealizationsInvalidation()
-        const scanInputs: ConfiguredProjectLibraryScanInputs = {
-          libraries: currentSettings
-            ? projectLibrariesFromSettings(
-                currentSettings.app.libraries.current
-              )
-            : [],
-          libraryTypes: typeById,
-          invalidation,
-        }
+        const libraries = currentSettings
+          ? projectLibrariesFromSettings(currentSettings.app.libraries.current)
+          : []
+        const activeLibraryIds = new Set(libraries.map((library) => library.id))
+        currentLibraryIds = libraries.map((library) => library.id)
 
-        if (
-          configuredProjectLibraryScanInputsAreEqual(
-            lastScannedInputs,
-            scanInputs
-          )
-        ) {
-          return
-        }
-
-        lastScannedInputs = scanInputs
-
-        abortController?.abort()
-        const loadController = new AbortController()
-        abortController = loadController
-        realizations.value = []
-
-        void readConfiguredProjectLibraryRealizations({
-          libraries: scanInputs.libraries,
-          libraryTypes: scanInputs.libraryTypes,
-          warnedMissingTypeLibraryIds,
-          signal: loadController.signal,
-        }).then((nextRealizations) => {
-          if (disposed || loadController.signal.aborted) {
-            return
+        for (const [libraryId, state] of scanStates) {
+          if (!activeLibraryIds.has(libraryId)) {
+            state.abortController?.abort()
+            scanStates.delete(libraryId)
           }
+        }
 
-          realizations.value = nextRealizations
+        libraries.forEach((library) => {
+          scanLibrary(library, typeById.get(library.type), invalidation)
         })
+        updateRealizations()
       })
     })
 
@@ -216,7 +471,9 @@ const configuredProjectLibraryRealizations = defineRegistryItemFactory(
         ],
         dispose: () => {
           disposed = true
-          abortController?.abort()
+          for (const state of scanStates.values()) {
+            state.abortController?.abort()
+          }
           disposeConfiguredProjectLibraryRealizationsEffect?.()
         },
       }),
@@ -224,6 +481,21 @@ const configuredProjectLibraryRealizations = defineRegistryItemFactory(
   },
   'project-libraries.configured-realizations'
 )
+
+const projectLibraryRealizationsRegistryService = defineRegistryItem({
+  id: 'project-libraries.realizations-service',
+  providesServices: [
+    provideService(projectLibraryRealizationsService, {
+      invalidate: invalidateProjectLibraryRealizations,
+      watchConfiguredLibraries: ({ libraries }) =>
+        watchConfiguredProjectLibraries({
+          libraries,
+          onInvalidateLibrary: (libraryId) =>
+            invalidateProjectLibraryRealizations({ libraryId }),
+        }),
+    } satisfies ProjectLibraryRealizationsService),
+  ],
+})
 
 function getProjectMoveSource({ project }: { project: HomeProjectEntry }) {
   if (!project.localProjectPath || !project.readWriteAccess) {
@@ -239,20 +511,20 @@ function getProjectMoveSource({ project }: { project: HomeProjectEntry }) {
 }
 
 const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
-  const systemIO = ctx.services.signal(systemIOService)
   const cloudSync = ctx.services.signal(cloudSyncService)
   const getWasmPromise = () =>
     ctx.valueSpecs.get(wasmPromiseValueSpec) ??
     new Error('Missing WASM promise registry value.')
   /**
-   * Directory operations still notify System IO's legacy folder cache for open
-   * editor/explorer flows, but Home discovery refreshes through projectLibraries.
+   * Directory operations know the configured library they changed, so they
+   * refresh that library's local realization discovery directly.
    */
-  const refreshLocalProjectRealizations = () => {
-    systemIO.value?.actor.send({
-      type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
-    })
-    invalidateProjectLibraryRealizations()
+  const refreshLocalProjectRealizations = (
+    ...libraries: readonly ProjectLibrary[]
+  ) => {
+    for (const library of libraries) {
+      invalidateProjectLibraryRealizations({ libraryId: library.id })
+    }
   }
 
   const operations: ProjectLibraryTypeOperations = {
@@ -269,7 +541,7 @@ const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
           requestedProjectTitle,
           wasmInstancePromise,
         })
-        refreshLocalProjectRealizations()
+        refreshLocalProjectRealizations(library)
 
         return project
       },
@@ -303,13 +575,13 @@ const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
           requestedProjectTitle: getHomeProjectDisplayName(project),
           wasmInstance: await wasmInstancePromise,
         })
-        refreshLocalProjectRealizations()
+        refreshLocalProjectRealizations(library)
 
         return result
       },
     },
     renameProject: {
-      run: async ({ project, requestedName }) => {
+      run: async ({ library, project, requestedName }) => {
         if (!project.localProjectPath || !project.readWriteAccess) {
           return
         }
@@ -318,11 +590,11 @@ const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
           project.localProjectPath,
           requestedName
         )
-        refreshLocalProjectRealizations()
+        refreshLocalProjectRealizations(library)
       },
     },
     deleteProject: {
-      run: async ({ project }) => {
+      run: async ({ library, project }) => {
         if (!project.localProjectPath || !project.readWriteAccess) {
           return
         }
@@ -343,7 +615,7 @@ const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
         if (project.remoteProjectId) {
           await cloudSyncActions?.deleteRemoteProject(project.remoteProjectId)
         }
-        refreshLocalProjectRealizations()
+        refreshLocalProjectRealizations(library)
       },
     },
     moveProjectFrom: {
@@ -352,14 +624,14 @@ const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
       run: ({ project }) => getProjectMoveSource({ project }),
     },
     moveProjectTo: {
-      run: async ({ library, source }) => {
+      run: async ({ library, sourceLibrary, source }) => {
         const result = await moveProjectIntoLocalDirectory({
           projectDirectoryPath: library.path,
           sourceProjectPath: source.localProjectPath,
           sourceProjectName: source.localProjectName,
           defaultFile: source.defaultFile,
         })
-        refreshLocalProjectRealizations()
+        refreshLocalProjectRealizations(sourceLibrary, library)
 
         return result
       },
@@ -406,8 +678,10 @@ const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
             if (!signal.aborted) {
               scheduleProjectDirectoryNameSyncFromTitles({
                 projects,
-                onProjectDirectoriesRenamed:
-                  invalidateProjectLibraryRealizations,
+                onProjectDirectoriesRenamed: () =>
+                  invalidateProjectLibraryRealizations({
+                    libraryId: library.id,
+                  }),
               })
             }
 
@@ -448,6 +722,7 @@ const projectLibrariesExtension = defineRegistryItem({
     configuredProjectLibraryRealizations,
     directoryProjectLibraryDefaultPolicy,
     directoryProjectLibraryType,
+    projectLibraryRealizationsRegistryService,
   ],
   provides: [provide(settingsValueSpec, projectLibrariesSettingsContribution)],
 })

--- a/src/lib/projectLibraries/registry/index.ts
+++ b/src/lib/projectLibraries/registry/index.ts
@@ -367,6 +367,13 @@ const configuredProjectLibraryRealizations = defineRegistryItemFactory(
       libraryType: ProjectLibraryTypeContribution | undefined,
       invalidation: ProjectLibraryRealizationsInvalidationSnapshot
     ) => {
+      /**
+       * Cached scan state is the active discovery cache entry for this library.
+       * It lets unchanged inputs skip redundant rescans, aborts stale in-flight
+       * reads when a new scan replaces them, keeps existing realizations visible
+       * while the same library source refreshes, and gives async completions a
+       * stable identity check before they publish results.
+       */
       const cachedScan = scanStates.get(library.id)
       const input: ConfiguredProjectLibraryScanInput = {
         library,

--- a/src/lib/projectLibraries/registry/index.ts
+++ b/src/lib/projectLibraries/registry/index.ts
@@ -367,7 +367,7 @@ const configuredProjectLibraryRealizations = defineRegistryItemFactory(
       libraryType: ProjectLibraryTypeContribution | undefined,
       invalidation: ProjectLibraryRealizationsInvalidationSnapshot
     ) => {
-      const previousState = scanStates.get(library.id)
+      const cachedScan = scanStates.get(library.id)
       const input: ConfiguredProjectLibraryScanInput = {
         library,
         libraryType,
@@ -377,13 +377,11 @@ const configuredProjectLibraryRealizations = defineRegistryItemFactory(
         ),
       }
 
-      if (
-        configuredProjectLibraryScanInputIsEqual(previousState?.input, input)
-      ) {
+      if (configuredProjectLibraryScanInputIsEqual(cachedScan?.input, input)) {
         return
       }
 
-      previousState?.abortController?.abort()
+      cachedScan?.abortController?.abort()
       const readRealizations = libraryType?.readRealizations
       if (!readRealizations) {
         warnMissingProjectLibraryTypeHandler(
@@ -402,10 +400,10 @@ const configuredProjectLibraryRealizations = defineRegistryItemFactory(
         input,
         abortController,
         realizations: configuredProjectLibrarySourceIsEqual(
-          previousState?.input,
+          cachedScan?.input,
           input
         )
-          ? (previousState?.realizations ?? [])
+          ? (cachedScan?.realizations ?? [])
           : [],
       }
       scanStates.set(library.id, state)

--- a/src/lib/projectLibraries/registry/invalidation.ts
+++ b/src/lib/projectLibraries/registry/invalidation.ts
@@ -1,11 +1,57 @@
 import { signal } from '@preact/signals-core'
 
-const projectLibraryRealizationsInvalidation = signal(0)
-
-export function invalidateProjectLibraryRealizations() {
-  projectLibraryRealizationsInvalidation.value += 1
+export type ProjectLibraryRealizationsInvalidationInput = {
+  libraryId?: string
 }
 
+export type ProjectLibraryRealizationsInvalidationSnapshot = {
+  global: number
+  byLibraryId: ReadonlyMap<string, number>
+}
+
+const projectLibraryRealizationsInvalidation =
+  signal<ProjectLibraryRealizationsInvalidationSnapshot>({
+    global: 0,
+    byLibraryId: new Map(),
+  })
+
+/**
+ * Marks configured local realization discovery stale. A library-scoped
+ * invalidation lets filesystem watchers and project-library operations refresh
+ * only the library whose concrete folders changed.
+ */
+export function invalidateProjectLibraryRealizations(
+  input: ProjectLibraryRealizationsInvalidationInput = {}
+) {
+  const current = projectLibraryRealizationsInvalidation.value
+  if (!input.libraryId) {
+    projectLibraryRealizationsInvalidation.value = {
+      global: current.global + 1,
+      byLibraryId: current.byLibraryId,
+    }
+    return
+  }
+
+  const byLibraryId = new Map(current.byLibraryId)
+  byLibraryId.set(input.libraryId, (byLibraryId.get(input.libraryId) ?? 0) + 1)
+  projectLibraryRealizationsInvalidation.value = {
+    global: current.global,
+    byLibraryId,
+  }
+}
+
+/** Returns the current invalidation generation snapshot for discovery effects. */
 export function readProjectLibraryRealizationsInvalidation() {
   return projectLibraryRealizationsInvalidation.value
+}
+
+/** Returns the generation number relevant to one configured library. */
+export function readProjectLibraryRealizationInvalidationForLibrary(
+  snapshot: ProjectLibraryRealizationsInvalidationSnapshot,
+  libraryId: string
+) {
+  return {
+    global: snapshot.global,
+    library: snapshot.byLibraryId.get(libraryId) ?? 0,
+  }
 }

--- a/src/preload.test.ts
+++ b/src/preload.test.ts
@@ -36,6 +36,7 @@ vi.mock('chokidar', () => ({
     watch: vi.fn(() => ({
       on: vi.fn(),
       off: vi.fn(),
+      close: vi.fn().mockResolvedValue(undefined),
     })),
   },
 }))

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -129,13 +129,17 @@ let fsWatchListeners = new Map<
 const watchFileOn = (
   path: string,
   key: string,
-  callback: (eventType: string, path: string) => void
+  callback: (eventType: string, path: string) => void,
+  options: { depth?: number } = {}
 ) => {
   let watchers = fsWatchListeners.get(path)
   if (!watchers) {
     watchers = new Map()
   }
-  const watcher = chokidar.watch(path, { depth: 1, ignoreInitial: true })
+  const watcher = chokidar.watch(path, {
+    depth: options.depth ?? 1,
+    ignoreInitial: true,
+  })
   watcher.on('all', callback)
   watchers.set(key, { watcher, callback })
   fsWatchListeners.set(path, watchers)
@@ -152,6 +156,9 @@ const watchFileOff = (path: string, key: string) => {
   }
   const { watcher, callback } = data
   watcher.off('all', callback)
+  void watcher.close().catch((error) => {
+    console.warn('Failed to close file watcher.', error)
+  })
   watchers.delete(key)
   if (watchers.size === 0) {
     fsWatchListeners.delete(path)

--- a/src/registry/contracts/projectLibraries.ts
+++ b/src/registry/contracts/projectLibraries.ts
@@ -1,4 +1,8 @@
-import { defineContract, defineValueSpec } from '@kittycad/registry'
+import {
+  defineContract,
+  defineService,
+  defineValueSpec,
+} from '@kittycad/registry'
 import type { Project } from '@src/lib/project'
 import type { DuplicateProjectResult } from '@src/lib/projectDuplication'
 import type {
@@ -100,6 +104,30 @@ export type ProjectLibraryRealizationContribution = Omit<
 export type ProjectLibraryRealizationContributionGroup =
   | ProjectLibraryRealizationContribution
   | readonly ProjectLibraryRealizationContribution[]
+
+export type ProjectLibraryRealizationsInvalidationInput = {
+  libraryId?: string
+}
+
+export type ProjectLibraryRealizationWatchOptions = {
+  libraries: readonly ProjectLibrary[]
+}
+
+export interface ProjectLibraryRealizationsService {
+  /**
+   * Refreshes configured realization discovery. Prefer passing `libraryId`
+   * whenever the caller knows which library changed.
+   */
+  invalidate: (input?: ProjectLibraryRealizationsInvalidationInput) => void
+  /**
+   * Watches configured library roots for realization boundary changes while a UI
+   * surface needs live discovery updates. The returned disposer must be called
+   * when that surface unmounts.
+   */
+  watchConfiguredLibraries: (
+    options: ProjectLibraryRealizationWatchOptions
+  ) => () => void
+}
 
 export interface ProjectLibraryOperation<
   Input extends { library: ProjectLibrary },
@@ -446,6 +474,10 @@ export function combineProjectLibraryRealizationContributions(
 }
 
 export const projectLibrariesContract = defineContract({
+  projectLibraryRealizationsService:
+    defineService<ProjectLibraryRealizationsService>(
+      'project-library-realizations'
+    ),
   projectLibraryTypesValueSpec: defineValueSpec<
     ProjectLibraryTypeContribution,
     Map<ProjectLibraryType, ProjectLibraryTypeContribution>
@@ -481,6 +513,7 @@ export const projectLibrariesContract = defineContract({
 })
 
 export const {
+  projectLibraryRealizationsService,
   projectLibraryTypesValueSpec,
   projectLibrarySettingDefaultsValueSpec,
   projectLibrarySettingDefaultPoliciesValueSpec,

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -72,6 +72,7 @@ import {
 } from '@src/registry/contracts/keymap'
 import {
   getHomeProjectEntriesForLibrary,
+  projectLibraryRealizationsService,
   projectLibraryTypesValueSpec,
 } from '@src/registry/contracts/projectLibraries'
 import {
@@ -159,6 +160,14 @@ const Home = () => {
     ...library,
     icon: projectLibraryTypes.get(library.type)?.icon ?? library.icon,
   }))
+  const projectLibraryRealizations = registry.optional(
+    projectLibraryRealizationsService
+  )
+  const projectLibraryWatchKey = projectLibraries
+    .map((library) =>
+      [library.id, library.type, library.path, library.source ?? ''].join(':')
+    )
+    .join('|')
   const homeProjectActions = registry.get(homeProjectActionsService)
   const hasCloudSyncFeature = userFeatures.useHas(
     OPFS_CLOUD_FEATURE_FLAG,
@@ -217,6 +226,13 @@ const Home = () => {
       },
     })
   }
+
+  useEffect(() => {
+    return projectLibraryRealizations?.watchConfiguredLibraries({
+      libraries: projectLibraries,
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- projectLibraryWatchKey tracks library identity and paths without rebinding on icon/title-only renders.
+  }, [projectLibraryRealizations, projectLibraryWatchKey])
 
   useEffect(() => {
     app.currentProjectLibraryIdSignal.value = selectedProjectLibraryId


### PR DESCRIPTION
Part of the #12805 stack. This PR gives `projectLibraries` ownership over external filesystem freshness for configured project libraries, so Home can stay current without binding realization discovery to the default project directory or `systemIOActor.context.folders`, since we are trying to kill `systemIOActor`.

As a reminder, "realization" is the term I've been using for the concrete files on disk for a given project.

1. Adds a `projectLibraryRealizationsService` for scoped invalidation and Home-mounted library watching.
2. Changes configured realization discovery to cache and rescan per library instead of clearing/rescanning every configured library for one dirty path.
3. Watches configured library roots with shallow `chokidar` listeners while Home is mounted, debounces invalidation, and schedules a settled follow-up for external folder copies.
4. Updates the preload watcher API so callers can request `depth: 0` and so unsubscribing closes the underlying watcher. These were bugs in the original implementation.

## How to test

1. Open the desktop app to Home with a directory project library configured.
2. In Finder or another file explorer, create a top-level project folder in that library and add a KCL file. The project should appear on Home without reloading the app.
3. Rename that top-level project folder externally. The Home card should update to the renamed project.
4. Delete that top-level project folder externally. The Home card should disappear.
5. With a large library, confirm Home remains usable while external folder changes settle; updates should debounce rather than rescanning on every emitted file event.

## Non-flagged users

This PR touches ungated Home and project-library discovery paths. Users without the cloud sync feature flag should still see the same behavior as today, just running through a new code path.

## Stack
This is PR 3 of 5.

1. #12843: project-library realization model and domain documentation.
2. #12849: configured project-library realization discovery.
3. This PR: project-library realization freshness without System IO.
4. #12844: cloud relationships and Home derivation without coalescing.
5. #12841: duplicate-copy review and cleanup UI.