### PR TITLE
Open KCL sample links in the default project library

### DIFF
--- a/e2e/playwright/testing-samples-loading.spec.ts
+++ b/e2e/playwright/testing-samples-loading.spec.ts
@@ -177,25 +177,20 @@ test.describe('Query parameter command', { tag: '@web' }, () => {
   })
 })
 
-test.describe(
-  'Legacy sample query parameter command',
-  { tag: ['@web', '@desktop'] },
-  () => {
-    test('should create the sample in the default project library', async ({
-      page,
-      toolbar,
-      editor,
-    }) => {
-      const sampleTitle = 'Aircraft telemetry antenna plate'
-      const sampleSlug = 'telemetry-antenna'
-      const projectSlug = 'aircraft-telemetry-antenna-plate'
-      const queryString = `?cmd=add-kcl-file-to-project&groupId=application&projectName=browser&source=kcl-samples&sample=${sampleSlug}/main.kcl`
-      await page.goto(page.url() + queryString)
-      await closeOnboardingModalIfPresent(page)
+test.describe('Legacy sample query parameter command', { tag: '@web' }, () => {
+  test('should create the sample in the default project library', async ({
+    page,
+    toolbar,
+    editor,
+  }) => {
+    const sampleTitle = 'Aircraft telemetry antenna plate'
+    const sampleSlug = 'telemetry-antenna'
+    const queryString = `?cmd=add-kcl-file-to-project&groupId=application&projectName=browser&source=kcl-samples&sample=${sampleSlug}/main.kcl`
+    await page.goto(page.url() + queryString)
+    await closeOnboardingModalIfPresent(page)
 
-      await toolbar.openPane(DefaultLayoutPaneID.Code)
-      await editor.expectEditor.toContain(sampleTitle, { timeout: 30_000 })
-      await expect(page).toHaveURL(new RegExp(`${projectSlug}%2Fmain\\.kcl$`))
-    })
-  }
-)
+    await toolbar.openPane(DefaultLayoutPaneID.Code)
+    await editor.expectEditor.toContain(sampleTitle, { timeout: 30_000 })
+    await expect(page).toHaveURL(/telemetry-antenna%2Fmain\.kcl$/)
+  })
+})

--- a/e2e/playwright/testing-samples-loading.spec.ts
+++ b/e2e/playwright/testing-samples-loading.spec.ts
@@ -143,19 +143,20 @@ test.describe('Testing loading external models', { tag: '@desktop' }, () => {
 })
 
 test.describe('Query parameter command', { tag: '@web' }, () => {
-  test('should add sample to demo project', async ({
+  test('should create a legacy sample in the default project library', async ({
     page,
     toolbar,
     editor,
   }) => {
     await closeOnboardingModalIfPresent(page)
 
-    const sampleTitle = 'Socket Head Cap Screw'
-    const sampleSlug = 'socket-head-cap-screw'
+    const sampleTitle = 'Aircraft telemetry antenna plate'
+    const sampleSlug = 'telemetry-antenna'
     const queryString = `?cmd=add-kcl-file-to-project&groupId=application&projectName=browser&source=kcl-samples&sample=${sampleSlug}/main.kcl`
     await page.goto(page.url() + queryString)
 
     await toolbar.openPane(DefaultLayoutPaneID.Code)
     await editor.expectEditor.toContain(sampleTitle, { timeout: 30_000 })
+    await expect(page).toHaveURL(/telemetry-antenna%2Fmain\.kcl$/)
   })
 })

--- a/e2e/playwright/testing-samples-loading.spec.ts
+++ b/e2e/playwright/testing-samples-loading.spec.ts
@@ -142,21 +142,21 @@ test.describe('Testing loading external models', { tag: '@desktop' }, () => {
   })
 })
 
-test.describe('Query parameter command', { tag: '@web' }, () => {
+test.describe('Query parameter command', { tag: ['@web', '@desktop'] }, () => {
   test('should create a legacy sample in the default project library', async ({
     page,
     toolbar,
     editor,
   }) => {
-    await closeOnboardingModalIfPresent(page)
-
     const sampleTitle = 'Aircraft telemetry antenna plate'
     const sampleSlug = 'telemetry-antenna'
+    const projectSlug = 'aircraft-telemetry-antenna-plate'
     const queryString = `?cmd=add-kcl-file-to-project&groupId=application&projectName=browser&source=kcl-samples&sample=${sampleSlug}/main.kcl`
     await page.goto(page.url() + queryString)
+    await closeOnboardingModalIfPresent(page)
 
     await toolbar.openPane(DefaultLayoutPaneID.Code)
     await editor.expectEditor.toContain(sampleTitle, { timeout: 30_000 })
-    await expect(page).toHaveURL(/telemetry-antenna%2Fmain\.kcl$/)
+    await expect(page).toHaveURL(new RegExp(`${projectSlug}%2Fmain\\.kcl$`))
   })
 })

--- a/e2e/playwright/testing-samples-loading.spec.ts
+++ b/e2e/playwright/testing-samples-loading.spec.ts
@@ -160,7 +160,7 @@ test.describe('Query parameter command', { tag: '@web' }, () => {
     await cmdBar.expectState({ stage: 'commandBarClosed' })
   })
 
-  test('should add sample to demo project', async ({
+  test('creates a current sample in the default project library', async ({
     page,
     toolbar,
     editor,
@@ -174,23 +174,6 @@ test.describe('Query parameter command', { tag: '@web' }, () => {
 
     await toolbar.openPane(DefaultLayoutPaneID.Code)
     await editor.expectEditor.toContain(sampleTitle, { timeout: 30_000 })
-  })
-})
-
-test.describe('Legacy sample query parameter command', { tag: '@web' }, () => {
-  test('should create the sample in the default project library', async ({
-    page,
-    toolbar,
-    editor,
-  }) => {
-    const sampleTitle = 'Aircraft telemetry antenna plate'
-    const sampleSlug = 'telemetry-antenna'
-    const queryString = `?cmd=add-kcl-file-to-project&groupId=application&projectName=browser&source=kcl-samples&sample=${sampleSlug}/main.kcl`
-    await page.goto(page.url() + queryString)
-    await closeOnboardingModalIfPresent(page)
-
-    await toolbar.openPane(DefaultLayoutPaneID.Code)
-    await editor.expectEditor.toContain(sampleTitle, { timeout: 30_000 })
-    await expect(page).toHaveURL(/telemetry-antenna%2Fmain\.kcl$/)
+    await expect(page).toHaveURL(/socket-head-cap-screw%2Fmain\.kcl$/)
   })
 })

--- a/src/hooks/useQueryParamEffects.ts
+++ b/src/hooks/useQueryParamEffects.ts
@@ -206,7 +206,8 @@ export function useQueryParamEffects() {
     let shouldCreateDefaultWebProject = false
     const samplePath = commandData.argDefaultValues?.sample
     const requestedProjectName = commandData.argDefaultValues?.projectName
-    const shouldCreateSampleProject =
+    const shouldCreateWebSampleProject =
+      !isDesktop() &&
       commandData.name === 'add-kcl-file-to-project' &&
       commandData.groupId === 'application' &&
       commandData.argDefaultValues?.source === 'kcl-samples' &&
@@ -214,7 +215,7 @@ export function useQueryParamEffects() {
       (requestedProjectName === 'browser' ||
         requestedProjectName === DEFAULT_WEB_PROJECT_NAME)
 
-    if (shouldCreateSampleProject) {
+    if (shouldCreateWebSampleProject) {
       let cancelled = false
 
       void (async () => {
@@ -235,20 +236,14 @@ export function useQueryParamEffects() {
           )
         }
 
-        const downloadedSample = await downloadKclSample(
-          samplePath,
-          isDesktop() ? '.' : ''
-        )
+        const downloadedSample = await downloadKclSample(samplePath)
         if (cancelled) {
           return
         }
 
         const importedProject = await projectLibraryTarget.createProject.run({
           library: projectLibraryTarget.library,
-          requestedProjectName: getProjectDirectoryNameFromTitle(
-            downloadedSample.sample.title,
-            downloadedSample.requestedProjectName
-          ),
+          requestedProjectName: downloadedSample.requestedProjectName,
           requestedProjectTitle: downloadedSample.sample.title,
           initialProject: downloadedSample.initialProject,
         })

--- a/src/hooks/useQueryParamEffects.ts
+++ b/src/hooks/useQueryParamEffects.ts
@@ -206,8 +206,7 @@ export function useQueryParamEffects() {
     let shouldCreateDefaultWebProject = false
     const samplePath = commandData.argDefaultValues?.sample
     const requestedProjectName = commandData.argDefaultValues?.projectName
-    const shouldCreateWebSampleProject =
-      !isDesktop() &&
+    const shouldCreateSampleProject =
       commandData.name === 'add-kcl-file-to-project' &&
       commandData.groupId === 'application' &&
       commandData.argDefaultValues?.source === 'kcl-samples' &&
@@ -215,7 +214,7 @@ export function useQueryParamEffects() {
       (requestedProjectName === 'browser' ||
         requestedProjectName === DEFAULT_WEB_PROJECT_NAME)
 
-    if (shouldCreateWebSampleProject) {
+    if (shouldCreateSampleProject) {
       let cancelled = false
 
       void (async () => {
@@ -236,14 +235,20 @@ export function useQueryParamEffects() {
           )
         }
 
-        const downloadedSample = await downloadKclSample(samplePath)
+        const downloadedSample = await downloadKclSample(
+          samplePath,
+          isDesktop() ? '.' : ''
+        )
         if (cancelled) {
           return
         }
 
         const importedProject = await projectLibraryTarget.createProject.run({
           library: projectLibraryTarget.library,
-          requestedProjectName: downloadedSample.requestedProjectName,
+          requestedProjectName: getProjectDirectoryNameFromTitle(
+            downloadedSample.sample.title,
+            downloadedSample.requestedProjectName
+          ),
           requestedProjectTitle: downloadedSample.sample.title,
           initialProject: downloadedSample.initialProject,
         })

--- a/src/hooks/useQueryParamEffects.ts
+++ b/src/hooks/useQueryParamEffects.ts
@@ -18,6 +18,7 @@ import {
 } from '@src/lib/downloadProject'
 import fsZds from '@src/lib/fs-zds'
 import { isDesktop } from '@src/lib/isDesktop'
+import { downloadKclSample } from '@src/lib/kclSamples'
 import { PATHS, safeEncodeForRouterPaths } from '@src/lib/paths'
 import { getProjectDirectoryNameFromTitle } from '@src/lib/projectName'
 import { DEFAULT_WEB_PROJECT_NAME } from '@src/lib/routeLoaders'
@@ -203,6 +204,78 @@ export function useQueryParamEffects() {
     if (!rawCommandData) return
     const commandData = rawCommandData
     let shouldCreateDefaultWebProject = false
+    const samplePath = commandData.argDefaultValues?.sample
+    const requestedProjectName = commandData.argDefaultValues?.projectName
+    const shouldCreateWebSampleProject =
+      !isDesktop() &&
+      commandData.name === 'add-kcl-file-to-project' &&
+      commandData.groupId === 'application' &&
+      commandData.argDefaultValues?.source === 'kcl-samples' &&
+      typeof samplePath === 'string' &&
+      (requestedProjectName === 'browser' ||
+        requestedProjectName === DEFAULT_WEB_PROJECT_NAME)
+
+    if (shouldCreateWebSampleProject) {
+      let cancelled = false
+
+      void (async () => {
+        await waitForIdleState({ systemIOActor: app.systemIOActor })
+        if (cancelled) {
+          return
+        }
+
+        await waitFor(app.settings.actor, (state) => state.matches('idle'))
+        if (cancelled) {
+          return
+        }
+
+        const projectLibraryTarget = app.getCreateProjectLibraryTargets()[0]
+        if (!projectLibraryTarget) {
+          return Promise.reject(
+            new Error('No writable project library is available.')
+          )
+        }
+
+        const downloadedSample = await downloadKclSample(samplePath)
+        if (cancelled) {
+          return
+        }
+
+        const importedProject = await projectLibraryTarget.createProject.run({
+          library: projectLibraryTarget.library,
+          requestedProjectName: downloadedSample.requestedProjectName,
+          requestedProjectTitle: downloadedSample.sample.title,
+          initialProject: downloadedSample.initialProject,
+        })
+        if (!importedProject?.default_file) {
+          return Promise.reject(
+            new Error('Unable to create the sample project.')
+          )
+        }
+        if (cancelled) {
+          return
+        }
+
+        void navigate(
+          `${PATHS.FILE}/${safeEncodeForRouterPaths(
+            importedProject.default_file
+          )}`
+        )
+      })().catch((error) => {
+        if (cancelled) {
+          return
+        }
+
+        cleanupQueryParams()
+        toast.error(
+          err(error) ? error.message : 'Failed to open the KCL sample.'
+        )
+      })
+
+      return () => {
+        cancelled = true
+      }
+    }
 
     // Web-only: prefill command data to automatically add to the demo project
     if (!isDesktop() && commandData.name === 'add-kcl-file-to-project') {

--- a/src/lib/commandBarConfigs/applicationCommandConfig.ts
+++ b/src/lib/commandBarConfigs/applicationCommandConfig.ts
@@ -11,7 +11,11 @@ import { getNextFileName, getUniqueProjectName } from '@src/lib/desktopFS'
 import { exportProjectZip } from '@src/lib/exportProjectZip'
 import fsZds from '@src/lib/fs-zds'
 import { isDesktop } from '@src/lib/isDesktop'
-import { everyKclSample, findKclSample } from '@src/lib/kclSamples'
+import {
+  downloadKclSample,
+  everyKclSample,
+  findKclSample,
+} from '@src/lib/kclSamples'
 import { isUserLoadableLayoutKey, userLoadableLayouts } from '@src/lib/layout'
 import {
   getEXTNoPeriod,
@@ -34,57 +38,26 @@ import type { ActorRefFrom } from 'xstate'
 
 function onSubmitKCLSampleCreation({
   sample,
-  kclSample,
   uniqueNameIfNeeded,
   systemIOActor,
   isProjectNew,
 }: {
   sample: string
-  kclSample: ReturnType<typeof findKclSample>
   uniqueNameIfNeeded: string
   systemIOActor: ActorRefFrom<typeof systemIOMachine>
   isProjectNew: boolean
 }) {
-  if (!kclSample) {
-    toast.error(
-      'The command could not be submitted, unable to find Zoo sample.'
-    )
-    return
-  }
-  const pathParts = webSafePathSplit(sample)
-  const projectPathPart = pathParts[0]
-  const files = kclSample.files
-
-  const filePromises = files.map((file) => {
-    const sampleCodeUrl =
-      (isDesktop() ? '.' : '') +
-      `/kcl-samples/${encodeURIComponent(
-        projectPathPart
-      )}/${encodeURIComponent(file)}`
-    return fetch(sampleCodeUrl).then((response) => {
-      return {
-        response,
-        file,
-        projectName: projectPathPart,
-      }
-    })
+  void downloadKclSample(sample, {
+    assetUrlPrefix: isDesktop() ? '.' : '',
   })
-
-  const requestedFiles: RequestedKCLFile[] = []
-  // If any fetches fail from the KCL Code download we will instantly reject
-  // No cleanup required since the fetch response is in memory
-  // TODO: Try to catch if there is a failure then delete the root folder and show error
-  Promise.all(filePromises)
-    .then(async (responses) => {
-      for (let i = 0; i < responses.length; i++) {
-        const response = responses[i]
-        const code = await response.response.text()
-        requestedFiles.push({
-          requestedCode: code,
-          requestedFileName: response.file,
+    .then(({ requestedProjectName: projectPathPart, initialProject }) => {
+      const requestedFiles: RequestedKCLFile[] = initialProject.files.map(
+        (file) => ({
+          requestedCode: new TextDecoder().decode(file.requestedData),
+          requestedFileName: file.requestedFileName,
           requestedProjectName: uniqueNameIfNeeded,
         })
-      }
+      )
 
       /**
        * When adding assemblies to an existing project create the assembly into a unique sub directory
@@ -170,7 +143,6 @@ export function createApplicationCommands({
           } else {
             onSubmitKCLSampleCreation({
               sample: data.sample,
-              kclSample,
               uniqueNameIfNeeded,
               systemIOActor: app.systemIOActor,
               isProjectNew,
@@ -401,7 +373,6 @@ export function createApplicationCommands({
         )
         onSubmitKCLSampleCreation({
           sample: data.sample,
-          kclSample,
           uniqueNameIfNeeded,
           systemIOActor: app.systemIOActor,
           isProjectNew: true,

--- a/src/lib/commandBarConfigs/applicationCommandConfig.ts
+++ b/src/lib/commandBarConfigs/applicationCommandConfig.ts
@@ -11,7 +11,11 @@ import { getNextFileName, getUniqueProjectName } from '@src/lib/desktopFS'
 import { exportProjectZip } from '@src/lib/exportProjectZip'
 import fsZds from '@src/lib/fs-zds'
 import { isDesktop } from '@src/lib/isDesktop'
-import { everyKclSample, findKclSample } from '@src/lib/kclSamples'
+import {
+  downloadKclSample,
+  everyKclSample,
+  findKclSample,
+} from '@src/lib/kclSamples'
 import { isUserLoadableLayoutKey, userLoadableLayouts } from '@src/lib/layout'
 import {
   getEXTNoPeriod,
@@ -34,70 +38,40 @@ import type { ActorRefFrom } from 'xstate'
 
 function onSubmitKCLSampleCreation({
   sample,
-  kclSample,
   uniqueNameIfNeeded,
   systemIOActor,
   isProjectNew,
 }: {
   sample: string
-  kclSample: ReturnType<typeof findKclSample>
   uniqueNameIfNeeded: string
   systemIOActor: ActorRefFrom<typeof systemIOMachine>
   isProjectNew: boolean
 }) {
-  if (!kclSample) {
-    toast.error(
-      'The command could not be submitted, unable to find Zoo sample.'
-    )
-    return
-  }
-  const pathParts = webSafePathSplit(sample)
-  const projectPathPart = pathParts[0]
-  const files = kclSample.files
-
-  const filePromises = files.map((file) => {
-    const sampleCodeUrl =
-      (isDesktop() ? '.' : '') +
-      `/kcl-samples/${encodeURIComponent(
-        projectPathPart
-      )}/${encodeURIComponent(file)}`
-    return fetch(sampleCodeUrl).then((response) => {
-      return {
-        response,
-        file,
-        projectName: projectPathPart,
-      }
-    })
-  })
-
-  const requestedFiles: RequestedKCLFile[] = []
   // If any fetches fail from the KCL Code download we will instantly reject
   // No cleanup required since the fetch response is in memory
   // TODO: Try to catch if there is a failure then delete the root folder and show error
-  Promise.all(filePromises)
-    .then(async (responses) => {
-      for (let i = 0; i < responses.length; i++) {
-        const response = responses[i]
-        const code = await response.response.text()
-        requestedFiles.push({
-          requestedCode: code,
-          requestedFileName: response.file,
+  void downloadKclSample(sample, isDesktop() ? '.' : '')
+    .then(({ initialProject, requestedProjectName }) => {
+      const decoder = new TextDecoder()
+      const requestedFiles: RequestedKCLFile[] = initialProject.files.map(
+        (file) => ({
+          requestedCode: decoder.decode(file.requestedData),
+          requestedFileName: file.requestedFileName,
           requestedProjectName: uniqueNameIfNeeded,
         })
-      }
+      )
 
       /**
        * When adding assemblies to an existing project create the assembly into a unique sub directory
        */
       if (!isProjectNew) {
         requestedFiles.forEach((requestedFile) => {
-          const subDirectoryName = projectPathPart
           const firstLevelDirectories = getAllSubDirectoriesAtProjectRoot(
             systemIOActor.getSnapshot().context,
             { projectFolderName: requestedFile.requestedProjectName }
           )
           const uniqueSubDirectoryName = getUniqueProjectName(
-            subDirectoryName,
+            requestedProjectName,
             firstLevelDirectories
           )
           requestedFile.requestedProjectName = joinOSPaths(
@@ -170,7 +144,6 @@ export function createApplicationCommands({
           } else {
             onSubmitKCLSampleCreation({
               sample: data.sample,
-              kclSample,
               uniqueNameIfNeeded,
               systemIOActor: app.systemIOActor,
               isProjectNew,
@@ -401,7 +374,6 @@ export function createApplicationCommands({
         )
         onSubmitKCLSampleCreation({
           sample: data.sample,
-          kclSample,
           uniqueNameIfNeeded,
           systemIOActor: app.systemIOActor,
           isProjectNew: true,

--- a/src/lib/commandBarConfigs/applicationCommandConfig.ts
+++ b/src/lib/commandBarConfigs/applicationCommandConfig.ts
@@ -11,11 +11,7 @@ import { getNextFileName, getUniqueProjectName } from '@src/lib/desktopFS'
 import { exportProjectZip } from '@src/lib/exportProjectZip'
 import fsZds from '@src/lib/fs-zds'
 import { isDesktop } from '@src/lib/isDesktop'
-import {
-  downloadKclSample,
-  everyKclSample,
-  findKclSample,
-} from '@src/lib/kclSamples'
+import { everyKclSample, findKclSample } from '@src/lib/kclSamples'
 import { isUserLoadableLayoutKey, userLoadableLayouts } from '@src/lib/layout'
 import {
   getEXTNoPeriod,
@@ -38,40 +34,70 @@ import type { ActorRefFrom } from 'xstate'
 
 function onSubmitKCLSampleCreation({
   sample,
+  kclSample,
   uniqueNameIfNeeded,
   systemIOActor,
   isProjectNew,
 }: {
   sample: string
+  kclSample: ReturnType<typeof findKclSample>
   uniqueNameIfNeeded: string
   systemIOActor: ActorRefFrom<typeof systemIOMachine>
   isProjectNew: boolean
 }) {
+  if (!kclSample) {
+    toast.error(
+      'The command could not be submitted, unable to find Zoo sample.'
+    )
+    return
+  }
+  const pathParts = webSafePathSplit(sample)
+  const projectPathPart = pathParts[0]
+  const files = kclSample.files
+
+  const filePromises = files.map((file) => {
+    const sampleCodeUrl =
+      (isDesktop() ? '.' : '') +
+      `/kcl-samples/${encodeURIComponent(
+        projectPathPart
+      )}/${encodeURIComponent(file)}`
+    return fetch(sampleCodeUrl).then((response) => {
+      return {
+        response,
+        file,
+        projectName: projectPathPart,
+      }
+    })
+  })
+
+  const requestedFiles: RequestedKCLFile[] = []
   // If any fetches fail from the KCL Code download we will instantly reject
   // No cleanup required since the fetch response is in memory
   // TODO: Try to catch if there is a failure then delete the root folder and show error
-  void downloadKclSample(sample, isDesktop() ? '.' : '')
-    .then(({ initialProject, requestedProjectName }) => {
-      const decoder = new TextDecoder()
-      const requestedFiles: RequestedKCLFile[] = initialProject.files.map(
-        (file) => ({
-          requestedCode: decoder.decode(file.requestedData),
-          requestedFileName: file.requestedFileName,
+  Promise.all(filePromises)
+    .then(async (responses) => {
+      for (let i = 0; i < responses.length; i++) {
+        const response = responses[i]
+        const code = await response.response.text()
+        requestedFiles.push({
+          requestedCode: code,
+          requestedFileName: response.file,
           requestedProjectName: uniqueNameIfNeeded,
         })
-      )
+      }
 
       /**
        * When adding assemblies to an existing project create the assembly into a unique sub directory
        */
       if (!isProjectNew) {
         requestedFiles.forEach((requestedFile) => {
+          const subDirectoryName = projectPathPart
           const firstLevelDirectories = getAllSubDirectoriesAtProjectRoot(
             systemIOActor.getSnapshot().context,
             { projectFolderName: requestedFile.requestedProjectName }
           )
           const uniqueSubDirectoryName = getUniqueProjectName(
-            requestedProjectName,
+            subDirectoryName,
             firstLevelDirectories
           )
           requestedFile.requestedProjectName = joinOSPaths(
@@ -144,6 +170,7 @@ export function createApplicationCommands({
           } else {
             onSubmitKCLSampleCreation({
               sample: data.sample,
+              kclSample,
               uniqueNameIfNeeded,
               systemIOActor: app.systemIOActor,
               isProjectNew,
@@ -374,6 +401,7 @@ export function createApplicationCommands({
         )
         onSubmitKCLSampleCreation({
           sample: data.sample,
+          kclSample,
           uniqueNameIfNeeded,
           systemIOActor: app.systemIOActor,
           isProjectNew: true,

--- a/src/lib/kclSamples.test.ts
+++ b/src/lib/kclSamples.test.ts
@@ -1,4 +1,4 @@
-import { downloadKclSample, findKclSample } from '@src/lib/kclSamples'
+import { downloadKclSample } from '@src/lib/kclSamples'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 afterEach(() => {
@@ -6,38 +6,16 @@ afterEach(() => {
 })
 
 describe('KCL samples', () => {
-  it('keeps legacy samples out of the current sample catalog', () => {
-    expect(findKclSample('angle-gauge/main.kcl')).toMatchObject({
-      title: 'Angle Gauge',
-    })
-    expect(findKclSample('telemetry-antenna/main.kcl')).toBeUndefined()
-  })
-
-  it('downloads current samples from the current asset directory', async () => {
-    const fetchMock = vi.fn(async () => new Response('// Angle Gauge\n'))
-    vi.stubGlobal('fetch', fetchMock)
-
-    await downloadKclSample('angle-gauge/main.kcl')
-
-    expect(fetchMock).toHaveBeenCalledWith('/kcl-samples/angle-gauge/main.kcl')
-  })
-
-  it('downloads legacy samples used by old deep links', async () => {
-    const code = '// Aircraft telemetry antenna plate\n'
+  it('downloads current samples for project creation', async () => {
+    const code = '// Angle Gauge\n'
     const fetchMock = vi.fn(async () => new Response(code))
     vi.stubGlobal('fetch', fetchMock)
 
-    const downloadedSample = await downloadKclSample(
-      'telemetry-antenna/main.kcl'
-    )
+    const downloadedSample = await downloadKclSample('angle-gauge/main.kcl')
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      '/kcl-samples-legacy/telemetry-antenna/main.kcl'
-    )
-    expect(downloadedSample.sample.title).toBe(
-      'Aircraft telemetry antenna plate'
-    )
-    expect(downloadedSample.requestedProjectName).toBe('telemetry-antenna')
+    expect(fetchMock).toHaveBeenCalledWith('/kcl-samples/angle-gauge/main.kcl')
+    expect(downloadedSample.sample.title).toBe('Angle Gauge')
+    expect(downloadedSample.requestedProjectName).toBe('angle-gauge')
     expect(downloadedSample.initialProject.entrypointFilePath).toBe('main.kcl')
     expect(downloadedSample.initialProject.files).toEqual([
       {
@@ -45,5 +23,24 @@ describe('KCL samples', () => {
         requestedData: new TextEncoder().encode(code),
       },
     ])
+  })
+
+  it('supports the relative asset URLs used by desktop', async () => {
+    const fetchMock = vi.fn(async () => new Response('// Angle Gauge\n'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await downloadKclSample('angle-gauge/main.kcl', { assetUrlPrefix: '.' })
+
+    expect(fetchMock).toHaveBeenCalledWith('./kcl-samples/angle-gauge/main.kcl')
+  })
+
+  it('rejects samples missing from the current catalog', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      downloadKclSample('telemetry-antenna/main.kcl')
+    ).rejects.toThrow("Couldn't find KCL sample.")
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/kclSamples.test.ts
+++ b/src/lib/kclSamples.test.ts
@@ -1,0 +1,40 @@
+import { downloadKclSample, findKclSample } from '@src/lib/kclSamples'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('KCL samples', () => {
+  it('keeps legacy samples out of the current sample catalog', () => {
+    expect(findKclSample('angle-gauge/main.kcl')).toMatchObject({
+      title: 'Angle Gauge',
+    })
+    expect(findKclSample('telemetry-antenna/main.kcl')).toBeUndefined()
+  })
+
+  it('downloads legacy samples used by old deep links', async () => {
+    const code = '// Aircraft telemetry antenna plate\n'
+    const fetchMock = vi.fn(async () => new Response(code))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const downloadedSample = await downloadKclSample(
+      'telemetry-antenna/main.kcl'
+    )
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/kcl-samples-legacy/telemetry-antenna/main.kcl'
+    )
+    expect(downloadedSample.sample.title).toBe(
+      'Aircraft telemetry antenna plate'
+    )
+    expect(downloadedSample.requestedProjectName).toBe('telemetry-antenna')
+    expect(downloadedSample.initialProject.entrypointFilePath).toBe('main.kcl')
+    expect(downloadedSample.initialProject.files).toEqual([
+      {
+        requestedFileName: 'main.kcl',
+        requestedData: new TextEncoder().encode(code),
+      },
+    ])
+  })
+})

--- a/src/lib/kclSamples.test.ts
+++ b/src/lib/kclSamples.test.ts
@@ -13,6 +13,15 @@ describe('KCL samples', () => {
     expect(findKclSample('telemetry-antenna/main.kcl')).toBeUndefined()
   })
 
+  it('downloads current samples from the current asset directory', async () => {
+    const fetchMock = vi.fn(async () => new Response('// Angle Gauge\n'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await downloadKclSample('angle-gauge/main.kcl')
+
+    expect(fetchMock).toHaveBeenCalledWith('/kcl-samples/angle-gauge/main.kcl')
+  })
+
   it('downloads legacy samples used by old deep links', async () => {
     const code = '// Aircraft telemetry antenna plate\n'
     const fetchMock = vi.fn(async () => new Response(code))

--- a/src/lib/kclSamples.ts
+++ b/src/lib/kclSamples.ts
@@ -16,8 +16,7 @@ export const findKclSample = (pathFromProjectDirectoryToFirstFile: string) => {
 }
 
 export async function downloadKclSample(
-  pathFromProjectDirectoryToFirstFile: string,
-  assetRoot = ''
+  pathFromProjectDirectoryToFirstFile: string
 ) {
   const currentSample = findKclSample(pathFromProjectDirectoryToFirstFile)
   const sample =
@@ -42,7 +41,7 @@ export async function downloadKclSample(
   const files = await Promise.all(
     sample.files.map(async (file) => {
       const response = await fetch(
-        `${assetRoot}/${assetDirectory}/${encodeURIComponent(
+        `/${assetDirectory}/${encodeURIComponent(
           requestedProjectName
         )}/${encodeURIComponent(file)}`
       )

--- a/src/lib/kclSamples.ts
+++ b/src/lib/kclSamples.ts
@@ -1,5 +1,4 @@
 import kclSamplesManifest from '@public/kcl-samples/manifest.json'
-import legacyKclSamplesManifest from '@public/kcl-samples-legacy/manifest.json'
 import { webSafePathSplit } from '@src/lib/paths'
 
 export const kclSamplesManifestWithNoMultipleFiles = kclSamplesManifest.filter(
@@ -16,20 +15,13 @@ export const findKclSample = (pathFromProjectDirectoryToFirstFile: string) => {
 }
 
 export async function downloadKclSample(
-  pathFromProjectDirectoryToFirstFile: string
+  pathFromProjectDirectoryToFirstFile: string,
+  { assetUrlPrefix = '' }: { assetUrlPrefix?: string } = {}
 ) {
-  const currentSample = findKclSample(pathFromProjectDirectoryToFirstFile)
-  const sample =
-    currentSample ??
-    legacyKclSamplesManifest.find(
-      (sample) =>
-        sample.pathFromProjectDirectoryToFirstFile ===
-        pathFromProjectDirectoryToFirstFile
-    )
+  const sample = findKclSample(pathFromProjectDirectoryToFirstFile)
   if (!sample) {
     return Promise.reject(new Error("Couldn't find KCL sample."))
   }
-  const assetDirectory = currentSample ? 'kcl-samples' : 'kcl-samples-legacy'
 
   const requestedProjectName = webSafePathSplit(
     sample.pathFromProjectDirectoryToFirstFile
@@ -41,7 +33,7 @@ export async function downloadKclSample(
   const files = await Promise.all(
     sample.files.map(async (file) => {
       const response = await fetch(
-        `/${assetDirectory}/${encodeURIComponent(
+        `${assetUrlPrefix}/kcl-samples/${encodeURIComponent(
           requestedProjectName
         )}/${encodeURIComponent(file)}`
       )

--- a/src/lib/kclSamples.ts
+++ b/src/lib/kclSamples.ts
@@ -1,4 +1,6 @@
 import kclSamplesManifest from '@public/kcl-samples/manifest.json'
+import legacyKclSamplesManifest from '@public/kcl-samples-legacy/manifest.json'
+import { webSafePathSplit } from '@src/lib/paths'
 
 export const kclSamplesManifestWithNoMultipleFiles = kclSamplesManifest.filter(
   (file) => !file.multipleFiles
@@ -11,4 +13,56 @@ export const findKclSample = (pathFromProjectDirectoryToFirstFile: string) => {
       sample.pathFromProjectDirectoryToFirstFile ===
       pathFromProjectDirectoryToFirstFile
   )
+}
+
+export async function downloadKclSample(
+  pathFromProjectDirectoryToFirstFile: string,
+  assetRoot = ''
+) {
+  const currentSample = findKclSample(pathFromProjectDirectoryToFirstFile)
+  const sample =
+    currentSample ??
+    legacyKclSamplesManifest.find(
+      (sample) =>
+        sample.pathFromProjectDirectoryToFirstFile ===
+        pathFromProjectDirectoryToFirstFile
+    )
+  if (!sample) {
+    return Promise.reject(new Error("Couldn't find KCL sample."))
+  }
+  const assetDirectory = currentSample ? 'kcl-samples' : 'kcl-samples-legacy'
+
+  const requestedProjectName = webSafePathSplit(
+    sample.pathFromProjectDirectoryToFirstFile
+  )[0]
+  if (!requestedProjectName) {
+    return Promise.reject(new Error('The KCL sample has an invalid path.'))
+  }
+
+  const files = await Promise.all(
+    sample.files.map(async (file) => {
+      const response = await fetch(
+        `${assetRoot}/${assetDirectory}/${encodeURIComponent(
+          requestedProjectName
+        )}/${encodeURIComponent(file)}`
+      )
+      if (!response.ok) {
+        return Promise.reject(new Error('Failed to fetch KCL sample file.'))
+      }
+
+      return {
+        requestedFileName: file,
+        requestedData: new Uint8Array(await response.arrayBuffer()),
+      }
+    })
+  )
+
+  return {
+    sample,
+    requestedProjectName,
+    initialProject: {
+      files,
+      entrypointFilePath: sample.file,
+    },
+  }
 }


### PR DESCRIPTION
Follow-up to #12951. Closes #12944. Uses the same `createProject` path and picks the default library, whatever is first.

## How to test on web

1. Open [the KCL sample URL](https://modeling-app-git-pierremtb-issue12943-sample-links-proje-52809e.vercel.dev.zoo.dev/?cmd=add-kcl-file-to-project&groupId=application&projectName=browser&source=kcl-samples&sample=socket-head-cap-screw/main.kcl).
2. Confirm `socket-head-cap-screw` is created in **Personal Cloud**.
3. Confirm `socket-head-cap-screw/main.kcl` opens and the editor contains “Socket Head Cap Screw”.