### PR TITLE
Fix member-expression spans to be more specific

### DIFF
--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -3177,18 +3177,23 @@ impl Node<MemberExpression> {
         exec_state: &mut ExecState,
         ctx: &ExecutorContext,
     ) -> Result<KclValueControlFlow, KclError> {
-        let meta = Metadata {
-            source_range: SourceRange::from(self),
-        };
+        // Evaluate each child with its own source range so that diagnostics
+        // raised while evaluating a child (module errors, missing-return
+        // warnings) point at that child instead of the whole member
+        // expression.
+        //
         // TODO: The order of execution is wrong. We should execute the object
         // *before* the property.
+        let property_meta = Metadata {
+            source_range: SourceRange::from(&self.property),
+        };
         let property_result = Property::try_from(
             self.computed,
             self.property.clone(),
             exec_state,
             self.into(),
             ctx,
-            &meta,
+            &property_meta,
             &[],
             StatementKind::Expression,
         )
@@ -3200,10 +3205,19 @@ impl Node<MemberExpression> {
             Err(EarlyReturn::Value(cf)) => return Ok(cf),
             Err(EarlyReturn::Error(err)) => return Err(err),
         };
+        let object_meta = Metadata {
+            source_range: SourceRange::from(&self.object),
+        };
         let object_cf = ctx
-            .execute_expr(&self.object, exec_state, &meta, &[], StatementKind::Expression)
+            .execute_expr(&self.object, exec_state, &object_meta, &[], StatementKind::Expression)
             .await?;
         let object = control_continue!(object_cf);
+
+        // Result values of the member access itself carry the whole
+        // expression's metadata.
+        let meta = Metadata {
+            source_range: SourceRange::from(self),
+        };
 
         // Check the property and object match -- e.g. ints for arrays, strs for objects.
         match (object, property, self.computed) {

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -4803,6 +4803,73 @@ type Color { | Red | Green | Red }
         parse_execute_with_project_dir(main, Some(crate::TypedPath(tmpdir.path().into()))).await
     }
 
+    /// Runs `main` with an empty imported module in mock execution and
+    /// returns the recorded compilation issues; the run may end in an error
+    /// (e.g. from operating on the module's missing return value).
+    async fn issues_with_empty_module(main: &str) -> Vec<crate::errors::CompilationIssue> {
+        let tmpdir = tempfile::TempDir::with_prefix("zma_kcl_member_ranges").unwrap();
+        tokio::fs::write(tmpdir.path().join("m.kcl"), "").await.unwrap();
+
+        let program = crate::Program::parse_no_errs(main).unwrap();
+        let ctx = ExecutorContext {
+            engine: Arc::new(EngineManager::new_mock()),
+            engine_batch: EngineBatchContext::default(),
+            fs: crate::fs::new_file_system_handle(crate::fs::FileManager::new()),
+            settings: ExecutorSettings {
+                project_directory: Some(crate::TypedPath(tmpdir.path().into())),
+                ..Default::default()
+            },
+            context_type: ContextType::Mock,
+            execution_callbacks: Default::default(),
+        };
+        let mut exec_state = ExecState::new(&ctx);
+        let _ = ctx.run(&program, &mut exec_state).await;
+        ctx.close().await;
+        exec_state.issues().to_vec()
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn member_object_diagnostics_use_object_range() {
+        // A diagnostic raised while evaluating a member expression's object
+        // (here, the imported module's missing-return warning) points at the
+        // object's own span, not the whole member expression.
+        let main = "import \"m.kcl\" as m
+x = m.field
+";
+        let issues = issues_with_empty_module(main).await;
+        let warning = issues
+            .iter()
+            .find(|issue| issue.message.contains("no return value"))
+            .expect("missing-return warning should be recorded");
+        let object_start = main.rfind("m.field").unwrap();
+        assert_eq!(
+            (warning.source_range.start(), warning.source_range.end()),
+            (object_start, object_start + 1),
+            "warning should point at the object's span"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn member_property_diagnostics_use_property_range() {
+        // Same for the computed property: the warning points at the index
+        // expression's span inside the brackets.
+        let main = "import \"m.kcl\" as m
+arr = [1]
+x = arr[m]
+";
+        let issues = issues_with_empty_module(main).await;
+        let warning = issues
+            .iter()
+            .find(|issue| issue.message.contains("no return value"))
+            .expect("missing-return warning should be recorded");
+        let prop_start = main.rfind("[m]").unwrap() + 1;
+        assert_eq!(
+            (warning.source_range.start(), warning.source_range.end()),
+            (prop_start, prop_start + 1),
+            "warning should point at the property's span"
+        );
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn backtrace_reports_fully_qualified_fn_names() {
         // An error inside a function called by a qualified name records the

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -4803,28 +4803,48 @@ type Color { | Red | Green | Red }
         parse_execute_with_project_dir(main, Some(crate::TypedPath(tmpdir.path().into()))).await
     }
 
-    /// Runs `main` with an empty imported module in mock execution and
-    /// returns the recorded compilation issues; the run may end in an error
-    /// (e.g. from operating on the module's missing return value).
+    /// Runs `main` with an empty imported module named `m.kcl` in mock
+    /// execution and returns the recorded compilation issues; the run may
+    /// end in an error (e.g. from operating on the module's missing return
+    /// value).
+    ///
+    /// The `m.kcl` module lives in an in-memory file system under a
+    /// synthetic project directory, so parallel tests share no on-disk
+    /// state and there is nothing to clean up even if the process is
+    /// killed.
     async fn issues_with_empty_module(main: &str) -> Vec<crate::errors::CompilationIssue> {
-        let tmpdir = tempfile::TempDir::with_prefix("zma_kcl_member_ranges").unwrap();
-        tokio::fs::write(tmpdir.path().join("m.kcl"), "").await.unwrap();
+        use futures::FutureExt;
+
+        let project_dir = crate::TypedPath::new("/zma-kcl-member-ranges");
+        // Key the file by the same join that import resolution performs, so
+        // the lookup matches on every platform.
+        let files = [(project_dir.join("m.kcl").to_string(), Vec::new())]
+            .into_iter()
+            .collect();
 
         let program = crate::Program::parse_no_errs(main).unwrap();
         let ctx = ExecutorContext {
             engine: Arc::new(EngineManager::new_mock()),
             engine_batch: EngineBatchContext::default(),
-            fs: crate::fs::new_file_system_handle(crate::fs::FileManager::new()),
+            fs: crate::fs::new_file_system_handle(crate::InMemoryFiles::new(files)),
             settings: ExecutorSettings {
-                project_directory: Some(crate::TypedPath(tmpdir.path().into())),
+                project_directory: Some(project_dir),
                 ..Default::default()
             },
             context_type: ContextType::Mock,
             execution_callbacks: Default::default(),
         };
         let mut exec_state = ExecState::new(&ctx);
-        let _ = ctx.run(&program, &mut exec_state).await;
+        // Close the context even if execution panics, then let the panic
+        // continue. An Err from the run itself is expected here (operating
+        // on the module's missing return value) and is deliberately ignored.
+        let run_result = std::panic::AssertUnwindSafe(ctx.run(&program, &mut exec_state))
+            .catch_unwind()
+            .await;
         ctx.close().await;
+        if let Err(panic) = run_result {
+            std::panic::resume_unwind(panic);
+        }
         exec_state.issues().to_vec()
     }
 


### PR DESCRIPTION
Part of #13009.

The recursive evaluator passed metadata for the entire member expression to both property and object evaluation, so diagnostics raised while evaluating a child -- module errors, the imported-module missing-return warning -- pointed at the whole expression. Evaluate each child with its own source range instead. Result values of the member access itself keep the whole expression's metadata.