### PR TITLE
Return execution diagnostics with sketch constraint reports

### DIFF
--- a/rust/kcl-python-bindings/kcl.pyi
+++ b/rust/kcl-python-bindings/kcl.pyi
@@ -53,6 +53,7 @@ __all__ = [
     "SnapshotOptions",
     "StepExportOptions",
     "StepImportOptions",
+    "StepImportTargetRepresentation",
     "StepPresentation",
     "StlExportOptions",
     "StlImportOptions",
@@ -600,6 +601,12 @@ class SketchConstraintReport:
     @property
     def errors(self) -> builtins.list[SketchConstraintStatus]: ...
     @property
+    def warnings(self) -> builtins.list[builtins.str]:
+        r"""
+        Rendered non-fatal KCL execution warnings collected while computing
+        the constraint report.
+        """
+    @property
     def is_complete(self) -> builtins.bool: ...
     @property
     def kcl_error(self) -> typing.Optional[KclErrorInfo]: ...
@@ -893,6 +900,20 @@ class PlyStorage(enum.Enum):
     BinaryBigEndian = ...
     r"""
     Encode payload as binary using big endian.
+    """
+
+@typing.final
+class StepImportTargetRepresentation(enum.Enum):
+    r"""
+    After importing, how should this model's data be represented?
+    """
+    Mesh = ...
+    r"""
+    Mesh of 2D geometry
+    """
+    Brep = ...
+    r"""
+    Boundary representation
     """
 
 @typing.final

--- a/rust/kcl-python-bindings/kcl.pyi
+++ b/rust/kcl-python-bindings/kcl.pyi
@@ -607,6 +607,18 @@ class SketchConstraintReport:
         the constraint report.
         """
     @property
+    def execution_errors(self) -> builtins.list[builtins.str]:
+        r"""
+        Rendered non-fatal KCL execution errors collected while computing the
+        constraint report.
+        """
+    @property
+    def execution_fatals(self) -> builtins.list[builtins.str]:
+        r"""
+        Rendered fatal KCL execution issues collected while computing the
+        constraint report.
+        """
+    @property
     def is_complete(self) -> builtins.bool: ...
     @property
     def kcl_error(self) -> typing.Optional[KclErrorInfo]: ...

--- a/rust/kcl-python-bindings/src/bridge/sketch_constraints.rs
+++ b/rust/kcl-python-bindings/src/bridge/sketch_constraints.rs
@@ -77,6 +77,10 @@ pub struct SketchConstraintReport {
     pub over_constrained: Vec<SketchConstraintStatus>,
     #[pyo3(get)]
     pub errors: Vec<SketchConstraintStatus>,
+    /// Rendered non-fatal KCL execution warnings collected while computing
+    /// the constraint report.
+    #[pyo3(get)]
+    pub warnings: Vec<String>,
     #[pyo3(get)]
     pub is_complete: bool,
     #[pyo3(get)]
@@ -98,6 +102,7 @@ impl From<kcl_lib::SketchConstraintReport> for SketchConstraintReport {
             under_constrained: r.under_constrained.into_iter().map(Into::into).collect(),
             over_constrained: r.over_constrained.into_iter().map(Into::into).collect(),
             errors: r.errors.into_iter().map(Into::into).collect(),
+            warnings: Vec::new(),
             is_complete: true,
             kcl_error: None,
         }

--- a/rust/kcl-python-bindings/src/bridge/sketch_constraints.rs
+++ b/rust/kcl-python-bindings/src/bridge/sketch_constraints.rs
@@ -81,6 +81,14 @@ pub struct SketchConstraintReport {
     /// the constraint report.
     #[pyo3(get)]
     pub warnings: Vec<String>,
+    /// Rendered non-fatal KCL execution errors collected while computing the
+    /// constraint report.
+    #[pyo3(get)]
+    pub execution_errors: Vec<String>,
+    /// Rendered fatal KCL execution issues collected while computing the
+    /// constraint report.
+    #[pyo3(get)]
+    pub execution_fatals: Vec<String>,
     #[pyo3(get)]
     pub is_complete: bool,
     #[pyo3(get)]
@@ -103,6 +111,8 @@ impl From<kcl_lib::SketchConstraintReport> for SketchConstraintReport {
             over_constrained: r.over_constrained.into_iter().map(Into::into).collect(),
             errors: r.errors.into_iter().map(Into::into).collect(),
             warnings: Vec::new(),
+            execution_errors: Vec::new(),
+            execution_fatals: Vec::new(),
             is_complete: true,
             kcl_error: None,
         }

--- a/rust/kcl-python-bindings/src/lib.rs
+++ b/rust/kcl-python-bindings/src/lib.rs
@@ -98,13 +98,14 @@ fn add_execution_issues(
     report: &mut SketchConstraintReport,
     filename: &str,
     code: &str,
-    issues: &[kcl_lib::CompilationIssue],
+    issues: Vec<kcl_lib::CompilationIssue>,
 ) {
     for issue in issues {
-        let rendered = kcl_lib::render_compilation_issue_miette(filename, code, issue.clone());
-        if issue.severity.is_fatal() {
+        let severity = issue.severity;
+        let rendered = kcl_lib::render_compilation_issue_miette(filename, code, issue);
+        if severity.is_fatal() {
             report.execution_fatals.push(rendered);
-        } else if issue.severity.is_err() {
+        } else if severity.is_err() {
             report.execution_errors.push(rendered);
         } else {
             report.warnings.push(rendered);
@@ -391,7 +392,7 @@ async fn sketch_constraint_report_impl(input: KclInput) -> PyResult<SketchConstr
         Ok((env_ref, _)) => {
             let outcome = state.into_exec_outcome(env_ref, &ctx).await.map_err(to_py_exception)?;
             let mut report: SketchConstraintReport = outcome.sketch_constraint_report().into();
-            add_execution_issues(&mut report, &filename, &code, &outcome.issues);
+            add_execution_issues(&mut report, &filename, &code, outcome.issues);
             Ok(report)
         }
         Err(err) => {
@@ -400,7 +401,7 @@ async fn sketch_constraint_report_impl(input: KclInput) -> PyResult<SketchConstr
             }
             let error_text = render_miette(err.clone(), &code);
             let mut report: SketchConstraintReport = err.sketch_constraint_report().into();
-            add_execution_issues(&mut report, &filename, &code, &err.non_fatal);
+            add_execution_issues(&mut report, &filename, &code, err.non_fatal);
             report.is_complete = false;
             report.kcl_error = Some(KclErrorInfo {
                 phase: "execution".to_string(),

--- a/rust/kcl-python-bindings/src/lib.rs
+++ b/rust/kcl-python-bindings/src/lib.rs
@@ -94,12 +94,21 @@ fn render_miette_for_parse(filename: &str, input: &str, error: kcl_lib::KclError
     format!("{report:?}")
 }
 
+fn render_execution_warnings(filename: &str, code: &str, issues: &[kcl_lib::CompilationIssue]) -> Vec<String> {
+    issues
+        .iter()
+        .filter(|issue| issue.severity.is_warning())
+        .map(|issue| kcl_lib::render_compilation_issue_miette(filename, code, issue.clone()))
+        .collect()
+}
+
 fn incomplete_sketch_constraint_report(phase: &str, text: String) -> SketchConstraintReport {
     SketchConstraintReport {
         fully_constrained: Vec::new(),
         under_constrained: Vec::new(),
         over_constrained: Vec::new(),
         errors: Vec::new(),
+        warnings: Vec::new(),
         is_complete: false,
         kcl_error: Some(KclErrorInfo {
             phase: phase.to_string(),
@@ -369,7 +378,9 @@ async fn sketch_constraint_report_impl(input: KclInput) -> PyResult<SketchConstr
     let result = match ctx.run(&program, &mut state).await {
         Ok((env_ref, _)) => {
             let outcome = state.into_exec_outcome(env_ref, &ctx).await.map_err(to_py_exception)?;
-            Ok(outcome.sketch_constraint_report().into())
+            let mut report: SketchConstraintReport = outcome.sketch_constraint_report().into();
+            report.warnings = render_execution_warnings(&filename, &code, &outcome.issues);
+            Ok(report)
         }
         Err(err) => {
             if err.is_retryable() {
@@ -377,6 +388,7 @@ async fn sketch_constraint_report_impl(input: KclInput) -> PyResult<SketchConstr
             }
             let error_text = render_miette(err.clone(), &code);
             let mut report: SketchConstraintReport = err.sketch_constraint_report().into();
+            report.warnings = render_execution_warnings(&filename, &code, &err.non_fatal);
             report.is_complete = false;
             report.kcl_error = Some(KclErrorInfo {
                 phase: "execution".to_string(),

--- a/rust/kcl-python-bindings/src/lib.rs
+++ b/rust/kcl-python-bindings/src/lib.rs
@@ -94,12 +94,22 @@ fn render_miette_for_parse(filename: &str, input: &str, error: kcl_lib::KclError
     format!("{report:?}")
 }
 
-fn render_execution_warnings(filename: &str, code: &str, issues: &[kcl_lib::CompilationIssue]) -> Vec<String> {
-    issues
-        .iter()
-        .filter(|issue| issue.severity.is_warning())
-        .map(|issue| kcl_lib::render_compilation_issue_miette(filename, code, issue.clone()))
-        .collect()
+fn add_execution_issues(
+    report: &mut SketchConstraintReport,
+    filename: &str,
+    code: &str,
+    issues: &[kcl_lib::CompilationIssue],
+) {
+    for issue in issues {
+        let rendered = kcl_lib::render_compilation_issue_miette(filename, code, issue.clone());
+        if issue.severity.is_fatal() {
+            report.execution_fatals.push(rendered);
+        } else if issue.severity.is_err() {
+            report.execution_errors.push(rendered);
+        } else {
+            report.warnings.push(rendered);
+        }
+    }
 }
 
 fn incomplete_sketch_constraint_report(phase: &str, text: String) -> SketchConstraintReport {
@@ -109,6 +119,8 @@ fn incomplete_sketch_constraint_report(phase: &str, text: String) -> SketchConst
         over_constrained: Vec::new(),
         errors: Vec::new(),
         warnings: Vec::new(),
+        execution_errors: Vec::new(),
+        execution_fatals: Vec::new(),
         is_complete: false,
         kcl_error: Some(KclErrorInfo {
             phase: phase.to_string(),
@@ -379,7 +391,7 @@ async fn sketch_constraint_report_impl(input: KclInput) -> PyResult<SketchConstr
         Ok((env_ref, _)) => {
             let outcome = state.into_exec_outcome(env_ref, &ctx).await.map_err(to_py_exception)?;
             let mut report: SketchConstraintReport = outcome.sketch_constraint_report().into();
-            report.warnings = render_execution_warnings(&filename, &code, &outcome.issues);
+            add_execution_issues(&mut report, &filename, &code, &outcome.issues);
             Ok(report)
         }
         Err(err) => {
@@ -388,7 +400,7 @@ async fn sketch_constraint_report_impl(input: KclInput) -> PyResult<SketchConstr
             }
             let error_text = render_miette(err.clone(), &code);
             let mut report: SketchConstraintReport = err.sketch_constraint_report().into();
-            report.warnings = render_execution_warnings(&filename, &code, &err.non_fatal);
+            add_execution_issues(&mut report, &filename, &code, &err.non_fatal);
             report.is_complete = false;
             report.kcl_error = Some(KclErrorInfo {
                 phase: "execution".to_string(),

--- a/rust/kcl-python-bindings/tests/tests.py
+++ b/rust/kcl-python-bindings/tests/tests.py
@@ -742,9 +742,17 @@ async def test_sketch_constraint_status_includes_execution_warnings():
         kcl.get_sketch_constraint_status_code, warning_sketch_code
     )
     assert report.total_sketches() == 1
+    assert len(report.fully_constrained) == 0
+    assert len(report.under_constrained) == 1
+    assert len(report.over_constrained) == 0
+    assert len(report.errors) == 0
     assert len(report.warnings) == 1
     assert "Instead of constraining to 90deg" in report.warnings[0]
     assert "constraint to Perpendicular" in report.warnings[0]
+    assert len(report.execution_errors) == 0
+    assert len(report.execution_fatals) == 0
+    assert report.is_complete is True
+    assert report.kcl_error is None
 
 
 @requires_engine
@@ -753,11 +761,17 @@ async def test_sketch_constraint_status_includes_non_fatal_execution_errors():
     report = await execute_with_retries(
         kcl.get_sketch_constraint_status_code, error_sketch_code
     )
-    assert report.is_complete is True
-    assert report.kcl_error is None
+    assert report.total_sketches() == 1
+    assert len(report.fully_constrained) == 0
+    assert len(report.under_constrained) == 1
+    assert len(report.over_constrained) == 0
+    assert len(report.errors) == 0
+    assert len(report.warnings) == 0
     assert len(report.execution_errors) == 1
     assert "expects an unlabeled first argument" in report.execution_errors[0]
     assert len(report.execution_fatals) == 0
+    assert report.is_complete is True
+    assert report.kcl_error is None
 
 
 @pytest.mark.asyncio

--- a/rust/kcl-python-bindings/tests/tests.py
+++ b/rust/kcl-python-bindings/tests/tests.py
@@ -677,6 +677,19 @@ warningSketch = sketch(on = XY) {
 }
 """
 
+error_sketch_code = """
+@settings(defaultLengthUnit = mm, kclVersion = 2.0)
+
+errorSketch = sketch(on = XY) {
+  bottom = line(start = [var 0, var 0], end = [var 10, var 0])
+  right = line(start = [var 10, var 0], end = [var 10, var 10])
+  top = line(start = [var 10, var 10], end = [var 0, var 10])
+  left = line(start = [var 0, var 10], end = [var 0, var 0])
+}
+errorRegion = region(point = [5, 5], sketch = errorSketch)
+errorSolid = extrude(sketches = errorRegion, length = 10)
+"""
+
 
 @requires_engine
 @pytest.mark.asyncio
@@ -734,6 +747,19 @@ async def test_sketch_constraint_status_includes_execution_warnings():
     assert "constraint to Perpendicular" in report.warnings[0]
 
 
+@requires_engine
+@pytest.mark.asyncio
+async def test_sketch_constraint_status_includes_non_fatal_execution_errors():
+    report = await execute_with_retries(
+        kcl.get_sketch_constraint_status_code, error_sketch_code
+    )
+    assert report.is_complete is True
+    assert report.kcl_error is None
+    assert len(report.execution_errors) == 1
+    assert "expects an unlabeled first argument" in report.execution_errors[0]
+    assert len(report.execution_fatals) == 0
+
+
 @pytest.mark.asyncio
 async def test_sketch_constraint_status_parse_error_returns_report():
     report = await kcl.get_sketch_constraint_status_code(parse_error_sketch_code)
@@ -742,6 +768,9 @@ async def test_sketch_constraint_status_parse_error_returns_report():
     assert len(report.under_constrained) == 0
     assert len(report.over_constrained) == 0
     assert len(report.errors) == 0
+    assert len(report.warnings) == 0
+    assert len(report.execution_errors) == 0
+    assert len(report.execution_fatals) == 0
     assert report.is_complete is False
     assert report.kcl_error is not None
     assert report.kcl_error.phase == "parse"

--- a/rust/kcl-python-bindings/tests/tests.py
+++ b/rust/kcl-python-bindings/tests/tests.py
@@ -664,6 +664,19 @@ s1 = sketch(on = YZ) {
   line1.end.at[1] == 7
 """
 
+warning_sketch_code = """
+@settings(defaultLengthUnit = mm)
+
+warningSketch = sketch(on = XY) {
+  horizontalLine = line(start = [var 0mm, var 0mm], end = [var 10mm, var 0mm])
+  verticalLine = line(start = [var 10mm, var 0mm], end = [var 10mm, var 10mm])
+  coincident([horizontalLine.end, verticalLine.start])
+  horizontal(horizontalLine)
+  vertical(verticalLine)
+  angle([horizontalLine, verticalLine]) == 90deg
+}
+"""
+
 
 @requires_engine
 @pytest.mark.asyncio
@@ -707,6 +720,18 @@ async def test_sketch_constraint_status_mixed():
     assert len(report.errors) == 0
     assert report.is_complete is True
     assert report.kcl_error is None
+
+
+@requires_engine
+@pytest.mark.asyncio
+async def test_sketch_constraint_status_includes_execution_warnings():
+    report = await execute_with_retries(
+        kcl.get_sketch_constraint_status_code, warning_sketch_code
+    )
+    assert report.total_sketches() == 1
+    assert len(report.warnings) == 1
+    assert "Instead of constraining to 90deg" in report.warnings[0]
+    assert "constraint to Perpendicular" in report.warnings[0]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- expose rendered warning, non-fatal error, and fatal execution diagnostics on `SketchConstraintReport`
- preserve diagnostics collected before a non-retryable KCL execution error
- verify that constraint categorization and execution diagnostics are returned together from the same KCL run
- regenerate the Python type stub

## Root cause

`get_sketch_constraint_status` executes the full KCL program, and its execution outcome already contains non-fatal diagnostics. The Python binding converted that outcome into a sketch constraint report without copying those issues, so downstream callers needed another full project execution to validate warnings and errors.

`text-to-cad` worked around the missing data in [PR #3852](https://github.com/KittyCAD/text-to-cad/pull/3852) by executing the same KCL project a second time through `zoo_execute_kcl`. That doubles Engine work and can approximately double latency when a modeling command is slow or stuck.

## Impact

Callers can now get sketch constraint status and the execution diagnostics collected by that same KCL run. The new report fields are additive for existing zoo-kcl callers:

- `warnings`
- `execution_errors`
- `execution_fatals`

This changes only the returned report. It does not add or change execution timeout behavior.

## Validation

- `cargo +nightly fmt --check -- kcl-python-bindings/src/bridge/sketch_constraints.rs kcl-python-bindings/src/lib.rs`
- `cargo clippy -p kcl-python-bindings --all-targets -- -D warnings`
- targeted Python binding tests (`3 passed`):
  - an under-constrained sketch and its execution warning are returned together
  - an under-constrained sketch and its completed non-fatal execution error are returned together
  - parse failures return an incomplete report with empty execution-diagnostic fields
- live partial-run regression: a non-fatal execution error followed by a fatal execution failure returned the partial constraint report, the earlier `execution_error`, and the final `kcl_error`
- generated Python stubs successfully

## Follow-up

- publish a new zoo-kcl release after merge
- replace the temporary Git pin in [text-to-cad #4043](https://github.com/KittyCAD/text-to-cad/pull/4043) with that release
- expose the same diagnostic contract through MCP if/when TTC upgrades to the current MCP API
