### PR TITLE
Allow legacy layoutId=ttc commands

### DIFF
--- a/e2e/playwright/testing-samples-loading.spec.ts
+++ b/e2e/playwright/testing-samples-loading.spec.ts
@@ -143,6 +143,23 @@ test.describe('Testing loading external models', { tag: '@desktop' }, () => {
 })
 
 test.describe('Query parameter command', { tag: '@web' }, () => {
+  test('applies the ttc layout without opening the command palette', async ({
+    page,
+    cmdBar,
+  }) => {
+    await page.goto('/?cmd=set-layout&groupId=application&layoutId=ttc')
+
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const layout = window.app.layout.get()
+          return 'sizes' in layout ? layout.sizes : []
+        })
+      )
+      .toEqual([0, 50, 50])
+    await cmdBar.expectState({ stage: 'commandBarClosed' })
+  })
+
   test('should add sample to demo project', async ({
     page,
     toolbar,

--- a/src/lib/commandBarConfigs/applicationCommandConfig.ts
+++ b/src/lib/commandBarConfigs/applicationCommandConfig.ts
@@ -601,6 +601,10 @@ export function createApplicationCommands({
             name: 'Zookeeper focus',
             value: 'zookeeper',
           },
+          {
+            name: 'Zookeeper focus (legacy URL)',
+            value: 'ttc',
+          },
         ] satisfies { name: string; value: keyof typeof userLoadableLayouts }[],
       },
     },


### PR DESCRIPTION
Fixes #12945. Follow-up to #12470. Immediate mitigation happens in website at https://github.com/KittyCAD/website/pull/4481, this is just so that old links can still work.