### PR TITLE
Move FS history onto project session

### DIFF
--- a/src/editor/plugins/fs/index.ts
+++ b/src/editor/plugins/fs/index.ts
@@ -3,10 +3,9 @@ import type { Extension, Transaction } from '@codemirror/state'
 import { Annotation, Compartment, StateEffect } from '@codemirror/state'
 import type { TransactionSpecNoChanges } from '@src/editor/HistoryView'
 import type { KclManager } from '@src/lang/KclManager'
-import type { systemIOMachine } from '@src/machines/systemIO/systemIOMachine'
-import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
+import type { ProjectSessionService } from '@src/registry/contracts/projectSession'
 import { EditorView } from 'codemirror'
-import type { ActorRefFrom } from 'xstate'
+import toast from 'react-hot-toast'
 
 const fsEffectCompartment = new Compartment()
 export const fsIgnoreAnnotationType = Annotation.define<true>()
@@ -50,12 +49,12 @@ export const fsArchiveFile = (props: FSEffectProps) => h(archiveFile.of(props))
 export const fsMoveFile = (props: FSEffectProps) => h(moveFile.of(props))
 
 /**
- * Builder function to provide necessary system dependencies for the
- * FS history extension. This is where FS un/redo editor events
- * actually call systemIO APIs.
+ * Builder function to provide necessary system dependencies for the FS history
+ * extension. This is where FS un/redo editor events apply project-session file
+ * operations.
  */
 export function buildFSHistoryExtension(
-  systemIOActor: ActorRefFrom<typeof systemIOMachine>,
+  projectSession: ProjectSessionService,
   kclManager: KclManager
 ) {
   const fsWiredListener = EditorView.updateListener.of((vu) => {
@@ -65,17 +64,7 @@ export function buildFSHistoryExtension(
       }
       for (const e of tr.effects) {
         if (e.is(restoreFile) || e.is(archiveFile) || e.is(moveFile)) {
-          const type = e.is(moveFile)
-            ? SystemIOMachineEvents.moveRecursive
-            : SystemIOMachineEvents.moveRecursiveAndNavigate
-
-          systemIOActor.send({
-            type,
-            data: {
-              ...e.value,
-              successMessage: getSuccessMessage(e, tr),
-            },
-          })
+          void applyFsHistoryEffect(projectSession, e, tr)
         }
       }
     }
@@ -97,6 +86,37 @@ export function buildFSHistoryExtension(
         effects: [fsEffectCompartment.reconfigure([])],
       },
       { shouldForwardToLocalHistory: false }
+    )
+  }
+}
+
+async function applyFsHistoryEffect(
+  projectSession: ProjectSessionService,
+  effect: StateEffect<unknown>,
+  transaction: Transaction
+) {
+  try {
+    if (effect.is(restoreFile)) {
+      await projectSession.restoreEntry({
+        archivedPath: effect.value.src,
+        targetPath: effect.value.target,
+      })
+    } else if (effect.is(archiveFile)) {
+      await projectSession.archiveEntry({
+        path: effect.value.src,
+        archivedPath: effect.value.target,
+      })
+    } else if (effect.is(moveFile)) {
+      await projectSession.moveEntry({
+        sourcePath: effect.value.src,
+        targetPath: effect.value.target,
+      })
+    }
+    toast.success(getSuccessMessage(effect, transaction))
+  } catch (error) {
+    console.error(error)
+    toast.error(
+      error instanceof Error ? error.message : 'File history operation failed.'
     )
   }
 }

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -359,6 +359,15 @@ interface ZDSProjectPathInput {
   path: string
 }
 
+interface ZDSProjectArchiveInput extends ZDSProjectPathInput {
+  archivedPath?: string
+}
+
+interface ZDSProjectRestoreInput {
+  archivedPath: string
+  targetPath: string
+}
+
 interface ZDSProjectRenameInput {
   oldPath: string
   newPath: string
@@ -889,16 +898,30 @@ export class ZDSProject {
   }
 
   async archiveEntry(
-    input: ZDSProjectPathInput,
+    input: ZDSProjectArchiveInput,
     fileSystemOperations = this.fileSystemOperations
   ) {
     await this.ensureProjectPaths(input.path)
 
-    const archivedPath = await toArchivePath(input.path)
+    const archivedPath = input.archivedPath ?? (await toArchivePath(input.path))
     await this.movePath(input.path, archivedPath, fileSystemOperations)
     this.closeProjectEntryEditors(input.path)
     this.forgetProjectEntryFiles(input.path)
     return { archivedPath }
+  }
+
+  async restoreEntry(
+    input: ZDSProjectRestoreInput,
+    fileSystemOperations = this.fileSystemOperations
+  ) {
+    await this.ensureProjectPaths(input.targetPath)
+
+    await this.movePath(
+      input.archivedPath,
+      input.targetPath,
+      fileSystemOperations
+    )
+    return input.targetPath
   }
 
   async applyFilePatch(

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -359,6 +359,15 @@ interface ZDSProjectPathInput {
   path: string
 }
 
+interface ZDSProjectArchiveInput extends ZDSProjectPathInput {
+  archivedPath?: string
+}
+
+interface ZDSProjectRestoreInput {
+  archivedPath: string
+  targetPath: string
+}
+
 interface ZDSProjectRenameInput {
   oldPath: string
   newPath: string
@@ -865,14 +874,21 @@ export class ZDSProject {
     return input.targetPath
   }
 
-  async archiveEntry(input: ZDSProjectPathInput) {
+  async archiveEntry(input: ZDSProjectArchiveInput) {
     await this.ensureProjectPaths(input.path)
 
-    const archivedPath = await toArchivePath(input.path)
+    const archivedPath = input.archivedPath ?? (await toArchivePath(input.path))
     await this.movePath(input.path, archivedPath)
     this.closeProjectEntryEditors(input.path)
     this.forgetProjectEntryFiles(input.path)
     return { archivedPath }
+  }
+
+  async restoreEntry(input: ZDSProjectRestoreInput) {
+    await this.ensureProjectPaths(input.targetPath)
+
+    await this.movePath(input.archivedPath, input.targetPath)
+    return input.targetPath
   }
 
   async applyFilePatch(input: ZDSProjectFilePatchInput) {

--- a/src/registry/contracts/projectSession.ts
+++ b/src/registry/contracts/projectSession.ts
@@ -21,6 +21,7 @@ export type ProjectSessionMutationOperation =
   | 'copy-entry'
   | 'move-entry'
   | 'archive-entry'
+  | 'restore-entry'
   | 'apply-file-patch'
 
 export interface ProjectSessionMutationState {
@@ -48,6 +49,11 @@ export interface ProjectSessionEntryPathInput {
   readonly path: string
 }
 
+export interface ProjectSessionArchiveEntryInput
+  extends ProjectSessionEntryPathInput {
+  readonly archivedPath?: string
+}
+
 export interface ProjectSessionEntryRenameInput {
   readonly oldPath: string
   readonly newPath: string
@@ -60,6 +66,11 @@ export interface ProjectSessionEntryCopyMoveInput {
 
 export interface ProjectSessionArchiveEntryResult {
   readonly archivedPath: string
+}
+
+export interface ProjectSessionRestoreEntryInput {
+  readonly archivedPath: string
+  readonly targetPath: string
 }
 
 export interface ProjectSessionFilePatchEntry {
@@ -100,8 +111,9 @@ export interface ProjectSessionService {
   copyEntry: (input: ProjectSessionEntryCopyMoveInput) => Promise<string>
   moveEntry: (input: ProjectSessionEntryCopyMoveInput) => Promise<string>
   archiveEntry: (
-    input: ProjectSessionEntryPathInput
+    input: ProjectSessionArchiveEntryInput
   ) => Promise<ProjectSessionArchiveEntryResult>
+  restoreEntry: (input: ProjectSessionRestoreEntryInput) => Promise<string>
   applyFilePatch: (input: ProjectSessionApplyFilePatchInput) => Promise<void>
   getCurrentProjectLibraryId: () => string | undefined
   setCurrentProjectLibraryId: (libraryId: string | undefined) => void

--- a/src/registry/extensions/projectSession/index.test.ts
+++ b/src/registry/extensions/projectSession/index.test.ts
@@ -78,6 +78,9 @@ describe('project session extension', () => {
         async ({ targetPath }: { targetPath: string }) => targetPath
       ),
       archiveEntry: vi.fn(async () => ({ archivedPath: '/archive/main.kcl' })),
+      restoreEntry: vi.fn(
+        async ({ targetPath }: { targetPath: string }) => targetPath
+      ),
       applyFilePatch: vi.fn(async () => undefined),
       close: vi.fn(),
     }
@@ -317,6 +320,10 @@ describe('project session extension', () => {
       path: '/projects/bracket/parts/copy.kcl',
     })
     await projectSession.archiveEntry({ path: '/projects/bracket/new.kcl' })
+    await projectSession.restoreEntry({
+      archivedPath: '/archive/main.kcl',
+      targetPath: '/projects/bracket/main.kcl',
+    })
     await projectSession.applyFilePatch({
       files: [{ path: '/projects/bracket/main.kcl', contents: 'cube(2)' }],
     })
@@ -370,13 +377,20 @@ describe('project session extension', () => {
       { path: '/projects/bracket/new.kcl' },
       batchFacade
     )
+    expect(project.mocks.restoreEntry).toHaveBeenCalledWith(
+      {
+        archivedPath: '/archive/main.kcl',
+        targetPath: '/projects/bracket/main.kcl',
+      },
+      batchFacade
+    )
     expect(project.mocks.applyFilePatch).toHaveBeenCalledWith(
       {
         files: [{ path: '/projects/bracket/main.kcl', contents: 'cube(2)' }],
       },
       batchFacade
     )
-    expect(project.mocks.refreshProjectTree).toHaveBeenCalledTimes(9)
+    expect(project.mocks.refreshProjectTree).toHaveBeenCalledTimes(10)
     expect(projectSession.projectTree.value?.name).toBe('bracket-fresh')
     expect(projectSession.mutation.value).toEqual({
       pending: false,

--- a/src/registry/extensions/projectSession/index.test.ts
+++ b/src/registry/extensions/projectSession/index.test.ts
@@ -58,6 +58,9 @@ describe('project session extension', () => {
         async ({ targetPath }: { targetPath: string }) => targetPath
       ),
       archiveEntry: vi.fn(async () => ({ archivedPath: '/archive/main.kcl' })),
+      restoreEntry: vi.fn(
+        async ({ targetPath }: { targetPath: string }) => targetPath
+      ),
       applyFilePatch: vi.fn(async () => undefined),
     }
     return {
@@ -222,6 +225,10 @@ describe('project session extension', () => {
       path: '/projects/bracket/parts/copy.kcl',
     })
     await projectSession.archiveEntry({ path: '/projects/bracket/new.kcl' })
+    await projectSession.restoreEntry({
+      archivedPath: '/archive/main.kcl',
+      targetPath: '/projects/bracket/main.kcl',
+    })
     await projectSession.applyFilePatch({
       files: [{ path: '/projects/bracket/main.kcl', contents: 'cube(2)' }],
     })
@@ -254,10 +261,14 @@ describe('project session extension', () => {
     expect(project.mocks.archiveEntry).toHaveBeenCalledWith({
       path: '/projects/bracket/new.kcl',
     })
+    expect(project.mocks.restoreEntry).toHaveBeenCalledWith({
+      archivedPath: '/archive/main.kcl',
+      targetPath: '/projects/bracket/main.kcl',
+    })
     expect(project.mocks.applyFilePatch).toHaveBeenCalledWith({
       files: [{ path: '/projects/bracket/main.kcl', contents: 'cube(2)' }],
     })
-    expect(project.mocks.refreshProjectTree).toHaveBeenCalledTimes(9)
+    expect(project.mocks.refreshProjectTree).toHaveBeenCalledTimes(10)
     expect(projectSession.projectTree.value?.name).toBe('bracket-fresh')
     expect(projectSession.mutation.value).toEqual({
       pending: false,

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -22,6 +22,7 @@ import { fsOperationQueue } from '@src/registry/contracts/fsOperationQueue'
 import { keymapService } from '@src/registry/contracts/keymap'
 import {
   type ProjectSessionApplyFilePatchInput,
+  type ProjectSessionArchiveEntryInput,
   type ProjectSessionEntryCopyMoveInput,
   type ProjectSessionEntryPathInput,
   type ProjectSessionEntryRenameInput,
@@ -29,6 +30,7 @@ import {
   type ProjectSessionMutationOperation,
   type ProjectSessionMutationState,
   type ProjectSessionOpenEditorInput,
+  type ProjectSessionRestoreEntryInput,
   type ProjectSessionService,
   projectSession,
 } from '@src/registry/contracts/projectSession'
@@ -214,7 +216,7 @@ export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
       }
 
       const disposeFSHistory = buildFSHistoryExtension(
-        systemIOActor,
+        serviceImpl,
         executingEditor
       )
       const disposeZookeeperHistory = buildZookeeperHistoryExtension({
@@ -443,9 +445,15 @@ export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
       runProjectMutation('move-entry', input.targetPath, (currentProject) =>
         currentProject.moveEntry(input)
       ),
-    archiveEntry: (input: ProjectSessionEntryPathInput) =>
+    archiveEntry: (input: ProjectSessionArchiveEntryInput) =>
       runProjectMutation('archive-entry', input.path, (currentProject) =>
         currentProject.archiveEntry(input)
+      ),
+    restoreEntry: (input: ProjectSessionRestoreEntryInput) =>
+      runProjectMutation(
+        'restore-entry',
+        input.targetPath,
+        (currentProject) => currentProject.restoreEntry(input)
       ),
     applyFilePatch: (input: ProjectSessionApplyFilePatchInput) =>
       runProjectMutation(

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -25,6 +25,7 @@ import {
 import { keymapService } from '@src/registry/contracts/keymap'
 import {
   type ProjectSessionApplyFilePatchInput,
+  type ProjectSessionArchiveEntryInput,
   type ProjectSessionEntryCopyMoveInput,
   type ProjectSessionEntryPathInput,
   type ProjectSessionEntryRenameInput,
@@ -32,6 +33,7 @@ import {
   type ProjectSessionMutationOperation,
   type ProjectSessionMutationState,
   type ProjectSessionOpenEditorInput,
+  type ProjectSessionRestoreEntryInput,
   type ProjectSessionService,
   projectSession,
 } from '@src/registry/contracts/projectSession'
@@ -222,7 +224,7 @@ export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
       }
 
       const disposeFSHistory = buildFSHistoryExtension(
-        systemIOActor,
+        serviceImpl,
         executingEditor
       )
       const disposeZookeeperHistory = buildZookeeperHistoryExtension({
@@ -505,9 +507,15 @@ export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
         input.targetPath,
         (currentProject, batch) => currentProject.moveEntry(input, batch)
       ),
-    archiveEntry: (input: ProjectSessionEntryPathInput) =>
+    archiveEntry: (input: ProjectSessionArchiveEntryInput) =>
       runProjectMutation('archive-entry', input.path, (currentProject, batch) =>
         currentProject.archiveEntry(input, batch)
+      ),
+    restoreEntry: (input: ProjectSessionRestoreEntryInput) =>
+      runProjectMutation(
+        'restore-entry',
+        input.targetPath,
+        (currentProject, batch) => currentProject.restoreEntry(input, batch)
       ),
     applyFilePatch: (input: ProjectSessionApplyFilePatchInput) =>
       runProjectMutation(


### PR DESCRIPTION
Part of the System.IO migration stack. This moves filesystem undo/redo side effects in the editor FS history bridge onto the project session file-operation API.

1. Adds projectSession restore-entry support alongside archive, move, and other file operations.
2. Implements restoreEntry on ZDSProject using the same project-root guards as the rest of the project file APIs.
3. Replaces editor FS history `systemIOActor.send` calls with projectSession restore/archive/move operations.

How to test
Perform explorer file deletes, moves, and renames from an open project, then use undo/redo and confirm the filesystem and editor state return to the expected files.