### PR TITLE
Make unit path tests portable on Windows

### DIFF
--- a/src/lib/desktop.test.ts
+++ b/src/lib/desktop.test.ts
@@ -1,9 +1,10 @@
+import { tmpdir } from 'node:os'
 import { PROJECT_SETTINGS_FILE_NAME } from '@src/lib/constants'
 import {
   createNewProjectDirectory,
   overwriteProjectTomlWithNewSettings,
 } from '@src/lib/desktop'
-import fsZds, { StorageName, moduleFsViaModuleImport } from '@src/lib/fs-zds'
+import fsZds, { moduleFsViaModuleImport, StorageName } from '@src/lib/fs-zds'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
@@ -26,6 +27,9 @@ beforeAll(async () => {
   })
 })
 
+const createTempDirectoryPath = () =>
+  fsZds.join(tmpdir(), `create-project-${crypto.randomUUID()}`)
+
 describe('createNewProjectDirectory', () => {
   afterEach(async () => {
     await Promise.all(
@@ -37,7 +41,7 @@ describe('createNewProjectDirectory', () => {
   })
 
   it('creates project.toml title metadata for new projects', async () => {
-    const projectDirectoryPath = `/tmp/create-project-${crypto.randomUUID()}`
+    const projectDirectoryPath = createTempDirectoryPath()
     createdProjectDirectoryPaths.push(projectDirectoryPath)
 
     const project = await createNewProjectDirectory(
@@ -64,7 +68,7 @@ describe('createNewProjectDirectory', () => {
   })
 
   it('can create project directories with separate project titles', async () => {
-    const projectDirectoryPath = `/tmp/create-project-${crypto.randomUUID()}`
+    const projectDirectoryPath = createTempDirectoryPath()
     createdProjectDirectoryPaths.push(projectDirectoryPath)
 
     const project = await createNewProjectDirectory(
@@ -94,8 +98,8 @@ describe('createNewProjectDirectory', () => {
   })
 
   it('uses the default directory library when creating new projects from settings', async () => {
-    const projectDirectoryPath = `/tmp/create-project-${crypto.randomUUID()}`
-    const legacyProjectDirectoryPath = `/tmp/create-project-${crypto.randomUUID()}`
+    const projectDirectoryPath = createTempDirectoryPath()
+    const legacyProjectDirectoryPath = createTempDirectoryPath()
     createdProjectDirectoryPaths.push(projectDirectoryPath)
     createdProjectDirectoryPaths.push(legacyProjectDirectoryPath)
 
@@ -127,7 +131,7 @@ describe('createNewProjectDirectory', () => {
   })
 
   it('treats serialized ENOENT strings as missing project.toml metadata', async () => {
-    const projectDirectoryPath = `/tmp/create-project-${crypto.randomUUID()}`
+    const projectDirectoryPath = createTempDirectoryPath()
     createdProjectDirectoryPaths.push(projectDirectoryPath)
 
     const originalReadFile = fsZds.readFile
@@ -135,7 +139,7 @@ describe('createNewProjectDirectory', () => {
     fsZds.readFile = (async (filePath: string, options?: unknown) => {
       if (
         !hasThrownSerializedEnoent &&
-        filePath.endsWith(`/${PROJECT_SETTINGS_FILE_NAME}`)
+        fsZds.basename(filePath) === PROJECT_SETTINGS_FILE_NAME
       ) {
         hasThrownSerializedEnoent = true
         return Promise.reject(
@@ -174,7 +178,7 @@ describe('createNewProjectDirectory', () => {
   })
 
   it('treats Electron ENOENT errors as missing project.toml metadata', async () => {
-    const projectDirectoryPath = `/tmp/create-project-${crypto.randomUUID()}`
+    const projectDirectoryPath = createTempDirectoryPath()
     createdProjectDirectoryPaths.push(projectDirectoryPath)
 
     const originalReadFile = fsZds.readFile
@@ -182,7 +186,7 @@ describe('createNewProjectDirectory', () => {
     fsZds.readFile = (async (filePath: string, options?: unknown) => {
       if (
         !hasThrownElectronEnoent &&
-        filePath.endsWith(`/${PROJECT_SETTINGS_FILE_NAME}`)
+        fsZds.basename(filePath) === PROJECT_SETTINGS_FILE_NAME
       ) {
         hasThrownElectronEnoent = true
         return Promise.reject(
@@ -221,7 +225,7 @@ describe('createNewProjectDirectory', () => {
   })
 
   it('preserves project metadata when writing project settings', async () => {
-    const projectDirectoryPath = `/tmp/create-project-${crypto.randomUUID()}`
+    const projectDirectoryPath = createTempDirectoryPath()
     const projectPath = fsZds.join(projectDirectoryPath, 'test-1')
     createdProjectDirectoryPaths.push(projectDirectoryPath)
 

--- a/src/lib/paths.test.ts
+++ b/src/lib/paths.test.ts
@@ -1,5 +1,5 @@
 import { APP_NAME } from '@src/lib/constants'
-import { StorageName, moduleFsViaModuleImport } from '@src/lib/fs-zds'
+import fsZds, { moduleFsViaModuleImport, StorageName } from '@src/lib/fs-zds'
 import {
   fileNameHasExtension,
   getFilePathRelativeToProject,
@@ -20,16 +20,19 @@ beforeAll(async () => {
   })
 })
 
+const absolutePath = (...parts: string[]) => fsZds.join(fsZds.sep, ...parts)
+
 describe('testing parseProjectRoute', () => {
   it('should parse a project as a subpath of project dir', async () => {
-    let config = {
+    const projectDirectory = absolutePath('home', 'somebody', 'projects')
+    const config = {
       settings: {
         project: {
-          directory: '/home/somebody/projects',
+          directory: projectDirectory,
         },
       },
     }
-    const route = '/home/somebody/projects/project'
+    const route = fsZds.join(projectDirectory, 'project')
     expect(parseProjectRoute(config, route)).toEqual({
       projectName: 'project',
       projectPath: route,
@@ -38,14 +41,15 @@ describe('testing parseProjectRoute', () => {
     })
   })
   it('should parse a project as the project dir', async () => {
-    let config = {
+    const projectDirectory = absolutePath('home', 'somebody', 'projects')
+    const config = {
       settings: {
         project: {
-          directory: '/home/somebody/projects',
+          directory: projectDirectory,
         },
       },
     }
-    const route = '/home/somebody/projects'
+    const route = projectDirectory
     expect(parseProjectRoute(config, route)).toEqual({
       projectName: null,
       projectPath: route,
@@ -54,94 +58,115 @@ describe('testing parseProjectRoute', () => {
     })
   })
   it('should parse a project with file in the project dir', async () => {
-    let config = {
+    const projectDirectory = absolutePath('home', 'somebody', 'projects')
+    const config = {
       settings: {
         project: {
-          directory: '/home/somebody/projects',
+          directory: projectDirectory,
         },
       },
     }
-    const route = '/home/somebody/projects/assembly/main.kcl'
+    const projectPath = fsZds.join(projectDirectory, 'assembly')
+    const route = fsZds.join(projectPath, 'main.kcl')
     expect(parseProjectRoute(config, route)).toEqual({
       projectName: 'assembly',
-      projectPath: '/home/somebody/projects/assembly',
+      projectPath,
       currentFileName: 'main.kcl',
       currentFilePath: route,
     })
   })
   it('should parse a project with file in a subdir in the project dir', async () => {
-    let config = {
+    const projectDirectory = absolutePath('home', 'somebody', 'projects')
+    const config = {
       settings: {
         project: {
-          directory: '/home/somebody/projects',
+          directory: projectDirectory,
         },
       },
     }
-    const route = '/home/somebody/projects/assembly/subdir/main.kcl'
+    const projectPath = fsZds.join(projectDirectory, 'assembly')
+    const route = fsZds.join(projectPath, 'subdir', 'main.kcl')
     expect(parseProjectRoute(config, route)).toEqual({
       projectName: 'assembly',
-      projectPath: '/home/somebody/projects/assembly',
+      projectPath,
       currentFileName: 'main.kcl',
       currentFilePath: route,
     })
   })
 
   it('should prefer the default directory library over the legacy project directory', async () => {
-    let config = {
+    const libraryProjectDirectory = absolutePath(
+      'home',
+      'somebody',
+      'library-projects'
+    )
+    const config = {
       settings: {
         app: {
           libraries: [
             {
               title: 'Projects',
-              path: '/home/somebody/library-projects',
+              path: libraryProjectDirectory,
               type: 'directory',
             },
           ],
         },
         project: {
-          directory: '/home/somebody/legacy-projects',
+          directory: absolutePath('home', 'somebody', 'legacy-projects'),
         },
       },
     }
-    const route = '/home/somebody/library-projects/assembly/main.kcl'
+    const projectPath = fsZds.join(libraryProjectDirectory, 'assembly')
+    const route = fsZds.join(projectPath, 'main.kcl')
     expect(parseProjectRoute(config, route)).toEqual({
       projectName: 'assembly',
-      projectPath: '/home/somebody/library-projects/assembly',
+      projectPath,
       currentFileName: 'main.kcl',
       currentFilePath: route,
     })
   })
 
   it('should respect an explicit empty libraries setting', async () => {
-    let config = {
+    const legacyProjectDirectory = absolutePath(
+      'home',
+      'somebody',
+      'legacy-projects'
+    )
+    const config = {
       settings: {
         app: {
           libraries: [],
         },
         project: {
-          directory: '/home/somebody/legacy-projects',
+          directory: legacyProjectDirectory,
         },
       },
     }
-    const route = '/home/somebody/legacy-projects/assembly/subdir/main.kcl'
+    const projectPath = fsZds.join(legacyProjectDirectory, 'assembly', 'subdir')
+    const route = fsZds.join(projectPath, 'main.kcl')
     expect(parseProjectRoute(config, route)).toEqual({
       projectName: 'subdir',
-      projectPath: '/home/somebody/legacy-projects/assembly/subdir',
+      projectPath,
       currentFileName: 'main.kcl',
       currentFilePath: route,
     })
   })
 
   it('should not parse a sibling path with the same prefix as inside the project dir', async () => {
-    let config = {
+    const projectDirectory = absolutePath(
+      'home',
+      'somebody',
+      'Documents',
+      'zoo-design-studio-projects'
+    )
+    const config = {
       settings: {
         project: {
-          directory: '/home/somebody/Documents/zoo-design-studio-projects',
+          directory: projectDirectory,
         },
       },
     }
-    const route =
-      '/home/somebody/Documents/zoo-design-studio-projects-2/project'
+    const route = fsZds.join(`${projectDirectory}-2`, 'project')
     expect(parseProjectRoute(config, route)).toEqual({
       projectName: 'project',
       projectPath: route,
@@ -151,19 +176,24 @@ describe('testing parseProjectRoute', () => {
   })
 
   it('should not parse a file in a sibling path with the same prefix as inside the project dir', async () => {
-    let config = {
+    const projectDirectory = absolutePath(
+      'home',
+      'somebody',
+      'Documents',
+      'zoo-design-studio-projects'
+    )
+    const config = {
       settings: {
         project: {
-          directory: '/home/somebody/Documents/zoo-design-studio-projects',
+          directory: projectDirectory,
         },
       },
     }
-    const route =
-      '/home/somebody/Documents/zoo-design-studio-projects-2/project/main.kcl'
+    const siblingProjectPath = fsZds.join(`${projectDirectory}-2`, 'project')
+    const route = fsZds.join(siblingProjectPath, 'main.kcl')
     expect(parseProjectRoute(config, route)).toEqual({
       projectName: 'project',
-      projectPath:
-        '/home/somebody/Documents/zoo-design-studio-projects-2/project',
+      projectPath: siblingProjectPath,
       currentFileName: 'main.kcl',
       currentFilePath: route,
     })
@@ -190,10 +220,11 @@ describe('testing web-safe project paths', () => {
   })
 
   it('should return a project-relative file path', () => {
+    const projectPath = absolutePath('some', 'path', 'Simple Box')
     expect(
       toProjectRelativePath(
-        '/some/path/Simple Box',
-        '/some/path/Simple Box/parts/generated/nested-part.kcl'
+        projectPath,
+        fsZds.join(projectPath, 'parts', 'generated', 'nested-part.kcl')
       )
     ).toEqual('parts/generated/nested-part.kcl')
   })
@@ -215,37 +246,61 @@ describe('testing web-safe project paths', () => {
 
 describe('testing project-relative paths', () => {
   it('returns the file path relative to the project when the file is inside the project directory', () => {
+    const applicationProjectDirectory = absolutePath(
+      'home',
+      'somebody',
+      'Documents',
+      'zoo-design-studio-projects'
+    )
     expect(
       parentPathRelativeToProject(
-        '/home/somebody/Documents/zoo-design-studio-projects/project/main.kcl',
-        '/home/somebody/Documents/zoo-design-studio-projects'
+        fsZds.join(applicationProjectDirectory, 'project', 'main.kcl'),
+        applicationProjectDirectory
       )
     ).toEqual('main.kcl')
   })
 
   it('returns an empty path when the file is in a sibling directory with the same prefix', () => {
+    const applicationProjectDirectory = absolutePath(
+      'home',
+      'somebody',
+      'Documents',
+      'zoo-design-studio-projects'
+    )
     expect(
       parentPathRelativeToProject(
-        '/home/somebody/Documents/zoo-design-studio-projects-2/project/main.kcl',
-        '/home/somebody/Documents/zoo-design-studio-projects'
+        fsZds.join(`${applicationProjectDirectory}-2`, 'project', 'main.kcl'),
+        applicationProjectDirectory
       )
     ).toEqual('')
   })
 
   it('returns the file path relative to the application directory when contained', () => {
+    const applicationProjectDirectory = absolutePath(
+      'home',
+      'somebody',
+      'Documents',
+      'zoo-design-studio-projects'
+    )
     expect(
       parentPathRelativeToApplicationDirectory(
-        '/home/somebody/Documents/zoo-design-studio-projects/project/main.kcl',
-        '/home/somebody/Documents/zoo-design-studio-projects'
+        fsZds.join(applicationProjectDirectory, 'project', 'main.kcl'),
+        applicationProjectDirectory
       )
-    ).toEqual('project/main.kcl')
+    ).toEqual(fsZds.join('project', 'main.kcl'))
   })
 
   it('returns an empty path relative to the application directory when the file is in a sibling prefix directory', () => {
+    const applicationProjectDirectory = absolutePath(
+      'home',
+      'somebody',
+      'Documents',
+      'zoo-design-studio-projects'
+    )
     expect(
       parentPathRelativeToApplicationDirectory(
-        '/home/somebody/Documents/zoo-design-studio-projects-2/project/main.kcl',
-        '/home/somebody/Documents/zoo-design-studio-projects'
+        fsZds.join(`${applicationProjectDirectory}-2`, 'project', 'main.kcl'),
+        applicationProjectDirectory
       )
     ).toEqual('')
   })


### PR DESCRIPTION
Makes unit tests use native path separators and the OS temp directory on Windows.

Validated with `make test-unit` (926 tests passing).