### PR TITLE
Error on self-CSG in P&C

### DIFF
--- a/src/lang/modifyAst/boolean.spec.ts
+++ b/src/lang/modifyAst/boolean.spec.ts
@@ -197,7 +197,11 @@ extrude002 = extrude(profile002, length = -1)`
             break
         }
 
-        expect(result).toEqual(new Error('Please check your selections'))
+        expect(result).toEqual(
+          new Error(
+            'The same body cannot be used more than once in a Boolean operation. Please check your selections.'
+          )
+        )
       }
     )
 
@@ -265,7 +269,11 @@ extrude002 = extrude(profile002, length = -1)`
                 wasmInstance: instanceInThisFile,
               })
 
-        expect(result).toEqual(new Error('Please check your selections'))
+        expect(result).toEqual(
+          new Error(
+            'The same body cannot be used more than once in a Boolean operation. Please check your selections.'
+          )
+        )
       }
     )
   })

--- a/src/lang/modifyAst/boolean.spec.ts
+++ b/src/lang/modifyAst/boolean.spec.ts
@@ -129,6 +129,33 @@ extrude002 = extrude(profile002, length = -1)`
       expect(newCode).toContain(code + '\n' + expectedNewLine)
     })
 
+    it('should reject the same sweep as both target and tool', async () => {
+      const code = `sketch001 = startSketchOn(XY)
+profile001 = circle(sketch001, center = [0.2, 0.2], radius = 0.1)
+extrude001 = extrude(profile001, length = 1)
+
+sketch002 = startSketchOn(XZ)
+profile002 = circle(sketch002, center = [0.2, 0.2], radius = 0.05)
+extrude002 = extrude(profile002, length = -1)`
+      const { ast, artifactGraph, solids, tools } = await getSolidsAndTools(
+        code,
+        [1],
+        [1],
+        instanceInThisFile,
+        kclManagerInThisFile
+      )
+
+      const result = addSubtract({
+        ast,
+        artifactGraph,
+        solids,
+        tools,
+        wasmInstance: instanceInThisFile,
+      })
+
+      expect(result).toEqual(new Error('Please check your selections'))
+    })
+
     it('should push a call in pipe if selection was in variable-less pipe', async () => {
       const code = `sketch001 = startSketchOn(XY)
 profile001 = circle(sketch001, center = [0.2, 0.2], radius = 0.1)

--- a/src/lang/modifyAst/boolean.spec.ts
+++ b/src/lang/modifyAst/boolean.spec.ts
@@ -1,6 +1,12 @@
 import type { KclManager } from '@src/lang/KclManager'
-import { addSplit, addSubtract } from '@src/lang/modifyAst/boolean'
+import {
+  addIntersect,
+  addSplit,
+  addSubtract,
+  addUnion,
+} from '@src/lang/modifyAst/boolean'
 import { recast } from '@src/lang/wasm'
+import type { ConnectionManager } from '@src/lib/engineConnection/connectionManager'
 import type RustContext from '@src/lib/rustContext'
 import {
   createSelectionFromArtifacts,
@@ -10,7 +16,6 @@ import {
 import { err } from '@src/lib/trap'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { Selections } from '@src/machines/modelingSharedTypes'
-import type { ConnectionManager } from '@src/lib/engineConnection/connectionManager'
 import { buildTheWorldAndConnectToEngine } from '@src/unitTestUtils'
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 
@@ -78,6 +83,193 @@ async function getSolidsAndTools(
 }
 
 describe('boolean', () => {
+  describe('rejecting reused bodies', () => {
+    const code = `sketch001 = startSketchOn(XY)
+profile001 = circle(sketch001, center = [0.2, 0.2], radius = 0.1)
+extrude001 = extrude(profile001, length = 1)
+
+sketch002 = startSketchOn(XZ)
+profile002 = circle(sketch002, center = [0.2, 0.2], radius = 0.05)
+extrude002 = extrude(profile002, length = -1)`
+
+    const reusedBodyCases = [
+      {
+        name: 'union solids',
+        operation: 'union',
+        solidIds: [1, 1],
+        toolIds: [],
+      },
+      {
+        name: 'intersect solids',
+        operation: 'intersect',
+        solidIds: [1, 1],
+        toolIds: [],
+      },
+      {
+        name: 'subtract targets and tools',
+        operation: 'subtract',
+        solidIds: [1],
+        toolIds: [1],
+      },
+      {
+        name: 'subtract targets',
+        operation: 'subtract',
+        solidIds: [1, 1],
+        toolIds: [0],
+      },
+      {
+        name: 'subtract tools',
+        operation: 'subtract',
+        solidIds: [0],
+        toolIds: [1, 1],
+      },
+      {
+        name: 'split targets and tools',
+        operation: 'split',
+        solidIds: [1],
+        toolIds: [1],
+      },
+      {
+        name: 'split targets',
+        operation: 'split',
+        solidIds: [1, 1],
+        toolIds: [],
+      },
+      {
+        name: 'split tools',
+        operation: 'split',
+        solidIds: [0],
+        toolIds: [1, 1],
+      },
+    ] satisfies Array<{
+      name: string
+      operation: 'union' | 'intersect' | 'subtract' | 'split'
+      solidIds: number[]
+      toolIds: number[]
+    }>
+
+    it.each(reusedBodyCases)(
+      'should reject reused bodies in $name',
+      async ({ operation, solidIds, toolIds }) => {
+        const { ast, artifactGraph, solids, tools } = await getSolidsAndTools(
+          code,
+          solidIds,
+          toolIds,
+          instanceInThisFile,
+          kclManagerInThisFile
+        )
+
+        let result: ReturnType<typeof addUnion>
+        switch (operation) {
+          case 'union':
+            result = addUnion({
+              ast,
+              artifactGraph,
+              solids,
+              wasmInstance: instanceInThisFile,
+            })
+            break
+          case 'intersect':
+            result = addIntersect({
+              ast,
+              artifactGraph,
+              solids,
+              wasmInstance: instanceInThisFile,
+            })
+            break
+          case 'subtract':
+            result = addSubtract({
+              ast,
+              artifactGraph,
+              solids,
+              tools,
+              wasmInstance: instanceInThisFile,
+            })
+            break
+          case 'split':
+            result = addSplit({
+              ast,
+              artifactGraph,
+              targets: solids,
+              tools,
+              wasmInstance: instanceInThisFile,
+            })
+            break
+        }
+
+        expect(result).toEqual(new Error('Please check your selections'))
+      }
+    )
+
+    it.each(['union', 'intersect'] as const)(
+      'should allow distinct bodies for %s',
+      async (operation) => {
+        const { ast, artifactGraph, solids } = await getSolidsAndTools(
+          code,
+          [0, 1],
+          [],
+          instanceInThisFile,
+          kclManagerInThisFile
+        )
+        const result =
+          operation === 'union'
+            ? addUnion({
+                ast,
+                artifactGraph,
+                solids,
+                wasmInstance: instanceInThisFile,
+              })
+            : addIntersect({
+                ast,
+                artifactGraph,
+                solids,
+                wasmInstance: instanceInThisFile,
+              })
+        if (err(result)) {
+          throw result
+        }
+
+        expect(recast(result.modifiedAst, instanceInThisFile)).toContain(
+          `${operation}([extrude001, extrude002])`
+        )
+      }
+    )
+
+    it.each(['subtract', 'split'] as const)(
+      'should reject the same variable-less pipe in %s targets and tools',
+      async (operation) => {
+        const pipeCode = `startSketchOn(XY)
+  |> circle(center = [0, 0], radius = 1)
+  |> extrude(length = 1)`
+        const { ast, artifactGraph, solids, tools } = await getSolidsAndTools(
+          pipeCode,
+          [0],
+          [0],
+          instanceInThisFile,
+          kclManagerInThisFile
+        )
+        const result =
+          operation === 'subtract'
+            ? addSubtract({
+                ast,
+                artifactGraph,
+                solids,
+                tools,
+                wasmInstance: instanceInThisFile,
+              })
+            : addSplit({
+                ast,
+                artifactGraph,
+                targets: solids,
+                tools,
+                wasmInstance: instanceInThisFile,
+              })
+
+        expect(result).toEqual(new Error('Please check your selections'))
+      }
+    )
+  })
+
   describe('Testing addSubtract', () => {
     async function runAddSubtractTest(
       code: string,
@@ -127,33 +319,6 @@ extrude002 = extrude(profile002, length = -1)`
         rustContextInThisFile
       )
       expect(newCode).toContain(code + '\n' + expectedNewLine)
-    })
-
-    it('should reject the same sweep as both target and tool', async () => {
-      const code = `sketch001 = startSketchOn(XY)
-profile001 = circle(sketch001, center = [0.2, 0.2], radius = 0.1)
-extrude001 = extrude(profile001, length = 1)
-
-sketch002 = startSketchOn(XZ)
-profile002 = circle(sketch002, center = [0.2, 0.2], radius = 0.05)
-extrude002 = extrude(profile002, length = -1)`
-      const { ast, artifactGraph, solids, tools } = await getSolidsAndTools(
-        code,
-        [1],
-        [1],
-        instanceInThisFile,
-        kclManagerInThisFile
-      )
-
-      const result = addSubtract({
-        ast,
-        artifactGraph,
-        solids,
-        tools,
-        wasmInstance: instanceInThisFile,
-      })
-
-      expect(result).toEqual(new Error('Please check your selections'))
     })
 
     it('should push a call in pipe if selection was in variable-less pipe', async () => {
@@ -319,8 +484,7 @@ extrude001 = extrude(profile001, length = -5, method = NEW)`
   })
 
   // From https://github.com/KittyCAD/modeling-app/blob/d83324ac30430af675806c143ee6fb30df8bdaa8/src/lang/modifyAst/boolean.test.ts#L7
-  // addIntersect and addUnion are not tested here, as they would be 1:1 with existing e2e tests
-  // so just adding extra addSubtract cases here
+  // The detailed addIntersect and addUnion behavior remains covered by the existing e2e tests.
 
   describe('Testing addSplit', () => {
     async function runAddSplitTest({

--- a/src/lang/modifyAst/boolean.ts
+++ b/src/lang/modifyAst/boolean.ts
@@ -1,3 +1,4 @@
+import type { Expr } from '@rust/kcl-lib/bindings/Expr'
 import type { Node } from '@rust/kcl-lib/bindings/Node'
 
 import {
@@ -12,6 +13,7 @@ import {
 } from '@src/lang/modifyAst'
 import {
   getVariableExprsFromSelection,
+  stringifyPathToNode,
   valueOrVariable,
 } from '@src/lang/queryAst'
 import type { ArtifactGraph, PathToNode, Program } from '@src/lang/wasm'
@@ -21,6 +23,56 @@ import { KCL_DEFAULT_CONSTANT_PREFIXES } from '@src/lib/constants'
 import { err } from '@src/lib/trap'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { Selections } from '@src/machines/modelingSharedTypes'
+
+const BOOLEAN_SELECTION_ERROR_MESSAGE = 'Please check your selections'
+
+type BooleanSelectionGroup = {
+  selections: Selections
+  exprs: Expr[]
+  pathIfPipe?: PathToNode
+}
+
+function booleanInputKey(expr: Expr, pathIfPipe?: PathToNode): string {
+  switch (expr.type) {
+    case 'Name':
+      return `Name:${expr.abs_path ? 'absolute' : 'relative'}:${[
+        ...expr.path.map(({ name }) => name),
+        expr.name.name,
+      ].join('::')}`
+    case 'MemberExpression':
+      return `MemberExpression:${expr.computed}:${booleanInputKey(
+        expr.object
+      )}:${booleanInputKey(expr.property)}`
+    case 'Literal':
+      return `Literal:${JSON.stringify(expr.value)}`
+    case 'PipeSubstitution':
+      return `PipeSubstitution:${
+        pathIfPipe ? stringifyPathToNode(pathIfPipe) : ''
+      }`
+    default:
+      return JSON.stringify(expr)
+  }
+}
+
+function validateBooleanSelections(
+  selectionGroups: BooleanSelectionGroup[]
+): Error | undefined {
+  const inputKeys = new Set<string>()
+
+  for (const { selections, exprs, pathIfPipe } of selectionGroups) {
+    if (exprs.length !== selections.graphSelections.length) {
+      return new Error(BOOLEAN_SELECTION_ERROR_MESSAGE)
+    }
+
+    for (const expr of exprs) {
+      const key = booleanInputKey(expr, pathIfPipe)
+      if (inputKeys.has(key)) {
+        return new Error(BOOLEAN_SELECTION_ERROR_MESSAGE)
+      }
+      inputKeys.add(key)
+    }
+  }
+}
 
 export function addUnion({
   ast,
@@ -55,6 +107,13 @@ export function addUnion({
   )
   if (err(vars)) {
     return vars
+  }
+
+  const selectionError = validateBooleanSelections([
+    { selections: solids, ...vars },
+  ])
+  if (selectionError) {
+    return selectionError
   }
 
   const objectsExpr = createVariableExpressionsArray(vars.exprs)
@@ -120,6 +179,13 @@ export function addIntersect({
   )
   if (err(vars)) {
     return vars
+  }
+
+  const selectionError = validateBooleanSelections([
+    { selections: solids, ...vars },
+  ])
+  if (selectionError) {
+    return selectionError
   }
 
   const objectsExpr = createVariableExpressionsArray(vars.exprs)
@@ -204,24 +270,12 @@ export function addSubtract({
     return toolVars
   }
 
-  const targetExprKeys = new Set(
-    vars.exprs.map((expr) =>
-      JSON.stringify([
-        expr,
-        expr.type === 'PipeSubstitution' ? vars.pathIfPipe : undefined,
-      ])
-    )
-  )
-  const hasSharedBody = toolVars.exprs.some((expr) =>
-    targetExprKeys.has(
-      JSON.stringify([
-        expr,
-        expr.type === 'PipeSubstitution' ? toolVars.pathIfPipe : undefined,
-      ])
-    )
-  )
-  if (hasSharedBody) {
-    return new Error('Please check your selections')
+  const selectionError = validateBooleanSelections([
+    { selections: solids, ...vars },
+    { selections: tools, ...toolVars },
+  ])
+  if (selectionError) {
+    return selectionError
   }
 
   const objectsExpr = createVariableExpressionsArray(vars.exprs)
@@ -314,6 +368,14 @@ export function addSplit({
     tools &&
       (tools.graphSelections.length > 0 || tools.otherSelections.length > 0)
   )
+  const selectionGroups: BooleanSelectionGroup[] = [
+    { selections: targets, ...vars },
+  ]
+  const targetSelectionError = validateBooleanSelections(selectionGroups)
+  if (targetSelectionError) {
+    return targetSelectionError
+  }
+
   const labeledArgs: ReturnType<typeof createLabeledArg>[] = []
   let pathIfNewPipe = vars.pathIfPipe
 
@@ -331,6 +393,11 @@ export function addSplit({
     )
     if (err(toolVars)) {
       return toolVars
+    }
+    selectionGroups.push({ selections: tools, ...toolVars })
+    const selectionError = validateBooleanSelections(selectionGroups)
+    if (selectionError) {
+      return selectionError
     }
 
     const toolsExpr = createVariableExpressionsArray(toolVars.exprs)

--- a/src/lang/modifyAst/boolean.ts
+++ b/src/lang/modifyAst/boolean.ts
@@ -24,7 +24,8 @@ import { err } from '@src/lib/trap'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { Selections } from '@src/machines/modelingSharedTypes'
 
-const BOOLEAN_SELECTION_ERROR_MESSAGE = 'Please check your selections'
+const BOOLEAN_SELECTION_ERROR_MESSAGE =
+  'The same body cannot be used more than once in a Boolean operation. Please check your selections.'
 
 type BooleanSelectionGroup = {
   selections: Selections

--- a/src/lang/modifyAst/boolean.ts
+++ b/src/lang/modifyAst/boolean.ts
@@ -204,6 +204,26 @@ export function addSubtract({
     return toolVars
   }
 
+  const targetExprKeys = new Set(
+    vars.exprs.map((expr) =>
+      JSON.stringify([
+        expr,
+        expr.type === 'PipeSubstitution' ? vars.pathIfPipe : undefined,
+      ])
+    )
+  )
+  const hasSharedBody = toolVars.exprs.some((expr) =>
+    targetExprKeys.has(
+      JSON.stringify([
+        expr,
+        expr.type === 'PipeSubstitution' ? toolVars.pathIfPipe : undefined,
+      ])
+    )
+  )
+  if (hasSharedBody) {
+    return new Error('Please check your selections')
+  }
+
   const objectsExpr = createVariableExpressionsArray(vars.exprs)
   const toolsExpr = createVariableExpressionsArray(toolVars.exprs)
   if (toolsExpr === null) {


### PR DESCRIPTION
Fixes #12983 by surfacing a helpful error message.

Rejects union, intersect, subtract, and split commands that reuse the same body, with a clear prompt to check the selections.

Ideally this should live in KCL, like in this draft #13007, but we need to consider breaking change implications first.

<img width="676" height="293" alt="image" src="https://github.com/user-attachments/assets/8e4c314c-1f39-40df-943e-4bf492e30fad" />
