### PR TITLE
React and error handling improvements for live feature tree operations

### DIFF
--- a/src/components/layout/areas/FeatureTreePane.tsx
+++ b/src/components/layout/areas/FeatureTreePane.tsx
@@ -288,10 +288,12 @@ export const FeatureTreePaneContents = memo(() => {
     unfilteredOperationsByModule,
     ROOT_MODULE_ID
   )
+  const visibilityOperations = getAllOperations(kclManager.operationsByModule)
   const isShowingStaleFeatureTree = hasParseErrors && operationList.length > 0
 
   // Live execution tracking: expand only the active module branch.
   const liveActiveModuleId = kclManager.liveActiveModuleId
+  const liveLatestOperationKey = kclManager.liveLatestOperationKey
 
   function goToError() {
     const l = layout.signal.value
@@ -397,7 +399,9 @@ export const FeatureTreePaneContents = memo(() => {
               modelingActor={modelingActor}
               engineCommandManager={engineCommandManager}
               onSelect={selectOperation}
+              visibilityOperations={visibilityOperations}
               liveActiveModuleId={liveActiveModuleId}
+              liveLatestOperationKey={liveLatestOperationKey}
             />
           ))}
         </>
@@ -423,7 +427,9 @@ function OperationItemGroup({
   modelingActor,
   engineCommandManager,
   onSelect,
+  visibilityOperations,
   isModuleOwned = false,
+  liveLatestOperationKey,
 }: Omit<OperationProps, 'item'> & {
   items: Operation[]
   isModuleOwned?: boolean
@@ -454,7 +460,9 @@ function OperationItemGroup({
           modelingActor={modelingActor}
           engineCommandManager={engineCommandManager}
           onSelect={onSelect}
+          visibilityOperations={visibilityOperations}
           isModuleOwned={isModuleOwned}
+          liveLatestOperationKey={liveLatestOperationKey}
         />
       )
     }
@@ -482,7 +490,9 @@ function OperationItemGroup({
               modelingActor={modelingActor}
               engineCommandManager={engineCommandManager}
               onSelect={onSelect}
+              visibilityOperations={visibilityOperations}
               isModuleOwned={isModuleOwned}
+              liveLatestOperationKey={liveLatestOperationKey}
             />
           </div>
         </div>
@@ -500,8 +510,10 @@ function OperationItemGroup({
                   modelingActor={modelingActor}
                   engineCommandManager={engineCommandManager}
                   onSelect={onSelect}
+                  visibilityOperations={visibilityOperations}
                   size="sm"
                   isModuleOwned={isModuleOwned}
+                  liveLatestOperationKey={liveLatestOperationKey}
                 />
               )
             })}
@@ -537,8 +549,10 @@ function OperationItemGroup({
                 modelingActor={modelingActor}
                 engineCommandManager={engineCommandManager}
                 onSelect={onSelect}
+                visibilityOperations={visibilityOperations}
                 size="sm"
                 isModuleOwned={isModuleOwned}
+                liveLatestOperationKey={liveLatestOperationKey}
               />
             )
           })}
@@ -558,8 +572,10 @@ function OperationBranchGroup({
   modelingActor,
   engineCommandManager,
   onSelect,
+  visibilityOperations,
   isModuleOwned = false,
   liveActiveModuleId,
+  liveLatestOperationKey,
 }: Omit<OperationProps, 'item'> & {
   parentItem: ModuleInstanceOperation
   childItems: OperationTreeNode[]
@@ -576,7 +592,9 @@ function OperationBranchGroup({
         modelingActor={modelingActor}
         engineCommandManager={engineCommandManager}
         onSelect={onSelect}
+        visibilityOperations={visibilityOperations}
         isModuleOwned={true}
+        liveLatestOperationKey={liveLatestOperationKey}
       />
     )
   }
@@ -617,7 +635,9 @@ function OperationBranchGroup({
             modelingActor={modelingActor}
             engineCommandManager={engineCommandManager}
             onSelect={onSelect}
+            visibilityOperations={visibilityOperations}
             isModuleOwned={true}
+            liveLatestOperationKey={liveLatestOperationKey}
           />
         </div>
       </div>
@@ -635,7 +655,9 @@ function OperationBranchGroup({
                 modelingActor={modelingActor}
                 engineCommandManager={engineCommandManager}
                 onSelect={onSelect}
+                visibilityOperations={visibilityOperations}
                 isModuleOwned={true}
+                liveLatestOperationKey={liveLatestOperationKey}
               />
             )
           })}
@@ -791,10 +813,13 @@ interface OperationProps {
   engineCommandManager: ConnectionManager
   modelingActor: ReturnType<typeof useModelingContext>['actor']
   onSelect: (sourceRange: SourceRange) => void
+  visibilityOperations: Operation[]
   size?: 'default' | 'sm'
   isModuleOwned?: boolean
   /** During live execution, the module that received the latest operation. */
   liveActiveModuleId?: number | null
+  /** During live execution, the operation that was most recently added. */
+  liveLatestOperationKey: string | null
   /** When set, this item is a deduplicated module reference; clicking scrolls to the expanded branch. */
   referenceModuleId?: number
 }
@@ -916,6 +941,8 @@ const OperationItem = ({
   size,
   isModuleOwned = false,
   referenceModuleId,
+  visibilityOperations,
+  liveLatestOperationKey,
 }: OperationProps) => {
   useSignals()
   const app = useApp()
@@ -932,8 +959,7 @@ const OperationItem = ({
   const sourceRange =
     'sourceRange' in item &&
     sourceRangeToUtf16(sourceRangeFromRust(item.sourceRange), kclManager.code)
-  const isLiveLatest =
-    kclManager.liveLatestOperationKey === getOperationKey(item)
+  const isLiveLatest = liveLatestOperationKey === getOperationKey(item)
   const isEditorSelected = useMemo(() => {
     if (!sourceRange) {
       return false
@@ -1413,7 +1439,7 @@ const OperationItem = ({
 
   const visibilityState = resolveFeatureTreeVisibility({
     item,
-    operations: getAllOperations(kclManager.operationsByModule),
+    operations: visibilityOperations,
     artifactGraph: kclManager.artifactGraph,
   })
 

--- a/src/lang/KclManager.spec.ts
+++ b/src/lang/KclManager.spec.ts
@@ -3,6 +3,7 @@ import type {
   SceneGraphDelta,
   SourceDelta,
 } from '@rust/kcl-lib/bindings/FrontendApi'
+import type { Operation } from '@rust/kcl-lib/bindings/Operation'
 import { createEmptyAst } from '@src/editor/plugins/ast'
 import { File, KclManager } from '@src/lang/KclManager'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -19,6 +20,7 @@ import {
   createKclManagerTestHarness,
   getLatestDispatchedDiagnostics,
 } from '@src/lang/testHelpers/kclManagerTestHarness'
+import { defaultNodePath } from '@src/lang/wasm'
 
 function createDeferred<T>() {
   let resolve!: (value: T) => void
@@ -63,6 +65,29 @@ function createEmptySceneGraphDelta(): SceneGraphDelta {
   }
 }
 
+function createLiveOperation(name: string, index: number): Operation {
+  return {
+    type: 'VariableDeclaration',
+    name,
+    value: {
+      type: 'Number',
+      value: index,
+      ty: { type: 'Unknown' },
+    },
+    visibility: 'default',
+    nodePath: defaultNodePath(),
+    sourceRange: [index, index + 1, 0],
+  }
+}
+
+type LiveOperationTestApi = {
+  dispatchUpdateOperations(operations: Operation[]): void
+}
+
+function liveOperationTestApi(kclManager: KclManager): LiveOperationTestApi {
+  return kclManager as unknown as LiveOperationTestApi
+}
+
 function enableSketchSolveEditorExecution(kclManager: KclManager) {
   kclManager.modelingState = {
     matches: (value: unknown) => value === 'sketchSolveMode',
@@ -77,6 +102,65 @@ afterEach(() => {
   vi.clearAllTimers()
   vi.useRealTimers()
   localStorage?.clear()
+})
+
+describe('KclManager live operation updates', () => {
+  it('finishes execution when a live UI publication throws', async () => {
+    const { kclManager } = createKclManagerTestHarness()
+    const liveOperations = liveOperationTestApi(kclManager)
+    const dispatchUpdateOperations =
+      liveOperations.dispatchUpdateOperations.bind(liveOperations)
+    const failedLiveOperation = createLiveOperation('failedLive', 0)
+    const ignoredLiveOperation = createLiveOperation('ignoredLive', 1)
+    const authoritativeOperation = createLiveOperation('authoritative', 2)
+    const finalExecState = {
+      ...kclManager.execState,
+      operations: { map: { 0: [authoritativeOperation] } },
+    }
+    let executionContinued = false
+
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+    const dispatchSpy = vi
+      .spyOn(liveOperations, 'dispatchUpdateOperations')
+      .mockImplementation((operations) => {
+        if (operations.includes(failedLiveOperation)) {
+          throw new Error('live UI publication failed')
+        }
+        dispatchUpdateOperations(operations)
+      })
+
+    kclManager.engineCommandManager.started = true
+    vi.spyOn(kclManager.rustContext, 'execute').mockImplementation(
+      async (_ast, _settings, _path, callbacks) => {
+        callbacks?.onOperation({
+          moduleId: 0,
+          operation: failedLiveOperation,
+          index: 0,
+        })
+        callbacks?.onOperation({
+          moduleId: 0,
+          operation: ignoredLiveOperation,
+          index: 1,
+        })
+        executionContinued = true
+        return finalExecState
+      }
+    )
+
+    await kclManager.executeAst({ ast: createEmptyAst(), executionId: 101 })
+
+    expect(executionContinued).toBe(true)
+    expect(kclManager.isExecuting).toBe(false)
+    expect(kclManager.operationsByModule).toBe(finalExecState.operations)
+    expect(dispatchSpy).not.toHaveBeenCalledWith([ignoredLiveOperation])
+    expect(dispatchSpy).toHaveBeenLastCalledWith([authoritativeOperation])
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Live operation updates failed')
+    )
+    consoleErrorSpy.mockRestore()
+  })
 })
 
 describe('KclManager diagnostics', () => {

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -1191,30 +1191,50 @@ export class KclManager extends File {
   }
 
   private createExecutionCallbacks(executionId: number): ExecCallbacks {
+    let liveOperationUpdatesFailed = false
+
     return {
       onOperation: (callback: OperationCallbackArgs) => {
-        if (
-          this.activeLiveOperationExecutionId !== executionId ||
-          this._cancelTokens.get(executionId)
-        ) {
-          return
+        try {
+          if (
+            liveOperationUpdatesFailed ||
+            this.activeLiveOperationExecutionId !== executionId ||
+            this._cancelTokens.get(executionId)
+          ) {
+            return
+          }
+
+          this._liveActiveModuleId.value = callback.moduleId
+          this._liveLatestOperationKey.value = getOperationKey(
+            callback.operation
+          )
+
+          const operationsByModule = applyOperationCallbackToOperationsByModule(
+            {
+              operationsByModule: this._liveOperationsByModule.value,
+              callback,
+            }
+          )
+          this._liveOperationsByModule.value = operationsByModule
+          this.dispatchUpdateOperations(
+            getOperationsForCurrentFile({
+              operationsByModule,
+              filenames: this.execState.filenames,
+              currentPath: this.path,
+            })
+          )
+        } catch (error) {
+          // An exception escaping into WASM can strand its async execution.
+          // Stop progressive updates for this run and let finalization continue.
+          liveOperationUpdatesFailed = true
+          const message =
+            error instanceof Error
+              ? (error.stack ?? error.message)
+              : String(error)
+          queueMicrotask(() =>
+            reportRejection(`Live operation updates failed: ${message}`)
+          )
         }
-
-        this._liveActiveModuleId.value = callback.moduleId
-        this._liveLatestOperationKey.value = getOperationKey(callback.operation)
-
-        const operationsByModule = applyOperationCallbackToOperationsByModule({
-          operationsByModule: this._liveOperationsByModule.value,
-          callback,
-        })
-        this._liveOperationsByModule.value = operationsByModule
-        this.dispatchUpdateOperations(
-          getOperationsForCurrentFile({
-            operationsByModule,
-            filenames: this.execState.filenames,
-            currentPath: this.path,
-          })
-        )
       },
     }
   }


### PR DESCRIPTION
Fixes #12676. Replaces #12686. Context: https://kittycadworkspace.slack.com/archives/C07A80B83FS/p1787064014282039

Instead of changing the way onOperation callbacks work, this focuses on fixing the core issues:
1. React subscription hell with liveLatestOperationKey leading to https://react.dev/errors/185; and
2. the WASM callback hanging on the React exception.

Today, 2 can happen if 1 happens. This PR addresses both. 