### PR TITLE
Back off cloud sync retries

### DIFF
--- a/src/lib/cloudSync/cloudApi.spec.ts
+++ b/src/lib/cloudSync/cloudApi.spec.ts
@@ -1,5 +1,7 @@
 import {
+  type CloudApiError,
   getRemoteProjectThumbnailUrl,
+  listRemoteProjects,
   normalizeRemoteProjectThumbnailUrl,
   remoteProjectThumbnailTargetPathFromUrl,
   thumbnailUrlFromRemoteProjectPayload,
@@ -85,5 +87,30 @@ describe('remote project thumbnail URLs', () => {
     expect((requestInit?.headers as Headers).get('Authorization')).toBe(
       'Bearer token-123'
     )
+  })
+
+  test('preserves retry-after delays on API failures', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => {
+      return new Response(JSON.stringify({ message: 'Too many requests' }), {
+        status: 429,
+        statusText: 'Too Many Requests',
+        headers: {
+          'content-type': 'application/json',
+          'retry-after': '7',
+        },
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      listRemoteProjects({
+        enabled: true,
+        baseUrl: 'https://api.dev.zoo.dev',
+      })
+    ).rejects.toMatchObject({
+      status: 429,
+      message: 'Too many requests',
+      retryAfterMs: 7000,
+    } satisfies Partial<CloudApiError>)
   })
 })

--- a/src/lib/cloudSync/cloudApi.ts
+++ b/src/lib/cloudSync/cloudApi.ts
@@ -4,7 +4,6 @@ import {
   prepareProjectFilesForCloudUpload,
   toArrayBuffer,
 } from '@src/lib/cloudSync/projectArchive'
-import { fetchWithSessionExpiration } from '@src/lib/sessionExpired'
 import type {
   CloudSyncConfig,
   ProjectArchiveFile,
@@ -12,15 +11,40 @@ import type {
   RemoteProjectSummary,
   Revision,
 } from '@src/lib/cloudSync/types'
+import { fetchWithSessionExpiration } from '@src/lib/sessionExpired'
 import { isArray } from '@src/lib/utils'
 
 export class CloudApiError extends Error {
   status: number
+  retryAfterMs?: number
 
-  constructor(status: number, message: string) {
+  constructor(
+    status: number,
+    message: string,
+    options: { retryAfterMs?: number } = {}
+  ) {
     super(message)
     this.status = status
+    this.retryAfterMs = options.retryAfterMs
   }
+}
+
+function retryAfterDelayMs(value: string | null) {
+  if (!value?.trim()) {
+    return undefined
+  }
+
+  const numericSeconds = Number(value)
+  if (Number.isFinite(numericSeconds) && numericSeconds >= 0) {
+    return numericSeconds * 1000
+  }
+
+  const retryAtMs = Date.parse(value)
+  if (Number.isNaN(retryAtMs)) {
+    return undefined
+  }
+
+  return Math.max(0, retryAtMs - Date.now())
 }
 
 function getBaseUrl(config: CloudSyncConfig) {
@@ -67,7 +91,9 @@ async function cloudFetch(
     }
 
     // eslint-disable-next-line suggest-no-throw/suggest-no-throw
-    throw new CloudApiError(response.status, message)
+    throw new CloudApiError(response.status, message, {
+      retryAfterMs: retryAfterDelayMs(response.headers.get('Retry-After')),
+    })
   }
 
   return response

--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -134,6 +134,7 @@ export function isCloudSyncConflictRevisionChangedError(error: unknown) {
 
 const SYNC_DEBOUNCE_MS = 2500
 const SYNC_RETRY_MS = 30_000
+const SYNC_RETRY_MAX_MS = 5 * 60 * 1000
 const REMOTE_INDEX_INTERVAL_MS = 5 * 60 * 1000
 const REMOTE_UPLOAD_FORBIDDEN_MESSAGE =
   'Cloud sync cannot upload local changes because this account does not have edit access to the linked cloud project. Local changes are safe on this device.'
@@ -145,6 +146,7 @@ let config: CloudSyncConfig = {
 }
 let syncTimer: ReturnType<typeof setTimeout> | undefined
 let syncInProgress = false
+let syncRetryAttempt = 0
 let lastRemoteIndexSyncAt = 0
 let initialLocalScanComplete = false
 let pendingStatusSyncedAt: string | undefined
@@ -195,10 +197,15 @@ function projectFailureKind(error: unknown) {
 
 function projectFailureError(
   kind: ProjectSyncFailureKind,
-  message: string
-): Error & { kind: ProjectSyncFailureKind } {
-  const error = new Error(message) as Error & { kind: ProjectSyncFailureKind }
+  message: string,
+  options: { retryAfterMs?: number } = {}
+): Error & { kind: ProjectSyncFailureKind; retryAfterMs?: number } {
+  const error = new Error(message) as Error & {
+    kind: ProjectSyncFailureKind
+    retryAfterMs?: number
+  }
   error.kind = kind
+  error.retryAfterMs = options.retryAfterMs
   return error
 }
 
@@ -206,13 +213,75 @@ function remoteUploadFailureFromError(error: unknown) {
   return error instanceof CloudApiError && error.status === 403
     ? projectFailureError(
         'remote-upload-forbidden',
-        REMOTE_UPLOAD_FORBIDDEN_MESSAGE
+        REMOTE_UPLOAD_FORBIDDEN_MESSAGE,
+        { retryAfterMs: error.retryAfterMs }
       )
     : error
 }
 
 function rejectRemoteUploadFailure(error: unknown): Promise<never> {
   return Promise.reject(remoteUploadFailureFromError(error))
+}
+
+function cloudApiRetryAfterMs(error: unknown): number | undefined {
+  if (error instanceof CloudApiError) {
+    return error.retryAfterMs
+  }
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'retryAfterMs' in error &&
+    typeof error.retryAfterMs === 'number'
+  ) {
+    return error.retryAfterMs
+  }
+  if (error instanceof Error && error.cause !== undefined) {
+    return cloudApiRetryAfterMs(error.cause)
+  }
+  return undefined
+}
+
+export function getCloudSyncRetryDelayMs({
+  attempt,
+  retryAfterMs,
+}: {
+  attempt: number
+  retryAfterMs?: number
+}) {
+  const normalizedAttempt = Math.max(0, Math.floor(attempt))
+  const exponentialDelay = Math.min(
+    SYNC_RETRY_MAX_MS,
+    SYNC_RETRY_MS * 2 ** normalizedAttempt
+  )
+
+  return Math.max(exponentialDelay, retryAfterMs ?? 0)
+}
+
+function nextSyncRetryDelayMs(error: unknown) {
+  const retryDelay = getCloudSyncRetryDelayMs({
+    attempt: syncRetryAttempt,
+    retryAfterMs: cloudApiRetryAfterMs(error),
+  })
+  syncRetryAttempt =
+    retryDelay >= SYNC_RETRY_MAX_MS ? syncRetryAttempt : syncRetryAttempt + 1
+
+  return retryDelay
+}
+
+function resetSyncRetryBackoff() {
+  syncRetryAttempt = 0
+}
+
+export function shouldScheduleCloudSyncPendingWork({
+  pendingCount,
+  state,
+  failureRetryScheduled,
+}: {
+  pendingCount: number
+  state: CloudSyncStatus['state']
+  failureRetryScheduled: boolean
+}) {
+  return pendingCount > 0 && state !== 'conflict' && !failureRetryScheduled
 }
 
 export function getCloudSyncProjectRootInDirectory(
@@ -2002,7 +2071,7 @@ function markCloudMetadataFailure(error: unknown) {
     lastFailure: errorMessage(error),
     lastFailureAt: nowIso(),
   })
-  scheduleSync(SYNC_RETRY_MS)
+  scheduleSyncFailureRetry(error)
 }
 
 async function markProjectSynced(
@@ -3224,6 +3293,8 @@ async function runCloudSync() {
     : undefined
   let remoteIndexFailed = false
   let remoteIndexFailureMessage: string | undefined
+  let remoteIndexFailure: unknown
+  let failureRetryScheduled = false
 
   try {
     let entries = await getAllOutboxEntries()
@@ -3234,6 +3305,7 @@ async function runCloudSync() {
       await syncRemoteIndex().catch((error) => {
         remoteIndexFailed = true
         remoteIndexFailureMessage = errorMessage(error)
+        remoteIndexFailure = error
         reportCloudSyncFailure('remote-index', error)
         updateStatus({
           state: 'failed',
@@ -3266,8 +3338,12 @@ async function runCloudSync() {
         lastFailureAt: nowIso(),
         ...(syncedAt ? { lastSyncedAt: syncedAt } : {}),
       })
-      scheduleSync(SYNC_RETRY_MS)
+      scheduleSyncFailureRetry(
+        remoteIndexFailure ?? new Error(remoteIndexFailureMessage)
+      )
+      failureRetryScheduled = true
     } else if (cloudSyncStatus.value.state !== 'conflict') {
+      resetSyncRetryBackoff()
       updateStatus({
         state: 'idle',
         activeProjectPath: undefined,
@@ -3281,8 +3357,11 @@ async function runCloudSync() {
       })
     }
     if (
-      cloudSyncStatus.value.pendingCount > 0 &&
-      cloudSyncStatus.value.state !== 'conflict'
+      shouldScheduleCloudSyncPendingWork({
+        pendingCount: cloudSyncStatus.value.pendingCount,
+        state: cloudSyncStatus.value.state,
+        failureRetryScheduled,
+      })
     ) {
       scheduleSync(SYNC_DEBOUNCE_MS)
     }
@@ -3298,13 +3377,17 @@ async function runCloudSync() {
       activeProjectPath: scopedScope?.syncable ? scopedProjectPath : undefined,
       ...(syncedAt ? { lastSyncedAt: syncedAt } : {}),
     })
-    scheduleSync(SYNC_RETRY_MS)
+    scheduleSyncFailureRetry(error)
+    failureRetryScheduled = true
   } finally {
     syncInProgress = false
     pendingStatusSyncedAt = undefined
     if (
-      cloudSyncStatus.value.pendingCount > 0 &&
-      cloudSyncStatus.value.state !== 'conflict'
+      shouldScheduleCloudSyncPendingWork({
+        pendingCount: cloudSyncStatus.value.pendingCount,
+        state: cloudSyncStatus.value.state,
+        failureRetryScheduled,
+      })
     ) {
       scheduleSync(SYNC_DEBOUNCE_MS)
     }
@@ -3315,6 +3398,7 @@ function scheduleSync(delay = SYNC_DEBOUNCE_MS) {
   if (!isConfiguredForCloud()) {
     return
   }
+
   if (syncTimer) {
     clearTimeout(syncTimer)
   }
@@ -3323,6 +3407,10 @@ function scheduleSync(delay = SYNC_DEBOUNCE_MS) {
     syncTimer = undefined
     void runCloudSync()
   }, delay)
+}
+
+function scheduleSyncFailureRetry(error: unknown) {
+  scheduleSync(nextSyncRetryDelayMs(error))
 }
 
 function scheduleRemoteIndexSync(delay = 0) {
@@ -3773,6 +3861,7 @@ export function configureCloudSyncEngine(nextConfig: CloudSyncConfig) {
   ) {
     lastRemoteIndexSyncAt = 0
     initialLocalScanComplete = false
+    resetSyncRetryBackoff()
   }
 
   if (!config.enabled) {
@@ -3783,6 +3872,7 @@ export function configureCloudSyncEngine(nextConfig: CloudSyncConfig) {
     detachVisibilityChangeListener?.()
     initialLocalScanComplete = false
     lastRemoteIndexSyncAt = 0
+    resetSyncRetryBackoff()
     cloudSyncRemoteProjects.value = []
     updateStatus({
       enabled: false,
@@ -3828,10 +3918,11 @@ export function configureCloudSyncEngine(nextConfig: CloudSyncConfig) {
 }
 
 export function retryCloudSyncEngine() {
+  resetSyncRetryBackoff()
   if (syncScopeProjectPath) {
     scheduleSync(0)
     return
   }
 
-  scheduleRemoteIndexSync()
+  scheduleRemoteIndexSync(0)
 }

--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -133,7 +133,7 @@ export function isCloudSyncConflictRevisionChangedError(error: unknown) {
 }
 
 const SYNC_DEBOUNCE_MS = 2500
-const SYNC_RETRY_MS = 30_000
+const SYNC_RETRY_MS = 10_000
 const SYNC_RETRY_MAX_MS = 5 * 60 * 1000
 const REMOTE_INDEX_INTERVAL_MS = 5 * 60 * 1000
 const REMOTE_UPLOAD_FORBIDDEN_MESSAGE =

--- a/src/lib/cloudSync/index.test.ts
+++ b/src/lib/cloudSync/index.test.ts
@@ -844,9 +844,9 @@ describe('cloudSync sync helpers', () => {
   })
 
   it('backs off sync retries exponentially and respects longer retry-after delays', () => {
-    expect(getCloudSyncRetryDelayMs({ attempt: 0 })).toBe(30_000)
-    expect(getCloudSyncRetryDelayMs({ attempt: 1 })).toBe(60_000)
-    expect(getCloudSyncRetryDelayMs({ attempt: 2 })).toBe(120_000)
+    expect(getCloudSyncRetryDelayMs({ attempt: 0 })).toBe(10_000)
+    expect(getCloudSyncRetryDelayMs({ attempt: 1 })).toBe(20_000)
+    expect(getCloudSyncRetryDelayMs({ attempt: 2 })).toBe(40_000)
     expect(getCloudSyncRetryDelayMs({ attempt: 10 })).toBe(5 * 60 * 1000)
     expect(
       getCloudSyncRetryDelayMs({

--- a/src/lib/cloudSync/index.test.ts
+++ b/src/lib/cloudSync/index.test.ts
@@ -10,6 +10,7 @@ import {
   getCloudSyncProjectSyncPreflightAction,
   getCloudSyncRemoteArchiveReconciliationAction,
   getCloudSyncRemoteIndexAction,
+  getCloudSyncRetryDelayMs,
   getCloudSyncScopePlan,
   type OutboxEntry,
   type ProjectArchiveFile,
@@ -17,6 +18,7 @@ import {
   prepareProjectFilesForCloudUpload,
   projectManifestsEqual,
   shouldAutoEnrollCloudLibraryProject,
+  shouldScheduleCloudSyncPendingWork,
 } from '@src/lib/cloudSync'
 import {
   getCloudProjectLibraryMaterializationDirectoryPath,
@@ -839,5 +841,44 @@ describe('cloudSync sync helpers', () => {
         hasBaseManifest: true,
       })
     ).toBe(true)
+  })
+
+  it('backs off sync retries exponentially and respects longer retry-after delays', () => {
+    expect(getCloudSyncRetryDelayMs({ attempt: 0 })).toBe(30_000)
+    expect(getCloudSyncRetryDelayMs({ attempt: 1 })).toBe(60_000)
+    expect(getCloudSyncRetryDelayMs({ attempt: 2 })).toBe(120_000)
+    expect(getCloudSyncRetryDelayMs({ attempt: 10 })).toBe(5 * 60 * 1000)
+    expect(
+      getCloudSyncRetryDelayMs({
+        attempt: 0,
+        retryAfterMs: 45_000,
+      })
+    ).toBe(45_000)
+  })
+
+  it('does not schedule normal pending-work debounce after a retry is scheduled', () => {
+    expect(
+      shouldScheduleCloudSyncPendingWork({
+        pendingCount: 1,
+        state: 'failed',
+        failureRetryScheduled: true,
+      })
+    ).toBe(false)
+
+    expect(
+      shouldScheduleCloudSyncPendingWork({
+        pendingCount: 1,
+        state: 'idle',
+        failureRetryScheduled: false,
+      })
+    ).toBe(true)
+
+    expect(
+      shouldScheduleCloudSyncPendingWork({
+        pendingCount: 1,
+        state: 'conflict',
+        failureRetryScheduled: false,
+      })
+    ).toBe(false)
   })
 })


### PR DESCRIPTION
Closes #13065. Cloud sync failures were scheduling the retry path, then immediately replacing that timer with the normal pending-work debounce because failed uploads intentionally leave their outbox entries queued. This changes failed cloud sync runs to keep the failure retry cadence, back off repeated failures, and honor `Retry-After` when the API or edge returns it.

We exponentially back off starting from `10s` and squaring until we hit a max of `5min` for these retries. The `2.5s` debounce timer for normal pending work still remains, and users with a ton of pending edits can still hit the API pretty hard when they open the app for the first time (this I'll address in a follow-up PR), but now the app will honor the retry timeout and fallback to a sane exponential backoff regardless.

Kinda hard to test since @iterion fixed up the API side of this problem 😅 .