### PR TITLE
Create a fresh tutorial project on onboarding replay

### DIFF
--- a/e2e/playwright/onboarding-tests.spec.ts
+++ b/e2e/playwright/onboarding-tests.spec.ts
@@ -76,7 +76,7 @@ test.describe('Onboarding tests', { tag: ['@desktop'] }, () => {
       })
     })
 
-    await test.step('Resetting onboarding from inside project should always overwrite `tutorial-project`', async () => {
+    await test.step('Replaying onboarding from settings creates a deduplicated project', async () => {
       await test.step('Reset onboarding from settings', async () => {
         await userMenuButton.click()
         await userMenuSettingsButton.click()
@@ -89,7 +89,7 @@ test.describe('Onboarding tests', { tag: ['@desktop'] }, () => {
       })
 
       await test.step('Gets to the onboarding start', async () => {
-        await expect(toolbar.projectName).toContainText('tutorial-project')
+        await expect(toolbar.projectName).toHaveText('tutorial-project-1')
         await expect(tutorialWelcomeHeading).toBeVisible()
       })
 
@@ -99,22 +99,25 @@ test.describe('Onboarding tests', { tag: ['@desktop'] }, () => {
         await expect.poll(() => page.url()).not.toContain('/onboarding')
       })
 
-      await test.step("Verify an additional project wasn't created", async () => {
+      await test.step('Verify the replay project was created', async () => {
         await toolbar.logoLink.click()
         await expect(homePage.tutorialBtn).not.toBeVisible()
         await homePage.expectState({
-          projectCards: [{ title: 'tutorial-project', fileCount: 2 }],
+          projectCards: [
+            { title: 'tutorial-project', fileCount: 2 },
+            { title: 'tutorial-project-1', fileCount: 1 },
+          ],
           sortBy: 'last-modified-desc',
         })
       })
     })
 
-    await test.step('Resetting onboarding from home help menu overwrites the `tutorial-project`', async () => {
+    await test.step('Replaying onboarding from Help creates another deduplicated project', async () => {
       await helpMenuButton.click()
       await helpMenuRestartOnboardingButton.click()
 
       await test.step('Gets to the onboarding start', async () => {
-        await expect(toolbar.projectName).toContainText('tutorial-project')
+        await expect(toolbar.projectName).toHaveText('tutorial-project-2')
         await expect(tutorialWelcomeHeading).toBeVisible()
       })
 
@@ -124,11 +127,15 @@ test.describe('Onboarding tests', { tag: ['@desktop'] }, () => {
         await expect.poll(() => page.url()).not.toContain('/onboarding')
       })
 
-      await test.step('Verify no new projects were created', async () => {
+      await test.step('Verify another replay project was created', async () => {
         await toolbar.logoLink.click()
         await expect(homePage.tutorialBtn).not.toBeVisible()
         await homePage.expectState({
-          projectCards: [{ title: 'tutorial-project', fileCount: 2 }],
+          projectCards: [
+            { title: 'tutorial-project', fileCount: 2 },
+            { title: 'tutorial-project-1', fileCount: 1 },
+            { title: 'tutorial-project-2', fileCount: 1 },
+          ],
           sortBy: 'last-modified-desc',
         })
       })

--- a/e2e/playwright/onboarding-tests.spec.ts
+++ b/e2e/playwright/onboarding-tests.spec.ts
@@ -5,7 +5,6 @@ test.describe('Onboarding tests', { tag: ['@desktop'] }, () => {
     page,
     homePage,
     toolbar,
-    editor,
     tronApp,
   }) => {
     if (!tronApp) throw new Error('tronApp is missing.')
@@ -76,8 +75,8 @@ test.describe('Onboarding tests', { tag: ['@desktop'] }, () => {
       })
     })
 
-    await test.step('Replaying onboarding from settings creates a deduplicated project', async () => {
-      await test.step('Reset onboarding from settings', async () => {
+    await test.step('Replaying onboarding from settings creates a uniquely named project', async () => {
+      await test.step('Replay onboarding from settings', async () => {
         await userMenuButton.click()
         await userMenuSettingsButton.click()
         await expect(settingsHeading).toBeVisible()
@@ -112,7 +111,7 @@ test.describe('Onboarding tests', { tag: ['@desktop'] }, () => {
       })
     })
 
-    await test.step('Replaying onboarding from Help creates another deduplicated project', async () => {
+    await test.step('Replaying onboarding from Help creates another uniquely named project', async () => {
       await helpMenuButton.click()
       await helpMenuRestartOnboardingButton.click()
 

--- a/e2e/playwright/onboarding-web.spec.ts
+++ b/e2e/playwright/onboarding-web.spec.ts
@@ -1,5 +1,6 @@
 import {
   type CloudProject,
+  createRemoteListGate,
   opfsPathExists,
   PROJECT_DIR,
   readOpfsTextFiles,
@@ -43,8 +44,10 @@ test(
   async ({ context, page }, testInfo) => {
     const remoteProjects: CloudProject[] = []
     const remoteRevisions = new Map<string, number>()
+    const remoteListGate = createRemoteListGate()
     const { calls: apiCalls } = await routeCloudProjects(context, {
       remoteProjects,
+      remoteListGate,
       createProject: () => {
         const index = remoteProjects.length
         const id = TUTORIAL_PROJECT_IDS[index]
@@ -84,8 +87,6 @@ test(
     await setup(context, page, testInfo, [OPFS_CLOUD_FEATURE_FLAG])
 
     await replayOnboardingFromSettings(page, 'tutorial-project')
-    await expect.poll(() => apiCalls.creates.length).toBe(1)
-    expect(apiCalls.creates[0]).toContain('tutorial-project')
     await expect
       .poll(async () => {
         const files = await readOpfsTextFiles(page, {
@@ -94,6 +95,38 @@ test(
         return files.main
       })
       .toContain('plateLength = 10')
+
+    await page.keyboard.press('Escape')
+    await expect(page.getByTestId('onboarding-content')).not.toBeVisible()
+    await expect.poll(() => page.url()).not.toContain('/onboarding')
+    await page.getByTestId('app-logo').click()
+    await expect(
+      page.getByRole('heading', {
+        name: /^(Project Libraries|Personal Cloud)$/,
+      })
+    ).toBeVisible()
+    const tutorialProjectLink = page.getByTestId('project-link').filter({
+      has: page
+        .getByTestId('project-title')
+        .filter({ hasText: /^tutorial-project$/ }),
+    })
+    await expect(tutorialProjectLink).toHaveCount(1)
+    await expect(
+      tutorialProjectLink.getByTestId('project-file-count')
+    ).toHaveText('1')
+    remoteListGate.release()
+    await expect.poll(() => apiCalls.creates.length).toBe(1)
+    expect(apiCalls.creates[0]).toContain('tutorial-project')
+    await expect
+      .poll(() => apiCalls.remoteListResponses)
+      .toBeGreaterThanOrEqual(1)
+    await expect(tutorialProjectLink).toHaveCount(1)
+    await expect(
+      tutorialProjectLink.getByTestId('project-file-count')
+    ).toHaveText('1')
+    await tutorialProjectLink.click()
+    await expect(page).toHaveURL(/tutorial-project%2Fmain\.kcl$/)
+
     await page.evaluate(async (mainPath) => {
       await window.fsZds.writeFile(
         mainPath,

--- a/e2e/playwright/onboarding-web.spec.ts
+++ b/e2e/playwright/onboarding-web.spec.ts
@@ -1,5 +1,6 @@
 import {
   type CloudProject,
+  opfsPathExists,
   PROJECT_DIR,
   readOpfsTextFiles,
   routeCloudProjects,
@@ -8,9 +9,15 @@ import { setup } from '@e2e/playwright/test-utils'
 import { expect, type Page, test } from '@playwright/test'
 import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
 
-const TUTORIAL_PROJECT_ID = '12902000-0000-4000-8000-000000000001'
+const TUTORIAL_PROJECT_IDS = [
+  '12902000-0000-4000-8000-000000000001',
+  '12902000-0000-4000-8000-000000000002',
+] as const
 
-async function replayOnboardingFromSettings(page: Page) {
+async function replayOnboardingFromSettings(
+  page: Page,
+  expectedProjectName: string
+) {
   await page.goto('/')
   await expect(
     page.getByRole('heading', {
@@ -24,43 +31,59 @@ async function replayOnboardingFromSettings(page: Page) {
   ).toBeVisible()
   await page.getByRole('button', { name: 'Replay onboarding' }).click()
 
-  await expect(page).toHaveURL(/tutorial-project%2Fmain\.kcl\/onboarding\//)
+  await expect(page).toHaveURL(
+    new RegExp(`${expectedProjectName}%2Fmain\\.kcl/onboarding/`)
+  )
   await expect(page.getByText('Welcome to Zoo Design Studio')).toBeVisible()
 }
 
 test(
-  'Replay onboarding creates and reuses the Personal Cloud tutorial',
+  'Replay onboarding creates a deduplicated Personal Cloud tutorial',
   { tag: '@web' },
   async ({ context, page }, testInfo) => {
     const remoteProjects: CloudProject[] = []
-    let remoteRevision = 1
+    const remoteRevisions = new Map<string, number>()
     const { calls: apiCalls } = await routeCloudProjects(context, {
       remoteProjects,
       createProject: () => {
+        const index = remoteProjects.length
+        const id = TUTORIAL_PROJECT_IDS[index]
+        if (!id) {
+          throw new Error('Unexpected extra tutorial project creation.')
+        }
+        const title =
+          index === 0 ? 'tutorial-project' : `tutorial-project-${index}`
         const project = {
-          id: TUTORIAL_PROJECT_ID,
-          title: 'tutorial-project',
-          revision: 'tutorial-project-rev-1',
+          id,
+          title,
+          revision: `${id}-rev-1`,
           files: {},
         }
         remoteProjects.push(project)
+        remoteRevisions.set(id, 1)
         return project
       },
       updateProject: ({ projectId }) => {
-        remoteRevision += 1
-        const revision = `tutorial-project-rev-${remoteRevision}`
-        if (remoteProjects[0]) {
-          remoteProjects[0].revision = revision
+        const project = remoteProjects.find(({ id }) => id === projectId)
+        if (!project) {
+          return undefined
         }
+        const revision = (remoteRevisions.get(project.id) ?? 1) + 1
+        remoteRevisions.set(project.id, revision)
+        project.revision = `${project.id}-rev-${revision}`
         return {
           status: 200,
-          body: { id: projectId, title: 'tutorial-project', revision },
+          body: {
+            id: project.id,
+            title: project.title,
+            revision: project.revision,
+          },
         }
       },
     })
     await setup(context, page, testInfo, [OPFS_CLOUD_FEATURE_FLAG])
 
-    await replayOnboardingFromSettings(page)
+    await replayOnboardingFromSettings(page, 'tutorial-project')
     await expect.poll(() => apiCalls.creates.length).toBe(1)
     await page.evaluate(async (mainPath) => {
       await window.fsZds.writeFile(
@@ -69,21 +92,55 @@ test(
       )
     }, `${PROJECT_DIR}/tutorial-project/main.kcl`)
     await expect.poll(() => apiCalls.updates.length).toBeGreaterThanOrEqual(1)
-    await replayOnboardingFromSettings(page)
 
-    const tutorialFiles = await readOpfsTextFiles(page, {
-      main: `${PROJECT_DIR}/tutorial-project/main.kcl`,
-      settings: `${PROJECT_DIR}/tutorial-project/project.toml`,
-    })
-    expect(tutorialFiles.main).toContain('plateLength = 10')
-    await expect.poll(() => apiCalls.updates.length).toBeGreaterThanOrEqual(2)
+    await replayOnboardingFromSettings(page, 'tutorial-project-1')
+    await expect.poll(() => apiCalls.creates.length).toBe(2)
+    expect(apiCalls.creates[1]).toContain('tutorial-project-1')
+
+    await page.getByTestId('onboarding-next').click()
+    await expect(page).toHaveURL(
+      /tutorial-project-1%2Fblank\.kcl\/onboarding\/desktop\/scene/
+    )
+    await expect
+      .poll(() =>
+        opfsPathExists(page, `${PROJECT_DIR}/tutorial-project-1/blank.kcl`)
+      )
+      .toBe(true)
+    expect(
+      await opfsPathExists(page, `${PROJECT_DIR}/tutorial-project/blank.kcl`)
+    ).toBe(false)
+
+    await page.goto(
+      `/file/${encodeURIComponent(
+        `${PROJECT_DIR}/tutorial-project-1/main.kcl`
+      )}/onboarding/desktop/prompt-to-edit-result`
+    )
+    await expect(page).toHaveURL(
+      /tutorial-project-1%2Fmain\.kcl\/onboarding\/desktop\/prompt-to-edit-result/
+    )
     await expect
       .poll(async () => {
         const files = await readOpfsTextFiles(page, {
-          settings: `${PROJECT_DIR}/tutorial-project/project.toml`,
+          replayMain: `${PROJECT_DIR}/tutorial-project-1/main.kcl`,
         })
-        return files.settings
+        return files.replayMain
       })
-      .toContain(`project_id = "${TUTORIAL_PROJECT_ID}"`)
+      .toContain('plateLength = 12')
+
+    const tutorialFiles = await readOpfsTextFiles(page, {
+      originalMain: `${PROJECT_DIR}/tutorial-project/main.kcl`,
+      originalSettings: `${PROJECT_DIR}/tutorial-project/project.toml`,
+      replayMain: `${PROJECT_DIR}/tutorial-project-1/main.kcl`,
+      replaySettings: `${PROJECT_DIR}/tutorial-project-1/project.toml`,
+    })
+    expect(tutorialFiles.originalMain).toBe('changed = true')
+    expect(tutorialFiles.replayMain).toContain('plateLength = 12')
+    expect(tutorialFiles.originalSettings).toContain(
+      `project_id = "${TUTORIAL_PROJECT_IDS[0]}"`
+    )
+    expect(tutorialFiles.replaySettings).toContain(
+      `project_id = "${TUTORIAL_PROJECT_IDS[1]}"`
+    )
+    expect(apiCalls.creates).toHaveLength(2)
   }
 )

--- a/e2e/playwright/onboarding-web.spec.ts
+++ b/e2e/playwright/onboarding-web.spec.ts
@@ -38,7 +38,7 @@ async function replayOnboardingFromSettings(
 }
 
 test(
-  'Replay onboarding creates a deduplicated Personal Cloud tutorial',
+  'Replay onboarding creates a uniquely named Personal Cloud tutorial',
   { tag: '@web' },
   async ({ context, page }, testInfo) => {
     const remoteProjects: CloudProject[] = []
@@ -85,6 +85,15 @@ test(
 
     await replayOnboardingFromSettings(page, 'tutorial-project')
     await expect.poll(() => apiCalls.creates.length).toBe(1)
+    expect(apiCalls.creates[0]).toContain('tutorial-project')
+    await expect
+      .poll(async () => {
+        const files = await readOpfsTextFiles(page, {
+          main: `${PROJECT_DIR}/tutorial-project/main.kcl`,
+        })
+        return files.main
+      })
+      .toContain('plateLength = 10')
     await page.evaluate(async (mainPath) => {
       await window.fsZds.writeFile(
         mainPath,
@@ -96,6 +105,14 @@ test(
     await replayOnboardingFromSettings(page, 'tutorial-project-1')
     await expect.poll(() => apiCalls.creates.length).toBe(2)
     expect(apiCalls.creates[1]).toContain('tutorial-project-1')
+    await expect
+      .poll(async () => {
+        const files = await readOpfsTextFiles(page, {
+          main: `${PROJECT_DIR}/tutorial-project-1/main.kcl`,
+        })
+        return files.main
+      })
+      .toContain('plateLength = 10')
 
     await page.getByTestId('onboarding-next').click()
     await expect(page).toHaveURL(
@@ -126,6 +143,13 @@ test(
         return files.replayMain
       })
       .toContain('plateLength = 12')
+    await expect
+      .poll(() =>
+        apiCalls.updates.some(
+          ({ projectId }) => projectId === TUTORIAL_PROJECT_IDS[1]
+        )
+      )
+      .toBe(true)
 
     const tutorialFiles = await readOpfsTextFiles(page, {
       originalMain: `${PROJECT_DIR}/tutorial-project/main.kcl`,

--- a/e2e/playwright/onboarding-web.spec.ts
+++ b/e2e/playwright/onboarding-web.spec.ts
@@ -1,0 +1,89 @@
+import {
+  type CloudProject,
+  PROJECT_DIR,
+  readOpfsTextFiles,
+  routeCloudProjects,
+} from '@e2e/playwright/lib/cloudSyncTestUtils'
+import { setup } from '@e2e/playwright/test-utils'
+import { expect, type Page, test } from '@playwright/test'
+import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
+
+const TUTORIAL_PROJECT_ID = '12902000-0000-4000-8000-000000000001'
+
+async function replayOnboardingFromSettings(page: Page) {
+  await page.goto('/')
+  await expect(
+    page.getByRole('heading', {
+      name: /^(Project Libraries|Personal Cloud)$/,
+    })
+  ).toBeVisible()
+
+  await page.getByRole('link', { name: 'Settings' }).last().click()
+  await expect(
+    page.getByRole('heading', { name: 'Settings', exact: true })
+  ).toBeVisible()
+  await page.getByRole('button', { name: 'Replay onboarding' }).click()
+
+  await expect(page).toHaveURL(/tutorial-project%2Fmain\.kcl\/onboarding\//)
+  await expect(page.getByText('Welcome to Zoo Design Studio')).toBeVisible()
+}
+
+test(
+  'Replay onboarding creates and reuses the Personal Cloud tutorial',
+  { tag: '@web' },
+  async ({ context, page }, testInfo) => {
+    const remoteProjects: CloudProject[] = []
+    let remoteRevision = 1
+    const { calls: apiCalls } = await routeCloudProjects(context, {
+      remoteProjects,
+      createProject: () => {
+        const project = {
+          id: TUTORIAL_PROJECT_ID,
+          title: 'tutorial-project',
+          revision: 'tutorial-project-rev-1',
+          files: {},
+        }
+        remoteProjects.push(project)
+        return project
+      },
+      updateProject: ({ projectId }) => {
+        remoteRevision += 1
+        const revision = `tutorial-project-rev-${remoteRevision}`
+        if (remoteProjects[0]) {
+          remoteProjects[0].revision = revision
+        }
+        return {
+          status: 200,
+          body: { id: projectId, title: 'tutorial-project', revision },
+        }
+      },
+    })
+    await setup(context, page, testInfo, [OPFS_CLOUD_FEATURE_FLAG])
+
+    await replayOnboardingFromSettings(page)
+    await expect.poll(() => apiCalls.creates.length).toBe(1)
+    await page.evaluate(async (mainPath) => {
+      await window.fsZds.writeFile(
+        mainPath,
+        new TextEncoder().encode('changed = true')
+      )
+    }, `${PROJECT_DIR}/tutorial-project/main.kcl`)
+    await expect.poll(() => apiCalls.updates.length).toBeGreaterThanOrEqual(1)
+    await replayOnboardingFromSettings(page)
+
+    const tutorialFiles = await readOpfsTextFiles(page, {
+      main: `${PROJECT_DIR}/tutorial-project/main.kcl`,
+      settings: `${PROJECT_DIR}/tutorial-project/project.toml`,
+    })
+    expect(tutorialFiles.main).toContain('plateLength = 10')
+    await expect.poll(() => apiCalls.updates.length).toBeGreaterThanOrEqual(2)
+    await expect
+      .poll(async () => {
+        const files = await readOpfsTextFiles(page, {
+          settings: `${PROJECT_DIR}/tutorial-project/project.toml`,
+        })
+        return files.settings
+      })
+      .toContain(`project_id = "${TUTORIAL_PROJECT_ID}"`)
+  }
+)

--- a/src/components/HelpMenu.tsx
+++ b/src/components/HelpMenu.tsx
@@ -20,13 +20,15 @@ const HelpMenuDivider = () => (
 )
 
 export function HelpMenu() {
-  const { settings, systemIOActor } = useApp()
+  const app = useApp()
+  const { settings, systemIOActor } = app
   const { kclManager } = useSingletons()
   const navigate = useNavigate()
   const filePath = useAbsoluteFilePath({ warnIfNoExecutingPath: false })
 
   const resetOnboardingWorkflow = () => {
     const props = {
+      app,
       onboardingStatus: onboardingStartPath,
       navigate,
       kclManager,

--- a/src/components/HelpMenu.tsx
+++ b/src/components/HelpMenu.tsx
@@ -26,7 +26,7 @@ export function HelpMenu() {
   const navigate = useNavigate()
   const filePath = useAbsoluteFilePath({ warnIfNoExecutingPath: false })
 
-  const resetOnboardingWorkflow = () => {
+  const replayOnboardingWorkflow = () => {
     const props = {
       app,
       onboardingStatus: onboardingStartPath,
@@ -41,7 +41,7 @@ export function HelpMenu() {
 
   const cb = (data: WebContentSendPayload) => {
     if (data.menuLabel === 'Help.Replay onboarding tutorial') {
-      resetOnboardingWorkflow()
+      replayOnboardingWorkflow()
     }
   }
   useMenuListener(cb)
@@ -143,7 +143,7 @@ export function HelpMenu() {
               as="button"
               onClick={() => {
                 close()
-                resetOnboardingWorkflow()
+                replayOnboardingWorkflow()
               }}
             >
               Replay onboarding tutorial

--- a/src/components/HelpMenu.tsx
+++ b/src/components/HelpMenu.tsx
@@ -4,7 +4,7 @@ import { defaultStatusBarItemClassNames } from '@src/components/StatusBar/Status
 import Tooltip from '@src/components/Tooltip'
 import { useAbsoluteFilePath } from '@src/hooks/useAbsoluteFilePath'
 import { useMenuListener } from '@src/hooks/useMenu'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp } from '@src/lib/boot'
 import { isDesktop } from '@src/lib/isDesktop'
 import { onboardingStartPath } from '@src/lib/onboardingPaths'
 import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
@@ -12,7 +12,10 @@ import { PATHS } from '@src/lib/paths'
 import { reportRejection } from '@src/lib/trap'
 import { withSiteBaseURL } from '@src/lib/withBaseURL'
 import type { WebContentSendPayload } from '@src/menu/channels'
-import { acceptOnboarding } from '@src/routes/Onboarding/utils'
+import {
+  acceptOnboarding,
+  reportOnboardingStartFailure,
+} from '@src/routes/Onboarding/utils'
 import { useNavigate } from 'react-router-dom'
 
 const HelpMenuDivider = () => (
@@ -21,22 +24,15 @@ const HelpMenuDivider = () => (
 
 export function HelpMenu() {
   const app = useApp()
-  const { settings, systemIOActor } = app
-  const { kclManager } = useSingletons()
   const navigate = useNavigate()
   const filePath = useAbsoluteFilePath({ warnIfNoExecutingPath: false })
 
   const replayOnboardingWorkflow = () => {
-    const props = {
+    void acceptOnboarding({
       app,
       onboardingStatus: onboardingStartPath,
       navigate,
-      kclManager,
-      systemIOActor,
-      settingsActor: settings.actor,
-      executingPath: filePath,
-    }
-    acceptOnboarding(props)
+    }).catch(reportOnboardingStartFailure)
   }
 
   const cb = (data: WebContentSendPayload) => {

--- a/src/components/OpenedProject.tsx
+++ b/src/components/OpenedProject.tsx
@@ -251,10 +251,7 @@ export function OpenedProject() {
             app,
             onboardingStatus: settingsValues.app.onboardingStatus.current,
             navigate,
-            kclManager,
             accountUrl: withSiteBaseURL('/account'),
-            systemIOActor,
-            settingsActor,
           }),
         {
           id: ONBOARDING_TOAST_ID,
@@ -272,9 +269,6 @@ export function OpenedProject() {
     navigate,
     searchParams.size,
     authToken,
-    kclManager,
-    systemIOActor,
-    settingsActor,
   ])
 
   // This is, at time of writing, the only spot we need @preact/signals-react,

--- a/src/components/OpenedProject.tsx
+++ b/src/components/OpenedProject.tsx
@@ -248,6 +248,7 @@ export function OpenedProject() {
       toast.success(
         () =>
           TutorialRequestToast({
+            app,
             onboardingStatus: settingsValues.app.onboardingStatus.current,
             navigate,
             kclManager,

--- a/src/components/Settings/AllSettingsFields.tsx
+++ b/src/components/Settings/AllSettingsFields.tsx
@@ -44,7 +44,8 @@ export const AllSettingsFields = forwardRef(
     { searchParamTab, isFileSettings }: AllSettingsFieldsProps,
     scrollRef: ForwardedRef<HTMLDivElement>
   ) => {
-    const { settings, layout, systemIOActor, userFeatures } = useApp()
+    const app = useApp()
+    const { settings, layout, systemIOActor, userFeatures } = app
     const { kclManager } = useSingletons()
     const location = useLocation()
     const navigate = useNavigate()
@@ -73,6 +74,7 @@ export const AllSettingsFields = forwardRef(
 
     async function restartOnboarding() {
       const props = {
+        app,
         onboardingStatus: onboardingStartPath,
         navigate,
         kclManager,

--- a/src/components/Settings/AllSettingsFields.tsx
+++ b/src/components/Settings/AllSettingsFields.tsx
@@ -2,8 +2,7 @@ import { ActionButton } from '@src/components/ActionButton'
 import type { Feature } from '@kittycad/lib'
 import { SettingsFieldInput } from '@src/components/Settings/SettingsFieldInput'
 import { SettingsSection } from '@src/components/Settings/SettingsSection'
-import { useAbsoluteFilePath } from '@src/hooks/useAbsoluteFilePath'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp } from '@src/lib/boot'
 import { getSettingsFolderPaths } from '@src/lib/desktopFS'
 import { isDesktop } from '@src/lib/isDesktop'
 import { onboardingStartPath } from '@src/lib/onboardingPaths'
@@ -26,7 +25,10 @@ import {
 import { reportRejection } from '@src/lib/trap'
 import { capitaliseFC, toSync } from '@src/lib/utils'
 import { userFeaturesContextHas } from '@src/machines/userFeaturesMachine'
-import { acceptOnboarding } from '@src/routes/Onboarding/utils'
+import {
+  acceptOnboarding,
+  reportOnboardingStartFailure,
+} from '@src/routes/Onboarding/utils'
 import { APP_VERSION, getReleaseUrl } from '@src/routes/utils'
 import type { ForwardedRef } from 'react'
 import { forwardRef, useMemo } from 'react'
@@ -45,16 +47,13 @@ export const AllSettingsFields = forwardRef(
     scrollRef: ForwardedRef<HTMLDivElement>
   ) => {
     const app = useApp()
-    const { settings, layout, systemIOActor, userFeatures } = app
-    const { kclManager } = useSingletons()
+    const { settings, layout, userFeatures } = app
     const location = useLocation()
     const navigate = useNavigate()
     const context = settings.useSettings()
     const userFeaturesContext = userFeatures.useContext()
     const hasFeature = (feature: Feature) =>
       userFeaturesContextHas(userFeaturesContext, feature, false)
-    const executingPath = useAbsoluteFilePath()
-
     const projectPath = useMemo(() => {
       const filteredPathname = location.pathname
         .replace(PATHS.FILE, '')
@@ -72,17 +71,12 @@ export const AllSettingsFields = forwardRef(
       return projectPath
     }, [location.pathname, isFileSettings])
 
-    async function restartOnboarding() {
-      const props = {
+    function restartOnboarding() {
+      return acceptOnboarding({
         app,
         onboardingStatus: onboardingStartPath,
         navigate,
-        kclManager,
-        systemIOActor,
-        settingsActor: settings.actor,
-        executingPath,
-      }
-      acceptOnboarding(props)
+      })
     }
 
     return (
@@ -163,7 +157,7 @@ export const AllSettingsFields = forwardRef(
             <ActionButton
               Element="button"
               onClick={() => {
-                restartOnboarding().catch(reportRejection)
+                void restartOnboarding().catch(reportOnboardingStartFailure)
               }}
               iconStart={{
                 icon: 'refresh',

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -1059,6 +1059,7 @@ export const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
             wasmInstancePromise,
             initialKclFile,
           })
+          refreshLocalCloudProjectEntries()
 
           if (cloudSyncStatus.value.enabled) {
             await ctx.services

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -1044,6 +1044,8 @@ export const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
           library,
           requestedProjectName,
           requestedProjectTitle,
+          initialKclFile,
+          reuseExistingProject,
         }) => {
           const wasmInstancePromise = getWasmPromise()
           if (wasmInstancePromise instanceof Error) {
@@ -1056,6 +1058,8 @@ export const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
             requestedProjectName,
             requestedProjectTitle,
             wasmInstancePromise,
+            initialKclFile,
+            reuseExistingProject,
           })
 
           if (cloudSyncStatus.value.enabled) {

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -1045,7 +1045,6 @@ export const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
           requestedProjectName,
           requestedProjectTitle,
           initialKclFile,
-          reuseExistingProject,
         }) => {
           const wasmInstancePromise = getWasmPromise()
           if (wasmInstancePromise instanceof Error) {
@@ -1059,7 +1058,6 @@ export const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
             requestedProjectTitle,
             wasmInstancePromise,
             initialKclFile,
-            reuseExistingProject,
           })
 
           if (cloudSyncStatus.value.enabled) {

--- a/src/lib/cloudSync/relationships.test.ts
+++ b/src/lib/cloudSync/relationships.test.ts
@@ -208,6 +208,32 @@ describe('deriveCloudProjectRelationships', () => {
       }),
     ])
   })
+
+  test('uses sync metadata to attach a cached realization without a cloud id', () => {
+    const localRealization = realization({
+      localProjectPath: '/cloud/tutorial-project',
+      libraryType: 'cloud',
+      cloudProjectId: undefined,
+    })
+
+    expect(
+      deriveCloudProjectRelationships({
+        realizations: [localRealization],
+        remoteProjects: [{ id: 'remote-123', title: 'tutorial-project' }],
+        metadata: [metadata({ localProjectPath: '/cloud/tutorial-project' })],
+      })
+    ).toEqual([
+      expect.objectContaining({
+        remoteProjectId: 'remote-123',
+        canonicalRealization: expect.objectContaining({
+          realization: localRealization,
+        }),
+        localRealizations: [
+          expect.objectContaining({ realization: localRealization }),
+        ],
+      }),
+    ])
+  })
 })
 
 describe('classifyCloudProjectDuplicateRisk', () => {

--- a/src/lib/cloudSync/relationships.ts
+++ b/src/lib/cloudSync/relationships.ts
@@ -278,7 +278,12 @@ function indexRelationshipInputs({
   }
 
   for (const realization of realizations) {
-    const remoteProjectId = realization.cloudProjectId?.trim()
+    const normalizedProjectPath = normalizePathForSync(
+      realization.localProjectPath
+    )
+    const remoteProjectId =
+      realization.cloudProjectId?.trim() ||
+      metadataByPath.get(normalizedProjectPath)?.remoteProjectId?.trim()
     if (!remoteProjectId) {
       continue
     }

--- a/src/lib/projectLibraries/operations.ts
+++ b/src/lib/projectLibraries/operations.ts
@@ -41,7 +41,6 @@ export async function createProjectInLocalDirectory({
   requestedProjectTitle,
   wasmInstancePromise,
   initialKclFile,
-  reuseExistingProject = false,
 }: {
   projectDirectoryPath: string
   requestedProjectName: string
@@ -51,16 +50,13 @@ export async function createProjectInLocalDirectory({
     fileName: string
     code: string
   }
-  reuseExistingProject?: boolean
 }): Promise<Project> {
   const existingProjectNames =
     await getProjectDirectoryEntryNames(projectDirectoryPath)
-  const uniqueProjectName = reuseExistingProject
-    ? requestedProjectName
-    : getUniqueProjectName(
-        requestedProjectName,
-        projectEntriesFromNames(projectDirectoryPath, existingProjectNames)
-      )
+  const uniqueProjectName = getUniqueProjectName(
+    requestedProjectName,
+    projectEntriesFromNames(projectDirectoryPath, existingProjectNames)
+  )
   const uniqueProjectTitle = getProjectTitleFromUniqueDirectoryName({
     requestedProjectTitle,
     requestedProjectDirectoryName: requestedProjectName,

--- a/src/lib/projectLibraries/operations.ts
+++ b/src/lib/projectLibraries/operations.ts
@@ -40,18 +40,27 @@ export async function createProjectInLocalDirectory({
   requestedProjectName,
   requestedProjectTitle,
   wasmInstancePromise,
+  initialKclFile,
+  reuseExistingProject = false,
 }: {
   projectDirectoryPath: string
   requestedProjectName: string
   requestedProjectTitle: string
   wasmInstancePromise: Promise<ModuleType> | ModuleType
+  initialKclFile?: {
+    fileName: string
+    code: string
+  }
+  reuseExistingProject?: boolean
 }): Promise<Project> {
   const existingProjectNames =
     await getProjectDirectoryEntryNames(projectDirectoryPath)
-  const uniqueProjectName = getUniqueProjectName(
-    requestedProjectName,
-    projectEntriesFromNames(projectDirectoryPath, existingProjectNames)
-  )
+  const uniqueProjectName = reuseExistingProject
+    ? requestedProjectName
+    : getUniqueProjectName(
+        requestedProjectName,
+        projectEntriesFromNames(projectDirectoryPath, existingProjectNames)
+      )
   const uniqueProjectTitle = getProjectTitleFromUniqueDirectoryName({
     requestedProjectTitle,
     requestedProjectDirectoryName: requestedProjectName,
@@ -61,9 +70,9 @@ export async function createProjectInLocalDirectory({
   return createNewProjectDirectory(
     uniqueProjectName,
     await wasmInstancePromise,
+    initialKclFile?.code,
     undefined,
-    undefined,
-    undefined,
+    initialKclFile?.fileName,
     projectDirectoryPath,
     uniqueProjectTitle
   )

--- a/src/lib/projectLibraries/registry/index.ts
+++ b/src/lib/projectLibraries/registry/index.ts
@@ -636,7 +636,13 @@ const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
 
   const operations: ProjectLibraryTypeOperations = {
     createProject: {
-      run: async ({ library, requestedProjectName, requestedProjectTitle }) => {
+      run: async ({
+        library,
+        requestedProjectName,
+        requestedProjectTitle,
+        initialKclFile,
+        reuseExistingProject,
+      }) => {
         const wasmInstancePromise = getWasmPromise()
         if (wasmInstancePromise instanceof Error) {
           return Promise.reject(wasmInstancePromise)
@@ -647,6 +653,8 @@ const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
           requestedProjectName,
           requestedProjectTitle,
           wasmInstancePromise,
+          initialKclFile,
+          reuseExistingProject,
         })
         refreshLocalProjectRealizations(library)
 

--- a/src/lib/projectLibraries/registry/index.ts
+++ b/src/lib/projectLibraries/registry/index.ts
@@ -641,7 +641,6 @@ const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
         requestedProjectName,
         requestedProjectTitle,
         initialKclFile,
-        reuseExistingProject,
       }) => {
         const wasmInstancePromise = getWasmPromise()
         if (wasmInstancePromise instanceof Error) {
@@ -654,7 +653,6 @@ const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
           requestedProjectTitle,
           wasmInstancePromise,
           initialKclFile,
-          reuseExistingProject,
         })
         refreshLocalProjectRealizations(library)
 

--- a/src/registry/contracts/projectLibraries.ts
+++ b/src/registry/contracts/projectLibraries.ts
@@ -144,7 +144,6 @@ export interface ProjectLibraryCreateProjectInput {
     fileName: string
     code: string
   }
-  reuseExistingProject?: boolean
 }
 
 export interface ProjectLibraryProjectInput {

--- a/src/registry/contracts/projectLibraries.ts
+++ b/src/registry/contracts/projectLibraries.ts
@@ -140,6 +140,11 @@ export interface ProjectLibraryCreateProjectInput {
   library: ProjectLibrary
   requestedProjectName: string
   requestedProjectTitle: string
+  initialKclFile?: {
+    fileName: string
+    code: string
+  }
+  reuseExistingProject?: boolean
 }
 
 export interface ProjectLibraryProjectInput {

--- a/src/registry/contracts/projectLibraries.ts
+++ b/src/registry/contracts/projectLibraries.ts
@@ -140,6 +140,7 @@ export interface ProjectLibraryCreateProjectInput {
   library: ProjectLibrary
   requestedProjectName: string
   requestedProjectTitle: string
+  /** Optional KCL file to write before publishing the new project. */
   initialKclFile?: {
     fileName: string
     code: string

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -419,6 +419,7 @@ const Home = () => {
                   Element="button"
                   onClick={() => {
                     acceptOnboarding({
+                      app,
                       onboardingStatus,
                       navigate,
                       kclManager,

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -14,7 +14,6 @@ import {
 } from '@src/components/StatusBar/defaultStatusBarItems'
 import { StatusBar } from '@src/components/StatusBar/StatusBar'
 import Tooltip from '@src/components/Tooltip'
-import { useAbsoluteFilePath } from '@src/hooks/useAbsoluteFilePath'
 import { useMenuListener } from '@src/hooks/useMenu'
 import {
   type ProjectStatus,
@@ -80,6 +79,7 @@ import {
   acceptOnboarding,
   needsToOnboard,
   onDismissOnboardingInvite,
+  reportOnboardingStartFailure,
 } from '@src/routes/Onboarding/utils'
 import type { HTMLProps } from 'react'
 import { useEffect, useState } from 'react'
@@ -99,18 +99,9 @@ const PROJECT_LIBRARY_PREVIEW_LIMIT = 6
 const Home = () => {
   useSignals()
   const app = useApp()
-  const {
-    auth,
-    billing,
-    commands,
-    settings,
-    systemIOActor,
-    registry,
-    userFeatures,
-  } = app
+  const { auth, billing, commands, settings, registry, userFeatures } = app
   const keymap = registry.optional(keymapService)
   const { kclManager } = useSingletons()
-  const executingPath = useAbsoluteFilePath({ warnIfNoExecutingPath: false })
   const settingsActor = settings.actor
   useQueryParamEffects(kclManager)
 
@@ -418,15 +409,11 @@ const Home = () => {
                 <ActionButton
                   Element="button"
                   onClick={() => {
-                    acceptOnboarding({
+                    void acceptOnboarding({
                       app,
                       onboardingStatus,
                       navigate,
-                      kclManager,
-                      systemIOActor,
-                      settingsActor,
-                      executingPath,
-                    })
+                    }).catch(reportOnboardingStartFailure)
                   }}
                   className={`${sidebarButtonClasses} !text-primary flex-1`}
                   iconStart={{

--- a/src/routes/Onboarding/DesktopOnboardingRoutes.tsx
+++ b/src/routes/Onboarding/DesktopOnboardingRoutes.tsx
@@ -1,9 +1,6 @@
 import { Spinner } from '@src/components/Spinner'
 import { useApp } from '@src/lib/boot'
-import {
-  ONBOARDING_PROJECT_NAME,
-  SEARCH_PARAM_ZOOKEEPER_PROMPT_KEY,
-} from '@src/lib/constants'
+import { SEARCH_PARAM_ZOOKEEPER_PROMPT_KEY } from '@src/lib/constants'
 import { modifiedColdPlate } from '@src/lib/exampleKcl'
 import { DefaultLayoutPaneID } from '@src/lib/layout'
 import {
@@ -58,9 +55,13 @@ const onboardingComponents: Record<DesktopOnboardingPath, React.JSX.Element> = {
   '/desktop/conclusion': <OnboardingConclusion />,
 }
 
+function useOnboardingProjectName() {
+  return useApp().project?.name
+}
+
 function Welcome() {
-  const app = useApp()
   const { systemIOActor } = useApp()
+  const projectName = useOnboardingProjectName()
   const thisOnboardingStatus: DesktopOnboardingPath = '/desktop'
 
   // Ensure panes are closed
@@ -68,11 +69,14 @@ function Welcome() {
 
   // Things that happen when we load this route
   useEffect(() => {
+    if (!projectName) {
+      return
+    }
     // Navigate to the `main.kcl` file
     systemIOActor.send({
       type: SystemIOMachineEvents.navigateToFile,
       data: {
-        requestedProjectName: app.project?.name || ONBOARDING_PROJECT_NAME,
+        requestedProjectName: projectName,
         requestedFileName: 'main.kcl',
         requestedSubRoute: joinRouterPaths(
           String(PATHS.ONBOARDING),
@@ -80,7 +84,7 @@ function Welcome() {
         ),
       },
     })
-  }, [systemIOActor, app.project?.name])
+  }, [systemIOActor, projectName])
 
   return (
     <div className="cursor-not-allowed fixed inset-0 z-50 grid items-end justify-center p-2">
@@ -101,6 +105,7 @@ function Welcome() {
 
 function Scene() {
   const { systemIOActor } = useApp()
+  const projectName = useOnboardingProjectName()
   const thisOnboardingStatus: DesktopOnboardingPath = '/desktop/scene'
 
   // Ensure panes are closed
@@ -108,15 +113,18 @@ function Scene() {
 
   // Things that happen when we load this route
   useEffect(() => {
+    if (!projectName) {
+      return
+    }
     // Create if necessary and navigate to the `blank.kcl` file
     systemIOActor.send({
       type: SystemIOMachineEvents.bulkCreateKCLFilesAndNavigateToFile,
       data: {
-        requestedProjectName: ONBOARDING_PROJECT_NAME,
+        requestedProjectName: projectName,
         requestedFileNameWithExtension: 'blank.kcl',
         files: [
           {
-            requestedProjectName: ONBOARDING_PROJECT_NAME,
+            requestedProjectName: projectName,
             requestedFileName: 'blank.kcl',
             requestedCode: '',
           },
@@ -128,7 +136,7 @@ function Scene() {
         ),
       },
     })
-  }, [systemIOActor])
+  }, [systemIOActor, projectName])
 
   return (
     <div className="pointer-events-none fixed inset-0 z-50 grid items-end justify-center p-2">
@@ -240,6 +248,7 @@ function ZookeeperPrompt() {
 
 function FeatureTreePane() {
   const { systemIOActor } = useApp()
+  const projectName = useOnboardingProjectName()
   const thisOnboardingStatus: DesktopOnboardingPath =
     '/desktop/feature-tree-pane'
   const generatedFileName = 'main.kcl'
@@ -252,10 +261,13 @@ function FeatureTreePane() {
 
   // navigate to the "generated" file
   useEffect(() => {
+    if (!projectName) {
+      return
+    }
     systemIOActor.send({
       type: SystemIOMachineEvents.navigateToFile,
       data: {
-        requestedProjectName: ONBOARDING_PROJECT_NAME,
+        requestedProjectName: projectName,
         requestedFileName: generatedFileName,
         requestedSubRoute: joinRouterPaths(
           String(PATHS.ONBOARDING),
@@ -263,7 +275,7 @@ function FeatureTreePane() {
         ),
       },
     })
-  }, [systemIOActor])
+  }, [systemIOActor, projectName])
 
   return (
     <div className="cursor-not-allowed fixed inset-0 z-[99] p-8 grid justify-center items-end">
@@ -374,6 +386,7 @@ function OtherPanes() {
 
 function PromptToEdit() {
   const { systemIOActor } = useApp()
+  const projectName = useOnboardingProjectName()
   const thisOnboardingStatus: DesktopOnboardingPath = '/desktop/prompt-to-edit'
 
   // Highlight the zookeeper button if it's present
@@ -382,10 +395,13 @@ function PromptToEdit() {
   // Open the zookeeper pane
   // Navigate to the sample file
   useEffect(() => {
+    if (!projectName) {
+      return
+    }
     systemIOActor.send({
       type: SystemIOMachineEvents.navigateToFile,
       data: {
-        requestedProjectName: ONBOARDING_PROJECT_NAME,
+        requestedProjectName: projectName,
         requestedFileName: 'main.kcl',
         requestedSubRoute: joinRouterPaths(
           String(PATHS.ONBOARDING),
@@ -393,7 +409,7 @@ function PromptToEdit() {
         ),
       },
     })
-  }, [systemIOActor])
+  }, [systemIOActor, projectName])
 
   return (
     <div className="cursor-not-allowed fixed inset-0 z-50 p-8 grid justify-center items-center">
@@ -491,6 +507,7 @@ function PromptToEditPrompt() {
 
 function PromptToEditResult() {
   const { systemIOActor } = useApp()
+  const projectName = useOnboardingProjectName()
   const thisOnboardingStatus: DesktopOnboardingPath =
     '/desktop/prompt-to-edit-result'
 
@@ -498,15 +515,18 @@ function PromptToEditResult() {
   useOnboardingPanes([DefaultLayoutPaneID.Code])
 
   useEffect(() => {
+    if (!projectName) {
+      return
+    }
     // Navigate to the `main.kcl` file
     systemIOActor.send({
       type: SystemIOMachineEvents.bulkCreateKCLFilesAndNavigateToProject,
       data: {
-        requestedProjectName: ONBOARDING_PROJECT_NAME,
+        requestedProjectName: projectName,
         files: [
           {
             requestedFileName: 'main.kcl',
-            requestedProjectName: ONBOARDING_PROJECT_NAME,
+            requestedProjectName: projectName,
             requestedCode: modifiedColdPlate,
           },
         ],
@@ -517,7 +537,7 @@ function PromptToEditResult() {
         ),
       },
     })
-  }, [systemIOActor])
+  }, [systemIOActor, projectName])
 
   return (
     <div className="cursor-not-allowed fixed inset-0 z-[99] p-8 grid justify-center items-end">

--- a/src/routes/Onboarding/DesktopOnboardingRoutes.tsx
+++ b/src/routes/Onboarding/DesktopOnboardingRoutes.tsx
@@ -55,13 +55,13 @@ const onboardingComponents: Record<DesktopOnboardingPath, React.JSX.Element> = {
   '/desktop/conclusion': <OnboardingConclusion />,
 }
 
-function useOnboardingProjectName() {
-  return useApp().project?.name
+function useOnboardingProjectIO() {
+  const { project, systemIOActor } = useApp()
+  return { projectName: project?.name, systemIOActor }
 }
 
 function Welcome() {
-  const { systemIOActor } = useApp()
-  const projectName = useOnboardingProjectName()
+  const { projectName, systemIOActor } = useOnboardingProjectIO()
   const thisOnboardingStatus: DesktopOnboardingPath = '/desktop'
 
   // Ensure panes are closed
@@ -104,8 +104,7 @@ function Welcome() {
 }
 
 function Scene() {
-  const { systemIOActor } = useApp()
-  const projectName = useOnboardingProjectName()
+  const { projectName, systemIOActor } = useOnboardingProjectIO()
   const thisOnboardingStatus: DesktopOnboardingPath = '/desktop/scene'
 
   // Ensure panes are closed
@@ -247,8 +246,7 @@ function ZookeeperPrompt() {
 }
 
 function FeatureTreePane() {
-  const { systemIOActor } = useApp()
-  const projectName = useOnboardingProjectName()
+  const { projectName, systemIOActor } = useOnboardingProjectIO()
   const thisOnboardingStatus: DesktopOnboardingPath =
     '/desktop/feature-tree-pane'
   const generatedFileName = 'main.kcl'
@@ -385,8 +383,7 @@ function OtherPanes() {
 }
 
 function PromptToEdit() {
-  const { systemIOActor } = useApp()
-  const projectName = useOnboardingProjectName()
+  const { projectName, systemIOActor } = useOnboardingProjectIO()
   const thisOnboardingStatus: DesktopOnboardingPath = '/desktop/prompt-to-edit'
 
   // Highlight the zookeeper button if it's present
@@ -506,8 +503,7 @@ function PromptToEditPrompt() {
 }
 
 function PromptToEditResult() {
-  const { systemIOActor } = useApp()
-  const projectName = useOnboardingProjectName()
+  const { projectName, systemIOActor } = useOnboardingProjectIO()
   const thisOnboardingStatus: DesktopOnboardingPath =
     '/desktop/prompt-to-edit-result'
 

--- a/src/routes/Onboarding/utils.spec.ts
+++ b/src/routes/Onboarding/utils.spec.ts
@@ -1,14 +1,193 @@
+import type { CreateProjectLibraryTarget } from '@src/lib/commandBarConfigs/projectsCommandConfig'
+import {
+  DEFAULT_PROJECT_LIBRARY_ID,
+  PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+  type ProjectLibrary,
+} from '@src/lib/projectLibraries'
+import type { Project } from '@src/lib/project'
 import type { OnboardingPath, OnboardingStatus } from '@src/lib/onboardingPaths'
 import {
+  acceptOnboarding,
   consumeRememberedOnboardingWorkflowPanes,
   needsToOnboard,
+  type OnboardingUtilDeps,
   shouldApplyRememberedOnboardingWorkflow,
   useAdjacentOnboardingSteps,
 } from '@src/routes/Onboarding/utils'
 import type { Location } from 'react-router-dom'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const originalElectron = window.electron
+
+function setDesktop(isDesktop: boolean) {
+  Object.defineProperty(window, 'electron', {
+    configurable: true,
+    value: isDesktop ? {} : undefined,
+  })
+}
+
+function createProject(defaultFile: string): Project {
+  const path = defaultFile.slice(0, defaultFile.lastIndexOf('/'))
+  return {
+    metadata: null,
+    kcl_file_count: 1,
+    directory_count: 0,
+    default_file: defaultFile,
+    path,
+    name: path.slice(path.lastIndexOf('/') + 1),
+    children: null,
+    readWriteAccess: true,
+  }
+}
+
+function createTarget({
+  id,
+  path,
+  result,
+}: {
+  id: string
+  path: string
+  result: Project | Promise<Project>
+}) {
+  const library: ProjectLibrary = {
+    id,
+    title: id,
+    path,
+    type: id === PERSONAL_CLOUD_PROJECT_LIBRARY_ID ? 'cloud' : 'directory',
+    order: 0,
+  }
+  const run = vi.fn(() => result)
+  const target: CreateProjectLibraryTarget = {
+    library,
+    createProject: { run },
+  }
+  return { run, target }
+}
+
+function createOnboardingDeps(
+  targets: CreateProjectLibraryTarget[],
+  navigate = vi.fn()
+): OnboardingUtilDeps {
+  return {
+    app: { getCreateProjectLibraryTargets: () => targets },
+    onboardingStatus: 'dismissed',
+    navigate,
+  }
+}
+
+afterEach(() => {
+  Object.defineProperty(window, 'electron', {
+    configurable: true,
+    value: originalElectron,
+  })
+})
 
 describe('Onboarding utility functions', () => {
+  describe('acceptOnboarding', () => {
+    it.each([
+      {
+        name: 'web Personal Cloud',
+        desktop: false,
+        ids: [DEFAULT_PROJECT_LIBRARY_ID, PERSONAL_CLOUD_PROJECT_LIBRARY_ID],
+        selectedId: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+        defaultFile:
+          '/documents/zoo-design-studio-projects/tutorial-project/main.kcl',
+      },
+      {
+        name: 'desktop directory',
+        desktop: true,
+        ids: [PERSONAL_CLOUD_PROJECT_LIBRARY_ID, DEFAULT_PROJECT_LIBRARY_ID],
+        selectedId: DEFAULT_PROJECT_LIBRARY_ID,
+        defaultFile: '/projects/tutorial-project-1/main.kcl',
+      },
+      {
+        name: 'cloud-only desktop',
+        desktop: true,
+        ids: [PERSONAL_CLOUD_PROJECT_LIBRARY_ID],
+        selectedId: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+        defaultFile: '/cloud/tutorial-project/main.kcl',
+      },
+      {
+        name: 'directory-only web fallback',
+        desktop: false,
+        ids: [DEFAULT_PROJECT_LIBRARY_ID],
+        selectedId: DEFAULT_PROJECT_LIBRARY_ID,
+        defaultFile: '/projects/tutorial-project/main.kcl',
+      },
+    ])('creates the tutorial through $name', async (testCase) => {
+      setDesktop(testCase.desktop)
+      const targets = testCase.ids.map((id) =>
+        createTarget({
+          id,
+          path: id === DEFAULT_PROJECT_LIBRARY_ID ? '/projects' : '/cloud',
+          result: createProject(testCase.defaultFile),
+        })
+      )
+      const selected = targets.find(
+        ({ target }) => target.library.id === testCase.selectedId
+      )
+      const navigate = vi.fn()
+
+      await acceptOnboarding(
+        createOnboardingDeps(
+          targets.map(({ target }) => target),
+          navigate
+        )
+      )
+
+      expect(selected?.run).toHaveBeenCalledWith({
+        library: selected?.target.library,
+        requestedProjectName: 'tutorial-project',
+        requestedProjectTitle: 'tutorial-project',
+        initialKclFile: {
+          fileName: 'main.kcl',
+          code: expect.stringContaining('plateLength = 10'),
+        },
+      })
+      for (const unselected of targets.filter(
+        ({ target }) => target.library.id !== testCase.selectedId
+      )) {
+        expect(unselected.run).not.toHaveBeenCalled()
+      }
+      expect(navigate).toHaveBeenCalledWith(
+        `/file/${encodeURIComponent(testCase.defaultFile)}/onboarding/desktop`
+      )
+    })
+
+    it('fails without overwriting when no writable library is available', async () => {
+      setDesktop(false)
+
+      await expect(acceptOnboarding(createOnboardingDeps([]))).rejects.toThrow(
+        'No writable project library'
+      )
+    })
+
+    it('shares an in-flight replay instead of creating the same suffix twice', async () => {
+      setDesktop(false)
+      let resolveProject: ((project: Project) => void) | undefined
+      const projectPromise = new Promise<Project>((resolve) => {
+        resolveProject = resolve
+      })
+      const cloud = createTarget({
+        id: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+        path: '/cloud',
+        result: projectPromise,
+      })
+      const navigate = vi.fn()
+      const deps = createOnboardingDeps([cloud.target], navigate)
+
+      const firstStart = acceptOnboarding(deps)
+      const secondStart = acceptOnboarding(deps)
+
+      expect(secondStart).toBe(firstStart)
+      expect(cloud.run).toHaveBeenCalledOnce()
+
+      resolveProject?.(createProject('/cloud/tutorial-project/main.kcl'))
+      await Promise.all([firstStart, secondStart])
+      expect(navigate).toHaveBeenCalledOnce()
+    })
+  })
+
   describe('useAdjacentOnboardingSteps', () => {
     it('Desktop beginning', () => {
       const stepResults = useAdjacentOnboardingSteps('/desktop', 'desktop')

--- a/src/routes/Onboarding/utils.tsx
+++ b/src/routes/Onboarding/utils.tsx
@@ -12,7 +12,6 @@ import { ActionButton } from '@src/components/ActionButton'
 import { CustomIcon, type CustomIconName } from '@src/components/CustomIcon'
 import Tooltip from '@src/components/Tooltip'
 import { useAbsoluteFilePath } from '@src/hooks/useAbsoluteFilePath'
-import type { KclManager } from '@src/lang/KclManager'
 import type { App } from '@src/lib/app'
 import { useApp } from '@src/lib/boot'
 import {
@@ -44,13 +43,9 @@ import {
   PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
 } from '@src/lib/projectLibraries'
 import { waitForToastAnimationEnd } from '@src/lib/toast'
-import { err, reportRejection } from '@src/lib/trap'
+import { err, reportRejection, trap } from '@src/lib/trap'
 import type { commandBarMachine } from '@src/machines/commandBarMachine'
 import type { SettingsActorType } from '@src/machines/settingsMachine'
-import {
-  type SystemIOActor,
-  SystemIOMachineEvents,
-} from '@src/machines/systemIO/utils'
 import toast from 'react-hot-toast'
 
 // Get the 1-indexed step number of the current onboarding step
@@ -328,85 +323,96 @@ export function OnboardingButtons({
 }
 
 export interface OnboardingUtilDeps {
-  app: App
+  app: Pick<App, 'getCreateProjectLibraryTargets'>
   onboardingStatus: OnboardingStatus
-  kclManager: KclManager
-  systemIOActor: SystemIOActor
-  settingsActor: SettingsActorType
   navigate: NavigateFunction
-  executingPath?: string
+}
+
+let pendingOnboardingStart: Promise<void> | undefined
+
+async function createOnboardingProject(
+  deps: OnboardingUtilDeps,
+  onboardingStatus: OnboardingStatus
+) {
+  const targets = deps.app.getCreateProjectLibraryTargets()
+  const isDesktopApp = typeof window !== 'undefined' && Boolean(window.electron)
+  const preferredLibraryId = isDesktopApp
+    ? DEFAULT_PROJECT_LIBRARY_ID
+    : PERSONAL_CLOUD_PROJECT_LIBRARY_ID
+  const projectLibraryTarget =
+    targets.find((target) => target.library.id === preferredLibraryId) ??
+    (isDesktopApp
+      ? targets.find(
+          (target) => target.library.id === PERSONAL_CLOUD_PROJECT_LIBRARY_ID
+        )
+      : undefined) ??
+    targets[0]
+
+  if (!projectLibraryTarget) {
+    return Promise.reject(
+      new Error('No writable project library is available for onboarding.')
+    )
+  }
+
+  const initialKclFile = coldPlateParts[0]
+  const project = await projectLibraryTarget.createProject.run({
+    library: projectLibraryTarget.library,
+    requestedProjectName: ONBOARDING_PROJECT_NAME,
+    requestedProjectTitle: ONBOARDING_PROJECT_NAME,
+    // Write the tutorial before cloud enrollment can observe a blank project.
+    initialKclFile: {
+      fileName: initialKclFile.requestedFileName,
+      code: initialKclFile.requestedCode,
+    },
+  })
+
+  if (!project?.default_file) {
+    return Promise.reject(new Error('Unable to create the onboarding project.'))
+  }
+
+  await deps.navigate(
+    joinRouterPaths(
+      PATHS.FILE,
+      safeEncodeForRouterPaths(project.default_file),
+      PATHS.ONBOARDING,
+      onboardingStatus
+    )
+  )
+}
+
+export function reportOnboardingStartFailure(reason: unknown) {
+  const error =
+    reason instanceof Error
+      ? reason
+      : new Error(`Unable to start onboarding: ${String(reason)}`)
+  trap(error, {
+    altErr: new Error(
+      'Unable to start the onboarding tutorial. Please try again.'
+    ),
+  })
 }
 
 /**
  * Accept to begin the onboarding tutorial,
  */
-export function acceptOnboarding(deps: OnboardingUtilDeps) {
+export function acceptOnboarding(deps: OnboardingUtilDeps): Promise<void> {
   // Non-path statuses should be coerced to the start path
   const onboardingStatus = !isOnboardingPath(deps.onboardingStatus)
     ? onboardingStartPath
     : deps.onboardingStatus
 
-  if (typeof window !== 'undefined') {
-    const targets = deps.app.getCreateProjectLibraryTargets()
-    const preferredLibraryId = window.electron
-      ? DEFAULT_PROJECT_LIBRARY_ID
-      : PERSONAL_CLOUD_PROJECT_LIBRARY_ID
-    const projectLibraryTarget =
-      targets.find((target) => target.library.id === preferredLibraryId) ??
-      (window.electron
-        ? targets.find(
-            (target) => target.library.id === PERSONAL_CLOUD_PROJECT_LIBRARY_ID
-          )
-        : undefined)
-    if (projectLibraryTarget) {
-      const initialKclFile = coldPlateParts[0]
-      void Promise.resolve(
-        projectLibraryTarget.createProject.run({
-          library: projectLibraryTarget.library,
-          requestedProjectName: ONBOARDING_PROJECT_NAME,
-          requestedProjectTitle: ONBOARDING_PROJECT_NAME,
-          initialKclFile: {
-            fileName: initialKclFile.requestedFileName,
-            code: initialKclFile.requestedCode,
-          },
-        })
-      )
-        .then((project) => {
-          if (!project?.default_file) {
-            return Promise.reject(
-              new Error('Unable to create the onboarding project.')
-            )
-          }
-          return deps.navigate(
-            joinRouterPaths(
-              PATHS.FILE,
-              safeEncodeForRouterPaths(project.default_file),
-              PATHS.ONBOARDING,
-              onboardingStatus
-            )
-          )
-        })
-        .catch(reportRejection)
-      return
-    }
+  if (pendingOnboardingStart) {
+    return pendingOnboardingStart
   }
 
-  /**
-   * Bulk create the tutorial sample and navigate to the project.
-   */
-  deps.systemIOActor.send({
-    type: SystemIOMachineEvents.bulkCreateKCLFilesAndNavigateToProject,
-    data: {
-      files: coldPlateParts.map((part) => ({
-        requestedProjectName: ONBOARDING_PROJECT_NAME,
-        ...part,
-      })),
-      // Fall back to legacy System IO if no writable library is configured.
-      override: true,
-      requestedProjectName: ONBOARDING_PROJECT_NAME,
-      requestedSubRoute: joinRouterPaths(PATHS.ONBOARDING, onboardingStatus),
-    },
+  const start = createOnboardingProject(deps, onboardingStatus)
+  const trackedStart = start.finally(() => {
+    if (pendingOnboardingStart === trackedStart) {
+      pendingOnboardingStart = undefined
+    }
   })
+  pendingOnboardingStart = trackedStart
+  return trackedStart
 }
 
 export function needsToOnboard(
@@ -493,8 +499,9 @@ export function TutorialRequestToast(
   const { settings } = useApp()
   function onSelectWorkflow(preference: OnboardingWorkflowPreference) {
     rememberedOnboardingWorkflowPreference = preference
-    acceptOnboarding(props)
-    toast.dismiss(ONBOARDING_TOAST_ID)
+    void acceptOnboarding(props)
+      .then(() => toast.dismiss(ONBOARDING_TOAST_ID))
+      .catch(reportOnboardingStartFailure)
   }
 
   return (

--- a/src/routes/Onboarding/utils.tsx
+++ b/src/routes/Onboarding/utils.tsx
@@ -361,7 +361,6 @@ export function acceptOnboarding(deps: OnboardingUtilDeps) {
             fileName: initialKclFile.requestedFileName,
             code: initialKclFile.requestedCode,
           },
-          reuseExistingProject: true,
         })
       )
         .then((project) => {

--- a/src/routes/Onboarding/utils.tsx
+++ b/src/routes/Onboarding/utils.tsx
@@ -14,6 +14,7 @@ import { Logo } from '@src/components/Logo'
 import Tooltip from '@src/components/Tooltip'
 import { useAbsoluteFilePath } from '@src/hooks/useAbsoluteFilePath'
 import type { KclManager } from '@src/lang/KclManager'
+import type { App } from '@src/lib/app'
 import { useApp } from '@src/lib/boot'
 import {
   ONBOARDING_DATA_ATTRIBUTE,
@@ -34,7 +35,12 @@ import {
   onboardingStartPath,
 } from '@src/lib/onboardingPaths'
 import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
-import { PATHS, joinRouterPaths } from '@src/lib/paths'
+import {
+  PATHS,
+  joinRouterPaths,
+  safeEncodeForRouterPaths,
+} from '@src/lib/paths'
+import { PERSONAL_CLOUD_PROJECT_LIBRARY_ID } from '@src/lib/projectLibraries'
 import { waitForToastAnimationEnd } from '@src/lib/toast'
 import { err, reportRejection } from '@src/lib/trap'
 import type { commandBarMachine } from '@src/machines/commandBarMachine'
@@ -320,6 +326,7 @@ export function OnboardingButtons({
 }
 
 export interface OnboardingUtilDeps {
+  app: App
   onboardingStatus: OnboardingStatus
   kclManager: KclManager
   systemIOActor: SystemIOActor
@@ -339,6 +346,44 @@ export function acceptOnboarding(deps: OnboardingUtilDeps) {
     ? onboardingStartPath
     : deps.onboardingStatus
 
+  if (typeof window !== 'undefined' && !window.electron) {
+    const cloudTarget = deps.app
+      .getCreateProjectLibraryTargets()
+      .find((target) => target.library.id === PERSONAL_CLOUD_PROJECT_LIBRARY_ID)
+    if (cloudTarget) {
+      const initialKclFile = coldPlateParts[0]
+      void Promise.resolve(
+        cloudTarget.createProject.run({
+          library: cloudTarget.library,
+          requestedProjectName: ONBOARDING_PROJECT_NAME,
+          requestedProjectTitle: ONBOARDING_PROJECT_NAME,
+          initialKclFile: {
+            fileName: initialKclFile.requestedFileName,
+            code: initialKclFile.requestedCode,
+          },
+          reuseExistingProject: true,
+        })
+      )
+        .then((project) => {
+          if (!project?.default_file) {
+            return Promise.reject(
+              new Error('Unable to create the onboarding project.')
+            )
+          }
+          return deps.navigate(
+            joinRouterPaths(
+              PATHS.FILE,
+              safeEncodeForRouterPaths(project.default_file),
+              PATHS.ONBOARDING,
+              onboardingStatus
+            )
+          )
+        })
+        .catch((error: unknown) => catchOnboardingWarnError(error, deps))
+      return
+    }
+  }
+
   /**
    * Bulk create the tutorial sample and navigate to the project.
    */
@@ -349,7 +394,7 @@ export function acceptOnboarding(deps: OnboardingUtilDeps) {
         requestedProjectName: ONBOARDING_PROJECT_NAME,
         ...part,
       })),
-      // Make a unique tutorial project each time
+      // Reset the reserved tutorial project.
       override: true,
       requestedProjectName: ONBOARDING_PROJECT_NAME,
       requestedSubRoute: joinRouterPaths(PATHS.ONBOARDING, onboardingStatus),
@@ -537,7 +582,7 @@ export function TutorialRequestToast(
  * `acceptOnboarding` and show a warning toast.
  */
 export async function catchOnboardingWarnError(
-  err: Error,
+  err: unknown,
   props: OnboardingUtilDeps
 ) {
   if (err instanceof Error && err.message === ERROR_MUST_WARN) {

--- a/src/routes/Onboarding/utils.tsx
+++ b/src/routes/Onboarding/utils.tsx
@@ -10,7 +10,6 @@ import onboardingWorkflowAiHeadset from '@src/assets/onboarding-workflow-ai-head
 import onboardingWorkflowKitt from '@src/assets/onboarding-workflow-kitt.png'
 import { ActionButton } from '@src/components/ActionButton'
 import { CustomIcon, type CustomIconName } from '@src/components/CustomIcon'
-import { Logo } from '@src/components/Logo'
 import Tooltip from '@src/components/Tooltip'
 import { useAbsoluteFilePath } from '@src/hooks/useAbsoluteFilePath'
 import type { KclManager } from '@src/lang/KclManager'
@@ -40,7 +39,10 @@ import {
   joinRouterPaths,
   safeEncodeForRouterPaths,
 } from '@src/lib/paths'
-import { PERSONAL_CLOUD_PROJECT_LIBRARY_ID } from '@src/lib/projectLibraries'
+import {
+  DEFAULT_PROJECT_LIBRARY_ID,
+  PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+} from '@src/lib/projectLibraries'
 import { waitForToastAnimationEnd } from '@src/lib/toast'
 import { err, reportRejection } from '@src/lib/trap'
 import type { commandBarMachine } from '@src/machines/commandBarMachine'
@@ -335,8 +337,6 @@ export interface OnboardingUtilDeps {
   executingPath?: string
 }
 
-export const ERROR_MUST_WARN = 'Must warn user before overwrite'
-
 /**
  * Accept to begin the onboarding tutorial,
  */
@@ -346,15 +346,23 @@ export function acceptOnboarding(deps: OnboardingUtilDeps) {
     ? onboardingStartPath
     : deps.onboardingStatus
 
-  if (typeof window !== 'undefined' && !window.electron) {
-    const cloudTarget = deps.app
-      .getCreateProjectLibraryTargets()
-      .find((target) => target.library.id === PERSONAL_CLOUD_PROJECT_LIBRARY_ID)
-    if (cloudTarget) {
+  if (typeof window !== 'undefined') {
+    const targets = deps.app.getCreateProjectLibraryTargets()
+    const preferredLibraryId = window.electron
+      ? DEFAULT_PROJECT_LIBRARY_ID
+      : PERSONAL_CLOUD_PROJECT_LIBRARY_ID
+    const projectLibraryTarget =
+      targets.find((target) => target.library.id === preferredLibraryId) ??
+      (window.electron
+        ? targets.find(
+            (target) => target.library.id === PERSONAL_CLOUD_PROJECT_LIBRARY_ID
+          )
+        : undefined)
+    if (projectLibraryTarget) {
       const initialKclFile = coldPlateParts[0]
       void Promise.resolve(
-        cloudTarget.createProject.run({
-          library: cloudTarget.library,
+        projectLibraryTarget.createProject.run({
+          library: projectLibraryTarget.library,
           requestedProjectName: ONBOARDING_PROJECT_NAME,
           requestedProjectTitle: ONBOARDING_PROJECT_NAME,
           initialKclFile: {
@@ -378,7 +386,7 @@ export function acceptOnboarding(deps: OnboardingUtilDeps) {
             )
           )
         })
-        .catch((error: unknown) => catchOnboardingWarnError(error, deps))
+        .catch(reportRejection)
       return
     }
   }
@@ -393,7 +401,7 @@ export function acceptOnboarding(deps: OnboardingUtilDeps) {
         requestedProjectName: ONBOARDING_PROJECT_NAME,
         ...part,
       })),
-      // Reset the reserved tutorial project.
+      // Fall back to legacy System IO if no writable library is configured.
       override: true,
       requestedProjectName: ONBOARDING_PROJECT_NAME,
       requestedSubRoute: joinRouterPaths(PATHS.ONBOARDING, onboardingStatus),
@@ -571,74 +579,6 @@ export function TutorialRequestToast(
             click here.
           </a>
         </p>
-      </div>
-    </div>
-  )
-}
-
-/**
- * Helper function to catch the `ERROR_MUST_WARN` error from
- * `acceptOnboarding` and show a warning toast.
- */
-export async function catchOnboardingWarnError(
-  err: unknown,
-  props: OnboardingUtilDeps
-) {
-  if (err instanceof Error && err.message === ERROR_MUST_WARN) {
-    toast.success(TutorialWebConfirmationToast(props), {
-      id: ONBOARDING_TOAST_ID,
-      duration: Number.POSITIVE_INFINITY,
-      icon: null,
-    })
-  } else {
-    toast.dismiss(ONBOARDING_TOAST_ID)
-    return reportRejection(err)
-  }
-}
-
-export function TutorialWebConfirmationToast(props: OnboardingUtilDeps) {
-  function onAccept() {
-    toast.dismiss(ONBOARDING_TOAST_ID)
-    acceptOnboarding(props)
-  }
-
-  return (
-    <div
-      data-testid="onboarding-toast-confirmation"
-      className="flex items-center gap-6 min-w-80"
-    >
-      <Logo className="w-auto h-8 flex-none" />
-      <div className="flex flex-col justify-between gap-6">
-        <section>
-          <h2>The welcome tutorial resets your code in the browser</h2>
-          <p className="text-sm text-chalkboard-70 dark:text-chalkboard-30">
-            We see you have some of your own code written in this project.
-            Please save it somewhere else before continuing the onboarding.
-          </p>
-        </section>
-        <div className="flex justify-between gap-8">
-          <ActionButton
-            Element="button"
-            iconStart={{
-              icon: 'close',
-            }}
-            data-negative-button="dismiss"
-            name="dismiss"
-            onClick={() => onDismissOnboardingInvite(props.settingsActor)}
-          >
-            I'll save it
-          </ActionButton>
-          <ActionButton
-            Element="button"
-            iconStart={{
-              icon: 'checkmark',
-            }}
-            name="accept"
-            onClick={onAccept}
-          >
-            Overwrite and begin
-          </ActionButton>
-        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
Fixes #12903

Creates a uniquely named tutorial project on every replay, on web and desktop. Tutorial files stay scoped to the new project.