### PR TITLE
Move Zookeeper file patches to project session

### DIFF
--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -932,7 +932,7 @@ export class ZDSProject {
 
     for (const file of input.files) {
       if (file.contents === null) {
-        await fileSystemOperations.rm(file.path)
+        await fileSystemOperations.rm(file.path, { force: true })
       } else {
         await this.writeFile(
           {

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -896,7 +896,7 @@ export class ZDSProject {
 
     for (const file of input.files) {
       if (file.contents === null) {
-        await this.fileSystemOperations.rm(file.path)
+        await this.fileSystemOperations.rm(file.path, { force: true })
       } else {
         await this.writeFile({
           path: file.path,

--- a/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.spec.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.spec.tsx
@@ -5,18 +5,23 @@ import { render, waitFor } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => {
+  const applyFilePatch = vi.fn(
+    async (_input: { files: { path: string; contents: string | null }[] }) =>
+      undefined
+  )
   const systemIOSend = vi.fn()
   const useWatchForNewFileRequestsFromZookeeper = vi.fn()
   const zookeeperSubscribe = vi.fn(() => ({ unsubscribe: vi.fn() }))
+  const project = {
+    name: 'demo',
+    path: '/workspace/demo',
+    executingPath: '/workspace/demo/other.kcl',
+    executingFileEntry: { value: { name: 'main.kcl' } },
+  }
   const projectSession = {
-    project: {
-      value: {
-        name: 'demo',
-        path: '/workspace/demo',
-        executingPath: '/workspace/demo/main.kcl',
-        executingFileEntry: { value: { name: 'main.kcl' } },
-      },
-    },
+    project: { value: project },
+    getProject: () => project,
+    applyFilePatch,
   }
   const kclManager = {
     captureEditorHistoryState: vi.fn(() => ({
@@ -32,8 +37,10 @@ const mocks = vi.hoisted(() => {
   }
 
   return {
+    applyFilePatch,
     kclManager,
     zookeeperSubscribe,
+    project,
     projectSession,
     systemIOSend,
     useWatchForNewFileRequestsFromZookeeper,
@@ -137,14 +144,9 @@ vi.mock('@src/lib/zookeeper/components/ZookeeperConversationPaneHooks', () => ({
   },
 }))
 
-vi.mock('@src/machines/systemIO/utils', async (importOriginal) => {
-  const original = await importOriginal<typeof SystemIOUtils>()
-
-  return {
-    ...original,
-    waitForIdleState: vi.fn(async () => undefined),
-  }
-})
+vi.mock('@src/machines/systemIO/utils', async (importOriginal) =>
+  importOriginal<typeof SystemIOUtils>()
+)
 
 vi.mock('@src/routes/utils', () => ({
   IS_STAGING_OR_DEBUG: false,
@@ -193,8 +195,10 @@ async function flushQueuedWork() {
 describe('ZookeeperConversationPaneWrapper', () => {
   test('does not start the next patch-backed Zookeeper edit until the previous editor refresh completes', async () => {
     mocks.systemIOSend.mockClear()
+    mocks.applyFilePatch.mockClear()
     mocks.kclManager.updateCodeEditor.mockClear()
     mocks.kclManager.path = '/workspace/demo/main.kcl'
+    mocks.project.executingPath = '/workspace/demo/other.kcl'
     mocks.watchCallback = undefined
 
     render(
@@ -214,24 +218,26 @@ describe('ZookeeperConversationPaneWrapper', () => {
 
     emitZookeeperFileRequest('intermediate code')
 
+    await waitFor(() => expect(mocks.applyFilePatch).toHaveBeenCalledTimes(1))
+
     await waitFor(() => expect(mocks.systemIOSend).toHaveBeenCalledTimes(1))
+    const firstNavigation = mocks.systemIOSend.mock.calls[0][0].data
+    expect(firstNavigation.onProjectLoaderComplete).toEqual(
+      expect.any(Function)
+    )
 
-    const firstRequest = mocks.systemIOSend.mock.calls[0][0].data
-    expect(firstRequest.onSuccess).toEqual(expect.any(Function))
-
-    // The filesystem callback completes before the route/editor refresh callback.
+    // The filesystem patch completes before the route/editor refresh callback.
     // Starting the next edit here can let the older refresh win and leave stale
     // intermediate KCL visible in the editor.
-    firstRequest.onFileSystemSuccess()
     await flushQueuedWork()
 
     emitZookeeperFileRequest('final code')
     await flushQueuedWork()
 
-    expect(mocks.systemIOSend).toHaveBeenCalledTimes(1)
+    expect(mocks.applyFilePatch).toHaveBeenCalledTimes(1)
 
     // Once the editor refresh has completed, the queued final edit can run.
-    firstRequest.onSuccess()
+    firstNavigation.onProjectLoaderComplete()
 
     expect(mocks.kclManager.updateCodeEditor).toHaveBeenCalledWith(
       'intermediate code',
@@ -244,19 +250,21 @@ describe('ZookeeperConversationPaneWrapper', () => {
       }
     )
 
-    await waitFor(() => expect(mocks.systemIOSend).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(mocks.applyFilePatch).toHaveBeenCalledTimes(2))
 
-    const secondRequest = mocks.systemIOSend.mock.calls[1][0].data
-    expect(secondRequest.files[0]).toMatchObject({
-      requestedFileName: 'main.kcl',
-      requestedCode: 'final code',
+    const secondPatch = mocks.applyFilePatch.mock.calls[1][0]
+    expect(secondPatch.files[0]).toMatchObject({
+      path: '/workspace/demo/main.kcl',
+      contents: 'final code',
     })
   })
 
   test('does not refresh a file that is no longer active or stall later edits', async () => {
     mocks.systemIOSend.mockClear()
+    mocks.applyFilePatch.mockClear()
     mocks.kclManager.updateCodeEditor.mockClear()
     mocks.kclManager.path = '/workspace/demo/main.kcl'
+    mocks.project.executingPath = '/workspace/demo/other.kcl'
     mocks.watchCallback = undefined
 
     render(
@@ -273,16 +281,16 @@ describe('ZookeeperConversationPaneWrapper', () => {
     )
 
     emitZookeeperFileRequest('intermediate code')
+    await waitFor(() => expect(mocks.applyFilePatch).toHaveBeenCalledTimes(1))
     await waitFor(() => expect(mocks.systemIOSend).toHaveBeenCalledTimes(1))
 
-    const firstRequest = mocks.systemIOSend.mock.calls[0][0].data
-    firstRequest.onFileSystemSuccess()
+    const firstNavigation = mocks.systemIOSend.mock.calls[0][0].data
     mocks.kclManager.path = '/workspace/demo/other.kcl'
-    firstRequest.onSuccess()
+    firstNavigation.onProjectLoaderComplete()
 
     expect(mocks.kclManager.updateCodeEditor).not.toHaveBeenCalled()
 
     emitZookeeperFileRequest('final code')
-    await waitFor(() => expect(mocks.systemIOSend).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(mocks.applyFilePatch).toHaveBeenCalledTimes(2))
   })
 })

--- a/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.spec.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.spec.tsx
@@ -5,18 +5,23 @@ import { render, waitFor } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => {
+  const applyFilePatch = vi.fn(
+    async (_input: { files: { path: string; contents: string | null }[] }) =>
+      undefined
+  )
   const systemIOSend = vi.fn()
   const useWatchForNewFileRequestsFromZookeeper = vi.fn()
   const zookeeperSubscribe = vi.fn(() => ({ unsubscribe: vi.fn() }))
+  const project = {
+    name: 'demo',
+    path: '/workspace/demo',
+    executingPath: '/workspace/demo/other.kcl',
+    executingFileEntry: { value: { name: 'main.kcl' } },
+  }
   const projectSession = {
-    project: {
-      value: {
-        name: 'demo',
-        path: '/workspace/demo',
-        executingPath: '/workspace/demo/main.kcl',
-        executingFileEntry: { value: { name: 'main.kcl' } },
-      },
-    },
+    project: { value: project },
+    getProject: () => project,
+    applyFilePatch,
   }
   const kclManager = {
     captureEditorHistoryState: vi.fn(() => ({
@@ -32,8 +37,10 @@ const mocks = vi.hoisted(() => {
   }
 
   return {
+    applyFilePatch,
     kclManager,
     zookeeperSubscribe,
+    project,
     projectSession,
     systemIOSend,
     useWatchForNewFileRequestsFromZookeeper,
@@ -134,14 +141,9 @@ vi.mock('@src/lib/zookeeper/components/ZookeeperConversationPaneHooks', () => ({
   },
 }))
 
-vi.mock('@src/machines/systemIO/utils', async (importOriginal) => {
-  const original = await importOriginal<typeof SystemIOUtils>()
-
-  return {
-    ...original,
-    waitForIdleState: vi.fn(async () => undefined),
-  }
-})
+vi.mock('@src/machines/systemIO/utils', async (importOriginal) =>
+  importOriginal<typeof SystemIOUtils>()
+)
 
 vi.mock('@src/routes/utils', () => ({
   IS_STAGING_OR_DEBUG: false,
@@ -190,8 +192,10 @@ async function flushQueuedWork() {
 describe('ZookeeperConversationPaneWrapper', () => {
   test('does not start the next patch-backed Zookeeper edit until the previous editor refresh completes', async () => {
     mocks.systemIOSend.mockClear()
+    mocks.applyFilePatch.mockClear()
     mocks.kclManager.updateCodeEditor.mockClear()
     mocks.kclManager.path = '/workspace/demo/main.kcl'
+    mocks.project.executingPath = '/workspace/demo/other.kcl'
     mocks.watchCallback = undefined
 
     render(
@@ -211,24 +215,26 @@ describe('ZookeeperConversationPaneWrapper', () => {
 
     emitZookeeperFileRequest('intermediate code')
 
+    await waitFor(() => expect(mocks.applyFilePatch).toHaveBeenCalledTimes(1))
+
     await waitFor(() => expect(mocks.systemIOSend).toHaveBeenCalledTimes(1))
+    const firstNavigation = mocks.systemIOSend.mock.calls[0][0].data
+    expect(firstNavigation.onProjectLoaderComplete).toEqual(
+      expect.any(Function)
+    )
 
-    const firstRequest = mocks.systemIOSend.mock.calls[0][0].data
-    expect(firstRequest.onSuccess).toEqual(expect.any(Function))
-
-    // The filesystem callback completes before the route/editor refresh callback.
+    // The filesystem patch completes before the route/editor refresh callback.
     // Starting the next edit here can let the older refresh win and leave stale
     // intermediate KCL visible in the editor.
-    firstRequest.onFileSystemSuccess()
     await flushQueuedWork()
 
     emitZookeeperFileRequest('final code')
     await flushQueuedWork()
 
-    expect(mocks.systemIOSend).toHaveBeenCalledTimes(1)
+    expect(mocks.applyFilePatch).toHaveBeenCalledTimes(1)
 
     // Once the editor refresh has completed, the queued final edit can run.
-    firstRequest.onSuccess()
+    firstNavigation.onProjectLoaderComplete()
 
     expect(mocks.kclManager.updateCodeEditor).toHaveBeenCalledWith(
       'intermediate code',
@@ -241,19 +247,21 @@ describe('ZookeeperConversationPaneWrapper', () => {
       }
     )
 
-    await waitFor(() => expect(mocks.systemIOSend).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(mocks.applyFilePatch).toHaveBeenCalledTimes(2))
 
-    const secondRequest = mocks.systemIOSend.mock.calls[1][0].data
-    expect(secondRequest.files[0]).toMatchObject({
-      requestedFileName: 'main.kcl',
-      requestedCode: 'final code',
+    const secondPatch = mocks.applyFilePatch.mock.calls[1][0]
+    expect(secondPatch.files[0]).toMatchObject({
+      path: '/workspace/demo/main.kcl',
+      contents: 'final code',
     })
   })
 
   test('does not refresh a file that is no longer active or stall later edits', async () => {
     mocks.systemIOSend.mockClear()
+    mocks.applyFilePatch.mockClear()
     mocks.kclManager.updateCodeEditor.mockClear()
     mocks.kclManager.path = '/workspace/demo/main.kcl'
+    mocks.project.executingPath = '/workspace/demo/other.kcl'
     mocks.watchCallback = undefined
 
     render(
@@ -270,16 +278,16 @@ describe('ZookeeperConversationPaneWrapper', () => {
     )
 
     emitZookeeperFileRequest('intermediate code')
+    await waitFor(() => expect(mocks.applyFilePatch).toHaveBeenCalledTimes(1))
     await waitFor(() => expect(mocks.systemIOSend).toHaveBeenCalledTimes(1))
 
-    const firstRequest = mocks.systemIOSend.mock.calls[0][0].data
-    firstRequest.onFileSystemSuccess()
+    const firstNavigation = mocks.systemIOSend.mock.calls[0][0].data
     mocks.kclManager.path = '/workspace/demo/other.kcl'
-    firstRequest.onSuccess()
+    firstNavigation.onProjectLoaderComplete()
 
     expect(mocks.kclManager.updateCodeEditor).not.toHaveBeenCalled()
 
     emitZookeeperFileRequest('final code')
-    await waitFor(() => expect(mocks.systemIOSend).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(mocks.applyFilePatch).toHaveBeenCalledTimes(2))
   })
 })

--- a/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.tsx
@@ -38,12 +38,13 @@ import {
   normalizeKCLFileDeletePath,
   prepareZookeeperNewFileRequest,
   SystemIOMachineEvents,
-  waitForIdleState,
 } from '@src/machines/systemIO/utils'
+import { ZOOKEEPER_FILE_WRITE_TOAST_ID } from '@src/lib/constants'
 import { projectSession } from '@src/registry/contracts/projectSession'
 import { IS_STAGING_OR_DEBUG } from '@src/routes/utils'
 import { applyPatch, parsePatch, reversePatch } from 'diff'
 import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
+import toast from 'react-hot-toast'
 
 function getZookeeperPatchPreviousCode(
   patch: ZookeeperEditPatch,
@@ -256,114 +257,171 @@ function ZookeeperConversationPaneInner(props: AreaTypeComponentProps) {
                     reserved: pendingHistoryReserved,
                   })
                 }
-                await waitForIdleState({ systemIOActor })
                 kclManager.zookeeperManagerMachineBulkManipulatingFileSystem = true
-                systemIOActor.send({
-                  type: SystemIOMachineEvents.bulkCreateAndDeleteKCLFilesAndNavigateToFile,
-                  data: {
-                    files: payload.files,
-                    filesToDelete: payload.filesToDelete,
-                    override: true,
-                    requestedProjectName: payload.requestedProjectName,
-                    requestedFileNameWithExtension:
-                      payload.requestedFileNameWithExtension ?? '',
-                    onFileSystemError: () => {
-                      if (pendingHistoryReserved || pendingHistoryStarted) {
-                        cancelPendingZookeeperHistoryWrite({ exchangeId })
-                      }
-                      historyWriteCompleted = true
-                      postWriteCompleted = true
-                      settleRequest()
-                    },
-                    onFileSystemSuccess: () => {
-                      if (historyRecorded) {
+                const handleFileSystemError = () => {
+                  if (pendingHistoryReserved || pendingHistoryStarted) {
+                    cancelPendingZookeeperHistoryWrite({ exchangeId })
+                  }
+                  historyWriteCompleted = true
+                  postWriteCompleted = true
+                  settleRequest()
+                }
+                const handleFileSystemSuccess = () => {
+                  if (historyRecorded) {
+                    historyWriteCompleted = true
+                    settleRequest()
+                    return
+                  }
+                  historyRecorded = true
+                  if (
+                    shouldRecordZookeeperHistory &&
+                    project?.path &&
+                    payload.zookeeperEditPatch
+                  ) {
+                    const currentFile = payload.files.find(
+                      (file) =>
+                        normalizeKCLFileDeletePath(file.requestedFileName) ===
+                        activeRelativePath
+                    )
+                    const currentEditorRelativePath =
+                      project.path && kclManager.path
+                        ? normalizeKCLFileDeletePath(
+                            fsZds.relative(project.path, kclManager.path)
+                          )
+                        : ''
+                    const currentEditorFile = payload.files.find(
+                      (file) =>
+                        normalizeKCLFileDeletePath(file.requestedFileName) ===
+                        currentEditorRelativePath
+                    )
+                    void completePendingZookeeperHistoryWrite({
+                      activeFileDeleted,
+                      activeFilePath,
+                      activeFileRequestedCode: currentFile?.requestedCode,
+                      currentFilePath: currentEditorFile
+                        ? kclManager.path
+                        : undefined,
+                      currentFileRequestedCode:
+                        currentEditorFile?.requestedCode,
+                      exchangeId,
+                      patch: payload.zookeeperEditPatch,
+                      projectPath: project.path,
+                    })
+                      .catch((error: unknown) => {
+                        console.error(
+                          'Failed to complete Zookeeper history write.',
+                          error
+                        )
+                      })
+                      .finally(() => {
                         historyWriteCompleted = true
                         settleRequest()
-                        return
+                      })
+                    return
+                  }
+                  historyWriteCompleted = true
+                  postWriteCompleted = true
+                  settleRequest()
+                }
+                const handlePostWriteSuccess = () => {
+                  if (
+                    shouldRefreshActiveEditor &&
+                    activeFileOutput &&
+                    kclManager.path === activeFilePath &&
+                    kclManager.code !== activeFileOutput.requestedCode
+                  ) {
+                    kclManager.updateCodeEditor(
+                      activeFileOutput.requestedCode,
+                      {
+                        shouldAddToHistory: false,
+                        shouldClearHistory: !shouldRecordZookeeperHistory,
+                        shouldExecute: true,
+                        shouldResetCamera: true,
+                        shouldWriteToDisk: !shouldRecordZookeeperHistory,
                       }
-                      historyRecorded = true
-                      if (
-                        shouldRecordZookeeperHistory &&
-                        project?.path &&
-                        payload.zookeeperEditPatch
-                      ) {
-                        const currentFile = payload.files.find(
-                          (file) =>
-                            normalizeKCLFileDeletePath(
-                              file.requestedFileName
-                            ) === activeRelativePath
-                        )
-                        const currentEditorRelativePath =
-                          project.path && kclManager.path
-                            ? normalizeKCLFileDeletePath(
-                                fsZds.relative(project.path, kclManager.path)
-                              )
-                            : ''
-                        const currentEditorFile = payload.files.find(
-                          (file) =>
-                            normalizeKCLFileDeletePath(
-                              file.requestedFileName
-                            ) === currentEditorRelativePath
-                        )
-                        void completePendingZookeeperHistoryWrite({
-                          activeFileDeleted,
-                          activeFilePath,
-                          activeFileRequestedCode: currentFile?.requestedCode,
-                          currentFilePath: currentEditorFile
-                            ? kclManager.path
-                            : undefined,
-                          currentFileRequestedCode:
-                            currentEditorFile?.requestedCode,
-                          exchangeId,
-                          patch: payload.zookeeperEditPatch,
-                          projectPath: project.path,
-                        })
-                          .catch((error: unknown) => {
-                            console.error(
-                              'Failed to complete Zookeeper history write.',
-                              error
-                            )
-                          })
-                          .finally(() => {
-                            historyWriteCompleted = true
-                            settleRequest()
-                          })
-                        return
-                      }
-                      historyWriteCompleted = true
-                      postWriteCompleted = true
-                      settleRequest()
-                    },
-                    ...(shouldRecordZookeeperHistory ||
-                    shouldRefreshActiveEditor
-                      ? {
-                          onSuccess: () => {
-                            if (
-                              shouldRefreshActiveEditor &&
-                              activeFileOutput &&
-                              kclManager.path === activeFilePath &&
-                              kclManager.code !== activeFileOutput.requestedCode
-                            ) {
-                              kclManager.updateCodeEditor(
-                                activeFileOutput.requestedCode,
-                                {
-                                  shouldAddToHistory: false,
-                                  shouldClearHistory:
-                                    !shouldRecordZookeeperHistory,
-                                  shouldExecute: true,
-                                  shouldResetCamera: true,
-                                  shouldWriteToDisk:
-                                    !shouldRecordZookeeperHistory,
-                                }
-                              )
-                            }
-                            postWriteCompleted = true
-                            settleRequest()
-                          },
-                        }
-                      : {}),
-                  },
-                })
+                    )
+                  }
+                  postWriteCompleted = true
+                  settleRequest()
+                }
+
+                try {
+                  const session = app.registry.get(projectSession)
+                  const currentProject = session.getProject()
+                  if (!currentProject) {
+                    throw new Error(
+                      'Cannot apply Zookeeper file request because no project is open.'
+                    )
+                  }
+                  const requestedFileNameWithExtension =
+                    payload.requestedFileNameWithExtension ?? ''
+                  await session.applyFilePatch({
+                    files: [
+                      ...payload.files.map((file) => ({
+                        path: fsZds.join(
+                          currentProject.path,
+                          file.requestedFileName
+                        ),
+                        contents: file.requestedCode,
+                      })),
+                      ...payload.filesToDelete.map((file) => ({
+                        path: fsZds.join(
+                          currentProject.path,
+                          normalizeKCLFileDeletePath(file.requestedFileName)
+                        ),
+                        contents: null,
+                      })),
+                    ],
+                  })
+                  const fileText = payload.files.length > 1 ? 'files' : 'file'
+                  toast.success(
+                    `Successfully overwrote ${payload.files.length} ${fileText}, ${payload.filesToDelete.length} deleted`,
+                    { id: ZOOKEEPER_FILE_WRITE_TOAST_ID }
+                  )
+                  handleFileSystemSuccess()
+
+                  const requestedRelativePath = normalizeKCLFileDeletePath(
+                    requestedFileNameWithExtension
+                  )
+                  const deletesRequestedFile = payload.filesToDelete.some(
+                    (file) =>
+                      normalizeKCLFileDeletePath(file.requestedFileName) ===
+                      requestedRelativePath
+                  )
+                  const requestedAbsolutePath = fsZds.join(
+                    currentProject.path,
+                    requestedFileNameWithExtension
+                  )
+                  const shouldNavigate =
+                    currentProject.name !== payload.requestedProjectName ||
+                    currentProject.executingPath !== requestedAbsolutePath ||
+                    deletesRequestedFile
+
+                  if (shouldNavigate) {
+                    systemIOActor.send({
+                      type: SystemIOMachineEvents.navigateToFile,
+                      data: {
+                        requestedProjectName: payload.requestedProjectName,
+                        requestedFileName: requestedFileNameWithExtension,
+                        onProjectLoaderComplete: handlePostWriteSuccess,
+                      },
+                    })
+                  } else {
+                    handlePostWriteSuccess()
+                  }
+                } catch (error) {
+                  handleFileSystemError()
+                  console.error(
+                    'Failed to process Zookeeper file request.',
+                    error
+                  )
+                  toast.error(
+                    error instanceof Error
+                      ? error.message
+                      : 'Failed to process Zookeeper file request.',
+                    { id: ZOOKEEPER_FILE_WRITE_TOAST_ID }
+                  )
+                }
               })().catch((error: unknown) => {
                 if (pendingHistoryReserved || pendingHistoryStarted) {
                   cancelPendingZookeeperHistoryWrite({ exchangeId })

--- a/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.tsx
@@ -39,12 +39,13 @@ import {
   normalizeKCLFileDeletePath,
   prepareZookeeperNewFileRequest,
   SystemIOMachineEvents,
-  waitForIdleState,
 } from '@src/machines/systemIO/utils'
+import { ZOOKEEPER_FILE_WRITE_TOAST_ID } from '@src/lib/constants'
 import { projectSession } from '@src/registry/contracts/projectSession'
 import { IS_STAGING_OR_DEBUG } from '@src/routes/utils'
 import { applyPatch, parsePatch, reversePatch } from 'diff'
 import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
+import toast from 'react-hot-toast'
 
 function getZookeeperPatchPreviousCode(
   patch: ZookeeperEditPatch,
@@ -264,114 +265,171 @@ function ZookeeperConversationPaneInner(props: AreaTypeComponentProps) {
                     reserved: pendingHistoryReserved,
                   })
                 }
-                await waitForIdleState({ systemIOActor })
                 kclManager.zookeeperManagerMachineBulkManipulatingFileSystem = true
-                systemIOActor.send({
-                  type: SystemIOMachineEvents.bulkCreateAndDeleteKCLFilesAndNavigateToFile,
-                  data: {
-                    files: payload.files,
-                    filesToDelete: payload.filesToDelete,
-                    override: true,
-                    requestedProjectName: payload.requestedProjectName,
-                    requestedFileNameWithExtension:
-                      payload.requestedFileNameWithExtension ?? '',
-                    onFileSystemError: () => {
-                      if (pendingHistoryReserved || pendingHistoryStarted) {
-                        cancelPendingZookeeperHistoryWrite({ exchangeId })
-                      }
-                      historyWriteCompleted = true
-                      postWriteCompleted = true
-                      settleRequest()
-                    },
-                    onFileSystemSuccess: () => {
-                      if (historyRecorded) {
+                const handleFileSystemError = () => {
+                  if (pendingHistoryReserved || pendingHistoryStarted) {
+                    cancelPendingZookeeperHistoryWrite({ exchangeId })
+                  }
+                  historyWriteCompleted = true
+                  postWriteCompleted = true
+                  settleRequest()
+                }
+                const handleFileSystemSuccess = () => {
+                  if (historyRecorded) {
+                    historyWriteCompleted = true
+                    settleRequest()
+                    return
+                  }
+                  historyRecorded = true
+                  if (
+                    shouldRecordZookeeperHistory &&
+                    project?.path &&
+                    payload.zookeeperEditPatch
+                  ) {
+                    const currentFile = payload.files.find(
+                      (file) =>
+                        normalizeKCLFileDeletePath(file.requestedFileName) ===
+                        activeRelativePath
+                    )
+                    const currentEditorRelativePath =
+                      project.path && kclManager.path
+                        ? normalizeKCLFileDeletePath(
+                            fsZds.relative(project.path, kclManager.path)
+                          )
+                        : ''
+                    const currentEditorFile = payload.files.find(
+                      (file) =>
+                        normalizeKCLFileDeletePath(file.requestedFileName) ===
+                        currentEditorRelativePath
+                    )
+                    void completePendingZookeeperHistoryWrite({
+                      activeFileDeleted,
+                      activeFilePath,
+                      activeFileRequestedCode: currentFile?.requestedCode,
+                      currentFilePath: currentEditorFile
+                        ? kclManager.path
+                        : undefined,
+                      currentFileRequestedCode:
+                        currentEditorFile?.requestedCode,
+                      exchangeId,
+                      patch: payload.zookeeperEditPatch,
+                      projectPath: project.path,
+                    })
+                      .catch((error: unknown) => {
+                        console.error(
+                          'Failed to complete Zookeeper history write.',
+                          error
+                        )
+                      })
+                      .finally(() => {
                         historyWriteCompleted = true
                         settleRequest()
-                        return
+                      })
+                    return
+                  }
+                  historyWriteCompleted = true
+                  postWriteCompleted = true
+                  settleRequest()
+                }
+                const handlePostWriteSuccess = () => {
+                  if (
+                    shouldRefreshActiveEditor &&
+                    activeFileOutput &&
+                    kclManager.path === activeFilePath &&
+                    kclManager.code !== activeFileOutput.requestedCode
+                  ) {
+                    kclManager.updateCodeEditor(
+                      activeFileOutput.requestedCode,
+                      {
+                        shouldAddToHistory: false,
+                        shouldClearHistory: !shouldRecordZookeeperHistory,
+                        shouldExecute: true,
+                        shouldResetCamera: true,
+                        shouldWriteToDisk: !shouldRecordZookeeperHistory,
                       }
-                      historyRecorded = true
-                      if (
-                        shouldRecordZookeeperHistory &&
-                        project?.path &&
-                        payload.zookeeperEditPatch
-                      ) {
-                        const currentFile = payload.files.find(
-                          (file) =>
-                            normalizeKCLFileDeletePath(
-                              file.requestedFileName
-                            ) === activeRelativePath
-                        )
-                        const currentEditorRelativePath =
-                          project.path && kclManager.path
-                            ? normalizeKCLFileDeletePath(
-                                fsZds.relative(project.path, kclManager.path)
-                              )
-                            : ''
-                        const currentEditorFile = payload.files.find(
-                          (file) =>
-                            normalizeKCLFileDeletePath(
-                              file.requestedFileName
-                            ) === currentEditorRelativePath
-                        )
-                        void completePendingZookeeperHistoryWrite({
-                          activeFileDeleted,
-                          activeFilePath,
-                          activeFileRequestedCode: currentFile?.requestedCode,
-                          currentFilePath: currentEditorFile
-                            ? kclManager.path
-                            : undefined,
-                          currentFileRequestedCode:
-                            currentEditorFile?.requestedCode,
-                          exchangeId,
-                          patch: payload.zookeeperEditPatch,
-                          projectPath: project.path,
-                        })
-                          .catch((error: unknown) => {
-                            console.error(
-                              'Failed to complete Zookeeper history write.',
-                              error
-                            )
-                          })
-                          .finally(() => {
-                            historyWriteCompleted = true
-                            settleRequest()
-                          })
-                        return
-                      }
-                      historyWriteCompleted = true
-                      postWriteCompleted = true
-                      settleRequest()
-                    },
-                    ...(shouldRecordZookeeperHistory ||
-                    shouldRefreshActiveEditor
-                      ? {
-                          onSuccess: () => {
-                            if (
-                              shouldRefreshActiveEditor &&
-                              activeFileOutput &&
-                              kclManager.path === activeFilePath &&
-                              kclManager.code !== activeFileOutput.requestedCode
-                            ) {
-                              kclManager.updateCodeEditor(
-                                activeFileOutput.requestedCode,
-                                {
-                                  shouldAddToHistory: false,
-                                  shouldClearHistory:
-                                    !shouldRecordZookeeperHistory,
-                                  shouldExecute: true,
-                                  shouldResetCamera: true,
-                                  shouldWriteToDisk:
-                                    !shouldRecordZookeeperHistory,
-                                }
-                              )
-                            }
-                            postWriteCompleted = true
-                            settleRequest()
-                          },
-                        }
-                      : {}),
-                  },
-                })
+                    )
+                  }
+                  postWriteCompleted = true
+                  settleRequest()
+                }
+
+                try {
+                  const session = app.registry.get(projectSession)
+                  const currentProject = session.getProject()
+                  if (!currentProject) {
+                    throw new Error(
+                      'Cannot apply Zookeeper file request because no project is open.'
+                    )
+                  }
+                  const requestedFileNameWithExtension =
+                    payload.requestedFileNameWithExtension ?? ''
+                  await session.applyFilePatch({
+                    files: [
+                      ...payload.files.map((file) => ({
+                        path: fsZds.join(
+                          currentProject.path,
+                          file.requestedFileName
+                        ),
+                        contents: file.requestedCode,
+                      })),
+                      ...payload.filesToDelete.map((file) => ({
+                        path: fsZds.join(
+                          currentProject.path,
+                          normalizeKCLFileDeletePath(file.requestedFileName)
+                        ),
+                        contents: null,
+                      })),
+                    ],
+                  })
+                  const fileText = payload.files.length > 1 ? 'files' : 'file'
+                  toast.success(
+                    `Successfully overwrote ${payload.files.length} ${fileText}, ${payload.filesToDelete.length} deleted`,
+                    { id: ZOOKEEPER_FILE_WRITE_TOAST_ID }
+                  )
+                  handleFileSystemSuccess()
+
+                  const requestedRelativePath = normalizeKCLFileDeletePath(
+                    requestedFileNameWithExtension
+                  )
+                  const deletesRequestedFile = payload.filesToDelete.some(
+                    (file) =>
+                      normalizeKCLFileDeletePath(file.requestedFileName) ===
+                      requestedRelativePath
+                  )
+                  const requestedAbsolutePath = fsZds.join(
+                    currentProject.path,
+                    requestedFileNameWithExtension
+                  )
+                  const shouldNavigate =
+                    currentProject.name !== payload.requestedProjectName ||
+                    currentProject.executingPath !== requestedAbsolutePath ||
+                    deletesRequestedFile
+
+                  if (shouldNavigate) {
+                    systemIOActor.send({
+                      type: SystemIOMachineEvents.navigateToFile,
+                      data: {
+                        requestedProjectName: payload.requestedProjectName,
+                        requestedFileName: requestedFileNameWithExtension,
+                        onProjectLoaderComplete: handlePostWriteSuccess,
+                      },
+                    })
+                  } else {
+                    handlePostWriteSuccess()
+                  }
+                } catch (error) {
+                  handleFileSystemError()
+                  console.error(
+                    'Failed to process Zookeeper file request.',
+                    error
+                  )
+                  toast.error(
+                    error instanceof Error
+                      ? error.message
+                      : 'Failed to process Zookeeper file request.',
+                    { id: ZOOKEEPER_FILE_WRITE_TOAST_ID }
+                  )
+                }
               })().catch((error: unknown) => {
                 if (pendingHistoryReserved || pendingHistoryStarted) {
                   cancelPendingZookeeperHistoryWrite({ exchangeId })

--- a/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.tsx
@@ -349,9 +349,12 @@ function ZookeeperConversationPaneInner(props: AreaTypeComponentProps) {
                   const session = app.registry.get(projectSession)
                   const currentProject = session.getProject()
                   if (!currentProject) {
-                    throw new Error(
-                      'Cannot apply Zookeeper file request because no project is open.'
+                    await Promise.reject(
+                      new Error(
+                        'Cannot apply Zookeeper file request because no project is open.'
+                      )
                     )
+                    return
                   }
                   const requestedFileNameWithExtension =
                     payload.requestedFileNameWithExtension ?? ''

--- a/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.tsx
@@ -357,9 +357,12 @@ function ZookeeperConversationPaneInner(props: AreaTypeComponentProps) {
                   const session = app.registry.get(projectSession)
                   const currentProject = session.getProject()
                   if (!currentProject) {
-                    throw new Error(
-                      'Cannot apply Zookeeper file request because no project is open.'
+                    await Promise.reject(
+                      new Error(
+                        'Cannot apply Zookeeper file request because no project is open.'
+                      )
                     )
+                    return
                   }
                   const requestedFileNameWithExtension =
                     payload.requestedFileNameWithExtension ?? ''


### PR DESCRIPTION
Part of the System.IO migration stack. This moves Zookeeper bulk file writes and deletes onto projectSession.applyFilePatch so generated edits share the project-session file pipeline.

1. Replaces `bulkCreateAndDeleteKCLFilesAndNavigateToFile` usage in the Zookeeper conversation wrapper with `projectSession.applyFilePatch`.
2. Preserves per-file history entries and queue behavior around accepted file changes.
3. Makes delete patches tolerate already-missing paths after project-root validation.

How to test
Accept a Zookeeper response that writes files, accepts deletes, and accepts mixed write/delete changes. Confirm files are patched once, history entries are created, and the editor navigation still lands on the expected file.