### PR TITLE
Fix AST walk to visit if-expression then branches

### DIFF
--- a/rust/kcl-lib/src/parsing/ast/types/mod.rs
+++ b/rust/kcl-lib/src/parsing/ast/types/mod.rs
@@ -5450,6 +5450,37 @@ fn demo(a) {
         );
     }
 
+    #[test]
+    fn test_rename_inside_if_then_branch() {
+        let code = r#"param1 = 1
+if true {
+  param1
+} else if false {
+  param1 + 1
+} else {
+  param1 + 2
+}
+"#;
+        let mut program = parse(code);
+        let pos = code.find("param1").unwrap() + 1;
+
+        program.rename_symbol("height", pos);
+
+        let formatted = program.recast_top(&Default::default(), 0);
+        assert_eq!(
+            formatted,
+            r#"height = 1
+if true {
+  height
+} else if false {
+  height + 1
+} else {
+  height + 2
+}
+"#
+        );
+    }
+
     /// Helper to create a comment NonCodeNode for tests.
     fn comment_node(text: &str) -> Node<NonCodeNode> {
         Node::no_src(NonCodeNode {

--- a/rust/kcl-lib/src/walk/ast_visitor.rs
+++ b/rust/kcl-lib/src/walk/ast_visitor.rs
@@ -102,8 +102,8 @@ impl<'tree> Visitable<'tree> for Node<'tree> {
                 vec![(&n.object).into(), (&n.property).into()]
             }
             Node::IfExpression(n) => {
-                let mut children = n.else_ifs.iter().map(|v| v.into()).collect::<Vec<Node>>();
-                children.insert(0, n.cond.as_ref().into());
+                let mut children = vec![n.cond.as_ref().into(), n.then_val.as_ref().into()];
+                children.extend(n.else_ifs.iter().map(Node::from));
                 children.push(n.final_else.as_ref().into());
                 children
             }
@@ -223,5 +223,36 @@ fn crow3() {
         let count_crows: CountCrows = Default::default();
         Visitable::visit(&prog, &count_crows).unwrap();
         assert_eq!(*count_crows.n.lock().unwrap(), 4);
+    }
+
+    /// All if-expression branches are visited, including the then branch.
+    #[test]
+    fn visits_all_if_expression_branches() {
+        let program = kcl!(
+            "\
+x = if true {
+  crow1 = 1
+  crow1
+} else if false {
+  crow2 = 2
+  crow2
+} else {
+  crow3 = 3
+  crow3
+}
+"
+        );
+
+        let count = Mutex::new(0usize);
+        crate::walk::walk(&program, |node| {
+            if let Node::VariableDeclarator(vd) = node
+                && vd.id.name.starts_with("crow")
+            {
+                *count.lock().unwrap() += 1;
+            }
+            Ok::<bool, anyhow::Error>(true)
+        })
+        .unwrap();
+        assert_eq!(*count.lock().unwrap(), 3);
     }
 }


### PR DESCRIPTION
The read-only walk's children for IfExpression included the condition, else-if branches, and final else, but omitted then_val. Visitors never saw anything inside an if expression's then branch, so lints skipped it.

Extracted from the rename work.