### PR TITLE
KCL: Return compilation issues in mock execution in Python

### DIFF
--- a/rust/kcl-python-bindings/files/experimentalfeatures.kcl
+++ b/rust/kcl-python-bindings/files/experimentalfeatures.kcl
@@ -1,0 +1,14 @@
+@settings(experimentalFeatures = deny)
+
+width = 20
+length = 10
+
+mySketch = startSketchOn(XY)
+  |> startProfile(at = [-width / 2, -length / 2])
+profile001 = conic(
+  mySketch,
+  end = [20, 0],
+  endTangent = [1, 1],
+  interior = [5, 5],
+  startTangent = [0, -1],
+)

--- a/rust/kcl-python-bindings/justfile
+++ b/rust/kcl-python-bindings/justfile
@@ -1,11 +1,11 @@
 test:
     uv pip install .[test]
     mkdir -p test-results
-    uv run pytest tests/tests.py --junitxml=test-results/junit.xml
+    uv run --no-sync pytest tests/tests.py --junitxml=test-results/junit.xml
 
 test-filter name:
     uv pip install .[test]
-    uv run pytest tests/tests.py::{{name}}
+    uv run --no-sync pytest tests/tests.py::{{name}}
 
 # One-time setup for local dev loop.
 dev-install:

--- a/rust/kcl-python-bindings/kcl.pyi
+++ b/rust/kcl-python-bindings/kcl.pyi
@@ -143,6 +143,7 @@ class CompilationIssue:
     def is_warning(self) -> builtins.bool: ...
     def is_err(self) -> builtins.bool: ...
     def is_fatal(self) -> builtins.bool: ...
+    def message(self) -> builtins.str: ...
 
 @typing.final
 class CreoImportOptions:
@@ -193,6 +194,7 @@ class ExecOutcome:
         Render the given compilation issue as a miette report string, using
         the source code and filename captured at execution time.
         """
+    def report_all(self) -> builtins.list[builtins.str]: ...
 
 @typing.final
 class ExportFile:
@@ -1392,12 +1394,12 @@ def lint_and_fix_families(code: builtins.str, families_to_fix: typing.Sequence[F
     Returns any unfixed lints.
     """
 
-async def mock_execute(path: builtins.str) -> builtins.bool:
+async def mock_execute(path: builtins.str) -> zooExecOutcome:
     r"""
     Mock execute the kcl code from a file path.
     """
 
-async def mock_execute_code(code: builtins.str) -> builtins.bool:
+async def mock_execute_code(code: builtins.str) -> zooExecOutcome:
     r"""
     Mock execute the kcl code.
     """

--- a/rust/kcl-python-bindings/src/bridge.rs
+++ b/rust/kcl-python-bindings/src/bridge.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 pub mod bounding_box;
+pub mod compilation_issue;
 pub mod physical_properties;
 pub mod sketch_constraints;
 

--- a/rust/kcl-python-bindings/src/bridge/compilation_issue.rs
+++ b/rust/kcl-python-bindings/src/bridge/compilation_issue.rs
@@ -1,0 +1,36 @@
+use pyo3::pyclass;
+use pyo3::pymethods;
+
+/// Wrapper for [kcl_lib::kcl_error::CompilationIssue].
+#[pyo3_stub_gen::derive::gen_stub_pyclass]
+#[pyclass(from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompilationIssue {
+    pub inner: kcl_lib::CompilationIssue,
+}
+
+impl From<kcl_lib::kcl_error::CompilationIssue> for CompilationIssue {
+    fn from(value: kcl_lib::kcl_error::CompilationIssue) -> Self {
+        Self { inner: value }
+    }
+}
+
+#[pyo3_stub_gen::derive::gen_stub_pymethods]
+#[pymethods]
+impl CompilationIssue {
+    pub fn is_warning(&self) -> bool {
+        self.inner.severity.is_warning()
+    }
+
+    pub fn is_err(&self) -> bool {
+        self.inner.severity.is_err()
+    }
+
+    pub fn is_fatal(&self) -> bool {
+        self.inner.severity.is_fatal()
+    }
+
+    pub fn message(&self) -> &str {
+        &self.inner.message
+    }
+}

--- a/rust/kcl-python-bindings/src/lib.rs
+++ b/rust/kcl-python-bindings/src/lib.rs
@@ -42,6 +42,7 @@ use serde::Serialize;
 use uuid::Uuid;
 
 use crate::bridge::bounding_box::BoundingBoxResponse;
+use crate::bridge::compilation_issue::CompilationIssue;
 use crate::bridge::physical_properties::PhysicalPropertiesRequest;
 use crate::bridge::physical_properties::PhysicalPropertiesResponse;
 use crate::bridge::sketch_constraints::KclErrorInfo;
@@ -262,40 +263,6 @@ async fn new_context_state(
     };
     let state = kcl_lib::ExecState::new(&ctx);
     Ok((ctx, state))
-}
-
-/// Wrapper for [kcl_lib::kcl_error::CompilationIssue].
-#[pyo3_stub_gen::derive::gen_stub_pyclass]
-#[pyclass(from_py_object)]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CompilationIssue {
-    inner: kcl_lib::CompilationIssue,
-}
-
-impl From<kcl_lib::kcl_error::CompilationIssue> for CompilationIssue {
-    fn from(value: kcl_lib::kcl_error::CompilationIssue) -> Self {
-        Self { inner: value }
-    }
-}
-
-#[pyo3_stub_gen::derive::gen_stub_pymethods]
-#[pymethods]
-impl CompilationIssue {
-    pub fn is_warning(&self) -> bool {
-        self.inner.severity.is_warning()
-    }
-
-    pub fn is_err(&self) -> bool {
-        self.inner.severity.is_err()
-    }
-
-    pub fn is_fatal(&self) -> bool {
-        self.inner.severity.is_fatal()
-    }
-
-    pub fn message(&self) -> &str {
-        &self.inner.message
-    }
 }
 
 /// Returned from execution functions.

--- a/rust/kcl-python-bindings/src/lib.rs
+++ b/rust/kcl-python-bindings/src/lib.rs
@@ -292,6 +292,10 @@ impl CompilationIssue {
     pub fn is_fatal(&self) -> bool {
         self.inner.severity.is_fatal()
     }
+
+    pub fn message(&self) -> &str {
+        &self.inner.message
+    }
 }
 
 /// Returned from execution functions.
@@ -315,6 +319,14 @@ impl ExecOutcome {
     /// the source code and filename captured at execution time.
     fn report(&self, issue: &CompilationIssue) -> String {
         kcl_lib::render_compilation_issue_miette(&self.filename, &self.code, issue.inner.clone())
+    }
+
+    fn report_all(&self) -> Vec<String> {
+        let mut out = Vec::with_capacity(self.issues.len());
+        for issue in self.issues.iter() {
+            out.push(self.report(issue));
+        }
+        out
     }
 }
 
@@ -575,23 +587,15 @@ async fn execute_code(code: String) -> PyResult<ExecOutcome> {
 /// Mock execute the kcl code.
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
 #[pyfunction]
-async fn mock_execute_code(code: String) -> PyResult<bool> {
-    spawn_py(async move {
-        execute_impl(KclInput::Code(code), true).await?;
-        Ok(true)
-    })
-    .await
+async fn mock_execute_code(code: String) -> PyResult<ExecOutcome> {
+    spawn_py(async move { execute_impl(KclInput::Code(code), true).await }).await
 }
 
 /// Mock execute the kcl code from a file path.
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
 #[pyfunction]
-async fn mock_execute(path: String) -> PyResult<bool> {
-    spawn_py(async move {
-        execute_impl(KclInput::Path(path), true).await?;
-        Ok(true)
-    })
-    .await
+async fn mock_execute(path: String) -> PyResult<ExecOutcome> {
+    spawn_py(async move { execute_impl(KclInput::Path(path), true).await }).await
 }
 
 /// Execute a kcl file and return a report of sketch constraint status.

--- a/rust/kcl-python-bindings/tests/tests.py
+++ b/rust/kcl-python-bindings/tests/tests.py
@@ -16,9 +16,7 @@ kcl_dir = os.path.join(
 tests_dir = os.path.join(kcl_dir, "tests")
 lego_file = os.path.join(kcl_dir, "e2e", "executor", "inputs", "lego.kcl")
 
-engine_error_file = os.path.join(
-    tests_dir, "error_large_fillet_radius", "input.kcl"
-)
+engine_error_file = os.path.join(tests_dir, "error_large_fillet_radius", "input.kcl")
 cube_step_file = os.path.join(
     os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "files", "cube.step"
 )
@@ -160,10 +158,27 @@ async def test_kcl_mock_execute_with_exception():
 
 
 @pytest.mark.asyncio
+async def test_kcl_mock_execute_with_warnings():
+    # Read from a file.
+    outcome = await kcl.mock_execute(
+        os.path.join(files_dir, "experimentalfeatures.kcl")
+    )
+
+    # Check the outcome contained the expected issues
+    issues = outcome.issues()
+    assert len(issues) == 1
+    issue = issues[0]
+    assert (
+        issue.message()
+        == "Use of `conic` is experimental and may change or be removed."
+    )
+
+
+@pytest.mark.asyncio
 async def test_kcl_mock_execute_with_engine_exception_should_pass():
     # Read from a file.
-    result = await kcl.mock_execute(engine_error_file)
-    assert result is True
+    issues = await kcl.mock_execute(engine_error_file)
+    assert issues == []
 
 
 @requires_engine
@@ -181,8 +196,8 @@ async def test_kcl_execute_with_engine_exception_should_fail():
 @pytest.mark.asyncio
 async def test_kcl_mock_execute():
     # Read from a file.
-    result = await kcl.mock_execute(lego_file)
-    assert result is True
+    issues = await kcl.mock_execute(lego_file)
+    assert issues == []
 
 
 @pytest.mark.asyncio
@@ -192,8 +207,8 @@ async def test_kcl_mock_execute_code():
         code = str(f.read())
         assert code is not None
         assert len(code) > 0
-        result = await kcl.mock_execute_code(code)
-        assert result is True
+        issues = await kcl.mock_execute_code(code)
+        assert issues == []
 
 
 @requires_engine

--- a/rust/kcl-python-bindings/tests/tests.py
+++ b/rust/kcl-python-bindings/tests/tests.py
@@ -177,8 +177,8 @@ async def test_kcl_mock_execute_with_warnings():
 @pytest.mark.asyncio
 async def test_kcl_mock_execute_with_engine_exception_should_pass():
     # Read from a file.
-    issues = await kcl.mock_execute(engine_error_file)
-    assert issues == []
+    outcome = await kcl.mock_execute(engine_error_file)
+    assert outcome.issues() == []
 
 
 @requires_engine
@@ -196,8 +196,8 @@ async def test_kcl_execute_with_engine_exception_should_fail():
 @pytest.mark.asyncio
 async def test_kcl_mock_execute():
     # Read from a file.
-    issues = await kcl.mock_execute(lego_file)
-    assert issues == []
+    outcome = await kcl.mock_execute(lego_file)
+    assert outcome.issues() == []
 
 
 @pytest.mark.asyncio
@@ -207,8 +207,8 @@ async def test_kcl_mock_execute_code():
         code = str(f.read())
         assert code is not None
         assert len(code) > 0
-        issues = await kcl.mock_execute_code(code)
-        assert issues == []
+        outcome = await kcl.mock_execute_code(code)
+        assert outcome.issues() == []
 
 
 @requires_engine


### PR DESCRIPTION
Closes https://github.com/KittyCAD/modeling-app/issues/13048

The `zoo_kcl` python library has methods for doing a real execution, and for doing mock execution. Real execution previously returned `ExecOutcome` (with methods for getting errors/issues), whereas mock execution only returned a bool for "fatal error or not". 

Now mock execution also returns a full `ExecOutcome`, which the Zoo MCP should use just like it uses from a full execution.

This will need to be integrated into the zoo MCP. Currently the MCP expects just a bool from mock execution, so it'll need to be updated, get the ExecOutcome, and check it for any compilation issues. You can either read each issue, or use the `report` method of `ExecOutcome` to get fancy issue reports, with the error message printed inline with the relevant KCL source code. This works just like normal execution.