### PR TITLE
Clear selection after deleting an operation

### DIFF
--- a/e2e/playwright/point-click.spec.ts
+++ b/e2e/playwright/point-click.spec.ts
@@ -514,7 +514,11 @@ sketch001 = extrude(region001, length = -12)`
         0
       )
       await operationButton.click({ button: 'left' })
-      await page.keyboard.press('Delete')
+      await expect(toolbar.selectionStatus).not.toContainText('No selection')
+      await toolbar.removeFeatureTreeOperation(operationButton)
+      await scene.settled()
+      await expect(toolbar.selectionStatus).toContainText('No selection')
+      await editor.expectEditor.not.toContain(expectedOutput)
     })
   })
 

--- a/src/lang/modifyAst/deleteSelection.ts
+++ b/src/lang/modifyAst/deleteSelection.ts
@@ -16,6 +16,16 @@ import type { Selection } from '@src/machines/modelingSharedTypes'
 export const deletionErrorMessage =
   'Unable to delete selection. Please edit manually in code pane.'
 
+function clearSelectionAfterDelete(kclManager: KclManager) {
+  kclManager.sendModelingEvent({
+    type: 'Set selection',
+    data: {
+      selectionType: 'completeSelection',
+      selection: { graphSelections: [], otherSelections: [] },
+    },
+  })
+}
+
 export async function deleteSelectionPromise({
   selection,
   systemDeps,
@@ -74,6 +84,7 @@ export async function deleteSelectionPromise({
       shouldExecute: true,
       shouldWriteToDisk: true,
     })
+    clearSelectionAfterDelete(systemDeps.kclManager)
     return
   }
 
@@ -126,4 +137,5 @@ export async function deleteSelectionPromise({
       isDeleting: true,
     }
   )
+  clearSelectionAfterDelete(systemDeps.kclManager)
 }


### PR DESCRIPTION
Fixes #13016

- Clears the modeling selection after a deletion succeeds.
- Covers the behavior in the focused offset-plane point-and-click test.