### PR TITLE
Preserve imported-module errors and backtraces

### DIFF
--- a/rust/kcl-error/src/error.rs
+++ b/rust/kcl-error/src/error.rs
@@ -362,6 +362,46 @@ impl KclError {
 
         new
     }
+
+    /// Add the statement that imported the module containing this error.
+    ///
+    /// Import locations are prepended so the original, deepest source range
+    /// remains last. KCL's diagnostic renderer treats the last source range as
+    /// primary and renders the preceding ranges as related context.
+    pub fn add_import_location(&self, import_name: String, source_range: SourceRange) -> Self {
+        let mut new = self.clone();
+        match &mut new {
+            KclError::Lexical { details: e }
+            | KclError::Syntax { details: e }
+            | KclError::Semantic { details: e }
+            | KclError::ImportCycle { details: e }
+            | KclError::Argument { details: e }
+            | KclError::Type { details: e }
+            | KclError::UserDefined { details: e }
+            | KclError::Io { details: e }
+            | KclError::Unexpected { details: e }
+            | KclError::ValueAlreadyDefined { details: e }
+            | KclError::UndefinedValue { details: e, .. }
+            | KclError::InvalidExpression { details: e }
+            | KclError::MaxCallStack { details: e }
+            | KclError::Refactor { details: e }
+            | KclError::Engine { details: e }
+            | KclError::EngineHangup { details: e, .. }
+            | KclError::EngineInternal { details: e }
+            | KclError::Internal { details: e } => {
+                e.backtrace.insert(
+                    0,
+                    BacktraceItem {
+                        source_range,
+                        fn_name: Some(import_name),
+                    },
+                );
+                e.source_ranges.insert(0, source_range);
+            }
+        }
+
+        new
+    }
 }
 
 #[derive(

--- a/rust/kcl-lib/src/errors.rs
+++ b/rust/kcl-lib/src/errors.rs
@@ -399,11 +399,17 @@ impl miette::Diagnostic for ReportWithOutputs {
     }
 
     fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
+        // Source ranges can span modules when an imported module fails. This
+        // report's source text belongs to the deepest (last) range, so only
+        // render labels from that module here; the other modules are emitted as
+        // related reports below.
+        let primary_module_id = self.error.error.source_ranges().last().map(|range| range.module_id());
         let iter = self
             .error
             .error
             .source_ranges()
             .into_iter()
+            .filter(move |range| Some(range.module_id()) == primary_module_id)
             .map(miette::SourceSpan::from)
             .map(|span| miette::LabeledSpan::new_with_span(Some(self.filename.to_string()), span));
         Some(Box::new(iter))

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -1826,6 +1826,14 @@ impl ExecutorContext {
             .await;
         exec_state.global.mod_loader.leave_module(path, source_range)?;
 
+        let import_name = match path {
+            ModulePath::Local {
+                original_import_path: Some(original),
+                ..
+            } => original.to_string(),
+            _ => path.to_string(),
+        };
+
         // TODO: ModuleArtifactState is getting dropped here when there's an
         // error.  Should we propagate it for non-root modules?
         result.map_err(|(err, _, _)| {
@@ -1837,12 +1845,12 @@ impl ExecutorContext {
                 KclError::EngineHangup { .. } | KclError::EngineInternal { .. } => {
                     // Propagate this type of error. It's likely a transient
                     // error that just needs to be retried.
-                    err.override_source_ranges(vec![source_range])
+                    err.add_import_location(format!("import {import_name}"), source_range)
                 }
                 // The module loaded successfully, so preserve execution errors
                 // exactly as they occurred inside it. Rewrapping them here loses
                 // the error kind, structured fields, and imported-file location.
-                _ => err,
+                _ => err.add_import_location(format!("import {import_name}"), source_range),
             }
         })
     }

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -1839,16 +1839,10 @@ impl ExecutorContext {
                     // error that just needs to be retried.
                     err.override_source_ranges(vec![source_range])
                 }
-                _ => {
-                    // TODO would be great to have line/column for the underlying error here
-                    KclError::new_semantic(KclErrorDetails::new(
-                        format!(
-                            "Error loading imported file ({path}). Open it to view more details.\n  {}",
-                            err.message()
-                        ),
-                        vec![source_range],
-                    ))
-                }
+                // The module loaded successfully, so preserve execution errors
+                // exactly as they occurred inside it. Rewrapping them here loses
+                // the error kind, structured fields, and imported-file location.
+                _ => err,
             }
         })
     }

--- a/rust/kcl-lib/src/execution/import_graph.rs
+++ b/rust/kcl-lib/src/execution/import_graph.rs
@@ -30,6 +30,39 @@ pub(crate) type DependencyInfo = (AstNode<ImportStatement>, ModuleId, ModulePath
 pub(crate) type UniverseMap = HashMap<TypedPath, AstNode<ImportStatement>>;
 pub(crate) type Universe = HashMap<String, DependencyInfo>;
 
+/// Add the ancestor import statements between `module_id` and the root module
+/// to an error raised while eagerly executing that module.
+///
+/// Imported modules are executed in dependency order, so a leaf can fail
+/// before its parents execute and naturally unwind. The universe still holds
+/// each module's importing statement, which lets us reconstruct that chain.
+/// `exec_module_from_ast` already adds the immediate import site, so this starts
+/// with its parent.
+pub(crate) fn add_import_backtrace(mut error: KclError, mut module_id: ModuleId, universe: &Universe) -> KclError {
+    let Some((immediate_import, _, _, _)) = universe
+        .values()
+        .find(|(_, candidate_id, _, _)| *candidate_id == module_id)
+    else {
+        return error;
+    };
+    module_id = SourceRange::from(immediate_import).module_id();
+
+    while module_id != ModuleId::default() {
+        let Some((import_stmt, _, _, _)) = universe
+            .values()
+            .find(|(_, candidate_id, _, _)| *candidate_id == module_id)
+        else {
+            break;
+        };
+
+        let import_site = SourceRange::from(import_stmt);
+        error = error.add_import_location(format!("import {}", import_stmt.path), import_site);
+        module_id = import_site.module_id();
+    }
+
+    error
+}
+
 /// Process a number of programs, returning the graph of dependencies.
 ///
 /// This will (currently) return a list of lists of IDs that can be safely

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -2370,6 +2370,52 @@ mod tests {
         assert!(!artifact.code_ref.node_path.is_empty());
     }
 
+    #[tokio::test]
+    async fn mock_import_preserves_inner_error() {
+        let tmpdir = tempfile::TempDir::with_prefix("zma_kcl_import_error").unwrap();
+        tokio::fs::write(
+            tmpdir.path().join("broken.kcl"),
+            "export brokenValue = missingName + 1\n",
+        )
+        .await
+        .unwrap();
+
+        let program = crate::Program::parse_no_errs("import brokenValue from \"broken.kcl\"\n\nbrokenValue\n").unwrap();
+        let ctx = ExecutorContext::new_mock(Some(ExecutorSettings {
+            project_directory: Some(crate::TypedPath(tmpdir.path().into())),
+            ..Default::default()
+        }))
+        .await;
+
+        let error = ctx
+            .run_mock(
+                &program,
+                &MockConfig {
+                    use_prev_memory: false,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap_err();
+        ctx.close().await;
+
+        let KclError::UndefinedValue { details, name } = &error.error else {
+            panic!("expected UndefinedValue, got {:#?}", error.error);
+        };
+        assert_eq!(name.as_deref(), Some("missingName"));
+        assert_eq!(details.message, "`missingName` is not defined");
+        assert_eq!(details.source_ranges.len(), 1);
+
+        let inner_range = details.source_ranges[0];
+        assert_ne!(inner_range.module_id(), ModuleId::default());
+        assert!(
+            error.source_files[&inner_range.module_id()]
+                .path
+                .to_string()
+                .ends_with("broken.kcl")
+        );
+    }
+
     /// Convenience function to get a JSON value from memory and unwrap.
     #[track_caller]
     fn mem_get_json(memory: &Stack, env: EnvironmentRef, name: &str) -> KclValue {

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -1826,6 +1826,7 @@ impl ExecutorContext {
                         exec_state.global.module_infos[&module_id].restore_repr(repr);
                     }
                     Err(e) => {
+                        let e = import_graph::add_import_backtrace(e, module_id, &universe);
                         return Err(exec_state.error_with_outputs(e, None, default_planes));
                     }
                 }
@@ -2371,7 +2372,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn mock_import_preserves_inner_error() {
+    async fn nested_import_preserves_inner_error_and_backtrace() {
         let tmpdir = tempfile::TempDir::with_prefix("zma_kcl_import_error").unwrap();
         tokio::fs::write(
             tmpdir.path().join("broken.kcl"),
@@ -2379,15 +2380,63 @@ mod tests {
         )
         .await
         .unwrap();
+        tokio::fs::write(
+            tmpdir.path().join("assembly.kcl"),
+            "import brokenValue from \"broken.kcl\"\n\nexport assemblyValue = brokenValue\n",
+        )
+        .await
+        .unwrap();
 
-        let program = crate::Program::parse_no_errs("import brokenValue from \"broken.kcl\"\n\nbrokenValue\n").unwrap();
-        let ctx = ExecutorContext::new_mock(Some(ExecutorSettings {
+        let main_code = "import assemblyValue from \"assembly.kcl\"\n\nassemblyValue\n";
+        let main_path = tmpdir.path().join("main.kcl");
+        tokio::fs::write(&main_path, main_code).await.unwrap();
+        let program = crate::Program::parse_no_errs(main_code).unwrap();
+        let settings = ExecutorSettings {
             project_directory: Some(crate::TypedPath(tmpdir.path().into())),
+            current_file: Some(crate::TypedPath(main_path.clone())),
             ..Default::default()
-        }))
-        .await;
+        };
 
-        let error = ctx
+        let assert_error = |error: &KclErrorWithOutputs| {
+            let KclError::UndefinedValue { details, name } = &error.error else {
+                panic!("expected UndefinedValue, got {:#?}", error.error);
+            };
+            assert_eq!(name.as_deref(), Some("missingName"));
+            assert_eq!(details.message, "`missingName` is not defined");
+            assert_eq!(
+                error
+                    .error
+                    .backtrace()
+                    .iter()
+                    .map(|frame| frame.fn_name.as_deref())
+                    .collect::<Vec<_>>(),
+                [Some("import assembly.kcl"), Some("import broken.kcl"), None]
+            );
+
+            let report = error.clone().into_miette_report_with_outputs(main_code).unwrap();
+            assert!(report.filename.ends_with("broken.kcl"));
+            assert_eq!(
+                report
+                    .related
+                    .iter()
+                    .map(|related| related.filename.as_str())
+                    .collect::<Vec<_>>(),
+                [
+                    main_path.to_string_lossy().as_ref(),
+                    tmpdir.path().join("assembly.kcl").to_string_lossy().as_ref()
+                ]
+            );
+
+            let rendered = format!("{:?}", miette::Report::new(report));
+            assert!(rendered.contains("broken.kcl"));
+            assert!(rendered.contains("assembly.kcl"));
+            assert!(rendered.contains("main.kcl"));
+            assert!(rendered.contains("export brokenValue = missingName + 1"));
+            assert!(!rendered.contains("Failed to read contents"));
+        };
+
+        let mock_ctx = ExecutorContext::new_mock(Some(settings.clone())).await;
+        let mock_error = mock_ctx
             .run_mock(
                 &program,
                 &MockConfig {
@@ -2397,23 +2446,14 @@ mod tests {
             )
             .await
             .unwrap_err();
-        ctx.close().await;
+        mock_ctx.close().await;
+        assert_error(&mock_error);
 
-        let KclError::UndefinedValue { details, name } = &error.error else {
-            panic!("expected UndefinedValue, got {:#?}", error.error);
-        };
-        assert_eq!(name.as_deref(), Some("missingName"));
-        assert_eq!(details.message, "`missingName` is not defined");
-        assert_eq!(details.source_ranges.len(), 1);
-
-        let inner_range = details.source_ranges[0];
-        assert_ne!(inner_range.module_id(), ModuleId::default());
-        assert!(
-            error.source_files[&inner_range.module_id()]
-                .path
-                .to_string()
-                .ends_with("broken.kcl")
-        );
+        let concurrent_ctx = ExecutorContext::new_mock(Some(settings)).await;
+        let mut exec_state = ExecState::new(&concurrent_ctx);
+        let concurrent_error = concurrent_ctx.run(&program, &mut exec_state).await.unwrap_err();
+        concurrent_ctx.close().await;
+        assert_error(&concurrent_error);
     }
 
     /// Convenience function to get a JSON value from memory and unwrap.


### PR DESCRIPTION
## Summary

- preserve the original `KclError` raised while executing an imported KCL module instead of replacing it with a generic semantic error
- retain structured fields such as `UndefinedValue.name` and keep the deepest imported-file source range primary
- reconstruct nested import ancestry for eager execution and record each import statement as a structured backtrace frame
- render importing files as related diagnostics without applying their ranges to the wrong source text
- cover both mock execution and the concurrent path used by normal execution with a three-file regression

## Root cause

`exec_module_from_ast` converted nearly every imported-module execution failure into a new `Semantic` error located at the caller's import statement. That discarded the original error kind, structured metadata, and imported-file source range before mock execution, Python, or Zookeeper could inspect it.

Normal execution also evaluates modules eagerly in dependency order. A leaf such as `broken.kcl` can therefore fail before `assembly.kcl` or `main.kcl` executes, so ordinary error unwinding cannot recover the complete import chain. This change reconstructs those ancestors from the existing import universe.

## Result

For `main.kcl -> assembly.kcl -> broken.kcl`, an undefined `missingName` now remains:

- `UndefinedValue` with `name = "missingName"`
- primary at the expression in `broken.kcl`
- related to the import statement in `assembly.kcl`
- related to the import statement in `main.kcl`

The same information survives in structured `backtrace` data and in the rendered text returned through the Python bindings to `mock_execute_project`.

## Validation

- `cargo test -p kcl-lib nested_import_preserves_inner_error_and_backtrace -- --nocapture`
- `cargo test -p kcl-lib execution::import_graph::tests -- --nocapture`
- `cargo test -p kcl-lib errors::tests -- --nocapture`
- `cargo test -p kcl-error`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`

Fixes #13080