### PR TITLE
Refresh cloud sync after environment switch

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -48,6 +48,22 @@ export function getEnvironmentNameFromEnv(
 
 /** Store the environment in memory to be accessed during runtime */
 let ENVIRONMENT: EnvironmentConfigurationRuntime | null = null
+type EnvironmentDomainChangeListener = () => void
+const environmentDomainChangeListeners =
+  new Set<EnvironmentDomainChangeListener>()
+
+export function onEnvironmentDomainChange(
+  listener: EnvironmentDomainChangeListener
+) {
+  environmentDomainChangeListeners.add(listener)
+  return () => environmentDomainChangeListeners.delete(listener)
+}
+
+function notifyEnvironmentDomainChange() {
+  for (const listener of environmentDomainChangeListeners) {
+    listener()
+  }
+}
 
 /** Update the runtime environment */
 export const updateEnvironment = (environment: string | null) => {
@@ -68,6 +84,7 @@ export const updateEnvironment = (environment: string | null) => {
     }
   }
   console.log('updating environment:', environment)
+  notifyEnvironmentDomainChange()
 }
 
 export const updateEnvironmentKittycadWebSocketUrl = (

--- a/src/registry/extensions/runtime/index.test.ts
+++ b/src/registry/extensions/runtime/index.test.ts
@@ -1,7 +1,8 @@
 import { Registry } from '@kittycad/registry'
+import { updateEnvironment } from '@src/env'
 import { runtimeService } from '@src/registry/contracts/runtime'
 import runtimeRegistryItem from '@src/registry/extensions/runtime'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 describe('runtime extension', () => {
   let registry: Registry | undefined
@@ -9,6 +10,8 @@ describe('runtime extension', () => {
   afterEach(() => {
     registry?.[Symbol.dispose]()
     registry = undefined
+    updateEnvironment(null)
+    vi.unstubAllGlobals()
   })
 
   it('provides runtime target and environment metadata', () => {
@@ -24,5 +27,30 @@ describe('runtime extension', () => {
     expect(current.environmentName).toBeTruthy()
     expect(runtime.current.value).toEqual(current)
     expect(runtime.refresh()).toEqual(runtime.current.value)
+  })
+
+  it('refreshes runtime metadata when the desktop environment changes', () => {
+    vi.stubGlobal('navigator', { userAgent: 'Electron' })
+    vi.stubGlobal('electron', {
+      process: {
+        env: {
+          NODE_ENV: 'test',
+          VITE_ZOO_BASE_DOMAIN: 'zoo.dev',
+        },
+      },
+    })
+    registry = new Registry()
+    registry.configure([runtimeRegistryItem])
+
+    const runtime = registry.get(runtimeService)
+
+    updateEnvironment('customer.example')
+
+    expect(runtime.current.value).toMatchObject({
+      target: 'desktop',
+      environmentName: 'customer.example',
+      baseDomain: 'customer.example',
+      apiBaseUrl: 'https://api.customer.example',
+    })
   })
 })

--- a/src/registry/extensions/runtime/index.ts
+++ b/src/registry/extensions/runtime/index.ts
@@ -5,7 +5,10 @@ import {
   provideService,
 } from '@kittycad/registry'
 import { signal } from '@preact/signals-core'
-import env, { getEnvironmentNameFromEnv } from '@src/env'
+import env, {
+  getEnvironmentNameFromEnv,
+  onEnvironmentDomainChange,
+} from '@src/env'
 import { IS_PLAYWRIGHT_KEY } from '@src/lib/constants'
 import { isDesktop as detectDesktop } from '@src/lib/isDesktop'
 import {
@@ -52,20 +55,23 @@ function readRuntimeInfo(): RuntimeInfo {
 
 export const runtimeExtension = defineRegistryItemFactory(() => {
   const current = signal(readRuntimeInfo())
+  const refresh = () => {
+    current.value = readRuntimeInfo()
+    return current.value
+  }
+  const stopEnvironmentSync = onEnvironmentDomainChange(refresh)
 
   const serviceImpl: RuntimeRegistryService = {
     current,
     get: () => current.value,
-    refresh: () => {
-      current.value = readRuntimeInfo()
-      return current.value
-    },
+    refresh,
   }
 
   return {
     item: defineRuntimeRegistryItem({
       id: 'runtime-extension',
       providesServices: [provideService(runtimeService, serviceImpl)],
+      dispose: stopEnvironmentSync,
     }),
   }
 }, 'runtime-extension')


### PR DESCRIPTION
Refreshes runtime configuration so cloud sync uses the selected desktop environment.

Fixes #12898.

Tested locally with `npm tronb:package:prod`. I can switch back and forth on the home page, sign in, and then see the right calls in the network tab.