### PR TITLE
Scope command availability by app context

### DIFF
--- a/e2e/playwright/command-bar-tests.spec.ts
+++ b/e2e/playwright/command-bar-tests.spec.ts
@@ -7,6 +7,26 @@ import { expect, test } from '@e2e/playwright/zoo-test'
 import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
 
 test.describe('Command bar tests', { tag: '@desktop' }, () => {
+  test('Command palette keeps its modeling context after search autofocus', async ({
+    page,
+    homePage,
+    scene,
+  }) => {
+    await page.setBodyDimensions({ width: 1200, height: 500 })
+    await homePage.goToModelingScene()
+    await scene.settled()
+    await scene.clickNoWhere()
+
+    await page.keyboard.press('ControlOrMeta+K')
+    const cmdSearchBar = page.getByPlaceholder('Search commands')
+    await expect(cmdSearchBar).toBeFocused()
+
+    await cmdSearchBar.fill('Reset view')
+    await expect(
+      page.getByRole('option', { name: 'Reset view', exact: false })
+    ).toBeVisible()
+  })
+
   test('Extrude from command bar selects extrude line after', async ({
     page,
     homePage,

--- a/e2e/playwright/command-bar-tests.spec.ts
+++ b/e2e/playwright/command-bar-tests.spec.ts
@@ -7,7 +7,7 @@ import { expect, test } from '@e2e/playwright/zoo-test'
 import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
 
 test.describe('Command bar tests', { tag: '@desktop' }, () => {
-  test('Command palette scopes Home, modeling, and editor commands', async ({
+  test('Command palette scopes Home, modeling, editor, and Settings commands', async ({
     page,
     homePage,
     scene,
@@ -15,41 +15,52 @@ test.describe('Command bar tests', { tag: '@desktop' }, () => {
     await page.setBodyDimensions({ width: 1200, height: 500 })
     await expect(page.getByPlaceholder('Search projects')).toBeVisible()
 
-    await page.keyboard.press('ControlOrMeta+K')
     const cmdSearchBar = page.getByPlaceholder('Search commands')
-    await cmdSearchBar.fill('Go to Telemetry')
-    await expect(
-      page.getByRole('option', { name: 'Go to Telemetry', exact: false })
-    ).toBeVisible()
-    await cmdSearchBar.fill('Reset view')
-    await expect(
-      page.getByRole('option', { name: 'Reset view', exact: false })
-    ).not.toBeVisible()
+    const command = (name: string) =>
+      page.getByRole('option', { name, exact: false })
+    const telemetryCommand = command('Go to Telemetry')
+    const resetViewCommand = command('Reset view')
+    const formatCodeCommand = command('Format Code')
+    const extrudeCommand = command('Pull a sketch into 3D')
+    const settingsHeading = page.getByRole('heading', {
+      name: 'Settings',
+      exact: true,
+    })
+    const openCommandPalette = async () => {
+      await page.keyboard.press('ControlOrMeta+K')
+      await expect(cmdSearchBar).toBeFocused()
+    }
+
+    await openCommandPalette()
+    await expect(telemetryCommand).toBeVisible()
+    await expect(resetViewCommand).toHaveCount(0)
     await page.keyboard.press('Escape')
 
     await homePage.goToModelingScene()
     await scene.settled()
     await scene.clickNoWhere()
 
-    await page.keyboard.press('ControlOrMeta+K')
-    await expect(cmdSearchBar).toBeFocused()
-
-    await cmdSearchBar.fill('Reset view')
-    await expect(
-      page.getByRole('option', { name: 'Reset view', exact: false })
-    ).toBeVisible()
+    await openCommandPalette()
+    await expect(resetViewCommand).toBeVisible()
+    await expect(extrudeCommand).toBeVisible()
     await page.keyboard.press('Escape')
 
     await page.locator('.cm-content').click()
-    await page.keyboard.press('ControlOrMeta+K')
-    await cmdSearchBar.fill('Reset view')
-    await expect(
-      page.getByRole('option', { name: 'Reset view', exact: false })
-    ).not.toBeVisible()
-    await cmdSearchBar.fill('Format Code')
-    await expect(
-      page.getByRole('option', { name: 'Format Code', exact: false })
-    ).toBeVisible()
+    await openCommandPalette()
+    await expect(formatCodeCommand).toBeVisible()
+    await expect(resetViewCommand).toHaveCount(0)
+    await page.keyboard.press('Escape')
+
+    await page.getByRole('link', { name: 'Settings' }).last().click()
+    await expect(settingsHeading).toBeVisible()
+    await openCommandPalette()
+    await expect(command('Settings · app · theme')).toBeVisible()
+    await expect(resetViewCommand).toHaveCount(0)
+    await page.keyboard.press('Escape')
+    await expect(settingsHeading).toBeVisible()
+    await expect(cmdSearchBar).not.toBeVisible()
+    await page.keyboard.press('Escape')
+    await expect(settingsHeading).not.toBeVisible()
   })
 
   test('Extrude from command bar selects extrude line after', async ({
@@ -454,6 +465,19 @@ test.describe('Command bar tests', { tag: '@desktop' }, () => {
 
     await page.mouse.click(700, 200)
     await expect(toolbar.exitSketchBtn).toBeVisible()
+
+    await page.keyboard.press('ControlOrMeta+K')
+    await expect(page.getByPlaceholder('Search commands')).toBeFocused()
+    await expect(
+      page.getByRole('option', { name: 'Reset view', exact: false })
+    ).toBeVisible()
+    await expect(
+      page.getByRole('option', {
+        name: 'Pull a sketch into 3D',
+        exact: false,
+      })
+    ).toHaveCount(0)
+    await page.keyboard.press('Escape')
 
     // Switch between sketch tools via the command bar
     if ((await lineToolButton.getAttribute('aria-pressed')) !== 'true') {

--- a/e2e/playwright/command-bar-tests.spec.ts
+++ b/e2e/playwright/command-bar-tests.spec.ts
@@ -7,23 +7,48 @@ import { expect, test } from '@e2e/playwright/zoo-test'
 import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
 
 test.describe('Command bar tests', { tag: '@desktop' }, () => {
-  test('Command palette keeps its modeling context after search autofocus', async ({
+  test('Command palette scopes Home, modeling, and editor commands', async ({
     page,
     homePage,
     scene,
   }) => {
     await page.setBodyDimensions({ width: 1200, height: 500 })
+    await expect(page.getByPlaceholder('Search projects')).toBeVisible()
+
+    await page.keyboard.press('ControlOrMeta+K')
+    const cmdSearchBar = page.getByPlaceholder('Search commands')
+    await cmdSearchBar.fill('Go to Telemetry')
+    await expect(
+      page.getByRole('option', { name: 'Go to Telemetry', exact: false })
+    ).toBeVisible()
+    await cmdSearchBar.fill('Reset view')
+    await expect(
+      page.getByRole('option', { name: 'Reset view', exact: false })
+    ).not.toBeVisible()
+    await page.keyboard.press('Escape')
+
     await homePage.goToModelingScene()
     await scene.settled()
     await scene.clickNoWhere()
 
     await page.keyboard.press('ControlOrMeta+K')
-    const cmdSearchBar = page.getByPlaceholder('Search commands')
     await expect(cmdSearchBar).toBeFocused()
 
     await cmdSearchBar.fill('Reset view')
     await expect(
       page.getByRole('option', { name: 'Reset view', exact: false })
+    ).toBeVisible()
+    await page.keyboard.press('Escape')
+
+    await page.locator('.cm-content').click()
+    await page.keyboard.press('ControlOrMeta+K')
+    await cmdSearchBar.fill('Reset view')
+    await expect(
+      page.getByRole('option', { name: 'Reset view', exact: false })
+    ).not.toBeVisible()
+    await cmdSearchBar.fill('Format Code')
+    await expect(
+      page.getByRole('option', { name: 'Format Code', exact: false })
     ).toBeVisible()
   })
 

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -27,9 +27,24 @@ import {
   RouterProvider,
   createBrowserRouter,
   createHashRouter,
+  matchPath,
+  useLocation,
 } from 'react-router-dom'
 
 const createRouter = isDesktop() ? createHashRouter : createBrowserRouter
+const settingsRoutePatterns = [
+  PATHS.HOME_SETTINGS,
+  `${PATHS.LIBRARY}/:libraryId${PATHS.SETTINGS}`,
+  `${PATHS.FILE}/:id${PATHS.SETTINGS}`,
+]
+
+function RouteCommandBar() {
+  const { pathname } = useLocation()
+  const settingsIsOpen = settingsRoutePatterns.some((pattern) =>
+    matchPath(pattern, pathname)
+  )
+  return settingsIsOpen ? null : <CommandBar />
+}
 
 /**
  * All routes in the app, used in src/lib/index.tsx
@@ -73,7 +88,7 @@ export const Router = () => {
                     <ModelingMachineProvider>
                       <Outlet />
                       <OpenedProject />
-                      <CommandBar />
+                      <RouteCommandBar />
                     </ModelingMachineProvider>
                   </Suspense>
                 </ModelingPageProvider>
@@ -111,7 +126,7 @@ export const Router = () => {
                 <>
                   <Outlet />
                   <Home />
-                  <CommandBar />
+                  <RouteCommandBar />
                 </>
               ),
               id: PATHS.HOME,
@@ -144,7 +159,7 @@ export const Router = () => {
                 <>
                   <Outlet />
                   <Home />
-                  <CommandBar />
+                  <RouteCommandBar />
                 </>
               ),
               id: PATHS.LIBRARY,

--- a/src/components/CommandBar/CommandBar.tsx
+++ b/src/components/CommandBar/CommandBar.tsx
@@ -12,7 +12,10 @@ import Tooltip from '@src/components/Tooltip'
 import { useApp } from '@src/lib/boot'
 import type { Command, CommandArgument } from '@src/lib/commandTypes'
 import useHotkeyWrapper from '@src/lib/hotkeyWrapper'
-import { isCommandSearchable } from '@src/registry/contracts/commands'
+import {
+  getCommandPaletteScopes,
+  isCommandSearchable,
+} from '@src/registry/contracts/commands'
 import {
   COMMAND_PALETTE_OPEN_KEYMAP_SCOPE,
   keymapScopesValueSpec,
@@ -27,9 +30,13 @@ export const CommandBar = () => {
   const keymap = registry.optional(keymapService)
   const commandBarState = cmd.useState()
   const isCommandBarOpen = !commandBarState.matches('Closed')
-  // Palette autofocus activates the editor scope, so keep the scope that opened it.
+  // Palette autofocus can change focus scopes, so keep the scope that opened it.
+  // Ordinary editable focus suppresses background shortcuts, not command discovery.
   const commandPaletteScopes = useMemo(
-    () => (isCommandBarOpen ? (keymap?.getCurrentScopes() ?? []) : []),
+    () =>
+      isCommandBarOpen
+        ? getCommandPaletteScopes(keymap?.getCurrentScopes() ?? [])
+        : [],
     [isCommandBarOpen, keymap]
   )
   const keymapScopes = registry.signal(keymapScopesValueSpec).value

--- a/src/components/CommandBar/CommandBar.tsx
+++ b/src/components/CommandBar/CommandBar.tsx
@@ -1,5 +1,5 @@
 import { Dialog, Popover, Transition } from '@headlessui/react'
-import { Fragment, useEffect } from 'react'
+import { Fragment, useEffect, useMemo } from 'react'
 import { useLocation } from 'react-router-dom'
 
 import CommandBarArgument from '@src/components/CommandBar/CommandBarArgument'
@@ -12,7 +12,12 @@ import Tooltip from '@src/components/Tooltip'
 import { useApp } from '@src/lib/boot'
 import type { Command, CommandArgument } from '@src/lib/commandTypes'
 import useHotkeyWrapper from '@src/lib/hotkeyWrapper'
-import { keymapService } from '@src/registry/contracts/keymap'
+import { isCommandSearchable } from '@src/registry/contracts/commands'
+import {
+  COMMAND_PALETTE_OPEN_KEYMAP_SCOPE,
+  keymapScopesValueSpec,
+  keymapService,
+} from '@src/registry/contracts/keymap'
 
 export const COMMAND_PALETTE_HOTKEY = 'mod+k'
 
@@ -22,6 +27,12 @@ export const CommandBar = () => {
   const keymap = registry.optional(keymapService)
   const commandBarState = cmd.useState()
   const isCommandBarOpen = !commandBarState.matches('Closed')
+  // Palette autofocus activates the editor scope, so keep the scope that opened it.
+  const commandPaletteScopes = useMemo(
+    () => (isCommandBarOpen ? (keymap?.getCurrentScopes() ?? []) : []),
+    [isCommandBarOpen, keymap]
+  )
+  const keymapScopes = registry.signal(keymapScopesValueSpec).value
   const {
     context: {
       selectedCommand,
@@ -61,10 +72,10 @@ export const CommandBar = () => {
       return
     }
 
-    keymap.applyScope('cmd-palette-open')
+    keymap.applyScope(COMMAND_PALETTE_OPEN_KEYMAP_SCOPE)
 
     return () => {
-      keymap.removeScope('cmd-palette-open')
+      keymap.removeScope(COMMAND_PALETTE_OPEN_KEYMAP_SCOPE)
     }
   }, [isCommandBarOpen, keymap])
 
@@ -169,14 +180,13 @@ export const CommandBar = () => {
           >
             {commandBarState.matches('Selecting command') ? (
               <CommandComboBox
-                options={commands.filter((command: Command) => {
-                  return (
-                    // By default everything is undefined
-                    // If marked explicitly as false hide
-                    command.hideFromSearch === undefined ||
-                    command.hideFromSearch === false
+                options={commands.filter((command: Command) =>
+                  isCommandSearchable(
+                    command,
+                    commandPaletteScopes,
+                    keymapScopes
                   )
-                })}
+                )}
               />
             ) : commandBarState.matches('Gathering arguments') ? (
               <CommandBarArgument stepBack={stepBack} />

--- a/src/components/CommandBar/CommandBar.tsx
+++ b/src/components/CommandBar/CommandBar.tsx
@@ -1,5 +1,5 @@
 import { Dialog, Popover, Transition } from '@headlessui/react'
-import { Fragment, useEffect, useMemo } from 'react'
+import { Fragment, useEffect, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 
 import CommandBarArgument from '@src/components/CommandBar/CommandBarArgument'
@@ -13,6 +13,7 @@ import { useApp } from '@src/lib/boot'
 import type { Command, CommandArgument } from '@src/lib/commandTypes'
 import useHotkeyWrapper from '@src/lib/hotkeyWrapper'
 import {
+  getEffectiveCommandScopeSet,
   getCommandPaletteScopes,
   isCommandSearchable,
 } from '@src/registry/contracts/commands'
@@ -30,16 +31,29 @@ export const CommandBar = () => {
   const keymap = registry.optional(keymapService)
   const commandBarState = cmd.useState()
   const isCommandBarOpen = !commandBarState.matches('Closed')
-  // Palette autofocus can change focus scopes, so keep the scope that opened it.
-  // Ordinary editable focus suppresses background shortcuts, not command discovery.
-  const commandPaletteScopes = useMemo(
-    () =>
-      isCommandBarOpen
-        ? getCommandPaletteScopes(keymap?.getCurrentScopes() ?? [])
-        : [],
-    [isCommandBarOpen, keymap]
-  )
+  const [commandPaletteSession, setCommandPaletteSession] = useState(() => ({
+    isOpen: isCommandBarOpen,
+    scopes: isCommandBarOpen
+      ? getCommandPaletteScopes(keymap?.getCurrentScopes() ?? [])
+      : [],
+  }))
+  let commandPaletteScopes = commandPaletteSession.scopes
+  if (commandPaletteSession.isOpen !== isCommandBarOpen) {
+    // Capture the launch context before the palette input's autofocus changes
+    // the active focus scope. React applies this update before committing.
+    commandPaletteScopes = isCommandBarOpen
+      ? getCommandPaletteScopes(keymap?.getCurrentScopes() ?? [])
+      : []
+    setCommandPaletteSession({
+      isOpen: isCommandBarOpen,
+      scopes: commandPaletteScopes,
+    })
+  }
   const keymapScopes = registry.signal(keymapScopesValueSpec).value
+  const effectiveCommandScopes = getEffectiveCommandScopeSet(
+    commandPaletteScopes,
+    keymapScopes
+  )
   const {
     context: {
       selectedCommand,
@@ -188,11 +202,7 @@ export const CommandBar = () => {
             {commandBarState.matches('Selecting command') ? (
               <CommandComboBox
                 options={commands.filter((command: Command) =>
-                  isCommandSearchable(
-                    command,
-                    commandPaletteScopes,
-                    keymapScopes
-                  )
+                  isCommandSearchable(command, effectiveCommandScopes)
                 )}
               />
             ) : commandBarState.matches('Gathering arguments') ? (

--- a/src/components/CommandBar/CommandBar.tsx
+++ b/src/components/CommandBar/CommandBar.tsx
@@ -106,6 +106,7 @@ export const CommandBar = () => {
     () => cmd.send({ type: 'Close' }),
     project?.executingEditor.value ?? undefined,
     {
+      enabled: isCommandBarOpen,
       enableOnFormTags: true,
       enableOnContentEditable: true,
     }

--- a/src/components/CommandComboBox.tsx
+++ b/src/components/CommandComboBox.tsx
@@ -1,6 +1,6 @@
 import { Combobox } from '@headlessui/react'
 import Fuse from 'fuse.js'
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import { CustomIcon } from '@src/components/CustomIcon'
 import { noAutofillInputProps } from '@src/lib/autofill'
@@ -17,7 +17,6 @@ function CommandComboBox({
   placeholder?: string
 }) {
   const [query, setQuery] = useState('')
-  const [filteredOptions, setFilteredOptions] = useState<typeof options>()
   const { commands } = useApp()
 
   const defaultOption =
@@ -35,16 +34,18 @@ function CommandComboBox({
     [options]
   )
 
-  const fuse = new Fuse(sortedOptions, {
-    keys: ['displayName', 'name', 'description'],
-    threshold: 0.3,
-    ignoreLocation: true,
-  })
+  const filteredOptions = useMemo(() => {
+    if (query.length === 0) {
+      return sortedOptions
+    }
 
-  useEffect(() => {
-    const results = fuse.search(query).map((result) => result.item)
-    setFilteredOptions(query.length > 0 ? results : sortedOptions)
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
+    return new Fuse(sortedOptions, {
+      keys: ['displayName', 'name', 'description'],
+      threshold: 0.3,
+      ignoreLocation: true,
+    })
+      .search(query)
+      .map((result) => result.item)
   }, [query, sortedOptions])
 
   function handleSelection(command: Command) {
@@ -80,12 +81,12 @@ function CommandComboBox({
           autoFocus
         />
       </div>
-      {filteredOptions?.length ? (
+      {filteredOptions.length ? (
         <Combobox.Options
           static
           className="overflow-y-auto max-h-96 cursor-pointer"
         >
-          {filteredOptions?.map((option) => (
+          {filteredOptions.map((option) => (
             <Combobox.Option
               key={option.groupId + option.name + (option.displayName || '')}
               value={option}

--- a/src/components/Explorer/ProjectExplorer.tsx
+++ b/src/components/Explorer/ProjectExplorer.tsx
@@ -617,6 +617,7 @@ export const ProjectExplorer = ({
     () => [
       {
         id: PROJECT_EXPLORER_COMMAND_IDS.arrowLeft,
+        scopes: [PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE],
         name: 'arrow-left',
         groupId: 'project-explorer',
         displayName: 'Close selected project explorer row',
@@ -626,6 +627,7 @@ export const ProjectExplorer = ({
       },
       {
         id: PROJECT_EXPLORER_COMMAND_IDS.arrowRight,
+        scopes: [PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE],
         name: 'arrow-right',
         groupId: 'project-explorer',
         displayName: 'Open selected project explorer row',
@@ -635,6 +637,7 @@ export const ProjectExplorer = ({
       },
       {
         id: PROJECT_EXPLORER_COMMAND_IDS.arrowUp,
+        scopes: [PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE],
         name: 'arrow-up',
         groupId: 'project-explorer',
         displayName: 'Move project explorer selection up',
@@ -644,6 +647,7 @@ export const ProjectExplorer = ({
       },
       {
         id: PROJECT_EXPLORER_COMMAND_IDS.arrowDown,
+        scopes: [PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE],
         name: 'arrow-down',
         groupId: 'project-explorer',
         displayName: 'Move project explorer selection down',
@@ -653,6 +657,7 @@ export const ProjectExplorer = ({
       },
       {
         id: PROJECT_EXPLORER_COMMAND_IDS.enter,
+        scopes: [PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE],
         name: 'enter',
         groupId: 'project-explorer',
         displayName: 'Open selected project explorer file',
@@ -662,6 +667,7 @@ export const ProjectExplorer = ({
       },
       {
         id: PROJECT_EXPLORER_COMMAND_IDS.rename,
+        scopes: [PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE],
         name: 'rename',
         groupId: 'project-explorer',
         displayName: 'Rename selected project explorer row',
@@ -671,6 +677,7 @@ export const ProjectExplorer = ({
       },
       {
         id: PROJECT_EXPLORER_COMMAND_IDS.delete,
+        scopes: [PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE],
         name: 'delete',
         groupId: 'project-explorer',
         displayName: 'Delete selected project explorer row',
@@ -680,6 +687,7 @@ export const ProjectExplorer = ({
       },
       {
         id: PROJECT_EXPLORER_COMMAND_IDS.copy,
+        scopes: [PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE],
         name: 'copy',
         groupId: 'project-explorer',
         displayName: 'Copy selected project explorer row',
@@ -689,6 +697,7 @@ export const ProjectExplorer = ({
       },
       {
         id: PROJECT_EXPLORER_COMMAND_IDS.paste,
+        scopes: [PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE],
         name: 'paste',
         groupId: 'project-explorer',
         displayName: 'Paste into selected project explorer row',

--- a/src/components/ModelingMachineProvider.tsx
+++ b/src/components/ModelingMachineProvider.tsx
@@ -30,7 +30,12 @@ import {
   EngineConnectionEvents,
   EngineConnectionStateType,
 } from '@src/lib/engineConnection/utils'
-import { keymapService } from '@src/registry/contracts/keymap'
+import {
+  MODE_MODELING_KEYMAP_SCOPE,
+  keymapService,
+} from '@src/registry/contracts/keymap'
+
+const MODELING_COMMAND_SCOPES = [MODE_MODELING_KEYMAP_SCOPE] as const
 
 export const ModelingMachineContext = createContext(
   {} as {
@@ -346,6 +351,7 @@ export const ModelingMachineProvider = ({
     send: modelingSend,
     actor: modelingActor,
     commandBarConfig,
+    scopes: MODELING_COMMAND_SCOPES,
     isExecuting: kclManager.isExecutingSignal.value,
     // TODO for when sketch tools are in the toolbar: This was added when we used one "Cancel" event,
     // but we need to support "SketchCancel" and basically

--- a/src/components/ModelingPageProvider.tsx
+++ b/src/components/ModelingPageProvider.tsx
@@ -22,6 +22,7 @@ import { PATHS } from '@src/lib/paths'
 import { markOnce } from '@src/lib/performance'
 import { isArray } from '@src/lib/utils'
 import { modelingMenuCallbackMostActions } from '@src/menu/register'
+import { FILE_AND_CODE_EDITOR_KEYMAP_SCOPES } from '@src/registry/contracts/keymap'
 
 function isNumberArray(value: unknown): value is number[] {
   return isArray(value) && value.every((item) => typeof item === 'number')
@@ -169,7 +170,12 @@ export const ModelingPageProvider = ({
     const filePath = PATHS.FILE + '/' + encodeURIComponent(file?.path)
 
     const { RouteTelemetryCommand, RouteHomeCommand, RouteSettingsCommand } =
-      createRouteCommands(navigate, location, filePath)
+      createRouteCommands(
+        navigate,
+        location,
+        filePath,
+        FILE_AND_CODE_EDITOR_KEYMAP_SCOPES
+      )
     commands.send({
       type: 'Add commands',
       data: {

--- a/src/hooks/useStateMachineCommands.ts
+++ b/src/hooks/useStateMachineCommands.ts
@@ -24,6 +24,7 @@ interface UseStateMachineCommandsArgs<
   send: (event: EventFrom<T>) => void
   actor: Actor<T>
   commandBarConfig?: StateMachineCommandSetConfig<T, S>
+  scopes: Command['scopes']
   isExecuting: boolean
   onCancel?: () => void
 }
@@ -44,6 +45,7 @@ export default function useStateMachineCommands<
   send,
   actor,
   commandBarConfig,
+  scopes,
   onCancel,
   isExecuting,
 }: UseStateMachineCommandsArgs<T, S>) {
@@ -83,6 +85,7 @@ export default function useStateMachineCommands<
           send,
           actor,
           commandBarConfig,
+          defaultScopes: scopes,
           onCancel,
           forceDisable: shouldDisableEngineCommands,
           showExperimentalCommands,
@@ -102,5 +105,10 @@ export default function useStateMachineCommands<
       })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
-  }, [shouldDisableEngineCommands, showExperimentalCommands, commandBarConfig])
+  }, [
+    shouldDisableEngineCommands,
+    showExperimentalCommands,
+    commandBarConfig,
+    scopes,
+  ])
 }

--- a/src/lib/commandBarConfigs/applicationCommandConfig.ts
+++ b/src/lib/commandBarConfigs/applicationCommandConfig.ts
@@ -29,6 +29,11 @@ import { getAllSubDirectoriesAtProjectRoot } from '@src/machines/systemIO/snapsh
 import type { systemIOMachine } from '@src/machines/systemIO/systemIOMachine'
 import type { RequestedKCLFile } from '@src/machines/systemIO/utils'
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
+import {
+  FILE_AND_CODE_EDITOR_KEYMAP_SCOPES,
+  GLOBAL_KEYMAP_SCOPES,
+  HOME_KEYMAP_SCOPE,
+} from '@src/registry/contracts/keymap'
 import toast from 'react-hot-toast'
 import type { ActorRefFrom } from 'xstate'
 
@@ -140,6 +145,7 @@ export function createApplicationCommands({
   wasmInstance: ModuleType
 }) {
   const addKCLFileToProject: Command = {
+    scopes: GLOBAL_KEYMAP_SCOPES,
     name: 'add-kcl-file-to-project',
     displayName: 'Add file to project',
     description:
@@ -371,6 +377,7 @@ export function createApplicationCommands({
    * Desktop only command for now!
    */
   const createASampleDesktopOnly: Command = {
+    scopes: [HOME_KEYMAP_SCOPE],
     name: 'create-a-sample',
     displayName: 'Create a sample',
     description: 'Create a new project from a Zoo Sample',
@@ -439,6 +446,7 @@ export function createApplicationCommands({
   }
 
   const switchEnvironmentsCommand: Command = {
+    scopes: GLOBAL_KEYMAP_SCOPES,
     name: 'switch-environments',
     displayName: 'Switch Environments',
     description: 'Connect the application runtime to a different environment',
@@ -468,6 +476,7 @@ export function createApplicationCommands({
   }
 
   const overrideEngineCommand: Command = {
+    scopes: GLOBAL_KEYMAP_SCOPES,
     name: 'override-engine',
     displayName: 'Override Engine',
     description: 'Connect the scene to a custom Engine WebSocket URL',
@@ -514,6 +523,7 @@ export function createApplicationCommands({
   }
 
   const overrideZookeeperCommand: Command = {
+    scopes: GLOBAL_KEYMAP_SCOPES,
     name: 'override-zookeeper',
     displayName: 'Override Zookeeper',
     description: 'Connect to a custom Zookeeper WebSocket URL',
@@ -558,6 +568,7 @@ export function createApplicationCommands({
   }
 
   const resetLayoutCommand: Command = {
+    scopes: FILE_AND_CODE_EDITOR_KEYMAP_SCOPES,
     name: 'reset-layout',
     displayName: 'Reset layout',
     description: 'Reset layout to the default configuration',
@@ -568,6 +579,7 @@ export function createApplicationCommands({
   }
 
   const setLayoutCommand: Command = {
+    scopes: FILE_AND_CODE_EDITOR_KEYMAP_SCOPES,
     name: 'set-layout',
     hideFromSearch: true,
     displayName: 'Set layout',
@@ -607,6 +619,7 @@ export function createApplicationCommands({
   }
 
   const checkForUpdatesCommand: Command = {
+    scopes: GLOBAL_KEYMAP_SCOPES,
     name: 'check-for-updates',
     displayName: 'Check for updates',
     description: 'Check for a newer desktop app version.',
@@ -625,6 +638,7 @@ export function createApplicationCommands({
   }
 
   const exportProjectZipCommand: Command = {
+    scopes: FILE_AND_CODE_EDITOR_KEYMAP_SCOPES,
     name: 'export-project-zip',
     displayName: 'Download project files',
     description: 'Download every file in the current project as a ZIP archive.',

--- a/src/lib/commandBarConfigs/authCommandConfig.ts
+++ b/src/lib/commandBarConfigs/authCommandConfig.ts
@@ -2,6 +2,7 @@ import type { Command } from '@src/lib/commandTypes'
 import { reportRejection } from '@src/lib/trap'
 import { refreshPage } from '@src/lib/utils'
 import type { authMachine } from '@src/machines/authMachine'
+import { GLOBAL_KEYMAP_SCOPES } from '@src/registry/contracts/keymap'
 import type { ActorRefFrom } from 'xstate'
 
 export function createAuthCommands({
@@ -11,6 +12,7 @@ export function createAuthCommands({
 }) {
   const authCommands: Command[] = [
     {
+      scopes: GLOBAL_KEYMAP_SCOPES,
       groupId: 'auth',
       name: 'log-out',
       displayName: 'Log out',
@@ -20,6 +22,7 @@ export function createAuthCommands({
       onSubmit: () => authActor.send({ type: 'Log out' }),
     },
     {
+      scopes: GLOBAL_KEYMAP_SCOPES,
       groupId: 'auth',
       name: 'refresh',
       displayName: 'Reload app',

--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -61,6 +61,7 @@ import type {
 import { getNextAvailableDatumName } from '@src/lang/modifyAst/gdt'
 import type { StdLibModelingCommandSchema } from '@src/lib/commandBarConfigs/modelingCommandStdLibTypes'
 import { capitaliseFC, isArray } from '@src/lib/utils'
+import { MODE_SKETCHING_KEYMAP_SCOPE } from '@src/registry/contracts/keymap'
 
 export type { HelixModes } from '@src/lib/commandBarConfigs/modelingCommandStdLibTypes'
 
@@ -378,6 +379,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
   },
   'change tool': [
     {
+      scopes: [MODE_SKETCHING_KEYMAP_SCOPE],
       description: 'Start drawing straight lines.',
       icon: 'line',
       displayName: 'Line',
@@ -391,6 +393,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       },
     },
     {
+      scopes: [MODE_SKETCHING_KEYMAP_SCOPE],
       description: 'Start drawing an arc tangent to the current segment.',
       icon: 'arc',
       displayName: 'Tangential Arc',
@@ -404,6 +407,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       },
     },
     {
+      scopes: [MODE_SKETCHING_KEYMAP_SCOPE],
       description: 'Start drawing a rectangle.',
       icon: 'rectangle',
       displayName: 'Rectangle',
@@ -1395,6 +1399,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
     ),
   },
   'Constrain length': {
+    scopes: [MODE_SKETCHING_KEYMAP_SCOPE],
     description: 'Constrain the length of one or more segments.',
     icon: 'dimension',
     args: {
@@ -1438,6 +1443,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
     },
   },
   'Constrain with named value': {
+    scopes: [MODE_SKETCHING_KEYMAP_SCOPE],
     description: 'Constrain a value by making it a named constant.',
     icon: 'make-variable',
     args: {

--- a/src/lib/commandBarConfigs/namedViewsConfig.ts
+++ b/src/lib/commandBarConfigs/namedViewsConfig.ts
@@ -16,6 +16,7 @@ import { err, reportRejection } from '@src/lib/trap'
 import { uuidv4 } from '@src/lib/utils'
 import type { SettingsActorType } from '@src/machines/settingsMachine'
 import type { ConnectionManager } from '@src/lib/engineConnection/connectionManager'
+import { MODE_MODELING_KEYMAP_SCOPE } from '@src/registry/contracts/keymap'
 
 function isWorldCoordinateSystemType(x: string): x is WorldCoordinateSystem {
   return x === 'right_handed_up_z' || x === 'right_handed_up_y'
@@ -109,6 +110,7 @@ export function createNamedViewsCommand(
   // hit the engine for the camera properties and write them back to disk
   // in project.toml.
   const createNamedViewCommand: Command = {
+    scopes: [MODE_MODELING_KEYMAP_SCOPE],
     name: 'Create named view',
     displayName: `Create named view`,
     description:
@@ -192,6 +194,7 @@ export function createNamedViewsCommand(
   // find it in the setting state, remove it from the array and
   // rewrite the project.toml settings to disk to delete the named view
   const deleteNamedViewCommand: Command = {
+    scopes: [MODE_MODELING_KEYMAP_SCOPE],
     name: 'Delete named view',
     displayName: `Delete named view`,
     description: 'Deletes the named view from settings',
@@ -256,6 +259,7 @@ export function createNamedViewsCommand(
 
   // Read the named view from settings state and pass that camera information to the engine command to set the view of the engine camera
   const loadNamedViewCommand: Command = {
+    scopes: [MODE_MODELING_KEYMAP_SCOPE],
     name: 'Load named view',
     displayName: `Load named view`,
     description: 'Loads your camera to the named view',

--- a/src/lib/commandBarConfigs/projectsCommandConfig.ts
+++ b/src/lib/commandBarConfigs/projectsCommandConfig.ts
@@ -22,6 +22,7 @@ import type {
   HomeProjectActionsService,
   HomeProjectEntry,
 } from '@src/registry/contracts/homeProjects'
+import { GLOBAL_KEYMAP_SCOPES } from '@src/registry/contracts/keymap'
 import type {
   ProjectLibraryCreateProjectInput,
   ProjectLibraryOperation,
@@ -289,6 +290,7 @@ export function createProjectCommands({
   ) => moveToLibraryOptions(context)[0]?.value ?? ''
 
   const openProjectCommand: Command = {
+    scopes: GLOBAL_KEYMAP_SCOPES,
     icon: 'folder',
     name: 'Open project',
     displayName: `Open project`,
@@ -322,6 +324,7 @@ export function createProjectCommands({
   }
 
   const createProjectCommand: Command = {
+    scopes: GLOBAL_KEYMAP_SCOPES,
     icon: 'folder',
     name: 'Create project',
     displayName: `Create project`,
@@ -401,6 +404,7 @@ export function createProjectCommands({
   }
 
   const moveToLibraryCommand: Command = {
+    scopes: GLOBAL_KEYMAP_SCOPES,
     icon: 'folder',
     name: 'Move to library',
     displayName: 'Move to library',
@@ -475,6 +479,7 @@ export function createProjectCommands({
   }
 
   const deleteProjectCommand: Command = {
+    scopes: GLOBAL_KEYMAP_SCOPES,
     icon: 'folder',
     name: 'Delete project',
     displayName: `Delete project`,
@@ -521,6 +526,7 @@ export function createProjectCommands({
   }
 
   const renameProjectCommand: Command = {
+    scopes: GLOBAL_KEYMAP_SCOPES,
     icon: 'folder',
     name: 'Rename project',
     displayName: `Rename project`,
@@ -586,6 +592,7 @@ export function createProjectCommands({
   }
 
   const importFileFromURL: Command = {
+    scopes: GLOBAL_KEYMAP_SCOPES,
     name: 'Import file from URL',
     groupId: 'projects',
     icon: 'file',

--- a/src/lib/commandBarConfigs/routeCommandConfig.ts
+++ b/src/lib/commandBarConfigs/routeCommandConfig.ts
@@ -6,9 +6,11 @@ import { PATHS, webSafeJoin } from '@src/lib/paths'
 export function createRouteCommands(
   navigate: NavigateFunction,
   location: Location,
-  filePath: string
+  filePath: string,
+  scopes: Command['scopes']
 ) {
   const RouteTelemetryCommand: Command = {
+    scopes,
     name: 'Go to Telemetry',
     displayName: `Go to Telemetry`,
     description: 'View the Telemetry metrics',
@@ -25,6 +27,7 @@ export function createRouteCommands(
   }
 
   const RouteHomeCommand: Command = {
+    scopes,
     name: 'Go to Home',
     displayName: `Go to Home`,
     description: 'Go to the home page',
@@ -37,6 +40,7 @@ export function createRouteCommands(
   }
 
   const RouteSettingsCommand: Command = {
+    scopes,
     name: 'Go to Settings',
     displayName: `Go to Settings`,
     description: 'Go to the settings page',

--- a/src/lib/commandBarConfigs/settingsCommandConfig.ts
+++ b/src/lib/commandBarConfigs/settingsCommandConfig.ts
@@ -20,6 +20,7 @@ import {
 } from '@src/lib/settings/settingsUtils'
 import type { PathValue } from '@src/lib/types'
 import type { settingsMachine } from '@src/machines/settingsMachine'
+import { GLOBAL_KEYMAP_SCOPES } from '@src/registry/contracts/keymap'
 
 // An array of the paths to all of the settings that have commandConfigs
 export const settingsWithCommandConfigs = (s: SettingsType) =>
@@ -114,6 +115,7 @@ export function createSettingsCommand({ type, actor }: CreateSettingsArgs) {
   const valueArg = buildCommandArgument(valueArgConfig, context, actor)
 
   const command: Command = {
+    scopes: GLOBAL_KEYMAP_SCOPES,
     name: type,
     displayName: `Settings · ${type
       .split('.')

--- a/src/lib/commandBarConfigs/standardViewsConfig.ts
+++ b/src/lib/commandBarConfigs/standardViewsConfig.ts
@@ -3,10 +3,12 @@ import type { Command } from '@src/lib/commandTypes'
 import { AxisNames } from '@src/lib/constants'
 import { reportRejection } from '@src/lib/trap'
 import { engineStreamZoomToFit } from '@src/lib/utils'
+import { MODE_MODELING_KEYMAP_SCOPE } from '@src/registry/contracts/keymap'
 
 export function createStandardViewsCommands(kclManager: KclManager) {
   const { engineCommandManager, sceneInfra } = kclManager
   const topViewCommand: Command = {
+    scopes: [MODE_MODELING_KEYMAP_SCOPE],
     name: 'Top view',
     displayName: `Top view`,
     description: 'Set to top view',
@@ -20,6 +22,7 @@ export function createStandardViewsCommands(kclManager: KclManager) {
     },
   }
   const rightViewCommand: Command = {
+    scopes: [MODE_MODELING_KEYMAP_SCOPE],
     name: 'Right view',
     displayName: `Right view`,
     description: 'Set to right view',
@@ -33,6 +36,7 @@ export function createStandardViewsCommands(kclManager: KclManager) {
     },
   }
   const frontViewCommand: Command = {
+    scopes: [MODE_MODELING_KEYMAP_SCOPE],
     name: 'Front view',
     displayName: `Front view`,
     description: 'Set to front view',
@@ -47,6 +51,7 @@ export function createStandardViewsCommands(kclManager: KclManager) {
   }
 
   const backViewCommand: Command = {
+    scopes: [MODE_MODELING_KEYMAP_SCOPE],
     name: 'Back view',
     displayName: `Back view`,
     description: 'Set to back view',
@@ -61,6 +66,7 @@ export function createStandardViewsCommands(kclManager: KclManager) {
   }
 
   const bottomViewCommand: Command = {
+    scopes: [MODE_MODELING_KEYMAP_SCOPE],
     name: 'Bottom view',
     displayName: `Bottom view`,
     description: 'Set to bottom view',
@@ -75,6 +81,7 @@ export function createStandardViewsCommands(kclManager: KclManager) {
   }
 
   const leftViewCommand: Command = {
+    scopes: [MODE_MODELING_KEYMAP_SCOPE],
     name: 'Left view',
     displayName: `Left view`,
     description: 'Set to left view',
@@ -89,6 +96,7 @@ export function createStandardViewsCommands(kclManager: KclManager) {
   }
 
   const zoomToFitCommand: Command = {
+    scopes: [MODE_MODELING_KEYMAP_SCOPE],
     name: 'Zoom to fit',
     displayName: `Zoom to fit`,
     description: 'Fits the model in the camera view',

--- a/src/lib/commandTypes.ts
+++ b/src/lib/commandTypes.ts
@@ -143,6 +143,8 @@ export type Command<
   icon?: Icon
   hide?: TARGET[number]
   hideFromSearch?: boolean
+  /** App contexts where this command may be discovered or executed. */
+  scopes?: readonly string[]
   disabled?: boolean
   status?: CommandStatus
 }

--- a/src/lib/commandTypes.ts
+++ b/src/lib/commandTypes.ts
@@ -86,6 +86,8 @@ export type FileFilter = {
 }
 export type FiltersConfig = FileFilter[]
 
+export type CommandScopes = readonly [string, ...string[]]
+
 export type StateMachineCommandSetSchema<T extends AnyStateMachine> = Partial<{
   [EventType in EventFrom<T>['type']]: Record<string, any>
 }>
@@ -143,8 +145,8 @@ export type Command<
   icon?: Icon
   hide?: TARGET[number]
   hideFromSearch?: boolean
-  /** App contexts where this command may be discovered or executed. */
-  scopes?: readonly string[]
+  /** App contexts where the command palette and keymap may expose this command. */
+  scopes: CommandScopes
   disabled?: boolean
   status?: CommandStatus
 }
@@ -156,10 +158,17 @@ export type CommandConfig<
     StateMachineCommandSetSchema<T>[CommandName] = StateMachineCommandSetSchema<T>[CommandName],
 > = Omit<
   Command<T, CommandName, CommandSchema>,
-  'name' | 'groupId' | 'onSubmit' | 'onCancel' | 'args' | 'needsReview'
+  | 'name'
+  | 'groupId'
+  | 'onSubmit'
+  | 'onCancel'
+  | 'args'
+  | 'needsReview'
+  | 'scopes'
 > & {
   needsReview?: boolean
   status?: CommandStatus
+  scopes?: CommandScopes
   args?: {
     [ArgName in keyof CommandSchema]: CommandArgumentConfig<
       CommandSchema[ArgName],

--- a/src/lib/commandUtils.test.ts
+++ b/src/lib/commandUtils.test.ts
@@ -1,5 +1,6 @@
 import type { CommandWithDisabledState } from '@src/lib/commandUtils'
 import { sortCommands } from '@src/lib/commandUtils'
+import { GLOBAL_KEYMAP_SCOPES } from '@src/registry/contracts/keymap'
 import { describe, expect, it } from 'vitest'
 
 function commandWithDisabled(
@@ -9,6 +10,7 @@ function commandWithDisabled(
 ): CommandWithDisabledState {
   return {
     command: {
+      scopes: GLOBAL_KEYMAP_SCOPES,
       name,
       groupId,
       needsReview: false,

--- a/src/lib/createMachineCommand.spec.ts
+++ b/src/lib/createMachineCommand.spec.ts
@@ -3,6 +3,10 @@ import { createActor, createMachine } from 'xstate'
 
 import type { StateMachineCommandSetConfig } from '@src/lib/commandTypes'
 import { createMachineCommand } from '@src/lib/createMachineCommand'
+import {
+  GLOBAL_KEYMAP_SCOPES,
+  MODE_SKETCHING_KEYMAP_SCOPE,
+} from '@src/registry/contracts/keymap'
 
 const testMachine = createMachine({
   id: 'testMachine',
@@ -45,6 +49,7 @@ const commandBarConfig = {
     {
       displayName: 'Available child',
       description: 'Available child command',
+      scopes: [MODE_SKETCHING_KEYMAP_SCOPE],
     },
   ],
   WithArguments: {
@@ -80,6 +85,7 @@ describe('createMachineCommand', () => {
         send: vi.fn(),
         actor,
         commandBarConfig,
+        defaultScopes: GLOBAL_KEYMAP_SCOPES,
       }
     )
 
@@ -99,6 +105,7 @@ describe('createMachineCommand', () => {
         send: vi.fn(),
         actor,
         commandBarConfig,
+        defaultScopes: GLOBAL_KEYMAP_SCOPES,
         showExperimentalCommands: true,
       }
     )
@@ -122,6 +129,7 @@ describe('createMachineCommand', () => {
         send: vi.fn(),
         actor,
         commandBarConfig,
+        defaultScopes: GLOBAL_KEYMAP_SCOPES,
       }
     )
 
@@ -130,6 +138,7 @@ describe('createMachineCommand', () => {
     expect(command).toMatchObject({
       name: 'Deprecated',
       status: 'deprecated',
+      scopes: GLOBAL_KEYMAP_SCOPES,
     })
   })
 
@@ -146,6 +155,7 @@ describe('createMachineCommand', () => {
       send: vi.fn(),
       actor,
       commandBarConfig,
+      defaultScopes: GLOBAL_KEYMAP_SCOPES,
     })
 
     actor.stop()
@@ -154,6 +164,7 @@ describe('createMachineCommand', () => {
       expect.objectContaining({
         name: 'ManyCommands',
         displayName: 'Available child',
+        scopes: [MODE_SKETCHING_KEYMAP_SCOPE],
       }),
     ])
   })
@@ -169,6 +180,7 @@ describe('createMachineCommand', () => {
         send: vi.fn(),
         actor,
         commandBarConfig,
+        defaultScopes: GLOBAL_KEYMAP_SCOPES,
       }
     )
 
@@ -202,6 +214,7 @@ describe('createMachineCommand', () => {
         send: vi.fn(),
         actor,
         commandBarConfig,
+        defaultScopes: GLOBAL_KEYMAP_SCOPES,
         showExperimentalCommands: true,
       }
     )

--- a/src/lib/createMachineCommand.ts
+++ b/src/lib/createMachineCommand.ts
@@ -27,6 +27,7 @@ interface CreateMachineCommandProps<
   send: Function
   actor: Actor<T>
   commandBarConfig?: StateMachineCommandSetConfig<T, S>
+  defaultScopes: Command['scopes']
   onCancel?: () => void
   forceDisable?: boolean
   showExperimentalCommands?: boolean
@@ -44,6 +45,7 @@ export function createMachineCommand<
   send,
   actor,
   commandBarConfig,
+  defaultScopes,
   onCancel,
   forceDisable = false,
   showExperimentalCommands = false,
@@ -73,6 +75,7 @@ export function createMachineCommand<
           send,
           actor,
           commandBarConfig: recursiveCommandBarConfig,
+          defaultScopes,
           onCancel,
           forceDisable,
           showExperimentalCommands,
@@ -102,6 +105,7 @@ export function createMachineCommand<
     groupId,
     icon,
     description: commandConfig.description,
+    scopes: commandConfig.scopes ?? defaultScopes,
     needsReview: commandConfig.needsReview || false,
     machineActor: actor,
     onSubmit: (data?: S[typeof type]) => {

--- a/src/lib/kclCommands.ts
+++ b/src/lib/kclCommands.ts
@@ -37,6 +37,7 @@ import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { CommandBarContext } from '@src/machines/commandBarMachine'
 import { listAllImportFilesWithinProject } from '@src/machines/systemIO/snapshotContext'
 import type { SystemIOActor } from '@src/machines/systemIO/utils'
+import { FILE_AND_CODE_EDITOR_KEYMAP_SCOPES } from '@src/registry/contracts/keymap'
 
 interface KclCommandConfig {
   // TODO: find a different approach that doesn't require
@@ -61,6 +62,7 @@ const EXECUTING_MESSAGE =
 export function kclCommands(commandProps: KclCommandConfig): Command[] {
   return [
     {
+      scopes: FILE_AND_CODE_EDITOR_KEYMAP_SCOPES,
       name: 'set-file-units',
       displayName: 'Set file units',
       description:
@@ -112,6 +114,7 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
       },
     },
     {
+      scopes: FILE_AND_CODE_EDITOR_KEYMAP_SCOPES,
       name: 'set-file-experimental-features',
       displayName: 'Set experimental features flag',
       description: 'Set the experimental features flag in the current file.',
@@ -185,6 +188,7 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
       },
     },
     {
+      scopes: FILE_AND_CODE_EDITOR_KEYMAP_SCOPES,
       name: 'Insert',
       description: 'Insert from a file in the current project directory',
       icon: 'import',
@@ -283,6 +287,7 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
       },
     },
     {
+      scopes: FILE_AND_CODE_EDITOR_KEYMAP_SCOPES,
       name: 'format-code',
       displayName: 'Format Code',
       description: 'Nicely formats the KCL code in the editor.',
@@ -294,6 +299,7 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
       },
     },
     {
+      scopes: FILE_AND_CODE_EDITOR_KEYMAP_SCOPES,
       name: 'parameter.create',
       displayName: 'Create parameter',
       description: 'Add a named constant to use in geometry',
@@ -358,6 +364,7 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
       },
     },
     {
+      scopes: FILE_AND_CODE_EDITOR_KEYMAP_SCOPES,
       name: 'parameter.edit',
       displayName: 'Edit parameter',
       description: 'Edit the value of a named constant',

--- a/src/machines/commandBarMachine.spec.ts
+++ b/src/machines/commandBarMachine.spec.ts
@@ -5,10 +5,12 @@ import type { MachineManager } from '@src/lib/MachineManager'
 import type { Command } from '@src/lib/commandTypes'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { commandBarMachine } from '@src/machines/commandBarMachine'
+import { GLOBAL_KEYMAP_SCOPES } from '@src/registry/contracts/keymap'
 
 describe('commandBarMachine', () => {
   it('preserves hidden default values that are not declared command args', () => {
     const command = {
+      scopes: GLOBAL_KEYMAP_SCOPES,
       name: 'Test command',
       groupId: 'test',
       needsReview: false,
@@ -60,6 +62,7 @@ describe('commandBarMachine', () => {
       reviewDetails,
     })
     const command = {
+      scopes: GLOBAL_KEYMAP_SCOPES,
       name: 'Test codemod',
       groupId: 'test',
       needsReview: true,

--- a/src/registry/contracts/commands.test.ts
+++ b/src/registry/contracts/commands.test.ts
@@ -1,11 +1,15 @@
 import {
+  getCommandPaletteScopes,
   isCommandAvailable,
   isCommandSearchable,
 } from '@src/registry/contracts/commands'
 import {
   CODE_EDITOR_FOCUSED_KEYMAP_SCOPE,
   DEFAULT_KEYMAP_SCOPES,
+  EDITABLE_FOCUSED_KEYMAP_SCOPE,
+  FILE_AND_CODE_EDITOR_KEYMAP_SCOPES,
   FILE_KEYMAP_SCOPES,
+  GLOBAL_KEYMAP_SCOPES,
   HOME_KEYMAP_SCOPE,
   MODE_MODELING_KEYMAP_SCOPE,
   SETTINGS_KEYMAP_SCOPE,
@@ -13,10 +17,27 @@ import {
 import { describe, expect, it } from 'vitest'
 
 describe('command context availability', () => {
-  it('treats commands without scopes as globally available', () => {
-    expect(isCommandAvailable({}, [], DEFAULT_KEYMAP_SCOPES)).toBe(true)
+  it('requires commands to declare their availability', () => {
+    expect(isCommandAvailable({}, [], DEFAULT_KEYMAP_SCOPES)).toBe(false)
     expect(
       isCommandAvailable({}, [HOME_KEYMAP_SCOPE], DEFAULT_KEYMAP_SCOPES)
+    ).toBe(false)
+    expect(
+      isCommandAvailable(
+        { scopes: ['   '] },
+        [HOME_KEYMAP_SCOPE],
+        DEFAULT_KEYMAP_SCOPES
+      )
+    ).toBe(false)
+  })
+
+  it('makes explicitly global commands available in every context', () => {
+    expect(
+      isCommandAvailable(
+        { scopes: GLOBAL_KEYMAP_SCOPES },
+        [HOME_KEYMAP_SCOPE],
+        DEFAULT_KEYMAP_SCOPES
+      )
     ).toBe(true)
   })
 
@@ -55,6 +76,54 @@ describe('command context availability', () => {
     ).toBe(false)
   })
 
+  it('keeps code commands available when editor focus supersedes file mode', () => {
+    expect(
+      isCommandAvailable(
+        { scopes: FILE_AND_CODE_EDITOR_KEYMAP_SCOPES },
+        [MODE_MODELING_KEYMAP_SCOPE, CODE_EDITOR_FOCUSED_KEYMAP_SCOPE],
+        DEFAULT_KEYMAP_SCOPES
+      )
+    ).toBe(true)
+  })
+
+  it('suppresses background contexts while an ordinary editable has focus', () => {
+    const activeScopes = [
+      MODE_MODELING_KEYMAP_SCOPE,
+      EDITABLE_FOCUSED_KEYMAP_SCOPE,
+    ]
+
+    expect(
+      isCommandAvailable(
+        { scopes: FILE_KEYMAP_SCOPES },
+        activeScopes,
+        DEFAULT_KEYMAP_SCOPES
+      )
+    ).toBe(false)
+    expect(
+      isCommandAvailable(
+        { scopes: GLOBAL_KEYMAP_SCOPES },
+        activeScopes,
+        DEFAULT_KEYMAP_SCOPES
+      )
+    ).toBe(true)
+  })
+
+  it('keeps transient editable focus out of palette discovery', () => {
+    const paletteScopes = getCommandPaletteScopes([
+      HOME_KEYMAP_SCOPE,
+      EDITABLE_FOCUSED_KEYMAP_SCOPE,
+    ])
+
+    expect(paletteScopes).toEqual([HOME_KEYMAP_SCOPE])
+    expect(
+      isCommandAvailable(
+        { scopes: [HOME_KEYMAP_SCOPE] },
+        paletteScopes,
+        DEFAULT_KEYMAP_SCOPES
+      )
+    ).toBe(true)
+  })
+
   it('supports extension-defined scopes', () => {
     const pluginScope = 'plugin.markdown-editor-focused'
 
@@ -87,7 +156,7 @@ describe('command context availability', () => {
     ).toBe(false)
     expect(
       isCommandSearchable(
-        { hideFromSearch: true },
+        { hideFromSearch: true, scopes: GLOBAL_KEYMAP_SCOPES },
         [MODE_MODELING_KEYMAP_SCOPE],
         DEFAULT_KEYMAP_SCOPES
       )

--- a/src/registry/contracts/commands.test.ts
+++ b/src/registry/contracts/commands.test.ts
@@ -1,0 +1,96 @@
+import {
+  isCommandAvailable,
+  isCommandSearchable,
+} from '@src/registry/contracts/commands'
+import {
+  CODE_EDITOR_FOCUSED_KEYMAP_SCOPE,
+  DEFAULT_KEYMAP_SCOPES,
+  FILE_KEYMAP_SCOPES,
+  HOME_KEYMAP_SCOPE,
+  MODE_MODELING_KEYMAP_SCOPE,
+  SETTINGS_KEYMAP_SCOPE,
+} from '@src/registry/contracts/keymap'
+import { describe, expect, it } from 'vitest'
+
+describe('command context availability', () => {
+  it('treats commands without scopes as globally available', () => {
+    expect(isCommandAvailable({}, [], DEFAULT_KEYMAP_SCOPES)).toBe(true)
+    expect(
+      isCommandAvailable({}, [HOME_KEYMAP_SCOPE], DEFAULT_KEYMAP_SCOPES)
+    ).toBe(true)
+  })
+
+  it.each(FILE_KEYMAP_SCOPES)(
+    'makes file commands available in %s',
+    (scope) => {
+      expect(
+        isCommandAvailable(
+          { scopes: FILE_KEYMAP_SCOPES },
+          [scope],
+          DEFAULT_KEYMAP_SCOPES
+        )
+      ).toBe(true)
+    }
+  )
+
+  it('hides file commands outside the effective file context', () => {
+    const command = { scopes: FILE_KEYMAP_SCOPES }
+
+    expect(
+      isCommandAvailable(command, [HOME_KEYMAP_SCOPE], DEFAULT_KEYMAP_SCOPES)
+    ).toBe(false)
+    expect(
+      isCommandAvailable(
+        command,
+        [MODE_MODELING_KEYMAP_SCOPE, SETTINGS_KEYMAP_SCOPE],
+        DEFAULT_KEYMAP_SCOPES
+      )
+    ).toBe(false)
+    expect(
+      isCommandAvailable(
+        command,
+        [MODE_MODELING_KEYMAP_SCOPE, CODE_EDITOR_FOCUSED_KEYMAP_SCOPE],
+        DEFAULT_KEYMAP_SCOPES
+      )
+    ).toBe(false)
+  })
+
+  it('supports extension-defined scopes', () => {
+    const pluginScope = 'plugin.markdown-editor-focused'
+
+    expect(isCommandAvailable({ scopes: [pluginScope] }, [pluginScope])).toBe(
+      true
+    )
+    expect(
+      isCommandAvailable(
+        { scopes: [pluginScope] },
+        [HOME_KEYMAP_SCOPE],
+        DEFAULT_KEYMAP_SCOPES
+      )
+    ).toBe(false)
+  })
+
+  it('combines context availability with command palette visibility', () => {
+    expect(
+      isCommandSearchable(
+        { scopes: FILE_KEYMAP_SCOPES },
+        [MODE_MODELING_KEYMAP_SCOPE],
+        DEFAULT_KEYMAP_SCOPES
+      )
+    ).toBe(true)
+    expect(
+      isCommandSearchable(
+        { scopes: FILE_KEYMAP_SCOPES },
+        [HOME_KEYMAP_SCOPE],
+        DEFAULT_KEYMAP_SCOPES
+      )
+    ).toBe(false)
+    expect(
+      isCommandSearchable(
+        { hideFromSearch: true },
+        [MODE_MODELING_KEYMAP_SCOPE],
+        DEFAULT_KEYMAP_SCOPES
+      )
+    ).toBe(false)
+  })
+})

--- a/src/registry/contracts/commands.test.ts
+++ b/src/registry/contracts/commands.test.ts
@@ -1,4 +1,5 @@
 import {
+  getEffectiveCommandScopeSet,
   getCommandPaletteScopes,
   isCommandAvailable,
   isCommandSearchable,
@@ -16,149 +17,92 @@ import {
 } from '@src/registry/contracts/keymap'
 import { describe, expect, it } from 'vitest'
 
+type AvailabilityCase = readonly [
+  command: Parameters<typeof isCommandAvailable>[0],
+  activeScopes: readonly string[],
+  expected: boolean,
+]
+
+const pluginScope = 'plugin.markdown-editor-focused'
+const fileCommand = { scopes: FILE_KEYMAP_SCOPES }
+const globalCommand = { scopes: GLOBAL_KEYMAP_SCOPES }
+const codeCommand = { scopes: FILE_AND_CODE_EDITOR_KEYMAP_SCOPES }
+const pluginCommand = { scopes: [pluginScope] as const }
+const availabilityCases: readonly AvailabilityCase[] = [
+  [{}, [], false],
+  [{}, [HOME_KEYMAP_SCOPE], false],
+  [{ scopes: ['   '] }, [HOME_KEYMAP_SCOPE], false],
+  [globalCommand, [HOME_KEYMAP_SCOPE], true],
+  ...FILE_KEYMAP_SCOPES.map(
+    (scope): AvailabilityCase => [fileCommand, [scope], true]
+  ),
+  [fileCommand, [HOME_KEYMAP_SCOPE], false],
+  [fileCommand, [MODE_MODELING_KEYMAP_SCOPE, SETTINGS_KEYMAP_SCOPE], false],
+  [
+    fileCommand,
+    [MODE_MODELING_KEYMAP_SCOPE, CODE_EDITOR_FOCUSED_KEYMAP_SCOPE],
+    false,
+  ],
+  [
+    codeCommand,
+    [MODE_MODELING_KEYMAP_SCOPE, CODE_EDITOR_FOCUSED_KEYMAP_SCOPE],
+    true,
+  ],
+  [
+    fileCommand,
+    [MODE_MODELING_KEYMAP_SCOPE, EDITABLE_FOCUSED_KEYMAP_SCOPE],
+    false,
+  ],
+  [
+    globalCommand,
+    [MODE_MODELING_KEYMAP_SCOPE, EDITABLE_FOCUSED_KEYMAP_SCOPE],
+    true,
+  ],
+  [pluginCommand, [pluginScope], true],
+  [pluginCommand, [HOME_KEYMAP_SCOPE], false],
+]
+
 describe('command context availability', () => {
-  it('requires commands to declare their availability', () => {
-    expect(isCommandAvailable({}, [], DEFAULT_KEYMAP_SCOPES)).toBe(false)
-    expect(
-      isCommandAvailable({}, [HOME_KEYMAP_SCOPE], DEFAULT_KEYMAP_SCOPES)
-    ).toBe(false)
-    expect(
-      isCommandAvailable(
-        { scopes: ['   '] },
-        [HOME_KEYMAP_SCOPE],
+  it.each(availabilityCases)(
+    'evaluates %o in %o as %s',
+    (command, scopes, expected) => {
+      const effectiveScopes = getEffectiveCommandScopeSet(
+        scopes,
         DEFAULT_KEYMAP_SCOPES
       )
-    ).toBe(false)
-  })
-
-  it('makes explicitly global commands available in every context', () => {
-    expect(
-      isCommandAvailable(
-        { scopes: GLOBAL_KEYMAP_SCOPES },
-        [HOME_KEYMAP_SCOPE],
-        DEFAULT_KEYMAP_SCOPES
-      )
-    ).toBe(true)
-  })
-
-  it.each(FILE_KEYMAP_SCOPES)(
-    'makes file commands available in %s',
-    (scope) => {
-      expect(
-        isCommandAvailable(
-          { scopes: FILE_KEYMAP_SCOPES },
-          [scope],
-          DEFAULT_KEYMAP_SCOPES
-        )
-      ).toBe(true)
+      expect(isCommandAvailable(command, effectiveScopes)).toBe(expected)
     }
   )
 
-  it('hides file commands outside the effective file context', () => {
-    const command = { scopes: FILE_KEYMAP_SCOPES }
-
-    expect(
-      isCommandAvailable(command, [HOME_KEYMAP_SCOPE], DEFAULT_KEYMAP_SCOPES)
-    ).toBe(false)
-    expect(
-      isCommandAvailable(
-        command,
-        [MODE_MODELING_KEYMAP_SCOPE, SETTINGS_KEYMAP_SCOPE],
-        DEFAULT_KEYMAP_SCOPES
-      )
-    ).toBe(false)
-    expect(
-      isCommandAvailable(
-        command,
-        [MODE_MODELING_KEYMAP_SCOPE, CODE_EDITOR_FOCUSED_KEYMAP_SCOPE],
-        DEFAULT_KEYMAP_SCOPES
-      )
-    ).toBe(false)
-  })
-
-  it('keeps code commands available when editor focus supersedes file mode', () => {
-    expect(
-      isCommandAvailable(
-        { scopes: FILE_AND_CODE_EDITOR_KEYMAP_SCOPES },
-        [MODE_MODELING_KEYMAP_SCOPE, CODE_EDITOR_FOCUSED_KEYMAP_SCOPE],
-        DEFAULT_KEYMAP_SCOPES
-      )
-    ).toBe(true)
-  })
-
-  it('suppresses background contexts while an ordinary editable has focus', () => {
-    const activeScopes = [
-      MODE_MODELING_KEYMAP_SCOPE,
-      EDITABLE_FOCUSED_KEYMAP_SCOPE,
-    ]
-
-    expect(
-      isCommandAvailable(
-        { scopes: FILE_KEYMAP_SCOPES },
-        activeScopes,
-        DEFAULT_KEYMAP_SCOPES
-      )
-    ).toBe(false)
-    expect(
-      isCommandAvailable(
-        { scopes: GLOBAL_KEYMAP_SCOPES },
-        activeScopes,
-        DEFAULT_KEYMAP_SCOPES
-      )
-    ).toBe(true)
-  })
-
   it('keeps transient editable focus out of palette discovery', () => {
-    const paletteScopes = getCommandPaletteScopes([
-      HOME_KEYMAP_SCOPE,
-      EDITABLE_FOCUSED_KEYMAP_SCOPE,
-    ])
-
-    expect(paletteScopes).toEqual([HOME_KEYMAP_SCOPE])
     expect(
-      isCommandAvailable(
-        { scopes: [HOME_KEYMAP_SCOPE] },
-        paletteScopes,
-        DEFAULT_KEYMAP_SCOPES
-      )
-    ).toBe(true)
-  })
-
-  it('supports extension-defined scopes', () => {
-    const pluginScope = 'plugin.markdown-editor-focused'
-
-    expect(isCommandAvailable({ scopes: [pluginScope] }, [pluginScope])).toBe(
-      true
-    )
-    expect(
-      isCommandAvailable(
-        { scopes: [pluginScope] },
-        [HOME_KEYMAP_SCOPE],
-        DEFAULT_KEYMAP_SCOPES
-      )
-    ).toBe(false)
+      getCommandPaletteScopes([
+        HOME_KEYMAP_SCOPE,
+        EDITABLE_FOCUSED_KEYMAP_SCOPE,
+      ])
+    ).toEqual([HOME_KEYMAP_SCOPE])
   })
 
   it('combines context availability with command palette visibility', () => {
+    const modelingScopes = getEffectiveCommandScopeSet(
+      [MODE_MODELING_KEYMAP_SCOPE],
+      DEFAULT_KEYMAP_SCOPES
+    )
+    const homeScopes = getEffectiveCommandScopeSet(
+      [HOME_KEYMAP_SCOPE],
+      DEFAULT_KEYMAP_SCOPES
+    )
+
     expect(
-      isCommandSearchable(
-        { scopes: FILE_KEYMAP_SCOPES },
-        [MODE_MODELING_KEYMAP_SCOPE],
-        DEFAULT_KEYMAP_SCOPES
-      )
+      isCommandSearchable({ scopes: FILE_KEYMAP_SCOPES }, modelingScopes)
     ).toBe(true)
     expect(
-      isCommandSearchable(
-        { scopes: FILE_KEYMAP_SCOPES },
-        [HOME_KEYMAP_SCOPE],
-        DEFAULT_KEYMAP_SCOPES
-      )
+      isCommandSearchable({ scopes: FILE_KEYMAP_SCOPES }, homeScopes)
     ).toBe(false)
     expect(
       isCommandSearchable(
         { hideFromSearch: true, scopes: GLOBAL_KEYMAP_SCOPES },
-        [MODE_MODELING_KEYMAP_SCOPE],
-        DEFAULT_KEYMAP_SCOPES
+        modelingScopes
       )
     ).toBe(false)
   })

--- a/src/registry/contracts/commands.ts
+++ b/src/registry/contracts/commands.ts
@@ -7,9 +7,9 @@ import {
 import type { Command } from '@src/lib/commandTypes'
 import type { CommandBarActorType } from '@src/machines/commandBarMachine'
 import {
-  type KeymapScope,
+  EDITABLE_FOCUSED_KEYMAP_SCOPE,
   getEffectiveKeymapScopes,
-  getKeymapItemScopes,
+  type KeymapScope,
 } from '@src/registry/contracts/keymap'
 import type { SnapshotFrom } from 'xstate'
 
@@ -22,22 +22,37 @@ export type CommandSystemService = {
 export const commandKey = (command: Command) =>
   command.id ?? `${command.groupId}:${String(command.name)}`
 
+export function getCommandPaletteScopes(activeScopes: readonly string[]) {
+  return activeScopes.filter((scope) => scope !== EDITABLE_FOCUSED_KEYMAP_SCOPE)
+}
+
+export function getCommandScopes(
+  command: Partial<Pick<Command, 'scopes'>>
+): readonly string[] {
+  return [
+    ...new Set(command.scopes?.map((scope) => scope.trim()).filter(Boolean)),
+  ]
+}
+
 export function isCommandAvailable(
-  command: Pick<Command, 'scopes'>,
+  command: Partial<Pick<Command, 'scopes'>>,
   activeScopes: readonly string[],
   keymapScopes: readonly KeymapScope[] = []
 ) {
+  const commandScopes = getCommandScopes(command)
+  if (commandScopes.length === 0) {
+    return false
+  }
+
   const effectiveScopes = new Set(
     getEffectiveKeymapScopes(activeScopes, keymapScopes)
   )
 
-  return getKeymapItemScopes(command).some((scope) =>
-    effectiveScopes.has(scope)
-  )
+  return commandScopes.some((scope) => effectiveScopes.has(scope))
 }
 
 export function isCommandSearchable(
-  command: Pick<Command, 'hideFromSearch' | 'scopes'>,
+  command: Pick<Command, 'hideFromSearch'> & Partial<Pick<Command, 'scopes'>>,
   activeScopes: readonly string[],
   keymapScopes: readonly KeymapScope[] = []
 ) {

--- a/src/registry/contracts/commands.ts
+++ b/src/registry/contracts/commands.ts
@@ -10,6 +10,7 @@ import {
   EDITABLE_FOCUSED_KEYMAP_SCOPE,
   getEffectiveKeymapScopes,
   type KeymapScope,
+  normalizeKeymapScopeIds,
 } from '@src/registry/contracts/keymap'
 import type { SnapshotFrom } from 'xstate'
 
@@ -26,39 +27,31 @@ export function getCommandPaletteScopes(activeScopes: readonly string[]) {
   return activeScopes.filter((scope) => scope !== EDITABLE_FOCUSED_KEYMAP_SCOPE)
 }
 
-export function getCommandScopes(
-  command: Partial<Pick<Command, 'scopes'>>
-): readonly string[] {
-  return [
-    ...new Set(command.scopes?.map((scope) => scope.trim()).filter(Boolean)),
-  ]
+export function getEffectiveCommandScopeSet(
+  activeScopes: readonly string[],
+  keymapScopes: readonly KeymapScope[] = []
+) {
+  return new Set(getEffectiveKeymapScopes(activeScopes, keymapScopes))
 }
 
 export function isCommandAvailable(
   command: Partial<Pick<Command, 'scopes'>>,
-  activeScopes: readonly string[],
-  keymapScopes: readonly KeymapScope[] = []
+  effectiveScopes: ReadonlySet<string>
 ) {
-  const commandScopes = getCommandScopes(command)
-  if (commandScopes.length === 0) {
-    return false
-  }
-
-  const effectiveScopes = new Set(
-    getEffectiveKeymapScopes(activeScopes, keymapScopes)
+  const commandScopes = normalizeKeymapScopeIds(command.scopes)
+  return (
+    commandScopes.length > 0 &&
+    commandScopes.some((scope) => effectiveScopes.has(scope))
   )
-
-  return commandScopes.some((scope) => effectiveScopes.has(scope))
 }
 
 export function isCommandSearchable(
   command: Pick<Command, 'hideFromSearch'> & Partial<Pick<Command, 'scopes'>>,
-  activeScopes: readonly string[],
-  keymapScopes: readonly KeymapScope[] = []
+  effectiveScopes: ReadonlySet<string>
 ) {
   return (
     command.hideFromSearch !== true &&
-    isCommandAvailable(command, activeScopes, keymapScopes)
+    isCommandAvailable(command, effectiveScopes)
   )
 }
 

--- a/src/registry/contracts/commands.ts
+++ b/src/registry/contracts/commands.ts
@@ -6,6 +6,11 @@ import {
 } from '@kittycad/registry'
 import type { Command } from '@src/lib/commandTypes'
 import type { CommandBarActorType } from '@src/machines/commandBarMachine'
+import {
+  type KeymapScope,
+  getEffectiveKeymapScopes,
+  getKeymapItemScopes,
+} from '@src/registry/contracts/keymap'
 import type { SnapshotFrom } from 'xstate'
 
 export type CommandSystemService = {
@@ -16,6 +21,31 @@ export type CommandSystemService = {
 
 export const commandKey = (command: Command) =>
   command.id ?? `${command.groupId}:${String(command.name)}`
+
+export function isCommandAvailable(
+  command: Pick<Command, 'scopes'>,
+  activeScopes: readonly string[],
+  keymapScopes: readonly KeymapScope[] = []
+) {
+  const effectiveScopes = new Set(
+    getEffectiveKeymapScopes(activeScopes, keymapScopes)
+  )
+
+  return getKeymapItemScopes(command).some((scope) =>
+    effectiveScopes.has(scope)
+  )
+}
+
+export function isCommandSearchable(
+  command: Pick<Command, 'hideFromSearch' | 'scopes'>,
+  activeScopes: readonly string[],
+  keymapScopes: readonly KeymapScope[] = []
+) {
+  return (
+    command.hideFromSearch !== true &&
+    isCommandAvailable(command, activeScopes, keymapScopes)
+  )
+}
 
 export const commandsContract = defineContract({
   commandSystemService: defineService<CommandSystemService>('command-system'),

--- a/src/registry/contracts/keymap.test.ts
+++ b/src/registry/contracts/keymap.test.ts
@@ -129,6 +129,48 @@ describe('keymap contract', () => {
     })
   })
 
+  it('falls back to an available binding without consuming the unavailable one', () => {
+    const baseItem = createKeymapItem({
+      id: 'base-command',
+      keystrokes: ['mod+k'],
+    })
+    const scopedItem = createKeymapItem({
+      id: 'scoped-command',
+      scopes: ['test-scope'],
+      keystrokes: ['mod+k'],
+    })
+    const tree = createKeymapTree([baseItem, scopedItem])
+
+    expect(
+      matchKeymapKeystrokes(
+        tree,
+        ['test-scope'],
+        ['mod+k'],
+        [],
+        (item) => item !== scopedItem
+      )
+    ).toEqual({ type: 'full', item: baseItem })
+  })
+
+  it('does not return a prefix for unavailable bindings', () => {
+    const item = createKeymapItem({
+      id: 'unavailable-command',
+      keystrokes: ['v', '1'],
+      scopes: [CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE],
+    })
+    const tree = createKeymapTree([item])
+
+    expect(
+      matchKeymapKeystrokes(
+        tree,
+        [CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE],
+        ['v'],
+        [],
+        () => false
+      )
+    ).toEqual({ type: 'none' })
+  })
+
   it('matches scoped items from a single prefix tree', () => {
     const baseItem = createKeymapItem({
       id: 'command-palette.open',

--- a/src/registry/contracts/keymap.ts
+++ b/src/registry/contracts/keymap.ts
@@ -485,10 +485,14 @@ export function createKeymapTree(items: readonly KeymapItem[]): KeymapTree {
   return { items, root }
 }
 
-export function getKeymapItemScopes(item: Pick<KeymapBinding, 'scopes'>) {
-  const scopes = [
-    ...new Set(item.scopes?.map((scope) => scope.trim()).filter(Boolean)),
+export function normalizeKeymapScopeIds(scopes: readonly string[] | undefined) {
+  return [
+    ...new Set((scopes ?? []).map((scope) => scope.trim()).filter(Boolean)),
   ]
+}
+
+export function getKeymapItemScopes(item: Pick<KeymapBinding, 'scopes'>) {
+  const scopes = normalizeKeymapScopeIds(item.scopes)
   const nonBaseScopes = scopes.filter((scope) => scope !== BASE_KEYMAP_SCOPE)
 
   return nonBaseScopes.length > 0 ? nonBaseScopes : [BASE_KEYMAP_SCOPE]

--- a/src/registry/contracts/keymap.ts
+++ b/src/registry/contracts/keymap.ts
@@ -15,11 +15,24 @@ export const MODE_SKETCHING_KEYMAP_SCOPE = 'mode-sketching'
 export const MODE_SKETCH_NO_FACE_KEYMAP_SCOPE = 'mode-sketch-no-face'
 export const MODE_SKETCH_SOLVE_KEYMAP_SCOPE = 'mode-sketch-solve'
 export const HOME_KEYMAP_SCOPE = 'home'
+export const COMMAND_PALETTE_OPEN_KEYMAP_SCOPE = 'cmd-palette-open'
+export const SETTINGS_KEYMAP_SCOPE = 'settings-open'
 export const PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE = 'project-explorer.focused'
 export const PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE =
   'project-explorer.renaming'
 export const KEYMAP_SCHEMA_VERSION = 1
 export const USER_KEYMAP_SOURCE = 'User'
+
+export const SKETCH_KEYMAP_SCOPES = [
+  MODE_SKETCHING_KEYMAP_SCOPE,
+  MODE_SKETCH_NO_FACE_KEYMAP_SCOPE,
+  MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
+] as const
+
+export const FILE_KEYMAP_SCOPES = [
+  MODE_MODELING_KEYMAP_SCOPE,
+  ...SKETCH_KEYMAP_SCOPES,
+] as const
 
 export type KeymapArguments =
   | null
@@ -36,6 +49,94 @@ export type KeymapScope = {
   group?: string
   userEditable?: boolean
 }
+
+const KEYMAP_CONTEXT_SCOPE_GROUP = 'context'
+const KEYMAP_PROJECT_EXPLORER_SCOPE_GROUP = 'project-explorer'
+
+export const DEFAULT_KEYMAP_SCOPES: readonly KeymapScope[] = [
+  {
+    id: BASE_KEYMAP_SCOPE,
+    displayName: 'Base',
+    priority: 0,
+    userEditable: false,
+  },
+  {
+    id: COMMAND_PALETTE_OPEN_KEYMAP_SCOPE,
+    displayName: 'Command palette open',
+    priority: 2000,
+    userEditable: false,
+  },
+  {
+    id: SETTINGS_KEYMAP_SCOPE,
+    displayName: 'Settings open',
+    group: KEYMAP_CONTEXT_SCOPE_GROUP,
+    priority: 1900,
+    userEditable: false,
+  },
+  {
+    id: HOME_KEYMAP_SCOPE,
+    displayName: 'Home',
+    group: KEYMAP_CONTEXT_SCOPE_GROUP,
+    priority: 50,
+    userEditable: false,
+  },
+  {
+    id: CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE,
+    displayName: 'Code editor not focused',
+    group: KEYMAP_CONTEXT_SCOPE_GROUP,
+    priority: 10,
+    userEditable: false,
+  },
+  {
+    id: MODE_MODELING_KEYMAP_SCOPE,
+    displayName: 'Modeling mode',
+    group: KEYMAP_CONTEXT_SCOPE_GROUP,
+    priority: 100,
+    userEditable: false,
+  },
+  {
+    id: MODE_SKETCHING_KEYMAP_SCOPE,
+    displayName: 'Legacy sketch mode',
+    group: KEYMAP_CONTEXT_SCOPE_GROUP,
+    priority: 200,
+    userEditable: false,
+  },
+  {
+    id: MODE_SKETCH_NO_FACE_KEYMAP_SCOPE,
+    displayName: 'Sketch no face mode',
+    group: KEYMAP_CONTEXT_SCOPE_GROUP,
+    priority: 210,
+    userEditable: false,
+  },
+  {
+    id: MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
+    displayName: 'Sketch mode',
+    group: KEYMAP_CONTEXT_SCOPE_GROUP,
+    priority: 220,
+    userEditable: false,
+  },
+  {
+    id: CODE_EDITOR_FOCUSED_KEYMAP_SCOPE,
+    displayName: 'Code editor focused',
+    group: KEYMAP_CONTEXT_SCOPE_GROUP,
+    priority: 1000,
+    userEditable: false,
+  },
+  {
+    id: PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE,
+    displayName: 'Project explorer focused',
+    group: KEYMAP_PROJECT_EXPLORER_SCOPE_GROUP,
+    priority: 100,
+    userEditable: false,
+  },
+  {
+    id: PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE,
+    displayName: 'Project explorer renaming',
+    group: KEYMAP_PROJECT_EXPLORER_SCOPE_GROUP,
+    priority: 200,
+    userEditable: false,
+  },
+]
 
 export type KeymapBinding = {
   command: string
@@ -86,6 +187,8 @@ export type KeymapMatch =
   | { type: 'none' }
   | { type: 'prefix' }
   | { type: 'full'; item: KeymapItem }
+
+export type KeymapItemAvailability = (item: KeymapItem) => boolean
 
 export type KeymapSource = 'global' | 'codeMirror'
 
@@ -367,7 +470,7 @@ export function createKeymapTree(items: readonly KeymapItem[]): KeymapTree {
   return { items, root }
 }
 
-export function getKeymapItemScopes(item: KeymapBinding) {
+export function getKeymapItemScopes(item: Pick<KeymapBinding, 'scopes'>) {
   const scopes = [
     ...new Set(item.scopes?.map((scope) => scope.trim()).filter(Boolean)),
   ]
@@ -658,7 +761,8 @@ export function matchKeymapKeystrokes(
   tree: KeymapTree,
   scopes: readonly string[],
   keystrokes: readonly string[],
-  keymapScopes: readonly KeymapScope[] = []
+  keymapScopes: readonly KeymapScope[] = [],
+  isItemAvailable: KeymapItemAvailability = () => true
 ): KeymapMatch {
   const normalizedKeystrokes = keystrokes.map(normalizeKeymapChord)
   const activeScopes = getEffectiveKeymapScopes(scopes, keymapScopes)
@@ -667,18 +771,18 @@ export function matchKeymapKeystrokes(
   let node = tree.root
   for (const chord of normalizedKeystrokes) {
     const child = node.children.get(chord)
-    if (!child || !nodeHasActiveItems(child, activeScopeSet)) {
+    if (!child || !nodeHasActiveItems(child, activeScopeSet, isItemAvailable)) {
       return { type: 'none' }
     }
     node = child
   }
 
-  const item = getActiveKeymapItem(node.items, activeScopes)
+  const item = getActiveKeymapItem(node.items, activeScopes, isItemAvailable)
   if (item) {
     return { type: 'full', item }
   }
 
-  if (nodeHasActiveItems(node, activeScopeSet)) {
+  if (nodeHasActiveItems(node, activeScopeSet, isItemAvailable)) {
     return { type: 'prefix' }
   }
 
@@ -687,31 +791,39 @@ export function matchKeymapKeystrokes(
 
 function nodeHasActiveItems(
   node: KeymapTreeNode,
-  activeScopes: ReadonlySet<string>
+  activeScopes: ReadonlySet<string>,
+  isItemAvailable: KeymapItemAvailability
 ): boolean {
   return (
-    node.items.some((item) => isKeymapItemActive(item, activeScopes)) ||
+    node.items.some(
+      (item) => isItemAvailable(item) && isKeymapItemActive(item, activeScopes)
+    ) ||
     [...node.children.values()].some((child) =>
-      nodeHasActiveItems(child, activeScopes)
+      nodeHasActiveItems(child, activeScopes, isItemAvailable)
     )
   )
 }
 
 function getActiveKeymapItem(
   items: readonly KeymapItem[],
-  activeScopes: readonly string[]
+  activeScopes: readonly string[],
+  isItemAvailable: KeymapItemAvailability
 ) {
   for (const scope of [...activeScopes].toReversed()) {
-    const item = items.find((candidate) =>
-      isKeymapItemActiveForScope(candidate, scope)
+    const item = items.find(
+      (candidate) =>
+        isItemAvailable(candidate) &&
+        isKeymapItemActiveForScope(candidate, scope)
     )
     if (item) {
       return item
     }
   }
 
-  return items.find((item) =>
-    isKeymapItemActiveForScope(item, BASE_KEYMAP_SCOPE)
+  return items.find(
+    (item) =>
+      isItemAvailable(item) &&
+      isKeymapItemActiveForScope(item, BASE_KEYMAP_SCOPE)
   )
 }
 

--- a/src/registry/contracts/keymap.ts
+++ b/src/registry/contracts/keymap.ts
@@ -10,6 +10,7 @@ import { type Platform, isArray } from '@src/lib/utils'
 export const BASE_KEYMAP_SCOPE = 'base'
 export const CODE_EDITOR_FOCUSED_KEYMAP_SCOPE = 'code-editor-focused'
 export const CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE = 'code-editor-not-focused'
+export const EDITABLE_FOCUSED_KEYMAP_SCOPE = 'editable-focused'
 export const MODE_MODELING_KEYMAP_SCOPE = 'mode-modeling'
 export const MODE_SKETCHING_KEYMAP_SCOPE = 'mode-sketching'
 export const MODE_SKETCH_NO_FACE_KEYMAP_SCOPE = 'mode-sketch-no-face'
@@ -23,6 +24,8 @@ export const PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE =
 export const KEYMAP_SCHEMA_VERSION = 1
 export const USER_KEYMAP_SOURCE = 'User'
 
+export const GLOBAL_KEYMAP_SCOPES = [BASE_KEYMAP_SCOPE] as const
+
 export const SKETCH_KEYMAP_SCOPES = [
   MODE_SKETCHING_KEYMAP_SCOPE,
   MODE_SKETCH_NO_FACE_KEYMAP_SCOPE,
@@ -32,6 +35,11 @@ export const SKETCH_KEYMAP_SCOPES = [
 export const FILE_KEYMAP_SCOPES = [
   MODE_MODELING_KEYMAP_SCOPE,
   ...SKETCH_KEYMAP_SCOPES,
+] as const
+
+export const FILE_AND_CODE_EDITOR_KEYMAP_SCOPES = [
+  ...FILE_KEYMAP_SCOPES,
+  CODE_EDITOR_FOCUSED_KEYMAP_SCOPE,
 ] as const
 
 export type KeymapArguments =
@@ -120,6 +128,13 @@ export const DEFAULT_KEYMAP_SCOPES: readonly KeymapScope[] = [
     displayName: 'Code editor focused',
     group: KEYMAP_CONTEXT_SCOPE_GROUP,
     priority: 1000,
+    userEditable: false,
+  },
+  {
+    id: EDITABLE_FOCUSED_KEYMAP_SCOPE,
+    displayName: 'Editable control focused',
+    group: KEYMAP_CONTEXT_SCOPE_GROUP,
+    priority: 1100,
     userEditable: false,
   },
   {

--- a/src/registry/extensions/commands/appCommands.ts
+++ b/src/registry/extensions/commands/appCommands.ts
@@ -9,7 +9,13 @@ import { selectAllInCurrentSketch } from '@src/lib/selections'
 import { reportRejection } from '@src/lib/trap'
 import type { CommandBarContext } from '@src/machines/commandBarMachine'
 import type { ModelingMachineEvent } from '@src/machines/modelingMachine'
-import { FILE_KEYMAP_SCOPES } from '@src/registry/contracts/keymap'
+import {
+  FILE_AND_CODE_EDITOR_KEYMAP_SCOPES,
+  FILE_KEYMAP_SCOPES,
+  HOME_KEYMAP_SCOPE,
+  SETTINGS_KEYMAP_SCOPE,
+  SKETCH_KEYMAP_SCOPES,
+} from '@src/registry/contracts/keymap'
 import toast from 'react-hot-toast'
 
 const APP_COMMAND_GROUP_ID = 'zds'
@@ -82,7 +88,7 @@ function createAppCommand({
   description?: Command['description']
   icon?: Command['icon']
   hideFromSearch?: boolean
-  scopes?: Command['scopes']
+  scopes: Command['scopes']
   onSubmit: Command['onSubmit']
 }): Command {
   return {
@@ -202,31 +208,37 @@ export const appCommands: readonly Command[] = [
   createAppCommand({
     id: APP_COMMAND_IDS.editor.undo,
     displayName: 'Undo',
+    scopes: FILE_AND_CODE_EDITOR_KEYMAP_SCOPES,
     onSubmit: (input) => getKclManager(input)?.undo(),
   }),
   createAppCommand({
     id: APP_COMMAND_IDS.editor.redo,
     displayName: 'Redo',
+    scopes: FILE_AND_CODE_EDITOR_KEYMAP_SCOPES,
     onSubmit: (input) => getKclManager(input)?.redo(),
   }),
   createAppCommand({
     id: APP_COMMAND_IDS.editor.format,
     displayName: 'Format code',
+    scopes: FILE_AND_CODE_EDITOR_KEYMAP_SCOPES,
     onSubmit: (input) => getKclManager(input)?.format().catch(reportRejection),
   }),
   createAppCommand({
     id: APP_COMMAND_IDS.editor.convertToVariable,
     displayName: 'Convert to variable',
+    scopes: FILE_AND_CODE_EDITOR_KEYMAP_SCOPES,
     onSubmit: (input) => getKclManager(input)?.convertToVariable(),
   }),
   createAppCommand({
     id: APP_COMMAND_IDS.editor.render,
     displayName: 'Render code',
+    scopes: FILE_AND_CODE_EDITOR_KEYMAP_SCOPES,
     onSubmit: reexecuteOrToastAutosaveBehavior,
   }),
   createAppCommand({
     id: APP_COMMAND_IDS.modeling.deleteSelection,
     displayName: 'Delete selection',
+    scopes: FILE_KEYMAP_SCOPES,
     onSubmit: deleteSelection,
   }),
   createAppCommand({
@@ -242,11 +254,13 @@ export const appCommands: readonly Command[] = [
   createAppCommand({
     id: APP_COMMAND_IDS.modeling.selectAllInCurrentSketch,
     displayName: 'Select all in current sketch',
+    scopes: SKETCH_KEYMAP_SCOPES,
     onSubmit: selectAllInCurrentSketchCommand,
   }),
   createAppCommand({
     id: APP_COMMAND_IDS.modeling.toggleSnapToGrid,
     displayName: 'Toggle snap to grid',
+    scopes: FILE_KEYMAP_SCOPES,
     onSubmit: toggleSnapToGrid,
   }),
   createAppCommand({
@@ -261,6 +275,7 @@ export const appCommands: readonly Command[] = [
   createAppCommand({
     id: APP_COMMAND_IDS.search.focusProjects,
     displayName: 'Focus project search',
+    scopes: [HOME_KEYMAP_SCOPE],
     onSubmit: () => {
       projectSearchFocusRequest.value += 1
     },
@@ -268,6 +283,7 @@ export const appCommands: readonly Command[] = [
   createAppCommand({
     id: APP_COMMAND_IDS.search.focusSettings,
     displayName: 'Focus settings search',
+    scopes: [SETTINGS_KEYMAP_SCOPE],
     onSubmit: () => {
       settingsSearchFocusRequest.value += 1
     },

--- a/src/registry/extensions/commands/appCommands.ts
+++ b/src/registry/extensions/commands/appCommands.ts
@@ -9,6 +9,7 @@ import { selectAllInCurrentSketch } from '@src/lib/selections'
 import { reportRejection } from '@src/lib/trap'
 import type { CommandBarContext } from '@src/machines/commandBarMachine'
 import type { ModelingMachineEvent } from '@src/machines/modelingMachine'
+import { FILE_KEYMAP_SCOPES } from '@src/registry/contracts/keymap'
 import toast from 'react-hot-toast'
 
 const APP_COMMAND_GROUP_ID = 'zds'
@@ -73,6 +74,7 @@ function createAppCommand({
   description,
   icon,
   hideFromSearch = true,
+  scopes,
   onSubmit,
 }: {
   id: string
@@ -80,6 +82,7 @@ function createAppCommand({
   description?: Command['description']
   icon?: Command['icon']
   hideFromSearch?: boolean
+  scopes?: Command['scopes']
   onSubmit: Command['onSubmit']
 }): Command {
   return {
@@ -90,6 +93,7 @@ function createAppCommand({
     description,
     icon,
     hideFromSearch,
+    scopes,
     needsReview: false,
     onSubmit,
   }
@@ -231,6 +235,7 @@ export const appCommands: readonly Command[] = [
     description: 'Center the camera on the current selection.',
     icon: 'camera',
     hideFromSearch: false,
+    scopes: FILE_KEYMAP_SCOPES,
     onSubmit: (input) =>
       sendModelingEvent(input, { type: 'Center camera on selection' }),
   }),
@@ -250,6 +255,7 @@ export const appCommands: readonly Command[] = [
     description: 'Restore the default camera position and view.',
     icon: 'refresh',
     hideFromSearch: false,
+    scopes: FILE_KEYMAP_SCOPES,
     onSubmit: resetView,
   }),
   createAppCommand({

--- a/src/registry/extensions/commands/index.spec.ts
+++ b/src/registry/extensions/commands/index.spec.ts
@@ -115,14 +115,6 @@ describe('commands extension', () => {
     )
   })
 
-  it('classifies every registry command into an explicit context', () => {
-    expect(
-      [...appCommands, ...toolbarCommands].every(
-        (command) => command.scopes.length > 0
-      )
-    ).toBe(true)
-  })
-
   it.each([
     [APP_COMMAND_IDS.editor.undo, FILE_AND_CODE_EDITOR_KEYMAP_SCOPES],
     [APP_COMMAND_IDS.editor.redo, FILE_AND_CODE_EDITOR_KEYMAP_SCOPES],
@@ -133,13 +125,11 @@ describe('commands extension', () => {
     ],
     [APP_COMMAND_IDS.editor.render, FILE_AND_CODE_EDITOR_KEYMAP_SCOPES],
     [APP_COMMAND_IDS.modeling.deleteSelection, FILE_KEYMAP_SCOPES],
-    [APP_COMMAND_IDS.modeling.centerCameraOnSelection, FILE_KEYMAP_SCOPES],
-    [APP_COMMAND_IDS.modeling.selectAllInCurrentSketch, SKETCH_KEYMAP_SCOPES],
     [APP_COMMAND_IDS.modeling.toggleSnapToGrid, FILE_KEYMAP_SCOPES],
-    [APP_COMMAND_IDS.view.reset, FILE_KEYMAP_SCOPES],
+    [APP_COMMAND_IDS.modeling.selectAllInCurrentSketch, SKETCH_KEYMAP_SCOPES],
     [APP_COMMAND_IDS.search.focusProjects, [HOME_KEYMAP_SCOPE]],
     [APP_COMMAND_IDS.search.focusSettings, [SETTINGS_KEYMAP_SCOPE]],
-  ] as const)('scopes app command %s', (commandId, scopes) => {
+  ] as const)('scopes representative app command %s', (commandId, scopes) => {
     expect(
       appCommands.find((command) => command.id === commandId)?.scopes
     ).toEqual(scopes)

--- a/src/registry/extensions/commands/index.spec.ts
+++ b/src/registry/extensions/commands/index.spec.ts
@@ -10,13 +10,18 @@ import type { Command } from '@src/lib/commandTypes'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { CommandBarContext } from '@src/machines/commandBarMachine'
 import {
+  commandKey,
   commandSystemService,
+  getEffectiveCommandScopeSet,
+  isCommandAvailable,
   provideCommand,
 } from '@src/registry/contracts/commands'
 import {
+  DEFAULT_KEYMAP_SCOPES,
   FILE_AND_CODE_EDITOR_KEYMAP_SCOPES,
   FILE_KEYMAP_SCOPES,
   GLOBAL_KEYMAP_SCOPES,
+  getKeymapItemScopes,
   HOME_KEYMAP_SCOPE,
   MODE_MODELING_KEYMAP_SCOPE,
   MODE_SKETCH_NO_FACE_KEYMAP_SCOPE,
@@ -27,6 +32,7 @@ import {
 } from '@src/registry/contracts/keymap'
 import { machineManagerService } from '@src/registry/contracts/machineManager'
 import { provideWasmPromise } from '@src/registry/contracts/wasm'
+import { defaultKeymap } from '@src/registry/extensions/keymap/defaultKeymap'
 import { describe, expect, it, vi } from 'vitest'
 import { commandsExtension } from '.'
 import { APP_COMMAND_IDS, appCommands } from './appCommands'
@@ -52,6 +58,12 @@ function createCommandBarContext({
   }
 
   return context
+}
+
+function commandIds(
+  groups: Readonly<Record<string, Readonly<Record<string, string>>>>
+) {
+  return Object.values(groups).flatMap((group) => Object.values(group))
 }
 
 describe('commands extension', () => {
@@ -99,20 +111,60 @@ describe('commands extension', () => {
     registry[Symbol.dispose]()
   })
 
-  it('provides toolbar commands for keymap-backed tool selection', () => {
-    expect(toolbarCommands.map((command) => command.id)).toContain(
-      TOOLBAR_COMMAND_IDS.sketchSolve.vertical
+  it('provides a toolbar command for every toolbar command id', () => {
+    expect(toolbarCommands.map((command) => command.id).toSorted()).toEqual(
+      commandIds(TOOLBAR_COMMAND_IDS).toSorted()
     )
   })
 
   it('provides an app command for every app command id', () => {
-    const appCommandIds = Object.values(APP_COMMAND_IDS).flatMap((group) =>
-      Object.values(group)
+    expect(appCommands.map((command) => command.id).toSorted()).toEqual(
+      commandIds(APP_COMMAND_IDS).toSorted()
+    )
+  })
+
+  it('keeps static default keybindings within command availability', () => {
+    const staticCommandIds = [
+      ...commandIds(APP_COMMAND_IDS),
+      ...commandIds(TOOLBAR_COMMAND_IDS),
+    ]
+    const staticCommandPrefixes = [
+      ...new Set(
+        staticCommandIds.map((id) => id.slice(0, id.lastIndexOf('.') + 1))
+      ),
+    ]
+    const commandsByKey = new Map(
+      [...appCommands, ...toolbarCommands].map((command) => [
+        commandKey(command),
+        command,
+      ])
+    )
+    const staticBindings = defaultKeymap.bindings.filter((binding) =>
+      staticCommandPrefixes.some((prefix) => binding.command.startsWith(prefix))
     )
 
-    expect(appCommands.map((command) => command.id).toSorted()).toEqual(
-      appCommandIds.toSorted()
-    )
+    for (const binding of staticBindings) {
+      const command = commandsByKey.get(binding.command)
+      expect(
+        command,
+        `Default keybinding ${binding.id} targets missing static command ${binding.command}`
+      ).toBeDefined()
+      if (!command) {
+        continue
+      }
+
+      const unavailableScopes = getKeymapItemScopes(binding).filter(
+        (scope) =>
+          !isCommandAvailable(
+            command,
+            getEffectiveCommandScopeSet([scope], DEFAULT_KEYMAP_SCOPES)
+          )
+      )
+      expect(
+        unavailableScopes,
+        `Default keybinding ${binding.id} exceeds ${binding.command} availability`
+      ).toEqual([])
+    }
   })
 
   it.each([

--- a/src/registry/extensions/commands/index.spec.ts
+++ b/src/registry/extensions/commands/index.spec.ts
@@ -13,7 +13,18 @@ import {
   commandSystemService,
   provideCommand,
 } from '@src/registry/contracts/commands'
-import { FILE_KEYMAP_SCOPES } from '@src/registry/contracts/keymap'
+import {
+  FILE_AND_CODE_EDITOR_KEYMAP_SCOPES,
+  FILE_KEYMAP_SCOPES,
+  GLOBAL_KEYMAP_SCOPES,
+  HOME_KEYMAP_SCOPE,
+  MODE_MODELING_KEYMAP_SCOPE,
+  MODE_SKETCH_NO_FACE_KEYMAP_SCOPE,
+  MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
+  MODE_SKETCHING_KEYMAP_SCOPE,
+  SETTINGS_KEYMAP_SCOPE,
+  SKETCH_KEYMAP_SCOPES,
+} from '@src/registry/contracts/keymap'
 import { machineManagerService } from '@src/registry/contracts/machineManager'
 import { provideWasmPromise } from '@src/registry/contracts/wasm'
 import { describe, expect, it, vi } from 'vitest'
@@ -47,6 +58,7 @@ describe('commands extension', () => {
   it('syncs registry command contributions into the command system service', () => {
     const commandsSlot = new Slot()
     const command: Command = {
+      scopes: GLOBAL_KEYMAP_SCOPES,
       groupId: 'test',
       name: 'test-command',
       needsReview: false,
@@ -101,6 +113,71 @@ describe('commands extension', () => {
     expect(appCommands.map((command) => command.id).toSorted()).toEqual(
       appCommandIds.toSorted()
     )
+  })
+
+  it('classifies every registry command into an explicit context', () => {
+    expect(
+      [...appCommands, ...toolbarCommands].every(
+        (command) => command.scopes.length > 0
+      )
+    ).toBe(true)
+  })
+
+  it.each([
+    [APP_COMMAND_IDS.editor.undo, FILE_AND_CODE_EDITOR_KEYMAP_SCOPES],
+    [APP_COMMAND_IDS.editor.redo, FILE_AND_CODE_EDITOR_KEYMAP_SCOPES],
+    [APP_COMMAND_IDS.editor.format, FILE_AND_CODE_EDITOR_KEYMAP_SCOPES],
+    [
+      APP_COMMAND_IDS.editor.convertToVariable,
+      FILE_AND_CODE_EDITOR_KEYMAP_SCOPES,
+    ],
+    [APP_COMMAND_IDS.editor.render, FILE_AND_CODE_EDITOR_KEYMAP_SCOPES],
+    [APP_COMMAND_IDS.modeling.deleteSelection, FILE_KEYMAP_SCOPES],
+    [APP_COMMAND_IDS.modeling.centerCameraOnSelection, FILE_KEYMAP_SCOPES],
+    [APP_COMMAND_IDS.modeling.selectAllInCurrentSketch, SKETCH_KEYMAP_SCOPES],
+    [APP_COMMAND_IDS.modeling.toggleSnapToGrid, FILE_KEYMAP_SCOPES],
+    [APP_COMMAND_IDS.view.reset, FILE_KEYMAP_SCOPES],
+    [APP_COMMAND_IDS.search.focusProjects, [HOME_KEYMAP_SCOPE]],
+    [APP_COMMAND_IDS.search.focusSettings, [SETTINGS_KEYMAP_SCOPE]],
+  ] as const)('scopes app command %s', (commandId, scopes) => {
+    expect(
+      appCommands.find((command) => command.id === commandId)?.scopes
+    ).toEqual(scopes)
+  })
+
+  it('scopes toolbar command families to their owning mode', () => {
+    expect(
+      toolbarCommands.find(
+        (command) => command.id === TOOLBAR_COMMAND_IDS.modeling.sketch
+      )?.scopes
+    ).toEqual([MODE_MODELING_KEYMAP_SCOPE])
+    expect(
+      toolbarCommands.find(
+        (command) => command.id === TOOLBAR_COMMAND_IDS.sketching.exit
+      )?.scopes
+    ).toEqual([MODE_SKETCHING_KEYMAP_SCOPE, MODE_SKETCH_NO_FACE_KEYMAP_SCOPE])
+    expect(
+      toolbarCommands
+        .filter(
+          (command) =>
+            command.id?.startsWith('zds.toolbar.sketchLegacy.') &&
+            command.id !== TOOLBAR_COMMAND_IDS.sketching.exit
+        )
+        .every(
+          (command) =>
+            command.scopes.length === 1 &&
+            command.scopes[0] === MODE_SKETCHING_KEYMAP_SCOPE
+        )
+    ).toBe(true)
+    expect(
+      toolbarCommands
+        .filter((command) => command.id?.startsWith('zds.toolbar.sketch.'))
+        .every(
+          (command) =>
+            command.scopes.length === 1 &&
+            command.scopes[0] === MODE_SKETCH_SOLVE_KEYMAP_SCOPE
+        )
+    ).toBe(true)
   })
 
   it('exposes view commands with command palette metadata', () => {

--- a/src/registry/extensions/commands/index.spec.ts
+++ b/src/registry/extensions/commands/index.spec.ts
@@ -123,7 +123,7 @@ describe('commands extension', () => {
     )
   })
 
-  it('keeps static default keybindings within command availability', () => {
+  it('keeps app and toolbar default keybindings within command availability', () => {
     const staticCommandIds = [
       ...commandIds(APP_COMMAND_IDS),
       ...commandIds(TOOLBAR_COMMAND_IDS),

--- a/src/registry/extensions/commands/index.spec.ts
+++ b/src/registry/extensions/commands/index.spec.ts
@@ -13,6 +13,7 @@ import {
   commandSystemService,
   provideCommand,
 } from '@src/registry/contracts/commands'
+import { FILE_KEYMAP_SCOPES } from '@src/registry/contracts/keymap'
 import { machineManagerService } from '@src/registry/contracts/machineManager'
 import { provideWasmPromise } from '@src/registry/contracts/wasm'
 import { describe, expect, it, vi } from 'vitest'
@@ -115,12 +116,14 @@ describe('commands extension', () => {
           displayName: 'Center camera on selection',
           description: 'Center the camera on the current selection.',
           icon: 'camera',
+          scopes: FILE_KEYMAP_SCOPES,
         }),
         expect.objectContaining({
           id: APP_COMMAND_IDS.view.reset,
           displayName: 'Reset view',
           description: 'Restore the default camera position and view.',
           icon: 'refresh',
+          scopes: FILE_KEYMAP_SCOPES,
         }),
       ])
     )

--- a/src/registry/extensions/commands/toolbarCommands.ts
+++ b/src/registry/extensions/commands/toolbarCommands.ts
@@ -17,6 +17,12 @@ import {
   type EquipTool,
   isSketchBlockSelected,
 } from '@src/machines/sketchSolve/sketchSolveImpl'
+import {
+  MODE_MODELING_KEYMAP_SCOPE,
+  MODE_SKETCH_NO_FACE_KEYMAP_SCOPE,
+  MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
+  MODE_SKETCHING_KEYMAP_SCOPE,
+} from '@src/registry/contracts/keymap'
 import type { StateFrom } from 'xstate'
 
 const TOOLBAR_COMMAND_GROUP_ID = 'toolbar'
@@ -76,6 +82,7 @@ type ToolbarCommandConfig = {
   displayName: string
   description: string
   icon?: Command['icon']
+  scopes: Command['scopes']
   onSubmit: Command['onSubmit']
 }
 
@@ -119,6 +126,7 @@ const createToolbarCommand = ({
   displayName,
   description,
   icon,
+  scopes,
   onSubmit,
 }: ToolbarCommandConfig): Command => ({
   id,
@@ -127,6 +135,7 @@ const createToolbarCommand = ({
   displayName,
   description,
   icon,
+  scopes,
   hideFromSearch: true,
   needsReview: false,
   onSubmit,
@@ -193,6 +202,7 @@ function createLegacySketchToolCommand({
     displayName,
     description,
     icon,
+    scopes: [MODE_SKETCHING_KEYMAP_SCOPE],
     onSubmit: (input) => {
       const state = getModelingState(input)
       if (!state || state.matches('Sketch no face')) {
@@ -220,6 +230,7 @@ function createSketchSolveToolCommand({
     displayName,
     description,
     icon,
+    scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
     onSubmit: (input) => {
       if (experimental && !hasSketchExperimentalFeatures(input)) {
         return
@@ -256,6 +267,7 @@ function createSketchSolveActionCommand({
     displayName,
     description,
     icon,
+    scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
     onSubmit: (input) => sendModelingEvent(input, { type: event }),
   })
 }
@@ -346,6 +358,7 @@ export const toolbarCommands: readonly Command[] = [
     displayName: 'Start or edit sketch',
     description: 'Start drawing a 2D sketch.',
     icon: 'sketch',
+    scopes: [MODE_MODELING_KEYMAP_SCOPE],
     onSubmit: enterSketch,
   }),
   createToolbarCommand({
@@ -353,12 +366,14 @@ export const toolbarCommands: readonly Command[] = [
     displayName: 'Exit sketch',
     description: 'Exit the current sketch.',
     icon: 'arrowShortLeft',
+    scopes: [MODE_SKETCHING_KEYMAP_SCOPE, MODE_SKETCH_NO_FACE_KEYMAP_SCOPE],
     onSubmit: exitSketch,
   }),
   createToolbarCommand({
     id: TOOLBAR_COMMAND_IDS.sketching.cancelTool,
     displayName: 'Cancel sketch tool',
     description: 'Cancel the active sketch tool.',
+    scopes: [MODE_SKETCHING_KEYMAP_SCOPE],
     onSubmit: cancelLegacySketchTool,
   }),
   createLegacySketchToolCommand({
@@ -422,12 +437,14 @@ export const toolbarCommands: readonly Command[] = [
     displayName: 'Exit sketch',
     description: 'Exit the current sketch.',
     icon: 'arrowShortLeft',
+    scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
     onSubmit: (input) => sendModelingEvent(input, { type: 'Exit sketch' }),
   }),
   createToolbarCommand({
     id: TOOLBAR_COMMAND_IDS.sketchSolve.cancel,
     displayName: 'Cancel sketch solve action',
     description: 'Cancel the active sketch solve action.',
+    scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
     onSubmit: (input) => sendModelingEvent(input, { type: 'Cancel' }),
   }),
   createSketchSolveToolCommand({

--- a/src/registry/extensions/engineScene/index.ts
+++ b/src/registry/extensions/engineScene/index.ts
@@ -75,7 +75,7 @@ const openMeasureToolKeymapItem: KeymapItem = {
   id: 'engine-scene.measure.open',
   title: 'Open measure tool',
   source: ENGINE_SCENE_KEYMAP_SOURCE,
-  scopes: [MODE_MODELING_KEYMAP_SCOPE],
+  scopes: openMeasureToolCommand.scopes,
   keystrokes: ['shift+m'],
   command: ENGINE_SCENE_COMMAND_IDS.openMeasureTool,
 }

--- a/src/registry/extensions/engineScene/index.ts
+++ b/src/registry/extensions/engineScene/index.ts
@@ -16,6 +16,7 @@ import {
 import { executingEditorService } from '@src/registry/contracts/executingEditor'
 import {
   type KeymapItem,
+  FILE_KEYMAP_SCOPES,
   MODE_MODELING_KEYMAP_SCOPE,
   provideKeymapItem,
 } from '@src/registry/contracts/keymap'
@@ -44,6 +45,7 @@ export const ENGINE_SCENE_COMMAND_IDS = Object.freeze({
 } as const)
 
 const captureScreenshotCommand: Command = {
+  scopes: FILE_KEYMAP_SCOPES,
   id: ENGINE_SCENE_COMMAND_IDS.captureScreenshot,
   name: ENGINE_SCENE_COMMAND_IDS.captureScreenshot,
   groupId: ENGINE_SCENE_COMMAND_GROUP_ID,
@@ -55,6 +57,7 @@ const captureScreenshotCommand: Command = {
 }
 
 const openMeasureToolCommand: Command = {
+  scopes: [MODE_MODELING_KEYMAP_SCOPE],
   id: ENGINE_SCENE_COMMAND_IDS.openMeasureTool,
   name: ENGINE_SCENE_COMMAND_IDS.openMeasureTool,
   groupId: ENGINE_SCENE_COMMAND_GROUP_ID,

--- a/src/registry/extensions/keymap/defaultKeymap.ts
+++ b/src/registry/extensions/keymap/defaultKeymap.ts
@@ -2,8 +2,10 @@ import { defineRegistryItem, provide } from '@kittycad/registry'
 import { isDesktop } from '@src/lib/isDesktop'
 import { getDeleteKeys } from '@src/lib/utils'
 import {
+  COMMAND_PALETTE_OPEN_KEYMAP_SCOPE,
   CODE_EDITOR_FOCUSED_KEYMAP_SCOPE,
   CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE,
+  FILE_KEYMAP_SCOPES,
   HOME_KEYMAP_SCOPE,
   type KeymapDocument,
   MODE_MODELING_KEYMAP_SCOPE,
@@ -11,18 +13,14 @@ import {
   MODE_SKETCH_NO_FACE_KEYMAP_SCOPE,
   MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
   PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE,
+  SETTINGS_KEYMAP_SCOPE,
+  SKETCH_KEYMAP_SCOPES,
   keymapValueSpec,
 } from '@src/registry/contracts/keymap'
 import { APP_COMMAND_IDS } from '@src/registry/extensions/commands/appCommands'
 import { TOOLBAR_COMMAND_IDS } from '@src/registry/extensions/commands/toolbarCommands'
 
 const BASE_KEYMAP_SOURCE = 'Base'
-const FILE_KEYMAP_SCOPES = [
-  MODE_MODELING_KEYMAP_SCOPE,
-  MODE_SKETCHING_KEYMAP_SCOPE,
-  MODE_SKETCH_NO_FACE_KEYMAP_SCOPE,
-  MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
-]
 
 export const PROJECT_EXPLORER_COMMAND_IDS = {
   arrowLeft: 'project-explorer.arrow-left',
@@ -74,14 +72,14 @@ export const defaultKeymap: KeymapDocument = {
     {
       id: 'command-palette.close',
       title: 'Close command palette',
-      scopes: ['cmd-palette-open'],
+      scopes: [COMMAND_PALETTE_OPEN_KEYMAP_SCOPE],
       keystrokes: ['mod+k'],
       command: 'zds.commandPalette.close',
     },
     {
       id: 'command-palette.close-slash',
       title: 'Close command palette',
-      scopes: ['cmd-palette-open'],
+      scopes: [COMMAND_PALETTE_OPEN_KEYMAP_SCOPE],
       keystrokes: ['mod+/'],
       command: 'zds.commandPalette.close',
       hidden: true,
@@ -96,7 +94,7 @@ export const defaultKeymap: KeymapDocument = {
     {
       id: 'settings.project',
       title: 'Project settings',
-      scopes: ['settings-open'],
+      scopes: [SETTINGS_KEYMAP_SCOPE],
       keystrokes: ['p'],
       command: 'zds.settings.tab',
       arguments: {
@@ -106,7 +104,7 @@ export const defaultKeymap: KeymapDocument = {
     {
       id: 'settings.user',
       title: 'User settings',
-      scopes: ['settings-open'],
+      scopes: [SETTINGS_KEYMAP_SCOPE],
       keystrokes: ['u'],
       command: 'zds.settings.tab',
       arguments: {
@@ -116,7 +114,7 @@ export const defaultKeymap: KeymapDocument = {
     {
       id: 'settings.focus-search',
       title: 'Focus settings search',
-      scopes: ['settings-open'],
+      scopes: [SETTINGS_KEYMAP_SCOPE],
       keystrokes: ['ctrl+.'],
       command: APP_COMMAND_IDS.search.focusSettings,
     },
@@ -203,11 +201,7 @@ export const defaultKeymap: KeymapDocument = {
     {
       id: 'modeling.select-all-in-current-sketch',
       title: 'Select all in current sketch',
-      scopes: [
-        MODE_SKETCHING_KEYMAP_SCOPE,
-        MODE_SKETCH_NO_FACE_KEYMAP_SCOPE,
-        MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
-      ],
+      scopes: SKETCH_KEYMAP_SCOPES,
       keystrokes: ['mod+a'],
       command: APP_COMMAND_IDS.modeling.selectAllInCurrentSketch,
     },

--- a/src/registry/extensions/keymap/defaultKeymap.ts
+++ b/src/registry/extensions/keymap/defaultKeymap.ts
@@ -2,20 +2,20 @@ import { defineRegistryItem, provide } from '@kittycad/registry'
 import { isDesktop } from '@src/lib/isDesktop'
 import { getDeleteKeys } from '@src/lib/utils'
 import {
-  COMMAND_PALETTE_OPEN_KEYMAP_SCOPE,
   CODE_EDITOR_FOCUSED_KEYMAP_SCOPE,
-  CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE,
+  COMMAND_PALETTE_OPEN_KEYMAP_SCOPE,
+  FILE_AND_CODE_EDITOR_KEYMAP_SCOPES,
   FILE_KEYMAP_SCOPES,
   HOME_KEYMAP_SCOPE,
   type KeymapDocument,
+  keymapValueSpec,
   MODE_MODELING_KEYMAP_SCOPE,
-  MODE_SKETCHING_KEYMAP_SCOPE,
   MODE_SKETCH_NO_FACE_KEYMAP_SCOPE,
   MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
+  MODE_SKETCHING_KEYMAP_SCOPE,
   PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE,
   SETTINGS_KEYMAP_SCOPE,
   SKETCH_KEYMAP_SCOPES,
-  keymapValueSpec,
 } from '@src/registry/contracts/keymap'
 import { APP_COMMAND_IDS } from '@src/registry/extensions/commands/appCommands'
 import { TOOLBAR_COMMAND_IDS } from '@src/registry/extensions/commands/toolbarCommands'
@@ -171,7 +171,7 @@ export const defaultKeymap: KeymapDocument = {
           {
             id: 'editor.format',
             title: 'Format code',
-            scopes: [CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE],
+            scopes: FILE_AND_CODE_EDITOR_KEYMAP_SCOPES,
             keystrokes: ['alt+shift+f'],
             command: APP_COMMAND_IDS.editor.format,
           },
@@ -180,7 +180,7 @@ export const defaultKeymap: KeymapDocument = {
     {
       id: 'editor.convert-to-variable',
       title: 'Convert to variable',
-      scopes: FILE_KEYMAP_SCOPES,
+      scopes: FILE_AND_CODE_EDITOR_KEYMAP_SCOPES,
       keystrokes: ['ctrl+shift+c'],
       command: APP_COMMAND_IDS.editor.convertToVariable,
     },

--- a/src/registry/extensions/keymap/index.spec.ts
+++ b/src/registry/extensions/keymap/index.spec.ts
@@ -4,6 +4,7 @@ import {
   defineRegistryItem,
   provideService,
 } from '@kittycad/registry'
+import type { Command } from '@src/lib/commandTypes'
 import {
   type CommandSystemService,
   commandSystemService,
@@ -11,9 +12,13 @@ import {
 import {
   CODE_EDITOR_FOCUSED_KEYMAP_SCOPE,
   CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE,
+  FILE_KEYMAP_SCOPES,
+  HOME_KEYMAP_SCOPE,
   KEYMAP_SCHEMA_VERSION,
+  MODE_MODELING_KEYMAP_SCOPE,
   MODE_SKETCHING_KEYMAP_SCOPE,
   MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
+  SETTINGS_KEYMAP_SCOPE,
   type PersistedKeymap,
   keymapService,
   provideKeymapDocument,
@@ -251,6 +256,131 @@ describe('keymap extension', () => {
       },
     })
     expect(onSubmit).not.toHaveBeenCalled()
+
+    registry[Symbol.dispose]()
+  })
+
+  it('does not let a user binding broaden a command context', () => {
+    const send = vi.fn()
+    const registry = createRegistryWithKeymapItems(
+      [
+        {
+          id: 'test.file-command-keymap',
+          title: 'Test file command keymap',
+          command: 'test.file-command',
+          source: 'User',
+          keystrokes: ['mod+u'],
+        },
+      ],
+      [
+        createTestCommandSystemItem(
+          [
+            {
+              id: 'test.file-command',
+              groupId: 'test',
+              name: 'Run file command',
+              needsReview: false,
+              scopes: FILE_KEYMAP_SCOPES,
+              onSubmit: vi.fn(),
+            },
+          ],
+          send
+        ),
+      ]
+    )
+    const keymap = registry.get(keymapService)
+    const createEvent = () =>
+      new KeyboardEvent('keydown', {
+        key: 'u',
+        ctrlKey: true,
+        metaKey: true,
+        cancelable: true,
+      })
+
+    keymap.applyScope(HOME_KEYMAP_SCOPE)
+    const homeEvent = createEvent()
+    expect(keymap.handleKeyDown(homeEvent, { source: 'global' })).toBe(false)
+    expect(homeEvent.defaultPrevented).toBe(false)
+    expect(send).not.toHaveBeenCalled()
+
+    keymap.applyScope(MODE_MODELING_KEYMAP_SCOPE)
+    const modelingEvent = createEvent()
+    expect(keymap.handleKeyDown(modelingEvent, { source: 'global' })).toBe(true)
+    expect(modelingEvent.defaultPrevented).toBe(true)
+    expect(send).toHaveBeenCalledOnce()
+
+    keymap.applyScope(SETTINGS_KEYMAP_SCOPE)
+    const settingsEvent = createEvent()
+    expect(keymap.handleKeyDown(settingsEvent, { source: 'global' })).toBe(
+      false
+    )
+    expect(settingsEvent.defaultPrevented).toBe(false)
+    expect(send).toHaveBeenCalledOnce()
+
+    registry[Symbol.dispose]()
+  })
+
+  it('falls back to an available command sharing an unavailable command chord', () => {
+    const send = vi.fn()
+    const registry = createRegistryWithKeymapItems(
+      [
+        {
+          id: 'test.file-command-keymap',
+          title: 'Test file command keymap',
+          command: 'test.file-command',
+          source: 'User',
+          keystrokes: ['mod+u'],
+        },
+        {
+          id: 'test.global-command-keymap',
+          title: 'Test global command keymap',
+          command: 'test.global-command',
+          source: 'User',
+          keystrokes: ['mod+u'],
+        },
+      ],
+      [
+        createTestCommandSystemItem(
+          [
+            {
+              id: 'test.file-command',
+              groupId: 'test',
+              name: 'Run file command',
+              needsReview: false,
+              scopes: FILE_KEYMAP_SCOPES,
+              onSubmit: vi.fn(),
+            },
+            {
+              id: 'test.global-command',
+              groupId: 'test',
+              name: 'Run global command',
+              needsReview: false,
+              onSubmit: vi.fn(),
+            },
+          ],
+          send
+        ),
+      ]
+    )
+    const keymap = registry.get(keymapService)
+    const event = new KeyboardEvent('keydown', {
+      key: 'u',
+      ctrlKey: true,
+      metaKey: true,
+      cancelable: true,
+    })
+
+    keymap.applyScope(HOME_KEYMAP_SCOPE)
+
+    expect(keymap.handleKeyDown(event, { source: 'global' })).toBe(true)
+    expect(event.defaultPrevented).toBe(true)
+    expect(send).toHaveBeenCalledWith({
+      type: 'Find and select command',
+      data: {
+        groupId: 'test',
+        name: 'Run global command',
+      },
+    })
 
     registry[Symbol.dispose]()
   })
@@ -547,6 +677,24 @@ function createRegistryWithKeymapItems(
     ),
   ])
   return registry
+}
+
+function createTestCommandSystemItem(
+  commands: Command[],
+  send: CommandSystemService['send']
+) {
+  return defineRegistryItem({
+    id: 'test-command-system',
+    providesServices: [
+      provideService(commandSystemService, {
+        actor: {
+          getSnapshot: () => ({ context: { commands } }),
+        },
+        send,
+        useState: vi.fn(),
+      } as unknown as CommandSystemService),
+    ],
+  })
 }
 
 function createKeyboardEventWithTarget(key: string, target: EventTarget) {

--- a/src/registry/extensions/keymap/index.spec.ts
+++ b/src/registry/extensions/keymap/index.spec.ts
@@ -12,7 +12,9 @@ import {
 import {
   CODE_EDITOR_FOCUSED_KEYMAP_SCOPE,
   CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE,
+  EDITABLE_FOCUSED_KEYMAP_SCOPE,
   FILE_KEYMAP_SCOPES,
+  GLOBAL_KEYMAP_SCOPES,
   HOME_KEYMAP_SCOPE,
   KEYMAP_SCHEMA_VERSION,
   MODE_MODELING_KEYMAP_SCOPE,
@@ -99,16 +101,33 @@ describe('keymap extension', () => {
   })
 
   it('marks a partial match and awaits more input', () => {
-    const registry = createRegistryWithKeymapItems([
-      {
-        id: 'test.keystrokes',
-        title: 'Test keystrokes',
-        command: 'test.keystrokes',
-        source: 'test',
-        keystrokes: ['q', 'w'],
-        scopes: [CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE],
-      },
-    ])
+    const registry = createRegistryWithKeymapItems(
+      [
+        {
+          id: 'test.keystrokes',
+          title: 'Test keystrokes',
+          command: 'test.keystrokes',
+          source: 'test',
+          keystrokes: ['q', 'w'],
+          scopes: [CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE],
+        },
+      ],
+      [
+        createTestCommandSystemItem(
+          [
+            {
+              id: 'test.keystrokes',
+              scopes: [CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE],
+              groupId: 'test',
+              name: 'Test keystrokes',
+              needsReview: false,
+              onSubmit: vi.fn(),
+            },
+          ],
+          vi.fn()
+        ),
+      ]
+    )
 
     const keymap = registry.get(keymapService)
     const event = new KeyboardEvent('keydown', { key: 'q' })
@@ -120,16 +139,28 @@ describe('keymap extension', () => {
   })
 
   it('runs a full match and clears partial match state', () => {
-    const registry = createRegistryWithKeymapItems([
-      {
-        id: 'test.full',
-        title: 'Test full',
-        command: 'zds.settings.tab',
-        source: 'test',
-        keystrokes: ['x'],
-        scopes: [CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE],
-      },
-    ])
+    const registry = createRegistryWithKeymapItems(
+      [
+        {
+          id: 'test.full-keymap',
+          title: 'Test full',
+          command: 'test.full',
+          source: 'test',
+          keystrokes: ['x'],
+          scopes: [CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE],
+        },
+      ],
+      [
+        createTestCommandSystemItem(
+          [
+            createTestCommand('test.full', [
+              CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE,
+            ]),
+          ],
+          vi.fn()
+        ),
+      ]
+    )
 
     const keymap = registry.get(keymapService)
     const event = new KeyboardEvent('keydown', { key: 'x' })
@@ -141,16 +172,33 @@ describe('keymap extension', () => {
   })
 
   it('matches macOS Option-modified letter chords by physical key code', () => {
-    const registry = createRegistryWithKeymapItems([
-      {
-        id: 'test.alt-d',
-        title: 'Test Alt+D',
-        command: 'test.alt-d',
-        source: 'test',
-        keystrokes: ['alt+d'],
-        scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
-      },
-    ])
+    const registry = createRegistryWithKeymapItems(
+      [
+        {
+          id: 'test.alt-d',
+          title: 'Test Alt+D',
+          command: 'test.alt-d',
+          source: 'test',
+          keystrokes: ['alt+d'],
+          scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
+        },
+      ],
+      [
+        createTestCommandSystemItem(
+          [
+            {
+              id: 'test.alt-d',
+              scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
+              groupId: 'test',
+              name: 'Test Alt+D',
+              needsReview: false,
+              onSubmit: vi.fn(),
+            },
+          ],
+          vi.fn()
+        ),
+      ]
+    )
 
     const keymap = registry.get(keymapService)
     keymap.applyScope(MODE_SKETCH_SOLVE_KEYMAP_SCOPE)
@@ -191,6 +239,45 @@ describe('keymap extension', () => {
     registry[Symbol.dispose]()
   })
 
+  it('does not let a user binding broaden a built-in action context', () => {
+    window.history.replaceState(null, '', '/settings?tab=user')
+    const registry = createRegistryWithKeymapItems([
+      {
+        id: 'test.user-settings-tab',
+        title: 'Test user settings tab',
+        command: 'zds.settings.tab',
+        source: 'User',
+        keystrokes: ['mod+u'],
+        arguments: { tab: 'keybindings' },
+      },
+    ])
+    const keymap = registry.get(keymapService)
+    const createEvent = () =>
+      new KeyboardEvent('keydown', {
+        key: 'u',
+        ctrlKey: true,
+        metaKey: true,
+        cancelable: true,
+      })
+
+    const outsideSettingsEvent = createEvent()
+    expect(
+      keymap.handleKeyDown(outsideSettingsEvent, { source: 'global' })
+    ).toBe(false)
+    expect(outsideSettingsEvent.defaultPrevented).toBe(false)
+    expect(new URL(window.location.href).searchParams.get('tab')).toBe('user')
+
+    keymap.applyScope(SETTINGS_KEYMAP_SCOPE)
+    const settingsEvent = createEvent()
+    expect(keymap.handleKeyDown(settingsEvent, { source: 'global' })).toBe(true)
+    expect(settingsEvent.defaultPrevented).toBe(true)
+    expect(new URL(window.location.href).searchParams.get('tab')).toBe(
+      'keybindings'
+    )
+
+    registry[Symbol.dispose]()
+  })
+
   it('selects non-built-in command IDs through the command system', () => {
     const onSubmit = vi.fn()
     const send = vi.fn()
@@ -219,6 +306,7 @@ describe('keymap extension', () => {
                         groupId: 'test',
                         name: 'Run test command',
                         needsReview: false,
+                        scopes: GLOBAL_KEYMAP_SCOPES,
                         args: {
                           value: {
                             inputType: 'string',
@@ -352,6 +440,7 @@ describe('keymap extension', () => {
             },
             {
               id: 'test.global-command',
+              scopes: GLOBAL_KEYMAP_SCOPES,
               groupId: 'test',
               name: 'Run global command',
               needsReview: false,
@@ -385,6 +474,33 @@ describe('keymap extension', () => {
     registry[Symbol.dispose]()
   })
 
+  it.each(['test.command-that-no-longer-exists', 'toString'])(
+    'does not consume a shortcut for unknown command %s',
+    (command) => {
+      const registry = createRegistryWithKeymapItems([
+        {
+          id: 'test.stale-command-keymap',
+          title: 'Stale command keymap',
+          command,
+          source: 'User',
+          keystrokes: ['mod+u'],
+        },
+      ])
+      const keymap = registry.get(keymapService)
+      const event = new KeyboardEvent('keydown', {
+        key: 'u',
+        ctrlKey: true,
+        metaKey: true,
+        cancelable: true,
+      })
+
+      expect(keymap.handleKeyDown(event, { source: 'global' })).toBe(false)
+      expect(event.defaultPrevented).toBe(false)
+
+      registry[Symbol.dispose]()
+    }
+  )
+
   it('waits for the initial persisted keymap load before saving overrides', async () => {
     let resolveInitialRead: ((keymap: PersistedKeymap) => void) | undefined
     persistenceMocks.readUserKeymapFile.mockReturnValueOnce(
@@ -392,7 +508,32 @@ describe('keymap extension', () => {
         resolveInitialRead = resolve
       })
     )
-    const registry = createRegistryWithKeymapItems([])
+    const registry = createRegistryWithKeymapItems(
+      [],
+      [
+        createTestCommandSystemItem(
+          [
+            {
+              id: 'zds.toolbar.sketchLegacy.line',
+              scopes: [MODE_SKETCHING_KEYMAP_SCOPE],
+              groupId: 'test',
+              name: 'Legacy sketch line',
+              needsReview: false,
+              onSubmit: vi.fn(),
+            },
+            {
+              id: 'zds.toolbar.sketch.line',
+              scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
+              groupId: 'test',
+              name: 'Sketch line',
+              needsReview: false,
+              onSubmit: vi.fn(),
+            },
+          ],
+          vi.fn()
+        ),
+      ]
+    )
 
     const keymap = registry.get(keymapService)
     keymap.applyScope(MODE_SKETCHING_KEYMAP_SCOPE)
@@ -430,15 +571,23 @@ describe('keymap extension', () => {
   })
 
   it('lets CodeMirror source handle contenteditable targets', () => {
-    const registry = createRegistryWithKeymapItems([
-      {
-        id: 'test.code-mirror',
-        title: 'Test CodeMirror',
-        command: 'zds.settings.tab',
-        source: 'test',
-        keystrokes: ['escape'],
-      },
-    ])
+    const registry = createRegistryWithKeymapItems(
+      [
+        {
+          id: 'test.code-mirror-keymap',
+          title: 'Test CodeMirror',
+          command: 'test.code-mirror',
+          source: 'test',
+          keystrokes: ['escape'],
+        },
+      ],
+      [
+        createTestCommandSystemItem(
+          [createTestCommand('test.code-mirror', GLOBAL_KEYMAP_SCOPES)],
+          vi.fn()
+        ),
+      ]
+    )
     const keymap = registry.get(keymapService)
     const target = document.createElement('div')
     target.contentEditable = 'true'
@@ -457,16 +606,28 @@ describe('keymap extension', () => {
   })
 
   it('ignores unmodified global shortcuts from input targets', () => {
-    const registry = createRegistryWithKeymapItems([
-      {
-        id: 'test.sketch-solve-line',
-        title: 'Test sketch solve line',
-        command: 'zds.settings.tab',
-        source: 'test',
-        keystrokes: ['l'],
-        scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
-      },
-    ])
+    const registry = createRegistryWithKeymapItems(
+      [
+        {
+          id: 'test.sketch-solve-line-keymap',
+          title: 'Test sketch solve line',
+          command: 'test.sketch-solve-line',
+          source: 'test',
+          keystrokes: ['l'],
+          scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
+        },
+      ],
+      [
+        createTestCommandSystemItem(
+          [
+            createTestCommand('test.sketch-solve-line', [
+              MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
+            ]),
+          ],
+          vi.fn()
+        ),
+      ]
+    )
     const keymap = registry.get(keymapService)
     const input = document.createElement('input')
     document.body.append(input)
@@ -474,6 +635,12 @@ describe('keymap extension', () => {
     keymap.applyScope(MODE_SKETCH_SOLVE_KEYMAP_SCOPE)
     keymap.removeScope(CODE_EDITOR_FOCUSED_KEYMAP_SCOPE)
     keymap.applyScope(CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE)
+    input.dispatchEvent(new FocusEvent('focusin', { bubbles: true }))
+
+    expect(keymap.getCurrentScopes()).not.toContain(
+      CODE_EDITOR_FOCUSED_KEYMAP_SCOPE
+    )
+    expect(keymap.getCurrentScopes()).toContain(EDITABLE_FOCUSED_KEYMAP_SCOPE)
 
     expect(
       keymap.handleKeyDown(createKeyboardEventWithTarget('l', input), {
@@ -485,17 +652,74 @@ describe('keymap extension', () => {
     registry[Symbol.dispose]()
   })
 
+  it('does not run modified mode shortcuts from input targets', () => {
+    const send = vi.fn()
+    const registry = createRegistryWithKeymapItems(
+      [
+        {
+          id: 'test.sketch-select-all-keymap',
+          title: 'Test sketch select all',
+          command: 'test.sketch-select-all',
+          source: 'test',
+          keystrokes: ['mod+a'],
+          scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
+        },
+      ],
+      [
+        createTestCommandSystemItem(
+          [
+            createTestCommand('test.sketch-select-all', [
+              MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
+            ]),
+          ],
+          send
+        ),
+      ]
+    )
+    const keymap = registry.get(keymapService)
+    const input = document.createElement('input')
+    document.body.append(input)
+
+    keymap.applyScope(MODE_SKETCH_SOLVE_KEYMAP_SCOPE)
+    input.dispatchEvent(new FocusEvent('focusin', { bubbles: true }))
+
+    const event = createKeyboardEventWithTarget('a', input, {
+      ctrlKey: true,
+      metaKey: true,
+      cancelable: true,
+    })
+    expect(keymap.getCurrentScopes()).toContain(EDITABLE_FOCUSED_KEYMAP_SCOPE)
+    expect(keymap.handleKeyDown(event, { source: 'global' })).toBe(false)
+    expect(event.defaultPrevented).toBe(false)
+    expect(send).not.toHaveBeenCalled()
+
+    input.remove()
+    registry[Symbol.dispose]()
+  })
+
   it('does not run mode keybindings from CodeMirror while the editor is focused', () => {
-    const registry = createRegistryWithKeymapItems([
-      {
-        id: 'test.sketch-solve-line',
-        title: 'Test sketch solve line',
-        command: 'zds.settings.tab',
-        source: 'test',
-        keystrokes: ['l'],
-        scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
-      },
-    ])
+    const registry = createRegistryWithKeymapItems(
+      [
+        {
+          id: 'test.sketch-solve-line-keymap',
+          title: 'Test sketch solve line',
+          command: 'test.sketch-solve-line',
+          source: 'test',
+          keystrokes: ['l'],
+          scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
+        },
+      ],
+      [
+        createTestCommandSystemItem(
+          [
+            createTestCommand('test.sketch-solve-line', [
+              MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
+            ]),
+          ],
+          vi.fn()
+        ),
+      ]
+    )
     const keymap = registry.get(keymapService)
     const event = new KeyboardEvent('keydown', { key: 'l' })
 
@@ -509,7 +733,22 @@ describe('keymap extension', () => {
   })
 
   it('handles default undo and redo keybindings from CodeMirror while the editor is focused', () => {
-    const registry = createRegistryWithKeymapItems([])
+    const registry = createRegistryWithKeymapItems(
+      [],
+      [
+        createTestCommandSystemItem(
+          ['zds.editor.undo', 'zds.editor.redo'].map((id) => ({
+            id,
+            scopes: [CODE_EDITOR_FOCUSED_KEYMAP_SCOPE],
+            groupId: 'test',
+            name: id,
+            needsReview: false,
+            onSubmit: vi.fn(),
+          })),
+          vi.fn()
+        ),
+      ]
+    )
     const keymap = registry.get(keymapService)
 
     keymap.removeScope(CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE)
@@ -540,17 +779,29 @@ describe('keymap extension', () => {
     registry[Symbol.dispose]()
   })
 
-  it('keeps editor focus priority until focus moves outside editable content', () => {
-    const registry = createRegistryWithKeymapItems([
-      {
-        id: 'test.sketch-solve-line',
-        title: 'Test sketch solve line',
-        command: 'zds.settings.tab',
-        source: 'test',
-        keystrokes: ['l'],
-        scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
-      },
-    ])
+  it('does not treat arbitrary editable content as the code editor', () => {
+    const registry = createRegistryWithKeymapItems(
+      [
+        {
+          id: 'test.sketch-solve-line-keymap',
+          title: 'Test sketch solve line',
+          command: 'test.sketch-solve-line',
+          source: 'test',
+          keystrokes: ['l'],
+          scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
+        },
+      ],
+      [
+        createTestCommandSystemItem(
+          [
+            createTestCommand('test.sketch-solve-line', [
+              MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
+            ]),
+          ],
+          vi.fn()
+        ),
+      ]
+    )
     const keymap = registry.get(keymapService)
     const editableTarget = document.createElement('div')
     editableTarget.contentEditable = 'true'
@@ -559,9 +810,10 @@ describe('keymap extension', () => {
     keymap.applyScope(MODE_SKETCH_SOLVE_KEYMAP_SCOPE)
     editableTarget.dispatchEvent(new FocusEvent('focusin', { bubbles: true }))
 
-    expect(keymap.getCurrentScopes()).toContain(
+    expect(keymap.getCurrentScopes()).not.toContain(
       CODE_EDITOR_FOCUSED_KEYMAP_SCOPE
     )
+    expect(keymap.getCurrentScopes()).toContain(EDITABLE_FOCUSED_KEYMAP_SCOPE)
     expect(
       keymap.handleKeyDown(createKeyboardEventWithTarget('l', editableTarget), {
         source: 'global',
@@ -570,11 +822,14 @@ describe('keymap extension', () => {
 
     document.body.dispatchEvent(new Event('pointerdown', { bubbles: true }))
 
+    expect(keymap.getCurrentScopes()).not.toContain(
+      EDITABLE_FOCUSED_KEYMAP_SCOPE
+    )
     expect(keymap.getCurrentScopes()).toContain(
       CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE
     )
     expect(
-      keymap.handleKeyDown(createKeyboardEventWithTarget('l', editableTarget), {
+      keymap.handleKeyDown(createKeyboardEventWithTarget('l', document.body), {
         source: 'global',
       })
     ).toBe(true)
@@ -584,16 +839,28 @@ describe('keymap extension', () => {
   })
 
   it('keeps editor focus priority while typing in the CodeMirror search field', () => {
-    const registry = createRegistryWithKeymapItems([
-      {
-        id: 'test.sketch-solve-line',
-        title: 'Test sketch solve line',
-        command: 'zds.settings.tab',
-        source: 'test',
-        keystrokes: ['l'],
-        scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
-      },
-    ])
+    const registry = createRegistryWithKeymapItems(
+      [
+        {
+          id: 'test.sketch-solve-line-keymap',
+          title: 'Test sketch solve line',
+          command: 'test.sketch-solve-line',
+          source: 'test',
+          keystrokes: ['l'],
+          scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
+        },
+      ],
+      [
+        createTestCommandSystemItem(
+          [
+            createTestCommand('test.sketch-solve-line', [
+              MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
+            ]),
+          ],
+          vi.fn()
+        ),
+      ]
+    )
     const keymap = registry.get(keymapService)
     const editor = document.createElement('div')
     const searchPanel = document.createElement('div')
@@ -697,8 +964,23 @@ function createTestCommandSystemItem(
   })
 }
 
-function createKeyboardEventWithTarget(key: string, target: EventTarget) {
-  const event = new KeyboardEvent('keydown', { key })
+function createTestCommand(id: string, scopes: Command['scopes']): Command {
+  return {
+    id,
+    scopes,
+    groupId: 'test',
+    name: id,
+    needsReview: false,
+    onSubmit: vi.fn(),
+  }
+}
+
+function createKeyboardEventWithTarget(
+  key: string,
+  target: EventTarget,
+  init: KeyboardEventInit = {}
+) {
+  const event = new KeyboardEvent('keydown', { ...init, key })
   Object.defineProperty(event, 'target', { value: target })
   return event
 }

--- a/src/registry/extensions/keymap/index.spec.ts
+++ b/src/registry/extensions/keymap/index.spec.ts
@@ -101,33 +101,16 @@ describe('keymap extension', () => {
   })
 
   it('marks a partial match and awaits more input', () => {
-    const registry = createRegistryWithKeymapItems(
-      [
-        {
-          id: 'test.keystrokes',
-          title: 'Test keystrokes',
-          command: 'test.keystrokes',
-          source: 'test',
-          keystrokes: ['q', 'w'],
-          scopes: [CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE],
-        },
-      ],
-      [
-        createTestCommandSystemItem(
-          [
-            {
-              id: 'test.keystrokes',
-              scopes: [CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE],
-              groupId: 'test',
-              name: 'Test keystrokes',
-              needsReview: false,
-              onSubmit: vi.fn(),
-            },
-          ],
-          vi.fn()
-        ),
-      ]
-    )
+    const registry = createRegistryWithKeymapItems([
+      {
+        id: 'test.keystrokes',
+        title: 'Test keystrokes',
+        command: 'test.keystrokes',
+        source: 'test',
+        keystrokes: ['q', 'w'],
+        scopes: [CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE],
+      },
+    ])
 
     const keymap = registry.get(keymapService)
     const event = new KeyboardEvent('keydown', { key: 'q' })
@@ -139,28 +122,16 @@ describe('keymap extension', () => {
   })
 
   it('runs a full match and clears partial match state', () => {
-    const registry = createRegistryWithKeymapItems(
-      [
-        {
-          id: 'test.full-keymap',
-          title: 'Test full',
-          command: 'test.full',
-          source: 'test',
-          keystrokes: ['x'],
-          scopes: [CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE],
-        },
-      ],
-      [
-        createTestCommandSystemItem(
-          [
-            createTestCommand('test.full', [
-              CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE,
-            ]),
-          ],
-          vi.fn()
-        ),
-      ]
-    )
+    const registry = createRegistryWithKeymapItems([
+      {
+        id: 'test.full-keymap',
+        title: 'Test full',
+        command: 'test.full',
+        source: 'test',
+        keystrokes: ['x'],
+        scopes: [CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE],
+      },
+    ])
 
     const keymap = registry.get(keymapService)
     const event = new KeyboardEvent('keydown', { key: 'x' })
@@ -172,33 +143,16 @@ describe('keymap extension', () => {
   })
 
   it('matches macOS Option-modified letter chords by physical key code', () => {
-    const registry = createRegistryWithKeymapItems(
-      [
-        {
-          id: 'test.alt-d',
-          title: 'Test Alt+D',
-          command: 'test.alt-d',
-          source: 'test',
-          keystrokes: ['alt+d'],
-          scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
-        },
-      ],
-      [
-        createTestCommandSystemItem(
-          [
-            {
-              id: 'test.alt-d',
-              scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
-              groupId: 'test',
-              name: 'Test Alt+D',
-              needsReview: false,
-              onSubmit: vi.fn(),
-            },
-          ],
-          vi.fn()
-        ),
-      ]
-    )
+    const registry = createRegistryWithKeymapItems([
+      {
+        id: 'test.alt-d',
+        title: 'Test Alt+D',
+        command: 'test.alt-d',
+        source: 'test',
+        keystrokes: ['alt+d'],
+        scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
+      },
+    ])
 
     const keymap = registry.get(keymapService)
     keymap.applyScope(MODE_SKETCH_SOLVE_KEYMAP_SCOPE)
@@ -292,39 +246,21 @@ describe('keymap extension', () => {
           arguments: { value: 'abc' },
         },
       ],
-      [
-        defineRegistryItem({
-          id: 'test-command-system',
-          providesServices: [
-            provideService(commandSystemService, {
-              actor: {
-                getSnapshot: () => ({
-                  context: {
-                    commands: [
-                      {
-                        id: 'test.command',
-                        groupId: 'test',
-                        name: 'Run test command',
-                        needsReview: false,
-                        scopes: GLOBAL_KEYMAP_SCOPES,
-                        args: {
-                          value: {
-                            inputType: 'string',
-                            required: true,
-                          },
-                        },
-                        onSubmit,
-                      },
-                    ],
-                  },
-                }),
+      {
+        commands: [
+          createTestCommand('test.command', GLOBAL_KEYMAP_SCOPES, {
+            name: 'Run test command',
+            args: {
+              value: {
+                inputType: 'string',
+                required: true,
               },
-              send,
-              useState: vi.fn(),
-            } as unknown as CommandSystemService),
-          ],
-        }),
-      ]
+            },
+            onSubmit,
+          }),
+        ],
+        send,
+      }
     )
 
     const keymap = registry.get(keymapService)
@@ -360,21 +296,14 @@ describe('keymap extension', () => {
           keystrokes: ['mod+u'],
         },
       ],
-      [
-        createTestCommandSystemItem(
-          [
-            {
-              id: 'test.file-command',
-              groupId: 'test',
-              name: 'Run file command',
-              needsReview: false,
-              scopes: FILE_KEYMAP_SCOPES,
-              onSubmit: vi.fn(),
-            },
-          ],
-          send
-        ),
-      ]
+      {
+        commands: [
+          createTestCommand('test.file-command', FILE_KEYMAP_SCOPES, {
+            name: 'Run file command',
+          }),
+        ],
+        send,
+      }
     )
     const keymap = registry.get(keymapService)
     const createEvent = () =>
@@ -427,29 +356,17 @@ describe('keymap extension', () => {
           keystrokes: ['mod+u'],
         },
       ],
-      [
-        createTestCommandSystemItem(
-          [
-            {
-              id: 'test.file-command',
-              groupId: 'test',
-              name: 'Run file command',
-              needsReview: false,
-              scopes: FILE_KEYMAP_SCOPES,
-              onSubmit: vi.fn(),
-            },
-            {
-              id: 'test.global-command',
-              scopes: GLOBAL_KEYMAP_SCOPES,
-              groupId: 'test',
-              name: 'Run global command',
-              needsReview: false,
-              onSubmit: vi.fn(),
-            },
-          ],
-          send
-        ),
-      ]
+      {
+        commands: [
+          createTestCommand('test.file-command', FILE_KEYMAP_SCOPES, {
+            name: 'Run file command',
+          }),
+          createTestCommand('test.global-command', GLOBAL_KEYMAP_SCOPES, {
+            name: 'Run global command',
+          }),
+        ],
+        send,
+      }
     )
     const keymap = registry.get(keymapService)
     const event = new KeyboardEvent('keydown', {
@@ -477,15 +394,18 @@ describe('keymap extension', () => {
   it.each(['test.command-that-no-longer-exists', 'toString'])(
     'does not consume a shortcut for unknown command %s',
     (command) => {
-      const registry = createRegistryWithKeymapItems([
-        {
-          id: 'test.stale-command-keymap',
-          title: 'Stale command keymap',
-          command,
-          source: 'User',
-          keystrokes: ['mod+u'],
-        },
-      ])
+      const registry = createRegistryWithKeymapItems(
+        [
+          {
+            id: 'test.stale-command-keymap',
+            title: 'Stale command keymap',
+            command,
+            source: 'User',
+            keystrokes: ['mod+u'],
+          },
+        ],
+        { commands: [] }
+      )
       const keymap = registry.get(keymapService)
       const event = new KeyboardEvent('keydown', {
         key: 'u',
@@ -508,32 +428,16 @@ describe('keymap extension', () => {
         resolveInitialRead = resolve
       })
     )
-    const registry = createRegistryWithKeymapItems(
-      [],
-      [
-        createTestCommandSystemItem(
-          [
-            {
-              id: 'zds.toolbar.sketchLegacy.line',
-              scopes: [MODE_SKETCHING_KEYMAP_SCOPE],
-              groupId: 'test',
-              name: 'Legacy sketch line',
-              needsReview: false,
-              onSubmit: vi.fn(),
-            },
-            {
-              id: 'zds.toolbar.sketch.line',
-              scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
-              groupId: 'test',
-              name: 'Sketch line',
-              needsReview: false,
-              onSubmit: vi.fn(),
-            },
-          ],
-          vi.fn()
-        ),
-      ]
-    )
+    const registry = createRegistryWithKeymapItems([], {
+      commands: [
+        createTestCommand('zds.toolbar.sketchLegacy.line', [
+          MODE_SKETCHING_KEYMAP_SCOPE,
+        ]),
+        createTestCommand('zds.toolbar.sketch.line', [
+          MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
+        ]),
+      ],
+    })
 
     const keymap = registry.get(keymapService)
     keymap.applyScope(MODE_SKETCHING_KEYMAP_SCOPE)
@@ -571,23 +475,15 @@ describe('keymap extension', () => {
   })
 
   it('lets CodeMirror source handle contenteditable targets', () => {
-    const registry = createRegistryWithKeymapItems(
-      [
-        {
-          id: 'test.code-mirror-keymap',
-          title: 'Test CodeMirror',
-          command: 'test.code-mirror',
-          source: 'test',
-          keystrokes: ['escape'],
-        },
-      ],
-      [
-        createTestCommandSystemItem(
-          [createTestCommand('test.code-mirror', GLOBAL_KEYMAP_SCOPES)],
-          vi.fn()
-        ),
-      ]
-    )
+    const registry = createRegistryWithKeymapItems([
+      {
+        id: 'test.code-mirror-keymap',
+        title: 'Test CodeMirror',
+        command: 'test.code-mirror',
+        source: 'test',
+        keystrokes: ['escape'],
+      },
+    ])
     const keymap = registry.get(keymapService)
     const target = document.createElement('div')
     target.contentEditable = 'true'
@@ -606,28 +502,16 @@ describe('keymap extension', () => {
   })
 
   it('ignores unmodified global shortcuts from input targets', () => {
-    const registry = createRegistryWithKeymapItems(
-      [
-        {
-          id: 'test.sketch-solve-line-keymap',
-          title: 'Test sketch solve line',
-          command: 'test.sketch-solve-line',
-          source: 'test',
-          keystrokes: ['l'],
-          scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
-        },
-      ],
-      [
-        createTestCommandSystemItem(
-          [
-            createTestCommand('test.sketch-solve-line', [
-              MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
-            ]),
-          ],
-          vi.fn()
-        ),
-      ]
-    )
+    const registry = createRegistryWithKeymapItems([
+      {
+        id: 'test.sketch-solve-line-keymap',
+        title: 'Test sketch solve line',
+        command: 'test.sketch-solve-line',
+        source: 'test',
+        keystrokes: ['l'],
+        scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
+      },
+    ])
     const keymap = registry.get(keymapService)
     const input = document.createElement('input')
     document.body.append(input)
@@ -665,16 +549,14 @@ describe('keymap extension', () => {
           scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
         },
       ],
-      [
-        createTestCommandSystemItem(
-          [
-            createTestCommand('test.sketch-select-all', [
-              MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
-            ]),
-          ],
-          send
-        ),
-      ]
+      {
+        commands: [
+          createTestCommand('test.sketch-select-all', [
+            MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
+          ]),
+        ],
+        send,
+      }
     )
     const keymap = registry.get(keymapService)
     const input = document.createElement('input')
@@ -698,28 +580,16 @@ describe('keymap extension', () => {
   })
 
   it('does not run mode keybindings from CodeMirror while the editor is focused', () => {
-    const registry = createRegistryWithKeymapItems(
-      [
-        {
-          id: 'test.sketch-solve-line-keymap',
-          title: 'Test sketch solve line',
-          command: 'test.sketch-solve-line',
-          source: 'test',
-          keystrokes: ['l'],
-          scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
-        },
-      ],
-      [
-        createTestCommandSystemItem(
-          [
-            createTestCommand('test.sketch-solve-line', [
-              MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
-            ]),
-          ],
-          vi.fn()
-        ),
-      ]
-    )
+    const registry = createRegistryWithKeymapItems([
+      {
+        id: 'test.sketch-solve-line-keymap',
+        title: 'Test sketch solve line',
+        command: 'test.sketch-solve-line',
+        source: 'test',
+        keystrokes: ['l'],
+        scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
+      },
+    ])
     const keymap = registry.get(keymapService)
     const event = new KeyboardEvent('keydown', { key: 'l' })
 
@@ -733,22 +603,11 @@ describe('keymap extension', () => {
   })
 
   it('handles default undo and redo keybindings from CodeMirror while the editor is focused', () => {
-    const registry = createRegistryWithKeymapItems(
-      [],
-      [
-        createTestCommandSystemItem(
-          ['zds.editor.undo', 'zds.editor.redo'].map((id) => ({
-            id,
-            scopes: [CODE_EDITOR_FOCUSED_KEYMAP_SCOPE],
-            groupId: 'test',
-            name: id,
-            needsReview: false,
-            onSubmit: vi.fn(),
-          })),
-          vi.fn()
-        ),
-      ]
-    )
+    const registry = createRegistryWithKeymapItems([], {
+      commands: ['zds.editor.undo', 'zds.editor.redo'].map((id) =>
+        createTestCommand(id, [CODE_EDITOR_FOCUSED_KEYMAP_SCOPE])
+      ),
+    })
     const keymap = registry.get(keymapService)
 
     keymap.removeScope(CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE)
@@ -780,28 +639,16 @@ describe('keymap extension', () => {
   })
 
   it('does not treat arbitrary editable content as the code editor', () => {
-    const registry = createRegistryWithKeymapItems(
-      [
-        {
-          id: 'test.sketch-solve-line-keymap',
-          title: 'Test sketch solve line',
-          command: 'test.sketch-solve-line',
-          source: 'test',
-          keystrokes: ['l'],
-          scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
-        },
-      ],
-      [
-        createTestCommandSystemItem(
-          [
-            createTestCommand('test.sketch-solve-line', [
-              MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
-            ]),
-          ],
-          vi.fn()
-        ),
-      ]
-    )
+    const registry = createRegistryWithKeymapItems([
+      {
+        id: 'test.sketch-solve-line-keymap',
+        title: 'Test sketch solve line',
+        command: 'test.sketch-solve-line',
+        source: 'test',
+        keystrokes: ['l'],
+        scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
+      },
+    ])
     const keymap = registry.get(keymapService)
     const editableTarget = document.createElement('div')
     editableTarget.contentEditable = 'true'
@@ -839,28 +686,16 @@ describe('keymap extension', () => {
   })
 
   it('keeps editor focus priority while typing in the CodeMirror search field', () => {
-    const registry = createRegistryWithKeymapItems(
-      [
-        {
-          id: 'test.sketch-solve-line-keymap',
-          title: 'Test sketch solve line',
-          command: 'test.sketch-solve-line',
-          source: 'test',
-          keystrokes: ['l'],
-          scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
-        },
-      ],
-      [
-        createTestCommandSystemItem(
-          [
-            createTestCommand('test.sketch-solve-line', [
-              MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
-            ]),
-          ],
-          vi.fn()
-        ),
-      ]
-    )
+    const registry = createRegistryWithKeymapItems([
+      {
+        id: 'test.sketch-solve-line-keymap',
+        title: 'Test sketch solve line',
+        command: 'test.sketch-solve-line',
+        source: 'test',
+        keystrokes: ['l'],
+        scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
+      },
+    ])
     const keymap = registry.get(keymapService)
     const editor = document.createElement('div')
     const searchPanel = document.createElement('div')
@@ -927,15 +762,26 @@ describe('keymap extension', () => {
   })
 })
 
+type TestRegistryOptions = {
+  commands?: Command[]
+  send?: CommandSystemService['send']
+}
+
 function createRegistryWithKeymapItems(
   items: Parameters<typeof provideKeymapItem>[0][],
-  extraItems: Parameters<Registry['configure']>[0] = []
+  options: TestRegistryOptions = {}
 ) {
+  const inferredCommands = [...new Set(items.map((item) => item.command))].map(
+    (id) => createTestCommand(id, GLOBAL_KEYMAP_SCOPES)
+  )
+  const commands = options.commands ?? inferredCommands
   const keymapSlot = new Slot()
   const registry = new Registry()
   registry.configure([
     keymapExtension,
-    ...extraItems,
+    ...(commands.length > 0
+      ? [createTestCommandSystemItem(commands, options.send ?? vi.fn())]
+      : []),
     keymapSlot.of(
       defineRegistryItem({
         id: 'test-keymap-items',
@@ -964,7 +810,11 @@ function createTestCommandSystemItem(
   })
 }
 
-function createTestCommand(id: string, scopes: Command['scopes']): Command {
+function createTestCommand(
+  id: string,
+  scopes: Command['scopes'],
+  overrides: Partial<Omit<Command, 'id' | 'scopes'>> = {}
+): Command {
   return {
     id,
     scopes,
@@ -972,6 +822,7 @@ function createTestCommand(id: string, scopes: Command['scopes']): Command {
     name: id,
     needsReview: false,
     onSubmit: vi.fn(),
+    ...overrides,
   }
 }
 

--- a/src/registry/extensions/keymap/index.spec.ts
+++ b/src/registry/extensions/keymap/index.spec.ts
@@ -206,15 +206,8 @@ describe('keymap extension', () => {
       },
     ])
     const keymap = registry.get(keymapService)
-    const createEvent = () =>
-      new KeyboardEvent('keydown', {
-        key: 'u',
-        ctrlKey: true,
-        metaKey: true,
-        cancelable: true,
-      })
 
-    const outsideSettingsEvent = createEvent()
+    const outsideSettingsEvent = createModUEvent()
     expect(
       keymap.handleKeyDown(outsideSettingsEvent, { source: 'global' })
     ).toBe(false)
@@ -222,7 +215,7 @@ describe('keymap extension', () => {
     expect(new URL(window.location.href).searchParams.get('tab')).toBe('user')
 
     keymap.applyScope(SETTINGS_KEYMAP_SCOPE)
-    const settingsEvent = createEvent()
+    const settingsEvent = createModUEvent()
     expect(keymap.handleKeyDown(settingsEvent, { source: 'global' })).toBe(true)
     expect(settingsEvent.defaultPrevented).toBe(true)
     expect(new URL(window.location.href).searchParams.get('tab')).toBe(
@@ -264,11 +257,7 @@ describe('keymap extension', () => {
     )
 
     const keymap = registry.get(keymapService)
-    const event = new KeyboardEvent('keydown', {
-      key: 'u',
-      ctrlKey: true,
-      metaKey: true,
-    })
+    const event = createModUEvent()
 
     expect(keymap.handleKeyDown(event, { source: 'global' })).toBe(true)
     expect(send).toHaveBeenCalledWith({
@@ -306,87 +295,26 @@ describe('keymap extension', () => {
       }
     )
     const keymap = registry.get(keymapService)
-    const createEvent = () =>
-      new KeyboardEvent('keydown', {
-        key: 'u',
-        ctrlKey: true,
-        metaKey: true,
-        cancelable: true,
-      })
 
     keymap.applyScope(HOME_KEYMAP_SCOPE)
-    const homeEvent = createEvent()
+    const homeEvent = createModUEvent()
     expect(keymap.handleKeyDown(homeEvent, { source: 'global' })).toBe(false)
     expect(homeEvent.defaultPrevented).toBe(false)
     expect(send).not.toHaveBeenCalled()
 
     keymap.applyScope(MODE_MODELING_KEYMAP_SCOPE)
-    const modelingEvent = createEvent()
+    const modelingEvent = createModUEvent()
     expect(keymap.handleKeyDown(modelingEvent, { source: 'global' })).toBe(true)
     expect(modelingEvent.defaultPrevented).toBe(true)
     expect(send).toHaveBeenCalledOnce()
 
     keymap.applyScope(SETTINGS_KEYMAP_SCOPE)
-    const settingsEvent = createEvent()
+    const settingsEvent = createModUEvent()
     expect(keymap.handleKeyDown(settingsEvent, { source: 'global' })).toBe(
       false
     )
     expect(settingsEvent.defaultPrevented).toBe(false)
     expect(send).toHaveBeenCalledOnce()
-
-    registry[Symbol.dispose]()
-  })
-
-  it('falls back to an available command sharing an unavailable command chord', () => {
-    const send = vi.fn()
-    const registry = createRegistryWithKeymapItems(
-      [
-        {
-          id: 'test.file-command-keymap',
-          title: 'Test file command keymap',
-          command: 'test.file-command',
-          source: 'User',
-          keystrokes: ['mod+u'],
-        },
-        {
-          id: 'test.global-command-keymap',
-          title: 'Test global command keymap',
-          command: 'test.global-command',
-          source: 'User',
-          keystrokes: ['mod+u'],
-        },
-      ],
-      {
-        commands: [
-          createTestCommand('test.file-command', FILE_KEYMAP_SCOPES, {
-            name: 'Run file command',
-          }),
-          createTestCommand('test.global-command', GLOBAL_KEYMAP_SCOPES, {
-            name: 'Run global command',
-          }),
-        ],
-        send,
-      }
-    )
-    const keymap = registry.get(keymapService)
-    const event = new KeyboardEvent('keydown', {
-      key: 'u',
-      ctrlKey: true,
-      metaKey: true,
-      cancelable: true,
-    })
-
-    keymap.applyScope(HOME_KEYMAP_SCOPE)
-
-    expect(keymap.handleKeyDown(event, { source: 'global' })).toBe(true)
-    expect(event.defaultPrevented).toBe(true)
-    expect(send).toHaveBeenCalledWith({
-      type: 'Find and select command',
-      data: {
-        groupId: 'test',
-        name: 'Run global command',
-      },
-    })
 
     registry[Symbol.dispose]()
   })
@@ -407,12 +335,7 @@ describe('keymap extension', () => {
         { commands: [] }
       )
       const keymap = registry.get(keymapService)
-      const event = new KeyboardEvent('keydown', {
-        key: 'u',
-        ctrlKey: true,
-        metaKey: true,
-        cancelable: true,
-      })
+      const event = createModUEvent()
 
       expect(keymap.handleKeyDown(event, { source: 'global' })).toBe(false)
       expect(event.defaultPrevented).toBe(false)
@@ -834,4 +757,13 @@ function createKeyboardEventWithTarget(
   const event = new KeyboardEvent('keydown', { ...init, key })
   Object.defineProperty(event, 'target', { value: target })
   return event
+}
+
+function createModUEvent() {
+  return new KeyboardEvent('keydown', {
+    key: 'u',
+    ctrlKey: true,
+    metaKey: true,
+    cancelable: true,
+  })
 }

--- a/src/registry/extensions/keymap/index.ts
+++ b/src/registry/extensions/keymap/index.ts
@@ -15,23 +15,16 @@ import { isArray } from '@src/lib/utils'
 import {
   commandKey,
   commandSystemService,
+  isCommandAvailable,
 } from '@src/registry/contracts/commands'
 import {
-  BASE_KEYMAP_SCOPE,
   CODE_EDITOR_FOCUSED_KEYMAP_SCOPE,
   CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE,
-  HOME_KEYMAP_SCOPE,
+  DEFAULT_KEYMAP_SCOPES,
   type KeymapArguments,
   type KeymapItem,
-  type KeymapScope,
   type KeymapService,
   type KeymapSource,
-  MODE_MODELING_KEYMAP_SCOPE,
-  MODE_SKETCHING_KEYMAP_SCOPE,
-  MODE_SKETCH_NO_FACE_KEYMAP_SCOPE,
-  MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
-  PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE,
-  PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE,
   createEmptyPersistedKeymap,
   createKeymapTree,
   createUnbindBinding,
@@ -51,92 +44,7 @@ import {
 import { createElement } from 'react'
 
 const PARTIAL_MATCH_TIMEOUT_MS = 1500
-const KEYMAP_CONTEXT_SCOPE_GROUP = 'context'
-const KEYMAP_PROJECT_EXPLORER_SCOPE_GROUP = 'project-explorer'
 type SettingsKeymapTab = 'project' | 'user' | 'keybindings' | 'plugins'
-
-const defaultKeymapScopes: readonly KeymapScope[] = [
-  {
-    id: BASE_KEYMAP_SCOPE,
-    displayName: 'Base',
-    priority: 0,
-    userEditable: false,
-  },
-  {
-    id: 'cmd-palette-open',
-    displayName: 'Command palette open',
-    priority: 2000,
-    userEditable: false,
-  },
-  {
-    id: 'settings-open',
-    displayName: 'Settings open',
-    priority: 1900,
-    userEditable: false,
-  },
-  {
-    id: HOME_KEYMAP_SCOPE,
-    displayName: 'Home',
-    priority: 50,
-    userEditable: false,
-  },
-  {
-    id: CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE,
-    displayName: 'Code editor not focused',
-    group: KEYMAP_CONTEXT_SCOPE_GROUP,
-    priority: 10,
-    userEditable: false,
-  },
-  {
-    id: MODE_MODELING_KEYMAP_SCOPE,
-    displayName: 'Modeling mode',
-    group: KEYMAP_CONTEXT_SCOPE_GROUP,
-    priority: 100,
-    userEditable: false,
-  },
-  {
-    id: MODE_SKETCHING_KEYMAP_SCOPE,
-    displayName: 'Legacy sketch mode',
-    group: KEYMAP_CONTEXT_SCOPE_GROUP,
-    priority: 200,
-    userEditable: false,
-  },
-  {
-    id: MODE_SKETCH_NO_FACE_KEYMAP_SCOPE,
-    displayName: 'Sketch no face mode',
-    group: KEYMAP_CONTEXT_SCOPE_GROUP,
-    priority: 210,
-    userEditable: false,
-  },
-  {
-    id: MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
-    displayName: 'Sketch mode',
-    group: KEYMAP_CONTEXT_SCOPE_GROUP,
-    priority: 220,
-    userEditable: false,
-  },
-  {
-    id: CODE_EDITOR_FOCUSED_KEYMAP_SCOPE,
-    displayName: 'Code editor focused',
-    group: KEYMAP_CONTEXT_SCOPE_GROUP,
-    priority: 1000,
-    userEditable: false,
-  },
-  {
-    id: PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE,
-    displayName: 'Project explorer focused',
-    group: KEYMAP_PROJECT_EXPLORER_SCOPE_GROUP,
-    priority: 100,
-    userEditable: false,
-  },
-  {
-    id: PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE,
-    displayName: 'Project explorer renaming',
-    group: KEYMAP_PROJECT_EXPLORER_SCOPE_GROUP,
-    priority: 200,
-    userEditable: false,
-  },
-]
 
 const keymapExtension = defineRegistryItemFactory((ctx) => {
   const contributedKeymapSignal = ctx.valueSpecs.signal(keymapValueSpec)
@@ -247,11 +155,29 @@ const keymapExtension = defineRegistryItemFactory((ctx) => {
       return false
     }
 
+    const commandSystem = ctx.services.optional(commandSystemService)
+    const registeredCommands =
+      commandSystem?.actor.getSnapshot().context.commands ?? []
+    const isItemAvailable = (item: KeymapItem) => {
+      const command = registeredCommands.find(
+        (candidate) => commandKey(candidate) === item.command
+      )
+
+      return (
+        command === undefined ||
+        isCommandAvailable(
+          command,
+          activeScopes.value,
+          keymapScopesSignal.value
+        )
+      )
+    }
     const match = matchKeymapKeystrokes(
       keymapSignal.value,
       activeScopes.value,
       [...pendingKeystrokes, chord],
-      keymapScopesSignal.value
+      keymapScopesSignal.value,
+      isItemAvailable
     )
 
     if (match.type === 'prefix') {
@@ -283,7 +209,8 @@ const keymapExtension = defineRegistryItemFactory((ctx) => {
       keymapSignal.value,
       activeScopes.value,
       [chord],
-      keymapScopesSignal.value
+      keymapScopesSignal.value,
+      isItemAvailable
     )
 
     if (retryMatch.type === 'prefix') {
@@ -398,7 +325,11 @@ const keymapExtension = defineRegistryItemFactory((ctx) => {
     const command = commandSystem?.actor
       .getSnapshot()
       .context.commands.find((cmd) => commandKey(cmd) === item.command)
-    if (!command || !commandSystem) {
+    if (
+      !command ||
+      !commandSystem ||
+      !isCommandAvailable(command, activeScopes.value, keymapScopesSignal.value)
+    ) {
       return
     }
 
@@ -476,7 +407,7 @@ const keymapExtension = defineRegistryItemFactory((ctx) => {
       id: 'keymap-extension',
       providesServices: [provideService(keymapService, serviceImpl)],
       provides: [
-        ...defaultKeymapScopes.map((scope) =>
+        ...DEFAULT_KEYMAP_SCOPES.map((scope) =>
           provide(keymapScopesValueSpec, scope, { key: scope.id })
         ),
         provide(

--- a/src/registry/extensions/keymap/index.ts
+++ b/src/registry/extensions/keymap/index.ts
@@ -8,7 +8,7 @@ import {
 import { computed, signal } from '@preact/signals-core'
 import { useSignals } from '@preact/signals-react/runtime'
 import type { StatusBarItemType } from '@src/components/StatusBar/statusBarTypes'
-import type { CommandScopes } from '@src/lib/commandTypes'
+import type { Command, CommandScopes } from '@src/lib/commandTypes'
 import makeUrlPathRelative from '@src/lib/makeUrlPathRelative'
 import { PATHS, webSafeJoin } from '@src/lib/paths'
 import { reportRejection } from '@src/lib/trap'
@@ -16,6 +16,7 @@ import { isArray } from '@src/lib/utils'
 import {
   commandKey,
   commandSystemService,
+  getEffectiveCommandScopeSet,
   isCommandAvailable,
 } from '@src/registry/contracts/commands'
 import {
@@ -51,12 +52,10 @@ import { createElement } from 'react'
 const PARTIAL_MATCH_TIMEOUT_MS = 1500
 type SettingsKeymapTab = 'project' | 'user' | 'keybindings' | 'plugins'
 
-const BUILT_IN_KEYMAP_COMMAND_SCOPES = new Map<string, CommandScopes>([
-  ['zds.commandPalette.open', GLOBAL_KEYMAP_SCOPES],
-  ['zds.commandPalette.close', [COMMAND_PALETTE_OPEN_KEYMAP_SCOPE]],
-  ['zds.settings.open', GLOBAL_KEYMAP_SCOPES],
-  ['zds.settings.tab', [SETTINGS_KEYMAP_SCOPE]],
-])
+type BuiltInKeymapCommand = {
+  scopes: CommandScopes
+  run: (item: KeymapItem) => unknown
+}
 
 const keymapExtension = defineRegistryItemFactory((ctx) => {
   const contributedKeymapSignal = ctx.valueSpecs.signal(keymapValueSpec)
@@ -75,6 +74,39 @@ const keymapExtension = defineRegistryItemFactory((ctx) => {
   ])
   const partialMatch = signal(false)
   const partialMatchProgress = signal(0)
+  const builtInKeymapCommands = new Map<string, BuiltInKeymapCommand>([
+    [
+      'zds.commandPalette.open',
+      {
+        scopes: GLOBAL_KEYMAP_SCOPES,
+        run: () =>
+          ctx.services.optional(commandSystemService)?.send({ type: 'Open' }),
+      },
+    ],
+    [
+      'zds.commandPalette.close',
+      {
+        scopes: [COMMAND_PALETTE_OPEN_KEYMAP_SCOPE],
+        run: () =>
+          ctx.services.optional(commandSystemService)?.send({ type: 'Close' }),
+      },
+    ],
+    [
+      'zds.settings.open',
+      {
+        scopes: GLOBAL_KEYMAP_SCOPES,
+        run: openSettings,
+      },
+    ],
+    [
+      'zds.settings.tab',
+      {
+        scopes: [SETTINGS_KEYMAP_SCOPE],
+        run: (item) =>
+          updateSettingsTab(getSettingsTabArgument(item.arguments)),
+      },
+    ],
+  ])
 
   const pendingKeystrokesBySource: Record<KeymapSource, string[]> = {
     global: [],
@@ -166,20 +198,28 @@ const keymapExtension = defineRegistryItemFactory((ctx) => {
     const commandSystem = ctx.services.optional(commandSystemService)
     const registeredCommands =
       commandSystem?.actor.getSnapshot().context.commands ?? []
+    const commandsByKey = new Map<string, Command>()
+    for (const command of registeredCommands) {
+      const key = commandKey(command)
+      if (!commandsByKey.has(key)) {
+        commandsByKey.set(key, command)
+      }
+    }
+    const effectiveCommandScopes = getEffectiveCommandScopeSet(
+      activeScopes.value,
+      keymapScopesSignal.value
+    )
     const isItemAvailable = (item: KeymapItem) => {
-      const command = registeredCommands.find(
-        (candidate) => commandKey(candidate) === item.command
-      )
-
-      const requiredScopes =
-        BUILT_IN_KEYMAP_COMMAND_SCOPES.get(item.command) ?? command?.scopes
-
-      return isCommandAvailable(
-        { scopes: requiredScopes },
-        activeScopes.value,
-        keymapScopesSignal.value
+      const command =
+        builtInKeymapCommands.get(item.command) ??
+        commandsByKey.get(item.command)
+      return (
+        command !== undefined &&
+        isCommandAvailable(command, effectiveCommandScopes)
       )
     }
+    const runAvailableKeymapItem = (item: KeymapItem) =>
+      runKeymapItem(item, commandsByKey, isItemAvailable(item))
     const match = matchKeymapKeystrokes(
       keymapSignal.value,
       activeScopes.value,
@@ -203,7 +243,7 @@ const keymapExtension = defineRegistryItemFactory((ctx) => {
       event.stopPropagation()
       event.stopImmediatePropagation()
       clearPendingKeystrokes()
-      runKeymapItem(match.item)
+      runAvailableKeymapItem(match.item)
       return true
     }
 
@@ -235,7 +275,7 @@ const keymapExtension = defineRegistryItemFactory((ctx) => {
       event.preventDefault()
       event.stopPropagation()
       event.stopImmediatePropagation()
-      runKeymapItem(retryMatch.item)
+      runAvailableKeymapItem(retryMatch.item)
       return true
     }
 
@@ -302,42 +342,31 @@ const keymapExtension = defineRegistryItemFactory((ctx) => {
     }),
   }
 
-  function runKeymapItem(item: KeymapItem) {
-    const result = runBuiltInKeymapCommand(item)
+  function runKeymapItem(
+    item: KeymapItem,
+    commandsByKey: ReadonlyMap<string, Command>,
+    isAvailable: boolean
+  ) {
+    if (!isAvailable) {
+      return
+    }
+
+    const builtInCommand = builtInKeymapCommands.get(item.command)
+    const result = builtInCommand
+      ? builtInCommand.run(item)
+      : runCommandById(item, commandsByKey)
     if (result instanceof Promise) {
       result.catch(reportRejection)
     }
   }
 
-  function runBuiltInKeymapCommand(item: KeymapItem): unknown {
-    switch (item.command) {
-      case 'zds.commandPalette.open':
-        return ctx.services
-          .optional(commandSystemService)
-          ?.send({ type: 'Open' })
-      case 'zds.commandPalette.close':
-        return ctx.services
-          .optional(commandSystemService)
-          ?.send({ type: 'Close' })
-      case 'zds.settings.open':
-        return openSettings()
-      case 'zds.settings.tab':
-        return updateSettingsTab(getSettingsTabArgument(item.arguments))
-      default:
-        return runCommandById(item)
-    }
-  }
-
-  function runCommandById(item: KeymapItem) {
+  function runCommandById(
+    item: KeymapItem,
+    commandsByKey: ReadonlyMap<string, Command>
+  ) {
     const commandSystem = ctx.services.optional(commandSystemService)
-    const command = commandSystem?.actor
-      .getSnapshot()
-      .context.commands.find((cmd) => commandKey(cmd) === item.command)
-    if (
-      !command ||
-      !commandSystem ||
-      !isCommandAvailable(command, activeScopes.value, keymapScopesSignal.value)
-    ) {
+    const command = commandsByKey.get(item.command)
+    if (!command || !commandSystem) {
       return
     }
 

--- a/src/registry/extensions/keymap/index.ts
+++ b/src/registry/extensions/keymap/index.ts
@@ -8,6 +8,7 @@ import {
 import { computed, signal } from '@preact/signals-core'
 import { useSignals } from '@preact/signals-react/runtime'
 import type { StatusBarItemType } from '@src/components/StatusBar/statusBarTypes'
+import type { CommandScopes } from '@src/lib/commandTypes'
 import makeUrlPathRelative from '@src/lib/makeUrlPathRelative'
 import { PATHS, webSafeJoin } from '@src/lib/paths'
 import { reportRejection } from '@src/lib/trap'
@@ -20,7 +21,10 @@ import {
 import {
   CODE_EDITOR_FOCUSED_KEYMAP_SCOPE,
   CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE,
+  COMMAND_PALETTE_OPEN_KEYMAP_SCOPE,
   DEFAULT_KEYMAP_SCOPES,
+  EDITABLE_FOCUSED_KEYMAP_SCOPE,
+  GLOBAL_KEYMAP_SCOPES,
   type KeymapArguments,
   type KeymapItem,
   type KeymapService,
@@ -34,6 +38,7 @@ import {
   matchKeymapKeystrokes,
   normalizeEventKey,
   resolveKeymapItems,
+  SETTINGS_KEYMAP_SCOPE,
 } from '@src/registry/contracts/keymap'
 import { statusBarLocalItemsValueSpec } from '@src/registry/contracts/statusBar'
 import { defaultKeymapItem } from '@src/registry/extensions/keymap/defaultKeymap'
@@ -45,6 +50,13 @@ import { createElement } from 'react'
 
 const PARTIAL_MATCH_TIMEOUT_MS = 1500
 type SettingsKeymapTab = 'project' | 'user' | 'keybindings' | 'plugins'
+
+const BUILT_IN_KEYMAP_COMMAND_SCOPES = new Map<string, CommandScopes>([
+  ['zds.commandPalette.open', GLOBAL_KEYMAP_SCOPES],
+  ['zds.commandPalette.close', [COMMAND_PALETTE_OPEN_KEYMAP_SCOPE]],
+  ['zds.settings.open', GLOBAL_KEYMAP_SCOPES],
+  ['zds.settings.tab', [SETTINGS_KEYMAP_SCOPE]],
+])
 
 const keymapExtension = defineRegistryItemFactory((ctx) => {
   const contributedKeymapSignal = ctx.valueSpecs.signal(keymapValueSpec)
@@ -146,11 +158,7 @@ const keymapExtension = defineRegistryItemFactory((ctx) => {
     if (
       !chord ||
       (source === 'global' &&
-        shouldIgnoreKeyboardEvent(
-          event,
-          pendingKeystrokes.length > 0,
-          activeScopes.value
-        ))
+        shouldIgnoreKeyboardEvent(event, pendingKeystrokes.length > 0))
     ) {
       return false
     }
@@ -163,13 +171,13 @@ const keymapExtension = defineRegistryItemFactory((ctx) => {
         (candidate) => commandKey(candidate) === item.command
       )
 
-      return (
-        command === undefined ||
-        isCommandAvailable(
-          command,
-          activeScopes.value,
-          keymapScopesSignal.value
-        )
+      const requiredScopes =
+        BUILT_IN_KEYMAP_COMMAND_SCOPES.get(item.command) ?? command?.scopes
+
+      return isCommandAvailable(
+        { scopes: requiredScopes },
+        activeScopes.value,
+        keymapScopesSignal.value
       )
     }
     const match = matchKeymapKeystrokes(
@@ -375,23 +383,31 @@ const keymapExtension = defineRegistryItemFactory((ctx) => {
     handleKeyDown(event, { source: 'global' })
   }
 
-  const syncEditorFocusScopeFromEventTarget = (target: EventTarget | null) => {
-    if (isEventFromEditableTarget(target)) {
+  const syncFocusScopeFromEventTarget = (target: EventTarget | null) => {
+    if (isEventFromCodeEditor(target)) {
       serviceImpl.removeScope(CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE)
+      serviceImpl.removeScope(EDITABLE_FOCUSED_KEYMAP_SCOPE)
       serviceImpl.applyScope(CODE_EDITOR_FOCUSED_KEYMAP_SCOPE)
       return
     }
 
     serviceImpl.removeScope(CODE_EDITOR_FOCUSED_KEYMAP_SCOPE)
+    if (isEventFromEditableTarget(target)) {
+      serviceImpl.removeScope(CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE)
+      serviceImpl.applyScope(EDITABLE_FOCUSED_KEYMAP_SCOPE)
+      return
+    }
+
+    serviceImpl.removeScope(EDITABLE_FOCUSED_KEYMAP_SCOPE)
     serviceImpl.applyScope(CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE)
   }
 
   const handleGlobalFocusIn = (event: FocusEvent) => {
-    syncEditorFocusScopeFromEventTarget(event.target)
+    syncFocusScopeFromEventTarget(event.target)
   }
 
   const handleGlobalPointerDown = (event: PointerEvent) => {
-    syncEditorFocusScopeFromEventTarget(event.target)
+    syncFocusScopeFromEventTarget(event.target)
   }
 
   if (typeof window !== 'undefined') {
@@ -496,8 +512,7 @@ function isMacPlatform() {
 
 function shouldIgnoreKeyboardEvent(
   event: KeyboardEvent,
-  hasPendingKeystrokes: boolean,
-  scopes: readonly string[]
+  hasPendingKeystrokes: boolean
 ) {
   if (event.metaKey || event.ctrlKey || event.altKey || hasPendingKeystrokes) {
     return false
@@ -505,9 +520,12 @@ function shouldIgnoreKeyboardEvent(
 
   return (
     isEventFromFormControl(event.target) ||
-    (scopes.includes(CODE_EDITOR_FOCUSED_KEYMAP_SCOPE) &&
-      isEventFromContentEditableTarget(event.target))
+    isEventFromContentEditableTarget(event.target)
   )
+}
+
+function isEventFromCodeEditor(target: EventTarget | null) {
+  return target instanceof Element && target.closest('.cm-editor') !== null
 }
 
 function isEventFromEditableTarget(target: EventTarget | null) {

--- a/src/registry/extensions/markdownEditor/index.ts
+++ b/src/registry/extensions/markdownEditor/index.ts
@@ -153,12 +153,14 @@ const markdownEditorKeymaps: readonly MarkdownEditorKeymapDefinition[] = [
   },
 ]
 
+const MARKDOWN_EDITOR_SCOPES = [MARKDOWN_EDITOR_FOCUSED_KEYMAP_SCOPE] as const
+
 const markdownEditorKeymapItems: readonly KeymapItem[] =
   markdownEditorKeymaps.map((keymap) => ({
     id: keymap.id,
     title: keymap.title,
     source: MARKDOWN_EDITOR_KEYMAP_SOURCE,
-    scopes: [MARKDOWN_EDITOR_FOCUSED_KEYMAP_SCOPE],
+    scopes: MARKDOWN_EDITOR_SCOPES,
     keystrokes: keymap.keystrokes,
     command: keymap.command,
     hidden: keymap.hidden,
@@ -173,7 +175,7 @@ const markdownEditorCommands: readonly Command[] = Object.values(
 
   return {
     id: commandId,
-    scopes: [MARKDOWN_EDITOR_FOCUSED_KEYMAP_SCOPE],
+    scopes: MARKDOWN_EDITOR_SCOPES,
     name: commandId,
     groupId: MARKDOWN_EDITOR_COMMAND_GROUP_ID,
     displayName: keymap?.title ?? commandId,

--- a/src/registry/extensions/markdownEditor/index.ts
+++ b/src/registry/extensions/markdownEditor/index.ts
@@ -173,6 +173,7 @@ const markdownEditorCommands: readonly Command[] = Object.values(
 
   return {
     id: commandId,
+    scopes: [MARKDOWN_EDITOR_FOCUSED_KEYMAP_SCOPE],
     name: commandId,
     groupId: MARKDOWN_EDITOR_COMMAND_GROUP_ID,
     displayName: keymap?.title ?? commandId,

--- a/src/registry/plugins/codeEditor/index.ts
+++ b/src/registry/plugins/codeEditor/index.ts
@@ -10,12 +10,9 @@ import type { AppHeaderItemProps } from '@src/registry/contracts/appHeader'
 import { appHeaderItemsValueSpec } from '@src/registry/contracts/appHeader'
 import { executingEditorService } from '@src/registry/contracts/executingEditor'
 import {
-  type KeymapDocument,
-  MODE_MODELING_KEYMAP_SCOPE,
-  MODE_SKETCHING_KEYMAP_SCOPE,
-  MODE_SKETCH_NO_FACE_KEYMAP_SCOPE,
-  MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
+  FILE_AND_CODE_EDITOR_KEYMAP_SCOPES,
   findKeymapItemForCommand,
+  type KeymapDocument,
   keymapKeystrokesDisplay,
   keymapScopesValueSpec,
   keymapService,
@@ -36,12 +33,7 @@ const codeEditorKeymap: KeymapDocument = {
     {
       id: 'code-editor.render',
       title: 'Render code',
-      scopes: [
-        MODE_MODELING_KEYMAP_SCOPE,
-        MODE_SKETCHING_KEYMAP_SCOPE,
-        MODE_SKETCH_NO_FACE_KEYMAP_SCOPE,
-        MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
-      ],
+      scopes: FILE_AND_CODE_EDITOR_KEYMAP_SCOPES,
       keystrokes: [RENDER_HOTKEY],
       command: APP_COMMAND_IDS.editor.render,
     },

--- a/src/registry/plugins/slicer/index.ts
+++ b/src/registry/plugins/slicer/index.ts
@@ -20,6 +20,7 @@ import {
   layoutActionLibraryValueSpec,
   layoutContributionsValueSpec,
 } from '@src/lib/layout/registry/contract'
+import { MODE_MODELING_KEYMAP_SCOPE } from '@src/registry/contracts/keymap'
 import { createZdsPlugin } from '@src/registry/createZdsPlugin'
 import {
   EXPORT_TO_SLICER_ACTION_TYPE,
@@ -78,6 +79,7 @@ function createExportToSlicerCommand({
   getKclManager: () => KclManager | undefined
 }): Command {
   return {
+    scopes: [MODE_MODELING_KEYMAP_SCOPE],
     id: EXPORT_TO_SLICER_COMMAND_ID,
     name: EXPORT_TO_SLICER_COMMAND_NAME,
     displayName: EXPORT_TO_SLICER_COMMAND_NAME,

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -250,7 +250,8 @@ const Home = () => {
     const { RouteTelemetryCommand, RouteSettingsCommand } = createRouteCommands(
       navigate,
       location,
-      ''
+      '',
+      [HOME_KEYMAP_SCOPE]
     )
 
     commands.send({

--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -4,6 +4,7 @@ import { Fragment, useEffect, useRef } from 'react'
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 
 import { pluginsValueSpec } from '@kittycad/registry'
+import { CommandBar } from '@src/components/CommandBar/CommandBar'
 import { CustomIcon } from '@src/components/CustomIcon'
 import { PluginsList } from '@src/components/PluginList'
 import { AllKeybindingsFields } from '@src/components/Settings/AllKeybindingsFields'
@@ -162,6 +163,7 @@ export const Settings = () => {
             data-testid="settings-dialog-panel"
             className="rounded relative mx-auto bg-chalkboard-10 dark:bg-chalkboard-100 border dark:border-chalkboard-70 w-[90vw] h-[80vh] max-h-[calc(100vh-2rem)] shadow-lg flex flex-col gap-8"
           >
+            <CommandBar />
             <div className="p-5 pb-0 flex justify-between items-center">
               <h1 className="text-2xl font-bold">Settings</h1>
               <div className="flex gap-4 items-start">

--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -16,6 +16,7 @@ import { PATHS } from '@src/lib/paths'
 import type { SettingsLevel } from '@src/lib/settings/settingsTypes'
 import { platform } from '@src/lib/utils'
 import {
+  SETTINGS_KEYMAP_SCOPE,
   findKeymapItemForCommand,
   keymapKeystrokesDisplay,
   keymapScopesValueSpec,
@@ -91,7 +92,7 @@ export const Settings = () => {
       ? findKeymapItemForCommand(
           keymap.keymap.value,
           APP_COMMAND_IDS.search.focusSettings,
-          ['settings-open'],
+          [SETTINGS_KEYMAP_SCOPE],
           app.registry.signal(keymapScopesValueSpec).value
         )?.keystrokes
       : undefined,
@@ -103,10 +104,10 @@ export const Settings = () => {
       return
     }
 
-    keymap.applyScope('settings-open')
+    keymap.applyScope(SETTINGS_KEYMAP_SCOPE)
 
     return () => {
-      keymap.removeScope('settings-open')
+      keymap.removeScope(SETTINGS_KEYMAP_SCOPE)
     }
   }, [keymap])
 


### PR DESCRIPTION
## Problem

`Reset view` and `Center camera on selection` were registered globally, so they appeared in the command palette on Home even though their shortcuts only worked in file contexts. Settings could also leave commands from the page behind it active.

## Solution

Commands now declare a context used by both the palette and shortcuts. Custom keybindings cannot make a command available outside that context.

Commands are removed from states where they do not apply:

- Camera commands from Home and the editor.
- Modeling-only commands, such as Extrude and standard views, from sketch and the editor.
- Legacy-sketch commands from modeling.
- Commands from the page behind Settings.

No commands are added.

Most modeling commands were already absent from Home because they are registered only when a file is open. Their contexts are now explicit so future registration changes cannot create the same mismatch.

Closes #12815
