### PR TITLE
Codex: Guard against self-subtract selections

### DIFF
--- a/src/lang/modifyAst/boolean.spec.ts
+++ b/src/lang/modifyAst/boolean.spec.ts
@@ -129,6 +129,33 @@ extrude002 = extrude(profile002, length = -1)`
       expect(newCode).toContain(code + '\n' + expectedNewLine)
     })
 
+    it('should reject the same sweep as both target and tool', async () => {
+      const code = `sketch001 = startSketchOn(XY)
+profile001 = circle(sketch001, center = [0.2, 0.2], radius = 0.1)
+extrude001 = extrude(profile001, length = 1)
+
+sketch002 = startSketchOn(XZ)
+profile002 = circle(sketch002, center = [0.2, 0.2], radius = 0.05)
+extrude002 = extrude(profile002, length = -1)`
+      const { ast, artifactGraph, solids, tools } = await getSolidsAndTools(
+        code,
+        [1],
+        [1],
+        instanceInThisFile,
+        kclManagerInThisFile
+      )
+
+      const result = addSubtract({
+        ast,
+        artifactGraph,
+        solids,
+        tools,
+        wasmInstance: instanceInThisFile,
+      })
+
+      expect(result).toEqual(new Error('Please check your selections'))
+    })
+
     it('should push a call in pipe if selection was in variable-less pipe', async () => {
       const code = `sketch001 = startSketchOn(XY)
 profile001 = circle(sketch001, center = [0.2, 0.2], radius = 0.1)

--- a/src/lang/modifyAst/boolean.ts
+++ b/src/lang/modifyAst/boolean.ts
@@ -204,6 +204,26 @@ export function addSubtract({
     return toolVars
   }
 
+  const targetExprKeys = new Set(
+    vars.exprs.map((expr) =>
+      JSON.stringify([
+        expr,
+        expr.type === 'PipeSubstitution' ? vars.pathIfPipe : undefined,
+      ])
+    )
+  )
+  const hasSharedBody = toolVars.exprs.some((expr) =>
+    targetExprKeys.has(
+      JSON.stringify([
+        expr,
+        expr.type === 'PipeSubstitution' ? toolVars.pathIfPipe : undefined,
+      ])
+    )
+  )
+  if (hasSharedBody) {
+    return new Error('Please check your selections')
+  }
+
   const objectsExpr = createVariableExpressionsArray(vars.exprs)
   const toolsExpr = createVariableExpressionsArray(toolVars.exprs)
   if (toolsExpr === null) {


### PR DESCRIPTION
Fixes #12983.

Rejects subtract commands that resolve to the same target and tool, and asks the user to check their selections.