### PR TITLE
Fix to execute whole-module names used as binary and unary operands

### DIFF
--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -1796,12 +1796,7 @@ impl ExecutorContext {
         metadata: &Metadata,
         exec_state: &mut ExecState,
     ) -> Result<KclValue, KclError> {
-        let being_declared = exec_state.mod_local.being_declared.clone();
-        let value = name
-            .get_result(exec_state, self)
-            .await
-            .map_err(|e| var_in_own_ref_err(e, &being_declared))?
-            .clone();
+        let value = name.get_result(exec_state, self).await?;
         if let KclValue::Module { value: module_id, meta } = value {
             Ok(self
                 .exec_module_for_result(module_id, exec_state, metadata.source_range)
@@ -3066,10 +3061,10 @@ impl Node<Name> {
         exec_state: &mut ExecState,
         ctx: &ExecutorContext,
     ) -> Result<KclValue, KclError> {
-        let being_declared = exec_state.mod_local.being_declared.clone();
-        self.get_result_inner(exec_state, ctx)
-            .await
-            .map_err(|e| var_in_own_ref_err(e, &being_declared))
+        // Await first so being_declared is read only on the error path,
+        // instead of cloned before every lookup.
+        let result = self.get_result_inner(exec_state, ctx).await;
+        result.map_err(|e| var_in_own_ref_err(e, &exec_state.mod_local.being_declared))
     }
 
     async fn get_result_inner(&self, exec_state: &mut ExecState, ctx: &ExecutorContext) -> Result<KclValue, KclError> {
@@ -3080,13 +3075,12 @@ impl Node<Name> {
             )));
         }
 
-        let mod_name = format!("{}{}", memory::MODULE_PREFIX, self.name.name);
-
         if self.path.is_empty() {
             if let Ok(item_value) = exec_state.stack().get(&self.name.name, self.into()) {
                 return Ok(item_value);
             }
 
+            let mod_name = format!("{}{}", memory::MODULE_PREFIX, self.name.name);
             let not_defined = match exec_state.stack().get(&mod_name, self.into()) {
                 Ok(module) => return Ok(module),
                 Err(err) => err,
@@ -3166,6 +3160,7 @@ impl Node<Name> {
             return item_value;
         }
 
+        let mod_name = format!("{}{}", memory::MODULE_PREFIX, self.name.name);
         let mod_exported = exports.contains(&mod_name);
         let mod_value = exec_state
             .stack()

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -1787,6 +1787,46 @@ impl ExecutorContext {
         })
     }
 
+    /// Resolve a name to its value, running the module body first when the name
+    /// refers to a module. Flat (module execution happens in its own fresh
+    /// root); shared by both executors.
+    pub(super) async fn resolve_name_for_eval(
+        &self,
+        name: &Node<Name>,
+        metadata: &Metadata,
+        exec_state: &mut ExecState,
+    ) -> Result<KclValue, KclError> {
+        let being_declared = exec_state.mod_local.being_declared.clone();
+        let value = name
+            .get_result(exec_state, self)
+            .await
+            .map_err(|e| var_in_own_ref_err(e, &being_declared))?
+            .clone();
+        if let KclValue::Module { value: module_id, meta } = value {
+            Ok(self
+                .exec_module_for_result(module_id, exec_state, metadata.source_range)
+                .await?
+                .unwrap_or_else(|| {
+                    exec_state.warn(
+                        CompilationIssue::err(
+                            metadata.source_range,
+                            "Imported module has no return value. The last statement of the module must be an expression, usually the Solid.",
+                        ),
+                        annotations::WARN_MOD_RETURN_VALUE,
+                    );
+
+                    let mut new_meta = vec![metadata.to_owned()];
+                    new_meta.extend(meta);
+                    KclValue::KclNone {
+                        value: Default::default(),
+                        meta: new_meta,
+                    }
+                }))
+        } else {
+            Ok(value)
+        }
+    }
+
     #[async_recursion]
     pub(crate) async fn execute_expr<'a: 'async_recursion>(
         &self,
@@ -1800,37 +1840,10 @@ impl ExecutorContext {
             Expr::None(none) => KclValue::from(none).continue_(),
             Expr::Literal(literal) => KclValue::from_literal((**literal).clone(), exec_state).continue_(),
             Expr::TagDeclarator(tag) => tag.execute(exec_state).await?.continue_(),
-            Expr::Name(name) => {
-                let being_declared = exec_state.mod_local.being_declared.clone();
-                let value = name
-                    .get_result(exec_state, self)
-                    .await
-                    .map_err(|e| var_in_own_ref_err(e, &being_declared))?
-                    .clone();
-                if let KclValue::Module { value: module_id, meta } = value {
-                    self.exec_module_for_result(
-                        module_id,
-                        exec_state,
-                        metadata.source_range
-                        ).await?.map(|v| v.continue_())
-                        .unwrap_or_else(|| {
-                            exec_state.warn(CompilationIssue::err(
-                                metadata.source_range,
-                                "Imported module has no return value. The last statement of the module must be an expression, usually the Solid.",
-                            ),
-                        annotations::WARN_MOD_RETURN_VALUE);
-
-                            let mut new_meta = vec![metadata.to_owned()];
-                            new_meta.extend(meta);
-                            KclValue::KclNone {
-                                value: Default::default(),
-                                meta: new_meta,
-                            }.continue_()
-                        })
-                } else {
-                    value.continue_()
-                }
-            }
+            Expr::Name(name) => self
+                .resolve_name_for_eval(name, metadata, exec_state)
+                .await?
+                .continue_(),
             Expr::BinaryExpression(binary_expression) => binary_expression.get_result(exec_state, self).await?,
             Expr::FunctionExpression(function_expression) => {
                 let attrs = annotations::get_fn_attrs(annotations, metadata.source_range)?;
@@ -3025,7 +3038,14 @@ impl BinaryPart {
     ) -> Result<KclValueControlFlow, KclError> {
         match self {
             BinaryPart::Literal(literal) => Ok(KclValue::from_literal((**literal).clone(), exec_state).continue_()),
-            BinaryPart::Name(name) => name.get_result(exec_state, ctx).await.map(KclValue::continue_),
+            BinaryPart::Name(name) => {
+                let metadata = Metadata {
+                    source_range: SourceRange::from(&**name),
+                };
+                ctx.resolve_name_for_eval(name, &metadata, exec_state)
+                    .await
+                    .map(KclValue::continue_)
+            }
             BinaryPart::BinaryExpression(binary_expression) => binary_expression.get_result(exec_state, ctx).await,
             BinaryPart::CallExpressionKw(call_expression) => call_expression.execute(exec_state, ctx).await,
             BinaryPart::UnaryExpression(unary_expression) => unary_expression.get_result(exec_state, ctx).await,

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -4903,6 +4903,43 @@ x = arr[m]
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn whole_module_name_executes_as_operand() {
+        // A whole-module import used as a binary or unary operand executes
+        // the module and operates on its final-expression value, exactly like
+        // using the name in expression position (x = m).
+        let main = r#"import "m.kcl" as m
+sum = m + m
+neg = -m
+"#;
+        let result = execute_with_modules(main, &[("m.kcl", "42\n")]).await.unwrap();
+        assert_eq!(
+            mem_get_json(result.exec_state.stack(), result.mem_env, "sum").as_f64(),
+            Some(84.0)
+        );
+        assert_eq!(
+            mem_get_json(result.exec_state.stack(), result.mem_env, "neg").as_f64(),
+            Some(-42.0)
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn whole_module_without_return_as_operand_errors() {
+        // Matches expression-position behavior: the module still executes,
+        // the missing-return fallback produces a KclNone, and the binary
+        // operation then rejects it. (A trailing declaration would count as
+        // the module's return value, so the module body must be empty.)
+        let main = "import \"m.kcl\" as m
+x = m + 1
+";
+        let err = execute_with_modules(main, &[("m.kcl", "")]).await.unwrap_err();
+        assert!(
+            err.message().contains("Expected a number, but found none"),
+            "expected the operand to be the module's missing-return KclNone, got: {}",
+            err.message()
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn enum_rejects_name_clash_with_module() {
         // One rule reached four ways: by declaring the enum second, by importing
         // the module second, and by importing the enum itself either by name or


### PR DESCRIPTION
Resolves #13009.

A name bound to a whole-module import resolved to the raw Module value when used as a binary or unary operand, so expressions like part + part errored without ever executing part.kcl -- unlike expression position (x = part), which executes the module and uses its final-expression value. Route operand names through the same resolution.

The helper matches the CEK branch's machine executor, which already resolves operand names this way.

The performance fix was pushing the creation of the error message down so that it's only ever done when there's an error.