### PR TITLE
CEK machine, take 2

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -163,7 +163,7 @@ jobs:
           name: nextest-archive
           path: rust/nextest-archive.tar.zst
   run-test-artifacts:
-    name: cargo test (shard ${{ matrix.partitionIndex}})
+    name: cargo test (${{ matrix.executor }}, shard ${{ matrix.partitionIndex}})
     runs-on: namespace-profile-ubuntu-8-cores
     needs: build-test-artifacts
     strategy:
@@ -171,6 +171,10 @@ jobs:
       matrix:
         partitionIndex: [1, 2, 3]
         partitionTotal: [3]
+        # Differential testing: the whole suite runs under both the recursive
+        # executor and the CEK machine executor, and must produce identical
+        # snapshots. See rust/kcl-lib/src/execution/machine.rs.
+        executor: [recursive, machine]
     steps:
       - uses: runs-on/action@v2.3.0
       - uses: actions/create-github-app-token@v3.2.0
@@ -225,6 +229,7 @@ jobs:
           ZOO_API_TOKEN: ${{secrets.ZOO_API_TOKEN}}
           ZOO_HOST: https://api.dev.zoo.dev
           RUST_MIN_STACK: 10485760000
+          KCL_EXECUTOR: ${{ matrix.executor }}
           TAB_API_URL: ${{ vars.TAB_API_URL }}
           TAB_API_KEY: ${{ secrets.TAB_API_KEY }}
           CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -219,9 +219,20 @@ jobs:
         run: |-
           cp nextest-archive.tar.zst rust/nextest-archive.tar.zst
           pushd rust
+          # The recursive leg runs the full suite. The machine leg reruns
+          # only executor-sensitive tests: packages and modules that never
+          # construct an ExecutorContext (parsers, printers, ts-rs bindings
+          # codegen, ...) behave identically under both executors, so they
+          # run once. Exclusion-based so that a new execution test is
+          # machine-covered by default.
+          executor_filter=()
+          if [ "${{ matrix.executor }}" = "machine" ]; then
+            executor_filter=(-E "package(kcl-lib) and not (test(/^parsing::/) or test(/^unparser::/) or test(/^walk::/) or test(/^settings::/) or test(/^fs::/) or test(/^fmt::/) or test(/^tooling::/) or test(/^errors::/) or test(/export_bindings/))")
+          fi
           cargo nextest run \
             --retries=10 --no-fail-fast --profile=ci --archive-file nextest-archive.tar.zst \
             --partition count:${{ matrix.partitionIndex}}/${{ matrix.partitionTotal }} \
+            "${executor_filter[@]}" \
             2>&1 | tee /tmp/github-actions.log || true  # let TAB determine failure
           popd
           .github/ci-cd-scripts/upload-results.sh

--- a/rust/kcl-error/src/error.rs
+++ b/rust/kcl-error/src/error.rs
@@ -144,6 +144,10 @@ impl KclError {
         KclError::InvalidExpression { details }
     }
 
+    pub fn new_max_call_stack(details: KclErrorDetails) -> KclError {
+        KclError::MaxCallStack { details }
+    }
+
     pub fn refactor(message: String) -> KclError {
         KclError::Refactor {
             details: KclErrorDetails {

--- a/rust/kcl-lib/Cargo.toml
+++ b/rust/kcl-lib/Cargo.toml
@@ -180,6 +180,10 @@ name = "digest_benchmark"
 harness = false
 
 [[bench]]
+name = "ast_benchmark"
+harness = false
+
+[[bench]]
 name = "lsp_semantic_tokens_benchmark_criterion"
 harness = false
 required-features = ["lsp-test-util"]

--- a/rust/kcl-lib/benches/ast_benchmark.rs
+++ b/rust/kcl-lib/benches/ast_benchmark.rs
@@ -1,0 +1,75 @@
+//! AST-focused benchmarks for the Arc-backed `BoxNode` change: parse cost,
+//! AST clone cost, and mutation passes (digest, node paths) on owned vs.
+//! shared trees.
+//!
+//! The `shared` variants retain the original program while mutating a clone,
+//! so every `BoxNode` is aliased and copy-on-write has to deep-clone as the
+//! pass descends. This models a `FunctionSource` from a previous run keeping
+//! function ASTs alive while an editor pass mutates the tree (the worst case
+//! for COW), not just a synthetic clone.
+
+use criterion::Criterion;
+use criterion::criterion_group;
+use criterion::criterion_main;
+
+pub fn bench_ast(c: &mut Criterion) {
+    for (name, file) in [
+        ("pipes_on_pipes", PIPES_PROGRAM),
+        ("big_kitt", KITT_PROGRAM),
+        ("mike_stress_test", MIKE_STRESS_TEST_PROGRAM),
+        ("lsystem", LSYSTEM_PROGRAM),
+    ] {
+        c.bench_function(&format!("ast_parse_{name}"), |b| {
+            b.iter(|| kcl_lib::Program::parse_no_errs(file).unwrap())
+        });
+
+        let prog = kcl_lib::Program::parse_no_errs(file).unwrap();
+
+        c.bench_function(&format!("ast_clone_{name}"), |b| {
+            let prog = prog.clone();
+            b.iter(move || prog.clone())
+        });
+
+        // Mutation passes on an exclusively owned tree (the common case:
+        // fresh from the parser). Setup produces an unshared copy each
+        // iteration; only the pass itself is timed.
+        c.bench_function(&format!("ast_digest_owned_{name}"), |b| {
+            b.iter_batched(
+                || kcl_lib::Program::parse_no_errs(file).unwrap(),
+                |mut prog| {
+                    prog.compute_digest();
+                    prog
+                },
+                criterion::BatchSize::LargeInput,
+            )
+        });
+
+        c.bench_function(&format!("ast_node_paths_owned_{name}"), |b| {
+            b.iter_batched(
+                || kcl_lib::Program::parse_no_errs(file).unwrap(),
+                |prog| prog.fill_node_paths(),
+                criterion::BatchSize::LargeInput,
+            )
+        });
+
+        // Clone-then-mutate-most with the ORIGINAL retained: every node is
+        // shared, so (with Arc-backed nodes) copy-on-write deep-clones the
+        // whole tree as the digest pass descends.
+        c.bench_function(&format!("ast_digest_shared_clone_{name}"), |b| {
+            let prog = prog.clone();
+            b.iter(move || {
+                let mut clone = prog.clone();
+                clone.compute_digest();
+                clone
+            })
+        });
+    }
+}
+
+criterion_group!(benches, bench_ast);
+criterion_main!(benches);
+
+const KITT_PROGRAM: &str = include_str!("../e2e/executor/inputs/kittycad_svg.kcl");
+const PIPES_PROGRAM: &str = include_str!("../e2e/executor/inputs/pipes_on_pipes.kcl");
+const MIKE_STRESS_TEST_PROGRAM: &str = include_str!("../tests/mike_stress_test/input.kcl");
+const LSYSTEM_PROGRAM: &str = include_str!("../e2e/executor/inputs/lsystem.kcl");

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -2334,72 +2334,7 @@ impl Node<SketchBlock> {
                 EarlyReturn::Error(err) => return Err(err),
             },
         };
-        let on_object_id = if let Some(object_id) = sketch_surface.object_id() {
-            object_id
-        } else {
-            let message = "The `on` argument should have an object after ensure_sketch_plane_in_engine".to_owned();
-            debug_assert!(false, "{message}");
-            return Err(internal_err(message, range));
-        };
-        let sketch_ctor_on = sketch_on_frontend_plane(&self.arguments, on_object_id);
-        let sketch_block_artifact_id = {
-            use crate::execution::CodeRef;
-            use crate::execution::SketchBlock;
-            use crate::front::Plane;
-            use crate::front::SourceRef;
-
-            let on_object = exec_state.mod_local.artifacts.scene_object_by_id(on_object_id);
-
-            // Get the plane artifact ID so that we can do an exclusive borrow.
-            let plane_artifact_id = on_object.map(|object| object.artifact_id);
-            let plane_info = match &sketch_surface {
-                SketchSurface::Plane(plane) => Some(super::artifact::artifact_plane_info(&plane.info)),
-                SketchSurface::Face(_) => None,
-            };
-
-            let standard_plane = match &sketch_ctor_on {
-                Plane::Default(plane) => Some(*plane),
-                Plane::Object(_) | Plane::PrimitiveFace(_) => None,
-            };
-
-            let artifact_id = ArtifactId::from(exec_state.next_uuid());
-            // Create the sketch scene object and replace its placeholder.
-            let sketch_scene_object = Object {
-                id: sketch_id,
-                kind: ObjectKind::Sketch(crate::frontend::sketch::Sketch {
-                    args: crate::front::SketchCtor { on: sketch_ctor_on },
-                    plane: on_object_id,
-                    segments: Default::default(),
-                    constraints: Default::default(),
-                }),
-                label: Default::default(),
-                comments: Default::default(),
-                artifact_id,
-                source: SourceRef::new(self.into(), self.node_path.clone()),
-            };
-            exec_state.set_scene_object(sketch_scene_object);
-
-            // Create and add the sketch block artifact.
-            exec_state.add_artifact(Artifact::SketchBlock(SketchBlock {
-                id: artifact_id,
-                standard_plane,
-                plane_id: plane_artifact_id,
-                plane_info,
-                // Fill this in later once we create the path. We can't just add
-                // the artifact later because order relative to constraint
-                // artifacts is significant.
-                path_id: None,
-                code_ref: CodeRef::placeholder(range),
-                sketch_id,
-            }));
-
-            exec_state.push_op(Operation::GroupBegin {
-                group: Group::SketchBlock { sketch_id },
-                node_path: NodePath::placeholder(),
-                source_range: range,
-            });
-            artifact_id
-        };
+        let sketch_block_artifact_id = self.scene_setup(sketch_id, &sketch_surface, exec_state)?;
 
         let (return_result, variables, sketch_block_state) = {
             // Don't early return until the stack frame is popped!
@@ -2477,6 +2412,287 @@ impl Node<SketchBlock> {
         };
         let mut sketch_block_state = sketch_block_state;
 
+        let return_value = self
+            .finalize_sketch_block(
+                sketch_id,
+                &sketch_surface,
+                sketch_block_artifact_id,
+                variables,
+                sketch_block_state,
+                exec_state,
+                ctx,
+            )
+            .await?;
+        Ok(if self.is_being_edited {
+            // When the sketch block is being edited, we exit the program
+            // immediately.
+            return_value.exit()
+        } else {
+            return_value.continue_()
+        })
+    }
+
+    /// Executes the arguments of the sketch block and returns the sketch ID and
+    /// surface. The surface is the `on` argument, which is basically a Plane or
+    /// Face.
+    ///
+    /// In sketch mode, the execution cache is used to look up the sketch
+    /// surface.
+    ///
+    /// The sketch ID is generated in either case so that it's stable. But only
+    /// a placeholder scene object is created for it.
+    async fn exec_arguments(
+        &self,
+        exec_state: &mut ExecState,
+        ctx: &ExecutorContext,
+    ) -> Result<(ObjectId, SketchSurface), EarlyReturn> {
+        let range = SourceRange::from(self);
+
+        if !exec_state.sketch_mode() {
+            // Evaluate arguments.
+            //
+            // Sketch mode only executes the sketch block body. Arguments must
+            // be evaluated in engine execution so that things like Planes and
+            // Faces can be created in the engine.
+            let mut labeled = IndexMap::new();
+            for labeled_arg in &self.arguments {
+                let source_range = SourceRange::from(labeled_arg.arg.clone());
+                let metadata = Metadata { source_range };
+                let value_cf = ctx
+                    .execute_expr(&labeled_arg.arg, exec_state, &metadata, &[], StatementKind::Expression)
+                    .await?;
+                let value = early_return!(value_cf);
+                let arg = Arg::new(value, source_range);
+                match &labeled_arg.label {
+                    Some(label) => {
+                        labeled.insert(label.name.clone(), arg);
+                    }
+                    None => {
+                        let name = labeled_arg.arg.ident_name();
+                        if let Some(name) = name {
+                            labeled.insert(name.to_owned(), arg);
+                        } else {
+                            return Err(KclError::new_semantic(KclErrorDetails::new(
+                                "Arguments to sketch blocks must be either labeled or simple identifiers".to_owned(),
+                                vec![SourceRange::from(&labeled_arg.arg)],
+                            ))
+                            .into());
+                        }
+                    }
+                }
+            }
+            self.finish_arguments_after_eval(labeled, exec_state, ctx).await
+        } else {
+            self.arguments_from_cache(exec_state)
+        }
+    }
+
+    /// The evaluation-free tail of sketch-block argument handling: validate
+    /// the arguments, resolve the `on` surface, ensure it exists in the
+    /// engine, and mint the stable sketch id. Shared by both executors.
+    pub(super) async fn finish_arguments_after_eval(
+        &self,
+        labeled: IndexMap<String, Arg>,
+        exec_state: &mut ExecState,
+        ctx: &ExecutorContext,
+    ) -> Result<(ObjectId, SketchSurface), EarlyReturn> {
+        let range = SourceRange::from(self);
+        let mut args = Args::new_no_args(
+            range,
+            self.node_path.clone(),
+            ctx.clone(),
+            Some(SketchBlock::CALLEE_NAME.to_owned()),
+        );
+        args.labeled = labeled;
+
+        // Report any arguments that aren't valid sketch block parameters.
+        // This is non-fatal so that the rest of the block still executes,
+        // matching how unexpected keyword arguments are handled for
+        // function calls.
+        //
+        // Checking arguments should be done after evaluating them, the same
+        // order as if we were calling a function.
+        self.check_for_unexpected_arguments(&args, exec_state)?;
+
+        let arg_on_value: KclValue =
+            args.get_kw_arg(SKETCH_BLOCK_PARAM_ON, &RuntimeType::sketch_or_surface(), exec_state)?;
+
+        let Some(arg_on) = SketchOrSurface::from_kcl_val(&arg_on_value) else {
+            let message = "The `on` argument to a sketch block must be convertible to a sketch or surface.".to_owned();
+            debug_assert!(false, "{message}");
+            return Err(KclError::new_semantic(KclErrorDetails::new(message, vec![range])).into());
+        };
+        let mut sketch_surface = arg_on.into_sketch_surface();
+
+        // Ensure that the plane has an ObjectId. Always create an Object so
+        // that we're consistent with IDs.
+        match &mut sketch_surface {
+            SketchSurface::Plane(plane) => {
+                // Ensure that it's been created in the engine.
+                ensure_sketch_plane_in_engine(plane, exec_state, ctx, range, self.node_path.clone()).await?;
+            }
+            SketchSurface::Face(_) => {
+                // All faces should already be created in the engine.
+            }
+        }
+
+        // Generate an ID for the sketch block. This must be done after
+        // arguments so that we get the same result when the arguments are
+        // cached. This must be done before the sketch block body so that no
+        // matter how many IDs are generated due to objects in the body, the
+        // sketch ID is always stable.
+        let sketch_id = exec_state.next_object_id();
+        exec_state.add_placeholder_scene_object(sketch_id, range, self.node_path.clone());
+        let on_cache_name = sketch_on_cache_name(sketch_id);
+        // Store in memory so that it's cached.
+        exec_state.mut_stack().add(on_cache_name, arg_on_value, range)?;
+
+        Ok((sketch_id, sketch_surface))
+    }
+
+    /// Sketch-mode path: arguments cannot be re-evaluated, so look the `on`
+    /// surface up from the execution cache. Flat; shared by both executors.
+    pub(super) fn arguments_from_cache(
+        &self,
+        exec_state: &mut ExecState,
+    ) -> Result<(ObjectId, SketchSurface), EarlyReturn> {
+        let range = SourceRange::from(self);
+        {
+            // In sketch mode, we can't re-evaluate arguments. Instead, look
+            // them up from cache.
+
+            // Generate an ID for the sketch block. This must be done before the
+            // sketch block body so that no matter how many IDs are generated
+            // due to objects in the body, the sketch ID is always stable.
+            let sketch_id = exec_state.next_object_id();
+            exec_state.add_placeholder_scene_object(sketch_id, range, self.node_path.clone());
+            let on_cache_name = sketch_on_cache_name(sketch_id);
+            let arg_on_value = exec_state.stack().get_owned(&on_cache_name, range)?;
+
+            let Some(arg_on) = SketchOrSurface::from_kcl_val(&arg_on_value) else {
+                let message =
+                    "The `on` argument to a sketch block must be convertible to a sketch or surface.".to_owned();
+                debug_assert!(false, "{message}");
+                return Err(KclError::new_semantic(KclErrorDetails::new(message, vec![range])).into());
+            };
+            let mut sketch_surface = arg_on.into_sketch_surface();
+
+            // Ensure that the plane has an ObjectId. Always create an Object so
+            // that we're consistent with IDs.
+            if sketch_surface.object_id().is_none() {
+                // Look up the last object. Since this is where we would have
+                // created it in real execution, it will be the last object.
+                let Some(last_object) = exec_state.mod_local.artifacts.scene_objects.last() else {
+                    return Err(internal_err(
+                        "In sketch mode, the `on` plane argument must refer to an existing plane object.",
+                        range,
+                    )
+                    .into());
+                };
+                sketch_surface.set_object_id(last_object.id);
+            }
+
+            Ok((sketch_id, sketch_surface))
+        }
+    }
+
+    /// Create the sketch scene object and sketch-block artifact, and open
+    /// the feature-tree group. Flat; shared by both executors.
+    pub(super) fn scene_setup(
+        &self,
+        sketch_id: ObjectId,
+        sketch_surface: &SketchSurface,
+        exec_state: &mut ExecState,
+    ) -> Result<ArtifactId, KclError> {
+        let range = SourceRange::from(self);
+        let on_object_id = if let Some(object_id) = sketch_surface.object_id() {
+            object_id
+        } else {
+            let message = "The `on` argument should have an object after ensure_sketch_plane_in_engine".to_owned();
+            debug_assert!(false, "{message}");
+            return Err(internal_err(message, range));
+        };
+        let sketch_ctor_on = sketch_on_frontend_plane(&self.arguments, on_object_id);
+        let sketch_block_artifact_id = {
+            use crate::execution::CodeRef;
+            use crate::execution::SketchBlock;
+            use crate::front::Plane;
+            use crate::front::SourceRef;
+
+            let on_object = exec_state.mod_local.artifacts.scene_object_by_id(on_object_id);
+
+            // Get the plane artifact ID so that we can do an exclusive borrow.
+            let plane_artifact_id = on_object.map(|object| object.artifact_id);
+            let plane_info = match &sketch_surface {
+                SketchSurface::Plane(plane) => Some(super::artifact::artifact_plane_info(&plane.info)),
+                SketchSurface::Face(_) => None,
+            };
+
+            let standard_plane = match &sketch_ctor_on {
+                Plane::Default(plane) => Some(*plane),
+                Plane::Object(_) | Plane::PrimitiveFace(_) => None,
+            };
+
+            let artifact_id = ArtifactId::from(exec_state.next_uuid());
+            // Create the sketch scene object and replace its placeholder.
+            let sketch_scene_object = Object {
+                id: sketch_id,
+                kind: ObjectKind::Sketch(crate::frontend::sketch::Sketch {
+                    args: crate::front::SketchCtor { on: sketch_ctor_on },
+                    plane: on_object_id,
+                    segments: Default::default(),
+                    constraints: Default::default(),
+                }),
+                label: Default::default(),
+                comments: Default::default(),
+                artifact_id,
+                source: SourceRef::new(self.into(), self.node_path.clone()),
+            };
+            exec_state.set_scene_object(sketch_scene_object);
+
+            // Create and add the sketch block artifact.
+            exec_state.add_artifact(Artifact::SketchBlock(SketchBlock {
+                id: artifact_id,
+                standard_plane,
+                plane_id: plane_artifact_id,
+                plane_info,
+                // Fill this in later once we create the path. We can't just add
+                // the artifact later because order relative to constraint
+                // artifacts is significant.
+                path_id: None,
+                code_ref: CodeRef::placeholder(range),
+                sketch_id,
+            }));
+
+            exec_state.push_op(Operation::GroupBegin {
+                group: Group::SketchBlock { sketch_id },
+                node_path: NodePath::placeholder(),
+                source_range: range,
+            });
+            artifact_id
+        };
+        Ok(sketch_block_artifact_id)
+    }
+
+    /// Solve constraints, send segments to the engine, update artifacts and
+    /// scene objects, close the feature-tree group, and build the sketch's
+    /// result object. Flat (the body has already executed); shared by both
+    /// executors.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) async fn finalize_sketch_block(
+        &self,
+        sketch_id: ObjectId,
+        sketch_surface: &SketchSurface,
+        sketch_block_artifact_id: ArtifactId,
+        variables: IndexMap<String, KclValue>,
+        mut sketch_block_state: SketchBlockState,
+        exec_state: &mut ExecState,
+        ctx: &ExecutorContext,
+    ) -> Result<KclValue, KclError> {
+        let range = SourceRange::from(self);
+        let metadata = Metadata {
+            source_range: SourceRange::from(self),
+        };
         // Translate sketch variables and constraints to solver input.
         let constraints = sketch_block_state
             .solver_constraints
@@ -2774,153 +2990,7 @@ impl Node<SketchBlock> {
             object_kind: KclObjectKind::Default,
             meta: vec![metadata],
         };
-        Ok(if self.is_being_edited {
-            // When the sketch block is being edited, we exit the program
-            // immediately.
-            return_value.exit()
-        } else {
-            return_value.continue_()
-        })
-    }
-
-    /// Executes the arguments of the sketch block and returns the sketch ID and
-    /// surface. The surface is the `on` argument, which is basically a Plane or
-    /// Face.
-    ///
-    /// In sketch mode, the execution cache is used to look up the sketch
-    /// surface.
-    ///
-    /// The sketch ID is generated in either case so that it's stable. But only
-    /// a placeholder scene object is created for it.
-    async fn exec_arguments(
-        &self,
-        exec_state: &mut ExecState,
-        ctx: &ExecutorContext,
-    ) -> Result<(ObjectId, SketchSurface), EarlyReturn> {
-        let range = SourceRange::from(self);
-
-        if !exec_state.sketch_mode() {
-            // Evaluate arguments.
-            //
-            // Sketch mode only executes the sketch block body. Arguments must
-            // be evaluated in engine execution so that things like Planes and
-            // Faces can be created in the engine.
-            let mut labeled = IndexMap::new();
-            for labeled_arg in &self.arguments {
-                let source_range = SourceRange::from(labeled_arg.arg.clone());
-                let metadata = Metadata { source_range };
-                let value_cf = ctx
-                    .execute_expr(&labeled_arg.arg, exec_state, &metadata, &[], StatementKind::Expression)
-                    .await?;
-                let value = early_return!(value_cf);
-                let arg = Arg::new(value, source_range);
-                match &labeled_arg.label {
-                    Some(label) => {
-                        labeled.insert(label.name.clone(), arg);
-                    }
-                    None => {
-                        let name = labeled_arg.arg.ident_name();
-                        if let Some(name) = name {
-                            labeled.insert(name.to_owned(), arg);
-                        } else {
-                            return Err(KclError::new_semantic(KclErrorDetails::new(
-                                "Arguments to sketch blocks must be either labeled or simple identifiers".to_owned(),
-                                vec![SourceRange::from(&labeled_arg.arg)],
-                            ))
-                            .into());
-                        }
-                    }
-                }
-            }
-            let mut args = Args::new_no_args(
-                range,
-                self.node_path.clone(),
-                ctx.clone(),
-                Some(SketchBlock::CALLEE_NAME.to_owned()),
-            );
-            args.labeled = labeled;
-
-            // Report any arguments that aren't valid sketch block parameters.
-            // This is non-fatal so that the rest of the block still executes,
-            // matching how unexpected keyword arguments are handled for
-            // function calls.
-            //
-            // Checking arguments should be done after evaluating them, the same
-            // order as if we were calling a function.
-            self.check_for_unexpected_arguments(&args, exec_state)?;
-
-            let arg_on_value: KclValue =
-                args.get_kw_arg(SKETCH_BLOCK_PARAM_ON, &RuntimeType::sketch_or_surface(), exec_state)?;
-
-            let Some(arg_on) = SketchOrSurface::from_kcl_val(&arg_on_value) else {
-                let message =
-                    "The `on` argument to a sketch block must be convertible to a sketch or surface.".to_owned();
-                debug_assert!(false, "{message}");
-                return Err(KclError::new_semantic(KclErrorDetails::new(message, vec![range])).into());
-            };
-            let mut sketch_surface = arg_on.into_sketch_surface();
-
-            // Ensure that the plane has an ObjectId. Always create an Object so
-            // that we're consistent with IDs.
-            match &mut sketch_surface {
-                SketchSurface::Plane(plane) => {
-                    // Ensure that it's been created in the engine.
-                    ensure_sketch_plane_in_engine(plane, exec_state, ctx, range, self.node_path.clone()).await?;
-                }
-                SketchSurface::Face(_) => {
-                    // All faces should already be created in the engine.
-                }
-            }
-
-            // Generate an ID for the sketch block. This must be done after
-            // arguments so that we get the same result when the arguments are
-            // cached. This must be done before the sketch block body so that no
-            // matter how many IDs are generated due to objects in the body, the
-            // sketch ID is always stable.
-            let sketch_id = exec_state.next_object_id();
-            exec_state.add_placeholder_scene_object(sketch_id, range, self.node_path.clone());
-            let on_cache_name = sketch_on_cache_name(sketch_id);
-            // Store in memory so that it's cached.
-            exec_state.mut_stack().add(on_cache_name, arg_on_value, range)?;
-
-            Ok((sketch_id, sketch_surface))
-        } else {
-            // In sketch mode, we can't re-evaluate arguments. Instead, look
-            // them up from cache.
-
-            // Generate an ID for the sketch block. This must be done before the
-            // sketch block body so that no matter how many IDs are generated
-            // due to objects in the body, the sketch ID is always stable.
-            let sketch_id = exec_state.next_object_id();
-            exec_state.add_placeholder_scene_object(sketch_id, range, self.node_path.clone());
-            let on_cache_name = sketch_on_cache_name(sketch_id);
-            let arg_on_value = exec_state.stack().get_owned(&on_cache_name, range)?;
-
-            let Some(arg_on) = SketchOrSurface::from_kcl_val(&arg_on_value) else {
-                let message =
-                    "The `on` argument to a sketch block must be convertible to a sketch or surface.".to_owned();
-                debug_assert!(false, "{message}");
-                return Err(KclError::new_semantic(KclErrorDetails::new(message, vec![range])).into());
-            };
-            let mut sketch_surface = arg_on.into_sketch_surface();
-
-            // Ensure that the plane has an ObjectId. Always create an Object so
-            // that we're consistent with IDs.
-            if sketch_surface.object_id().is_none() {
-                // Look up the last object. Since this is where we would have
-                // created it in real execution, it will be the last object.
-                let Some(last_object) = exec_state.mod_local.artifacts.scene_objects.last() else {
-                    return Err(internal_err(
-                        "In sketch mode, the `on` plane argument must refer to an existing plane object.",
-                        range,
-                    )
-                    .into());
-                };
-                sketch_surface.set_object_id(last_object.id);
-            }
-
-            Ok((sketch_id, sketch_surface))
-        }
+        Ok(return_value)
     }
 
     /// Report a non-fatal error for each argument that isn't a valid sketch

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -2410,7 +2410,6 @@ impl Node<SketchBlock> {
                 self,
             ));
         };
-        let mut sketch_block_state = sketch_block_state;
 
         let return_value = self
             .finalize_sketch_block(
@@ -2446,8 +2445,6 @@ impl Node<SketchBlock> {
         exec_state: &mut ExecState,
         ctx: &ExecutorContext,
     ) -> Result<(ObjectId, SketchSurface), EarlyReturn> {
-        let range = SourceRange::from(self);
-
         if !exec_state.sketch_mode() {
             // Evaluate arguments.
             //
@@ -2690,9 +2687,6 @@ impl Node<SketchBlock> {
         ctx: &ExecutorContext,
     ) -> Result<KclValue, KclError> {
         let range = SourceRange::from(self);
-        let metadata = Metadata {
-            source_range: SourceRange::from(self),
-        };
         // Translate sketch variables and constraints to solver input.
         let constraints = sketch_block_state
             .solver_constraints

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -1787,6 +1787,41 @@ impl ExecutorContext {
         })
     }
 
+    /// Resolve a name to its value, running the module body first when the name
+    /// refers to a module. Flat (module execution happens in its own fresh
+    /// root); shared by both executors.
+    pub(super) async fn resolve_name_for_eval(
+        &self,
+        name: &Node<Name>,
+        metadata: &Metadata,
+        exec_state: &mut ExecState,
+    ) -> Result<KclValue, KclError> {
+        let value = name.get_result(exec_state, self).await?;
+        if let KclValue::Module { value: module_id, meta } = value {
+            Ok(self
+                .exec_module_for_result(module_id, exec_state, metadata.source_range)
+                .await?
+                .unwrap_or_else(|| {
+                    exec_state.warn(
+                        CompilationIssue::err(
+                            metadata.source_range,
+                            "Imported module has no return value. The last statement of the module must be an expression, usually the Solid.",
+                        ),
+                        annotations::WARN_MOD_RETURN_VALUE,
+                    );
+
+                    let mut new_meta = vec![metadata.to_owned()];
+                    new_meta.extend(meta);
+                    KclValue::KclNone {
+                        value: Default::default(),
+                        meta: new_meta,
+                    }
+                }))
+        } else {
+            Ok(value)
+        }
+    }
+
     #[async_recursion]
     pub(crate) async fn execute_expr<'a: 'async_recursion>(
         &self,
@@ -1800,37 +1835,10 @@ impl ExecutorContext {
             Expr::None(none) => KclValue::from(none).continue_(),
             Expr::Literal(literal) => KclValue::from_literal((**literal).clone(), exec_state).continue_(),
             Expr::TagDeclarator(tag) => tag.execute(exec_state).await?.continue_(),
-            Expr::Name(name) => {
-                let being_declared = exec_state.mod_local.being_declared.clone();
-                let value = name
-                    .get_result(exec_state, self)
-                    .await
-                    .map_err(|e| var_in_own_ref_err(e, &being_declared))?
-                    .clone();
-                if let KclValue::Module { value: module_id, meta } = value {
-                    self.exec_module_for_result(
-                        module_id,
-                        exec_state,
-                        metadata.source_range
-                        ).await?.map(|v| v.continue_())
-                        .unwrap_or_else(|| {
-                            exec_state.warn(CompilationIssue::err(
-                                metadata.source_range,
-                                "Imported module has no return value. The last statement of the module must be an expression, usually the Solid.",
-                            ),
-                        annotations::WARN_MOD_RETURN_VALUE);
-
-                            let mut new_meta = vec![metadata.to_owned()];
-                            new_meta.extend(meta);
-                            KclValue::KclNone {
-                                value: Default::default(),
-                                meta: new_meta,
-                            }.continue_()
-                        })
-                } else {
-                    value.continue_()
-                }
-            }
+            Expr::Name(name) => self
+                .resolve_name_for_eval(name, metadata, exec_state)
+                .await?
+                .continue_(),
             Expr::BinaryExpression(binary_expression) => binary_expression.get_result(exec_state, self).await?,
             Expr::FunctionExpression(function_expression) => {
                 let attrs = annotations::get_fn_attrs(annotations, metadata.source_range)?;
@@ -3025,7 +3033,14 @@ impl BinaryPart {
     ) -> Result<KclValueControlFlow, KclError> {
         match self {
             BinaryPart::Literal(literal) => Ok(KclValue::from_literal((**literal).clone(), exec_state).continue_()),
-            BinaryPart::Name(name) => name.get_result(exec_state, ctx).await.map(KclValue::continue_),
+            BinaryPart::Name(name) => {
+                let metadata = Metadata {
+                    source_range: SourceRange::from(&**name),
+                };
+                ctx.resolve_name_for_eval(name, &metadata, exec_state)
+                    .await
+                    .map(KclValue::continue_)
+            }
             BinaryPart::BinaryExpression(binary_expression) => binary_expression.get_result(exec_state, ctx).await,
             BinaryPart::CallExpressionKw(call_expression) => call_expression.execute(exec_state, ctx).await,
             BinaryPart::UnaryExpression(unary_expression) => unary_expression.get_result(exec_state, ctx).await,
@@ -3046,10 +3061,10 @@ impl Node<Name> {
         exec_state: &mut ExecState,
         ctx: &ExecutorContext,
     ) -> Result<KclValue, KclError> {
-        let being_declared = exec_state.mod_local.being_declared.clone();
-        self.get_result_inner(exec_state, ctx)
-            .await
-            .map_err(|e| var_in_own_ref_err(e, &being_declared))
+        // Await first so being_declared is read only on the error path,
+        // instead of cloned before every lookup.
+        let result = self.get_result_inner(exec_state, ctx).await;
+        result.map_err(|e| var_in_own_ref_err(e, &exec_state.mod_local.being_declared))
     }
 
     async fn get_result_inner(&self, exec_state: &mut ExecState, ctx: &ExecutorContext) -> Result<KclValue, KclError> {
@@ -3060,13 +3075,12 @@ impl Node<Name> {
             )));
         }
 
-        let mod_name = format!("{}{}", memory::MODULE_PREFIX, self.name.name);
-
         if self.path.is_empty() {
             if let Ok(item_value) = exec_state.stack().get(&self.name.name, self.into()) {
                 return Ok(item_value);
             }
 
+            let mod_name = format!("{}{}", memory::MODULE_PREFIX, self.name.name);
             let not_defined = match exec_state.stack().get(&mod_name, self.into()) {
                 Ok(module) => return Ok(module),
                 Err(err) => err,
@@ -3146,6 +3160,7 @@ impl Node<Name> {
             return item_value;
         }
 
+        let mod_name = format!("{}{}", memory::MODULE_PREFIX, self.name.name);
         let mod_exported = exports.contains(&mod_name);
         let mod_value = exec_state
             .stack()

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -1948,6 +1948,22 @@ impl ExecutorContext {
         Ok(item)
     }
 
+    /// Evaluate a single expression on whichever executor is active, as a
+    /// fresh root. For bounded internal evaluations (e.g. GD&T's constant
+    /// plane lookup).
+    pub(crate) async fn eval_expr_fresh_root(
+        &self,
+        expr: &Expr,
+        exec_state: &mut ExecState,
+        metadata: &Metadata,
+    ) -> Result<KclValueControlFlow, KclError> {
+        if self.is_machine_executor() {
+            return crate::execution::machine::run_expr(self, expr, exec_state, metadata).await;
+        }
+        self.execute_expr(expr, exec_state, metadata, &[], StatementKind::Expression)
+            .await
+    }
+
     /// Create the closure value for a function expression, including the
     /// recursive-closure placeholder fixup and binding a named `fn name() {}`
     /// in the current scope. Flat; shared by both executors.

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -888,7 +888,7 @@ impl<'a> StatementKind<'a> {
 
 impl ExecutorContext {
     /// Returns true if importing the prelude should be skipped.
-    async fn handle_annotations(
+    pub(super) async fn handle_annotations(
         &self,
         annotations: impl Iterator<Item = &Node<Annotation>>,
         body_type: BodyType,

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -1067,8 +1067,12 @@ impl ExecutorContext {
         body_type: BodyType,
     ) -> Result<Option<KclValueControlFlow>, KclError>
     where
-        B: CodeBlock + Sync,
+        B: CodeBlock + crate::execution::machine::ToMachineBlock + Sync,
     {
+        if self.is_machine_executor() {
+            return crate::execution::machine::run_block(self, block.to_machine_block(), exec_state, body_type).await;
+        }
+
         let mut last_expr = None;
         // Iterate over the body of the program.
         for statement in block.body() {
@@ -2265,7 +2269,7 @@ fn reject_glob_import_clash(
 
 /// When executing in sketch mode, whether we should skip executing this
 /// expression.
-fn sketch_mode_should_skip(expr: &Expr) -> bool {
+pub(super) fn sketch_mode_should_skip(expr: &Expr) -> bool {
     match expr {
         Expr::SketchBlock(sketch_block) => !sketch_block.is_being_edited,
         _ => true,
@@ -2410,7 +2414,6 @@ impl Node<SketchBlock> {
                 self,
             ));
         };
-
         let return_value = self
             .finalize_sketch_block(
                 sketch_id,
@@ -2854,7 +2857,7 @@ impl Node<SketchBlock> {
         for unsolved_segment in &sketch_block_state.needed_by_engine {
             solved_segments.push(substitute_sketch_var_in_segment(
                 unsolved_segment.clone(),
-                &sketch_surface,
+                sketch_surface,
                 sketch_engine_id,
                 None,
                 &solve_outcome,
@@ -2875,7 +2878,7 @@ impl Node<SketchBlock> {
 
         // Build the sketch and send everything to the engine.
         let sketch = create_segments_in_engine(
-            &sketch_surface,
+            sketch_surface,
             sketch_engine_id,
             &mut solved_segments,
             &sketch_block_state.segment_tags,
@@ -2904,7 +2907,7 @@ impl Node<SketchBlock> {
         // the same.
         let variables = substitute_sketch_vars(
             variables,
-            &sketch_surface,
+            sketch_surface,
             sketch_engine_id,
             sketch.as_ref(),
             &solve_outcome,
@@ -3010,7 +3013,7 @@ impl Node<SketchBlock> {
         Ok(())
     }
 
-    async fn load_sketch2_into_current_scope(
+    pub(super) async fn load_sketch2_into_current_scope(
         &self,
         exec_state: &mut ExecState,
         ctx: &ExecutorContext,
@@ -3070,7 +3073,7 @@ impl Node<SketchBlock> {
 }
 
 impl SketchBlock {
-    fn prep_mem(&self, parent: EnvironmentRef, exec_state: &mut ExecState) -> Result<(), KclError> {
+    pub(super) fn prep_mem(&self, parent: EnvironmentRef, exec_state: &mut ExecState) -> Result<(), KclError> {
         exec_state.mut_stack().push_new_env_for_call(parent)
     }
 }
@@ -3114,7 +3117,7 @@ impl Node<SketchVar> {
     }
 }
 
-fn apply_ascription(
+pub(super) fn apply_ascription(
     value: &KclValue,
     ty: &Node<Type>,
     exec_state: &mut ExecState,
@@ -6545,7 +6548,24 @@ impl Node<ArrayRangeExpression> {
                 StatementKind::Expression,
             )
             .await?;
-        let start_val = control_continue!(start_val);
+        let start_val_for_build = control_continue!(start_val);
+        let metadata = Metadata::from(&self.end_element);
+        let end_val = ctx
+            .execute_expr(&self.end_element, exec_state, &metadata, &[], StatementKind::Expression)
+            .await?;
+        let end_val = control_continue!(end_val);
+        self.build_range(start_val_for_build, end_val, exec_state)
+            .map(KclValue::continue_)
+    }
+
+    /// Build the range value from evaluated endpoints. The evaluation-free
+    /// second half of range execution, shared by both executors.
+    pub(super) fn build_range(
+        &self,
+        start_val: KclValue,
+        end_val: KclValue,
+        exec_state: &mut ExecState,
+    ) -> Result<KclValue, KclError> {
         let start = start_val
             .as_ty_f64()
             .ok_or(KclError::new_semantic(KclErrorDetails::new(
@@ -6555,11 +6575,6 @@ impl Node<ArrayRangeExpression> {
                 ),
                 vec![self.into()],
             )))?;
-        let metadata = Metadata::from(&self.end_element);
-        let end_val = ctx
-            .execute_expr(&self.end_element, exec_state, &metadata, &[], StatementKind::Expression)
-            .await?;
-        let end_val = control_continue!(end_val);
         let end = end_val.as_ty_f64().ok_or(KclError::new_semantic(KclErrorDetails::new(
             format!(
                 "Expected number for range end but found {}",
@@ -6609,8 +6624,7 @@ impl Node<ArrayRangeExpression> {
                 })
                 .collect(),
             ty: RuntimeType::Primitive(PrimitiveType::Number(ty)),
-        }
-        .continue_())
+        })
     }
 }
 
@@ -7428,6 +7442,8 @@ d = b + c
             },
             context_type: ContextType::Mock,
             execution_callbacks: Default::default(),
+            executor_kind: Default::default(),
+            machine_call_depth_limit: crate::execution::machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
         };
         let mut exec_state = ExecState::new(&exec_ctxt);
 

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -4234,7 +4234,7 @@ impl Node<BinaryExpression> {
                     match left_part {
                         BinaryPart::BinaryExpression(child) => {
                             stack.push(State::FromLeft { node });
-                            stack.push(State::EvaluateLeft(*child));
+                            stack.push(State::EvaluateLeft(child.into_node()));
                         }
                         part => {
                             let left_value = part.get_result(exec_state, ctx).await?;
@@ -4254,7 +4254,7 @@ impl Node<BinaryExpression> {
                     match right_part {
                         BinaryPart::BinaryExpression(child) => {
                             stack.push(State::FromRight { node, left });
-                            stack.push(State::EvaluateLeft(*child));
+                            stack.push(State::EvaluateLeft(child.into_node()));
                         }
                         part => {
                             let right_value = part.get_result(exec_state, ctx).await?;

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -6565,6 +6565,7 @@ impl Node<ArrayRangeExpression> {
             )
             .await?;
         let start_val_for_build = control_continue!(start_val);
+        self.validate_range_start(&start_val_for_build)?;
         let metadata = Metadata::from(&self.end_element);
         let end_val = ctx
             .execute_expr(&self.end_element, exec_state, &metadata, &[], StatementKind::Expression)
@@ -6572,6 +6573,23 @@ impl Node<ArrayRangeExpression> {
         let end_val = control_continue!(end_val);
         self.build_range(start_val_for_build, end_val, exec_state)
             .map(KclValue::continue_)
+    }
+
+    /// Validate the evaluated start endpoint, preserving the original error
+    /// ordering: a bad start is reported before the end element is ever
+    /// evaluated. Shared by both executors; `build_range` re-checks it,
+    /// which is redundant but keeps `build_range` total on its own.
+    pub(super) fn validate_range_start(&self, start_val: &KclValue) -> Result<(), KclError> {
+        if start_val.as_ty_f64().is_none() {
+            return Err(KclError::new_semantic(KclErrorDetails::new(
+                format!(
+                    "Expected number for range start but found {}",
+                    start_val.human_friendly_type()
+                ),
+                vec![self.into()],
+            )));
+        }
+        Ok(())
     }
 
     /// Build the range value from evaluated endpoints. The evaluation-free

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -106,10 +106,12 @@ use crate::parsing::ast::types::BinaryPart;
 use crate::parsing::ast::types::BodyItem;
 use crate::parsing::ast::types::CodeBlock;
 use crate::parsing::ast::types::Expr;
+use crate::parsing::ast::types::FunctionExpression;
 use crate::parsing::ast::types::Identifier;
 use crate::parsing::ast::types::IfExpression;
 use crate::parsing::ast::types::ImportPath;
 use crate::parsing::ast::types::ImportSelector;
+use crate::parsing::ast::types::ImportStatement;
 use crate::parsing::ast::types::ItemVisibility;
 use crate::parsing::ast::types::MemberExpression;
 use crate::parsing::ast::types::Name;
@@ -117,13 +119,16 @@ use crate::parsing::ast::types::Node;
 use crate::parsing::ast::types::ObjectExpression;
 use crate::parsing::ast::types::PipeExpression;
 use crate::parsing::ast::types::Program;
+use crate::parsing::ast::types::ReturnStatement;
 use crate::parsing::ast::types::SketchBlock;
 use crate::parsing::ast::types::SketchVar;
 use crate::parsing::ast::types::TagDeclarator;
 use crate::parsing::ast::types::Type;
+use crate::parsing::ast::types::TypeDeclaration;
 use crate::parsing::ast::types::TypeDeclarationDefinition;
 use crate::parsing::ast::types::UnaryExpression;
 use crate::parsing::ast::types::UnaryOperator;
+use crate::parsing::ast::types::VariableDeclaration;
 use crate::std::StdFnProps;
 use crate::std::args::FromKclValue;
 use crate::std::args::TyF64;
@@ -1072,193 +1077,7 @@ impl ExecutorContext {
                     if exec_state.sketch_mode() {
                         continue;
                     }
-                    if !matches!(body_type, BodyType::Root) {
-                        return Err(KclError::new_semantic(KclErrorDetails::new(
-                            "Imports are only supported at the top-level of a file.".to_owned(),
-                            vec![import_stmt.into()],
-                        )));
-                    }
-
-                    let source_range = SourceRange::from(import_stmt);
-                    let attrs = &import_stmt.outer_attrs;
-                    let module_path = ModulePath::from_import_path(
-                        &import_stmt.path,
-                        &self.settings.project_directory,
-                        &exec_state.mod_local.path,
-                    )?;
-                    let module_id = self
-                        .open_module(&import_stmt.path, attrs, &module_path, exec_state, source_range)
-                        .await?;
-
-                    if let ModulePath::Local { value, .. } = &module_path {
-                        let name = import_stmt
-                            .module_name()
-                            .unwrap_or_else(|| value.file_name().unwrap_or_default());
-                        exec_state.push_op(Operation::ModuleInstance {
-                            name,
-                            module_id,
-                            glob: matches!(import_stmt.selector, ImportSelector::Glob(_)),
-                            node_path: NodePath::placeholder(),
-                            source_range,
-                        });
-                    }
-
-                    match &import_stmt.selector {
-                        ImportSelector::List { items } => {
-                            let (env_ref, module_exports) =
-                                self.exec_module_for_items(module_id, exec_state, source_range).await?;
-                            for import_item in items {
-                                // Extract the item from the module.
-                                let mem = &exec_state.stack().memory;
-                                let mut value =
-                                    mem.get_from_owned(&import_item.name.name, env_ref, import_item.into(), 0);
-                                let ty_name = format!("{}{}", memory::TYPE_PREFIX, import_item.name.name);
-                                let mut ty = mem.get_from_owned(&ty_name, env_ref, import_item.into(), 0);
-                                let mod_name = format!("{}{}", memory::MODULE_PREFIX, import_item.name.name);
-                                let mut mod_value = mem.get_from_owned(&mod_name, env_ref, import_item.into(), 0);
-
-                                if value.is_err() && ty.is_err() && mod_value.is_err() {
-                                    return Err(KclError::new_undefined_value(
-                                        KclErrorDetails::new(
-                                            format!("{} is not defined in module", import_item.name.name),
-                                            vec![SourceRange::from(&import_item.name)],
-                                        ),
-                                        None,
-                                    ));
-                                }
-
-                                // Check that the item is allowed to be imported (in at least one namespace).
-                                if value.is_ok() && !module_exports.contains(&import_item.name.name) {
-                                    value = Err(KclError::new_semantic(KclErrorDetails::new(
-                                        format!(
-                                            "Cannot import \"{}\" from module because it is not exported. Add \"export\" before the definition to export it.",
-                                            import_item.name.name
-                                        ),
-                                        vec![SourceRange::from(&import_item.name)],
-                                    )));
-                                }
-
-                                if ty.is_ok() && !module_exports.contains(&ty_name) {
-                                    ty = Err(KclError::new_semantic(KclErrorDetails::new(
-                                        format!(
-                                            "Cannot import \"{}\" from module because it is not exported. Add \"export\" before the definition to export it.",
-                                            import_item.name.name
-                                        ),
-                                        vec![SourceRange::from(&import_item.name)],
-                                    )));
-                                }
-
-                                if mod_value.is_ok() && !module_exports.contains(&mod_name) {
-                                    mod_value = Err(KclError::new_semantic(KclErrorDetails::new(
-                                        format!(
-                                            "Cannot import \"{}\" from module because it is not exported. Add \"export\" before the definition to export it.",
-                                            import_item.name.name
-                                        ),
-                                        vec![SourceRange::from(&import_item.name)],
-                                    )));
-                                }
-
-                                if value.is_err() && ty.is_err() && mod_value.is_err() {
-                                    return value.map(|v| Some(v.continue_()));
-                                }
-
-                                // Add the item to the current module.
-                                if let Ok(value) = value {
-                                    exec_state.mut_stack().add(
-                                        import_item.identifier().to_owned(),
-                                        value,
-                                        SourceRange::from(&import_item.name),
-                                    )?;
-
-                                    if let ItemVisibility::Export = import_stmt.visibility {
-                                        exec_state
-                                            .mod_local
-                                            .module_exports
-                                            .push(import_item.identifier().to_owned());
-                                    }
-                                }
-
-                                if let Ok(ty) = ty {
-                                    let ty_name = format!("{}{}", memory::TYPE_PREFIX, import_item.identifier());
-                                    if matches!(
-                                        &ty,
-                                        KclValue::Type {
-                                            value: TypeDef::Enum(_),
-                                            ..
-                                        }
-                                    ) {
-                                        reject_enum_clashing_with_module(
-                                            exec_state,
-                                            import_item.identifier(),
-                                            SourceRange::from(&import_item.name),
-                                        )?;
-                                    }
-                                    exec_state.mut_stack().add(
-                                        ty_name.clone(),
-                                        ty,
-                                        SourceRange::from(&import_item.name),
-                                    )?;
-
-                                    if let ItemVisibility::Export = import_stmt.visibility {
-                                        exec_state.mod_local.module_exports.push(ty_name);
-                                    }
-                                }
-
-                                if let Ok(mod_value) = mod_value {
-                                    let mod_name = format!("{}{}", memory::MODULE_PREFIX, import_item.identifier());
-                                    reject_module_clashing_with_enum(
-                                        exec_state,
-                                        import_item.identifier(),
-                                        SourceRange::from(&import_item.name),
-                                    )?;
-                                    exec_state.mut_stack().add(
-                                        mod_name.clone(),
-                                        mod_value,
-                                        SourceRange::from(&import_item.name),
-                                    )?;
-
-                                    if let ItemVisibility::Export = import_stmt.visibility {
-                                        exec_state.mod_local.module_exports.push(mod_name);
-                                    }
-                                }
-                            }
-                        }
-                        ImportSelector::Glob(_) => {
-                            let (env_ref, module_exports) =
-                                self.exec_module_for_items(module_id, exec_state, source_range).await?;
-                            for name in module_exports.iter() {
-                                let item = exec_state
-                                    .stack()
-                                    .memory
-                                    .get_from_owned(name, env_ref, source_range, 0)
-                                    .map_err(|_err| {
-                                        internal_err(
-                                            format!("{name} is not defined in module (but was exported?)"),
-                                            source_range,
-                                        )
-                                    })?;
-                                reject_glob_import_clash(exec_state, name, &item, source_range)?;
-                                exec_state.mut_stack().add(name.to_owned(), item, source_range)?;
-
-                                if let ItemVisibility::Export = import_stmt.visibility {
-                                    exec_state.mod_local.module_exports.push(name.clone());
-                                }
-                            }
-                        }
-                        ImportSelector::None { .. } => {
-                            let name = import_stmt.module_name().unwrap();
-                            reject_module_clashing_with_enum(exec_state, &name, source_range)?;
-                            let item = KclValue::Module {
-                                value: module_id,
-                                meta: vec![source_range.into()],
-                            };
-                            exec_state.mut_stack().add(
-                                format!("{}{}", memory::MODULE_PREFIX, name),
-                                item,
-                                source_range,
-                            )?;
-                        }
-                    }
+                    self.exec_import_statement(import_stmt, body_type, exec_state).await?;
                     last_expr = None;
                 }
                 BodyItem::ExpressionStatement(expression_statement) => {
@@ -1317,91 +1136,8 @@ impl ExecutorContext {
                         last_expr = Some(rhs);
                         break;
                     }
-                    let mut rhs = rhs.into_value();
-
-                    // Attach the variable name to unsolved segments as a tag.
-                    // While executing the body of a sketch block, the segments
-                    // won't have been solved yet.
-                    if let KclValue::Segment { value } = &mut rhs
-                        && let SegmentRepr::Unsolved { segment } = &mut value.repr
-                    {
-                        segment.tag = Some(TagIdentifier {
-                            value: variable_declaration.declaration.id.name.clone(),
-                            info: Default::default(),
-                            meta: vec![SourceRange::from(&variable_declaration.declaration.id).into()],
-                        });
-                    }
-                    let rhs = rhs; // Remove mutability.
-
-                    let should_bind_name =
-                        if let Some(fn_name) = variable_declaration.declaration.init.fn_declaring_name() {
-                            // Declaring a function with a name, so only bind
-                            // the variable name if it differs from the function
-                            // name.
-                            var_name != fn_name
-                        } else {
-                            // Not declaring a function, so we should bind the
-                            // variable name.
-                            true
-                        };
-                    if should_bind_name {
-                        exec_state
-                            .mut_stack()
-                            .add(var_name.clone(), rhs.clone(), source_range)?;
-                    }
-
-                    if let Some(sketch_block_state) = exec_state.mod_local.sketch_block.as_mut()
-                        && let KclValue::Segment { value } = &rhs
-                    {
-                        // Add segment to mapping so that we can tag it when
-                        // sending to the engine.
-                        let segment_object_id = match &value.repr {
-                            SegmentRepr::Unsolved { segment } => segment.object_id,
-                            SegmentRepr::Solved { segment } => segment.object_id,
-                        };
-                        sketch_block_state
-                            .segment_tags
-                            .entry(segment_object_id)
-                            .or_insert_with(|| {
-                                let id_node = &variable_declaration.declaration.id;
-                                Node::new(
-                                    TagDeclarator {
-                                        name: id_node.name.clone(),
-                                        digest: None,
-                                    },
-                                    id_node.start,
-                                    id_node.end,
-                                    id_node.module_id,
-                                )
-                            });
-                    }
-
-                    // Track operations, for the feature tree.
-                    // Don't track these operations if the KCL code being executed is in the stdlib,
-                    // because users shouldn't know about stdlib internals -- it's useless noise, to them.
-                    let should_show_in_feature_tree =
-                        !exec_state.mod_local.inside_stdlib && rhs.show_variable_in_feature_tree();
-                    if should_show_in_feature_tree {
-                        exec_state.push_op(Operation::VariableDeclaration {
-                            name: var_name.clone(),
-                            value: op_from_kcl_value(&rhs),
-                            visibility: variable_declaration.visibility,
-                            node_path: NodePath::placeholder(),
-                            source_range,
-                        });
-                    }
-
-                    // Track exports.
-                    if let ItemVisibility::Export = variable_declaration.visibility {
-                        if matches!(body_type, BodyType::Root) {
-                            exec_state.mod_local.module_exports.push(var_name);
-                        } else {
-                            exec_state.err(CompilationIssue::err(
-                                variable_declaration.as_source_range(),
-                                "Exports are only supported at the top-level of a file. Remove `export` or move it to the top-level.",
-                            ));
-                        }
-                    }
+                    let rhs =
+                        self.bind_variable_declaration(variable_declaration, rhs.into_value(), body_type, exec_state)?;
                     // Variable declaration can be the return value of a module.
                     last_expr = matches!(body_type, BodyType::Root).then_some(rhs.continue_());
                 }
@@ -1409,137 +1145,7 @@ impl ExecutorContext {
                     if exec_state.sketch_mode() {
                         continue;
                     }
-
-                    let metadata = Metadata::from(&**ty);
-                    let attrs = annotations::get_fn_attrs(&ty.outer_attrs, metadata.source_range)?.unwrap_or_default();
-                    match attrs.impl_ {
-                        annotations::Impl::Rust
-                        | annotations::Impl::RustConstrainable
-                        | annotations::Impl::RustConstraint => {
-                            let std_path = match &exec_state.mod_local.path {
-                                ModulePath::Std { value } => value,
-                                ModulePath::Local { .. } | ModulePath::Main => {
-                                    return Err(KclError::new_semantic(KclErrorDetails::new(
-                                        "User-defined types are not yet supported.".to_owned(),
-                                        vec![metadata.source_range],
-                                    )));
-                                }
-                            };
-                            let (t, props) = crate::std::std_ty(std_path, &ty.name.name);
-                            let value = KclValue::Type {
-                                value: TypeDef::RustRepr(t, props),
-                                meta: vec![metadata],
-                                experimental: attrs.experimental,
-                            };
-                            let name_in_mem = format!("{}{}", memory::TYPE_PREFIX, ty.name.name);
-                            exec_state
-                                .mut_stack()
-                                .add(name_in_mem.clone(), value, metadata.source_range)
-                                .map_err(|_| {
-                                    KclError::new_semantic(KclErrorDetails::new(
-                                        format!("Redefinition of type {}.", ty.name.name),
-                                        vec![metadata.source_range],
-                                    ))
-                                })?;
-
-                            if let ItemVisibility::Export = ty.visibility {
-                                exec_state.mod_local.module_exports.push(name_in_mem);
-                            }
-                        }
-                        // Do nothing for primitive types, they get special treatment and their declarations are just for documentation.
-                        annotations::Impl::Primitive => {}
-                        annotations::Impl::Kcl | annotations::Impl::KclConstrainable => match &ty.definition {
-                            TypeDeclarationDefinition::Alias { ty: alias } => {
-                                let value = KclValue::Type {
-                                    value: TypeDef::Alias(
-                                        RuntimeType::from_parsed(
-                                            alias.inner.clone(),
-                                            exec_state,
-                                            metadata.source_range,
-                                            attrs.impl_ == annotations::Impl::KclConstrainable,
-                                            false,
-                                        )
-                                        .map_err(|e| KclError::new_semantic(e.into()))?,
-                                    ),
-                                    meta: vec![metadata],
-                                    experimental: attrs.experimental,
-                                };
-                                let name_in_mem = format!("{}{}", memory::TYPE_PREFIX, ty.name.name);
-                                exec_state
-                                    .mut_stack()
-                                    .add(name_in_mem.clone(), value, metadata.source_range)
-                                    .map_err(|_| {
-                                        KclError::new_semantic(KclErrorDetails::new(
-                                            format!("Redefinition of type {}.", ty.name.name),
-                                            vec![metadata.source_range],
-                                        ))
-                                    })?;
-
-                                if let ItemVisibility::Export = ty.visibility {
-                                    exec_state.mod_local.module_exports.push(name_in_mem);
-                                }
-                            }
-                            TypeDeclarationDefinition::Bare => {
-                                return Err(KclError::new_semantic(KclErrorDetails::new(
-                                    "User-defined types are not yet supported.".to_owned(),
-                                    vec![metadata.source_range],
-                                )));
-                            }
-                            TypeDeclarationDefinition::Enum(decl) => {
-                                // Identity is module plus declared name, so `type Color` in
-                                // two function bodies of one file would be one type with two
-                                // variant sets. A V1 limitation, liftable in enum v2 by
-                                // giving `EnumTypeId` a declaration site.
-                                if !matches!(body_type, BodyType::Root) {
-                                    return Err(KclError::new_semantic(KclErrorDetails::new(
-                                        format!(
-                                            "Enum declarations are only supported at the top-level of a file. Move `type {}` to the top-level.",
-                                            ty.name.name
-                                        ),
-                                        vec![metadata.source_range],
-                                    )));
-                                }
-
-                                reject_enum_clashing_with_module(exec_state, &ty.name.name, metadata.source_range)?;
-
-                                let variants = decl.variants.iter().map(|v| v.name.name.clone()).collect();
-                                let id = EnumTypeId::new(metadata.source_range.module_id(), ty.name.name.clone());
-                                // Constructing the definition is the validation step: nothing
-                                // below runs, so nothing reaches memory, unless every variant
-                                // name is distinct.
-                                let def = EnumTypeDef::new(id, variants).map_err(|duplicate| {
-                                    KclError::new_semantic(KclErrorDetails::new(
-                                        format!("Duplicate variant `{}` in enum `{}`.", duplicate.name, ty.name.name),
-                                        vec![
-                                            decl.variants[duplicate.first_index].as_source_range(),
-                                            decl.variants[duplicate.duplicate_index].as_source_range(),
-                                        ],
-                                    ))
-                                })?;
-
-                                let value = KclValue::Type {
-                                    value: TypeDef::Enum(Arc::new(def)),
-                                    meta: vec![metadata],
-                                    experimental: attrs.experimental,
-                                };
-                                let name_in_mem = format!("{}{}", memory::TYPE_PREFIX, ty.name.name);
-                                exec_state
-                                    .mut_stack()
-                                    .add(name_in_mem.clone(), value, metadata.source_range)
-                                    .map_err(|_| {
-                                        KclError::new_semantic(KclErrorDetails::new(
-                                            format!("Redefinition of type {}.", ty.name.name),
-                                            vec![metadata.source_range],
-                                        ))
-                                    })?;
-
-                                if let ItemVisibility::Export = ty.visibility {
-                                    exec_state.mod_local.module_exports.push(name_in_mem);
-                                }
-                            }
-                        },
-                    }
-
+                    self.exec_type_declaration(ty, body_type, exec_state)?;
                     last_expr = None;
                 }
                 BodyItem::ReturnStatement(return_statement) => {
@@ -1570,15 +1176,7 @@ impl ExecutorContext {
                         break;
                     }
                     let value = value_cf.into_value();
-                    exec_state
-                        .mut_stack()
-                        .add(memory::RETURN_NAME.to_owned(), value, metadata.source_range)
-                        .map_err(|_| {
-                            KclError::new_semantic(KclErrorDetails::new(
-                                "Multiple returns from a single function.".to_owned(),
-                                vec![metadata.source_range],
-                            ))
-                        })?;
+                    Self::bind_return_value(return_statement, value, exec_state)?;
                     last_expr = None;
                 }
             }
@@ -1597,6 +1195,462 @@ impl ExecutorContext {
         }
 
         Ok(last_expr)
+    }
+
+    /// Execute an import statement. Flat: this does not evaluate KCL
+    /// sub-expressions (module execution happens in its own fresh root), so
+    /// both executors share it.
+    pub(super) async fn exec_import_statement(
+        &self,
+        import_stmt: &Node<ImportStatement>,
+        body_type: BodyType,
+        exec_state: &mut ExecState,
+    ) -> Result<(), KclError> {
+        if !matches!(body_type, BodyType::Root) {
+            return Err(KclError::new_semantic(KclErrorDetails::new(
+                "Imports are only supported at the top-level of a file.".to_owned(),
+                vec![import_stmt.into()],
+            )));
+        }
+
+        let source_range = SourceRange::from(import_stmt);
+        let attrs = &import_stmt.outer_attrs;
+        let module_path = ModulePath::from_import_path(
+            &import_stmt.path,
+            &self.settings.project_directory,
+            &exec_state.mod_local.path,
+        )?;
+        let module_id = self
+            .open_module(&import_stmt.path, attrs, &module_path, exec_state, source_range)
+            .await?;
+
+        if let ModulePath::Local { value, .. } = &module_path {
+            let name = import_stmt
+                .module_name()
+                .unwrap_or_else(|| value.file_name().unwrap_or_default());
+            exec_state.push_op(Operation::ModuleInstance {
+                name,
+                module_id,
+                glob: matches!(import_stmt.selector, ImportSelector::Glob(_)),
+                node_path: NodePath::placeholder(),
+                source_range,
+            });
+        }
+
+        match &import_stmt.selector {
+            ImportSelector::List { items } => {
+                let (env_ref, module_exports) = self.exec_module_for_items(module_id, exec_state, source_range).await?;
+                for import_item in items {
+                    // Extract the item from the module.
+                    let mem = &exec_state.stack().memory;
+                    let mut value = mem.get_from_owned(&import_item.name.name, env_ref, import_item.into(), 0);
+                    let ty_name = format!("{}{}", memory::TYPE_PREFIX, import_item.name.name);
+                    let mut ty = mem.get_from_owned(&ty_name, env_ref, import_item.into(), 0);
+                    let mod_name = format!("{}{}", memory::MODULE_PREFIX, import_item.name.name);
+                    let mut mod_value = mem.get_from_owned(&mod_name, env_ref, import_item.into(), 0);
+
+                    if value.is_err() && ty.is_err() && mod_value.is_err() {
+                        return Err(KclError::new_undefined_value(
+                            KclErrorDetails::new(
+                                format!("{} is not defined in module", import_item.name.name),
+                                vec![SourceRange::from(&import_item.name)],
+                            ),
+                            None,
+                        ));
+                    }
+
+                    // Check that the item is allowed to be imported (in at least one namespace).
+                    if value.is_ok() && !module_exports.contains(&import_item.name.name) {
+                        value = Err(KclError::new_semantic(KclErrorDetails::new(
+                            format!(
+                                "Cannot import \"{}\" from module because it is not exported. Add \"export\" before the definition to export it.",
+                                import_item.name.name
+                            ),
+                            vec![SourceRange::from(&import_item.name)],
+                        )));
+                    }
+
+                    if ty.is_ok() && !module_exports.contains(&ty_name) {
+                        ty = Err(KclError::new_semantic(KclErrorDetails::new(
+                            format!(
+                                "Cannot import \"{}\" from module because it is not exported. Add \"export\" before the definition to export it.",
+                                import_item.name.name
+                            ),
+                            vec![SourceRange::from(&import_item.name)],
+                        )));
+                    }
+
+                    if mod_value.is_ok() && !module_exports.contains(&mod_name) {
+                        mod_value = Err(KclError::new_semantic(KclErrorDetails::new(
+                            format!(
+                                "Cannot import \"{}\" from module because it is not exported. Add \"export\" before the definition to export it.",
+                                import_item.name.name
+                            ),
+                            vec![SourceRange::from(&import_item.name)],
+                        )));
+                    }
+
+                    if value.is_err() && ty.is_err() && mod_value.is_err() {
+                        return value.map(|_| ());
+                    }
+
+                    // Add the item to the current module.
+                    if let Ok(value) = value {
+                        exec_state.mut_stack().add(
+                            import_item.identifier().to_owned(),
+                            value,
+                            SourceRange::from(&import_item.name),
+                        )?;
+
+                        if let ItemVisibility::Export = import_stmt.visibility {
+                            exec_state
+                                .mod_local
+                                .module_exports
+                                .push(import_item.identifier().to_owned());
+                        }
+                    }
+
+                    if let Ok(ty) = ty {
+                        let ty_name = format!("{}{}", memory::TYPE_PREFIX, import_item.identifier());
+                        if matches!(
+                            &ty,
+                            KclValue::Type {
+                                value: TypeDef::Enum(_),
+                                ..
+                            }
+                        ) {
+                            reject_enum_clashing_with_module(
+                                exec_state,
+                                import_item.identifier(),
+                                SourceRange::from(&import_item.name),
+                            )?;
+                        }
+                        exec_state
+                            .mut_stack()
+                            .add(ty_name.clone(), ty, SourceRange::from(&import_item.name))?;
+
+                        if let ItemVisibility::Export = import_stmt.visibility {
+                            exec_state.mod_local.module_exports.push(ty_name);
+                        }
+                    }
+
+                    if let Ok(mod_value) = mod_value {
+                        let mod_name = format!("{}{}", memory::MODULE_PREFIX, import_item.identifier());
+                        reject_module_clashing_with_enum(
+                            exec_state,
+                            import_item.identifier(),
+                            SourceRange::from(&import_item.name),
+                        )?;
+                        exec_state.mut_stack().add(
+                            mod_name.clone(),
+                            mod_value,
+                            SourceRange::from(&import_item.name),
+                        )?;
+
+                        if let ItemVisibility::Export = import_stmt.visibility {
+                            exec_state.mod_local.module_exports.push(mod_name);
+                        }
+                    }
+                }
+            }
+            ImportSelector::Glob(_) => {
+                let (env_ref, module_exports) = self.exec_module_for_items(module_id, exec_state, source_range).await?;
+                for name in module_exports.iter() {
+                    let item = exec_state
+                        .stack()
+                        .memory
+                        .get_from_owned(name, env_ref, source_range, 0)
+                        .map_err(|_err| {
+                            internal_err(
+                                format!("{name} is not defined in module (but was exported?)"),
+                                source_range,
+                            )
+                        })?;
+                    reject_glob_import_clash(exec_state, name, &item, source_range)?;
+                    exec_state.mut_stack().add(name.to_owned(), item, source_range)?;
+
+                    if let ItemVisibility::Export = import_stmt.visibility {
+                        exec_state.mod_local.module_exports.push(name.clone());
+                    }
+                }
+            }
+            ImportSelector::None { .. } => {
+                let name = import_stmt.module_name().unwrap();
+                reject_module_clashing_with_enum(exec_state, &name, source_range)?;
+                let item = KclValue::Module {
+                    value: module_id,
+                    meta: vec![source_range.into()],
+                };
+                exec_state
+                    .mut_stack()
+                    .add(format!("{}{}", memory::MODULE_PREFIX, name), item, source_range)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Execute a type declaration. Flat; shared by both executors.
+    pub(super) fn exec_type_declaration(
+        &self,
+        ty: &Node<TypeDeclaration>,
+        body_type: BodyType,
+        exec_state: &mut ExecState,
+    ) -> Result<(), KclError> {
+        let metadata = Metadata::from(ty);
+        let attrs = annotations::get_fn_attrs(&ty.outer_attrs, metadata.source_range)?.unwrap_or_default();
+        match attrs.impl_ {
+            annotations::Impl::Rust | annotations::Impl::RustConstrainable | annotations::Impl::RustConstraint => {
+                let std_path = match &exec_state.mod_local.path {
+                    ModulePath::Std { value } => value,
+                    ModulePath::Local { .. } | ModulePath::Main => {
+                        return Err(KclError::new_semantic(KclErrorDetails::new(
+                            "User-defined types are not yet supported.".to_owned(),
+                            vec![metadata.source_range],
+                        )));
+                    }
+                };
+                let (t, props) = crate::std::std_ty(std_path, &ty.name.name);
+                let value = KclValue::Type {
+                    value: TypeDef::RustRepr(t, props),
+                    meta: vec![metadata],
+                    experimental: attrs.experimental,
+                };
+                let name_in_mem = format!("{}{}", memory::TYPE_PREFIX, ty.name.name);
+                exec_state
+                    .mut_stack()
+                    .add(name_in_mem.clone(), value, metadata.source_range)
+                    .map_err(|_| {
+                        KclError::new_semantic(KclErrorDetails::new(
+                            format!("Redefinition of type {}.", ty.name.name),
+                            vec![metadata.source_range],
+                        ))
+                    })?;
+
+                if let ItemVisibility::Export = ty.visibility {
+                    exec_state.mod_local.module_exports.push(name_in_mem);
+                }
+            }
+            // Do nothing for primitive types, they get special treatment and their declarations are just for documentation.
+            annotations::Impl::Primitive => {}
+            annotations::Impl::Kcl | annotations::Impl::KclConstrainable => match &ty.definition {
+                TypeDeclarationDefinition::Alias { ty: alias } => {
+                    let value = KclValue::Type {
+                        value: TypeDef::Alias(
+                            RuntimeType::from_parsed(
+                                alias.inner.clone(),
+                                exec_state,
+                                metadata.source_range,
+                                attrs.impl_ == annotations::Impl::KclConstrainable,
+                                false,
+                            )
+                            .map_err(|e| KclError::new_semantic(e.into()))?,
+                        ),
+                        meta: vec![metadata],
+                        experimental: attrs.experimental,
+                    };
+                    let name_in_mem = format!("{}{}", memory::TYPE_PREFIX, ty.name.name);
+                    exec_state
+                        .mut_stack()
+                        .add(name_in_mem.clone(), value, metadata.source_range)
+                        .map_err(|_| {
+                            KclError::new_semantic(KclErrorDetails::new(
+                                format!("Redefinition of type {}.", ty.name.name),
+                                vec![metadata.source_range],
+                            ))
+                        })?;
+
+                    if let ItemVisibility::Export = ty.visibility {
+                        exec_state.mod_local.module_exports.push(name_in_mem);
+                    }
+                }
+                TypeDeclarationDefinition::Bare => {
+                    return Err(KclError::new_semantic(KclErrorDetails::new(
+                        "User-defined types are not yet supported.".to_owned(),
+                        vec![metadata.source_range],
+                    )));
+                }
+                TypeDeclarationDefinition::Enum(decl) => {
+                    // Identity is module plus declared name, so `type Color` in
+                    // two function bodies of one file would be one type with two
+                    // variant sets. A V1 limitation, liftable in enum v2 by
+                    // giving `EnumTypeId` a declaration site.
+                    if !matches!(body_type, BodyType::Root) {
+                        return Err(KclError::new_semantic(KclErrorDetails::new(
+                            format!(
+                                "Enum declarations are only supported at the top-level of a file. Move `type {}` to the top-level.",
+                                ty.name.name
+                            ),
+                            vec![metadata.source_range],
+                        )));
+                    }
+
+                    reject_enum_clashing_with_module(exec_state, &ty.name.name, metadata.source_range)?;
+
+                    let variants = decl.variants.iter().map(|v| v.name.name.clone()).collect();
+                    let id = EnumTypeId::new(metadata.source_range.module_id(), ty.name.name.clone());
+                    // Constructing the definition is the validation step: nothing
+                    // below runs, so nothing reaches memory, unless every variant
+                    // name is distinct.
+                    let def = EnumTypeDef::new(id, variants).map_err(|duplicate| {
+                        KclError::new_semantic(KclErrorDetails::new(
+                            format!("Duplicate variant `{}` in enum `{}`.", duplicate.name, ty.name.name),
+                            vec![
+                                decl.variants[duplicate.first_index].as_source_range(),
+                                decl.variants[duplicate.duplicate_index].as_source_range(),
+                            ],
+                        ))
+                    })?;
+
+                    let value = KclValue::Type {
+                        value: TypeDef::Enum(Arc::new(def)),
+                        meta: vec![metadata],
+                        experimental: attrs.experimental,
+                    };
+                    let name_in_mem = format!("{}{}", memory::TYPE_PREFIX, ty.name.name);
+                    exec_state
+                        .mut_stack()
+                        .add(name_in_mem.clone(), value, metadata.source_range)
+                        .map_err(|_| {
+                            KclError::new_semantic(KclErrorDetails::new(
+                                format!("Redefinition of type {}.", ty.name.name),
+                                vec![metadata.source_range],
+                            ))
+                        })?;
+
+                    if let ItemVisibility::Export = ty.visibility {
+                        exec_state.mod_local.module_exports.push(name_in_mem);
+                    }
+                }
+            },
+        }
+
+        Ok(())
+    }
+
+    /// Bind the evaluated right-hand side of a variable declaration: segment
+    /// tag attachment, name binding, sketch-block segment tags, feature-tree
+    /// operation, and export tracking. The evaluation-free second half of
+    /// variable-declaration execution, shared by both executors. Returns the
+    /// bound value (which becomes the module result when this is the last
+    /// Root statement).
+    pub(super) fn bind_variable_declaration(
+        &self,
+        variable_declaration: &Node<VariableDeclaration>,
+        rhs: KclValue,
+        body_type: BodyType,
+        exec_state: &mut ExecState,
+    ) -> Result<KclValue, KclError> {
+        let var_name = variable_declaration.declaration.id.name.to_string();
+        let source_range = SourceRange::from(&variable_declaration.declaration.init);
+        let mut rhs = rhs;
+
+        // Attach the variable name to unsolved segments as a tag.
+        // While executing the body of a sketch block, the segments
+        // won't have been solved yet.
+        if let KclValue::Segment { value } = &mut rhs
+            && let SegmentRepr::Unsolved { segment } = &mut value.repr
+        {
+            segment.tag = Some(TagIdentifier {
+                value: variable_declaration.declaration.id.name.clone(),
+                info: Default::default(),
+                meta: vec![SourceRange::from(&variable_declaration.declaration.id).into()],
+            });
+        }
+        let rhs = rhs; // Remove mutability.
+
+        let should_bind_name = if let Some(fn_name) = variable_declaration.declaration.init.fn_declaring_name() {
+            // Declaring a function with a name, so only bind
+            // the variable name if it differs from the function
+            // name.
+            var_name != fn_name
+        } else {
+            // Not declaring a function, so we should bind the
+            // variable name.
+            true
+        };
+        if should_bind_name {
+            exec_state
+                .mut_stack()
+                .add(var_name.clone(), rhs.clone(), source_range)?;
+        }
+
+        if let Some(sketch_block_state) = exec_state.mod_local.sketch_block.as_mut()
+            && let KclValue::Segment { value } = &rhs
+        {
+            // Add segment to mapping so that we can tag it when
+            // sending to the engine.
+            let segment_object_id = match &value.repr {
+                SegmentRepr::Unsolved { segment } => segment.object_id,
+                SegmentRepr::Solved { segment } => segment.object_id,
+            };
+            sketch_block_state
+                .segment_tags
+                .entry(segment_object_id)
+                .or_insert_with(|| {
+                    let id_node = &variable_declaration.declaration.id;
+                    Node::new(
+                        TagDeclarator {
+                            name: id_node.name.clone(),
+                            digest: None,
+                        },
+                        id_node.start,
+                        id_node.end,
+                        id_node.module_id,
+                    )
+                });
+        }
+
+        // Track operations, for the feature tree.
+        // Don't track these operations if the KCL code being executed is in the stdlib,
+        // because users shouldn't know about stdlib internals -- it's useless noise, to them.
+        let should_show_in_feature_tree = !exec_state.mod_local.inside_stdlib && rhs.show_variable_in_feature_tree();
+        if should_show_in_feature_tree {
+            exec_state.push_op(Operation::VariableDeclaration {
+                name: var_name.clone(),
+                value: op_from_kcl_value(&rhs),
+                visibility: variable_declaration.visibility,
+                node_path: NodePath::placeholder(),
+                source_range,
+            });
+        }
+
+        // Track exports.
+        if let ItemVisibility::Export = variable_declaration.visibility {
+            if matches!(body_type, BodyType::Root) {
+                exec_state.mod_local.module_exports.push(var_name);
+            } else {
+                exec_state.err(CompilationIssue::err(
+                                variable_declaration.as_source_range(),
+                                "Exports are only supported at the top-level of a file. Remove `export` or move it to the top-level.",
+                            ));
+            }
+        }
+        Ok(rhs)
+    }
+
+    /// Record a return statement's evaluated value as the function result
+    /// (`__return`). NOTE: deliberately does NOT stop the enclosing block --
+    /// statements after a `return` still execute, exactly like the historical
+    /// behavior (see the ReturnStatement arm of exec_block); a second
+    /// executed `return` is the "Multiple returns" error. Shared by both
+    /// executors.
+    pub(super) fn bind_return_value(
+        return_statement: &Node<ReturnStatement>,
+        value: KclValue,
+        exec_state: &mut ExecState,
+    ) -> Result<(), KclError> {
+        let metadata = Metadata::from(return_statement);
+        exec_state
+            .mut_stack()
+            .add(memory::RETURN_NAME.to_owned(), value, metadata.source_range)
+            .map_err(|_| {
+                KclError::new_semantic(KclErrorDetails::new(
+                    "Multiple returns from a single function.".to_owned(),
+                    vec![metadata.source_range],
+                ))
+            })?;
+        Ok(())
     }
 
     pub async fn open_module(
@@ -1840,103 +1894,9 @@ impl ExecutorContext {
                 .await?
                 .continue_(),
             Expr::BinaryExpression(binary_expression) => binary_expression.get_result(exec_state, self).await?,
-            Expr::FunctionExpression(function_expression) => {
-                let attrs = annotations::get_fn_attrs(annotations, metadata.source_range)?;
-                let experimental = attrs
-                    .as_ref()
-                    .map(|a| a.experimental)
-                    // Use the default for the field, not the bool type.
-                    .unwrap_or_else(|| FnAttrs::default().experimental);
-
-                // Check the KCL @(feature_tree = ) annotation.
-                let include_in_feature_tree = attrs
-                    .as_ref()
-                    .map(|a| a.include_in_feature_tree)
-                    // Use the default for the field, not the bool type.
-                    .unwrap_or_else(|| FnAttrs::default().include_in_feature_tree);
-                let (mut closure, placeholder_env_ref) = if let Some(attrs) = attrs
-                    && (attrs.impl_ == annotations::Impl::Rust
-                        || attrs.impl_ == annotations::Impl::RustConstrainable
-                        || attrs.impl_ == annotations::Impl::RustConstraint)
-                {
-                    if let ModulePath::Std { value: std_path } = &exec_state.mod_local.path {
-                        let (func, props) = crate::std::std_fn(std_path, statement_kind.expect_name());
-                        (
-                            KclValue::Function {
-                                value: Box::new(FunctionSource::rust(func, function_expression.clone(), props, attrs)),
-                                meta: vec![metadata.to_owned()],
-                            },
-                            None,
-                        )
-                    } else {
-                        return Err(KclError::new_semantic(KclErrorDetails::new(
-                            "Rust implementation of functions is restricted to the standard library".to_owned(),
-                            vec![metadata.source_range],
-                        )));
-                    }
-                } else {
-                    let std_props = function_expression
-                        .name_str()
-                        .and_then(|name| exec_state.mod_local.path.build_std_fully_qualified_name(name))
-                        .map(|name| StdFnProps::default(&name));
-                    // Snapshotting memory here is crucial for semantics so that we close
-                    // over variables. Variables defined lexically later shouldn't
-                    // be available to the function body.
-                    let (env_ref, placeholder_env_ref) = if function_expression.name.is_some() {
-                        // Recursive function needs a snapshot that includes
-                        // itself.
-                        let dummy = EnvironmentRef::dummy();
-                        (dummy, Some(dummy))
-                    } else {
-                        (exec_state.mut_stack().snapshot()?, None)
-                    };
-                    (
-                        KclValue::Function {
-                            value: Box::new(FunctionSource::kcl(
-                                function_expression.clone(),
-                                env_ref,
-                                KclFunctionSourceParams {
-                                    std_props,
-                                    experimental,
-                                    include_in_feature_tree,
-                                },
-                            )),
-                            meta: vec![metadata.to_owned()],
-                        },
-                        placeholder_env_ref,
-                    )
-                };
-
-                // Resolve the signature's type names now, in the scope where
-                // the declaration is written. Call sites consume the stored
-                // resolutions and never look type names up themselves.
-                if let KclValue::Function { value, .. } = &mut closure {
-                    value.resolve_signature_types(exec_state)?;
-                }
-
-                // If the function expression has a name, i.e. `fn name() {}`,
-                // bind it in the current scope.
-                if let Some(fn_name) = &function_expression.name {
-                    // If we used a placeholder env ref for recursion, fix it up
-                    // with the name recursively bound so that it's available in
-                    // the function body.
-                    if let Some(placeholder_env_ref) = placeholder_env_ref {
-                        closure = exec_state.mut_stack().add_recursive_closure(
-                            fn_name.name.to_owned(),
-                            closure,
-                            placeholder_env_ref,
-                            metadata.source_range,
-                        )?;
-                    } else {
-                        // Regular non-recursive binding.
-                        exec_state
-                            .mut_stack()
-                            .add(fn_name.name.clone(), closure.clone(), metadata.source_range)?;
-                    }
-                }
-
-                closure.continue_()
-            }
+            Expr::FunctionExpression(function_expression) => self
+                .create_function_closure(function_expression, annotations, metadata, statement_kind, exec_state)?
+                .continue_(),
             Expr::CallExpressionKw(call_expression) => call_expression.execute(exec_state, self).await?,
             Expr::PipeExpression(pipe_expression) => pipe_expression.get_result(exec_state, self).await?,
             Expr::PipeSubstitution(pipe_substitution) => match statement_kind {
@@ -1982,6 +1942,114 @@ impl ExecutorContext {
             Expr::SketchVar(expr) => expr.get_result(exec_state, self).await?.continue_(),
         };
         Ok(item)
+    }
+
+    /// Create the closure value for a function expression, including the
+    /// recursive-closure placeholder fixup and binding a named `fn name() {}`
+    /// in the current scope. Flat; shared by both executors.
+    pub(super) fn create_function_closure(
+        &self,
+        function_expression: &crate::parsing::ast::types::BoxNode<FunctionExpression>,
+        annotations: &[Node<Annotation>],
+        metadata: &Metadata,
+        statement_kind: StatementKind<'_>,
+        exec_state: &mut ExecState,
+    ) -> Result<KclValue, KclError> {
+        let attrs = annotations::get_fn_attrs(annotations, metadata.source_range)?;
+        let experimental = attrs
+            .as_ref()
+            .map(|a| a.experimental)
+            // Use the default for the field, not the bool type.
+            .unwrap_or_else(|| FnAttrs::default().experimental);
+
+        // Check the KCL @(feature_tree = ) annotation.
+        let include_in_feature_tree = attrs
+            .as_ref()
+            .map(|a| a.include_in_feature_tree)
+            // Use the default for the field, not the bool type.
+            .unwrap_or_else(|| FnAttrs::default().include_in_feature_tree);
+        let (mut closure, placeholder_env_ref) = if let Some(attrs) = attrs
+            && (attrs.impl_ == annotations::Impl::Rust
+                || attrs.impl_ == annotations::Impl::RustConstrainable
+                || attrs.impl_ == annotations::Impl::RustConstraint)
+        {
+            if let ModulePath::Std { value: std_path } = &exec_state.mod_local.path {
+                let (func, props) = crate::std::std_fn(std_path, statement_kind.expect_name());
+                (
+                    KclValue::Function {
+                        value: Box::new(FunctionSource::rust(func, function_expression.clone(), props, attrs)),
+                        meta: vec![metadata.to_owned()],
+                    },
+                    None,
+                )
+            } else {
+                return Err(KclError::new_semantic(KclErrorDetails::new(
+                    "Rust implementation of functions is restricted to the standard library".to_owned(),
+                    vec![metadata.source_range],
+                )));
+            }
+        } else {
+            let std_props = function_expression
+                .name_str()
+                .and_then(|name| exec_state.mod_local.path.build_std_fully_qualified_name(name))
+                .map(|name| StdFnProps::default(&name));
+            // Snapshotting memory here is crucial for semantics so that we close
+            // over variables. Variables defined lexically later shouldn't
+            // be available to the function body.
+            let (env_ref, placeholder_env_ref) = if function_expression.name.is_some() {
+                // Recursive function needs a snapshot that includes
+                // itself.
+                let dummy = EnvironmentRef::dummy();
+                (dummy, Some(dummy))
+            } else {
+                (exec_state.mut_stack().snapshot()?, None)
+            };
+            (
+                KclValue::Function {
+                    value: Box::new(FunctionSource::kcl(
+                        function_expression.clone(),
+                        env_ref,
+                        KclFunctionSourceParams {
+                            std_props,
+                            experimental,
+                            include_in_feature_tree,
+                        },
+                    )),
+                    meta: vec![metadata.to_owned()],
+                },
+                placeholder_env_ref,
+            )
+        };
+
+        // Resolve the signature's type names now, in the scope where
+        // the declaration is written. Call sites consume the stored
+        // resolutions and never look type names up themselves.
+        if let KclValue::Function { value, .. } = &mut closure {
+            value.resolve_signature_types(exec_state)?;
+        }
+
+        // If the function expression has a name, i.e. `fn name() {}`,
+        // bind it in the current scope.
+        if let Some(fn_name) = &function_expression.name {
+            // If we used a placeholder env ref for recursion, fix it up
+            // with the name recursively bound so that it's available in
+            // the function body.
+            if let Some(placeholder_env_ref) = placeholder_env_ref {
+                closure = exec_state.mut_stack().add_recursive_closure(
+                    fn_name.name.to_owned(),
+                    closure,
+                    placeholder_env_ref,
+                    metadata.source_range,
+                )?;
+            } else {
+                // Regular non-recursive binding.
+                exec_state
+                    .mut_stack()
+                    .add(fn_name.name.clone(), closure.clone(), metadata.source_range)?;
+            }
+        }
+
+        Ok(closure)
     }
 }
 
@@ -3227,7 +3295,19 @@ impl Node<MemberExpression> {
             .execute_expr(&self.object, exec_state, &object_meta, &[], StatementKind::Expression)
             .await?;
         let object = control_continue!(object_cf);
+        self.apply_member(object, property, exec_state, ctx).await
+    }
 
+    /// Apply property access or indexing to an already-evaluated object: the
+    /// evaluation-free second half of member-expression execution, shared by
+    /// both executors.
+    pub(super) async fn apply_member(
+        &self,
+        object: KclValue,
+        property: Property,
+        exec_state: &mut ExecState,
+        ctx: &ExecutorContext,
+    ) -> Result<KclValueControlFlow, KclError> {
         // Result values of the member access itself carry the whole
         // expression's metadata.
         let meta = Metadata {
@@ -4279,7 +4359,7 @@ impl Node<BinaryExpression> {
             .ok_or_else(|| Self::missing_result_error(self))
     }
 
-    async fn apply_operator(
+    pub(super) async fn apply_operator(
         &self,
         exec_state: &mut ExecState,
         ctx: &ExecutorContext,
@@ -6123,10 +6203,16 @@ impl Node<UnaryExpression> {
         exec_state: &mut ExecState,
         ctx: &ExecutorContext,
     ) -> Result<KclValueControlFlow, KclError> {
+        let value = self.argument.get_result(exec_state, ctx).await?;
+        let value = control_continue!(value);
+        self.apply_unary(value, exec_state).map(KclValue::continue_)
+    }
+
+    /// Apply the unary operator to an already-evaluated operand. Shared by
+    /// both executors.
+    pub(super) fn apply_unary(&self, value: KclValue, exec_state: &mut ExecState) -> Result<KclValue, KclError> {
         match self.operator {
             UnaryOperator::Not => {
-                let value = self.argument.get_result(exec_state, ctx).await?;
-                let value = control_continue!(value);
                 let KclValue::Bool {
                     value: bool_value,
                     meta: _,
@@ -6148,11 +6234,9 @@ impl Node<UnaryExpression> {
                     meta,
                 };
 
-                Ok(negated.continue_())
+                Ok(negated)
             }
             UnaryOperator::Neg => {
-                let value = self.argument.get_result(exec_state, ctx).await?;
-                let value = control_continue!(value);
                 let err = || {
                     KclError::new_semantic(KclErrorDetails::new(
                         format!(
@@ -6171,8 +6255,7 @@ impl Node<UnaryExpression> {
                             value: -value,
                             meta,
                             ty: *ty,
-                        }
-                        .continue_())
+                        })
                     }
                     KclValue::Plane { value } => {
                         let mut plane = value.clone();
@@ -6190,7 +6273,7 @@ impl Node<UnaryExpression> {
 
                         plane.id = exec_state.next_uuid();
                         plane.object_id = None;
-                        Ok(KclValue::Plane { value: plane }.continue_())
+                        Ok(KclValue::Plane { value: plane })
                     }
                     KclValue::Object {
                         value: values, meta, ..
@@ -6250,26 +6333,21 @@ impl Node<UnaryExpression> {
                             meta: meta.clone(),
                             constrainable: false,
                             object_kind: KclObjectKind::Default,
-                        }
-                        .continue_())
+                        })
                     }
                     _ => Err(err()),
                 }
             }
-            UnaryOperator::Plus => {
-                let operand = self.argument.get_result(exec_state, ctx).await?;
-                let operand = control_continue!(operand);
-                match operand {
-                    KclValue::Number { .. } | KclValue::Plane { .. } => Ok(operand.continue_()),
-                    _ => Err(KclError::new_semantic(KclErrorDetails::new(
-                        format!(
-                            "You can only apply unary + to numbers or planes, but this is a {}",
-                            operand.human_friendly_type()
-                        ),
-                        vec![self.into()],
-                    ))),
-                }
-            }
+            UnaryOperator::Plus => match value {
+                KclValue::Number { .. } | KclValue::Plane { .. } => Ok(value),
+                _ => Err(KclError::new_semantic(KclErrorDetails::new(
+                    format!(
+                        "You can only apply unary + to numbers or planes, but this is a {}",
+                        value.human_friendly_type()
+                    ),
+                    vec![self.into()],
+                ))),
+            },
         }
     }
 }
@@ -6575,7 +6653,7 @@ impl Node<IfExpression> {
 }
 
 #[derive(Debug)]
-enum Property {
+pub(super) enum Property {
     UInt(usize),
     String(String),
 }
@@ -6612,6 +6690,13 @@ impl Property {
         // If the property expression exited, e.g. by calling exit(), propagate
         // the exit so that it terminates the enclosing module.
         let prop_value = early_return!(prop_value);
+        Ok(Self::from_value(prop_value, sr)?)
+    }
+
+    /// Convert an already-evaluated computed-property value (the expression
+    /// inside array brackets) into a Property. Shared by both executors.
+    pub(super) fn from_value(prop_value: KclValue, sr: SourceRange) -> Result<Self, KclError> {
+        let property_sr = vec![sr];
         match prop_value {
             KclValue::Number { value, ty, meta: _ } => {
                 if !matches!(
@@ -6625,8 +6710,7 @@ impl Property {
                             "{value} is not a valid index, indices must be non-dimensional numbers. If you're sure this is correct, you can add `: number(Count)` to tell KCL this number is an index"
                         ),
                         property_sr,
-                    ))
-                    .into());
+                    )));
                 }
                 if let Some(x) = crate::try_f64_to_usize(value) {
                     Ok(Property::UInt(x))
@@ -6634,15 +6718,13 @@ impl Property {
                     Err(KclError::new_semantic(KclErrorDetails::new(
                         format!("{value} is not a valid index, indices must be whole numbers >= 0"),
                         property_sr,
-                    ))
-                    .into())
+                    )))
                 }
             }
             _ => Err(KclError::new_semantic(KclErrorDetails::new(
                 "Only numbers (>= 0) can be indexes".to_owned(),
                 vec![sr],
-            ))
-            .into()),
+            ))),
         }
     }
 }

--- a/rust/kcl-lib/src/execution/fn_call.rs
+++ b/rust/kcl-lib/src/execution/fn_call.rs
@@ -2418,6 +2418,8 @@ plane = startSketchOn(XY)
             settings: Default::default(),
             context_type: ContextType::Mock,
             execution_callbacks: Default::default(),
+            executor_kind: Default::default(),
+            machine_call_depth_limit: crate::execution::machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
         };
         let mut exec_state = ExecState::new(&exec_ctxt);
         exec_state.set_deprecation_version_override(Some("2.0"));

--- a/rust/kcl-lib/src/execution/fn_call.rs
+++ b/rust/kcl-lib/src/execution/fn_call.rs
@@ -304,6 +304,39 @@ impl FunctionSource {
         args: Args<Sugary>,
         callsite: SourceRange,
     ) -> Result<Option<KclValueControlFlow>, KclError> {
+        let (state, args) = self.call_setup(&fn_name, exec_state, args, callsite)?;
+        // Do not early return via ? or something until we've called
+        // call_finish (or call_abort_on_arg_binding_failure), so that the
+        // ambient flags are restored and the callee env is popped.
+        let result = match &self.body {
+            FunctionBody::Rust(f) => f(exec_state, args).await.map(Some),
+            FunctionBody::Kcl(_) => {
+                if let Err(e) = assign_args_to_params_kw(self, args, exec_state) {
+                    return Err(Self::call_abort_on_arg_binding_failure(state, e, exec_state));
+                }
+
+                let block_result = ctx.exec_block(&self.ast.body, exec_state, BodyType::Block).await;
+                self.kcl_body_result(block_result, exec_state)
+            }
+        };
+        self.call_finish(state, result, exec_state)
+    }
+
+    /// The first half of a function call: warnings, argument type checking,
+    /// operation setup, pushing the callee environment, and stdlib
+    /// ambient-flag tracking. After this succeeds, the callee environment is
+    /// pushed and the ambient flags are set, so every path must reach
+    /// [`Self::call_finish`] (or [`Self::call_abort_on_arg_binding_failure`])
+    /// to balance them. The recursive executor keeps the returned [`CallState`]
+    /// across the body await; the machine executor parks it in a call-boundary
+    /// continuation.
+    pub(super) fn call_setup(
+        &self,
+        fn_name: &Option<String>,
+        exec_state: &mut ExecState,
+        args: Args<Sugary>,
+        callsite: SourceRange,
+    ) -> Result<(CallState, Args), KclError> {
         // The KCL stdlib is allowed to use deprecated sketch1 functions inside.
         let warn_on_deprecated_usage = !exec_state.mod_local.inside_stdlib;
         if warn_on_deprecated_usage {
@@ -481,36 +514,89 @@ impl FunctionSource {
             &mut exec_state.mod_local.stdlib_entry_source_range,
             stdlib_entry_source_range,
         );
-        // Do not early return via ? or something until we've
-        // - put this `prev_inside_stdlib` value back.
-        // - called the pop_env.
-        let result = match &self.body {
-            FunctionBody::Rust(f) => f(exec_state, args).await.map(Some),
-            FunctionBody::Kcl(_) => {
-                if let Err(e) = assign_args_to_params_kw(self, args, exec_state) {
-                    exec_state.mod_local.inside_stdlib = prev_inside_stdlib;
-                    exec_state.mut_stack().pop_env()?;
-                    return Err(e);
-                }
 
-                ctx.exec_block(&self.ast.body, exec_state, BodyType::Block)
-                    .await
-                    .map(|cf| {
-                        if let Some(cf) = cf
-                            && cf.is_some_return()
-                        {
-                            return Some(cf);
-                        }
-                        // Ignore the block's value and extract the return value
-                        // from memory.
-                        exec_state
-                            .stack()
-                            .get(memory::RETURN_NAME, self.ast.as_source_range())
-                            .ok()
-                            .map(KclValue::continue_)
-                    })
+        Ok((
+            CallState {
+                prev_inside_stdlib,
+                prev_stdlib_entry_source_range,
+                op,
+                should_track_operation,
+                is_calling_into_stdlib,
+                face_tag_names,
+            },
+            args,
+        ))
+    }
+
+    /// Compute a KCL function body's result while the callee environment is
+    /// still pushed: an `Exit` passes through untouched; otherwise the
+    /// function's result is the `__return` value recorded in the callee
+    /// environment, if any.
+    ///
+    /// NOTE: a `return` statement does NOT stop the body -- it records
+    /// `__return` and execution continues to the following statements (see
+    /// exec_block's ReturnStatement arm). The block's own trailing value is
+    /// deliberately ignored here; only `__return` counts.
+    pub(super) fn kcl_body_result(
+        &self,
+        block_result: Result<Option<KclValueControlFlow>, KclError>,
+        exec_state: &mut ExecState,
+    ) -> Result<Option<KclValueControlFlow>, KclError> {
+        block_result.map(|cf| {
+            if let Some(cf) = cf
+                && cf.is_some_return()
+            {
+                return Some(cf);
             }
-        };
+            // Ignore the block's value and extract the return value
+            // from memory.
+            exec_state
+                .stack()
+                .get(memory::RETURN_NAME, self.ast.as_source_range())
+                .ok()
+                .map(KclValue::continue_)
+        })
+    }
+
+    /// The failure path when binding a KCL function's arguments fails, before
+    /// the body ran: restore `inside_stdlib` and pop the callee environment.
+    /// Deliberately asymmetric with [`Self::call_finish`] -- it does not
+    /// restore `stdlib_entry_source_range` and does not finalize the
+    /// operation -- preserving the recursive executor's historical behavior
+    /// exactly.
+    pub(super) fn call_abort_on_arg_binding_failure(
+        state: CallState,
+        e: KclError,
+        exec_state: &mut ExecState,
+    ) -> KclError {
+        exec_state.mod_local.inside_stdlib = state.prev_inside_stdlib;
+        match exec_state.mut_stack().pop_env() {
+            Ok(_) => e,
+            Err(pop_err) => pop_err,
+        }
+    }
+
+    /// The second half of a function call: restore the ambient stdlib flags,
+    /// pop the callee environment, finalize the operation, and then -- for
+    /// normal completions only -- apply tag updates and return-type coercion.
+    /// `Exit` control flow bypasses tags and coercion (it terminates the whole
+    /// evaluation rather than completing this function normally), and errors
+    /// skip them too; both still restore ambient state and finalize the
+    /// operation.
+    pub(super) fn call_finish(
+        &self,
+        state: CallState,
+        result: Result<Option<KclValueControlFlow>, KclError>,
+        exec_state: &mut ExecState,
+    ) -> Result<Option<KclValueControlFlow>, KclError> {
+        let CallState {
+            prev_inside_stdlib,
+            prev_stdlib_entry_source_range,
+            op,
+            should_track_operation,
+            is_calling_into_stdlib,
+            face_tag_names,
+        } = state;
         exec_state.mod_local.inside_stdlib = prev_inside_stdlib;
         exec_state.mod_local.stdlib_entry_source_range = prev_stdlib_entry_source_range;
         exec_state.mut_stack().pop_env()?;
@@ -561,6 +647,20 @@ impl FunctionSource {
 
         coerce_result_type(result, self, exec_state).map(|r| r.map(KclValue::continue_))
     }
+}
+
+/// State captured by [`FunctionSource::call_setup`] that
+/// [`FunctionSource::call_finish`] needs to complete the call: the ambient
+/// flags to restore, the deferred operation, and details of what was called.
+#[derive(Debug)]
+pub(super) struct CallState {
+    prev_inside_stdlib: bool,
+    prev_stdlib_entry_source_range: Option<SourceRange>,
+    /// Deferred stdlib-call operation, pushed by call_finish.
+    op: Option<Operation>,
+    should_track_operation: bool,
+    is_calling_into_stdlib: bool,
+    face_tag_names: Vec<String>,
 }
 
 impl FunctionBody {

--- a/rust/kcl-lib/src/execution/fn_call.rs
+++ b/rust/kcl-lib/src/execution/fn_call.rs
@@ -1481,7 +1481,7 @@ mod test {
                 digest: None,
             });
             let func_src = FunctionSource::kcl(
-                Box::new(func_expr),
+                crate::parsing::ast::types::BoxNode::new(func_expr),
                 EnvironmentRef::dummy(),
                 crate::execution::kcl_value::KclFunctionSourceParams {
                     std_props: None,

--- a/rust/kcl-lib/src/execution/fn_call.rs
+++ b/rust/kcl-lib/src/execution/fn_call.rs
@@ -1286,7 +1286,7 @@ fn type_check_params_kw(
     Ok(result)
 }
 
-fn assign_args_to_params_kw(
+pub(super) fn assign_args_to_params_kw(
     fn_def: &FunctionSource,
     args: Args<Desugared>,
     exec_state: &mut ExecState,
@@ -1607,6 +1607,8 @@ mod test {
                 settings: Default::default(),
                 context_type: ContextType::Mock,
                 execution_callbacks: Default::default(),
+                executor_kind: Default::default(),
+                machine_call_depth_limit: crate::execution::machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
             };
             let mut exec_state = ExecState::new(&exec_ctxt);
             exec_state.mod_local.stack = Stack::new_for_tests();

--- a/rust/kcl-lib/src/execution/fn_call.rs
+++ b/rust/kcl-lib/src/execution/fn_call.rs
@@ -1607,7 +1607,7 @@ mod test {
                 settings: Default::default(),
                 context_type: ContextType::Mock,
                 execution_callbacks: Default::default(),
-                executor_kind: Default::default(),
+                executor_kind: crate::execution::machine::ExecutorKind::from_env(),
                 machine_call_depth_limit: crate::execution::machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
             };
             let mut exec_state = ExecState::new(&exec_ctxt);
@@ -2418,7 +2418,7 @@ plane = startSketchOn(XY)
             settings: Default::default(),
             context_type: ContextType::Mock,
             execution_callbacks: Default::default(),
-            executor_kind: Default::default(),
+            executor_kind: crate::execution::machine::ExecutorKind::from_env(),
             machine_call_depth_limit: crate::execution::machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
         };
         let mut exec_state = ExecState::new(&exec_ctxt);

--- a/rust/kcl-lib/src/execution/fn_call.rs
+++ b/rust/kcl-lib/src/execution/fn_call.rs
@@ -36,6 +36,7 @@ use crate::parsing::ast::types::Type;
 use crate::std::ConsumedSolidArgCheck;
 use crate::std::RegionBehavior;
 use crate::std::StaleRegionPolicy;
+use crate::std::region_consumption::PendingRegionConsumption;
 use crate::std::region_consumption::prepare_region_consumption;
 use crate::std::region_consumption::record_consumed_regions;
 use crate::std::region_consumption::validate_region_args_not_consumed;
@@ -523,6 +524,7 @@ impl FunctionSource {
                 should_track_operation,
                 is_calling_into_stdlib,
                 face_tag_names,
+                pending_region_consumption,
             },
             args,
         ))
@@ -596,6 +598,7 @@ impl FunctionSource {
             should_track_operation,
             is_calling_into_stdlib,
             face_tag_names,
+            pending_region_consumption,
         } = state;
         exec_state.mod_local.inside_stdlib = prev_inside_stdlib;
         exec_state.mod_local.stdlib_entry_source_range = prev_stdlib_entry_source_range;
@@ -661,6 +664,7 @@ pub(super) struct CallState {
     should_track_operation: bool,
     is_calling_into_stdlib: bool,
     face_tag_names: Vec<String>,
+    pending_region_consumption: Option<PendingRegionConsumption>,
 }
 
 impl FunctionBody {

--- a/rust/kcl-lib/src/execution/freedom_analysis_tests.rs
+++ b/rust/kcl-lib/src/execution/freedom_analysis_tests.rs
@@ -19,6 +19,8 @@ async fn run_with_freedom_analysis(kcl: &str) -> Vec<(ObjectId, Freedom)> {
         settings: ExecutorSettings::default(),
         context_type: ContextType::Mock,
         execution_callbacks: Default::default(),
+        executor_kind: Default::default(),
+        machine_call_depth_limit: crate::execution::machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
     };
 
     let mock_config = MockConfig {

--- a/rust/kcl-lib/src/execution/kcl_value.rs
+++ b/rust/kcl-lib/src/execution/kcl_value.rs
@@ -254,7 +254,7 @@ pub struct KclFunctionSourceParams {
 impl FunctionSource {
     pub fn rust(
         func: crate::std::StdFn,
-        ast: Box<Node<FunctionExpression>>,
+        ast: crate::parsing::ast::types::BoxNode<FunctionExpression>,
         props: StdFnProps,
         attrs: FnAttrs,
     ) -> Self {
@@ -276,7 +276,11 @@ impl FunctionSource {
         }
     }
 
-    pub fn kcl(ast: Box<Node<FunctionExpression>>, memory: EnvironmentRef, params: KclFunctionSourceParams) -> Self {
+    pub fn kcl(
+        ast: crate::parsing::ast::types::BoxNode<FunctionExpression>,
+        memory: EnvironmentRef,
+        params: KclFunctionSourceParams,
+    ) -> Self {
         let KclFunctionSourceParams {
             std_props,
             experimental,

--- a/rust/kcl-lib/src/execution/kcl_value.rs
+++ b/rust/kcl-lib/src/execution/kcl_value.rs
@@ -43,6 +43,7 @@ use crate::execution::types::NumericType;
 use crate::execution::types::NumericTypeExt;
 use crate::execution::types::PrimitiveType;
 use crate::execution::types::RuntimeType;
+use crate::parsing::ast::types::BoxNode;
 use crate::parsing::ast::types::DefaultParamVal;
 use crate::parsing::ast::types::FunctionExpression;
 use crate::parsing::ast::types::KclNone;
@@ -141,7 +142,7 @@ pub enum KclValue {
         meta: Vec<Metadata>,
     },
     TagIdentifier(Box<TagIdentifier>),
-    TagDeclarator(crate::parsing::ast::types::BoxNode<TagDeclarator>),
+    TagDeclarator(BoxNode<TagDeclarator>),
     GdtAnnotation {
         value: Box<GdtAnnotation>,
     },
@@ -242,7 +243,7 @@ pub struct FunctionSource {
     pub include_in_feature_tree: bool,
     pub std_props: Option<StdFnProps>,
     pub body: FunctionBody,
-    pub ast: crate::parsing::ast::types::BoxNode<FunctionExpression>,
+    pub ast: BoxNode<FunctionExpression>,
 }
 
 pub struct KclFunctionSourceParams {
@@ -252,12 +253,7 @@ pub struct KclFunctionSourceParams {
 }
 
 impl FunctionSource {
-    pub fn rust(
-        func: crate::std::StdFn,
-        ast: crate::parsing::ast::types::BoxNode<FunctionExpression>,
-        props: StdFnProps,
-        attrs: FnAttrs,
-    ) -> Self {
+    pub fn rust(func: crate::std::StdFn, ast: BoxNode<FunctionExpression>, props: StdFnProps, attrs: FnAttrs) -> Self {
         let (input_arg, named_args) = Self::args_from_ast(&ast);
 
         FunctionSource {
@@ -276,11 +272,7 @@ impl FunctionSource {
         }
     }
 
-    pub fn kcl(
-        ast: crate::parsing::ast::types::BoxNode<FunctionExpression>,
-        memory: EnvironmentRef,
-        params: KclFunctionSourceParams,
-    ) -> Self {
+    pub fn kcl(ast: BoxNode<FunctionExpression>, memory: EnvironmentRef, params: KclFunctionSourceParams) -> Self {
         let KclFunctionSourceParams {
             std_props,
             experimental,

--- a/rust/kcl-lib/src/execution/machine.rs
+++ b/rust/kcl-lib/src/execution/machine.rs
@@ -386,6 +386,59 @@ enum Kont {
     // ---- sketch blocks ----
     SketchArgs(Box<SketchArgsState>),
     SketchBody(Box<SketchBodyState>),
+
+    // ---- resumable higher-order builtins ----
+    /// The reified native-loop state of map/reduce/patternTransform: their
+    /// callbacks run on THIS stack, so arbitrarily deep callback nesting
+    /// cannot overflow the native stack.
+    Resume(Box<ResumeState>),
+}
+
+/// Which resumable builtin is mid-iteration, with its loop state.
+#[derive(Debug)]
+enum ResumeState {
+    Map(MapResume),
+    Reduce(ReduceResume),
+    PatternTransform(PatternTransformResume),
+}
+
+#[derive(Debug)]
+struct MapResume {
+    f: FunctionSource,
+    rest: std::vec::IntoIter<KclValue>,
+    done: Vec<KclValue>,
+    source_range: SourceRange,
+    node_path: Option<crate::NodePath>,
+}
+
+#[derive(Debug)]
+struct ReduceResume {
+    f: FunctionSource,
+    rest: std::vec::IntoIter<KclValue>,
+    source_range: SourceRange,
+    node_path: Option<crate::NodePath>,
+}
+
+#[derive(Debug)]
+struct PatternTransformResume {
+    transform: FunctionSource,
+    instances: u32,
+    /// The repetition to run next; make_transform iterates 1..instances.
+    next_i: u32,
+    transforms: Vec<Vec<kittycad_modeling_cmds::shared::Transform>>,
+    geometry: PatternGeometry,
+    use_original: bool,
+    source_range: SourceRange,
+    node_path: Option<crate::NodePath>,
+    /// The builtin's own (desugared) arguments; the final engine application
+    /// reads its metadata exactly like the recursive executor does.
+    args: Args,
+}
+
+#[derive(Debug)]
+enum PatternGeometry {
+    Solids(Vec<crate::execution::Solid>),
+    Sketches(Vec<crate::execution::Sketch>),
 }
 
 /// Argument-evaluation state for a call: mirrors the argument loop of
@@ -410,7 +463,34 @@ struct BoundaryState {
     fn_src: FunctionSource,
     fn_name: Option<String>,
     callsite: SourceRange,
-    fn_meta: Vec<Metadata>,
+    /// What kind of raw result this boundary receives.
+    expects: BoundaryExpects,
+    /// Who initiated the call, which decides what happens to the finished
+    /// result (and whether errors get a backtrace entry).
+    completion: BoundaryCompletion,
+}
+
+/// The raw result shape a call boundary receives.
+#[derive(Debug)]
+enum BoundaryExpects {
+    /// A KCL function body ran: the block result arrives and the function's
+    /// value is the recorded __return.
+    KclBlock,
+    /// A resumable builtin's iteration produced the value directly.
+    StdValue,
+}
+
+/// Who initiated a call.
+#[derive(Debug)]
+enum BoundaryCompletion {
+    /// A call expression: a missing result is the "undefined function
+    /// result" error, and unwinding errors gain a backtrace entry.
+    CallExpr { fn_meta: Vec<Metadata> },
+    /// A callback invoked by a resumable builtin (map/reduce/
+    /// patternTransform): the finished result feeds the builtin's resume
+    /// continuation, and -- like the recursive executor's call_kw callers --
+    /// errors get no extra backtrace entry.
+    Callback,
 }
 
 /// Argument-evaluation state for a sketch block (non-sketch-mode).
@@ -463,11 +543,51 @@ pub(super) async fn run_block(
         in_flight: InFlight::None,
         last: None,
     };
-    let mut control = match step_block(root, None, &mut konts, exec_state, ctx).await {
+    let control = match step_block(root, None, &mut konts, exec_state, ctx).await {
         Ok(c) => c,
         Err(e) => return Err(unwind_error(e, &mut konts, exec_state)),
     };
+    match run_loop(ctx, control, konts, exec_state).await? {
+        RootResult::Done(applied) => applied.expect_block(),
+        RootResult::Exited(cf) => Ok(Some(cf)),
+    }
+}
 
+/// Run a single expression to completion on a fresh machine root. Used for
+/// bounded, internal evaluations (e.g. GD&T's constant `XY` plane lookup).
+pub(crate) async fn run_expr(
+    ctx: &ExecutorContext,
+    expr: &Expr,
+    exec_state: &mut ExecState,
+    metadata: &Metadata,
+) -> Result<KclValueControlFlow, KclError> {
+    let req = EvalRequest {
+        node: EvalNode::Expr(expr.clone()),
+        metadata: *metadata,
+        decl_name: None,
+        annotations: Vec::new(),
+    };
+    match run_loop(ctx, Control::Eval(Box::new(req)), Vec::new(), exec_state).await? {
+        RootResult::Done(applied) => Ok(applied.expect_value()?.continue_()),
+        RootResult::Exited(cf) => Ok(cf),
+    }
+}
+
+/// How a fresh root ended.
+enum RootResult {
+    /// The root computation finished with this result.
+    Done(Applied),
+    /// An exit() unwound all the way out (cleanups already ran).
+    Exited(KclValueControlFlow),
+}
+
+/// The machine loop: step until the continuation stack is exhausted.
+async fn run_loop(
+    ctx: &ExecutorContext,
+    mut control: Control,
+    mut konts: Vec<Kont>,
+    exec_state: &mut ExecState,
+) -> Result<RootResult, KclError> {
     loop {
         control = match control {
             Control::Eval(req) => match step_eval(*req, &mut konts, exec_state, ctx).await {
@@ -476,9 +596,7 @@ pub(super) async fn run_block(
             },
             Control::Apply(applied) => match konts.pop() {
                 None => {
-                    // The fresh root is done; the root BlockSeq's result is the
-                    // block result.
-                    return applied.expect_block();
+                    return Ok(RootResult::Done(applied));
                 }
                 Some(kont) => match step_apply(kont, applied, &mut konts, exec_state, ctx).await {
                     Ok(c) => c,
@@ -487,7 +605,7 @@ pub(super) async fn run_block(
             },
             Control::Exit(cf) => {
                 let cf = unwind_exit(cf, &mut konts, exec_state)?;
-                return Ok(Some(cf));
+                return Ok(RootResult::Exited(cf));
             }
         };
     }
@@ -519,11 +637,11 @@ fn unwind_exit(
                     }
                     Err(e) => {
                         // pop_env failed; propagate through the error unwind.
-                        return Err(unwind_error(
-                            e.add_unwind_location(b.fn_name.clone(), b.callsite),
-                            konts,
-                            exec_state,
-                        ));
+                        let e = match &b.completion {
+                            BoundaryCompletion::CallExpr { .. } => e.add_unwind_location(b.fn_name.clone(), b.callsite),
+                            BoundaryCompletion::Callback => e,
+                        };
+                        return Err(unwind_error(e, konts, exec_state));
                     }
                 }
             }
@@ -553,7 +671,15 @@ fn unwind_error(mut e: KclError, konts: &mut Vec<Kont>, exec_state: &mut ExecSta
                 exec_state.mod_local.machine_call_depth = exec_state.mod_local.machine_call_depth.saturating_sub(1);
                 match b.fn_src.call_finish(b.state, Err(e), exec_state) {
                     Err(finished) => {
-                        e = finished.add_unwind_location(b.fn_name.clone(), b.callsite);
+                        // Callback boundaries get no backtrace entry, matching
+                        // the recursive executor (call_kw callers do not call
+                        // add_unwind_location).
+                        e = match &b.completion {
+                            BoundaryCompletion::CallExpr { .. } => {
+                                finished.add_unwind_location(b.fn_name.clone(), b.callsite)
+                            }
+                            BoundaryCompletion::Callback => finished,
+                        };
                     }
                     Ok(_) => {
                         e = KclError::new_internal(KclErrorDetails::new(
@@ -603,7 +729,11 @@ fn cleanup(kont: Kont, exec_state: &mut ExecState) {
         | Kont::LabelDone { .. }
         | Kont::PipeFirstDone { .. }
         | Kont::CallArgs(_)
-        | Kont::SketchArgs(_) => {}
+        | Kont::SketchArgs(_)
+        // Resumable-builtin loop state holds no ambient state: on unwind it
+        // is simply dropped, which is how exit() and errors inside callbacks
+        // abandon the rest of the iteration.
+        | Kont::Resume(_) => {}
         // Handled by the unwind loops directly.
         Kont::CallBoundary(_) | Kont::SketchBody(_) => unreachable!("boundaries are handled by the unwind loops"),
     }
@@ -1041,25 +1171,50 @@ async fn step_apply(
 
         Kont::CallArgs(state) => call_args_step(*state, applied, konts, exec_state, ctx).await,
         Kont::CallBoundary(boundary) => {
-            let block_result = applied.expect_block()?;
             exec_state.mod_local.machine_call_depth = exec_state.mod_local.machine_call_depth.saturating_sub(1);
             let BoundaryState {
                 state,
                 fn_src,
                 fn_name,
                 callsite,
-                fn_meta,
+                expects,
+                completion,
             } = *boundary;
-            // Read __return from the callee env (still pushed), then finish.
-            let result = fn_src.kcl_body_result(Ok(block_result), exec_state);
-            let finished = fn_src
-                .call_finish(state, result, exec_state)
-                .map_err(|e| e.add_unwind_location(fn_name.clone(), callsite))?;
-            finish_call_value(finished, fn_name, callsite, fn_meta)
+            let result = match expects {
+                BoundaryExpects::KclBlock => {
+                    // Read __return from the callee env (still pushed).
+                    let block_result = applied.expect_block()?;
+                    fn_src.kcl_body_result(Ok(block_result), exec_state)
+                }
+                BoundaryExpects::StdValue => {
+                    let value = applied.expect_value()?;
+                    Ok(Some(value.continue_()))
+                }
+            };
+            match completion {
+                BoundaryCompletion::CallExpr { fn_meta } => {
+                    let finished = fn_src
+                        .call_finish(state, result, exec_state)
+                        .map_err(|e| e.add_unwind_location(fn_name.clone(), callsite))?;
+                    finish_call_value(finished, fn_name, callsite, fn_meta)
+                }
+                BoundaryCompletion::Callback => {
+                    let finished = fn_src.call_finish(state, result, exec_state)?;
+                    match finished {
+                        Some(cf) if cf.is_some_return() => Ok(Control::Exit(cf)),
+                        Some(cf) => resume_drive(Feed::Callback(Some(cf.into_value())), konts, exec_state, ctx).await,
+                        None => resume_drive(Feed::Callback(None), konts, exec_state, ctx).await,
+                    }
+                }
+            }
         }
 
         Kont::SketchArgs(state) => sketch_args_step(*state, applied, konts, exec_state, ctx).await,
         Kont::SketchBody(state) => sketch_body_finish(*state, applied, exec_state, ctx).await,
+        Kont::Resume(_) => Err(KclError::new_internal(KclErrorDetails::new(
+            "machine executor: a value applied directly to resumable-builtin loop state".to_owned(),
+            Vec::new(),
+        ))),
     }
 }
 
@@ -1424,9 +1579,7 @@ async fn call_args_step(
     }
 }
 
-/// All arguments evaluated: build `Args`, run call setup, and either await a
-/// Rust builtin inline (a flat leaf) or push a call boundary plus the KCL
-/// function body (no native recursion).
+/// All arguments evaluated: build `Args` and run the call.
 async fn dispatch_call(
     state: CallArgsState,
     konts: &mut Vec<Kont>,
@@ -1456,6 +1609,51 @@ async fn dispatch_call(
         fn_name.clone(),
     );
 
+    match machine_call(
+        fn_src,
+        fn_display_name,
+        callsite,
+        args,
+        BoundaryCompletion::CallExpr { fn_meta },
+        konts,
+        exec_state,
+        ctx,
+    )
+    .await?
+    {
+        MachineCallOutcome::Control(control) => Ok(control),
+        MachineCallOutcome::LeafCallbackDone(_) => Err(KclError::new_internal(KclErrorDetails::new(
+            "machine executor: call expression produced a callback result".to_owned(),
+            vec![callsite],
+        ))),
+    }
+}
+
+/// What a machine call produced immediately.
+enum MachineCallOutcome {
+    /// Continue the machine with this control.
+    Control(Control),
+    /// A leaf builtin invoked as a callback completed synchronously; the
+    /// caller's feed loop hands this to the resume continuation (kept out of
+    /// the return path so runs of leaf callbacks use constant native stack).
+    LeafCallbackDone(Option<KclValue>),
+}
+
+/// Run a call on the machine: setup, then a flat leaf await (plain Rust
+/// builtins), a resumable-builtin entry (map/reduce/patternTransform), or a
+/// call boundary plus the KCL function body (no native recursion). Shared by
+/// call expressions and resumable-builtin callbacks.
+#[allow(clippy::too_many_arguments)]
+async fn machine_call(
+    fn_src: FunctionSource,
+    fn_name: Option<String>,
+    callsite: SourceRange,
+    args: Args<crate::execution::fn_call::Sugary>,
+    completion: BoundaryCompletion,
+    konts: &mut Vec<Kont>,
+    exec_state: &mut ExecState,
+    ctx: &ExecutorContext,
+) -> Result<MachineCallOutcome, KclError> {
     // Guard against runaway recursion: machine-native calls do not grow the
     // native stack, so this is policy, not a native-stack limit. It must
     // behave when raised to 50,000 or more.
@@ -1468,42 +1666,374 @@ async fn dispatch_call(
             vec![callsite],
         )));
     }
+    let decorate = |e: KclError, completion: &BoundaryCompletion| match completion {
+        BoundaryCompletion::CallExpr { .. } => e.add_unwind_location(fn_name.clone(), callsite),
+        BoundaryCompletion::Callback => e,
+    };
+
+    let resumable = match &fn_src.body {
+        FunctionBody::Rust(_) => fn_src.std_props.as_ref().and_then(|p| p.resumable),
+        FunctionBody::Kcl(_) => None,
+    };
+    if let Some(kind) = resumable {
+        let (call_state, args) = match fn_src.call_setup(&fn_name, exec_state, args, callsite) {
+            Ok(x) => x,
+            Err(e) => return Err(decorate(e, &completion)),
+        };
+        exec_state.mod_local.machine_call_depth += 1;
+        konts.push(Kont::CallBoundary(Box::new(BoundaryState {
+            state: call_state,
+            fn_src: fn_src.clone(),
+            fn_name,
+            callsite,
+            expects: BoundaryExpects::StdValue,
+            completion,
+        })));
+        // Parse errors after this point unwind through the boundary just
+        // pushed, finalizing the operation with is_error = true -- exactly
+        // like an error inside the recursive builtin's body.
+        return resumable_entry(kind, args, konts, exec_state, ctx)
+            .await
+            .map(MachineCallOutcome::Control);
+    }
 
     match &fn_src.body {
         FunctionBody::Rust(f) => {
-            // A flat leaf: setup, await the builtin, finish. Higher-order
-            // builtins (map/reduce/patternTransform) re-enter KCL through
-            // call_kw, which fresh-roots a machine run per callback until the
-            // resumable-callback phase lands.
-            let (call_state, args) = fn_src
-                .call_setup(&fn_display_name, exec_state, args, callsite)
-                .map_err(|e| e.add_unwind_location(fn_name.clone(), callsite))?;
+            // A flat leaf: setup, await the builtin, finish.
+            let f = *f;
+            let (call_state, args) = match fn_src.call_setup(&fn_name, exec_state, args, callsite) {
+                Ok(x) => x,
+                Err(e) => return Err(decorate(e, &completion)),
+            };
             let result = f(exec_state, args).await.map(Some);
-            let finished = fn_src
-                .call_finish(call_state, result, exec_state)
-                .map_err(|e| e.add_unwind_location(fn_name.clone(), callsite))?;
-            finish_call_value(finished, fn_display_name, callsite, fn_meta)
+            let finished = match fn_src.call_finish(call_state, result, exec_state) {
+                Ok(x) => x,
+                Err(e) => return Err(decorate(e, &completion)),
+            };
+            match completion {
+                BoundaryCompletion::CallExpr { fn_meta } => {
+                    finish_call_value(finished, fn_name, callsite, fn_meta).map(MachineCallOutcome::Control)
+                }
+                BoundaryCompletion::Callback => match finished {
+                    Some(cf) if cf.is_some_return() => Ok(MachineCallOutcome::Control(Control::Exit(cf))),
+                    Some(cf) => Ok(MachineCallOutcome::LeafCallbackDone(Some(cf.into_value()))),
+                    None => Ok(MachineCallOutcome::LeafCallbackDone(None)),
+                },
+            }
         }
         FunctionBody::Kcl(_) => {
-            let (call_state, args) = fn_src
-                .call_setup(&fn_display_name, exec_state, args, callsite)
-                .map_err(|e| e.add_unwind_location(fn_name.clone(), callsite))?;
+            let (call_state, args) = match fn_src.call_setup(&fn_name, exec_state, args, callsite) {
+                Ok(x) => x,
+                Err(e) => return Err(decorate(e, &completion)),
+            };
             if let Err(e) = crate::execution::fn_call::assign_args_to_params_kw(&fn_src, args, exec_state) {
                 let e = FunctionSource::call_abort_on_arg_binding_failure(call_state, e, exec_state);
-                return Err(e.add_unwind_location(fn_name.clone(), callsite));
+                return Err(decorate(e, &completion));
             }
             exec_state.mod_local.machine_call_depth += 1;
             let body = BlockRef::FnBody(fn_src.ast.arc());
             konts.push(Kont::CallBoundary(Box::new(BoundaryState {
                 state: call_state,
                 fn_src,
-                fn_name: fn_display_name,
+                fn_name,
                 callsite,
-                fn_meta,
+                expects: BoundaryExpects::KclBlock,
+                completion,
             })));
             push_block(body, BodyType::Block, konts);
-            step_block_kick(konts, exec_state, ctx).await
+            step_block_kick(konts, exec_state, ctx)
+                .await
+                .map(MachineCallOutcome::Control)
         }
+    }
+}
+
+/// Start a resumable builtin: parse its arguments (the boundary is already
+/// pushed, so failures finalize the operation like a builtin-body error) and
+/// run the first callback -- or produce the empty result immediately.
+async fn resumable_entry(
+    kind: crate::std::ResumableKind,
+    args: Args,
+    konts: &mut Vec<Kont>,
+    exec_state: &mut ExecState,
+    ctx: &ExecutorContext,
+) -> Result<Control, KclError> {
+    let source_range = args.source_range;
+    let node_path = args.node_path.clone();
+    let resume = match kind {
+        crate::std::ResumableKind::Map => {
+            let (array, f) = crate::std::array::map_parse_args(&args, exec_state)?;
+            ResumeState::Map(MapResume {
+                f,
+                rest: array.into_iter(),
+                done: Vec::new(),
+                source_range,
+                node_path,
+            })
+        }
+        crate::std::ResumableKind::Reduce => {
+            let (array, f, initial) = crate::std::array::reduce_parse_args(&args, exec_state)?;
+            konts.push(Kont::Resume(Box::new(ResumeState::Reduce(ReduceResume {
+                f,
+                rest: array.into_iter(),
+                source_range,
+                node_path,
+            }))));
+            // The accumulator rides the callback results: seed it as if a
+            // callback had just produced the initial value.
+            return resume_drive(Feed::Callback(Some(initial)), konts, exec_state, ctx).await;
+        }
+        crate::std::ResumableKind::PatternTransform => {
+            let (solids, instances, transform, use_original) =
+                crate::std::patterns::pattern_transform_parse_args(&args, exec_state)?;
+            crate::std::patterns::pattern_check_instances(instances, source_range)?;
+            ResumeState::PatternTransform(PatternTransformResume {
+                transform,
+                instances,
+                next_i: 1,
+                transforms: Vec::with_capacity(usize::try_from(instances).unwrap_or_default()),
+                geometry: PatternGeometry::Solids(solids),
+                use_original: use_original.unwrap_or_default(),
+                source_range,
+                node_path,
+                args,
+            })
+        }
+        crate::std::ResumableKind::PatternTransform2d => {
+            let (sketches, instances, transform, use_original) =
+                crate::std::patterns::pattern_transform_2d_parse_args(&args, exec_state)?;
+            crate::std::patterns::pattern_check_instances(instances, source_range)?;
+            ResumeState::PatternTransform(PatternTransformResume {
+                transform,
+                instances,
+                next_i: 1,
+                transforms: Vec::with_capacity(usize::try_from(instances).unwrap_or_default()),
+                geometry: PatternGeometry::Sketches(sketches),
+                use_original: use_original.unwrap_or_default(),
+                source_range,
+                node_path,
+                args,
+            })
+        }
+    };
+    konts.push(Kont::Resume(Box::new(resume)));
+    resume_drive(Feed::Advance, konts, exec_state, ctx).await
+}
+
+/// What drives the next resume step.
+enum Feed {
+    /// Start the builtin's next iteration (entry).
+    Advance,
+    /// A callback just completed with this result.
+    Callback(Option<KclValue>),
+}
+
+/// Drive the innermost resume continuation. Loop-based (not recursive) so a
+/// run of leaf-builtin callbacks completes in constant native stack: each
+/// synchronously-finished callback feeds the next iteration of this loop.
+async fn resume_drive(
+    mut feed: Feed,
+    konts: &mut Vec<Kont>,
+    exec_state: &mut ExecState,
+    ctx: &ExecutorContext,
+) -> Result<Control, KclError> {
+    loop {
+        let Some(Kont::Resume(resume)) = konts.pop() else {
+            return Err(KclError::new_internal(KclErrorDetails::new(
+                "machine executor: callback finished with no resumable builtin awaiting it".to_owned(),
+                Vec::new(),
+            )));
+        };
+        let outcome = match feed {
+            Feed::Advance => resume_next(*resume, konts, exec_state, ctx).await?,
+            Feed::Callback(value) => resume_step(*resume, value, konts, exec_state, ctx).await?,
+        };
+        match outcome {
+            ResumeOutcome::Control(control) => return Ok(control),
+            ResumeOutcome::CallbackDone(value) => {
+                feed = Feed::Callback(value);
+            }
+        }
+    }
+}
+
+enum ResumeOutcome {
+    /// The machine continues with this control (a callback was started on
+    /// the continuation stack, or the builtin finished and its value was
+    /// applied).
+    Control(Control),
+    /// A leaf-builtin callback completed synchronously; feed this to the
+    /// next resume step.
+    CallbackDone(Option<KclValue>),
+}
+
+/// Record a callback's result, then continue the builtin's iteration.
+async fn resume_step(
+    resume: ResumeState,
+    fed: Option<KclValue>,
+    konts: &mut Vec<Kont>,
+    exec_state: &mut ExecState,
+    ctx: &ExecutorContext,
+) -> Result<ResumeOutcome, KclError> {
+    match resume {
+        ResumeState::Map(mut m) => {
+            let value = fed.ok_or_else(|| crate::std::array::map_missing_value_error(m.source_range))?;
+            m.done.push(value);
+            resume_next(ResumeState::Map(m), konts, exec_state, ctx).await
+        }
+        ResumeState::Reduce(r) => {
+            // fed is the new accumulator (or the seeded initial value).
+            let accum = fed.ok_or_else(|| crate::std::array::reduce_missing_value_error(r.source_range))?;
+            resume_reduce_next(r, accum, konts, exec_state, ctx).await
+        }
+        ResumeState::PatternTransform(mut p) => {
+            let value = fed.ok_or_else(|| crate::std::patterns::transform_missing_value_error(p.source_range))?;
+            let transforms = match &p.geometry {
+                PatternGeometry::Solids(_) => crate::std::patterns::transforms_from_callback_value::<
+                    crate::execution::Solid,
+                >(value, p.source_range, exec_state)?,
+                PatternGeometry::Sketches(_) => crate::std::patterns::transforms_from_callback_value::<
+                    crate::execution::Sketch,
+                >(value, p.source_range, exec_state)?,
+            };
+            p.transforms.push(transforms);
+            p.next_i += 1;
+            resume_next(ResumeState::PatternTransform(p), konts, exec_state, ctx).await
+        }
+    }
+}
+
+/// Start the builtin's next callback, or finish the builtin and apply its
+/// value (which lands on the builtin's call boundary).
+async fn resume_next(
+    resume: ResumeState,
+    konts: &mut Vec<Kont>,
+    exec_state: &mut ExecState,
+    ctx: &ExecutorContext,
+) -> Result<ResumeOutcome, KclError> {
+    match resume {
+        ResumeState::Map(mut m) => match m.rest.next() {
+            Some(elem) => {
+                let f = m.f.clone();
+                let callsite = m.source_range;
+                let args =
+                    crate::std::array::map_callback_args(elem, m.source_range, m.node_path.clone(), exec_state, ctx);
+                konts.push(Kont::Resume(Box::new(ResumeState::Map(m))));
+                start_callback(f, callsite, args, konts, exec_state, ctx).await
+            }
+            None => Ok(ResumeOutcome::Control(Control::Apply(Applied::Value(
+                crate::std::array::map_result(m.done),
+            )))),
+        },
+        ResumeState::PatternTransform(p) => {
+            if p.next_i < p.instances {
+                let f = p.transform.clone();
+                let callsite = p.source_range;
+                let args = crate::std::patterns::transform_callback_args(
+                    p.next_i,
+                    p.source_range,
+                    p.node_path.clone(),
+                    exec_state,
+                    ctx,
+                );
+                konts.push(Kont::Resume(Box::new(ResumeState::PatternTransform(p))));
+                start_callback(f, callsite, args, konts, exec_state, ctx).await
+            } else {
+                // All transforms collected: apply them to the geometry via
+                // the engine (a flat await), then the value lands on the
+                // builtin's call boundary.
+                let value = match p.geometry {
+                    PatternGeometry::Solids(solids) => {
+                        let out = crate::std::patterns::execute_pattern_transform::<crate::execution::Solid>(
+                            p.transforms,
+                            solids,
+                            p.use_original,
+                            exec_state,
+                            &p.args,
+                        )
+                        .await?;
+                        KclValue::from(out)
+                    }
+                    PatternGeometry::Sketches(sketches) => {
+                        let out = crate::std::patterns::execute_pattern_transform::<crate::execution::Sketch>(
+                            p.transforms,
+                            sketches,
+                            p.use_original,
+                            exec_state,
+                            &p.args,
+                        )
+                        .await?;
+                        KclValue::from(out)
+                    }
+                };
+                Ok(ResumeOutcome::Control(Control::Apply(Applied::Value(value))))
+            }
+        }
+        ResumeState::Reduce(_) => Err(KclError::new_internal(KclErrorDetails::new(
+            "machine executor: reduce must advance through resume_reduce_next".to_owned(),
+            Vec::new(),
+        ))),
+    }
+}
+
+/// Reduce carries its accumulator between callbacks.
+async fn resume_reduce_next(
+    mut r: ReduceResume,
+    accum: KclValue,
+    konts: &mut Vec<Kont>,
+    exec_state: &mut ExecState,
+    ctx: &ExecutorContext,
+) -> Result<ResumeOutcome, KclError> {
+    match r.rest.next() {
+        Some(elem) => {
+            let f = r.f.clone();
+            let callsite = r.source_range;
+            let args = crate::std::array::reduce_callback_args(
+                elem,
+                accum,
+                r.source_range,
+                r.node_path.clone(),
+                exec_state,
+                ctx,
+            );
+            konts.push(Kont::Resume(Box::new(ResumeState::Reduce(r))));
+            start_callback(f, callsite, args, konts, exec_state, ctx).await
+        }
+        None => Ok(ResumeOutcome::Control(Control::Apply(Applied::Value(accum)))),
+    }
+}
+
+/// Run one callback via the shared call path. A KCL callback pushes its
+/// boundary and body and returns Control; a leaf builtin completes inline,
+/// in which case the just-pushed Resume kont is popped again by the caller's
+/// feed loop.
+async fn start_callback(
+    f: FunctionSource,
+    callsite: SourceRange,
+    args: Args<crate::execution::fn_call::Sugary>,
+    konts: &mut Vec<Kont>,
+    exec_state: &mut ExecState,
+    ctx: &ExecutorContext,
+) -> Result<ResumeOutcome, KclError> {
+    // Boxed to break the async cycle machine_call -> resume -> machine_call.
+    // The edge is bounded: a leaf callback returns LeafCallbackDone (the
+    // caller's feed loop continues iterating with constant native stack), a
+    // KCL callback returns through the continuation stack, and only a
+    // callback that is itself a resumable builtin adds one nested frame.
+    match Box::pin(machine_call(
+        f,
+        None,
+        callsite,
+        args,
+        BoundaryCompletion::Callback,
+        konts,
+        exec_state,
+        ctx,
+    ))
+    .await?
+    {
+        MachineCallOutcome::Control(control) => Ok(ResumeOutcome::Control(control)),
+        MachineCallOutcome::LeafCallbackDone(value) => Ok(ResumeOutcome::CallbackDone(value)),
     }
 }
 
@@ -1833,6 +2363,55 @@ forever(1)
             let avg = start.elapsed() / RUNS as u32;
             println!("{kind:?}: {avg:?} per run over {RUNS} runs");
         }
+    }
+
+    /// The key requirement of the resumable-callback protocol: map calling a
+    /// function that maps again, nested hundreds of levels deep, runs on the
+    /// machine's continuation stack with no native-stack growth per level.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn deeply_nested_map_callbacks() {
+        let code = r#"fn nest(@depth) {
+  return if depth == 0 {
+    1
+  } else {
+    map([depth - 1], f = nest)[0]
+  }
+}
+result = nest(400)
+"#;
+        let result = run_machine(code).await.unwrap();
+        let value = result
+            .exec_state
+            .stack()
+            .memory
+            .get_from_owned("result", result.mem_env, SourceRange::default(), 0)
+            .unwrap();
+        let KclValue::Number { value, .. } = value else {
+            panic!("expected a number, found {value:?}");
+        };
+        assert_eq!(value, 1.0);
+    }
+
+    /// A long run of leaf-builtin callbacks completes in constant native
+    /// stack (the feed loop, not recursion).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn many_leaf_callbacks() {
+        let code = r#"fn double(@x) {
+  return x * 2
+}
+result = map([0..4999], f = double)
+"#;
+        let result = run_machine(code).await.unwrap();
+        let value = result
+            .exec_state
+            .stack()
+            .memory
+            .get_from_owned("result", result.mem_env, SourceRange::default(), 0)
+            .unwrap();
+        let KclValue::HomArray { value, .. } = value else {
+            panic!("expected an array, found {value:?}");
+        };
+        assert_eq!(value.len(), 5000);
     }
 
     /// Deep pipelines ride the continuation stack, not the native stack.

--- a/rust/kcl-lib/src/execution/machine.rs
+++ b/rust/kcl-lib/src/execution/machine.rs
@@ -1,0 +1,1836 @@
+//! The CEK machine executor: evaluates KCL on an explicit, heap-allocated
+//! continuation stack instead of the native call stack.
+//!
+//! The recursive executor (`execute_expr` and friends in `exec_ast.rs`) grows
+//! the native stack proportionally to KCL nesting depth, which overflows in
+//! wasm. This module re-expresses evaluation as a CEK abstract machine with an
+//! ambient mutable store:
+//!
+//! - C (control): [`Control`] -- either descend into an expression
+//!   ([`Control::Eval`]), hand a finished value to the innermost continuation
+//!   ([`Control::Apply`]), or unwind an `exit()` ([`Control::Exit`]).
+//! - E (environment): already reified as `EnvironmentRef` plus the mutable
+//!   env-stack arena, exactly as the recursive executor uses it.
+//! - K (continuations): a `Vec<Kont>`, one defunctionalized variant per
+//!   recursion site of the recursive executor.
+//!
+//! The store (artifacts, operations log, id generators, engine connection) is
+//! ambient `&mut ExecState`, threaded through every step -- so this is a CEK
+//! machine with an ambient mutable store, not a pure CESK machine.
+//!
+//! Async stays async: engine I/O and ordinary stdlib calls remain flat
+//! `.await` leaves inside the loop. They do not grow the native stack with KCL
+//! depth. Only recursion on evaluating KCL expressions moved onto the explicit
+//! stack.
+//!
+//! Semantics contract: this machine replicates the recursive executor
+//! byte-for-byte -- including evaluation order (ids and engine commands are
+//! order-dependent), the operations log, ambient-state save/restore, error
+//! paths (including their historical asymmetries), and the deliberate
+//! write-and-continue behavior of `return` statements. The simulation-test
+//! suite runs under both executors and requires identical snapshots.
+//!
+//! Bounded native re-entry still exists in two places, by design:
+//! - Module execution (imports, module-value results) runs the module body in
+//!   a fresh machine root via `exec_module_body`, adding O(1) native frames
+//!   per module nesting level.
+//! - Until the resumable-callback phase lands, higher-order stdlib functions
+//!   (`map`, `reduce`, `patternTransform`) call back into KCL through
+//!   `call_kw`, which fresh-roots a machine run per callback, adding O(1)
+//!   native frames per callback nesting level (bounded by the recursive
+//!   executor's call-stack cap, which still guards that path).
+
+use std::sync::Arc;
+
+use indexmap::IndexMap;
+
+use crate::SourceRange;
+use crate::errors::KclError;
+use crate::errors::KclErrorDetails;
+use crate::execution::ArtifactId;
+use crate::execution::BodyType;
+use crate::execution::ExecState;
+use crate::execution::ExecutorContext;
+use crate::execution::KclValue;
+use crate::execution::KclValueControlFlow;
+use crate::execution::Metadata;
+use crate::execution::ModelingCmdMeta;
+use crate::execution::SketchSurface;
+use crate::execution::cad_op::Operation;
+use crate::execution::exec_ast::Property;
+use crate::execution::fn_call::Arg;
+use crate::execution::fn_call::Args;
+use crate::execution::fn_call::CallState;
+use crate::execution::kcl_value::FunctionBody;
+use crate::execution::kcl_value::FunctionSource;
+use crate::execution::kcl_value::KclObjectFields;
+use crate::execution::state::SketchBlockState;
+use crate::execution::types::PrimitiveType;
+use crate::execution::types::RuntimeType;
+use crate::front::ObjectId;
+use crate::parsing::ast::types::Annotation;
+use crate::parsing::ast::types::ArrayExpression;
+use crate::parsing::ast::types::ArrayRangeExpression;
+use crate::parsing::ast::types::AscribedExpression;
+use crate::parsing::ast::types::BinaryExpression;
+use crate::parsing::ast::types::BinaryPart;
+use crate::parsing::ast::types::Block;
+use crate::parsing::ast::types::BodyItem;
+use crate::parsing::ast::types::CallExpressionKw;
+use crate::parsing::ast::types::CodeBlock;
+use crate::parsing::ast::types::Expr;
+use crate::parsing::ast::types::FunctionExpression;
+use crate::parsing::ast::types::IfExpression;
+use crate::parsing::ast::types::LabelledExpression;
+use crate::parsing::ast::types::MemberExpression;
+use crate::parsing::ast::types::Node;
+use crate::parsing::ast::types::ObjectExpression;
+use crate::parsing::ast::types::PipeExpression;
+use crate::parsing::ast::types::Program;
+use crate::parsing::ast::types::SketchBlock;
+use crate::parsing::ast::types::UnaryExpression;
+
+/// Which executor evaluates KCL. Crate-internal: set on
+/// [`ExecutorContext`] at construction time and immutable during a run.
+/// Cloning the context (fresh roots, `Args`) inherits the same kind, so every
+/// module and callback runs on the same executor.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) enum ExecutorKind {
+    /// The historical recursive tree-walking evaluator.
+    #[default]
+    Recursive,
+    /// The CEK machine in this module.
+    Machine,
+}
+
+impl ExecutorKind {
+    /// Test-harness selection of the executor via the `KCL_EXECUTOR` env var
+    /// (`machine` or `recursive`). Used only by test context factories so the
+    /// simulation suite can run under both executors; production contexts are
+    /// never configured from the environment.
+    pub(crate) fn from_test_env() -> Self {
+        match std::env::var("KCL_EXECUTOR").as_deref() {
+            Ok("machine") => ExecutorKind::Machine,
+            _ => ExecutorKind::Recursive,
+        }
+    }
+}
+
+/// Default limit for the machine executor's call-depth guard. This replaces
+/// the recursive executor's native-stack-motivated cap for machine-native
+/// calls: depth is heap-bounded, so the limit is purely a runaway-recursion
+/// policy. It must remain correct when internally raised to 50,000 or more.
+pub(crate) const DEFAULT_MACHINE_CALL_DEPTH_LIMIT: usize = 1000;
+
+/// Convert an entry block into an owned handle the machine can keep in a
+/// continuation without lifetimes.
+pub(crate) trait ToMachineBlock {
+    fn to_machine_block(&self) -> BlockRef;
+}
+
+impl ToMachineBlock for Node<Program> {
+    fn to_machine_block(&self) -> BlockRef {
+        // One shallow clone per fresh root: children are Arc-backed, so this
+        // copies one Vec of enum discriminants, not the tree.
+        BlockRef::Program(Arc::new(self.clone()))
+    }
+}
+
+impl ToMachineBlock for Node<Block> {
+    fn to_machine_block(&self) -> BlockRef {
+        BlockRef::Block(Arc::new(self.clone()))
+    }
+}
+
+/// An owned handle to a block of statements. Function and sketch bodies are
+/// projected out of their enclosing node's `Arc` so pushing a call costs no
+/// clone.
+#[derive(Debug, Clone)]
+pub(crate) enum BlockRef {
+    Program(Arc<Node<Program>>),
+    Block(Arc<Node<Block>>),
+    FnBody(Arc<Node<FunctionExpression>>),
+    SketchBody(Arc<Node<SketchBlock>>),
+}
+
+impl BlockRef {
+    fn body(&self) -> &[BodyItem] {
+        match self {
+            BlockRef::Program(p) => p.body(),
+            BlockRef::Block(b) => b.body(),
+            BlockRef::FnBody(f) => f.body.body(),
+            BlockRef::SketchBody(s) => s.body.body(),
+        }
+    }
+
+    fn to_source_range(&self) -> SourceRange {
+        match self {
+            BlockRef::Program(p) => p.to_source_range(),
+            BlockRef::Block(b) => b.to_source_range(),
+            BlockRef::FnBody(f) => f.body.to_source_range(),
+            BlockRef::SketchBody(s) => s.body.to_source_range(),
+        }
+    }
+}
+
+/// A node the machine can evaluate. `BinaryPart` is a distinct enum from
+/// `Expr` (binary operands are `BinaryPart`s), so the machine's eval step
+/// takes this union.
+// Variant sizes intentionally differ: these are the machine's heap frames,
+// and boxing every payload would add an allocation per step.
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Clone)]
+enum EvalNode {
+    Expr(Expr),
+    BinaryPart(BinaryPart),
+}
+
+/// One evaluation request: the node plus the context the recursive executor
+/// passed as parameters to `execute_expr`.
+#[derive(Debug)]
+struct EvalRequest {
+    node: EvalNode,
+    metadata: Metadata,
+    /// `Some(name)` when this is the top-level init of `name = ...`, i.e. the
+    /// recursive executor's `StatementKind::Declaration`. Everything else is
+    /// `StatementKind::Expression`.
+    decl_name: Option<String>,
+    /// Outer annotations of the enclosing declaration; consumed by function
+    /// expressions. Empty everywhere else.
+    annotations: Vec<Node<Annotation>>,
+}
+
+impl EvalRequest {
+    fn expr(node: &Expr) -> Self {
+        EvalRequest {
+            node: EvalNode::Expr(node.clone()),
+            metadata: Metadata {
+                source_range: SourceRange::from(node),
+            },
+            decl_name: None,
+            annotations: Vec::new(),
+        }
+    }
+
+    fn binary_part(part: &BinaryPart) -> Self {
+        EvalRequest {
+            node: EvalNode::BinaryPart(part.clone()),
+            metadata: Metadata {
+                source_range: SourceRange::from(part),
+            },
+            decl_name: None,
+            annotations: Vec::new(),
+        }
+    }
+}
+
+/// "C": what the machine does next.
+// Variant sizes intentionally differ: these are the machine's heap frames,
+// and boxing every payload would add an allocation per step.
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
+enum Control {
+    /// Descend into an expression.
+    Eval(Box<EvalRequest>),
+    /// A value is ready; hand it to the innermost continuation.
+    Apply(Applied),
+    /// `exit()` was called (or an edited sketch block finished): unwind every
+    /// continuation -- running cleanups, and the exit flavor of call_finish on
+    /// call boundaries -- out to the fresh root, which returns the carried
+    /// control-flow value.
+    Exit(KclValueControlFlow),
+}
+
+/// What a finished sub-computation produced.
+// Variant sizes intentionally differ: these are the machine's heap frames,
+// and boxing every payload would add an allocation per step.
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
+enum Applied {
+    /// An expression's value.
+    Value(KclValue),
+    /// A completed block's result: the recursive executor's
+    /// `exec_block` return value (`last_expr`).
+    Block(Option<KclValueControlFlow>),
+}
+
+impl Applied {
+    fn expect_value(self) -> Result<KclValue, KclError> {
+        match self {
+            Applied::Value(v) => Ok(v),
+            Applied::Block(_) => Err(KclError::new_internal(KclErrorDetails::new(
+                "machine executor: expected an expression value, found a block result".to_owned(),
+                Vec::new(),
+            ))),
+        }
+    }
+
+    fn expect_block(self) -> Result<Option<KclValueControlFlow>, KclError> {
+        match self {
+            Applied::Block(b) => Ok(b),
+            Applied::Value(_) => Err(KclError::new_internal(KclErrorDetails::new(
+                "machine executor: expected a block result, found an expression value".to_owned(),
+                Vec::new(),
+            ))),
+        }
+    }
+}
+
+/// Which statement of a block is in flight, with any ambient state to restore
+/// when it finishes or unwinds.
+#[derive(Debug)]
+enum InFlight {
+    /// No statement is mid-evaluation.
+    None,
+    Expression,
+    /// A variable declaration's init is being evaluated; holds the
+    /// `being_declared` value to restore.
+    Declaration {
+        prev_being_declared: Option<String>,
+    },
+    Return,
+}
+
+/// The defunctionalized continuation: one variant per recursion site of the
+/// recursive executor. Every variant holds owned handles (Arcs or values), no
+/// lifetimes.
+#[derive(Debug)]
+enum Kont {
+    /// Statement sequencing: replaces `exec_block`'s `for` loop.
+    BlockSeq {
+        block: BlockRef,
+        body_type: BodyType,
+        /// Index of the statement currently in flight (when `in_flight` is not
+        /// `None`) or the next statement to run.
+        index: usize,
+        in_flight: InFlight,
+        last: Option<KclValueControlFlow>,
+    },
+
+    // ---- binary / unary ----
+    /// Have the LHS; evaluate the RHS next.
+    BinaryLhsDone {
+        node: Arc<Node<BinaryExpression>>,
+    },
+    /// Have both operands; apply the operator (may await a CSG engine call).
+    BinaryRhsDone {
+        node: Arc<Node<BinaryExpression>>,
+        left: KclValue,
+    },
+    UnaryDone {
+        node: Arc<Node<UnaryExpression>>,
+    },
+
+    // ---- aggregates ----
+    ArrayElems {
+        node: Arc<Node<ArrayExpression>>,
+        index: usize,
+        done: Vec<KclValue>,
+    },
+    ObjectProps {
+        node: Arc<Node<ObjectExpression>>,
+        index: usize,
+        done: KclObjectFields,
+    },
+    RangeStartDone {
+        node: Arc<Node<ArrayRangeExpression>>,
+    },
+    RangeEndDone {
+        node: Arc<Node<ArrayRangeExpression>>,
+        start: KclValue,
+    },
+
+    // ---- access / control / pipes ----
+    /// Computed member property evaluated next (property before object,
+    /// replicating the recursive executor's evaluation order).
+    MemberPropDone {
+        node: Arc<Node<MemberExpression>>,
+    },
+    MemberObjDone {
+        node: Arc<Node<MemberExpression>>,
+        property: Property,
+    },
+    IfCondDone {
+        node: Arc<Node<IfExpression>>,
+        /// 0 = the main condition; 1..=n = else-if conditions.
+        arm: usize,
+    },
+    /// An if arm's block completed; unwrap its value as the if's result.
+    IfArmDone {
+        node: Arc<Node<IfExpression>>,
+    },
+    AscribeDone {
+        node: Arc<Node<AscribedExpression>>,
+    },
+    LabelDone {
+        node: Arc<Node<LabelledExpression>>,
+    },
+    /// The pipe's first element evaluated under the PARENT pipe value.
+    PipeFirstDone {
+        node: Arc<Node<PipeExpression>>,
+    },
+    PipeSeq {
+        node: Arc<Node<PipeExpression>>,
+        index: usize,
+        saved_pipe_value: Option<KclValue>,
+    },
+
+    // ---- calls ----
+    CallArgs(Box<CallArgsState>),
+    /// A KCL function call boundary. `call_finish` runs on normal completion,
+    /// on `Exit` (exit flavor: restores and op-finalize, no tags/coercion),
+    /// and on error unwind.
+    CallBoundary(Box<BoundaryState>),
+
+    // ---- sketch blocks ----
+    SketchArgs(Box<SketchArgsState>),
+    SketchBody(Box<SketchBodyState>),
+}
+
+/// Argument-evaluation state for a call: mirrors the argument loop of
+/// `CallExpressionKw::execute`.
+#[derive(Debug)]
+struct CallArgsState {
+    node: Arc<Node<CallExpressionKw>>,
+    fn_src: FunctionSource,
+    /// Source ranges of the function value, for the undefined-result error.
+    fn_meta: Vec<Metadata>,
+    /// None while the unlabeled arg (if any) is in flight; Some(i) while
+    /// arguments[i] is.
+    cursor: Option<usize>,
+    unlabeled: Vec<(Option<String>, Arg)>,
+    labeled: IndexMap<String, Arg>,
+}
+
+/// Everything a call boundary needs to finish the call and decorate errors.
+#[derive(Debug)]
+struct BoundaryState {
+    state: CallState,
+    fn_src: FunctionSource,
+    fn_name: Option<String>,
+    callsite: SourceRange,
+    fn_meta: Vec<Metadata>,
+}
+
+/// Argument-evaluation state for a sketch block (non-sketch-mode).
+#[derive(Debug)]
+struct SketchArgsState {
+    node: Arc<Node<SketchBlock>>,
+    index: usize,
+    labeled: IndexMap<String, Arg>,
+}
+
+/// Ambient state a sketch-block body wraps; restored on every exit path.
+#[derive(Debug)]
+struct SketchBodyState {
+    node: Arc<Node<SketchBlock>>,
+    sketch_id: ObjectId,
+    sketch_surface: SketchSurface,
+    sketch_block_artifact_id: ArtifactId,
+    saved_sketch_block: Option<SketchBlockState>,
+    saved_sketch_mode: bool,
+    /// Whether the body's child environment was pushed (the sketch2 alias
+    /// environment always is, before this kont exists).
+    child_env_pushed: bool,
+}
+
+impl ExecutorContext {
+    pub(crate) fn is_machine_executor(&self) -> bool {
+        self.executor_kind == ExecutorKind::Machine
+    }
+}
+
+/// Run a block to completion on the machine. This is the machine's fresh-root
+/// entry, with `exec_block`'s exact contract: the returned value is the
+/// block's `last_expr` (which the module wrapper, call protocol, and sketch
+/// handling consume exactly as they do for the recursive executor). An
+/// `exit()` unwinds to this root and is returned as an `Exit`-flavored
+/// control-flow value.
+pub(super) async fn run_block(
+    ctx: &ExecutorContext,
+    block: BlockRef,
+    exec_state: &mut ExecState,
+    body_type: BodyType,
+) -> Result<Option<KclValueControlFlow>, KclError> {
+    let mut konts: Vec<Kont> = Vec::new();
+    // Kick the root block sequence off: stepping a block with no statement in
+    // flight advances to its first statement.
+    let root = Kont::BlockSeq {
+        block,
+        body_type,
+        index: 0,
+        in_flight: InFlight::None,
+        last: None,
+    };
+    let mut control = match step_block(root, None, &mut konts, exec_state, ctx).await {
+        Ok(c) => c,
+        Err(e) => return Err(unwind_error(e, &mut konts, exec_state)),
+    };
+
+    loop {
+        control = match control {
+            Control::Eval(req) => match step_eval(*req, &mut konts, exec_state, ctx).await {
+                Ok(c) => c,
+                Err(e) => return Err(unwind_error(e, &mut konts, exec_state)),
+            },
+            Control::Apply(applied) => match konts.pop() {
+                None => {
+                    // The fresh root is done; the root BlockSeq's result is the
+                    // block result.
+                    return applied.expect_block();
+                }
+                Some(kont) => match step_apply(kont, applied, &mut konts, exec_state, ctx).await {
+                    Ok(c) => c,
+                    Err(e) => return Err(unwind_error(e, &mut konts, exec_state)),
+                },
+            },
+            Control::Exit(cf) => {
+                let cf = unwind_exit(cf, &mut konts, exec_state)?;
+                return Ok(Some(cf));
+            }
+        };
+    }
+}
+
+/// Unwind every continuation for an `exit()`: cleanups on non-boundaries, the
+/// exit flavor of `call_finish` on call boundaries (restore ambient flags, pop
+/// the callee env, finalize the operation -- skipping tags and coercion), and
+/// the balancing sketch cleanup (including its feature-tree `GroupEnd`).
+fn unwind_exit(
+    mut cf: KclValueControlFlow,
+    konts: &mut Vec<Kont>,
+    exec_state: &mut ExecState,
+) -> Result<KclValueControlFlow, KclError> {
+    while let Some(kont) = konts.pop() {
+        match kont {
+            Kont::CallBoundary(b) => {
+                exec_state.mod_local.machine_call_depth = exec_state.mod_local.machine_call_depth.saturating_sub(1);
+                // The exit flavor: call_finish's Exit bypass runs restores,
+                // pop_env, and op finalization, then returns the Exit
+                // unchanged before tags/coercion.
+                match b.fn_src.call_finish(b.state, Ok(Some(cf)), exec_state) {
+                    Ok(Some(v)) => cf = v,
+                    Ok(None) => {
+                        return Err(KclError::new_internal(KclErrorDetails::new(
+                            "machine executor: exit vanished at a call boundary".to_owned(),
+                            vec![b.callsite],
+                        )));
+                    }
+                    Err(e) => {
+                        // pop_env failed; propagate through the error unwind.
+                        return Err(unwind_error(
+                            e.add_unwind_location(b.fn_name.clone(), b.callsite),
+                            konts,
+                            exec_state,
+                        ));
+                    }
+                }
+            }
+            Kont::SketchBody(sb) => {
+                sketch_body_cleanup(*sb, exec_state);
+                // Balance the GroupBegin operation pushed by scene_setup so
+                // the feature tree stays well-formed (matches the recursive
+                // executor's exit path; its error path deliberately skips
+                // this).
+                exec_state.push_op(Operation::GroupEnd);
+            }
+            other => cleanup(other, exec_state),
+        }
+    }
+    Ok(cf)
+}
+
+/// Unwind every continuation for an error: cleanups on non-boundaries,
+/// `call_finish` with the error on call boundaries (which finalizes the
+/// operation with `is_error = true`), and per-boundary backtrace decoration
+/// via `add_unwind_location`, innermost first -- exactly like errors bubbling
+/// out of the recursive executor's nested calls.
+fn unwind_error(mut e: KclError, konts: &mut Vec<Kont>, exec_state: &mut ExecState) -> KclError {
+    while let Some(kont) = konts.pop() {
+        match kont {
+            Kont::CallBoundary(b) => {
+                exec_state.mod_local.machine_call_depth = exec_state.mod_local.machine_call_depth.saturating_sub(1);
+                match b.fn_src.call_finish(b.state, Err(e), exec_state) {
+                    Err(finished) => {
+                        e = finished.add_unwind_location(b.fn_name.clone(), b.callsite);
+                    }
+                    Ok(_) => {
+                        e = KclError::new_internal(KclErrorDetails::new(
+                            "machine executor: error vanished at a call boundary".to_owned(),
+                            vec![b.callsite],
+                        ));
+                    }
+                }
+            }
+            Kont::SketchBody(sb) => {
+                // The recursive executor's error path restores ambient sketch
+                // state and pops both envs but does NOT push the balancing
+                // GroupEnd (a historical asymmetry with the exit path).
+                sketch_body_cleanup(*sb, exec_state);
+            }
+            other => cleanup(other, exec_state),
+        }
+    }
+    e
+}
+
+/// Restore ambient state for a non-boundary continuation popped during
+/// unwinding. Continuations without ambient state are simply dropped.
+fn cleanup(kont: Kont, exec_state: &mut ExecState) {
+    match kont {
+        Kont::BlockSeq { in_flight, .. } => {
+            if let InFlight::Declaration { prev_being_declared } = in_flight {
+                exec_state.mod_local.being_declared = prev_being_declared;
+            }
+        }
+        Kont::PipeSeq { saved_pipe_value, .. } => {
+            exec_state.mod_local.pipe_value = saved_pipe_value;
+        }
+        // Evaluation-only continuations hold no ambient state.
+        Kont::BinaryLhsDone { .. }
+        | Kont::BinaryRhsDone { .. }
+        | Kont::UnaryDone { .. }
+        | Kont::ArrayElems { .. }
+        | Kont::ObjectProps { .. }
+        | Kont::RangeStartDone { .. }
+        | Kont::RangeEndDone { .. }
+        | Kont::MemberPropDone { .. }
+        | Kont::MemberObjDone { .. }
+        | Kont::IfCondDone { .. }
+        | Kont::IfArmDone { .. }
+        | Kont::AscribeDone { .. }
+        | Kont::LabelDone { .. }
+        | Kont::PipeFirstDone { .. }
+        | Kont::CallArgs(_)
+        | Kont::SketchArgs(_) => {}
+        // Handled by the unwind loops directly.
+        Kont::CallBoundary(_) | Kont::SketchBody(_) => unreachable!("boundaries are handled by the unwind loops"),
+    }
+}
+
+/// Restore the ambient state wrapped around a sketch-block body, in the
+/// recursive executor's exact order: pop the body's child environment (if it
+/// was pushed), restore sketch_mode, take the sketch-block state back out,
+/// pop the sketch2 alias environment. Finalization is skipped entirely --
+/// that's the point on unwind paths.
+fn sketch_body_cleanup(sb: SketchBodyState, exec_state: &mut ExecState) {
+    if sb.child_env_pushed {
+        let _ = exec_state.mut_stack().pop_env();
+    }
+    exec_state.mod_local.sketch_mode = sb.saved_sketch_mode;
+    let _ = std::mem::replace(&mut exec_state.mod_local.sketch_block, sb.saved_sketch_block);
+    let _ = exec_state.mut_stack().pop_env();
+}
+
+/// One eval step: the recursive executor's `execute_expr` dispatch, pushing a
+/// continuation and descending instead of awaiting recursively. Leaves
+/// produce `Apply` directly (some via flat awaits).
+async fn step_eval(
+    req: EvalRequest,
+    konts: &mut Vec<Kont>,
+    exec_state: &mut ExecState,
+    ctx: &ExecutorContext,
+) -> Result<Control, KclError> {
+    let EvalRequest {
+        node,
+        metadata,
+        decl_name,
+        annotations,
+    } = req;
+    let expr = match node {
+        EvalNode::Expr(e) => e,
+        EvalNode::BinaryPart(part) => {
+            // BinaryPart is a strict subset of Expr's variants; route through
+            // the same arms.
+            match part {
+                BinaryPart::Literal(literal) => {
+                    return Ok(Control::Apply(Applied::Value(KclValue::from_literal(
+                        literal.as_ref().clone(),
+                        exec_state,
+                    ))));
+                }
+                BinaryPart::Name(name) => {
+                    let value = ctx.resolve_name_for_eval(&name, &metadata, exec_state).await?;
+                    return Ok(Control::Apply(Applied::Value(value)));
+                }
+                BinaryPart::BinaryExpression(node) => Expr::BinaryExpression(node),
+                BinaryPart::CallExpressionKw(node) => Expr::CallExpressionKw(node),
+                BinaryPart::UnaryExpression(node) => Expr::UnaryExpression(node),
+                BinaryPart::MemberExpression(node) => Expr::MemberExpression(node),
+                BinaryPart::ArrayExpression(node) => Expr::ArrayExpression(node),
+                BinaryPart::ArrayRangeExpression(node) => Expr::ArrayRangeExpression(node),
+                BinaryPart::ObjectExpression(node) => Expr::ObjectExpression(node),
+                BinaryPart::IfExpression(node) => Expr::IfExpression(node),
+                BinaryPart::AscribedExpression(node) => Expr::AscribedExpression(node),
+                BinaryPart::SketchVar(node) => Expr::SketchVar(node),
+            }
+        }
+    };
+
+    match expr {
+        // ---- leaves ----
+        Expr::None(none) => Ok(Control::Apply(Applied::Value(KclValue::from(&none)))),
+        Expr::Literal(literal) => Ok(Control::Apply(Applied::Value(KclValue::from_literal(
+            literal.as_ref().clone(),
+            exec_state,
+        )))),
+        Expr::TagDeclarator(tag) => {
+            let value = tag.execute(exec_state).await?;
+            Ok(Control::Apply(Applied::Value(value)))
+        }
+        Expr::Name(name) => {
+            let value = ctx.resolve_name_for_eval(&name, &metadata, exec_state).await?;
+            Ok(Control::Apply(Applied::Value(value)))
+        }
+        Expr::FunctionExpression(function_expression) => {
+            let statement_kind = match &decl_name {
+                Some(name) => crate::execution::StatementKind::Declaration { name },
+                None => crate::execution::StatementKind::Expression,
+            };
+            let value = ctx.create_function_closure(
+                &function_expression,
+                &annotations,
+                &metadata,
+                statement_kind,
+                exec_state,
+            )?;
+            Ok(Control::Apply(Applied::Value(value)))
+        }
+        Expr::PipeSubstitution(pipe_substitution) => match &decl_name {
+            Some(name) => {
+                let message =
+                    format!("you cannot declare variable {name} as %, because % can only be used in function calls");
+                Err(KclError::new_semantic(KclErrorDetails::new(
+                    message,
+                    vec![pipe_substitution.as_ref().into()],
+                )))
+            }
+            None => match exec_state.mod_local.pipe_value.clone() {
+                Some(x) => Ok(Control::Apply(Applied::Value(x))),
+                None => Err(KclError::new_semantic(KclErrorDetails::new(
+                    "cannot use % outside a pipe expression".to_owned(),
+                    vec![pipe_substitution.as_ref().into()],
+                ))),
+            },
+        },
+        Expr::SketchVar(expr) => {
+            let value = expr.get_result(exec_state, ctx).await?;
+            Ok(Control::Apply(Applied::Value(value)))
+        }
+
+        // ---- aggregates ----
+        Expr::ArrayExpression(node) => {
+            let node = node.arc();
+            if node.elements.is_empty() {
+                return Ok(Control::Apply(Applied::Value(KclValue::HomArray {
+                    value: Vec::new(),
+                    ty: RuntimeType::Primitive(PrimitiveType::Any),
+                })));
+            }
+            let first = EvalRequest::expr(&node.elements[0]);
+            konts.push(Kont::ArrayElems {
+                node,
+                index: 0,
+                done: Vec::new(),
+            });
+            Ok(Control::Eval(Box::new(first)))
+        }
+        Expr::ObjectExpression(node) => {
+            let node = node.arc();
+            if node.properties.is_empty() {
+                return Ok(Control::Apply(Applied::Value(KclValue::Object {
+                    value: KclObjectFields::with_capacity(0),
+                    meta: vec![Metadata {
+                        source_range: SourceRange::from(node.as_ref()),
+                    }],
+                    constrainable: false,
+                    object_kind: crate::execution::kcl_value::KclObjectKind::Default,
+                })));
+            }
+            let first = EvalRequest::expr(&node.properties[0].value);
+            konts.push(Kont::ObjectProps {
+                node,
+                index: 0,
+                done: KclObjectFields::default(),
+            });
+            Ok(Control::Eval(Box::new(first)))
+        }
+        Expr::ArrayRangeExpression(node) => {
+            let node = node.arc();
+            let start = EvalRequest::expr(&node.start_element);
+            konts.push(Kont::RangeStartDone { node });
+            Ok(Control::Eval(Box::new(start)))
+        }
+
+        // ---- operators ----
+        Expr::BinaryExpression(node) => {
+            let node = node.arc();
+            let left = EvalRequest::binary_part(&node.left);
+            konts.push(Kont::BinaryLhsDone { node });
+            Ok(Control::Eval(Box::new(left)))
+        }
+        Expr::UnaryExpression(node) => {
+            let node = node.arc();
+            let operand = EvalRequest::binary_part(&node.argument);
+            konts.push(Kont::UnaryDone { node });
+            Ok(Control::Eval(Box::new(operand)))
+        }
+
+        // ---- access / control ----
+        Expr::MemberExpression(node) => {
+            let node = node.arc();
+            if node.computed {
+                let prop = EvalRequest::expr(&node.property);
+                konts.push(Kont::MemberPropDone { node });
+                Ok(Control::Eval(Box::new(prop)))
+            } else {
+                // Non-computed properties are identifier names, not evaluated.
+                let Expr::Name(identifier) = &node.property else {
+                    // Should actually be impossible because the parser would reject it.
+                    return Err(KclError::new_semantic(KclErrorDetails::new(
+                        "Object expressions like `obj.property` must use simple identifier names, not complex expressions"
+                            .to_owned(),
+                        vec![SourceRange::from(node.as_ref())],
+                    )));
+                };
+                let property = Property::String(identifier.to_string());
+                let object = EvalRequest::expr(&node.object);
+                konts.push(Kont::MemberObjDone { node, property });
+                Ok(Control::Eval(Box::new(object)))
+            }
+        }
+        Expr::IfExpression(node) => {
+            let node = node.arc();
+            let cond = EvalRequest {
+                node: EvalNode::Expr((*node.cond).clone()),
+                metadata: Metadata::from(node.as_ref()),
+                decl_name: None,
+                annotations: Vec::new(),
+            };
+            konts.push(Kont::IfCondDone { node, arm: 0 });
+            Ok(Control::Eval(Box::new(cond)))
+        }
+        Expr::AscribedExpression(node) => {
+            let node = node.arc();
+            let inner = EvalRequest {
+                node: EvalNode::Expr(node.expr.clone()),
+                metadata: Metadata {
+                    source_range: SourceRange::from(node.as_ref()),
+                },
+                decl_name: None,
+                annotations: Vec::new(),
+            };
+            konts.push(Kont::AscribeDone { node });
+            Ok(Control::Eval(Box::new(inner)))
+        }
+        Expr::LabelledExpression(node) => {
+            let node = node.arc();
+            let inner = EvalRequest {
+                node: EvalNode::Expr(node.expr.clone()),
+                metadata,
+                decl_name: None,
+                annotations: Vec::new(),
+            };
+            konts.push(Kont::LabelDone { node });
+            Ok(Control::Eval(Box::new(inner)))
+        }
+
+        // ---- pipes ----
+        Expr::PipeExpression(node) => {
+            let node = node.arc();
+            let Some(first) = node.body.first() else {
+                return Err(KclError::new_semantic(KclErrorDetails::new(
+                    "Pipe expressions cannot be empty".to_owned(),
+                    vec![SourceRange::from(node.as_ref())],
+                )));
+            };
+            // The first element is evaluated under the PARENT's pipe value
+            // (a nested pipe expression sees the outer %).
+            let first = EvalRequest::expr(first);
+            konts.push(Kont::PipeFirstDone { node });
+            Ok(Control::Eval(Box::new(first)))
+        }
+
+        // ---- calls ----
+        Expr::CallExpressionKw(node) => {
+            let node = node.arc();
+            start_call(node, konts, exec_state, ctx).await
+        }
+
+        // ---- sketch blocks ----
+        Expr::SketchBlock(node) => {
+            let node = node.arc();
+            start_sketch_block(node, konts, exec_state, ctx).await
+        }
+    }
+}
+
+/// One apply step: hand a finished value to the innermost continuation. The
+/// recursive executor's post-await code for each recursion site.
+async fn step_apply(
+    kont: Kont,
+    applied: Applied,
+    konts: &mut Vec<Kont>,
+    exec_state: &mut ExecState,
+    ctx: &ExecutorContext,
+) -> Result<Control, KclError> {
+    match kont {
+        Kont::BlockSeq { .. } => step_block(kont, Some(applied), konts, exec_state, ctx).await,
+
+        Kont::BinaryLhsDone { node } => {
+            let left = applied.expect_value()?;
+            let right = EvalRequest::binary_part(&node.right);
+            konts.push(Kont::BinaryRhsDone { node, left });
+            Ok(Control::Eval(Box::new(right)))
+        }
+        Kont::BinaryRhsDone { node, left } => {
+            let right = applied.expect_value()?;
+            let value = node.apply_operator(exec_state, ctx, left, right).await?;
+            Ok(Control::Apply(Applied::Value(value)))
+        }
+        Kont::UnaryDone { node } => {
+            let operand = applied.expect_value()?;
+            let value = node.apply_unary(operand, exec_state)?;
+            Ok(Control::Apply(Applied::Value(value)))
+        }
+
+        Kont::ArrayElems { node, index, mut done } => {
+            done.push(applied.expect_value()?);
+            let next = index + 1;
+            if next < node.elements.len() {
+                let elem = EvalRequest::expr(&node.elements[next]);
+                konts.push(Kont::ArrayElems {
+                    node,
+                    index: next,
+                    done,
+                });
+                Ok(Control::Eval(Box::new(elem)))
+            } else {
+                Ok(Control::Apply(Applied::Value(KclValue::HomArray {
+                    value: done,
+                    ty: RuntimeType::Primitive(PrimitiveType::Any),
+                })))
+            }
+        }
+        Kont::ObjectProps { node, index, mut done } => {
+            let value = applied.expect_value()?;
+            done.insert(node.properties[index].key.name.clone(), value);
+            let next = index + 1;
+            if next < node.properties.len() {
+                let prop = EvalRequest::expr(&node.properties[next].value);
+                konts.push(Kont::ObjectProps {
+                    node,
+                    index: next,
+                    done,
+                });
+                Ok(Control::Eval(Box::new(prop)))
+            } else {
+                Ok(Control::Apply(Applied::Value(KclValue::Object {
+                    value: done,
+                    meta: vec![Metadata {
+                        source_range: SourceRange::from(node.as_ref()),
+                    }],
+                    constrainable: false,
+                    object_kind: crate::execution::kcl_value::KclObjectKind::Default,
+                })))
+            }
+        }
+        Kont::RangeStartDone { node } => {
+            let start = applied.expect_value()?;
+            let end = EvalRequest::expr(&node.end_element);
+            konts.push(Kont::RangeEndDone { node, start });
+            Ok(Control::Eval(Box::new(end)))
+        }
+        Kont::RangeEndDone { node, start } => {
+            let end = applied.expect_value()?;
+            let value = node.build_range(start, end, exec_state)?;
+            Ok(Control::Apply(Applied::Value(value)))
+        }
+
+        Kont::MemberPropDone { node } => {
+            let prop_value = applied.expect_value()?;
+            let property = Property::from_value(prop_value, SourceRange::from(node.as_ref()))?;
+            let object = EvalRequest::expr(&node.object);
+            konts.push(Kont::MemberObjDone { node, property });
+            Ok(Control::Eval(Box::new(object)))
+        }
+        Kont::MemberObjDone { node, property } => {
+            let object = applied.expect_value()?;
+            let cf = node.apply_member(object, property, exec_state, ctx).await?;
+            // apply_member only ever produces Continue values.
+            Ok(Control::Apply(Applied::Value(cf.into_value())))
+        }
+
+        Kont::IfCondDone { node, arm } => {
+            let cond_value = applied.expect_value()?;
+            if cond_value.get_bool()? {
+                let block = if arm == 0 {
+                    BlockRef::Program(node.then_val.arc())
+                } else {
+                    BlockRef::Program(node.else_ifs[arm - 1].then_val.arc())
+                };
+                konts.push(Kont::IfArmDone { node });
+                push_block(block, BodyType::Block, konts);
+                step_block_kick(konts, exec_state, ctx).await
+            } else if arm < node.else_ifs.len() {
+                let cond = EvalRequest {
+                    node: EvalNode::Expr(node.else_ifs[arm].cond.clone()),
+                    metadata: Metadata::from(node.as_ref()),
+                    decl_name: None,
+                    annotations: Vec::new(),
+                };
+                konts.push(Kont::IfCondDone { node, arm: arm + 1 });
+                Ok(Control::Eval(Box::new(cond)))
+            } else {
+                let block = BlockRef::Program(node.final_else.arc());
+                konts.push(Kont::IfArmDone { node });
+                push_block(block, BodyType::Block, konts);
+                step_block_kick(konts, exec_state, ctx).await
+            }
+        }
+        Kont::IfArmDone { node } => {
+            let block_result = applied.expect_block()?;
+            // Blocks used as if arms must end in an expression (enforced by
+            // the parser), so this is always Some.
+            let Some(cf) = block_result else {
+                return Err(KclError::new_internal(KclErrorDetails::new(
+                    "if-expression arm produced no value".to_owned(),
+                    vec![SourceRange::from(node.as_ref())],
+                )));
+            };
+            Ok(Control::Apply(Applied::Value(cf.into_value())))
+        }
+
+        Kont::AscribeDone { node } => {
+            let value = applied.expect_value()?;
+            let value = crate::execution::exec_ast::apply_ascription(
+                &value,
+                &node.ty,
+                exec_state,
+                SourceRange::from(node.as_ref()),
+            )?;
+            Ok(Control::Apply(Applied::Value(value)))
+        }
+        Kont::LabelDone { node } => {
+            let value = applied.expect_value()?;
+            exec_state
+                .mut_stack()
+                .add(node.label.name.clone(), value.clone(), SourceRange::from(node.as_ref()))?;
+            // TODO this lets us use the label as a variable name, but not as a tag in most cases
+            Ok(Control::Apply(Applied::Value(value)))
+        }
+
+        Kont::PipeFirstDone { node } => {
+            let output = applied.expect_value()?;
+            // Now that the first element is evaluated, following elements use
+            // it as %; the parent's pipe value is restored when this pipe
+            // finishes (or unwinds).
+            let saved_pipe_value = exec_state.mod_local.pipe_value.replace(output);
+            pipe_advance(node, 1, saved_pipe_value, konts, exec_state)
+        }
+        Kont::PipeSeq {
+            node,
+            index,
+            saved_pipe_value,
+        } => {
+            let output = applied.expect_value()?;
+            exec_state.mod_local.pipe_value = Some(output);
+            pipe_advance(node, index + 1, saved_pipe_value, konts, exec_state)
+        }
+
+        Kont::CallArgs(state) => call_args_step(*state, applied, konts, exec_state, ctx).await,
+        Kont::CallBoundary(boundary) => {
+            let block_result = applied.expect_block()?;
+            exec_state.mod_local.machine_call_depth = exec_state.mod_local.machine_call_depth.saturating_sub(1);
+            let BoundaryState {
+                state,
+                fn_src,
+                fn_name,
+                callsite,
+                fn_meta,
+            } = *boundary;
+            // Read __return from the callee env (still pushed), then finish.
+            let result = fn_src.kcl_body_result(Ok(block_result), exec_state);
+            let finished = fn_src
+                .call_finish(state, result, exec_state)
+                .map_err(|e| e.add_unwind_location(fn_name.clone(), callsite))?;
+            finish_call_value(finished, fn_name, callsite, fn_meta)
+        }
+
+        Kont::SketchArgs(state) => sketch_args_step(*state, applied, konts, exec_state, ctx).await,
+        Kont::SketchBody(state) => sketch_body_finish(*state, applied, exec_state, ctx).await,
+    }
+}
+
+/// Push a block-sequencing continuation.
+fn push_block(block: BlockRef, body_type: BodyType, konts: &mut Vec<Kont>) {
+    konts.push(Kont::BlockSeq {
+        block,
+        body_type,
+        index: 0,
+        in_flight: InFlight::None,
+        last: None,
+    });
+}
+
+/// Immediately step the just-pushed block so it starts its first statement
+/// (or completes immediately when empty).
+async fn step_block_kick(
+    konts: &mut Vec<Kont>,
+    exec_state: &mut ExecState,
+    ctx: &ExecutorContext,
+) -> Result<Control, KclError> {
+    let kont = konts.pop().expect("block was just pushed");
+    step_block(kont, None, konts, exec_state, ctx).await
+}
+
+/// Advance a block: apply the in-flight statement's value (if any), then run
+/// statements until one needs an expression evaluated (returning `Eval`) or
+/// the block completes (returning `Apply(Block(last))`). Flat statements
+/// (imports, type declarations) execute inline.
+async fn step_block(
+    kont: Kont,
+    applied: Option<Applied>,
+    konts: &mut Vec<Kont>,
+    exec_state: &mut ExecState,
+    ctx: &ExecutorContext,
+) -> Result<Control, KclError> {
+    let Kont::BlockSeq {
+        block,
+        body_type,
+        mut index,
+        mut in_flight,
+        mut last,
+    } = kont
+    else {
+        return Err(KclError::new_internal(KclErrorDetails::new(
+            "machine executor: step_block on a non-block continuation".to_owned(),
+            Vec::new(),
+        )));
+    };
+
+    // Finish the in-flight statement.
+    if let Some(applied) = applied {
+        let value = applied.expect_value()?;
+        match std::mem::replace(&mut in_flight, InFlight::None) {
+            InFlight::None => {
+                return Err(KclError::new_internal(KclErrorDetails::new(
+                    "machine executor: value applied to a block with no statement in flight".to_owned(),
+                    Vec::new(),
+                )));
+            }
+            InFlight::Expression => {
+                // Exit control flow never arrives here as a value: it takes
+                // the Exit unwind path instead. A normal value continues.
+                last = Some(value.continue_());
+                index += 1;
+            }
+            InFlight::Declaration { prev_being_declared } => {
+                // Declaration over, so unset this context.
+                exec_state.mod_local.being_declared = prev_being_declared;
+                let BodyItem::VariableDeclaration(variable_declaration) = &block.body()[index] else {
+                    return Err(KclError::new_internal(KclErrorDetails::new(
+                        "machine executor: in-flight declaration is not a declaration".to_owned(),
+                        Vec::new(),
+                    )));
+                };
+                let rhs = ctx.bind_variable_declaration(variable_declaration, value, body_type, exec_state)?;
+                // Variable declaration can be the return value of a module.
+                last = matches!(body_type, BodyType::Root).then_some(rhs.continue_());
+                index += 1;
+            }
+            InFlight::Return => {
+                let BodyItem::ReturnStatement(return_statement) = &block.body()[index] else {
+                    return Err(KclError::new_internal(KclErrorDetails::new(
+                        "machine executor: in-flight return is not a return".to_owned(),
+                        Vec::new(),
+                    )));
+                };
+                crate::execution::ExecutorContext::bind_return_value(return_statement, value, exec_state)?;
+                last = None;
+                index += 1;
+            }
+        }
+    }
+
+    // Run statements until one needs an Eval.
+    loop {
+        let Some(statement) = block.body().get(index) else {
+            // Block complete.
+            if matches!(body_type, BodyType::Root) {
+                // Flush the batch queue.
+                exec_state
+                    .flush_batch(
+                        ModelingCmdMeta::new(exec_state, ctx, block.to_source_range()),
+                        // True here tells the engine to flush all the end commands as well like fillets
+                        // and chamfers where the engine would otherwise eat the ID of the segments.
+                        true,
+                    )
+                    .await?;
+            }
+            return Ok(Control::Apply(Applied::Block(last)));
+        };
+
+        match statement {
+            BodyItem::ImportStatement(import_stmt) => {
+                if exec_state.sketch_mode() {
+                    index += 1;
+                    continue;
+                }
+                ctx.exec_import_statement(import_stmt, body_type, exec_state).await?;
+                last = None;
+                index += 1;
+            }
+            BodyItem::TypeDeclaration(ty) => {
+                if exec_state.sketch_mode() {
+                    index += 1;
+                    continue;
+                }
+                ctx.exec_type_declaration(ty, exec_state)?;
+                last = None;
+                index += 1;
+            }
+            BodyItem::ExpressionStatement(expression_statement) => {
+                if exec_state.sketch_mode()
+                    && crate::execution::exec_ast::sketch_mode_should_skip(&expression_statement.expression)
+                {
+                    index += 1;
+                    continue;
+                }
+                let req = EvalRequest {
+                    node: EvalNode::Expr(expression_statement.expression.clone()),
+                    metadata: Metadata::from(expression_statement),
+                    decl_name: None,
+                    annotations: Vec::new(),
+                };
+                konts.push(Kont::BlockSeq {
+                    block,
+                    body_type,
+                    index,
+                    in_flight: InFlight::Expression,
+                    last,
+                });
+                return Ok(Control::Eval(Box::new(req)));
+            }
+            BodyItem::VariableDeclaration(variable_declaration) => {
+                if exec_state.sketch_mode()
+                    && crate::execution::exec_ast::sketch_mode_should_skip(&variable_declaration.declaration.init)
+                {
+                    index += 1;
+                    continue;
+                }
+                let var_name = variable_declaration.declaration.id.name.to_string();
+                let source_range = SourceRange::from(&variable_declaration.declaration.init);
+
+                // During the evaluation of the variable's RHS, set context that this is all happening inside a variable
+                // declaration, for the given name. This helps improve user-facing error messages.
+                let lhs = variable_declaration.inner.name().to_owned();
+                let prev_being_declared = exec_state.mod_local.being_declared.take();
+                exec_state.mod_local.being_declared = Some(lhs);
+
+                let req = EvalRequest {
+                    node: EvalNode::Expr(variable_declaration.declaration.init.clone()),
+                    metadata: Metadata { source_range },
+                    decl_name: Some(var_name),
+                    annotations: variable_declaration.outer_attrs.clone(),
+                };
+                konts.push(Kont::BlockSeq {
+                    block,
+                    body_type,
+                    index,
+                    in_flight: InFlight::Declaration { prev_being_declared },
+                    last,
+                });
+                return Ok(Control::Eval(Box::new(req)));
+            }
+            BodyItem::ReturnStatement(return_statement) => {
+                if exec_state.sketch_mode()
+                    && crate::execution::exec_ast::sketch_mode_should_skip(&return_statement.argument)
+                {
+                    index += 1;
+                    continue;
+                }
+                let metadata = Metadata::from(return_statement);
+                if matches!(body_type, BodyType::Root) {
+                    return Err(KclError::new_semantic(KclErrorDetails::new(
+                        "Cannot return from outside a function.".to_owned(),
+                        vec![metadata.source_range],
+                    )));
+                }
+                let req = EvalRequest {
+                    node: EvalNode::Expr(return_statement.argument.clone()),
+                    metadata,
+                    decl_name: None,
+                    annotations: Vec::new(),
+                };
+                konts.push(Kont::BlockSeq {
+                    block,
+                    body_type,
+                    index,
+                    in_flight: InFlight::Return,
+                    last,
+                });
+                return Ok(Control::Eval(Box::new(req)));
+            }
+        }
+    }
+}
+
+/// Advance a pipe to `index`: check the element (tag declarators are not
+/// allowed in pipe tails), evaluate it, or finish the pipe when past the end.
+fn pipe_advance(
+    node: Arc<Node<PipeExpression>>,
+    index: usize,
+    saved_pipe_value: Option<KclValue>,
+    konts: &mut Vec<Kont>,
+    exec_state: &mut ExecState,
+) -> Result<Control, KclError> {
+    if index >= node.body.len() {
+        // Safe to unwrap here, because pipe_value always has something pushed in when the pipe starts.
+        let final_output = exec_state.mod_local.pipe_value.take().ok_or_else(|| {
+            KclError::new_internal(KclErrorDetails::new(
+                "machine executor: pipe finished with no pipe value".to_owned(),
+                vec![SourceRange::from(node.as_ref())],
+            ))
+        })?;
+        // Restore the previous pipe value.
+        exec_state.mod_local.pipe_value = saved_pipe_value;
+        return Ok(Control::Apply(Applied::Value(final_output)));
+    }
+    let expression = &node.body[index];
+    if let Expr::TagDeclarator(_) = expression {
+        let e = KclError::new_semantic(KclErrorDetails::new(
+            format!("This cannot be in a PipeExpression: {expression:?}"),
+            vec![expression.into()],
+        ));
+        // Restore before erroring; the continuation holding the saved value
+        // hasn't been pushed yet.
+        exec_state.mod_local.pipe_value = saved_pipe_value;
+        return Err(e);
+    }
+    let req = EvalRequest::expr(expression);
+    konts.push(Kont::PipeSeq {
+        node,
+        index,
+        saved_pipe_value,
+    });
+    Ok(Control::Eval(Box::new(req)))
+}
+
+/// Begin a call: resolve the callee (before evaluating arguments, exactly
+/// like the recursive executor), then start evaluating arguments -- or
+/// dispatch immediately for zero-argument calls.
+async fn start_call(
+    node: Arc<Node<CallExpressionKw>>,
+    konts: &mut Vec<Kont>,
+    exec_state: &mut ExecState,
+    ctx: &ExecutorContext,
+) -> Result<Control, KclError> {
+    let callsite: SourceRange = SourceRange::from(node.as_ref());
+
+    // Resolve the function before evaluating arguments so calls can mutate
+    // exec_state without holding a memory borrow.
+    let func: KclValue = node.callee.get_result(exec_state, ctx).await?;
+
+    let Some(fn_src) = func.as_function() else {
+        return Err(KclError::new_semantic(KclErrorDetails::new(
+            "cannot call this because it isn't a function".to_string(),
+            vec![callsite],
+        )));
+    };
+    let fn_src = fn_src.clone();
+    let fn_meta = match &func {
+        KclValue::Function { meta, .. } => meta.clone(),
+        _ => Vec::new(),
+    };
+
+    let state = CallArgsState {
+        node,
+        fn_src,
+        fn_meta,
+        cursor: None,
+        unlabeled: Vec::new(),
+        labeled: IndexMap::new(),
+    };
+
+    // Evaluate the unlabeled first param, if any exists; otherwise the
+    // labeled arguments in order; otherwise dispatch with no arguments.
+    if let Some(arg_expr) = &state.node.unlabeled {
+        let req = EvalRequest::expr(arg_expr);
+        konts.push(Kont::CallArgs(Box::new(state)));
+        Ok(Control::Eval(Box::new(req)))
+    } else if !state.node.arguments.is_empty() {
+        let mut state = state;
+        state.cursor = Some(0);
+        let req = EvalRequest::expr(&state.node.arguments[0].arg);
+        konts.push(Kont::CallArgs(Box::new(state)));
+        Ok(Control::Eval(Box::new(req)))
+    } else {
+        dispatch_call(state, konts, exec_state, ctx).await
+    }
+}
+
+/// Record an evaluated argument and evaluate the next, or dispatch the call
+/// when all arguments are done.
+async fn call_args_step(
+    mut state: CallArgsState,
+    applied: Applied,
+    konts: &mut Vec<Kont>,
+    exec_state: &mut ExecState,
+    ctx: &ExecutorContext,
+) -> Result<Control, KclError> {
+    let value = applied.expect_value()?;
+    match state.cursor {
+        None => {
+            let arg_expr = state.node.unlabeled.as_ref().ok_or_else(|| {
+                KclError::new_internal(KclErrorDetails::new(
+                    "machine executor: unlabeled argument vanished".to_owned(),
+                    vec![SourceRange::from(state.node.as_ref())],
+                ))
+            })?;
+            let source_range = SourceRange::from(arg_expr);
+            let label = arg_expr.ident_name().map(str::to_owned);
+            state.unlabeled.push((label, Arg::new(value, source_range)));
+        }
+        Some(i) => {
+            let arg_expr = &state.node.arguments[i];
+            let source_range = SourceRange::from(&arg_expr.arg);
+            let arg = Arg::new(value, source_range);
+            match &arg_expr.label {
+                Some(l) => {
+                    state.labeled.insert(l.name.clone(), arg);
+                }
+                None => {
+                    state
+                        .unlabeled
+                        .push((arg_expr.arg.ident_name().map(str::to_owned), arg));
+                }
+            }
+        }
+    }
+
+    let next = match state.cursor {
+        None => 0,
+        Some(i) => i + 1,
+    };
+    if next < state.node.arguments.len() {
+        state.cursor = Some(next);
+        let req = EvalRequest::expr(&state.node.arguments[next].arg);
+        konts.push(Kont::CallArgs(Box::new(state)));
+        Ok(Control::Eval(Box::new(req)))
+    } else {
+        dispatch_call(state, konts, exec_state, ctx).await
+    }
+}
+
+/// All arguments evaluated: build `Args`, run call setup, and either await a
+/// Rust builtin inline (a flat leaf) or push a call boundary plus the KCL
+/// function body (no native recursion).
+async fn dispatch_call(
+    state: CallArgsState,
+    konts: &mut Vec<Kont>,
+    exec_state: &mut ExecState,
+    ctx: &ExecutorContext,
+) -> Result<Control, KclError> {
+    let CallArgsState {
+        node,
+        fn_src,
+        fn_meta,
+        cursor: _,
+        unlabeled,
+        labeled,
+    } = state;
+    let callsite: SourceRange = SourceRange::from(node.as_ref());
+    let fn_name_node = &node.callee;
+    let fn_name = Some(fn_name_node.name.name.clone());
+    let fn_display_name = Some(fn_name_node.to_string());
+
+    let args = Args::new(
+        labeled,
+        unlabeled,
+        callsite,
+        node.node_path.clone(),
+        exec_state,
+        ctx.clone(),
+        fn_name.clone(),
+    );
+
+    // Guard against runaway recursion: machine-native calls do not grow the
+    // native stack, so this is policy, not a native-stack limit. It must
+    // behave when raised to 50,000 or more.
+    if exec_state.mod_local.machine_call_depth >= ctx.machine_call_depth_limit {
+        return Err(KclError::new_semantic(KclErrorDetails::new(
+            format!(
+                "Call depth limit ({}) exceeded. This usually means a function is recursing without a base case.",
+                ctx.machine_call_depth_limit
+            ),
+            vec![callsite],
+        )));
+    }
+
+    match &fn_src.body {
+        FunctionBody::Rust(f) => {
+            // A flat leaf: setup, await the builtin, finish. Higher-order
+            // builtins (map/reduce/patternTransform) re-enter KCL through
+            // call_kw, which fresh-roots a machine run per callback until the
+            // resumable-callback phase lands.
+            let (call_state, args) = fn_src
+                .call_setup(&fn_display_name, exec_state, args, callsite)
+                .map_err(|e| e.add_unwind_location(fn_name.clone(), callsite))?;
+            let result = f(exec_state, args).await.map(Some);
+            let finished = fn_src
+                .call_finish(call_state, result, exec_state)
+                .map_err(|e| e.add_unwind_location(fn_name.clone(), callsite))?;
+            finish_call_value(finished, fn_display_name, callsite, fn_meta)
+        }
+        FunctionBody::Kcl(_) => {
+            let (call_state, args) = fn_src
+                .call_setup(&fn_display_name, exec_state, args, callsite)
+                .map_err(|e| e.add_unwind_location(fn_name.clone(), callsite))?;
+            if let Err(e) = crate::execution::fn_call::assign_args_to_params_kw(&fn_src, args, exec_state) {
+                let e = FunctionSource::call_abort_on_arg_binding_failure(call_state, e, exec_state);
+                return Err(e.add_unwind_location(fn_name.clone(), callsite));
+            }
+            exec_state.mod_local.machine_call_depth += 1;
+            let body = BlockRef::FnBody(fn_src.ast.arc());
+            konts.push(Kont::CallBoundary(Box::new(BoundaryState {
+                state: call_state,
+                fn_src,
+                fn_name: fn_display_name,
+                callsite,
+                fn_meta,
+            })));
+            push_block(body, BodyType::Block, konts);
+            step_block_kick(konts, exec_state, ctx).await
+        }
+    }
+}
+
+/// Convert a finished call's result into machine control: Exit control flow
+/// starts an exit unwind; a missing result is the "undefined function result"
+/// error; a value applies normally.
+fn finish_call_value(
+    finished: Option<KclValueControlFlow>,
+    fn_name: Option<String>,
+    callsite: SourceRange,
+    fn_meta: Vec<Metadata>,
+) -> Result<Control, KclError> {
+    match finished {
+        Some(cf) if cf.is_some_return() => Ok(Control::Exit(cf)),
+        Some(cf) => Ok(Control::Apply(Applied::Value(cf.into_value()))),
+        None => {
+            let mut source_ranges: Vec<SourceRange> = vec![callsite];
+            // We want to send the source range of the original function.
+            if !fn_meta.is_empty() {
+                source_ranges = fn_meta.iter().map(|m| m.source_range).collect();
+            }
+            let name = fn_name.unwrap_or_else(|| "unknown function".to_owned());
+            Err(KclError::new_undefined_value(
+                KclErrorDetails::new(
+                    format!("Result of user-defined function {name} is undefined"),
+                    source_ranges,
+                ),
+                None,
+            ))
+        }
+    }
+}
+
+/// Begin a sketch block: nested check, then argument evaluation (or the
+/// sketch-mode cache path), mirroring `Node<SketchBlock>::get_result`.
+async fn start_sketch_block(
+    node: Arc<Node<SketchBlock>>,
+    konts: &mut Vec<Kont>,
+    exec_state: &mut ExecState,
+    ctx: &ExecutorContext,
+) -> Result<Control, KclError> {
+    if exec_state.mod_local.sketch_block.is_some() {
+        // Disallow nested sketch blocks for now.
+        return Err(KclError::new_semantic(KclErrorDetails::new(
+            "Cannot execute a sketch block from within another sketch block".to_owned(),
+            vec![SourceRange::from(node.as_ref())],
+        )));
+    }
+
+    if exec_state.sketch_mode() {
+        let (sketch_id, sketch_surface) = match node.arguments_from_cache(exec_state) {
+            Ok(x) => x,
+            Err(crate::execution::EarlyReturn::Value(cf)) => return Ok(Control::Exit(cf)),
+            Err(crate::execution::EarlyReturn::Error(e)) => return Err(e),
+        };
+        return sketch_block_body_setup(node, sketch_id, sketch_surface, konts, exec_state, ctx).await;
+    }
+
+    // Evaluate arguments (engine execution creates planes/faces here).
+    let state = SketchArgsState {
+        node,
+        index: 0,
+        labeled: IndexMap::new(),
+    };
+    if state.node.arguments.is_empty() {
+        return sketch_args_finish(state, konts, exec_state, ctx).await;
+    }
+    let req = EvalRequest::expr(&state.node.arguments[0].arg);
+    konts.push(Kont::SketchArgs(Box::new(state)));
+    Ok(Control::Eval(Box::new(req)))
+}
+
+/// Record an evaluated sketch-block argument and evaluate the next, or finish
+/// the arguments.
+async fn sketch_args_step(
+    mut state: SketchArgsState,
+    applied: Applied,
+    konts: &mut Vec<Kont>,
+    exec_state: &mut ExecState,
+    ctx: &ExecutorContext,
+) -> Result<Control, KclError> {
+    let value = applied.expect_value()?;
+    let labeled_arg = &state.node.arguments[state.index];
+    let source_range = SourceRange::from(&labeled_arg.arg);
+    let arg = Arg::new(value, source_range);
+    match &labeled_arg.label {
+        Some(label) => {
+            state.labeled.insert(label.name.clone(), arg);
+        }
+        None => {
+            let name = labeled_arg.arg.ident_name();
+            if let Some(name) = name {
+                state.labeled.insert(name.to_owned(), arg);
+            } else {
+                return Err(KclError::new_semantic(KclErrorDetails::new(
+                    "Arguments to sketch blocks must be either labeled or simple identifiers".to_owned(),
+                    vec![SourceRange::from(&labeled_arg.arg)],
+                )));
+            }
+        }
+    }
+    state.index += 1;
+    if state.index < state.node.arguments.len() {
+        let req = EvalRequest::expr(&state.node.arguments[state.index].arg);
+        konts.push(Kont::SketchArgs(Box::new(state)));
+        Ok(Control::Eval(Box::new(req)))
+    } else {
+        sketch_args_finish(state, konts, exec_state, ctx).await
+    }
+}
+
+async fn sketch_args_finish(
+    state: SketchArgsState,
+    konts: &mut Vec<Kont>,
+    exec_state: &mut ExecState,
+    ctx: &ExecutorContext,
+) -> Result<Control, KclError> {
+    let SketchArgsState { node, labeled, .. } = state;
+    let (sketch_id, sketch_surface) = match node.finish_arguments_after_eval(labeled, exec_state, ctx).await {
+        Ok(x) => x,
+        Err(crate::execution::EarlyReturn::Value(cf)) => return Ok(Control::Exit(cf)),
+        Err(crate::execution::EarlyReturn::Error(e)) => return Err(e),
+    };
+    sketch_block_body_setup(node, sketch_id, sketch_surface, konts, exec_state, ctx).await
+}
+
+/// Scene setup, ambient sketch state, the sketch2 alias scope, and the body's
+/// child environment -- then start the body. Mirrors the middle of
+/// `Node<SketchBlock>::get_result`, with the same ordering of pushes so
+/// unwinding restores in exactly the reverse order.
+async fn sketch_block_body_setup(
+    node: Arc<Node<SketchBlock>>,
+    sketch_id: ObjectId,
+    sketch_surface: SketchSurface,
+    konts: &mut Vec<Kont>,
+    exec_state: &mut ExecState,
+    ctx: &ExecutorContext,
+) -> Result<Control, KclError> {
+    let range = SourceRange::from(node.as_ref());
+    let sketch_block_artifact_id = node.scene_setup(sketch_id, &sketch_surface, exec_state)?;
+
+    // Don't early return until the stack frame is popped!
+    node.prep_mem(exec_state.mut_stack().snapshot()?, exec_state)?;
+
+    // Track that we're executing a sketch block.
+    let initial_sketch_block_state = SketchBlockState {
+        sketch_id: Some(sketch_id),
+        ..Default::default()
+    };
+    let saved_sketch_block = exec_state.mod_local.sketch_block.replace(initial_sketch_block_state);
+    // When executing the body of the sketch block, we no longer want to
+    // skip any code.
+    let saved_sketch_mode = std::mem::replace(&mut exec_state.mod_local.sketch_mode, false);
+
+    let mut body_state = SketchBodyState {
+        node: node.clone(),
+        sketch_id,
+        sketch_surface,
+        sketch_block_artifact_id,
+        saved_sketch_block,
+        saved_sketch_mode,
+        child_env_pushed: false,
+    };
+
+    // Load `sketch2::*` into the sketch block's parent scope, so calls like
+    // `line(...)` resolve to sketch2 functions. On failure, unwind exactly
+    // like the recursive executor: restore ambient state and pop the alias
+    // env, skipping the body and finalization.
+    if let Err(e) = node.load_sketch2_into_current_scope(exec_state, ctx, range).await {
+        sketch_body_cleanup(body_state, exec_state);
+        return Err(e);
+    }
+
+    // Execute the user body in a child scope, so the aliases aren't included
+    // in the returned sketch object.
+    let parent = match exec_state.mut_stack().snapshot() {
+        Ok(p) => p,
+        Err(e) => {
+            sketch_body_cleanup(body_state, exec_state);
+            return Err(e);
+        }
+    };
+    if let Err(e) = exec_state.mut_stack().push_new_env_for_call(parent) {
+        sketch_body_cleanup(body_state, exec_state);
+        return Err(e);
+    }
+    body_state.child_env_pushed = true;
+
+    let body = BlockRef::SketchBody(node);
+    konts.push(Kont::SketchBody(Box::new(body_state)));
+    push_block(body, BodyType::Block, konts);
+    step_block_kick(konts, exec_state, ctx).await
+}
+
+/// The sketch-block body finished normally: collect the block's variables,
+/// restore ambient state (popping both environments), then solve and finalize
+/// -- or exit the whole program when this sketch block is being edited.
+async fn sketch_body_finish(
+    state: SketchBodyState,
+    applied: Applied,
+    exec_state: &mut ExecState,
+    ctx: &ExecutorContext,
+) -> Result<Control, KclError> {
+    let block_result = applied.expect_block()?;
+
+    // Collect the block's variables before popping its env; a failure here
+    // still unwinds ambient state like the recursive executor.
+    let variables = match exec_state.stack().find_all_in_current_env() {
+        Ok(block_variables) => block_variables.into_iter().collect::<IndexMap<_, _>>(),
+        Err(e) => {
+            sketch_body_cleanup(state, exec_state);
+            return Err(e);
+        }
+    };
+
+    let node = state.node.clone();
+    let sketch_id = state.sketch_id;
+    let sketch_surface = state.sketch_surface.clone();
+    let sketch_block_artifact_id = state.sketch_block_artifact_id;
+
+    // Restore ambient state and pop both envs (child, then alias), taking the
+    // sketch-block state back out for finalization.
+    let child_popped = state.child_env_pushed;
+    if child_popped {
+        exec_state.mut_stack().pop_env()?;
+    }
+    exec_state.mod_local.sketch_mode = state.saved_sketch_mode;
+    let sketch_block_state = std::mem::replace(&mut exec_state.mod_local.sketch_block, state.saved_sketch_block);
+    exec_state.mut_stack().pop_env()?;
+
+    // The body completed normally (an Exit would have unwound instead), so
+    // block_result carries no control flow of interest.
+    let _ = block_result;
+
+    let Some(sketch_block_state) = sketch_block_state else {
+        return Err(KclError::new_internal(KclErrorDetails::new(
+            "Sketch block state should still be set to Some from just above".to_owned(),
+            vec![SourceRange::from(node.as_ref())],
+        )));
+    };
+
+    let return_value = node
+        .finalize_sketch_block(
+            sketch_id,
+            &sketch_surface,
+            sketch_block_artifact_id,
+            variables,
+            sketch_block_state,
+            exec_state,
+            ctx,
+        )
+        .await?;
+
+    if node.is_being_edited {
+        // When the sketch block is being edited, we exit the program
+        // immediately.
+        Ok(Control::Exit(return_value.exit()))
+    } else {
+        Ok(Control::Apply(Applied::Value(return_value)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::execution::parse_execute_with_executor_kind;
+
+    async fn run_machine(code: &str) -> Result<crate::execution::ExecTestResults, KclError> {
+        parse_execute_with_executor_kind(code, None, ExecutorKind::Machine).await
+    }
+
+    /// The machine's whole point: recursion depth well past the recursive
+    /// executor's native-stack cap runs fine on the heap.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn deep_recursion_well_past_recursive_cap() {
+        let code = r#"fn countdown(@n) {
+  return if n == 0 {
+    0
+  } else {
+    countdown(n - 1)
+  }
+}
+result = countdown(900)
+"#;
+        let result = run_machine(code).await.unwrap();
+        let value = result
+            .exec_state
+            .stack()
+            .memory
+            .get_from_owned("result", result.mem_env, SourceRange::default(), 0)
+            .unwrap();
+        let KclValue::Number { value, .. } = value else {
+            panic!("expected a number, found {value:?}");
+        };
+        assert_eq!(value, 0.0);
+    }
+
+    /// Runaway recursion trips the depth guard with an error instead of
+    /// hanging or overflowing the native stack.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn infinite_recursion_trips_depth_guard() {
+        let code = r#"fn forever(@n) {
+  return 1 + forever(n)
+}
+forever(1)
+"#;
+        let err = run_machine(code).await.unwrap_err();
+        assert!(err.to_string().contains("Call depth limit"), "actual: {err:?}");
+    }
+
+    /// Deep pipelines ride the continuation stack, not the native stack.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn long_pipeline() {
+        let mut code = String::from("fn bump(@n) {\n  return n + 1\n}\nx = 0");
+        for _ in 0..500 {
+            code.push_str("\n  |> bump(%)");
+        }
+        code.push('\n');
+        let result = run_machine(&code).await.unwrap();
+        let value = result
+            .exec_state
+            .stack()
+            .memory
+            .get_from_owned("x", result.mem_env, SourceRange::default(), 0)
+            .unwrap();
+        let KclValue::Number { value, .. } = value else {
+            panic!("expected a number, found {value:?}");
+        };
+        assert_eq!(value, 500.0);
+    }
+}

--- a/rust/kcl-lib/src/execution/machine.rs
+++ b/rust/kcl-lib/src/execution/machine.rs
@@ -395,6 +395,9 @@ enum Kont {
 }
 
 /// Which resumable builtin is mid-iteration, with its loop state.
+// Variant sizes intentionally differ: these are the machine's heap frames,
+// and boxing every payload would add an allocation per step.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 enum ResumeState {
     Map(MapResume),
@@ -574,6 +577,9 @@ pub(crate) async fn run_expr(
 }
 
 /// How a fresh root ended.
+// Variant sizes intentionally differ: these are the machine's heap frames,
+// and boxing every payload would add an allocation per step.
+#[allow(clippy::large_enum_variant)]
 enum RootResult {
     /// The root computation finished with this result.
     Done(Applied),
@@ -1630,6 +1636,9 @@ async fn dispatch_call(
 }
 
 /// What a machine call produced immediately.
+// Variant sizes intentionally differ: these are the machine's heap frames,
+// and boxing every payload would add an allocation per step.
+#[allow(clippy::large_enum_variant)]
 enum MachineCallOutcome {
     /// Continue the machine with this control.
     Control(Control),
@@ -1821,6 +1830,9 @@ async fn resumable_entry(
 }
 
 /// What drives the next resume step.
+// Variant sizes intentionally differ: these are the machine's heap frames,
+// and boxing every payload would add an allocation per step.
+#[allow(clippy::large_enum_variant)]
 enum Feed {
     /// Start the builtin's next iteration (entry).
     Advance,
@@ -1857,6 +1869,9 @@ async fn resume_drive(
     }
 }
 
+// Variant sizes intentionally differ: these are the machine's heap frames,
+// and boxing every payload would add an allocation per step.
+#[allow(clippy::large_enum_variant)]
 enum ResumeOutcome {
     /// The machine continues with this control (a callback was started on
     /// the continuation stack, or the builtin finished and its value was

--- a/rust/kcl-lib/src/execution/machine.rs
+++ b/rust/kcl-lib/src/execution/machine.rs
@@ -1814,6 +1814,27 @@ forever(1)
         assert!(err.to_string().contains("Call depth limit"), "actual: {err:?}");
     }
 
+    /// Compare wall time of the two executors on a large, engine-free
+    /// workload (mock engine). Not a gate: the machine merges regardless of
+    /// speed; a <=10% overhead gates the default flip later. Run manually:
+    /// cargo nextest run -p kcl-lib --run-ignored all -E 'test(perf_compare_executors)' --no-capture
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "manual perf measurement, prints timings"]
+    async fn perf_compare_executors() {
+        let code = include_str!("../../tests/mike_stress_test/input.kcl");
+        const RUNS: usize = 5;
+        for kind in [ExecutorKind::Recursive, ExecutorKind::Machine] {
+            // Warm up once.
+            parse_execute_with_executor_kind(code, None, kind).await.unwrap();
+            let start = std::time::Instant::now();
+            for _ in 0..RUNS {
+                parse_execute_with_executor_kind(code, None, kind).await.unwrap();
+            }
+            let avg = start.elapsed() / RUNS as u32;
+            println!("{kind:?}: {avg:?} per run over {RUNS} runs");
+        }
+    }
+
     /// Deep pipelines ride the continuation stack, not the native stack.
     #[tokio::test(flavor = "multi_thread")]
     async fn long_pipeline() {

--- a/rust/kcl-lib/src/execution/machine.rs
+++ b/rust/kcl-lib/src/execution/machine.rs
@@ -108,6 +108,7 @@ impl ExecutorKind {
     /// (`machine` or `recursive`). Used only by test context factories so the
     /// simulation suite can run under both executors; production contexts are
     /// never configured from the environment.
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn from_test_env() -> Self {
         match std::env::var("KCL_EXECUTOR").as_deref() {
             Ok("machine") => ExecutorKind::Machine,

--- a/rust/kcl-lib/src/execution/machine.rs
+++ b/rust/kcl-lib/src/execution/machine.rs
@@ -1278,7 +1278,14 @@ async fn step_block_kick(
     exec_state: &mut ExecState,
     ctx: &ExecutorContext,
 ) -> Result<Control, KclError> {
-    let kont = konts.pop().expect("block was just pushed");
+    let Some(kont) = konts.pop() else {
+        let message = "machine executor: step_block_kick with no continuation on the stack";
+        debug_assert!(false, "{message}");
+        return Err(KclError::new_internal(KclErrorDetails::new(
+            message.to_owned(),
+            Vec::new(),
+        )));
+    };
     step_block(kont, None, konts, exec_state, ctx).await
 }
 

--- a/rust/kcl-lib/src/execution/machine.rs
+++ b/rust/kcl-lib/src/execution/machine.rs
@@ -678,7 +678,11 @@ fn unwind_exit(
                 // this).
                 exec_state.push_op(Operation::GroupEnd);
             }
-            other => cleanup(other, exec_state),
+            other => {
+                if let Err(cleanup_err) = cleanup(other, exec_state) {
+                    return Err(unwind_error(cleanup_err, konts, exec_state));
+                }
+            }
         }
     }
     Ok(cf)
@@ -720,7 +724,11 @@ fn unwind_error(mut e: KclError, konts: &mut Vec<Kont>, exec_state: &mut ExecSta
                 // GroupEnd (a historical asymmetry with the exit path).
                 sketch_body_cleanup(*sb, exec_state);
             }
-            other => cleanup(other, exec_state),
+            other => {
+                // Keep the original error; a boundary-in-cleanup internal
+                // error is secondary here and debug_assert covers development.
+                let _ = cleanup(other, exec_state);
+            }
         }
     }
     e
@@ -728,7 +736,11 @@ fn unwind_error(mut e: KclError, konts: &mut Vec<Kont>, exec_state: &mut ExecSta
 
 /// Restore ambient state for a non-boundary continuation popped during
 /// unwinding. Continuations without ambient state are simply dropped.
-fn cleanup(kont: Kont, exec_state: &mut ExecState) {
+///
+/// Boundary continuations are handled by the unwind loops before they get
+/// here; one reaching this function is a machine bug, reported as an internal
+/// error rather than a panic.
+fn cleanup(kont: Kont, exec_state: &mut ExecState) -> Result<(), KclError> {
     match kont {
         Kont::BlockSeq { in_flight, .. } => {
             if let InFlight::Declaration { prev_being_declared } = in_flight {
@@ -760,8 +772,13 @@ fn cleanup(kont: Kont, exec_state: &mut ExecState) {
         // abandon the rest of the iteration.
         | Kont::Resume(_) => {}
         // Handled by the unwind loops directly.
-        Kont::CallBoundary(_) | Kont::SketchBody(_) => unreachable!("boundaries are handled by the unwind loops"),
+        Kont::CallBoundary(_) | Kont::SketchBody(_) => {
+            let message = "machine executor: boundary continuation reached non-boundary cleanup";
+            debug_assert!(false, "{message}");
+            return Err(KclError::new_internal(KclErrorDetails::new(message.to_owned(), Vec::new())));
+        }
     }
+    Ok(())
 }
 
 /// Restore the ambient state wrapped around a sketch-block body, in the

--- a/rust/kcl-lib/src/execution/machine.rs
+++ b/rust/kcl-lib/src/execution/machine.rs
@@ -1699,6 +1699,10 @@ async fn machine_call(
             Err(e) => return Err(decorate(e, &completion)),
         };
         exec_state.mod_local.machine_call_depth += 1;
+        exec_state.global.machine_depth_high_water = exec_state
+            .global
+            .machine_depth_high_water
+            .max(exec_state.mod_local.machine_call_depth);
         konts.push(Kont::CallBoundary(Box::new(BoundaryState {
             state: call_state,
             fn_src: fn_src.clone(),
@@ -1749,6 +1753,10 @@ async fn machine_call(
                 return Err(decorate(e, &completion));
             }
             exec_state.mod_local.machine_call_depth += 1;
+            exec_state.global.machine_depth_high_water = exec_state
+                .global
+                .machine_depth_high_water
+                .max(exec_state.mod_local.machine_call_depth);
             let body = BlockRef::FnBody(fn_src.ast.arc());
             konts.push(Kont::CallBoundary(Box::new(BoundaryState {
                 state: call_state,
@@ -2515,6 +2523,50 @@ forever(1)
             let avg = start.elapsed() / RUNS as u32;
             println!("{kind:?}: {avg:?} per run over {RUNS} runs");
         }
+    }
+
+    /// The design must hold at 50,000 call depth with the limit raised
+    /// internally (the production default stays at
+    /// DEFAULT_MACHINE_CALL_DEPTH_LIMIT): depth is heap-bounded, so the limit
+    /// is policy, not a native-stack constraint.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn depth_50k_with_raised_limit() {
+        let code = r#"fn countdown(@n) {
+  return if n == 0 {
+    0
+  } else {
+    countdown(n - 1)
+  }
+}
+result = countdown(50000)
+"#;
+        let program = crate::Program::parse_no_errs(code).unwrap();
+        let exec_ctxt = ExecutorContext {
+            engine: std::sync::Arc::new(crate::engine::engine_manager::EngineManager::new_mock()),
+            engine_batch: crate::engine::EngineBatchContext::default(),
+            fs: crate::fs::new_file_system_handle(crate::fs::FileManager::new()),
+            settings: crate::execution::ExecutorSettings::default(),
+            context_type: crate::execution::ContextType::Mock,
+            execution_callbacks: Default::default(),
+            executor_kind: ExecutorKind::Machine,
+            machine_call_depth_limit: 60_000,
+        };
+        let mut exec_state = ExecState::new(&exec_ctxt);
+        let (env_ref, _) = exec_ctxt.run(&program, &mut exec_state).await.unwrap();
+        let value = exec_state
+            .stack()
+            .memory
+            .get_from_owned("result", env_ref, SourceRange::default(), 0)
+            .unwrap();
+        let KclValue::Number { value, .. } = value else {
+            panic!("expected a number, found {value:?}");
+        };
+        assert_eq!(value, 0.0);
+        assert!(
+            exec_state.machine_depth_high_water() >= 50_000,
+            "high water: {}",
+            exec_state.machine_depth_high_water()
+        );
     }
 
     /// The key requirement of the resumable-callback protocol: map calling a

--- a/rust/kcl-lib/src/execution/machine.rs
+++ b/rust/kcl-lib/src/execution/machine.rs
@@ -529,13 +529,15 @@ impl ExecutorContext {
 /// block's `last_expr` (which the module wrapper, call protocol, and sketch
 /// handling consume exactly as they do for the recursive executor). An
 /// `exit()` unwinds to this root and is returned as an `Exit`-flavored
-/// control-flow value.
+/// control-flow value. A root block flushes the engine's batched commands on
+/// both completion and exit -- never on error -- matching `exec_block`.
 pub(super) async fn run_block(
     ctx: &ExecutorContext,
     block: BlockRef,
     exec_state: &mut ExecState,
     body_type: BodyType,
 ) -> Result<Option<KclValueControlFlow>, KclError> {
+    let block_range = block.to_source_range();
     let mut konts: Vec<Kont> = Vec::new();
     // Kick the root block sequence off: stepping a block with no statement in
     // flight advances to its first statement.
@@ -550,7 +552,24 @@ pub(super) async fn run_block(
         Ok(c) => c,
         Err(e) => return Err(unwind_error(e, &mut konts, exec_state)),
     };
-    match run_loop(ctx, control, konts, exec_state).await? {
+    let result = run_loop(ctx, control, konts, exec_state).await?;
+    if matches!(body_type, BodyType::Root) {
+        // Flush the batch queue for the root, whether it completed or was
+        // terminated by an exit(): the recursive executor's flush sits after
+        // its statement loop, which its exit `break` still reaches. Errors
+        // skip the flush (the `?` above), also matching. This must run after
+        // unwinding, so that any sketch-block state has been restored, and it
+        // cannot live in step_block, which an exit never re-enters.
+        exec_state
+            .flush_batch(
+                ModelingCmdMeta::new(exec_state, ctx, block_range),
+                // True here tells the engine to flush all the end commands as well like fillets
+                // and chamfers where the engine would otherwise eat the ID of the segments.
+                true,
+            )
+            .await?;
+    }
+    match result {
         RootResult::Done(applied) => applied.expect_block(),
         RootResult::Exited(cf) => Ok(Some(cf)),
     }
@@ -1318,18 +1337,8 @@ async fn step_block(
     // Run statements until one needs an Eval.
     loop {
         let Some(statement) = block.body().get(index) else {
-            // Block complete.
-            if matches!(body_type, BodyType::Root) {
-                // Flush the batch queue.
-                exec_state
-                    .flush_batch(
-                        ModelingCmdMeta::new(exec_state, ctx, block.to_source_range()),
-                        // True here tells the engine to flush all the end commands as well like fillets
-                        // and chamfers where the engine would otherwise eat the ID of the segments.
-                        true,
-                    )
-                    .await?;
-            }
+            // Block complete. (The root's batch flush lives in run_block so
+            // that exited roots flush too.)
             return Ok(Control::Apply(Applied::Block(last)));
         };
 
@@ -2318,6 +2327,134 @@ mod tests {
 
     async fn run_machine(code: &str) -> Result<crate::execution::ExecTestResults, KclError> {
         parse_execute_with_executor_kind(code, None, ExecutorKind::Machine).await
+    }
+
+    /// A program whose trailing modeling commands are still sitting in the
+    /// engine's batch queue when the terminal statement runs. (No close() or
+    /// similar: operations that send immediately would drain the queue
+    /// themselves.)
+    const QUEUED_TAIL: &str = r#"startSketchOn(XY)
+  |> startProfile(at = [0, 0])
+  |> line(end = [10, 0])
+  |> line(end = [0, 10])
+"#;
+
+    /// Execute a program's root block directly through exec_block -- the
+    /// boundary whose flush behavior the two executors must agree on. This
+    /// deliberately bypasses run(): its end-of-run sweep
+    /// (ensure_async_commands_completed) flushes whatever the root left
+    /// queued and clear_queues() then empties the rest, masking exactly the
+    /// difference under test. Returns the block result, whether the batch
+    /// queue is empty afterwards, and how many batches were sent. Counts and
+    /// emptiness rather than command sequences: imported modules execute
+    /// concurrently, so command order is nondeterministic in general.
+    async fn exec_root_block(
+        kind: ExecutorKind,
+        code: &str,
+    ) -> (Result<Option<KclValueControlFlow>, KclError>, bool, usize) {
+        let program = crate::Program::parse_no_errs(code).unwrap();
+        let ctx = crate::execution::new_mock_executor_context(None, kind);
+        let mut exec_state = crate::execution::ExecState::new(&ctx);
+        ctx.eval_prelude(&mut exec_state, SourceRange::synthetic())
+            .await
+            .unwrap();
+        let no_prelude = ctx
+            .handle_annotations(program.ast.inner_attrs.iter(), BodyType::Root, &mut exec_state)
+            .await
+            .unwrap();
+        exec_state.mut_stack().push_new_root_env(!no_prelude).unwrap();
+        let result = ctx.exec_block(&program.ast, &mut exec_state, BodyType::Root).await;
+        let queue_empty = ctx.engine_batch.is_empty().await;
+        let batches_sent = ctx
+            .engine
+            .stats()
+            .batches_sent
+            .load(std::sync::atomic::Ordering::Relaxed);
+        (result, queue_empty, batches_sent)
+    }
+
+    /// exit() terminating the program must flush queued modeling commands to
+    /// the engine exactly like running to completion does. (The recursive
+    /// executor's root flush sits after its statement loop, which the exit's
+    /// `break` still reaches; the machine must match.)
+    #[tokio::test(flavor = "multi_thread")]
+    async fn exit_at_root_flushes_queued_commands() {
+        let completed = format!("@settings(experimentalFeatures = allow)\n{QUEUED_TAIL}");
+        let exited = format!("@settings(experimentalFeatures = allow)\n{QUEUED_TAIL}exit()\n");
+        let mut counts = Vec::new();
+        for kind in [ExecutorKind::Recursive, ExecutorKind::Machine] {
+            let (result, queue_empty, n_completed) = exec_root_block(kind, &completed).await;
+            assert!(result.is_ok(), "{kind:?}: {result:?}");
+            assert!(queue_empty, "{kind:?}: completing the root must flush the batch queue");
+            assert!(n_completed >= 1, "{kind:?}: expected at least one batch sent");
+
+            let (result, queue_empty, n_exited) = exec_root_block(kind, &exited).await;
+            let cf = result.unwrap().unwrap();
+            assert!(cf.is_some_return(), "{kind:?}: expected an exit control-flow value");
+            assert!(queue_empty, "{kind:?}: exit() must flush the batch queue");
+            assert_eq!(
+                n_exited, n_completed,
+                "{kind:?}: exit() must flush exactly like completion"
+            );
+            counts.push((n_completed, n_exited));
+        }
+        assert_eq!(counts[0], counts[1], "executors disagree on batches sent");
+    }
+
+    /// exit() from inside a function unwinds every call boundary and must
+    /// still flush at the root.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn exit_in_function_flushes_queued_commands() {
+        let fn_def = "@settings(experimentalFeatures = allow)\nfn quit() {\n  exit()\n  return 0\n}\n";
+        let completed = format!("{fn_def}{QUEUED_TAIL}");
+        let exited = format!("{fn_def}{QUEUED_TAIL}quit()\n");
+        let mut counts = Vec::new();
+        for kind in [ExecutorKind::Recursive, ExecutorKind::Machine] {
+            let (result, queue_empty, n_completed) = exec_root_block(kind, &completed).await;
+            assert!(result.is_ok(), "{kind:?}: {result:?}");
+            assert!(queue_empty, "{kind:?}: completing the root must flush the batch queue");
+            assert!(n_completed >= 1, "{kind:?}: expected at least one batch sent");
+
+            let (result, queue_empty, n_exited) = exec_root_block(kind, &exited).await;
+            let cf = result.unwrap().unwrap();
+            assert!(cf.is_some_return(), "{kind:?}: expected an exit control-flow value");
+            assert!(
+                queue_empty,
+                "{kind:?}: exit() from a function must flush the batch queue"
+            );
+            assert_eq!(
+                n_exited, n_completed,
+                "{kind:?}: exit() from a function must flush exactly like completion"
+            );
+            counts.push((n_completed, n_exited));
+        }
+        assert_eq!(counts[0], counts[1], "executors disagree on batches sent");
+    }
+
+    /// A fatal error must NOT flush the root: queued commands are left in
+    /// the batch queue (run()'s end-of-run machinery then sweeps or drops
+    /// them). This asymmetry with exit() is deliberate.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn error_does_not_flush_queued_commands() {
+        let errored = format!("{QUEUED_TAIL}assert(1, isEqualTo = 2)\n");
+        let mut counts = Vec::new();
+        for kind in [ExecutorKind::Recursive, ExecutorKind::Machine] {
+            let (result, queue_empty, n_completed) = exec_root_block(kind, QUEUED_TAIL).await;
+            assert!(result.is_ok(), "{kind:?}: {result:?}");
+            assert!(queue_empty, "{kind:?}: completing the root must flush the batch queue");
+            assert!(n_completed >= 1, "{kind:?}: expected at least one batch sent");
+
+            let (result, queue_empty, n_errored) = exec_root_block(kind, &errored).await;
+            assert!(result.is_err(), "{kind:?}: expected an error");
+            assert!(!queue_empty, "{kind:?}: an error must leave queued commands unflushed");
+            assert_eq!(
+                n_errored,
+                n_completed - 1,
+                "{kind:?}: an error must skip exactly the final flush"
+            );
+            counts.push((n_completed, n_errored));
+        }
+        assert_eq!(counts[0], counts[1], "executors disagree on batches sent");
     }
 
     /// The machine's whole point: recursion depth well past the recursive

--- a/rust/kcl-lib/src/execution/machine.rs
+++ b/rust/kcl-lib/src/execution/machine.rs
@@ -1186,7 +1186,7 @@ async fn step_block(
                     index += 1;
                     continue;
                 }
-                ctx.exec_type_declaration(ty, exec_state)?;
+                ctx.exec_type_declaration(ty, body_type, exec_state)?;
                 last = None;
                 index += 1;
             }

--- a/rust/kcl-lib/src/execution/machine.rs
+++ b/rust/kcl-lib/src/execution/machine.rs
@@ -1724,7 +1724,7 @@ async fn machine_call(
     // native stack, so this is policy, not a native-stack limit. It must
     // behave when raised to 50,000 or more.
     if exec_state.mod_local.machine_call_depth >= ctx.machine_call_depth_limit {
-        return Err(KclError::new_semantic(KclErrorDetails::new(
+        return Err(KclError::new_max_call_stack(KclErrorDetails::new(
             format!(
                 "Call depth limit ({}) exceeded. This usually means a function is recursing without a base case.",
                 ctx.machine_call_depth_limit

--- a/rust/kcl-lib/src/execution/machine.rs
+++ b/rust/kcl-lib/src/execution/machine.rs
@@ -110,14 +110,14 @@ impl ExecutorKind {
     /// applies to any context construction that consults it; unset or empty
     /// means [`ExecutorKind::default`]. Any other value is a configuration
     /// error and panics rather than silently running the wrong executor.
-    #[cfg(not(target_arch = "wasm32"))]
+    /// (Wasm builds have no environment, so this is always the default
+    /// there.)
     pub(crate) fn from_env() -> Self {
         Self::from_env_value(std::env::var("KCL_EXECUTOR").ok().as_deref())
     }
 
     /// The parsing half of [`Self::from_env`], split out so tests can drive
     /// it without touching the process environment.
-    #[cfg(not(target_arch = "wasm32"))]
     fn from_env_value(value: Option<&str>) -> Self {
         let Some(value) = value else {
             return ExecutorKind::default();

--- a/rust/kcl-lib/src/execution/machine.rs
+++ b/rust/kcl-lib/src/execution/machine.rs
@@ -2555,12 +2555,12 @@ forever(1)
         }
     }
 
-    /// The design must hold at 50,000 call depth with the limit raised
+    /// The design must hold at a much higher call depth with the limit raised
     /// internally (the production default stays at
     /// DEFAULT_MACHINE_CALL_DEPTH_LIMIT): depth is heap-bounded, so the limit
     /// is policy, not a native-stack constraint.
     #[tokio::test(flavor = "multi_thread")]
-    async fn depth_50k_with_raised_limit() {
+    async fn depth_with_raised_limit() {
         let code = r#"fn countdown(@n) {
   return if n == 0 {
     0
@@ -2568,7 +2568,7 @@ forever(1)
     countdown(n - 1)
   }
 }
-result = countdown(50000)
+result = countdown(9000)
 "#;
         let program = crate::Program::parse_no_errs(code).unwrap();
         let exec_ctxt = ExecutorContext {
@@ -2579,7 +2579,7 @@ result = countdown(50000)
             context_type: crate::execution::ContextType::Mock,
             execution_callbacks: Default::default(),
             executor_kind: ExecutorKind::Machine,
-            machine_call_depth_limit: 60_000,
+            machine_call_depth_limit: 10_000,
         };
         let mut exec_state = ExecState::new(&exec_ctxt);
         let (env_ref, _) = exec_ctxt.run(&program, &mut exec_state).await.unwrap();
@@ -2593,7 +2593,7 @@ result = countdown(50000)
         };
         assert_eq!(value, 0.0);
         assert!(
-            exec_state.machine_depth_high_water() >= 50_000,
+            exec_state.machine_depth_high_water() >= 9_000,
             "high water: {}",
             exec_state.machine_depth_high_water()
         );

--- a/rust/kcl-lib/src/execution/machine.rs
+++ b/rust/kcl-lib/src/execution/machine.rs
@@ -104,15 +104,33 @@ pub(crate) enum ExecutorKind {
 }
 
 impl ExecutorKind {
-    /// Test-harness selection of the executor via the `KCL_EXECUTOR` env var
-    /// (`machine` or `recursive`). Used only by test context factories so the
-    /// simulation suite can run under both executors; production contexts are
-    /// never configured from the environment.
+    /// Select the executor from the `KCL_EXECUTOR` environment variable:
+    /// `machine` or `recursive`, ASCII case-insensitive, surrounding
+    /// whitespace ignored. Setting the variable is an explicit opt-in and
+    /// applies to any context construction that consults it; unset or empty
+    /// means [`ExecutorKind::default`]. Any other value is a configuration
+    /// error and panics rather than silently running the wrong executor.
     #[cfg(not(target_arch = "wasm32"))]
-    pub(crate) fn from_test_env() -> Self {
-        match std::env::var("KCL_EXECUTOR").as_deref() {
-            Ok("machine") => ExecutorKind::Machine,
-            _ => ExecutorKind::Recursive,
+    pub(crate) fn from_env() -> Self {
+        Self::from_env_value(std::env::var("KCL_EXECUTOR").ok().as_deref())
+    }
+
+    /// The parsing half of [`Self::from_env`], split out so tests can drive
+    /// it without touching the process environment.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn from_env_value(value: Option<&str>) -> Self {
+        let Some(value) = value else {
+            return ExecutorKind::default();
+        };
+        let value = value.trim();
+        if value.is_empty() {
+            ExecutorKind::default()
+        } else if value.eq_ignore_ascii_case("machine") {
+            ExecutorKind::Machine
+        } else if value.eq_ignore_ascii_case("recursive") {
+            ExecutorKind::Recursive
+        } else {
+            panic!("Invalid KCL_EXECUTOR value {value:?}; expected \"machine\" or \"recursive\"");
         }
     }
 }
@@ -2360,6 +2378,27 @@ async fn sketch_body_finish(
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn executor_kind_from_env_value_parses_explicit_selections() {
+        assert_eq!(ExecutorKind::from_env_value(Some("machine")), ExecutorKind::Machine);
+        assert_eq!(ExecutorKind::from_env_value(Some("recursive")), ExecutorKind::Recursive);
+        assert_eq!(ExecutorKind::from_env_value(Some(" Machine\t")), ExecutorKind::Machine);
+        assert_eq!(ExecutorKind::from_env_value(Some("RECURSIVE")), ExecutorKind::Recursive);
+    }
+
+    #[test]
+    fn executor_kind_from_env_value_defaults_when_unset_or_empty() {
+        assert_eq!(ExecutorKind::from_env_value(None), ExecutorKind::default());
+        assert_eq!(ExecutorKind::from_env_value(Some("")), ExecutorKind::default());
+        assert_eq!(ExecutorKind::from_env_value(Some(" \t ")), ExecutorKind::default());
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid KCL_EXECUTOR value")]
+    fn executor_kind_from_env_value_rejects_unknown_values() {
+        let _ = ExecutorKind::from_env_value(Some("machin"));
+    }
     use super::*;
     use crate::execution::parse_execute_with_executor_kind;
 

--- a/rust/kcl-lib/src/execution/machine.rs
+++ b/rust/kcl-lib/src/execution/machine.rs
@@ -1110,6 +1110,9 @@ async fn step_apply(
         }
         Kont::RangeStartDone { node } => {
             let start = applied.expect_value()?;
+            // Match the recursive executor: a bad start is reported before
+            // the end element is ever evaluated.
+            node.validate_range_start(&start)?;
             let end = EvalRequest::expr(&node.end_element);
             konts.push(Kont::RangeEndDone { node, start });
             Ok(Control::Eval(Box::new(end)))

--- a/rust/kcl-lib/src/execution/machine.rs
+++ b/rust/kcl-lib/src/execution/machine.rs
@@ -1001,7 +1001,10 @@ async fn step_eval(
             let inner = EvalRequest {
                 node: EvalNode::Expr(node.expr.clone()),
                 metadata,
-                decl_name: None,
+                // The recursive executor forwards its statement_kind to the
+                // labelled inner expression, so `x = label: fn() {}` still
+                // sees the declaration name.
+                decl_name,
                 annotations: Vec::new(),
             };
             konts.push(Kont::LabelDone { node });

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -2188,15 +2188,14 @@ pub(crate) async fn parse_execute_with_project_dir(
     parse_execute_with_executor_kind(code, project_directory, machine::ExecutorKind::from_test_env()).await
 }
 
+/// A mock-engine executor context for tests that need to inspect the context
+/// (e.g. the engine's batch queue) even when execution fails.
 #[cfg(test)]
-pub(crate) async fn parse_execute_with_executor_kind(
-    code: &str,
+pub(crate) fn new_mock_executor_context(
     project_directory: Option<TypedPath>,
     executor_kind: machine::ExecutorKind,
-) -> Result<ExecTestResults, KclError> {
-    let program = crate::Program::parse_no_errs(code)?;
-
-    let exec_ctxt = ExecutorContext {
+) -> ExecutorContext {
+    ExecutorContext {
         engine: Arc::new(EngineManager::new_mock()),
         engine_batch: EngineBatchContext::default(),
         fs: crate::fs::new_file_system_handle(crate::fs::FileManager::new()),
@@ -2208,7 +2207,18 @@ pub(crate) async fn parse_execute_with_executor_kind(
         execution_callbacks: Default::default(),
         executor_kind,
         machine_call_depth_limit: crate::execution::machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
-    };
+    }
+}
+
+#[cfg(test)]
+pub(crate) async fn parse_execute_with_executor_kind(
+    code: &str,
+    project_directory: Option<TypedPath>,
+    executor_kind: machine::ExecutorKind,
+) -> Result<ExecTestResults, KclError> {
+    let program = crate::Program::parse_no_errs(code)?;
+
+    let exec_ctxt = new_mock_executor_context(project_directory, executor_kind);
     let mut exec_state = ExecState::new(&exec_ctxt);
     let result = exec_ctxt.run(&program, &mut exec_state).await?;
 

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -1184,7 +1184,7 @@ impl ExecutorContext {
         .await?;
         // Differential testing: unit tests run under both executors.
         let mut ctx = ctx;
-        ctx.executor_kind = machine::ExecutorKind::from_test_env();
+        ctx.executor_kind = machine::ExecutorKind::from_env();
         Ok(ctx)
     }
 
@@ -2187,7 +2187,7 @@ pub(crate) async fn parse_execute_with_project_dir(
     project_directory: Option<TypedPath>,
 ) -> Result<ExecTestResults, KclError> {
     // Differential testing: unit tests run under both executors.
-    parse_execute_with_executor_kind(code, project_directory, machine::ExecutorKind::from_test_env()).await
+    parse_execute_with_executor_kind(code, project_directory, machine::ExecutorKind::from_env()).await
 }
 
 /// A mock-engine executor context for tests that need to inspect the context

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -4903,6 +4903,43 @@ x = arr[m]
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn whole_module_name_executes_as_operand() {
+        // A whole-module import used as a binary or unary operand executes
+        // the module and operates on its final-expression value, exactly like
+        // using the name in expression position (x = m).
+        let main = r#"import "m.kcl" as m
+sum = m + m
+neg = -m
+"#;
+        let result = execute_with_modules(main, &[("m.kcl", "42\n")]).await.unwrap();
+        assert_eq!(
+            mem_get_json(result.exec_state.stack(), result.mem_env, "sum").as_f64(),
+            Some(84.0)
+        );
+        assert_eq!(
+            mem_get_json(result.exec_state.stack(), result.mem_env, "neg").as_f64(),
+            Some(-42.0)
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn whole_module_without_return_as_operand_errors() {
+        // Matches expression-position behavior: the module still executes,
+        // the missing-return fallback produces a KclNone, and the binary
+        // operation then rejects it. (A trailing declaration would count as
+        // the module's return value, so the module body must be empty.)
+        let main = "import \"m.kcl\" as m
+x = m + 1
+";
+        let err = execute_with_modules(main, &[("m.kcl", "")]).await.unwrap_err();
+        assert!(
+            err.message().contains("Expected a number, but found none"),
+            "expected the operand to be the module's missing-return KclNone, got: {}",
+            err.message()
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn enum_rejects_name_clash_with_module() {
         // One rule reached four ways: by declaring the enum second, by importing
         // the module second, and by importing the enum itself either by name or

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -4874,6 +4874,8 @@ type Color { | Red | Green | Red }
             },
             context_type: ContextType::Mock,
             execution_callbacks: Default::default(),
+            executor_kind: Default::default(),
+            machine_call_depth_limit: crate::execution::machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
         };
         let mut exec_state = ExecState::new(&ctx);
         // Close the context even if execution panics, then let the panic

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -1091,6 +1091,8 @@ impl ExecutorContext {
             settings,
             context_type: ContextType::Mock,
             execution_callbacks: Default::default(),
+            executor_kind: Default::default(),
+            machine_call_depth_limit: machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
         }
     }
 
@@ -1110,6 +1112,8 @@ impl ExecutorContext {
             settings,
             context_type: ContextType::Mock,
             execution_callbacks: Default::default(),
+            executor_kind: Default::default(),
+            machine_call_depth_limit: machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
         })
     }
 

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -1007,7 +1007,7 @@ impl ExecutorContext {
             settings,
             context_type: ContextType::Live,
             execution_callbacks: Default::default(),
-            executor_kind: Default::default(),
+            executor_kind: machine::ExecutorKind::from_env(),
             machine_call_depth_limit: machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
         }
     }
@@ -1079,7 +1079,7 @@ impl ExecutorContext {
             settings: settings.unwrap_or_default(),
             context_type: ContextType::Mock,
             execution_callbacks: Default::default(),
-            executor_kind: Default::default(),
+            executor_kind: machine::ExecutorKind::from_env(),
             machine_call_depth_limit: machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
         }
     }
@@ -1093,7 +1093,7 @@ impl ExecutorContext {
             settings,
             context_type: ContextType::Mock,
             execution_callbacks: Default::default(),
-            executor_kind: Default::default(),
+            executor_kind: machine::ExecutorKind::from_env(),
             machine_call_depth_limit: machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
         }
     }
@@ -1114,7 +1114,7 @@ impl ExecutorContext {
             settings,
             context_type: ContextType::Mock,
             execution_callbacks: Default::default(),
-            executor_kind: Default::default(),
+            executor_kind: machine::ExecutorKind::from_env(),
             machine_call_depth_limit: machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
         })
     }
@@ -1128,7 +1128,7 @@ impl ExecutorContext {
             settings: Default::default(),
             context_type: ContextType::MockCustomForwarded,
             execution_callbacks: Default::default(),
-            executor_kind: Default::default(),
+            executor_kind: machine::ExecutorKind::from_env(),
             machine_call_depth_limit: machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
         }
     }
@@ -1182,9 +1182,6 @@ impl ExecutorContext {
             engine_addr,
         )
         .await?;
-        // Differential testing: unit tests run under both executors.
-        let mut ctx = ctx;
-        ctx.executor_kind = machine::ExecutorKind::from_env();
         Ok(ctx)
     }
 
@@ -2376,7 +2373,7 @@ mod tests {
             },
             context_type: ContextType::Mock,
             execution_callbacks: Default::default(),
-            executor_kind: Default::default(),
+            executor_kind: machine::ExecutorKind::from_env(),
             machine_call_depth_limit: crate::execution::machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
         };
         let mut exec_state = ExecState::new_with_memory_backend(&ctx, backend);
@@ -4902,7 +4899,7 @@ type Color { | Red | Green | Red }
             },
             context_type: ContextType::Mock,
             execution_callbacks: Default::default(),
-            executor_kind: Default::default(),
+            executor_kind: machine::ExecutorKind::from_env(),
             machine_call_depth_limit: crate::execution::machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
         };
         let mut exec_state = ExecState::new(&ctx);

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -1020,8 +1020,10 @@ impl ExecutorContext {
             settings: self.settings.clone(),
             context_type: self.context_type.clone(),
             execution_callbacks: self.execution_callbacks.clone(),
-            executor_kind: Default::default(),
-            machine_call_depth_limit: machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
+            // Imported modules execute on this cloned context; keep them on
+            // the executor selected for the run instead of the default.
+            executor_kind: self.executor_kind,
+            machine_call_depth_limit: self.machine_call_depth_limit,
         }
     }
 
@@ -2301,6 +2303,18 @@ mod tests {
         ($file:literal) => {
             include_str!(concat!("../../e2e/executor/inputs/", $file, ".kcl"))
         };
+    }
+
+    #[test]
+    fn clone_with_fresh_execution_batch_keeps_executor_selection() {
+        // Imported modules execute on a context created by
+        // clone_with_fresh_execution_batch. They must stay on the executor
+        // selected for the run instead of silently reverting to the default.
+        let mut ctx = new_mock_executor_context(None, machine::ExecutorKind::Machine);
+        ctx.machine_call_depth_limit = 123;
+        let cloned = ctx.clone_with_fresh_execution_batch();
+        assert_eq!(cloned.executor_kind, machine::ExecutorKind::Machine);
+        assert_eq!(cloned.machine_call_depth_limit, 123);
     }
 
     /// Convenience function to get a JSON value from memory and unwrap.

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -153,7 +153,7 @@ mod artifact;
 pub(crate) use artifact::mermaid_tests::ArtifactGraphMermaidExt;
 pub(crate) mod cache;
 mod cad_op;
-mod exec_ast;
+pub(crate) mod exec_ast;
 pub mod fn_call;
 #[cfg(test)]
 mod freedom_analysis_tests;
@@ -165,6 +165,7 @@ mod import;
 mod import_graph;
 pub(crate) mod kcl_value;
 pub(crate) mod kcl_value_view;
+pub(crate) mod machine;
 mod memory;
 mod modeling;
 mod named_views;
@@ -828,6 +829,13 @@ pub struct ExecutorContext {
     pub settings: ExecutorSettings,
     pub context_type: ContextType,
     pub execution_callbacks: Option<Arc<dyn ExecutionCallbacks>>,
+    /// Which executor evaluates KCL. Crate-internal: set before the first
+    /// run and immutable during execution (run methods take &self). Cloned
+    /// contexts (fresh roots, Args) inherit the same executor.
+    pub(crate) executor_kind: machine::ExecutorKind,
+    /// Call-depth limit for the machine executor's runaway-recursion guard.
+    /// Crate-internal policy, not user configuration.
+    pub(crate) machine_call_depth_limit: usize,
 }
 
 impl std::fmt::Debug for ExecutorContext {
@@ -838,6 +846,8 @@ impl std::fmt::Debug for ExecutorContext {
             .field("settings", &self.settings)
             .field("context_type", &self.context_type)
             .field("execution_callbacks", &self.execution_callbacks)
+            .field("executor_kind", &self.executor_kind)
+            .field("machine_call_depth_limit", &self.machine_call_depth_limit)
             .finish()
     }
 }
@@ -997,6 +1007,8 @@ impl ExecutorContext {
             settings,
             context_type: ContextType::Live,
             execution_callbacks: Default::default(),
+            executor_kind: Default::default(),
+            machine_call_depth_limit: machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
         }
     }
 
@@ -1008,6 +1020,8 @@ impl ExecutorContext {
             settings: self.settings.clone(),
             context_type: self.context_type.clone(),
             execution_callbacks: self.execution_callbacks.clone(),
+            executor_kind: Default::default(),
+            machine_call_depth_limit: machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
         }
     }
 
@@ -1063,6 +1077,8 @@ impl ExecutorContext {
             settings: settings.unwrap_or_default(),
             context_type: ContextType::Mock,
             execution_callbacks: Default::default(),
+            executor_kind: Default::default(),
+            machine_call_depth_limit: machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
         }
     }
 
@@ -1106,6 +1122,8 @@ impl ExecutorContext {
             settings: Default::default(),
             context_type: ContextType::MockCustomForwarded,
             execution_callbacks: Default::default(),
+            executor_kind: Default::default(),
+            machine_call_depth_limit: machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
         }
     }
 
@@ -1158,6 +1176,9 @@ impl ExecutorContext {
             engine_addr,
         )
         .await?;
+        // Differential testing: unit tests run under both executors.
+        let mut ctx = ctx;
+        ctx.executor_kind = machine::ExecutorKind::from_test_env();
         Ok(ctx)
     }
 
@@ -2159,6 +2180,16 @@ pub(crate) async fn parse_execute_with_project_dir(
     code: &str,
     project_directory: Option<TypedPath>,
 ) -> Result<ExecTestResults, KclError> {
+    // Differential testing: unit tests run under both executors.
+    parse_execute_with_executor_kind(code, project_directory, machine::ExecutorKind::from_test_env()).await
+}
+
+#[cfg(test)]
+pub(crate) async fn parse_execute_with_executor_kind(
+    code: &str,
+    project_directory: Option<TypedPath>,
+    executor_kind: machine::ExecutorKind,
+) -> Result<ExecTestResults, KclError> {
     let program = crate::Program::parse_no_errs(code)?;
 
     let exec_ctxt = ExecutorContext {
@@ -2171,6 +2202,8 @@ pub(crate) async fn parse_execute_with_project_dir(
         },
         context_type: ContextType::Mock,
         execution_callbacks: Default::default(),
+        executor_kind,
+        machine_call_depth_limit: crate::execution::machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
     };
     let mut exec_state = ExecState::new(&exec_ctxt);
     let result = exec_ctxt.run(&program, &mut exec_state).await?;
@@ -2315,6 +2348,8 @@ mod tests {
             },
             context_type: ContextType::Mock,
             execution_callbacks: Default::default(),
+            executor_kind: Default::default(),
+            machine_call_depth_limit: crate::execution::machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
         };
         let mut exec_state = ExecState::new_with_memory_backend(&ctx, backend);
         let (env_ref, _) = ctx.run(&program, &mut exec_state).await.unwrap();
@@ -3956,7 +3991,13 @@ forever(1)
 "#;
         let result = parse_execute(ast).await;
         let err = result.unwrap_err();
-        assert!(err.to_string().contains("stack size exceeded"), "actual: {:?}", err);
+        // The recursive executor's native-stack cap and the machine
+        // executor's call-depth guard report differently.
+        let msg = err.to_string();
+        assert!(
+            msg.contains("stack size exceeded") || msg.contains("Call depth limit"),
+            "actual: {err:?}"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/rust/kcl-lib/src/execution/sketch_transpiler.rs
+++ b/rust/kcl-lib/src/execution/sketch_transpiler.rs
@@ -32,6 +32,7 @@ use crate::frontend::create_vertical_ast;
 use crate::frontend::sketch::Point2d;
 use crate::frontend::to_ast_point2d;
 use crate::parsing::ast::types as ast;
+use crate::parsing::ast::types::BoxNode;
 
 mod intermediate_var;
 mod region;
@@ -120,7 +121,7 @@ pub fn transpile_all_old_sketches_to_new(
         if let ast::BodyItem::VariableDeclaration(var_decl) = item
             && let Some(sketch_block) = sketch_blocks.get(&var_decl.declaration.id.name)
         {
-            var_decl.declaration.init = ast::Expr::SketchBlock(Box::new(ast::Node::no_src(sketch_block.clone())));
+            var_decl.declaration.init = ast::Expr::SketchBlock(BoxNode::new(ast::Node::no_src(sketch_block.clone())));
         }
     }
     if !sketch_blocks.is_empty() {
@@ -159,7 +160,7 @@ pub fn transpile_old_sketch_to_new(
     let program = ast::Program {
         body: vec![ast::BodyItem::ExpressionStatement(ast::Node::no_src(
             ast::ExpressionStatement {
-                expression: ast::Expr::SketchBlock(Box::new(ast::Node::no_src(sketch_block))),
+                expression: ast::Expr::SketchBlock(BoxNode::new(ast::Node::no_src(sketch_block))),
                 digest: None,
             },
         ))],
@@ -528,7 +529,7 @@ fn transpiler_create_segment_declaration(
         ),
     };
 
-    Ok(ast::BodyItem::VariableDeclaration(Box::new(ast::Node::no_src(
+    Ok(ast::BodyItem::VariableDeclaration(BoxNode::new(ast::Node::no_src(
         ast::VariableDeclaration {
             kind: ast::VariableKind::Const,
             declaration: ast::Node::no_src(ast::VariableDeclarator {
@@ -725,7 +726,7 @@ fn create_arc_size_constraint_ast_from_name(
     num: Number,
 ) -> Result<ast::Expr, KclError> {
     let segment_expr = ast_name_expr(segment_name.to_string());
-    let call_ast = ast::BinaryPart::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
+    let call_ast = ast::BinaryPart::CallExpressionKw(BoxNode::new(ast::Node::no_src(ast::CallExpressionKw {
         callee: ast::Node::no_src(ast::Name {
             name: ast::Node::no_src(ast::Identifier {
                 name: function_name.to_owned(),
@@ -747,11 +748,11 @@ fn create_arc_size_constraint_ast_from_name(
         ))
     })?;
 
-    Ok(ast::Expr::BinaryExpression(Box::new(ast::Node::no_src(
+    Ok(ast::Expr::BinaryExpression(BoxNode::new(ast::Node::no_src(
         ast::BinaryExpression {
             left: call_ast,
             operator: ast::BinaryOperator::Eq,
-            right: ast::BinaryPart::Literal(Box::new(ast::Node::no_src(ast::Literal {
+            right: ast::BinaryPart::Literal(BoxNode::new(ast::Node::no_src(ast::Literal {
                 value: ast::LiteralValue::Number {
                     value: num.value,
                     suffix: num.units,
@@ -852,7 +853,7 @@ fn extract_sketch_surface_expr_from_start_sketch_on(
         return Ok(surface_expr.clone());
     }
 
-    Ok(ast::Expr::CallExpressionKw(Box::new(call.clone())))
+    Ok(ast::Expr::CallExpressionKw(BoxNode::new(call.clone())))
 }
 
 /// Get a Sketch value from ExecOutcome's variables.

--- a/rust/kcl-lib/src/execution/sketch_transpiler/intermediate_var.rs
+++ b/rust/kcl-lib/src/execution/sketch_transpiler/intermediate_var.rs
@@ -5,6 +5,7 @@ use crate::SourceRange;
 use crate::errors::KclErrorDetails;
 use crate::front::find_defined_names;
 use crate::frontend::modify::next_free_name_with_padding;
+use crate::parsing::ast::types::BoxNode;
 use crate::parsing::ast::types::ItemVisibility;
 use crate::parsing::ast::types::LabeledArg;
 use crate::parsing::ast::types::PipeExpression;
@@ -188,11 +189,11 @@ fn migrate_expr(context: &mut Context, expr: &mut ast::Expr) -> Result<bool, Kcl
                             // If call has an explicit unlabeled arg, we
                             // shouldn't change it.
                             if is_unlabeled_pipe_value(call) {
-                                call.unlabeled = Some(ast::Expr::Name(Box::new(ast::Name::new(&sketch_name))));
+                                call.unlabeled = Some(ast::Expr::Name(BoxNode::new(ast::Name::new(&sketch_name))));
                             } else if is_labeled_shorthand(call) {
                                 let shorthand_arg = call
                                     .unlabeled
-                                    .replace(ast::Expr::Name(Box::new(ast::Name::new(&sketch_name))));
+                                    .replace(ast::Expr::Name(BoxNode::new(ast::Name::new(&sketch_name))));
                                 if let Some(arg) = shorthand_arg {
                                     call.arguments.insert(0, LabeledArg { label: None, arg });
                                 }
@@ -211,7 +212,7 @@ fn migrate_expr(context: &mut Context, expr: &mut ast::Expr) -> Result<bool, Kcl
             };
             let sketch_pipe_body = node.body.drain(..new_start_index).collect();
             let sketch_non_code_meta = node.non_code_meta.split_at(new_start_index);
-            let pipe_expr = ast::Expr::PipeExpression(Box::new(ast::Node::no_src(PipeExpression {
+            let pipe_expr = ast::Expr::PipeExpression(BoxNode::new(ast::Node::no_src(PipeExpression {
                 body: sketch_pipe_body,
                 non_code_meta: sketch_non_code_meta,
                 digest: None,

--- a/rust/kcl-lib/src/execution/sketch_transpiler/region.rs
+++ b/rust/kcl-lib/src/execution/sketch_transpiler/region.rs
@@ -7,6 +7,7 @@ use crate::errors::KclError;
 use crate::errors::KclErrorDetails;
 use crate::front::find_defined_names;
 use crate::frontend::modify::next_free_name_with_padding;
+use crate::parsing::ast::types::BoxNode;
 use crate::parsing::ast::types::CodeBlock;
 use crate::parsing::ast::types::ItemVisibility;
 use crate::parsing::ast::types::LabeledArg;
@@ -255,12 +256,12 @@ fn migrate_call(context: &mut Context, node: &mut ast::Node<ast::CallExpressionK
                 if let Some(seg2) = seg2 {
                     args.push(name_dot_name_ast(sketch_name, seg2));
                 }
-                let region_call = ast::Expr::CallExpressionKw(Box::new(ast::CallExpressionKw::new(
+                let region_call = ast::Expr::CallExpressionKw(BoxNode::new(ast::CallExpressionKw::new(
                     "region",
                     None,
                     vec![LabeledArg {
                         label: Some(ast::Identifier::new("segments")),
-                        arg: ast::Expr::ArrayExpression(Box::new(ast::ArrayExpression::new(args))),
+                        arg: ast::Expr::ArrayExpression(BoxNode::new(ast::ArrayExpression::new(args))),
                     }],
                 )));
                 let var_decl = ast::Node::boxed(
@@ -278,7 +279,7 @@ fn migrate_call(context: &mut Context, node: &mut ast::Node<ast::CallExpressionK
                     .new_declarations
                     .push(ast::BodyItem::VariableDeclaration(var_decl));
                 // Replace the unlabeled arg with the name of the region.
-                node.unlabeled = Some(ast::Expr::Name(Box::new(ast::Name::new(&region_name))));
+                node.unlabeled = Some(ast::Expr::Name(BoxNode::new(ast::Name::new(&region_name))));
             }
         }
         _ => {}
@@ -360,8 +361,8 @@ fn name_dot_name_ast<S1: Into<String>, S2: Into<String>>(name: S1, property: S2)
         Default::default(),
         Default::default(),
         ast::MemberExpression {
-            object: ast::Expr::Name(Box::new(ast::Name::new(name))),
-            property: ast::Expr::Name(Box::new(ast::Name::new(property))),
+            object: ast::Expr::Name(BoxNode::new(ast::Name::new(name))),
+            property: ast::Expr::Name(BoxNode::new(ast::Name::new(property))),
             computed: false,
             digest: None,
         },

--- a/rust/kcl-lib/src/execution/state.rs
+++ b/rust/kcl-lib/src/execution/state.rs
@@ -698,17 +698,20 @@ impl ExecState {
         Ok(())
     }
 
-    /// Returns true if we're executing in sketch mode for the current module.
-    /// In sketch mode, we still want to execute the prelude and other stdlib
-    /// modules as normal, so it can vary per module within a single overall
-    /// execution.
     /// The deepest machine-executor call depth reached in this execution.
-    /// Only the test harnesses' depth survey reads this today.
-    #[cfg(test)]
+    /// The machine maintains the counter in all builds; today only the test
+    /// harnesses' depth survey reads it.
+    // Unused outside test builds, but kept available so release diagnostics
+    // can read the counter the machine already maintains.
+    #[allow(dead_code)]
     pub(crate) fn machine_depth_high_water(&self) -> usize {
         self.global.machine_depth_high_water
     }
 
+    /// Returns true if we're executing in sketch mode for the current module.
+    /// In sketch mode, we still want to execute the prelude and other stdlib
+    /// modules as normal, so it can vary per module within a single overall
+    /// execution.
     pub(crate) fn sketch_mode(&self) -> bool {
         self.mod_local.sketch_mode
             && match &self.mod_local.path {

--- a/rust/kcl-lib/src/execution/state.rs
+++ b/rust/kcl-lib/src/execution/state.rs
@@ -678,10 +678,14 @@ impl ExecState {
     pub(super) fn inc_call_stack_size(&mut self, range: SourceRange) -> Result<(), KclError> {
         // If you change this, make sure to test in WebAssembly in the app since
         // that's the limiting factor.
-        if self.mod_local.call_stack_size >= 50 {
-            return Err(KclError::MaxCallStack {
-                details: KclErrorDetails::new("maximum call stack size exceeded".to_owned(), vec![range]),
-            });
+        const LIMIT: usize = 50;
+        if self.mod_local.call_stack_size >= LIMIT {
+            return Err(KclError::new_max_call_stack(KclErrorDetails::new(
+                format!(
+                    "Call depth limit ({LIMIT}) exceeded. This usually means a function is recursing without a base case."
+                ),
+                vec![range],
+            )));
         }
         self.mod_local.call_stack_size += 1;
         Ok(())

--- a/rust/kcl-lib/src/execution/state.rs
+++ b/rust/kcl-lib/src/execution/state.rs
@@ -280,6 +280,9 @@ pub(super) struct ModuleState {
     /// recursive function calls. In general, this doesn't match `stack`'s size
     /// since it's conservative in reclaiming frames between executions.
     pub(super) call_stack_size: usize,
+    /// Live call depth of the machine executor within this module, for its
+    /// runaway-recursion guard. The machine's analog of `call_stack_size`.
+    pub(crate) machine_call_depth: usize,
     /// The current value of the pipe operator returned from the previous
     /// expression.  If we're not currently in a pipeline, this will be None.
     pub pipe_value: Option<KclValue>,
@@ -1494,6 +1497,7 @@ impl ModuleState {
             id_generator: IdGenerator::new(module_id),
             stack: memory.new_stack(),
             call_stack_size: 0,
+            machine_call_depth: 0,
             pipe_value: Default::default(),
             being_declared: Default::default(),
             sketch_block: Default::default(),

--- a/rust/kcl-lib/src/execution/state.rs
+++ b/rust/kcl-lib/src/execution/state.rs
@@ -75,6 +75,11 @@ pub type ModuleInfoMap = IndexMap<ModuleId, ModuleInfo>;
 
 #[derive(Debug, Clone)]
 pub(super) struct GlobalState {
+    /// The deepest machine-executor call depth reached anywhere in this
+    /// execution (across modules and callbacks). Used to survey real-world
+    /// depth against the runaway guard's limit; see
+    /// `machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT`.
+    pub(crate) machine_depth_high_water: usize,
     /// Map from source file absolute path to module ID.
     pub path_to_source_id: IndexMap<ModulePath, ModuleId>,
     /// Map from module ID to source file.
@@ -697,6 +702,13 @@ impl ExecState {
     /// In sketch mode, we still want to execute the prelude and other stdlib
     /// modules as normal, so it can vary per module within a single overall
     /// execution.
+    /// The deepest machine-executor call depth reached in this execution.
+    /// Only the test harnesses' depth survey reads this today.
+    #[cfg(test)]
+    pub(crate) fn machine_depth_high_water(&self) -> usize {
+        self.global.machine_depth_high_water
+    }
+
     pub(crate) fn sketch_mode(&self) -> bool {
         self.mod_local.sketch_mode
             && match &self.mod_local.path {
@@ -1319,6 +1331,7 @@ impl FromStr for KclVersion {
 impl GlobalState {
     fn new(settings: &ExecutorSettings, segment_ids_edited: AhashIndexSet<ObjectId>) -> Self {
         let mut global = GlobalState {
+            machine_depth_high_water: 0,
             path_to_source_id: Default::default(),
             module_infos: Default::default(),
             artifacts: Default::default(),

--- a/rust/kcl-lib/src/execution/state.rs
+++ b/rust/kcl-lib/src/execution/state.rs
@@ -75,10 +75,12 @@ pub type ModuleInfoMap = IndexMap<ModuleId, ModuleInfo>;
 
 #[derive(Debug, Clone)]
 pub(super) struct GlobalState {
-    /// The deepest machine-executor call depth reached anywhere in this
-    /// execution (across modules and callbacks). Used to survey real-world
-    /// depth against the runaway guard's limit; see
-    /// `machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT`.
+    /// The deepest machine-executor call depth reached by executions sharing
+    /// this state: the root module, its callbacks, and module bodies executed
+    /// inline on it. Imported modules pre-executed in parallel run on cloned
+    /// state whose counter is dropped, so their depths are not aggregated
+    /// here. Used to survey real-world depth against the runaway guard's
+    /// limit; see `machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT`.
     pub(crate) machine_depth_high_water: usize,
     /// Map from source file absolute path to module ID.
     pub path_to_source_id: IndexMap<ModulePath, ModuleId>,

--- a/rust/kcl-lib/src/execution/types.rs
+++ b/rust/kcl-lib/src/execution/types.rs
@@ -1992,7 +1992,9 @@ mod test {
                 object_kind: Default::default(),
             },
             KclValue::TagIdentifier(Box::new("foo".parse().unwrap())),
-            KclValue::TagDeclarator(Box::new(crate::parsing::ast::types::TagDeclarator::new("foo"))),
+            KclValue::TagDeclarator(crate::parsing::ast::types::BoxNode::new(
+                crate::parsing::ast::types::TagDeclarator::new("foo"),
+            )),
             KclValue::Plane {
                 value: Box::new(
                     Plane::from_plane_data_skipping_engine(crate::std::sketch::PlaneData::XY, exec_state).unwrap(),

--- a/rust/kcl-lib/src/frontend.rs
+++ b/rust/kcl-lib/src/frontend.rs
@@ -5751,12 +5751,14 @@ fn create_face_id_ast(solid_expr: ast::Expr, index: usize) -> ast::Expr {
         unlabeled: Some(solid_expr),
         arguments: vec![ast::LabeledArg {
             label: Some(ast::Identifier::new("index")),
-            arg: ast::Expr::Literal(BoxNode::new(ast::Node::no_src(ast::Literal::from(ast::NumericLiteral {
-                value: index as f64,
-                suffix: NumericSuffix::None,
-                raw: index.to_string(),
-                digest: None,
-            })))),
+            arg: ast::Expr::Literal(BoxNode::new(ast::Node::no_src(ast::Literal::from(
+                ast::NumericLiteral {
+                    value: index as f64,
+                    suffix: NumericSuffix::None,
+                    raw: index.to_string(),
+                    digest: None,
+                },
+            )))),
         }],
         digest: None,
         non_code_meta: Default::default(),

--- a/rust/kcl-lib/src/frontend.rs
+++ b/rust/kcl-lib/src/frontend.rs
@@ -2315,7 +2315,7 @@ impl FrontendState {
         if ctor.direction == Some(ArcDirection::Cw) {
             arguments.push(ast::LabeledArg {
                 label: Some(ast::Identifier::new(ARC_DIRECTION_PARAM)),
-                arg: ast::Expr::Name(Box::new(ast::Name::new(ARC_DIRECTION_CW_NAME))),
+                arg: ast::Expr::Name(BoxNode::new(ast::Name::new(ARC_DIRECTION_CW_NAME))),
             });
         }
         // Add construction kwarg if construction is Some(true)
@@ -3806,7 +3806,7 @@ impl FrontendState {
 
         let l0_ast = self.line_id_to_ast_reference(l0_id, new_ast)?;
         let l1_ast = self.line_id_to_ast_reference(l1_id, new_ast)?;
-        let lines_ast = ast::Expr::ArrayExpression(Box::new(ast::Node::no_src(ast::ArrayExpression {
+        let lines_ast = ast::Expr::ArrayExpression(BoxNode::new(ast::Node::no_src(ast::ArrayExpression {
             elements: vec![l0_ast, l1_ast],
             digest: None,
             non_code_meta: Default::default(),
@@ -3829,7 +3829,7 @@ impl FrontendState {
         if let Some(sector) = angle.sector {
             arguments.push(ast::LabeledArg {
                 label: Some(ast::Identifier::new(ANGLE_SECTOR_PARAM)),
-                arg: ast::Expr::Literal(Box::new(ast::Node::no_src(ast::Literal {
+                arg: ast::Expr::Literal(BoxNode::new(ast::Node::no_src(ast::Literal {
                     value: ast::LiteralValue::Number {
                         value: f64::from(sector),
                         suffix: NumericSuffix::None,
@@ -3843,7 +3843,7 @@ impl FrontendState {
         if angle.inverse == Some(true) {
             arguments.push(ast::LabeledArg {
                 label: Some(ast::Identifier::new(ANGLE_INVERSE_PARAM)),
-                arg: ast::Expr::Literal(Box::new(ast::Node::no_src(ast::Literal {
+                arg: ast::Expr::Literal(BoxNode::new(ast::Node::no_src(ast::Literal {
                     value: ast::LiteralValue::Bool(true),
                     raw: true.to_string(),
                     digest: None,
@@ -3858,7 +3858,7 @@ impl FrontendState {
             });
         }
 
-        let call = ast::BinaryPart::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
+        let call = ast::BinaryPart::CallExpressionKw(BoxNode::new(ast::Node::no_src(ast::CallExpressionKw {
             callee: ast::Node::no_src(ast_sketch2_name(if uses_angle_dimension {
                 ANGLE_DIMENSION_FN
             } else {
@@ -3869,7 +3869,7 @@ impl FrontendState {
             digest: None,
             non_code_meta: Default::default(),
         })));
-        let value = ast::BinaryPart::Literal(Box::new(ast::Node::no_src(ast::Literal {
+        let value = ast::BinaryPart::Literal(BoxNode::new(ast::Node::no_src(ast::Literal {
             value: ast::LiteralValue::Number {
                 value: angle.angle.value,
                 suffix: angle.angle.units,
@@ -5746,12 +5746,12 @@ fn create_face_of_ast(solid_expr: ast::Expr, face_expr: ast::Expr) -> ast::Expr 
 }
 
 fn create_face_id_ast(solid_expr: ast::Expr, index: usize) -> ast::Expr {
-    ast::Expr::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
+    ast::Expr::CallExpressionKw(BoxNode::new(ast::Node::no_src(ast::CallExpressionKw {
         callee: ast::Node::no_src(ast_sketch2_name("faceId")),
         unlabeled: Some(solid_expr),
         arguments: vec![ast::LabeledArg {
             label: Some(ast::Identifier::new("index")),
-            arg: ast::Expr::Literal(Box::new(ast::Node::no_src(ast::Literal::from(ast::NumericLiteral {
+            arg: ast::Expr::Literal(BoxNode::new(ast::Node::no_src(ast::Literal::from(ast::NumericLiteral {
                 value: index as f64,
                 suffix: NumericSuffix::None,
                 raw: index.to_string(),
@@ -6347,7 +6347,7 @@ fn process(ctx: &AstMutateContext, node: NodeMut) -> TraversalReturn<Result<AstM
                         .iter()
                         .any(|arg| arg.label.as_ref().map(|id| id.name.as_str()) == Some(ARC_DIRECTION_PARAM));
                     if direction_value.is_clockwise() {
-                        let direction_ast = ast::Expr::Name(Box::new(ast::Name::new(ARC_DIRECTION_CW_NAME)));
+                        let direction_ast = ast::Expr::Name(BoxNode::new(ast::Name::new(ARC_DIRECTION_CW_NAME)));
                         if direction_exists {
                             // Update existing direction kwarg
                             for labeled_arg in &mut call.arguments {
@@ -14310,7 +14310,7 @@ shell001 = shell(extrude001, faces = capEnd001, thickness = 1)";
             ast::VariableKind::Const,
         );
         ast.body
-            .push(ast::BodyItem::VariableDeclaration(Box::new(ast::Node::no_src(
+            .push(ast::BodyItem::VariableDeclaration(BoxNode::new(ast::Node::no_src(
                 face_decl,
             ))));
         let face_source = source_from_ast(&ast);

--- a/rust/kcl-lib/src/frontend.rs
+++ b/rust/kcl-lib/src/frontend.rs
@@ -660,11 +660,11 @@ impl SketchApi for FrontendState {
             );
             new_ast
                 .body
-                .push(ast::BodyItem::VariableDeclaration(Box::new(ast::Node::no_src(
+                .push(ast::BodyItem::VariableDeclaration(BoxNode::new(ast::Node::no_src(
                     face_decl,
                 ))));
             defined_names.insert(face_name.clone());
-            plane_ast = ast::Expr::Name(Box::new(ast::Name::new(&face_name)));
+            plane_ast = ast::Expr::Name(BoxNode::new(ast::Name::new(&face_name)));
         }
         let sketch_ast = ast::SketchBlock {
             arguments: vec![ast::LabeledArg {
@@ -683,14 +683,14 @@ impl SketchApi for FrontendState {
         let sketch_decl = ast::VariableDeclaration::new(
             ast::VariableDeclarator::new(
                 &sketch_name,
-                ast::Expr::SketchBlock(Box::new(ast::Node::no_src(sketch_ast))),
+                ast::Expr::SketchBlock(BoxNode::new(ast::Node::no_src(sketch_ast))),
             ),
             ast::ItemVisibility::Default,
             ast::VariableKind::Const,
         );
         new_ast
             .body
-            .push(ast::BodyItem::VariableDeclaration(Box::new(ast::Node::no_src(
+            .push(ast::BodyItem::VariableDeclaration(BoxNode::new(ast::Node::no_src(
                 sketch_decl,
             ))));
         // Convert to string source to create real source ranges.
@@ -2047,7 +2047,7 @@ impl FrontendState {
         // Create updated KCL source from args.
         let at_ast = to_ast_point2d(&ctor.position)
             .map_err(|err| KclErrorWithOutputs::no_outputs(KclError::refactor(err.to_string())))?;
-        let point_ast = ast::Expr::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
+        let point_ast = ast::Expr::CallExpressionKw(BoxNode::new(ast::Node::no_src(ast::CallExpressionKw {
             callee: ast::Node::no_src(ast_sketch2_name(POINT_FN)),
             unlabeled: None,
             arguments: vec![ast::LabeledArg {
@@ -2180,14 +2180,14 @@ impl FrontendState {
         if ctor.construction == Some(true) {
             arguments.push(ast::LabeledArg {
                 label: Some(ast::Identifier::new(CONSTRUCTION_PARAM)),
-                arg: ast::Expr::Literal(Box::new(ast::Node::no_src(ast::Literal {
+                arg: ast::Expr::Literal(BoxNode::new(ast::Node::no_src(ast::Literal {
                     value: ast::LiteralValue::Bool(true),
                     raw: "true".to_string(),
                     digest: None,
                 }))),
             });
         }
-        let line_ast = ast::Expr::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
+        let line_ast = ast::Expr::CallExpressionKw(BoxNode::new(ast::Node::no_src(ast::CallExpressionKw {
             callee: ast::Node::no_src(ast_sketch2_name(LINE_FN)),
             unlabeled: None,
             arguments,
@@ -2322,14 +2322,14 @@ impl FrontendState {
         if ctor.construction == Some(true) {
             arguments.push(ast::LabeledArg {
                 label: Some(ast::Identifier::new(CONSTRUCTION_PARAM)),
-                arg: ast::Expr::Literal(Box::new(ast::Node::no_src(ast::Literal {
+                arg: ast::Expr::Literal(BoxNode::new(ast::Node::no_src(ast::Literal {
                     value: ast::LiteralValue::Bool(true),
                     raw: "true".to_string(),
                     digest: None,
                 }))),
             });
         }
-        let arc_ast = ast::Expr::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
+        let arc_ast = ast::Expr::CallExpressionKw(BoxNode::new(ast::Node::no_src(ast::CallExpressionKw {
             callee: ast::Node::no_src(ast_sketch2_name(ARC_FN)),
             unlabeled: None,
             arguments,
@@ -2451,14 +2451,14 @@ impl FrontendState {
         if ctor.construction == Some(true) {
             arguments.push(ast::LabeledArg {
                 label: Some(ast::Identifier::new(CONSTRUCTION_PARAM)),
-                arg: ast::Expr::Literal(Box::new(ast::Node::no_src(ast::Literal {
+                arg: ast::Expr::Literal(BoxNode::new(ast::Node::no_src(ast::Literal {
                     value: ast::LiteralValue::Bool(true),
                     raw: "true".to_string(),
                     digest: None,
                 }))),
             });
         }
-        let circle_ast = ast::Expr::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
+        let circle_ast = ast::Expr::CallExpressionKw(BoxNode::new(ast::Node::no_src(ast::CallExpressionKw {
             callee: ast::Node::no_src(ast_sketch2_name(CIRCLE_FN)),
             unlabeled: None,
             arguments,
@@ -2576,14 +2576,14 @@ impl FrontendState {
         if ctor.construction == Some(true) {
             arguments.push(ast::LabeledArg {
                 label: Some(ast::Identifier::new(CONSTRUCTION_PARAM)),
-                arg: ast::Expr::Literal(Box::new(ast::Node::no_src(ast::Literal {
+                arg: ast::Expr::Literal(BoxNode::new(ast::Node::no_src(ast::Literal {
                     value: ast::LiteralValue::Bool(true),
                     raw: "true".to_string(),
                     digest: None,
                 }))),
             });
         }
-        let spline_ast = ast::Expr::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
+        let spline_ast = ast::Expr::CallExpressionKw(BoxNode::new(ast::Node::no_src(ast::CallExpressionKw {
             callee: ast::Node::no_src(ast_sketch2_name(CONTROL_POINT_SPLINE_FN)),
             unlabeled: None,
             arguments,
@@ -3136,7 +3136,7 @@ impl FrontendState {
             .map(|segment| self.coincident_segment_to_ast(segment, new_ast))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let array_expr = ast::Expr::ArrayExpression(Box::new(ast::Node::no_src(ast::ArrayExpression {
+        let array_expr = ast::Expr::ArrayExpression(BoxNode::new(ast::Node::no_src(ast::ArrayExpression {
             elements: segment_asts,
             digest: None,
             non_code_meta: Default::default(),
@@ -3187,7 +3187,7 @@ impl FrontendState {
             .map(|point| self.axis_constraint_segment_to_ast(point, new_ast))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let array_expr = ast::Expr::ArrayExpression(Box::new(ast::Node::no_src(ast::ArrayExpression {
+        let array_expr = ast::Expr::ArrayExpression(BoxNode::new(ast::Node::no_src(ast::ArrayExpression {
             elements: point_asts,
             digest: None,
             non_code_meta: Default::default(),
@@ -3240,7 +3240,7 @@ impl FrontendState {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        let array_expr = ast::Expr::ArrayExpression(Box::new(ast::Node::no_src(ast::ArrayExpression {
+        let array_expr = ast::Expr::ArrayExpression(BoxNode::new(ast::Node::no_src(ast::ArrayExpression {
             elements: line_asts,
             digest: None,
             non_code_meta: Default::default(),
@@ -3293,7 +3293,7 @@ impl FrontendState {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        let array_expr = ast::Expr::ArrayExpression(Box::new(ast::Node::no_src(ast::ArrayExpression {
+        let array_expr = ast::Expr::ArrayExpression(BoxNode::new(ast::Node::no_src(ast::ArrayExpression {
             elements: line_asts,
             digest: None,
             non_code_meta: Default::default(),
@@ -3326,7 +3326,7 @@ impl FrontendState {
             .map(|segment_id| self.equal_radius_segment_id_to_ast_reference(*segment_id, new_ast))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let array_expr = ast::Expr::ArrayExpression(Box::new(ast::Node::no_src(ast::ArrayExpression {
+        let array_expr = ast::Expr::ArrayExpression(BoxNode::new(ast::Node::no_src(ast::ArrayExpression {
             elements: input_asts,
             digest: None,
             non_code_meta: Default::default(),
@@ -3726,23 +3726,24 @@ impl FrontendState {
         };
 
         // Create the distance() call.
-        let distance_call_ast = ast::BinaryPart::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
-            callee: ast::Node::no_src(ast_sketch2_name(DISTANCE_FN)),
-            unlabeled: Some(ast::Expr::ArrayExpression(Box::new(ast::Node::no_src(
-                ast::ArrayExpression {
-                    elements: vec![pt0_ast, pt1_ast],
-                    digest: None,
-                    non_code_meta: Default::default(),
-                },
-            )))),
-            arguments,
-            digest: None,
-            non_code_meta: Default::default(),
-        })));
-        let distance_ast = ast::Expr::BinaryExpression(Box::new(ast::Node::no_src(ast::BinaryExpression {
+        let distance_call_ast =
+            ast::BinaryPart::CallExpressionKw(BoxNode::new(ast::Node::no_src(ast::CallExpressionKw {
+                callee: ast::Node::no_src(ast_sketch2_name(DISTANCE_FN)),
+                unlabeled: Some(ast::Expr::ArrayExpression(BoxNode::new(ast::Node::no_src(
+                    ast::ArrayExpression {
+                        elements: vec![pt0_ast, pt1_ast],
+                        digest: None,
+                        non_code_meta: Default::default(),
+                    },
+                )))),
+                arguments,
+                digest: None,
+                non_code_meta: Default::default(),
+            })));
+        let distance_ast = ast::Expr::BinaryExpression(BoxNode::new(ast::Node::no_src(ast::BinaryExpression {
             left: distance_call_ast,
             operator: ast::BinaryOperator::Eq,
-            right: ast::BinaryPart::Literal(Box::new(ast::Node::no_src(ast::Literal {
+            right: ast::BinaryPart::Literal(BoxNode::new(ast::Node::no_src(ast::Literal {
                 value: ast::LiteralValue::Number {
                     value: distance.distance.value,
                     suffix: distance.distance.units,
@@ -3775,7 +3776,7 @@ impl FrontendState {
     ) -> Result<AstNodeRef, KclError> {
         let sketch_id = sketch;
         let (angle_call_ast, angle_value_ast) = self.angle_constraint_ast_parts(&angle, new_ast)?;
-        let angle_ast = ast::Expr::BinaryExpression(Box::new(ast::Node::no_src(ast::BinaryExpression {
+        let angle_ast = ast::Expr::BinaryExpression(BoxNode::new(ast::Node::no_src(ast::BinaryExpression {
             left: angle_call_ast,
             operator: ast::BinaryOperator::Eq,
             right: angle_value_ast,
@@ -4146,17 +4147,17 @@ impl FrontendState {
         };
 
         // Create the function call.
-        let call_ast = ast::BinaryPart::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
+        let call_ast = ast::BinaryPart::CallExpressionKw(BoxNode::new(ast::Node::no_src(ast::CallExpressionKw {
             callee: ast::Node::no_src(ast_sketch2_name(params.function_name)),
             unlabeled: Some(arc_ast),
             arguments,
             digest: None,
             non_code_meta: Default::default(),
         })));
-        let constraint_ast = ast::Expr::BinaryExpression(Box::new(ast::Node::no_src(ast::BinaryExpression {
+        let constraint_ast = ast::Expr::BinaryExpression(BoxNode::new(ast::Node::no_src(ast::BinaryExpression {
             left: call_ast,
             operator: ast::BinaryOperator::Eq,
-            right: ast::BinaryPart::Literal(Box::new(ast::Node::no_src(ast::Literal {
+            right: ast::BinaryPart::Literal(BoxNode::new(ast::Node::no_src(ast::Literal {
                 value: ast::LiteralValue::Number {
                     value: params.value,
                     suffix: params.units,
@@ -4206,23 +4207,24 @@ impl FrontendState {
         };
 
         // Create the horizontalDistance() call.
-        let distance_call_ast = ast::BinaryPart::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
-            callee: ast::Node::no_src(ast_sketch2_name(HORIZONTAL_DISTANCE_FN)),
-            unlabeled: Some(ast::Expr::ArrayExpression(Box::new(ast::Node::no_src(
-                ast::ArrayExpression {
-                    elements: vec![pt0_ast, pt1_ast],
-                    digest: None,
-                    non_code_meta: Default::default(),
-                },
-            )))),
-            arguments,
-            digest: None,
-            non_code_meta: Default::default(),
-        })));
-        let distance_ast = ast::Expr::BinaryExpression(Box::new(ast::Node::no_src(ast::BinaryExpression {
+        let distance_call_ast =
+            ast::BinaryPart::CallExpressionKw(BoxNode::new(ast::Node::no_src(ast::CallExpressionKw {
+                callee: ast::Node::no_src(ast_sketch2_name(HORIZONTAL_DISTANCE_FN)),
+                unlabeled: Some(ast::Expr::ArrayExpression(BoxNode::new(ast::Node::no_src(
+                    ast::ArrayExpression {
+                        elements: vec![pt0_ast, pt1_ast],
+                        digest: None,
+                        non_code_meta: Default::default(),
+                    },
+                )))),
+                arguments,
+                digest: None,
+                non_code_meta: Default::default(),
+            })));
+        let distance_ast = ast::Expr::BinaryExpression(BoxNode::new(ast::Node::no_src(ast::BinaryExpression {
             left: distance_call_ast,
             operator: ast::BinaryOperator::Eq,
-            right: ast::BinaryPart::Literal(Box::new(ast::Node::no_src(ast::Literal {
+            right: ast::BinaryPart::Literal(BoxNode::new(ast::Node::no_src(ast::Literal {
                 value: ast::LiteralValue::Number {
                     value: distance.distance.value,
                     suffix: distance.distance.units,
@@ -4276,23 +4278,24 @@ impl FrontendState {
         };
 
         // Create the verticalDistance() call.
-        let distance_call_ast = ast::BinaryPart::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
-            callee: ast::Node::no_src(ast_sketch2_name(VERTICAL_DISTANCE_FN)),
-            unlabeled: Some(ast::Expr::ArrayExpression(Box::new(ast::Node::no_src(
-                ast::ArrayExpression {
-                    elements: vec![pt0_ast, pt1_ast],
-                    digest: None,
-                    non_code_meta: Default::default(),
-                },
-            )))),
-            arguments,
-            digest: None,
-            non_code_meta: Default::default(),
-        })));
-        let distance_ast = ast::Expr::BinaryExpression(Box::new(ast::Node::no_src(ast::BinaryExpression {
+        let distance_call_ast =
+            ast::BinaryPart::CallExpressionKw(BoxNode::new(ast::Node::no_src(ast::CallExpressionKw {
+                callee: ast::Node::no_src(ast_sketch2_name(VERTICAL_DISTANCE_FN)),
+                unlabeled: Some(ast::Expr::ArrayExpression(BoxNode::new(ast::Node::no_src(
+                    ast::ArrayExpression {
+                        elements: vec![pt0_ast, pt1_ast],
+                        digest: None,
+                        non_code_meta: Default::default(),
+                    },
+                )))),
+                arguments,
+                digest: None,
+                non_code_meta: Default::default(),
+            })));
+        let distance_ast = ast::Expr::BinaryExpression(BoxNode::new(ast::Node::no_src(ast::BinaryExpression {
             left: distance_call_ast,
             operator: ast::BinaryOperator::Eq,
-            right: ast::BinaryPart::Literal(Box::new(ast::Node::no_src(ast::Literal {
+            right: ast::BinaryPart::Literal(BoxNode::new(ast::Node::no_src(ast::Literal {
                 value: ast::LiteralValue::Number {
                     value: distance.distance.value,
                     suffix: distance.distance.units,
@@ -4546,9 +4549,9 @@ impl FrontendState {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        let call_ast = ast::Expr::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
+        let call_ast = ast::Expr::CallExpressionKw(BoxNode::new(ast::Node::no_src(ast::CallExpressionKw {
             callee: ast::Node::no_src(ast_sketch2_name(LinesAtAngleKind::Parallel.to_function_name())),
-            unlabeled: Some(ast::Expr::ArrayExpression(Box::new(ast::Node::no_src(
+            unlabeled: Some(ast::Expr::ArrayExpression(BoxNode::new(ast::Node::no_src(
                 ast::ArrayExpression {
                     elements: line_asts,
                     digest: None,
@@ -4637,9 +4640,9 @@ impl FrontendState {
         let line1_ast = self.line_id_to_ast_reference(line1_id, new_ast)?;
 
         // Create the parallel() or perpendicular() call.
-        let call_ast = ast::Expr::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
+        let call_ast = ast::Expr::CallExpressionKw(BoxNode::new(ast::Node::no_src(ast::CallExpressionKw {
             callee: ast::Node::no_src(ast_sketch2_name(angle_kind.to_function_name())),
-            unlabeled: Some(ast::Expr::ArrayExpression(Box::new(ast::Node::no_src(
+            unlabeled: Some(ast::Expr::ArrayExpression(BoxNode::new(ast::Node::no_src(
                 ast::ArrayExpression {
                     elements: vec![line0_ast, line1_ast],
                     digest: None,
@@ -5723,14 +5726,14 @@ fn default_plane_ast_expr(name: crate::engine::PlaneName) -> ast::Expr {
 }
 
 fn negated_plane_ast_expr(name: &str) -> ast::Expr {
-    ast::Expr::UnaryExpression(Box::new(ast::UnaryExpression::new(
+    ast::Expr::UnaryExpression(BoxNode::new(ast::UnaryExpression::new(
         ast::UnaryOperator::Neg,
-        ast::BinaryPart::Name(Box::new(ast_name(name.to_owned()))),
+        ast::BinaryPart::Name(BoxNode::new(ast_name(name.to_owned()))),
     )))
 }
 
 fn create_face_of_ast(solid_expr: ast::Expr, face_expr: ast::Expr) -> ast::Expr {
-    ast::Expr::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
+    ast::Expr::CallExpressionKw(BoxNode::new(ast::Node::no_src(ast::CallExpressionKw {
         callee: ast::Node::no_src(ast_sketch2_name("faceOf")),
         unlabeled: Some(solid_expr),
         arguments: vec![ast::LabeledArg {
@@ -5819,7 +5822,7 @@ fn get_or_insert_ast_reference(
             "Expected variable name returned from AddVariableDeclaration".to_owned(),
         ));
     };
-    let var_expr = ast::Expr::Name(Box::new(ast::Name::new(&var_name)));
+    let var_expr = ast::Expr::Name(BoxNode::new(ast::Name::new(&var_name)));
     let Some(property) = property else {
         // No property; just return the variable name.
         return Ok(var_expr);
@@ -6209,7 +6212,7 @@ fn process(ctx: &AstMutateContext, node: NodeMut) -> TraversalReturn<Result<AstM
                 sketch_block
                     .body
                     .items
-                    .push(ast::BodyItem::VariableDeclaration(Box::new(ast::Node::no_src(
+                    .push(ast::BodyItem::VariableDeclaration(BoxNode::new(ast::Node::no_src(
                         ast::VariableDeclaration::new(
                             ast::VariableDeclarator::new(&name, expr.clone()),
                             ast::ItemVisibility::Default,
@@ -6231,7 +6234,7 @@ fn process(ctx: &AstMutateContext, node: NodeMut) -> TraversalReturn<Result<AstM
                     return TraversalReturn::new_break(Ok(AstMutateCommandReturn::None));
                 };
                 let mutate_node =
-                    ast::BodyItem::VariableDeclaration(Box::new(ast::Node::no_src(ast::VariableDeclaration::new(
+                    ast::BodyItem::VariableDeclaration(BoxNode::new(ast::Node::no_src(ast::VariableDeclaration::new(
                         ast::VariableDeclarator::new(&name, expr_stmt.expression.clone()),
                         ast::ItemVisibility::Default,
                         ast::VariableKind::Const,
@@ -6286,18 +6289,19 @@ fn process(ctx: &AstMutateContext, node: NodeMut) -> TraversalReturn<Result<AstM
                             // Update existing construction kwarg
                             for labeled_arg in &mut call.arguments {
                                 if labeled_arg.label.as_ref().map(|id| id.name.as_str()) == Some(CONSTRUCTION_PARAM) {
-                                    labeled_arg.arg = ast::Expr::Literal(Box::new(ast::Node::no_src(ast::Literal {
-                                        value: ast::LiteralValue::Bool(true),
-                                        raw: "true".to_string(),
-                                        digest: None,
-                                    })));
+                                    labeled_arg.arg =
+                                        ast::Expr::Literal(BoxNode::new(ast::Node::no_src(ast::Literal {
+                                            value: ast::LiteralValue::Bool(true),
+                                            raw: "true".to_string(),
+                                            digest: None,
+                                        })));
                                 }
                             }
                         } else {
                             // Add new construction kwarg
                             call.arguments.push(ast::LabeledArg {
                                 label: Some(ast::Identifier::new(CONSTRUCTION_PARAM)),
-                                arg: ast::Expr::Literal(Box::new(ast::Node::no_src(ast::Literal {
+                                arg: ast::Expr::Literal(BoxNode::new(ast::Node::no_src(ast::Literal {
                                     value: ast::LiteralValue::Bool(true),
                                     raw: "true".to_string(),
                                     digest: None,
@@ -6377,18 +6381,19 @@ fn process(ctx: &AstMutateContext, node: NodeMut) -> TraversalReturn<Result<AstM
                             // Update existing construction kwarg
                             for labeled_arg in &mut call.arguments {
                                 if labeled_arg.label.as_ref().map(|id| id.name.as_str()) == Some(CONSTRUCTION_PARAM) {
-                                    labeled_arg.arg = ast::Expr::Literal(Box::new(ast::Node::no_src(ast::Literal {
-                                        value: ast::LiteralValue::Bool(true),
-                                        raw: "true".to_string(),
-                                        digest: None,
-                                    })));
+                                    labeled_arg.arg =
+                                        ast::Expr::Literal(BoxNode::new(ast::Node::no_src(ast::Literal {
+                                            value: ast::LiteralValue::Bool(true),
+                                            raw: "true".to_string(),
+                                            digest: None,
+                                        })));
                                 }
                             }
                         } else {
                             // Add new construction kwarg
                             call.arguments.push(ast::LabeledArg {
                                 label: Some(ast::Identifier::new(CONSTRUCTION_PARAM)),
-                                arg: ast::Expr::Literal(Box::new(ast::Node::no_src(ast::Literal {
+                                arg: ast::Expr::Literal(BoxNode::new(ast::Node::no_src(ast::Literal {
                                     value: ast::LiteralValue::Bool(true),
                                     raw: "true".to_string(),
                                     digest: None,
@@ -6433,18 +6438,19 @@ fn process(ctx: &AstMutateContext, node: NodeMut) -> TraversalReturn<Result<AstM
                             // Update existing construction kwarg
                             for labeled_arg in &mut call.arguments {
                                 if labeled_arg.label.as_ref().map(|id| id.name.as_str()) == Some(CONSTRUCTION_PARAM) {
-                                    labeled_arg.arg = ast::Expr::Literal(Box::new(ast::Node::no_src(ast::Literal {
-                                        value: ast::LiteralValue::Bool(true),
-                                        raw: "true".to_string(),
-                                        digest: None,
-                                    })));
+                                    labeled_arg.arg =
+                                        ast::Expr::Literal(BoxNode::new(ast::Node::no_src(ast::Literal {
+                                            value: ast::LiteralValue::Bool(true),
+                                            raw: "true".to_string(),
+                                            digest: None,
+                                        })));
                                 }
                             }
                         } else {
                             // Add new construction kwarg
                             call.arguments.push(ast::LabeledArg {
                                 label: Some(ast::Identifier::new(CONSTRUCTION_PARAM)),
-                                arg: ast::Expr::Literal(Box::new(ast::Node::no_src(ast::Literal {
+                                arg: ast::Expr::Literal(BoxNode::new(ast::Node::no_src(ast::Literal {
                                     value: ast::LiteralValue::Bool(true),
                                     raw: "true".to_string(),
                                     digest: None,
@@ -6481,17 +6487,18 @@ fn process(ctx: &AstMutateContext, node: NodeMut) -> TraversalReturn<Result<AstM
                         if construction_exists {
                             for labeled_arg in &mut call.arguments {
                                 if labeled_arg.label.as_ref().map(|id| id.name.as_str()) == Some(CONSTRUCTION_PARAM) {
-                                    labeled_arg.arg = ast::Expr::Literal(Box::new(ast::Node::no_src(ast::Literal {
-                                        value: ast::LiteralValue::Bool(true),
-                                        raw: "true".to_string(),
-                                        digest: None,
-                                    })));
+                                    labeled_arg.arg =
+                                        ast::Expr::Literal(BoxNode::new(ast::Node::no_src(ast::Literal {
+                                            value: ast::LiteralValue::Bool(true),
+                                            raw: "true".to_string(),
+                                            digest: None,
+                                        })));
                                 }
                             }
                         } else {
                             call.arguments.push(ast::LabeledArg {
                                 label: Some(ast::Identifier::new(CONSTRUCTION_PARAM)),
-                                arg: ast::Expr::Literal(Box::new(ast::Node::no_src(ast::Literal {
+                                arg: ast::Expr::Literal(BoxNode::new(ast::Node::no_src(ast::Literal {
                                     value: ast::LiteralValue::Bool(true),
                                     raw: "true".to_string(),
                                     digest: None,
@@ -6592,7 +6599,7 @@ fn process(ctx: &AstMutateContext, node: NodeMut) -> TraversalReturn<Result<AstM
                         *value
                     ))));
                 };
-                sketch_var.initial = Some(Box::new(ast::Node::no_src(literal)));
+                sketch_var.initial = Some(BoxNode::new(ast::Node::no_src(literal)));
                 return TraversalReturn::new_break(Ok(AstMutateCommandReturn::None));
             }
         }
@@ -6956,7 +6963,7 @@ fn preserve_var_solution_literal_style(
 }
 
 pub(crate) fn to_ast_point2d(point: &Point2d<Expr>) -> anyhow::Result<ast::Expr> {
-    Ok(ast::Expr::ArrayExpression(Box::new(ast::Node {
+    Ok(ast::Expr::ArrayExpression(BoxNode::new(ast::Node {
         inner: ast::ArrayExpression {
             elements: vec![to_source_expr(&point.x)?, to_source_expr(&point.y)?],
             non_code_meta: Default::default(),
@@ -6973,7 +6980,7 @@ pub(crate) fn to_ast_point2d(point: &Point2d<Expr>) -> anyhow::Result<ast::Expr>
 }
 
 pub(crate) fn to_ast_point2d_array(points: &[Point2d<Expr>]) -> anyhow::Result<ast::Expr> {
-    Ok(ast::Expr::ArrayExpression(Box::new(ast::Node::no_src(
+    Ok(ast::Expr::ArrayExpression(BoxNode::new(ast::Node::no_src(
         ast::ArrayExpression {
             elements: points.iter().map(to_ast_point2d).collect::<anyhow::Result<Vec<_>>>()?,
             digest: None,
@@ -6983,13 +6990,13 @@ pub(crate) fn to_ast_point2d_array(points: &[Point2d<Expr>]) -> anyhow::Result<a
 }
 
 fn to_ast_point2d_number(point: &Point2d<Number>) -> anyhow::Result<ast::Expr> {
-    Ok(ast::Expr::ArrayExpression(Box::new(ast::Node::no_src(
+    Ok(ast::Expr::ArrayExpression(BoxNode::new(ast::Node::no_src(
         ast::ArrayExpression {
             elements: vec![
-                ast::Expr::Literal(Box::new(ast::Node::no_src(ast::Literal::from(to_source_number(
+                ast::Expr::Literal(BoxNode::new(ast::Node::no_src(ast::Literal::from(to_source_number(
                     point.x,
                 )?)))),
-                ast::Expr::Literal(Box::new(ast::Node::no_src(ast::Literal::from(to_source_number(
+                ast::Expr::Literal(BoxNode::new(ast::Node::no_src(ast::Literal::from(to_source_number(
                     point.y,
                 )?)))),
             ],
@@ -7001,7 +7008,7 @@ fn to_ast_point2d_number(point: &Point2d<Number>) -> anyhow::Result<ast::Expr> {
 
 fn to_source_expr(expr: &Expr) -> anyhow::Result<ast::Expr> {
     match expr {
-        Expr::Number(number) => Ok(ast::Expr::Literal(Box::new(ast::Node {
+        Expr::Number(number) => Ok(ast::Expr::Literal(BoxNode::new(ast::Node {
             inner: ast::Literal::from(to_source_number(*number)?),
             start: Default::default(),
             end: Default::default(),
@@ -7011,9 +7018,9 @@ fn to_source_expr(expr: &Expr) -> anyhow::Result<ast::Expr> {
             pre_comments: Default::default(),
             comment_start: Default::default(),
         }))),
-        Expr::Var(number) => Ok(ast::Expr::SketchVar(Box::new(ast::Node {
+        Expr::Var(number) => Ok(ast::Expr::SketchVar(BoxNode::new(ast::Node {
             inner: ast::SketchVar {
-                initial: Some(Box::new(ast::Node {
+                initial: Some(BoxNode::new(ast::Node {
                     inner: to_source_number(*number)?,
                     start: Default::default(),
                     end: Default::default(),
@@ -7047,7 +7054,7 @@ fn to_source_number(number: Number) -> anyhow::Result<ast::NumericLiteral> {
 }
 
 pub(crate) fn ast_name_expr(name: String) -> ast::Expr {
-    ast::Expr::Name(Box::new(ast_name(name)))
+    ast::Expr::Name(BoxNode::new(ast_name(name)))
 }
 
 fn ast_name(name: String) -> ast::Node<ast::Name> {
@@ -7106,14 +7113,14 @@ pub(crate) fn create_coincident_ast(exprs: impl IntoIterator<Item = ast::Expr>) 
     debug_assert!(elements.len() >= 2, "Coincident AST should have at least 2 inputs");
 
     // Create array [expr1, expr2, ...]
-    let array_expr = ast::Expr::ArrayExpression(Box::new(ast::Node::no_src(ast::ArrayExpression {
+    let array_expr = ast::Expr::ArrayExpression(BoxNode::new(ast::Node::no_src(ast::ArrayExpression {
         elements,
         digest: None,
         non_code_meta: Default::default(),
     })));
 
     // Create coincident([...])
-    ast::Expr::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
+    ast::Expr::CallExpressionKw(BoxNode::new(ast::Node::no_src(ast::CallExpressionKw {
         callee: ast::Node::no_src(ast_sketch2_name(COINCIDENT_FN)),
         unlabeled: Some(array_expr),
         arguments: Default::default(),
@@ -7124,7 +7131,7 @@ pub(crate) fn create_coincident_ast(exprs: impl IntoIterator<Item = ast::Expr>) 
 
 /// Create an AST node for line(start = [...], end = [...])
 pub(crate) fn create_line_ast(start_ast: ast::Expr, end_ast: ast::Expr) -> ast::Expr {
-    ast::Expr::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
+    ast::Expr::CallExpressionKw(BoxNode::new(ast::Node::no_src(ast::CallExpressionKw {
         callee: ast::Node::no_src(ast_sketch2_name(LINE_FN)),
         unlabeled: None,
         arguments: vec![
@@ -7144,7 +7151,7 @@ pub(crate) fn create_line_ast(start_ast: ast::Expr, end_ast: ast::Expr) -> ast::
 
 /// Create an AST node for arc(start = [...], end = [...], center = [...])
 pub(crate) fn create_arc_ast(start_ast: ast::Expr, end_ast: ast::Expr, center_ast: ast::Expr) -> ast::Expr {
-    ast::Expr::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
+    ast::Expr::CallExpressionKw(BoxNode::new(ast::Node::no_src(ast::CallExpressionKw {
         callee: ast::Node::no_src(ast_sketch2_name(ARC_FN)),
         unlabeled: None,
         arguments: vec![
@@ -7168,7 +7175,7 @@ pub(crate) fn create_arc_ast(start_ast: ast::Expr, end_ast: ast::Expr, center_as
 
 /// Create an AST node for circle(start = [...], center = [...])
 pub(crate) fn create_circle_ast(start_ast: ast::Expr, center_ast: ast::Expr) -> ast::Expr {
-    ast::Expr::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
+    ast::Expr::CallExpressionKw(BoxNode::new(ast::Node::no_src(ast::CallExpressionKw {
         callee: ast::Node::no_src(ast_sketch2_name(CIRCLE_FN)),
         unlabeled: None,
         arguments: vec![
@@ -7188,7 +7195,7 @@ pub(crate) fn create_circle_ast(start_ast: ast::Expr, center_ast: ast::Expr) -> 
 
 /// Create an AST node for horizontal(line)
 pub(crate) fn create_horizontal_ast(line_expr: ast::Expr) -> ast::Expr {
-    ast::Expr::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
+    ast::Expr::CallExpressionKw(BoxNode::new(ast::Node::no_src(ast::CallExpressionKw {
         callee: ast::Node::no_src(ast_sketch2_name(HORIZONTAL_FN)),
         unlabeled: Some(line_expr),
         arguments: Default::default(),
@@ -7199,7 +7206,7 @@ pub(crate) fn create_horizontal_ast(line_expr: ast::Expr) -> ast::Expr {
 
 /// Create an AST node for vertical(line)
 pub(crate) fn create_vertical_ast(line_expr: ast::Expr) -> ast::Expr {
-    ast::Expr::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
+    ast::Expr::CallExpressionKw(BoxNode::new(ast::Node::no_src(ast::CallExpressionKw {
         callee: ast::Node::no_src(ast_sketch2_name(VERTICAL_FN)),
         unlabeled: Some(line_expr),
         arguments: Default::default(),
@@ -7210,9 +7217,9 @@ pub(crate) fn create_vertical_ast(line_expr: ast::Expr) -> ast::Expr {
 
 /// Create a member expression like object.property (e.g., line1.end)
 pub(crate) fn create_member_expression(object_expr: ast::Expr, property: &str) -> ast::Expr {
-    ast::Expr::MemberExpression(Box::new(ast::Node::no_src(ast::MemberExpression {
+    ast::Expr::MemberExpression(BoxNode::new(ast::Node::no_src(ast::MemberExpression {
         object: object_expr,
-        property: ast::Expr::Name(Box::new(ast::Node::no_src(ast::Name {
+        property: ast::Expr::Name(BoxNode::new(ast::Node::no_src(ast::Name {
             name: ast::Node::no_src(ast::Identifier {
                 name: property.to_string(),
                 digest: None,
@@ -7227,14 +7234,16 @@ pub(crate) fn create_member_expression(object_expr: ast::Expr, property: &str) -
 }
 
 pub(crate) fn create_index_expression(object_expr: ast::Expr, index: usize) -> ast::Expr {
-    ast::Expr::MemberExpression(Box::new(ast::Node::no_src(ast::MemberExpression {
+    ast::Expr::MemberExpression(BoxNode::new(ast::Node::no_src(ast::MemberExpression {
         object: object_expr,
-        property: ast::Expr::Literal(Box::new(ast::Node::no_src(ast::Literal::from(ast::NumericLiteral {
-            value: index as f64,
-            suffix: NumericSuffix::None,
-            raw: index.to_string(),
-            digest: None,
-        })))),
+        property: ast::Expr::Literal(BoxNode::new(ast::Node::no_src(ast::Literal::from(
+            ast::NumericLiteral {
+                value: index as f64,
+                suffix: NumericSuffix::None,
+                raw: index.to_string(),
+                digest: None,
+            },
+        )))),
         computed: true,
         digest: None,
     })))
@@ -7243,27 +7252,27 @@ pub(crate) fn create_index_expression(object_expr: ast::Expr, index: usize) -> a
 /// Create an AST node for `fixed([point, [x, y]])`.
 fn create_fixed_point_constraint_ast(point_expr: ast::Expr, position: Point2d<Number>) -> anyhow::Result<ast::Expr> {
     // Create [x, y] array literal.
-    let x_literal = ast::Expr::Literal(Box::new(ast::Node::no_src(ast::Literal::from(to_source_number(
+    let x_literal = ast::Expr::Literal(BoxNode::new(ast::Node::no_src(ast::Literal::from(to_source_number(
         position.x,
     )?))));
-    let y_literal = ast::Expr::Literal(Box::new(ast::Node::no_src(ast::Literal::from(to_source_number(
+    let y_literal = ast::Expr::Literal(BoxNode::new(ast::Node::no_src(ast::Literal::from(to_source_number(
         position.y,
     )?))));
-    let point_array = ast::Expr::ArrayExpression(Box::new(ast::Node::no_src(ast::ArrayExpression {
+    let point_array = ast::Expr::ArrayExpression(BoxNode::new(ast::Node::no_src(ast::ArrayExpression {
         elements: vec![x_literal, y_literal],
         digest: None,
         non_code_meta: Default::default(),
     })));
 
     // Create [point, [x, y]] outer array.
-    let array_expr = ast::Expr::ArrayExpression(Box::new(ast::Node::no_src(ast::ArrayExpression {
+    let array_expr = ast::Expr::ArrayExpression(BoxNode::new(ast::Node::no_src(ast::ArrayExpression {
         elements: vec![point_expr, point_array],
         digest: None,
         non_code_meta: Default::default(),
     })));
 
     // Create fixed([...])
-    Ok(ast::Expr::CallExpressionKw(Box::new(ast::Node::no_src(
+    Ok(ast::Expr::CallExpressionKw(BoxNode::new(ast::Node::no_src(
         ast::CallExpressionKw {
             callee: ast::Node::no_src(ast_sketch2_name(FIXED_FN)),
             unlabeled: Some(array_expr),
@@ -7276,14 +7285,14 @@ fn create_fixed_point_constraint_ast(point_expr: ast::Expr, position: Point2d<Nu
 
 /// Create an AST node for equalLength([line1, line2, ...])
 pub(crate) fn create_equal_length_ast(line_exprs: Vec<ast::Expr>) -> ast::Expr {
-    let array_expr = ast::Expr::ArrayExpression(Box::new(ast::Node::no_src(ast::ArrayExpression {
+    let array_expr = ast::Expr::ArrayExpression(BoxNode::new(ast::Node::no_src(ast::ArrayExpression {
         elements: line_exprs,
         digest: None,
         non_code_meta: Default::default(),
     })));
 
     // Create equalLength([...])
-    ast::Expr::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
+    ast::Expr::CallExpressionKw(BoxNode::new(ast::Node::no_src(ast::CallExpressionKw {
         callee: ast::Node::no_src(ast_sketch2_name(EQUAL_LENGTH_FN)),
         unlabeled: Some(array_expr),
         arguments: Default::default(),
@@ -7294,13 +7303,13 @@ pub(crate) fn create_equal_length_ast(line_exprs: Vec<ast::Expr>) -> ast::Expr {
 
 /// Create an AST node for equalRadius([seg1, seg2, ...])
 pub(crate) fn create_equal_radius_ast(segment_exprs: Vec<ast::Expr>) -> ast::Expr {
-    let array_expr = ast::Expr::ArrayExpression(Box::new(ast::Node::no_src(ast::ArrayExpression {
+    let array_expr = ast::Expr::ArrayExpression(BoxNode::new(ast::Node::no_src(ast::ArrayExpression {
         elements: segment_exprs,
         digest: None,
         non_code_meta: Default::default(),
     })));
 
-    ast::Expr::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
+    ast::Expr::CallExpressionKw(BoxNode::new(ast::Node::no_src(ast::CallExpressionKw {
         callee: ast::Node::no_src(ast_sketch2_name(EQUAL_RADIUS_FN)),
         unlabeled: Some(array_expr),
         arguments: Default::default(),
@@ -7311,13 +7320,13 @@ pub(crate) fn create_equal_radius_ast(segment_exprs: Vec<ast::Expr>) -> ast::Exp
 
 /// Create an AST node for tangent([seg1, seg2])
 pub(crate) fn create_tangent_ast(seg1_expr: ast::Expr, seg2_expr: ast::Expr) -> ast::Expr {
-    let array_expr = ast::Expr::ArrayExpression(Box::new(ast::Node::no_src(ast::ArrayExpression {
+    let array_expr = ast::Expr::ArrayExpression(BoxNode::new(ast::Node::no_src(ast::ArrayExpression {
         elements: vec![seg1_expr, seg2_expr],
         digest: None,
         non_code_meta: Default::default(),
     })));
 
-    ast::Expr::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
+    ast::Expr::CallExpressionKw(BoxNode::new(ast::Node::no_src(ast::CallExpressionKw {
         callee: ast::Node::no_src(ast_sketch2_name(TANGENT_FN)),
         unlabeled: Some(array_expr),
         arguments: Default::default(),
@@ -7328,7 +7337,7 @@ pub(crate) fn create_tangent_ast(seg1_expr: ast::Expr, seg2_expr: ast::Expr) -> 
 
 /// Create an AST node for symmetric([input1, input2], axis = line)
 pub(crate) fn create_symmetric_ast(input_exprs: Vec<ast::Expr>, axis_expr: ast::Expr) -> ast::Expr {
-    let array_expr = ast::Expr::ArrayExpression(Box::new(ast::Node::no_src(ast::ArrayExpression {
+    let array_expr = ast::Expr::ArrayExpression(BoxNode::new(ast::Node::no_src(ast::ArrayExpression {
         elements: input_exprs,
         digest: None,
         non_code_meta: Default::default(),
@@ -7338,7 +7347,7 @@ pub(crate) fn create_symmetric_ast(input_exprs: Vec<ast::Expr>, axis_expr: ast::
         arg: axis_expr,
     }];
 
-    ast::Expr::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
+    ast::Expr::CallExpressionKw(BoxNode::new(ast::Node::no_src(ast::CallExpressionKw {
         callee: ast::Node::no_src(ast_sketch2_name(SYMMETRIC_FN)),
         unlabeled: Some(array_expr),
         arguments,
@@ -7354,7 +7363,7 @@ pub(crate) fn create_midpoint_ast(segment_expr: ast::Expr, point_expr: ast::Expr
         arg: point_expr,
     }];
 
-    ast::Expr::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
+    ast::Expr::CallExpressionKw(BoxNode::new(ast::Node::no_src(ast::CallExpressionKw {
         callee: ast::Node::no_src(ast_sketch2_name(MIDPOINT_FN)),
         unlabeled: Some(segment_expr),
         arguments,
@@ -14613,7 +14622,7 @@ part = subtract(boxSolid, tools = [cutSolid])
             ast::VariableKind::Const,
         );
         ast.body
-            .push(ast::BodyItem::VariableDeclaration(Box::new(ast::Node::no_src(
+            .push(ast::BodyItem::VariableDeclaration(BoxNode::new(ast::Node::no_src(
                 cap_face_decl,
             ))));
         let generated_source = source_from_ast(&ast);

--- a/rust/kcl-lib/src/lint/checks/chained_profiles.rs
+++ b/rust/kcl-lib/src/lint/checks/chained_profiles.rs
@@ -12,6 +12,7 @@ use crate::lint::rule::FindingFamily;
 use crate::lint::rule::def_finding;
 use crate::parsing::ast::types::ArrayExpression;
 use crate::parsing::ast::types::BodyItem;
+use crate::parsing::ast::types::BoxNode;
 use crate::parsing::ast::types::CallExpressionKw;
 use crate::parsing::ast::types::Expr;
 use crate::parsing::ast::types::ItemVisibility;
@@ -93,7 +94,7 @@ fn check_body(block: &AstNode<Program>, whole_program: &AstNode<Program>) -> Res
                 (call, result)
             } else {
                 let result = add_unlabeled_arg_to_first_call(&mut rest, unlabeled_arg);
-                (Expr::PipeExpression(Box::new(PipeExpression::new(rest))), result)
+                (Expr::PipeExpression(BoxNode::new(PipeExpression::new(rest))), result)
             };
             if result.is_err() {
                 // We needed an unlabeled arg, but we don't have one. We aren't
@@ -112,7 +113,7 @@ fn check_body(block: &AstNode<Program>, whole_program: &AstNode<Program>) -> Res
             };
             new_program.body.insert(
                 item_index + 1,
-                BodyItem::VariableDeclaration(Box::new(AstNode::no_src(VariableDeclaration::new(
+                BodyItem::VariableDeclaration(BoxNode::new(AstNode::no_src(VariableDeclaration::new(
                     VariableDeclarator::new(&new_var_name, next_expr),
                     ItemVisibility::Default,
                     VariableKind::Const,
@@ -158,7 +159,7 @@ fn check_body_item_for_pipe(node: Node) -> (Option<Expr>, Vec<(usize, SourceRang
             // entire pipeline as the unlabeled arg.
             (
                 unlabeled.or_else(|| {
-                    Some(Expr::Name(Box::new(AstNode::<Name>::from(
+                    Some(Expr::Name(BoxNode::new(AstNode::<Name>::from(
                         var_decl.declaration.id.clone(),
                     ))))
                 }),
@@ -331,12 +332,12 @@ fn add_variable_to_extrude_call(call: &mut CallExpressionKw, new_var_name: &str)
     if let Some(unlabeled) = &mut call.unlabeled {
         match unlabeled {
             Expr::ArrayExpression(array) => {
-                array.elements.push(Expr::Name(Box::new(Name::new(new_var_name))));
+                array.elements.push(Expr::Name(BoxNode::new(Name::new(new_var_name))));
             }
             _ => {
                 let first = unlabeled.clone();
-                let new_array = vec![first, Expr::Name(Box::new(Name::new(new_var_name)))];
-                *unlabeled = Expr::ArrayExpression(Box::new(ArrayExpression::new(new_array)));
+                let new_array = vec![first, Expr::Name(BoxNode::new(Name::new(new_var_name)))];
+                *unlabeled = Expr::ArrayExpression(BoxNode::new(ArrayExpression::new(new_array)));
             }
         }
         return true;

--- a/rust/kcl-lib/src/parsing/ast/types/literal_value.rs
+++ b/rust/kcl-lib/src/parsing/ast/types/literal_value.rs
@@ -5,6 +5,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use super::Node;
+use crate::parsing::ast::types::BoxNode;
 use crate::parsing::ast::types::Expr;
 use crate::parsing::ast::types::Literal;
 use crate::parsing::token::NumericSuffix;
@@ -72,7 +73,7 @@ impl fmt::Display for LiteralValue {
 
 impl From<Node<Literal>> for Expr {
     fn from(literal: Node<Literal>) -> Self {
-        Expr::Literal(Box::new(literal))
+        Expr::Literal(BoxNode::new(literal))
     }
 }
 

--- a/rust/kcl-lib/src/parsing/ast/types/mod.rs
+++ b/rust/kcl-lib/src/parsing/ast/types/mod.rs
@@ -126,7 +126,7 @@ impl<T> Node<T> {
     }
 
     pub fn boxed(start: usize, end: usize, module_id: ModuleId, inner: T) -> BoxNode<T> {
-        Box::new(Node {
+        BoxNode::new(Node {
             inner,
             start,
             end,
@@ -146,7 +146,7 @@ impl<T> Node<T> {
         node_path: NodePath,
         inner: T,
     ) -> BoxNode<T> {
-        Box::new(Node {
+        BoxNode::new(Node {
             inner,
             start,
             end,
@@ -257,7 +257,173 @@ impl<T> From<&BoxNode<T>> for SourceRange {
     }
 }
 
-pub type BoxNode<T> = Box<Node<T>>;
+/// Counts how many times [`BoxNode`]'s copy-on-write `DerefMut` had to
+/// deep-clone a node because its `Arc` was shared at mutation time. Parse,
+/// execute, and digest workloads are expected to keep this at 0 (they only
+/// mutate exclusively owned trees); editing workloads that mutate a shared
+/// tree may see bounded nonzero counts.
+#[cfg(debug_assertions)]
+#[doc(hidden)]
+pub static BOX_NODE_COW_CLONES: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// An AST node shared behind an [`Arc`], so owned handles to subtrees (e.g. a
+/// function body held by a closure value) are cheap to clone and carry no
+/// lifetimes.
+///
+/// This is a newtype rather than a bare `Arc<Node<T>>` so that:
+///
+/// - `DerefMut` keeps every existing in-place mutation site (digests, node
+///   paths, code-mod edits) compiling, via copy-on-write ([`Arc::make_mut`]).
+///   Mutating an exclusively owned tree (refcount 1, the common case) stays
+///   in place with no copying.
+/// - The serde and ts-rs impls stay transparent: `BoxNode<T>` serializes
+///   exactly like `Node<T>` did when this was `Box<Node<T>>`. (The workspace
+///   does not enable serde's `rc` feature, so `Arc<Node<T>>` has no serde
+///   impls of its own.)
+///
+/// Caveat: if a node's `Arc` is shared at mutation time (e.g. a function AST
+/// kept alive by a `FunctionSource` clone from a previous run), `DerefMut`
+/// silently deep-clones that node. [`BOX_NODE_COW_CLONES`] counts those
+/// clones in debug builds.
+pub struct BoxNode<T>(Arc<Node<T>>);
+
+impl<T> BoxNode<T> {
+    pub fn new(node: Node<T>) -> Self {
+        Self(Arc::new(node))
+    }
+
+    /// A cheap owned handle to the shared node.
+    pub fn arc(&self) -> Arc<Node<T>> {
+        self.0.clone()
+    }
+}
+
+impl<T: Clone> BoxNode<T> {
+    /// Take the node out, cloning only if the `Arc` is shared (it usually is
+    /// not). The successor of moving out of the old `Box<Node<T>>`.
+    pub fn into_node(self) -> Node<T> {
+        Arc::unwrap_or_clone(self.0)
+    }
+}
+
+impl<T> AsRef<Node<T>> for BoxNode<T> {
+    fn as_ref(&self) -> &Node<T> {
+        &self.0
+    }
+}
+
+impl<T: Clone> AsMut<Node<T>> for BoxNode<T> {
+    /// Copy-on-write, like `DerefMut`.
+    fn as_mut(&mut self) -> &mut Node<T> {
+        self
+    }
+}
+
+impl<T> Clone for BoxNode<T> {
+    fn clone(&self) -> Self {
+        // Cheap: clones the Arc, not the node.
+        Self(self.0.clone())
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for BoxNode<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Delegate so output matches the old Box<Node<T>>.
+        self.0.fmt(f)
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for BoxNode<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<T: PartialEq> PartialEq for BoxNode<T> {
+    fn eq(&self, other: &Self) -> bool {
+        // Arc compares by pointee, same as Box did.
+        self.0 == other.0
+    }
+}
+
+impl<T> Deref for BoxNode<T> {
+    type Target = Node<T>;
+
+    fn deref(&self) -> &Node<T> {
+        &self.0
+    }
+}
+
+impl<T: Clone> DerefMut for BoxNode<T> {
+    fn deref_mut(&mut self) -> &mut Node<T> {
+        #[cfg(debug_assertions)]
+        if Arc::strong_count(&self.0) > 1 || Arc::weak_count(&self.0) > 0 {
+            // Arc::make_mut below will deep-clone this node.
+            BOX_NODE_COW_CLONES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+        Arc::make_mut(&mut self.0)
+    }
+}
+
+// Serialize as the inner Node<T>, not the Arc, keeping the serialized form
+// (JSON, MessagePack, ts-rs) byte-identical to the old Box<Node<T>>.
+impl<T> Serialize for BoxNode<T>
+where
+    Node<T>: Serialize,
+{
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.as_ref().serialize(serializer)
+    }
+}
+
+impl<'de, T> Deserialize<'de> for BoxNode<T>
+where
+    Node<T>: Deserialize<'de>,
+{
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Node::<T>::deserialize(deserializer).map(BoxNode::new)
+    }
+}
+
+// Transparent ts-rs impl, mirroring ts-rs's own wrapper impls (e.g. TS for
+// Box<T>), so the generated TypeScript is unchanged from Box<Node<T>>.
+impl<T> ts_rs::TS for BoxNode<T>
+where
+    Node<T>: ts_rs::TS,
+{
+    type WithoutGenerics = Self;
+    type OptionInnerType = Self;
+
+    fn name(cfg: &ts_rs::Config) -> String {
+        <Node<T> as ts_rs::TS>::name(cfg)
+    }
+    fn inline(cfg: &ts_rs::Config) -> String {
+        <Node<T> as ts_rs::TS>::inline(cfg)
+    }
+    fn inline_flattened(cfg: &ts_rs::Config) -> String {
+        <Node<T> as ts_rs::TS>::inline_flattened(cfg)
+    }
+    fn visit_dependencies(v: &mut impl ts_rs::TypeVisitor)
+    where
+        Self: 'static,
+    {
+        <Node<T> as ts_rs::TS>::visit_dependencies(v);
+    }
+    fn visit_generics(v: &mut impl ts_rs::TypeVisitor)
+    where
+        Self: 'static,
+    {
+        <Node<T> as ts_rs::TS>::visit_generics(v);
+        v.visit::<Node<T>>();
+    }
+    fn decl(_: &ts_rs::Config) -> String {
+        panic!("wrapper type cannot be declared")
+    }
+    fn decl_concrete(_: &ts_rs::Config) -> String {
+        panic!("wrapper type cannot be declared")
+    }
+}
+
 pub type NodeList<T> = Vec<Node<T>>;
 pub type NodeRef<'a, T> = &'a Node<T>;
 pub type NodeRefMut<'a, T> = &'a mut Node<T>;
@@ -347,7 +513,7 @@ fn kcl_version_expr(kcl_version: &str) -> Result<Expr, KclError> {
         ),
     };
 
-    Ok(Expr::Literal(Box::new(Node::no_src(Literal {
+    Ok(Expr::Literal(BoxNode::new(Node::no_src(Literal {
         value,
         raw,
         digest: None,
@@ -475,7 +641,7 @@ impl Node<Program> {
                 if let Some(len) = length_units {
                     node.inner.add_or_update(
                         annotations::SETTINGS_UNIT_LENGTH,
-                        Expr::Name(Box::new(Name::new(len.to_string()))),
+                        Expr::Name(BoxNode::new(Name::new(len.to_string()))),
                     );
                 }
                 // Previous source range no longer makes sense, but we want to
@@ -491,7 +657,7 @@ impl Node<Program> {
             if let Some(len) = length_units {
                 settings.inner.add_or_update(
                     annotations::SETTINGS_UNIT_LENGTH,
-                    Expr::Name(Box::new(Name::new(len.to_string()))),
+                    Expr::Name(BoxNode::new(Name::new(len.to_string()))),
                 );
             }
 
@@ -558,7 +724,7 @@ impl Node<Program> {
                 if let Some(level) = warning_level {
                     node.inner.add_or_update(
                         annotations::SETTINGS_EXPERIMENTAL_FEATURES,
-                        Expr::Name(Box::new(Name::new(level.as_str()))),
+                        Expr::Name(BoxNode::new(Name::new(level.as_str()))),
                     );
                 }
                 // Previous source range no longer makes sense, but we want to
@@ -574,7 +740,7 @@ impl Node<Program> {
             if let Some(level) = warning_level {
                 settings.inner.add_or_update(
                     annotations::SETTINGS_EXPERIMENTAL_FEATURES,
-                    Expr::Name(Box::new(Name::new(level.as_str()))),
+                    Expr::Name(BoxNode::new(Name::new(level.as_str()))),
                 );
             }
 
@@ -2628,7 +2794,7 @@ pub struct LabeledArg {
 
 impl From<Node<CallExpressionKw>> for Expr {
     fn from(call_expression: Node<CallExpressionKw>) -> Self {
-        Expr::CallExpressionKw(Box::new(call_expression))
+        Expr::CallExpressionKw(BoxNode::new(call_expression))
     }
 }
 
@@ -3270,7 +3436,7 @@ impl From<&BoxNode<TagDeclarator>> for KclValue {
 
 impl From<&Node<TagDeclarator>> for KclValue {
     fn from(tag: &Node<TagDeclarator>) -> Self {
-        KclValue::TagDeclarator(Box::new(tag.clone()))
+        KclValue::TagDeclarator(BoxNode::new(tag.clone()))
     }
 }
 
@@ -3365,7 +3531,7 @@ impl PipeSubstitution {
 
 impl From<Node<PipeSubstitution>> for Expr {
     fn from(pipe_substitution: Node<PipeSubstitution>) -> Self {
-        Expr::PipeSubstitution(Box::new(pipe_substitution))
+        Expr::PipeSubstitution(BoxNode::new(pipe_substitution))
     }
 }
 
@@ -3384,7 +3550,7 @@ pub struct ArrayExpression {
 
 impl From<Node<ArrayExpression>> for Expr {
     fn from(array_expression: Node<ArrayExpression>) -> Self {
-        Expr::ArrayExpression(Box::new(array_expression))
+        Expr::ArrayExpression(BoxNode::new(array_expression))
     }
 }
 
@@ -3444,7 +3610,7 @@ pub struct ArrayRangeExpression {
 
 impl From<Node<ArrayRangeExpression>> for Expr {
     fn from(array_expression: Node<ArrayRangeExpression>) -> Self {
-        Expr::ArrayRangeExpression(Box::new(array_expression))
+        Expr::ArrayRangeExpression(BoxNode::new(array_expression))
     }
 }
 
@@ -3877,7 +4043,7 @@ pub struct PipeExpression {
 
 impl From<Node<PipeExpression>> for Expr {
     fn from(pipe_expression: Node<PipeExpression>) -> Self {
-        Expr::PipeExpression(Box::new(pipe_expression))
+        Expr::PipeExpression(BoxNode::new(pipe_expression))
     }
 }
 
@@ -4385,8 +4551,8 @@ impl FunctionExpression {
     }
 
     #[cfg(test)]
-    pub fn dummy() -> Box<Node<Self>> {
-        Box::new(Node::new(
+    pub fn dummy() -> BoxNode<Self> {
+        BoxNode::new(Node::new(
             FunctionExpression {
                 name: None,
                 params: Vec::new(),
@@ -5950,5 +6116,32 @@ if true {
         assert!(meta.start_nodes.is_empty());
         assert_eq!(meta.non_code_nodes.len(), 1);
         assert_eq!(meta.non_code_nodes[&0][0].value(), "after 1");
+    }
+    #[test]
+    fn box_node_cow_clones_zero_for_parse_digest_node_paths() {
+        // compute_digest and fill_node_paths mutate the AST in place through
+        // BoxNode's copy-on-write DerefMut. On an exclusively owned tree
+        // (fresh from the parser), make_mut must never deep-clone; a nonzero
+        // delta here means some pass left an Arc shared before mutating.
+        let code = r#"fn cube(@side, center) {
+  x = if side > 1 { side * 2 } else { side + 1 }
+  return startSketchOn(XY)
+    |> startProfile(at = [center[0] - side, center[1] - side])
+    |> line(end = [side * 2, 0], tag = $edge1)
+    |> line(end = [0, x])
+    |> close()
+    |> extrude(length = side)
+}
+part = cube(10, [0, 0])
+"#;
+        let before = BOX_NODE_COW_CLONES.load(std::sync::atomic::Ordering::Relaxed);
+        let (program, issues) = crate::Program::parse(code).unwrap();
+        assert!(issues.is_empty(), "{issues:?}");
+        let mut program = program.unwrap();
+        program.compute_digest();
+        let program = program.fill_node_paths();
+        drop(program);
+        let after = BOX_NODE_COW_CLONES.load(std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(after, before, "BoxNode COW deep-cloned on an exclusively owned AST");
     }
 }

--- a/rust/kcl-lib/src/parsing/ast/types/mod.rs
+++ b/rust/kcl-lib/src/parsing/ast/types/mod.rs
@@ -6118,6 +6118,9 @@ if true {
         assert_eq!(meta.non_code_nodes[&0][0].value(), "after 1");
     }
     #[test]
+    // The counter only exists with debug assertions; release test builds
+    // must still compile.
+    #[cfg(debug_assertions)]
     fn box_node_cow_clones_zero_for_parse_digest_node_paths() {
         // compute_digest and fill_node_paths mutate the AST in place through
         // BoxNode's copy-on-write DerefMut. On an exclusively owned tree

--- a/rust/kcl-lib/src/parsing/math.rs
+++ b/rust/kcl-lib/src/parsing/math.rs
@@ -47,7 +47,7 @@ fn evaluate(rpn: Vec<BinaryExpressionToken>) -> Result<Node<BinaryExpression>, C
         operand_stack.push(expr)
     }
     if let Some(BinaryPart::BinaryExpression(expr)) = operand_stack.pop() {
-        Ok(*expr)
+        Ok(expr.into_node())
     } else {
         // If this branch is used, the evaluation algorithm has a bug and must be fixed.
         // This is a programmer error, not a user error.
@@ -125,6 +125,7 @@ impl From<BinaryOperator> for BinaryExpressionToken {
 mod tests {
     use super::*;
     use crate::ModuleId;
+    use crate::parsing::ast::types::BoxNode;
     use crate::parsing::ast::types::Literal;
     use crate::parsing::ast::types::LiteralValue;
     use crate::parsing::token::NumericSuffix;
@@ -133,7 +134,7 @@ mod tests {
     fn parse_and_evaluate() {
         /// Make a literal
         fn lit(n: u8) -> BinaryPart {
-            BinaryPart::Literal(Box::new(Node::new(
+            BinaryPart::Literal(BoxNode::new(Node::new(
                 Literal {
                     value: LiteralValue::Number {
                         value: n as f64,

--- a/rust/kcl-lib/src/parsing/parser.rs
+++ b/rust/kcl-lib/src/parsing/parser.rs
@@ -2991,7 +2991,7 @@ fn ty_decl(i: &mut TokenSlice) -> ModalResult<BoxNode<TypeDeclaration>> {
 
         ParseContext::experimental("type aliases", ty.as_source_range());
 
-        TypeDeclarationDefinition::Alias { ty: Box::new(ty) }
+        TypeDeclarationDefinition::Alias { ty: BoxNode::new(ty) }
     } else if peek((opt(whitespace), open_brace)).parse_next(i).is_ok() {
         ignore_whitespace(i);
         if let Some(args_range) = args_range {

--- a/rust/kcl-lib/src/parsing/parser.rs
+++ b/rust/kcl-lib/src/parsing/parser.rs
@@ -814,7 +814,7 @@ fn numeric_literal(i: &mut TokenSlice) -> ModalResult<Node<NumericLiteral>> {
 
 fn literal(i: &mut TokenSlice) -> ModalResult<BoxNode<Literal>> {
     alt((string_literal, unsigned_number_literal, bool_value))
-        .map(Box::new)
+        .map(BoxNode::new)
         .context(expected("a KCL literal, like 'myPart' or 3"))
         .parse_next(i)
 }
@@ -928,7 +928,7 @@ fn sketch_var(i: &mut TokenSlice) -> ModalResult<Node<SketchVar>> {
 
     Ok(Node::new(
         SketchVar {
-            initial: literal.map(Box::new),
+            initial: literal.map(BoxNode::new),
             digest: None,
         },
         var_token.start,
@@ -1128,9 +1128,9 @@ pub enum NonCodeOr<T> {
 /// Parse a KCL array of elements.
 fn array(i: &mut TokenSlice) -> ModalResult<Expr> {
     alt((
-        array_empty.map(Box::new).map(Expr::ArrayExpression),
-        array_end_start.map(Box::new).map(Expr::ArrayRangeExpression),
-        array_elem_by_elem.map(Box::new).map(Expr::ArrayExpression),
+        array_empty.map(BoxNode::new).map(Expr::ArrayExpression),
+        array_end_start.map(BoxNode::new).map(Expr::ArrayRangeExpression),
+        array_elem_by_elem.map(BoxNode::new).map(Expr::ArrayExpression),
     ))
     .parse_next(i)
 }
@@ -1300,7 +1300,7 @@ fn object_property_same_key_and_val(i: &mut TokenSlice) -> ModalResult<Node<Obje
     let module_id = key.module_id;
     Ok(Node::new(
         ObjectProperty {
-            value: Expr::Name(Box::new(key.clone().into())),
+            value: Expr::Name(BoxNode::new(key.clone().into())),
             key,
             digest: None,
         },
@@ -1578,7 +1578,7 @@ fn else_if(i: &mut TokenSlice) -> ModalResult<Node<ElseIf>> {
     let then_val = program
         .verify(|block| block.ends_with_expr())
         .parse_next(i)
-        .map(Box::new)?;
+        .map(BoxNode::new)?;
     ignore_whitespace(i);
     let end = close_brace(i)?.end;
     ignore_whitespace(i);
@@ -1617,7 +1617,7 @@ fn if_expr(i: &mut TokenSlice) -> ModalResult<BoxNode<IfExpression>> {
         .verify(|block| block.ends_with_expr())
         .parse_next(i)
         .map_err(|e| e.cut())
-        .map(Box::new)?;
+        .map(BoxNode::new)?;
     ignore_whitespace(i);
     let _ = close_brace(i)?;
     ignore_whitespace(i);
@@ -1669,7 +1669,7 @@ fn if_expr(i: &mut TokenSlice) -> ModalResult<BoxNode<IfExpression>> {
         return if_with_no_else(cond, then_val, else_ifs);
     }
     ignore_whitespace(i);
-    let Ok(final_else) = program.parse_next(i).map(Box::new) else {
+    let Ok(final_else) = program.parse_next(i).map(BoxNode::new) else {
         ParseContext::err(CompilationIssue::err(else_range, IF_ELSE_CANNOT_BE_EMPTY));
         let _ = opt(close_brace).parse_next(i);
         return if_with_no_else(cond, then_val, else_ifs);
@@ -1714,7 +1714,7 @@ fn function_expr(i: &mut TokenSlice) -> ModalResult<Expr> {
         let err = CompilationIssue::fatal(result.as_source_range(), "Anonymous function requires `fn` before `(`");
         return Err(ErrMode::Cut(err.into()));
     }
-    Ok(Expr::FunctionExpression(Box::new(result)))
+    Ok(Expr::FunctionExpression(BoxNode::new(result)))
 }
 
 // Looks like
@@ -1780,7 +1780,7 @@ fn member_expression_dot(i: &mut TokenSlice) -> ModalResult<(Expr, usize, bool)>
         .map(|p| {
             let ni: Node<Identifier> = *p;
             let nn: Node<Name> = ni.into();
-            Expr::Name(Box::new(nn))
+            Expr::Name(BoxNode::new(nn))
         })
         .parse_next(i)?;
     let end = property.end();
@@ -1835,7 +1835,7 @@ fn build_member_expression(object: Expr, mut members: Vec<(Expr, usize, bool)>) 
         .fold(initial_member_expression, |accumulated, (property, end, computed)| {
             Node::new(
                 MemberExpression {
-                    object: Expr::MemberExpression(Box::new(accumulated)),
+                    object: Expr::MemberExpression(BoxNode::new(accumulated)),
                     computed,
                     property,
                     digest: None,
@@ -2683,7 +2683,7 @@ fn expression_but_not_pipe(i: &mut TokenSlice) -> ModalResult<Expr> {
 
     let start = i.checkpoint();
     let mut expr = alt((
-        unary_expression.map(Box::new).map(Expr::UnaryExpression),
+        unary_expression.map(BoxNode::new).map(Expr::UnaryExpression),
         expr_allowed_in_pipe_expr,
     ))
     .context(expected("a KCL value"))
@@ -2691,16 +2691,18 @@ fn expression_but_not_pipe(i: &mut TokenSlice) -> ModalResult<Expr> {
 
     if has_binary_operator_after_optional_ascription(i) {
         i.reset(&start);
-        expr = Expr::BinaryExpression(Box::new(binary_expression.parse_next(i)?));
+        expr = Expr::BinaryExpression(BoxNode::new(binary_expression.parse_next(i)?));
     }
 
     let ty = opt((colon, opt(whitespace), type_)).parse_next(i)?;
     if let Some((_, _, ty)) = ty {
-        expr = Expr::AscribedExpression(Box::new(AscribedExpression::new(expr, ty)))
+        expr = Expr::AscribedExpression(BoxNode::new(AscribedExpression::new(expr, ty)))
     }
     let label = opt(label).parse_next(i)?;
     match label {
-        Some(label) => Ok(Expr::LabelledExpression(Box::new(LabelledExpression::new(expr, label)))),
+        Some(label) => Ok(Expr::LabelledExpression(BoxNode::new(LabelledExpression::new(
+            expr, label,
+        )))),
         None => Ok(expr),
     }
 }
@@ -2732,15 +2734,15 @@ fn unnecessarily_bracketed(i: &mut TokenSlice) -> ModalResult<Expr> {
 fn expr_allowed_in_pipe_expr(i: &mut TokenSlice) -> ModalResult<Expr> {
     let parsed_expr = alt((
         alt((
-            bool_value.map(Box::new).map(Expr::Literal),
-            tag.map(Box::new).map(Expr::TagDeclarator),
+            bool_value.map(BoxNode::new).map(Expr::Literal),
+            tag.map(BoxNode::new).map(Expr::TagDeclarator),
             literal.map(Expr::Literal),
-            sketch_var.map(Box::new).map(Expr::SketchVar),
+            sketch_var.map(BoxNode::new).map(Expr::SketchVar),
             fn_call_or_sketch_block,
-            name.map(Box::new).map(Expr::Name),
+            name.map(BoxNode::new).map(Expr::Name),
             array,
-            object.map(Box::new).map(Expr::ObjectExpression),
-            pipe_sub.map(Box::new).map(Expr::PipeSubstitution),
+            object.map(BoxNode::new).map(Expr::ObjectExpression),
+            pipe_sub.map(BoxNode::new).map(Expr::PipeSubstitution),
         )),
         alt((function_expr, if_expr.map(Expr::IfExpression), unnecessarily_bracketed)),
     ))
@@ -2749,7 +2751,7 @@ fn expr_allowed_in_pipe_expr(i: &mut TokenSlice) -> ModalResult<Expr> {
 
     if let Ok(Some(members)) = opt(find_members).parse_next(i) {
         let mem = build_member_expression(parsed_expr, members);
-        return Ok(Expr::MemberExpression(Box::new(mem)));
+        return Ok(Expr::MemberExpression(BoxNode::new(mem)));
     }
     Ok(parsed_expr)
 }
@@ -2759,17 +2761,17 @@ fn possible_operands(i: &mut TokenSlice) -> ModalResult<Expr> {
     let mut expr = alt((
         alt((
             if_expr.map(Expr::IfExpression),
-            unary_expression.map(Box::new).map(Expr::UnaryExpression),
-            bool_value.map(Box::new).map(Expr::Literal),
+            unary_expression.map(BoxNode::new).map(Expr::UnaryExpression),
+            bool_value.map(BoxNode::new).map(Expr::Literal),
             literal.map(Expr::Literal),
-            sketch_var.map(Box::new).map(Expr::SketchVar),
+            sketch_var.map(BoxNode::new).map(Expr::SketchVar),
             fn_call_or_sketch_block,
-            name.map(Box::new).map(Expr::Name),
+            name.map(BoxNode::new).map(Expr::Name),
             array,
-            object.map(Box::new).map(Expr::ObjectExpression),
+            object.map(BoxNode::new).map(Expr::ObjectExpression),
         )),
         alt((
-            binary_expr_in_parens.map(Box::new).map(Expr::BinaryExpression),
+            binary_expr_in_parens.map(BoxNode::new).map(Expr::BinaryExpression),
             unnecessarily_bracketed,
         )),
     ))
@@ -2779,12 +2781,12 @@ fn possible_operands(i: &mut TokenSlice) -> ModalResult<Expr> {
     .parse_next(i)?;
     if let Ok(Some(members)) = opt(find_members).parse_next(i) {
         let mem = build_member_expression(expr, members);
-        expr = Expr::MemberExpression(Box::new(mem));
+        expr = Expr::MemberExpression(BoxNode::new(mem));
     }
 
     let ty = opt((colon, opt(whitespace), type_)).parse_next(i)?;
     if let Some((_, _, ty)) = ty {
-        expr = Expr::AscribedExpression(Box::new(AscribedExpression::new(expr, ty)))
+        expr = Expr::AscribedExpression(BoxNode::new(AscribedExpression::new(expr, ty)))
     }
 
     Ok(expr)
@@ -2849,7 +2851,7 @@ fn declaration(i: &mut TokenSlice) -> ModalResult<BoxNode<VariableDeclaration>> 
                     func.name = Some(id.clone());
                     func
                 })
-                .map(Box::new)
+                .map(BoxNode::new)
                 .map(Expr::FunctionExpression)
                 .context(expected("a KCL function expression, like () { return 1 }"))
                 .parse_next(i);
@@ -3901,12 +3903,12 @@ fn primitive_type(i: &mut TokenSlice) -> ModalResult<Node<PrimitiveType>> {
                 if let Some((args, ret)) = tys {
                     if let Some((unnamed, named)) = args {
                         if let Some(unnamed) = unnamed {
-                            ft.unnamed_arg = Some(Box::new(unnamed));
+                            ft.unnamed_arg = Some(BoxNode::new(unnamed));
                         }
                         ft.named_args = named;
                     }
                     if let Some((_, _, ty)) = ret {
-                        ft.return_type = Some(Box::new(ty));
+                        ft.return_type = Some(BoxNode::new(ty));
                     }
                 }
 
@@ -4039,7 +4041,7 @@ fn parameter(i: &mut TokenSlice) -> ModalResult<ParamDescription> {
         arg_name,
         type_,
         default_value: match (question_mark.is_some(), default_literal) {
-            (true, Some(lit)) => Some(DefaultParamVal::Literal(*lit)),
+            (true, Some(lit)) => Some(DefaultParamVal::Literal(lit.into_node())),
             (true, None) => Some(DefaultParamVal::none()),
             (false, None) => None,
             (false, Some(lit)) => {
@@ -4196,7 +4198,9 @@ fn labelled_fn_call(i: &mut TokenSlice) -> ModalResult<Expr> {
 
     let label = opt(label).parse_next(i)?;
     match label {
-        Some(label) => Ok(Expr::LabelledExpression(Box::new(LabelledExpression::new(expr, label)))),
+        Some(label) => Ok(Expr::LabelledExpression(BoxNode::new(LabelledExpression::new(
+            expr, label,
+        )))),
         None => Ok(expr),
     }
 }
@@ -4267,7 +4271,7 @@ fn fn_call_or_sketch_block(i: &mut TokenSlice) -> ModalResult<Expr> {
                 ));
             }
         }
-        return Ok(Expr::SketchBlock(Box::new(Node {
+        return Ok(Expr::SketchBlock(BoxNode::new(Node {
             start,
             end,
             module_id,
@@ -4284,7 +4288,7 @@ fn fn_call_or_sketch_block(i: &mut TokenSlice) -> ModalResult<Expr> {
             },
         })));
     }
-    Ok(Expr::CallExpressionKw(Box::new(fn_call)))
+    Ok(Expr::CallExpressionKw(BoxNode::new(fn_call)))
 }
 
 fn fn_call_kw(i: &mut TokenSlice) -> ModalResult<Node<CallExpressionKw>> {
@@ -4626,7 +4630,7 @@ e
         let Expr::MemberExpression(expr) = in_ctx(|| expression.parse(tokens)).unwrap() else {
             panic!();
         };
-        let Expr::BinaryExpression(be) = expr.inner.property else {
+        let Expr::BinaryExpression(be) = expr.into_node().inner.property else {
             panic!();
         };
         assert_eq!(be.inner.operator, BinaryOperator::Add);
@@ -4872,11 +4876,11 @@ mySk1 = startSketchOn(XY)
         let BodyItem::VariableDeclaration(item) = body.remove(0) else {
             panic!("expected vardec");
         };
-        let val = item.inner.declaration.inner.init;
+        let val = item.into_node().inner.declaration.inner.init;
         let Expr::PipeExpression(pipe) = val else {
             panic!("expected pipe");
         };
-        let mut noncode = pipe.inner.non_code_meta;
+        let mut noncode = pipe.into_node().inner.non_code_meta;
         assert_eq!(noncode.non_code_nodes.len(), 1);
         let comment = noncode.non_code_nodes.remove(&0).unwrap().pop().unwrap();
         assert_eq!(
@@ -4930,7 +4934,10 @@ mySk1 = startSketchOn(XY)
 
         let tokens = crate::parsing::token::lex(test_input, ModuleId::default()).unwrap();
         let (body, non_code_meta) = match in_ctx(|| expression.parse_next(&mut tokens.as_slice())).unwrap() {
-            Expr::PipeExpression(e) => (e.inner.body, e.inner.non_code_meta),
+            Expr::PipeExpression(e) => {
+                let e = e.into_node();
+                (e.inner.body, e.inner.non_code_meta)
+            }
             _ => panic!(),
         };
 
@@ -5177,7 +5184,7 @@ mySk1 = startSketchOn(XY)
         };
 
         assert_eq!(middle.operator, BinaryOperator::Div);
-        let BinaryPart::BinaryExpression(inner) = middle.inner.left else {
+        let BinaryPart::BinaryExpression(inner) = middle.into_node().inner.left else {
             panic!("expected nested binary expression");
         };
         assert_eq!(inner.operator, BinaryOperator::Sub);
@@ -5598,7 +5605,7 @@ mySk1 = startSketchOn(XY)
             },
             BinaryExpression {
                 operator: BinaryOperator::Add,
-                left: BinaryPart::Literal(Box::new(Node::with_node_path(
+                left: BinaryPart::Literal(BoxNode::new(Node::with_node_path(
                     Literal {
                         value: LiteralValue::Number {
                             value: 5.0,
@@ -5618,7 +5625,7 @@ mySk1 = startSketchOn(XY)
                         ],
                     },
                 ))),
-                right: BinaryPart::Literal(Box::new(Node::with_node_path(
+                right: BinaryPart::Literal(BoxNode::new(Node::with_node_path(
                     Literal {
                         value: "a".into(),
                         raw: r#""a""#.to_owned(),
@@ -5673,7 +5680,7 @@ mySk1 = startSketchOn(XY)
                                 ],
                             },
                             BinaryExpression {
-                                left: BinaryPart::Literal(Box::new(Node::with_node_path(
+                                left: BinaryPart::Literal(BoxNode::new(Node::with_node_path(
                                     Literal {
                                         value: LiteralValue::Number {
                                             value: 5.0,
@@ -5694,7 +5701,7 @@ mySk1 = startSketchOn(XY)
                                     },
                                 ))),
                                 operator: BinaryOperator::Add,
-                                right: BinaryPart::Literal(Box::new(Node::with_node_path(
+                                right: BinaryPart::Literal(BoxNode::new(Node::with_node_path(
                                     Literal {
                                         value: LiteralValue::Number {
                                             value: 6.0,

--- a/rust/kcl-lib/src/simulation_tests.rs
+++ b/rust/kcl-lib/src/simulation_tests.rs
@@ -315,6 +315,15 @@ async fn execute_test(test: &Test, render_to_png: bool, export_step: bool) {
                 );
             }
 
+            // Depth survey: when KCL_DEPTH_HIGH_WATER_FILE is set, append the
+            // machine executor's high-water call depth for this program, to
+            // validate the runaway guard's default limit against real code.
+            if let Ok(path) = std::env::var("KCL_DEPTH_HIGH_WATER_FILE") {
+                use std::io::Write;
+                if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(path) {
+                    let _ = writeln!(f, "{}\t{}", exec_state.machine_depth_high_water(), test.name);
+                }
+            }
             let fail_path = test.output_dir.join("execution_error.snap");
             if std::fs::exists(&fail_path).unwrap() {
                 panic!(

--- a/rust/kcl-lib/src/std/array.rs
+++ b/rust/kcl-lib/src/std/array.rs
@@ -16,9 +16,55 @@ use crate::execution::types::RuntimeType;
 
 /// Apply a function to each element of an array.
 pub async fn map(exec_state: &mut ExecState, args: Args) -> Result<KclValueControlFlow, KclError> {
+    let (array, f) = map_parse_args(&args, exec_state)?;
+    inner_map(array, f, exec_state, &args).await
+}
+
+/// Parse map's arguments. Shared by the recursive executor's `map` and the
+/// machine executor's resumable entry.
+pub(crate) fn map_parse_args(
+    args: &Args,
+    exec_state: &mut ExecState,
+) -> Result<(Vec<KclValue>, FunctionSource), KclError> {
     let array: Vec<KclValue> = args.get_unlabeled_kw_arg("array", &RuntimeType::any_array(), exec_state)?;
     let f: FunctionSource = args.get_kw_arg("f", &RuntimeType::function(), exec_state)?;
-    inner_map(array, f, exec_state, &args).await
+    Ok((array, f))
+}
+
+/// Build the per-element callback arguments for map. Shared by both
+/// executors.
+pub(crate) fn map_callback_args(
+    input: KclValue,
+    source_range: SourceRange,
+    node_path: Option<NodePath>,
+    exec_state: &mut ExecState,
+    ctxt: &ExecutorContext,
+) -> Args<crate::execution::fn_call::Sugary> {
+    Args::new(
+        Default::default(),
+        vec![(None, Arg::new(input, source_range))],
+        source_range,
+        node_path,
+        exec_state,
+        ctxt.clone(),
+        Some("map closure".to_owned()),
+    )
+}
+
+/// The result of map's whole iteration. Shared by both executors.
+pub(crate) fn map_result(done: Vec<KclValue>) -> KclValue {
+    KclValue::HomArray {
+        value: done,
+        ty: RuntimeType::any(),
+    }
+}
+
+/// Error when a map callback produces no value. Shared by both executors.
+pub(crate) fn map_missing_value_error(source_range: SourceRange) -> KclError {
+    KclError::new_semantic(KclErrorDetails::new(
+        "Map function must return a value".to_owned(),
+        vec![source_range],
+    ))
 }
 
 async fn inner_map(
@@ -43,11 +89,7 @@ async fn inner_map(
         let new_elem = control_continue!(new_elem_cf);
         new_array.push(new_elem);
     }
-    Ok(KclValue::HomArray {
-        value: new_array,
-        ty: RuntimeType::any(),
-    }
-    .continue_())
+    Ok(map_result(new_array).continue_())
 }
 
 async fn call_map_closure(
@@ -58,32 +100,58 @@ async fn call_map_closure(
     exec_state: &mut ExecState,
     ctxt: &ExecutorContext,
 ) -> Result<KclValueControlFlow, KclError> {
-    let args = Args::new(
-        Default::default(),
-        vec![(None, Arg::new(input, source_range))],
-        source_range,
-        node_path,
-        exec_state,
-        ctxt.clone(),
-        Some("map closure".to_owned()),
-    );
+    let args = map_callback_args(input, source_range, node_path, exec_state, ctxt);
     let output = map_fn.call_kw(None, exec_state, ctxt, args, source_range).await?;
-    let source_ranges = vec![source_range];
-    let output = output.ok_or_else(|| {
-        KclError::new_semantic(KclErrorDetails::new(
-            "Map function must return a value".to_owned(),
-            source_ranges,
-        ))
-    })?;
+    let output = output.ok_or_else(|| map_missing_value_error(source_range))?;
     Ok(output)
 }
 
 /// For each item in an array, update a value.
 pub async fn reduce(exec_state: &mut ExecState, args: Args) -> Result<KclValueControlFlow, KclError> {
+    let (array, f, initial) = reduce_parse_args(&args, exec_state)?;
+    inner_reduce(array, initial, f, exec_state, &args).await
+}
+
+/// Parse reduce's arguments. Shared by both executors.
+pub(crate) fn reduce_parse_args(
+    args: &Args,
+    exec_state: &mut ExecState,
+) -> Result<(Vec<KclValue>, FunctionSource, KclValue), KclError> {
     let array: Vec<KclValue> = args.get_unlabeled_kw_arg("array", &RuntimeType::any_array(), exec_state)?;
     let f: FunctionSource = args.get_kw_arg("f", &RuntimeType::function(), exec_state)?;
     let initial: KclValue = args.get_kw_arg("initial", &RuntimeType::any(), exec_state)?;
-    inner_reduce(array, initial, f, exec_state, &args).await
+    Ok((array, f, initial))
+}
+
+/// Build the per-element callback arguments for reduce. Shared by both
+/// executors.
+pub(crate) fn reduce_callback_args(
+    elem: KclValue,
+    accum: KclValue,
+    source_range: SourceRange,
+    node_path: Option<NodePath>,
+    exec_state: &mut ExecState,
+    ctxt: &ExecutorContext,
+) -> Args<crate::execution::fn_call::Sugary> {
+    let mut labeled = IndexMap::with_capacity(1);
+    labeled.insert("accum".to_string(), Arg::new(accum, source_range));
+    Args::new(
+        labeled,
+        vec![(None, Arg::new(elem, source_range))],
+        source_range,
+        node_path,
+        exec_state,
+        ctxt.clone(),
+        Some("reduce closure".to_owned()),
+    )
+}
+
+/// Error when a reduce callback produces no value. Shared by both executors.
+pub(crate) fn reduce_missing_value_error(source_range: SourceRange) -> KclError {
+    KclError::new_semantic(KclErrorDetails::new(
+        "Reducer function must return a value".to_string(),
+        vec![source_range],
+    ))
 }
 
 async fn inner_reduce(
@@ -123,29 +191,11 @@ async fn call_reduce_closure(
     ctxt: &ExecutorContext,
 ) -> Result<KclValueControlFlow, KclError> {
     // Call the reduce fn for this repetition.
-    let mut labeled = IndexMap::with_capacity(1);
-    labeled.insert("accum".to_string(), Arg::new(accum, source_range));
-    let reduce_fn_args = Args::new(
-        labeled,
-        vec![(None, Arg::new(elem, source_range))],
-        source_range,
-        node_path,
-        exec_state,
-        ctxt.clone(),
-        Some("reduce closure".to_owned()),
-    );
+    let reduce_fn_args = reduce_callback_args(elem, accum, source_range, node_path, exec_state, ctxt);
     let transform_fn_return = reduce_fn
         .call_kw(None, exec_state, ctxt, reduce_fn_args, source_range)
         .await?;
-
-    // Unpack the returned transform object.
-    let source_ranges = vec![source_range];
-    let out = transform_fn_return.ok_or_else(|| {
-        KclError::new_semantic(KclErrorDetails::new(
-            "Reducer function must return a value".to_string(),
-            source_ranges,
-        ))
-    })?;
+    let out = transform_fn_return.ok_or_else(|| reduce_missing_value_error(source_range))?;
     Ok(out)
 }
 

--- a/rust/kcl-lib/src/std/gdt.rs
+++ b/rust/kcl-lib/src/std/gdt.rs
@@ -20,14 +20,12 @@ use crate::exec::KclValue;
 use crate::execution::Artifact;
 use crate::execution::ArtifactId;
 use crate::execution::CodeRef;
-use crate::execution::ControlFlowKind;
 use crate::execution::Face;
 use crate::execution::GdtAnnotation;
 use crate::execution::GdtAnnotationArtifact;
 use crate::execution::Metadata;
 use crate::execution::ModelingCmdMeta;
 use crate::execution::Plane;
-use crate::execution::StatementKind;
 use crate::execution::TagIdentifier;
 use crate::execution::types::ArrayLen;
 use crate::execution::types::RuntimeType;
@@ -1706,21 +1704,9 @@ fn resolve_datums(datums: Option<Vec<String>>, args: &Args, annotation_name: &st
 async fn xy_plane(exec_state: &mut ExecState, args: &Args) -> Result<Plane, KclError> {
     let plane_ast = plane_ast("XY", args.source_range);
     let metadata = Metadata::from(args.source_range);
-    let plane_value = args
-        .ctx
-        .execute_expr(&plane_ast, exec_state, &metadata, &[], StatementKind::Expression)
-        .await?;
-    let plane_value = match plane_value.control {
-        ControlFlowKind::Continue => plane_value.into_value(),
-        ControlFlowKind::Exit => {
-            let message = "Early return inside plane value is currently not supported".to_owned();
-            debug_assert!(false, "{}", &message);
-            return Err(KclError::new_internal(KclErrorDetails::new(
-                message,
-                vec![args.source_range],
-            )));
-        }
-    };
+    let plane_value = args.ctx.eval_expr_fresh_root(&plane_ast, exec_state, &metadata).await?;
+    // Evaluating a constant name cannot exit().
+    let plane_value = plane_value.into_value();
     Ok(plane_value
         .as_plane()
         .ok_or_else(|| {

--- a/rust/kcl-lib/src/std/gdt.rs
+++ b/rust/kcl-lib/src/std/gdt.rs
@@ -32,6 +32,7 @@ use crate::execution::TagIdentifier;
 use crate::execution::types::ArrayLen;
 use crate::execution::types::RuntimeType;
 use crate::parsing::ast::types as ast;
+use crate::parsing::ast::types::BoxNode;
 use crate::std::Args;
 use crate::std::args::FromKclValue;
 use crate::std::args::TyF64;
@@ -1734,7 +1735,7 @@ async fn xy_plane(exec_state: &mut ExecState, args: &Args) -> Result<Plane, KclE
 /// An AST node for a plane with the given name.
 fn plane_ast(plane_name: &str, range: SourceRange) -> ast::Node<ast::Expr> {
     ast::Node::new(
-        ast::Expr::Name(Box::new(ast::Node::new(
+        ast::Expr::Name(BoxNode::new(ast::Node::new(
             ast::Name {
                 name: ast::Identifier::new(plane_name),
                 path: Vec::new(),

--- a/rust/kcl-lib/src/std/mod.rs
+++ b/rust/kcl-lib/src/std/mod.rs
@@ -147,6 +147,21 @@ pub struct StdFnProps {
     pub name: String,
     pub(crate) consumed_solid_arg_check: ConsumedSolidArgCheck,
     pub(crate) region_behavior: RegionBehavior,
+    /// Set for the few builtins that call back into KCL (map, reduce,
+    /// patternTransform): the machine executor routes them to a resumable
+    /// entry so their callbacks run on the machine's continuation stack
+    /// instead of re-entering natively. The recursive executor ignores this.
+    pub(crate) resumable: Option<ResumableKind>,
+}
+
+/// Which resumable builtin this is. See
+/// `crate::execution::machine`'s resume continuations.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ResumableKind {
+    Map,
+    Reduce,
+    PatternTransform,
+    PatternTransform2d,
 }
 
 impl StdFnProps {
@@ -155,7 +170,13 @@ impl StdFnProps {
             name: name.to_owned(),
             consumed_solid_arg_check: Default::default(),
             region_behavior: Default::default(),
+            resumable: None,
         }
+    }
+
+    pub(crate) fn resumable(mut self, kind: ResumableKind) -> Self {
+        self.resumable = Some(kind);
+        self
     }
 
     pub(crate) fn warn_deprecated_on_consumed_solid_args(mut self) -> Self {
@@ -491,7 +512,7 @@ pub(crate) fn std_fn(path: &str, fn_name: &str) -> (crate::std::StdFn, StdFnProp
         ),
         ("solid", "patternTransform") => (
             |e, a| Box::pin(crate::std::patterns::pattern_transform(e, a)),
-            StdFnProps::default("std::solid::patternTransform"),
+            StdFnProps::default("std::solid::patternTransform").resumable(ResumableKind::PatternTransform),
         ),
         ("solid", "patternLinear3d") => (
             |e, a| Box::pin(crate::std::patterns::pattern_linear_3d(e, a).map(|r| r.map(KclValue::continue_))),
@@ -515,11 +536,15 @@ pub(crate) fn std_fn(path: &str, fn_name: &str) -> (crate::std::StdFn, StdFnProp
         ),
         ("array", "map") => (
             |e, a| Box::pin(crate::std::array::map(e, a)),
-            StdFnProps::default("std::array::map").reads_regions_locally(),
+            StdFnProps::default("std::array::map")
+                .reads_regions_locally()
+                .resumable(ResumableKind::Map),
         ),
         ("array", "reduce") => (
             |e, a| Box::pin(crate::std::array::reduce(e, a)),
-            StdFnProps::default("std::array::reduce").reads_regions_locally(),
+            StdFnProps::default("std::array::reduce")
+                .reads_regions_locally()
+                .resumable(ResumableKind::Reduce),
         ),
         ("array", "push") => (
             |e, a| Box::pin(crate::std::array::push(e, a).map(|r| r.map(KclValue::continue_))),
@@ -602,7 +627,7 @@ pub(crate) fn std_fn(path: &str, fn_name: &str) -> (crate::std::StdFn, StdFnProp
         ),
         ("sketch", "patternTransform2d") => (
             |e, a| Box::pin(crate::std::patterns::pattern_transform_2d(e, a)),
-            StdFnProps::default("std::sketch::patternTransform2d"),
+            StdFnProps::default("std::sketch::patternTransform2d").resumable(ResumableKind::PatternTransform2d),
         ),
         ("sketch", "revolve") => (
             |e, a| Box::pin(crate::std::revolve::revolve(e, a).map(|r| r.map(KclValue::continue_))),

--- a/rust/kcl-lib/src/std/patterns.rs
+++ b/rust/kcl-lib/src/std/patterns.rs
@@ -66,10 +66,7 @@ const MUST_HAVE_ONE_INSTANCE: &str = "There must be at least 1 instance of your 
 
 /// Repeat some 3D solid, changing each repetition slightly.
 pub async fn pattern_transform(exec_state: &mut ExecState, args: Args) -> Result<KclValueControlFlow, KclError> {
-    let solids = args.get_unlabeled_kw_arg("solids", &RuntimeType::solids(), exec_state)?;
-    let instances: u32 = args.get_kw_arg("instances", &RuntimeType::count(), exec_state)?;
-    let transform: FunctionSource = args.get_kw_arg("transform", &RuntimeType::function(), exec_state)?;
-    let use_original = args.get_kw_arg_opt("useOriginal", &RuntimeType::bool(), exec_state)?;
+    let (solids, instances, transform, use_original) = pattern_transform_parse_args(&args, exec_state)?;
 
     match inner_pattern_transform(solids, instances, transform, use_original, exec_state, &args).await {
         Ok(solids) => Ok(KclValue::continue_(solids.into())),
@@ -82,10 +79,7 @@ pub async fn pattern_transform(exec_state: &mut ExecState, args: Args) -> Result
 
 /// Repeat some 2D sketch, changing each repetition slightly.
 pub async fn pattern_transform_2d(exec_state: &mut ExecState, args: Args) -> Result<KclValueControlFlow, KclError> {
-    let sketches = args.get_unlabeled_kw_arg("sketches", &RuntimeType::sketches(), exec_state)?;
-    let instances: u32 = args.get_kw_arg("instances", &RuntimeType::count(), exec_state)?;
-    let transform: FunctionSource = args.get_kw_arg("transform", &RuntimeType::function(), exec_state)?;
-    let use_original = args.get_kw_arg_opt("useOriginal", &RuntimeType::bool(), exec_state)?;
+    let (sketches, instances, transform, use_original) = pattern_transform_2d_parse_args(&args, exec_state)?;
 
     match inner_pattern_transform_2d(sketches, instances, transform, use_original, exec_state, &args).await {
         Ok(sketches) => Ok(KclValue::continue_(sketches.into())),
@@ -94,6 +88,113 @@ pub async fn pattern_transform_2d(exec_state: &mut ExecState, args: Args) -> Res
         Err(EarlyReturn::Value(cf)) => Ok(cf),
         Err(EarlyReturn::Error(err)) => Err(err),
     }
+}
+
+/// Parse patternTransform's arguments. Shared by both executors.
+pub(crate) fn pattern_transform_parse_args(
+    args: &Args,
+    exec_state: &mut ExecState,
+) -> Result<(Vec<Solid>, u32, FunctionSource, Option<bool>), KclError> {
+    let solids = args.get_unlabeled_kw_arg("solids", &RuntimeType::solids(), exec_state)?;
+    let instances: u32 = args.get_kw_arg("instances", &RuntimeType::count(), exec_state)?;
+    let transform: FunctionSource = args.get_kw_arg("transform", &RuntimeType::function(), exec_state)?;
+    let use_original = args.get_kw_arg_opt("useOriginal", &RuntimeType::bool(), exec_state)?;
+    Ok((solids, instances, transform, use_original))
+}
+
+/// Parse patternTransform2d's arguments. Shared by both executors.
+pub(crate) fn pattern_transform_2d_parse_args(
+    args: &Args,
+    exec_state: &mut ExecState,
+) -> Result<(Vec<Sketch>, u32, FunctionSource, Option<bool>), KclError> {
+    let sketches = args.get_unlabeled_kw_arg("sketches", &RuntimeType::sketches(), exec_state)?;
+    let instances: u32 = args.get_kw_arg("instances", &RuntimeType::count(), exec_state)?;
+    let transform: FunctionSource = args.get_kw_arg("transform", &RuntimeType::function(), exec_state)?;
+    let use_original = args.get_kw_arg_opt("useOriginal", &RuntimeType::bool(), exec_state)?;
+    Ok((sketches, instances, transform, use_original))
+}
+
+/// The "at least 1 instance" check both executors run before the callback
+/// loop.
+pub(crate) fn pattern_check_instances(instances: u32, source_range: SourceRange) -> Result<(), KclError> {
+    if instances < 1 {
+        return Err(KclError::new_semantic(KclErrorDetails::new(
+            MUST_HAVE_ONE_INSTANCE.to_owned(),
+            vec![source_range],
+        )));
+    }
+    Ok(())
+}
+
+/// Build the per-repetition callback arguments for patternTransform. Shared
+/// by both executors.
+pub(crate) fn transform_callback_args(
+    i: u32,
+    source_range: SourceRange,
+    node_path: Option<NodePath>,
+    exec_state: &mut ExecState,
+    ctxt: &ExecutorContext,
+) -> Args<crate::execution::fn_call::Sugary> {
+    let repetition_num = KclValue::Number {
+        value: i.into(),
+        ty: NumericType::count(),
+        meta: vec![source_range.into()],
+    };
+    Args::new(
+        Default::default(),
+        vec![(None, Arg::new(repetition_num, source_range))],
+        source_range,
+        node_path,
+        exec_state,
+        ctxt.clone(),
+        Some("transform closure".to_owned()),
+    )
+}
+
+/// Error when a transform callback produces no value. Shared by both
+/// executors.
+pub(crate) fn transform_missing_value_error(source_range: SourceRange) -> KclError {
+    KclError::new_semantic(KclErrorDetails::new(
+        "Transform function must return a value".to_string(),
+        vec![source_range],
+    ))
+}
+
+/// Unpack a transform callback's returned value into engine transforms: the
+/// evaluation-free tail of make_transform, shared by both executors.
+pub(crate) fn transforms_from_callback_value<T: GeometryTrait>(
+    transform_fn_return: KclValue,
+    source_range: SourceRange,
+    exec_state: &mut ExecState,
+) -> Result<Vec<Transform>, KclError> {
+    let source_ranges = vec![source_range];
+    let transforms = match transform_fn_return {
+        KclValue::Object { value, .. } => vec![value],
+        KclValue::Tuple { value, .. } | KclValue::HomArray { value, .. } => {
+            let transforms: Vec<_> = value
+                .into_iter()
+                .map(|val| {
+                    val.into_object().ok_or(KclError::new_semantic(KclErrorDetails::new(
+                        "Transform function must return a transform object".to_string(),
+                        source_ranges.clone(),
+                    )))
+                })
+                .collect::<Result<_, KclError>>()?;
+            transforms
+        }
+        _ => {
+            return Err(KclError::new_semantic(KclErrorDetails::new(
+                "Transform function must return a transform object".to_string(),
+                source_ranges,
+            )));
+        }
+    };
+
+    let transforms = transforms
+        .into_iter()
+        .map(|obj| transform_from_obj_fields::<T>(obj, source_ranges.clone(), exec_state))
+        .collect::<Result<_, KclError>>()?;
+    Ok(transforms)
 }
 
 async fn inner_pattern_transform(
@@ -106,13 +207,7 @@ async fn inner_pattern_transform(
 ) -> Result<Vec<Solid>, EarlyReturn> {
     // Build the vec of transforms, one for each repetition.
     let mut transform_vec = Vec::with_capacity(usize::try_from(instances).unwrap());
-    if instances < 1 {
-        return Err(KclError::new_semantic(KclErrorDetails::new(
-            MUST_HAVE_ONE_INSTANCE.to_owned(),
-            vec![args.source_range],
-        ))
-        .into());
-    }
+    pattern_check_instances(instances, args.source_range)?;
     for i in 1..instances {
         let t = make_transform::<Solid>(
             i,
@@ -145,13 +240,7 @@ async fn inner_pattern_transform_2d(
 ) -> Result<Vec<Sketch>, EarlyReturn> {
     // Build the vec of transforms, one for each repetition.
     let mut transform_vec = Vec::with_capacity(usize::try_from(instances).unwrap());
-    if instances < 1 {
-        return Err(KclError::new_semantic(KclErrorDetails::new(
-            MUST_HAVE_ONE_INSTANCE.to_owned(),
-            vec![args.source_range],
-        ))
-        .into());
-    }
+    pattern_check_instances(instances, args.source_range)?;
     for i in 1..instances {
         let t = make_transform::<Sketch>(
             i,
@@ -174,7 +263,7 @@ async fn inner_pattern_transform_2d(
     .await?)
 }
 
-async fn execute_pattern_transform<T: GeometryTrait>(
+pub(crate) async fn execute_pattern_transform<T: GeometryTrait>(
     transforms: Vec<Vec<Transform>>,
     geo_set: T::Set,
     use_original: bool,
@@ -257,66 +346,24 @@ async fn make_transform<T: GeometryTrait>(
     ctxt: &ExecutorContext,
 ) -> Result<Vec<Transform>, EarlyReturn> {
     // Call the transform fn for this repetition.
-    let repetition_num = KclValue::Number {
-        value: i.into(),
-        ty: NumericType::count(),
-        meta: vec![source_range.into()],
-    };
-    let transform_fn_args = Args::new(
-        Default::default(),
-        vec![(None, Arg::new(repetition_num, source_range))],
-        source_range,
-        node_path,
-        exec_state,
-        ctxt.clone(),
-        Some("transform closure".to_owned()),
-    );
+    let transform_fn_args = transform_callback_args(i, source_range, node_path, exec_state, ctxt);
     let transform_fn_return = transform
         .call_kw(None, exec_state, ctxt, transform_fn_args, source_range)
         .await?;
 
     // Unpack the returned transform object.
-    let source_ranges = vec![source_range];
-    let transform_fn_return = transform_fn_return.ok_or_else(|| {
-        KclError::new_semantic(KclErrorDetails::new(
-            "Transform function must return a value".to_string(),
-            source_ranges.clone(),
-        ))
-    })?;
+    let transform_fn_return = transform_fn_return.ok_or_else(|| transform_missing_value_error(source_range))?;
 
     // If the callback exited, e.g. by calling exit(), skip building the
     // pattern, and propagate the exit so that it terminates the enclosing
     // module.
     let transform_fn_return = early_return!(transform_fn_return);
 
-    let transforms = match transform_fn_return {
-        KclValue::Object { value, .. } => vec![value],
-        KclValue::Tuple { value, .. } | KclValue::HomArray { value, .. } => {
-            let transforms: Vec<_> = value
-                .into_iter()
-                .map(|val| {
-                    val.into_object().ok_or(KclError::new_semantic(KclErrorDetails::new(
-                        "Transform function must return a transform object".to_string(),
-                        source_ranges.clone(),
-                    )))
-                })
-                .collect::<Result<_, KclError>>()?;
-            transforms
-        }
-        _ => {
-            return Err(KclError::new_semantic(KclErrorDetails::new(
-                "Transform function must return a transform object".to_string(),
-                source_ranges,
-            ))
-            .into());
-        }
-    };
-
-    let transforms = transforms
-        .into_iter()
-        .map(|obj| transform_from_obj_fields::<T>(obj, source_ranges.clone(), exec_state))
-        .collect::<Result<_, KclError>>()?;
-    Ok(transforms)
+    Ok(transforms_from_callback_value::<T>(
+        transform_fn_return,
+        source_range,
+        exec_state,
+    )?)
 }
 
 fn transform_from_obj_fields<T: GeometryTrait>(

--- a/rust/kcl-lib/src/std/region_consumption.rs
+++ b/rust/kcl-lib/src/std/region_consumption.rs
@@ -19,6 +19,7 @@ use crate::std::RegionBehavior;
 
 const REGION_REUSE_WORKAROUND: &str = "Create a separate region for each consuming operation by calling `region(...)` multiple times with the original sketch. Do not clone the source sketch.";
 
+#[derive(Debug)]
 pub(crate) struct PendingRegionConsumption {
     region_ids: AhashIndexSet<Uuid>,
     operation: ConsumedRegionOperation,

--- a/rust/kcl-lib/src/test_server.rs
+++ b/rust/kcl-lib/src/test_server.rs
@@ -221,9 +221,12 @@ pub async fn new_context(with_auth: bool, current_file: Option<PathBuf>) -> Resu
     if let Some(current_file) = current_file {
         settings.with_current_file(crate::TypedPath(current_file));
     }
-    let ctx = ExecutorContext::new(&client, settings)
+    let mut ctx = ExecutorContext::new(&client, settings)
         .await
         .map_err(ConnectionError::Establishing)?;
+    // Differential testing: the simulation suite runs under both executors
+    // (see the machine-executor CI job).
+    ctx.executor_kind = crate::execution::machine::ExecutorKind::from_test_env();
     Ok(ctx)
 }
 

--- a/rust/kcl-lib/src/test_server.rs
+++ b/rust/kcl-lib/src/test_server.rs
@@ -226,7 +226,7 @@ pub async fn new_context(with_auth: bool, current_file: Option<PathBuf>) -> Resu
         .map_err(ConnectionError::Establishing)?;
     // Differential testing: the simulation suite runs under both executors
     // (see the machine-executor CI job).
-    ctx.executor_kind = crate::execution::machine::ExecutorKind::from_test_env();
+    ctx.executor_kind = crate::execution::machine::ExecutorKind::from_env();
     Ok(ctx)
 }
 

--- a/rust/kcl-lib/src/test_server.rs
+++ b/rust/kcl-lib/src/test_server.rs
@@ -221,12 +221,9 @@ pub async fn new_context(with_auth: bool, current_file: Option<PathBuf>) -> Resu
     if let Some(current_file) = current_file {
         settings.with_current_file(crate::TypedPath(current_file));
     }
-    let mut ctx = ExecutorContext::new(&client, settings)
+    let ctx = ExecutorContext::new(&client, settings)
         .await
         .map_err(ConnectionError::Establishing)?;
-    // Differential testing: the simulation suite runs under both executors
-    // (see the machine-executor CI job).
-    ctx.executor_kind = crate::execution::machine::ExecutorKind::from_env();
     Ok(ctx)
 }
 


### PR DESCRIPTION
# Overview

Re-expresses KCL evaluation as a CEK abstract machine (`execution/machine.rs`, ~2,700 lines): an explicit continuation stack replaces native async recursion, so evaluation depth is bounded by the heap instead of the native stack — the wasm constraint behind the old 50-call cap. A call-depth guard (default 1000) replaces that cap; runaway recursion now errors in ~0.15 s where the recursive executor hangs. The recursive executor remains the default and is untouched semantically; `KCL_EXECUTOR=machine` is the explicit opt-in.

Resolves #12990. Related #11638. Replaces #12566.

## Review Guide

<details><summary>Click to expand</summary>

Review guide (bottom → top)

| Commits | What | Review as |
|---|---|---|
| `BoxNode` Arc newtype + call-site migration | AST handles become Arc-backed copy-on-write; serde/ts-rs **byte-identical** (CI-gated since #12746) so konts can hold AST cheaply | Mechanical; ~180 call sites, compiler-driven |
| `call_setup`/`call_finish`, statement/expr halves, sketch-block halves | Evaluation-free logic extracted so both executors share one implementation of everything that isn't control flow | Pure code moves — big diffs, no behavior |
| **`machine.rs`** + wasm fix + drift adaptation | Control/Kont step loop, one Kont per recursion site; call boundaries reuse `call_setup`/`call_finish`; exit/error unwinds replicate the recursive executor's ordering *including its historical asymmetries*; `return` stays write-and-continue | The core — read closely |
| Resumable callbacks + clippy | `map`/`reduce`/`patternTransform{,2d}` callbacks run on the machine's stack (`Kont::Resume` feed loop) instead of re-entering natively | Second-trickiest part |
| Flush-on-exit + 50k stress + depth survey | Root-exit batch flush parity (tests drive `exec_block` directly); 50k-depth test; high-water instrumentation | |
| Review fixes from #12566 | No-panic unwinds, executor propagation to imported modules (+test), range validate-start-before-eval-end, `decl_name` through labels, doc corrections | One commit per review comment |
| `KCL_EXECUTOR` plumbing + CI | Strict env parsing (typo ⇒ panic, never the wrong executor silently); read at **every** `ExecutorContext` construction; machine CI leg runs only executor-sensitive tests (2,761 of 3,591 — parsers/printers/ts-rs codegen run once)
</details>

## Parity evidence

- Differential CI matrix: the suite runs under both executors and must be snapshot-identical (this harness caught a real bug during development).
- Real-world depth over 332 kcl-samples: max **6** → 167× headroom under the 1000 guard; 50,000-deep recursion passes natively.
- Perf: release-mode mock-execute of `mike_stress_test` (manual `perf_compare_executors`, avg of 5 runs): machine **99.1 ms** vs recursive **100.0 ms** — dead even, within noise.

## Exec Benchmark

mock execute, `mike_stress_test`, avg of 5 runs after warm-up

Profile | Recursive | Machine | Delta |
|---|---|---|---|
| **release** | 100.0 ms | **99.1 ms** | machine −0.8% |
| dev (for reference) | 461.7 ms | 473.8 ms | machine +2.6%

## AST Benchmarks

`Box` was changed to `Arc` in the AST.

AST benchmarks vs `main` (criterion, release, M-series; same bench file run on main via `--save-baseline`)

| Benchmark | This branch (big_kitt / pipes / mike_stress) | vs main |
|---|---|---|
| `ast_parse` | 6.4 / 18.2 / 23.4 ms | −1.7…−2.9% |
| `ast_clone` | 283 / 660 / 790 **ns** (was ms-scale: full deep copy) | **−99.8%** |
| `ast_digest_owned` | 148 / 454 / 532 µs | −1.5…+1.2% (noise) |
| `ast_node_paths_owned` | 76 / 236 / 265 µs | −5.4…−0.4% |
| `ast_digest_shared_clone` (COW worst case) | 303 / 950 / 1051 µs | **+6.0…+10.0%**

The regression is the deliberate COW trade-off: mutating a *shared* tree pays `Arc::make_mut` copies. It's an editor-side path, µs-scale absolute, and execution-relevant paths are neutral-to-better; a `BOX_NODE_COW_CLONES` debug counter + regression test pin that parse/digest/node-paths stay zero-clone.

## Known intentional difference

Exceeding the call depth guard error message has new text that includes the call depth limit.