### PR TITLE
Move explorer mutations to project session

### DIFF
--- a/e2e/playwright/onboarding-web.spec.ts
+++ b/e2e/playwright/onboarding-web.spec.ts
@@ -14,7 +14,6 @@ const TUTORIAL_PROJECT_IDS = [
   '12902000-0000-4000-8000-000000000001',
   '12902000-0000-4000-8000-000000000002',
 ] as const
-const ONBOARDING_REPLAY_TIMEOUT = 15_000
 
 async function replayOnboardingFromSettings(
   page: Page,
@@ -34,41 +33,9 @@ async function replayOnboardingFromSettings(
   await page.getByRole('button', { name: 'Replay onboarding' }).click()
 
   await expect(page).toHaveURL(
-    new RegExp(`${expectedProjectName}%2Fmain\\.kcl/onboarding/`),
-    { timeout: ONBOARDING_REPLAY_TIMEOUT }
+    new RegExp(`${expectedProjectName}%2Fmain\\.kcl/onboarding/`)
   )
-  await expect(page.getByText('Welcome to Zoo Design Studio')).toBeVisible({
-    timeout: ONBOARDING_REPLAY_TIMEOUT,
-  })
-}
-
-async function expectOnboardingNextButton(page: Page) {
-  const onboardingNextButton = page.getByTestId('onboarding-next')
-  await expect(onboardingNextButton).toBeVisible({
-    timeout: ONBOARDING_REPLAY_TIMEOUT,
-  })
-  return onboardingNextButton
-}
-
-async function expectOnboardingHeading(page: Page, name: string) {
-  await expect(page.getByRole('heading', { name, exact: true })).toBeVisible({
-    timeout: ONBOARDING_REPLAY_TIMEOUT,
-  })
-}
-
-async function expectOnboardingUrl(page: Page, pattern: RegExp) {
-  await expect(page).toHaveURL(pattern, {
-    timeout: ONBOARDING_REPLAY_TIMEOUT,
-  })
-}
-
-async function replaceWithOnboardingUrl(
-  page: Page,
-  url: string,
-  pattern: RegExp
-) {
-  await page.evaluate((nextUrl) => window.location.replace(nextUrl), url)
-  await expectOnboardingUrl(page, pattern)
+  await expect(page.getByText('Welcome to Zoo Design Studio')).toBeVisible()
 }
 
 async function expectBackDoesNotReopenOnboarding(page: Page) {
@@ -139,14 +106,10 @@ test(
     const conclusionUrl = `/file/${encodeURIComponent(
       `${PROJECT_DIR}/tutorial-project/main.kcl`
     )}/onboarding/desktop/conclusion`
-    await replaceWithOnboardingUrl(
-      page,
-      conclusionUrl,
-      /\/onboarding\/desktop\/conclusion$/
-    )
-    await expectOnboardingHeading(page, 'Time to start building')
-    await (await expectOnboardingNextButton(page)).click()
-    await expectOnboardingUrl(page, /\/home$/)
+    await page.evaluate((url) => window.location.replace(url), conclusionUrl)
+    await expect(page).toHaveURL(/\/onboarding\/desktop\/conclusion$/)
+    await page.getByTestId('onboarding-next').click()
+    await expect(page).toHaveURL(/\/home$/)
     await expectBackDoesNotReopenOnboarding(page)
     await expect(
       page.getByRole('heading', {
@@ -196,9 +159,8 @@ test(
       })
       .toContain('plateLength = 10')
 
-    await (await expectOnboardingNextButton(page)).click()
-    await expectOnboardingUrl(
-      page,
+    await page.getByTestId('onboarding-next').click()
+    await expect(page).toHaveURL(
       /tutorial-project-1%2Fblank\.kcl\/onboarding\/desktop\/scene/
     )
     await expect
@@ -213,12 +175,13 @@ test(
     const promptResultUrl = `/file/${encodeURIComponent(
       `${PROJECT_DIR}/tutorial-project-1/main.kcl`
     )}/onboarding/desktop/prompt-to-edit-result`
-    await replaceWithOnboardingUrl(
-      page,
-      promptResultUrl,
+    await page.evaluate((url) => window.location.replace(url), promptResultUrl)
+    await expect(page).toHaveURL(
       /tutorial-project-1%2Fmain\.kcl\/onboarding\/desktop\/prompt-to-edit-result/
     )
-    await expectOnboardingHeading(page, 'Result')
+    await expect(
+      page.getByRole('heading', { name: 'Result', exact: true })
+    ).toBeVisible()
     await expect
       .poll(async () => {
         const files = await readOpfsTextFiles(page, {

--- a/e2e/playwright/onboarding-web.spec.ts
+++ b/e2e/playwright/onboarding-web.spec.ts
@@ -14,6 +14,7 @@ const TUTORIAL_PROJECT_IDS = [
   '12902000-0000-4000-8000-000000000001',
   '12902000-0000-4000-8000-000000000002',
 ] as const
+const ONBOARDING_REPLAY_TIMEOUT = 15_000
 
 async function replayOnboardingFromSettings(
   page: Page,
@@ -33,9 +34,41 @@ async function replayOnboardingFromSettings(
   await page.getByRole('button', { name: 'Replay onboarding' }).click()
 
   await expect(page).toHaveURL(
-    new RegExp(`${expectedProjectName}%2Fmain\\.kcl/onboarding/`)
+    new RegExp(`${expectedProjectName}%2Fmain\\.kcl/onboarding/`),
+    { timeout: ONBOARDING_REPLAY_TIMEOUT }
   )
-  await expect(page.getByText('Welcome to Zoo Design Studio')).toBeVisible()
+  await expect(page.getByText('Welcome to Zoo Design Studio')).toBeVisible({
+    timeout: ONBOARDING_REPLAY_TIMEOUT,
+  })
+}
+
+async function expectOnboardingNextButton(page: Page) {
+  const onboardingNextButton = page.getByTestId('onboarding-next')
+  await expect(onboardingNextButton).toBeVisible({
+    timeout: ONBOARDING_REPLAY_TIMEOUT,
+  })
+  return onboardingNextButton
+}
+
+async function expectOnboardingHeading(page: Page, name: string) {
+  await expect(page.getByRole('heading', { name, exact: true })).toBeVisible({
+    timeout: ONBOARDING_REPLAY_TIMEOUT,
+  })
+}
+
+async function expectOnboardingUrl(page: Page, pattern: RegExp) {
+  await expect(page).toHaveURL(pattern, {
+    timeout: ONBOARDING_REPLAY_TIMEOUT,
+  })
+}
+
+async function replaceWithOnboardingUrl(
+  page: Page,
+  url: string,
+  pattern: RegExp
+) {
+  await page.evaluate((nextUrl) => window.location.replace(nextUrl), url)
+  await expectOnboardingUrl(page, pattern)
 }
 
 async function expectBackDoesNotReopenOnboarding(page: Page) {
@@ -106,10 +139,14 @@ test(
     const conclusionUrl = `/file/${encodeURIComponent(
       `${PROJECT_DIR}/tutorial-project/main.kcl`
     )}/onboarding/desktop/conclusion`
-    await page.evaluate((url) => window.location.replace(url), conclusionUrl)
-    await expect(page).toHaveURL(/\/onboarding\/desktop\/conclusion$/)
-    await page.getByTestId('onboarding-next').click()
-    await expect(page).toHaveURL(/\/home$/)
+    await replaceWithOnboardingUrl(
+      page,
+      conclusionUrl,
+      /\/onboarding\/desktop\/conclusion$/
+    )
+    await expectOnboardingHeading(page, 'Time to start building')
+    await (await expectOnboardingNextButton(page)).click()
+    await expectOnboardingUrl(page, /\/home$/)
     await expectBackDoesNotReopenOnboarding(page)
     await expect(
       page.getByRole('heading', {
@@ -159,8 +196,9 @@ test(
       })
       .toContain('plateLength = 10')
 
-    await page.getByTestId('onboarding-next').click()
-    await expect(page).toHaveURL(
+    await (await expectOnboardingNextButton(page)).click()
+    await expectOnboardingUrl(
+      page,
       /tutorial-project-1%2Fblank\.kcl\/onboarding\/desktop\/scene/
     )
     await expect
@@ -175,13 +213,12 @@ test(
     const promptResultUrl = `/file/${encodeURIComponent(
       `${PROJECT_DIR}/tutorial-project-1/main.kcl`
     )}/onboarding/desktop/prompt-to-edit-result`
-    await page.evaluate((url) => window.location.replace(url), promptResultUrl)
-    await expect(page).toHaveURL(
+    await replaceWithOnboardingUrl(
+      page,
+      promptResultUrl,
       /tutorial-project-1%2Fmain\.kcl\/onboarding\/desktop\/prompt-to-edit-result/
     )
-    await expect(
-      page.getByRole('heading', { name: 'Result', exact: true })
-    ).toBeVisible()
+    await expectOnboardingHeading(page, 'Result')
     await expect
       .poll(async () => {
         const files = await readOpfsTextFiles(page, {

--- a/src/components/Explorer/ProjectExplorer.spec.tsx
+++ b/src/components/Explorer/ProjectExplorer.spec.tsx
@@ -83,13 +83,17 @@ let project: Project = PROJECT_TEMPLATE
 
 function createFakeOpenedProject(projectTree: Project) {
   const projectIORefSignal = signal(projectTree)
+  const mocks = {
+    createFile: vi.fn(async ({ path }: { path: string }) => path),
+    refreshProjectTree: vi.fn(async () => projectIORefSignal.value),
+  }
   return {
     path: projectTree.path,
     name: projectTree.name,
     projectIORefSignal,
-    createFile: vi.fn(async ({ path }: { path: string }) => path),
-    refreshProjectTree: vi.fn(async () => projectIORefSignal.value),
-  } as unknown as ZDSProject
+    ...mocks,
+    mocks,
+  } as unknown as ZDSProject & { mocks: typeof mocks }
 }
 
 describe('ProjectExplorer', () => {
@@ -907,7 +911,7 @@ describe('ProjectExplorer', () => {
     fireEvent.keyUp(renameField, { key: 'Enter' })
 
     await waitFor(() => {
-      expect(openedProject.createFile).toHaveBeenCalledWith({
+      expect(openedProject.mocks.createFile).toHaveBeenCalledWith({
         path: `/${applicationDirectory}/${projectName}/notes.txt`,
       })
     })

--- a/src/components/Explorer/ProjectExplorer.spec.tsx
+++ b/src/components/Explorer/ProjectExplorer.spec.tsx
@@ -1,11 +1,15 @@
+import { signal } from '@preact/signals-core'
 import { ProjectExplorer } from '@src/components/Explorer/ProjectExplorer'
 import {
   type FileExplorerEntry,
   addPlaceHoldersForNewFileAndFolder,
 } from '@src/components/Explorer/utils'
+import type { ZDSProject } from '@src/lang/KclManager'
+import { app } from '@src/lib/boot'
 import { StorageName, moduleFsViaModuleImport } from '@src/lib/fs-zds'
 import type { FileEntry, Project } from '@src/lib/project'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
+import { projectSessionService } from '@src/registry/contracts/projectSession'
 import {
   PROJECT_EXPLORER_COMMAND_IDS,
   defaultKeymap,
@@ -77,12 +81,26 @@ const PROJECT_TEMPLATE: Project = {
 }
 let project: Project = PROJECT_TEMPLATE
 
+function createFakeOpenedProject(projectTree: Project) {
+  const projectIORefSignal = signal(projectTree)
+  return {
+    path: projectTree.path,
+    name: projectTree.name,
+    projectIORefSignal,
+    createFile: vi.fn(async ({ path }: { path: string }) => path),
+    refreshProjectTree: vi.fn(async () => projectIORefSignal.value),
+  } as unknown as ZDSProject
+}
+
 describe('ProjectExplorer', () => {
   beforeEach(() => {
     // reset the project before each test
     project = JSON.parse(JSON.stringify(PROJECT_TEMPLATE))
+    app.registry.get(projectSessionService).clearProject()
   })
   afterEach(() => {
+    app.registry.get(projectSessionService).clearProject()
+    vi.restoreAllMocks()
     cleanup()
   })
   it('should render no rows', () => {
@@ -845,6 +863,55 @@ describe('ProjectExplorer', () => {
       .closest('[role="treeitem"]')
     expect(activeFolder.nextElementSibling).toBe(contextMenuFileRow)
     expect(contextMenuFileRow).toHaveAttribute('aria-level', '2')
+  })
+  it('should create files through the project session service', async () => {
+    addPlaceHoldersForNewFileAndFolder(project.children, project.path)
+    const openedProject = createFakeOpenedProject(project)
+    app.registry.get(projectSessionService).setProject(openedProject)
+    const systemIOSend = vi.spyOn(app.systemIOActor, 'send')
+
+    const { rerender } = render(
+      <ProjectExplorer
+        wasmInstance={wasmInstance}
+        project={project}
+        file={oneFile}
+        createFilePressed={-1}
+        createFolderPressed={-1}
+        refreshExplorerPressed={-1}
+        collapsePressed={-1}
+        onRowClicked={(row: FileExplorerEntry, index: number) => {}}
+        onRowEnter={(row: FileExplorerEntry, index: number) => {}}
+        readOnly={false}
+        canNavigate={true}
+      />
+    )
+
+    rerender(
+      <ProjectExplorer
+        wasmInstance={wasmInstance}
+        project={project}
+        file={oneFile}
+        createFilePressed={performance.now()}
+        createFolderPressed={-1}
+        refreshExplorerPressed={-1}
+        collapsePressed={-1}
+        onRowClicked={(row: FileExplorerEntry, index: number) => {}}
+        onRowEnter={(row: FileExplorerEntry, index: number) => {}}
+        readOnly={false}
+        canNavigate={true}
+      />
+    )
+
+    const renameField = screen.getByTestId('file-rename-field')
+    fireEvent.change(renameField, { target: { value: 'notes.txt' } })
+    fireEvent.keyUp(renameField, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(openedProject.createFile).toHaveBeenCalledWith({
+        path: `/${applicationDirectory}/${projectName}/notes.txt`,
+      })
+    })
+    expect(systemIOSend).not.toHaveBeenCalled()
   })
   it('should render a placefolder for a folder when create folder is pressed', () => {
     const mainFile = createFile('main.kcl')

--- a/src/components/Explorer/ProjectExplorer.spec.tsx
+++ b/src/components/Explorer/ProjectExplorer.spec.tsx
@@ -9,7 +9,7 @@ import { app } from '@src/lib/boot'
 import { StorageName, moduleFsViaModuleImport } from '@src/lib/fs-zds'
 import type { FileEntry, Project } from '@src/lib/project'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
-import { projectSessionService } from '@src/registry/contracts/projectSession'
+import { projectSession } from '@src/registry/contracts/projectSession'
 import {
   PROJECT_EXPLORER_COMMAND_IDS,
   defaultKeymap,
@@ -100,10 +100,10 @@ describe('ProjectExplorer', () => {
   beforeEach(() => {
     // reset the project before each test
     project = JSON.parse(JSON.stringify(PROJECT_TEMPLATE))
-    app.registry.get(projectSessionService).clearProject()
+    app.registry.get(projectSession).clearProject()
   })
   afterEach(() => {
-    app.registry.get(projectSessionService).clearProject()
+    app.registry.get(projectSession).clearProject()
     vi.restoreAllMocks()
     cleanup()
   })
@@ -871,7 +871,7 @@ describe('ProjectExplorer', () => {
   it('should create files through the project session service', async () => {
     addPlaceHoldersForNewFileAndFolder(project.children, project.path)
     const openedProject = createFakeOpenedProject(project)
-    app.registry.get(projectSessionService).setProject(openedProject)
+    app.registry.get(projectSession).setProject(openedProject)
     const systemIOSend = vi.spyOn(app.systemIOActor, 'send')
 
     const { rerender } = render(

--- a/src/components/Explorer/ProjectExplorer.tsx
+++ b/src/components/Explorer/ProjectExplorer.tsx
@@ -40,7 +40,7 @@ import {
   PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE,
   keymapService,
 } from '@src/registry/contracts/keymap'
-import { projectSessionService } from '@src/registry/contracts/projectSession'
+import { projectSession } from '@src/registry/contracts/projectSession'
 import { projectExplorerRowContextMenuItemsValueSpec } from '@src/registry/contracts/projectExplorer'
 import { PROJECT_EXPLORER_COMMAND_IDS } from '@src/registry/extensions/keymap/defaultKeymap'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -179,8 +179,8 @@ export const ProjectExplorer = ({
 }) => {
   useSignals()
   const { commands, registry, systemIOActor } = useApp()
-  const projectSession = registry.get(projectSessionService)
-  const projectSessionMutation = projectSession.mutation.value
+  const session = registry.get(projectSession)
+  const projectSessionMutation = session.mutation.value
   const keymap = registry.optional(keymapService)
   const rowContextMenuItems = registry.signal(
     projectExplorerRowContextMenuItemsValueSpec
@@ -788,7 +788,7 @@ export const ProjectExplorer = ({
               })
 
               const arrayBuffer = await file.arrayBuffer()
-              await projectSession.writeFile({
+              await session.writeFile({
                 path: destinationPath,
                 contents: new Uint8Array(arrayBuffer),
                 overwrite: false,
@@ -814,13 +814,7 @@ export const ProjectExplorer = ({
         }
       }
     },
-    [
-      readOnly,
-      project.path,
-      wasmInstance,
-      projectSession,
-      setFileTreeMutationPending,
-    ]
+    [readOnly, project.path, wasmInstance, session, setFileTreeMutationPending]
   )
 
   const handleDragOverTarget = useCallback(
@@ -930,7 +924,7 @@ export const ProjectExplorer = ({
       if (result && result.src && result.target) {
         void runFileTreeMutation({
           mutation: () =>
-            projectSession.copyEntry({
+            session.copyEntry({
               sourcePath: result.src,
               targetPath: result.target,
             }),
@@ -1037,7 +1031,7 @@ export const ProjectExplorer = ({
 
             void runFileTreeMutation({
               mutation: async () => {
-                const { archivedPath } = await projectSession.archiveEntry({
+                const { archivedPath } = await session.archiveEntry({
                   path: src,
                 })
                 kclManager.addGlobalHistoryEvent(
@@ -1117,7 +1111,7 @@ export const ProjectExplorer = ({
                 const { src, target } = result
                 void runFileTreeMutation({
                   mutation: async () => {
-                    await projectSession.moveEntry({
+                    await session.moveEntry({
                       sourcePath: src,
                       targetPath: target,
                     })
@@ -1174,7 +1168,7 @@ export const ProjectExplorer = ({
                   )
                   void runFileTreeMutation({
                     mutation: () =>
-                      projectSession.createFolder({
+                      session.createFolder({
                         path: requestedAbsolutePath,
                       }),
                     successMessage: `Folder ${requestedName} written successfully`,
@@ -1205,7 +1199,7 @@ export const ProjectExplorer = ({
                       )
                     void runFileTreeMutation({
                       mutation: () =>
-                        projectSession.renameEntry({
+                        session.renameEntry({
                           oldPath,
                           newPath,
                         }),
@@ -1223,7 +1217,7 @@ export const ProjectExplorer = ({
                   } else {
                     void runFileTreeMutation({
                       mutation: () =>
-                        projectSession.renameEntry({
+                        session.renameEntry({
                           oldPath,
                           newPath,
                         }),
@@ -1263,7 +1257,7 @@ export const ProjectExplorer = ({
                 )
                 void runFileTreeMutation({
                   mutation: () =>
-                    projectSession.createFile({
+                    session.createFile({
                       path: requestedAbsolutePath,
                     }),
                   successMessage: 'Successfully created 1 file',
@@ -1283,7 +1277,7 @@ export const ProjectExplorer = ({
                 // so non-KCL files (.md, .txt, ...) don't get KCL boilerplate.
                 void runFileTreeMutation({
                   mutation: () =>
-                    projectSession.createFile({
+                    session.createFile({
                       path: requestedAbsolutePath,
                     }),
                   successMessage: `File ${fileName} written successfully`,
@@ -1316,7 +1310,7 @@ export const ProjectExplorer = ({
               )
               void runFileTreeMutation({
                 mutation: () =>
-                  projectSession.renameEntry({
+                  session.renameEntry({
                     oldPath: requestedAbsoluteFilePathWithExtension,
                     newPath,
                   }),

--- a/src/components/Explorer/ProjectExplorer.tsx
+++ b/src/components/Explorer/ProjectExplorer.tsx
@@ -1266,7 +1266,7 @@ export const ProjectExplorer = ({
                     projectSession.createFile({
                       path: requestedAbsolutePath,
                     }),
-                  successMessage: `File ${fileName} written successfully`,
+                  successMessage: 'Successfully created 1 file',
                   onSuccess: () => {
                     systemIOActor.send({
                       type: SystemIOMachineEvents.navigateToFile,

--- a/src/components/Explorer/ProjectExplorer.tsx
+++ b/src/components/Explorer/ProjectExplorer.tsx
@@ -22,7 +22,6 @@ import { useApp, useSingletons } from '@src/lib/boot'
 import type { Command } from '@src/lib/commandTypes'
 import { FILE_EXT } from '@src/lib/constants'
 import { getNextFileName, sortFilesAndDirectories } from '@src/lib/desktopFS'
-import fsZds from '@src/lib/fs-zds'
 import {
   desktopSafePathJoin,
   desktopSafePathSplit,
@@ -31,23 +30,19 @@ import {
   joinOSPaths,
   parentPathRelativeToApplicationDirectory,
   parentPathRelativeToProject,
-  toArchivePath,
 } from '@src/lib/paths'
 import type { FileEntry, Project } from '@src/lib/project'
 import type { MaybePressOrBlur } from '@src/lib/types'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
-import {
-  SystemIOMachineEvents,
-  SystemIOMachineStates,
-} from '@src/machines/systemIO/utils'
+import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
 import {
   PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE,
   PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE,
   keymapService,
 } from '@src/registry/contracts/keymap'
+import { projectSessionService } from '@src/registry/contracts/projectSession'
 import { projectExplorerRowContextMenuItemsValueSpec } from '@src/registry/contracts/projectExplorer'
 import { PROJECT_EXPLORER_COMMAND_IDS } from '@src/registry/extensions/keymap/defaultKeymap'
-import { useSelector } from '@xstate/react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { FocusEvent as ReactFocusEvent } from 'react'
 import toast from 'react-hot-toast'
@@ -58,18 +53,6 @@ const isFileExplorerEntryOpened = (
 ): boolean => {
   return rows[entry.key]
 }
-
-const FILE_TREE_MUTATION_STATES = [
-  SystemIOMachineStates.renamingFolder,
-  SystemIOMachineStates.renamingFile,
-  SystemIOMachineStates.deletingFileOrFolder,
-  SystemIOMachineStates.renamingFileAndNavigateToFile,
-  SystemIOMachineStates.renamingFolderAndNavigateToFile,
-  SystemIOMachineStates.deletingFileOrFolderAndNavigate,
-  SystemIOMachineStates.copyingRecursive,
-  SystemIOMachineStates.movingRecursive,
-  SystemIOMachineStates.movingRecursiveAndNavigate,
-] as const
 
 const handleExternalDragEvent = (e: React.DragEvent): boolean => {
   if (!isExternalFileDrag(e)) {
@@ -196,23 +179,14 @@ export const ProjectExplorer = ({
 }) => {
   useSignals()
   const { commands, registry, systemIOActor } = useApp()
+  const projectSession = registry.get(projectSessionService)
+  const projectSessionMutation = projectSession.mutation.value
   const keymap = registry.optional(keymapService)
   const rowContextMenuItems = registry.signal(
     projectExplorerRowContextMenuItemsValueSpec
   ).value
   const { kclManager } = useSingletons()
-  const isSystemIOIdle = useSelector(systemIOActor, (state) =>
-    state.matches(SystemIOMachineStates.idle)
-  )
-  const isSystemIOFileTreeMutation = useSelector(systemIOActor, (state) =>
-    FILE_TREE_MUTATION_STATES.some((fileTreeMutationState) =>
-      state.matches(fileTreeMutationState)
-    )
-  )
-  const lastRecursiveMoveTarget = useSelector(
-    systemIOActor,
-    (state) => state.context.lastRecursiveMoveTarget
-  )
+  const lastFileTreeMutationTarget = projectSessionMutation.lastTargetPath
   const errors = kclManager.errorsSignal.value
   const applicationProjectDirectory =
     overrideApplicationProjectDirectory || getParentAbsolutePath(project.path)
@@ -285,7 +259,7 @@ export const ProjectExplorer = ({
 
   onRowEnterRef.current = onRowEnter
   const isFileTreeInteractionDisabled =
-    isFileTreeMutationPending || isSystemIOFileTreeMutation
+    isFileTreeMutationPending || projectSessionMutation.pending
   isFileTreeInteractionDisabledRef.current = isFileTreeInteractionDisabled
 
   const setFileTreeMutationPending = useCallback((isPending: boolean) => {
@@ -293,19 +267,38 @@ export const ProjectExplorer = ({
     setIsFileTreeMutationPending(isPending)
   }, [])
 
-  const sendFileTreeMutationEvent = useCallback(
-    (event: Parameters<typeof systemIOActor.send>[0]) => {
+  const runFileTreeMutation = useCallback(
+    async (input: {
+      mutation: () => Promise<unknown>
+      successMessage: string
+      onSuccess?: () => void
+    }) => {
       setFileTreeMutationPending(true)
-      systemIOActor.send(event)
+      try {
+        await input.mutation()
+        input.onSuccess?.()
+        toast.success(input.successMessage)
+      } catch (error) {
+        console.error(error)
+        toast.error(
+          error instanceof Error ? error.message : 'File operation failed.'
+        )
+      } finally {
+        setFileTreeMutationPending(false)
+      }
     },
-    [setFileTreeMutationPending, systemIOActor]
+    [setFileTreeMutationPending]
   )
 
   useEffect(() => {
-    if (isSystemIOIdle && isFileTreeMutationPending) {
+    if (!projectSessionMutation.pending && isFileTreeMutationPending) {
       setFileTreeMutationPending(false)
     }
-  }, [isFileTreeMutationPending, isSystemIOIdle, setFileTreeMutationPending])
+  }, [
+    isFileTreeMutationPending,
+    projectSessionMutation.pending,
+    setFileTreeMutationPending,
+  ])
 
   // fake row is used for new files or folders, you should not be able to have multiple fake rows for creation
   const [fakeRow, setFakeRow] = useState<{
@@ -778,58 +771,54 @@ export const ProjectExplorer = ({
       // Copy supported files to the target directory
       if (supportedFiles.length > 0) {
         setFileTreeMutationPending(true)
-        const targetPath = getDropTargetPath(target, project.path)
-        const createdDirs = new Set<string>()
+        try {
+          const targetPath = getDropTargetPath(target, project.path)
 
-        for (const { file, relativePath } of supportedFiles) {
-          try {
-            const destinationDirPath = relativePath
-              ? joinOSPaths(targetPath, relativePath)
-              : targetPath
+          for (const { file, relativePath } of supportedFiles) {
+            try {
+              const destinationDirPath = relativePath
+                ? joinOSPaths(targetPath, relativePath)
+                : targetPath
 
-            // Create parent directories if needed
-            if (relativePath && !createdDirs.has(destinationDirPath)) {
-              await fsZds.mkdir(destinationDirPath, { recursive: true })
-              createdDirs.add(destinationDirPath)
+              const { path: destinationPath } = await getNextFileName({
+                entryName: file.name,
+                baseDir: destinationDirPath,
+                wasmInstance,
+                preserveUnknownExtension: true,
+              })
+
+              const arrayBuffer = await file.arrayBuffer()
+              await projectSession.writeFile({
+                path: destinationPath,
+                contents: new Uint8Array(arrayBuffer),
+                overwrite: false,
+              })
+            } catch (e) {
+              console.error('Failed to copy file:', file.name, e)
+              toast.error(`Failed to import ${file.name}.`)
             }
-
-            const { path: destinationPath } = await getNextFileName({
-              entryName: file.name,
-              baseDir: destinationDirPath,
-              wasmInstance,
-              preserveUnknownExtension: true,
-            })
-
-            const arrayBuffer = await file.arrayBuffer()
-            await fsZds.writeFile(destinationPath, new Uint8Array(arrayBuffer))
-          } catch (e) {
-            console.error('Failed to copy file:', file.name, e)
-            toast.error(`Failed to import ${file.name}.`)
           }
+
+          // Open the target folder so the user can see the imported files
+          if (target?.children) {
+            const newOpenedRows = { ...openedRowsRef.current }
+            newOpenedRows[target.key] = true
+            setOpenedRows(newOpenedRows)
+          }
+
+          toast.success(
+            `Imported ${supportedFiles.length} file${supportedFiles.length > 1 ? 's' : ''}.`
+          )
+        } finally {
+          setFileTreeMutationPending(false)
         }
-
-        // Open the target folder so the user can see the imported files
-        if (target?.children) {
-          const newOpenedRows = { ...openedRowsRef.current }
-          newOpenedRows[target.key] = true
-          setOpenedRows(newOpenedRows)
-        }
-
-        // Refresh the explorer to show the new files
-        systemIOActor.send({
-          type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
-        })
-
-        toast.success(
-          `Imported ${supportedFiles.length} file${supportedFiles.length > 1 ? 's' : ''}.`
-        )
       }
     },
     [
       readOnly,
       project.path,
       wasmInstance,
-      systemIOActor,
+      projectSession,
       setFileTreeMutationPending,
     ]
   )
@@ -900,16 +889,16 @@ export const ProjectExplorer = ({
         pathIterator.pop()
       }
     }
-    const recursiveMoveTargetRow = lastRecursiveMoveTarget
+    const recursiveMoveTargetRow = lastFileTreeMutationTarget
       ? flattenedData.find(
           (child) =>
-            child.path === lastRecursiveMoveTarget &&
+            child.path === lastFileTreeMutationTarget &&
             rowPathMatchesTreeParent(child, project)
         )
       : undefined
     const shouldRevealRecursiveMoveTarget =
       !!recursiveMoveTargetRow &&
-      lastRecursiveMoveTarget !== lastRevealedRecursiveMoveTargetRef.current
+      lastFileTreeMutationTarget !== lastRevealedRecursiveMoveTargetRef.current
     if (shouldRevealRecursiveMoveTarget) {
       const moveTargetKey =
         recursiveMoveTargetRow.children === null
@@ -922,7 +911,7 @@ export const ProjectExplorer = ({
         openedRowsForRender[key] = true
         pathIterator.pop()
       }
-      lastRevealedRecursiveMoveTargetRef.current = lastRecursiveMoveTarget
+      lastRevealedRecursiveMoveTargetRef.current = lastFileTreeMutationTarget
     }
 
     const copyEntryToTarget = (src: FileEntry, target: FileEntry) => {
@@ -939,12 +928,13 @@ export const ProjectExplorer = ({
         '-copy-'
       )
       if (result && result.src && result.target) {
-        sendFileTreeMutationEvent({
-          type: SystemIOMachineEvents.copyRecursive,
-          data: {
-            src: result.src,
-            target: result.target,
-          },
+        void runFileTreeMutation({
+          mutation: () =>
+            projectSession.copyEntry({
+              sourcePath: result.src,
+              targetPath: result.target,
+            }),
+          successMessage: 'Copied successfully',
         })
       } else {
         toast.error('Failed to copy and paste the result is null.')
@@ -1043,65 +1033,33 @@ export const ProjectExplorer = ({
 
             const shouldWeNavigate =
               file?.path?.startsWith(child.path) && canNavigate
+            const src = child.path
 
-            if (shouldWeNavigate && file && file.path) {
-              const src = child.path
-              setFileTreeMutationPending(true)
-              toArchivePath(src)
-                .then((target) => {
-                  sendFileTreeMutationEvent({
-                    type: SystemIOMachineEvents.moveRecursiveAndNavigate,
+            void runFileTreeMutation({
+              mutation: async () => {
+                const { archivedPath } = await projectSession.archiveEntry({
+                  path: src,
+                })
+                kclManager.addGlobalHistoryEvent(
+                  fsArchiveFile({
+                    src,
+                    target: archivedPath,
+                    requestedProjectName: project.name,
+                  })
+                )
+              },
+              successMessage: 'Archived successfully',
+              onSuccess: () => {
+                if (shouldWeNavigate && file?.path) {
+                  systemIOActor.send({
+                    type: SystemIOMachineEvents.navigateToProject,
                     data: {
-                      src,
-                      target,
-                      successMessage: 'Archived successfully',
                       requestedProjectName: project.name,
                     },
                   })
-                  kclManager.addGlobalHistoryEvent(
-                    fsArchiveFile({
-                      src,
-                      target,
-                      requestedProjectName: project.name,
-                    })
-                  )
-                })
-                .catch((e) => {
-                  setFileTreeMutationPending(false)
-                  console.error(e)
-                  console.warn(
-                    `Error while archiving: the deletion of ${child.path} may have been unrecoverable.`
-                  )
-                })
-            } else {
-              const src = child.path
-              setFileTreeMutationPending(true)
-              toArchivePath(src)
-                .then((target) => {
-                  sendFileTreeMutationEvent({
-                    type: SystemIOMachineEvents.moveRecursive,
-                    data: {
-                      src,
-                      target,
-                      successMessage: 'Archived successfully',
-                    },
-                  })
-                  kclManager.addGlobalHistoryEvent(
-                    fsArchiveFile({
-                      src,
-                      target,
-                      requestedProjectName: project.name,
-                    })
-                  )
-                })
-                .catch((e) => {
-                  setFileTreeMutationPending(false)
-                  console.error(e)
-                  console.warn(
-                    `Error while archiving: the deletion of ${child.path} may have been unrecoverable.`
-                  )
-                })
-            }
+                }
+              },
+            })
           },
           onOpenInNewWindow: () => {
             window.electron?.openInNewWindow(row.path)
@@ -1157,20 +1115,22 @@ export const ProjectExplorer = ({
               )
               if (result && result.src && result.target) {
                 const { src, target } = result
-                sendFileTreeMutationEvent({
-                  type: SystemIOMachineEvents.moveRecursive,
-                  data: {
-                    src,
-                    target,
+                void runFileTreeMutation({
+                  mutation: async () => {
+                    await projectSession.moveEntry({
+                      sourcePath: src,
+                      targetPath: target,
+                    })
+                    kclManager.addGlobalHistoryEvent(
+                      fsMoveFile({
+                        src,
+                        target,
+                        requestedProjectName: project.name,
+                      })
+                    )
                   },
+                  successMessage: 'Moved successfully',
                 })
-                kclManager.addGlobalHistoryEvent(
-                  fsMoveFile({
-                    src,
-                    target,
-                    requestedProjectName: project.name,
-                  })
-                )
               } else {
                 toast.error('Failed to copy and paste the result is null.')
               }
@@ -1208,24 +1168,26 @@ export const ProjectExplorer = ({
               if (requestedName !== name) {
                 if (row.isFake) {
                   // create
-                  sendFileTreeMutationEvent({
-                    type: SystemIOMachineEvents.createBlankFolder,
-                    data: {
-                      requestedAbsolutePath: joinOSPaths(
-                        getParentAbsolutePath(row.path),
-                        requestedName
-                      ),
-                    },
+                  const requestedAbsolutePath = joinOSPaths(
+                    getParentAbsolutePath(row.path),
+                    requestedName
+                  )
+                  void runFileTreeMutation({
+                    mutation: () =>
+                      projectSession.createFolder({
+                        path: requestedAbsolutePath,
+                      }),
+                    successMessage: `Folder ${requestedName} written successfully`,
                   })
                 } else {
                   const absolutePathToParentDirectory = getParentAbsolutePath(
                     row.path
                   )
-                  const oldPath = fsZds.join(
+                  const oldPath = joinOSPaths(
                     absolutePathToParentDirectory,
                     name
                   )
-                  const newPath = fsZds.join(
+                  const newPath = joinOSPaths(
                     absolutePathToParentDirectory,
                     requestedName
                   )
@@ -1241,24 +1203,31 @@ export const ProjectExplorer = ({
                         file?.path?.replace(oldPath, newPath),
                         applicationProjectDirectory
                       )
-                    sendFileTreeMutationEvent({
-                      type: SystemIOMachineEvents.renameFolderAndNavigateToFile,
-                      data: {
-                        requestedFolderName: requestedName,
-                        folderName: name,
-                        absolutePathToParentDirectory,
-                        requestedProjectName: project.name,
-                        requestedFileNameWithExtension,
+                    void runFileTreeMutation({
+                      mutation: () =>
+                        projectSession.renameEntry({
+                          oldPath,
+                          newPath,
+                        }),
+                      successMessage: `Successfully renamed folder "${name}" to "${requestedName}"`,
+                      onSuccess: () => {
+                        systemIOActor.send({
+                          type: SystemIOMachineEvents.navigateToFile,
+                          data: {
+                            requestedProjectName: project.name,
+                            requestedFileName: requestedFileNameWithExtension,
+                          },
+                        })
                       },
                     })
                   } else {
-                    sendFileTreeMutationEvent({
-                      type: SystemIOMachineEvents.renameFolder,
-                      data: {
-                        requestedFolderName: requestedName,
-                        folderName: name,
-                        absolutePathToParentDirectory,
-                      },
+                    void runFileTreeMutation({
+                      mutation: () =>
+                        projectSession.renameEntry({
+                          oldPath,
+                          newPath,
+                        }),
+                      successMessage: `Successfully renamed folder "${name}" to "${requestedName}"`,
                     })
                   }
 
@@ -1292,23 +1261,32 @@ export const ProjectExplorer = ({
                   requestedAbsolutePath,
                   applicationProjectDirectory
                 )
-                sendFileTreeMutationEvent({
-                  type: SystemIOMachineEvents.importFileFromURL,
-                  data: {
-                    requestedCode: '',
-                    requestedProjectName: project.name,
-                    requestedFileNameWithExtension: pathRelativeToParent,
+                void runFileTreeMutation({
+                  mutation: () =>
+                    projectSession.createFile({
+                      path: requestedAbsolutePath,
+                    }),
+                  successMessage: `File ${fileName} written successfully`,
+                  onSuccess: () => {
+                    systemIOActor.send({
+                      type: SystemIOMachineEvents.navigateToFile,
+                      data: {
+                        requestedProjectName: project.name,
+                        requestedFileName: pathRelativeToParent,
+                      },
+                    })
                   },
                 })
               } else {
                 // Create a blank file. The actor seeds default KCL content only
                 // for .kcl files and writes an empty file for everything else,
                 // so non-KCL files (.md, .txt, ...) don't get KCL boilerplate.
-                sendFileTreeMutationEvent({
-                  type: SystemIOMachineEvents.createBlankFile,
-                  data: {
-                    requestedAbsolutePath,
-                  },
+                void runFileTreeMutation({
+                  mutation: () =>
+                    projectSession.createFile({
+                      path: requestedAbsolutePath,
+                    }),
+                  successMessage: `File ${fileName} written successfully`,
                 })
               }
             } else {
@@ -1328,16 +1306,31 @@ export const ProjectExplorer = ({
               const shouldWeNavigate =
                 requestedAbsoluteFilePathWithExtension === file?.path &&
                 canNavigate
-              sendFileTreeMutationEvent({
-                type: shouldWeNavigate
-                  ? SystemIOMachineEvents.renameFileAndNavigateToFile
-                  : SystemIOMachineEvents.renameFile,
-                data: {
-                  requestedFileNameWithExtension: fileName,
-                  fileNameWithExtension: name,
-                  absolutePathToParentDirectory: getParentAbsolutePath(
-                    row.path
-                  ),
+              const newPath = joinOSPaths(
+                getParentAbsolutePath(row.path),
+                fileName
+              )
+              const requestedFileName = parentPathRelativeToProject(
+                newPath,
+                applicationProjectDirectory
+              )
+              void runFileTreeMutation({
+                mutation: () =>
+                  projectSession.renameEntry({
+                    oldPath: requestedAbsoluteFilePathWithExtension,
+                    newPath,
+                  }),
+                successMessage: `Successfully renamed file "${name}" to "${fileName}"`,
+                onSuccess: () => {
+                  if (shouldWeNavigate) {
+                    systemIOActor.send({
+                      type: SystemIOMachineEvents.navigateToFile,
+                      data: {
+                        requestedProjectName: project.name,
+                        requestedFileName,
+                      },
+                    })
+                  }
                 },
               })
             }

--- a/src/components/Explorer/ProjectExplorer.tsx
+++ b/src/components/Explorer/ProjectExplorer.tsx
@@ -41,7 +41,7 @@ import {
   PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE,
   keymapService,
 } from '@src/registry/contracts/keymap'
-import { projectSessionService } from '@src/registry/contracts/projectSession'
+import { projectSession } from '@src/registry/contracts/projectSession'
 import { projectExplorerRowContextMenuItemsValueSpec } from '@src/registry/contracts/projectExplorer'
 import { PROJECT_EXPLORER_COMMAND_IDS } from '@src/registry/extensions/keymap/defaultKeymap'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -180,8 +180,8 @@ export const ProjectExplorer = ({
 }) => {
   useSignals()
   const { commands, registry, systemIOActor } = useApp()
-  const projectSession = registry.get(projectSessionService)
-  const projectSessionMutation = projectSession.mutation.value
+  const session = registry.get(projectSession)
+  const projectSessionMutation = session.mutation.value
   const keymap = registry.optional(keymapService)
   const rowContextMenuItems = registry.signal(
     projectExplorerRowContextMenuItemsValueSpec
@@ -789,7 +789,7 @@ export const ProjectExplorer = ({
               })
 
               const arrayBuffer = await file.arrayBuffer()
-              await projectSession.writeFile({
+              await session.writeFile({
                 path: destinationPath,
                 contents: new Uint8Array(arrayBuffer),
                 overwrite: false,
@@ -815,13 +815,7 @@ export const ProjectExplorer = ({
         }
       }
     },
-    [
-      readOnly,
-      project.path,
-      wasmInstance,
-      projectSession,
-      setFileTreeMutationPending,
-    ]
+    [readOnly, project.path, wasmInstance, session, setFileTreeMutationPending]
   )
 
   const handleDragOverTarget = useCallback(
@@ -931,7 +925,7 @@ export const ProjectExplorer = ({
       if (result && result.src && result.target) {
         void runFileTreeMutation({
           mutation: () =>
-            projectSession.copyEntry({
+            session.copyEntry({
               sourcePath: result.src,
               targetPath: result.target,
             }),
@@ -1039,7 +1033,7 @@ export const ProjectExplorer = ({
 
             void runFileTreeMutation({
               mutation: async () => {
-                const { archivedPath } = await projectSession.archiveEntry({
+                const { archivedPath } = await session.archiveEntry({
                   path: src,
                 })
                 kclManager.addGlobalHistoryEvent(
@@ -1119,7 +1113,7 @@ export const ProjectExplorer = ({
                 const { src, target } = result
                 void runFileTreeMutation({
                   mutation: async () => {
-                    await projectSession.moveEntry({
+                    await session.moveEntry({
                       sourcePath: src,
                       targetPath: target,
                     })
@@ -1176,7 +1170,7 @@ export const ProjectExplorer = ({
                   )
                   void runFileTreeMutation({
                     mutation: () =>
-                      projectSession.createFolder({
+                      session.createFolder({
                         path: requestedAbsolutePath,
                       }),
                     successMessage: `Folder ${requestedName} written successfully`,
@@ -1207,7 +1201,7 @@ export const ProjectExplorer = ({
                       )
                     void runFileTreeMutation({
                       mutation: () =>
-                        projectSession.renameEntry({
+                        session.renameEntry({
                           oldPath,
                           newPath,
                         }),
@@ -1225,7 +1219,7 @@ export const ProjectExplorer = ({
                   } else {
                     void runFileTreeMutation({
                       mutation: () =>
-                        projectSession.renameEntry({
+                        session.renameEntry({
                           oldPath,
                           newPath,
                         }),
@@ -1265,7 +1259,7 @@ export const ProjectExplorer = ({
                 )
                 void runFileTreeMutation({
                   mutation: () =>
-                    projectSession.createFile({
+                    session.createFile({
                       path: requestedAbsolutePath,
                     }),
                   successMessage: 'Successfully created 1 file',
@@ -1285,7 +1279,7 @@ export const ProjectExplorer = ({
                 // so non-KCL files (.md, .txt, ...) don't get KCL boilerplate.
                 void runFileTreeMutation({
                   mutation: () =>
-                    projectSession.createFile({
+                    session.createFile({
                       path: requestedAbsolutePath,
                     }),
                   successMessage: `File ${fileName} written successfully`,
@@ -1318,7 +1312,7 @@ export const ProjectExplorer = ({
               )
               void runFileTreeMutation({
                 mutation: () =>
-                  projectSession.renameEntry({
+                  session.renameEntry({
                     oldPath: requestedAbsoluteFilePathWithExtension,
                     newPath,
                   }),

--- a/src/components/Explorer/ProjectExplorer.tsx
+++ b/src/components/Explorer/ProjectExplorer.tsx
@@ -23,7 +23,6 @@ import { useApp, useSingletons } from '@src/lib/boot'
 import type { Command } from '@src/lib/commandTypes'
 import { FILE_EXT } from '@src/lib/constants'
 import { getNextFileName, sortFilesAndDirectories } from '@src/lib/desktopFS'
-import fsZds from '@src/lib/fs-zds'
 import {
   desktopSafePathJoin,
   desktopSafePathSplit,
@@ -32,23 +31,19 @@ import {
   joinOSPaths,
   parentPathRelativeToApplicationDirectory,
   parentPathRelativeToProject,
-  toArchivePath,
 } from '@src/lib/paths'
 import type { FileEntry, Project } from '@src/lib/project'
 import type { MaybePressOrBlur } from '@src/lib/types'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
-import {
-  SystemIOMachineEvents,
-  SystemIOMachineStates,
-} from '@src/machines/systemIO/utils'
+import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
 import {
   PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE,
   PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE,
   keymapService,
 } from '@src/registry/contracts/keymap'
+import { projectSessionService } from '@src/registry/contracts/projectSession'
 import { projectExplorerRowContextMenuItemsValueSpec } from '@src/registry/contracts/projectExplorer'
 import { PROJECT_EXPLORER_COMMAND_IDS } from '@src/registry/extensions/keymap/defaultKeymap'
-import { useSelector } from '@xstate/react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { FocusEvent as ReactFocusEvent } from 'react'
 import toast from 'react-hot-toast'
@@ -59,18 +54,6 @@ const isFileExplorerEntryOpened = (
 ): boolean => {
   return rows[entry.key]
 }
-
-const FILE_TREE_MUTATION_STATES = [
-  SystemIOMachineStates.renamingFolder,
-  SystemIOMachineStates.renamingFile,
-  SystemIOMachineStates.deletingFileOrFolder,
-  SystemIOMachineStates.renamingFileAndNavigateToFile,
-  SystemIOMachineStates.renamingFolderAndNavigateToFile,
-  SystemIOMachineStates.deletingFileOrFolderAndNavigate,
-  SystemIOMachineStates.copyingRecursive,
-  SystemIOMachineStates.movingRecursive,
-  SystemIOMachineStates.movingRecursiveAndNavigate,
-] as const
 
 const handleExternalDragEvent = (e: React.DragEvent): boolean => {
   if (!isExternalFileDrag(e)) {
@@ -197,23 +180,14 @@ export const ProjectExplorer = ({
 }) => {
   useSignals()
   const { commands, registry, systemIOActor } = useApp()
+  const projectSession = registry.get(projectSessionService)
+  const projectSessionMutation = projectSession.mutation.value
   const keymap = registry.optional(keymapService)
   const rowContextMenuItems = registry.signal(
     projectExplorerRowContextMenuItemsValueSpec
   ).value
   const { kclManager } = useSingletons()
-  const isSystemIOIdle = useSelector(systemIOActor, (state) =>
-    state.matches(SystemIOMachineStates.idle)
-  )
-  const isSystemIOFileTreeMutation = useSelector(systemIOActor, (state) =>
-    FILE_TREE_MUTATION_STATES.some((fileTreeMutationState) =>
-      state.matches(fileTreeMutationState)
-    )
-  )
-  const lastRecursiveMoveTarget = useSelector(
-    systemIOActor,
-    (state) => state.context.lastRecursiveMoveTarget
-  )
+  const lastFileTreeMutationTarget = projectSessionMutation.lastTargetPath
   const errors = kclManager.errorsSignal.value
   const applicationProjectDirectory =
     overrideApplicationProjectDirectory || getParentAbsolutePath(project.path)
@@ -286,7 +260,7 @@ export const ProjectExplorer = ({
 
   onRowEnterRef.current = onRowEnter
   const isFileTreeInteractionDisabled =
-    isFileTreeMutationPending || isSystemIOFileTreeMutation
+    isFileTreeMutationPending || projectSessionMutation.pending
   isFileTreeInteractionDisabledRef.current = isFileTreeInteractionDisabled
 
   const setFileTreeMutationPending = useCallback((isPending: boolean) => {
@@ -294,19 +268,38 @@ export const ProjectExplorer = ({
     setIsFileTreeMutationPending(isPending)
   }, [])
 
-  const sendFileTreeMutationEvent = useCallback(
-    (event: Parameters<typeof systemIOActor.send>[0]) => {
+  const runFileTreeMutation = useCallback(
+    async (input: {
+      mutation: () => Promise<unknown>
+      successMessage: string
+      onSuccess?: () => void
+    }) => {
       setFileTreeMutationPending(true)
-      systemIOActor.send(event)
+      try {
+        await input.mutation()
+        input.onSuccess?.()
+        toast.success(input.successMessage)
+      } catch (error) {
+        console.error(error)
+        toast.error(
+          error instanceof Error ? error.message : 'File operation failed.'
+        )
+      } finally {
+        setFileTreeMutationPending(false)
+      }
     },
-    [setFileTreeMutationPending, systemIOActor]
+    [setFileTreeMutationPending]
   )
 
   useEffect(() => {
-    if (isSystemIOIdle && isFileTreeMutationPending) {
+    if (!projectSessionMutation.pending && isFileTreeMutationPending) {
       setFileTreeMutationPending(false)
     }
-  }, [isFileTreeMutationPending, isSystemIOIdle, setFileTreeMutationPending])
+  }, [
+    isFileTreeMutationPending,
+    projectSessionMutation.pending,
+    setFileTreeMutationPending,
+  ])
 
   // fake row is used for new files or folders, you should not be able to have multiple fake rows for creation
   const [fakeRow, setFakeRow] = useState<{
@@ -779,58 +772,54 @@ export const ProjectExplorer = ({
       // Copy supported files to the target directory
       if (supportedFiles.length > 0) {
         setFileTreeMutationPending(true)
-        const targetPath = getDropTargetPath(target, project.path)
-        const createdDirs = new Set<string>()
+        try {
+          const targetPath = getDropTargetPath(target, project.path)
 
-        for (const { file, relativePath } of supportedFiles) {
-          try {
-            const destinationDirPath = relativePath
-              ? joinOSPaths(targetPath, relativePath)
-              : targetPath
+          for (const { file, relativePath } of supportedFiles) {
+            try {
+              const destinationDirPath = relativePath
+                ? joinOSPaths(targetPath, relativePath)
+                : targetPath
 
-            // Create parent directories if needed
-            if (relativePath && !createdDirs.has(destinationDirPath)) {
-              await fsZds.mkdir(destinationDirPath, { recursive: true })
-              createdDirs.add(destinationDirPath)
+              const { path: destinationPath } = await getNextFileName({
+                entryName: file.name,
+                baseDir: destinationDirPath,
+                wasmInstance,
+                preserveUnknownExtension: true,
+              })
+
+              const arrayBuffer = await file.arrayBuffer()
+              await projectSession.writeFile({
+                path: destinationPath,
+                contents: new Uint8Array(arrayBuffer),
+                overwrite: false,
+              })
+            } catch (e) {
+              console.error('Failed to copy file:', file.name, e)
+              toast.error(`Failed to import ${file.name}.`)
             }
-
-            const { path: destinationPath } = await getNextFileName({
-              entryName: file.name,
-              baseDir: destinationDirPath,
-              wasmInstance,
-              preserveUnknownExtension: true,
-            })
-
-            const arrayBuffer = await file.arrayBuffer()
-            await fsZds.writeFile(destinationPath, new Uint8Array(arrayBuffer))
-          } catch (e) {
-            console.error('Failed to copy file:', file.name, e)
-            toast.error(`Failed to import ${file.name}.`)
           }
+
+          // Open the target folder so the user can see the imported files
+          if (target?.children) {
+            const newOpenedRows = { ...openedRowsRef.current }
+            newOpenedRows[target.key] = true
+            setOpenedRows(newOpenedRows)
+          }
+
+          toast.success(
+            `Imported ${supportedFiles.length} file${supportedFiles.length > 1 ? 's' : ''}.`
+          )
+        } finally {
+          setFileTreeMutationPending(false)
         }
-
-        // Open the target folder so the user can see the imported files
-        if (target?.children) {
-          const newOpenedRows = { ...openedRowsRef.current }
-          newOpenedRows[target.key] = true
-          setOpenedRows(newOpenedRows)
-        }
-
-        // Refresh the explorer to show the new files
-        systemIOActor.send({
-          type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
-        })
-
-        toast.success(
-          `Imported ${supportedFiles.length} file${supportedFiles.length > 1 ? 's' : ''}.`
-        )
       }
     },
     [
       readOnly,
       project.path,
       wasmInstance,
-      systemIOActor,
+      projectSession,
       setFileTreeMutationPending,
     ]
   )
@@ -901,16 +890,16 @@ export const ProjectExplorer = ({
         pathIterator.pop()
       }
     }
-    const recursiveMoveTargetRow = lastRecursiveMoveTarget
+    const recursiveMoveTargetRow = lastFileTreeMutationTarget
       ? flattenedData.find(
           (child) =>
-            child.path === lastRecursiveMoveTarget &&
+            child.path === lastFileTreeMutationTarget &&
             rowPathMatchesTreeParent(child, project)
         )
       : undefined
     const shouldRevealRecursiveMoveTarget =
       !!recursiveMoveTargetRow &&
-      lastRecursiveMoveTarget !== lastRevealedRecursiveMoveTargetRef.current
+      lastFileTreeMutationTarget !== lastRevealedRecursiveMoveTargetRef.current
     if (shouldRevealRecursiveMoveTarget) {
       const moveTargetKey =
         recursiveMoveTargetRow.children === null
@@ -923,7 +912,7 @@ export const ProjectExplorer = ({
         openedRowsForRender[key] = true
         pathIterator.pop()
       }
-      lastRevealedRecursiveMoveTargetRef.current = lastRecursiveMoveTarget
+      lastRevealedRecursiveMoveTargetRef.current = lastFileTreeMutationTarget
     }
 
     const copyEntryToTarget = (src: FileEntry, target: FileEntry) => {
@@ -940,12 +929,13 @@ export const ProjectExplorer = ({
         '-copy-'
       )
       if (result && result.src && result.target) {
-        sendFileTreeMutationEvent({
-          type: SystemIOMachineEvents.copyRecursive,
-          data: {
-            src: result.src,
-            target: result.target,
-          },
+        void runFileTreeMutation({
+          mutation: () =>
+            projectSession.copyEntry({
+              sourcePath: result.src,
+              targetPath: result.target,
+            }),
+          successMessage: 'Copied successfully',
         })
       } else {
         toast.error('Failed to copy and paste the result is null.')
@@ -1045,65 +1035,33 @@ export const ProjectExplorer = ({
             const shouldWeNavigate =
               isPathWithinFileExplorerEntry(file?.path, child.path) &&
               canNavigate
+            const src = child.path
 
-            if (shouldWeNavigate && file && file.path) {
-              const src = child.path
-              setFileTreeMutationPending(true)
-              toArchivePath(src)
-                .then((target) => {
-                  sendFileTreeMutationEvent({
-                    type: SystemIOMachineEvents.moveRecursiveAndNavigate,
+            void runFileTreeMutation({
+              mutation: async () => {
+                const { archivedPath } = await projectSession.archiveEntry({
+                  path: src,
+                })
+                kclManager.addGlobalHistoryEvent(
+                  fsArchiveFile({
+                    src,
+                    target: archivedPath,
+                    requestedProjectName: project.name,
+                  })
+                )
+              },
+              successMessage: 'Archived successfully',
+              onSuccess: () => {
+                if (shouldWeNavigate && file?.path) {
+                  systemIOActor.send({
+                    type: SystemIOMachineEvents.navigateToProject,
                     data: {
-                      src,
-                      target,
-                      successMessage: 'Archived successfully',
                       requestedProjectName: project.name,
                     },
                   })
-                  kclManager.addGlobalHistoryEvent(
-                    fsArchiveFile({
-                      src,
-                      target,
-                      requestedProjectName: project.name,
-                    })
-                  )
-                })
-                .catch((e) => {
-                  setFileTreeMutationPending(false)
-                  console.error(e)
-                  console.warn(
-                    `Error while archiving: the deletion of ${child.path} may have been unrecoverable.`
-                  )
-                })
-            } else {
-              const src = child.path
-              setFileTreeMutationPending(true)
-              toArchivePath(src)
-                .then((target) => {
-                  sendFileTreeMutationEvent({
-                    type: SystemIOMachineEvents.moveRecursive,
-                    data: {
-                      src,
-                      target,
-                      successMessage: 'Archived successfully',
-                    },
-                  })
-                  kclManager.addGlobalHistoryEvent(
-                    fsArchiveFile({
-                      src,
-                      target,
-                      requestedProjectName: project.name,
-                    })
-                  )
-                })
-                .catch((e) => {
-                  setFileTreeMutationPending(false)
-                  console.error(e)
-                  console.warn(
-                    `Error while archiving: the deletion of ${child.path} may have been unrecoverable.`
-                  )
-                })
-            }
+                }
+              },
+            })
           },
           onOpenInNewWindow: () => {
             window.electron?.openInNewWindow(row.path)
@@ -1159,20 +1117,22 @@ export const ProjectExplorer = ({
               )
               if (result && result.src && result.target) {
                 const { src, target } = result
-                sendFileTreeMutationEvent({
-                  type: SystemIOMachineEvents.moveRecursive,
-                  data: {
-                    src,
-                    target,
+                void runFileTreeMutation({
+                  mutation: async () => {
+                    await projectSession.moveEntry({
+                      sourcePath: src,
+                      targetPath: target,
+                    })
+                    kclManager.addGlobalHistoryEvent(
+                      fsMoveFile({
+                        src,
+                        target,
+                        requestedProjectName: project.name,
+                      })
+                    )
                   },
+                  successMessage: 'Moved successfully',
                 })
-                kclManager.addGlobalHistoryEvent(
-                  fsMoveFile({
-                    src,
-                    target,
-                    requestedProjectName: project.name,
-                  })
-                )
               } else {
                 toast.error('Failed to copy and paste the result is null.')
               }
@@ -1210,24 +1170,26 @@ export const ProjectExplorer = ({
               if (requestedName !== name) {
                 if (row.isFake) {
                   // create
-                  sendFileTreeMutationEvent({
-                    type: SystemIOMachineEvents.createBlankFolder,
-                    data: {
-                      requestedAbsolutePath: joinOSPaths(
-                        getParentAbsolutePath(row.path),
-                        requestedName
-                      ),
-                    },
+                  const requestedAbsolutePath = joinOSPaths(
+                    getParentAbsolutePath(row.path),
+                    requestedName
+                  )
+                  void runFileTreeMutation({
+                    mutation: () =>
+                      projectSession.createFolder({
+                        path: requestedAbsolutePath,
+                      }),
+                    successMessage: `Folder ${requestedName} written successfully`,
                   })
                 } else {
                   const absolutePathToParentDirectory = getParentAbsolutePath(
                     row.path
                   )
-                  const oldPath = fsZds.join(
+                  const oldPath = joinOSPaths(
                     absolutePathToParentDirectory,
                     name
                   )
-                  const newPath = fsZds.join(
+                  const newPath = joinOSPaths(
                     absolutePathToParentDirectory,
                     requestedName
                   )
@@ -1243,24 +1205,31 @@ export const ProjectExplorer = ({
                         file?.path?.replace(oldPath, newPath),
                         applicationProjectDirectory
                       )
-                    sendFileTreeMutationEvent({
-                      type: SystemIOMachineEvents.renameFolderAndNavigateToFile,
-                      data: {
-                        requestedFolderName: requestedName,
-                        folderName: name,
-                        absolutePathToParentDirectory,
-                        requestedProjectName: project.name,
-                        requestedFileNameWithExtension,
+                    void runFileTreeMutation({
+                      mutation: () =>
+                        projectSession.renameEntry({
+                          oldPath,
+                          newPath,
+                        }),
+                      successMessage: `Successfully renamed folder "${name}" to "${requestedName}"`,
+                      onSuccess: () => {
+                        systemIOActor.send({
+                          type: SystemIOMachineEvents.navigateToFile,
+                          data: {
+                            requestedProjectName: project.name,
+                            requestedFileName: requestedFileNameWithExtension,
+                          },
+                        })
                       },
                     })
                   } else {
-                    sendFileTreeMutationEvent({
-                      type: SystemIOMachineEvents.renameFolder,
-                      data: {
-                        requestedFolderName: requestedName,
-                        folderName: name,
-                        absolutePathToParentDirectory,
-                      },
+                    void runFileTreeMutation({
+                      mutation: () =>
+                        projectSession.renameEntry({
+                          oldPath,
+                          newPath,
+                        }),
+                      successMessage: `Successfully renamed folder "${name}" to "${requestedName}"`,
                     })
                   }
 
@@ -1294,23 +1263,32 @@ export const ProjectExplorer = ({
                   requestedAbsolutePath,
                   applicationProjectDirectory
                 )
-                sendFileTreeMutationEvent({
-                  type: SystemIOMachineEvents.importFileFromURL,
-                  data: {
-                    requestedCode: '',
-                    requestedProjectName: project.name,
-                    requestedFileNameWithExtension: pathRelativeToParent,
+                void runFileTreeMutation({
+                  mutation: () =>
+                    projectSession.createFile({
+                      path: requestedAbsolutePath,
+                    }),
+                  successMessage: `File ${fileName} written successfully`,
+                  onSuccess: () => {
+                    systemIOActor.send({
+                      type: SystemIOMachineEvents.navigateToFile,
+                      data: {
+                        requestedProjectName: project.name,
+                        requestedFileName: pathRelativeToParent,
+                      },
+                    })
                   },
                 })
               } else {
                 // Create a blank file. The actor seeds default KCL content only
                 // for .kcl files and writes an empty file for everything else,
                 // so non-KCL files (.md, .txt, ...) don't get KCL boilerplate.
-                sendFileTreeMutationEvent({
-                  type: SystemIOMachineEvents.createBlankFile,
-                  data: {
-                    requestedAbsolutePath,
-                  },
+                void runFileTreeMutation({
+                  mutation: () =>
+                    projectSession.createFile({
+                      path: requestedAbsolutePath,
+                    }),
+                  successMessage: `File ${fileName} written successfully`,
                 })
               }
             } else {
@@ -1330,16 +1308,31 @@ export const ProjectExplorer = ({
               const shouldWeNavigate =
                 requestedAbsoluteFilePathWithExtension === file?.path &&
                 canNavigate
-              sendFileTreeMutationEvent({
-                type: shouldWeNavigate
-                  ? SystemIOMachineEvents.renameFileAndNavigateToFile
-                  : SystemIOMachineEvents.renameFile,
-                data: {
-                  requestedFileNameWithExtension: fileName,
-                  fileNameWithExtension: name,
-                  absolutePathToParentDirectory: getParentAbsolutePath(
-                    row.path
-                  ),
+              const newPath = joinOSPaths(
+                getParentAbsolutePath(row.path),
+                fileName
+              )
+              const requestedFileName = parentPathRelativeToProject(
+                newPath,
+                applicationProjectDirectory
+              )
+              void runFileTreeMutation({
+                mutation: () =>
+                  projectSession.renameEntry({
+                    oldPath: requestedAbsoluteFilePathWithExtension,
+                    newPath,
+                  }),
+                successMessage: `Successfully renamed file "${name}" to "${fileName}"`,
+                onSuccess: () => {
+                  if (shouldWeNavigate) {
+                    systemIOActor.send({
+                      type: SystemIOMachineEvents.navigateToFile,
+                      data: {
+                        requestedProjectName: project.name,
+                        requestedFileName,
+                      },
+                    })
+                  }
                 },
               })
             }

--- a/src/components/Explorer/ProjectExplorer.tsx
+++ b/src/components/Explorer/ProjectExplorer.tsx
@@ -1268,7 +1268,7 @@ export const ProjectExplorer = ({
                     projectSession.createFile({
                       path: requestedAbsolutePath,
                     }),
-                  successMessage: `File ${fileName} written successfully`,
+                  successMessage: 'Successfully created 1 file',
                   onSuccess: () => {
                     systemIOActor.send({
                       type: SystemIOMachineEvents.navigateToFile,


### PR DESCRIPTION
Part of the System.IO migration stack. This routes ProjectExplorer file and folder mutations through the project session service while leaving navigation behavior for the following stack item.

1. Replaces ProjectExplorer create, write, copy, move, rename, and archive sends with projectSession file operations.
2. Uses projectSession mutation state for pending indicators and target-path tracking.
3. Updates explorer tests to seed a project session and assert mutations reach the opened project.

How to test
Use the explorer to create files and folders, drag/drop files, copy/paste, rename, and delete entries. Confirm pending UI and success/error toasts still line up with the selected explorer item.