### PR TITLE
Add router registry service

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -3,22 +3,31 @@ import { Auth } from '@src/Auth'
 import { OpenInDesktopAppHandler } from '@src/components/OpenInDesktopAppHandler'
 import { RouteProvider } from '@src/components/RouteProvider'
 import { SystemIOMachineLogicListener } from '@src/components/SystemIOMachineLogicListener'
+import { useApp } from '@src/lib/boot'
+import { routerService } from '@src/registry/contracts/router'
+import { RouterServiceSync } from '@src/registry/extensions/router/RouterServiceSync'
 import { Outlet } from 'react-router-dom'
 
 // Root component will live for the entire applications runtime
 // This is a great place to add polling code.
 function RootLayout() {
+  const app = useApp()
+  const router = app.registry.get(routerService)
+
   return (
-    <OpenInDesktopAppHandler>
-      <RouteProvider>
-        <Auth>
-          <AppStateProvider>
-            <SystemIOMachineLogicListener />
-            <Outlet />
-          </AppStateProvider>
-        </Auth>
-      </RouteProvider>
-    </OpenInDesktopAppHandler>
+    <>
+      <RouterServiceSync router={router} />
+      <OpenInDesktopAppHandler>
+        <RouteProvider>
+          <Auth>
+            <AppStateProvider>
+              <SystemIOMachineLogicListener />
+              <Outlet />
+            </AppStateProvider>
+          </Auth>
+        </RouteProvider>
+      </OpenInDesktopAppHandler>
+    </>
   )
 }
 

--- a/src/registry/contracts/router.ts
+++ b/src/registry/contracts/router.ts
@@ -1,0 +1,32 @@
+import { defineContract, defineService } from '@kittycad/registry'
+import type { ReadonlySignal } from '@preact/signals-core'
+import type { Location, NavigateFunction } from 'react-router-dom'
+
+export type RouterRuntimeValues = {
+  location: Location
+  navigate: NavigateFunction
+}
+
+/**
+ * Shared app routing service.
+ *
+ * The service is constructed before React Router is mounted, so its public
+ * values are non-nullable while `isReady` records whether they have been seeded
+ * from an active router runtime.
+ */
+export type RouterRegistryService = {
+  location: ReadonlySignal<Location>
+  isReady: ReadonlySignal<boolean>
+  navigate: NavigateFunction
+  getLocation: () => Location
+  setLocation: (location: Location) => void
+  setNavigate: (navigate: NavigateFunction) => () => void
+  seed: (values: RouterRuntimeValues) => () => void
+  reset: () => void
+}
+
+export const routerContract = defineContract({
+  routerService: defineService<RouterRegistryService>('router.service'),
+})
+
+export const { routerService } = routerContract

--- a/src/registry/extensions/router/RouterServiceSync.test.tsx
+++ b/src/registry/extensions/router/RouterServiceSync.test.tsx
@@ -1,0 +1,31 @@
+import { render, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import { createRouterRegistryService } from '.'
+import { RouterServiceSync } from './RouterServiceSync'
+
+describe('RouterServiceSync', () => {
+  it('seeds the router service from React Router hooks', async () => {
+    const router = createRouterRegistryService()
+
+    render(
+      <MemoryRouter initialEntries={['/initial?tab=unit#anchor']}>
+        <RouterServiceSync router={router} />
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(router.isReady.value).toBe(true)
+      expect(router.location.value.pathname).toBe('/initial')
+    })
+
+    expect(router.location.value.search).toBe('?tab=unit')
+    expect(router.location.value.hash).toBe('#anchor')
+
+    void router.navigate('/next')
+
+    await waitFor(() => {
+      expect(router.location.value.pathname).toBe('/next')
+    })
+  })
+})

--- a/src/registry/extensions/router/RouterServiceSync.tsx
+++ b/src/registry/extensions/router/RouterServiceSync.tsx
@@ -1,0 +1,20 @@
+import type { RouterRegistryService } from '@src/registry/contracts/router'
+import { useLayoutEffect } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+
+export function RouterServiceSync({
+  router,
+}: {
+  router: RouterRegistryService
+}) {
+  const location = useLocation()
+  const navigate = useNavigate()
+
+  useLayoutEffect(() => router.setNavigate(navigate), [router, navigate])
+
+  useLayoutEffect(() => {
+    router.setLocation(location)
+  }, [router, location])
+
+  return null
+}

--- a/src/registry/extensions/router/index.test.ts
+++ b/src/registry/extensions/router/index.test.ts
@@ -1,0 +1,130 @@
+import { Registry } from '@kittycad/registry'
+import { routerService } from '@src/registry/contracts/router'
+import routerRegistryItem, { createRouterRegistryService } from '.'
+import type { Location, NavigateFunction } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const testLocation = (pathname: string): Location => ({
+  pathname,
+  search: '',
+  hash: '',
+  state: null,
+  key: pathname,
+})
+
+describe('router extension', () => {
+  let registry: Registry | undefined
+
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/')
+  })
+
+  afterEach(() => {
+    registry?.[Symbol.dispose]()
+    registry = undefined
+    window.history.replaceState(null, '', '/')
+  })
+
+  it('provides non-nullable browser-backed fallback values', () => {
+    window.history.replaceState(
+      { usr: { from: 'browser' }, key: 'browser-key' },
+      '',
+      '/browser?tab=unit#anchor'
+    )
+
+    registry = new Registry()
+    registry.configure([routerRegistryItem])
+
+    const router = registry.get(routerService)
+    const location = testLocation('/settings')
+    const navigate = vi.fn()
+
+    expect(router.location.value).toMatchObject({
+      pathname: '/browser',
+      search: '?tab=unit',
+      hash: '#anchor',
+      state: { from: 'browser' },
+      key: 'browser-key',
+    })
+    expect(router.getLocation()).toBe(router.location.value)
+    expect(router.isReady.value).toBe(false)
+
+    void router.navigate('/home?from=fallback#top')
+
+    expect(router.location.value).toMatchObject({
+      pathname: '/home',
+      search: '?from=fallback',
+      hash: '#top',
+      state: null,
+    })
+
+    const state = { source: 'fallback' }
+    void router.navigate(
+      { pathname: '/replace', search: '?x=1', hash: '#hash' },
+      { replace: true, state }
+    )
+
+    expect(window.history.state).toEqual(state)
+    expect(router.location.value).toMatchObject({
+      pathname: '/replace',
+      search: '?x=1',
+      hash: '#hash',
+      state,
+    })
+
+    const historyGo = vi
+      .spyOn(window.history, 'go')
+      .mockImplementation(() => undefined)
+
+    void router.navigate(-1)
+
+    expect(historyGo).toHaveBeenCalledWith(-1)
+    historyGo.mockRestore()
+
+    router.setLocation(location)
+    const disposeNavigate = router.setNavigate(
+      navigate as unknown as NavigateFunction
+    )
+
+    expect(router.location.value).toBe(location)
+    expect(router.isReady.value).toBe(true)
+
+    void router.navigate('/home')
+    void router.navigate(-1)
+
+    expect(navigate).toHaveBeenCalledWith('/home', undefined)
+    expect(navigate).toHaveBeenCalledWith(-1)
+
+    disposeNavigate()
+
+    expect(router.isReady.value).toBe(false)
+    void router.navigate('/fallback-again')
+    expect(router.location.value.pathname).toBe('/fallback-again')
+  })
+
+  it('does not reset a newer navigate function from an older cleanup', () => {
+    const router = createRouterRegistryService()
+    const firstNavigate = vi.fn()
+    const secondNavigate = vi.fn()
+
+    const disposeFirstNavigate = router.setNavigate(
+      firstNavigate as unknown as NavigateFunction
+    )
+    const disposeSecondNavigate = router.setNavigate(
+      secondNavigate as unknown as NavigateFunction
+    )
+
+    disposeFirstNavigate()
+    void router.navigate('/home')
+
+    expect(firstNavigate).not.toHaveBeenCalled()
+    expect(secondNavigate).toHaveBeenCalledWith('/home', undefined)
+    expect(router.isReady.value).toBe(true)
+
+    disposeSecondNavigate()
+
+    expect(router.isReady.value).toBe(false)
+    void router.navigate('/after-dispose')
+    expect(router.location.value.pathname).toBe('/after-dispose')
+  })
+})

--- a/src/registry/extensions/router/index.test.ts
+++ b/src/registry/extensions/router/index.test.ts
@@ -1,7 +1,7 @@
 import { Registry } from '@kittycad/registry'
 import { routerService } from '@src/registry/contracts/router'
 import routerRegistryItem, { createRouterRegistryService } from '.'
-import type { Location, NavigateFunction } from 'react-router-dom'
+import type { Location } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const testLocation = (pathname: string): Location => ({
@@ -82,9 +82,7 @@ describe('router extension', () => {
     historyGo.mockRestore()
 
     router.setLocation(location)
-    const disposeNavigate = router.setNavigate(
-      navigate as unknown as NavigateFunction
-    )
+    const disposeNavigate = router.setNavigate(navigate)
 
     expect(router.location.value).toBe(location)
     expect(router.isReady.value).toBe(true)
@@ -107,12 +105,8 @@ describe('router extension', () => {
     const firstNavigate = vi.fn()
     const secondNavigate = vi.fn()
 
-    const disposeFirstNavigate = router.setNavigate(
-      firstNavigate as unknown as NavigateFunction
-    )
-    const disposeSecondNavigate = router.setNavigate(
-      secondNavigate as unknown as NavigateFunction
-    )
+    const disposeFirstNavigate = router.setNavigate(firstNavigate)
+    const disposeSecondNavigate = router.setNavigate(secondNavigate)
 
     disposeFirstNavigate()
     void router.navigate('/home')

--- a/src/registry/extensions/router/index.ts
+++ b/src/registry/extensions/router/index.ts
@@ -1,0 +1,173 @@
+import {
+  defineRegistryItem,
+  defineRegistryItemFactory,
+  defineRuntimeRegistryItem,
+  provideService,
+} from '@kittycad/registry'
+import { signal } from '@preact/signals-core'
+import {
+  createPath,
+  type Location,
+  type NavigateFunction,
+  type NavigateOptions,
+  type To,
+} from 'react-router-dom'
+
+import {
+  type RouterRegistryService,
+  type RouterRuntimeValues,
+  routerService,
+} from '@src/registry/contracts/router'
+
+const initialLocation: Location = {
+  pathname: '/',
+  search: '',
+  hash: '',
+  state: null,
+  key: 'default',
+}
+
+const isReactRouterHistoryState = (
+  historyState: unknown
+): historyState is { usr: unknown; key?: unknown } =>
+  Boolean(
+    historyState &&
+      typeof historyState === 'object' &&
+      'usr' in historyState &&
+      'key' in historyState
+  )
+
+const readHistoryStateValue = (historyState: unknown) => {
+  if (isReactRouterHistoryState(historyState)) {
+    return historyState.usr
+  }
+
+  return historyState ?? null
+}
+
+const readHistoryStateKey = (historyState: unknown) => {
+  if (
+    isReactRouterHistoryState(historyState) &&
+    typeof historyState.key === 'string'
+  ) {
+    return historyState.key
+  }
+
+  return initialLocation.key
+}
+
+const readBrowserLocation = (): Location => {
+  if (typeof window === 'undefined') {
+    return initialLocation
+  }
+
+  return {
+    pathname: window.location.pathname || initialLocation.pathname,
+    search: window.location.search,
+    hash: window.location.hash,
+    state: readHistoryStateValue(window.history.state),
+    key: readHistoryStateKey(window.history.state),
+  }
+}
+
+const createUnseededNavigate = (syncLocation: () => void): NavigateFunction =>
+  ((toOrDelta: To | number, options?: NavigateOptions) => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    if (typeof toOrDelta === 'number') {
+      window.history.go(toOrDelta)
+      syncLocation()
+      return
+    }
+
+    const path =
+      typeof toOrDelta === 'string' ? toOrDelta : createPath(toOrDelta)
+
+    try {
+      if (options?.replace) {
+        window.history.replaceState(options.state ?? null, '', path)
+      } else {
+        window.history.pushState(options?.state ?? null, '', path)
+      }
+      syncLocation()
+    } catch {
+      if (options?.replace) {
+        window.location.replace(path)
+      } else {
+        window.location.assign(path)
+      }
+    }
+  }) as NavigateFunction
+
+export const createRouterRegistryService = (): RouterRegistryService => {
+  const location = signal<Location>(readBrowserLocation())
+  const isReady = signal(false)
+  const syncBrowserLocation = () => {
+    location.value = readBrowserLocation()
+  }
+  let activeNavigate = createUnseededNavigate(syncBrowserLocation)
+
+  const navigate = ((toOrDelta: To | number, options?: NavigateOptions) => {
+    if (typeof toOrDelta === 'number') {
+      return activeNavigate(toOrDelta)
+    }
+
+    return activeNavigate(toOrDelta, options)
+  }) as NavigateFunction
+
+  const resetNavigate = (navigateToReset: NavigateFunction) => {
+    if (activeNavigate !== navigateToReset) {
+      return
+    }
+
+    activeNavigate = createUnseededNavigate(syncBrowserLocation)
+    syncBrowserLocation()
+    isReady.value = false
+  }
+
+  const serviceImpl: RouterRegistryService = {
+    location,
+    isReady,
+    navigate,
+    getLocation: () => location.value,
+    setLocation: (nextLocation) => {
+      location.value = nextLocation
+    },
+    setNavigate: (nextNavigate) => {
+      activeNavigate = nextNavigate
+      isReady.value = true
+
+      return () => resetNavigate(nextNavigate)
+    },
+    seed: (values: RouterRuntimeValues) => {
+      serviceImpl.setLocation(values.location)
+      return serviceImpl.setNavigate(values.navigate)
+    },
+    reset: () => {
+      syncBrowserLocation()
+      activeNavigate = createUnseededNavigate(syncBrowserLocation)
+      isReady.value = false
+    },
+  }
+
+  return serviceImpl
+}
+
+export const routerExtension = defineRegistryItemFactory(() => {
+  const serviceImpl = createRouterRegistryService()
+
+  return {
+    item: defineRuntimeRegistryItem({
+      id: 'router-extension',
+      providesServices: [provideService(routerService, serviceImpl)],
+      dispose: serviceImpl.reset,
+    }),
+  }
+}, 'router-extension')
+
+export default defineRegistryItem({
+  id: 'router',
+  uses: [routerExtension],
+})

--- a/src/registry/extensions/router/index.ts
+++ b/src/registry/extensions/router/index.ts
@@ -70,8 +70,9 @@ const readBrowserLocation = (): Location => {
   }
 }
 
-const createUnseededNavigate = (syncLocation: () => void): NavigateFunction =>
-  ((toOrDelta: To | number, options?: NavigateOptions) => {
+const createUnseededNavigate =
+  (syncLocation: () => void): NavigateFunction =>
+  (toOrDelta: To | number, options?: NavigateOptions) => {
     if (typeof window === 'undefined') {
       return
     }
@@ -99,7 +100,7 @@ const createUnseededNavigate = (syncLocation: () => void): NavigateFunction =>
         window.location.assign(path)
       }
     }
-  }) as NavigateFunction
+  }
 
 export const createRouterRegistryService = (): RouterRegistryService => {
   const location = signal<Location>(readBrowserLocation())
@@ -109,13 +110,16 @@ export const createRouterRegistryService = (): RouterRegistryService => {
   }
   let activeNavigate = createUnseededNavigate(syncBrowserLocation)
 
-  const navigate = ((toOrDelta: To | number, options?: NavigateOptions) => {
+  const navigate: NavigateFunction = (
+    toOrDelta: To | number,
+    options?: NavigateOptions
+  ) => {
     if (typeof toOrDelta === 'number') {
       return activeNavigate(toOrDelta)
     }
 
     return activeNavigate(toOrDelta, options)
-  }) as NavigateFunction
+  }
 
   const resetNavigate = (navigateToReset: NavigateFunction) => {
     if (activeNavigate !== navigateToReset) {


### PR DESCRIPTION
Adds a router registry service so extension and app code can read the current React Router location and call the active navigate function without adding another top-level App subsystem.

1. Adds a `routerService` contract with non-nullable `location` and `navigate` values plus an `isReady` signal for whether React Router has seeded the runtime values.
2. Provides a browser-backed fallback location and navigation implementation before the app router mounts, using `window.location`, `window.history`, and React Router's path formatting helper.
3. Mounts `RouterServiceSync` in `RootLayout` so `useLocation()` and `useNavigate()` seed the registry service from inside the router tree.
4. Covers both the fallback service behavior and the React Router hook bridge with unit tests.

How to test:

Exercise code that reads `app.registry.get(routerService)` before and after `RootLayout` mounts. Confirm fallback navigation updates browser history before seeding, and confirm normal React Router navigation is used after seeding. The targeted router unit tests and TypeScript check pass locally.