### PR TITLE
fix(kcl): link a type to the module that declares it

### DIFF
--- a/rust/kcl-lib/src/docs/gen_std_tests.rs
+++ b/rust/kcl-lib/src/docs/gen_std_tests.rs
@@ -853,6 +853,26 @@ mod tests {
                 expected_text: "`[a, b, c]`",
                 expected_no_text: "[a, b, c]",
             },
+            // A type links to the page of the module that declares it, not to
+            // `std::types`. `Orientation` and `Projection` are declared in
+            // `std::view`; `Solid` keeps the `std-types-` form, so the rule is
+            // "ask the type where its page is" rather than "swap one module for
+            // another".
+            Test {
+                input: "Solid",
+                expected_text: "[`Solid`](/docs/kcl-std/types/std-types-Solid)",
+                expected_no_text: "Solid",
+            },
+            Test {
+                input: "Orientation",
+                expected_text: "[`Orientation`](/docs/kcl-std/types/std-view-Orientation)",
+                expected_no_text: "Orientation",
+            },
+            Test {
+                input: "Projection | Solid",
+                expected_text: "[`Projection`](/docs/kcl-std/types/std-view-Projection) or [`Solid`](/docs/kcl-std/types/std-types-Solid)",
+                expected_no_text: "Projection | Solid",
+            },
         ];
         for test in tests {
             let actual_text = cleanup_type_string(test.input, true, &kcl_std);

--- a/rust/kcl-lib/src/docs/gen_std_tests/type_formatter.rs
+++ b/rust/kcl-lib/src/docs/gen_std_tests/type_formatter.rs
@@ -47,8 +47,13 @@ impl<'i> KclType<'i> {
                     } else if ty.starts_with("fn") {
                         format!("[`{ty}`](/docs/kcl-std/types/std-types-fn)")
                     // Special case for `tag` because it exists as a type but is deprecated and mostly used as an arg name
-                    } else if matches!(kcl_std.find_by_name(ty), Some(DocData::Ty(_))) && ty != "tag" {
-                        format!("[`{ty}`](/docs/kcl-std/types/std-types-{ty})")
+                    } else if let Some(doc @ DocData::Ty(_)) = kcl_std.find_by_name(ty)
+                        && ty != "tag"
+                    {
+                        // Ask the type where its own page is rather than assuming
+                        // `std::types`: a type declared in any other module, such as
+                        // `std::view::Orientation`, has its page under that module.
+                        format!("[`{ty}`](/docs/kcl-std/{})", doc.file_name())
                     } else {
                         ty.to_owned()
                     }


### PR DESCRIPTION
- type_formatter used the DocData it looked up only to confirm the type exists, then hardcoded `std-types-{ty}`; it now uses DocData::file_name(), which already yields the right path
- No generated page changes today: std::view declares Orientation and Projection but no signature references them yet, so the bug is latent. The first function to use a type from outside std::types would ship dead links
- Add rows to test_cleanup_type_string: Orientation, a Projection | Solid union, and bare Solid to pin that std::types types keep their path