### PR TITLE
Hide region intermediates from the Feature Tree

### DIFF
--- a/e2e/playwright/sketch-solve-edit.spec.ts
+++ b/e2e/playwright/sketch-solve-edit.spec.ts
@@ -2201,8 +2201,13 @@ test.describe('Sketch solve edit tests', { tag: '@desktop' }, () => {
       ).not.toBeInViewport()
     })
 
-    await test.step('Remove extrude from feature tree', async () => {
+    await test.step('Region stays hidden when removing extrude from feature tree', async () => {
       await toolbar.openFeatureTreePane()
+      const regionOp = toolbar.featureTreePane.getByRole('button', {
+        name: /^(Region|region001)$/,
+      })
+      await expect(regionOp).toHaveCount(0)
+
       const extrudeOp = toolbar.featureTreePane
         .getByRole('button', { name: /^(Extrude|extrude001)$/ })
         .first()
@@ -2210,18 +2215,8 @@ test.describe('Sketch solve edit tests', { tag: '@desktop' }, () => {
       await toolbar.removeFeatureTreeOperation(extrudeOp)
       await scene.settled()
       await editor.expectEditor.not.toContain('extrude(')
-    })
-
-    await test.step('Remove region from feature tree and expect original code', async () => {
-      await toolbar.openFeatureTreePane()
-      const regionOp = toolbar.featureTreePane
-        .getByRole('button', { name: /^(Region|region001)$/ })
-        .first()
-      await expect(regionOp).toBeVisible()
-      await toolbar.removeFeatureTreeOperation(regionOp)
-      await scene.settled()
-      await editor.expectEditor.not.toContain('region(')
-      await editor.expectEditor.toContain(square, { shouldNormalise: true })
+      await editor.expectEditor.toContain('region(')
+      await expect(regionOp).toHaveCount(0)
     })
   })
 

--- a/src/components/layout/areas/FeatureTreePane.test.ts
+++ b/src/components/layout/areas/FeatureTreePane.test.ts
@@ -90,6 +90,17 @@ describe('buildOperationTree', () => {
     })
   })
 
+  it('omits regions while preserving neighboring features', () => {
+    const extrude = createStdLibCallOperation('extrude', [21, 40, 0])
+    const operationsByModule: OperationsByModule = {
+      map: {
+        0: [createStdLibCallOperation('region', [0, 20, 0]), extrude],
+      },
+    }
+
+    expect(buildOperationTree(operationsByModule, 0)).toEqual([extrude])
+  })
+
   it('deduplicates ModuleInstance when multiple modules import the same module', () => {
     const operationsByModule: OperationsByModule = {
       map: {

--- a/src/lib/operationGrouping.ts
+++ b/src/lib/operationGrouping.ts
@@ -163,7 +163,7 @@ const operationFilters = [
   isNotUserFunctionWithNoOperations,
   isNotInsideGroup,
   isNotGroupEnd,
-  isNotHideOperation,
+  isNotFeatureTreeImplementationDetail,
 ]
 
 /**
@@ -232,8 +232,10 @@ function isNotGroupEnd(ops: Operation[]): Operation[] {
 }
 
 /**
- * A filter to exclude `hide()` operations from a list of operations.
+ * A filter to exclude implementation-detail operations from the feature tree.
  */
-function isNotHideOperation(ops: Operation[]): Operation[] {
-  return ops.filter((op) => !(op.type === 'StdLibCall' && op.name === 'hide'))
+function isNotFeatureTreeImplementationDetail(ops: Operation[]): Operation[] {
+  return ops.filter(
+    (op) => !(op.type === 'StdLibCall' && ['hide', 'region'].includes(op.name))
+  )
 }


### PR DESCRIPTION
## Problem

`region()` calls are intermediate profiles, but they appear as top-level Feature Tree entries and add noise.

## Solution

Hide region rows while keeping their consuming operations visible. Region records remain available in the execution stream, so modeling behavior is unchanged.

<img width="1369" height="1278" alt="Screenshot 2026-08-12 at 19 18 02" src="https://github.com/user-attachments/assets/f299e54a-7c85-45ae-a0ce-2ef3f36b32aa" />


Closes #12928
