### PR TITLE
Add project session file management

### DIFF
--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -20,6 +20,7 @@ import {
 import { getNodeFromPath, getSettingsAnnotation } from '@src/lang/queryAst'
 import { CommandLogType } from '@src/lang/std/commandLog'
 import { isTopLevelModule, topLevelRange } from '@src/lang/util'
+import { newKclFile } from '@src/lang/project'
 import type {
   ArtifactGraph,
   ExecCallbacks,
@@ -49,6 +50,7 @@ import {
   DEFAULT_EXPERIMENTAL_FEATURES,
   DEFAULT_KCL_VERSION,
   EXECUTE_AST_INTERRUPT_ERROR_MESSAGE,
+  FILE_EXT,
 } from '@src/lib/constants'
 import { getOperationKey } from '@src/lib/featureTreeOperationTree'
 import fsZds from '@src/lib/fs-zds'
@@ -163,10 +165,14 @@ import { projectFsManager } from '@src/lang/std/fileSystemManager'
 import type { App } from '@src/lib/app'
 import { getAutomaticallyRenderEnabledFromSettings } from '@src/lib/automaticRendering'
 import { isCodeTheSame, normalizeLineEndings } from '@src/lib/codeEditor'
-import { isPathNotFoundError } from '@src/lib/desktop'
+import {
+  getProjectInfo,
+  isPathNotFoundError,
+  readAppSettingsFile,
+} from '@src/lib/desktop'
 import { bracket } from '@src/lib/exampleKcl'
 import { setKclVersion } from '@src/lib/kclVersion'
-import { getStringAfterLastSeparator } from '@src/lib/paths'
+import { getStringAfterLastSeparator, toArchivePath } from '@src/lib/paths'
 import type { FileEntry, Project } from '@src/lib/project'
 import { resetCameraPosition } from '@src/lib/resetCameraPosition'
 import { createThumbnailPNGOnDesktop } from '@src/lib/screenshot'
@@ -325,6 +331,39 @@ declare global {
 window.EditorSelection = EditorSelection
 window.EditorView = EditorView
 
+type ZDSProjectFileContents = string | Uint8Array<ArrayBuffer>
+
+interface ZDSProjectFileWriteInput {
+  path: string
+  contents?: ZDSProjectFileContents
+  overwrite?: boolean
+  useDefaultKclContents?: boolean
+}
+
+interface ZDSProjectPathInput {
+  path: string
+}
+
+interface ZDSProjectRenameInput {
+  oldPath: string
+  newPath: string
+}
+
+interface ZDSProjectCopyMoveInput {
+  sourcePath: string
+  targetPath: string
+}
+
+interface ZDSProjectFilePatchInput {
+  files: readonly {
+    path: string
+    contents: string | null
+  }[]
+}
+
+const normalizeProjectPathForComparison = (path: string) =>
+  fsZds.resolve(path).replace(/\\/g, '/')
+
 /**
  * A project contains 0 or more editors, one of which is the "executing" one
  * that connects to the geometry engine.
@@ -391,6 +430,7 @@ export class ZDSProject {
     // TODO: Clear current executing editor's execution status
 
     if (newPath === null) {
+      this.#executingPath.value = null
       return
     }
     const foundPathSignal = this.findEditor(newPath)
@@ -528,6 +568,269 @@ export class ZDSProject {
       editor.close()
     }
     this.editors.clear()
+  }
+
+  private isPathInsideProject(path: string) {
+    const projectPath = normalizeProjectPathForComparison(this.path)
+    const targetPath = normalizeProjectPathForComparison(path)
+    return (
+      targetPath === projectPath || targetPath.startsWith(`${projectPath}/`)
+    )
+  }
+
+  private assertPathInsideProject(path: string) {
+    if (!this.isPathInsideProject(path)) {
+      throw new Error(`Path "${path}" is outside project "${this.path}".`)
+    }
+  }
+
+  private isPathAtOrUnder(path: string, targetPath: string) {
+    const normalizedPath = normalizeProjectPathForComparison(path)
+    const normalizedTargetPath = normalizeProjectPathForComparison(targetPath)
+    return (
+      normalizedPath === normalizedTargetPath ||
+      normalizedPath.startsWith(`${normalizedTargetPath}/`)
+    )
+  }
+
+  private replaceProjectEntryPath(
+    path: string,
+    oldPath: string,
+    newPath: string
+  ) {
+    if (!this.isPathAtOrUnder(path, oldPath)) {
+      return path
+    }
+    if (
+      normalizeProjectPathForComparison(path) ===
+      normalizeProjectPathForComparison(oldPath)
+    ) {
+      return newPath
+    }
+    return newPath + path.slice(oldPath.length)
+  }
+
+  private async pathExists(path: string) {
+    try {
+      await fsZds.stat(path)
+      return true
+    } catch (error) {
+      if (isPathNotFoundError(error)) {
+        return false
+      }
+      return Promise.reject(error)
+    }
+  }
+
+  private async getFileWriteContents({
+    path,
+    contents,
+    useDefaultKclContents = false,
+  }: ZDSProjectFileWriteInput): Promise<Uint8Array<ArrayBuffer>> {
+    if (contents instanceof Uint8Array) {
+      return contents
+    }
+
+    const textContents = contents ?? ''
+    if (!useDefaultKclContents || fsZds.extname(path) !== FILE_EXT) {
+      return new Uint8Array(File.encoder.encode(textContents))
+    }
+
+    const wasmInstance = await this.app.wasmPromise
+    const configuration = await readAppSettingsFile(wasmInstance)
+    if (err(configuration)) {
+      return Promise.reject(configuration)
+    }
+
+    const codeToWrite = newKclFile(
+      textContents,
+      configuration?.settings?.modeling?.base_unit ??
+        DEFAULT_DEFAULT_LENGTH_UNIT,
+      wasmInstance
+    )
+    if (err(codeToWrite)) {
+      return Promise.reject(codeToWrite)
+    }
+
+    return new Uint8Array(File.encoder.encode(codeToWrite))
+  }
+
+  private rewriteProjectEntryPaths(oldPath: string, newPath: string) {
+    this.files.forEach((file) => {
+      const nextPath = this.replaceProjectEntryPath(file.path, oldPath, newPath)
+      if (nextPath !== file.path) {
+        file.path = nextPath
+      }
+    })
+
+    for (const [pathSignal, editor] of this.editors) {
+      const nextPath = this.replaceProjectEntryPath(
+        pathSignal.value,
+        oldPath,
+        newPath
+      )
+      if (nextPath !== pathSignal.value) {
+        pathSignal.value = nextPath
+        editor.path = nextPath
+      }
+    }
+  }
+
+  private closeProjectEntryEditors(path: string) {
+    for (const [pathSignal, editor] of this.editors) {
+      if (!this.isPathAtOrUnder(pathSignal.value, path)) {
+        continue
+      }
+
+      editor.close()
+      this.editors.delete(pathSignal)
+      if (this.#executingPath.value === pathSignal) {
+        this.#executingPath.value = null
+      }
+    }
+  }
+
+  private forgetProjectEntryFiles(path: string) {
+    this.files = this.files.filter(
+      (file) => !this.isPathAtOrUnder(file.path, path)
+    )
+  }
+
+  private async movePath(sourcePath: string, targetPath: string) {
+    await fsZds.mkdir(fsZds.dirname(targetPath), { recursive: true })
+    try {
+      await fsZds.rename(sourcePath, targetPath)
+      return
+    } catch {
+      // Fall back to copy/remove for cases like cross-device moves.
+    }
+
+    await fsZds.cp(sourcePath, targetPath, { recursive: true })
+    await fsZds.rm(sourcePath, { recursive: true })
+  }
+
+  async refreshProjectTree() {
+    const refreshedProject = await getProjectInfo(
+      this.path,
+      await this.app.wasmPromise
+    )
+    const currentProject = this.projectIORefSignal.value
+    const ownedProject = {
+      ...refreshedProject,
+      ...(currentProject.libraryPath
+        ? { libraryPath: currentProject.libraryPath }
+        : {}),
+      ...(currentProject.libraryType
+        ? { libraryType: currentProject.libraryType }
+        : {}),
+    }
+    this.projectIORefSignal.value = ownedProject
+    return ownedProject
+  }
+
+  async createFile(input: ZDSProjectFileWriteInput) {
+    return this.writeFile({
+      ...input,
+      overwrite: false,
+      useDefaultKclContents: input.useDefaultKclContents ?? true,
+    })
+  }
+
+  async writeFile(input: ZDSProjectFileWriteInput) {
+    this.assertPathInsideProject(input.path)
+    if (input.overwrite === false && (await this.pathExists(input.path))) {
+      return Promise.reject(new Error(`File already exists: ${input.path}`))
+    }
+
+    await fsZds.mkdir(fsZds.dirname(input.path), { recursive: true })
+    await fsZds.writeFile(input.path, await this.getFileWriteContents(input))
+    return input.path
+  }
+
+  async createFolder(input: ZDSProjectPathInput) {
+    this.assertPathInsideProject(input.path)
+    if (await this.pathExists(input.path)) {
+      return Promise.reject(new Error(`Folder already exists: ${input.path}`))
+    }
+
+    await fsZds.mkdir(input.path, { recursive: true })
+    return input.path
+  }
+
+  async renameEntry(input: ZDSProjectRenameInput) {
+    this.assertPathInsideProject(input.oldPath)
+    this.assertPathInsideProject(input.newPath)
+    if (input.oldPath === input.newPath) {
+      return input.newPath
+    }
+    if (await this.pathExists(input.newPath)) {
+      return Promise.reject(new Error(`Path already exists: ${input.newPath}`))
+    }
+
+    await fsZds.rename(input.oldPath, input.newPath)
+    this.rewriteProjectEntryPaths(input.oldPath, input.newPath)
+    return input.newPath
+  }
+
+  async deleteEntry(input: ZDSProjectPathInput) {
+    this.assertPathInsideProject(input.path)
+    await fsZds.rm(input.path, { recursive: true })
+    this.closeProjectEntryEditors(input.path)
+    this.forgetProjectEntryFiles(input.path)
+    return input.path
+  }
+
+  async copyEntry(input: ZDSProjectCopyMoveInput) {
+    this.assertPathInsideProject(input.sourcePath)
+    this.assertPathInsideProject(input.targetPath)
+    await fsZds.cp(input.sourcePath, input.targetPath, {
+      recursive: true,
+      force: false,
+    })
+    return input.targetPath
+  }
+
+  async moveEntry(input: ZDSProjectCopyMoveInput) {
+    this.assertPathInsideProject(input.sourcePath)
+    this.assertPathInsideProject(input.targetPath)
+    await this.movePath(input.sourcePath, input.targetPath)
+    this.rewriteProjectEntryPaths(input.sourcePath, input.targetPath)
+    return input.targetPath
+  }
+
+  async archiveEntry(input: ZDSProjectPathInput) {
+    this.assertPathInsideProject(input.path)
+    const archivedPath = await toArchivePath(input.path)
+    await this.movePath(input.path, archivedPath)
+    this.closeProjectEntryEditors(input.path)
+    this.forgetProjectEntryFiles(input.path)
+    return { archivedPath }
+  }
+
+  async applyFilePatch(input: ZDSProjectFilePatchInput) {
+    for (const file of input.files) {
+      this.assertPathInsideProject(file.path)
+    }
+
+    for (const file of input.files) {
+      if (file.contents === null) {
+        await fsZds.rm(file.path)
+      } else {
+        await this.writeFile({
+          path: file.path,
+          contents: file.contents,
+          overwrite: true,
+          useDefaultKclContents: false,
+        })
+      }
+    }
+
+    await this.syncReplayedFilesToRust(
+      input.files.map((file) => ({
+        absolutePath: file.path,
+        nextContent: file.contents,
+      }))
+    )
   }
 
   /** Handle updates from the disk representation of the project */

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -189,6 +189,7 @@ import {
   waitForUserFeaturesSettled,
 } from '@src/machines/userFeaturesMachine'
 import type { ExecutingEditorService } from '@src/registry/contracts/executingEditor'
+import type { FsOperationQueueService } from '@src/registry/contracts/fsOperationQueue'
 import {
   CODE_EDITOR_FOCUSED_KEYMAP_SCOPE,
   CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE,
@@ -361,6 +362,34 @@ interface ZDSProjectFilePatchInput {
   }[]
 }
 
+/**
+ * Narrow filesystem mutation surface supplied by projectSession.
+ *
+ * ZDSProject owns project-level mutation semantics, but the actual filesystem
+ * effects run through the registry queue for ordering and journaling.
+ */
+export type ZDSProjectFileSystemOperations = Pick<
+  FsOperationQueueService,
+  'cp' | 'mkdir' | 'rename' | 'rm' | 'writeFile'
+>
+
+const createUnconfiguredProjectFileSystemOperationsError = () =>
+  new Error('Project filesystem operations are not configured.')
+
+const unconfiguredProjectFileSystemOperations: ZDSProjectFileSystemOperations =
+  {
+    cp: () =>
+      Promise.reject(createUnconfiguredProjectFileSystemOperationsError()),
+    mkdir: () =>
+      Promise.reject(createUnconfiguredProjectFileSystemOperationsError()),
+    rename: () =>
+      Promise.reject(createUnconfiguredProjectFileSystemOperationsError()),
+    rm: () =>
+      Promise.reject(createUnconfiguredProjectFileSystemOperationsError()),
+    writeFile: () =>
+      Promise.reject(createUnconfiguredProjectFileSystemOperationsError()),
+  }
+
 const normalizeProjectPathForComparison = (path: string) =>
   fsZds.resolve(path).replace(/\\/g, '/')
 
@@ -393,6 +422,8 @@ export class ZDSProject {
   }))
 
   private fileWatcherId = uuidv4()
+  private fileSystemOperations: ZDSProjectFileSystemOperations =
+    unconfiguredProjectFileSystemOperations
 
   constructor(
     public projectIORefSignal: Signal<Project>,
@@ -404,6 +435,12 @@ export class ZDSProject {
       this.fileWatcherId,
       this.onUpdateFromDisk
     )
+  }
+
+  setFileSystemOperations(
+    fileSystemOperations: ZDSProjectFileSystemOperations
+  ) {
+    this.fileSystemOperations = fileSystemOperations
   }
 
   /** Clean up resources and watchers for Project */
@@ -698,16 +735,20 @@ export class ZDSProject {
   }
 
   private async movePath(sourcePath: string, targetPath: string) {
-    await fsZds.mkdir(fsZds.dirname(targetPath), { recursive: true })
+    const fileSystemOperations = this.fileSystemOperations
+
+    await fileSystemOperations.mkdir(fsZds.dirname(targetPath), {
+      recursive: true,
+    })
     try {
-      await fsZds.rename(sourcePath, targetPath)
+      await fileSystemOperations.rename(sourcePath, targetPath)
       return
     } catch {
       // Fall back to copy/remove for cases like cross-device moves.
     }
 
-    await fsZds.cp(sourcePath, targetPath, { recursive: true })
-    await fsZds.rm(sourcePath, { recursive: true })
+    await fileSystemOperations.cp(sourcePath, targetPath, { recursive: true })
+    await fileSystemOperations.rm(sourcePath, { recursive: true })
   }
 
   async refreshProjectTree() {
@@ -747,8 +788,14 @@ export class ZDSProject {
       return Promise.reject(new Error(`File already exists: ${input.path}`))
     }
 
-    await fsZds.mkdir(fsZds.dirname(input.path), { recursive: true })
-    await fsZds.writeFile(input.path, await this.getFileWriteContents(input))
+    const fileSystemOperations = this.fileSystemOperations
+    await fileSystemOperations.mkdir(fsZds.dirname(input.path), {
+      recursive: true,
+    })
+    await fileSystemOperations.writeFile(
+      input.path,
+      await this.getFileWriteContents(input)
+    )
     return input.path
   }
 
@@ -762,7 +809,7 @@ export class ZDSProject {
       return Promise.reject(new Error(`Folder already exists: ${input.path}`))
     }
 
-    await fsZds.mkdir(input.path, { recursive: true })
+    await this.fileSystemOperations.mkdir(input.path, { recursive: true })
     return input.path
   }
 
@@ -781,7 +828,7 @@ export class ZDSProject {
       return Promise.reject(new Error(`Path already exists: ${input.newPath}`))
     }
 
-    await fsZds.rename(input.oldPath, input.newPath)
+    await this.fileSystemOperations.rename(input.oldPath, input.newPath)
     this.rewriteProjectEntryPaths(input.oldPath, input.newPath)
     return input.newPath
   }
@@ -792,7 +839,7 @@ export class ZDSProject {
       return Promise.reject(outsideProjectError)
     }
 
-    await fsZds.rm(input.path, { recursive: true })
+    await this.fileSystemOperations.rm(input.path, { recursive: true })
     this.closeProjectEntryEditors(input.path)
     this.forgetProjectEntryFiles(input.path)
     return input.path
@@ -806,7 +853,7 @@ export class ZDSProject {
       return Promise.reject(outsideProjectError)
     }
 
-    await fsZds.cp(input.sourcePath, input.targetPath, {
+    await this.fileSystemOperations.cp(input.sourcePath, input.targetPath, {
       recursive: true,
       force: false,
     })
@@ -849,7 +896,7 @@ export class ZDSProject {
 
     for (const file of input.files) {
       if (file.contents === null) {
-        await fsZds.rm(file.path)
+        await this.fileSystemOperations.rm(file.path)
       } else {
         await this.writeFile({
           path: file.path,

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -20,6 +20,7 @@ import {
 import { getNodeFromPath, getSettingsAnnotation } from '@src/lang/queryAst'
 import { CommandLogType } from '@src/lang/std/commandLog'
 import { isTopLevelModule, topLevelRange } from '@src/lang/util'
+import { newKclFile } from '@src/lang/project'
 import type {
   ArtifactGraph,
   ExecCallbacks,
@@ -49,6 +50,7 @@ import {
   DEFAULT_EXPERIMENTAL_FEATURES,
   DEFAULT_KCL_VERSION,
   EXECUTE_AST_INTERRUPT_ERROR_MESSAGE,
+  FILE_EXT,
 } from '@src/lib/constants'
 import { getOperationKey } from '@src/lib/featureTreeOperationTree'
 import fsZds from '@src/lib/fs-zds'
@@ -163,10 +165,14 @@ import { projectFsManager } from '@src/lang/std/fileSystemManager'
 import type { App } from '@src/lib/app'
 import { getAutomaticallyRenderEnabledFromSettings } from '@src/lib/automaticRendering'
 import { isCodeTheSame, normalizeLineEndings } from '@src/lib/codeEditor'
-import { isPathNotFoundError } from '@src/lib/desktop'
+import {
+  getProjectInfo,
+  isPathNotFoundError,
+  readAppSettingsFile,
+} from '@src/lib/desktop'
 import { bracket } from '@src/lib/exampleKcl'
 import { setKclVersion } from '@src/lib/kclVersion'
-import { getStringAfterLastSeparator } from '@src/lib/paths'
+import { getStringAfterLastSeparator, toArchivePath } from '@src/lib/paths'
 import type { FileEntry, Project } from '@src/lib/project'
 import { resetCameraPosition } from '@src/lib/resetCameraPosition'
 import { createThumbnailPNGOnDesktop } from '@src/lib/screenshot'
@@ -325,6 +331,39 @@ declare global {
 window.EditorSelection = EditorSelection
 window.EditorView = EditorView
 
+type ZDSProjectFileContents = string | Uint8Array<ArrayBuffer>
+
+interface ZDSProjectFileWriteInput {
+  path: string
+  contents?: ZDSProjectFileContents
+  overwrite?: boolean
+  useDefaultKclContents?: boolean
+}
+
+interface ZDSProjectPathInput {
+  path: string
+}
+
+interface ZDSProjectRenameInput {
+  oldPath: string
+  newPath: string
+}
+
+interface ZDSProjectCopyMoveInput {
+  sourcePath: string
+  targetPath: string
+}
+
+interface ZDSProjectFilePatchInput {
+  files: readonly {
+    path: string
+    contents: string | null
+  }[]
+}
+
+const normalizeProjectPathForComparison = (path: string) =>
+  fsZds.resolve(path).replace(/\\/g, '/')
+
 /**
  * A project contains 0 or more editors, one of which is the "executing" one
  * that connects to the geometry engine.
@@ -391,6 +430,7 @@ export class ZDSProject {
     // TODO: Clear current executing editor's execution status
 
     if (newPath === null) {
+      this.#executingPath.value = null
       return
     }
     const foundPathSignal = this.findEditor(newPath)
@@ -525,6 +565,269 @@ export class ZDSProject {
       editor.close()
     }
     this.editors.clear()
+  }
+
+  private isPathInsideProject(path: string) {
+    const projectPath = normalizeProjectPathForComparison(this.path)
+    const targetPath = normalizeProjectPathForComparison(path)
+    return (
+      targetPath === projectPath || targetPath.startsWith(`${projectPath}/`)
+    )
+  }
+
+  private assertPathInsideProject(path: string) {
+    if (!this.isPathInsideProject(path)) {
+      throw new Error(`Path "${path}" is outside project "${this.path}".`)
+    }
+  }
+
+  private isPathAtOrUnder(path: string, targetPath: string) {
+    const normalizedPath = normalizeProjectPathForComparison(path)
+    const normalizedTargetPath = normalizeProjectPathForComparison(targetPath)
+    return (
+      normalizedPath === normalizedTargetPath ||
+      normalizedPath.startsWith(`${normalizedTargetPath}/`)
+    )
+  }
+
+  private replaceProjectEntryPath(
+    path: string,
+    oldPath: string,
+    newPath: string
+  ) {
+    if (!this.isPathAtOrUnder(path, oldPath)) {
+      return path
+    }
+    if (
+      normalizeProjectPathForComparison(path) ===
+      normalizeProjectPathForComparison(oldPath)
+    ) {
+      return newPath
+    }
+    return newPath + path.slice(oldPath.length)
+  }
+
+  private async pathExists(path: string) {
+    try {
+      await fsZds.stat(path)
+      return true
+    } catch (error) {
+      if (isPathNotFoundError(error)) {
+        return false
+      }
+      return Promise.reject(error)
+    }
+  }
+
+  private async getFileWriteContents({
+    path,
+    contents,
+    useDefaultKclContents = false,
+  }: ZDSProjectFileWriteInput): Promise<Uint8Array<ArrayBuffer>> {
+    if (contents instanceof Uint8Array) {
+      return contents
+    }
+
+    const textContents = contents ?? ''
+    if (!useDefaultKclContents || fsZds.extname(path) !== FILE_EXT) {
+      return new Uint8Array(File.encoder.encode(textContents))
+    }
+
+    const wasmInstance = await this.app.wasmPromise
+    const configuration = await readAppSettingsFile(wasmInstance)
+    if (err(configuration)) {
+      return Promise.reject(configuration)
+    }
+
+    const codeToWrite = newKclFile(
+      textContents,
+      configuration?.settings?.modeling?.base_unit ??
+        DEFAULT_DEFAULT_LENGTH_UNIT,
+      wasmInstance
+    )
+    if (err(codeToWrite)) {
+      return Promise.reject(codeToWrite)
+    }
+
+    return new Uint8Array(File.encoder.encode(codeToWrite))
+  }
+
+  private rewriteProjectEntryPaths(oldPath: string, newPath: string) {
+    this.files.forEach((file) => {
+      const nextPath = this.replaceProjectEntryPath(file.path, oldPath, newPath)
+      if (nextPath !== file.path) {
+        file.path = nextPath
+      }
+    })
+
+    for (const [pathSignal, editor] of this.editors) {
+      const nextPath = this.replaceProjectEntryPath(
+        pathSignal.value,
+        oldPath,
+        newPath
+      )
+      if (nextPath !== pathSignal.value) {
+        pathSignal.value = nextPath
+        editor.path = nextPath
+      }
+    }
+  }
+
+  private closeProjectEntryEditors(path: string) {
+    for (const [pathSignal, editor] of this.editors) {
+      if (!this.isPathAtOrUnder(pathSignal.value, path)) {
+        continue
+      }
+
+      editor.close()
+      this.editors.delete(pathSignal)
+      if (this.#executingPath.value === pathSignal) {
+        this.#executingPath.value = null
+      }
+    }
+  }
+
+  private forgetProjectEntryFiles(path: string) {
+    this.files = this.files.filter(
+      (file) => !this.isPathAtOrUnder(file.path, path)
+    )
+  }
+
+  private async movePath(sourcePath: string, targetPath: string) {
+    await fsZds.mkdir(fsZds.dirname(targetPath), { recursive: true })
+    try {
+      await fsZds.rename(sourcePath, targetPath)
+      return
+    } catch {
+      // Fall back to copy/remove for cases like cross-device moves.
+    }
+
+    await fsZds.cp(sourcePath, targetPath, { recursive: true })
+    await fsZds.rm(sourcePath, { recursive: true })
+  }
+
+  async refreshProjectTree() {
+    const refreshedProject = await getProjectInfo(
+      this.path,
+      await this.app.wasmPromise
+    )
+    const currentProject = this.projectIORefSignal.value
+    const ownedProject = {
+      ...refreshedProject,
+      ...(currentProject.libraryPath
+        ? { libraryPath: currentProject.libraryPath }
+        : {}),
+      ...(currentProject.libraryType
+        ? { libraryType: currentProject.libraryType }
+        : {}),
+    }
+    this.projectIORefSignal.value = ownedProject
+    return ownedProject
+  }
+
+  async createFile(input: ZDSProjectFileWriteInput) {
+    return this.writeFile({
+      ...input,
+      overwrite: false,
+      useDefaultKclContents: input.useDefaultKclContents ?? true,
+    })
+  }
+
+  async writeFile(input: ZDSProjectFileWriteInput) {
+    this.assertPathInsideProject(input.path)
+    if (input.overwrite === false && (await this.pathExists(input.path))) {
+      return Promise.reject(new Error(`File already exists: ${input.path}`))
+    }
+
+    await fsZds.mkdir(fsZds.dirname(input.path), { recursive: true })
+    await fsZds.writeFile(input.path, await this.getFileWriteContents(input))
+    return input.path
+  }
+
+  async createFolder(input: ZDSProjectPathInput) {
+    this.assertPathInsideProject(input.path)
+    if (await this.pathExists(input.path)) {
+      return Promise.reject(new Error(`Folder already exists: ${input.path}`))
+    }
+
+    await fsZds.mkdir(input.path, { recursive: true })
+    return input.path
+  }
+
+  async renameEntry(input: ZDSProjectRenameInput) {
+    this.assertPathInsideProject(input.oldPath)
+    this.assertPathInsideProject(input.newPath)
+    if (input.oldPath === input.newPath) {
+      return input.newPath
+    }
+    if (await this.pathExists(input.newPath)) {
+      return Promise.reject(new Error(`Path already exists: ${input.newPath}`))
+    }
+
+    await fsZds.rename(input.oldPath, input.newPath)
+    this.rewriteProjectEntryPaths(input.oldPath, input.newPath)
+    return input.newPath
+  }
+
+  async deleteEntry(input: ZDSProjectPathInput) {
+    this.assertPathInsideProject(input.path)
+    await fsZds.rm(input.path, { recursive: true })
+    this.closeProjectEntryEditors(input.path)
+    this.forgetProjectEntryFiles(input.path)
+    return input.path
+  }
+
+  async copyEntry(input: ZDSProjectCopyMoveInput) {
+    this.assertPathInsideProject(input.sourcePath)
+    this.assertPathInsideProject(input.targetPath)
+    await fsZds.cp(input.sourcePath, input.targetPath, {
+      recursive: true,
+      force: false,
+    })
+    return input.targetPath
+  }
+
+  async moveEntry(input: ZDSProjectCopyMoveInput) {
+    this.assertPathInsideProject(input.sourcePath)
+    this.assertPathInsideProject(input.targetPath)
+    await this.movePath(input.sourcePath, input.targetPath)
+    this.rewriteProjectEntryPaths(input.sourcePath, input.targetPath)
+    return input.targetPath
+  }
+
+  async archiveEntry(input: ZDSProjectPathInput) {
+    this.assertPathInsideProject(input.path)
+    const archivedPath = await toArchivePath(input.path)
+    await this.movePath(input.path, archivedPath)
+    this.closeProjectEntryEditors(input.path)
+    this.forgetProjectEntryFiles(input.path)
+    return { archivedPath }
+  }
+
+  async applyFilePatch(input: ZDSProjectFilePatchInput) {
+    for (const file of input.files) {
+      this.assertPathInsideProject(file.path)
+    }
+
+    for (const file of input.files) {
+      if (file.contents === null) {
+        await fsZds.rm(file.path)
+      } else {
+        await this.writeFile({
+          path: file.path,
+          contents: file.contents,
+          overwrite: true,
+          useDefaultKclContents: false,
+        })
+      }
+    }
+
+    await this.syncReplayedFilesToRust(
+      input.files.map((file) => ({
+        absolutePath: file.path,
+        nextContent: file.contents,
+      }))
+    )
   }
 
   /** Handle updates from the disk representation of the project */

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -189,7 +189,7 @@ import {
   waitForUserFeaturesSettled,
 } from '@src/machines/userFeaturesMachine'
 import type { ExecutingEditorService } from '@src/registry/contracts/executingEditor'
-import type { FsOperationQueueService } from '@src/registry/contracts/fsOperationQueue'
+import type { FsMutationOperations } from '@src/registry/contracts/fsOperationQueue'
 import {
   CODE_EDITOR_FOCUSED_KEYMAP_SCOPE,
   CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE,
@@ -368,10 +368,7 @@ interface ZDSProjectFilePatchInput {
  * ZDSProject owns project-level mutation semantics, but the actual filesystem
  * effects run through the registry queue for ordering and journaling.
  */
-export type ZDSProjectFileSystemOperations = Pick<
-  FsOperationQueueService,
-  'cp' | 'mkdir' | 'rename' | 'rm' | 'writeFile'
->
+export type ZDSProjectFileSystemOperations = FsMutationOperations
 
 export interface ZDSProjectFileSystemOperationProvider {
   getFileSystemOperations: () => ZDSProjectFileSystemOperations
@@ -727,9 +724,11 @@ export class ZDSProject {
     )
   }
 
-  private async movePath(sourcePath: string, targetPath: string) {
-    const fileSystemOperations = this.fileSystemOperations
-
+  private async movePath(
+    sourcePath: string,
+    targetPath: string,
+    fileSystemOperations: ZDSProjectFileSystemOperations
+  ) {
     await fileSystemOperations.mkdir(fsZds.dirname(targetPath), {
       recursive: true,
     })
@@ -763,22 +762,30 @@ export class ZDSProject {
     return ownedProject
   }
 
-  async createFile(input: ZDSProjectFileWriteInput) {
-    return this.writeFile({
-      ...input,
-      overwrite: false,
-      useDefaultKclContents: input.useDefaultKclContents ?? true,
-    })
+  async createFile(
+    input: ZDSProjectFileWriteInput,
+    fileSystemOperations = this.fileSystemOperations
+  ) {
+    return this.writeFile(
+      {
+        ...input,
+        overwrite: false,
+        useDefaultKclContents: input.useDefaultKclContents ?? true,
+      },
+      fileSystemOperations
+    )
   }
 
-  async writeFile(input: ZDSProjectFileWriteInput) {
+  async writeFile(
+    input: ZDSProjectFileWriteInput,
+    fileSystemOperations = this.fileSystemOperations
+  ) {
     await this.ensureProjectPaths(input.path)
 
     if (input.overwrite === false && (await this.pathExists(input.path))) {
       return Promise.reject(new Error(`File already exists: ${input.path}`))
     }
 
-    const fileSystemOperations = this.fileSystemOperations
     await fileSystemOperations.mkdir(fsZds.dirname(input.path), {
       recursive: true,
     })
@@ -789,18 +796,24 @@ export class ZDSProject {
     return input.path
   }
 
-  async createFolder(input: ZDSProjectPathInput) {
+  async createFolder(
+    input: ZDSProjectPathInput,
+    fileSystemOperations = this.fileSystemOperations
+  ) {
     await this.ensureProjectPaths(input.path)
 
     if (await this.pathExists(input.path)) {
       return Promise.reject(new Error(`Folder already exists: ${input.path}`))
     }
 
-    await this.fileSystemOperations.mkdir(input.path, { recursive: true })
+    await fileSystemOperations.mkdir(input.path, { recursive: true })
     return input.path
   }
 
-  async renameEntry(input: ZDSProjectRenameInput) {
+  async renameEntry(
+    input: ZDSProjectRenameInput,
+    fileSystemOperations = this.fileSystemOperations
+  ) {
     await this.ensureProjectPaths(input.oldPath, input.newPath)
 
     if (input.oldPath === input.newPath) {
@@ -810,61 +823,83 @@ export class ZDSProject {
       return Promise.reject(new Error(`Path already exists: ${input.newPath}`))
     }
 
-    await this.fileSystemOperations.rename(input.oldPath, input.newPath)
+    await fileSystemOperations.rename(input.oldPath, input.newPath)
     this.rewriteProjectEntryPaths(input.oldPath, input.newPath)
     return input.newPath
   }
 
-  async deleteEntry(input: ZDSProjectPathInput) {
+  async deleteEntry(
+    input: ZDSProjectPathInput,
+    fileSystemOperations = this.fileSystemOperations
+  ) {
     await this.ensureProjectPaths(input.path)
 
-    await this.fileSystemOperations.rm(input.path, { recursive: true })
+    await fileSystemOperations.rm(input.path, { recursive: true })
     this.closeProjectEntryEditors(input.path)
     this.forgetProjectEntryFiles(input.path)
     return input.path
   }
 
-  async copyEntry(input: ZDSProjectCopyMoveInput) {
+  async copyEntry(
+    input: ZDSProjectCopyMoveInput,
+    fileSystemOperations = this.fileSystemOperations
+  ) {
     await this.ensureProjectPaths(input.sourcePath, input.targetPath)
 
-    await this.fileSystemOperations.cp(input.sourcePath, input.targetPath, {
+    await fileSystemOperations.cp(input.sourcePath, input.targetPath, {
       recursive: true,
       force: false,
     })
     return input.targetPath
   }
 
-  async moveEntry(input: ZDSProjectCopyMoveInput) {
+  async moveEntry(
+    input: ZDSProjectCopyMoveInput,
+    fileSystemOperations = this.fileSystemOperations
+  ) {
     await this.ensureProjectPaths(input.sourcePath, input.targetPath)
 
-    await this.movePath(input.sourcePath, input.targetPath)
+    await this.movePath(
+      input.sourcePath,
+      input.targetPath,
+      fileSystemOperations
+    )
     this.rewriteProjectEntryPaths(input.sourcePath, input.targetPath)
     return input.targetPath
   }
 
-  async archiveEntry(input: ZDSProjectPathInput) {
+  async archiveEntry(
+    input: ZDSProjectPathInput,
+    fileSystemOperations = this.fileSystemOperations
+  ) {
     await this.ensureProjectPaths(input.path)
 
     const archivedPath = await toArchivePath(input.path)
-    await this.movePath(input.path, archivedPath)
+    await this.movePath(input.path, archivedPath, fileSystemOperations)
     this.closeProjectEntryEditors(input.path)
     this.forgetProjectEntryFiles(input.path)
     return { archivedPath }
   }
 
-  async applyFilePatch(input: ZDSProjectFilePatchInput) {
+  async applyFilePatch(
+    input: ZDSProjectFilePatchInput,
+    fileSystemOperations = this.fileSystemOperations
+  ) {
     await this.ensureProjectPaths(...input.files.map((file) => file.path))
 
     for (const file of input.files) {
       if (file.contents === null) {
-        await this.fileSystemOperations.rm(file.path)
+        await fileSystemOperations.rm(file.path)
       } else {
-        await this.writeFile({
-          path: file.path,
-          contents: file.contents,
-          overwrite: true,
-          useDefaultKclContents: false,
-        })
+        await this.writeFile(
+          {
+            path: file.path,
+            contents: file.contents,
+            overwrite: true,
+            useDefaultKclContents: false,
+          },
+          fileSystemOperations
+        )
       }
     }
 

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -373,22 +373,9 @@ export type ZDSProjectFileSystemOperations = Pick<
   'cp' | 'mkdir' | 'rename' | 'rm' | 'writeFile'
 >
 
-const createUnconfiguredProjectFileSystemOperationsError = () =>
-  new Error('Project filesystem operations are not configured.')
-
-const unconfiguredProjectFileSystemOperations: ZDSProjectFileSystemOperations =
-  {
-    cp: () =>
-      Promise.reject(createUnconfiguredProjectFileSystemOperationsError()),
-    mkdir: () =>
-      Promise.reject(createUnconfiguredProjectFileSystemOperationsError()),
-    rename: () =>
-      Promise.reject(createUnconfiguredProjectFileSystemOperationsError()),
-    rm: () =>
-      Promise.reject(createUnconfiguredProjectFileSystemOperationsError()),
-    writeFile: () =>
-      Promise.reject(createUnconfiguredProjectFileSystemOperationsError()),
-  }
+export interface ZDSProjectFileSystemOperationProvider {
+  getFileSystemOperations: () => ZDSProjectFileSystemOperations
+}
 
 const normalizeProjectPathForComparison = (path: string) =>
   fsZds.resolve(path).replace(/\\/g, '/')
@@ -422,25 +409,21 @@ export class ZDSProject {
   }))
 
   private fileWatcherId = uuidv4()
-  private fileSystemOperations: ZDSProjectFileSystemOperations =
-    unconfiguredProjectFileSystemOperations
+  private fileSystemOperations: ZDSProjectFileSystemOperations
 
   constructor(
     public projectIORefSignal: Signal<Project>,
-    private app: App
+    private app: App,
+    fileSystemOperationProvider: ZDSProjectFileSystemOperationProvider
   ) {
+    this.fileSystemOperations =
+      fileSystemOperationProvider.getFileSystemOperations()
     this.files = this.collectProjectFiles(projectIORefSignal.value)
     window.electron?.watchFileOn(
       projectIORefSignal.value.path,
       this.fileWatcherId,
       this.onUpdateFromDisk
     )
-  }
-
-  setFileSystemOperations(
-    fileSystemOperations: ZDSProjectFileSystemOperations
-  ) {
-    this.fileSystemOperations = fileSystemOperations
   }
 
   /** Clean up resources and watchers for Project */
@@ -453,8 +436,12 @@ export class ZDSProject {
   }
 
   /** Open a project, with the option to open an initial editor too */
-  static async open(projectRef: Signal<Project>, app: App) {
-    return new ZDSProject(projectRef, app)
+  static async open(
+    projectRef: Signal<Project>,
+    app: App,
+    fileSystemOperationProvider: ZDSProjectFileSystemOperationProvider
+  ) {
+    return new ZDSProject(projectRef, app, fileSystemOperationProvider)
   }
 
   get executingPath() {
@@ -615,11 +602,20 @@ export class ZDSProject {
     )
   }
 
-  private getPathOutsideProjectError(path: string) {
-    if (!this.isPathInsideProject(path)) {
-      return new Error(`Path "${path}" is outside project "${this.path}".`)
+  private getPathOutsideProjectError(...paths: string[]) {
+    for (const path of paths) {
+      if (!this.isPathInsideProject(path)) {
+        return new Error(`Path "${path}" is outside project "${this.path}".`)
+      }
     }
     return undefined
+  }
+
+  private ensureProjectPaths(...paths: string[]) {
+    const outsideProjectError = this.getPathOutsideProjectError(...paths)
+    return outsideProjectError
+      ? Promise.reject(outsideProjectError)
+      : Promise.resolve()
   }
 
   private isPathAtOrUnder(path: string, targetPath: string) {
@@ -779,10 +775,7 @@ export class ZDSProject {
   }
 
   async writeFile(input: ZDSProjectFileWriteInput) {
-    const outsideProjectError = this.getPathOutsideProjectError(input.path)
-    if (outsideProjectError) {
-      return Promise.reject(outsideProjectError)
-    }
+    await this.ensureProjectPaths(input.path)
 
     if (input.overwrite === false && (await this.pathExists(input.path))) {
       return Promise.reject(new Error(`File already exists: ${input.path}`))
@@ -800,10 +793,7 @@ export class ZDSProject {
   }
 
   async createFolder(input: ZDSProjectPathInput) {
-    const outsideProjectError = this.getPathOutsideProjectError(input.path)
-    if (outsideProjectError) {
-      return Promise.reject(outsideProjectError)
-    }
+    await this.ensureProjectPaths(input.path)
 
     if (await this.pathExists(input.path)) {
       return Promise.reject(new Error(`Folder already exists: ${input.path}`))
@@ -814,12 +804,7 @@ export class ZDSProject {
   }
 
   async renameEntry(input: ZDSProjectRenameInput) {
-    const outsideProjectError =
-      this.getPathOutsideProjectError(input.oldPath) ??
-      this.getPathOutsideProjectError(input.newPath)
-    if (outsideProjectError) {
-      return Promise.reject(outsideProjectError)
-    }
+    await this.ensureProjectPaths(input.oldPath, input.newPath)
 
     if (input.oldPath === input.newPath) {
       return input.newPath
@@ -834,10 +819,7 @@ export class ZDSProject {
   }
 
   async deleteEntry(input: ZDSProjectPathInput) {
-    const outsideProjectError = this.getPathOutsideProjectError(input.path)
-    if (outsideProjectError) {
-      return Promise.reject(outsideProjectError)
-    }
+    await this.ensureProjectPaths(input.path)
 
     await this.fileSystemOperations.rm(input.path, { recursive: true })
     this.closeProjectEntryEditors(input.path)
@@ -846,12 +828,7 @@ export class ZDSProject {
   }
 
   async copyEntry(input: ZDSProjectCopyMoveInput) {
-    const outsideProjectError =
-      this.getPathOutsideProjectError(input.sourcePath) ??
-      this.getPathOutsideProjectError(input.targetPath)
-    if (outsideProjectError) {
-      return Promise.reject(outsideProjectError)
-    }
+    await this.ensureProjectPaths(input.sourcePath, input.targetPath)
 
     await this.fileSystemOperations.cp(input.sourcePath, input.targetPath, {
       recursive: true,
@@ -861,12 +838,7 @@ export class ZDSProject {
   }
 
   async moveEntry(input: ZDSProjectCopyMoveInput) {
-    const outsideProjectError =
-      this.getPathOutsideProjectError(input.sourcePath) ??
-      this.getPathOutsideProjectError(input.targetPath)
-    if (outsideProjectError) {
-      return Promise.reject(outsideProjectError)
-    }
+    await this.ensureProjectPaths(input.sourcePath, input.targetPath)
 
     await this.movePath(input.sourcePath, input.targetPath)
     this.rewriteProjectEntryPaths(input.sourcePath, input.targetPath)
@@ -874,10 +846,7 @@ export class ZDSProject {
   }
 
   async archiveEntry(input: ZDSProjectPathInput) {
-    const outsideProjectError = this.getPathOutsideProjectError(input.path)
-    if (outsideProjectError) {
-      return Promise.reject(outsideProjectError)
-    }
+    await this.ensureProjectPaths(input.path)
 
     const archivedPath = await toArchivePath(input.path)
     await this.movePath(input.path, archivedPath)
@@ -887,12 +856,7 @@ export class ZDSProject {
   }
 
   async applyFilePatch(input: ZDSProjectFilePatchInput) {
-    for (const file of input.files) {
-      const outsideProjectError = this.getPathOutsideProjectError(file.path)
-      if (outsideProjectError) {
-        return Promise.reject(outsideProjectError)
-      }
-    }
+    await this.ensureProjectPaths(...input.files.map((file) => file.path))
 
     for (const file of input.files) {
       if (file.contents === null) {

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -575,10 +575,11 @@ export class ZDSProject {
     )
   }
 
-  private assertPathInsideProject(path: string) {
+  private getPathOutsideProjectError(path: string) {
     if (!this.isPathInsideProject(path)) {
-      throw new Error(`Path "${path}" is outside project "${this.path}".`)
+      return new Error(`Path "${path}" is outside project "${this.path}".`)
     }
+    return undefined
   }
 
   private isPathAtOrUnder(path: string, targetPath: string) {
@@ -734,7 +735,11 @@ export class ZDSProject {
   }
 
   async writeFile(input: ZDSProjectFileWriteInput) {
-    this.assertPathInsideProject(input.path)
+    const outsideProjectError = this.getPathOutsideProjectError(input.path)
+    if (outsideProjectError) {
+      return Promise.reject(outsideProjectError)
+    }
+
     if (input.overwrite === false && (await this.pathExists(input.path))) {
       return Promise.reject(new Error(`File already exists: ${input.path}`))
     }
@@ -745,7 +750,11 @@ export class ZDSProject {
   }
 
   async createFolder(input: ZDSProjectPathInput) {
-    this.assertPathInsideProject(input.path)
+    const outsideProjectError = this.getPathOutsideProjectError(input.path)
+    if (outsideProjectError) {
+      return Promise.reject(outsideProjectError)
+    }
+
     if (await this.pathExists(input.path)) {
       return Promise.reject(new Error(`Folder already exists: ${input.path}`))
     }
@@ -755,8 +764,13 @@ export class ZDSProject {
   }
 
   async renameEntry(input: ZDSProjectRenameInput) {
-    this.assertPathInsideProject(input.oldPath)
-    this.assertPathInsideProject(input.newPath)
+    const outsideProjectError =
+      this.getPathOutsideProjectError(input.oldPath) ??
+      this.getPathOutsideProjectError(input.newPath)
+    if (outsideProjectError) {
+      return Promise.reject(outsideProjectError)
+    }
+
     if (input.oldPath === input.newPath) {
       return input.newPath
     }
@@ -770,7 +784,11 @@ export class ZDSProject {
   }
 
   async deleteEntry(input: ZDSProjectPathInput) {
-    this.assertPathInsideProject(input.path)
+    const outsideProjectError = this.getPathOutsideProjectError(input.path)
+    if (outsideProjectError) {
+      return Promise.reject(outsideProjectError)
+    }
+
     await fsZds.rm(input.path, { recursive: true })
     this.closeProjectEntryEditors(input.path)
     this.forgetProjectEntryFiles(input.path)
@@ -778,8 +796,13 @@ export class ZDSProject {
   }
 
   async copyEntry(input: ZDSProjectCopyMoveInput) {
-    this.assertPathInsideProject(input.sourcePath)
-    this.assertPathInsideProject(input.targetPath)
+    const outsideProjectError =
+      this.getPathOutsideProjectError(input.sourcePath) ??
+      this.getPathOutsideProjectError(input.targetPath)
+    if (outsideProjectError) {
+      return Promise.reject(outsideProjectError)
+    }
+
     await fsZds.cp(input.sourcePath, input.targetPath, {
       recursive: true,
       force: false,
@@ -788,15 +811,24 @@ export class ZDSProject {
   }
 
   async moveEntry(input: ZDSProjectCopyMoveInput) {
-    this.assertPathInsideProject(input.sourcePath)
-    this.assertPathInsideProject(input.targetPath)
+    const outsideProjectError =
+      this.getPathOutsideProjectError(input.sourcePath) ??
+      this.getPathOutsideProjectError(input.targetPath)
+    if (outsideProjectError) {
+      return Promise.reject(outsideProjectError)
+    }
+
     await this.movePath(input.sourcePath, input.targetPath)
     this.rewriteProjectEntryPaths(input.sourcePath, input.targetPath)
     return input.targetPath
   }
 
   async archiveEntry(input: ZDSProjectPathInput) {
-    this.assertPathInsideProject(input.path)
+    const outsideProjectError = this.getPathOutsideProjectError(input.path)
+    if (outsideProjectError) {
+      return Promise.reject(outsideProjectError)
+    }
+
     const archivedPath = await toArchivePath(input.path)
     await this.movePath(input.path, archivedPath)
     this.closeProjectEntryEditors(input.path)
@@ -806,7 +838,10 @@ export class ZDSProject {
 
   async applyFilePatch(input: ZDSProjectFilePatchInput) {
     for (const file of input.files) {
-      this.assertPathInsideProject(file.path)
+      const outsideProjectError = this.getPathOutsideProjectError(file.path)
+      if (outsideProjectError) {
+        return Promise.reject(outsideProjectError)
+      }
     }
 
     for (const file of input.files) {

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -189,6 +189,7 @@ import {
   waitForUserFeaturesSettled,
 } from '@src/machines/userFeaturesMachine'
 import type { ExecutingEditorService } from '@src/registry/contracts/executingEditor'
+import type { FsOperationQueueService } from '@src/registry/contracts/fsOperationQueue'
 import {
   CODE_EDITOR_FOCUSED_KEYMAP_SCOPE,
   CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE,
@@ -361,6 +362,34 @@ interface ZDSProjectFilePatchInput {
   }[]
 }
 
+/**
+ * Narrow filesystem mutation surface supplied by projectSession.
+ *
+ * ZDSProject owns project-level mutation semantics, but the actual filesystem
+ * effects run through the registry queue for ordering and journaling.
+ */
+export type ZDSProjectFileSystemOperations = Pick<
+  FsOperationQueueService,
+  'cp' | 'mkdir' | 'rename' | 'rm' | 'writeFile'
+>
+
+const createUnconfiguredProjectFileSystemOperationsError = () =>
+  new Error('Project filesystem operations are not configured.')
+
+const unconfiguredProjectFileSystemOperations: ZDSProjectFileSystemOperations =
+  {
+    cp: () =>
+      Promise.reject(createUnconfiguredProjectFileSystemOperationsError()),
+    mkdir: () =>
+      Promise.reject(createUnconfiguredProjectFileSystemOperationsError()),
+    rename: () =>
+      Promise.reject(createUnconfiguredProjectFileSystemOperationsError()),
+    rm: () =>
+      Promise.reject(createUnconfiguredProjectFileSystemOperationsError()),
+    writeFile: () =>
+      Promise.reject(createUnconfiguredProjectFileSystemOperationsError()),
+  }
+
 const normalizeProjectPathForComparison = (path: string) =>
   fsZds.resolve(path).replace(/\\/g, '/')
 
@@ -393,6 +422,8 @@ export class ZDSProject {
   }))
 
   private fileWatcherId = uuidv4()
+  private fileSystemOperations: ZDSProjectFileSystemOperations =
+    unconfiguredProjectFileSystemOperations
 
   constructor(
     public projectIORefSignal: Signal<Project>,
@@ -404,6 +435,12 @@ export class ZDSProject {
       this.fileWatcherId,
       this.onUpdateFromDisk
     )
+  }
+
+  setFileSystemOperations(
+    fileSystemOperations: ZDSProjectFileSystemOperations
+  ) {
+    this.fileSystemOperations = fileSystemOperations
   }
 
   /** Clean up resources and watchers for Project */
@@ -695,16 +732,20 @@ export class ZDSProject {
   }
 
   private async movePath(sourcePath: string, targetPath: string) {
-    await fsZds.mkdir(fsZds.dirname(targetPath), { recursive: true })
+    const fileSystemOperations = this.fileSystemOperations
+
+    await fileSystemOperations.mkdir(fsZds.dirname(targetPath), {
+      recursive: true,
+    })
     try {
-      await fsZds.rename(sourcePath, targetPath)
+      await fileSystemOperations.rename(sourcePath, targetPath)
       return
     } catch {
       // Fall back to copy/remove for cases like cross-device moves.
     }
 
-    await fsZds.cp(sourcePath, targetPath, { recursive: true })
-    await fsZds.rm(sourcePath, { recursive: true })
+    await fileSystemOperations.cp(sourcePath, targetPath, { recursive: true })
+    await fileSystemOperations.rm(sourcePath, { recursive: true })
   }
 
   async refreshProjectTree() {
@@ -744,8 +785,14 @@ export class ZDSProject {
       return Promise.reject(new Error(`File already exists: ${input.path}`))
     }
 
-    await fsZds.mkdir(fsZds.dirname(input.path), { recursive: true })
-    await fsZds.writeFile(input.path, await this.getFileWriteContents(input))
+    const fileSystemOperations = this.fileSystemOperations
+    await fileSystemOperations.mkdir(fsZds.dirname(input.path), {
+      recursive: true,
+    })
+    await fileSystemOperations.writeFile(
+      input.path,
+      await this.getFileWriteContents(input)
+    )
     return input.path
   }
 
@@ -759,7 +806,7 @@ export class ZDSProject {
       return Promise.reject(new Error(`Folder already exists: ${input.path}`))
     }
 
-    await fsZds.mkdir(input.path, { recursive: true })
+    await this.fileSystemOperations.mkdir(input.path, { recursive: true })
     return input.path
   }
 
@@ -778,7 +825,7 @@ export class ZDSProject {
       return Promise.reject(new Error(`Path already exists: ${input.newPath}`))
     }
 
-    await fsZds.rename(input.oldPath, input.newPath)
+    await this.fileSystemOperations.rename(input.oldPath, input.newPath)
     this.rewriteProjectEntryPaths(input.oldPath, input.newPath)
     return input.newPath
   }
@@ -789,7 +836,7 @@ export class ZDSProject {
       return Promise.reject(outsideProjectError)
     }
 
-    await fsZds.rm(input.path, { recursive: true })
+    await this.fileSystemOperations.rm(input.path, { recursive: true })
     this.closeProjectEntryEditors(input.path)
     this.forgetProjectEntryFiles(input.path)
     return input.path
@@ -803,7 +850,7 @@ export class ZDSProject {
       return Promise.reject(outsideProjectError)
     }
 
-    await fsZds.cp(input.sourcePath, input.targetPath, {
+    await this.fileSystemOperations.cp(input.sourcePath, input.targetPath, {
       recursive: true,
       force: false,
     })
@@ -846,7 +893,7 @@ export class ZDSProject {
 
     for (const file of input.files) {
       if (file.contents === null) {
-        await fsZds.rm(file.path)
+        await this.fileSystemOperations.rm(file.path)
       } else {
         await this.writeFile({
           path: file.path,

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -373,22 +373,9 @@ export type ZDSProjectFileSystemOperations = Pick<
   'cp' | 'mkdir' | 'rename' | 'rm' | 'writeFile'
 >
 
-const createUnconfiguredProjectFileSystemOperationsError = () =>
-  new Error('Project filesystem operations are not configured.')
-
-const unconfiguredProjectFileSystemOperations: ZDSProjectFileSystemOperations =
-  {
-    cp: () =>
-      Promise.reject(createUnconfiguredProjectFileSystemOperationsError()),
-    mkdir: () =>
-      Promise.reject(createUnconfiguredProjectFileSystemOperationsError()),
-    rename: () =>
-      Promise.reject(createUnconfiguredProjectFileSystemOperationsError()),
-    rm: () =>
-      Promise.reject(createUnconfiguredProjectFileSystemOperationsError()),
-    writeFile: () =>
-      Promise.reject(createUnconfiguredProjectFileSystemOperationsError()),
-  }
+export interface ZDSProjectFileSystemOperationProvider {
+  getFileSystemOperations: () => ZDSProjectFileSystemOperations
+}
 
 const normalizeProjectPathForComparison = (path: string) =>
   fsZds.resolve(path).replace(/\\/g, '/')
@@ -422,25 +409,21 @@ export class ZDSProject {
   }))
 
   private fileWatcherId = uuidv4()
-  private fileSystemOperations: ZDSProjectFileSystemOperations =
-    unconfiguredProjectFileSystemOperations
+  private fileSystemOperations: ZDSProjectFileSystemOperations
 
   constructor(
     public projectIORefSignal: Signal<Project>,
-    private app: App
+    private app: App,
+    fileSystemOperationProvider: ZDSProjectFileSystemOperationProvider
   ) {
+    this.fileSystemOperations =
+      fileSystemOperationProvider.getFileSystemOperations()
     this.files = this.collectProjectFiles(projectIORefSignal.value)
     window.electron?.watchFileOn(
       projectIORefSignal.value.path,
       this.fileWatcherId,
       this.onUpdateFromDisk
     )
-  }
-
-  setFileSystemOperations(
-    fileSystemOperations: ZDSProjectFileSystemOperations
-  ) {
-    this.fileSystemOperations = fileSystemOperations
   }
 
   /** Clean up resources and watchers for Project */
@@ -453,8 +436,12 @@ export class ZDSProject {
   }
 
   /** Open a project, with the option to open an initial editor too */
-  static async open(projectRef: Signal<Project>, app: App) {
-    return new ZDSProject(projectRef, app)
+  static async open(
+    projectRef: Signal<Project>,
+    app: App,
+    fileSystemOperationProvider: ZDSProjectFileSystemOperationProvider
+  ) {
+    return new ZDSProject(projectRef, app, fileSystemOperationProvider)
   }
 
   get executingPath() {
@@ -612,11 +599,20 @@ export class ZDSProject {
     )
   }
 
-  private getPathOutsideProjectError(path: string) {
-    if (!this.isPathInsideProject(path)) {
-      return new Error(`Path "${path}" is outside project "${this.path}".`)
+  private getPathOutsideProjectError(...paths: string[]) {
+    for (const path of paths) {
+      if (!this.isPathInsideProject(path)) {
+        return new Error(`Path "${path}" is outside project "${this.path}".`)
+      }
     }
     return undefined
+  }
+
+  private ensureProjectPaths(...paths: string[]) {
+    const outsideProjectError = this.getPathOutsideProjectError(...paths)
+    return outsideProjectError
+      ? Promise.reject(outsideProjectError)
+      : Promise.resolve()
   }
 
   private isPathAtOrUnder(path: string, targetPath: string) {
@@ -776,10 +772,7 @@ export class ZDSProject {
   }
 
   async writeFile(input: ZDSProjectFileWriteInput) {
-    const outsideProjectError = this.getPathOutsideProjectError(input.path)
-    if (outsideProjectError) {
-      return Promise.reject(outsideProjectError)
-    }
+    await this.ensureProjectPaths(input.path)
 
     if (input.overwrite === false && (await this.pathExists(input.path))) {
       return Promise.reject(new Error(`File already exists: ${input.path}`))
@@ -797,10 +790,7 @@ export class ZDSProject {
   }
 
   async createFolder(input: ZDSProjectPathInput) {
-    const outsideProjectError = this.getPathOutsideProjectError(input.path)
-    if (outsideProjectError) {
-      return Promise.reject(outsideProjectError)
-    }
+    await this.ensureProjectPaths(input.path)
 
     if (await this.pathExists(input.path)) {
       return Promise.reject(new Error(`Folder already exists: ${input.path}`))
@@ -811,12 +801,7 @@ export class ZDSProject {
   }
 
   async renameEntry(input: ZDSProjectRenameInput) {
-    const outsideProjectError =
-      this.getPathOutsideProjectError(input.oldPath) ??
-      this.getPathOutsideProjectError(input.newPath)
-    if (outsideProjectError) {
-      return Promise.reject(outsideProjectError)
-    }
+    await this.ensureProjectPaths(input.oldPath, input.newPath)
 
     if (input.oldPath === input.newPath) {
       return input.newPath
@@ -831,10 +816,7 @@ export class ZDSProject {
   }
 
   async deleteEntry(input: ZDSProjectPathInput) {
-    const outsideProjectError = this.getPathOutsideProjectError(input.path)
-    if (outsideProjectError) {
-      return Promise.reject(outsideProjectError)
-    }
+    await this.ensureProjectPaths(input.path)
 
     await this.fileSystemOperations.rm(input.path, { recursive: true })
     this.closeProjectEntryEditors(input.path)
@@ -843,12 +825,7 @@ export class ZDSProject {
   }
 
   async copyEntry(input: ZDSProjectCopyMoveInput) {
-    const outsideProjectError =
-      this.getPathOutsideProjectError(input.sourcePath) ??
-      this.getPathOutsideProjectError(input.targetPath)
-    if (outsideProjectError) {
-      return Promise.reject(outsideProjectError)
-    }
+    await this.ensureProjectPaths(input.sourcePath, input.targetPath)
 
     await this.fileSystemOperations.cp(input.sourcePath, input.targetPath, {
       recursive: true,
@@ -858,12 +835,7 @@ export class ZDSProject {
   }
 
   async moveEntry(input: ZDSProjectCopyMoveInput) {
-    const outsideProjectError =
-      this.getPathOutsideProjectError(input.sourcePath) ??
-      this.getPathOutsideProjectError(input.targetPath)
-    if (outsideProjectError) {
-      return Promise.reject(outsideProjectError)
-    }
+    await this.ensureProjectPaths(input.sourcePath, input.targetPath)
 
     await this.movePath(input.sourcePath, input.targetPath)
     this.rewriteProjectEntryPaths(input.sourcePath, input.targetPath)
@@ -871,10 +843,7 @@ export class ZDSProject {
   }
 
   async archiveEntry(input: ZDSProjectPathInput) {
-    const outsideProjectError = this.getPathOutsideProjectError(input.path)
-    if (outsideProjectError) {
-      return Promise.reject(outsideProjectError)
-    }
+    await this.ensureProjectPaths(input.path)
 
     const archivedPath = await toArchivePath(input.path)
     await this.movePath(input.path, archivedPath)
@@ -884,12 +853,7 @@ export class ZDSProject {
   }
 
   async applyFilePatch(input: ZDSProjectFilePatchInput) {
-    for (const file of input.files) {
-      const outsideProjectError = this.getPathOutsideProjectError(file.path)
-      if (outsideProjectError) {
-        return Promise.reject(outsideProjectError)
-      }
-    }
+    await this.ensureProjectPaths(...input.files.map((file) => file.path))
 
     for (const file of input.files) {
       if (file.contents === null) {

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -578,10 +578,11 @@ export class ZDSProject {
     )
   }
 
-  private assertPathInsideProject(path: string) {
+  private getPathOutsideProjectError(path: string) {
     if (!this.isPathInsideProject(path)) {
-      throw new Error(`Path "${path}" is outside project "${this.path}".`)
+      return new Error(`Path "${path}" is outside project "${this.path}".`)
     }
+    return undefined
   }
 
   private isPathAtOrUnder(path: string, targetPath: string) {
@@ -737,7 +738,11 @@ export class ZDSProject {
   }
 
   async writeFile(input: ZDSProjectFileWriteInput) {
-    this.assertPathInsideProject(input.path)
+    const outsideProjectError = this.getPathOutsideProjectError(input.path)
+    if (outsideProjectError) {
+      return Promise.reject(outsideProjectError)
+    }
+
     if (input.overwrite === false && (await this.pathExists(input.path))) {
       return Promise.reject(new Error(`File already exists: ${input.path}`))
     }
@@ -748,7 +753,11 @@ export class ZDSProject {
   }
 
   async createFolder(input: ZDSProjectPathInput) {
-    this.assertPathInsideProject(input.path)
+    const outsideProjectError = this.getPathOutsideProjectError(input.path)
+    if (outsideProjectError) {
+      return Promise.reject(outsideProjectError)
+    }
+
     if (await this.pathExists(input.path)) {
       return Promise.reject(new Error(`Folder already exists: ${input.path}`))
     }
@@ -758,8 +767,13 @@ export class ZDSProject {
   }
 
   async renameEntry(input: ZDSProjectRenameInput) {
-    this.assertPathInsideProject(input.oldPath)
-    this.assertPathInsideProject(input.newPath)
+    const outsideProjectError =
+      this.getPathOutsideProjectError(input.oldPath) ??
+      this.getPathOutsideProjectError(input.newPath)
+    if (outsideProjectError) {
+      return Promise.reject(outsideProjectError)
+    }
+
     if (input.oldPath === input.newPath) {
       return input.newPath
     }
@@ -773,7 +787,11 @@ export class ZDSProject {
   }
 
   async deleteEntry(input: ZDSProjectPathInput) {
-    this.assertPathInsideProject(input.path)
+    const outsideProjectError = this.getPathOutsideProjectError(input.path)
+    if (outsideProjectError) {
+      return Promise.reject(outsideProjectError)
+    }
+
     await fsZds.rm(input.path, { recursive: true })
     this.closeProjectEntryEditors(input.path)
     this.forgetProjectEntryFiles(input.path)
@@ -781,8 +799,13 @@ export class ZDSProject {
   }
 
   async copyEntry(input: ZDSProjectCopyMoveInput) {
-    this.assertPathInsideProject(input.sourcePath)
-    this.assertPathInsideProject(input.targetPath)
+    const outsideProjectError =
+      this.getPathOutsideProjectError(input.sourcePath) ??
+      this.getPathOutsideProjectError(input.targetPath)
+    if (outsideProjectError) {
+      return Promise.reject(outsideProjectError)
+    }
+
     await fsZds.cp(input.sourcePath, input.targetPath, {
       recursive: true,
       force: false,
@@ -791,15 +814,24 @@ export class ZDSProject {
   }
 
   async moveEntry(input: ZDSProjectCopyMoveInput) {
-    this.assertPathInsideProject(input.sourcePath)
-    this.assertPathInsideProject(input.targetPath)
+    const outsideProjectError =
+      this.getPathOutsideProjectError(input.sourcePath) ??
+      this.getPathOutsideProjectError(input.targetPath)
+    if (outsideProjectError) {
+      return Promise.reject(outsideProjectError)
+    }
+
     await this.movePath(input.sourcePath, input.targetPath)
     this.rewriteProjectEntryPaths(input.sourcePath, input.targetPath)
     return input.targetPath
   }
 
   async archiveEntry(input: ZDSProjectPathInput) {
-    this.assertPathInsideProject(input.path)
+    const outsideProjectError = this.getPathOutsideProjectError(input.path)
+    if (outsideProjectError) {
+      return Promise.reject(outsideProjectError)
+    }
+
     const archivedPath = await toArchivePath(input.path)
     await this.movePath(input.path, archivedPath)
     this.closeProjectEntryEditors(input.path)
@@ -809,7 +841,10 @@ export class ZDSProject {
 
   async applyFilePatch(input: ZDSProjectFilePatchInput) {
     for (const file of input.files) {
-      this.assertPathInsideProject(file.path)
+      const outsideProjectError = this.getPathOutsideProjectError(file.path)
+      if (outsideProjectError) {
+        return Promise.reject(outsideProjectError)
+      }
     }
 
     for (const file of input.files) {

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -893,4 +893,90 @@ describe('project system', () => {
       app.dispose()
     }
   })
+
+  it('manages the opened project tree through project session file methods', async () => {
+    const projectPath = `/tmp/app-project-session-tree-${crypto.randomUUID()}`
+    const mainPath = fsZds.join(projectPath, 'main.kcl')
+    const createdPath = fsZds.join(projectPath, 'parts', 'created.kcl')
+    const renamedPath = fsZds.join(projectPath, 'parts', 'renamed.kcl')
+    const app = createAppForTest()
+
+    try {
+      await writeText(mainPath, 'main = true\n')
+      const project: Project = {
+        name: fsZds.basename(projectPath),
+        default_file: mainPath,
+        directory_count: 0,
+        kcl_file_count: 1,
+        metadata: null,
+        path: projectPath,
+        readWriteAccess: true,
+        children: [
+          {
+            name: 'main.kcl',
+            path: mainPath,
+            children: null,
+          },
+        ],
+      }
+
+      const openedProject = await app.openProject(project)
+      const session = app.registry.get(projectSession)
+
+      await session.writeFile({
+        path: createdPath,
+        contents: 'created = true\n',
+      })
+
+      expect(session.projectTree.value?.children).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'parts',
+            children: expect.arrayContaining([
+              expect.objectContaining({
+                name: 'created.kcl',
+                path: createdPath,
+              }),
+            ]),
+          }),
+        ])
+      )
+      expect(openedProject.projectIORefSignal.value).toBe(
+        session.projectTree.value
+      )
+
+      await session.renameEntry({
+        oldPath: createdPath,
+        newPath: renamedPath,
+      })
+
+      await expect(fsZds.readFile(createdPath, 'utf8')).rejects.toThrow()
+      await expect(fsZds.readFile(renamedPath, 'utf8')).resolves.toBe(
+        'created = true\n'
+      )
+      expect(session.projectTree.value?.children).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'parts',
+            children: expect.arrayContaining([
+              expect.objectContaining({
+                name: 'renamed.kcl',
+                path: renamedPath,
+              }),
+            ]),
+          }),
+        ])
+      )
+
+      await expect(
+        session.writeFile({
+          path: fsZds.resolve(projectPath, '..', 'outside.kcl'),
+          contents: 'outside = true\n',
+        })
+      ).rejects.toThrow('outside project')
+    } finally {
+      app.dispose()
+      await fsZds.rm(projectPath, { recursive: true, force: true })
+    }
+  })
 })

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -300,7 +300,6 @@ describe('project system', () => {
     try {
       session.setProject({
         projectIORefSignal: signal(mockProject),
-        setFileSystemOperations: vi.fn(),
       } as unknown as NonNullable<ReturnType<typeof session.getProject>>)
       app.singletons.kclManager.modelingState = {
         matches: (state: string) => state === 'sketchSolveMode',

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -28,6 +28,7 @@ import { billingService } from '@src/registry/contracts/billing'
 import { commandsValueSpec } from '@src/registry/contracts/commands'
 import { engineConnectionService } from '@src/registry/contracts/engineConnection'
 import { executingEditorService } from '@src/registry/contracts/executingEditor'
+import { fsOperationQueue } from '@src/registry/contracts/fsOperationQueue'
 import { machineManagerService } from '@src/registry/contracts/machineManager'
 import { projectSession } from '@src/registry/contracts/projectSession'
 import { userFeaturesService } from '@src/registry/contracts/userFeatures'
@@ -299,7 +300,8 @@ describe('project system', () => {
     try {
       session.setProject({
         projectIORefSignal: signal(mockProject),
-      } as NonNullable<ReturnType<typeof session.getProject>>)
+        setFileSystemOperations: vi.fn(),
+      } as unknown as NonNullable<ReturnType<typeof session.getProject>>)
       app.singletons.kclManager.modelingState = {
         matches: (state: string) => state === 'sketchSolveMode',
       } as unknown as NonNullable<KclManager['modelingState']>
@@ -922,6 +924,8 @@ describe('project system', () => {
 
       const openedProject = await app.openProject(project)
       const session = app.registry.get(projectSession)
+      const queue = app.registry.get(fsOperationQueue)
+      queue.clearJournal()
 
       await session.writeFile({
         path: createdPath,
@@ -954,6 +958,24 @@ describe('project system', () => {
       await expect(fsZds.readFile(renamedPath, 'utf8')).resolves.toBe(
         'created = true\n'
       )
+      expect(queue.getJournal()).toEqual([
+        expect.objectContaining({
+          kind: 'mkdir',
+          status: 'completed',
+          targetPath: fsZds.dirname(createdPath),
+        }),
+        expect.objectContaining({
+          kind: 'write-file',
+          status: 'completed',
+          targetPath: createdPath,
+        }),
+        expect.objectContaining({
+          kind: 'rename',
+          sourcePath: createdPath,
+          status: 'completed',
+          targetPath: renamedPath,
+        }),
+      ])
       expect(session.projectTree.value?.children).toEqual(
         expect.arrayContaining([
           expect.objectContaining({

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -349,7 +349,11 @@ export class App implements AppSubsystems {
       this.settings.get().app.libraries.current
     )
     const projectIORefSignal = signal(ownedProject)
-    const openedProject = await ZDSProject.open(projectIORefSignal, this)
+    const openedProject = await ZDSProject.open(
+      projectIORefSignal,
+      this,
+      session
+    )
     session.setProject(openedProject)
     this.setCloudSyncOpenedProject(ownedProject)
 

--- a/src/registry/contracts/projectSession.ts
+++ b/src/registry/contracts/projectSession.ts
@@ -1,6 +1,70 @@
 import { defineContract, defineService } from '@kittycad/registry'
 import type { Signal } from '@preact/signals-core'
-import type { ZDSProject } from '@src/lang/KclManager'
+import type { KclManager, ZDSProject } from '@src/lang/KclManager'
+import type { Project } from '@src/lib/project'
+
+export type ProjectSessionMutationOperation =
+  | 'refresh-project-tree'
+  | 'open-editor'
+  | 'close-editor'
+  | 'close-all-editors'
+  | 'create-file'
+  | 'write-file'
+  | 'create-folder'
+  | 'rename-entry'
+  | 'delete-entry'
+  | 'copy-entry'
+  | 'move-entry'
+  | 'archive-entry'
+  | 'apply-file-patch'
+
+export interface ProjectSessionMutationState {
+  readonly pending: boolean
+  readonly operation?: ProjectSessionMutationOperation
+  readonly targetPath?: string
+  readonly lastTargetPath?: string
+}
+
+export interface ProjectSessionOpenEditorInput {
+  readonly path: string
+  readonly editor?: KclManager
+  readonly code?: string
+  readonly isExecuting?: boolean
+}
+
+export interface ProjectSessionFileWriteInput {
+  readonly path: string
+  readonly contents?: string | Uint8Array<ArrayBuffer>
+  readonly overwrite?: boolean
+  readonly useDefaultKclContents?: boolean
+}
+
+export interface ProjectSessionEntryPathInput {
+  readonly path: string
+}
+
+export interface ProjectSessionEntryRenameInput {
+  readonly oldPath: string
+  readonly newPath: string
+}
+
+export interface ProjectSessionEntryCopyMoveInput {
+  readonly sourcePath: string
+  readonly targetPath: string
+}
+
+export interface ProjectSessionArchiveEntryResult {
+  readonly archivedPath: string
+}
+
+export interface ProjectSessionFilePatchEntry {
+  readonly path: string
+  readonly contents: string | null
+}
+
+export interface ProjectSessionApplyFilePatchInput {
+  readonly files: readonly ProjectSessionFilePatchEntry[]
+}
 
 /**
  * Owns the currently opened project session.
@@ -10,10 +74,28 @@ import type { ZDSProject } from '@src/lang/KclManager'
  */
 export interface ProjectSessionService {
   readonly project: Signal<ZDSProject | undefined>
+  readonly projectTree: Signal<Project | undefined>
   readonly currentProjectLibraryId: Signal<string | undefined>
+  readonly mutation: Signal<ProjectSessionMutationState>
   getProject: () => ZDSProject | undefined
   setProject: (project: ZDSProject | undefined) => void
   clearProject: () => void
+  getProjectTree: () => Project | undefined
+  refreshProjectTree: () => Promise<Project | undefined>
+  openEditor: (input: ProjectSessionOpenEditorInput) => Promise<KclManager>
+  closeEditor: (input: ProjectSessionEntryPathInput) => void
+  closeAllEditors: () => void
+  createFile: (input: ProjectSessionFileWriteInput) => Promise<string>
+  writeFile: (input: ProjectSessionFileWriteInput) => Promise<string>
+  createFolder: (input: ProjectSessionEntryPathInput) => Promise<string>
+  renameEntry: (input: ProjectSessionEntryRenameInput) => Promise<string>
+  deleteEntry: (input: ProjectSessionEntryPathInput) => Promise<string>
+  copyEntry: (input: ProjectSessionEntryCopyMoveInput) => Promise<string>
+  moveEntry: (input: ProjectSessionEntryCopyMoveInput) => Promise<string>
+  archiveEntry: (
+    input: ProjectSessionEntryPathInput
+  ) => Promise<ProjectSessionArchiveEntryResult>
+  applyFilePatch: (input: ProjectSessionApplyFilePatchInput) => Promise<void>
   getCurrentProjectLibraryId: () => string | undefined
   setCurrentProjectLibraryId: (libraryId: string | undefined) => void
 }

--- a/src/registry/contracts/projectSession.ts
+++ b/src/registry/contracts/projectSession.ts
@@ -1,6 +1,10 @@
 import { defineContract, defineService } from '@kittycad/registry'
 import type { Signal } from '@preact/signals-core'
-import type { KclManager, ZDSProject } from '@src/lang/KclManager'
+import type {
+  KclManager,
+  ZDSProject,
+  ZDSProjectFileSystemOperations,
+} from '@src/lang/KclManager'
 import type { Project } from '@src/lib/project'
 
 export type ProjectSessionMutationOperation =
@@ -78,6 +82,7 @@ export interface ProjectSessionService {
   readonly currentProjectLibraryId: Signal<string | undefined>
   readonly mutation: Signal<ProjectSessionMutationState>
   getProject: () => ZDSProject | undefined
+  getFileSystemOperations: () => ZDSProjectFileSystemOperations
   setProject: (project: ZDSProject | undefined) => void
   clearProject: () => void
   getProjectTree: () => Project | undefined

--- a/src/registry/extensions/projectSession/index.test.ts
+++ b/src/registry/extensions/projectSession/index.test.ts
@@ -92,6 +92,25 @@ describe('project session extension', () => {
     expect(projectSession.projectTree.value).toBeUndefined()
   })
 
+  it('mirrors external updates from the opened project tree signal', () => {
+    const projectSession = configureProjectSession()
+    const project = createFakeProject()
+    const updatedProjectTree = createProjectTree('bracket-updated')
+
+    projectSession.setProject(project)
+
+    project.projectIORefSignal.value = updatedProjectTree
+
+    expect(projectSession.getProjectTree()).toBe(updatedProjectTree)
+    expect(projectSession.projectTree.value).toBe(updatedProjectTree)
+
+    projectSession.clearProject()
+    project.projectIORefSignal.value = createProjectTree('after-clear')
+
+    expect(projectSession.getProjectTree()).toBeUndefined()
+    expect(projectSession.projectTree.value).toBeUndefined()
+  })
+
   it('tracks the current project library id', () => {
     const projectSession = configureProjectSession()
 

--- a/src/registry/extensions/projectSession/index.test.ts
+++ b/src/registry/extensions/projectSession/index.test.ts
@@ -1,8 +1,11 @@
 import { Registry } from '@kittycad/registry'
+import { signal } from '@preact/signals-core'
+import type { KclManager } from '@src/lang/KclManager'
 import type { ZDSProject } from '@src/lang/KclManager'
+import type { Project } from '@src/lib/project'
 import { projectSession } from '@src/registry/contracts/projectSession'
 import projectSessionRegistryItem from '@src/registry/extensions/projectSession'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 describe('project session extension', () => {
   let registry: Registry | undefined
@@ -12,44 +15,254 @@ describe('project session extension', () => {
     registry = undefined
   })
 
-  it('provides the opened project session through registry signals', () => {
+  function configureProjectSession() {
     registry = new Registry()
     registry.configure([projectSessionRegistryItem])
+    return registry.get(projectSession)
+  }
 
-    const session = registry.get(projectSession)
-    const project = { name: 'bracket' } as ZDSProject
+  function createProjectTree(name = 'bracket'): Project {
+    return {
+      name,
+      path: `/projects/${name}`,
+      children: [],
+      default_file: `/projects/${name}/main.kcl`,
+      directory_count: 0,
+      kcl_file_count: 1,
+      metadata: null,
+      readWriteAccess: true,
+    }
+  }
 
-    expect(session.getProject()).toBeUndefined()
-    expect(session.project.value).toBeUndefined()
+  function createFakeProject(projectTree = createProjectTree()) {
+    const refreshedProjectTree = createProjectTree(`${projectTree.name}-fresh`)
+    return {
+      path: projectTree.path,
+      name: projectTree.name,
+      projectIORefSignal: signal(projectTree),
+      refreshProjectTree: vi.fn(async () => refreshedProjectTree),
+      openEditor: vi.fn(async () => ({}) as KclManager),
+      closeEditor: vi.fn(),
+      closeAllEditors: vi.fn(),
+      createFile: vi.fn(async ({ path }: { path: string }) => path),
+      writeFile: vi.fn(async ({ path }: { path: string }) => path),
+      createFolder: vi.fn(async ({ path }: { path: string }) => path),
+      renameEntry: vi.fn(async ({ newPath }: { newPath: string }) => newPath),
+      deleteEntry: vi.fn(async ({ path }: { path: string }) => path),
+      copyEntry: vi.fn(
+        async ({ targetPath }: { targetPath: string }) => targetPath
+      ),
+      moveEntry: vi.fn(
+        async ({ targetPath }: { targetPath: string }) => targetPath
+      ),
+      archiveEntry: vi.fn(async () => ({ archivedPath: '/archive/main.kcl' })),
+      applyFilePatch: vi.fn(async () => undefined),
+    } as unknown as ZDSProject
+  }
 
-    session.setProject(project)
+  it('provides the opened project session through registry signals', () => {
+    const projectSession = configureProjectSession()
+    const project = createFakeProject()
 
-    expect(session.getProject()).toBe(project)
-    expect(session.project.value).toBe(project)
+    expect(projectSession.getProject()).toBeUndefined()
+    expect(projectSession.project.value).toBeUndefined()
+    expect(projectSession.getProjectTree()).toBeUndefined()
+    expect(projectSession.projectTree.value).toBeUndefined()
 
-    session.clearProject()
+    projectSession.setProject(project)
 
-    expect(session.getProject()).toBeUndefined()
-    expect(session.project.value).toBeUndefined()
+    expect(projectSession.getProject()).toBe(project)
+    expect(projectSession.project.value).toBe(project)
+    expect(projectSession.getProjectTree()).toBe(
+      project.projectIORefSignal.value
+    )
+    expect(projectSession.projectTree.value).toBe(
+      project.projectIORefSignal.value
+    )
+
+    projectSession.clearProject()
+
+    expect(projectSession.getProject()).toBeUndefined()
+    expect(projectSession.project.value).toBeUndefined()
+    expect(projectSession.getProjectTree()).toBeUndefined()
+    expect(projectSession.projectTree.value).toBeUndefined()
   })
 
   it('tracks the current project library id', () => {
-    registry = new Registry()
-    registry.configure([projectSessionRegistryItem])
+    const projectSession = configureProjectSession()
 
-    const session = registry.get(projectSession)
+    expect(projectSession.getCurrentProjectLibraryId()).toBeUndefined()
+    expect(projectSession.currentProjectLibraryId.value).toBeUndefined()
 
-    expect(session.getCurrentProjectLibraryId()).toBeUndefined()
-    expect(session.currentProjectLibraryId.value).toBeUndefined()
+    projectSession.setCurrentProjectLibraryId('directory:projects')
 
-    session.setCurrentProjectLibraryId('directory:projects')
+    expect(projectSession.getCurrentProjectLibraryId()).toBe(
+      'directory:projects'
+    )
+    expect(projectSession.currentProjectLibraryId.value).toBe(
+      'directory:projects'
+    )
 
-    expect(session.getCurrentProjectLibraryId()).toBe('directory:projects')
-    expect(session.currentProjectLibraryId.value).toBe('directory:projects')
+    projectSession.setCurrentProjectLibraryId(undefined)
 
-    session.setCurrentProjectLibraryId(undefined)
+    expect(projectSession.getCurrentProjectLibraryId()).toBeUndefined()
+    expect(projectSession.currentProjectLibraryId.value).toBeUndefined()
+  })
 
-    expect(session.getCurrentProjectLibraryId()).toBeUndefined()
-    expect(session.currentProjectLibraryId.value).toBeUndefined()
+  it('refreshes the hydrated project tree through the opened project', async () => {
+    const projectSession = configureProjectSession()
+    const project = createFakeProject()
+    projectSession.setProject(project)
+
+    const refreshedProjectTree = await projectSession.refreshProjectTree()
+
+    expect(project.refreshProjectTree).toHaveBeenCalledOnce()
+    expect(refreshedProjectTree).toBe(projectSession.projectTree.value)
+    expect(projectSession.getProjectTree()).toBe(refreshedProjectTree)
+    expect(projectSession.mutation.value).toEqual({
+      pending: false,
+      operation: 'refresh-project-tree',
+      lastTargetPath: project.path,
+    })
+  })
+
+  it('delegates editor management through the opened project', async () => {
+    const projectSession = configureProjectSession()
+    const project = createFakeProject()
+    projectSession.setProject(project)
+
+    const editor = {} as KclManager
+    await projectSession.openEditor({
+      path: '/projects/bracket/main.kcl',
+      editor,
+      code: 'cube(1)',
+      isExecuting: false,
+    })
+    projectSession.closeEditor({ path: '/projects/bracket/main.kcl' })
+    projectSession.closeAllEditors()
+
+    expect(project.openEditor).toHaveBeenCalledWith(
+      '/projects/bracket/main.kcl',
+      editor,
+      'cube(1)',
+      false
+    )
+    expect(project.closeEditor).toHaveBeenCalledWith(
+      '/projects/bracket/main.kcl'
+    )
+    expect(project.closeAllEditors).toHaveBeenCalledOnce()
+  })
+
+  it('delegates file management through the opened project and refreshes projectTree', async () => {
+    const projectSession = configureProjectSession()
+    const project = createFakeProject()
+    projectSession.setProject(project)
+
+    await projectSession.createFile({ path: '/projects/bracket/new.kcl' })
+    await projectSession.writeFile({
+      path: '/projects/bracket/main.kcl',
+      contents: 'cube(1)',
+    })
+    await projectSession.createFolder({ path: '/projects/bracket/parts' })
+    await projectSession.renameEntry({
+      oldPath: '/projects/bracket/old.kcl',
+      newPath: '/projects/bracket/new.kcl',
+    })
+    await projectSession.copyEntry({
+      sourcePath: '/projects/bracket/new.kcl',
+      targetPath: '/projects/bracket/copy.kcl',
+    })
+    await projectSession.moveEntry({
+      sourcePath: '/projects/bracket/copy.kcl',
+      targetPath: '/projects/bracket/parts/copy.kcl',
+    })
+    await projectSession.deleteEntry({
+      path: '/projects/bracket/parts/copy.kcl',
+    })
+    await projectSession.archiveEntry({ path: '/projects/bracket/new.kcl' })
+    await projectSession.applyFilePatch({
+      files: [{ path: '/projects/bracket/main.kcl', contents: 'cube(2)' }],
+    })
+
+    expect(project.createFile).toHaveBeenCalledWith({
+      path: '/projects/bracket/new.kcl',
+    })
+    expect(project.writeFile).toHaveBeenCalledWith({
+      path: '/projects/bracket/main.kcl',
+      contents: 'cube(1)',
+    })
+    expect(project.createFolder).toHaveBeenCalledWith({
+      path: '/projects/bracket/parts',
+    })
+    expect(project.renameEntry).toHaveBeenCalledWith({
+      oldPath: '/projects/bracket/old.kcl',
+      newPath: '/projects/bracket/new.kcl',
+    })
+    expect(project.copyEntry).toHaveBeenCalledWith({
+      sourcePath: '/projects/bracket/new.kcl',
+      targetPath: '/projects/bracket/copy.kcl',
+    })
+    expect(project.moveEntry).toHaveBeenCalledWith({
+      sourcePath: '/projects/bracket/copy.kcl',
+      targetPath: '/projects/bracket/parts/copy.kcl',
+    })
+    expect(project.deleteEntry).toHaveBeenCalledWith({
+      path: '/projects/bracket/parts/copy.kcl',
+    })
+    expect(project.archiveEntry).toHaveBeenCalledWith({
+      path: '/projects/bracket/new.kcl',
+    })
+    expect(project.applyFilePatch).toHaveBeenCalledWith({
+      files: [{ path: '/projects/bracket/main.kcl', contents: 'cube(2)' }],
+    })
+    expect(project.refreshProjectTree).toHaveBeenCalledTimes(9)
+    expect(projectSession.projectTree.value?.name).toBe('bracket-fresh')
+    expect(projectSession.mutation.value).toEqual({
+      pending: false,
+      operation: 'apply-file-patch',
+      lastTargetPath: '/projects/bracket/main.kcl',
+    })
+  })
+
+  it('tracks pending mutation state while a file operation is in flight', async () => {
+    const projectSession = configureProjectSession()
+    const project = createFakeProject()
+    let finishCreateFile: (() => void) | undefined
+    project.createFile = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          finishCreateFile = () => resolve('/projects/bracket/new.kcl')
+        })
+    )
+    projectSession.setProject(project)
+
+    const pendingCreate = projectSession.createFile({
+      path: '/projects/bracket/new.kcl',
+    })
+
+    expect(projectSession.mutation.value).toEqual({
+      pending: true,
+      operation: 'create-file',
+      targetPath: '/projects/bracket/new.kcl',
+    })
+
+    finishCreateFile?.()
+    await pendingCreate
+
+    expect(projectSession.mutation.value).toEqual({
+      pending: false,
+      operation: 'create-file',
+      lastTargetPath: '/projects/bracket/new.kcl',
+    })
+  })
+
+  it('rejects mutating methods when no project is open', async () => {
+    const projectSession = configureProjectSession()
+
+    await expect(
+      projectSession.createFile({ path: '/projects/bracket/main.kcl' })
+    ).rejects.toThrow('No project is currently open.')
+    await expect(projectSession.refreshProjectTree()).resolves.toBeUndefined()
+    expect(projectSession.projectTree.value).toBeUndefined()
   })
 })

--- a/src/registry/extensions/projectSession/index.test.ts
+++ b/src/registry/extensions/projectSession/index.test.ts
@@ -3,6 +3,7 @@ import { signal } from '@preact/signals-core'
 import type { KclManager } from '@src/lang/KclManager'
 import type { ZDSProject } from '@src/lang/KclManager'
 import type { Project } from '@src/lib/project'
+import { fsOperationQueue } from '@src/registry/contracts/fsOperationQueue'
 import { projectSession } from '@src/registry/contracts/projectSession'
 import projectSessionRegistryItem from '@src/registry/extensions/projectSession'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -19,6 +20,11 @@ describe('project session extension', () => {
     registry = new Registry()
     registry.configure([projectSessionRegistryItem])
     return registry.get(projectSession)
+  }
+
+  async function flushMicrotasks() {
+    await Promise.resolve()
+    await Promise.resolve()
   }
 
   function createProjectTree(name = 'bracket'): Project {
@@ -240,6 +246,20 @@ describe('project session extension', () => {
     })
     expect(project.mocks.refreshProjectTree).toHaveBeenCalledTimes(9)
     expect(projectSession.projectTree.value?.name).toBe('bracket-fresh')
+    expect(registry?.get(fsOperationQueue).getJournal()).toEqual([
+      expect.objectContaining({ kind: 'create-file', status: 'completed' }),
+      expect.objectContaining({ kind: 'write-file', status: 'completed' }),
+      expect.objectContaining({ kind: 'create-folder', status: 'completed' }),
+      expect.objectContaining({ kind: 'rename-entry', status: 'completed' }),
+      expect.objectContaining({ kind: 'copy-entry', status: 'completed' }),
+      expect.objectContaining({ kind: 'move-entry', status: 'completed' }),
+      expect.objectContaining({ kind: 'delete-entry', status: 'completed' }),
+      expect.objectContaining({ kind: 'archive-entry', status: 'completed' }),
+      expect.objectContaining({
+        kind: 'apply-file-patch',
+        status: 'completed',
+      }),
+    ])
     expect(projectSession.mutation.value).toEqual({
       pending: false,
       operation: 'apply-file-patch',
@@ -263,6 +283,7 @@ describe('project session extension', () => {
     const pendingCreate = projectSession.createFile({
       path: '/projects/bracket/new.kcl',
     })
+    await flushMicrotasks()
 
     expect(projectSession.mutation.value).toEqual({
       pending: true,

--- a/src/registry/extensions/projectSession/index.test.ts
+++ b/src/registry/extensions/projectSession/index.test.ts
@@ -3,7 +3,6 @@ import { signal } from '@preact/signals-core'
 import type { KclManager } from '@src/lang/KclManager'
 import type { ZDSProject } from '@src/lang/KclManager'
 import type { Project } from '@src/lib/project'
-import { fsOperationQueue } from '@src/registry/contracts/fsOperationQueue'
 import { projectSession } from '@src/registry/contracts/projectSession'
 import projectSessionRegistryItem from '@src/registry/extensions/projectSession'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -47,6 +46,7 @@ describe('project session extension', () => {
       openEditor: vi.fn(async () => ({}) as KclManager),
       closeEditor: vi.fn(),
       closeAllEditors: vi.fn(),
+      setFileSystemOperations: vi.fn(),
       createFile: vi.fn(async ({ path }: { path: string }) => path),
       writeFile: vi.fn(async ({ path }: { path: string }) => path),
       createFolder: vi.fn(async ({ path }: { path: string }) => path),
@@ -81,6 +81,17 @@ describe('project session extension', () => {
 
     projectSession.setProject(project)
 
+    const injectedFileSystemOperations =
+      project.mocks.setFileSystemOperations.mock.calls[0]?.[0]
+    expect(injectedFileSystemOperations).toEqual(
+      expect.objectContaining({
+        cp: expect.any(Function),
+        mkdir: expect.any(Function),
+        rename: expect.any(Function),
+        rm: expect.any(Function),
+        writeFile: expect.any(Function),
+      })
+    )
     expect(projectSession.getProject()).toBe(project)
     expect(projectSession.project.value).toBe(project)
     expect(projectSession.getProjectTree()).toBe(
@@ -246,20 +257,6 @@ describe('project session extension', () => {
     })
     expect(project.mocks.refreshProjectTree).toHaveBeenCalledTimes(9)
     expect(projectSession.projectTree.value?.name).toBe('bracket-fresh')
-    expect(registry?.get(fsOperationQueue).getJournal()).toEqual([
-      expect.objectContaining({ kind: 'create-file', status: 'completed' }),
-      expect.objectContaining({ kind: 'write-file', status: 'completed' }),
-      expect.objectContaining({ kind: 'create-folder', status: 'completed' }),
-      expect.objectContaining({ kind: 'rename-entry', status: 'completed' }),
-      expect.objectContaining({ kind: 'copy-entry', status: 'completed' }),
-      expect.objectContaining({ kind: 'move-entry', status: 'completed' }),
-      expect.objectContaining({ kind: 'delete-entry', status: 'completed' }),
-      expect.objectContaining({ kind: 'archive-entry', status: 'completed' }),
-      expect.objectContaining({
-        kind: 'apply-file-patch',
-        status: 'completed',
-      }),
-    ])
     expect(projectSession.mutation.value).toEqual({
       pending: false,
       operation: 'apply-file-patch',

--- a/src/registry/extensions/projectSession/index.test.ts
+++ b/src/registry/extensions/projectSession/index.test.ts
@@ -1,8 +1,8 @@
 import { Registry } from '@kittycad/registry'
 import { signal } from '@preact/signals-core'
-import type { KclManager } from '@src/lang/KclManager'
-import type { ZDSProject } from '@src/lang/KclManager'
+import type { KclManager, ZDSProject } from '@src/lang/KclManager'
 import type { Project } from '@src/lib/project'
+import { fsOperationQueue } from '@src/registry/contracts/fsOperationQueue'
 import { projectSession } from '@src/registry/contracts/projectSession'
 import projectSessionRegistryItem from '@src/registry/extensions/projectSession'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -143,6 +143,7 @@ describe('project session extension', () => {
     expect(projectSession.getFileSystemOperations()).toEqual(
       expect.objectContaining({
         cp: expect.any(Function),
+        batch: expect.any(Function),
         mkdir: expect.any(Function),
         rename: expect.any(Function),
         rm: expect.any(Function),
@@ -226,37 +227,61 @@ describe('project session extension', () => {
       files: [{ path: '/projects/bracket/main.kcl', contents: 'cube(2)' }],
     })
 
-    expect(project.mocks.createFile).toHaveBeenCalledWith({
-      path: '/projects/bracket/new.kcl',
+    const batchFacade = expect.objectContaining({
+      id: expect.any(String),
+      run: expect.any(Function),
+      writeFile: expect.any(Function),
     })
-    expect(project.mocks.writeFile).toHaveBeenCalledWith({
-      path: '/projects/bracket/main.kcl',
-      contents: 'cube(1)',
-    })
-    expect(project.mocks.createFolder).toHaveBeenCalledWith({
-      path: '/projects/bracket/parts',
-    })
-    expect(project.mocks.renameEntry).toHaveBeenCalledWith({
-      oldPath: '/projects/bracket/old.kcl',
-      newPath: '/projects/bracket/new.kcl',
-    })
-    expect(project.mocks.copyEntry).toHaveBeenCalledWith({
-      sourcePath: '/projects/bracket/new.kcl',
-      targetPath: '/projects/bracket/copy.kcl',
-    })
-    expect(project.mocks.moveEntry).toHaveBeenCalledWith({
-      sourcePath: '/projects/bracket/copy.kcl',
-      targetPath: '/projects/bracket/parts/copy.kcl',
-    })
-    expect(project.mocks.deleteEntry).toHaveBeenCalledWith({
-      path: '/projects/bracket/parts/copy.kcl',
-    })
-    expect(project.mocks.archiveEntry).toHaveBeenCalledWith({
-      path: '/projects/bracket/new.kcl',
-    })
-    expect(project.mocks.applyFilePatch).toHaveBeenCalledWith({
-      files: [{ path: '/projects/bracket/main.kcl', contents: 'cube(2)' }],
-    })
+    expect(project.mocks.createFile).toHaveBeenCalledWith(
+      { path: '/projects/bracket/new.kcl' },
+      batchFacade
+    )
+    expect(project.mocks.writeFile).toHaveBeenCalledWith(
+      {
+        path: '/projects/bracket/main.kcl',
+        contents: 'cube(1)',
+      },
+      batchFacade
+    )
+    expect(project.mocks.createFolder).toHaveBeenCalledWith(
+      { path: '/projects/bracket/parts' },
+      batchFacade
+    )
+    expect(project.mocks.renameEntry).toHaveBeenCalledWith(
+      {
+        oldPath: '/projects/bracket/old.kcl',
+        newPath: '/projects/bracket/new.kcl',
+      },
+      batchFacade
+    )
+    expect(project.mocks.copyEntry).toHaveBeenCalledWith(
+      {
+        sourcePath: '/projects/bracket/new.kcl',
+        targetPath: '/projects/bracket/copy.kcl',
+      },
+      batchFacade
+    )
+    expect(project.mocks.moveEntry).toHaveBeenCalledWith(
+      {
+        sourcePath: '/projects/bracket/copy.kcl',
+        targetPath: '/projects/bracket/parts/copy.kcl',
+      },
+      batchFacade
+    )
+    expect(project.mocks.deleteEntry).toHaveBeenCalledWith(
+      { path: '/projects/bracket/parts/copy.kcl' },
+      batchFacade
+    )
+    expect(project.mocks.archiveEntry).toHaveBeenCalledWith(
+      { path: '/projects/bracket/new.kcl' },
+      batchFacade
+    )
+    expect(project.mocks.applyFilePatch).toHaveBeenCalledWith(
+      {
+        files: [{ path: '/projects/bracket/main.kcl', contents: 'cube(2)' }],
+      },
+      batchFacade
+    )
     expect(project.mocks.refreshProjectTree).toHaveBeenCalledTimes(9)
     expect(projectSession.projectTree.value?.name).toBe('bracket-fresh')
     expect(projectSession.mutation.value).toEqual({
@@ -298,6 +323,54 @@ describe('project session extension', () => {
       operation: 'create-file',
       lastTargetPath: '/projects/bracket/new.kcl',
     })
+  })
+
+  it('keeps project mutations exclusive through their tree refresh', async () => {
+    const projectSession = configureProjectSession()
+    const project = createFakeProject()
+    let finishCreateFile: (() => void) | undefined
+    const order: string[] = []
+    project.mocks.createFile = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          order.push('create:start')
+          finishCreateFile = () => {
+            order.push('create:end')
+            resolve('/projects/bracket/new.kcl')
+          }
+        })
+    )
+    project.mocks.writeFile = vi.fn(async () => {
+      order.push('write')
+      return '/projects/bracket/main.kcl'
+    })
+    project.createFile = project.mocks.createFile
+    project.writeFile = project.mocks.writeFile
+    projectSession.setProject(project)
+
+    const create = projectSession.createFile({
+      path: '/projects/bracket/new.kcl',
+    })
+    const write = projectSession.writeFile({
+      path: '/projects/bracket/main.kcl',
+      contents: 'cube(1)',
+    })
+    await flushMicrotasks()
+
+    expect(order).toEqual(['create:start'])
+    expect(projectSession.mutation.value.operation).toBe('create-file')
+
+    finishCreateFile?.()
+    await Promise.all([create, write])
+
+    expect(order).toEqual(['create:start', 'create:end', 'write'])
+    const queue = registry?.get(fsOperationQueue)
+    expect(
+      queue?.getJournal().map(({ kind, status }) => ({ kind, status }))
+    ).toEqual([
+      { kind: 'create-file', status: 'completed' },
+      { kind: 'write-file', status: 'completed' },
+    ])
   })
 
   it('rejects mutating methods when no project is open', async () => {

--- a/src/registry/extensions/projectSession/index.test.ts
+++ b/src/registry/extensions/projectSession/index.test.ts
@@ -46,7 +46,6 @@ describe('project session extension', () => {
       openEditor: vi.fn(async () => ({}) as KclManager),
       closeEditor: vi.fn(),
       closeAllEditors: vi.fn(),
-      setFileSystemOperations: vi.fn(),
       createFile: vi.fn(async ({ path }: { path: string }) => path),
       writeFile: vi.fn(async ({ path }: { path: string }) => path),
       createFolder: vi.fn(async ({ path }: { path: string }) => path),
@@ -81,17 +80,6 @@ describe('project session extension', () => {
 
     projectSession.setProject(project)
 
-    const injectedFileSystemOperations =
-      project.mocks.setFileSystemOperations.mock.calls[0]?.[0]
-    expect(injectedFileSystemOperations).toEqual(
-      expect.objectContaining({
-        cp: expect.any(Function),
-        mkdir: expect.any(Function),
-        rename: expect.any(Function),
-        rm: expect.any(Function),
-        writeFile: expect.any(Function),
-      })
-    )
     expect(projectSession.getProject()).toBe(project)
     expect(projectSession.project.value).toBe(project)
     expect(projectSession.getProjectTree()).toBe(
@@ -147,6 +135,20 @@ describe('project session extension', () => {
 
     expect(projectSession.getCurrentProjectLibraryId()).toBeUndefined()
     expect(projectSession.currentProjectLibraryId.value).toBeUndefined()
+  })
+
+  it('provides queue-backed filesystem operations for opened projects', () => {
+    const projectSession = configureProjectSession()
+
+    expect(projectSession.getFileSystemOperations()).toEqual(
+      expect.objectContaining({
+        cp: expect.any(Function),
+        mkdir: expect.any(Function),
+        rename: expect.any(Function),
+        rm: expect.any(Function),
+        writeFile: expect.any(Function),
+      })
+    )
   })
 
   it('refreshes the hydrated project tree through the opened project', async () => {

--- a/src/registry/extensions/projectSession/index.test.ts
+++ b/src/registry/extensions/projectSession/index.test.ts
@@ -36,10 +36,7 @@ describe('project session extension', () => {
 
   function createFakeProject(projectTree = createProjectTree()) {
     const refreshedProjectTree = createProjectTree(`${projectTree.name}-fresh`)
-    return {
-      path: projectTree.path,
-      name: projectTree.name,
-      projectIORefSignal: signal(projectTree),
+    const mocks = {
       refreshProjectTree: vi.fn(async () => refreshedProjectTree),
       openEditor: vi.fn(async () => ({}) as KclManager),
       closeEditor: vi.fn(),
@@ -57,7 +54,14 @@ describe('project session extension', () => {
       ),
       archiveEntry: vi.fn(async () => ({ archivedPath: '/archive/main.kcl' })),
       applyFilePatch: vi.fn(async () => undefined),
-    } as unknown as ZDSProject
+    }
+    return {
+      path: projectTree.path,
+      name: projectTree.name,
+      projectIORefSignal: signal(projectTree),
+      ...mocks,
+      mocks,
+    } as unknown as ZDSProject & { mocks: typeof mocks }
   }
 
   it('provides the opened project session through registry signals', () => {
@@ -116,7 +120,7 @@ describe('project session extension', () => {
 
     const refreshedProjectTree = await projectSession.refreshProjectTree()
 
-    expect(project.refreshProjectTree).toHaveBeenCalledOnce()
+    expect(project.mocks.refreshProjectTree).toHaveBeenCalledOnce()
     expect(refreshedProjectTree).toBe(projectSession.projectTree.value)
     expect(projectSession.getProjectTree()).toBe(refreshedProjectTree)
     expect(projectSession.mutation.value).toEqual({
@@ -141,16 +145,16 @@ describe('project session extension', () => {
     projectSession.closeEditor({ path: '/projects/bracket/main.kcl' })
     projectSession.closeAllEditors()
 
-    expect(project.openEditor).toHaveBeenCalledWith(
+    expect(project.mocks.openEditor).toHaveBeenCalledWith(
       '/projects/bracket/main.kcl',
       editor,
       'cube(1)',
       false
     )
-    expect(project.closeEditor).toHaveBeenCalledWith(
+    expect(project.mocks.closeEditor).toHaveBeenCalledWith(
       '/projects/bracket/main.kcl'
     )
-    expect(project.closeAllEditors).toHaveBeenCalledOnce()
+    expect(project.mocks.closeAllEditors).toHaveBeenCalledOnce()
   })
 
   it('delegates file management through the opened project and refreshes projectTree', async () => {
@@ -184,38 +188,38 @@ describe('project session extension', () => {
       files: [{ path: '/projects/bracket/main.kcl', contents: 'cube(2)' }],
     })
 
-    expect(project.createFile).toHaveBeenCalledWith({
+    expect(project.mocks.createFile).toHaveBeenCalledWith({
       path: '/projects/bracket/new.kcl',
     })
-    expect(project.writeFile).toHaveBeenCalledWith({
+    expect(project.mocks.writeFile).toHaveBeenCalledWith({
       path: '/projects/bracket/main.kcl',
       contents: 'cube(1)',
     })
-    expect(project.createFolder).toHaveBeenCalledWith({
+    expect(project.mocks.createFolder).toHaveBeenCalledWith({
       path: '/projects/bracket/parts',
     })
-    expect(project.renameEntry).toHaveBeenCalledWith({
+    expect(project.mocks.renameEntry).toHaveBeenCalledWith({
       oldPath: '/projects/bracket/old.kcl',
       newPath: '/projects/bracket/new.kcl',
     })
-    expect(project.copyEntry).toHaveBeenCalledWith({
+    expect(project.mocks.copyEntry).toHaveBeenCalledWith({
       sourcePath: '/projects/bracket/new.kcl',
       targetPath: '/projects/bracket/copy.kcl',
     })
-    expect(project.moveEntry).toHaveBeenCalledWith({
+    expect(project.mocks.moveEntry).toHaveBeenCalledWith({
       sourcePath: '/projects/bracket/copy.kcl',
       targetPath: '/projects/bracket/parts/copy.kcl',
     })
-    expect(project.deleteEntry).toHaveBeenCalledWith({
+    expect(project.mocks.deleteEntry).toHaveBeenCalledWith({
       path: '/projects/bracket/parts/copy.kcl',
     })
-    expect(project.archiveEntry).toHaveBeenCalledWith({
+    expect(project.mocks.archiveEntry).toHaveBeenCalledWith({
       path: '/projects/bracket/new.kcl',
     })
-    expect(project.applyFilePatch).toHaveBeenCalledWith({
+    expect(project.mocks.applyFilePatch).toHaveBeenCalledWith({
       files: [{ path: '/projects/bracket/main.kcl', contents: 'cube(2)' }],
     })
-    expect(project.refreshProjectTree).toHaveBeenCalledTimes(9)
+    expect(project.mocks.refreshProjectTree).toHaveBeenCalledTimes(9)
     expect(projectSession.projectTree.value?.name).toBe('bracket-fresh')
     expect(projectSession.mutation.value).toEqual({
       pending: false,
@@ -228,12 +232,13 @@ describe('project session extension', () => {
     const projectSession = configureProjectSession()
     const project = createFakeProject()
     let finishCreateFile: (() => void) | undefined
-    project.createFile = vi.fn(
+    project.mocks.createFile = vi.fn(
       () =>
         new Promise<string>((resolve) => {
           finishCreateFile = () => resolve('/projects/bracket/new.kcl')
         })
     )
+    project.createFile = project.mocks.createFile
     projectSession.setProject(project)
 
     const pendingCreate = projectSession.createFile({

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -133,23 +133,6 @@ export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
     }
   }
 
-  const runQueuedProjectMutation = <Result>(
-    operation: ProjectSessionMutationOperation,
-    targetPath: string | undefined,
-    run: (currentProject: ZDSProject) => Promise<Result>,
-    options: { refreshProjectTree?: boolean } = {}
-  ) =>
-    ctx.services.get(fsOperationQueue).run(
-      {
-        kind: operation,
-        targetPath,
-        metadata: {
-          service: 'projectSession',
-        },
-      },
-      () => runProjectMutation(operation, targetPath, run, options)
-    )
-
   const serviceImpl: ProjectSessionService = {
     project,
     projectTree,
@@ -157,6 +140,7 @@ export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
     mutation,
     getProject: () => project.value,
     setProject: (nextProject) => {
+      nextProject?.setFileSystemOperations(ctx.services.get(fsOperationQueue))
       project.value = nextProject
       watchProjectTree(nextProject)
     },
@@ -219,45 +203,39 @@ export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
       }
     },
     createFile: (input: ProjectSessionFileWriteInput) =>
-      runQueuedProjectMutation('create-file', input.path, (currentProject) =>
+      runProjectMutation('create-file', input.path, (currentProject) =>
         currentProject.createFile(input)
       ),
     writeFile: (input: ProjectSessionFileWriteInput) =>
-      runQueuedProjectMutation('write-file', input.path, (currentProject) =>
+      runProjectMutation('write-file', input.path, (currentProject) =>
         currentProject.writeFile(input)
       ),
     createFolder: (input: ProjectSessionEntryPathInput) =>
-      runQueuedProjectMutation('create-folder', input.path, (currentProject) =>
+      runProjectMutation('create-folder', input.path, (currentProject) =>
         currentProject.createFolder(input)
       ),
     renameEntry: (input: ProjectSessionEntryRenameInput) =>
-      runQueuedProjectMutation(
-        'rename-entry',
-        input.newPath,
-        (currentProject) => currentProject.renameEntry(input)
+      runProjectMutation('rename-entry', input.newPath, (currentProject) =>
+        currentProject.renameEntry(input)
       ),
     deleteEntry: (input: ProjectSessionEntryPathInput) =>
-      runQueuedProjectMutation('delete-entry', input.path, (currentProject) =>
+      runProjectMutation('delete-entry', input.path, (currentProject) =>
         currentProject.deleteEntry(input)
       ),
     copyEntry: (input: ProjectSessionEntryCopyMoveInput) =>
-      runQueuedProjectMutation(
-        'copy-entry',
-        input.targetPath,
-        (currentProject) => currentProject.copyEntry(input)
+      runProjectMutation('copy-entry', input.targetPath, (currentProject) =>
+        currentProject.copyEntry(input)
       ),
     moveEntry: (input: ProjectSessionEntryCopyMoveInput) =>
-      runQueuedProjectMutation(
-        'move-entry',
-        input.targetPath,
-        (currentProject) => currentProject.moveEntry(input)
+      runProjectMutation('move-entry', input.targetPath, (currentProject) =>
+        currentProject.moveEntry(input)
       ),
     archiveEntry: (input: ProjectSessionEntryPathInput) =>
-      runQueuedProjectMutation('archive-entry', input.path, (currentProject) =>
+      runProjectMutation('archive-entry', input.path, (currentProject) =>
         currentProject.archiveEntry(input)
       ),
     applyFilePatch: (input: ProjectSessionApplyFilePatchInput) =>
-      runQueuedProjectMutation(
+      runProjectMutation(
         'apply-file-patch',
         input.files.at(-1)?.path,
         (currentProject) => currentProject.applyFilePatch(input)

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -7,24 +7,212 @@ import {
 import { signal } from '@preact/signals-core'
 import type { ZDSProject } from '@src/lang/KclManager'
 import {
-  projectSession,
+  type ProjectSessionApplyFilePatchInput,
+  type ProjectSessionEntryCopyMoveInput,
+  type ProjectSessionEntryPathInput,
+  type ProjectSessionEntryRenameInput,
+  type ProjectSessionFileWriteInput,
+  type ProjectSessionMutationOperation,
+  type ProjectSessionMutationState,
+  type ProjectSessionOpenEditorInput,
   type ProjectSessionService,
+  projectSession,
 } from '@src/registry/contracts/projectSession'
 
 export const projectSessionExtension = defineRegistryItemFactory(() => {
   const project = signal<ZDSProject | undefined>(undefined)
+  const projectTree = signal(project.value?.projectIORefSignal.value)
   const currentProjectLibraryId = signal<string | undefined>(undefined)
+  const mutation = signal<ProjectSessionMutationState>({ pending: false })
+
+  const setMutation = ({
+    pending,
+    operation,
+    targetPath,
+    lastTargetPath,
+  }: ProjectSessionMutationState) => {
+    mutation.value = {
+      pending,
+      ...(operation ? { operation } : {}),
+      ...(targetPath ? { targetPath } : {}),
+      ...(lastTargetPath ? { lastTargetPath } : {}),
+    }
+  }
+
+  const requireProject = () => {
+    const currentProject = project.value
+    if (!currentProject) {
+      throw new Error('No project is currently open.')
+    }
+    return currentProject
+  }
+
+  const syncProjectTree = () => {
+    projectTree.value = project.value?.projectIORefSignal.value
+    return projectTree.value
+  }
+
+  const refreshProjectTree = async () => {
+    const currentProject = project.value
+    if (!currentProject) {
+      projectTree.value = undefined
+      return undefined
+    }
+
+    setMutation({
+      pending: true,
+      operation: 'refresh-project-tree',
+      targetPath: currentProject.path,
+      lastTargetPath: mutation.value.lastTargetPath,
+    })
+    try {
+      projectTree.value = await currentProject.refreshProjectTree()
+      return projectTree.value
+    } finally {
+      setMutation({
+        pending: false,
+        operation: 'refresh-project-tree',
+        lastTargetPath: currentProject.path,
+      })
+    }
+  }
+
+  const runProjectMutation = async <Result>(
+    operation: ProjectSessionMutationOperation,
+    targetPath: string | undefined,
+    run: (currentProject: ZDSProject) => Promise<Result>,
+    options: { refreshProjectTree?: boolean } = {}
+  ) => {
+    const currentProject = requireProject()
+    setMutation({
+      pending: true,
+      operation,
+      targetPath,
+      lastTargetPath: mutation.value.lastTargetPath,
+    })
+    try {
+      const result = await run(currentProject)
+      if (options.refreshProjectTree ?? true) {
+        projectTree.value = await currentProject.refreshProjectTree()
+      } else {
+        syncProjectTree()
+      }
+      setMutation({
+        pending: false,
+        operation,
+        lastTargetPath: targetPath,
+      })
+      return result
+    } catch (error) {
+      setMutation({
+        pending: false,
+        operation,
+        lastTargetPath: targetPath,
+      })
+      return Promise.reject(error)
+    }
+  }
 
   const serviceImpl: ProjectSessionService = {
     project,
+    projectTree,
     currentProjectLibraryId,
+    mutation,
     getProject: () => project.value,
     setProject: (nextProject) => {
       project.value = nextProject
+      syncProjectTree()
     },
     clearProject: () => {
       project.value = undefined
+      syncProjectTree()
     },
+    getProjectTree: () => projectTree.value,
+    refreshProjectTree,
+    openEditor: (input: ProjectSessionOpenEditorInput) =>
+      runProjectMutation(
+        'open-editor',
+        input.path,
+        (currentProject) =>
+          currentProject.openEditor(
+            input.path,
+            input.editor,
+            input.code,
+            input.isExecuting
+          ),
+        { refreshProjectTree: false }
+      ),
+    closeEditor: (input: ProjectSessionEntryPathInput) => {
+      setMutation({
+        pending: true,
+        operation: 'close-editor',
+        targetPath: input.path,
+        lastTargetPath: mutation.value.lastTargetPath,
+      })
+      try {
+        requireProject().closeEditor(input.path)
+      } finally {
+        setMutation({
+          pending: false,
+          operation: 'close-editor',
+          lastTargetPath: input.path,
+        })
+      }
+    },
+    closeAllEditors: () => {
+      setMutation({
+        pending: true,
+        operation: 'close-all-editors',
+        lastTargetPath: mutation.value.lastTargetPath,
+      })
+      try {
+        requireProject().closeAllEditors()
+      } finally {
+        setMutation({
+          pending: false,
+          operation: 'close-all-editors',
+          lastTargetPath: mutation.value.lastTargetPath,
+        })
+      }
+    },
+    createFile: (input: ProjectSessionFileWriteInput) =>
+      runProjectMutation('create-file', input.path, (currentProject) =>
+        currentProject.createFile(input)
+      ),
+    writeFile: (input: ProjectSessionFileWriteInput) =>
+      runProjectMutation('write-file', input.path, (currentProject) =>
+        currentProject.writeFile(input)
+      ),
+    createFolder: (input: ProjectSessionEntryPathInput) =>
+      runProjectMutation('create-folder', input.path, (currentProject) =>
+        currentProject.createFolder(input)
+      ),
+    renameEntry: (input: ProjectSessionEntryRenameInput) =>
+      runProjectMutation('rename-entry', input.newPath, (currentProject) =>
+        currentProject.renameEntry(input)
+      ),
+    deleteEntry: (input: ProjectSessionEntryPathInput) =>
+      runProjectMutation('delete-entry', input.path, (currentProject) =>
+        currentProject.deleteEntry(input)
+      ),
+    copyEntry: (input: ProjectSessionEntryCopyMoveInput) =>
+      runProjectMutation('copy-entry', input.targetPath, (currentProject) =>
+        currentProject.copyEntry(input)
+      ),
+    moveEntry: (input: ProjectSessionEntryCopyMoveInput) =>
+      runProjectMutation('move-entry', input.targetPath, (currentProject) =>
+        currentProject.moveEntry(input)
+      ),
+    archiveEntry: (input: ProjectSessionEntryPathInput) =>
+      runProjectMutation('archive-entry', input.path, (currentProject) =>
+        currentProject.archiveEntry(input)
+      ),
+    applyFilePatch: (input: ProjectSessionApplyFilePatchInput) =>
+      runProjectMutation(
+        'apply-file-patch',
+        input.files.at(-1)?.path,
+        (currentProject) => currentProject.applyFilePatch(input)
+      ),
     getCurrentProjectLibraryId: () => currentProjectLibraryId.value,
     setCurrentProjectLibraryId: (libraryId) => {
       currentProjectLibraryId.value = libraryId

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -6,7 +6,10 @@ import {
 } from '@kittycad/registry'
 import { effect, signal } from '@preact/signals-core'
 import type { ZDSProject } from '@src/lang/KclManager'
-import { fsOperationQueue } from '@src/registry/contracts/fsOperationQueue'
+import {
+  type FsOperationBatch,
+  fsOperationQueue,
+} from '@src/registry/contracts/fsOperationQueue'
 import {
   type ProjectSessionApplyFilePatchInput,
   type ProjectSessionEntryCopyMoveInput,
@@ -93,7 +96,7 @@ export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
     }
   }
 
-  const runProjectMutation = async <Result>(
+  const runProjectOperation = async <Result>(
     operation: ProjectSessionMutationOperation,
     targetPath: string | undefined,
     run: (currentProject: ZDSProject) => Promise<Result>,
@@ -133,6 +136,30 @@ export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
     }
   }
 
+  const runProjectMutation = <Result>(
+    operation: ProjectSessionMutationOperation,
+    targetPath: string | undefined,
+    run: (
+      currentProject: ZDSProject,
+      fileSystemOperations: FsOperationBatch
+    ) => Promise<Result>,
+    options: { refreshProjectTree?: boolean } = {}
+  ) =>
+    ctx.services.get(fsOperationQueue).batch(
+      {
+        kind: operation,
+        targetPath,
+        metadata: { service: 'projectSession' },
+      },
+      (fileSystemOperations) =>
+        runProjectOperation(
+          operation,
+          targetPath,
+          (currentProject) => run(currentProject, fileSystemOperations),
+          options
+        )
+    )
+
   const serviceImpl: ProjectSessionService = {
     project,
     projectTree,
@@ -151,7 +178,7 @@ export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
     getProjectTree: () => projectTree.value,
     refreshProjectTree,
     openEditor: (input: ProjectSessionOpenEditorInput) =>
-      runProjectMutation(
+      runProjectOperation(
         'open-editor',
         input.path,
         (currentProject) =>
@@ -203,42 +230,48 @@ export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
       }
     },
     createFile: (input: ProjectSessionFileWriteInput) =>
-      runProjectMutation('create-file', input.path, (currentProject) =>
-        currentProject.createFile(input)
+      runProjectMutation('create-file', input.path, (currentProject, batch) =>
+        currentProject.createFile(input, batch)
       ),
     writeFile: (input: ProjectSessionFileWriteInput) =>
-      runProjectMutation('write-file', input.path, (currentProject) =>
-        currentProject.writeFile(input)
+      runProjectMutation('write-file', input.path, (currentProject, batch) =>
+        currentProject.writeFile(input, batch)
       ),
     createFolder: (input: ProjectSessionEntryPathInput) =>
-      runProjectMutation('create-folder', input.path, (currentProject) =>
-        currentProject.createFolder(input)
+      runProjectMutation('create-folder', input.path, (currentProject, batch) =>
+        currentProject.createFolder(input, batch)
       ),
     renameEntry: (input: ProjectSessionEntryRenameInput) =>
-      runProjectMutation('rename-entry', input.newPath, (currentProject) =>
-        currentProject.renameEntry(input)
+      runProjectMutation(
+        'rename-entry',
+        input.newPath,
+        (currentProject, batch) => currentProject.renameEntry(input, batch)
       ),
     deleteEntry: (input: ProjectSessionEntryPathInput) =>
-      runProjectMutation('delete-entry', input.path, (currentProject) =>
-        currentProject.deleteEntry(input)
+      runProjectMutation('delete-entry', input.path, (currentProject, batch) =>
+        currentProject.deleteEntry(input, batch)
       ),
     copyEntry: (input: ProjectSessionEntryCopyMoveInput) =>
-      runProjectMutation('copy-entry', input.targetPath, (currentProject) =>
-        currentProject.copyEntry(input)
+      runProjectMutation(
+        'copy-entry',
+        input.targetPath,
+        (currentProject, batch) => currentProject.copyEntry(input, batch)
       ),
     moveEntry: (input: ProjectSessionEntryCopyMoveInput) =>
-      runProjectMutation('move-entry', input.targetPath, (currentProject) =>
-        currentProject.moveEntry(input)
+      runProjectMutation(
+        'move-entry',
+        input.targetPath,
+        (currentProject, batch) => currentProject.moveEntry(input, batch)
       ),
     archiveEntry: (input: ProjectSessionEntryPathInput) =>
-      runProjectMutation('archive-entry', input.path, (currentProject) =>
-        currentProject.archiveEntry(input)
+      runProjectMutation('archive-entry', input.path, (currentProject, batch) =>
+        currentProject.archiveEntry(input, batch)
       ),
     applyFilePatch: (input: ProjectSessionApplyFilePatchInput) =>
       runProjectMutation(
         'apply-file-patch',
         input.files.at(-1)?.path,
-        (currentProject) => currentProject.applyFilePatch(input)
+        (currentProject, batch) => currentProject.applyFilePatch(input, batch)
       ),
     getCurrentProjectLibraryId: () => currentProjectLibraryId.value,
     setCurrentProjectLibraryId: (libraryId) => {

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -139,8 +139,8 @@ export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
     currentProjectLibraryId,
     mutation,
     getProject: () => project.value,
+    getFileSystemOperations: () => ctx.services.get(fsOperationQueue),
     setProject: (nextProject) => {
-      nextProject?.setFileSystemOperations(ctx.services.get(fsOperationQueue))
       project.value = nextProject
       watchProjectTree(nextProject)
     },

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -39,10 +39,10 @@ export const projectSessionExtension = defineRegistryItemFactory(() => {
     }
   }
 
-  const requireProject = () => {
+  const getRequiredProject = () => {
     const currentProject = project.value
     if (!currentProject) {
-      throw new Error('No project is currently open.')
+      return new Error('No project is currently open.')
     }
     return currentProject
   }
@@ -83,7 +83,11 @@ export const projectSessionExtension = defineRegistryItemFactory(() => {
     run: (currentProject: ZDSProject) => Promise<Result>,
     options: { refreshProjectTree?: boolean } = {}
   ) => {
-    const currentProject = requireProject()
+    const currentProject = getRequiredProject()
+    if (currentProject instanceof Error) {
+      return Promise.reject(currentProject)
+    }
+
     setMutation({
       pending: true,
       operation,
@@ -150,7 +154,10 @@ export const projectSessionExtension = defineRegistryItemFactory(() => {
         lastTargetPath: mutation.value.lastTargetPath,
       })
       try {
-        requireProject().closeEditor(input.path)
+        const currentProject = getRequiredProject()
+        if (!(currentProject instanceof Error)) {
+          currentProject.closeEditor(input.path)
+        }
       } finally {
         setMutation({
           pending: false,
@@ -166,7 +173,10 @@ export const projectSessionExtension = defineRegistryItemFactory(() => {
         lastTargetPath: mutation.value.lastTargetPath,
       })
       try {
-        requireProject().closeAllEditors()
+        const currentProject = getRequiredProject()
+        if (!(currentProject instanceof Error)) {
+          currentProject.closeAllEditors()
+        }
       } finally {
         setMutation({
           pending: false,

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -4,7 +4,7 @@ import {
   defineRuntimeRegistryItem,
   provideService,
 } from '@kittycad/registry'
-import { signal } from '@preact/signals-core'
+import { effect, signal } from '@preact/signals-core'
 import type { ZDSProject } from '@src/lang/KclManager'
 import {
   type ProjectSessionApplyFilePatchInput,
@@ -24,6 +24,7 @@ export const projectSessionExtension = defineRegistryItemFactory(() => {
   const projectTree = signal(project.value?.projectIORefSignal.value)
   const currentProjectLibraryId = signal<string | undefined>(undefined)
   const mutation = signal<ProjectSessionMutationState>({ pending: false })
+  let disposeProjectTreeSync: (() => void) | undefined
 
   const setMutation = ({
     pending,
@@ -50,6 +51,19 @@ export const projectSessionExtension = defineRegistryItemFactory(() => {
   const syncProjectTree = () => {
     projectTree.value = project.value?.projectIORefSignal.value
     return projectTree.value
+  }
+
+  const watchProjectTree = (nextProject: ZDSProject | undefined) => {
+    disposeProjectTreeSync?.()
+    disposeProjectTreeSync = undefined
+    if (!nextProject) {
+      projectTree.value = undefined
+      return
+    }
+
+    disposeProjectTreeSync = effect(() => {
+      projectTree.value = nextProject.projectIORefSignal.value
+    })
   }
 
   const refreshProjectTree = async () => {
@@ -125,11 +139,11 @@ export const projectSessionExtension = defineRegistryItemFactory(() => {
     getProject: () => project.value,
     setProject: (nextProject) => {
       project.value = nextProject
-      syncProjectTree()
+      watchProjectTree(nextProject)
     },
     clearProject: () => {
       project.value = undefined
-      syncProjectTree()
+      watchProjectTree(undefined)
     },
     getProjectTree: () => projectTree.value,
     refreshProjectTree,
@@ -233,6 +247,10 @@ export const projectSessionExtension = defineRegistryItemFactory(() => {
     item: defineRuntimeRegistryItem({
       id: 'project-session-extension',
       providesServices: [provideService(projectSession, serviceImpl)],
+      dispose: () => {
+        disposeProjectTreeSync?.()
+        disposeProjectTreeSync = undefined
+      },
     }),
   }
 }, 'project-session-extension')

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -6,6 +6,7 @@ import {
 } from '@kittycad/registry'
 import { effect, signal } from '@preact/signals-core'
 import type { ZDSProject } from '@src/lang/KclManager'
+import { fsOperationQueue } from '@src/registry/contracts/fsOperationQueue'
 import {
   type ProjectSessionApplyFilePatchInput,
   type ProjectSessionEntryCopyMoveInput,
@@ -18,8 +19,9 @@ import {
   type ProjectSessionService,
   projectSession,
 } from '@src/registry/contracts/projectSession'
+import fsOperationQueueRegistryItem from '@src/registry/extensions/fsOperationQueue'
 
-export const projectSessionExtension = defineRegistryItemFactory(() => {
+export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
   const project = signal<ZDSProject | undefined>(undefined)
   const projectTree = signal(project.value?.projectIORefSignal.value)
   const currentProjectLibraryId = signal<string | undefined>(undefined)
@@ -131,6 +133,23 @@ export const projectSessionExtension = defineRegistryItemFactory(() => {
     }
   }
 
+  const runQueuedProjectMutation = <Result>(
+    operation: ProjectSessionMutationOperation,
+    targetPath: string | undefined,
+    run: (currentProject: ZDSProject) => Promise<Result>,
+    options: { refreshProjectTree?: boolean } = {}
+  ) =>
+    ctx.services.get(fsOperationQueue).run(
+      {
+        kind: operation,
+        targetPath,
+        metadata: {
+          service: 'projectSession',
+        },
+      },
+      () => runProjectMutation(operation, targetPath, run, options)
+    )
+
   const serviceImpl: ProjectSessionService = {
     project,
     projectTree,
@@ -200,39 +219,45 @@ export const projectSessionExtension = defineRegistryItemFactory(() => {
       }
     },
     createFile: (input: ProjectSessionFileWriteInput) =>
-      runProjectMutation('create-file', input.path, (currentProject) =>
+      runQueuedProjectMutation('create-file', input.path, (currentProject) =>
         currentProject.createFile(input)
       ),
     writeFile: (input: ProjectSessionFileWriteInput) =>
-      runProjectMutation('write-file', input.path, (currentProject) =>
+      runQueuedProjectMutation('write-file', input.path, (currentProject) =>
         currentProject.writeFile(input)
       ),
     createFolder: (input: ProjectSessionEntryPathInput) =>
-      runProjectMutation('create-folder', input.path, (currentProject) =>
+      runQueuedProjectMutation('create-folder', input.path, (currentProject) =>
         currentProject.createFolder(input)
       ),
     renameEntry: (input: ProjectSessionEntryRenameInput) =>
-      runProjectMutation('rename-entry', input.newPath, (currentProject) =>
-        currentProject.renameEntry(input)
+      runQueuedProjectMutation(
+        'rename-entry',
+        input.newPath,
+        (currentProject) => currentProject.renameEntry(input)
       ),
     deleteEntry: (input: ProjectSessionEntryPathInput) =>
-      runProjectMutation('delete-entry', input.path, (currentProject) =>
+      runQueuedProjectMutation('delete-entry', input.path, (currentProject) =>
         currentProject.deleteEntry(input)
       ),
     copyEntry: (input: ProjectSessionEntryCopyMoveInput) =>
-      runProjectMutation('copy-entry', input.targetPath, (currentProject) =>
-        currentProject.copyEntry(input)
+      runQueuedProjectMutation(
+        'copy-entry',
+        input.targetPath,
+        (currentProject) => currentProject.copyEntry(input)
       ),
     moveEntry: (input: ProjectSessionEntryCopyMoveInput) =>
-      runProjectMutation('move-entry', input.targetPath, (currentProject) =>
-        currentProject.moveEntry(input)
+      runQueuedProjectMutation(
+        'move-entry',
+        input.targetPath,
+        (currentProject) => currentProject.moveEntry(input)
       ),
     archiveEntry: (input: ProjectSessionEntryPathInput) =>
-      runProjectMutation('archive-entry', input.path, (currentProject) =>
+      runQueuedProjectMutation('archive-entry', input.path, (currentProject) =>
         currentProject.archiveEntry(input)
       ),
     applyFilePatch: (input: ProjectSessionApplyFilePatchInput) =>
-      runProjectMutation(
+      runQueuedProjectMutation(
         'apply-file-patch',
         input.files.at(-1)?.path,
         (currentProject) => currentProject.applyFilePatch(input)
@@ -257,5 +282,5 @@ export const projectSessionExtension = defineRegistryItemFactory(() => {
 
 export default defineRegistryItem({
   id: 'project-session',
-  uses: [projectSessionExtension],
+  uses: [fsOperationQueueRegistryItem, projectSessionExtension],
 })


### PR DESCRIPTION
Stacks on #12886 to add the opened-project file/editor session API that follow-up PRs can use to retire System.IO editor flows.

1. Adds `projectTree` and mutation-state signals to `projectSessionService`.
2. Adds project-session editor helpers and file-entry mutation helpers backed by the current `ZDSProject`.
3. Teaches `ZDSProject` to refresh its hydrated project tree, guard project-root mutations, preserve library ownership metadata, and keep open editor paths aligned across rename/move/delete/archive helpers.
4. Covers the additive API with project-session unit tests and an App integration test against real NodeFS project-tree refreshes.

## How to test

Open a project, create/rename files under the project tree, and verify the file explorer can be migrated to read the current project's `projectTree` without using System.IO folder state. Exercise Zookeeper edits and undo/redo to ensure current project file registry behavior is unchanged.