### PR TITLE
Document how to avoid circular KCL imports

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -48,16 +48,31 @@ jobs:
           branch: main
           path: rust/kcl-wasm-lib/pkg
 
+      - name: Validate Wasm cache
+        id: validate-wasm
+        if: ${{ steps.download-wasm.outcome == 'success' }}
+        shell: bash
+        run: |
+          expected_rust_tree=$(git rev-parse HEAD:rust)
+          cached_rust_tree=$(cat rust/kcl-wasm-lib/pkg/kcl_wasm_lib.rust-tree 2>/dev/null || true)
+
+          if [[ "${cached_rust_tree}" == "${expected_rust_tree}" ]]; then
+            echo "valid=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+            echo "Cached Wasm was built from a different Rust tree; rebuilding."
+          fi
+
       - name: Build Wasm condition
         id: wasm
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
-          DOWNLOAD_OUTCOME: ${{ steps.download-wasm.outcome }}
+          CACHE_VALID: ${{ steps.validate-wasm.outputs.valid || 'false' }}
           RUST_CHANGES: ${{ steps.filter.outputs.rust || 'false' }}
         run: |
-          # Build Wasm with Rust changes, cache misses, or for stacked PRs
+          # Build Wasm with Rust changes, stale/missing caches, or for stacked PRs
           if [[ "${RUST_CHANGES}" == 'true' || \
-                "${DOWNLOAD_OUTCOME}" == 'failure' || \
+                "${CACHE_VALID}" != 'true' || \
                 ( -n "${BASE_REF}" && "${BASE_REF}" != 'main' ) ]]; then
             echo "should-build-wasm=true" >> $GITHUB_OUTPUT
           else
@@ -98,6 +113,10 @@ jobs:
         shell: bash
         run: |
           cp -R rust/kcl-lib/expected-bindings/ts-rs rust/kcl-lib/bindings
+
+      - name: Record Wasm Rust tree
+        shell: bash
+        run: git rev-parse HEAD:rust > rust/kcl-wasm-lib/pkg/kcl_wasm_lib.rust-tree
 
       - name: Copy Wasm to public
         run: |

--- a/docs/kcl-lang/modules.md
+++ b/docs/kcl-lang/modules.md
@@ -105,7 +105,7 @@ import makeWheel from "wheel.kcl"
 wheel = makeWheel()
 ```
 
-For larger projects, keep dependencies flowing in one direction:
+For all projects, keep dependencies flowing in one direction:
 
 1. Parameter modules import nothing.
 2. Utility modules may import parameters.

--- a/docs/kcl-lang/modules.md
+++ b/docs/kcl-lang/modules.md
@@ -55,6 +55,67 @@ Imported symbols can be renamed for convenience or to avoid name collisions.
 import increment as inc, decrement as dec from "util.kcl"
 ```
 
+## Avoid circular imports
+
+Imports between local KCL files must form an acyclic dependency graph: following
+the imports from one file must never lead back to that file. KCL cannot execute
+a project with a circular import.
+
+For example, this project has a circular import because `main.kcl` imports
+`wheel.kcl`, which imports `main.kcl`:
+
+```norun
+// main.kcl
+import makeWheel from "wheel.kcl"
+
+export wheelDiameter = 20mm
+wheel = makeWheel()
+
+// wheel.kcl
+import wheelDiameter from "main.kcl"
+
+export fn makeWheel() {
+  return wheelDiameter
+}
+```
+
+Executing this project reports a `circular import of modules is not allowed`
+error. Re-exports can create the same problem if they lead back to an earlier
+module.
+
+To break a cycle, move shared values and functions into a dependency-only file
+that does not import its consumers. Both of the original files can then import
+the shared dependency:
+
+```norun
+// parameters.kcl
+export wheelDiameter = 20mm
+
+// wheel.kcl
+import wheelDiameter from "parameters.kcl"
+
+export fn makeWheel() {
+  return wheelDiameter
+}
+
+// main.kcl
+import wheelDiameter from "parameters.kcl"
+import makeWheel from "wheel.kcl"
+
+wheel = makeWheel()
+```
+
+For larger projects, keep dependencies flowing in one direction:
+
+1. Parameter modules import nothing.
+2. Utility modules may import parameters.
+3. Part modules may import parameters and utilities.
+4. Assembly files and `main.kcl` may import parts.
+
+Part, utility, and parameter modules should not import `main.kcl`. If two files
+need the same definition, extract it into a lower-level shared module instead of
+making the files import each other.
+
 ## Subdirectories
 
 You can import files from the current directory or from subdirectories, but if importing from a


### PR DESCRIPTION
## Summary

- state that local KCL imports must form an acyclic dependency graph
- add a minimal two-file circular-import example and the resulting error
- show how to break the cycle by extracting shared definitions into a dependency-only `parameters.kcl` module
- recommend a one-way project hierarchy from parameters and utilities through parts to `main.kcl`
- validate downloaded WASM artifacts against the exact `rust/` source tree so stale bindings are rebuilt instead of reused

## Why

The module reference explains import/export syntax and encourages splitting projects into modules for parallel execution, but it never says that circular imports are invalid or shows how to repair one.

A production trace review found 880 circular-import failures across 456 traces. The repeated failures indicate that agents often detect the cycle but lack actionable guidance for restructuring the project. This page is part of the KCL documentation corpus used by Zookeeper, so placing the rule and repair pattern here makes it available during both code generation and error recovery.

The first CI run also exposed an independent cache-validity bug: app builds reused a June 30 WASM artifact that predates the current `set_kcl_runtime_flags` export. The cache now carries the source-tree ID it was built from and is rejected when that ID is missing or differs, preventing docs-only changes from compiling against obsolete generated bindings.

## Validation

- verified the documented bad example fails mock execution with `KCL ImportCycle error`
- verified the extracted `parameters.kcl` example mock-executes successfully
- parsed `.github/workflows/build-wasm.yml` as YAML
- exercised the missing-marker path and verified it selects a rebuild
- `git diff --check`
