### PR TITLE
Tolerate transient Engine disconnects

### DIFF
--- a/src/lib/engineConnection/connection.ts
+++ b/src/lib/engineConnection/connection.ts
@@ -58,6 +58,7 @@ export class Connection extends EventTarget {
     pong: number | undefined
   }
   private _pingIntervalId: ReturnType<typeof setInterval> | undefined
+  private clearDisconnectedTimeout: (() => void) | undefined
   timeoutToForceConnectId: ReturnType<typeof setTimeout> | undefined
 
   peerConnection: RTCPeerConnection | undefined
@@ -472,11 +473,13 @@ export class Connection extends EventTarget {
     const onNegotiationNeeded = createOnNegotiationNeeded()
     const onSignalingStateChange = createOnSignalingStateChange()
     const onIceCandidateError = createOnIceCandidateError()
-    const onConnectionStateChange = createOnConnectionStateChange({
-      dispatchEvent: this.dispatchEvent.bind(this),
-      connection: this,
-      tearDownManager: this.tearDownManager.bind(this),
-    })
+    const { onConnectionStateChange, clearDisconnectedTimeout } =
+      createOnConnectionStateChange({
+        dispatchEvent: this.dispatchEvent.bind(this),
+        connection: this,
+        tearDownManager: this.tearDownManager.bind(this),
+      })
+    this.clearDisconnectedTimeout = clearDisconnectedTimeout
     const onTrack = createOnTrack({
       setMediaStream: this.setMediaStream.bind(this),
       setWebrtcStatsCollector: this.setWebrtcStatsCollector.bind(this),
@@ -865,6 +868,8 @@ export class Connection extends EventTarget {
   }
 
   cleanUpTimeouts() {
+    this.clearDisconnectedTimeout?.()
+    this.clearDisconnectedTimeout = undefined
     clearTimeout(this.timeoutToForceConnectId)
     this.timeoutToForceConnectId = undefined
   }

--- a/src/lib/engineConnection/connection.ts
+++ b/src/lib/engineConnection/connection.ts
@@ -809,23 +809,16 @@ export class Connection extends EventTarget {
       return
     }
 
-    if (this.peerConnection.connectionState !== 'closed') {
-      EngineDebugger.addLog({
-        label: 'connection',
-        message: 'disconnectPeerConnection',
-        metadata: { id: this.id },
-      })
-      this.peerConnection.close()
-    } else {
-      EngineDebugger.addLog({
-        label: 'connection',
-        message: 'disconnectPeerConnection',
-        metadata: {
-          id: this.id,
-          connectionState: this.peerConnection.connectionState,
-        },
-      })
-    }
+    EngineDebugger.addLog({
+      label: 'connection',
+      message: 'disconnectPeerConnection',
+      metadata: {
+        id: this.id,
+        connectionState: this.peerConnection.connectionState,
+      },
+    })
+
+    this.peerConnection.close()
   }
 
   removeAllEventListeners() {

--- a/src/lib/engineConnection/connection.ts
+++ b/src/lib/engineConnection/connection.ts
@@ -809,7 +809,7 @@ export class Connection extends EventTarget {
       return
     }
 
-    if (this.peerConnection.connectionState === 'closed') {
+    if (this.peerConnection.connectionState !== 'closed') {
       EngineDebugger.addLog({
         label: 'connection',
         message: 'disconnectPeerConnection',

--- a/src/lib/engineConnection/peerConnection.test.ts
+++ b/src/lib/engineConnection/peerConnection.test.ts
@@ -30,14 +30,16 @@ describe('createOnConnectionStateChange', () => {
   beforeEach(() => vi.useFakeTimers())
   afterEach(() => vi.useRealTimers())
 
-  it('allows a transient disconnection to recover', () => {
+  it('allows the same peer connection to recover', () => {
     const { peerConnection, tearDownManager } = setup()
 
     peerConnection.connectionState = 'disconnected'
     peerConnection.dispatchEvent(new Event('connectionstatechange'))
-    peerConnection.connectionState = 'connected'
+    peerConnection.connectionState = 'connecting'
     peerConnection.dispatchEvent(new Event('connectionstatechange'))
     vi.advanceTimersByTime(PEER_CONNECTION_DISCONNECTED_GRACE_PERIOD_MS)
+    peerConnection.connectionState = 'connected'
+    peerConnection.dispatchEvent(new Event('connectionstatechange'))
 
     expect(tearDownManager).not.toHaveBeenCalled()
   })

--- a/src/lib/engineConnection/peerConnection.test.ts
+++ b/src/lib/engineConnection/peerConnection.test.ts
@@ -13,17 +13,23 @@ const setup = () => {
   const peerConnection = new TestPeerConnection()
   const dispatchEvent = vi.fn(() => true)
   const tearDownManager = vi.fn()
-  const onConnectionStateChange = createOnConnectionStateChange({
-    dispatchEvent,
-    connection: { mediaStream: new MediaStream() } as Connection,
-    tearDownManager,
-  })
+  const { onConnectionStateChange, clearDisconnectedTimeout } =
+    createOnConnectionStateChange({
+      dispatchEvent,
+      connection: { mediaStream: new MediaStream() } as Connection,
+      tearDownManager,
+    })
   peerConnection.addEventListener(
     'connectionstatechange',
     onConnectionStateChange
   )
 
-  return { peerConnection, dispatchEvent, tearDownManager }
+  return {
+    peerConnection,
+    dispatchEvent,
+    tearDownManager,
+    clearDisconnectedTimeout,
+  }
 }
 
 describe('createOnConnectionStateChange', () => {
@@ -57,5 +63,17 @@ describe('createOnConnectionStateChange', () => {
     expect(tearDownManager).toHaveBeenCalledWith({
       peerConnectionDisconnected: true,
     })
+  })
+
+  it('cancels a pending teardown when the connection is cleaned up', () => {
+    const { peerConnection, tearDownManager, clearDisconnectedTimeout } =
+      setup()
+
+    peerConnection.connectionState = 'disconnected'
+    peerConnection.dispatchEvent(new Event('connectionstatechange'))
+    clearDisconnectedTimeout()
+    vi.advanceTimersByTime(PEER_CONNECTION_DISCONNECTED_GRACE_PERIOD_MS)
+
+    expect(tearDownManager).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/engineConnection/peerConnection.test.ts
+++ b/src/lib/engineConnection/peerConnection.test.ts
@@ -1,0 +1,59 @@
+import type { Connection } from '@src/lib/engineConnection/connection'
+import {
+  createOnConnectionStateChange,
+  PEER_CONNECTION_DISCONNECTED_GRACE_PERIOD_MS,
+} from '@src/lib/engineConnection/peerConnection'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+class TestPeerConnection extends EventTarget {
+  connectionState: RTCPeerConnectionState = 'new'
+}
+
+const setup = () => {
+  const peerConnection = new TestPeerConnection()
+  const dispatchEvent = vi.fn(() => true)
+  const tearDownManager = vi.fn()
+  const onConnectionStateChange = createOnConnectionStateChange({
+    dispatchEvent,
+    connection: { mediaStream: new MediaStream() } as Connection,
+    tearDownManager,
+  })
+  peerConnection.addEventListener(
+    'connectionstatechange',
+    onConnectionStateChange
+  )
+
+  return { peerConnection, dispatchEvent, tearDownManager }
+}
+
+describe('createOnConnectionStateChange', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('allows a transient disconnection to recover', () => {
+    const { peerConnection, tearDownManager } = setup()
+
+    peerConnection.connectionState = 'disconnected'
+    peerConnection.dispatchEvent(new Event('connectionstatechange'))
+    peerConnection.connectionState = 'connected'
+    peerConnection.dispatchEvent(new Event('connectionstatechange'))
+    vi.advanceTimersByTime(PEER_CONNECTION_DISCONNECTED_GRACE_PERIOD_MS)
+
+    expect(tearDownManager).not.toHaveBeenCalled()
+  })
+
+  it('tears down a connection that remains disconnected', () => {
+    const { peerConnection, dispatchEvent, tearDownManager } = setup()
+
+    peerConnection.connectionState = 'disconnected'
+    peerConnection.dispatchEvent(new Event('connectionstatechange'))
+    vi.advanceTimersByTime(PEER_CONNECTION_DISCONNECTED_GRACE_PERIOD_MS)
+
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'offline' })
+    )
+    expect(tearDownManager).toHaveBeenCalledWith({
+      peerConnectionDisconnected: true,
+    })
+  })
+})

--- a/src/lib/engineConnection/peerConnection.ts
+++ b/src/lib/engineConnection/peerConnection.ts
@@ -16,6 +16,8 @@ import {
   EngineConnectionStateType,
 } from '@src/lib/engineConnection/utils'
 
+export const PEER_CONNECTION_DISCONNECTED_GRACE_PERIOD_MS = 10_000
+
 export function createOnIceCandidate({
   initiateConnectionExclusive,
   send,
@@ -161,17 +163,26 @@ export function createOnConnectionStateChange({
 }) {
   // https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/connectionstatechange_event
   // Event type: generic Event type...
-  const onConnectionStateChange = (event: any) => {
+  let disconnectedTimeout: ReturnType<typeof setTimeout> | undefined
+
+  const clearDisconnectedTimeout = () => {
+    clearTimeout(disconnectedTimeout)
+    disconnectedTimeout = undefined
+  }
+
+  const onConnectionStateChange = (event: Event) => {
+    const peerConnection = event.target as RTCPeerConnection | undefined
     EngineDebugger.addLog({
       label: 'onConnectionStateChange',
       message: 'connectionstatechange',
-      metadata: { event, connectionState: event.target?.connectionState },
+      metadata: { event, connectionState: peerConnection?.connectionState },
     })
 
-    switch (event.target?.connectionState) {
+    switch (peerConnection?.connectionState) {
       // From what I understand, only after have we done the ICE song and
       // dance is it safest to connect the video tracks / stream
       case 'connected':
+        clearDisconnectedTimeout()
         dispatchEvent(
           new CustomEvent(EngineConnectionEvents.NewTrack, {
             detail: { conn: connection, mediaStream: connection.mediaStream },
@@ -181,14 +192,23 @@ export function createOnConnectionStateChange({
       case 'connecting':
         break
       case 'failed':
+        clearDisconnectedTimeout()
         dispatchEvent(new CustomEvent(EngineConnectionEvents.Offline, {}))
         tearDownManager({ peerConnectionFailed: true })
         break
       case 'disconnected':
-        dispatchEvent(new CustomEvent(EngineConnectionEvents.Offline, {}))
-        tearDownManager({ peerConnectionDisconnected: true })
+        disconnectedTimeout ??= setTimeout(() => {
+          disconnectedTimeout = undefined
+          if (peerConnection?.connectionState !== 'disconnected') {
+            return
+          }
+
+          dispatchEvent(new CustomEvent(EngineConnectionEvents.Offline, {}))
+          tearDownManager({ peerConnectionDisconnected: true })
+        }, PEER_CONNECTION_DISCONNECTED_GRACE_PERIOD_MS)
         break
       case 'closed':
+        clearDisconnectedTimeout()
         dispatchEvent(new CustomEvent(EngineConnectionEvents.Offline, {}))
         tearDownManager({ peerConnectionClosed: true })
         break

--- a/src/lib/engineConnection/peerConnection.ts
+++ b/src/lib/engineConnection/peerConnection.ts
@@ -217,6 +217,15 @@ export function createOnConnectionStateChange({
         tearDownManager({ peerConnectionClosed: true })
         break
       default:
+        EngineDebugger.addLog({
+          label: 'onConnectionStateChange',
+          message: 'connectionstatechange',
+          metadata: {
+            event,
+            connectionState: peerConnection?.connectionState,
+            unknown: true,
+          },
+        })
         break
     }
   }

--- a/src/lib/engineConnection/peerConnection.ts
+++ b/src/lib/engineConnection/peerConnection.ts
@@ -178,6 +178,11 @@ export function createOnConnectionStateChange({
       metadata: { event, connectionState: peerConnection?.connectionState },
     })
 
+    /**
+     * `disconnected` can be transient, so give this peer connection one grace
+     * period to recover. Each subsequent concrete state owns canceling that
+     * timer. If no state change occurs, the timeout tears the peer down.
+     */
     switch (peerConnection?.connectionState) {
       // From what I understand, only after have we done the ICE song and
       // dance is it safest to connect the video tracks / stream
@@ -189,7 +194,9 @@ export function createOnConnectionStateChange({
           })
         )
         break
+      case 'new':
       case 'connecting':
+        clearDisconnectedTimeout()
         break
       case 'failed':
         clearDisconnectedTimeout()
@@ -197,12 +204,8 @@ export function createOnConnectionStateChange({
         tearDownManager({ peerConnectionFailed: true })
         break
       case 'disconnected':
-        disconnectedTimeout ??= setTimeout(() => {
+        disconnectedTimeout = setTimeout(() => {
           disconnectedTimeout = undefined
-          if (peerConnection?.connectionState !== 'disconnected') {
-            return
-          }
-
           dispatchEvent(new CustomEvent(EngineConnectionEvents.Offline, {}))
           tearDownManager({ peerConnectionDisconnected: true })
         }, PEER_CONNECTION_DISCONNECTED_GRACE_PERIOD_MS)

--- a/src/lib/engineConnection/peerConnection.ts
+++ b/src/lib/engineConnection/peerConnection.ts
@@ -181,7 +181,8 @@ export function createOnConnectionStateChange({
     /**
      * `disconnected` can be transient, so give this peer connection one grace
      * period to recover. Each subsequent concrete state owns canceling that
-     * timer. If no state change occurs, the timeout tears the peer down.
+     * timer, and the owning Connection cancels it during any other teardown.
+     * If neither occurs, the timeout tears the peer down.
      */
     switch (peerConnection?.connectionState) {
       // From what I understand, only after have we done the ICE song and
@@ -220,7 +221,7 @@ export function createOnConnectionStateChange({
     }
   }
 
-  return onConnectionStateChange
+  return { onConnectionStateChange, clearDisconnectedTimeout }
 }
 
 export function createOnTrack({


### PR DESCRIPTION
Fixes #12906

- Give transient WebRTC disconnects time to recover.
- Close stale peer connections during teardown.

This helps users on high-latency or unstable VPN routes by avoiding a full Engine reconnect for brief WebRTC interruptions. It does not improve Zookeeper connectivity or fix initial Engine connections when the VPN cannot reach our TURN relay.