### PR TITLE
Remove extra defensive code for popup fix

### DIFF
--- a/src/components/ToolbarDropdownPanel.test.tsx
+++ b/src/components/ToolbarDropdownPanel.test.tsx
@@ -4,18 +4,6 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
 import { ToolbarDropdownPanel } from '@src/components/ToolbarDropdownPanel'
 
-const mocks = vi.hoisted(() => ({
-  reportClientError: vi.fn(async () => {}),
-}))
-
-vi.mock('@src/lib/clientErrors', () => ({
-  ClientErrorCode: {
-    ToolbarDropdownAnchorPositioningError:
-      'toolbar_dropdown_anchor_positioning_error',
-  },
-  reportClientError: mocks.reportClientError,
-}))
-
 const originalHidePopover = Object.getOwnPropertyDescriptor(
   HTMLElement.prototype,
   'hidePopover'
@@ -41,11 +29,7 @@ function Dropdown({ label }: { label: string }) {
 
   return (
     <>
-      <button
-        ref={buttonRef}
-        type="button"
-        data-onboarding-id={`${label.toLowerCase()}-dropdown-button`}
-      >
+      <button ref={buttonRef} type="button">
         {label}
       </button>
       <ToolbarDropdownPanel buttonRef={buttonRef} open>
@@ -57,7 +41,6 @@ function Dropdown({ label }: { label: string }) {
 
 describe('ToolbarDropdownPanel', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
     Object.defineProperties(HTMLElement.prototype, {
       hidePopover: { configurable: true, value: vi.fn() },
       showPopover: { configurable: true, value: vi.fn() },
@@ -87,14 +70,6 @@ describe('ToolbarDropdownPanel', () => {
   })
 
   test('connects each trigger and panel with a unique explicit anchor', async () => {
-    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(
-      function (this: HTMLElement) {
-        return this.tagName === 'BUTTON'
-          ? new DOMRect(100, 100, 40, 30)
-          : new DOMRect(20, 146, 200, 100)
-      }
-    )
-
     const { container } = render(
       <>
         <Dropdown label="First" />
@@ -119,66 +94,5 @@ describe('ToolbarDropdownPanel', () => {
       secondAnchor
     )
     expect(firstAnchor).not.toBe(secondAnchor)
-    expect(mocks.reportClientError).not.toHaveBeenCalled()
-  })
-
-  test('falls back to trigger geometry when native anchoring does not resolve', async () => {
-    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(
-      function (this: HTMLElement) {
-        return this.tagName === 'BUTTON'
-          ? new DOMRect(520, 120, 40, 30)
-          : new DOMRect(0, 0, 200, 100)
-      }
-    )
-
-    const { container } = render(<Dropdown label="Tools" />)
-    const panel = container.querySelector<HTMLElement>('[popover]')
-
-    expect(panel).not.toBeNull()
-    if (!panel) return
-
-    await waitFor(() => {
-      expect(panel.style.position).toBe('fixed')
-    })
-
-    expect(panel.style.left).toBe('440px')
-    expect(panel.style.top).toBe('166px')
-    expect(mocks.reportClientError).toHaveBeenCalledWith({
-      code: 'toolbar_dropdown_anchor_positioning_error',
-      errorName: 'ToolbarDropdownAnchorPositioningError',
-      message: 'Toolbar dropdown CSS anchor positioning did not resolve.',
-      dedupeKey: 'ToolbarDropdownPanel:unresolved-css-anchor',
-      extra: expect.objectContaining({
-        source: 'ToolbarDropdownPanel',
-        buttonRect: {
-          height: 30,
-          left: 520,
-          top: 120,
-          width: 40,
-        },
-        panelRect: {
-          height: 100,
-          left: 0,
-          top: 0,
-          width: 200,
-        },
-        cssSupport: {
-          anchorName: true,
-          positionAnchor: true,
-          anchorFunction: true,
-        },
-        computedAnchorStyles: expect.objectContaining({
-          buttonAnchorNameSet: true,
-          panelPositionAnchorSet: true,
-          anchorNamesMatch: true,
-        }),
-        triggerOnboardingId: 'tools-dropdown-button',
-        viewport: expect.objectContaining({
-          devicePixelRatio: window.devicePixelRatio,
-          height: window.innerHeight,
-          width: window.innerWidth,
-        }),
-      }),
-    })
   })
 })

--- a/src/components/ToolbarDropdownPanel.tsx
+++ b/src/components/ToolbarDropdownPanel.tsx
@@ -1,6 +1,4 @@
 import { Popover } from '@headlessui/react'
-import { ClientErrorCode, reportClientError } from '@src/lib/clientErrors'
-import { reportRejection } from '@src/lib/trap'
 import type { CSSProperties, ReactNode, RefObject } from 'react'
 import { useEffect, useId, useRef } from 'react'
 
@@ -10,7 +8,6 @@ type ToolbarDropdownPanelProps = {
   open: boolean
 }
 
-const anchorTolerance = 2
 const dropdownGap = 16
 const viewportPadding = 8
 
@@ -23,141 +20,6 @@ const panelStyle = {
   positionTry: 'flip-block',
   positionTryFallbacks: 'flip-block',
 } as CSSProperties
-
-function resetPanelToAnchorPosition(panel: HTMLElement) {
-  panel.style.removeProperty('bottom')
-  panel.style.removeProperty('left')
-  panel.style.removeProperty('position')
-  panel.style.removeProperty('right')
-  panel.style.removeProperty('top')
-  panel.style.inset = 'unset'
-  panel.style.insetInlineStart = 'anchor(50%)'
-  panel.style.insetBlockStart = 'anchor(end)'
-  panel.style.marginBlockStart = `${dropdownGap}px`
-  panel.style.transform =
-    'translateX(calc(-50% + var(--toolbar-dropdown-offset-x, 0px)))'
-}
-
-function isPanelAnchoredToButton(panelRect: DOMRect, buttonRect: DOMRect) {
-  const horizontallyCentered =
-    Math.abs(
-      panelRect.left +
-        panelRect.width / 2 -
-        (buttonRect.left + buttonRect.width / 2)
-    ) <= anchorTolerance
-  const verticallyAttached =
-    Math.abs(panelRect.top - (buttonRect.bottom + dropdownGap)) <=
-      anchorTolerance ||
-    Math.abs(panelRect.bottom - (buttonRect.top - dropdownGap)) <=
-      anchorTolerance
-
-  return horizontallyCentered && verticallyAttached
-}
-
-function rectToReport(rect: DOMRect) {
-  return {
-    height: rect.height,
-    left: rect.left,
-    top: rect.top,
-    width: rect.width,
-  }
-}
-
-function cssSupports(property: string, value: string) {
-  return typeof CSS !== 'undefined' && typeof CSS.supports === 'function'
-    ? CSS.supports(property, value)
-    : false
-}
-
-function isPopoverOpen(panel: HTMLElement) {
-  try {
-    return panel.matches(':popover-open')
-  } catch {
-    return undefined
-  }
-}
-
-function reportUnresolvedAnchor(
-  panel: HTMLElement,
-  button: HTMLElement,
-  panelRect: DOMRect,
-  buttonRect: DOMRect
-) {
-  const buttonStyle = window.getComputedStyle(button)
-  const panelComputedStyle = window.getComputedStyle(panel)
-  const buttonAnchorName = buttonStyle.getPropertyValue('anchor-name')
-  const panelPositionAnchor =
-    panelComputedStyle.getPropertyValue('position-anchor')
-
-  void reportClientError({
-    code: ClientErrorCode.ToolbarDropdownAnchorPositioningError,
-    errorName: 'ToolbarDropdownAnchorPositioningError',
-    message: 'Toolbar dropdown CSS anchor positioning did not resolve.',
-    dedupeKey: 'ToolbarDropdownPanel:unresolved-css-anchor',
-    extra: {
-      source: 'ToolbarDropdownPanel',
-      buttonRect: rectToReport(buttonRect),
-      panelRect: rectToReport(panelRect),
-      computedAnchorStyles: {
-        buttonAnchorNameSet: Boolean(buttonAnchorName),
-        panelPositionAnchorSet: Boolean(panelPositionAnchor),
-        anchorNamesMatch:
-          Boolean(buttonAnchorName) && buttonAnchorName === panelPositionAnchor,
-        panelPosition: panelComputedStyle.position,
-        panelInsetBlockStart:
-          panelComputedStyle.getPropertyValue('inset-block-start'),
-        panelInsetInlineStart:
-          panelComputedStyle.getPropertyValue('inset-inline-start'),
-        panelTransform: panelComputedStyle.transform,
-      },
-      cssSupport: {
-        anchorName: cssSupports('anchor-name', '--toolbar-dropdown'),
-        positionAnchor: cssSupports('position-anchor', '--toolbar-dropdown'),
-        anchorFunction: cssSupports('inset-block-start', 'anchor(end)'),
-      },
-      triggerOnboardingId: button.getAttribute('data-onboarding-id'),
-      panelIsPopoverOpen: isPopoverOpen(panel),
-      viewport: {
-        devicePixelRatio: window.devicePixelRatio,
-        height: window.innerHeight,
-        width: window.innerWidth,
-      },
-    },
-  }).catch(reportRejection)
-}
-
-function positionPanelFromButton(panel: HTMLElement, button: HTMLElement) {
-  const buttonRect = button.getBoundingClientRect()
-  const panelRect = panel.getBoundingClientRect()
-  const maxLeft = Math.max(
-    viewportPadding,
-    window.innerWidth - viewportPadding - panelRect.width
-  )
-  const maxTop = Math.max(
-    viewportPadding,
-    window.innerHeight - viewportPadding - panelRect.height
-  )
-  const centeredLeft =
-    buttonRect.left + buttonRect.width / 2 - panelRect.width / 2
-  const belowButton = buttonRect.bottom + dropdownGap
-  const aboveButton = buttonRect.top - dropdownGap - panelRect.height
-  const preferredTop =
-    belowButton + panelRect.height > window.innerHeight - viewportPadding &&
-    aboveButton >= viewportPadding
-      ? aboveButton
-      : belowButton
-  const left = Math.min(Math.max(centeredLeft, viewportPadding), maxLeft)
-  const top = Math.min(Math.max(preferredTop, viewportPadding), maxTop)
-
-  panel.style.inset = 'auto'
-  panel.style.insetInlineStart = 'auto'
-  panel.style.insetBlockStart = 'auto'
-  panel.style.marginBlockStart = '0'
-  panel.style.position = 'fixed'
-  panel.style.transform = 'none'
-  panel.style.left = `${left}px`
-  panel.style.top = `${top}px`
-}
 
 function restoreStyleProperty(
   element: HTMLElement,
@@ -223,18 +85,10 @@ export function ToolbarDropdownPanel({
         return
       }
 
-      const updatePanelPosition = () => {
-        resetPanelToAnchorPosition(panel)
+      const updatePanelOffset = () => {
         panel.style.setProperty('--toolbar-dropdown-offset-x', '0px')
 
         const panelRect = panel.getBoundingClientRect()
-        const buttonRect = button.getBoundingClientRect()
-        if (!isPanelAnchoredToButton(panelRect, buttonRect)) {
-          reportUnresolvedAnchor(panel, button, panelRect, buttonRect)
-          positionPanelFromButton(panel, button)
-          return
-        }
-
         // Keep the anchored dropdown centered unless it would overflow the viewport.
         const leftOverflow = viewportPadding - panelRect.left
         const rightOverflow =
@@ -250,15 +104,10 @@ export function ToolbarDropdownPanel({
       }
       // @ts-ignore-next-line -- React is not up to date about the options that can be passed
       panel.showPopover({ source: button })
-      updatePanelPosition()
-      window.addEventListener('resize', updatePanelPosition)
-      window.addEventListener('scroll', updatePanelPosition, true)
+      updatePanelOffset()
 
       return () => {
-        window.removeEventListener('resize', updatePanelPosition)
-        window.removeEventListener('scroll', updatePanelPosition, true)
         panel.style.removeProperty('--toolbar-dropdown-offset-x')
-        resetPanelToAnchorPosition(panel)
         restoreAnchors()
       }
     }

--- a/src/lib/clientErrors.ts
+++ b/src/lib/clientErrors.ts
@@ -28,7 +28,6 @@ export enum ClientErrorCode {
   DesktopRenderProcessGone = 'desktop_render_process_gone',
   EngineDisconnect = 'engine_disconnect',
   SystemIOError = 'system_io_error',
-  ToolbarDropdownAnchorPositioningError = 'toolbar_dropdown_anchor_positioning_error',
   UserFeaturesFetchError = 'user_features_fetch_error',
   ZookeeperActorError = 'zookeeper_actor_error',
   ZookeeperSetupError = 'zookeeper_setup_error',


### PR DESCRIPTION
Related to #12981 

https://modeling-app-git-andrewvarga-adhoctest-popup-fix-without-e83f63.vercel.dev.zoo.dev/home

Tested in these browsers, it worked in all of them, so I think this extra protection code Patch Goblin generated is not needed.

Mac: Firefox 153.0.4, Chrome 151.0.7922.138, Safari 26.3.1
Ubuntu: Firefox 152.0.5, Chrome 151.0.7922.108
Windows: Firefox 153.0.4, Chrome 151.0.7922.138, Edge 151.0.4129.86
