### PR TITLE
KCL: Break client <-> engine serde into a separate crate

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2347,6 +2347,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kcl-engine-codec"
+version = "0.2.181"
+dependencies = [
+ "kittycad-modeling-cmds",
+ "rmp-serde",
+ "serde_json",
+]
+
+[[package]]
 name = "kcl-error"
 version = "0.2.181"
 dependencies = [
@@ -2446,6 +2455,7 @@ dependencies = [
  "kcl-api",
  "kcl-derive-docs",
  "kcl-directory-test-macro",
+ "kcl-engine-codec",
  "kcl-error",
  "kcl-syntax",
  "kittycad",
@@ -2465,7 +2475,6 @@ dependencies = [
  "regex",
  "reqwest",
  "rgba_simple",
- "rmp-serde",
  "schemars 0.8.22",
  "serde",
  "serde_json",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2398,6 +2398,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kcl-engine-codec"
+version = "0.2.177"
+dependencies = [
+ "kittycad-modeling-cmds",
+ "rmp-serde",
+ "serde_json",
+]
+
+[[package]]
 name = "kcl-error"
 version = "0.2.177"
 dependencies = [
@@ -2490,6 +2499,7 @@ dependencies = [
  "kcl-api",
  "kcl-derive-docs",
  "kcl-directory-test-macro",
+ "kcl-engine-codec",
  "kcl-error",
  "kcl-syntax",
  "kittycad",
@@ -2510,7 +2520,6 @@ dependencies = [
  "regex",
  "reqwest",
  "rgba_simple",
- "rmp-serde",
  "ropey",
  "schemars 0.8.22",
  "serde",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "kcl-bumper",
   "kcl-derive-docs",
   "kcl-directory-test-macro",
+  "kcl-engine-codec",
   "kcl-error",
   "kcl-language-server",
   "kcl-language-server-release",

--- a/rust/justfile
+++ b/rust/justfile
@@ -112,6 +112,7 @@ publish-kcl-part2 version:
     git tag kcl-{{ version }} -m "Release kcl-{{ version }}"
     cargo publish -p kcl-derive-docs
     cargo publish -p kcl-directory-test-macro
+    cargo publish -p kcl-engine-codec
     cargo publish -p kcl-syntax
     cargo publish -p kcl-lib
     cargo publish -p kcl-test-server

--- a/rust/justfile
+++ b/rust/justfile
@@ -109,6 +109,7 @@ publish-kcl-part2 version:
     git tag kcl-{{ version }} -m "Release kcl-{{ version }}"
     cargo publish -p kcl-derive-docs
     cargo publish -p kcl-directory-test-macro
+    cargo publish -p kcl-engine-codec
     cargo publish -p kcl-syntax
     cargo publish -p kcl-lib
     cargo publish -p kcl-test-server

--- a/rust/kcl-bumper/src/main.rs
+++ b/rust/kcl-bumper/src/main.rs
@@ -9,8 +9,14 @@ use toml_edit::value;
 
 /// Deps that need to be updated in lock-step.
 const KCL_API_DEPS: [&str; 1] = ["kcl-error"];
-const KCL_LIB_DEPS: [&str; 4] = ["kcl-api", "kcl-derive-docs", "kcl-error", "kcl-syntax"];
 const KCL_LANGUAGE_SERVER_DEPS: [&str; 1] = ["kcl-lib"];
+const KCL_LIB_DEPS: [&str; 5] = [
+    "kcl-api",
+    "kcl-derive-docs",
+    "kcl-engine-codec",
+    "kcl-error",
+    "kcl-syntax",
+];
 const KCL_TEST_SERVER_DEPS: [&str; 1] = ["kcl-lib"];
 
 fn main() -> Result<()> {
@@ -274,6 +280,7 @@ version = "0.2.128"
 
 [dependencies]
 kcl-derive-docs = { version = "0.1", path = "../kcl-derive-docs" }
+kcl-engine-codec = { version = "0.1", path = "../kcl-engine-codec" }
 kcl-error = { version = "0.1", path = "../kcl-error" }
         "#;
 
@@ -285,6 +292,12 @@ kcl-error = { version = "0.1", path = "../kcl-error" }
 
         assert_eq!(
             cargo_dot_toml["dependencies"]["kcl-derive-docs"]["version"]
+                .as_value()
+                .and_then(Value::as_str),
+            Some("=0.2.129")
+        );
+        assert_eq!(
+            cargo_dot_toml["dependencies"]["kcl-engine-codec"]["version"]
                 .as_value()
                 .and_then(Value::as_str),
             Some("=0.2.129")

--- a/rust/kcl-bumper/src/main.rs
+++ b/rust/kcl-bumper/src/main.rs
@@ -9,7 +9,13 @@ use toml_edit::value;
 
 /// Deps that need to be updated in lock-step.
 const KCL_API_DEPS: [&str; 1] = ["kcl-error"];
-const KCL_LIB_DEPS: [&str; 4] = ["kcl-api", "kcl-derive-docs", "kcl-error", "kcl-syntax"];
+const KCL_LIB_DEPS: [&str; 5] = [
+    "kcl-api",
+    "kcl-derive-docs",
+    "kcl-engine-codec",
+    "kcl-error",
+    "kcl-syntax",
+];
 const KCL_TEST_SERVER_DEPS: [&str; 1] = ["kcl-lib"];
 
 fn main() -> Result<()> {
@@ -270,6 +276,7 @@ version = "0.2.128"
 
 [dependencies]
 kcl-derive-docs = { version = "0.1", path = "../kcl-derive-docs" }
+kcl-engine-codec = { version = "0.1", path = "../kcl-engine-codec" }
 kcl-error = { version = "0.1", path = "../kcl-error" }
         "#;
 
@@ -281,6 +288,12 @@ kcl-error = { version = "0.1", path = "../kcl-error" }
 
         assert_eq!(
             cargo_dot_toml["dependencies"]["kcl-derive-docs"]["version"]
+                .as_value()
+                .and_then(Value::as_str),
+            Some("=0.2.129")
+        );
+        assert_eq!(
+            cargo_dot_toml["dependencies"]["kcl-engine-codec"]["version"]
                 .as_value()
                 .and_then(Value::as_str),
             Some("=0.2.129")

--- a/rust/kcl-engine-codec/Cargo.toml
+++ b/rust/kcl-engine-codec/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "kcl-engine-codec"
+description = "Serialization and deserialization for the KCL engine protocol"
+version = "0.2.181"
+edition = "2024"
+license = "MIT"
+repository = "https://github.com/KittyCAD/modeling-app"
+authors = ["KittyCAD, Inc"]
+
+[dependencies]
+kittycad-modeling-cmds = { workspace = true }
+rmp-serde = { workspace = true }
+serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/rust/kcl-engine-codec/Cargo.toml
+++ b/rust/kcl-engine-codec/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "kcl-engine-codec"
+description = "Serialization and deserialization for the KCL engine protocol"
+version = "0.2.177"
+edition = "2024"
+license = "MIT"
+repository = "https://github.com/KittyCAD/modeling-app"
+authors = ["KittyCAD, Inc"]
+
+[dependencies]
+kittycad-modeling-cmds = { workspace = true }
+rmp-serde = { workspace = true }
+serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/rust/kcl-engine-codec/src/lib.rs
+++ b/rust/kcl-engine-codec/src/lib.rs
@@ -1,0 +1,53 @@
+//! Concrete serializers and deserializers for the engine WebSocket protocol.
+//!
+//! Keeping these entry points in a small crate lets Cargo cache the large serde
+//! monomorphizations generated for the modeling command types across `kcl-lib`
+//! recompiles.
+
+use kittycad_modeling_cmds::websocket::WebSocketRequest;
+use kittycad_modeling_cmds::websocket::WebSocketResponse;
+
+/// Deserialize a JSON engine response.
+pub fn deserialize_response_json(message: &str) -> Result<WebSocketResponse, serde_json::Error> {
+    serde_json::from_str(message)
+}
+
+/// Deserialize a MessagePack engine response.
+pub fn deserialize_response_msgpack(message: &[u8]) -> Result<WebSocketResponse, rmp_serde::decode::Error> {
+    rmp_serde::from_slice(message)
+}
+
+/// Serialize an engine request as JSON.
+pub fn serialize_request_json(request: &WebSocketRequest) -> Result<String, serde_json::Error> {
+    serde_json::to_string(request)
+}
+
+/// Serialize an engine request as named MessagePack.
+pub fn serialize_request_msgpack(request: &WebSocketRequest) -> Result<Vec<u8>, rmp_serde::encode::Error> {
+    rmp_serde::to_vec_named(request)
+}
+
+#[cfg(test)]
+mod tests {
+    use kittycad_modeling_cmds::websocket::OkWebSocketResponseData;
+
+    use super::*;
+
+    #[test]
+    fn request_serializers_accept_ping() {
+        let request = WebSocketRequest::Ping {};
+
+        assert_eq!(serialize_request_json(&request).unwrap(), r#"{"type":"ping"}"#);
+        assert!(!serialize_request_msgpack(&request).unwrap().is_empty());
+    }
+
+    #[test]
+    fn response_deserializers_round_trip_pong() {
+        let response = WebSocketResponse::success(None, OkWebSocketResponseData::Pong {});
+        let json = serde_json::to_string(&response).unwrap();
+        let msgpack = rmp_serde::to_vec_named(&response).unwrap();
+
+        assert_eq!(deserialize_response_json(&json).unwrap(), response);
+        assert_eq!(deserialize_response_msgpack(&msgpack).unwrap(), response);
+    }
+}

--- a/rust/kcl-lib/Cargo.toml
+++ b/rust/kcl-lib/Cargo.toml
@@ -71,6 +71,7 @@ indexmap = { workspace = true, features = ["serde", "rayon"] }
 itertools = "0.15.0"
 kcl-api = { version = "=0.2.177", path = "../kcl-api" }
 kcl-derive-docs = { version = "=0.2.177", path = "../kcl-derive-docs" }
+kcl-engine-codec = { version = "=0.2.177", path = "../kcl-engine-codec" }
 kcl-error = { version = "=0.2.177", path = "../kcl-error" }
 kcl-syntax = { version = "=0.2.177", path = "../kcl-syntax" }
 ezpz = { workspace = true }
@@ -94,7 +95,6 @@ reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls-native-roots",
 ] }
 rgba_simple = "0.10.0"
-rmp-serde = { workspace = true }
 ropey = "1.6.1"
 schemars = { version = "0.8.17", features = [
   "impl_json_schema",

--- a/rust/kcl-lib/Cargo.toml
+++ b/rust/kcl-lib/Cargo.toml
@@ -67,6 +67,7 @@ indexmap = { workspace = true, features = ["serde", "rayon"] }
 itertools = "0.15.0"
 kcl-api = { version = "=0.2.181", path = "../kcl-api" }
 kcl-derive-docs = { version = "=0.2.181", path = "../kcl-derive-docs" }
+kcl-engine-codec = { version = "=0.2.181", path = "../kcl-engine-codec" }
 kcl-error = { version = "=0.2.181", path = "../kcl-error" }
 kcl-syntax = { version = "=0.2.181", path = "../kcl-syntax" }
 ezpz = { workspace = true }
@@ -89,7 +90,6 @@ reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls-native-roots",
 ] }
 rgba_simple = "0.10.0"
-rmp-serde = { workspace = true }
 schemars = { version = "0.8.17", features = [
   "impl_json_schema",
   "indexmap2",

--- a/rust/kcl-lib/src/engine/engine_manager/wasm_transport.rs
+++ b/rust/kcl-lib/src/engine/engine_manager/wasm_transport.rs
@@ -71,7 +71,7 @@ impl ResponseContext {
     }
 
     pub async fn send_response(&self, data: js_sys::Uint8Array) {
-        let ws_result: WebSocketResponse = match rmp_serde::from_slice(&data.to_vec()) {
+        let ws_result: WebSocketResponse = match kcl_engine_codec::deserialize_response_msgpack(&data.to_vec()) {
             Ok(res) => res,
             Err(_) => return,
         };
@@ -118,7 +118,7 @@ impl WasmTransport {
                 vec![source_range],
             ))
         })?;
-        let cmd_str = serde_json::to_string(cmd).map_err(|e| {
+        let cmd_str = kcl_engine_codec::serialize_request_json(cmd).map_err(|e| {
             KclError::new_engine(KclErrorDetails::new(
                 format!("Failed to serialize modeling command: {:?}", e),
                 vec![source_range],
@@ -218,12 +218,13 @@ impl EngineTransport for WasmTransport {
         }
 
         let data = js_sys::Uint8Array::from(value);
-        let ws_result: WebSocketResponse = rmp_serde::from_slice(&data.to_vec()).map_err(|e| {
-            KclError::new_engine(KclErrorDetails::new(
-                format!("Failed to deserialize msgpack response from engine: {:?}", e),
-                vec![source_range],
-            ))
-        })?;
+        let ws_result: WebSocketResponse =
+            kcl_engine_codec::deserialize_response_msgpack(&data.to_vec()).map_err(|e| {
+                KclError::new_engine(KclErrorDetails::new(
+                    format!("Failed to deserialize msgpack response from engine: {:?}", e),
+                    vec![source_range],
+                ))
+            })?;
 
         Ok(ws_result)
     }

--- a/rust/kcl-lib/src/engine/engine_manager/ws_transport.rs
+++ b/rust/kcl-lib/src/engine/engine_manager/ws_transport.rs
@@ -48,10 +48,10 @@ impl TcpRead {
             Err(e) => return Err(anyhow!("Error reading from engine's WebSocket: {e}").into()),
         };
         let msg: WebSocketResponse = match msg {
-            WsMsg::Text(text) => serde_json::from_str(&text)
+            WsMsg::Text(text) => kcl_engine_codec::deserialize_response_json(&text)
                 .map_err(anyhow::Error::from)
                 .map_err(WebSocketReadError::from)?,
-            WsMsg::Binary(bin) => rmp_serde::from_slice(&bin)
+            WsMsg::Binary(bin) => kcl_engine_codec::deserialize_response_msgpack(&bin)
                 .map_err(anyhow::Error::from)
                 .map_err(WebSocketReadError::from)?,
             other => return Err(anyhow!("Unexpected WebSocket message from engine API: {other}").into()),
@@ -278,7 +278,8 @@ impl WebSocketTransport {
         request: WebSocketRequest,
         tcp_write: &mut WebSocketTcpWrite,
     ) -> anyhow::Result<()> {
-        let msg = rmp_serde::to_vec_named(&request).map_err(|e| anyhow!("could not serialize msgpack: {e}"))?;
+        let msg = kcl_engine_codec::serialize_request_msgpack(&request)
+            .map_err(|e| anyhow!("could not serialize msgpack: {e}"))?;
         tcp_write
             .send(WsMsg::Binary(msg.into()))
             .await
@@ -288,7 +289,8 @@ impl WebSocketTransport {
 
     /// Send the given `request` to the engine via the WebSocket connection `tcp_write`.
     async fn inner_send_to_engine(request: WebSocketRequest, tcp_write: &mut WebSocketTcpWrite) -> anyhow::Result<()> {
-        let msg = serde_json::to_string(&request).map_err(|e| anyhow!("could not serialize json: {e}"))?;
+        let msg =
+            kcl_engine_codec::serialize_request_json(&request).map_err(|e| anyhow!("could not serialize json: {e}"))?;
         tcp_write
             .send(WsMsg::Text(msg.into()))
             .await


### PR DESCRIPTION
Core problem I'm trying to improve: making incremental compiles of kcl-lib quicker, so I spend less time waiting for compilation in my core edit-compile-test loop.

Observation: The big WebSocketRequest enum (and WebSocketResponse) generate a lot of Rust IR which makes a lot of work for both rustc and llvm. Most of it is due to serde, which generates a lot of compile-time code to make the runtime IO very quick.

Theory: If we break that into its own Rust crate, separate from kcl-lib, and import that crate for kcl-lib, then Cargo will cache the complex serde stuff in its own build. Then if we change a line in kcl-lib, when recompiling kcl-lib, it won't need to rerun any serde-related stuff, and the incremental build will be a bit faster.

So: this PR puts all the generic serde stuff for WebSocketRequest/Response into its own crate called `kcl-engine-codec`.

## Methodology

I asked Codex to investigate why incremental rebuilds of kcl-lib took so long, and to look for some hot spots in the code to consider breaking out into its own function. It noticed the massive amount of serde LLVM lines, and then broke the main source (sending the big enum to/from the engine) into its own crate.

## Adam's results

I'm not super impressed with the incremental recompile time, but it does make a little improvement. Incremental compiles (in my edit-compile-test loop) are 11.95s on this branch and 13.04s on main. I measured this by 

- Running `cargo clean` 
- Running a test: `cargo nextest run -p kcl-lib -- std::fillet::tests::fillet_default_depends_on_kcl_version`
- Then, three times:
  - Make a tiny edit, e.g. changing an error string in the `fillet` function
  - Rerun the test from above
  - Take the average of all 3 test build times.

IMO cutting off one second from the incremental crate rebuilds is a minor but real improvement. Full crate rebuilds went from 68 seconds to 64 seconds, again, minor but real.

Why is this faster? Let's look at `cargo build -p kcl-lib --timings` on main and on this branch.

Main:

<img width="1171" height="217" alt="cbt_main" src="https://github.com/user-attachments/assets/66c85f16-b02c-4e54-9168-9d4fed98597c" />

Branch: 

<img width="1143" height="220" alt="cbt_branch" src="https://github.com/user-attachments/assets/1de7b3c9-cd3b-4969-9eec-7ab99c8d428c" />

You can see some parallelism of the build: Cargo can build all the Serde-related engine request/response deserialization stuff in parallel with other crates, like `kittycad` and `faer`. The purple section is code generation, indicating that a lot of serde-related code generation has been moved out of the kcl-lib crate compile, so that incremental recompiles won't have to do it again.



## Codex summary

<img width="816" height="749" alt="Screenshot 2026-08-18 at 9 25 12 AM" src="https://github.com/user-attachments/assets/d42c9b59-6554-4eca-bdf6-0bc02d4f5695" />
