### PR TITLE
Document consumed solids in boolean operations

### DIFF
--- a/docs/kcl-std/functions/std-solid-intersect.md
+++ b/docs/kcl-std/functions/std-solid-intersect.md
@@ -20,11 +20,16 @@ returning a new solid representing the volume that is common to all input
 solids. This operation is useful for determining shared material regions,
 verifying fit, and analyzing overlapping geometries in assemblies.
 
+This operation consumes every input solid. After it succeeds, the original
+solid variables cannot be used in another modeling operation. Assign the
+returned solid or solids to a new variable and use that result for any
+subsequent operations.
+
 ### Arguments
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `solids` | [[`Solid`](/docs/kcl-std/types/std-types-Solid); 2+] | The solids to intersect. | Yes |
+| `solids` | [[`Solid`](/docs/kcl-std/types/std-types-Solid); 2+] | The solids to intersect. Every input solid is consumed by this operation. | Yes |
 | `tolerance` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | Defines the smallest distance below which two entities are considered coincident, intersecting, coplanar, or similar. For most use cases, it should not be changed from its default value of 10^-7 millimeters. | No |
 | `legacyMethod` | [`bool`](/docs/kcl-std/types/std-types-bool) | **Deprecated as of KCL 2.0.** You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
 

--- a/docs/kcl-std/functions/std-solid-subtract.md
+++ b/docs/kcl-std/functions/std-solid-subtract.md
@@ -22,12 +22,18 @@ representing the material that remains after all tool solids have been cut
 away. This function is essential for machining simulations, cavity creation,
 and complex multi-body part modeling.
 
+This operation consumes both the base solids and the tool solids. After it
+succeeds, neither set of original variables can be used in another modeling
+operation. Assign the returned solid or solids to a new variable and use that
+result for subsequent operations. For multiple cuts, pass each `subtract`
+result into the next call instead of reusing the original base solid.
+
 ### Arguments
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `solids` | [[`Solid`](/docs/kcl-std/types/std-types-Solid); 1+] | The solids to use as the base to subtract from. | Yes |
-| `tools` | [[`Solid`](/docs/kcl-std/types/std-types-Solid)] | The solids to subtract. | Yes |
+| `solids` | [[`Solid`](/docs/kcl-std/types/std-types-Solid); 1+] | The solids to use as the base to subtract from. These solids are consumed by this operation. | Yes |
+| `tools` | [[`Solid`](/docs/kcl-std/types/std-types-Solid)] | The solids to subtract. These tool solids are also consumed by this operation. | Yes |
 | `tolerance` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | Defines the smallest distance below which two entities are considered coincident, intersecting, coplanar, or similar. For most use cases, it should not be changed from its default value of 10^-7 millimeters. | No |
 | `legacyMethod` | [`bool`](/docs/kcl-std/types/std-types-bool) | **Deprecated as of KCL 2.0.** You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
 

--- a/docs/kcl-std/functions/std-solid-union.md
+++ b/docs/kcl-std/functions/std-solid-union.md
@@ -15,13 +15,16 @@ union(
 ): [Solid; 1+]
 ```
 
-
+This operation consumes every input solid. After it succeeds, the original
+solid variables cannot be used in another modeling operation. Assign the
+returned solid or solids to a new variable and use that result for any
+subsequent operations.
 
 ### Arguments
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `solids` | [[`Solid`](/docs/kcl-std/types/std-types-Solid); 2+] | The solids to union. | Yes |
+| `solids` | [[`Solid`](/docs/kcl-std/types/std-types-Solid); 2+] | The solids to union. Every input solid is consumed by this operation. | Yes |
 | `tolerance` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | Defines the smallest distance below which two entities are considered coincident, intersecting, coplanar, or similar. For most use cases, it should not be changed from its default value of 10^-7 millimeters. | No |
 | `legacyMethod` | [`bool`](/docs/kcl-std/types/std-types-bool) | **Deprecated as of KCL 2.0.** You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
 

--- a/rust/kcl-lib/expected-bindings/ts-rs/StdLibCommands.ts
+++ b/rust/kcl-lib/expected-bindings/ts-rs/StdLibCommands.ts
@@ -4796,7 +4796,7 @@ export default {
       {
         "name": "solids",
         "ty": "[Solid; 2+]",
-        "docs": "The solids to intersect.",
+        "docs": "The solids to intersect. Every input solid is consumed by this operation.",
         "required": true,
         "special": true,
         "experimental": false,
@@ -8239,7 +8239,7 @@ export default {
       {
         "name": "solids",
         "ty": "[Solid; 1+]",
-        "docs": "The solids to use as the base to subtract from.",
+        "docs": "The solids to use as the base to subtract from. These solids are consumed by this operation.",
         "required": true,
         "special": true,
         "experimental": false,
@@ -8249,7 +8249,7 @@ export default {
       {
         "name": "tools",
         "ty": "[Solid]",
-        "docs": "The solids to subtract.",
+        "docs": "The solids to subtract. These tool solids are also consumed by this operation.",
         "required": true,
         "special": false,
         "experimental": false,
@@ -8650,7 +8650,7 @@ export default {
       {
         "name": "solids",
         "ty": "[Solid; 2+]",
-        "docs": "The solids to union.",
+        "docs": "The solids to union. Every input solid is consumed by this operation.",
         "required": true,
         "special": true,
         "experimental": false,

--- a/rust/kcl-lib/std/solid.kcl
+++ b/rust/kcl-lib/std/solid.kcl
@@ -1030,6 +1030,11 @@ export fn patternCircular3d(
 
 /// Union two or more solids into a single solid.
 ///
+/// This operation consumes every input solid. After it succeeds, the original
+/// solid variables cannot be used in another modeling operation. Assign the
+/// returned solid or solids to a new variable and use that result for any
+/// subsequent operations.
+///
 /// ```kcl,legacySketch
 /// // Union two cubes using the stdlib functions.
 ///
@@ -1099,7 +1104,7 @@ export fn patternCircular3d(
 /// ```
 @(impl = std_rust, feature_tree = true)
 export fn union(
-  /// The solids to union.
+  /// The solids to union. Every input solid is consumed by this operation.
   @solids: [Solid; 2+],
   /// Defines the smallest distance below which two entities are considered coincident, intersecting, coplanar, or similar. For most use cases, it should not be changed from its default value of 10^-7 millimeters.
   tolerance?: number(Length),
@@ -1117,6 +1122,11 @@ export fn union(
 /// returning a new solid representing the volume that is common to all input
 /// solids. This operation is useful for determining shared material regions,
 /// verifying fit, and analyzing overlapping geometries in assemblies.
+///
+/// This operation consumes every input solid. After it succeeds, the original
+/// solid variables cannot be used in another modeling operation. Assign the
+/// returned solid or solids to a new variable and use that result for any
+/// subsequent operations.
 ///
 /// ```kcl,legacySketch
 /// // Intersect two cubes using the stdlib functions.
@@ -1162,7 +1172,7 @@ export fn union(
 /// ```
 @(impl = std_rust, feature_tree = true)
 export fn intersect(
-  /// The solids to intersect.
+  /// The solids to intersect. Every input solid is consumed by this operation.
   @solids: [Solid; 2+],
   /// Defines the smallest distance below which two entities are considered coincident, intersecting, coplanar, or similar. For most use cases, it should not be changed from its default value of 10^-7 millimeters.
   tolerance?: number(Length),
@@ -1180,6 +1190,12 @@ export fn intersect(
 /// representing the material that remains after all tool solids have been cut
 /// away. This function is essential for machining simulations, cavity creation,
 /// and complex multi-body part modeling.
+///
+/// This operation consumes both the base solids and the tool solids. After it
+/// succeeds, neither set of original variables can be used in another modeling
+/// operation. Assign the returned solid or solids to a new variable and use that
+/// result for subsequent operations. For multiple cuts, pass each `subtract`
+/// result into the next call instead of reusing the original base solid.
 ///
 /// ```kcl,legacySketch
 /// // Subtract a cylinder from a cube using the stdlib functions.
@@ -1320,9 +1336,9 @@ export fn intersect(
 /// ```
 @(impl = std_rust, feature_tree = true)
 export fn subtract(
-  /// The solids to use as the base to subtract from.
+  /// The solids to use as the base to subtract from. These solids are consumed by this operation.
   @solids: [Solid; 1+],
-  /// The solids to subtract.
+  /// The solids to subtract. These tool solids are also consumed by this operation.
   tools: [Solid],
   /// Defines the smallest distance below which two entities are considered coincident, intersecting, coplanar, or similar. For most use cases, it should not be changed from its default value of 10^-7 millimeters.
   tolerance?: number(Length),


### PR DESCRIPTION
## Summary

- document that `union` and `intersect` consume every input solid
- document that `subtract` consumes both its base solids and tool solids
- explain that subsequent boolean operations must use the returned result instead of reusing an original solid
- regenerate the checked-in stdlib reference pages from the Rust-owned KCL docstrings

## Why

Mock execution correctly reports a semantic error when KCL reuses a solid that a prior boolean operation consumed, but the searchable `union`, `intersect`, and `subtract` reference pages did not explain that ownership rule. As a result, documentation retrieval could return the relevant function page without giving Zookeeper the guidance needed to avoid or repair the error.

This is documentation-only; it makes the existing runtime behavior explicit and retrievable.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo nextest run --retries 0 -p kcl-lib --features artifact-graph docs::gen_std_tests::test_generate_stdlib_markdown_docs`
- `git diff --check`