### PR TITLE
Move project CRUD to home services

### DIFF
--- a/src/components/ProjectSidebarMenu.tsx
+++ b/src/components/ProjectSidebarMenu.tsx
@@ -18,8 +18,13 @@ import {
 } from '@src/lib/paths'
 import type { FileEntry, Project } from '@src/lib/project'
 import { getProjectDisplayName } from '@src/lib/projectDisplayName'
+import { normalizeLibraryPath } from '@src/lib/projectLibraries'
+import { reportRejection } from '@src/lib/trap'
 import type { IndexLoaderData } from '@src/lib/types'
-import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
+import {
+  homeProjectActionsService,
+  homeProjectEntriesValueSpec,
+} from '@src/registry/contracts/homeProjects'
 import {
   findKeymapItemForCommand,
   keymapKeystrokesDisplay,
@@ -256,6 +261,37 @@ function ProjectMenuPopover({
   const contributedProjectBreadcrumbBadges = app.registry.signal(
     projectExplorerProjectBreadcrumbBadgesValueSpec
   ).value
+  const homeProjectActions = app.registry.optional(homeProjectActionsService)
+  const homeProjectEntries = app.registry.signal(
+    homeProjectEntriesValueSpec
+  ).value
+  const currentHomeProject = useMemo(() => {
+    if (!project) {
+      return undefined
+    }
+
+    const normalizedProjectPath = normalizeLibraryPath(project.path)
+    return (
+      homeProjectEntries.find(
+        (entry) =>
+          entry.localProjectPath &&
+          normalizeLibraryPath(entry.localProjectPath) === normalizedProjectPath
+      ) ??
+      homeProjectEntries.find(
+        (entry) =>
+          entry.localProjectName === project.name || entry.name === project.name
+      )
+    )
+  }, [homeProjectEntries, project])
+  const duplicateProjectTarget =
+    homeProjectActions &&
+    currentHomeProject &&
+    homeProjectActions.canDuplicate(currentHomeProject)
+      ? {
+          actions: homeProjectActions,
+          project: currentHomeProject,
+        }
+      : undefined
 
   const exportCommandInfo = { name: 'Export', groupId: 'modeling' }
   const exportProjectZipCommandInfo = {
@@ -311,7 +347,7 @@ function ProjectMenuPopover({
           },
         },
         { kind: 'break', id: 'after-settings' },
-        project
+        duplicateProjectTarget
           ? {
               id: 'duplicate-project',
               Element: 'button' as const,
@@ -324,14 +360,9 @@ function ProjectMenuPopover({
                 </span>
               ),
               onClick: () => {
-                app.systemIOActor.send({
-                  type: SystemIOMachineEvents.duplicateProject,
-                  data: {
-                    projectName: project.name,
-                    projectPath: project.path,
-                    requestedProjectName: getProjectDisplayName(project),
-                  },
-                })
+                void duplicateProjectTarget.actions
+                  .duplicate(duplicateProjectTarget.project)
+                  .catch(reportRejection)
               },
             }
           : null,
@@ -537,9 +568,9 @@ function ProjectMenuPopover({
       homeNavigationEnabled,
       projectPath,
       project,
+      duplicateProjectTarget,
       contributedProjectMenuItems,
       commands.actor,
-      app.systemIOActor,
       file,
       filePath,
       machineCount,

--- a/src/lib/commandBarConfigs/projectsCommandConfig.spec.ts
+++ b/src/lib/commandBarConfigs/projectsCommandConfig.spec.ts
@@ -4,7 +4,6 @@ import type { Project } from '@src/lib/project'
 import type { ProjectLibrary } from '@src/lib/projectLibraries'
 import type { commandBarMachine } from '@src/machines/commandBarMachine'
 import type { systemIOMachine } from '@src/machines/systemIO/systemIOMachine'
-import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
 import type {
   HomeProjectActionsService,
   HomeProjectEntry,
@@ -147,7 +146,7 @@ describe('project command config', () => {
     ])
   })
 
-  it('creates project directories from project titles', () => {
+  it('requires a project library target when creating projects', () => {
     const systemIOActor = createSystemIOActor()
     const commands = createProjectCommands({
       systemIOActor,
@@ -161,13 +160,7 @@ describe('project command config', () => {
       name: ' My Cool Project! ',
     })
 
-    expect(systemIOActor.send).toHaveBeenCalledWith({
-      type: SystemIOMachineEvents.createProject,
-      data: {
-        requestedProjectName: 'my-cool-project',
-        requestedProjectTitle: 'My Cool Project!',
-      },
-    })
+    expect(systemIOActor.send).not.toHaveBeenCalled()
   })
 
   it('creates projects through the selected library target', () => {
@@ -333,7 +326,7 @@ describe('project command config', () => {
     ])
   })
 
-  it('labels existing project options by title while submitting directory names', () => {
+  it('keeps legacy project directory options for opening projects only', () => {
     const systemIOActor = createSystemIOActor([
       createProject({
         name: 'bracket-directory',
@@ -362,23 +355,13 @@ describe('project command config', () => {
         isCurrent: false,
       },
     ])
-    expect(deleteCommand && projectOptions(deleteCommand, 'name')).toEqual([
-      {
-        name: 'Display Bracket',
-        value: 'bracket-directory',
-        isCurrent: false,
-      },
-    ])
-    expect(renameCommand && projectOptions(renameCommand, 'oldName')).toEqual([
-      {
-        name: 'Display Bracket',
-        value: 'bracket-directory',
-        isCurrent: false,
-      },
-    ])
+    expect(deleteCommand && projectOptions(deleteCommand, 'name')).toEqual([])
+    expect(renameCommand && projectOptions(renameCommand, 'oldName')).toEqual(
+      []
+    )
   })
 
-  it('renames project titles without replacing the project directory identifier', () => {
+  it('requires a home project action target when renaming projects', () => {
     const systemIOActor = createSystemIOActor([
       createProject({
         name: 'bracket-directory',
@@ -412,14 +395,7 @@ describe('project command config', () => {
       newName: 'Retitled Bracket',
     })
 
-    expect(systemIOActor.send).toHaveBeenCalledWith({
-      type: SystemIOMachineEvents.renameProject,
-      data: {
-        projectName: 'bracket-directory',
-        requestedProjectName: 'Retitled Bracket',
-        redirect: true,
-      },
-    })
+    expect(systemIOActor.send).not.toHaveBeenCalled()
   })
 
   it('uses home project entries for project command options', () => {
@@ -745,11 +721,11 @@ describe('project command config', () => {
       enableProjectDirectoryCommands: true,
       getCurrentProjectDirectoryName: () => 'bracket-directory',
     })
-    const renameCommand = commands.find(
-      (command) => command.name === 'Rename project'
+    const openCommand = commands.find(
+      (command) => command.name === 'Open project'
     )
 
-    expect(renameCommand && projectOptions(renameCommand, 'oldName')).toEqual([
+    expect(openCommand && projectOptions(openCommand, 'name')).toEqual([
       {
         name: 'Display Bracket',
         value: 'bracket-directory',

--- a/src/lib/commandBarConfigs/projectsCommandConfig.ts
+++ b/src/lib/commandBarConfigs/projectsCommandConfig.ts
@@ -166,16 +166,18 @@ export function createProjectCommands({
     }))
 
   const projectOptions = (action: HomeProjectCommandAction) => {
-    if (action === 'moveToLibrary') {
-      return homeProjectOptions(action) ?? []
+    const options = homeProjectOptions(action)
+    if (options) {
+      return options
     }
 
-    return (
-      homeProjectOptions(action) ??
-      getProjectDirectoryOptions(folderSnapshot(), {
+    if (action === 'open') {
+      return getProjectDirectoryOptions(folderSnapshot(), {
         defaultValue: currentProjectDirectoryNameSnapshot(),
       })
-    )
+    }
+
+    return []
   }
 
   const projectDisplayNameFromCommandValue = (
@@ -342,7 +344,7 @@ export function createProjectCommands({
     onSubmit: (record) => {
       if (record) {
         const target = selectedCreateProjectTarget(record.libraryId)
-        if (getCreateProjectLibraryTargets && !target) {
+        if (!target) {
           toast.error(
             'Add a writable project library before creating a project.'
           )
@@ -362,26 +364,16 @@ export function createProjectCommands({
           return
         }
 
-        if (target) {
-          return Promise.resolve(
-            target.createProject.run({
-              library: target.library,
-              requestedProjectName,
-              requestedProjectTitle,
-            })
-          ).then((project) => {
-            if (project?.default_file) {
-              navigateToProjectFile(project.default_file)
-            }
-          })
-        }
-
-        systemIOActor.send({
-          type: SystemIOMachineEvents.createProject,
-          data: {
+        return Promise.resolve(
+          target.createProject.run({
+            library: target.library,
             requestedProjectName,
             requestedProjectTitle,
-          },
+          })
+        ).then((project) => {
+          if (project?.default_file) {
+            navigateToProjectFile(project.default_file)
+          }
         })
       }
     },
@@ -497,14 +489,12 @@ export function createProjectCommands({
     onSubmit: (record) => {
       if (record) {
         const target = selectedHomeProjectTarget(record.name, 'delete')
-        if (target) {
-          return target.actions.delete(target.project)
+        if (!target) {
+          toast.error('Select a project that can be deleted.')
+          return
         }
 
-        systemIOActor.send({
-          type: SystemIOMachineEvents.deleteProject,
-          data: { requestedProjectName: record.name },
-        })
+        return target.actions.delete(target.project)
       }
     },
     reviewMessage: ({ argumentsToSubmit }) => {
@@ -543,24 +533,12 @@ export function createProjectCommands({
     onSubmit: (record) => {
       if (record) {
         const target = selectedHomeProjectTarget(record.oldName, 'rename')
-        if (target) {
-          return target.actions.rename(target.project, record.newName)
+        if (!target) {
+          toast.error('Select a project that can be renamed.')
+          return
         }
 
-        // Only redirect back to the project when not on the home page
-        const hash = window.location.hash
-        const pathname = hash
-          ? hash.replace(/^#/, '')
-          : window.location.pathname
-        const isOnHomePage = pathname.startsWith(PATHS.HOME)
-        systemIOActor.send({
-          type: SystemIOMachineEvents.renameProject,
-          data: {
-            requestedProjectName: record.newName,
-            projectName: record.oldName,
-            redirect: !isOnHomePage, // only redirect when renaming from within a project
-          },
-        })
+        return target.actions.rename(target.project, record.newName)
       }
     },
     args: {

--- a/src/registry/extensions/projectExplorer/projectMenu.spec.tsx
+++ b/src/registry/extensions/projectExplorer/projectMenu.spec.tsx
@@ -1,7 +1,18 @@
-import { Registry } from '@kittycad/registry'
+import {
+  Registry,
+  defineRegistryItem,
+  provide,
+  provideService,
+} from '@kittycad/registry'
 import ProjectSidebarMenu from '@src/components/ProjectSidebarMenu'
 import type { App } from '@src/lib/app'
+import { homeProjectEntryFromProject } from '@src/lib/homeProjects'
 import type { Project } from '@src/lib/project'
+import type { HomeProjectActionsService } from '@src/registry/contracts/homeProjects'
+import {
+  homeProjectActionsService,
+  homeProjectEntriesValueSpec,
+} from '@src/registry/contracts/homeProjects'
 import getDesktopAppExtension from '@src/registry/extensions/getDesktopApp'
 import { fireEvent, render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
@@ -47,9 +58,50 @@ function renderWithRouter(children: ReactNode) {
   return render(<BrowserRouter>{children}</BrowserRouter>)
 }
 
+function createHomeProjectActions(): HomeProjectActionsService {
+  return {
+    canOpen: vi.fn(() => true),
+    canDuplicate: vi.fn(() => true),
+    canRename: vi.fn(() => true),
+    canDelete: vi.fn(() => true),
+    canMoveToLibrary: vi.fn(() => false),
+    canReviewDuplicateRealizations: vi.fn(() => false),
+    open: vi.fn(async (project) => ({
+      defaultFile: project.defaultFile ?? '',
+    })),
+    duplicate: vi.fn(async () => undefined),
+    rename: vi.fn(async () => undefined),
+    delete: vi.fn(async () => undefined),
+    getMoveToLibraryTargets: vi.fn(() => []),
+    moveToLibrary: vi.fn(async () => undefined),
+    deleteDuplicateRealizations: vi.fn(async () => undefined),
+  }
+}
+
 function createProjectMenuApp() {
   const registry = new Registry()
-  registry.configure([projectExplorerExtension, getDesktopAppExtension])
+  const homeProjectActions = createHomeProjectActions()
+  const homeProjectEntry = homeProjectEntryFromProject(projectWellFormed)
+  registry.configure([
+    projectExplorerExtension,
+    getDesktopAppExtension,
+    defineRegistryItem({
+      id: 'test-home-project-actions',
+      providesServices: [
+        provideService(homeProjectActionsService, homeProjectActions),
+      ],
+    }),
+    defineRegistryItem({
+      id: 'test-home-project-entries',
+      provides: [
+        provide(homeProjectEntriesValueSpec, {
+          ...homeProjectEntry,
+          id: `local:${projectWellFormed.path}`,
+          libraryIds: ['test-library'],
+        }),
+      ],
+    }),
+  ])
   const commandsActor = createActor(
     createMachine({
       context: {
@@ -82,6 +134,7 @@ function createProjectMenuApp() {
       },
       registry,
     } as unknown as App,
+    homeProjectActions,
     dispose: () => {
       commandsActor.stop()
       registry[Symbol.dispose]()
@@ -142,7 +195,7 @@ describe('project explorer project menu', () => {
   })
 
   test('duplicates the current project', async () => {
-    const { app, dispose } = createProjectMenuApp()
+    const { app, homeProjectActions, dispose } = createProjectMenuApp()
 
     try {
       renderWithRouter(
@@ -160,14 +213,13 @@ describe('project explorer project menu', () => {
       }
       fireEvent.click(duplicateButton)
 
-      expect(app.systemIOActor.send).toHaveBeenCalledWith({
-        type: 'duplicate project',
-        data: {
-          projectName: projectWellFormed.name,
-          projectPath: projectWellFormed.path,
-          requestedProjectName: projectWellFormed.title,
-        },
-      })
+      expect(homeProjectActions.duplicate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          localProjectPath: projectWellFormed.path,
+          localProjectName: projectWellFormed.name,
+        })
+      )
+      expect(app.systemIOActor.send).not.toHaveBeenCalled()
     } finally {
       dispose()
     }


### PR DESCRIPTION
Part of the System.IO migration stack. This leaves project create, duplicate, rename, and delete behavior with the project-library and Home project services instead of sending those mutations through System.IO.

1. Requires project-library create targets for the Create project command and removes the System.IO create fallback.
2. Requires Home project action targets for Rename project and Delete project command handling.
3. Routes the project menu Duplicate project action through `homeProjectActionsService.duplicate` using the active Home project entry.

How to test
Create a project from a configured writable library, rename and delete Home project cards from the command bar, and duplicate the active project from the project menu. Confirm unsupported projects are not offered for rename/delete and no project CRUD mutation depends on System.IO.