### PR TITLE
Codex: Make Zookeeper connections more tolerant of unreliable networks

### DIFF
--- a/e2e/playwright/zookeeper.spec.ts
+++ b/e2e/playwright/zookeeper.spec.ts
@@ -5,6 +5,34 @@ import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
 const ZK_MOCK_REPLY_MARKER =
   'ZOO_MAGIC_STRING_TRIGGER_MOCK_REPLY_D39D279C6F84FA63AD49364FDEFB4A27D0E15BA7FB0975D4D6E003A8A594E460'
 
+const STEP_PART_SOURCE =
+  'rust/kcl-lib/e2e/executor/inputs/mcmaster-parts/91251a404-bolt.step'
+
+const populatePartProject = async (
+  projectsDirectory: string,
+  projectName: string,
+  partCount: number
+) => {
+  const [fsp, path] = await Promise.all([
+    import('node:fs/promises'),
+    import('node:path'),
+  ])
+  const projectDirectory = path.join(projectsDirectory, projectName)
+  await fsp.mkdir(projectDirectory, { recursive: true })
+  await fsp.writeFile(path.join(projectDirectory, 'main.kcl'), '')
+  await Promise.all(
+    Array.from({ length: partCount }, (_, index) =>
+      fsp.copyFile(
+        STEP_PART_SOURCE,
+        path.join(
+          projectDirectory,
+          `part${String(index + 1).padStart(3, '0')}.step`
+        )
+      )
+    )
+  )
+}
+
 test.describe('Zookeeper tests', { tag: ['@desktop', '@web'] }, () => {
   test('Happy path: new project, easy prompt, good result', async ({
     page,
@@ -72,4 +100,49 @@ test.describe('Zookeeper tests', { tag: ['@desktop', '@web'] }, () => {
       })
     }
   )
+})
+
+test.describe('Zookeeper large project tests', { tag: '@desktop' }, () => {
+  test('Zookeeper keeps the same conversation as a project grows from 20 to 35 STEP parts', async ({
+    page,
+    folderSetupFn,
+    homePage,
+    scene,
+    toolbar,
+    copilot,
+  }) => {
+    test.setTimeout(180_000)
+    const projectName = 'many-parts'
+    let projectsDirectory = ''
+
+    await folderSetupFn((directory) => {
+      projectsDirectory = directory
+      return populatePartProject(directory, projectName, 20)
+    })
+    await page.setBodyDimensions({ width: 1500, height: 1000 })
+    await homePage.openProject(projectName)
+    await scene.settled()
+
+    const submitPrompt = async (partCount: number) => {
+      await toolbar.closePane(DefaultLayoutPaneID.Code)
+      await toolbar.openPane(DefaultLayoutPaneID.Zookeeper)
+      await copilot.conversationInput.fill(
+        `Confirm this project has ${partCount} parts [${ZK_MOCK_REPLY_MARKER}]`
+      )
+      await copilot.submitButton.click()
+      await expect(copilot.placeHolderResponse).toBeVisible({
+        timeout: 130_000,
+      })
+      await expect(copilot.placeHolderResponse).not.toBeVisible({
+        timeout: 130_000,
+      })
+    }
+
+    await submitPrompt(20)
+
+    await populatePartProject(projectsDirectory, projectName, 35)
+    await submitPrompt(35)
+
+    await expect(page.getByTestId('ml-request-chat-bubble')).toHaveCount(2)
+  })
 })

--- a/src/lib/zookeeper/components/ZookeeperConversationPane.spec.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPane.spec.tsx
@@ -70,7 +70,7 @@ type FakeZookeeperSnapshot = {
     conversationId?: string
     defaultMode?: MlCopilotModeId
     modeOptions?: MlCopilotModeOption[]
-    ws?: Pick<WebSocket, 'readyState'>
+    ws?: EventTarget & { readyState: WebSocket['readyState'] }
   }
   matches: (state: unknown) => boolean
 }
@@ -106,7 +106,7 @@ const createFakeActor = ({
   setupAttempt?: number
   includeConversationId?: boolean
   conversationId?: string
-  ws?: Pick<WebSocket, 'readyState'>
+  ws?: EventTarget & { readyState: WebSocket['readyState'] }
 } = {}): FakeZookeeperActor => {
   const snapshot: FakeZookeeperSnapshot = {
     value,
@@ -402,10 +402,10 @@ beforeAll(async () => {
 })
 
 describe('ZookeeperConversationPane', () => {
-  test('uses browser network events only as reconnect hints', () => {
-    const ws: { readyState: WebSocket['readyState'] } = {
-      readyState: WebSocket.OPEN,
-    }
+  test('shows browser offline recovery without replacing a live connection', () => {
+    const ws = Object.assign(new EventTarget(), {
+      readyState: WebSocket.OPEN as WebSocket['readyState'],
+    })
     const zookeeperManagerActor = createFakeActor({
       awaitingResponse: false,
       ws,
@@ -415,9 +415,12 @@ describe('ZookeeperConversationPane', () => {
 
     act(() => {
       window.dispatchEvent(new Event('offline'))
-      window.dispatchEvent(new Event('online'))
     })
 
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'No internet connection.'
+    )
+    expect(screen.getByRole('button', { name: /reconnect/i })).toBeEnabled()
     expect(zookeeperManagerActor.send).not.toHaveBeenCalledWith({
       type: ZookeeperManagerTransitions.NetworkOffline,
     })
@@ -426,6 +429,30 @@ describe('ZookeeperConversationPane', () => {
         type: ZookeeperManagerTransitions.CacheSetupAndConnect,
       })
     )
+
+    act(() => {
+      ws.dispatchEvent(new MessageEvent('message'))
+    })
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+    act(() => {
+      window.dispatchEvent(new Event('offline'))
+    })
+    fireEvent.click(screen.getByRole('button', { name: /reconnect/i }))
+    expect(zookeeperManagerActor.send).toHaveBeenCalledWith({
+      type: ZookeeperManagerTransitions.NetworkOffline,
+    })
+    expect(zookeeperManagerActor.send).toHaveBeenCalledWith({
+      type: ZookeeperManagerTransitions.CacheSetupAndConnect,
+      refParentSend: zookeeperManagerActor.send,
+      conversationId: 'conversation-id',
+    })
+    zookeeperManagerActor.send.mockClear()
+
+    act(() => {
+      window.dispatchEvent(new Event('online'))
+    })
+    expect(zookeeperManagerActor.send).not.toHaveBeenCalled()
 
     ws.readyState = WebSocket.CONNECTING
     act(() => {

--- a/src/lib/zookeeper/components/ZookeeperConversationPane.spec.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPane.spec.tsx
@@ -403,9 +403,10 @@ beforeAll(async () => {
 
 describe('ZookeeperConversationPane', () => {
   test('shows browser offline recovery without replacing a live connection', () => {
-    const ws = Object.assign(new EventTarget(), {
-      readyState: WebSocket.OPEN,
-    })
+    const ws: EventTarget & { readyState: WebSocket['readyState'] } =
+      Object.assign(new EventTarget(), {
+        readyState: WebSocket.OPEN,
+      })
     const zookeeperManagerActor = createFakeActor({
       awaitingResponse: false,
       ws,

--- a/src/lib/zookeeper/components/ZookeeperConversationPane.spec.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPane.spec.tsx
@@ -404,7 +404,7 @@ beforeAll(async () => {
 describe('ZookeeperConversationPane', () => {
   test('shows browser offline recovery without replacing a live connection', () => {
     const ws = Object.assign(new EventTarget(), {
-      readyState: WebSocket.OPEN as WebSocket['readyState'],
+      readyState: WebSocket.OPEN,
     })
     const zookeeperManagerActor = createFakeActor({
       awaitingResponse: false,

--- a/src/lib/zookeeper/components/ZookeeperConversationPane.spec.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPane.spec.tsx
@@ -402,10 +402,13 @@ beforeAll(async () => {
 })
 
 describe('ZookeeperConversationPane', () => {
-  test('ignores browser network events while the Zookeeper socket is open', () => {
+  test('uses browser network events only as reconnect hints', () => {
+    const ws: { readyState: WebSocket['readyState'] } = {
+      readyState: WebSocket.OPEN,
+    }
     const zookeeperManagerActor = createFakeActor({
       awaitingResponse: false,
-      ws: { readyState: WebSocket.OPEN },
+      ws,
     })
 
     renderPane({ zookeeperManagerActor })
@@ -423,59 +426,23 @@ describe('ZookeeperConversationPane', () => {
         type: ZookeeperManagerTransitions.CacheSetupAndConnect,
       })
     )
-  })
 
-  test('shows recovery while offline and reconnects when the browser comes online', async () => {
-    vi.useFakeTimers()
-    const zookeeperManagerActor = createFakeActor({
-      awaitingResponse: false,
+    ws.readyState = WebSocket.CLOSED
+    act(() => {
+      window.dispatchEvent(new Event('offline'))
+    })
+    expect(zookeeperManagerActor.send).not.toHaveBeenCalledWith({
+      type: ZookeeperManagerTransitions.NetworkOffline,
     })
 
-    try {
-      renderPane({ zookeeperManagerActor })
-
-      act(() => {
-        window.dispatchEvent(new Event('offline'))
-      })
-
-      expect(zookeeperManagerActor.send).toHaveBeenCalledWith({
-        type: ZookeeperManagerTransitions.NetworkOffline,
-      })
-      expect(screen.getByRole('alert')).toHaveTextContent(
-        'No internet connection.'
-      )
-      expect(screen.getByTestId('connection-recovery')).toBeInTheDocument()
-      expect(screen.getByRole('button', { name: /reconnect/i })).toBeEnabled()
-      expect(
-        screen.queryByRole('button', { name: /Clear chat/ })
-      ).not.toBeInTheDocument()
-      expect(
-        screen.getByTestId('ml-ephant-conversation-input-button')
-      ).toBeDisabled()
-      expect(screen.queryByTestId('loading')).not.toBeInTheDocument()
-
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(3000)
-      })
-
-      expect(zookeeperManagerActor.send).not.toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: ZookeeperManagerTransitions.CacheSetupAndConnect,
-        })
-      )
-
-      act(() => {
-        window.dispatchEvent(new Event('online'))
-      })
-      expect(zookeeperManagerActor.send).toHaveBeenCalledWith({
-        type: ZookeeperManagerTransitions.CacheSetupAndConnect,
-        refParentSend: zookeeperManagerActor.send,
-        conversationId: 'conversation-id',
-      })
-      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-    } finally {
-      vi.useRealTimers()
-    }
+    act(() => {
+      window.dispatchEvent(new Event('online'))
+    })
+    expect(zookeeperManagerActor.send).toHaveBeenCalledWith({
+      type: ZookeeperManagerTransitions.CacheSetupAndConnect,
+      refParentSend: zookeeperManagerActor.send,
+      conversationId: 'conversation-id',
+    })
   })
 
   test('waits for the saved conversation lookup before reconnecting an initially offline project', async () => {

--- a/src/lib/zookeeper/components/ZookeeperConversationPane.spec.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPane.spec.tsx
@@ -427,6 +427,16 @@ describe('ZookeeperConversationPane', () => {
       })
     )
 
+    ws.readyState = WebSocket.CONNECTING
+    act(() => {
+      window.dispatchEvent(new Event('online'))
+    })
+    expect(zookeeperManagerActor.send).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: ZookeeperManagerTransitions.CacheSetupAndConnect,
+      })
+    )
+
     ws.readyState = WebSocket.CLOSED
     act(() => {
       window.dispatchEvent(new Event('offline'))

--- a/src/lib/zookeeper/components/ZookeeperConversationPane.spec.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPane.spec.tsx
@@ -70,6 +70,7 @@ type FakeZookeeperSnapshot = {
     conversationId?: string
     defaultMode?: MlCopilotModeId
     modeOptions?: MlCopilotModeOption[]
+    ws?: Pick<WebSocket, 'readyState'>
   }
   matches: (state: unknown) => boolean
 }
@@ -93,6 +94,7 @@ const createFakeActor = ({
   setupAttempt = 0,
   includeConversationId = true,
   conversationId = 'conversation-id',
+  ws,
 }: {
   conversation?: Conversation
   defaultMode?: MlCopilotModeId
@@ -104,6 +106,7 @@ const createFakeActor = ({
   setupAttempt?: number
   includeConversationId?: boolean
   conversationId?: string
+  ws?: Pick<WebSocket, 'readyState'>
 } = {}): FakeZookeeperActor => {
   const snapshot: FakeZookeeperSnapshot = {
     value,
@@ -117,6 +120,7 @@ const createFakeActor = ({
       conversationId: includeConversationId ? conversationId : undefined,
       defaultMode,
       modeOptions,
+      ws,
     },
     matches: (state: unknown) => state === value,
   }
@@ -398,6 +402,29 @@ beforeAll(async () => {
 })
 
 describe('ZookeeperConversationPane', () => {
+  test('ignores browser network events while the Zookeeper socket is open', () => {
+    const zookeeperManagerActor = createFakeActor({
+      awaitingResponse: false,
+      ws: { readyState: WebSocket.OPEN },
+    })
+
+    renderPane({ zookeeperManagerActor })
+
+    act(() => {
+      window.dispatchEvent(new Event('offline'))
+      window.dispatchEvent(new Event('online'))
+    })
+
+    expect(zookeeperManagerActor.send).not.toHaveBeenCalledWith({
+      type: ZookeeperManagerTransitions.NetworkOffline,
+    })
+    expect(zookeeperManagerActor.send).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: ZookeeperManagerTransitions.CacheSetupAndConnect,
+      })
+    )
+  })
+
   test('shows recovery while offline and reconnects when the browser comes online', async () => {
     vi.useFakeTimers()
     const zookeeperManagerActor = createFakeActor({

--- a/src/lib/zookeeper/components/ZookeeperConversationPane.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPane.tsx
@@ -59,6 +59,7 @@ export const ZookeeperConversationPane = (props: {
   const isSubmittingFromQueue = useRef(false)
   const isClearingChat = useRef(false)
   const [isClearingChatPending, setIsClearingChatPending] = useState(false)
+  const [showManualConnect, setShowManualConnect] = useState(false)
   const steeredId = useRef<string | null>(null)
   const savedProjectConversationLookupLoaded = useRef(false)
   const savedProjectConversationId = useRef<string | undefined>(undefined)
@@ -86,6 +87,9 @@ export const ZookeeperConversationPane = (props: {
   })
   const conversationId = useSelector(props.zookeeperManagerActor, (actor) => {
     return actor.context.conversationId
+  })
+  const ws = useSelector(props.zookeeperManagerActor, (actor) => {
+    return actor.context.ws
   })
   const isSettingUp = useSelector(props.zookeeperManagerActor, (actor) => {
     return actor.matches(ZookeeperManagerStates.Setup)
@@ -204,10 +208,22 @@ export const ZookeeperConversationPane = (props: {
     })
   }, [props.zookeeperManagerActor, props.theProject?.path])
 
+  const onReconnect = useCallback(() => {
+    setShowManualConnect(false)
+    if (showManualConnect) {
+      props.zookeeperManagerActor.send({
+        type: ZookeeperManagerTransitions.NetworkOffline,
+      })
+    }
+    reconnect()
+  }, [props.zookeeperManagerActor, reconnect, showManualConnect])
+
   useEffect(() => {
-    // Browser connectivity signals can be unreliable on spotty networks. Let
-    // the WebSocket own disconnect detection and use `online` as a reconnect hint.
+    // Browser connectivity signals can be unreliable on spotty networks. An
+    // offline event shows recovery without automatically closing the socket.
+    const showOfflineRecovery = () => setShowManualConnect(true)
     const reconnectWhenOnline = () => {
+      setShowManualConnect(false)
       const readyState =
         props.zookeeperManagerActor.getSnapshot().context.ws?.readyState
       // Do not replace a healthy socket or restart a connection in progress.
@@ -220,9 +236,19 @@ export const ZookeeperConversationPane = (props: {
       reconnect()
     }
 
+    window.addEventListener('offline', showOfflineRecovery)
     window.addEventListener('online', reconnectWhenOnline)
-    return () => window.removeEventListener('online', reconnectWhenOnline)
+    return () => {
+      window.removeEventListener('offline', showOfflineRecovery)
+      window.removeEventListener('online', reconnectWhenOnline)
+    }
   }, [props.zookeeperManagerActor, reconnect])
+
+  useEffect(() => {
+    const dismissOfflineRecovery = () => setShowManualConnect(false)
+    ws?.addEventListener('message', dismissOfflineRecovery)
+    return () => ws?.removeEventListener('message', dismissOfflineRecovery)
+  }, [ws])
 
   useEffect(() => {
     // Abrupt closes retry automatically. Terminal setup failures wait for the
@@ -623,9 +649,12 @@ export const ZookeeperConversationPane = (props: {
       onClickClearChat={() => {
         void onClickClearChat()
       }}
-      onReconnect={reconnect}
-      connectionError={closeReason}
+      onReconnect={onReconnect}
+      connectionError={
+        showManualConnect ? 'No internet connection.' : closeReason
+      }
       connectionFailed={setupFailed}
+      showManualConnect={showManualConnect}
       canClearChat={setupFailed && conversationId !== undefined}
       isClearingChat={isClearingChatPending}
       loadingMessage={

--- a/src/lib/zookeeper/components/ZookeeperConversationPane.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPane.tsx
@@ -3,7 +3,6 @@ import {
   type QueuedMessage,
 } from '@src/lib/zookeeper/components/ZookeeperConversation'
 import { ZookeeperConversationWelcome } from '@src/lib/zookeeper/components/ZookeeperConversationWelcome'
-import { useOnWindowOnlineOffline } from '@src/hooks/network/useOnWindowOnlineOffline'
 import type { useModelingContext } from '@src/hooks/useModelingContext'
 import type { KclManager } from '@src/lang/KclManager'
 import { SEARCH_PARAM_ZOOKEEPER_PROMPT_KEY } from '@src/lib/constants'
@@ -23,7 +22,7 @@ import type { ModelingMachineContext } from '@src/machines/modelingSharedTypes'
 import { collectProjectFiles } from '@src/machines/systemIO/utils'
 import { S } from '@src/machines/utils'
 import { useSelector } from '@xstate/react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { NIL as uuidNIL } from 'uuid'
 import type { SnapshotFrom } from 'xstate'
@@ -60,9 +59,6 @@ export const ZookeeperConversationPane = (props: {
   const isSubmittingFromQueue = useRef(false)
   const isClearingChat = useRef(false)
   const [isClearingChatPending, setIsClearingChatPending] = useState(false)
-  const [showManualConnect, setShowManualConnect] = useState(
-    typeof navigator !== 'undefined' && navigator.onLine === false
-  )
   const steeredId = useRef<string | null>(null)
   const savedProjectConversationLookupLoaded = useRef(false)
   const savedProjectConversationId = useRef<string | undefined>(undefined)
@@ -170,7 +166,7 @@ export const ZookeeperConversationPane = (props: {
     })
   }
 
-  const needsReconnect = abruptlyClosed || showManualConnect
+  const needsReconnect = abruptlyClosed
 
   const reconnect = useCallback(() => {
     if (isClearingChat.current) {
@@ -208,57 +204,29 @@ export const ZookeeperConversationPane = (props: {
     })
   }, [props.zookeeperManagerActor, props.theProject?.path])
 
-  const onReconnect = useCallback(() => {
-    setShowManualConnect(false)
-    reconnect()
-  }, [reconnect])
-
-  const onWindowOnlineOfflineParams = useMemo(
-    () => ({
-      close: () => {
-        // OS connectivity checks can flap under VPNs while this socket is healthy.
-        if (
-          props.zookeeperManagerActor.getSnapshot().context.ws?.readyState ===
-          WebSocket.OPEN
-        ) {
-          return
-        }
-        reconnectAfterSavedConversationLookup.current = false
-        setShowManualConnect(true)
-        props.zookeeperManagerActor.send({
-          type: ZookeeperManagerTransitions.NetworkOffline,
-        })
-      },
-      connect: () => {
-        if (
-          props.zookeeperManagerActor.getSnapshot().context.ws?.readyState ===
-          WebSocket.OPEN
-        ) {
-          return
-        }
-        onReconnect()
-      },
-    }),
-    [onReconnect, props.zookeeperManagerActor]
-  )
-  useOnWindowOnlineOffline(onWindowOnlineOfflineParams)
-
   useEffect(() => {
-    if (typeof navigator === 'undefined' || navigator.onLine) {
-      return
+    // `navigator.onLine` can report false under VPNs. Let the WebSocket own
+    // disconnect detection and use an `online` event only as a reconnect hint.
+    const reconnectWhenOnline = () => {
+      // A browser event can fire even though the current connection is healthy.
+      // Replacing an open socket would interrupt the active conversation.
+      if (
+        props.zookeeperManagerActor.getSnapshot().context.ws?.readyState ===
+        WebSocket.OPEN
+      ) {
+        return
+      }
+      reconnect()
     }
-    props.zookeeperManagerActor.send({
-      type: ZookeeperManagerTransitions.NetworkOffline,
-    })
-  }, [props.zookeeperManagerActor])
+
+    window.addEventListener('online', reconnectWhenOnline)
+    return () => window.removeEventListener('online', reconnectWhenOnline)
+  }, [props.zookeeperManagerActor, reconnect])
 
   useEffect(() => {
-    if (
-      !needsReconnect ||
-      setupFailed ||
-      showManualConnect ||
-      isClearingChatPending
-    ) {
+    // Abrupt closes retry automatically. Terminal setup failures wait for the
+    // user, while clear-chat owns its connection lifecycle until it completes.
+    if (!needsReconnect || setupFailed || isClearingChatPending) {
       return
     }
 
@@ -266,13 +234,7 @@ export const ZookeeperConversationPane = (props: {
     return () => {
       clearTimeout(timeoutReconnect)
     }
-  }, [
-    isClearingChatPending,
-    needsReconnect,
-    reconnect,
-    setupFailed,
-    showManualConnect,
-  ])
+  }, [isClearingChatPending, needsReconnect, reconnect, setupFailed])
 
   const onCancel = () => {
     props.zookeeperManagerActor.send({
@@ -660,12 +622,9 @@ export const ZookeeperConversationPane = (props: {
       onClickClearChat={() => {
         void onClickClearChat()
       }}
-      onReconnect={onReconnect}
-      connectionError={
-        showManualConnect ? 'No internet connection.' : closeReason
-      }
+      onReconnect={reconnect}
+      connectionError={closeReason}
       connectionFailed={setupFailed}
-      showManualConnect={showManualConnect}
       canClearChat={setupFailed && conversationId !== undefined}
       isClearingChat={isClearingChatPending}
       loadingMessage={

--- a/src/lib/zookeeper/components/ZookeeperConversationPane.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPane.tsx
@@ -216,13 +216,28 @@ export const ZookeeperConversationPane = (props: {
   const onWindowOnlineOfflineParams = useMemo(
     () => ({
       close: () => {
+        // OS connectivity checks can flap under VPNs while this socket is healthy.
+        if (
+          props.zookeeperManagerActor.getSnapshot().context.ws?.readyState ===
+          WebSocket.OPEN
+        ) {
+          return
+        }
         reconnectAfterSavedConversationLookup.current = false
         setShowManualConnect(true)
         props.zookeeperManagerActor.send({
           type: ZookeeperManagerTransitions.NetworkOffline,
         })
       },
-      connect: onReconnect,
+      connect: () => {
+        if (
+          props.zookeeperManagerActor.getSnapshot().context.ws?.readyState ===
+          WebSocket.OPEN
+        ) {
+          return
+        }
+        onReconnect()
+      },
     }),
     [onReconnect, props.zookeeperManagerActor]
   )

--- a/src/lib/zookeeper/components/ZookeeperConversationPane.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPane.tsx
@@ -205,14 +205,15 @@ export const ZookeeperConversationPane = (props: {
   }, [props.zookeeperManagerActor, props.theProject?.path])
 
   useEffect(() => {
-    // `navigator.onLine` can report false under VPNs. Let the WebSocket own
-    // disconnect detection and use an `online` event only as a reconnect hint.
+    // Browser connectivity signals can be unreliable on spotty networks. Let
+    // the WebSocket own disconnect detection and use `online` as a reconnect hint.
     const reconnectWhenOnline = () => {
-      // A browser event can fire even though the current connection is healthy.
-      // Replacing an open socket would interrupt the active conversation.
+      const readyState =
+        props.zookeeperManagerActor.getSnapshot().context.ws?.readyState
+      // Do not replace a healthy socket or restart a connection in progress.
       if (
-        props.zookeeperManagerActor.getSnapshot().context.ws?.readyState ===
-        WebSocket.OPEN
+        readyState === WebSocket.OPEN ||
+        readyState === WebSocket.CONNECTING
       ) {
         return
       }

--- a/src/lib/zookeeper/zookeeperManagerMachine.test.ts
+++ b/src/lib/zookeeper/zookeeperManagerMachine.test.ts
@@ -64,6 +64,7 @@ class ControllableSetupWebSocket extends EventTarget {
   readonly sentPayloads: string[] = []
   binaryType: BinaryType = 'blob'
   readyState = ControllableSetupWebSocket.CONNECTING
+  bufferedAmount = 0
 
   constructor(url: string) {
     super()
@@ -588,6 +589,17 @@ describe('zookeeperManagerMachine', () => {
 
         expect(ControllableSetupWebSocket.instances).toHaveLength(1)
         expect(actor.getSnapshot().context.setupAttempt).toBe(0)
+
+        socket.bufferedAmount = 1
+        await vi.advanceTimersByTimeAsync(
+          ZOOKEEPER_HEARTBEAT_TIMEOUT_MS + ZOOKEEPER_HEARTBEAT_INTERVAL_MS * 2
+        )
+        expect(
+          actor
+            .getSnapshot()
+            .matches(ZookeeperManagerStates.WaitForContinueCheck)
+        ).toBe(true)
+        socket.bufferedAmount = 0
 
         await vi.advanceTimersByTimeAsync(ZOOKEEPER_HEARTBEAT_INTERVAL_MS)
         vi.setSystemTime(Date.now() + ZOOKEEPER_HEARTBEAT_TIMEOUT_MS * 2)

--- a/src/lib/zookeeper/zookeeperManagerMachine.test.ts
+++ b/src/lib/zookeeper/zookeeperManagerMachine.test.ts
@@ -620,7 +620,7 @@ describe('zookeeperManagerMachine', () => {
   })
 
   describe('ContinueCheck', () => {
-    it('sends continue requests when the last exchange was interrupted', async () => {
+    it('continues with source files and changed project assets', async () => {
       const ws: TestWebSocket = new TestSocket() as TestWebSocket
       const interruptedConversation: Conversation = {
         exchanges: [
@@ -654,6 +654,11 @@ describe('zookeeperManagerMachine', () => {
           relPath: 'notes.txt',
           data: new Blob(['notes']),
         },
+        {
+          type: 'other',
+          relPath: 'unchanged.txt',
+          data: new Blob(['unchanged']),
+        },
       ]
       const machine = zookeeperManagerMachine.provide({
         actors: {
@@ -663,6 +668,10 @@ describe('zookeeperManagerMachine', () => {
           >(async () => ({
             ws,
             conversation: interruptedConversation,
+            projectAssetSignatures: {
+              'unchanged.txt':
+                'aaa8d3c8d74ad3e8f6b1772aa9c7e0eaa528cb42fc93599ce2f125b00d4c424c',
+            },
           })),
         },
       })
@@ -707,6 +716,14 @@ describe('zookeeperManagerMachine', () => {
           current_files: {
             'main.kcl': Array.from(new TextEncoder().encode('cube()')),
             'notes.txt': Array.from(new TextEncoder().encode('notes')),
+          },
+          active_file: 'newFile.kcl',
+        }),
+        JSON.stringify({
+          type: 'project_context',
+          project_name: 'zoo-project',
+          current_files: {
+            'main.kcl': Array.from(new TextEncoder().encode('cube()')),
           },
           active_file: 'newFile.kcl',
         }),

--- a/src/lib/zookeeper/zookeeperManagerMachine.test.ts
+++ b/src/lib/zookeeper/zookeeperManagerMachine.test.ts
@@ -64,7 +64,6 @@ class ControllableSetupWebSocket extends EventTarget {
   readonly sentPayloads: string[] = []
   binaryType: BinaryType = 'blob'
   readyState = ControllableSetupWebSocket.CONNECTING
-  bufferedAmount = 0
 
   constructor(url: string) {
     super()
@@ -544,7 +543,7 @@ describe('zookeeperManagerMachine', () => {
       }
     })
 
-    it('recovers if a responsive websocket later stops responding', async () => {
+    it('allows slow setup progress and recovers if the websocket later stops responding', async () => {
       vi.useFakeTimers()
       vi.stubGlobal('WebSocket', ControllableSetupWebSocket)
       const actor = createActor(zookeeperManagerMachine, {
@@ -561,6 +560,9 @@ describe('zookeeperManagerMachine', () => {
         })
 
         const socket = ControllableSetupWebSocket.instances[0]
+        await vi.advanceTimersByTimeAsync(
+          ZOOKEEPER_SETUP_INACTIVITY_TIMEOUT_MS / 2
+        )
         socket.open()
         await vi.waitFor(() => {
           expect(socket.sentPayloads).toContain(
@@ -568,11 +570,10 @@ describe('zookeeperManagerMachine', () => {
           )
         })
 
-        for (let heartbeat = 0; heartbeat < 3; heartbeat += 1) {
-          await vi.advanceTimersByTimeAsync(20_000)
-          socket.receive({ pong: {} })
-        }
-        await vi.advanceTimersByTimeAsync(20_000)
+        await vi.advanceTimersByTimeAsync(
+          ZOOKEEPER_SETUP_INACTIVITY_TIMEOUT_MS / 2 +
+            ZOOKEEPER_HEARTBEAT_INTERVAL_MS
+        )
         socket.receive({
           conversation_id: {
             conversation_id: 'conversation-id',
@@ -589,17 +590,6 @@ describe('zookeeperManagerMachine', () => {
 
         expect(ControllableSetupWebSocket.instances).toHaveLength(1)
         expect(actor.getSnapshot().context.setupAttempt).toBe(0)
-
-        socket.bufferedAmount = 1
-        await vi.advanceTimersByTimeAsync(
-          ZOOKEEPER_HEARTBEAT_TIMEOUT_MS + ZOOKEEPER_HEARTBEAT_INTERVAL_MS * 2
-        )
-        expect(
-          actor
-            .getSnapshot()
-            .matches(ZookeeperManagerStates.WaitForContinueCheck)
-        ).toBe(true)
-        socket.bufferedAmount = 0
 
         await vi.advanceTimersByTimeAsync(ZOOKEEPER_HEARTBEAT_INTERVAL_MS)
         vi.setSystemTime(Date.now() + ZOOKEEPER_HEARTBEAT_TIMEOUT_MS * 2)

--- a/src/lib/zookeeper/zookeeperManagerMachine.ts
+++ b/src/lib/zookeeper/zookeeperManagerMachine.ts
@@ -361,6 +361,7 @@ export interface ZookeeperManagerContext {
   awaitingResponse: boolean
   attachmentsLoadedForCurrentPrompt: boolean
   pendingBackendShutdown: boolean
+  projectAssetSignatures: Record<string, string>
   defaultMode?: MlCopilotModeId
   modeOptions?: MlCopilotModeOption[]
   cachedSetup?: {
@@ -391,6 +392,7 @@ export const zookeeperDefaultContext = (args: {
   awaitingResponse: false,
   attachmentsLoadedForCurrentPrompt: true,
   pendingBackendShutdown: false,
+  projectAssetSignatures: {},
   defaultMode: undefined,
   modeOptions: undefined,
 })
@@ -527,6 +529,88 @@ async function toMlCopilotFile(file: File): Promise<MlCopilotFile> {
     mimetype: file.type || 'application/octet-stream',
     data: Array.from(new Uint8Array(await file.arrayBuffer())),
   }
+}
+
+const ZOOKEEPER_PROJECT_ASSET_CHUNK_BYTES = 16 * 1024 * 1024
+const ZOOKEEPER_BUFFERED_AMOUNT_LOW_WATER_MARK = 1024 * 1024
+
+const isZookeeperSourceFile = (name: string) => /\.(kcl|md)$/i.test(name)
+
+async function waitForZookeeperSocketBuffer(ws: WebSocket) {
+  while (ws.bufferedAmount > ZOOKEEPER_BUFFERED_AMOUNT_LOW_WATER_MARK) {
+    if (ws.readyState !== WebSocket.OPEN) {
+      return Promise.reject(
+        new Error('WebSocket closed while uploading project files')
+      )
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+}
+
+async function zookeeperAssetSignature(data: ArrayBuffer) {
+  const digest = await crypto.subtle.digest('SHA-256', data)
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, '0')
+  ).join('')
+}
+
+async function sendProjectFileChunks(args: {
+  ws: WebSocket
+  files: KittyCadLibFile[]
+  projectName?: string
+  activeFile?: string
+  previousAssetSignatures: Record<string, string>
+}) {
+  const sourceFiles: Record<string, number[]> = {}
+  const assetSignatures: Record<string, string> = {}
+  for (const file of args.files.filter((file) =>
+    isZookeeperSourceFile(file.name)
+  )) {
+    sourceFiles[file.name] = Array.from(
+      new Uint8Array(await file.data.arrayBuffer())
+    )
+  }
+
+  let assetChunk: Record<string, number[]> = {}
+  let assetChunkBytes = 0
+  const sendAssetChunk = async () => {
+    if (assetChunkBytes === 0) {
+      return
+    }
+    const request: MlCopilotProjectContextRequest = {
+      type: 'project_context',
+      project_name: args.projectName,
+      current_files: { ...sourceFiles, ...assetChunk },
+      ...(args.activeFile ? { active_file: args.activeFile } : {}),
+    }
+    args.ws.send(JSON.stringify(request))
+    assetChunk = {}
+    assetChunkBytes = 0
+    await waitForZookeeperSocketBuffer(args.ws)
+  }
+
+  for (const file of args.files.filter(
+    (file) => !isZookeeperSourceFile(file.name)
+  )) {
+    const data = await file.data.arrayBuffer()
+    const bytes = new Uint8Array(data)
+    const signature = await zookeeperAssetSignature(data)
+    assetSignatures[file.name] = signature
+    if (args.previousAssetSignatures[file.name] === signature) {
+      continue
+    }
+    if (
+      assetChunkBytes > 0 &&
+      assetChunkBytes + bytes.byteLength > ZOOKEEPER_PROJECT_ASSET_CHUNK_BYTES
+    ) {
+      await sendAssetChunk()
+    }
+    assetChunk[file.name] = Array.from(bytes)
+    assetChunkBytes += bytes.byteLength
+  }
+  await sendAssetChunk()
+
+  return { sourceFiles, assetSignatures }
 }
 
 export const ZookeeperConversationToMarkdown = (
@@ -841,6 +925,7 @@ export const zookeeperManagerMachine = setup({
         awaitingResponse: false,
         attachmentsLoadedForCurrentPrompt: true,
         pendingBackendShutdown: false,
+        projectAssetSignatures: {},
         cachedSetup: {
           refParentSend: event.refParentSend,
           conversationId: event.conversationId,
@@ -1282,13 +1367,13 @@ export const zookeeperManagerMachine = setup({
       })
       if (isErr(requestData)) return Promise.reject(requestData)
 
-      const filesAsByteArrays: Record<string, number[]> = {}
-
-      for (let file of requestData.files) {
-        filesAsByteArrays[file.name] = Array.from(
-          new Uint8Array(await file.data.arrayBuffer())
-        )
-      }
+      const { sourceFiles, assetSignatures } = await sendProjectFileChunks({
+        ws: context.ws,
+        files: requestData.files,
+        projectName: requestData.body.project_name,
+        activeFile: requestData.activeFile,
+        previousAssetSignatures: context.projectAssetSignatures,
+      })
 
       const additionalFiles =
         event.additionalFiles && event.additionalFiles.length > 0
@@ -1303,7 +1388,7 @@ export const zookeeperManagerMachine = setup({
         ...(requestData.body.source_ranges !== undefined
           ? { source_ranges: requestData.body.source_ranges }
           : {}),
-        current_files: filesAsByteArrays,
+        current_files: sourceFiles,
         ...(requestData.activeFile
           ? { active_file: requestData.activeFile }
           : {}),
@@ -1328,6 +1413,7 @@ export const zookeeperManagerMachine = setup({
         conversation,
         fileFocusedOnInEditor: event.fileSelectedDuringPrompting.entry,
         projectNameCurrentlyOpened: requestData.body.project_name,
+        projectAssetSignatures: assetSignatures,
         attachmentsLoadedForCurrentPrompt:
           !event.additionalFiles || event.additionalFiles.length === 0,
       }
@@ -1348,7 +1434,6 @@ export const zookeeperManagerMachine = setup({
         }
       }
 
-      const filesAsByteArrays: Record<string, number[]> = {}
       const files: KittyCadLibFile[] = []
 
       event.projectFiles.forEach((file) => {
@@ -1365,19 +1450,6 @@ export const zookeeperManagerMachine = setup({
         })
       })
 
-      for (let file of files) {
-        filesAsByteArrays[file.name] = Array.from(
-          new Uint8Array(await file.data.arrayBuffer())
-        )
-      }
-
-      const requestProjectContext: MlCopilotProjectContextRequest = {
-        type: 'project_context',
-        project_name: event.projectName,
-        current_files: filesAsByteArrays,
-        ...(event.activeFile ? { active_file: event.activeFile } : {}),
-      }
-
       const requestContinue: Extract<
         MlCopilotClientMessage,
         { type: 'system' }
@@ -1387,11 +1459,26 @@ export const zookeeperManagerMachine = setup({
       }
 
       context.ws.send(JSON.stringify(requestContinue))
+
+      const { sourceFiles, assetSignatures } = await sendProjectFileChunks({
+        ws: context.ws,
+        files,
+        projectName: event.projectName,
+        activeFile: event.activeFile,
+        previousAssetSignatures: context.projectAssetSignatures,
+      })
+      const requestProjectContext: MlCopilotProjectContextRequest = {
+        type: 'project_context',
+        project_name: event.projectName,
+        current_files: sourceFiles,
+        ...(event.activeFile ? { active_file: event.activeFile } : {}),
+      }
       context.ws.send(JSON.stringify(requestProjectContext))
 
       return {
         awaitingResponse: true,
         projectNameCurrentlyOpened: event.projectName,
+        projectAssetSignatures: assetSignatures,
       }
     }),
     [ZookeeperManagerTransitions.Cancel]: fromPromise(async function (

--- a/src/lib/zookeeper/zookeeperManagerMachine.ts
+++ b/src/lib/zookeeper/zookeeperManagerMachine.ts
@@ -204,10 +204,10 @@ export enum ZookeeperManagerTransitions {
 }
 
 export const NUMBER_OF_ZOOKEEPER_SETUP_ATTEMPTS = 3
-export const ZOOKEEPER_SETUP_INACTIVITY_TIMEOUT_MS = 30_000
+export const ZOOKEEPER_SETUP_INACTIVITY_TIMEOUT_MS = 60_000
 export const ZOOKEEPER_SETUP_ATTEMPT_TIMEOUT_MS = 120_000
 export const ZOOKEEPER_HEARTBEAT_INTERVAL_MS = 4_000
-export const ZOOKEEPER_HEARTBEAT_TIMEOUT_MS = 30_000
+export const ZOOKEEPER_HEARTBEAT_TIMEOUT_MS = 120_000
 const ZOOKEEPER_HEARTBEAT_TIMER_DRIFT_GRACE_MS = 5_000
 
 const ZOOKEEPER_PROJECT_TOO_LARGE_CLOSE_REASON =
@@ -901,6 +901,9 @@ export const zookeeperManagerMachine = setup({
         url,
         readyState: getWebSocketReadyStateLabel(ws.readyState),
       })
+      theRefParentSend({
+        type: ZookeeperManagerTransitions.SetupProgress,
+      })
 
       let maybeReplayedExchanges: Exchange[] = []
       let maybeModeOptions: MlCopilotModeOption[] | undefined
@@ -912,10 +915,13 @@ export const zookeeperManagerMachine = setup({
           let devCalledClose = false
           let attemptCanceled = false
 
-          // Any WS protocol messages will trigger the `api` heartbeat update.
+          // Anchor the timeout to the first unanswered ping. Repeated pings do
+          // not move that deadline, and any server message clears it below.
+          // A fixed deadline is used instead of `bufferedAmount`, which only
+          // describes Chromium's local send queue and can stay nonzero forever.
           let heartbeatSentAt: number | undefined
           const pingIntervalId = setInterval(() => {
-            if (ws.readyState !== WebSocket.OPEN || ws.bufferedAmount > 0) {
+            if (ws.readyState !== WebSocket.OPEN) {
               return
             }
             const now = Date.now()
@@ -937,13 +943,14 @@ export const zookeeperManagerMachine = setup({
                   })
                   return
                 }
+                // A large clock jump means the app was suspended and its timer
+                // ran late; start a fresh heartbeat instead of blaming the VPN.
                 heartbeatSentAt = undefined
-              } else {
-                return
               }
             }
             ws.send(JSON.stringify({ type: 'ping' }))
-            heartbeatSentAt = now
+            // Keep timing from the first ping until the server answers.
+            heartbeatSentAt ??= now
           }, ZOOKEEPER_HEARTBEAT_INTERVAL_MS)
           const cancelSetupAttempt = () => {
             if (attemptCanceled) {
@@ -978,6 +985,7 @@ export const zookeeperManagerMachine = setup({
             if (attemptCanceled) {
               return
             }
+            // Any server message proves the connection is still responsive.
             heartbeatSentAt = undefined
 
             let response: unknown

--- a/src/lib/zookeeper/zookeeperManagerMachine.ts
+++ b/src/lib/zookeeper/zookeeperManagerMachine.ts
@@ -915,7 +915,7 @@ export const zookeeperManagerMachine = setup({
           // Any WS protocol messages will trigger the `api` heartbeat update.
           let heartbeatSentAt: number | undefined
           const pingIntervalId = setInterval(() => {
-            if (ws.readyState !== WebSocket.OPEN) {
+            if (ws.readyState !== WebSocket.OPEN || ws.bufferedAmount > 0) {
               return
             }
             const now = Date.now()
@@ -938,10 +938,12 @@ export const zookeeperManagerMachine = setup({
                   return
                 }
                 heartbeatSentAt = undefined
+              } else {
+                return
               }
             }
             ws.send(JSON.stringify({ type: 'ping' }))
-            heartbeatSentAt ??= now
+            heartbeatSentAt = now
           }, ZOOKEEPER_HEARTBEAT_INTERVAL_MS)
           const cancelSetupAttempt = () => {
             if (attemptCanceled) {

--- a/src/lib/zookeeper/zookeeperManagerMachine.ts
+++ b/src/lib/zookeeper/zookeeperManagerMachine.ts
@@ -901,6 +901,7 @@ export const zookeeperManagerMachine = setup({
         url,
         readyState: getWebSocketReadyStateLabel(ws.readyState),
       })
+      // Give conversation replay a fresh inactivity window after a slow open.
       theRefParentSend({
         type: ZookeeperManagerTransitions.SetupProgress,
       })
@@ -915,10 +916,7 @@ export const zookeeperManagerMachine = setup({
           let devCalledClose = false
           let attemptCanceled = false
 
-          // Anchor the timeout to the first unanswered ping. Repeated pings do
-          // not move that deadline, and any server message clears it below.
-          // A fixed deadline is used instead of `bufferedAmount`, which only
-          // describes Chromium's local send queue and can stay nonzero forever.
+          // Any WS protocol messages will trigger the `api` heartbeat update.
           let heartbeatSentAt: number | undefined
           const pingIntervalId = setInterval(() => {
             if (ws.readyState !== WebSocket.OPEN) {
@@ -943,13 +941,10 @@ export const zookeeperManagerMachine = setup({
                   })
                   return
                 }
-                // A large clock jump means the app was suspended and its timer
-                // ran late; start a fresh heartbeat instead of blaming the VPN.
                 heartbeatSentAt = undefined
               }
             }
             ws.send(JSON.stringify({ type: 'ping' }))
-            // Keep timing from the first ping until the server answers.
             heartbeatSentAt ??= now
           }, ZOOKEEPER_HEARTBEAT_INTERVAL_MS)
           const cancelSetupAttempt = () => {
@@ -985,7 +980,6 @@ export const zookeeperManagerMachine = setup({
             if (attemptCanceled) {
               return
             }
-            // Any server message proves the connection is still responsive.
             heartbeatSentAt = undefined
 
             let response: unknown


### PR DESCRIPTION
Towards #12906

Makes Zookeeper more tolerant of spotty or high-latency connections:

- Keeps a live socket when browser connectivity signals are unreliable.
- Allows slower setup and heartbeat responses while retaining hard retry limits.
- Splits large project assets into bounded WebSocket frames and only resends changed assets.

A growing STEP project reproduced a chat reset when its JSON payload reached 198 MB, above the service's 128 MB frame limit. With this change, the same conversation survived 20→90 parts and frames stayed below 46 MB.

This does not fix blocked or unreachable routes. We are also still confirming whether the user's project contains imported assets; a KCL-only failure may have a different cause.