### PR TITLE
Fix replay onboarding for cloud projects on web

### DIFF
--- a/e2e/playwright/onboarding-web.spec.ts
+++ b/e2e/playwright/onboarding-web.spec.ts
@@ -1,0 +1,67 @@
+import {
+  PROJECT_DIR,
+  readOpfsTextFiles,
+  routeCloudProjects,
+} from '@e2e/playwright/lib/cloudSyncTestUtils'
+import { setup } from '@e2e/playwright/test-utils'
+import { expect, test } from '@playwright/test'
+import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
+
+test(
+  'Replay onboarding from cloud home opens the tutorial',
+  { tag: '@web' },
+  async ({ context, page }, testInfo) => {
+    const { calls: apiCalls } = await routeCloudProjects(context, {
+      remoteProjects: [],
+      createProject: () => ({
+        id: 'tutorial-project-cloud-id',
+        title: 'tutorial-project',
+        revision: 'tutorial-project-rev-1',
+        files: {},
+      }),
+    })
+    await setup(context, page, testInfo, [OPFS_CLOUD_FEATURE_FLAG])
+
+    await test.step('Open the cloud project home page', async () => {
+      await page.goto('/')
+      await expect(
+        page.getByRole('heading', {
+          name: /^(Project Libraries|Personal Cloud)$/,
+        })
+      ).toBeVisible()
+    })
+
+    await test.step('Open user settings from home', async () => {
+      await page.getByRole('link', { name: 'Settings' }).last().click()
+      await expect(
+        page.getByRole('heading', { name: 'Settings', exact: true })
+      ).toBeVisible()
+    })
+
+    await test.step('Replay onboarding and open the tutorial project', async () => {
+      await page.getByRole('button', { name: 'Replay onboarding' }).click()
+
+      await expect(page).toHaveURL(/tutorial-project%2Fmain\.kcl\/onboarding\//)
+      await expect(page.getByText('Welcome to Zoo Design Studio')).toBeVisible()
+    })
+
+    await test.step('Create and enroll the tutorial as a cloud project', async () => {
+      const tutorialFiles = await readOpfsTextFiles(page, {
+        main: `${PROJECT_DIR}/tutorial-project/main.kcl`,
+        settings: `${PROJECT_DIR}/tutorial-project/project.toml`,
+      })
+
+      expect(tutorialFiles.main).toContain('plateLength = 10')
+      await expect.poll(() => apiCalls.creates.length).toBeGreaterThanOrEqual(1)
+      expect(apiCalls.creates[0]).toContain('tutorial-project')
+      await expect
+        .poll(async () => {
+          const files = await readOpfsTextFiles(page, {
+            settings: `${PROJECT_DIR}/tutorial-project/project.toml`,
+          })
+          return files.settings
+        })
+        .toContain('project_id = "tutorial-project-cloud-id"')
+    })
+  }
+)

--- a/src/components/SystemIOMachineLogicListener.tsx
+++ b/src/components/SystemIOMachineLogicListener.tsx
@@ -16,7 +16,10 @@ import {
   webSafePathSplit,
 } from '@src/lib/paths'
 import { lspService } from '@src/lang/lsp/registry/contract'
-import { getDefaultDirectoryProjectLibraryPath } from '@src/lib/projectLibraries'
+import {
+  getDefaultDirectoryProjectLibraryPath,
+  getDefaultLocalProjectLibraryPath,
+} from '@src/lib/projectLibraries'
 import {
   useHasListedProjects,
   useLastOperation,
@@ -50,6 +53,9 @@ export function SystemIOMachineLogicListener() {
     getDefaultDirectoryProjectLibraryPath(
       settingsValues.app.libraries.current
     ) || ''
+  const defaultLocalProjectLibraryPath =
+    getDefaultLocalProjectLibraryPath(settingsValues.app.libraries.current) ||
+    ''
   const { pathname } = useLocation()
 
   function safestNavigateToFile({
@@ -74,7 +80,7 @@ export function SystemIOMachineLogicListener() {
       filePathWithExtension = decodeURIComponent(encodedURI)
       projectDirectory = getProjectDirectoryFromKCLFilePath(
         filePathWithExtension,
-        defaultDirectoryLibraryPath
+        defaultLocalProjectLibraryPath
       )
     }
 
@@ -217,12 +223,12 @@ export function SystemIOMachineLogicListener() {
         systemIOActor.send({
           type: SystemIOMachineEvents.setProjectDirectoryPath,
           data: {
-            requestedProjectDirectoryPath: defaultDirectoryLibraryPath,
+            requestedProjectDirectoryPath: defaultLocalProjectLibraryPath,
           },
         })
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
-    }, [defaultDirectoryLibraryPath, pathname])
+    }, [defaultLocalProjectLibraryPath, pathname])
   }
 
   const useDefaultProjectName = () => {

--- a/src/lib/projectLibraries/index.ts
+++ b/src/lib/projectLibraries/index.ts
@@ -97,6 +97,21 @@ export function getDefaultDirectoryProjectLibraryPath(
   return getDefaultDirectoryProjectLibrarySetting(libraries)?.path
 }
 
+/**
+ * Return the local storage root used by legacy System IO workflows.
+ * Directory libraries take precedence, while cloud libraries provide their
+ * local materialization path when web has replaced the default directory.
+ */
+export function getDefaultLocalProjectLibraryPath(
+  libraries: readonly ProjectLibrarySetting[] | undefined
+) {
+  return (
+    getDefaultDirectoryProjectLibraryPath(libraries) ??
+    libraries?.find((library) => library.type === CLOUD_PROJECT_LIBRARY_TYPE)
+      ?.path
+  )
+}
+
 export function normalizeLibraryPath(path: string) {
   return path.replaceAll('\\', '/').replace(/\/+$/g, '')
 }

--- a/src/registry/contracts/projectLibraries.test.ts
+++ b/src/registry/contracts/projectLibraries.test.ts
@@ -7,6 +7,7 @@ import {
   getDefaultCloudProjectLibrarySetting,
   getDefaultDirectoryProjectLibraryPath,
   getDefaultDirectoryProjectLibrarySetting,
+  getDefaultLocalProjectLibraryPath,
   getProjectLibraryIdFromSetting,
   LEGACY_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH,
   moveProjectLibrarySetting,
@@ -213,6 +214,36 @@ describe('project library settings', () => {
   test('allows the project libraries setting to be absent', () => {
     expect(getDefaultDirectoryProjectLibraryPath(undefined)).toBeUndefined()
     expect(getDefaultDirectoryProjectLibrarySetting(undefined)).toBeUndefined()
+    expect(getDefaultLocalProjectLibraryPath(undefined)).toBeUndefined()
+  })
+
+  test('uses a cloud materialization path when no directory library exists', () => {
+    expect(
+      getDefaultLocalProjectLibraryPath([
+        {
+          title: 'Personal Cloud',
+          path: '/documents/zoo-modeling-app-projects',
+          type: 'cloud',
+        },
+      ])
+    ).toBe('/documents/zoo-modeling-app-projects')
+  })
+
+  test('prefers a directory library over a cloud materialization path', () => {
+    expect(
+      getDefaultLocalProjectLibraryPath([
+        {
+          title: 'Personal Cloud',
+          path: '/documents/zoo-modeling-app-projects',
+          type: 'cloud',
+        },
+        {
+          title: 'Client Projects',
+          path: '/client-projects',
+          type: 'directory',
+        },
+      ])
+    ).toBe('/client-projects')
   })
 
   test('finds the most specific directory library containing a project path', () => {


### PR DESCRIPTION
Replay onboarding is currently broken on the web app when cloud projects are enabled. If you go to `Settings → Replay onboarding`, it fails with `Unable to determine the project directory.`

It looks like onboarding still expects the old directory-library setup, but the web app now uses a Personal Cloud library instead. This change falls back to the cloud library local OPFS path when there is no directory library, which allows the existing onboarding flow to create and open `tutorial-project`.

I think this is probably a reasonable short-term fix. Anything written into that local cloud path should be picked up by the cloud filesystem observer and enrolled for sync, so it should still end up as a cloud project. That said, it is a bit indirect because onboarding is not actually using the cloud library `createProject` operation.

A better long-term fix might be to make the project-library abstraction support creating a project from a set of template files. Onboarding needs to write a few predefined files, overwrite an existing `tutorial-project`, and then navigate into a specific onboarding route, so it does not quite fit the normal blank-project creation flow.

I added unit coverage for choosing the cloud path when there is no directory library, along with a web E2E test that enables cloud projects and replays onboarding from the home page. The test verifies that the tutorial opens at `tutorial-project/main.kcl`, that the expected cold-plate code is written into OPFS, that cloud sync sends a project-create request, and that the returned cloud project ID is persisted to `project.toml`.

I am not completely sure whether we want to keep this smaller fix or move onboarding over to the project-library flow now, so I would appreciate any thoughts.