### PR TITLE
Read explorer tree from project session

### DIFF
--- a/src/components/Explorer/ProjectExplorer.tsx
+++ b/src/components/Explorer/ProjectExplorer.tsx
@@ -170,6 +170,7 @@ export const ProjectExplorer = ({
   createFilePressed,
   createFolderPressed,
   refreshExplorerPressed,
+  onRefreshExplorer,
   collapsePressed,
   onRowClicked,
   onRowDoubleClicked,
@@ -184,6 +185,7 @@ export const ProjectExplorer = ({
   createFilePressed: number
   createFolderPressed: number
   refreshExplorerPressed: number
+  onRefreshExplorer?: () => void
   collapsePressed: number
   onRowClicked: (row: FileExplorerEntry, domIndex: number) => void
   onRowDoubleClicked?: (row: FileExplorerEntry, domIndex: number) => void
@@ -358,12 +360,8 @@ export const ProjectExplorer = ({
     if (refreshExplorerPressed <= 0) {
       return
     }
-    // TODO: Refresh only this path from the Project. This will refresh your entire application project directory
-    // It is correct but can be slow if there are many projects
-    systemIOActor.send({
-      type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
-    })
-  }, [refreshExplorerPressed, systemIOActor])
+    onRefreshExplorer?.()
+  }, [onRefreshExplorer, refreshExplorerPressed])
 
   useEffect(() => {
     if (collapsePressed <= 0) {

--- a/src/components/Explorer/ProjectExplorer.tsx
+++ b/src/components/Explorer/ProjectExplorer.tsx
@@ -171,6 +171,7 @@ export const ProjectExplorer = ({
   createFilePressed,
   createFolderPressed,
   refreshExplorerPressed,
+  onRefreshExplorer,
   collapsePressed,
   onRowClicked,
   onRowDoubleClicked,
@@ -185,6 +186,7 @@ export const ProjectExplorer = ({
   createFilePressed: number
   createFolderPressed: number
   refreshExplorerPressed: number
+  onRefreshExplorer?: () => void
   collapsePressed: number
   onRowClicked: (row: FileExplorerEntry, domIndex: number) => void
   onRowDoubleClicked?: (row: FileExplorerEntry, domIndex: number) => void
@@ -359,12 +361,8 @@ export const ProjectExplorer = ({
     if (refreshExplorerPressed <= 0) {
       return
     }
-    // TODO: Refresh only this path from the Project. This will refresh your entire application project directory
-    // It is correct but can be slow if there are many projects
-    systemIOActor.send({
-      type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
-    })
-  }, [refreshExplorerPressed, systemIOActor])
+    onRefreshExplorer?.()
+  }, [onRefreshExplorer, refreshExplorerPressed])
 
   useEffect(() => {
     if (collapsePressed <= 0) {

--- a/src/components/HelpMenu.tsx
+++ b/src/components/HelpMenu.tsx
@@ -8,7 +8,7 @@ import { useApp } from '@src/lib/boot'
 import { isDesktop } from '@src/lib/isDesktop'
 import { onboardingStartPath } from '@src/lib/onboardingPaths'
 import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
-import { PATHS } from '@src/lib/paths'
+import { appendRouterSubRouteWithSearch, PATHS } from '@src/lib/paths'
 import { reportRejection } from '@src/lib/trap'
 import { withSiteBaseURL } from '@src/lib/withBaseURL'
 import type { WebContentSendPayload } from '@src/menu/channels'
@@ -127,8 +127,14 @@ export function HelpMenu() {
               onClick={() => {
                 const targetPath =
                   filePath !== undefined
-                    ? filePath + PATHS.SETTINGS_KEYBINDINGS
-                    : PATHS.HOME + PATHS.SETTINGS_KEYBINDINGS
+                    ? appendRouterSubRouteWithSearch(
+                        filePath,
+                        PATHS.SETTINGS_KEYBINDINGS
+                      )
+                    : appendRouterSubRouteWithSearch(
+                        PATHS.HOME,
+                        PATHS.SETTINGS_KEYBINDINGS
+                      )
                 void navigate(targetPath)
               }}
               data-testid="keybindings-button"

--- a/src/components/ProjectSidebarMenu.tsx
+++ b/src/components/ProjectSidebarMenu.tsx
@@ -11,7 +11,11 @@ import { sendAddFileToProjectCommandForCurrentProject } from '@src/lib/commandBa
 import { APP_NAME } from '@src/lib/constants'
 import { hotkeyDisplay } from '@src/lib/hotkeys'
 import { isDesktop } from '@src/lib/isDesktop'
-import { getProjectRelativeFilePath, PATHS } from '@src/lib/paths'
+import {
+  appendRouterSubRouteWithSearch,
+  getProjectRelativeFilePath,
+  PATHS,
+} from '@src/lib/paths'
 import type { FileEntry, Project } from '@src/lib/project'
 import { getProjectDisplayName } from '@src/lib/projectDisplayName'
 import type { IndexLoaderData } from '@src/lib/types'
@@ -295,8 +299,14 @@ function ProjectMenuPopover({
           onClick: () => {
             const targetPath =
               filePath !== undefined
-                ? filePath + PATHS.SETTINGS_PROJECT
-                : PATHS.HOME + PATHS.SETTINGS_PROJECT
+                ? appendRouterSubRouteWithSearch(
+                    filePath,
+                    PATHS.SETTINGS_PROJECT
+                  )
+                : appendRouterSubRouteWithSearch(
+                    PATHS.HOME,
+                    PATHS.SETTINGS_PROJECT
+                  )
             void navigate(targetPath)
           },
         },

--- a/src/components/UserSidebarMenu.tsx
+++ b/src/components/UserSidebarMenu.tsx
@@ -13,7 +13,7 @@ import usePlatform from '@src/hooks/usePlatform'
 import { useApp } from '@src/lib/boot'
 import { listAllEnvironmentsWithTokens } from '@src/lib/desktop'
 import { isDesktop } from '@src/lib/isDesktop'
-import { PATHS } from '@src/lib/paths'
+import { appendRouterSubRouteWithSearch, PATHS } from '@src/lib/paths'
 import { reportRejection } from '@src/lib/trap'
 import { withSiteBaseURL } from '@src/lib/withBaseURL'
 
@@ -77,8 +77,11 @@ const UserSidebarMenu = ({ user }: { user?: UserResponse }) => {
           onClick: () => {
             const targetPath =
               filePath !== undefined
-                ? filePath + PATHS.SETTINGS_USER
-                : PATHS.HOME + PATHS.SETTINGS_USER
+                ? appendRouterSubRouteWithSearch(filePath, PATHS.SETTINGS_USER)
+                : appendRouterSubRouteWithSearch(
+                    PATHS.HOME,
+                    PATHS.SETTINGS_USER
+                  )
             void navigate(targetPath)
           },
         },
@@ -88,8 +91,14 @@ const UserSidebarMenu = ({ user }: { user?: UserResponse }) => {
           children: 'Keyboard shortcuts',
           onClick: () => {
             const targetPath = location.pathname.includes(PATHS.FILE)
-              ? filePath + PATHS.SETTINGS_KEYBINDINGS
-              : PATHS.HOME + PATHS.SETTINGS_KEYBINDINGS
+              ? appendRouterSubRouteWithSearch(
+                  filePath ?? location.pathname,
+                  PATHS.SETTINGS_KEYBINDINGS
+                )
+              : appendRouterSubRouteWithSearch(
+                  PATHS.HOME,
+                  PATHS.SETTINGS_KEYBINDINGS
+                )
             void navigate(targetPath)
           },
         },

--- a/src/components/layout/areas/ProjectExplorerPane.test.ts
+++ b/src/components/layout/areas/ProjectExplorerPane.test.ts
@@ -18,8 +18,8 @@ const project = (name: string, children: Project['children']): Project => ({
 })
 
 describe('getProjectExplorerProjectWithPlaceholders', () => {
-  it('uses the loaded project while folder hydration is pending', () => {
-    const loadedProject = project('demo', [
+  it('duplicates the project tree and adds create placeholders', () => {
+    const sourceProject = project('demo', [
       {
         name: 'main.kcl',
         path: '/projects/demo/main.kcl',
@@ -28,8 +28,7 @@ describe('getProjectExplorerProjectWithPlaceholders', () => {
     ])
 
     const explorerProject = getProjectExplorerProjectWithPlaceholders({
-      loadedProject,
-      projects: undefined,
+      project: sourceProject,
     })
 
     expect(explorerProject?.children?.map((child) => child.name)).toEqual([
@@ -37,36 +36,8 @@ describe('getProjectExplorerProjectWithPlaceholders', () => {
       'main.kcl',
       FILE_PLACEHOLDER_NAME,
     ])
-    expect(loadedProject.children?.map((child) => child.name)).toEqual([
+    expect(sourceProject.children?.map((child) => child.name)).toEqual([
       'main.kcl',
-    ])
-  })
-
-  it('prefers the hydrated project from the folder list', () => {
-    const loadedProject = project('demo', [
-      {
-        name: 'stale.kcl',
-        path: '/projects/demo/stale.kcl',
-        children: null,
-      },
-    ])
-    const hydratedProject = project('demo', [
-      {
-        name: 'fresh.kcl',
-        path: '/projects/demo/fresh.kcl',
-        children: null,
-      },
-    ])
-
-    const explorerProject = getProjectExplorerProjectWithPlaceholders({
-      loadedProject,
-      projects: [hydratedProject],
-    })
-
-    expect(explorerProject?.children?.map((child) => child.name)).toEqual([
-      FOLDER_PLACEHOLDER_NAME,
-      'fresh.kcl',
-      FILE_PLACEHOLDER_NAME,
     ])
   })
 })

--- a/src/components/layout/areas/ProjectExplorerPane.tsx
+++ b/src/components/layout/areas/ProjectExplorerPane.tsx
@@ -1,3 +1,4 @@
+import { useSignals } from '@preact/signals-react/runtime'
 import { FileExplorerHeaderActions } from '@src/components/Explorer/FileExplorerHeaderActions'
 import { ProjectExplorer } from '@src/components/Explorer/ProjectExplorer'
 import type { FileExplorerEntry } from '@src/components/Explorer/utils'
@@ -27,22 +28,21 @@ import {
 } from '@src/lib/paths'
 import type { Project } from '@src/lib/project'
 import { reportRejection } from '@src/lib/trap'
-import {
-  useFolders,
-  useProjectDirectoryPath,
-} from '@src/machines/systemIO/hooks'
+import { useProjectDirectoryPath } from '@src/machines/systemIO/hooks'
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
 import { projectSession } from '@src/registry/contracts/projectSession'
 import { use, useCallback, useEffect, useRef, useState } from 'react'
 import toast from 'react-hot-toast'
 
 export function ProjectExplorerPane(props: AreaTypeComponentProps) {
+  useSignals()
   const app = useApp()
   const { commands, systemIOActor, layout } = app
-  const project = app.registry.get(projectSession).project.value
+  const session = app.registry.get(projectSession)
+  const project = session.project.value
+  const projectTree = session.projectTree.value
   const { kclManager } = useSingletons()
   const wasmInstance = use(kclManager.wasmInstancePromise)
-  const projects = useFolders()
   const projectDirectoryPath = useProjectDirectoryPath()
   const projectRef = useRef(project?.projectIORefSignal)
   const [theProject, setTheProject] = useState<Project | null>(null)
@@ -60,23 +60,12 @@ export function ProjectExplorerPane(props: AreaTypeComponentProps) {
       return
     }
 
-    const loadedProject = project.projectIORefSignal.value
-    if (projects === undefined) {
-      systemIOActor.send({
-        type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
-      })
-    }
-
     const duplicated = getProjectExplorerProjectWithPlaceholders({
-      loadedProject,
-      projects,
+      project: projectTree ?? project.projectIORefSignal.value,
     })
 
-    if (!duplicated) {
-      return
-    }
     setTheProject(duplicated)
-  }, [file, projects, project, systemIOActor])
+  }, [file, project, projectTree])
 
   const [createFilePressed, setCreateFilePressed] = useState<number>(0)
   const [createFolderPressed, setCreateFolderPressed] = useState<number>(0)
@@ -264,6 +253,9 @@ export function ProjectExplorerPane(props: AreaTypeComponentProps) {
             createFilePressed={createFilePressed}
             createFolderPressed={createFolderPressed}
             refreshExplorerPressed={refreshExplorerPressed}
+            onRefreshExplorer={() =>
+              projectSession.refreshProjectTree().catch(reportRejection)
+            }
             collapsePressed={collapsePressed}
             onRowClicked={onRowClicked}
             onRowDoubleClicked={onRowDoubleClicked}

--- a/src/components/layout/areas/ProjectExplorerPane.tsx
+++ b/src/components/layout/areas/ProjectExplorerPane.tsx
@@ -253,9 +253,9 @@ export function ProjectExplorerPane(props: AreaTypeComponentProps) {
             createFilePressed={createFilePressed}
             createFolderPressed={createFolderPressed}
             refreshExplorerPressed={refreshExplorerPressed}
-            onRefreshExplorer={() =>
-              projectSession.refreshProjectTree().catch(reportRejection)
-            }
+            onRefreshExplorer={() => {
+              void session.refreshProjectTree().catch(reportRejection)
+            }}
             collapsePressed={collapsePressed}
             onRowClicked={onRowClicked}
             onRowDoubleClicked={onRowDoubleClicked}

--- a/src/components/layout/areas/ProjectExplorerPane.utils.ts
+++ b/src/components/layout/areas/ProjectExplorerPane.utils.ts
@@ -2,21 +2,11 @@ import { addPlaceHoldersForNewFileAndFolder } from '@src/components/Explorer/pla
 import type { Project } from '@src/lib/project'
 
 export function getProjectExplorerProjectWithPlaceholders({
-  loadedProject,
-  projects,
+  project,
 }: {
-  loadedProject: Project
-  projects: Project[] | undefined
+  project: Project
 }) {
-  const sourceProject =
-    projects?.find((p) => p.name === loadedProject.name) ??
-    (projects === undefined ? loadedProject : null)
-
-  if (!sourceProject) {
-    return null
-  }
-
-  const duplicated = structuredClone(sourceProject)
+  const duplicated = structuredClone(project)
   addPlaceHoldersForNewFileAndFolder(duplicated.children, duplicated.path)
   return duplicated
 }

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -20,7 +20,10 @@ import { getChangedSettingsAtLevel } from '@src/lib/settings/settingsUtils'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { notifyActiveWasmInstance } from '@src/lib/wasmLifecycle'
 import { zookeeperEditPatchHistoryEvent } from '@src/lib/zookeeper/editorPlugin'
-import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
+import {
+  SystemIOMachineEvents,
+  waitForIdleState,
+} from '@src/machines/systemIO/utils'
 import type { UserFeaturesContext } from '@src/machines/userFeaturesMachine'
 import { UserFeaturesState } from '@src/machines/userFeaturesMachine'
 import { appHeaderItemsValueSpec } from '@src/registry/contracts/appHeader'
@@ -896,6 +899,71 @@ describe('project system', () => {
       expect(session.getProject()).toBeUndefined()
     } finally {
       app.dispose()
+    }
+  })
+
+  it('hydrates opened project tree from already-read SystemIO folders', async () => {
+    const projectDirectoryPath = `/tmp/app-project-session-system-io-tree-${crypto.randomUUID()}`
+    const projectPath = fsZds.join(projectDirectoryPath, 'bracket')
+    const mainPath = fsZds.join(projectPath, 'main.kcl')
+    const nestedPath = fsZds.join(projectPath, 'parts', 'nested.kcl')
+    const app = createAppForTest()
+
+    try {
+      await writeText(mainPath, 'main = true\n')
+      await writeText(nestedPath, 'nested = true\n')
+      app.systemIOActor.send({
+        type: SystemIOMachineEvents.setProjectDirectoryPath,
+        data: { requestedProjectDirectoryPath: projectDirectoryPath },
+      })
+      await waitForIdleState({ systemIOActor: app.systemIOActor })
+      const hydratedProject = app.systemIOActor
+        .getSnapshot()
+        .context.folders?.find((project) => project.path === projectPath)
+
+      expect(hydratedProject?.children).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'parts',
+            children: expect.arrayContaining([
+              expect.objectContaining({
+                name: 'nested.kcl',
+                path: nestedPath,
+              }),
+            ]),
+          }),
+        ])
+      )
+
+      const staleProjectTree: Project = {
+        name: 'bracket',
+        default_file: mainPath,
+        directory_count: 0,
+        kcl_file_count: 1,
+        metadata: null,
+        path: projectPath,
+        readWriteAccess: true,
+        children: [
+          {
+            name: 'main.kcl',
+            path: mainPath,
+            children: null,
+          },
+        ],
+      }
+
+      const session = app.registry.get(projectSession)
+      const openedProject = await session.openProject(staleProjectTree)
+
+      expect(openedProject.projectIORefSignal.value.children).toEqual(
+        hydratedProject?.children
+      )
+      expect(session.projectTree.value?.children).toEqual(
+        hydratedProject?.children
+      )
+    } finally {
+      app.dispose()
+      await fsZds.rm(projectDirectoryPath, { recursive: true, force: true })
     }
   })
 

--- a/src/lib/commandBarConfigs/routeCommandConfig.ts
+++ b/src/lib/commandBarConfigs/routeCommandConfig.ts
@@ -1,7 +1,11 @@
 import type { Location, NavigateFunction } from 'react-router-dom'
 
 import type { Command } from '@src/lib/commandTypes'
-import { PATHS, webSafeJoin } from '@src/lib/paths'
+import {
+  appendRouterSubRouteWithSearch,
+  PATHS,
+  webSafeJoin,
+} from '@src/lib/paths'
 
 export function createRouteCommands(
   navigate: NavigateFunction,
@@ -45,8 +49,8 @@ export function createRouteCommands(
     needsReview: false,
     onSubmit: (_data) => {
       const path = location.pathname.includes(PATHS.FILE)
-        ? filePath + PATHS.SETTINGS + '?tab=project'
-        : PATHS.HOME + PATHS.SETTINGS
+        ? appendRouterSubRouteWithSearch(filePath, PATHS.SETTINGS_PROJECT)
+        : appendRouterSubRouteWithSearch(PATHS.HOME, PATHS.SETTINGS)
       void navigate(path)
     },
   }

--- a/src/lib/paths.test.ts
+++ b/src/lib/paths.test.ts
@@ -1,6 +1,8 @@
 import { APP_NAME } from '@src/lib/constants'
 import fsZds, { moduleFsViaModuleImport, StorageName } from '@src/lib/fs-zds'
 import {
+  appendRouterSubRoute,
+  appendRouterSubRouteWithSearch,
   fileNameHasExtension,
   getFilePathRelativeToProject,
   getProjectRelativeFilePath,
@@ -8,6 +10,7 @@ import {
   parentPathRelativeToApplicationDirectory,
   parentPathRelativeToProject,
   parseProjectRoute,
+  stripTrailingRouterSubRoute,
   toProjectRelativePath,
   toWebSafePath,
 } from '@src/lib/paths'
@@ -359,6 +362,37 @@ describe('testing getRouterSearchFromRequestUrl', () => {
         true
       )
     ).toEqual('?debug=true')
+  })
+})
+
+describe('testing router sub-routes', () => {
+  it('appends a router sub-route once', () => {
+    expect(appendRouterSubRoute('/home', '/settings')).toEqual('/home/settings')
+    expect(appendRouterSubRoute('/home/settings', '/settings')).toEqual(
+      '/home/settings'
+    )
+  })
+
+  it('appends search and hash to a file router sub-route', () => {
+    const fileRoute = '/file/%2Fprojects%2Fbracket%2Fmain.kcl'
+
+    expect(
+      appendRouterSubRouteWithSearch(fileRoute, '/settings?tab=user#libraries')
+    ).toEqual(
+      '/file/%2Fprojects%2Fbracket%2Fmain.kcl/settings?tab=user#libraries'
+    )
+  })
+
+  it('strips only trailing router sub-routes', () => {
+    expect(stripTrailingRouterSubRoute('/home/settings', '/settings')).toEqual(
+      '/home'
+    )
+    expect(
+      stripTrailingRouterSubRoute(
+        '/file/%2Fprojects%2Fsettings%2Fmain.kcl/settings',
+        '/settings'
+      )
+    ).toEqual('/file/%2Fprojects%2Fsettings%2Fmain.kcl')
   })
 })
 

--- a/src/lib/paths.test.ts
+++ b/src/lib/paths.test.ts
@@ -1,6 +1,8 @@
 import { APP_NAME } from '@src/lib/constants'
 import fsZds, { moduleFsViaModuleImport, StorageName } from '@src/lib/fs-zds'
 import {
+  appendRouterSubRoute,
+  appendRouterSubRouteWithSearch,
   fileNameHasExtension,
   getFilePathRelativeToProject,
   getProjectRelativeFilePath,
@@ -8,6 +10,7 @@ import {
   parentPathRelativeToApplicationDirectory,
   parentPathRelativeToProject,
   parseProjectRoute,
+  stripTrailingRouterSubRoute,
   toProjectRelativePath,
   toWebSafePath,
 } from '@src/lib/paths'
@@ -487,6 +490,37 @@ describe('testing getRouterSearchFromRequestUrl', () => {
         true
       )
     ).toEqual('?debug=true')
+  })
+})
+
+describe('testing router sub-routes', () => {
+  it('appends a router sub-route once', () => {
+    expect(appendRouterSubRoute('/home', '/settings')).toEqual('/home/settings')
+    expect(appendRouterSubRoute('/home/settings', '/settings')).toEqual(
+      '/home/settings'
+    )
+  })
+
+  it('appends search and hash to a file router sub-route', () => {
+    const fileRoute = '/file/%2Fprojects%2Fbracket%2Fmain.kcl'
+
+    expect(
+      appendRouterSubRouteWithSearch(fileRoute, '/settings?tab=user#libraries')
+    ).toEqual(
+      '/file/%2Fprojects%2Fbracket%2Fmain.kcl/settings?tab=user#libraries'
+    )
+  })
+
+  it('strips only trailing router sub-routes', () => {
+    expect(stripTrailingRouterSubRoute('/home/settings', '/settings')).toEqual(
+      '/home'
+    )
+    expect(
+      stripTrailingRouterSubRoute(
+        '/file/%2Fprojects%2Fsettings%2Fmain.kcl/settings',
+        '/settings'
+      )
+    ).toEqual('/file/%2Fprojects%2Fsettings%2Fmain.kcl')
   })
 })
 

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -188,6 +188,54 @@ export function joinRouterPaths(...parts: string[]): string {
   return `/${cleanedUpPath}`
 }
 
+export function stripTrailingRouterSubRoute(
+  pathname: string,
+  subRoute: string
+): string {
+  const routeSegment = `/${subRoute.replace(/^\/+|\/+$/g, '')}`
+  if (routeSegment === '/') {
+    return pathname
+  }
+
+  let strippedPathname = pathname
+  while (strippedPathname.endsWith(routeSegment)) {
+    strippedPathname = strippedPathname.slice(0, -routeSegment.length)
+  }
+
+  return strippedPathname || PATHS.INDEX
+}
+
+export function appendRouterSubRoute(
+  pathname: string,
+  subRoute: string
+): string {
+  return joinRouterPaths(
+    stripTrailingRouterSubRoute(pathname, subRoute),
+    subRoute
+  )
+}
+
+export function appendRouterSubRouteWithSearch(
+  pathname: string,
+  subRouteWithSearch: string
+): string {
+  const hashIndex = subRouteWithSearch.indexOf('#')
+  const subRouteWithoutHash =
+    hashIndex === -1
+      ? subRouteWithSearch
+      : subRouteWithSearch.slice(0, hashIndex)
+  const hash = hashIndex === -1 ? '' : subRouteWithSearch.slice(hashIndex)
+  const searchIndex = subRouteWithoutHash.indexOf('?')
+  const subRoute =
+    searchIndex === -1
+      ? subRouteWithoutHash
+      : subRouteWithoutHash.slice(0, searchIndex)
+  const search =
+    searchIndex === -1 ? '' : subRouteWithoutHash.slice(searchIndex)
+
+  return `${appendRouterSubRoute(pathname, subRoute)}${search}${hash}`
+}
+
 /**
  * Joins any number of arguments of strings to create a OS level path that is safe
  * A path will be created of the format /value/value1/value2

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -230,6 +230,54 @@ export function joinRouterPaths(...parts: string[]): string {
   return `/${cleanedUpPath}`
 }
 
+export function stripTrailingRouterSubRoute(
+  pathname: string,
+  subRoute: string
+): string {
+  const routeSegment = `/${subRoute.replace(/^\/+|\/+$/g, '')}`
+  if (routeSegment === '/') {
+    return pathname
+  }
+
+  let strippedPathname = pathname
+  while (strippedPathname.endsWith(routeSegment)) {
+    strippedPathname = strippedPathname.slice(0, -routeSegment.length)
+  }
+
+  return strippedPathname || PATHS.INDEX
+}
+
+export function appendRouterSubRoute(
+  pathname: string,
+  subRoute: string
+): string {
+  return joinRouterPaths(
+    stripTrailingRouterSubRoute(pathname, subRoute),
+    subRoute
+  )
+}
+
+export function appendRouterSubRouteWithSearch(
+  pathname: string,
+  subRouteWithSearch: string
+): string {
+  const hashIndex = subRouteWithSearch.indexOf('#')
+  const subRouteWithoutHash =
+    hashIndex === -1
+      ? subRouteWithSearch
+      : subRouteWithSearch.slice(0, hashIndex)
+  const hash = hashIndex === -1 ? '' : subRouteWithSearch.slice(hashIndex)
+  const searchIndex = subRouteWithoutHash.indexOf('?')
+  const subRoute =
+    searchIndex === -1
+      ? subRouteWithoutHash
+      : subRouteWithoutHash.slice(0, searchIndex)
+  const search =
+    searchIndex === -1 ? '' : subRouteWithoutHash.slice(searchIndex)
+
+  return `${appendRouterSubRoute(pathname, subRoute)}${search}${hash}`
+}
+
 /**
  * Joins any number of arguments of strings to create a OS level path that is safe
  * A path will be created of the format /value/value1/value2

--- a/src/menu/register.ts
+++ b/src/menu/register.ts
@@ -1,6 +1,6 @@
 import type { KclManager } from '@src/lang/KclManager'
 import { AxisNames } from '@src/lib/constants'
-import { PATHS } from '@src/lib/paths'
+import { appendRouterSubRouteWithSearch, PATHS } from '@src/lib/paths'
 import type { Project } from '@src/lib/project'
 import { getProjectDisplayName } from '@src/lib/projectDisplayName'
 import type { SettingsType } from '@src/lib/settings/initialSettings'
@@ -101,25 +101,33 @@ export function modelingMenuCallbackMostActions({
         console.warn('filePath is undefined')
         return
       }
-      void navigate(filePath + PATHS.SETTINGS_USER)
+      void navigate(
+        appendRouterSubRouteWithSearch(filePath, PATHS.SETTINGS_USER)
+      )
     } else if (data.menuLabel === 'File.Preferences.Keybindings') {
       if (!filePath) {
         console.warn('filePath is undefined')
         return
       }
-      void navigate(filePath + PATHS.SETTINGS_KEYBINDINGS)
+      void navigate(
+        appendRouterSubRouteWithSearch(filePath, PATHS.SETTINGS_KEYBINDINGS)
+      )
     } else if (data.menuLabel === 'Edit.Change project directory') {
       if (!filePath) {
         console.warn('filePath is undefined')
         return
       }
-      void navigate(filePath + PATHS.SETTINGS_USER + '#libraries')
+      void navigate(
+        `${appendRouterSubRouteWithSearch(filePath, PATHS.SETTINGS_USER)}#libraries`
+      )
     } else if (data.menuLabel === 'File.Preferences.Project settings') {
       if (!filePath) {
         console.warn('filePath is undefined')
         return
       }
-      void navigate(filePath + PATHS.SETTINGS_PROJECT)
+      void navigate(
+        appendRouterSubRouteWithSearch(filePath, PATHS.SETTINGS_PROJECT)
+      )
     } else if (data.menuLabel === 'File.Sign out') {
       authActor.send({ type: 'Log out' })
     } else if (
@@ -140,7 +148,9 @@ export function modelingMenuCallbackMostActions({
         console.warn('filePath is undefined')
         return
       }
-      void navigate(filePath + PATHS.SETTINGS_USER + '#defaultUnit')
+      void navigate(
+        `${appendRouterSubRouteWithSearch(filePath, PATHS.SETTINGS_USER)}#defaultUnit`
+      )
     } else if (data.menuLabel === 'File.Add file to project') {
       const currentProject = settingsActor.getSnapshot().context.currentProject
       commandBarActor.send({

--- a/src/registry/extensions/keymap/index.ts
+++ b/src/registry/extensions/keymap/index.ts
@@ -8,8 +8,7 @@ import {
 import { computed, signal } from '@preact/signals-core'
 import { useSignals } from '@preact/signals-react/runtime'
 import type { StatusBarItemType } from '@src/components/StatusBar/statusBarTypes'
-import makeUrlPathRelative from '@src/lib/makeUrlPathRelative'
-import { PATHS, webSafeJoin } from '@src/lib/paths'
+import { appendRouterSubRoute, PATHS } from '@src/lib/paths'
 import { reportRejection } from '@src/lib/trap'
 import { isArray } from '@src/lib/utils'
 import {
@@ -603,9 +602,7 @@ function isEventFromFormControl(target: EventTarget | null) {
 
 function openSettings() {
   const pathname = getRouterPathname()
-  const settingsPath = pathname.includes(PATHS.SETTINGS)
-    ? pathname
-    : webSafeJoin([pathname, makeUrlPathRelative(PATHS.SETTINGS)])
+  const settingsPath = appendRouterSubRoute(pathname, PATHS.SETTINGS)
 
   pushRouterPath(
     `${settingsPath}${pathname.includes(PATHS.FILE) ? '?tab=project' : ''}`

--- a/src/registry/extensions/projectSession/index.test.ts
+++ b/src/registry/extensions/projectSession/index.test.ts
@@ -79,6 +79,7 @@ describe('project session extension', () => {
       ),
       archiveEntry: vi.fn(async () => ({ archivedPath: '/archive/main.kcl' })),
       applyFilePatch: vi.fn(async () => undefined),
+      close: vi.fn(),
     }
     return {
       path: projectTree.path,
@@ -115,6 +116,42 @@ describe('project session extension', () => {
     expect(projectSession.project.value).toBeUndefined()
     expect(projectSession.getProjectTree()).toBeUndefined()
     expect(projectSession.projectTree.value).toBeUndefined()
+  })
+
+  it('reuses the active project when opening the same project path', async () => {
+    const cloudSync = createCloudSyncService()
+    const projectSession = configureProjectSession([
+      defineRegistryItem({
+        id: 'test-cloud-sync-active-project',
+        providesServices: [provideService(cloudSyncService, cloudSync)],
+      }),
+    ])
+    const projectTree = createProjectTree()
+    const project = createFakeProject(projectTree)
+    const updatedProjectTree: Project = {
+      ...projectTree,
+      children: [
+        {
+          name: 'main.kcl',
+          path: '/projects/bracket/main.kcl',
+          children: null,
+        },
+        {
+          name: 'nested.kcl',
+          path: '/projects/bracket/nested.kcl',
+          children: null,
+        },
+      ],
+      kcl_file_count: 2,
+    }
+    projectSession.setProject(project)
+
+    const reopenedProject = await projectSession.openProject(updatedProjectTree)
+
+    expect(reopenedProject).toBe(project)
+    expect(projectSession.getProject()).toBe(project)
+    expect(projectSession.getProjectTree()).toEqual(updatedProjectTree)
+    expect(project.mocks.close).not.toHaveBeenCalled()
   })
 
   it('mirrors external updates from the opened project tree signal', () => {

--- a/src/registry/extensions/projectSession/index.test.ts
+++ b/src/registry/extensions/projectSession/index.test.ts
@@ -7,6 +7,8 @@ import { projectSession } from '@src/registry/contracts/projectSession'
 import projectSessionRegistryItem from '@src/registry/extensions/projectSession'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+vi.mock('@src/lib/wasm_lib_wrapper', () => ({}))
+
 describe('project session extension', () => {
   let registry: Registry | undefined
 
@@ -59,6 +61,7 @@ describe('project session extension', () => {
       ),
       archiveEntry: vi.fn(async () => ({ archivedPath: '/archive/main.kcl' })),
       applyFilePatch: vi.fn(async () => undefined),
+      close: vi.fn(),
     }
     return {
       path: projectTree.path,
@@ -95,6 +98,36 @@ describe('project session extension', () => {
     expect(projectSession.project.value).toBeUndefined()
     expect(projectSession.getProjectTree()).toBeUndefined()
     expect(projectSession.projectTree.value).toBeUndefined()
+  })
+
+  it('reuses the active project when opening the same project path', async () => {
+    const projectSession = configureProjectSession()
+    const projectTree = createProjectTree()
+    const project = createFakeProject(projectTree)
+    const updatedProjectTree: Project = {
+      ...projectTree,
+      children: [
+        {
+          name: 'main.kcl',
+          path: '/projects/bracket/main.kcl',
+          children: null,
+        },
+        {
+          name: 'nested.kcl',
+          path: '/projects/bracket/nested.kcl',
+          children: null,
+        },
+      ],
+      kcl_file_count: 2,
+    }
+    projectSession.setProject(project)
+
+    const reopenedProject = await projectSession.openProject(updatedProjectTree)
+
+    expect(reopenedProject).toBe(project)
+    expect(projectSession.getProject()).toBe(project)
+    expect(projectSession.getProjectTree()).toEqual(updatedProjectTree)
+    expect(project.mocks.close).not.toHaveBeenCalled()
   })
 
   it('mirrors external updates from the opened project tree signal', () => {

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -179,27 +179,32 @@ export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
   }
 
   const watchSystemIOProjectTree = (projectIORefSignal: Signal<Project>) => {
+    const syncProjectTreeFromFolders = (folders: Project[] | undefined) => {
+      const foundProject = (folders ?? []).find(
+        (candidate) =>
+          candidate.name === projectIORefSignal.value.name &&
+          candidate.path === projectIORefSignal.value.path
+      )
+      if (!foundProject || projectIORefSignal.value === foundProject) {
+        return
+      }
+      projectIORefSignal.value = {
+        ...foundProject,
+        ...(projectIORefSignal.value.libraryPath
+          ? { libraryPath: projectIORefSignal.value.libraryPath }
+          : {}),
+        ...(projectIORefSignal.value.libraryType
+          ? { libraryType: projectIORefSignal.value.libraryType }
+          : {}),
+      }
+    }
+
     projectFoldersSubscription?.unsubscribe()
-    projectFoldersSubscription = ctx.services
-      .get(systemIOService)
-      .actor.subscribe(({ context }) => {
-        const foundProject = (context.folders ?? []).find(
-          (candidate) =>
-            candidate.name === projectIORefSignal.value.name &&
-            candidate.path === projectIORefSignal.value.path
-        )
-        if (foundProject && projectIORefSignal.value !== foundProject) {
-          projectIORefSignal.value = {
-            ...foundProject,
-            ...(projectIORefSignal.value.libraryPath
-              ? { libraryPath: projectIORefSignal.value.libraryPath }
-              : {}),
-            ...(projectIORefSignal.value.libraryType
-              ? { libraryType: projectIORefSignal.value.libraryType }
-              : {}),
-          }
-        }
-      })
+    const systemIOActor = ctx.services.get(systemIOService).actor
+    syncProjectTreeFromFolders(systemIOActor.getSnapshot().context.folders)
+    projectFoldersSubscription = systemIOActor.subscribe(({ context }) => {
+      syncProjectTreeFromFolders(context.folders)
+    })
   }
 
   const watchProjectHistoryExtensions = () => {
@@ -259,6 +264,22 @@ export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
   }
 
   const openProject = async (projectIORef: Project) => {
+    const currentProject = project.value
+    if (currentProject?.path === projectIORef.path) {
+      const currentProjectTree = currentProject.projectIORefSignal.value
+      const libraryPath =
+        projectIORef.libraryPath ?? currentProjectTree.libraryPath
+      const libraryType =
+        projectIORef.libraryType ?? currentProjectTree.libraryType
+      currentProject.projectIORefSignal.value = {
+        ...projectIORef,
+        ...(libraryPath ? { libraryPath } : {}),
+        ...(libraryType ? { libraryType } : {}),
+      }
+      syncProjectTree()
+      return currentProject
+    }
+
     serviceImpl.clearProject()
     setMutation({
       pending: true,

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -182,27 +182,32 @@ export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
   }
 
   const watchSystemIOProjectTree = (projectIORefSignal: Signal<Project>) => {
+    const syncProjectTreeFromFolders = (folders: Project[] | undefined) => {
+      const foundProject = (folders ?? []).find(
+        (candidate) =>
+          candidate.name === projectIORefSignal.value.name &&
+          candidate.path === projectIORefSignal.value.path
+      )
+      if (!foundProject || projectIORefSignal.value === foundProject) {
+        return
+      }
+      projectIORefSignal.value = {
+        ...foundProject,
+        ...(projectIORefSignal.value.libraryPath
+          ? { libraryPath: projectIORefSignal.value.libraryPath }
+          : {}),
+        ...(projectIORefSignal.value.libraryType
+          ? { libraryType: projectIORefSignal.value.libraryType }
+          : {}),
+      }
+    }
+
     projectFoldersSubscription?.unsubscribe()
-    projectFoldersSubscription = ctx.services
-      .get(systemIOService)
-      .actor.subscribe(({ context }) => {
-        const foundProject = (context.folders ?? []).find(
-          (candidate) =>
-            candidate.name === projectIORefSignal.value.name &&
-            candidate.path === projectIORefSignal.value.path
-        )
-        if (foundProject && projectIORefSignal.value !== foundProject) {
-          projectIORefSignal.value = {
-            ...foundProject,
-            ...(projectIORefSignal.value.libraryPath
-              ? { libraryPath: projectIORefSignal.value.libraryPath }
-              : {}),
-            ...(projectIORefSignal.value.libraryType
-              ? { libraryType: projectIORefSignal.value.libraryType }
-              : {}),
-          }
-        }
-      })
+    const systemIOActor = ctx.services.get(systemIOService).actor
+    syncProjectTreeFromFolders(systemIOActor.getSnapshot().context.folders)
+    projectFoldersSubscription = systemIOActor.subscribe(({ context }) => {
+      syncProjectTreeFromFolders(context.folders)
+    })
   }
 
   const watchProjectHistoryExtensions = () => {

--- a/src/registry/extensions/settings/index.ts
+++ b/src/registry/extensions/settings/index.ts
@@ -6,7 +6,7 @@ import {
   provideService,
 } from '@kittycad/registry'
 import { signal } from '@preact/signals-core'
-import { PATHS, webSafeJoin } from '@src/lib/paths'
+import { appendRouterSubRoute, PATHS } from '@src/lib/paths'
 import type { SettingsType } from '@src/lib/settings/initialSettings'
 import { createSettings } from '@src/lib/settings/initialSettings'
 import {
@@ -112,7 +112,7 @@ const settingsRegistryItem = defineRegistryItem({
       element: 'link',
       icon: 'settings',
       href: (location) =>
-        `${webSafeJoin([location.pathname, PATHS.SETTINGS])}${
+        `${appendRouterSubRoute(location.pathname, PATHS.SETTINGS)}${
           location.pathname.includes(PATHS.FILE) ? '?tab=project' : ''
         }`,
       'data-testid': 'settings-link',

--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -12,7 +12,7 @@ import { SettingsSearchBar } from '@src/components/Settings/SettingsSearchBar'
 import { SettingsSectionsList } from '@src/components/Settings/SettingsSectionsList'
 import { SettingsTabs } from '@src/components/Settings/SettingsTabs'
 import { useApp } from '@src/lib/boot'
-import { PATHS } from '@src/lib/paths'
+import { PATHS, stripTrailingRouterSubRoute } from '@src/lib/paths'
 import type { SettingsLevel } from '@src/lib/settings/settingsTypes'
 import { platform } from '@src/lib/utils'
 import {
@@ -47,7 +47,13 @@ export const Settings = () => {
     if (document.activeElement instanceof HTMLInputElement) {
       document.activeElement.blur()
     }
-    void navigate(location.pathname.replace(PATHS.SETTINGS, ''))
+    const targetPath = stripTrailingRouterSubRoute(
+      location.pathname,
+      PATHS.SETTINGS
+    )
+    void navigate(targetPath, {
+      replace: true,
+    })
   }
   const location = useLocation()
   const isFileSettings = location.pathname.includes(PATHS.FILE)


### PR DESCRIPTION
Part of the System.IO migration stack. This moves ProjectExplorerPane's file tree read path onto the registry-backed project session so the explorer consumes `projectSession.projectTree` directly.

1. Reads the explorer tree from `projectSession.projectTree` instead of the legacy folder snapshot hook.
2. Lets ProjectExplorer request refreshes through a callback supplied by the pane.
3. Keeps placeholder-folder shaping isolated in the pane utility and updates its focused test.

How to test
Open a local project and confirm the file explorer renders the current project tree, placeholder folders still appear where expected, and refresh updates the tree without relying on System.IO folder state.