### PR TITLE
Surface Free cloud training disclosure

### DIFF
--- a/src/lib/projectLibraries/trainingDisclosure.test.ts
+++ b/src/lib/projectLibraries/trainingDisclosure.test.ts
@@ -1,0 +1,54 @@
+import {
+  CLOUD_PROJECT_LIBRARY_TYPE,
+  DIRECTORY_PROJECT_LIBRARY_TYPE,
+  type ProjectLibrary,
+} from '@src/lib/projectLibraries'
+import { shouldShowFreeCloudProjectTrainingDisclosure } from '@src/lib/projectLibraries/trainingDisclosure'
+import { describe, expect, it } from 'vitest'
+
+function library(type: ProjectLibrary['type']): ProjectLibrary {
+  return {
+    id: `${type}-library`,
+    title: 'Projects',
+    path: '/projects',
+    type,
+  }
+}
+
+describe('shouldShowFreeCloudProjectTrainingDisclosure', () => {
+  it('shows the disclosure for Free users viewing a cloud library', () => {
+    expect(
+      shouldShowFreeCloudProjectTrainingDisclosure({
+        library: library(CLOUD_PROJECT_LIBRARY_TYPE),
+        hasSubscription: false,
+      })
+    ).toBe(true)
+  })
+
+  it('hides the disclosure for paid users viewing a cloud library', () => {
+    expect(
+      shouldShowFreeCloudProjectTrainingDisclosure({
+        library: library(CLOUD_PROJECT_LIBRARY_TYPE),
+        hasSubscription: true,
+      })
+    ).toBe(false)
+  })
+
+  it('hides the disclosure until billing has loaded', () => {
+    expect(
+      shouldShowFreeCloudProjectTrainingDisclosure({
+        library: library(CLOUD_PROJECT_LIBRARY_TYPE),
+        hasSubscription: undefined,
+      })
+    ).toBe(false)
+  })
+
+  it('hides the disclosure for Free users viewing a directory library', () => {
+    expect(
+      shouldShowFreeCloudProjectTrainingDisclosure({
+        library: library(DIRECTORY_PROJECT_LIBRARY_TYPE),
+        hasSubscription: false,
+      })
+    ).toBe(false)
+  })
+})

--- a/src/lib/projectLibraries/trainingDisclosure.ts
+++ b/src/lib/projectLibraries/trainingDisclosure.ts
@@ -1,0 +1,19 @@
+import {
+  CLOUD_PROJECT_LIBRARY_TYPE,
+  type ProjectLibrary,
+} from '@src/lib/projectLibraries'
+
+export const FREE_CLOUD_PROJECT_TRAINING_POLICY_URL =
+  'https://zoo.dev/terms-and-conditions#7-customer-materials-and-data'
+
+export function shouldShowFreeCloudProjectTrainingDisclosure({
+  library,
+  hasSubscription,
+}: {
+  library?: Pick<ProjectLibrary, 'type'>
+  hasSubscription: boolean | undefined
+}) {
+  return (
+    library?.type === CLOUD_PROJECT_LIBRARY_TYPE && hasSubscription === false
+  )
+}

--- a/src/routes/Home.test.tsx
+++ b/src/routes/Home.test.tsx
@@ -1,0 +1,67 @@
+import type { ProjectLibrary } from '@src/lib/projectLibraries'
+import {
+  FREE_CLOUD_PROJECT_TRAINING_POLICY_URL,
+  shouldShowFreeCloudProjectTrainingDisclosure,
+} from '@src/lib/projectLibraries/trainingDisclosure'
+import { HomeHeader } from '@src/routes/HomeHeader'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+
+const cloudLibrary = {
+  id: 'cloud-personal',
+  title: 'Personal Cloud',
+  path: '/documents/Zoo Projects',
+  type: 'cloud',
+} satisfies ProjectLibrary
+
+function renderHomeHeader({
+  showFreeCloudProjectTrainingDisclosure,
+}: {
+  showFreeCloudProjectTrainingDisclosure: boolean
+}) {
+  render(
+    <MemoryRouter>
+      <HomeHeader
+        title="Personal Cloud"
+        library={cloudLibrary}
+        setQuery={vi.fn()}
+        sort="modified:desc"
+        setSearchParams={vi.fn()}
+        readWriteProjectDir={{ value: true, error: undefined }}
+        showFreeCloudProjectTrainingDisclosure={
+          showFreeCloudProjectTrainingDisclosure
+        }
+      />
+    </MemoryRouter>
+  )
+}
+
+describe('HomeHeader', () => {
+  it('shows the Free cloud-project training disclosure with the policy link', () => {
+    renderHomeHeader({
+      showFreeCloudProjectTrainingDisclosure:
+        shouldShowFreeCloudProjectTrainingDisclosure({
+          library: cloudLibrary,
+          hasSubscription: false,
+        }),
+    })
+
+    expect(
+      screen.getByText(/Zoo trains on Free user cloud projects/)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: 'See our policy' })
+    ).toHaveAttribute('href', FREE_CLOUD_PROJECT_TRAINING_POLICY_URL)
+  })
+
+  it('does not show the disclosure when the condition is false', () => {
+    renderHomeHeader({
+      showFreeCloudProjectTrainingDisclosure: false,
+    })
+
+    expect(
+      screen.queryByText(/Zoo trains on Free user cloud projects/)
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -7,10 +7,7 @@ import AppProjectCard from '@src/components/AppProjectCard/AppProjectCard'
 import { CustomIcon, type CustomIconName } from '@src/components/CustomIcon'
 import Loading from '@src/components/Loading'
 import { useNetworkMachineStatus } from '@src/components/NetworkMachineIndicator'
-import {
-  ProjectSearchBar,
-  useProjectSearch,
-} from '@src/components/ProjectSearchBar'
+import { useProjectSearch } from '@src/components/ProjectSearchBar'
 import {
   defaultGlobalStatusBarItems,
   defaultLocalStatusBarItems,
@@ -41,11 +38,8 @@ import {
   type ProjectLibrary,
   projectLibrariesFromSettings,
 } from '@src/lib/projectLibraries'
-import {
-  getNextSearchParams,
-  getSortFunction,
-  getSortIcon,
-} from '@src/lib/sorting'
+import { shouldShowFreeCloudProjectTrainingDisclosure } from '@src/lib/projectLibraries/trainingDisclosure'
+import { getSortFunction } from '@src/lib/sorting'
 import { reportRejection } from '@src/lib/trap'
 import { platform } from '@src/lib/utils'
 import { withSiteBaseURL } from '@src/lib/withBaseURL'
@@ -81,6 +75,7 @@ import {
   statusBarLocalItemsValueSpec,
 } from '@src/registry/contracts/statusBar'
 import { APP_COMMAND_IDS } from '@src/registry/extensions/commands/appCommands'
+import { HomeHeader } from '@src/routes/HomeHeader'
 import {
   acceptOnboarding,
   needsToOnboard,
@@ -96,11 +91,6 @@ import {
   useParams,
   useSearchParams,
 } from 'react-router-dom'
-
-type ReadWriteProjectState = {
-  value: boolean
-  error: unknown
-}
 
 const PROJECT_LIBRARY_PREVIEW_LIMIT = 6
 
@@ -227,11 +217,11 @@ const Home = () => {
     })
   }
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: projectLibraryWatchKey tracks library identity and paths without rebinding on icon/title-only renders.
   useEffect(() => {
     return projectLibraryRealizations?.watchConfiguredLibraries({
       libraries: projectLibraries,
     })
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- projectLibraryWatchKey tracks library identity and paths without rebinding on icon/title-only renders.
   }, [projectLibraryRealizations, projectLibraryWatchKey])
 
   useEffect(() => {
@@ -409,6 +399,12 @@ const Home = () => {
           setSearchParams={setSearchParams}
           readWriteProjectDir={readWriteProjectDir}
           projectSearchKeybinding={projectSearchKeybinding}
+          showFreeCloudProjectTrainingDisclosure={shouldShowFreeCloudProjectTrainingDisclosure(
+            {
+              library: selectedProjectLibrary,
+              hasSubscription: billingContext.hasSubscription,
+            }
+          )}
           className="col-start-2 -col-end-1"
         />
         <aside
@@ -623,128 +619,6 @@ const Home = () => {
         ]}
       />
     </div>
-  )
-}
-
-interface HomeHeaderProps extends HTMLProps<HTMLDivElement> {
-  title: string
-  library?: ProjectLibrary
-  showLibraryBackLink?: boolean
-  setQuery: (query: string) => void
-  sort: string
-  setSearchParams: (params: Record<string, string>) => void
-  readWriteProjectDir: ReadWriteProjectState
-  projectSearchKeybinding?: string
-}
-
-function HomeHeader({
-  title,
-  library,
-  showLibraryBackLink = false,
-  setQuery,
-  sort,
-  setSearchParams,
-  readWriteProjectDir,
-  projectSearchKeybinding,
-  ...rest
-}: HomeHeaderProps) {
-  const isSortByModified = sort?.includes('modified') || !sort || sort === null
-
-  return (
-    <section {...rest}>
-      <div className="flex flex-col md:flex-row gap-4 justify-between md:items-center select-none">
-        <div className="flex gap-8 items-center">
-          <div className="flex flex-col gap-1">
-            {library && showLibraryBackLink && (
-              <Link
-                to={PATHS.HOME}
-                className="text-sm text-chalkboard-70 underline underline-offset-2 dark:text-chalkboard-30"
-              >
-                All libraries
-              </Link>
-            )}
-            <h1 className="text-3xl font-bold">{title}</h1>
-          </div>
-        </div>
-        <div className="flex flex-col sm:flex-row gap-2 sm:items-center">
-          <ProjectSearchBar
-            setQuery={setQuery}
-            keybinding={projectSearchKeybinding}
-          />
-          <div className="flex gap-2 items-center">
-            <small>Sort by</small>
-            <ActionButton
-              Element="button"
-              data-testid="home-sort-by-name"
-              className={`text-xs border-primary/10 ${
-                !sort.includes('name')
-                  ? 'text-chalkboard-80 dark:text-chalkboard-40'
-                  : ''
-              }`}
-              onClick={() => setSearchParams(getNextSearchParams(sort, 'name'))}
-              iconStart={{
-                icon: getSortIcon(sort, 'name'),
-                bgClassName: 'bg-transparent',
-                iconClassName: !sort.includes('name')
-                  ? '!text-chalkboard-90 dark:!text-chalkboard-30'
-                  : '',
-              }}
-            >
-              Name
-            </ActionButton>
-            <ActionButton
-              Element="button"
-              data-testid="home-sort-by-modified"
-              className={`text-xs border-primary/10 ${
-                !isSortByModified
-                  ? 'text-chalkboard-80 dark:text-chalkboard-40'
-                  : ''
-              }`}
-              onClick={() =>
-                setSearchParams(getNextSearchParams(sort, 'modified'))
-              }
-              iconStart={{
-                icon: sort ? getSortIcon(sort, 'modified') : 'arrowDown',
-                bgClassName: 'bg-transparent',
-                iconClassName: !isSortByModified
-                  ? '!text-chalkboard-90 dark:!text-chalkboard-30'
-                  : '',
-              }}
-            >
-              Last Modified
-            </ActionButton>
-          </div>
-        </div>
-      </div>
-      {library ? (
-        <p className="my-4 break-words text-sm text-chalkboard-80 dark:text-chalkboard-30">
-          Loaded from{' '}
-          <Link
-            data-testid="project-directory-settings-link"
-            to={`${PATHS.HOME + PATHS.SETTINGS_USER}#libraries`}
-            className="text-chalkboard-90 dark:text-chalkboard-20 underline underline-offset-2"
-          >
-            {formatProjectLibraryPathForDisplay(library)}
-          </Link>
-        </p>
-      ) : null}
-      {!readWriteProjectDir.value && (
-        <section>
-          <div className="flex items-center select-none">
-            <div className="flex gap-8 items-center justify-between grow bg-destroy-80 text-white py-1 px-4 my-2 rounded-sm">
-              <p className="">{errorMessage(readWriteProjectDir.error)}</p>
-              <Link
-                data-testid="project-directory-settings-link"
-                to={`${PATHS.HOME + PATHS.SETTINGS_USER}#libraries`}
-                className="py-1 text-white underline underline-offset-2 text-sm"
-              >
-                Manage Project Libraries
-              </Link>
-            </div>
-          </div>
-        </section>
-      )}
-    </section>
   )
 }
 
@@ -1085,20 +959,6 @@ function ProjectCardList({
       ))}
     </ul>
   )
-}
-
-/** Type narrowing function of unknown error to a string */
-function errorMessage(error: unknown): string {
-  if (error !== undefined && error instanceof Error) {
-    return error.message
-  }
-  if (error && typeof error === 'object') {
-    return JSON.stringify(error)
-  }
-  if (typeof error === 'string') {
-    return error
-  }
-  return 'Unknown error'
 }
 
 export default Home

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -222,6 +222,7 @@ const Home = () => {
     return projectLibraryRealizations?.watchConfiguredLibraries({
       libraries: projectLibraries,
     })
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- projectLibraryWatchKey tracks library identity and paths without rebinding on icon/title-only renders.
   }, [projectLibraryRealizations, projectLibraryWatchKey])
 
   useEffect(() => {

--- a/src/routes/HomeHeader.tsx
+++ b/src/routes/HomeHeader.tsx
@@ -1,0 +1,169 @@
+import { ActionButton } from '@src/components/ActionButton'
+import { ProjectSearchBar } from '@src/components/ProjectSearchBar'
+import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
+import { PATHS } from '@src/lib/paths'
+import {
+  formatProjectLibraryPathForDisplay,
+  type ProjectLibrary,
+} from '@src/lib/projectLibraries'
+import { FREE_CLOUD_PROJECT_TRAINING_POLICY_URL } from '@src/lib/projectLibraries/trainingDisclosure'
+import { getNextSearchParams, getSortIcon } from '@src/lib/sorting'
+import type { HTMLProps } from 'react'
+import { Link } from 'react-router-dom'
+
+type ReadWriteProjectState = {
+  value: boolean
+  error: unknown
+}
+
+interface HomeHeaderProps extends HTMLProps<HTMLDivElement> {
+  title: string
+  library?: ProjectLibrary
+  showLibraryBackLink?: boolean
+  setQuery: (query: string) => void
+  sort: string
+  setSearchParams: (params: Record<string, string>) => void
+  readWriteProjectDir: ReadWriteProjectState
+  projectSearchKeybinding?: string
+  showFreeCloudProjectTrainingDisclosure?: boolean
+}
+
+export function HomeHeader({
+  title,
+  library,
+  showLibraryBackLink = false,
+  setQuery,
+  sort,
+  setSearchParams,
+  readWriteProjectDir,
+  projectSearchKeybinding,
+  showFreeCloudProjectTrainingDisclosure = false,
+  ...rest
+}: HomeHeaderProps) {
+  const isSortByModified = sort?.includes('modified') || !sort || sort === null
+
+  return (
+    <section {...rest}>
+      <div className="flex flex-col md:flex-row gap-4 justify-between md:items-center select-none">
+        <div className="flex gap-8 items-center">
+          <div className="flex flex-col gap-1">
+            {library && showLibraryBackLink && (
+              <Link
+                to={PATHS.HOME}
+                className="text-sm text-chalkboard-70 underline underline-offset-2 dark:text-chalkboard-30"
+              >
+                All libraries
+              </Link>
+            )}
+            <h1 className="text-3xl font-bold">{title}</h1>
+          </div>
+        </div>
+        <div className="flex flex-col sm:flex-row gap-2 sm:items-center">
+          <ProjectSearchBar
+            setQuery={setQuery}
+            keybinding={projectSearchKeybinding}
+          />
+          <div className="flex gap-2 items-center">
+            <small>Sort by</small>
+            <ActionButton
+              Element="button"
+              data-testid="home-sort-by-name"
+              className={`text-xs border-primary/10 ${
+                !sort.includes('name')
+                  ? 'text-chalkboard-80 dark:text-chalkboard-40'
+                  : ''
+              }`}
+              onClick={() => setSearchParams(getNextSearchParams(sort, 'name'))}
+              iconStart={{
+                icon: getSortIcon(sort, 'name'),
+                bgClassName: 'bg-transparent',
+                iconClassName: !sort.includes('name')
+                  ? '!text-chalkboard-90 dark:!text-chalkboard-30'
+                  : '',
+              }}
+            >
+              Name
+            </ActionButton>
+            <ActionButton
+              Element="button"
+              data-testid="home-sort-by-modified"
+              className={`text-xs border-primary/10 ${
+                !isSortByModified
+                  ? 'text-chalkboard-80 dark:text-chalkboard-40'
+                  : ''
+              }`}
+              onClick={() =>
+                setSearchParams(getNextSearchParams(sort, 'modified'))
+              }
+              iconStart={{
+                icon: sort ? getSortIcon(sort, 'modified') : 'arrowDown',
+                bgClassName: 'bg-transparent',
+                iconClassName: !isSortByModified
+                  ? '!text-chalkboard-90 dark:!text-chalkboard-30'
+                  : '',
+              }}
+            >
+              Last Modified
+            </ActionButton>
+          </div>
+        </div>
+      </div>
+      {library ? (
+        <p className="my-4 break-words text-sm text-chalkboard-80 dark:text-chalkboard-30">
+          Loaded from{' '}
+          <Link
+            data-testid="project-directory-settings-link"
+            to={`${PATHS.HOME + PATHS.SETTINGS_USER}#libraries`}
+            className="text-chalkboard-90 dark:text-chalkboard-20 underline underline-offset-2"
+          >
+            {formatProjectLibraryPathForDisplay(library)}
+          </Link>
+          {showFreeCloudProjectTrainingDisclosure && (
+            <>
+              . Zoo trains on Free user cloud projects.{' '}
+              <a
+                href={FREE_CLOUD_PROJECT_TRAINING_POLICY_URL}
+                onClick={openExternalBrowserIfDesktop(
+                  FREE_CLOUD_PROJECT_TRAINING_POLICY_URL
+                )}
+                className="text-chalkboard-90 dark:text-chalkboard-20 underline underline-offset-2"
+              >
+                See our policy
+              </a>
+            </>
+          )}
+        </p>
+      ) : null}
+      {!readWriteProjectDir.value && (
+        <section>
+          <div className="flex items-center select-none">
+            <div className="flex gap-8 items-center justify-between grow bg-destroy-80 text-white py-1 px-4 my-2 rounded-sm">
+              <p className="">{errorMessage(readWriteProjectDir.error)}</p>
+              <Link
+                data-testid="project-directory-settings-link"
+                to={`${PATHS.HOME + PATHS.SETTINGS_USER}#libraries`}
+                className="py-1 text-white underline underline-offset-2 text-sm"
+              >
+                Manage Project Libraries
+              </Link>
+            </div>
+          </div>
+        </section>
+      )}
+    </section>
+  )
+}
+
+/** Type narrowing function of unknown error to a string */
+function errorMessage(error: unknown): string {
+  if (error !== undefined && error instanceof Error) {
+    return error.message
+  }
+  if (error && typeof error === 'object') {
+    return JSON.stringify(error)
+  }
+  if (typeof error === 'string') {
+    return error
+  }
+  return 'Unknown error'
+}


### PR DESCRIPTION
Adds the requested disclosure on library details pages so Free users viewing cloud libraries can see that Zoo may train on Free user cloud projects and reach the relevant policy section.

1. Extracts the Home header into a route-adjacent component so the disclosure copy can be rendered and tested directly.
2. Gates the disclosure on cloud library type plus Free-tier billing state.
3. Adds focused predicate and header render coverage for showing the disclosure, hiding it for paid or non-cloud cases, and linking to the policy.

## How to test

Open the Home library details view for a cloud library as a Free user and confirm the `Loaded from` line includes the training disclosure and policy link. Also check a paid account or local directory library to confirm the extra sentence is absent.