### PR TITLE
fix(kcl): report the sketch variable name in constraint reports

### DIFF
--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -2650,6 +2650,22 @@ impl Node<SketchBlock> {
             };
 
             let artifact_id = ArtifactId::from(exec_state.next_uuid());
+            // Label the sketch with the name of the variable whose right-hand
+            // side is being evaluated. This function runs before the sketch
+            // body executes, so for `mySketch = sketch(on = XY) { ... }`,
+            // `being_declared` still holds `mySketch` rather than a name
+            // declared inside the body.
+            //
+            // The label is the nearest enclosing declaration, which is not
+            // always the sketch's own name:
+            // - `part = extrude(sketch(on = XY) { ... }, length = 10)` labels
+            //   the sketch `part`.
+            // - A sketch constructed inside a function body and returned takes
+            //   the name of the declaration in progress at the call site, so
+            //   two calls to that function can produce the same label.
+            // - A sketch written as an expression statement has no declaration
+            //   in progress, so its label is the empty string.
+            let label = exec_state.mod_local.being_declared.clone().unwrap_or_default();
             // Create the sketch scene object and replace its placeholder.
             let sketch_scene_object = Object {
                 id: sketch_id,
@@ -2659,7 +2675,7 @@ impl Node<SketchBlock> {
                     segments: Default::default(),
                     constraints: Default::default(),
                 }),
-                label: Default::default(),
+                label,
                 comments: Default::default(),
                 artifact_id,
                 source: SourceRef::new(self.into(), self.node_path.clone()),

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -388,7 +388,18 @@ pub enum ConstraintKind {
 /// distinguish this from a genuinely constrained sketch.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SketchConstraintStatus {
-    /// The variable name of the sketch (e.g., "sketch001").
+    /// Name of the variable the sketch was assigned to, for example
+    /// "sketch001". This is the nearest enclosing declaration at the point the
+    /// sketch was created, which is not always the sketch's own name:
+    /// - Empty for a sketch written as an expression statement, because there
+    ///   is no enclosing declaration.
+    /// - The outer variable's name for a sketch passed straight into another
+    ///   call, as in `part = extrude(sketch(on = XY) { ... }, length = 10)`.
+    /// - The same name for two sketches, when a function body declares the
+    ///   sketch and is called more than once.
+    ///
+    /// The report carries no other sketch identifier, so a caller cannot tell
+    /// apart two entries that share a name.
     pub name: String,
     /// Overall constraint status derived from per-segment freedom.
     pub status: ConstraintKind,
@@ -4770,6 +4781,84 @@ s2 = sketch(on = XZ) {
         );
         assert_eq!(report.fully_constrained.len(), 1);
         assert_eq!(report.under_constrained.len(), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_constraint_report_reports_sketch_names() {
+        // One file holding a fully constrained, an under-constrained, and an
+        // over-constrained sketch. Every entry carries the name of the
+        // variable its sketch was assigned to, so a caller can say which
+        // sketch needs correcting.
+        let kcl = r#"
+@settings(experimentalFeatures = allow)
+
+fixedSketch = sketch(on = YZ) {
+  line1 = line(start = [var 2mm, var 8mm], end = [var 5mm, var 7mm])
+  line1.start.at[0] == 2
+  line1.start.at[1] == 8
+  line1.end.at[0] == 5
+  line1.end.at[1] == 7
+}
+
+looseSketch = sketch(on = XZ) {
+  line1 = line(start = [var 1mm, var 2mm], end = [var 3mm, var 4mm])
+}
+
+conflictSketch = sketch(on = XY) {
+  line1 = line(start = [var 2mm, var 8mm], end = [var 5mm, var 7mm])
+  line1.start.at[0] == 2
+  line1.start.at[1] == 8
+  line1.end.at[0] == 5
+  line1.end.at[1] == 7
+  distance([line1.start, line1.end]) == 100mm
+}
+"#;
+        let report = run_constraint_report(kcl).await;
+        assert_eq!(report.errors.len(), 0);
+        assert_eq!(report.fully_constrained.len(), 1);
+        assert_eq!(report.under_constrained.len(), 1);
+        assert_eq!(report.over_constrained.len(), 1);
+        assert_eq!(report.fully_constrained[0].name, "fixedSketch");
+        assert_eq!(report.under_constrained[0].name, "looseSketch");
+        assert_eq!(report.over_constrained[0].name, "conflictSketch");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_constraint_report_name_empty_without_declaration() {
+        // A sketch written as an expression statement has no enclosing
+        // variable declaration, so there is no name to report. This pins the
+        // documented limitation of SketchConstraintStatus::name.
+        let kcl = r#"
+sketch(on = YZ) {
+  line1 = line(start = [var 1.32mm, var -1.93mm], end = [var 6.08mm, var 2.51mm])
+}
+"#;
+        let report = run_constraint_report(kcl).await;
+        assert_eq!(report.under_constrained.len(), 1);
+        assert_eq!(report.under_constrained[0].name, "");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_constraint_report_names_repeat_across_calls() {
+        // Both sketches come from the same declaration inside the function
+        // body, so both entries carry that declaration's name and the report
+        // cannot tell them apart. This pins the documented limitation of
+        // SketchConstraintStatus::name.
+        let kcl = r#"
+fn makeSketch() {
+  inner = sketch(on = XY) {
+    line1 = line(start = [var 1mm, var 2mm], end = [var 3mm, var 4mm])
+  }
+  return inner
+}
+
+first = makeSketch()
+second = makeSketch()
+"#;
+        let report = run_constraint_report(kcl).await;
+        assert_eq!(report.under_constrained.len(), 2);
+        assert_eq!(report.under_constrained[0].name, "inner");
+        assert_eq!(report.under_constrained[1].name, "inner");
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/rust/kcl-python-bindings/kcl.pyi
+++ b/rust/kcl-python-bindings/kcl.pyi
@@ -629,7 +629,13 @@ class SketchConstraintStatus:
     Per-sketch summary of constraint freedom analysis.
     """
     @property
-    def name(self) -> builtins.str: ...
+    def name(self) -> builtins.str:
+        r"""
+        Name of the variable the sketch was assigned to. Empty when the sketch
+        has no enclosing variable declaration, and shared between entries when
+        two sketches resolve to the same declaration. The report carries no
+        other sketch identifier.
+        """
     @property
     def status(self) -> zooConstraintKind: ...
     @property

--- a/rust/kcl-python-bindings/src/bridge/sketch_constraints.rs
+++ b/rust/kcl-python-bindings/src/bridge/sketch_constraints.rs
@@ -29,6 +29,10 @@ impl From<kcl_lib::ConstraintKind> for ConstraintKind {
 #[pyclass(from_py_object)]
 #[derive(Debug, Clone)]
 pub struct SketchConstraintStatus {
+    /// Name of the variable the sketch was assigned to. Empty when the sketch
+    /// has no enclosing variable declaration, and shared between entries when
+    /// two sketches resolve to the same declaration. The report carries no
+    /// other sketch identifier.
     #[pyo3(get)]
     pub name: String,
     #[pyo3(get)]

--- a/rust/kcl-python-bindings/tests/tests.py
+++ b/rust/kcl-python-bindings/tests/tests.py
@@ -639,6 +639,31 @@ s2 = sketch(on = XZ) {
 }
 """
 
+named_sketches_all_statuses_code = """
+@settings(experimentalFeatures = allow)
+
+fixedSketch = sketch(on = YZ) {
+  line1 = line(start = [var 2mm, var 8mm], end = [var 5mm, var 7mm])
+  line1.start.at[0] == 2
+  line1.start.at[1] == 8
+  line1.end.at[0] == 5
+  line1.end.at[1] == 7
+}
+
+looseSketch = sketch(on = XZ) {
+  line1 = line(start = [var 1mm, var 2mm], end = [var 3mm, var 4mm])
+}
+
+conflictSketch = sketch(on = XY) {
+  line1 = line(start = [var 2mm, var 8mm], end = [var 5mm, var 7mm])
+  line1.start.at[0] == 2
+  line1.start.at[1] == 8
+  line1.end.at[0] == 5
+  line1.end.at[1] == 7
+  distance([line1.start, line1.end]) == 100mm
+}
+"""
+
 execution_error_after_sketch_code = """
 @settings(experimentalFeatures = allow)
 
@@ -733,6 +758,28 @@ async def test_sketch_constraint_status_mixed():
     assert len(report.errors) == 0
     assert report.is_complete is True
     assert report.kcl_error is None
+    assert report.fully_constrained[0].name == "s1"
+    assert report.under_constrained[0].name == "s2"
+
+
+@requires_engine
+@pytest.mark.asyncio
+async def test_sketch_constraint_status_reports_names():
+    # One file holding a fully constrained, an under-constrained, and an
+    # over-constrained sketch. Every entry carries the name of the variable its
+    # sketch was assigned to, so a caller can say which sketch needs
+    # correcting.
+    report = await execute_with_retries(
+        kcl.get_sketch_constraint_status_code, named_sketches_all_statuses_code
+    )
+    assert report.total_sketches() == 3
+    assert len(report.errors) == 0
+    assert len(report.fully_constrained) == 1
+    assert len(report.under_constrained) == 1
+    assert len(report.over_constrained) == 1
+    assert report.fully_constrained[0].name == "fixedSketch"
+    assert report.under_constrained[0].name == "looseSketch"
+    assert report.over_constrained[0].name == "conflictSketch"
 
 
 @requires_engine


### PR DESCRIPTION
- Label the sketch scene object with the variable being declared; `SketchConstraintStatus.name` was always empty because nothing ever set `Object.label`
- Document the three cases where that name is not the sketch's own name: expression statement, inline argument to another call, function called more than once
- Cover names for fully, under, and over-constrained sketches in one file, in both the Rust and Python suites, and pin the empty and repeated cases
- Refs #13052; stable source identity for unnamed sketches stays open