### PR TITLE
Create blank projects for Zookeeper web links

### DIFF
--- a/e2e/playwright/cloud-sync.spec.ts
+++ b/e2e/playwright/cloud-sync.spec.ts
@@ -38,6 +38,84 @@ async function expectCloudSyncHomeReady(page: Page) {
 }
 
 test(
+  'creates a fresh blank Personal Cloud project for every Zookeeper deep link',
+  { tag: ['@web'] },
+  async ({ context, page }, testInfo) => {
+    const createdProjects: CloudProject[] = [
+      {
+        id: '12945000-0000-4000-8000-000000000001',
+        title: 'demo-project',
+        revision: 'demo-project-rev-1',
+        files: {},
+      },
+      {
+        id: '12945000-0000-4000-8000-000000000002',
+        title: 'demo-project-1',
+        revision: 'demo-project-1-rev-1',
+        files: {},
+      },
+    ]
+    let createIndex = 0
+    const remoteProjects: CloudProject[] = []
+    const { calls: apiCalls } = await routeCloudProjects(context, {
+      remoteProjects,
+      createProject: () => {
+        const project = createdProjects[createIndex++]
+        if (!project) {
+          throw new Error('Unexpected extra demo project creation.')
+        }
+        remoteProjects.push(project)
+        return project
+      },
+    })
+    const prompt = 'Design a spur gear'
+    const deepLink =
+      `/?cmd=set-layout&groupId=application&layoutId=zookeeper` +
+      `&ttc-prompt=${encodeURIComponent(prompt)}`
+
+    await setup(context, page, testInfo, [OPFS_CLOUD_FEATURE_FLAG])
+
+    for (const [index, projectName] of [
+      'demo-project',
+      'demo-project-1',
+    ].entries()) {
+      await page.goto(deepLink)
+
+      await expectProjectFileRoute(page)
+      await expect(page).toHaveURL(new RegExp(`${projectName}%2Fmain\\.kcl`))
+      await expect
+        .poll(() =>
+          page.evaluate(() => {
+            const layout = window.app.layout.get()
+            return 'sizes' in layout ? layout.sizes : []
+          })
+        )
+        .toEqual([0, 50, 50])
+      await expect(page.getByTestId('command-bar-wrapper')).not.toBeVisible()
+      await expect(
+        page.getByTestId('ml-ephant-conversation-input')
+      ).toHaveValue(prompt)
+      await expect
+        .poll(() => new URL(page.url()).searchParams.has('cmd'))
+        .toBe(false)
+      await expect
+        .poll(() => new URL(page.url()).searchParams.has('ttc-prompt'))
+        .toBe(false)
+      await expect.poll(() => apiCalls.creates.length).toBe(index + 1)
+      await expect
+        .poll(() =>
+          opfsPathExists(page, `${PROJECT_DIR}/${projectName}/main.kcl`)
+        )
+        .toBe(true)
+      const files = await readOpfsTextFiles(page, {
+        main: `${PROJECT_DIR}/${projectName}/main.kcl`,
+      })
+      expect(files.main.trim()).toBe('@settings(kclVersion = 2.0)')
+    }
+  }
+)
+
+test(
   'streams remote-only projects into an empty local list and materializes opened clones',
   { tag: ['@web'] },
   async ({ context, page }, testInfo) => {

--- a/src/hooks/useQueryParamEffects.ts
+++ b/src/hooks/useQueryParamEffects.ts
@@ -1,4 +1,5 @@
 import { base64ToString } from '@src/lib/base64'
+import type { App } from '@src/lib/app'
 import { useApp } from '@src/lib/boot'
 import type { ProjectsCommandSchema } from '@src/lib/commandBarConfigs/projectsCommandConfig'
 import {
@@ -11,6 +12,8 @@ import {
   POOL_QUERY_PARAM,
   PROJECT_ENTRYPOINT,
   PROJECT_ID_QUERY_PARAM,
+  LEGACY_SEARCH_PARAM_ZOOKEEPER_PROMPT_KEY,
+  SEARCH_PARAM_ZOOKEEPER_PROMPT_KEY,
 } from '@src/lib/constants'
 import {
   downloadProjectById,
@@ -19,6 +22,7 @@ import {
 import fsZds from '@src/lib/fs-zds'
 import { isDesktop } from '@src/lib/isDesktop'
 import { PATHS, safeEncodeForRouterPaths } from '@src/lib/paths'
+import { PERSONAL_CLOUD_PROJECT_LIBRARY_ID } from '@src/lib/projectLibraries'
 import { getProjectDirectoryNameFromTitle } from '@src/lib/projectName'
 import { DEFAULT_WEB_PROJECT_NAME } from '@src/lib/routeLoaders'
 import { err } from '@src/lib/trap'
@@ -39,6 +43,35 @@ export type CreateFileSchemaMethodOptional = Omit<
   'method'
 > & {
   method?: 'newProject' | 'existingProject'
+}
+
+let pendingWebLayoutProjectCreation: Promise<string> | undefined
+
+async function createFreshWebLayoutProject(app: App) {
+  await waitForIdleState({ systemIOActor: app.systemIOActor })
+  await waitFor(app.settings.actor, (state) => state.matches('idle'))
+
+  const targets = app.getCreateProjectLibraryTargets()
+  const projectLibraryTarget =
+    targets.find(
+      (target) => target.library.id === PERSONAL_CLOUD_PROJECT_LIBRARY_ID
+    ) ?? targets[0]
+  if (!projectLibraryTarget) {
+    return Promise.reject(
+      new Error('No writable project library is available.')
+    )
+  }
+
+  const project = await projectLibraryTarget.createProject.run({
+    library: projectLibraryTarget.library,
+    requestedProjectName: DEFAULT_WEB_PROJECT_NAME,
+    requestedProjectTitle: DEFAULT_WEB_PROJECT_NAME,
+  })
+  if (!project?.default_file) {
+    return Promise.reject(new Error('Unable to create a blank project.'))
+  }
+
+  return project.default_file
 }
 
 /**
@@ -202,6 +235,52 @@ export function useQueryParamEffects() {
     const rawCommandData = buildGenericCommandArgs(searchParams)
     if (!rawCommandData) return
     const commandData = rawCommandData
+    const shouldCreateWebLayoutProject =
+      !isDesktop() &&
+      commandData.groupId === 'application' &&
+      commandData.name === 'set-layout' &&
+      !app.project
+
+    if (shouldCreateWebLayoutProject) {
+      let cancelled = false
+      pendingWebLayoutProjectCreation ??= createFreshWebLayoutProject(app)
+
+      void pendingWebLayoutProjectCreation
+        .then((defaultFile) => {
+          if (cancelled) {
+            return
+          }
+
+          void navigate(
+            {
+              pathname: `${PATHS.FILE}/${safeEncodeForRouterPaths(defaultFile)}`,
+              search: searchParams.toString(),
+            },
+            { replace: true }
+          )
+        })
+        .catch((error) => {
+          pendingWebLayoutProjectCreation = undefined
+          if (!cancelled) {
+            toast.error(
+              err(error) ? error.message : 'Failed to create a blank project.'
+            )
+          }
+        })
+
+      return () => {
+        cancelled = true
+      }
+    }
+
+    if (
+      !isDesktop() &&
+      commandData.groupId === 'application' &&
+      commandData.name === 'set-layout'
+    ) {
+      pendingWebLayoutProjectCreation = undefined
+    }
+
     let shouldCreateDefaultWebProject = false
 
     // Web-only: prefill command data to automatically add to the demo project
@@ -300,6 +379,8 @@ export function useQueryParamEffects() {
             CMD_GROUP_QUERY_PARAM,
             CREATE_FILE_URL_PARAM,
             POOL_QUERY_PARAM,
+            SEARCH_PARAM_ZOOKEEPER_PROMPT_KEY,
+            LEGACY_SEARCH_PARAM_ZOOKEEPER_PROMPT_KEY,
           ]
 
           return !reservedKeys.includes(key)

--- a/src/lib/zookeeper/components/ZookeeperConversationPane.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPane.tsx
@@ -6,7 +6,10 @@ import { ZookeeperConversationWelcome } from '@src/lib/zookeeper/components/Zook
 import { useOnWindowOnlineOffline } from '@src/hooks/network/useOnWindowOnlineOffline'
 import type { useModelingContext } from '@src/hooks/useModelingContext'
 import type { KclManager } from '@src/lang/KclManager'
-import { SEARCH_PARAM_ZOOKEEPER_PROMPT_KEY } from '@src/lib/constants'
+import {
+  LEGACY_SEARCH_PARAM_ZOOKEEPER_PROMPT_KEY,
+  SEARCH_PARAM_ZOOKEEPER_PROMPT_KEY,
+} from '@src/lib/constants'
 import { getParentAbsolutePath } from '@src/lib/paths'
 import type { FileEntry, Project } from '@src/lib/project'
 import type { SettingsType } from '@src/lib/settings/initialSettings'
@@ -585,13 +588,16 @@ export const ZookeeperConversationPane = (props: {
   // We watch the URL for a query parameter to set the defaultPrompt
   // for the conversation.
   useEffect(() => {
-    const ttcPromptParam = searchParams.get(SEARCH_PARAM_ZOOKEEPER_PROMPT_KEY)
-    if (ttcPromptParam) {
-      setDefaultPrompt(ttcPromptParam)
+    const promptParam =
+      searchParams.get(SEARCH_PARAM_ZOOKEEPER_PROMPT_KEY) ??
+      searchParams.get(LEGACY_SEARCH_PARAM_ZOOKEEPER_PROMPT_KEY)
+    if (promptParam) {
+      setDefaultPrompt(promptParam)
 
       // Now clear that param
       const newSearchParams = new URLSearchParams(searchParams)
       newSearchParams.delete(SEARCH_PARAM_ZOOKEEPER_PROMPT_KEY)
+      newSearchParams.delete(LEGACY_SEARCH_PARAM_ZOOKEEPER_PROMPT_KEY)
       setSearchParams(newSearchParams, { replace: true })
     }
   }, [searchParams, setSearchParams])


### PR DESCRIPTION
Closes #12945 (for real).

## Summary

Zookeeper “Try in browser” links currently apply the requested layout but leave users on the project library because no project is open.

This change makes root-level web `set-layout` links create and open a fresh blank Personal Cloud project before applying the layout. Repeated visits create uniquely named projects such as `demo-project` and `demo-project-1`, so an existing project is never silently reused or overwritten.

The link’s query parameters are preserved during navigation, and both `zookeeper-prompt` and the legacy website parameter `ttc-prompt` prefill Zookeeper after the project opens. The layout command is then consumed normally without showing the command palette.

## How to test

1. Click this link to the Vercel preview https://modeling-app-git-pierremtb-issue-12945-create-blank-project.vercel.dev.zoo.dev/?cmd=set-layout&groupId=application&layoutId=zookeeper&ttc-prompt=Design%20a%20spur%20gear.
3. Confirm a blank `demo-project` opens with the Zookeeper layout, the prompt is prefilled, and the command palette does not appear.
4. Open the same link again and confirm a new blank project such as `demo-project-1` opens.