### PR TITLE
feat(kcl): resolve function signature types at definition time

### DIFF
--- a/docs/kcl-std/functions/std-sketch-patternTransform2d.md
+++ b/docs/kcl-std/functions/std-sketch-patternTransform2d.md
@@ -12,7 +12,7 @@ patternTransform2d(
   @sketches: [Sketch; 1+],
   instances: number(_),
   transform: fn(number(_)): { },
-  useOriginal?: boolean,
+  useOriginal?: bool,
 ): [Sketch; 1+]
 ```
 
@@ -25,7 +25,7 @@ patternTransform2d(
 | `sketches` | [[`Sketch`](/docs/kcl-std/types/std-types-Sketch); 1+] | The sketch(es) to duplicate. | Yes |
 | `instances` | [`number(_)`](/docs/kcl-std/types/std-types-number) | The number of total instances. Must be greater than or equal to 1. This includes the original entity. For example, if instances is 2, there will be two copies -- the original, and one new copy. If instances is 1, this has no effect. | Yes |
 | `transform` | [`fn(number(_)): { }`](/docs/kcl-std/types/std-types-fn) | How each replica should be transformed. The transform function takes a single parameter: an integer representing which number replication the transform is for. E.g. the first replica to be transformed will be passed the argument `1`. This simplifies your math: the transform function can rely on id `0` being the original instance passed into the `patternTransform`. See the examples. | Yes |
-| `useOriginal` | `boolean` | If the target was sketched on an extrusion, setting this will use the original sketch as the target, not the entire joined solid. | No |
+| `useOriginal` | [`bool`](/docs/kcl-std/types/std-types-bool) | If the target was sketched on an extrusion, setting this will use the original sketch as the target, not the entire joined solid. | No |
 
 ### Returns
 

--- a/rust/kcl-lib/expected-bindings/ts-rs/StdLibCommands.ts
+++ b/rust/kcl-lib/expected-bindings/ts-rs/StdLibCommands.ts
@@ -6072,7 +6072,7 @@ export default {
       },
       {
         "name": "useOriginal",
-        "ty": "boolean",
+        "ty": "bool",
         "docs": "If the target was sketched on an extrusion, setting this will use the original sketch as the target, not the entire joined solid.",
         "required": false,
         "special": false,

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -1899,6 +1899,13 @@ impl ExecutorContext {
                     )
                 };
 
+                // Resolve the signature's type names now, in the scope where
+                // the declaration is written. Call sites consume the stored
+                // resolutions and never look type names up themselves.
+                if let KclValue::Function { value, .. } = &mut closure {
+                    value.resolve_signature_types(exec_state)?;
+                }
+
                 // If the function expression has a name, i.e. `fn name() {}`,
                 // bind it in the current scope.
                 if let Some(fn_name) = &function_expression.name {

--- a/rust/kcl-lib/src/execution/fn_call.rs
+++ b/rust/kcl-lib/src/execution/fn_call.rs
@@ -898,6 +898,27 @@ pub(crate) fn unexpected_kw_arg_message(label: &str, callee_name: Option<&str>) 
     )
 }
 
+/// Fetch the definition-time resolution of a type written in a function
+/// signature.
+///
+/// [`FunctionSource::resolve_signature_types`] runs whenever a function
+/// declaration executes, so a written type without a stored resolution is a
+/// bug in KCL, not in the user's program.
+fn resolved_signature_type<'a>(
+    resolved: Option<&'a RuntimeType>,
+    written: &Type,
+    source_range: SourceRange,
+) -> Result<&'a RuntimeType, KclError> {
+    resolved.ok_or_else(|| {
+        KclError::new_internal(KclErrorDetails::new(
+            format!(
+                "The type `{written}` in this function's signature was not resolved when the function was declared. This is a bug in KCL and not in your code, please report this to Zoo."
+            ),
+            vec![source_range],
+        ))
+    })
+}
+
 fn type_check_params_kw(
     fn_name: Option<&str>,
     fn_def: &FunctionSource,
@@ -981,13 +1002,10 @@ fn type_check_params_kw(
         {
             let mut arg = unlabeled_arg.1;
             if let Some(ty) = ty {
-                // Suppress warnings about types because they should only be
-                // warned about once for the function definition.
-                let rty = RuntimeType::from_parsed(ty.clone(), exec_state, arg.source_range, false, true)
-                    .map_err(|e| KclError::new_semantic(e.into()))?;
+                let rty = resolved_signature_type(fn_def.resolved_input_ty.as_ref(), ty, arg.source_range)?;
                 arg.value = arg
                     .value
-                    .coerce(&rty, CoercionMode::implicit(), exec_state)
+                    .coerce(rty, CoercionMode::implicit(), exec_state)
                     .map_err(|_| {
                         KclError::new_argument(KclErrorDetails::new(
                             format!(
@@ -1079,19 +1097,16 @@ fn type_check_params_kw(
                 deprecated_since: _,
                 default_value: def,
                 ty,
+                resolved_ty,
             }) => {
                 // For optional args, passing None should be the same as not passing an arg.
                 if !(def.is_some() && matches!(arg.value, KclValue::KclNone { .. })) {
                     if let Some(ty) = ty {
-                        // Suppress warnings about types because they should
-                        // only be warned about once for the function
-                        // definition.
-                        let rty = RuntimeType::from_parsed(ty.clone(), exec_state, arg.source_range, false, true)
-                            .map_err(|e| KclError::new_semantic(e.into()))?;
+                        let rty = resolved_signature_type(resolved_ty.as_ref(), ty, arg.source_range)?;
                         arg.value = arg
                                 .value
                                 .coerce(
-                                    &rty,
+                                    rty,
                                     CoercionMode::implicit(),
                                     exec_state,
                                 )
@@ -1231,10 +1246,11 @@ fn coerce_result_type(
         return Ok(result);
     };
 
-    // Suppress warnings about types because they should only be warned
-    // about once for the function definition.
-    let ty = RuntimeType::from_parsed(ret_ty.inner.clone(), exec_state, ret_ty.as_source_range(), false, true)
-        .map_err(|e| KclError::new_semantic(e.into()))?;
+    let ty = resolved_signature_type(
+        fn_def.resolved_return_ty.as_ref(),
+        &ret_ty.inner,
+        ret_ty.as_source_range(),
+    )?;
 
     // `never` describes the absence of normal completion, so either successful
     // result shape violates the function's declared contract.
@@ -1254,7 +1270,7 @@ fn coerce_result_type(
         return Ok(None);
     };
 
-    let val = val.coerce(&ty, CoercionMode::implicit(), exec_state).map_err(|_| {
+    let val = val.coerce(ty, CoercionMode::implicit(), exec_state).map_err(|_| {
         KclError::new_type(KclErrorDetails::new(
             format!(
                 "This function requires its result to be {}",

--- a/rust/kcl-lib/src/execution/kcl_value.rs
+++ b/rust/kcl-lib/src/execution/kcl_value.rs
@@ -208,13 +208,27 @@ pub struct NamedParam {
     pub deprecated_since: Option<VersionConstraint>,
     pub default_value: Option<DefaultParamVal>,
     pub ty: Option<Type>,
+    /// The `RuntimeType` that `ty` resolved to when the function declaration
+    /// executed, so the resolution happened in the scope where the signature
+    /// is written. `None` when `ty` is `None`. Populated by
+    /// [`FunctionSource::resolve_signature_types`].
+    pub resolved_ty: Option<RuntimeType>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct FunctionSource {
     pub input_arg: Option<(String, Option<Type>)>,
+    /// The `RuntimeType` that the input (unlabeled) argument's type resolved
+    /// to when the function declaration executed. `None` when the input
+    /// argument has no type annotation. Populated by
+    /// [`FunctionSource::resolve_signature_types`].
+    pub resolved_input_ty: Option<RuntimeType>,
     pub named_args: IndexMap<String, NamedParam>,
     pub return_type: Option<Node<Type>>,
+    /// The `RuntimeType` that `return_type` resolved to when the function
+    /// declaration executed. `None` when `return_type` is `None`. Populated
+    /// by [`FunctionSource::resolve_signature_types`].
+    pub resolved_return_ty: Option<RuntimeType>,
     pub deprecated: bool,
     /// Constraint on the KCL version at which this function is deprecated, e.g.
     /// "2.0". When the active `kclVersion` is at or after this, calls trigger a
@@ -244,8 +258,10 @@ impl FunctionSource {
 
         FunctionSource {
             input_arg,
+            resolved_input_ty: None,
             named_args,
             return_type: ast.return_type.clone(),
+            resolved_return_ty: None,
             deprecated: attrs.deprecated,
             deprecated_since: attrs.deprecated_since,
             experimental: attrs.experimental,
@@ -265,8 +281,10 @@ impl FunctionSource {
         let (input_arg, named_args) = Self::args_from_ast(&ast);
         FunctionSource {
             input_arg,
+            resolved_input_ty: None,
             named_args,
             return_type: ast.return_type.clone(),
+            resolved_return_ty: None,
             deprecated: false,
             deprecated_since: None,
             experimental,
@@ -298,6 +316,7 @@ impl FunctionSource {
                     deprecated_since: p.deprecated_since.clone(),
                     default_value: p.default_value.clone(),
                     ty: p.param_type.as_ref().map(|t| t.inner.clone()),
+                    resolved_ty: None,
                 },
             );
         }
@@ -307,6 +326,42 @@ impl FunctionSource {
 
     pub(crate) fn is_std(&self) -> bool {
         self.std_props.is_some()
+    }
+
+    /// Resolve every parameter type and the return type of this function's
+    /// signature into a `RuntimeType`, looking type names up in the current
+    /// environment.
+    ///
+    /// This must run while the function declaration executes, so that a type
+    /// name in a signature resolves in the scope where the signature is
+    /// written. Argument and return-value coercion consume the stored results
+    /// and perform no name resolution of their own. A name that does not
+    /// resolve is an error at the declaration, and an experimental type warns
+    /// here, once, rather than at every call.
+    pub(crate) fn resolve_signature_types(&mut self, exec_state: &mut ExecState) -> Result<(), KclError> {
+        for param in &self.ast.params {
+            let Some(ty) = &param.param_type else {
+                continue;
+            };
+            let resolved = RuntimeType::from_parsed(ty.inner.clone(), exec_state, ty.as_source_range(), false, false)
+                .map_err(|e| KclError::new_semantic(e.into()))?;
+            if param.labeled {
+                if let Some(named) = self.named_args.get_mut(&param.identifier.name) {
+                    named.resolved_ty = Some(resolved);
+                }
+            } else {
+                self.resolved_input_ty = Some(resolved);
+            }
+        }
+
+        if let Some(ret_ty) = &self.return_type {
+            self.resolved_return_ty = Some(
+                RuntimeType::from_parsed(ret_ty.inner.clone(), exec_state, ret_ty.as_source_range(), false, false)
+                    .map_err(|e| KclError::new_semantic(e.into()))?,
+            );
+        }
+
+        Ok(())
     }
 }
 

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -4879,6 +4879,177 @@ type Color { | Red | Green | Red }
         }
     }
 
+    // The next five tests pin lexical resolution of signature types: a type
+    // name written in a function signature resolves in the scope where the
+    // declaration executes, never in the caller's scope. Before
+    // definition-time resolution, signature types were looked up at each call
+    // in the caller's environment, so a std or user module whose exported
+    // types a caller had not imported under their bare names was uncallable.
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn signature_types_resolve_in_declaring_module() {
+        let colors = (
+            "colors.kcl",
+            "@settings(experimentalFeatures = allow)\nexport type Color { | Red | Green }\n\nexport fn paint(@c: Color) {\n  return c\n}\n",
+        );
+        // The caller can reach `colors::Color` but never binds the bare name
+        // `Color`, so resolving the signature in the caller's scope would fail.
+        let main =
+            "@settings(experimentalFeatures = allow)\nimport \"colors.kcl\"\nr = colors::paint(colors::Color::Red)\n";
+
+        let result = execute_with_modules(main, &[colors]).await.unwrap();
+        let KclValue::Enum { value } = mem_get_json(result.exec_state.stack(), result.mem_env, "r") else {
+            panic!("`r` should hold an enum value");
+        };
+        assert_eq!(value.qualified_name(), "Color::Red");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn signature_types_resolve_under_import_alias() {
+        // An import alias renames the caller's binding for the module. The
+        // declaring module's scope is unaffected, so the signature must
+        // resolve identically under any alias.
+        let colors = (
+            "colors.kcl",
+            "@settings(experimentalFeatures = allow)\nexport type Color { | Red | Green }\n\nexport fn paint(@c: Color) {\n  return c\n}\n",
+        );
+        let main = "@settings(experimentalFeatures = allow)\nimport \"colors.kcl\" as painter\nr = painter::paint(painter::Color::Red)\n";
+
+        let result = execute_with_modules(main, &[colors]).await.unwrap();
+        let KclValue::Enum { value } = mem_get_json(result.exec_state.stack(), result.mem_env, "r") else {
+            panic!("`r` should hold an enum value");
+        };
+        assert_eq!(value.qualified_name(), "Color::Red");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn signature_types_ignore_caller_scope() {
+        // `broken.kcl` names a type it does not define. The caller defines
+        // that name, which caller-scope resolution would have used. The
+        // declaration must fail when the module loads, without consulting the
+        // caller's binding.
+        let broken = (
+            "broken.kcl",
+            "@settings(experimentalFeatures = allow)\nexport fn f(@x: Missing) {\n  return x\n}\n",
+        );
+        let main = "@settings(experimentalFeatures = allow)\ntype Missing = string\nimport \"broken.kcl\"\nr = broken::f(\"hi\")\n";
+
+        let err = execute_with_modules(main, &[broken]).await.unwrap_err();
+        assert!(
+            err.message().contains("Unknown type: Missing"),
+            "message: {}",
+            err.message()
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn signature_types_reject_forward_reference() {
+        // Resolution happens when the declaration executes, so a type declared
+        // later in the file is not visible. The function is never called; the
+        // error must surface at the declaration itself.
+        let main = "@settings(experimentalFeatures = allow)\nfn f(@x: Later) {\n  return x\n}\ntype Later = string\n";
+
+        let err = parse_execute(main).await.unwrap_err();
+        assert!(
+            err.message().contains("Unknown type: Later"),
+            "message: {}",
+            err.message()
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn signature_types_resolve_in_enclosing_scope() {
+        // The declaring scope is the closure's scope, not merely the declaring
+        // module: the anonymous function's signature must see the alias in the
+        // enclosing function body. Caller-scope resolution would use the
+        // module-level `Width = string` and fail to coerce `42`.
+        let main = "@settings(experimentalFeatures = allow)\ntype Width = string\nfn makeMeasure() {\n  type Width = number(mm)\n  return fn(@w: Width) { return w }\n}\nmeasure = makeMeasure()\nr = measure(42)\n";
+
+        let result = parse_execute(main).await.unwrap();
+        let KclValue::Number { value, .. } = mem_get_json(result.exec_state.stack(), result.mem_env, "r") else {
+            panic!("`r` should hold a number");
+        };
+        assert_eq!(value, 42.0);
+    }
+
+    // Pins that numeric types in signatures are settings-independent, so
+    // definition-time resolution changed nothing for them: in type
+    // annotations, bare `number` maps to `Any` before the settings-reading
+    // path, and every explicit suffix maps to a settings-free type. A literal
+    // argument therefore takes its unit from the CALLER's module defaults;
+    // the declaring module's defaults (`in` here) must never leak in. If a
+    // future change makes a signature's number type depend on module default
+    // units, the declaring-module scope of definition-time resolution starts
+    // to matter and this pin fails.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn signature_number_types_ignore_module_default_units() {
+        let units_in = (
+            "units_in.kcl",
+            "@settings(defaultLengthUnit = in)\nexport fn passThrough(@x: number(Length)) {\n  return x\n}\n",
+        );
+        // The caller's default length unit is mm (the test default), so the
+        // unitless literal is 42 mm by the time it reaches the parameter.
+        let main = "import \"units_in.kcl\"\na = units_in::passThrough(42)\nb = units_in::passThrough(42mm)\nc = units_in::passThrough(42in)\n";
+
+        let result = execute_with_modules(main, &[units_in]).await.unwrap();
+        for (name, expected_ty) in [
+            // The unitless literal keeps its `Default` type, and that type
+            // records the CALLER's module settings. Declaring-module leakage
+            // would show here as `len: Inches`.
+            //
+            // That the coercion to `number(Length)` leaves the type as
+            // `Default` rather than concretizing it to `Known(Millimeters)`
+            // is pre-existing coercion behavior which this test observes but
+            // does not endorse. If coercion later concretizes, update the
+            // expected type; the pin here is the settings provenance.
+            (
+                "a",
+                kcl_api::NumericType::Default {
+                    len: kcl_api::UnitLength::Millimeters,
+                    angle: kcl_api::UnitAngle::Degrees,
+                },
+            ),
+            (
+                "b",
+                kcl_api::NumericType::Known(kcl_api::UnitType::Length(kcl_api::UnitLength::Millimeters)),
+            ),
+            (
+                "c",
+                kcl_api::NumericType::Known(kcl_api::UnitType::Length(kcl_api::UnitLength::Inches)),
+            ),
+        ] {
+            let KclValue::Number { value, ty, .. } = mem_get_json(result.exec_state.stack(), result.mem_env, name)
+            else {
+                panic!("`{name}` should hold a number");
+            };
+            assert_eq!(value, 42.0, "`{name}` should keep its magnitude");
+            assert_eq!(ty, expected_ty, "`{name}` should keep the caller-side unit context");
+        }
+    }
+
+    // Pins the sharpest shadowing case, from a hand-written example during
+    // review: BOTH scopes define the same type name with different meanings,
+    // so the test observes which one the signature uses, not merely whether a
+    // name is present. `m1.kcl`'s `A` is `string` and is NOT exported; the
+    // caller's own `A` is `number(mm)`. The signature must use m1's `A`, so
+    // passing `2mm` is a type error. Caller-scope resolution would have used
+    // the caller's `A` and accepted the call.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn signature_types_use_declaring_scope_when_both_scopes_define_the_name() {
+        let m1 = (
+            "m1.kcl",
+            "@settings(experimentalFeatures = allow)\ntype A = string\n\nexport fn test(@a: A) {\n  return a\n}\n",
+        );
+        let main =
+            "@settings(experimentalFeatures = allow)\nimport * from \"m1.kcl\"\ntype A = number(mm)\nx = test(2mm)\n";
+
+        let err = execute_with_modules(main, &[m1]).await.unwrap_err();
+        assert_eq!(
+            err.message(),
+            "The input argument of `test` requires a value with type `A`, but found a number (mm) (with type `number(mm)`)."
+        );
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn enum_rejects_bad_variant_paths() {
         let allow = "@settings(experimentalFeatures = allow)\n";

--- a/rust/kcl-lib/std/gdt.kcl
+++ b/rust/kcl-lib/std/gdt.kcl
@@ -2,7 +2,9 @@
 /// This can be used for model-based definition (MBD).
 
 @no_std
-@settings(defaultLengthUnit = mm, kclVersion = 1.0)
+@settings(defaultLengthUnit = mm, kclVersion = 1.0, experimentalFeatures = allow)
+
+import Edge, Face, GdtAnnotation, Plane, Point2d, TaggedFace from "std::types"
 
 /// GD&T datum feature.
 ///

--- a/rust/kcl-lib/std/sketch.kcl
+++ b/rust/kcl-lib/std/sketch.kcl
@@ -7,6 +7,8 @@
 @no_std
 @settings(defaultLengthUnit = mm, kclVersion = 1.0, experimentalFeatures = allow)
 
+import Axis2d, Axis3d, BoundedEdge, Edge, Face, Helix, Plane, Point2d, Point3d, Segment, Sketch, Solid, TaggedEdge, TaggedFace from "std::types"
+
 /// Start a new 2-dimensional sketch on a specific plane or face.
 ///
 /// This is part of sketch v1 and is deprecated in favor of

--- a/rust/kcl-lib/std/sketch.kcl
+++ b/rust/kcl-lib/std/sketch.kcl
@@ -1259,7 +1259,7 @@ export fn patternTransform2d(
   /// How each replica should be transformed. The transform function takes a single parameter: an integer representing which number replication the transform is for. E.g. the first replica to be transformed will be passed the argument `1`. This simplifies your math: the transform function can rely on id `0` being the original instance passed into the `patternTransform`. See the examples.
   transform: fn(number(Count)): {},
   /// If the target was sketched on an extrusion, setting this will use the original sketch as the target, not the entire joined solid.
-  useOriginal?: boolean = false,
+  useOriginal?: bool = false,
 ): [Sketch; 1+] {}
 
 /// Get the opposite edge to the edge given.

--- a/rust/kcl-lib/std/solid.kcl
+++ b/rust/kcl-lib/std/solid.kcl
@@ -4,7 +4,7 @@
 @no_std
 @settings(defaultLengthUnit = mm, kclVersion = 1.0, experimentalFeatures = allow)
 
-import Face from "std::types"
+import Axis3d, BoundedEdge, Edge, Face, Plane, Point3d, Solid, TaggedEdge, TaggedFace from "std::types"
 
 /// Blend a transitional edge along a tagged path, smoothing the sharp edge.
 ///

--- a/rust/kcl-lib/std/transform.kcl
+++ b/rust/kcl-lib/std/transform.kcl
@@ -3,7 +3,7 @@
 @no_std
 @settings(defaultLengthUnit = mm, kclVersion = 1.0, experimentalFeatures = allow)
 
-import Axis3d from "std::types"
+import Axis2d, Axis3d, Edge, GdtAnnotation, Helix, Plane, Point3d, Segment, Sketch, Solid from "std::types"
 
 /// Mirror a sketch.
 ///

--- a/rust/kcl-lib/std/vector.kcl
+++ b/rust/kcl-lib/std/vector.kcl
@@ -2,6 +2,7 @@
 @settings(defaultLengthUnit = mm, kclVersion = 1.0, experimentalFeatures = allow)
 
 import assert from "std"
+import Point3d from "std::types"
 import * from "std::array"
 import pow, sqrt from "std::math"
 


### PR DESCRIPTION
Type names in function signatures now resolve when the declaration
executes, in the scope where the signature is written. Previously they
resolved at every call, in the caller's environment.

Why: a signature can name types the caller has no binding for. The
concrete blocker: `std::view` is imported namespaced by the prelude, so
a signature like `oriented(@orientation: Orientation)` was uncallable --
every user call failed with "Unknown type: Orientation", and type
positions cannot be qualified (`view::Orientation` is not writable
there). The same applies to any user module whose exported functions use
module-local types. Resolving where the signature is written removes the
whole class.


Semantics and compatibility:

- forward references are errors: a signature cannot name a type declared
  later in its file
- an unknown type name in a signature errors at the declaration even if
  the function is never called; this fail-fast surfaced a real latent
  bug (first commit: `patternTransform2d`'s `useOriginal?: boolean` --
  not a type; any caller passing the argument already errored)
- code without `experimentalFeatures = allow` cannot observe the change:
  every construct that could add a type binding beyond the prelude
  (aliases, enums, bare type declarations, std imports) is parse-gated
  at error severity, and the prelude is uniform across modules
- number types in signatures are settings-independent (bare `number`
  maps to `Any` before the settings-reading path; every suffix maps to a
  settings-free type), so unit semantics are unchanged -- pinned by test
- five `@no_std` std files gained explicit `std::types` imports; their
  signatures previously resolved through the caller's prelude. `gdt.kcl`
  thereby needs the `experimentalFeatures = allow` line its siblings
  already carry (file-scoped; does not extend to consumers)



