### PR TITLE
Allow smartlist markdown

### DIFF
--- a/src/components/MarkdownText.test.tsx
+++ b/src/components/MarkdownText.test.tsx
@@ -1,0 +1,46 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { MarkdownText } from '@src/components/MarkdownText'
+
+const mixedListResponse = `I made the following updates:
+
+- Added a rectangular base plate.
+- Added four corner mounting holes.
+- Added a centered circular cutout.
+- Added fillets to the outside corners.
+- Updated the model dimensions.
+1. Changed the plate width to 120 mm.
+2. Changed the plate height to 80 mm.
+3. Changed the plate thickness to 6 mm.`
+
+const expectedItems = [
+  'Added a rectangular base plate.',
+  'Added four corner mounting holes.',
+  'Added a centered circular cutout.',
+  'Added fillets to the outside corners.',
+  'Updated the model dimensions.',
+  'Changed the plate width to 120 mm.',
+  'Changed the plate height to 80 mm.',
+  'Changed the plate thickness to 6 mm.',
+]
+
+describe('MarkdownText', () => {
+  it('renders contiguous unordered and ordered items as separate lists', () => {
+    const { container } = render(<MarkdownText text={mixedListResponse} />)
+
+    const lists = container.querySelectorAll('ul, ol')
+    expect(lists).toHaveLength(2)
+
+    const [unorderedList, orderedList] = lists
+    expect(unorderedList.tagName).toBe('UL')
+    expect(unorderedList.querySelectorAll(':scope > li')).toHaveLength(5)
+    expect(unorderedList.nextElementSibling).toBe(orderedList)
+    expect(orderedList.tagName).toBe('OL')
+    expect(orderedList.querySelectorAll(':scope > li')).toHaveLength(3)
+
+    expect(
+      Array.from(container.querySelectorAll('li'), (item) => item.textContent)
+    ).toEqual(expectedItems)
+  })
+})

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -6,6 +6,7 @@ import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
 export const MARKED_OPTIONS: MarkedOptions = {
   gfm: true,
   breaks: true,
+  smartLists: true,
   sanitize: true,
   unescape,
   escape,


### PR DESCRIPTION
See this [slack thread](https://kittycadworkspace.slack.com/archives/C0B790N2G67/p1786643392490959)

The issue arose out of Zookeeper returning a mixed list of unordered and ordered items