### PR TITLE
Surface cloud sync status in project menu

### DIFF
--- a/src/components/CloudConflictDialog.spec.tsx
+++ b/src/components/CloudConflictDialog.spec.tsx
@@ -1,6 +1,11 @@
-import { CloudConflictDialog } from '@src/components/CloudConflictDialog'
+import {
+  CloudConflictDialog,
+  CloudSyncErrorDialogHost,
+  openCloudSyncErrorDialog,
+} from '@src/components/CloudConflictDialog'
 import {
   loadCloudSyncProjectConflictInspection,
+  retryCloudSync,
   resolveCloudSyncProjectConflict,
 } from '@src/lib/cloudSync'
 import { Themes } from '@src/lib/theme'
@@ -106,6 +111,7 @@ vi.mock('@src/lib/cloudSync', async () => {
     loadCloudSyncProjectConflictInspection: vi
       .fn()
       .mockResolvedValue(cloudConflictDialogSpecMocks.inspection),
+    retryCloudSync: vi.fn(),
     resolveCloudSyncProjectConflict: vi.fn().mockResolvedValue(undefined),
   }
 })
@@ -192,6 +198,41 @@ describe('CloudConflictDialog', () => {
 
     expect(loadCloudSyncProjectConflictInspection).toHaveBeenCalledWith(
       '/projects/local'
+    )
+  })
+
+  test('shows cloud sync error details with one retry action', async () => {
+    openCloudSyncErrorDialog({
+      title: 'Cloud sync failed',
+      message: 'Cloud sync cannot upload local changes.',
+      projectName: 'Demo project',
+      occurredAt: '2026-07-17T12:00:00.000Z',
+    })
+
+    render(<CloudSyncErrorDialogHost />)
+
+    expect(screen.getByTestId('cloud-sync-error-dialog')).toHaveTextContent(
+      'Cloud sync failed'
+    )
+    expect(screen.getByText(/Demo project/)).toBeInTheDocument()
+    expect(screen.getByText(/Last reported/)).toBeInTheDocument()
+    expect(
+      screen.getByText('Cloud sync cannot upload local changes.')
+    ).toBeInTheDocument()
+    expect(screen.queryByText('Close')).not.toBeInTheDocument()
+
+    const retryButton = screen.getByTestId('cloud-sync-error-retry-button')
+    expect(
+      retryButton.querySelector('svg[aria-label="refresh"]')
+    ).not.toBeNull()
+
+    fireEvent.click(retryButton)
+
+    expect(retryCloudSync).toHaveBeenCalledTimes(1)
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId('cloud-sync-error-dialog')
+      ).not.toBeInTheDocument()
     )
   })
 })

--- a/src/components/CloudConflictDialog.tsx
+++ b/src/components/CloudConflictDialog.tsx
@@ -1,4 +1,5 @@
 import { Dialog } from '@headlessui/react'
+import { signal } from '@preact/signals-core'
 import { useSignals } from '@preact/signals-react/runtime'
 import { ActionButton } from '@src/components/ActionButton'
 import {
@@ -14,6 +15,7 @@ import {
   getCloudSyncProjectMetadataIndex,
   isCloudSyncConflictRevisionChangedError,
   loadCloudSyncProjectConflictInspection,
+  retryCloudSync,
   resolveCloudSyncProjectConflict,
 } from '@src/lib/cloudSync'
 import {
@@ -21,6 +23,7 @@ import {
   type ConflictFileStatus,
   type ConflictInspection,
 } from '@src/lib/cloudSync/conflictInspection'
+import { formatDateTime, formatOptionalDateTime } from '@src/lib/dateTime'
 import fsZds from '@src/lib/fs-zds'
 import type { ResolvedTheme } from '@src/lib/theme'
 import { reportRejection } from '@src/lib/trap'
@@ -35,21 +38,40 @@ type CloudConflictDialogProps = {
   onResolved?: () => void
 }
 
+type CloudConflictDialogRequest = {
+  projectPath: string
+  projectName?: string
+}
+
+type CloudSyncErrorDialogRequest = {
+  title: string
+  message: string
+  projectName?: string
+  occurredAt?: string
+}
+
 type ConflictInspectionState =
   | { status: 'loading' }
   | { status: 'ready'; inspection: ConflictInspection }
   | { status: 'error'; message: string }
 
-function messageFromError(error: unknown) {
-  return error instanceof Error ? error.message : String(error)
+const cloudConflictDialogRequest = signal<CloudConflictDialogRequest | null>(
+  null
+)
+const cloudSyncErrorDialogRequest = signal<CloudSyncErrorDialogRequest | null>(
+  null
+)
+
+export function openCloudConflictDialog(request: CloudConflictDialogRequest) {
+  cloudConflictDialogRequest.value = request
 }
 
-function formatDateTime(dateTimeMs: number | undefined) {
-  if (dateTimeMs === undefined || Number.isNaN(dateTimeMs)) {
-    return 'Unknown'
-  }
+export function openCloudSyncErrorDialog(request: CloudSyncErrorDialogRequest) {
+  cloudSyncErrorDialogRequest.value = request
+}
 
-  return new Date(dateTimeMs).toLocaleString()
+function messageFromError(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
 }
 
 function conflictStatusLabel(status: ConflictFileStatus) {
@@ -531,5 +553,145 @@ export function CloudConflictDialog({
         </Dialog.Panel>
       </div>
     </Dialog>
+  )
+}
+
+function CloudSyncErrorDialog({
+  request,
+  onDismiss,
+}: {
+  request: CloudSyncErrorDialogRequest
+  onDismiss: () => void
+}) {
+  const formattedTime = formatOptionalDateTime(request.occurredAt)
+
+  return (
+    <Dialog
+      open={true}
+      onClose={onDismiss}
+      className="fixed inset-0 z-50 overflow-y-auto p-4"
+    >
+      <Dialog.Overlay className="fixed inset-0 bg-chalkboard-10/80 dark:bg-chalkboard-110/40" />
+      <div className="relative flex min-h-full items-center justify-center">
+        <Dialog.Panel
+          className="relative flex w-[min(92vw,34rem)] flex-col rounded border border-destroy-40 bg-chalkboard-10 shadow-lg dark:border-destroy-80 dark:bg-chalkboard-100"
+          data-testid="cloud-sync-error-dialog"
+        >
+          <div className="flex items-center justify-between gap-4 border-b border-chalkboard-20 p-4 dark:border-chalkboard-70">
+            <div className="min-w-0 flex-1">
+              <Dialog.Title as="h2" className="text-xl font-bold">
+                {request.title}
+              </Dialog.Title>
+            </div>
+            <button
+              type="button"
+              onClick={onDismiss}
+              className="m-0 border-none p-0 bg-destroy-10/20 hover:bg-destroy-10 focus:bg-destroy-10 focus:outline-none focus:ring-0 dark:bg-destroy-80/20 dark:hover:bg-destroy-80/50 dark:focus:bg-destroy-80/50"
+              data-testid="cloud-sync-error-close-button"
+            >
+              <CustomIcon name="close" className="h-5 w-5" />
+            </button>
+          </div>
+
+          <div className="space-y-4 p-4 text-sm">
+            <Dialog.Description as="div" className="space-y-2">
+              {request.projectName && (
+                <p className="break-words">
+                  Cloud sync hit an error for{' '}
+                  <span className="font-medium">{request.projectName}</span>.
+                </p>
+              )}
+              {formattedTime && (
+                <p className="text-chalkboard-70 dark:text-chalkboard-40">
+                  Last reported {formattedTime}
+                </p>
+              )}
+            </Dialog.Description>
+
+            <p className="whitespace-pre-wrap break-words rounded border border-destroy-40 bg-destroy-10/50 px-3 py-2 text-destroy-80 dark:border-destroy-80 dark:bg-destroy-80/20 dark:text-destroy-20">
+              {request.message}
+            </p>
+          </div>
+
+          <div className="flex justify-end gap-2 border-t border-chalkboard-20 p-4 dark:border-chalkboard-70">
+            <ActionButton
+              Element="button"
+              type="button"
+              iconStart={{
+                icon: 'refresh',
+                size: 'sm',
+                className: 'p-1',
+                bgClassName: '!bg-transparent dark:!bg-transparent',
+              }}
+              onClick={() => {
+                retryCloudSync()
+                onDismiss()
+              }}
+              className="bg-primary text-white hover:bg-primary/90 dark:bg-primary dark:text-white dark:hover:bg-primary/90"
+              data-testid="cloud-sync-error-retry-button"
+            >
+              Retry cloud sync
+            </ActionButton>
+          </div>
+        </Dialog.Panel>
+      </div>
+    </Dialog>
+  )
+}
+
+export function CloudConflictDialogHost({
+  resolvedTheme,
+}: {
+  resolvedTheme: ResolvedTheme
+}) {
+  useSignals()
+  const conflictDialog = cloudConflictDialogRequest.value
+
+  useEffect(() => {
+    return () => {
+      cloudConflictDialogRequest.value = null
+    }
+  }, [])
+
+  if (!conflictDialog) {
+    return null
+  }
+
+  return (
+    <CloudConflictDialog
+      projectPath={conflictDialog.projectPath}
+      projectName={conflictDialog.projectName}
+      resolvedTheme={resolvedTheme}
+      onDismiss={() => {
+        cloudConflictDialogRequest.value = null
+      }}
+      onResolved={() => {
+        cloudConflictDialogRequest.value = null
+      }}
+    />
+  )
+}
+
+export function CloudSyncErrorDialogHost() {
+  useSignals()
+  const errorDialog = cloudSyncErrorDialogRequest.value
+
+  useEffect(() => {
+    return () => {
+      cloudSyncErrorDialogRequest.value = null
+    }
+  }, [])
+
+  if (!errorDialog) {
+    return null
+  }
+
+  return (
+    <CloudSyncErrorDialog
+      request={errorDialog}
+      onDismiss={() => {
+        cloudSyncErrorDialogRequest.value = null
+      }}
+    />
   )
 }

--- a/src/components/ProjectSidebarMenu.tsx
+++ b/src/components/ProjectSidebarMenu.tsx
@@ -91,6 +91,8 @@ function isProjectMenuBreak(
 
 const noopProjectClose: ProjectCloseHandler = () => undefined
 const noopHomeNavigate = () => undefined
+const projectMenuItemLabelClassName = 'min-w-0 flex-1 truncate'
+const projectMenuItemHotkeyClassName = 'hotkey shrink-0'
 
 export function canNavigateHome({
   isDesktopApp,
@@ -277,11 +279,16 @@ function ProjectMenuPopover({
           Element: 'button' as const,
           children: (
             <>
-              <span className="flex-1" data-testid="project-settings">
+              <span
+                className={projectMenuItemLabelClassName}
+                data-testid="project-settings"
+              >
                 Project settings
               </span>
               {projectSettingsKeybinding && (
-                <kbd className="hotkey">{projectSettingsKeybinding}</kbd>
+                <kbd className={projectMenuItemHotkeyClassName}>
+                  {projectSettingsKeybinding}
+                </kbd>
               )}
             </>
           ),
@@ -300,7 +307,7 @@ function ProjectMenuPopover({
               Element: 'button' as const,
               children: (
                 <span
-                  className="flex-1"
+                  className={projectMenuItemLabelClassName}
                   data-testid="project-sidebar-duplicate-project"
                 >
                   Duplicate project
@@ -353,7 +360,10 @@ function ProjectMenuPopover({
               Element: 'button' as const,
               className,
               children: (
-                <span className="flex-1" data-testid={dataTestId}>
+                <span
+                  className={projectMenuItemLabelClassName}
+                  data-testid={dataTestId}
+                >
                   {label}
                 </span>
               ),
@@ -367,8 +377,10 @@ function ProjectMenuPopover({
           Element: 'button' as const,
           children: (
             <>
-              <span className="flex-1">Add file to project</span>
-              <kbd className="hotkey">
+              <span className={projectMenuItemLabelClassName}>
+                Add file to project
+              </span>
+              <kbd className={projectMenuItemHotkeyClassName}>
                 {hotkeyDisplay('mod+alt+l', platform)}
               </kbd>
             </>
@@ -384,8 +396,10 @@ function ProjectMenuPopover({
           Element: 'button' as const,
           children: (
             <>
-              <span className="flex-1">Export current part</span>
-              <kbd className="hotkey">
+              <span className={projectMenuItemLabelClassName}>
+                Export current part
+              </span>
+              <kbd className={projectMenuItemHotkeyClassName}>
                 {hotkeyDisplay('ctrl+shift+e', platform)}
               </kbd>
               {!findCommand(exportCommandInfo) && (
@@ -411,7 +425,9 @@ function ProjectMenuPopover({
           className: isDesktop() ? 'hidden' : '',
           children: (
             <>
-              <span className="flex-1">Download project files</span>
+              <span className={projectMenuItemLabelClassName}>
+                Download project files
+              </span>
               {!findCommand(exportProjectZipCommandInfo) && (
                 <Tooltip
                   position="right"
@@ -435,7 +451,9 @@ function ProjectMenuPopover({
           className: !isDesktop() || !machineApiEnabled ? 'hidden' : '',
           children: (
             <>
-              <span>Make current part</span>
+              <span className={projectMenuItemLabelClassName}>
+                Make current part
+              </span>
               {!findCommand(makeCommandInfo) && (
                 <Tooltip
                   position="right"
@@ -458,7 +476,9 @@ function ProjectMenuPopover({
         {
           id: 'go-home',
           Element: 'button' as const,
-          children: 'Go to Home',
+          children: (
+            <span className={projectMenuItemLabelClassName}>Go to Home</span>
+          ),
           className: !homeNavigationEnabled ? 'hidden' : '',
           onClick: () => {
             onProjectClose(file || null, project?.path || null, true)
@@ -535,7 +555,7 @@ function ProjectMenuPopover({
   }, [contributedProjectBreadcrumbBadges, project, projectPath])
 
   const menuItemClassName =
-    'relative !font-sans flex items-center gap-2 rounded-sm py-1.5 px-2 cursor-pointer hover:bg-chalkboard-20 dark:hover:bg-chalkboard-80 border-none text-left '
+    'relative !font-sans flex min-h-8 w-full items-center justify-start gap-2 rounded-sm px-2 py-1 cursor-pointer hover:bg-chalkboard-20 dark:hover:bg-chalkboard-80 border-none text-left text-sm leading-5 text-chalkboard-100 dark:text-chalkboard-10 '
 
   return (
     <Popover className="relative min-w-0">
@@ -562,7 +582,7 @@ function ProjectMenuPopover({
                 if (isProjectMenuBreak(props)) {
                   return index !== projectMenuItems.length - 1 ? (
                     <li key={props.id} className="contents">
-                      <hr className="border-chalkboard-20 dark:border-chalkboard-80" />
+                      <hr className="my-0 border-chalkboard-20 dark:border-chalkboard-80" />
                     </li>
                   ) : null
                 }

--- a/src/components/ProjectSidebarMenu.tsx
+++ b/src/components/ProjectSidebarMenu.tsx
@@ -2,7 +2,6 @@ import { Popover, Transition } from '@headlessui/react'
 import { useSignals } from '@preact/signals-react/runtime'
 import type { ActionButtonProps } from '@src/components/ActionButton'
 import { ActionButton } from '@src/components/ActionButton'
-import { useCloudSyncProjectConflict } from '@src/components/CloudConflictDialog'
 import { CustomIcon } from '@src/components/CustomIcon'
 import { Logo } from '@src/components/Logo'
 import Tooltip from '@src/components/Tooltip'
@@ -24,8 +23,11 @@ import {
   keymapService,
 } from '@src/registry/contracts/keymap'
 import {
+  type ProjectExplorerProjectBreadcrumbBadge,
+  type ProjectExplorerProjectBreadcrumbBadgeContext,
   type ProjectExplorerProjectMenuItem,
   type ProjectExplorerProjectMenuItemContext,
+  projectExplorerProjectBreadcrumbBadgesValueSpec,
   projectExplorerProjectMenuItemsValueSpec,
 } from '@src/registry/contracts/projectExplorer'
 import { useSelector } from '@xstate/react'
@@ -68,6 +70,10 @@ type ProjectMenuItem =
       id: string
     }
   | null
+type ProjectBreadcrumbBadgeItem = {
+  item: ProjectExplorerProjectBreadcrumbBadge
+  context: ProjectExplorerProjectBreadcrumbBadgeContext
+}
 
 function isContributedProjectMenuItem(
   item: Exclude<ProjectMenuItem, null>
@@ -234,13 +240,15 @@ function ProjectMenuPopover({
       : [`mod+${isDesktop() ? '' : 'shift'}+,`],
     platform
   )
-  const cloudConflictMetadata = useCloudSyncProjectConflict(project?.path)
   const commandsSelector = (state: SnapshotFrom<typeof commands.actor>) =>
     state.context.commands
   const commandList = useSelector(commands.actor, commandsSelector)
   const projectPath = project?.path
   const contributedProjectMenuItems = app.registry.signal(
     projectExplorerProjectMenuItemsValueSpec
+  ).value
+  const contributedProjectBreadcrumbBadges = app.registry.signal(
+    projectExplorerProjectBreadcrumbBadgesValueSpec
   ).value
 
   const exportCommandInfo = { name: 'Export', groupId: 'modeling' }
@@ -511,6 +519,21 @@ function ProjectMenuPopover({
     ]
   )
 
+  const projectBreadcrumbBadges = useMemo<ProjectBreadcrumbBadgeItem[]>(() => {
+    if (!projectPath || !project) {
+      return []
+    }
+
+    const context = { projectPath, project }
+    return contributedProjectBreadcrumbBadges.flatMap((item) => {
+      if (item.isVisible && !item.isVisible(context)) {
+        return []
+      }
+
+      return [{ item, context }]
+    })
+  }, [contributedProjectBreadcrumbBadges, project, projectPath])
+
   const menuItemClassName =
     'relative !font-sans flex items-center gap-2 rounded-sm py-1.5 px-2 cursor-pointer hover:bg-chalkboard-20 dark:hover:bg-chalkboard-80 border-none text-left '
 
@@ -519,7 +542,7 @@ function ProjectMenuPopover({
       <ProjectBreadcrumbButton
         project={project}
         file={file}
-        hasCloudConflict={Boolean(cloudConflictMetadata)}
+        contributedBadges={projectBreadcrumbBadges}
       />
 
       <Transition
@@ -582,11 +605,11 @@ function ProjectMenuPopover({
 export function ProjectBreadcrumbButton({
   project,
   file,
-  hasCloudConflict = false,
+  contributedBadges = [],
 }: {
   project?: IndexLoaderData['project']
   file?: IndexLoaderData['file']
-  hasCloudConflict?: boolean
+  contributedBadges?: ProjectBreadcrumbBadgeItem[]
 }) {
   // Breadcrumb for project and project-relative file path
   const relativeFilePath = getProjectRelativeFilePath(project, file)
@@ -603,6 +626,8 @@ export function ProjectBreadcrumbButton({
   const projectNameRef = useRef<HTMLSpanElement>(null)
   const filePathRef = useRef<HTMLSpanElement>(null)
   const [isBreadCrumbTruncated, setIsBreadCrumbTruncated] = useState(false)
+  const badgeClassName =
+    'hidden shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium leading-none sm:inline-flex'
 
   useEffect(() => {
     const isTruncated = (element: HTMLElement | null) =>
@@ -664,14 +689,39 @@ export function ProjectBreadcrumbButton({
           {breadCrumb.filePath}
         </span>
       </div>
-      {hasCloudConflict && (
-        <span
-          className="hidden shrink-0 rounded bg-warn-20 px-1.5 py-0.5 text-[10px] font-medium leading-none text-warn-90 dark:bg-warn-80 dark:text-warn-10 sm:inline-flex"
-          data-testid="project-sidebar-cloud-conflict-badge"
-        >
-          Cloud conflict
-        </span>
-      )}
+      {contributedBadges.map(({ item, context }) => {
+        if (item.Component) {
+          const Component = item.Component
+          return (
+            <Component
+              key={item.id}
+              context={context}
+              className={badgeClassName}
+            />
+          )
+        }
+
+        const label =
+          typeof item.label === 'function' ? item.label(context) : item.label
+        const dataTestId =
+          typeof item.dataTestId === 'function'
+            ? item.dataTestId(context)
+            : item.dataTestId
+        const className =
+          typeof item.className === 'function'
+            ? item.className(context)
+            : item.className
+
+        return (
+          <span
+            key={item.id}
+            className={`${badgeClassName} ${className ?? ''}`}
+            data-testid={dataTestId}
+          >
+            {label}
+          </span>
+        )
+      })}
       <CustomIcon
         name="caretDown"
         className="w-4 h-4 shrink-0 text-chalkboard-70 dark:text-chalkboard-40 ui-open:rotate-180"

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -11,7 +11,6 @@ import ProjectSidebarMenu from '@src/components/ProjectSidebarMenu'
 import type { App } from '@src/lib/app'
 import { cloudSyncRemoteProjects, cloudSyncStatus } from '@src/lib/cloudSync'
 import {
-  CloudConflictDialogHost,
   cloudSyncPlugin,
   cloudSyncProjectLibraryType,
   getCloudSyncStatusBarPresentation,
@@ -29,7 +28,7 @@ import {
   type ProjectLibrarySetting,
   projectLibrariesFromSettings,
 } from '@src/lib/projectLibraries'
-import { Themes } from '@src/lib/theme'
+import { appHeaderItemsValueSpec } from '@src/registry/contracts/appHeader'
 import type { CloudSyncRegistryService } from '@src/registry/contracts/cloudSync'
 import {
   cloudProjectRelationshipsService,
@@ -59,20 +58,96 @@ import { afterEach, describe, expect, test, vi } from 'vitest'
 import { createActor, createMachine } from 'xstate'
 
 const cloudConflictDialogMocks = vi.hoisted(
-  (): { conflict: unknown; dialogProjectPaths: string[] } => ({
+  (): {
+    conflict: unknown
+    conflictDialogProjectPath?: string
+    dialogProjectPaths: string[]
+    errorDialogMessage?: string
+    listeners: Set<() => void>
+    notify: () => void
+  } => ({
     conflict: undefined,
+    conflictDialogProjectPath: undefined,
     dialogProjectPaths: [],
+    errorDialogMessage: undefined,
+    listeners: new Set(),
+    notify: () => {
+      for (const listener of cloudConflictDialogMocks.listeners) {
+        listener()
+      }
+    },
   })
 )
 
-vi.mock('@src/components/CloudConflictDialog', () => ({
-  CloudConflictDialog: ({ projectPath }: { projectPath: string }) => {
-    cloudConflictDialogMocks.dialogProjectPaths.push(projectPath)
-    return <div data-testid="cloud-conflict-dialog">{projectPath}</div>
-  },
-  useCloudSyncProjectConflict: () => cloudConflictDialogMocks.conflict,
-  useCloudSyncProjectConflicts: () => [],
-}))
+vi.mock('@src/components/CloudConflictDialog', async () => {
+  const React = await vi.importActual<typeof import('react')>('react')
+
+  function useMockDialogSignalRender() {
+    const [, forceRender] = React.useState(0)
+
+    React.useEffect(() => {
+      const listener = () => forceRender((count) => count + 1)
+      cloudConflictDialogMocks.listeners.add(listener)
+
+      return () => {
+        cloudConflictDialogMocks.listeners.delete(listener)
+      }
+    }, [])
+  }
+
+  function MockCloudConflictDialogHost() {
+    useMockDialogSignalRender()
+
+    if (cloudConflictDialogMocks.conflictDialogProjectPath) {
+      cloudConflictDialogMocks.dialogProjectPaths.push(
+        cloudConflictDialogMocks.conflictDialogProjectPath
+      )
+    }
+
+    return (
+      <>
+        {cloudConflictDialogMocks.conflictDialogProjectPath && (
+          <div data-testid="cloud-conflict-dialog">
+            {cloudConflictDialogMocks.conflictDialogProjectPath}
+          </div>
+        )}
+      </>
+    )
+  }
+
+  function MockCloudSyncErrorDialogHost() {
+    useMockDialogSignalRender()
+
+    return (
+      <>
+        {cloudConflictDialogMocks.errorDialogMessage && (
+          <div data-testid="cloud-sync-error-dialog">
+            {cloudConflictDialogMocks.errorDialogMessage}
+          </div>
+        )}
+      </>
+    )
+  }
+
+  return {
+    CloudConflictDialog: ({ projectPath }: { projectPath: string }) => {
+      cloudConflictDialogMocks.dialogProjectPaths.push(projectPath)
+      return <div data-testid="cloud-conflict-dialog">{projectPath}</div>
+    },
+    CloudConflictDialogHost: MockCloudConflictDialogHost,
+    CloudSyncErrorDialogHost: MockCloudSyncErrorDialogHost,
+    openCloudConflictDialog: ({ projectPath }: { projectPath: string }) => {
+      cloudConflictDialogMocks.conflictDialogProjectPath = projectPath
+      cloudConflictDialogMocks.notify()
+    },
+    openCloudSyncErrorDialog: ({ message }: { message: string }) => {
+      cloudConflictDialogMocks.errorDialogMessage = message
+      cloudConflictDialogMocks.notify()
+    },
+    useCloudSyncProjectConflict: () => cloudConflictDialogMocks.conflict,
+    useCloudSyncProjectConflicts: () => [],
+  }
+})
 
 vi.mock('@src/lib/desktop', () => ({
   writeProjectTitleToProjectToml: vi.fn().mockResolvedValue(undefined),
@@ -139,6 +214,19 @@ type TestSettings = {
 
 function renderWithRouter(children: ReactNode) {
   return render(<BrowserRouter>{children}</BrowserRouter>)
+}
+
+function CloudSyncDialogHostContribution({ app }: { app: App }) {
+  const item = app.registry
+    .get(appHeaderItemsValueSpec)
+    .find((item) => item.id === 'cloud-sync.dialog-app-header-item')
+  expect(item).toBeDefined()
+  if (!item) {
+    return null
+  }
+
+  const Component = item.Component
+  return <Component app={app} className="" />
 }
 
 function createCloudSyncService(): CloudSyncRegistryService {
@@ -341,7 +429,9 @@ function enableCloudSyncPlugin(registry: Registry) {
 afterEach(() => {
   window.electron = originalElectron
   cloudConflictDialogMocks.conflict = undefined
+  cloudConflictDialogMocks.conflictDialogProjectPath = undefined
   cloudConflictDialogMocks.dialogProjectPaths = []
+  cloudConflictDialogMocks.errorDialogMessage = undefined
   cloudSyncStatus.value = {
     enabled: false,
     state: 'disabled',
@@ -371,6 +461,45 @@ describe('cloud sync status presentation', () => {
 })
 
 describe('cloud sync status bar conflict dialog', () => {
+  test('contributes the cloud sync status bar item only on home', () => {
+    cloudSyncStatus.value = {
+      enabled: true,
+      state: 'idle',
+      pendingCount: 0,
+    }
+    const registry = new Registry()
+    const settings = createSettingsService({})
+    const settingsExtension = defineRegistryItem({
+      id: 'test-settings-service',
+      providesServices: [provideService(settingsService, settings.service)],
+    })
+    const userFeaturesExtension = defineRegistryItem({
+      id: 'test-user-features-service',
+      providesServices: [
+        provideService(userFeaturesService, createUserFeaturesService()),
+      ],
+    })
+
+    registry.configure([
+      settingsExtension,
+      userFeaturesExtension,
+      cloudSyncPlugin,
+    ])
+    enableCloudSyncPlugin(registry)
+
+    try {
+      expect(
+        registry
+          .get(statusBarGlobalItemsValueSpec)
+          .find((item) => item.id === 'cloud-sync')
+      ).toMatchObject({
+        scopes: ['home'],
+      })
+    } finally {
+      registry[Symbol.dispose]()
+    }
+  })
+
   test('keeps inspecting the clicked project when global conflict status changes', async () => {
     cloudConflictDialogMocks.conflict = {
       conflict: {
@@ -417,8 +546,19 @@ describe('cloud sync status bar conflict dialog', () => {
       }
 
       const StatusBarItem = statusItem.component
+      const app = {
+        registry,
+        settings: {
+          useSettings: () => settings.settingsSignal.value,
+        },
+      } as unknown as App
       window.history.pushState({}, '', '/file/%2Fprojects%2Fcurrent%2Fmain.kcl')
-      renderWithRouter(<StatusBarItem />)
+      renderWithRouter(
+        <>
+          <StatusBarItem />
+          <CloudSyncDialogHostContribution app={app} />
+        </>
+      )
 
       fireEvent.click(screen.getByTestId('cloud-sync-status'))
       expect(
@@ -448,8 +588,80 @@ describe('cloud sync status bar conflict dialog', () => {
   })
 })
 
-describe('cloud sync conflict project menu item', () => {
+describe('cloud sync project menu item', () => {
+  test('shows synced state from the project sidebar menu', async () => {
+    cloudSyncStatus.value = {
+      enabled: true,
+      state: 'idle',
+      pendingCount: 0,
+      scopedProjectCloudProjectId: 'remote-123',
+      lastSyncedAt: new Date(now).toISOString(),
+    }
+    const cloudSync = createCloudSyncService()
+    const { app, dispose } = createProjectMenuApp(cloudSync)
+
+    try {
+      renderWithRouter(
+        <>
+          <ProjectSidebarMenu
+            app={app}
+            enableMenu
+            project={projectWellFormed}
+          />
+          <CloudSyncDialogHostContribution app={app} />
+        </>
+      )
+
+      fireEvent.click(screen.getByTestId('project-sidebar-toggle'))
+
+      expect(
+        await screen.findByTestId('project-sidebar-cloud-sync-status')
+      ).toHaveTextContent('Cloud synced')
+    } finally {
+      dispose()
+    }
+  })
+
+  test('hides quiet cloud sync state for unlinked local projects', () => {
+    cloudSyncStatus.value = {
+      enabled: true,
+      state: 'idle',
+      pendingCount: 0,
+    }
+    const cloudSync = createCloudSyncService()
+    const { app, dispose } = createProjectMenuApp(cloudSync)
+
+    try {
+      renderWithRouter(
+        <>
+          <ProjectSidebarMenu
+            app={app}
+            enableMenu
+            project={projectWellFormed}
+          />
+          <CloudSyncDialogHostContribution app={app} />
+        </>
+      )
+
+      fireEvent.click(screen.getByTestId('project-sidebar-toggle'))
+
+      expect(
+        screen.queryByTestId('project-sidebar-cloud-sync-status')
+      ).not.toBeInTheDocument()
+    } finally {
+      dispose()
+    }
+  })
+
   test('opens conflict resolution from the project sidebar menu', async () => {
+    cloudSyncStatus.value = {
+      enabled: true,
+      state: 'conflict',
+      pendingCount: 0,
+      activeProjectPath: projectWellFormed.path,
+      lastFailure: 'Cloud sync conflict: local and remote both changed.',
+      lastFailureAt: new Date(now).toISOString(),
+    }
     cloudConflictDialogMocks.conflict = {
       conflict: {
         conflictProjectPath: `${projectWellFormed.path} (cloud conflict)`,
@@ -468,7 +680,7 @@ describe('cloud sync conflict project menu item', () => {
             enableMenu
             project={projectWellFormed}
           />
-          <CloudConflictDialogHost resolvedTheme={Themes.Dark} />
+          <CloudSyncDialogHostContribution app={app} />
         </>
       )
 
@@ -482,6 +694,85 @@ describe('cloud sync conflict project menu item', () => {
       ).toHaveTextContent(projectWellFormed.path)
       expect(cloudSync.startProjectSync).not.toHaveBeenCalled()
       expect(cloudSync.disconnectProjectSync).not.toHaveBeenCalled()
+    } finally {
+      dispose()
+    }
+  })
+
+  test('opens cloud sync error details from the project sidebar menu', async () => {
+    cloudSyncStatus.value = {
+      enabled: true,
+      state: 'failed',
+      pendingCount: 1,
+      activeProjectPath: projectWellFormed.path,
+      lastFailure: 'Cloud sync cannot upload local changes.',
+      lastFailureKind: 'remote-upload-forbidden',
+      lastFailureAt: new Date(now).toISOString(),
+    }
+    const cloudSync = createCloudSyncService()
+    const { app, dispose } = createProjectMenuApp(cloudSync)
+
+    try {
+      renderWithRouter(
+        <>
+          <ProjectSidebarMenu
+            app={app}
+            enableMenu
+            project={projectWellFormed}
+          />
+          <CloudSyncDialogHostContribution app={app} />
+        </>
+      )
+
+      expect(
+        screen.getByTestId('project-sidebar-cloud-error-badge')
+      ).toHaveTextContent('Cloud error')
+
+      fireEvent.click(screen.getByTestId('project-sidebar-toggle'))
+      fireEvent.click(
+        await screen.findByTestId('project-sidebar-inspect-cloud-sync-error')
+      )
+
+      expect(
+        await screen.findByTestId('cloud-sync-error-dialog')
+      ).toHaveTextContent('Cloud sync cannot upload local changes.')
+      expect(cloudSync.startProjectSync).not.toHaveBeenCalled()
+      expect(cloudSync.disconnectProjectSync).not.toHaveBeenCalled()
+    } finally {
+      dispose()
+    }
+  })
+
+  test('keeps cloud sync error visible during scheduled retry pulses', async () => {
+    cloudSyncStatus.value = {
+      enabled: true,
+      state: 'syncing',
+      pendingCount: 1,
+      activeProjectPath: projectWellFormed.path,
+      lastFailure: 'Cloud sync cannot upload local changes.',
+      lastFailureKind: 'remote-upload-forbidden',
+      lastFailureAt: new Date(now).toISOString(),
+    }
+    const cloudSync = createCloudSyncService()
+    const { app, dispose } = createProjectMenuApp(cloudSync)
+
+    try {
+      renderWithRouter(
+        <ProjectSidebarMenu app={app} enableMenu project={projectWellFormed} />
+      )
+
+      expect(
+        screen.getByTestId('project-sidebar-cloud-error-badge')
+      ).toHaveTextContent('Cloud error')
+
+      fireEvent.click(screen.getByTestId('project-sidebar-toggle'))
+
+      expect(
+        await screen.findByTestId('project-sidebar-inspect-cloud-sync-error')
+      ).toHaveTextContent('Cloud sync blocked')
+      expect(
+        screen.queryByTestId('project-sidebar-cloud-sync-status')
+      ).not.toBeInTheDocument()
     } finally {
       dispose()
     }

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -52,6 +52,7 @@ import {
   userFeaturesService,
 } from '@src/registry/contracts/userFeatures'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type * as ReactModule from 'react'
 import type { ReactNode } from 'react'
 import { BrowserRouter } from 'react-router-dom'
 import { afterEach, describe, expect, test, vi } from 'vitest'
@@ -80,7 +81,7 @@ const cloudConflictDialogMocks = vi.hoisted(
 )
 
 vi.mock('@src/components/CloudConflictDialog', async () => {
-  const React = await vi.importActual<typeof import('react')>('react')
+  const React = await vi.importActual<typeof ReactModule>('react')
 
   function useMockDialogSignalRender() {
     const [, forceRender] = React.useState(0)

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -444,7 +444,7 @@ function CloudSyncProjectMenuItem({
     ? 'bg-warn-10/60 text-warn-90 hover:!bg-warn-20 focus:!bg-warn-20 dark:bg-warn-80/20 dark:text-warn-10 dark:hover:!bg-warn-80/30 dark:focus:!bg-warn-80/30'
     : isError
       ? 'bg-destroy-10/60 text-destroy-80 hover:!bg-destroy-10 focus:!bg-destroy-10 dark:bg-destroy-80/20 dark:text-destroy-20 dark:hover:!bg-destroy-80/30 dark:focus:!bg-destroy-80/30'
-      : 'text-chalkboard-80 hover:!bg-chalkboard-20 focus:!bg-chalkboard-20 dark:text-chalkboard-30 dark:hover:!bg-chalkboard-80 dark:focus:!bg-chalkboard-80'
+      : 'hover:!bg-chalkboard-20 focus:!bg-chalkboard-20 dark:hover:!bg-chalkboard-80 dark:focus:!bg-chalkboard-80'
   const dataTestId = isConflict
     ? 'project-sidebar-inspect-cloud-conflicts'
     : isError
@@ -486,7 +486,7 @@ function CloudSyncProjectMenuItem({
           close()
         }}
       >
-        <span className="flex-1" data-testid={dataTestId}>
+        <span className="min-w-0 flex-1 truncate" data-testid={dataTestId}>
           {label}
         </span>
       </ActionButton>

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -17,9 +17,12 @@ import { useSignals } from '@preact/signals-react/runtime'
 import { ActionButton } from '@src/components/ActionButton'
 import { ActionIcon } from '@src/components/ActionIcon'
 import {
-  CloudConflictDialog,
-  useCloudSyncProjectConflict,
+  CloudConflictDialogHost,
+  CloudSyncErrorDialogHost,
+  openCloudConflictDialog,
+  openCloudSyncErrorDialog,
   useCloudSyncProjectConflicts,
+  useCloudSyncProjectConflict,
 } from '@src/components/CloudConflictDialog'
 import type { CustomIconName } from '@src/components/CustomIcon'
 import { defaultStatusBarItemClassNames } from '@src/components/StatusBar/StatusBar'
@@ -69,16 +72,22 @@ import {
   canRevealInFileExplorer,
   revealInFileExplorer,
 } from '@src/lib/revealInFileExplorer'
-import { getResolvedTheme, type ResolvedTheme } from '@src/lib/theme'
+import { getResolvedTheme } from '@src/lib/theme'
 import { reportRejection } from '@src/lib/trap'
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
 import { userFeaturesContextHas } from '@src/machines/userFeaturesMachine'
+import {
+  type AppHeaderItemProps,
+  appHeaderItemsValueSpec,
+} from '@src/registry/contracts/appHeader'
 import {
   cloudProjectRelationshipsService,
   cloudSyncService,
 } from '@src/registry/contracts/cloudSync'
 import {
+  type ProjectExplorerProjectBreadcrumbBadgeComponentProps,
   type ProjectExplorerProjectMenuItemComponentProps,
+  projectExplorerProjectBreadcrumbBadgesValueSpec,
   projectExplorerProjectMenuItemsValueSpec,
 } from '@src/registry/contracts/projectExplorer'
 import {
@@ -109,19 +118,6 @@ type CloudSyncStatusBarPresentation = {
   iconClassName: string
   isBlocked: boolean
   tooltip: string
-}
-
-type CloudConflictDialogRequest = {
-  projectPath: string
-  projectName?: string
-}
-
-const cloudConflictDialogRequest = signal<CloudConflictDialogRequest | null>(
-  null
-)
-
-function openCloudConflictDialog(request: CloudConflictDialogRequest) {
-  cloudConflictDialogRequest.value = request
 }
 
 function CloudProjectLibrarySettingsDetails({
@@ -222,11 +218,7 @@ export function getCloudSyncStatusBarPresentation(
   }
 }
 
-function CloudSyncStatusBarItem({
-  resolvedTheme,
-}: {
-  resolvedTheme: ResolvedTheme
-}) {
+function CloudSyncStatusBarItem() {
   useSignals()
   const location = useLocation()
   const status = cloudSyncStatus.value
@@ -268,91 +260,76 @@ function CloudSyncStatusBarItem({
         : ''
   const statusBarClassName = `${defaultStatusBarItemClassNames} ${blockedClassName}`
 
-  return (
-    <>
-      {shouldListConflicts ? (
-        <Popover className="relative flex items-stretch">
-          <Popover.Button as={Fragment}>
-            <button
-              className={statusBarClassName}
-              data-testid="cloud-sync-status"
-              type="button"
-            >
-              {statusBarButtonContent}
-            </button>
-          </Popover.Button>
-          <Popover.Panel as={Fragment}>
-            <div
-              className="absolute left-0 bottom-full z-20 mb-1 flex w-72 max-w-[calc(100vw-1rem)] flex-col gap-1 rounded border border-chalkboard-30 bg-chalkboard-10 p-2 text-xs shadow-lg dark:border-chalkboard-80 dark:bg-chalkboard-90"
-              data-testid="cloud-conflict-list"
-            >
-              <div className="px-2 py-1 font-bold text-chalkboard-100 dark:text-chalkboard-10">
-                Projects with cloud conflicts
-              </div>
-              {conflictMetadataList === undefined ? (
-                <p className="px-2 py-1 text-chalkboard-70 dark:text-chalkboard-40">
-                  Loading conflicted projects...
-                </p>
-              ) : conflictMetadataList.length > 0 ? (
-                conflictMetadataList.map((metadata) => (
-                  <button
-                    key={metadata.localProjectPath}
-                    type="button"
-                    className="rounded px-2 py-1 text-left text-chalkboard-100 hover:bg-chalkboard-20 focus:bg-chalkboard-20 focus:outline-none dark:text-chalkboard-10 dark:hover:bg-chalkboard-80 dark:focus:bg-chalkboard-80"
-                    onClick={() =>
-                      openCloudConflictDialog({
-                        projectPath: metadata.localProjectPath,
-                        projectName: metadata.projectName,
-                      })
-                    }
-                  >
-                    {metadata.projectName}
-                  </button>
-                ))
-              ) : (
-                <p className="px-2 py-1 text-chalkboard-70 dark:text-chalkboard-40">
-                  No conflicted projects found.
-                </p>
-              )}
-            </div>
-          </Popover.Panel>
-        </Popover>
-      ) : (
+  return shouldListConflicts ? (
+    <Popover className="relative flex items-stretch">
+      <Popover.Button as={Fragment}>
         <button
-          type="button"
           className={statusBarClassName}
           data-testid="cloud-sync-status"
-          onClick={() => {
-            if (canInspectConflict && activeProjectPath) {
-              openCloudConflictDialog({
-                projectPath: activeProjectPath,
-              })
-              return
-            }
-            retryCloudSync()
-          }}
+          type="button"
         >
           {statusBarButtonContent}
         </button>
-      )}
-      <CloudConflictDialogHost resolvedTheme={resolvedTheme} />
-    </>
+      </Popover.Button>
+      <Popover.Panel as={Fragment}>
+        <div
+          className="absolute left-0 bottom-full z-20 mb-1 flex w-72 max-w-[calc(100vw-1rem)] flex-col gap-1 rounded border border-chalkboard-30 bg-chalkboard-10 p-2 text-xs shadow-lg dark:border-chalkboard-80 dark:bg-chalkboard-90"
+          data-testid="cloud-conflict-list"
+        >
+          <div className="px-2 py-1 font-bold text-chalkboard-100 dark:text-chalkboard-10">
+            Projects with cloud conflicts
+          </div>
+          {conflictMetadataList === undefined ? (
+            <p className="px-2 py-1 text-chalkboard-70 dark:text-chalkboard-40">
+              Loading conflicted projects...
+            </p>
+          ) : conflictMetadataList.length > 0 ? (
+            conflictMetadataList.map((metadata) => (
+              <button
+                key={metadata.localProjectPath}
+                type="button"
+                className="rounded px-2 py-1 text-left text-chalkboard-100 hover:bg-chalkboard-20 focus:bg-chalkboard-20 focus:outline-none dark:text-chalkboard-10 dark:hover:bg-chalkboard-80 dark:focus:bg-chalkboard-80"
+                onClick={() =>
+                  openCloudConflictDialog({
+                    projectPath: metadata.localProjectPath,
+                    projectName: metadata.projectName,
+                  })
+                }
+              >
+                {metadata.projectName}
+              </button>
+            ))
+          ) : (
+            <p className="px-2 py-1 text-chalkboard-70 dark:text-chalkboard-40">
+              No conflicted projects found.
+            </p>
+          )}
+        </div>
+      </Popover.Panel>
+    </Popover>
+  ) : (
+    <button
+      type="button"
+      className={statusBarClassName}
+      data-testid="cloud-sync-status"
+      onClick={() => {
+        if (canInspectConflict && activeProjectPath) {
+          openCloudConflictDialog({
+            projectPath: activeProjectPath,
+          })
+          return
+        }
+        retryCloudSync()
+      }}
+    >
+      {statusBarButtonContent}
+    </button>
   )
 }
 
 const cloudSyncStatusBarItem = defineRegistryItemFactory((ctx) => {
   const settings = ctx.services.signal(settingsService)
   const userFeatures = ctx.services.signal(userFeaturesService)
-  function CloudSyncStatusBarItemWithSettings() {
-    const settingsValues = (
-      settings.value as NonNullable<typeof settings.value>
-    ).useSettings()
-    return (
-      <CloudSyncStatusBarItem
-        resolvedTheme={getResolvedTheme(settingsValues.app.theme.current)}
-      />
-    )
-  }
 
   const statusBarItem = computed(() =>
     nullableStatusBarItem(
@@ -366,8 +343,8 @@ const cloudSyncStatusBarItem = defineRegistryItemFactory((ctx) => {
         cloudSyncStatus.value.enabled
         ? {
             id: 'cloud-sync',
-            component: CloudSyncStatusBarItemWithSettings,
-            scopes: ['home', 'file'],
+            component: CloudSyncStatusBarItem,
+            scopes: ['home'],
             order: 2,
           }
         : null
@@ -387,97 +364,253 @@ const cloudSyncStatusBarItemContribution = defineRegistryItem({
   uses: [cloudSyncStatusBarItem],
 })
 
-function CloudConflictProjectMenuItem({
+function cloudSyncStatusAppliesToProject(
+  status: CloudSyncStatus,
+  projectPath: string
+) {
+  return (
+    !status.activeProjectPath ||
+    normalizePathForSync(status.activeProjectPath) ===
+      normalizePathForSync(projectPath)
+  )
+}
+
+function cloudSyncFailureAppliesToProject(
+  status: CloudSyncStatus,
+  projectPath: string
+) {
+  return (
+    Boolean(status.lastFailure && status.activeProjectPath) &&
+    normalizePathForSync(status.activeProjectPath ?? '') ===
+      normalizePathForSync(projectPath)
+  )
+}
+
+function CloudSyncProjectMenuItem({
   context,
   className,
   close,
 }: ProjectExplorerProjectMenuItemComponentProps) {
+  useSignals()
+  const status = cloudSyncStatus.value
   const conflictMetadata = useCloudSyncProjectConflict(context.projectPath)
+  const projectName = getProjectDisplayName(context.project)
+  const presentation = getCloudSyncStatusBarPresentation(status)
+  const isActiveProjectStatus = cloudSyncStatusAppliesToProject(
+    status,
+    context.projectPath
+  )
+  const isError =
+    status.enabled &&
+    status.state !== 'conflict' &&
+    cloudSyncFailureAppliesToProject(status, context.projectPath)
+  const errorMessage = isError
+    ? status.lastFailure ||
+      'Cloud sync failed without a reported error message.'
+    : undefined
 
-  if (!conflictMetadata) {
+  if (!status.enabled) {
     return null
   }
+
+  const isConflict =
+    Boolean(conflictMetadata) ||
+    (status.state === 'conflict' && isActiveProjectStatus)
+  const hasCloudSyncProjectStatus =
+    isConflict ||
+    isError ||
+    Boolean(status.scopedProjectCloudProjectId) ||
+    (isActiveProjectStatus &&
+      (status.state === 'syncing' || status.pendingCount > 0))
+
+  if (!hasCloudSyncProjectStatus) {
+    return null
+  }
+
+  const label = isConflict
+    ? 'Cloud conflict'
+    : isError
+      ? status.lastFailureKind === 'remote-upload-forbidden'
+        ? 'Cloud sync blocked'
+        : 'Cloud sync failed'
+      : presentation.label
+  const icon = isConflict ? 'triangleExclamation' : presentation.icon
+  const iconClassName = isConflict
+    ? '!text-warn-80 dark:!text-warn-10'
+    : isError
+      ? '!text-destroy-80 dark:!text-destroy-20'
+      : `!text-chalkboard-60 dark:!text-chalkboard-40 ${presentation.iconClassName}`
+  const statusClassName = isConflict
+    ? 'bg-warn-10/60 text-warn-90 hover:!bg-warn-20 focus:!bg-warn-20 dark:bg-warn-80/20 dark:text-warn-10 dark:hover:!bg-warn-80/30 dark:focus:!bg-warn-80/30'
+    : isError
+      ? 'bg-destroy-10/60 text-destroy-80 hover:!bg-destroy-10 focus:!bg-destroy-10 dark:bg-destroy-80/20 dark:text-destroy-20 dark:hover:!bg-destroy-80/30 dark:focus:!bg-destroy-80/30'
+      : 'text-chalkboard-80 hover:!bg-chalkboard-20 focus:!bg-chalkboard-20 dark:text-chalkboard-30 dark:hover:!bg-chalkboard-80 dark:focus:!bg-chalkboard-80'
+  const dataTestId = isConflict
+    ? 'project-sidebar-inspect-cloud-conflicts'
+    : isError
+      ? 'project-sidebar-inspect-cloud-sync-error'
+      : 'project-sidebar-cloud-sync-status'
 
   return (
     <li className="contents">
       <ActionButton
         Element="button"
-        iconStart={{
-          icon: 'triangleExclamation',
+        iconEnd={{
+          icon,
           bgClassName: '!bg-transparent dark:!bg-transparent',
-          iconClassName: '!text-warn-80 dark:!text-warn-10',
+          iconClassName,
+          size: 'sm',
         }}
-        className={`${className}bg-warn-10/50 text-warn-90 hover:!bg-warn-20 focus:!bg-warn-20 dark:bg-warn-80/20 dark:text-warn-10 dark:hover:!bg-warn-80/30 dark:focus:!bg-warn-80/30`}
+        className={`${className}${statusClassName}`}
         onClick={() => {
-          openCloudConflictDialog({
-            projectPath: context.projectPath,
-            projectName: getProjectDisplayName(context.project),
-          })
+          if (isConflict) {
+            openCloudConflictDialog({
+              projectPath: context.projectPath,
+              projectName,
+            })
+            close()
+            return
+          }
+          if (errorMessage) {
+            openCloudSyncErrorDialog({
+              title: presentation.label,
+              message: errorMessage,
+              projectName,
+              occurredAt: status.lastFailureAt,
+            })
+            close()
+            return
+          }
+
+          retryCloudSync()
           close()
         }}
       >
-        <span
-          className="flex-1"
-          data-testid="project-sidebar-inspect-cloud-conflicts"
-        >
-          Inspect cloud conflicts
+        <span className="flex-1" data-testid={dataTestId}>
+          {label}
         </span>
       </ActionButton>
     </li>
   )
 }
 
-export function CloudConflictDialogHost({
-  resolvedTheme,
-}: {
-  resolvedTheme: ResolvedTheme
-}) {
+function CloudSyncProjectBreadcrumbBadge({
+  context,
+  className,
+}: ProjectExplorerProjectBreadcrumbBadgeComponentProps) {
   useSignals()
-  const dialog = cloudConflictDialogRequest.value
+  const conflictMetadata = useCloudSyncProjectConflict(context.projectPath)
+  const status = cloudSyncStatus.value
+  const isActiveProjectStatus = cloudSyncStatusAppliesToProject(
+    status,
+    context.projectPath
+  )
+  const isConflict =
+    Boolean(conflictMetadata) ||
+    (status.enabled && status.state === 'conflict' && isActiveProjectStatus)
+  const isError =
+    status.enabled &&
+    status.state !== 'conflict' &&
+    cloudSyncFailureAppliesToProject(status, context.projectPath)
 
-  useEffect(() => {
-    return () => {
-      cloudConflictDialogRequest.value = null
-    }
-  }, [])
-
-  if (!dialog) {
+  if (!isConflict && !isError) {
     return null
   }
 
+  const badge = isConflict
+    ? {
+        label: 'Cloud conflict',
+        className: 'bg-warn-20 text-warn-90 dark:bg-warn-80 dark:text-warn-10',
+        dataTestId: 'project-sidebar-cloud-conflict-badge',
+      }
+    : {
+        label: 'Cloud error',
+        className:
+          'bg-destroy-10 text-destroy-80 ring-1 ring-inset ring-destroy-40 dark:bg-destroy-80 dark:text-destroy-10 dark:ring-destroy-70',
+        dataTestId: 'project-sidebar-cloud-error-badge',
+      }
+
   return (
-    <CloudConflictDialog
-      projectPath={dialog.projectPath}
-      projectName={dialog.projectName}
-      resolvedTheme={resolvedTheme}
-      onDismiss={() => {
-        cloudConflictDialogRequest.value = null
-      }}
-      onResolved={() => {
-        cloudConflictDialogRequest.value = null
-      }}
-    />
+    <span
+      className={`${className} ${badge.className}`}
+      data-testid={badge.dataTestId}
+    >
+      {badge.label}
+    </span>
   )
 }
 
-const cloudConflictProjectMenuItem = defineRegistryItemFactory(() => {
+function CloudSyncDialogAppHeaderItem({ app }: AppHeaderItemProps) {
+  const settingsValues = app.settings.useSettings()
+
+  return (
+    <>
+      <CloudConflictDialogHost
+        resolvedTheme={getResolvedTheme(settingsValues.app.theme.current)}
+      />
+      <CloudSyncErrorDialogHost />
+    </>
+  )
+}
+
+export { CloudConflictDialogHost }
+
+const cloudSyncProjectBreadcrumbBadge = defineRegistryItemFactory(() => {
   return {
     item: defineRuntimeRegistryItem({
-      id: 'cloud-sync.conflict-project-menu-item',
+      id: 'cloud-sync.project-breadcrumb-badge',
       provides: [
         provide(
-          projectExplorerProjectMenuItemsValueSpec,
+          projectExplorerProjectBreadcrumbBadgesValueSpec,
           {
-            id: 'cloud-sync.conflict-project-menu-item',
-            order: 9,
-            Component: CloudConflictProjectMenuItem,
+            id: 'cloud-sync.project-breadcrumb-badge',
+            order: 10,
+            Component: CloudSyncProjectBreadcrumbBadge,
           },
-          { key: 'cloud-sync.conflict-project-menu-item' }
+          { key: 'cloud-sync.project-breadcrumb-badge' }
         ),
       ],
     }),
   }
-}, 'cloud-sync.conflict-project-menu-item')
+}, 'cloud-sync.project-breadcrumb-badge')
+
+const cloudSyncDialogAppHeaderItem = defineRegistryItemFactory(() => {
+  return {
+    item: defineRuntimeRegistryItem({
+      id: 'cloud-sync.dialog-app-header-item',
+      provides: [
+        provide(
+          appHeaderItemsValueSpec,
+          {
+            id: 'cloud-sync.dialog-app-header-item',
+            order: 1000,
+            Component: CloudSyncDialogAppHeaderItem,
+          },
+          { key: 'cloud-sync.dialog-app-header-item' }
+        ),
+      ],
+    }),
+  }
+}, 'cloud-sync.dialog-app-header-item')
+
+const cloudSyncProjectMenuItem = defineRegistryItemFactory(() => {
+  return {
+    item: defineRuntimeRegistryItem({
+      id: 'cloud-sync.project-menu-item',
+      provides: [
+        provide(
+          projectExplorerProjectMenuItemsValueSpec,
+          {
+            id: 'cloud-sync.project-menu-item',
+            order: 9,
+            Component: CloudSyncProjectMenuItem,
+          },
+          { key: 'cloud-sync.project-menu-item' }
+        ),
+      ],
+    }),
+  }
+}, 'cloud-sync.project-menu-item')
 
 function remoteThumbnailCacheKey(project: RemoteProjectSummary) {
   return [
@@ -1154,7 +1287,9 @@ export const cloudSyncPlugin = createZdsPlugin({
   title: 'Cloud sync',
   description: 'Cloud-backed project sync controls and status.',
   items: [
-    cloudConflictProjectMenuItem,
+    cloudSyncDialogAppHeaderItem,
+    cloudSyncProjectBreadcrumbBadge,
+    cloudSyncProjectMenuItem,
     cloudSyncStatusBarItemContribution,
     cloudSyncCloudProjectRelationships,
   ],

--- a/src/lib/dateTime.ts
+++ b/src/lib/dateTime.ts
@@ -1,0 +1,16 @@
+export function formatDateTime(dateTimeMs: number | undefined) {
+  if (dateTimeMs === undefined || Number.isNaN(dateTimeMs)) {
+    return 'Unknown'
+  }
+
+  return new Date(dateTimeMs).toLocaleString()
+}
+
+export function formatOptionalDateTime(dateTime: string | undefined) {
+  if (!dateTime) {
+    return undefined
+  }
+
+  const parsed = Date.parse(dateTime)
+  return Number.isNaN(parsed) ? undefined : formatDateTime(parsed)
+}

--- a/src/registry/contracts/projectExplorer.ts
+++ b/src/registry/contracts/projectExplorer.ts
@@ -30,6 +30,17 @@ export interface ProjectExplorerProjectMenuItemContext {
   project: Project
 }
 
+export interface ProjectExplorerProjectBreadcrumbBadgeContext {
+  projectPath: string
+  project: Project
+}
+
+export interface ProjectExplorerProjectBreadcrumbBadgeComponentProps {
+  context: ProjectExplorerProjectBreadcrumbBadgeContext
+  /** The base badge classes from ProjectSidebarMenu. */
+  className: string
+}
+
 /**
  * Render props for project menu contributions that need hooks, local state, or
  * dialogs instead of a simple label and onSelect callback.
@@ -76,9 +87,46 @@ export type ProjectExplorerProjectMenuItem =
       Component: ComponentType<ProjectExplorerProjectMenuItemComponentProps>
     })
 
+type ProjectExplorerProjectBreadcrumbBadgeBase = {
+  id: string
+  order?: number
+  isVisible?: (context: ProjectExplorerProjectBreadcrumbBadgeContext) => boolean
+}
+
+type ProjectExplorerProjectBreadcrumbBadgeSlotProps = {
+  label:
+    | ReactNode
+    | ((context: ProjectExplorerProjectBreadcrumbBadgeContext) => ReactNode)
+  dataTestId?:
+    | string
+    | ((
+        context: ProjectExplorerProjectBreadcrumbBadgeContext
+      ) => string | undefined)
+  className?:
+    | string
+    | ((
+        context: ProjectExplorerProjectBreadcrumbBadgeContext
+      ) => string | undefined)
+}
+
+export type ProjectExplorerProjectBreadcrumbBadge =
+  | (ProjectExplorerProjectBreadcrumbBadgeBase &
+      ProjectExplorerProjectBreadcrumbBadgeSlotProps & {
+        Component?: undefined
+      })
+  | (ProjectExplorerProjectBreadcrumbBadgeBase & {
+      Component: ComponentType<ProjectExplorerProjectBreadcrumbBadgeComponentProps>
+    })
+
 const byOrder = (
-  a: ProjectExplorerRowContextMenuItem | ProjectExplorerProjectMenuItem,
-  b: ProjectExplorerRowContextMenuItem | ProjectExplorerProjectMenuItem
+  a:
+    | ProjectExplorerRowContextMenuItem
+    | ProjectExplorerProjectMenuItem
+    | ProjectExplorerProjectBreadcrumbBadge,
+  b:
+    | ProjectExplorerRowContextMenuItem
+    | ProjectExplorerProjectMenuItem
+    | ProjectExplorerProjectBreadcrumbBadge
 ) => (a.order || 0) - (b.order || 0)
 
 export const projectExplorerContract = defineContract({
@@ -87,6 +135,14 @@ export const projectExplorerContract = defineContract({
     ProjectExplorerProjectMenuItem[]
   >({
     name: 'project-explorer-project-menu-items',
+    defaultValue: [],
+    combine: (items) => items.toSorted(byOrder),
+  }),
+  projectExplorerProjectBreadcrumbBadgesValueSpec: defineValueSpec<
+    ProjectExplorerProjectBreadcrumbBadge,
+    ProjectExplorerProjectBreadcrumbBadge[]
+  >({
+    name: 'project-explorer-project-breadcrumb-badges',
     defaultValue: [],
     combine: (items) => items.toSorted(byOrder),
   }),
@@ -101,6 +157,7 @@ export const projectExplorerContract = defineContract({
 })
 
 export const {
+  projectExplorerProjectBreadcrumbBadgesValueSpec,
   projectExplorerProjectMenuItemsValueSpec,
   projectExplorerRowContextMenuItemsValueSpec,
 } = projectExplorerContract

--- a/src/registry/extensions/getDesktopApp/GetDesktopApp.tsx
+++ b/src/registry/extensions/getDesktopApp/GetDesktopApp.tsx
@@ -30,7 +30,7 @@ function GetDesktopAppLink({
       data-testid={testId}
       onMouseUp={onMouseUp}
     >
-      <span className="flex-1">Get desktop app</span>
+      <span className="min-w-0 flex-1 truncate">Get desktop app</span>
     </ActionButton>
   )
 }


### PR DESCRIPTION
Addresses the project-menu cloud sync status follow-up by making cloud conflict, error, and sync state visible from the project breadcrumb and sidebar project menu, with dialogs hosted outside the status bar.

1. Adds an extensible project breadcrumb badge contribution point and renders contributed badges in `ProjectSidebarMenu`.
2. Moves cloud conflict and cloud error dialog hosting into an app-header contribution so status/menu actions can open dialogs from the right UI scope.
3. Replaces the conflict-only project menu contribution with a cloud sync status row for synced, syncing, conflict, and error states.
4. Adds focused coverage for sidebar status rows, breadcrumb badges, dialog hosting, and the cloud sync error dialog.

## Screenshots

### Synced project menu

<img width="644" height="369" alt="Screenshot 2026-08-07 at 5 04 43 PM" src="https://github.com/user-attachments/assets/b7945fdd-ee81-45ad-92c1-5867a29624e0" />

### Cloud conflict or error state

<img width="924" height="439" alt="Screenshot 2026-08-07 at 12 45 53 PM" src="https://github.com/user-attachments/assets/950c1f03-f129-48a1-add1-ecb48915aac1" />
<img width="862" height="439" alt="Screenshot 2026-08-07 at 12 46 01 PM" src="https://github.com/user-attachments/assets/b37f70cc-8dee-43fb-a758-434779d5e02e" />
<img width="581" height="337" alt="Screenshot 2026-08-07 at 12 46 07 PM" src="https://github.com/user-attachments/assets/82447947-caf5-4240-b129-4c963548e1c4" />
<img width="894" height="425" alt="Screenshot 2026-08-07 at 12 52 13 PM" src="https://github.com/user-attachments/assets/13e20e3d-b689-480e-a263-1f69b80e931d" />


## How to test

Open a cloud-linked project and use the project sidebar menu to check synced or syncing status, cloud-conflict inspection, and cloud-error detail states. Also try an unlinked local project and confirm the cloud sync row stays hidden. To induce a cloud-error state, steal the ID below and replace the cloud sync ID of any throwaway project of yours, then make an edit:
```
5353de80-252e-4857-91d2-3595e1381230
```