### PR TITLE
Open Aquarium projects in the default project library

### DIFF
--- a/e2e/playwright/cloud-sync.spec.ts
+++ b/e2e/playwright/cloud-sync.spec.ts
@@ -163,8 +163,8 @@ test(
   { tag: ['@web'] },
   async ({ context, page }, testInfo) => {
     const publicProjectId = 'aquarium-shared-project'
-    const publicProjectTitle = 'Aquarium shared project #3 (sample)'
-    const publicProjectDirectoryName = 'aquarium-shared-project-3-sample'
+    const publicProjectTitle = '!!!'
+    const publicProjectDirectoryName = 'shared-project'
     const publicProjectSettingsId = '29501ba6-dfa1-486f-b51d-aa9331ee441e'
     const publicProjectFiles = {
       'main.kcl': 'aquariumShared = 1\n',
@@ -192,8 +192,7 @@ test(
             status: 200,
             contentType: 'application/zip',
             headers: {
-              'content-disposition':
-                'attachment; filename="aquarium-shared-project.zip"',
+              'content-disposition': 'attachment; filename="...zip"',
             },
             body: publicProjectArchive,
           })
@@ -262,6 +261,7 @@ test(
     await expect(
       page.getByText('Unable to determine the project directory.')
     ).toHaveCount(0)
+    await expectProjectFileRoute(page)
   }
 )
 

--- a/e2e/playwright/cloud-sync.spec.ts
+++ b/e2e/playwright/cloud-sync.spec.ts
@@ -163,10 +163,16 @@ test(
   { tag: ['@web'] },
   async ({ context, page }, testInfo) => {
     const publicProjectId = 'aquarium-shared-project'
-    const publicProjectTitle = 'Aquarium shared project'
+    const publicProjectTitle = 'Aquarium shared project #3 (sample)'
+    const publicProjectDirectoryName = 'aquarium-shared-project-3-sample'
+    const publicProjectSettingsId = '29501ba6-dfa1-486f-b51d-aa9331ee441e'
     const publicProjectFiles = {
       'main.kcl': 'aquariumShared = 1\n',
-      'project.toml': projectToml(publicProjectTitle, publicProjectId),
+      'project.toml': [
+        '[settings.meta]',
+        `id = "${publicProjectSettingsId}"`,
+        '',
+      ].join('\n'),
     }
     const personalCloudProject: CloudProject = {
       id: 'personal-cloud-copy',
@@ -228,24 +234,31 @@ test(
       .toBe(1)
     await expect
       .poll(() =>
-        opfsPathExists(page, `${PROJECT_DIR}/${publicProjectTitle}/main.kcl`)
+        opfsPathExists(
+          page,
+          `${PROJECT_DIR}/${publicProjectDirectoryName}/main.kcl`
+        )
       )
       .toBe(true)
     await expect
       .poll(async () => {
         const files = await readOpfsTextFiles(page, {
-          projectToml: `${PROJECT_DIR}/${publicProjectTitle}/project.toml`,
+          projectToml: `${PROJECT_DIR}/${publicProjectDirectoryName}/project.toml`,
         })
         return files.projectToml
       })
       .toContain('project_id = "personal-cloud-copy"')
 
     const files = await readOpfsTextFiles(page, {
-      main: `${PROJECT_DIR}/${publicProjectTitle}/main.kcl`,
-      projectToml: `${PROJECT_DIR}/${publicProjectTitle}/project.toml`,
+      main: `${PROJECT_DIR}/${publicProjectDirectoryName}/main.kcl`,
+      projectToml: `${PROJECT_DIR}/${publicProjectDirectoryName}/project.toml`,
     })
     expect(files.main).toContain('aquariumShared = 1')
-    expect(files.projectToml).not.toContain(publicProjectId)
+    const clonedProjectSettingsId = files.projectToml.match(
+      /\[settings\.meta\]\s*\nid = "([^"]+)"/
+    )?.[1]
+    expect(clonedProjectSettingsId).toBeDefined()
+    expect(clonedProjectSettingsId).not.toBe(publicProjectSettingsId)
     await expect(
       page.getByText('Unable to determine the project directory.')
     ).toHaveCount(0)

--- a/e2e/playwright/cloud-sync.spec.ts
+++ b/e2e/playwright/cloud-sync.spec.ts
@@ -8,6 +8,7 @@ import {
   readOpfsTextFiles,
   routeCloudProjects,
   seedCloudSyncState,
+  zipProject,
 } from '@e2e/playwright/lib/cloudSyncTestUtils'
 import { setup } from '@e2e/playwright/test-utils'
 import { expect, type Page, test } from '@playwright/test'
@@ -154,6 +155,100 @@ test(
     expect(apiCalls.remoteListResponses).toBe(
       remoteListResponsesAfterMaterialization
     )
+  }
+)
+
+test(
+  'opens a shared project in Personal Cloud when no project is already open',
+  { tag: ['@web'] },
+  async ({ context, page }, testInfo) => {
+    const publicProjectId = 'aquarium-shared-project'
+    const publicProjectTitle = 'Aquarium shared project'
+    const publicProjectFiles = {
+      'main.kcl': 'aquariumShared = 1\n',
+      'project.toml': projectToml(publicProjectTitle, publicProjectId),
+    }
+    const personalCloudProject: CloudProject = {
+      id: 'personal-cloud-copy',
+      title: publicProjectTitle,
+      revision: 'personal-cloud-copy-rev-1',
+      files: publicProjectFiles,
+    }
+    const publicProjectArchive = await zipProject(publicProjectFiles)
+    let publicProjectDownloads = 0
+    await context.route(
+      `**/projects/public/${publicProjectId}**`,
+      async (route) => {
+        const url = new URL(route.request().url())
+        if (url.pathname.endsWith('/download')) {
+          publicProjectDownloads += 1
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/zip',
+            headers: {
+              'content-disposition':
+                'attachment; filename="aquarium-shared-project.zip"',
+            },
+            body: publicProjectArchive,
+          })
+          return
+        }
+
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            categories: [],
+            description: '',
+            id: publicProjectId,
+            like_count: 0,
+            owner: { username: 'aquarium' },
+            published_at: '2026-08-12T00:00:00Z',
+            title: publicProjectTitle,
+          }),
+        })
+      }
+    )
+    const { calls: apiCalls } = await routeCloudProjects(context, {
+      remoteProjects: [personalCloudProject],
+      listedProjects: [],
+      createProject: () => personalCloudProject,
+    })
+
+    await setup(context, page, testInfo, [OPFS_CLOUD_FEATURE_FLAG])
+    await page.goto(`/?project-id=${publicProjectId}&ask-open-desktop=true`)
+    await page.getByTestId('continue-to-web-app-button').click()
+
+    await expectProjectFileRoute(page)
+    expect(publicProjectDownloads).toBe(1)
+    await expect
+      .poll(() => apiCalls.creates.length, {
+        timeout: CLOUD_SYNC_E2E_TIMEOUT,
+      })
+      .toBe(1)
+    await expect
+      .poll(() =>
+        opfsPathExists(page, `${PROJECT_DIR}/${publicProjectTitle}/main.kcl`)
+      )
+      .toBe(true)
+    await expect
+      .poll(async () => {
+        const files = await readOpfsTextFiles(page, {
+          projectToml: `${PROJECT_DIR}/${publicProjectTitle}/project.toml`,
+        })
+        return files.projectToml
+      })
+      .toContain('project_id = "personal-cloud-copy"')
+
+    const files = await readOpfsTextFiles(page, {
+      main: `${PROJECT_DIR}/${publicProjectTitle}/main.kcl`,
+      projectToml: `${PROJECT_DIR}/${publicProjectTitle}/project.toml`,
+    })
+    expect(files.main).toContain('aquariumShared = 1')
+    expect(files.projectToml).not.toContain(publicProjectId)
+    await expect(
+      page.getByText('Unable to determine the project directory.')
+    ).toHaveCount(0)
   }
 )
 

--- a/src/components/OpenedProject.tsx
+++ b/src/components/OpenedProject.tsx
@@ -76,7 +76,7 @@ export function OpenedProject() {
   const defaultAreaLibrary = useDefaultAreaLibrary()
   const defaultActionLibrary = useDefaultActionLibrary()
   const { state: modelingState, send: modelingSend } = useModelingContext()
-  useQueryParamEffects(kclManager)
+  useQueryParamEffects()
   const [nativeFileMenuCreated, setNativeFileMenuCreated] = useState(false)
   const location = useLocation()
   const navigate = useNavigate()

--- a/src/hooks/useQueryParamEffects.ts
+++ b/src/hooks/useQueryParamEffects.ts
@@ -185,7 +185,7 @@ export function useQueryParamEffects(kclManager: KclManager) {
           projectDirectoryPath: targetProjectDirectoryPath,
           requestedProjectName: getProjectDirectoryNameFromTitle(
             projectName,
-            downloadedProject.projectName
+            'shared-project'
           ),
           requestedProjectTitle: projectName,
           files: downloadedProject.files,

--- a/src/hooks/useQueryParamEffects.ts
+++ b/src/hooks/useQueryParamEffects.ts
@@ -129,12 +129,14 @@ export function useQueryParamEffects() {
 
       const projectLibraryTarget = app.getCreateProjectLibraryTargets()[0]
       if (!projectLibraryTarget) {
-        throw new Error('No writable project library is available.')
+        return Promise.reject(
+          new Error('No writable project library is available.')
+        )
       }
 
       const projectName = await getPublicProjectNameById(projectId)
       if (err(projectName)) {
-        throw projectName
+        return Promise.reject(projectName)
       }
       if (cancelled) {
         return
@@ -142,7 +144,7 @@ export function useQueryParamEffects() {
 
       const downloadedProject = await downloadProjectById(projectId)
       if (err(downloadedProject)) {
-        throw downloadedProject
+        return Promise.reject(downloadedProject)
       }
       if (cancelled) {
         return
@@ -162,7 +164,7 @@ export function useQueryParamEffects() {
         },
       })
       if (!importedProject?.default_file) {
-        throw new Error('Unable to create the shared project.')
+        return Promise.reject(new Error('Unable to create the shared project.'))
       }
       if (cancelled) {
         return

--- a/src/hooks/useQueryParamEffects.ts
+++ b/src/hooks/useQueryParamEffects.ts
@@ -1,6 +1,7 @@
 import type { KclManager } from '@src/lang/KclManager'
 import { base64ToString } from '@src/lib/base64'
 import { useApp } from '@src/lib/boot'
+import { getCloudProjectLibraryMaterializationDirectoryPath } from '@src/lib/cloudSync/paths'
 import type { ProjectsCommandSchema } from '@src/lib/commandBarConfigs/projectsCommandConfig'
 import {
   ASK_TO_OPEN_QUERY_PARAM,
@@ -13,6 +14,7 @@ import {
   PROJECT_ENTRYPOINT,
   PROJECT_ID_QUERY_PARAM,
 } from '@src/lib/constants'
+import { getProjectInfo } from '@src/lib/desktop'
 import { getUniqueProjectName } from '@src/lib/desktopFS'
 import {
   downloadProjectById,
@@ -24,7 +26,10 @@ import { PATHS, safeEncodeForRouterPaths } from '@src/lib/paths'
 import {
   CLOUD_PROJECT_LIBRARY_TYPE,
   getDefaultDirectoryProjectLibraryPath,
+  isPersonalCloudProjectLibrarySetting,
 } from '@src/lib/projectLibraries'
+import { importProjectFilesIntoLocalDirectory } from '@src/lib/projectLibraries/operations'
+import { invalidateProjectLibraryRealizations } from '@src/lib/projectLibraries/registry/invalidation'
 import { DEFAULT_WEB_PROJECT_NAME } from '@src/lib/routeLoaders'
 import { err } from '@src/lib/trap'
 import { getAllSubDirectoriesAtProjectRoot } from '@src/machines/systemIO/snapshotContext'
@@ -74,10 +79,24 @@ export function useQueryParamEffects(kclManager: KclManager) {
     searchParams.has(CMD_NAME_QUERY_PARAM) &&
     searchParams.has(CMD_GROUP_QUERY_PARAM)
 
-  function getCurrentCloudLibraryPath() {
+  async function getCloudLibraryPathForSharedProject() {
     const currentProject = app.project?.projectIORefSignal.value
-    return currentProject?.libraryType === CLOUD_PROJECT_LIBRARY_TYPE
-      ? currentProject.libraryPath
+    if (currentProject?.libraryType === CLOUD_PROJECT_LIBRARY_TYPE) {
+      return currentProject.libraryPath
+    }
+
+    if (isDesktop()) {
+      return undefined
+    }
+
+    await waitFor(app.settings.actor, (state) => state.matches('idle'))
+    const personalCloudLibrary = app.settings
+      .get()
+      .app.libraries.current.find(isPersonalCloudProjectLibrarySetting)
+    return personalCloudLibrary
+      ? getCloudProjectLibraryMaterializationDirectoryPath(
+          personalCloudLibrary
+        ).catch(() => undefined)
       : undefined
   }
 
@@ -136,7 +155,63 @@ export function useQueryParamEffects(kclManager: KclManager) {
         return
       }
 
-      const targetProjectDirectoryPath = getCurrentCloudLibraryPath()
+      const targetProjectDirectoryPath =
+        await getCloudLibraryPathForSharedProject()
+      if (cancelled) {
+        return
+      }
+      if (targetProjectDirectoryPath && !isDesktop()) {
+        const projectName = await getPublicProjectNameById(projectId)
+        if (err(projectName)) {
+          clearProjectIdSearchParam()
+          toast.error(projectName.message)
+          return
+        }
+        if (cancelled) {
+          return
+        }
+
+        const downloadedProject = await downloadProjectById(projectId)
+        if (err(downloadedProject)) {
+          clearProjectIdSearchParam()
+          toast.error(downloadedProject.message)
+          return
+        }
+        if (cancelled) {
+          return
+        }
+
+        const importedProject = await importProjectFilesIntoLocalDirectory({
+          projectDirectoryPath: targetProjectDirectoryPath,
+          requestedProjectName: projectName,
+          requestedProjectTitle: projectName,
+          files: downloadedProject.files,
+          entrypointFilePath:
+            downloadedProject.entrypointFilePath ?? PROJECT_ENTRYPOINT,
+          wasmInstancePromise: kclManager.wasmInstancePromise,
+        })
+        invalidateProjectLibraryRealizations()
+        await app.registry
+          .get(cloudSyncService)
+          .startProjectSync(importedProject.path)
+        app.systemIOActor.send({
+          type: SystemIOMachineEvents.setProjectDirectoryPath,
+          data: {
+            requestedProjectDirectoryPath: targetProjectDirectoryPath,
+          },
+        })
+        await waitForIdleState({ systemIOActor: app.systemIOActor })
+        if (cancelled) {
+          return
+        }
+        void navigate(
+          `${PATHS.FILE}/${safeEncodeForRouterPaths(
+            importedProject.default_file
+          )}`
+        )
+        return
+      }
+
       const localCloudProject = targetProjectDirectoryPath
         ? await app.registry
             .get(cloudSyncService)
@@ -150,10 +225,12 @@ export function useQueryParamEffects(kclManager: KclManager) {
         app.systemIOActor.send({
           type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
         })
+        const project = await getProjectInfo(
+          localCloudProject.projectPath,
+          await kclManager.wasmInstancePromise
+        )
         void navigate(
-          `${PATHS.FILE}/${safeEncodeForRouterPaths(
-            localCloudProject.projectPath
-          )}`
+          `${PATHS.FILE}/${safeEncodeForRouterPaths(project.default_file)}`
         )
         return
       }

--- a/src/hooks/useQueryParamEffects.ts
+++ b/src/hooks/useQueryParamEffects.ts
@@ -1,7 +1,5 @@
-import type { KclManager } from '@src/lang/KclManager'
 import { base64ToString } from '@src/lib/base64'
 import { useApp } from '@src/lib/boot'
-import { getCloudProjectLibraryMaterializationDirectoryPath } from '@src/lib/cloudSync/paths'
 import type { ProjectsCommandSchema } from '@src/lib/commandBarConfigs/projectsCommandConfig'
 import {
   ASK_TO_OPEN_QUERY_PARAM,
@@ -14,7 +12,6 @@ import {
   PROJECT_ENTRYPOINT,
   PROJECT_ID_QUERY_PARAM,
 } from '@src/lib/constants'
-import { getUniqueProjectName } from '@src/lib/desktopFS'
 import {
   downloadProjectById,
   getPublicProjectNameById,
@@ -22,23 +19,14 @@ import {
 import fsZds from '@src/lib/fs-zds'
 import { isDesktop } from '@src/lib/isDesktop'
 import { PATHS, safeEncodeForRouterPaths } from '@src/lib/paths'
-import {
-  CLOUD_PROJECT_LIBRARY_TYPE,
-  getDefaultDirectoryProjectLibraryPath,
-  isPersonalCloudProjectLibrarySetting,
-} from '@src/lib/projectLibraries'
-import { importProjectFilesIntoLocalDirectory } from '@src/lib/projectLibraries/operations'
-import { invalidateProjectLibraryRealizations } from '@src/lib/projectLibraries/registry/invalidation'
 import { getProjectDirectoryNameFromTitle } from '@src/lib/projectName'
 import { DEFAULT_WEB_PROJECT_NAME } from '@src/lib/routeLoaders'
 import { err } from '@src/lib/trap'
-import { getAllSubDirectoriesAtProjectRoot } from '@src/machines/systemIO/snapshotContext'
 import {
   SystemIOMachineEvents,
   SystemIOMachineStates,
   waitForIdleState,
 } from '@src/machines/systemIO/utils'
-import { cloudSyncService } from '@src/registry/contracts/cloudSync'
 import { useEffect } from 'react'
 import toast from 'react-hot-toast'
 import { useNavigate, useSearchParams } from 'react-router-dom'
@@ -59,7 +47,7 @@ export type CreateFileSchemaMethodOptional = Omit<
  * `?createFile`
  * "?cmd=<some-command-name>&groupId=<some-group-id>"
  */
-export function useQueryParamEffects(kclManager: KclManager) {
+export function useQueryParamEffects() {
   const app = useApp()
   const { auth, commands } = app
   const authState = auth.useAuthState()
@@ -78,27 +66,6 @@ export function useQueryParamEffects(kclManager: KclManager) {
     !hasAskToOpen &&
     searchParams.has(CMD_NAME_QUERY_PARAM) &&
     searchParams.has(CMD_GROUP_QUERY_PARAM)
-
-  async function getCloudLibraryPathForSharedProject() {
-    const currentProject = app.project?.projectIORefSignal.value
-    if (currentProject?.libraryType === CLOUD_PROJECT_LIBRARY_TYPE) {
-      return currentProject.libraryPath
-    }
-
-    if (isDesktop()) {
-      return undefined
-    }
-
-    await waitFor(app.settings.actor, (state) => state.matches('idle'))
-    const personalCloudLibrary = app.settings
-      .get()
-      .app.libraries.current.find(isPersonalCloudProjectLibrarySetting)
-    return personalCloudLibrary
-      ? getCloudProjectLibraryMaterializationDirectoryPath(
-          personalCloudLibrary
-        ).catch(() => undefined)
-      : undefined
-  }
 
   /**
    * Watches for legacy `?create-file` hook, which share links currently use.
@@ -155,93 +122,19 @@ export function useQueryParamEffects(kclManager: KclManager) {
         return
       }
 
-      const targetProjectDirectoryPath =
-        await getCloudLibraryPathForSharedProject()
+      await waitFor(app.settings.actor, (state) => state.matches('idle'))
       if (cancelled) {
         return
       }
-      if (targetProjectDirectoryPath && !isDesktop()) {
-        const projectName = await getPublicProjectNameById(projectId)
-        if (err(projectName)) {
-          clearProjectIdSearchParam()
-          toast.error(projectName.message)
-          return
-        }
-        if (cancelled) {
-          return
-        }
 
-        const downloadedProject = await downloadProjectById(projectId)
-        if (err(downloadedProject)) {
-          clearProjectIdSearchParam()
-          toast.error(downloadedProject.message)
-          return
-        }
-        if (cancelled) {
-          return
-        }
-
-        const importedProject = await importProjectFilesIntoLocalDirectory({
-          projectDirectoryPath: targetProjectDirectoryPath,
-          requestedProjectName: getProjectDirectoryNameFromTitle(
-            projectName,
-            'shared-project'
-          ),
-          requestedProjectTitle: projectName,
-          files: downloadedProject.files,
-          entrypointFilePath:
-            downloadedProject.entrypointFilePath ?? PROJECT_ENTRYPOINT,
-          wasmInstancePromise: kclManager.wasmInstancePromise,
-        })
-        invalidateProjectLibraryRealizations()
-        await app.registry
-          .get(cloudSyncService)
-          .startProjectSync(importedProject.path)
-        app.systemIOActor.send({
-          type: SystemIOMachineEvents.setProjectDirectoryPath,
-          data: {
-            requestedProjectDirectoryPath: targetProjectDirectoryPath,
-          },
-        })
-        await waitForIdleState({ systemIOActor: app.systemIOActor })
-        if (cancelled) {
-          return
-        }
-        void navigate(
-          `${PATHS.FILE}/${safeEncodeForRouterPaths(
-            importedProject.default_file
-          )}`
-        )
-        return
+      const projectLibraryTarget = app.getCreateProjectLibraryTargets()[0]
+      if (!projectLibraryTarget) {
+        throw new Error('No writable project library is available.')
       }
 
-      const localCloudProject = targetProjectDirectoryPath
-        ? await app.registry
-            .get(cloudSyncService)
-            .ensureProjectLocallySynced(projectId, targetProjectDirectoryPath)
-            .catch(() => undefined)
-        : undefined
-      if (cancelled) {
-        return
-      }
-      if (localCloudProject) {
-        app.systemIOActor.send({
-          type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
-        })
-        void navigate(
-          `${PATHS.FILE}/${safeEncodeForRouterPaths(
-            localCloudProject.projectPath
-          )}`
-        )
-        return
-      }
-
-      const reservedProjectDestination =
-        await getReservedProjectDestination(projectId)
-      if (err(reservedProjectDestination)) {
-        clearProjectIdSearchParam()
-        toast.error(reservedProjectDestination.message)
-        return
+      const projectName = await getPublicProjectNameById(projectId)
+      if (err(projectName)) {
+        throw projectName
       }
       if (cancelled) {
         return
@@ -249,43 +142,37 @@ export function useQueryParamEffects(kclManager: KclManager) {
 
       const downloadedProject = await downloadProjectById(projectId)
       if (err(downloadedProject)) {
-        clearProjectIdSearchParam()
-        toast.error(downloadedProject.message)
-        return
+        throw downloadedProject
       }
       if (cancelled) {
         return
       }
 
-      const files = !isDesktop()
-        ? downloadedProject.files.map((file) => ({
-            ...file,
-            requestedProjectName:
-              reservedProjectDestination.requestedProjectName,
-            requestedFileName: fsZds.join(
-              reservedProjectDestination.requestedSubDirectoryName,
-              file.requestedFileName
-            ),
-          }))
-        : downloadedProject.files
-      const requestedFileNameWithExtension =
-        !isDesktop() && downloadedProject.entrypointFilePath
-          ? fsZds.join(
-              reservedProjectDestination.requestedSubDirectoryName,
-              downloadedProject.entrypointFilePath
-            )
-          : downloadedProject.entrypointFilePath
-
-      app.systemIOActor.send({
-        type: SystemIOMachineEvents.bulkImportProjectFilesAndNavigateToFile,
-        data: {
-          files,
-          requestedProjectName: reservedProjectDestination.requestedProjectName,
-          requestedFileNameWithExtension,
+      const importedProject = await projectLibraryTarget.createProject.run({
+        library: projectLibraryTarget.library,
+        requestedProjectName: getProjectDirectoryNameFromTitle(
+          projectName,
+          'shared-project'
+        ),
+        requestedProjectTitle: projectName,
+        initialProject: {
+          files: downloadedProject.files,
+          entrypointFilePath:
+            downloadedProject.entrypointFilePath ?? PROJECT_ENTRYPOINT,
         },
       })
+      if (!importedProject?.default_file) {
+        throw new Error('Unable to create the shared project.')
+      }
+      if (cancelled) {
+        return
+      }
 
-      await waitForIdleState({ systemIOActor: app.systemIOActor })
+      void navigate(
+        `${PATHS.FILE}/${safeEncodeForRouterPaths(
+          importedProject.default_file
+        )}`
+      )
     })().catch((error) => {
       if (cancelled) {
         return
@@ -302,74 +189,6 @@ export function useQueryParamEffects(kclManager: KclManager) {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
   }, [shouldOpenProjectId, setSearchParams, authState])
-
-  async function getReservedProjectDestination(projectId: string): Promise<
-    | {
-        requestedProjectName: string
-        requestedSubDirectoryName: string
-      }
-    | Error
-  > {
-    const projectName = await getPublicProjectNameById(projectId)
-    if (projectName instanceof Error) {
-      return projectName
-    }
-
-    await waitFor(app.settings.actor, (state) => state.matches('idle'))
-
-    const systemIOContext = app.systemIOActor.getSnapshot().context
-    const projectDirectoryPath = getDefaultDirectoryProjectLibraryPath(
-      app.settings.get().app.libraries.current
-    )
-    if (!projectDirectoryPath) {
-      return new Error('Unable to determine the project directory.')
-    }
-
-    if (isDesktop()) {
-      const projectDirectoryEntries = await fsZds.readdir(projectDirectoryPath)
-      const requestedProjectName = getUniqueProjectName(
-        projectName,
-        projectDirectoryEntries.map((name) => ({
-          name,
-          path: fsZds.join(projectDirectoryPath, name),
-          children: [],
-        }))
-      )
-      await fsZds.mkdir(
-        fsZds.join(projectDirectoryPath, requestedProjectName),
-        {
-          recursive: true,
-        }
-      )
-      return {
-        requestedProjectName,
-        requestedSubDirectoryName: projectName,
-      }
-    }
-
-    const requestedProjectName =
-      app.settings.actor.getSnapshot().context.currentProject?.name ??
-      DEFAULT_WEB_PROJECT_NAME
-    const requestedSubDirectoryName = getUniqueProjectName(
-      projectName,
-      getAllSubDirectoriesAtProjectRoot(systemIOContext, {
-        projectFolderName: requestedProjectName,
-      })
-    )
-    await fsZds.mkdir(
-      fsZds.join(
-        projectDirectoryPath,
-        requestedProjectName,
-        requestedSubDirectoryName
-      ),
-      { recursive: true }
-    )
-
-    return {
-      requestedProjectName,
-      requestedSubDirectoryName,
-    }
-  }
 
   /**
    * Generic commands are triggered by query parameters

--- a/src/hooks/useQueryParamEffects.ts
+++ b/src/hooks/useQueryParamEffects.ts
@@ -14,7 +14,6 @@ import {
   PROJECT_ENTRYPOINT,
   PROJECT_ID_QUERY_PARAM,
 } from '@src/lib/constants'
-import { getProjectInfo } from '@src/lib/desktop'
 import { getUniqueProjectName } from '@src/lib/desktopFS'
 import {
   downloadProjectById,
@@ -30,6 +29,7 @@ import {
 } from '@src/lib/projectLibraries'
 import { importProjectFilesIntoLocalDirectory } from '@src/lib/projectLibraries/operations'
 import { invalidateProjectLibraryRealizations } from '@src/lib/projectLibraries/registry/invalidation'
+import { getProjectDirectoryNameFromTitle } from '@src/lib/projectName'
 import { DEFAULT_WEB_PROJECT_NAME } from '@src/lib/routeLoaders'
 import { err } from '@src/lib/trap'
 import { getAllSubDirectoriesAtProjectRoot } from '@src/machines/systemIO/snapshotContext'
@@ -183,7 +183,10 @@ export function useQueryParamEffects(kclManager: KclManager) {
 
         const importedProject = await importProjectFilesIntoLocalDirectory({
           projectDirectoryPath: targetProjectDirectoryPath,
-          requestedProjectName: projectName,
+          requestedProjectName: getProjectDirectoryNameFromTitle(
+            projectName,
+            downloadedProject.projectName
+          ),
           requestedProjectTitle: projectName,
           files: downloadedProject.files,
           entrypointFilePath:
@@ -225,12 +228,10 @@ export function useQueryParamEffects(kclManager: KclManager) {
         app.systemIOActor.send({
           type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
         })
-        const project = await getProjectInfo(
-          localCloudProject.projectPath,
-          await kclManager.wasmInstancePromise
-        )
         void navigate(
-          `${PATHS.FILE}/${safeEncodeForRouterPaths(project.default_file)}`
+          `${PATHS.FILE}/${safeEncodeForRouterPaths(
+            localCloudProject.projectPath
+          )}`
         )
         return
       }

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -1045,6 +1045,7 @@ export const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
           requestedProjectName,
           requestedProjectTitle,
           initialKclFile,
+          initialProject,
         }) => {
           const wasmInstancePromise = getWasmPromise()
           if (wasmInstancePromise instanceof Error) {
@@ -1058,6 +1059,7 @@ export const cloudSyncProjectLibraryType = defineRegistryItemFactory((ctx) => {
             requestedProjectTitle,
             wasmInstancePromise,
             initialKclFile,
+            initialProject,
           })
           refreshLocalCloudProjectEntries()
 

--- a/src/lib/projectLibraries/index.ts
+++ b/src/lib/projectLibraries/index.ts
@@ -40,6 +40,14 @@ export interface ProjectLibrary extends ProjectLibrarySetting {
   order?: number
 }
 
+export interface ProjectLibraryInitialProject {
+  files: readonly {
+    requestedFileName: string
+    requestedData: Uint8Array<ArrayBuffer>
+  }[]
+  entrypointFilePath: string
+}
+
 export type SerializedProjectLibrarySetting = Omit<
   ProjectLibrarySetting,
   'path'

--- a/src/lib/projectLibraries/operations.test.ts
+++ b/src/lib/projectLibraries/operations.test.ts
@@ -1,5 +1,5 @@
 import fsZds, { moduleFsViaModuleImport, StorageName } from '@src/lib/fs-zds'
-import { importProjectFilesIntoLocalDirectory } from '@src/lib/projectLibraries/operations'
+import { createProjectInLocalDirectory } from '@src/lib/projectLibraries/operations'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { beforeAll, describe, expect, it } from 'vitest'
 
@@ -10,7 +10,7 @@ beforeAll(async () => {
   })
 })
 
-describe('importProjectFilesIntoLocalDirectory', () => {
+describe('createProjectInLocalDirectory', () => {
   it('rejects project names outside the selected library', async () => {
     const testRoot = `/tmp/shared-project-import-${crypto.randomUUID()}`
     const projectDirectoryPath = fsZds.join(testRoot, 'library')
@@ -18,17 +18,19 @@ describe('importProjectFilesIntoLocalDirectory', () => {
 
     try {
       await expect(
-        importProjectFilesIntoLocalDirectory({
+        createProjectInLocalDirectory({
           projectDirectoryPath,
           requestedProjectName: '..',
           requestedProjectTitle: 'Unsafe project',
-          files: [
-            {
-              requestedFileName: 'main.kcl',
-              requestedData: new TextEncoder().encode('x = 1\n'),
-            },
-          ],
-          entrypointFilePath: 'main.kcl',
+          initialProject: {
+            files: [
+              {
+                requestedFileName: 'main.kcl',
+                requestedData: new TextEncoder().encode('x = 1\n'),
+              },
+            ],
+            entrypointFilePath: 'main.kcl',
+          },
           wasmInstancePromise: {} as ModuleType,
         })
       ).rejects.toThrow('invalid project directory name')

--- a/src/lib/projectLibraries/operations.test.ts
+++ b/src/lib/projectLibraries/operations.test.ts
@@ -1,7 +1,9 @@
 import fsZds, { moduleFsViaModuleImport, StorageName } from '@src/lib/fs-zds'
 import { createProjectInLocalDirectory } from '@src/lib/projectLibraries/operations'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
-import { beforeAll, describe, expect, it } from 'vitest'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@src/lib/wasm_lib_wrapper', () => ({}))
 
 beforeAll(async () => {
   await moduleFsViaModuleImport({

--- a/src/lib/projectLibraries/operations.test.ts
+++ b/src/lib/projectLibraries/operations.test.ts
@@ -1,0 +1,44 @@
+import fsZds, { moduleFsViaModuleImport, StorageName } from '@src/lib/fs-zds'
+import { importProjectFilesIntoLocalDirectory } from '@src/lib/projectLibraries/operations'
+import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
+import { beforeAll, describe, expect, it } from 'vitest'
+
+beforeAll(async () => {
+  await moduleFsViaModuleImport({
+    type: StorageName.NodeFS,
+    options: {},
+  })
+})
+
+describe('importProjectFilesIntoLocalDirectory', () => {
+  it('rejects project names outside the selected library', async () => {
+    const testRoot = `/tmp/shared-project-import-${crypto.randomUUID()}`
+    const projectDirectoryPath = fsZds.join(testRoot, 'library')
+    await fsZds.mkdir(projectDirectoryPath, { recursive: true })
+
+    try {
+      await expect(
+        importProjectFilesIntoLocalDirectory({
+          projectDirectoryPath,
+          requestedProjectName: '..',
+          requestedProjectTitle: 'Unsafe project',
+          files: [
+            {
+              requestedFileName: 'main.kcl',
+              requestedData: new TextEncoder().encode('x = 1\n'),
+            },
+          ],
+          entrypointFilePath: 'main.kcl',
+          wasmInstancePromise: {} as ModuleType,
+        })
+      ).rejects.toThrow('invalid project directory name')
+
+      await expect(
+        fsZds.stat(fsZds.join(testRoot, 'main.kcl'))
+      ).rejects.toBeDefined()
+      await expect(fsZds.readdir(projectDirectoryPath)).resolves.toEqual([])
+    } finally {
+      await fsZds.rm(testRoot, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/lib/projectLibraries/operations.ts
+++ b/src/lib/projectLibraries/operations.ts
@@ -129,6 +129,23 @@ export async function importProjectFilesIntoLocalDirectory({
     `${DUPLICATE_PROJECT_TEMPORARY_PREFIX}${v4()}`
   )
   const projectPath = fsZds.join(projectDirectoryPath, uniqueProjectName)
+  const relativeProjectPath = fsZds.relative(
+    fsZds.resolve(projectDirectoryPath),
+    fsZds.resolve(projectPath)
+  )
+  if (
+    !relativeProjectPath ||
+    relativeProjectPath === '..' ||
+    relativeProjectPath.startsWith(`..${fsZds.sep}`) ||
+    relativeProjectPath.includes(fsZds.sep) ||
+    relativeProjectPath === fsZds.resolve(relativeProjectPath)
+  ) {
+    return Promise.reject(
+      new Error(
+        `The shared project contained an invalid project directory name: "${requestedProjectName}".`
+      )
+    )
+  }
 
   await fsZds.mkdir(temporaryProjectPath, { recursive: true })
   try {

--- a/src/lib/projectLibraries/operations.ts
+++ b/src/lib/projectLibraries/operations.ts
@@ -1,15 +1,16 @@
 import {
+  DUPLICATE_PROJECT_TEMPORARY_PREFIX,
+  PROJECT_SETTINGS_FILE_NAME,
+} from '@src/lib/constants'
+import {
   createNewProjectDirectory,
   getProjectInfo,
   isPathNotFoundError,
 } from '@src/lib/desktop'
-import {
-  DUPLICATE_PROJECT_TEMPORARY_PREFIX,
-  PROJECT_SETTINGS_FILE_NAME,
-} from '@src/lib/constants'
 import { getUniqueProjectName } from '@src/lib/desktopFS'
 import fsZds from '@src/lib/fs-zds'
 import type { FileEntry, Project } from '@src/lib/project'
+import type { ProjectLibraryInitialProject } from '@src/lib/projectLibraries'
 import { getProjectTitleFromUniqueDirectoryName } from '@src/lib/projectName'
 import {
   prepareProjectTomlForDuplication,
@@ -62,6 +63,7 @@ export async function createProjectInLocalDirectory({
   requestedProjectTitle,
   wasmInstancePromise,
   initialKclFile,
+  initialProject,
 }: {
   projectDirectoryPath: string
   requestedProjectName: string
@@ -71,6 +73,7 @@ export async function createProjectInLocalDirectory({
     fileName: string
     code: string
   }
+  initialProject?: ProjectLibraryInitialProject
 }): Promise<Project> {
   const existingProjectNames =
     await getProjectDirectoryEntryNames(projectDirectoryPath)
@@ -83,6 +86,17 @@ export async function createProjectInLocalDirectory({
     requestedProjectDirectoryName: requestedProjectName,
     uniqueProjectDirectoryName: uniqueProjectName,
   })
+
+  if (initialProject) {
+    return createProjectFromFilesInLocalDirectory({
+      projectDirectoryPath,
+      requestedProjectName,
+      projectName: uniqueProjectName,
+      projectTitle: uniqueProjectTitle,
+      initialProject,
+      wasmInstancePromise,
+    })
+  }
 
   return createNewProjectDirectory(
     uniqueProjectName,
@@ -95,40 +109,26 @@ export async function createProjectInLocalDirectory({
   )
 }
 
-export async function importProjectFilesIntoLocalDirectory({
+async function createProjectFromFilesInLocalDirectory({
   projectDirectoryPath,
   requestedProjectName,
-  requestedProjectTitle,
-  files,
-  entrypointFilePath,
+  projectName,
+  projectTitle,
+  initialProject,
   wasmInstancePromise,
 }: {
   projectDirectoryPath: string
   requestedProjectName: string
-  requestedProjectTitle: string
-  files: readonly {
-    requestedFileName: string
-    requestedData: Uint8Array<ArrayBuffer>
-  }[]
-  entrypointFilePath: string
+  projectName: string
+  projectTitle: string
+  initialProject: ProjectLibraryInitialProject
   wasmInstancePromise: Promise<ModuleType> | ModuleType
 }): Promise<Project> {
-  const existingProjectNames =
-    await getProjectDirectoryEntryNames(projectDirectoryPath)
-  const uniqueProjectName = getUniqueProjectName(
-    requestedProjectName,
-    projectEntriesFromNames(projectDirectoryPath, existingProjectNames)
-  )
-  const uniqueProjectTitle = getProjectTitleFromUniqueDirectoryName({
-    requestedProjectTitle,
-    requestedProjectDirectoryName: requestedProjectName,
-    uniqueProjectDirectoryName: uniqueProjectName,
-  })
   const temporaryProjectPath = fsZds.join(
     projectDirectoryPath,
     `${DUPLICATE_PROJECT_TEMPORARY_PREFIX}${v4()}`
   )
-  const projectPath = fsZds.join(projectDirectoryPath, uniqueProjectName)
+  const projectPath = fsZds.join(projectDirectoryPath, projectName)
   const relativeProjectPath = fsZds.relative(
     fsZds.resolve(projectDirectoryPath),
     fsZds.resolve(projectPath)
@@ -149,7 +149,7 @@ export async function importProjectFilesIntoLocalDirectory({
 
   await fsZds.mkdir(temporaryProjectPath, { recursive: true })
   try {
-    for (const file of files) {
+    for (const file of initialProject.files) {
       if (file.requestedFileName === PROJECT_SETTINGS_FILE_NAME) {
         continue
       }
@@ -180,7 +180,7 @@ export async function importProjectFilesIntoLocalDirectory({
       await fsZds.writeFile(targetPath, file.requestedData)
     }
 
-    const sourceProjectToml = files.find(
+    const sourceProjectToml = initialProject.files.find(
       (file) => file.requestedFileName === PROJECT_SETTINGS_FILE_NAME
     )
     const projectTomlWithEntrypoint =
@@ -188,11 +188,11 @@ export async function importProjectFilesIntoLocalDirectory({
         sourceProjectToml
           ? new TextDecoder().decode(sourceProjectToml.requestedData)
           : '',
-        entrypointFilePath
+        initialProject.entrypointFilePath
       )
     const projectToml = prepareProjectTomlForDuplication(
       projectTomlWithEntrypoint,
-      uniqueProjectTitle,
+      projectTitle,
       v4()
     )
     if (isErr(projectToml)) {

--- a/src/lib/projectLibraries/operations.ts
+++ b/src/lib/projectLibraries/operations.ts
@@ -1,12 +1,23 @@
 import {
   createNewProjectDirectory,
+  getProjectInfo,
   isPathNotFoundError,
 } from '@src/lib/desktop'
+import {
+  DUPLICATE_PROJECT_TEMPORARY_PREFIX,
+  PROJECT_SETTINGS_FILE_NAME,
+} from '@src/lib/constants'
 import { getUniqueProjectName } from '@src/lib/desktopFS'
 import fsZds from '@src/lib/fs-zds'
 import type { FileEntry, Project } from '@src/lib/project'
 import { getProjectTitleFromUniqueDirectoryName } from '@src/lib/projectName'
+import {
+  prepareProjectTomlForDuplication,
+  setProjectDefaultFileInProjectTomlContents,
+} from '@src/lib/projectTomlMetadata'
+import { isErr } from '@src/lib/trap'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
+import { v4 } from 'uuid'
 
 export interface MoveProjectIntoLocalDirectoryResult {
   localProjectPath: string
@@ -33,6 +44,16 @@ function projectEntriesFromNames(
     path: fsZds.join(projectDirectoryPath, name),
     children: [],
   }))
+}
+
+async function rejectProjectImport(
+  temporaryProjectPath: string,
+  error: unknown
+): Promise<never> {
+  await fsZds
+    .rm(temporaryProjectPath, { recursive: true })
+    .catch(() => undefined)
+  return Promise.reject(error)
 }
 
 export async function createProjectInLocalDirectory({
@@ -72,6 +93,104 @@ export async function createProjectInLocalDirectory({
     projectDirectoryPath,
     uniqueProjectTitle
   )
+}
+
+export async function importProjectFilesIntoLocalDirectory({
+  projectDirectoryPath,
+  requestedProjectName,
+  requestedProjectTitle,
+  files,
+  entrypointFilePath,
+  wasmInstancePromise,
+}: {
+  projectDirectoryPath: string
+  requestedProjectName: string
+  requestedProjectTitle: string
+  files: readonly {
+    requestedFileName: string
+    requestedData: Uint8Array<ArrayBuffer>
+  }[]
+  entrypointFilePath: string
+  wasmInstancePromise: Promise<ModuleType> | ModuleType
+}): Promise<Project> {
+  const existingProjectNames =
+    await getProjectDirectoryEntryNames(projectDirectoryPath)
+  const uniqueProjectName = getUniqueProjectName(
+    requestedProjectName,
+    projectEntriesFromNames(projectDirectoryPath, existingProjectNames)
+  )
+  const uniqueProjectTitle = getProjectTitleFromUniqueDirectoryName({
+    requestedProjectTitle,
+    requestedProjectDirectoryName: requestedProjectName,
+    uniqueProjectDirectoryName: uniqueProjectName,
+  })
+  const temporaryProjectPath = fsZds.join(
+    projectDirectoryPath,
+    `${DUPLICATE_PROJECT_TEMPORARY_PREFIX}${v4()}`
+  )
+  const projectPath = fsZds.join(projectDirectoryPath, uniqueProjectName)
+
+  await fsZds.mkdir(temporaryProjectPath, { recursive: true })
+  try {
+    for (const file of files) {
+      if (file.requestedFileName === PROJECT_SETTINGS_FILE_NAME) {
+        continue
+      }
+
+      const targetPath = fsZds.resolve(
+        temporaryProjectPath,
+        file.requestedFileName
+      )
+      const relativeTargetPath = fsZds.relative(
+        temporaryProjectPath,
+        targetPath
+      )
+      if (
+        !relativeTargetPath ||
+        relativeTargetPath === '..' ||
+        relativeTargetPath.startsWith(`..${fsZds.sep}`) ||
+        relativeTargetPath === fsZds.resolve(relativeTargetPath)
+      ) {
+        return rejectProjectImport(
+          temporaryProjectPath,
+          new Error(
+            `The shared project contained an invalid file path: "${file.requestedFileName}".`
+          )
+        )
+      }
+
+      await fsZds.mkdir(fsZds.dirname(targetPath), { recursive: true })
+      await fsZds.writeFile(targetPath, file.requestedData)
+    }
+
+    const sourceProjectToml = files.find(
+      (file) => file.requestedFileName === PROJECT_SETTINGS_FILE_NAME
+    )
+    const projectTomlWithEntrypoint =
+      setProjectDefaultFileInProjectTomlContents(
+        sourceProjectToml
+          ? new TextDecoder().decode(sourceProjectToml.requestedData)
+          : '',
+        entrypointFilePath
+      )
+    const projectToml = prepareProjectTomlForDuplication(
+      projectTomlWithEntrypoint,
+      uniqueProjectTitle,
+      v4()
+    )
+    if (isErr(projectToml)) {
+      return rejectProjectImport(temporaryProjectPath, projectToml)
+    }
+    await fsZds.writeFile(
+      fsZds.join(temporaryProjectPath, PROJECT_SETTINGS_FILE_NAME),
+      new TextEncoder().encode(projectToml)
+    )
+    await fsZds.rename(temporaryProjectPath, projectPath)
+  } catch (error) {
+    return rejectProjectImport(temporaryProjectPath, error)
+  }
+
+  return getProjectInfo(projectPath, await wasmInstancePromise)
 }
 
 function getMovedDefaultFile({

--- a/src/lib/projectLibraries/registry/index.ts
+++ b/src/lib/projectLibraries/registry/index.ts
@@ -641,6 +641,7 @@ const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
         requestedProjectName,
         requestedProjectTitle,
         initialKclFile,
+        initialProject,
       }) => {
         const wasmInstancePromise = getWasmPromise()
         if (wasmInstancePromise instanceof Error) {
@@ -653,6 +654,7 @@ const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
           requestedProjectTitle,
           wasmInstancePromise,
           initialKclFile,
+          initialProject,
         })
         refreshLocalProjectRealizations(library)
 

--- a/src/registry/contracts/projectLibraries.ts
+++ b/src/registry/contracts/projectLibraries.ts
@@ -7,6 +7,7 @@ import type { Project } from '@src/lib/project'
 import type { DuplicateProjectResult } from '@src/lib/projectDuplication'
 import type {
   ProjectLibrary,
+  ProjectLibraryInitialProject,
   ProjectLibrarySetting,
   ProjectLibraryType,
 } from '@src/lib/projectLibraries'
@@ -145,6 +146,8 @@ export interface ProjectLibraryCreateProjectInput {
     fileName: string
     code: string
   }
+  /** Optional complete project to write before publishing it. */
+  initialProject?: ProjectLibraryInitialProject
 }
 
 export interface ProjectLibraryProjectInput {

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -103,7 +103,7 @@ const Home = () => {
   const keymap = registry.optional(keymapService)
   const { kclManager } = useSingletons()
   const settingsActor = settings.actor
-  useQueryParamEffects(kclManager)
+  useQueryParamEffects()
 
   useEffect(() => {
     if (!keymap) {


### PR DESCRIPTION
Fixes #12943. Picks the default library, whatever is first. 

## How to test on web

1. Open [the Aquarium handoff URL](https://modeling-app-git-pierremtb-issue12943-aquarium-links-are-90f5ef.vercel.dev.zoo.dev/?project-id=606094e3-2e89-406a-a66c-07f23dfb7ab0&ask-open-desktop=true).
2. Click **Continue to the web app**.
3. Confirm the handoff through [the Home URL](https://modeling-app-git-pierremtb-issue12943-aquarium-links-are-90f5ef.vercel.dev.zoo.dev/home?project-id=606094e3-2e89-406a-a66c-07f23dfb7ab0) clones the project into **Personal Cloud** and opens it without the “Unable to determine the project directory.” error.


**Note that I also tested this on desktop with a custom prod build**. If Personal Cloud is first, it picks it, if the Directory Library is first, it picks it.
