### PR TITLE
Move mutable AST traversal to walk submodule

### DIFF
--- a/rust/kcl-lib/src/frontend.rs
+++ b/rust/kcl-lib/src/frontend.rs
@@ -87,10 +87,6 @@ use crate::frontend::sketch::SegmentCtor;
 use crate::frontend::sketch::SketchApi;
 use crate::frontend::sketch::SketchCtor;
 use crate::frontend::sketch::Vertical;
-use crate::frontend::traverse::MutateBodyItem;
-use crate::frontend::traverse::TraversalReturn;
-use crate::frontend::traverse::Visitor;
-use crate::frontend::traverse::dfs_mut;
 use crate::id::IncIdGenerator;
 use crate::parsing::ast::types as ast;
 use crate::parsing::ast::types::BoxNode;
@@ -100,6 +96,10 @@ use crate::pretty::NumericSuffix;
 use crate::std::constraints::LinesAtAngleKind;
 use crate::walk::NodeMut;
 use crate::walk::Visitable;
+use crate::walk::traverse::MutateBodyItem;
+use crate::walk::traverse::TraversalReturn;
+use crate::walk::traverse::Visitor;
+use crate::walk::traverse::dfs_mut;
 
 pub(crate) mod api;
 pub(crate) mod modify;
@@ -117,7 +117,6 @@ struct SketchCheckpoint {
     point_freedom_cache: HashMap<ObjectId, Freedom>,
     mock_memory: Option<SketchModeState>,
 }
-mod traverse;
 pub(crate) mod trim;
 
 struct ArcSizeConstraintParams {

--- a/rust/kcl-lib/src/walk/mod.rs
+++ b/rust/kcl-lib/src/walk/mod.rs
@@ -3,6 +3,7 @@
 mod ast_node;
 mod ast_visitor;
 mod ast_walk;
+pub(crate) mod traverse;
 
 pub(crate) use ast_node::AstNodeError;
 pub(crate) use ast_node::Node;

--- a/rust/kcl-lib/src/walk/traverse.rs
+++ b/rust/kcl-lib/src/walk/traverse.rs
@@ -6,7 +6,7 @@ use std::ops::ControlFlow;
 use crate::parsing::ast::types as ast;
 use crate::walk::NodeMut;
 
-pub(super) struct TraversalReturn<B, C = ()> {
+pub(crate) struct TraversalReturn<B, C = ()> {
     pub mutate_body_item: MutateBodyItem,
     pub control_flow: ControlFlow<B, C>,
 }
@@ -15,7 +15,7 @@ pub(super) struct TraversalReturn<B, C = ()> {
 /// visited node. Only reliably delivered when paired with
 /// `ControlFlow::Break`; see [`dfs_mut`].
 #[derive(Default)]
-pub(super) enum MutateBodyItem {
+pub(crate) enum MutateBodyItem {
     #[default]
     None,
     Mutate(Box<ast::BodyItem>),
@@ -28,7 +28,7 @@ impl MutateBodyItem {
     }
 }
 
-pub(super) trait Visitor {
+pub(crate) trait Visitor {
     type Break;
     type Continue;
 
@@ -85,7 +85,7 @@ impl<B, C> TraversalReturn<B, C> {
 /// reliably applied. A request paired with `ControlFlow::Continue` may be
 /// dropped, depending on where in the enclosing body item's subtree it was
 /// returned, because traversing a subsequent node discards it.
-pub(super) fn dfs_mut<V: Visitor>(
+pub(crate) fn dfs_mut<V: Visitor>(
     program: &mut ast::Node<ast::Program>,
     visitor: &mut V,
 ) -> ControlFlow<V::Break, V::Continue> {


### PR DESCRIPTION
No semantic changes. This just moves the module and exposes it to the entire crate so that it's clear that it's intended to be used by anything in the whole crate.

Spurred by #12292. Related: #12925.