### PR TITLE
KCL: Bump kcmc; remove second copy of kcl-api from tree

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1176,7 +1176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2268,7 +2268,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2353,7 +2353,7 @@ name = "kcl-api"
 version = "0.2.177"
 dependencies = [
  "indexmap 2.14.0",
- "kcl-error 0.2.177",
+ "kcl-error",
  "kittycad-measurements",
  "kittycad-unit-conversion-derive",
  "parse-display",
@@ -2363,24 +2363,6 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
- "ts-rs",
- "uuid",
-]
-
-[[package]]
-name = "kcl-api"
-version = "0.2.177"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1d3fc0895e0d708050aed042896dc70ba57a703d6f050002ff64d3dd07a319"
-dependencies = [
- "indexmap 2.14.0",
- "kcl-error 0.2.177 (registry+https://github.com/rust-lang/crates.io-index)",
- "kittycad-measurements",
- "kittycad-unit-conversion-derive",
- "parse-display",
- "parse-display-derive",
- "schemars 0.8.22",
- "serde",
  "ts-rs",
  "uuid",
 ]
@@ -2421,20 +2403,6 @@ version = "0.2.177"
 dependencies = [
  "miette",
  "pyo3",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "thiserror 2.0.19",
- "ts-rs",
-]
-
-[[package]]
-name = "kcl-error"
-version = "0.2.177"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ce1e594aab4c1522f5478a6e06d541203f56a7a29247aa88d16e81ab3070d5"
-dependencies = [
- "miette",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -2519,10 +2487,10 @@ dependencies = [
  "insta",
  "itertools 0.15.0",
  "js-sys",
- "kcl-api 0.2.177",
+ "kcl-api",
  "kcl-derive-docs",
  "kcl-directory-test-macro",
- "kcl-error 0.2.177",
+ "kcl-error",
  "kcl-syntax",
  "kittycad",
  "kittycad-modeling-cmds",
@@ -2578,7 +2546,7 @@ name = "kcl-python-bindings"
 version = "0.3.177"
 dependencies = [
  "anyhow",
- "kcl-api 0.2.177",
+ "kcl-api",
  "kcl-lib",
  "kittycad-modeling-cmds",
  "miette",
@@ -2690,9 +2658,9 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.221"
+version = "0.2.222"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe600ba7cd69823c0357eb1cff3894088153736b74c28090920b88db9a8c324"
+checksum = "429353fb14439ab30767213d09f81edb56f9313c3ede8e095deaaaf840f6ab83"
 dependencies = [
  "anyhow",
  "bon",
@@ -2702,8 +2670,6 @@ dependencies = [
  "enum-iterator-derive",
  "euler",
  "http 1.5.0",
- "kcl-api 0.2.177 (registry+https://github.com/rust-lang/crates.io-index)",
- "kcl-error 0.2.177 (registry+https://github.com/rust-lang/crates.io-index)",
  "kittycad-measurements",
  "kittycad-modeling-cmds-macros",
  "kittycad-unit-conversion-derive",
@@ -3195,7 +3161,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4059,7 +4025,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4467,7 +4433,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5274,7 +5240,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5283,7 +5249,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6305,7 +6271,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -29,7 +29,7 @@ kittycad = { version = "0.4.13", default-features = false, features = [
   "js",
   "requests",
 ] }
-kittycad-modeling-cmds = { version = "0.2.221", features = [
+kittycad-modeling-cmds = { version = "0.2.222", features = [
   "ts-rs",
   "websocket",
 ] }

--- a/rust/kcl-lib/src/engine/engine_manager/ws_transport.rs
+++ b/rust/kcl-lib/src/engine/engine_manager/ws_transport.rs
@@ -320,7 +320,7 @@ impl WebSocketTransport {
                                 WebSocketRequest::ModelingCmdReq(ModelingCmdReq {
                                     cmd: ModelingCmd::ImportFiles { .. },
                                     cmd_id: _,
-                                }) | WebSocketRequest::ExecKclProject { .. }
+                                })
                             ) {
                                 Self::inner_send_to_engine_binary(req, &mut tcp_write).await
                             } else {


### PR DESCRIPTION
Pulls in this kcmc PR: https://github.com/KittyCAD/modeling-api/pull/1322

It made kcl-error and kcl-api dependencies optional, so that if you're not going to execute KCL, you don't need them.

This is one such user. Hopefully should speed up builds.