### PR TITLE
Use CEK executor feature flag in ZDS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@csstools/postcss-oklab-function": "^4.0.12",
         "@headlessui/react": "^1.7.19",
         "@headlessui/tailwindcss": "^0.2.2",
-        "@kittycad/lib": "^4.3.23",
+        "@kittycad/lib": "^4.3.24",
         "@lezer/highlight": "^1.2.1",
         "@lezer/lr": "^1.4.10",
         "@microlink/react-json-view": "^1.31.20",
@@ -9308,9 +9308,9 @@
       "license": "MIT"
     },
     "node_modules/@kittycad/lib": {
-      "version": "4.3.23",
-      "resolved": "https://registry.npmjs.org/@kittycad/lib/-/lib-4.3.23.tgz",
-      "integrity": "sha512-95SLDGPSCpbEDA/MNgNSSpigzK5qUjzL2UyL5MvQ9yJomY8MaB2Afv0cDVPJN62dlVJKto+snUj8XkwnFZXuCw==",
+      "version": "4.3.24",
+      "resolved": "https://registry.npmjs.org/@kittycad/lib/-/lib-4.3.24.tgz",
+      "integrity": "sha512-SDAhhMHaBgmi+HtT5FCnsVCgumHH9M6iJuPH1+94CV+Q3QdLXg6yzZ/TfVpZLlftopZyQTTZ2ao6wcTcFAzNBg==",
       "license": "MIT",
       "dependencies": {
         "@kittycad/kcl-wasm-lib": "0.1.174",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@csstools/postcss-oklab-function": "^4.0.12",
     "@headlessui/react": "^1.7.19",
     "@headlessui/tailwindcss": "^0.2.2",
-    "@kittycad/lib": "^4.3.23",
+    "@kittycad/lib": "^4.3.24",
     "@lezer/highlight": "^1.2.1",
     "@lezer/lr": "^1.4.10",
     "@microlink/react-json-view": "^1.31.20",

--- a/rust/kcl-lib/expected-bindings/ts-rs/KclRuntimeFlags.ts
+++ b/rust/kcl-lib/expected-bindings/ts-rs/KclRuntimeFlags.ts
@@ -3,5 +3,9 @@ import type { RuntimeFlag } from "./RuntimeFlag";
 
 /**
  * Maps 1-1 to the KCL related flags added to the Admin portal and TS.
+ *
+ * Fields missing from a deserialized payload become [`RuntimeFlag::Unset`],
+ * so a sender built before a flag existed falls back to Rust-side defaults
+ * instead of failing to parse.
  */
 export type KclRuntimeFlags = { use_cek_executor: RuntimeFlag, use_new_lexer_parser: RuntimeFlag, };

--- a/rust/kcl-lib/expected-bindings/ts-rs/KclRuntimeFlags.ts
+++ b/rust/kcl-lib/expected-bindings/ts-rs/KclRuntimeFlags.ts
@@ -4,4 +4,4 @@ import type { RuntimeFlag } from "./RuntimeFlag";
 /**
  * Maps 1-1 to the KCL related flags added to the Admin portal and TS.
  */
-export type KclRuntimeFlags = { use_new_lexer_parser: RuntimeFlag, };
+export type KclRuntimeFlags = { use_cek_executor: RuntimeFlag, use_new_lexer_parser: RuntimeFlag, };

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -6874,6 +6874,7 @@ mod test {
     use crate::errors::Severity;
     use crate::exec::UnitType;
     use crate::execution::ContextType;
+    use crate::execution::machine::ExecutorKind;
     use crate::execution::parse_execute;
 
     fn assert_angle_degrees(actual: ezpz::datatypes::Angle, expected: f64) {
@@ -7476,7 +7477,7 @@ d = b + c
             },
             context_type: ContextType::Mock,
             execution_callbacks: Default::default(),
-            executor_kind: Default::default(),
+            executor_kind: ExecutorKind::resolve(),
             machine_call_depth_limit: crate::execution::machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
         };
         let mut exec_state = ExecState::new(&exec_ctxt);

--- a/rust/kcl-lib/src/execution/fn_call.rs
+++ b/rust/kcl-lib/src/execution/fn_call.rs
@@ -1607,7 +1607,7 @@ mod test {
                 settings: Default::default(),
                 context_type: ContextType::Mock,
                 execution_callbacks: Default::default(),
-                executor_kind: crate::execution::machine::ExecutorKind::from_env(),
+                executor_kind: crate::execution::machine::ExecutorKind::resolve(),
                 machine_call_depth_limit: crate::execution::machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
             };
             let mut exec_state = ExecState::new(&exec_ctxt);
@@ -2418,7 +2418,7 @@ plane = startSketchOn(XY)
             settings: Default::default(),
             context_type: ContextType::Mock,
             execution_callbacks: Default::default(),
-            executor_kind: crate::execution::machine::ExecutorKind::from_env(),
+            executor_kind: crate::execution::machine::ExecutorKind::resolve(),
             machine_call_depth_limit: crate::execution::machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
         };
         let mut exec_state = ExecState::new(&exec_ctxt);

--- a/rust/kcl-lib/src/execution/freedom_analysis_tests.rs
+++ b/rust/kcl-lib/src/execution/freedom_analysis_tests.rs
@@ -5,6 +5,7 @@ use crate::ExecutorSettings;
 use crate::engine::engine_manager::EngineManager;
 use crate::execution::ContextType;
 use crate::execution::MockConfig;
+use crate::execution::machine::ExecutorKind;
 use crate::front::Freedom;
 use crate::front::ObjectKind;
 use crate::frontend::api::ObjectId;
@@ -19,7 +20,7 @@ async fn run_with_freedom_analysis(kcl: &str) -> Vec<(ObjectId, Freedom)> {
         settings: ExecutorSettings::default(),
         context_type: ContextType::Mock,
         execution_callbacks: Default::default(),
-        executor_kind: Default::default(),
+        executor_kind: ExecutorKind::resolve(),
         machine_call_depth_limit: crate::execution::machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
     };
 

--- a/rust/kcl-lib/src/execution/machine.rs
+++ b/rust/kcl-lib/src/execution/machine.rs
@@ -40,6 +40,7 @@
 //!   native frames per callback nesting level (bounded by the recursive
 //!   executor's call-stack cap, which still guards that path).
 
+use std::env;
 use std::sync::Arc;
 
 use indexmap::IndexMap;
@@ -68,6 +69,7 @@ use crate::execution::state::SketchBlockState;
 use crate::execution::types::PrimitiveType;
 use crate::execution::types::RuntimeType;
 use crate::front::ObjectId;
+use crate::kcl_runtime_flags;
 use crate::parsing::ast::types::Annotation;
 use crate::parsing::ast::types::ArrayExpression;
 use crate::parsing::ast::types::ArrayRangeExpression;
@@ -89,49 +91,108 @@ use crate::parsing::ast::types::PipeExpression;
 use crate::parsing::ast::types::Program;
 use crate::parsing::ast::types::SketchBlock;
 use crate::parsing::ast::types::UnaryExpression;
+use crate::runtime_flags::RuntimeFlagResolve;
+use crate::runtime_flags::resolve_from_sources;
+
+/// Environment variable selecting which executor implementation to use.
+const KCL_EXECUTOR_ENV_VAR: &str = "KCL_EXECUTOR";
 
 /// Which executor evaluates KCL. Crate-internal: set on
 /// [`ExecutorContext`] at construction time and immutable during a run.
 /// Cloning the context (fresh roots, `Args`) inherits the same kind, so every
 /// module and callback runs on the same executor.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+///
+/// Precedence: runtime flags > test override > `KCL_EXECUTOR` >
+/// [`ExecutorKind::resolve_default()`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ExecutorKind {
     /// The historical recursive tree-walking evaluator.
-    #[default]
     Recursive,
     /// The CEK machine in this module.
     Machine,
 }
 
-impl ExecutorKind {
-    /// Select the executor from the `KCL_EXECUTOR` environment variable:
-    /// `machine` or `recursive`, ASCII case-insensitive, surrounding
-    /// whitespace ignored. Setting the variable is an explicit opt-in and
-    /// applies to any context construction that consults it; unset or empty
-    /// means [`ExecutorKind::default`]. Any other value is a configuration
-    /// error and panics rather than silently running the wrong executor.
-    /// (Wasm builds have no environment, so this is always the default
-    /// there.)
-    pub(crate) fn from_env() -> Self {
-        Self::from_env_value(std::env::var("KCL_EXECUTOR").ok().as_deref())
+impl std::fmt::Display for ExecutorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExecutorKind::Recursive => write!(f, "recursive"),
+            ExecutorKind::Machine => write!(f, "machine"),
+        }
+    }
+}
+
+impl RuntimeFlagResolve for ExecutorKind {
+    fn on() -> Self {
+        Self::Machine
     }
 
-    /// The parsing half of [`Self::from_env`], split out so tests can drive
-    /// it without touching the process environment.
-    fn from_env_value(value: Option<&str>) -> Self {
-        let Some(value) = value else {
-            return ExecutorKind::default();
-        };
+    fn off() -> Self {
+        Self::Recursive
+    }
+
+    fn resolve_default() -> Self {
+        Self::Recursive
+    }
+
+    /// Select the executor from the `KCL_EXECUTOR` environment variable:
+    /// `machine` or `recursive`, ASCII case-insensitive, surrounding whitespace
+    /// ignored. Setting the variable is an explicit opt-in and applies to any
+    /// context construction that consults it; unset or empty means
+    /// [`ExecutorKind::default`]. Any other value is a configuration error that
+    /// warns and then uses the default. (Wasm builds have no environment, so
+    /// this is always the default there.)
+    fn parse_env_var(value: &str) -> Self {
         let value = value.trim();
         if value.is_empty() {
-            ExecutorKind::default()
+            Self::resolve_default()
         } else if value.eq_ignore_ascii_case("machine") {
             ExecutorKind::Machine
         } else if value.eq_ignore_ascii_case("recursive") {
             ExecutorKind::Recursive
         } else {
-            panic!("Invalid KCL_EXECUTOR value {value:?}; expected \"machine\" or \"recursive\"");
+            let def = Self::resolve_default();
+            // A mistyped value should not crash the process: warn and fall back
+            // to the default (the conservative choice for a misconfiguration).
+            Self::warn_once(|| {
+                format!(
+                    "Unsupported {KCL_EXECUTOR_ENV_VAR} value `{value}`; expected `recursive` or `machine`. Defaulting to `{def}`."
+                )
+            });
+            def
         }
+    }
+}
+
+impl ExecutorKind {
+    /// Resolve the active executor (see precedence on [`ExecutorKind`]).
+    pub(crate) fn resolve() -> Self {
+        let env_value = match env::var(KCL_EXECUTOR_ENV_VAR) {
+            Ok(value) => Some(value),
+            Err(env::VarError::NotPresent) => None,
+            Err(env::VarError::NotUnicode(value)) => {
+                // Invalid-unicode env var: warn and fall back rather than crash.
+                Self::warn_once(|| {
+                    let def = Self::resolve_default();
+                    format!(
+                        "{KCL_EXECUTOR_ENV_VAR} must be valid unicode; got `{}`. Defaulting to `{def}`.",
+                        value.to_string_lossy()
+                    )
+                });
+                None
+            }
+        };
+
+        resolve_from_sources(kcl_runtime_flags().use_cek_executor, None, env_value.as_deref())
+    }
+
+    /// Emit a one-time configuration warning through `crate::log` (gated on
+    /// `ZOO_LOG`). `resolve`/`parse` run on every executor creation, so a
+    /// misconfigured `KCL_EXECUTOR` must not warn -- or allocate the message --
+    /// on every call. One guard suffices: only one kind of misconfiguration can
+    /// occur per process, since the env var holds a single value.
+    fn warn_once(make_message: impl FnOnce() -> String) {
+        static WARNED: std::sync::Once = std::sync::Once::new();
+        WARNED.call_once(|| crate::log::log(make_message()));
     }
 }
 
@@ -2381,24 +2442,23 @@ mod tests {
 
     #[test]
     fn executor_kind_from_env_value_parses_explicit_selections() {
-        assert_eq!(ExecutorKind::from_env_value(Some("machine")), ExecutorKind::Machine);
-        assert_eq!(ExecutorKind::from_env_value(Some("recursive")), ExecutorKind::Recursive);
-        assert_eq!(ExecutorKind::from_env_value(Some(" Machine\t")), ExecutorKind::Machine);
-        assert_eq!(ExecutorKind::from_env_value(Some("RECURSIVE")), ExecutorKind::Recursive);
+        assert_eq!(ExecutorKind::parse_env_var("machine"), ExecutorKind::Machine);
+        assert_eq!(ExecutorKind::parse_env_var("recursive"), ExecutorKind::Recursive);
+        assert_eq!(ExecutorKind::parse_env_var(" Machine\t"), ExecutorKind::Machine);
+        assert_eq!(ExecutorKind::parse_env_var("RECURSIVE"), ExecutorKind::Recursive);
     }
 
     #[test]
-    fn executor_kind_from_env_value_defaults_when_unset_or_empty() {
-        assert_eq!(ExecutorKind::from_env_value(None), ExecutorKind::default());
-        assert_eq!(ExecutorKind::from_env_value(Some("")), ExecutorKind::default());
-        assert_eq!(ExecutorKind::from_env_value(Some(" \t ")), ExecutorKind::default());
+    fn executor_kind_from_env_value_defaults_when_empty() {
+        assert_eq!(ExecutorKind::parse_env_var(""), ExecutorKind::resolve_default());
+        assert_eq!(ExecutorKind::parse_env_var(" \t "), ExecutorKind::resolve_default());
     }
 
     #[test]
-    #[should_panic(expected = "Invalid KCL_EXECUTOR value")]
-    fn executor_kind_from_env_value_rejects_unknown_values() {
-        let _ = ExecutorKind::from_env_value(Some("machin"));
+    fn executor_kind_from_env_value_defaults_when_unknown_value() {
+        assert_eq!(ExecutorKind::parse_env_var("machin"), ExecutorKind::resolve_default());
     }
+
     use super::*;
     use crate::execution::parse_execute_with_executor_kind;
 

--- a/rust/kcl-lib/src/execution/machine.rs
+++ b/rust/kcl-lib/src/execution/machine.rs
@@ -108,6 +108,13 @@ const KCL_EXECUTOR_ENV_VAR: &str = "KCL_EXECUTOR";
 /// `ExecutorContext` they construct, and everything else must keep following
 /// `KCL_EXECUTOR` so the CI matrix genuinely runs the suite under both
 /// executors.
+///
+/// Selection is deliberately a process-global runtime flag rather than an
+/// `ExecutorSettings` field: TS reaches executor settings only through the
+/// user-settings `Configuration` schema (TOML / JsonSchema / generated docs),
+/// and settings participate in execution-cache comparison, so a transient
+/// rollout flag does not belong there. The app rebuilds the context per wasm
+/// call, so the global still yields per-execution capture.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ExecutorKind {
     /// The historical recursive tree-walking evaluator.

--- a/rust/kcl-lib/src/execution/machine.rs
+++ b/rust/kcl-lib/src/execution/machine.rs
@@ -102,8 +102,12 @@ const KCL_EXECUTOR_ENV_VAR: &str = "KCL_EXECUTOR";
 /// Cloning the context (fresh roots, `Args`) inherits the same kind, so every
 /// module and callback runs on the same executor.
 ///
-/// Precedence: runtime flags > test override > `KCL_EXECUTOR` >
-/// [`ExecutorKind::resolve_default()`].
+/// Precedence: runtime flags > `KCL_EXECUTOR` >
+/// [`ExecutorKind::resolve_default()`]. The shared resolver's test-override
+/// slot is deliberately unused here: tests pin a kind by passing it to the
+/// `ExecutorContext` they construct, and everything else must keep following
+/// `KCL_EXECUTOR` so the CI matrix genuinely runs the suite under both
+/// executors.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ExecutorKind {
     /// The historical recursive tree-walking evaluator.
@@ -182,6 +186,8 @@ impl ExecutorKind {
             }
         };
 
+        // The `None` is the test-override slot: unlike `LexerMode`, the
+        // executor never supplies one (see the type-level docs).
         resolve_from_sources(kcl_runtime_flags().use_cek_executor, None, env_value.as_deref())
     }
 
@@ -2459,7 +2465,80 @@ mod tests {
         assert_eq!(ExecutorKind::parse_env_var("machin"), ExecutorKind::resolve_default());
     }
 
+    fn set_runtime_executor_flag(flag: RuntimeFlag) {
+        crate::set_kcl_runtime_flags(KclRuntimeFlags {
+            use_cek_executor: flag,
+            ..Default::default()
+        });
+    }
+
+    fn reset_runtime_executor_flags() {
+        crate::set_kcl_runtime_flags(KclRuntimeFlags::DEFAULT);
+    }
+
+    /// Flags are process-global; setting them is race-free under nextest's
+    /// process-per-test isolation.
+    #[test]
+    fn runtime_flag_on_selects_machine_executor() {
+        set_runtime_executor_flag(RuntimeFlag::On);
+        assert_eq!(ExecutorKind::resolve(), ExecutorKind::Machine);
+        reset_runtime_executor_flags();
+    }
+
+    /// Must hold even on the CI machine leg (`KCL_EXECUTOR=machine`): the
+    /// runtime flag outranks the env var.
+    #[test]
+    fn runtime_flag_off_selects_recursive_executor() {
+        set_runtime_executor_flag(RuntimeFlag::Off);
+        assert_eq!(ExecutorKind::resolve(), ExecutorKind::Recursive);
+        reset_runtime_executor_flags();
+    }
+
+    #[test]
+    fn runtime_flag_takes_priority_over_env() {
+        assert_eq!(
+            resolve_from_sources::<ExecutorKind>(RuntimeFlag::Off, None, Some("machine")),
+            ExecutorKind::Recursive
+        );
+        assert_eq!(
+            resolve_from_sources::<ExecutorKind>(RuntimeFlag::On, None, Some("recursive")),
+            ExecutorKind::Machine
+        );
+    }
+
+    #[test]
+    fn unset_runtime_flag_allows_env_to_select_executor() {
+        assert_eq!(
+            resolve_from_sources::<ExecutorKind>(RuntimeFlag::Unset, None, Some("machine")),
+            ExecutorKind::Machine
+        );
+        assert_eq!(
+            resolve_from_sources::<ExecutorKind>(RuntimeFlag::Unset, None, Some("recursive")),
+            ExecutorKind::Recursive
+        );
+    }
+
+    #[test]
+    fn unset_runtime_flag_and_missing_env_selects_default_executor() {
+        assert_eq!(
+            resolve_from_sources::<ExecutorKind>(RuntimeFlag::Unset, None, None),
+            ExecutorKind::Recursive
+        );
+    }
+
+    /// The ZDS feature flag controls exactly this: a context built through a
+    /// public constructor picks up the flag as its kind.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn runtime_flag_on_threads_machine_kind_into_mock_context() {
+        set_runtime_executor_flag(RuntimeFlag::On);
+        let ctx = ExecutorContext::new_mock(None).await;
+        assert_eq!(ctx.executor_kind, ExecutorKind::Machine);
+        reset_runtime_executor_flags();
+    }
+
     use super::*;
+    use crate::KclRuntimeFlags;
+    use crate::RuntimeFlag;
     use crate::execution::parse_execute_with_executor_kind;
 
     async fn run_machine(code: &str) -> Result<crate::execution::ExecTestResults, KclError> {

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -1007,7 +1007,7 @@ impl ExecutorContext {
             settings,
             context_type: ContextType::Live,
             execution_callbacks: Default::default(),
-            executor_kind: machine::ExecutorKind::from_env(),
+            executor_kind: machine::ExecutorKind::resolve(),
             machine_call_depth_limit: machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
         }
     }
@@ -1079,7 +1079,7 @@ impl ExecutorContext {
             settings: settings.unwrap_or_default(),
             context_type: ContextType::Mock,
             execution_callbacks: Default::default(),
-            executor_kind: machine::ExecutorKind::from_env(),
+            executor_kind: machine::ExecutorKind::resolve(),
             machine_call_depth_limit: machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
         }
     }
@@ -1093,7 +1093,7 @@ impl ExecutorContext {
             settings,
             context_type: ContextType::Mock,
             execution_callbacks: Default::default(),
-            executor_kind: machine::ExecutorKind::from_env(),
+            executor_kind: machine::ExecutorKind::resolve(),
             machine_call_depth_limit: machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
         }
     }
@@ -1114,7 +1114,7 @@ impl ExecutorContext {
             settings,
             context_type: ContextType::Mock,
             execution_callbacks: Default::default(),
-            executor_kind: machine::ExecutorKind::from_env(),
+            executor_kind: machine::ExecutorKind::resolve(),
             machine_call_depth_limit: machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
         })
     }
@@ -1128,7 +1128,7 @@ impl ExecutorContext {
             settings: Default::default(),
             context_type: ContextType::MockCustomForwarded,
             execution_callbacks: Default::default(),
-            executor_kind: machine::ExecutorKind::from_env(),
+            executor_kind: machine::ExecutorKind::resolve(),
             machine_call_depth_limit: machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
         }
     }
@@ -2184,7 +2184,7 @@ pub(crate) async fn parse_execute_with_project_dir(
     project_directory: Option<TypedPath>,
 ) -> Result<ExecTestResults, KclError> {
     // Differential testing: unit tests run under both executors.
-    parse_execute_with_executor_kind(code, project_directory, machine::ExecutorKind::from_env()).await
+    parse_execute_with_executor_kind(code, project_directory, machine::ExecutorKind::resolve()).await
 }
 
 /// A mock-engine executor context for tests that need to inspect the context
@@ -2373,7 +2373,7 @@ mod tests {
             },
             context_type: ContextType::Mock,
             execution_callbacks: Default::default(),
-            executor_kind: machine::ExecutorKind::from_env(),
+            executor_kind: machine::ExecutorKind::resolve(),
             machine_call_depth_limit: crate::execution::machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
         };
         let mut exec_state = ExecState::new_with_memory_backend(&ctx, backend);
@@ -4899,7 +4899,7 @@ type Color { | Red | Green | Red }
             },
             context_type: ContextType::Mock,
             execution_callbacks: Default::default(),
-            executor_kind: machine::ExecutorKind::from_env(),
+            executor_kind: machine::ExecutorKind::resolve(),
             machine_call_depth_limit: crate::execution::machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
         };
         let mut exec_state = ExecState::new(&ctx);

--- a/rust/kcl-lib/src/parsing/token/mod.rs
+++ b/rust/kcl-lib/src/parsing/token/mod.rs
@@ -25,6 +25,8 @@ use crate::errors::KclError;
 use crate::kcl_runtime_flags;
 use crate::parsing::ast::types::ItemVisibility;
 use crate::parsing::ast::types::VariableKind;
+use crate::runtime_flags::RuntimeFlagResolve;
+use crate::runtime_flags::resolve_from_sources;
 
 mod tokeniser;
 
@@ -611,6 +613,24 @@ pub(crate) enum LexerMode {
     New,
 }
 
+impl RuntimeFlagResolve for LexerMode {
+    fn on() -> Self {
+        Self::New
+    }
+
+    fn off() -> Self {
+        Self::Old
+    }
+
+    fn resolve_default() -> Self {
+        Self::DEFAULT
+    }
+
+    fn parse_env_var(value: &str) -> Self {
+        Self::parse(value)
+    }
+}
+
 impl LexerMode {
     /// The mode used when `KCL_LEXER` is unset.
     const DEFAULT: Self = Self::Old;
@@ -640,17 +660,7 @@ impl LexerMode {
     }
 
     fn resolve_from_sources(runtime_flag: RuntimeFlag, test_override: Option<Self>, env_value: Option<&str>) -> Self {
-        match runtime_flag {
-            RuntimeFlag::On => return Self::New,
-            RuntimeFlag::Off => return Self::Old,
-            RuntimeFlag::Unset => {}
-        }
-
-        if let Some(mode) = test_override {
-            return mode;
-        }
-
-        env_value.map(Self::parse).unwrap_or(Self::DEFAULT)
+        resolve_from_sources(runtime_flag, test_override, env_value)
     }
 
     #[cfg(test)]
@@ -793,6 +803,7 @@ mod lexer_mode_tests {
     fn set_runtime_lexer_flag(flag: RuntimeFlag) {
         crate::set_kcl_runtime_flags(KclRuntimeFlags {
             use_new_lexer_parser: flag,
+            ..Default::default()
         });
     }
 
@@ -838,6 +849,7 @@ mod lexer_mode_tests {
             crate::kcl_runtime_flags(),
             KclRuntimeFlags {
                 use_new_lexer_parser: RuntimeFlag::Unset,
+                ..Default::default()
             }
         );
     }

--- a/rust/kcl-lib/src/runtime_flags.rs
+++ b/rust/kcl-lib/src/runtime_flags.rs
@@ -26,11 +26,13 @@ pub enum RuntimeFlag {
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, ts_rs::TS)]
 #[ts(export)]
 pub struct KclRuntimeFlags {
+    pub use_cek_executor: RuntimeFlag,
     pub use_new_lexer_parser: RuntimeFlag,
 }
 
 impl KclRuntimeFlags {
     pub const DEFAULT: Self = Self {
+        use_cek_executor: RuntimeFlag::Unset,
         use_new_lexer_parser: RuntimeFlag::Unset,
     };
 }
@@ -58,4 +60,31 @@ pub fn kcl_runtime_flags() -> KclRuntimeFlags {
         Ok(guard) => *guard,
         Err(poisoned) => *poisoned.into_inner(),
     }
+}
+
+pub(crate) trait RuntimeFlagResolve {
+    fn on() -> Self;
+    fn off() -> Self;
+    /// Not named `default()` so that it doesn't collide with
+    /// `Default::default()`.
+    fn resolve_default() -> Self;
+    fn parse_env_var(value: &str) -> Self;
+}
+
+pub(crate) fn resolve_from_sources<T: RuntimeFlagResolve>(
+    runtime_flag: RuntimeFlag,
+    test_override: Option<T>,
+    env_value: Option<&str>,
+) -> T {
+    match runtime_flag {
+        RuntimeFlag::On => return T::on(),
+        RuntimeFlag::Off => return T::off(),
+        RuntimeFlag::Unset => {}
+    }
+
+    if let Some(mode) = test_override {
+        return mode;
+    }
+
+    env_value.map(T::parse_env_var).unwrap_or_else(T::resolve_default)
 }

--- a/rust/kcl-lib/src/runtime_flags.rs
+++ b/rust/kcl-lib/src/runtime_flags.rs
@@ -23,10 +23,16 @@ pub enum RuntimeFlag {
 }
 
 /// Maps 1-1 to the KCL related flags added to the Admin portal and TS.
+///
+/// Fields missing from a deserialized payload become [`RuntimeFlag::Unset`],
+/// so a sender built before a flag existed falls back to Rust-side defaults
+/// instead of failing to parse.
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, ts_rs::TS)]
 #[ts(export)]
 pub struct KclRuntimeFlags {
+    #[serde(default)]
     pub use_cek_executor: RuntimeFlag,
+    #[serde(default)]
     pub use_new_lexer_parser: RuntimeFlag,
 }
 
@@ -87,4 +93,27 @@ pub(crate) fn resolve_from_sources<T: RuntimeFlagResolve>(
     }
 
     env_value.map(T::parse_env_var).unwrap_or_else(T::resolve_default)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserializing_empty_flags_defaults_to_unset() {
+        let flags: KclRuntimeFlags = serde_json::from_str("{}").unwrap();
+        assert_eq!(flags, KclRuntimeFlags::DEFAULT);
+    }
+
+    #[test]
+    fn deserializing_partial_flags_defaults_missing_fields_to_unset() {
+        let flags: KclRuntimeFlags = serde_json::from_str(r#"{"use_new_lexer_parser":"On"}"#).unwrap();
+        assert_eq!(
+            flags,
+            KclRuntimeFlags {
+                use_cek_executor: RuntimeFlag::Unset,
+                use_new_lexer_parser: RuntimeFlag::On,
+            }
+        );
+    }
 }

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -198,7 +198,7 @@ function createRuntimeFlagsWasmInstance() {
 
 function expectedRuntimeFlags(
   useNewLexerParser: 'On' | 'Off',
-  useCekExecutor: 'On' | 'Off' = 'Off'
+  useCekExecutor: 'On' | 'Off'
 ) {
   return JSON.stringify({
     use_cek_executor: useCekExecutor,
@@ -330,7 +330,7 @@ describe('project system', () => {
       await wasmPromise
 
       expect(wasmInstance.set_kcl_runtime_flags).toHaveBeenCalledWith(
-        expectedRuntimeFlags('Off')
+        expectedRuntimeFlags('Off', 'Off')
       )
     } finally {
       app.dispose()
@@ -354,7 +354,7 @@ describe('project system', () => {
       userFeatures.setFeatureIds(new Set([KCL_NEW_LEXER_PARSER_FEATURE_FLAG]))
 
       expect(wasmInstance.set_kcl_runtime_flags).toHaveBeenCalledWith(
-        expectedRuntimeFlags('On')
+        expectedRuntimeFlags('On', 'Off')
       )
     } finally {
       app.dispose()
@@ -404,7 +404,7 @@ describe('project system', () => {
       await notifyActiveWasmInstance(nextWasmInstance)
 
       expect(nextWasmInstance.set_kcl_runtime_flags).toHaveBeenCalledWith(
-        expectedRuntimeFlags('On')
+        expectedRuntimeFlags('On', 'Off')
       )
     } finally {
       app.dispose()

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -4,6 +4,7 @@ import { signal } from '@preact/signals-core'
 import { File, type KclManager } from '@src/lang/KclManager'
 import { App } from '@src/lib/app'
 import {
+  KCL_CEK_EXECUTOR_FEATURE_FLAG,
   KCL_NEW_LEXER_PARSER_FEATURE_FLAG,
   OPFS_CLOUD_FEATURE_FLAG,
 } from '@src/lib/constants'
@@ -195,8 +196,12 @@ function createRuntimeFlagsWasmInstance() {
   }
 }
 
-function expectedRuntimeFlags(useNewLexerParser: 'On' | 'Off') {
+function expectedRuntimeFlags(
+  useNewLexerParser: 'On' | 'Off',
+  useCekExecutor: 'On' | 'Off' = 'Off'
+) {
   return JSON.stringify({
+    use_cek_executor: useCekExecutor,
     use_new_lexer_parser: useNewLexerParser,
   })
 }
@@ -350,6 +355,30 @@ describe('project system', () => {
 
       expect(wasmInstance.set_kcl_runtime_flags).toHaveBeenCalledWith(
         expectedRuntimeFlags('On')
+      )
+    } finally {
+      app.dispose()
+    }
+  })
+
+  it('updates the CEK executor runtime flag when the feature is enabled', async () => {
+    const userFeatures = createUserFeaturesForTest(new Set())
+    const wasmInstance = createRuntimeFlagsWasmInstance()
+    const wasmPromise = Promise.resolve(wasmInstance)
+    const app = createAppForTest({
+      userFeatures,
+      wasmPromise,
+      registryOverrides: [createTestWasmRegistryItem(wasmPromise)],
+    })
+
+    try {
+      await wasmPromise
+      wasmInstance.set_kcl_runtime_flags.mockClear()
+
+      userFeatures.setFeatureIds(new Set([KCL_CEK_EXECUTOR_FEATURE_FLAG]))
+
+      expect(wasmInstance.set_kcl_runtime_flags).toHaveBeenCalledWith(
+        expectedRuntimeFlags('Off', 'On')
       )
     } finally {
       app.dispose()

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -35,6 +35,7 @@ export const EXPERIMENTAL_POINT_AND_CLICK_FLAG: Feature =
 export const OPFS_CLOUD_FEATURE_FLAG: Feature = 'web_app_file_browser'
 export const SEGMENTS_BASED_REGIONS_FEATURE_FLAG: Feature =
   'segments_based_regions'
+export const KCL_CEK_EXECUTOR_FEATURE_FLAG: Feature = 'kcl_cek_executor'
 export const KCL_NEW_LEXER_PARSER_FEATURE_FLAG: Feature = 'kcl_new_lexer_parser'
 /** Gates named view changes to ZDS UI */
 export const NAMED_VIEWS_UI_FEATURE_FLAG: Feature = 'named_views_ui'

--- a/src/lib/kclRuntimeFlags.test.ts
+++ b/src/lib/kclRuntimeFlags.test.ts
@@ -1,5 +1,8 @@
 import type { Feature } from '@kittycad/lib'
-import { KCL_NEW_LEXER_PARSER_FEATURE_FLAG } from '@src/lib/constants'
+import {
+  KCL_CEK_EXECUTOR_FEATURE_FLAG,
+  KCL_NEW_LEXER_PARSER_FEATURE_FLAG,
+} from '@src/lib/constants'
 import {
   kclRuntimeFlagsFromUserFeatures,
   setKclRuntimeFlagsOnWasm,
@@ -20,7 +23,19 @@ describe('kcl runtime flags', () => {
         userFeaturesWith(new Set([KCL_NEW_LEXER_PARSER_FEATURE_FLAG]))
       )
     ).toEqual({
+      use_cek_executor: 'Off',
       use_new_lexer_parser: 'On',
+    })
+  })
+
+  it('maps the enabled CEK executor feature to On', () => {
+    expect(
+      kclRuntimeFlagsFromUserFeatures(
+        userFeaturesWith(new Set([KCL_CEK_EXECUTOR_FEATURE_FLAG]))
+      )
+    ).toEqual({
+      use_cek_executor: 'On',
+      use_new_lexer_parser: 'Off',
     })
   })
 
@@ -28,6 +43,7 @@ describe('kcl runtime flags', () => {
     expect(
       kclRuntimeFlagsFromUserFeatures(userFeaturesWith(new Set()))
     ).toEqual({
+      use_cek_executor: 'Off',
       use_new_lexer_parser: 'Off',
     })
   })
@@ -44,6 +60,7 @@ describe('kcl runtime flags', () => {
 
     expect(wasmInstance.set_kcl_runtime_flags).toHaveBeenCalledWith(
       JSON.stringify({
+        use_cek_executor: 'Off',
         use_new_lexer_parser: 'On',
       })
     )

--- a/src/lib/kclRuntimeFlags.ts
+++ b/src/lib/kclRuntimeFlags.ts
@@ -1,5 +1,8 @@
 import type { KclRuntimeFlags } from '@rust/kcl-lib/bindings/KclRuntimeFlags'
-import { KCL_NEW_LEXER_PARSER_FEATURE_FLAG } from '@src/lib/constants'
+import {
+  KCL_CEK_EXECUTOR_FEATURE_FLAG,
+  KCL_NEW_LEXER_PARSER_FEATURE_FLAG,
+} from '@src/lib/constants'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { UserFeaturesRegistryService } from '@src/registry/contracts/userFeatures'
 
@@ -10,6 +13,9 @@ export function kclRuntimeFlagsFromUserFeatures(
   userFeatures: RuntimeFlagUserFeatures
 ): KclRuntimeFlags {
   return {
+    use_cek_executor: userFeatures.has(KCL_CEK_EXECUTOR_FEATURE_FLAG, false)
+      ? 'On'
+      : 'Off',
     use_new_lexer_parser: userFeatures.has(
       KCL_NEW_LEXER_PARSER_FEATURE_FLAG,
       false


### PR DESCRIPTION
Resolves #12991. Stacked on #12990.

A lot of this is based on the lexer feature flag. I pulled out some of that Rust code and made a trait that new feature flags can implement.

There are bugs in how we initialize the feature flags in ZDS and pass them to the KCL interpreter. You'll see console errors from using the old executor even when the new executor is enabled. Both are run. This is caused by pre-existing issues that need to be fixed before flipping the feature flag default value. But they shouldn't need to block this PR. See the initiative for those separate bug issues.