### PR TITLE
Throttle bulk cloud sync project API requests

### DIFF
--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -135,6 +135,8 @@ export function isCloudSyncConflictRevisionChangedError(error: unknown) {
 const SYNC_DEBOUNCE_MS = 2500
 const SYNC_RETRY_MS = 10_000
 const SYNC_RETRY_MAX_MS = 5 * 60 * 1000
+const PROJECT_API_THROTTLE_MS = 250
+const PROJECT_API_THROTTLE_JITTER_MS = 250
 const REMOTE_INDEX_INTERVAL_MS = 5 * 60 * 1000
 const REMOTE_UPLOAD_FORBIDDEN_MESSAGE =
   'Cloud sync cannot upload local changes because this account does not have edit access to the linked cloud project. Local changes are safe on this device.'
@@ -154,6 +156,15 @@ let detachVisibilityChangeListener: (() => void) | undefined
 let syncScopeProjectPath: string | undefined
 let syncScopeSyncable = false
 const scheduledProjectDirectoryNameSyncs = new Set<string>()
+
+/**
+ * Per-run throttle for automatic full-library syncs. It spaces project API
+ * request starts so large local backlogs drain without a tight startup burst.
+ */
+type CloudSyncProjectApiRequestThrottle = () => Promise<void>
+
+const unthrottledCloudSyncProjectApiRequest: CloudSyncProjectApiRequestThrottle =
+  async () => undefined
 
 export const cloudSyncStatus = signal<CloudSyncStatus>({
   enabled: false,
@@ -270,6 +281,73 @@ function nextSyncRetryDelayMs(error: unknown) {
 
 function resetSyncRetryBackoff() {
   syncRetryAttempt = 0
+}
+
+export function getCloudSyncProjectApiThrottleDelayMs({
+  elapsedMs,
+  jitterRatio,
+}: {
+  elapsedMs: number
+  jitterRatio: number
+}) {
+  const clamp = (value: number, min: number, max: number) => {
+    if (!Number.isFinite(value)) {
+      return min
+    }
+    return Math.min(max, Math.max(min, value))
+  }
+  const intervalMs =
+    PROJECT_API_THROTTLE_MS +
+    Math.round(PROJECT_API_THROTTLE_JITTER_MS * clamp(jitterRatio, 0, 1))
+
+  return Math.max(0, intervalMs - Math.max(0, Math.floor(elapsedMs)))
+}
+
+export function shouldThrottleCloudSyncProjectApiRequests({
+  hasSyncScope,
+  projectCount,
+}: {
+  hasSyncScope: boolean
+  projectCount: number
+}) {
+  return !hasSyncScope && projectCount > 1
+}
+
+function createCloudSyncProjectApiRequestThrottle({
+  enabled,
+}: {
+  enabled: boolean
+}): CloudSyncProjectApiRequestThrottle {
+  if (!enabled) {
+    return unthrottledCloudSyncProjectApiRequest
+  }
+
+  const sleep = (ms: number) =>
+    new Promise<void>((resolve) => {
+      setTimeout(resolve, ms)
+    })
+
+  let lastRequestStartedAt: number | undefined
+  return async () => {
+    if (lastRequestStartedAt !== undefined) {
+      const delayMs = getCloudSyncProjectApiThrottleDelayMs({
+        elapsedMs: Date.now() - lastRequestStartedAt,
+        jitterRatio: Math.random(),
+      })
+      if (delayMs > 0) {
+        await sleep(delayMs)
+      }
+    }
+    lastRequestStartedAt = Date.now()
+  }
+}
+
+async function runCloudSyncProjectApiRequest<T>(
+  throttleProjectApiRequest: CloudSyncProjectApiRequestThrottle,
+  request: () => Promise<T>
+) {
+  await throttleProjectApiRequest()
+  return request()
 }
 
 export function shouldScheduleCloudSyncPendingWork({
@@ -2571,10 +2649,16 @@ export function getCloudSyncKnownLocalRemoteIndexAction({
   return 'index-known-local'
 }
 
-async function syncDeletedProject(metadata: ProjectMetadata) {
-  if (metadata.remoteProjectId) {
+async function syncDeletedProject(
+  metadata: ProjectMetadata,
+  throttleProjectApiRequest: CloudSyncProjectApiRequestThrottle = unthrottledCloudSyncProjectApiRequest
+) {
+  const remoteProjectId = metadata.remoteProjectId
+  if (remoteProjectId) {
     try {
-      await deleteRemoteProject(config, metadata.remoteProjectId)
+      await runCloudSyncProjectApiRequest(throttleProjectApiRequest, () =>
+        deleteRemoteProject(config, remoteProjectId)
+      )
     } catch (error) {
       if (!(error instanceof CloudApiError && error.status === 404)) {
         // eslint-disable-next-line suggest-no-throw/suggest-no-throw
@@ -2664,7 +2748,11 @@ async function localProjectChangedFromSyncBase(metadata: ProjectMetadata) {
   return !projectManifestsEqual(localManifest, metadata.baseManifest)
 }
 
-async function syncProject(projectPath: string, entries: OutboxEntry[]) {
+async function syncProject(
+  projectPath: string,
+  entries: OutboxEntry[],
+  throttleProjectApiRequest: CloudSyncProjectApiRequestThrottle = unthrottledCloudSyncProjectApiRequest
+) {
   let metadata = await getOrCreateProjectMetadata(projectPath)
   if (isProjectSyncExcluded(metadata)) {
     await clearOutboxEntriesForProject(metadata.localProjectPath)
@@ -2702,7 +2790,7 @@ async function syncProject(projectPath: string, entries: OutboxEntry[]) {
       hasRemoteRevision: Boolean(metadata.remoteRevision),
     })
     if (initialAction === 'delete-remote') {
-      await syncDeletedProject(metadata)
+      await syncDeletedProject(metadata, throttleProjectApiRequest)
       return
     }
 
@@ -2723,8 +2811,12 @@ async function syncProject(projectPath: string, entries: OutboxEntry[]) {
     let remoteChanged = false
     let localChanged = true
     if (metadata.remoteProjectId) {
+      const remoteProjectId = metadata.remoteProjectId
       try {
-        remoteProject = await getRemoteProject(config, metadata.remoteProjectId)
+        remoteProject = await runCloudSyncProjectApiRequest(
+          throttleProjectApiRequest,
+          () => getRemoteProject(config, remoteProjectId)
+        )
       } catch (error) {
         if (error instanceof CloudApiError && error.status === 404) {
           await reconcileMissingRemoteProject(metadata, {
@@ -2775,10 +2867,9 @@ async function syncProject(projectPath: string, entries: OutboxEntry[]) {
     })
 
     if (preflightAction === 'create-remote') {
-      const created = await createRemoteProject(
-        config,
-        metadata.localProjectPath,
-        localFiles
+      const created = await runCloudSyncProjectApiRequest(
+        throttleProjectApiRequest,
+        () => createRemoteProject(config, metadata.localProjectPath, localFiles)
       )
       await writeLocalProjectCloudProjectId(
         metadata.localProjectPath,
@@ -2820,14 +2911,18 @@ async function syncProject(projectPath: string, entries: OutboxEntry[]) {
     }
 
     if (preflightAction === 'push-local-with-expected-revision') {
-      const updated = await updateRemoteProject({
-        config,
-        projectPath: metadata.localProjectPath,
-        projectId: remoteProjectId,
-        files: localFiles,
-        expectedRevision: metadata.remoteRevision,
-        entrypointPath: getRemoteProjectEntrypointPath(remoteProject),
-      }).catch(rejectRemoteUploadFailure)
+      const updated = await runCloudSyncProjectApiRequest(
+        throttleProjectApiRequest,
+        () =>
+          updateRemoteProject({
+            config,
+            projectPath: metadata.localProjectPath,
+            projectId: remoteProjectId,
+            files: localFiles,
+            expectedRevision: metadata.remoteRevision,
+            entrypointPath: getRemoteProjectEntrypointPath(remoteProject),
+          })
+      ).catch(rejectRemoteUploadFailure)
       await clearOutboxEntriesForProject(metadata.localProjectPath)
       await markProjectSynced(
         metadata,
@@ -2837,9 +2932,9 @@ async function syncProject(projectPath: string, entries: OutboxEntry[]) {
       return
     }
 
-    const remoteArchive = await downloadRemoteProjectArchive(
-      config,
-      remoteProjectId
+    const remoteArchive = await runCloudSyncProjectApiRequest(
+      throttleProjectApiRequest,
+      () => downloadRemoteProjectArchive(config, remoteProjectId)
     )
     const remoteFiles = filterCloudSyncProjectFilesForSync(
       withRemoteProjectMetadataInArchiveFiles(
@@ -2903,13 +2998,17 @@ async function syncProject(projectPath: string, entries: OutboxEntry[]) {
     if (reconciliationAction === 'auto-reconcile' && autoReconciledFiles) {
       const autoReconciledManifest =
         await projectManifestFromFiles(autoReconciledFiles)
-      const updated = await updateRemoteProject({
-        config,
-        projectPath: metadata.localProjectPath,
-        projectId: remoteProjectId,
-        files: autoReconciledFiles,
-        expectedRevision: remoteRevision,
-      }).catch(rejectRemoteUploadFailure)
+      const updated = await runCloudSyncProjectApiRequest(
+        throttleProjectApiRequest,
+        () =>
+          updateRemoteProject({
+            config,
+            projectPath: metadata.localProjectPath,
+            projectId: remoteProjectId,
+            files: autoReconciledFiles,
+            expectedRevision: remoteRevision,
+          })
+      ).catch(rejectRemoteUploadFailure)
       await replaceLocalProjectWithFiles(
         metadata.localProjectPath,
         autoReconciledFiles
@@ -2935,7 +3034,9 @@ async function syncProject(projectPath: string, entries: OutboxEntry[]) {
   }
 }
 
-async function syncRemoteIndex() {
+async function syncRemoteIndex(
+  throttleProjectApiRequest: CloudSyncProjectApiRequestThrottle = unthrottledCloudSyncProjectApiRequest
+) {
   const now = Date.now()
   if (now - lastRemoteIndexSyncAt < REMOTE_INDEX_INTERVAL_MS) {
     return
@@ -2946,7 +3047,10 @@ async function syncRemoteIndex() {
     await localFs.mkdir(projectDirectory, { recursive: true })
   }
 
-  const remoteProjects = await listRemoteProjects(config)
+  const remoteProjects = await runCloudSyncProjectApiRequest(
+    throttleProjectApiRequest,
+    () => listRemoteProjects(config)
+  )
   cloudSyncRemoteProjects.value = remoteProjects
   const remoteProjectIds = new Set(
     remoteProjects.map((remoteProject) => remoteProject.id).filter(Boolean)
@@ -3119,7 +3223,11 @@ async function syncRemoteIndex() {
         }
 
         if (knownLocalRemoteIndexAction === 'sync-known-local') {
-          await syncProject(nextLocalMetadata.localProjectPath, [])
+          await syncProject(
+            nextLocalMetadata.localProjectPath,
+            [],
+            throttleProjectApiRequest
+          )
           const syncedMetadata = await getProjectMetadata(
             nextLocalMetadata.localProjectPath
           )
@@ -3188,7 +3296,11 @@ async function syncRemoteIndex() {
           removeMetadata(existingProjectPath)
         }
         upsertMetadata(nextMetadata)
-        await syncProject(nextMetadata.localProjectPath, [])
+        await syncProject(
+          nextMetadata.localProjectPath,
+          [],
+          throttleProjectApiRequest
+        )
         const syncedMetadata = await getProjectMetadata(existingProjectPath)
         const nextSyncedMetadata =
           syncedMetadata ??
@@ -3299,10 +3411,24 @@ async function runCloudSync() {
   try {
     let entries = await getAllOutboxEntries()
     let syncScopePlan = getCloudSyncScopePlanForScope(entries, scopedScope)
+    let throttleProjectApiRequest = createCloudSyncProjectApiRequestThrottle({
+      enabled: shouldThrottleCloudSyncProjectApiRequests({
+        hasSyncScope: Boolean(scopedScope),
+        projectCount: syncScopePlan.projectPaths.length,
+      }),
+    })
     if (syncScopePlan.shouldSyncRemoteIndex) {
       updateStatus({ state: 'syncing' })
       await enqueueExistingCloudLibraryProjectsForInitialSync()
-      await syncRemoteIndex().catch((error) => {
+      entries = await getAllOutboxEntries()
+      syncScopePlan = getCloudSyncScopePlanForScope(entries, scopedScope)
+      throttleProjectApiRequest = createCloudSyncProjectApiRequestThrottle({
+        enabled: shouldThrottleCloudSyncProjectApiRequests({
+          hasSyncScope: Boolean(scopedScope),
+          projectCount: syncScopePlan.projectPaths.length,
+        }),
+      })
+      await syncRemoteIndex(throttleProjectApiRequest).catch((error) => {
         remoteIndexFailed = true
         remoteIndexFailureMessage = errorMessage(error)
         remoteIndexFailure = error
@@ -3321,7 +3447,8 @@ async function runCloudSync() {
     for (const projectPath of syncScopePlan.projectPaths) {
       await syncProject(
         projectPath,
-        outboxEntriesForProject(entries, projectPath)
+        outboxEntriesForProject(entries, projectPath),
+        throttleProjectApiRequest
       )
     }
 

--- a/src/lib/cloudSync/index.test.ts
+++ b/src/lib/cloudSync/index.test.ts
@@ -4,6 +4,7 @@ import {
   getCloudSyncInitialLocalProjectSyncAction,
   getCloudSyncKnownLocalRemoteIndexAction,
   getCloudSyncMissingRemoteProjectAction,
+  getCloudSyncProjectApiThrottleDelayMs,
   getCloudSyncProjectModifiedTime,
   getCloudSyncProjectRootInDirectories,
   getCloudSyncProjectRootInDirectory,
@@ -19,6 +20,7 @@ import {
   projectManifestsEqual,
   shouldAutoEnrollCloudLibraryProject,
   shouldScheduleCloudSyncPendingWork,
+  shouldThrottleCloudSyncProjectApiRequests,
 } from '@src/lib/cloudSync'
 import {
   getCloudProjectLibraryMaterializationDirectoryPath,
@@ -854,6 +856,60 @@ describe('cloudSync sync helpers', () => {
         retryAfterMs: 45_000,
       })
     ).toBe(45_000)
+  })
+
+  it('throttles full-sync project API requests with bounded jitter', () => {
+    expect(
+      getCloudSyncProjectApiThrottleDelayMs({
+        elapsedMs: 0,
+        jitterRatio: 0,
+      })
+    ).toBe(250)
+    expect(
+      getCloudSyncProjectApiThrottleDelayMs({
+        elapsedMs: 0,
+        jitterRatio: 1,
+      })
+    ).toBe(500)
+    expect(
+      getCloudSyncProjectApiThrottleDelayMs({
+        elapsedMs: 100,
+        jitterRatio: 0.5,
+      })
+    ).toBe(275)
+    expect(
+      getCloudSyncProjectApiThrottleDelayMs({
+        elapsedMs: 500,
+        jitterRatio: 0.5,
+      })
+    ).toBe(0)
+    expect(
+      getCloudSyncProjectApiThrottleDelayMs({
+        elapsedMs: 0,
+        jitterRatio: Number.NaN,
+      })
+    ).toBe(250)
+  })
+
+  it('throttles project API requests only for multi-project full syncs', () => {
+    expect(
+      shouldThrottleCloudSyncProjectApiRequests({
+        hasSyncScope: false,
+        projectCount: 2,
+      })
+    ).toBe(true)
+    expect(
+      shouldThrottleCloudSyncProjectApiRequests({
+        hasSyncScope: false,
+        projectCount: 1,
+      })
+    ).toBe(false)
+    expect(
+      shouldThrottleCloudSyncProjectApiRequests({
+        hasSyncScope: true,
+        projectCount: 2,
+      })
+    ).toBe(false)
   })
 
   it('does not schedule normal pending-work debounce after a retry is scheduled', () => {


### PR DESCRIPTION
Stacks on #13078, adding polish to #13065.

When a user opens ZDS with cloud sync enabled, any un-synced work is gathered up in the "pending outbox", the remote versions fetched with `GET` requests, then any diff pushed up to the cloud remote as `PUT`s. This occurs in a tight burst. This PR adds a 250–500ms throttle between those items before they head out. The retry/backoff PR in #13078 handles failures after they happen; this one reduces the chance of tripping rate limits or edge protections in the first place.

Note that this PR keeps single-project syncs un-throttled so normal foreground work stays responsive.