### PR TITLE
KCL: Don't run the 'frontend' benchmark in codspeed

### DIFF
--- a/.github/workflows/cargo-bench.yml
+++ b/.github/workflows/cargo-bench.yml
@@ -51,13 +51,22 @@ jobs:
       - name: Build the benchmark target(s)
         run: |
           cd rust
-          cargo codspeed build
+          cargo codspeed build \
+            --bench benchmark_kcl_samples \
+            --bench compiler_benchmark_criterion \
+            --bench digest_benchmark \
+            --bench memory_benchmark_criterion
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@v5.0.1
         with:
           mode: simulation
           working-directory: rust
-          run: cargo codspeed run
+          run: >-
+            cargo codspeed run
+            --bench benchmark_kcl_samples
+            --bench compiler_benchmark_criterion
+            --bench digest_benchmark
+            --bench memory_benchmark_criterion
           token: ${{ secrets.CODSPEED_TOKEN }}
         env:
           ZOO_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}


### PR DESCRIPTION
This benchmark usually fails with some engine IO error, we should really only be running it locally.