### PR TITLE
Nicer banner with Upgrade button when out of credits

### DIFF
--- a/src/lib/zookeeper/components/ZookeeperConnectionErrorBanner.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConnectionErrorBanner.tsx
@@ -1,0 +1,100 @@
+import { ActionButton } from '@src/components/ActionButton'
+import { withSiteBaseURL } from '@src/lib/withBaseURL'
+import { isZookeeperBillingError } from '@src/lib/zookeeper/zookeeperBilling'
+
+const terminalRecoveryButtonClassName =
+  'h-7 w-fit !border-chalkboard-30 !bg-chalkboard-10 enabled:hover:!border-chalkboard-40 enabled:hover:!bg-chalkboard-20 disabled:!border-chalkboard-20 disabled:!bg-chalkboard-20/50 disabled:!text-chalkboard-60 focus-visible:outline-appForeground dark:!border-chalkboard-70 dark:!bg-chalkboard-90 dark:enabled:hover:!border-chalkboard-60 dark:enabled:hover:!bg-chalkboard-80 dark:disabled:!border-chalkboard-70 dark:disabled:!bg-chalkboard-90 dark:disabled:!text-chalkboard-40'
+
+const billingButtonClassName =
+  'h-7 w-fit !border-ml-green !bg-ml-green !text-chalkboard-100 hover:brightness-95 focus-visible:outline-appForeground'
+
+export interface ZookeeperConnectionErrorBannerProps {
+  connectionError?: string
+  canClearChat?: boolean
+  isClearingChat?: boolean
+  onReconnect: () => void
+  onClickClearChat: () => void
+}
+
+export function ZookeeperConnectionErrorBanner(
+  props: ZookeeperConnectionErrorBannerProps
+) {
+  const isBillingError = isZookeeperBillingError(props.connectionError)
+
+  return (
+    <div
+      className={`m-4 flex flex-col gap-3 rounded-md border p-4 text-left ${
+        isBillingError
+          ? 'border-ml-green bg-ml-green/10 dark:border-ml-green dark:bg-ml-green/10'
+          : 'border-destroy-30 bg-destroy-10 dark:border-destroy-70 dark:bg-destroy-80/20'
+      }`}
+      role="alert"
+    >
+      <div className="flex items-start gap-2">
+        <div className="flex flex-col gap-1">
+          <p className="font-semibold">
+            {isBillingError
+              ? "You're out of Zookeeper credits."
+              : (props.connectionError ??
+                'Zookeeper disconnected unexpectedly.')}
+          </p>
+          <p className="text-sm text-chalkboard-70 dark:text-chalkboard-30">
+            {isBillingError
+              ? 'Enable pay as you go or upgrade your plan to continue using Zookeeper.'
+              : props.canClearChat
+                ? 'Reconnect to try loading this conversation again.'
+                : 'Reconnect to try connecting again.'}
+          </p>
+        </div>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {isBillingError && (
+          <ActionButton
+            Element="externalLink"
+            aria-label="Upgrade"
+            to={withSiteBaseURL('/account/billing')}
+            className={billingButtonClassName}
+            iconStart={{ icon: 'link' }}
+            rel="noreferrer"
+            tabIndex={0}
+          >
+            Upgrade
+          </ActionButton>
+        )}
+        <ActionButton
+          Element="button"
+          aria-label="Reconnect"
+          type="button"
+          className={terminalRecoveryButtonClassName}
+          iconStart={{ icon: 'refresh' }}
+          onClick={props.onReconnect}
+          disabled={props.isClearingChat}
+          tabIndex={0}
+        >
+          Reconnect
+        </ActionButton>
+      </div>
+      {!isBillingError && props.canClearChat && (
+        <div className="flex flex-col gap-2 border-t border-destroy-30 pt-3 dark:border-destroy-70">
+          <p className="text-sm text-chalkboard-70 dark:text-chalkboard-30">
+            If reconnecting still does not work, clearing the chat is a last
+            resort. Previous conversation data will no longer be visible in this
+            pane.
+          </p>
+          <ActionButton
+            Element="button"
+            aria-label={props.isClearingChat ? 'Clearing...' : 'Clear chat'}
+            type="button"
+            className={`${terminalRecoveryButtonClassName} !text-destroy-80 dark:!text-destroy-20`}
+            iconStart={{ icon: 'trash' }}
+            onClick={props.onClickClearChat}
+            disabled={props.isClearingChat}
+            tabIndex={0}
+          >
+            {props.isClearingChat ? 'Clearing...' : 'Clear chat'}
+          </ActionButton>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/lib/zookeeper/components/ZookeeperConnectionErrorBanner.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConnectionErrorBanner.tsx
@@ -54,7 +54,7 @@ export function ZookeeperConnectionErrorBanner(
             aria-label="Upgrade"
             to={withSiteBaseURL('/account/billing')}
             className={billingButtonClassName}
-            iconStart={{ icon: 'link', bgClassName: '!bg-transparent' }}
+            iconStart={{ icon: 'link', bgClassName: '!bg-transparent ml-1' }}
             rel="noreferrer"
             tabIndex={0}
           >
@@ -66,7 +66,7 @@ export function ZookeeperConnectionErrorBanner(
           aria-label="Reconnect"
           type="button"
           className={terminalRecoveryButtonClassName}
-          iconStart={{ icon: 'refresh', bgClassName: '!bg-transparent' }}
+          iconStart={{ icon: 'refresh', bgClassName: '!bg-transparent ml-1' }}
           onClick={props.onReconnect}
           disabled={props.isClearingChat}
           tabIndex={0}
@@ -86,7 +86,7 @@ export function ZookeeperConnectionErrorBanner(
             aria-label={props.isClearingChat ? 'Clearing...' : 'Clear chat'}
             type="button"
             className={`${terminalRecoveryButtonClassName} !text-destroy-80 dark:!text-destroy-20`}
-            iconStart={{ icon: 'trash', bgClassName: '!bg-transparent' }}
+            iconStart={{ icon: 'trash', bgClassName: '!bg-transparent ml-1' }}
             onClick={props.onClickClearChat}
             disabled={props.isClearingChat}
             tabIndex={0}

--- a/src/lib/zookeeper/components/ZookeeperConnectionErrorBanner.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConnectionErrorBanner.tsx
@@ -54,7 +54,7 @@ export function ZookeeperConnectionErrorBanner(
             aria-label="Upgrade"
             to={withSiteBaseURL('/account/billing')}
             className={billingButtonClassName}
-            iconStart={{ icon: 'link' }}
+            iconStart={{ icon: 'link', bgClassName: '!bg-transparent' }}
             rel="noreferrer"
             tabIndex={0}
           >
@@ -66,7 +66,7 @@ export function ZookeeperConnectionErrorBanner(
           aria-label="Reconnect"
           type="button"
           className={terminalRecoveryButtonClassName}
-          iconStart={{ icon: 'refresh' }}
+          iconStart={{ icon: 'refresh', bgClassName: '!bg-transparent' }}
           onClick={props.onReconnect}
           disabled={props.isClearingChat}
           tabIndex={0}
@@ -86,7 +86,7 @@ export function ZookeeperConnectionErrorBanner(
             aria-label={props.isClearingChat ? 'Clearing...' : 'Clear chat'}
             type="button"
             className={`${terminalRecoveryButtonClassName} !text-destroy-80 dark:!text-destroy-20`}
-            iconStart={{ icon: 'trash' }}
+            iconStart={{ icon: 'trash', bgClassName: '!bg-transparent' }}
             onClick={props.onClickClearChat}
             disabled={props.isClearingChat}
             tabIndex={0}

--- a/src/lib/zookeeper/components/ZookeeperConversation.spec.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversation.spec.tsx
@@ -159,7 +159,11 @@ describe('ZookeeperConversation', () => {
     expect(clearChatButton).toHaveClass('!bg-chalkboard-10')
     expect(
       clearChatButton.querySelector('svg[aria-label="trash"]')?.parentElement
-    ).toHaveClass('bg-chalkboard-20', 'dark:bg-chalkboard-80')
+    ).toHaveClass(
+      'bg-chalkboard-20',
+      'dark:bg-chalkboard-80',
+      '!bg-transparent'
+    )
 
     fireEvent.click(reconnectButton)
     fireEvent.click(clearChatButton)
@@ -225,9 +229,13 @@ describe('ZookeeperConversation', () => {
       withSiteBaseURL('/account/billing')
     )
     expect(
-      billingLink.querySelector('svg[aria-label="link"]')
-    ).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Reconnect' })).toBeEnabled()
+      billingLink.querySelector('svg[aria-label="link"]')?.parentElement
+    ).toHaveClass('!bg-transparent')
+    const reconnectButton = screen.getByRole('button', { name: 'Reconnect' })
+    expect(reconnectButton).toBeEnabled()
+    expect(
+      reconnectButton.querySelector('svg[aria-label="refresh"]')?.parentElement
+    ).toHaveClass('!bg-transparent')
   })
 
   test('shows setup progress while loading a conversation', () => {

--- a/src/lib/zookeeper/components/ZookeeperConversation.spec.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversation.spec.tsx
@@ -187,6 +187,49 @@ describe('ZookeeperConversation', () => {
     expect(screen.getByRole('alert')).not.toHaveTextContent('a last resort')
   })
 
+  test('shows billing recovery without offering to clear the chat', () => {
+    const billingError =
+      'This request is not included in your current plan, and your account has no API credits available. Enable pay as you go or update your plan in your account: https://dev.zoo.dev/account/billing'
+
+    render(
+      <ZookeeperConversation
+        isLoading={false}
+        connectionError={billingError}
+        connectionFailed={true}
+        canClearChat={true}
+        onProcess={() => {}}
+        onClickClearChat={() => {}}
+        onReconnect={() => {}}
+        onCancel={() => {}}
+        needsReconnect={true}
+        contexts={[]}
+        disabled={true}
+        hasPromptCompleted={true}
+        isProcessing={false}
+        queue={[]}
+        onRemoveFromQueue={() => {}}
+        onSteer={() => {}}
+      />
+    )
+
+    const alert = screen.getByRole('alert')
+    expect(alert).toHaveClass('border-ml-green', 'bg-ml-green/10')
+    expect(alert).toHaveTextContent("You're out of Zookeeper credits.")
+    expect(alert).toHaveTextContent('Enable pay as you go')
+    expect(
+      screen.queryByRole('button', { name: 'Clear chat' })
+    ).not.toBeInTheDocument()
+    const billingLink = screen.getByRole('link', { name: 'Upgrade' })
+    expect(billingLink).toHaveAttribute(
+      'href',
+      withSiteBaseURL('/account/billing')
+    )
+    expect(
+      billingLink.querySelector('svg[aria-label="link"]')
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Reconnect' })).toBeEnabled()
+  })
+
   test('shows setup progress while loading a conversation', () => {
     render(
       <ZookeeperConversation

--- a/src/lib/zookeeper/components/ZookeeperConversation.spec.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversation.spec.tsx
@@ -162,7 +162,8 @@ describe('ZookeeperConversation', () => {
     ).toHaveClass(
       'bg-chalkboard-20',
       'dark:bg-chalkboard-80',
-      '!bg-transparent'
+      '!bg-transparent',
+      'ml-1'
     )
 
     fireEvent.click(reconnectButton)
@@ -230,12 +231,12 @@ describe('ZookeeperConversation', () => {
     )
     expect(
       billingLink.querySelector('svg[aria-label="link"]')?.parentElement
-    ).toHaveClass('!bg-transparent')
+    ).toHaveClass('!bg-transparent', 'ml-1')
     const reconnectButton = screen.getByRole('button', { name: 'Reconnect' })
     expect(reconnectButton).toBeEnabled()
     expect(
       reconnectButton.querySelector('svg[aria-label="refresh"]')?.parentElement
-    ).toHaveClass('!bg-transparent')
+    ).toHaveClass('!bg-transparent', 'ml-1')
   })
 
   test('shows setup progress while loading a conversation', () => {

--- a/src/lib/zookeeper/components/ZookeeperConversation.spec.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversation.spec.tsx
@@ -193,8 +193,7 @@ describe('ZookeeperConversation', () => {
   })
 
   test('shows billing recovery without offering to clear the chat', () => {
-    const billingError =
-      'This request is not included in your current plan, and your account has no API credits available. Enable pay as you go or update your plan in your account: https://dev.zoo.dev/account/billing'
+    const billingError = 'no API credits available'
 
     render(
       <ZookeeperConversation

--- a/src/lib/zookeeper/components/ZookeeperConversation.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversation.tsx
@@ -1,5 +1,4 @@
 import { Popover } from '@headlessui/react'
-import { ActionButton } from '@src/components/ActionButton'
 import { ConnectionRecovery } from '@src/components/ConnectionRecovery'
 import { CustomIcon } from '@src/components/CustomIcon'
 import { ExchangeCard } from '@src/components/ExchangeCard'
@@ -12,6 +11,7 @@ import { useApp } from '@src/lib/boot'
 import { dataUrlToFile, takeViewportScreenshot } from '@src/lib/screenshot'
 import { err } from '@src/lib/trap'
 import { isNonNullable } from '@src/lib/utils'
+import { ZookeeperConnectionErrorBanner } from '@src/lib/zookeeper/components/ZookeeperConnectionErrorBanner'
 import type {
   Conversation,
   Exchange,
@@ -27,9 +27,6 @@ import type { ChangeEvent, ReactNode } from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 const noop = () => {}
-
-const terminalRecoveryButtonClassName =
-  'h-7 w-fit !border-chalkboard-30 !bg-chalkboard-10 enabled:hover:!border-chalkboard-40 enabled:hover:!bg-chalkboard-20 disabled:!border-chalkboard-20 disabled:!bg-chalkboard-20/50 disabled:!text-chalkboard-60 focus-visible:outline-appForeground dark:!border-chalkboard-70 dark:!bg-chalkboard-90 dark:enabled:hover:!border-chalkboard-60 dark:enabled:hover:!bg-chalkboard-80 dark:disabled:!border-chalkboard-70 dark:disabled:!bg-chalkboard-90 dark:disabled:!text-chalkboard-40'
 
 export const SHOW_ZOOKEEPER_REASONING_MODE_DROPDOWN = true
 
@@ -722,59 +719,13 @@ export const ZookeeperConversation = (props: ZookeeperConversationProps) => {
                   reconnectDisabled={props.isClearingChat}
                 />
               ) : props.needsReconnect && props.connectionFailed ? (
-                <div
-                  className="m-4 flex flex-col gap-3 rounded-md border border-destroy-30 bg-destroy-10 p-4 text-left dark:border-destroy-70 dark:bg-destroy-80/20"
-                  role="alert"
-                >
-                  <div className="flex items-start gap-2">
-                    <div className="flex flex-col gap-1">
-                      <p className="font-semibold">
-                        {props.connectionError ??
-                          'Zookeeper disconnected unexpectedly.'}
-                      </p>
-                      <p className="text-sm text-chalkboard-70 dark:text-chalkboard-30">
-                        {props.canClearChat
-                          ? 'Reconnect to try loading this conversation again.'
-                          : 'Reconnect to try connecting again.'}
-                      </p>
-                    </div>
-                  </div>
-                  <ActionButton
-                    Element="button"
-                    aria-label="Reconnect"
-                    type="button"
-                    className={terminalRecoveryButtonClassName}
-                    iconStart={{ icon: 'refresh' }}
-                    onClick={props.onReconnect}
-                    disabled={props.isClearingChat}
-                    tabIndex={0}
-                  >
-                    Reconnect
-                  </ActionButton>
-                  {props.canClearChat && (
-                    <div className="flex flex-col gap-2 border-t border-destroy-30 pt-3 dark:border-destroy-70">
-                      <p className="text-sm text-chalkboard-70 dark:text-chalkboard-30">
-                        If reconnecting still does not work, clearing the chat
-                        is a last resort. Previous conversation data will no
-                        longer be visible in this pane.
-                      </p>
-                      <ActionButton
-                        Element="button"
-                        aria-label={
-                          props.isClearingChat ? 'Clearing...' : 'Clear chat'
-                        }
-                        type="button"
-                        className={`${terminalRecoveryButtonClassName} !text-destroy-80 dark:!text-destroy-20`}
-                        iconStart={{ icon: 'trash' }}
-                        onClick={props.onClickClearChat}
-                        disabled={props.isClearingChat}
-                        tabIndex={0}
-                      >
-                        {props.isClearingChat ? 'Clearing...' : 'Clear chat'}
-                      </ActionButton>
-                    </div>
-                  )}
-                </div>
+                <ZookeeperConnectionErrorBanner
+                  connectionError={props.connectionError}
+                  canClearChat={props.canClearChat}
+                  isClearingChat={props.isClearingChat}
+                  onReconnect={props.onReconnect}
+                  onClickClearChat={props.onClickClearChat}
+                />
               ) : props.blockedReason ? (
                 <StarterCard text={props.blockedReason} />
               ) : props.isLoading === false ? (

--- a/src/lib/zookeeper/zookeeperBilling.ts
+++ b/src/lib/zookeeper/zookeeperBilling.ts
@@ -1,0 +1,16 @@
+const ZOOKEEPER_BILLING_ERROR_MARKERS = [
+  'no api credits available',
+  'enable pay as you go',
+  '/account/billing',
+]
+
+export function isZookeeperBillingError(message?: string): boolean {
+  if (!message) {
+    return false
+  }
+
+  const normalizedMessage = message.toLowerCase()
+  return ZOOKEEPER_BILLING_ERROR_MARKERS.some((marker) =>
+    normalizedMessage.includes(marker)
+  )
+}

--- a/src/lib/zookeeper/zookeeperManagerMachine.test.ts
+++ b/src/lib/zookeeper/zookeeperManagerMachine.test.ts
@@ -115,6 +115,9 @@ type SetupActorInput = {
 
 const completedConversationStartedAt = new Date('2026-07-15T12:00:00.000Z')
 
+const billingError =
+  'This request is not included in your current plan, and your account has no API credits available. Enable pay as you go or update your plan in your account: https://dev.zoo.dev/account/billing'
+
 describe('createZookeeperCorrelation', () => {
   it('creates a unique correlation ID and includes the Engine API call ID', () => {
     const first = createZookeeperCorrelation('engine-api-call-id')
@@ -379,6 +382,112 @@ describe('zookeeperManagerMachine', () => {
         setupFailed: false,
         conversationId: 'conversation-id',
       })
+
+      actor.stop()
+    })
+
+    it('surfaces a billing error after retrying setup', async () => {
+      const { fetchMock, reports } = stubClientErrorFetch()
+      vi.stubGlobal('WebSocket', ControllableSetupWebSocket)
+      const actor = createActor(zookeeperManagerMachine, {
+        input: {
+          apiToken: 'token',
+        },
+      }).start()
+
+      actor.send({
+        type: ZookeeperManagerTransitions.CacheSetupAndConnect,
+        refParentSend: vi.fn(),
+      })
+
+      for (
+        let attempt = 0;
+        attempt < NUMBER_OF_ZOOKEEPER_SETUP_ATTEMPTS;
+        attempt += 1
+      ) {
+        await vi.waitFor(() => {
+          expect(ControllableSetupWebSocket.instances).toHaveLength(attempt + 1)
+        })
+        const socket = ControllableSetupWebSocket.instances[attempt]
+        socket.open()
+        await vi.waitFor(() => {
+          expect(socket.sentPayloads).toContain(
+            JSON.stringify({ type: 'list_modes' })
+          )
+        })
+        socket.receive({ error: { detail: billingError } })
+      }
+
+      await waitFor(
+        actor,
+        (state) => state.matches(S.Await) && state.context.setupFailed
+      )
+
+      expect(ControllableSetupWebSocket.instances).toHaveLength(
+        NUMBER_OF_ZOOKEEPER_SETUP_ATTEMPTS
+      )
+      expect(actor.getSnapshot().context.closeReason).toBe(billingError)
+      for (const socket of ControllableSetupWebSocket.instances) {
+        expect(socket.close).toHaveBeenCalledOnce()
+      }
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(reports).toHaveLength(1)
+      expect(reports[0]).toMatchObject({
+        code: 'zookeeper_setup_error',
+        message: billingError,
+      })
+
+      actor.stop()
+    })
+
+    it('turns a billing response on an active connection into a recoverable close', async () => {
+      vi.stubGlobal('WebSocket', ControllableSetupWebSocket)
+      const actor = createActor(zookeeperManagerMachine, {
+        input: {
+          apiToken: 'token',
+        },
+      }).start()
+
+      actor.send({
+        type: ZookeeperManagerTransitions.CacheSetupAndConnect,
+        refParentSend: vi.fn(),
+      })
+
+      const socket = ControllableSetupWebSocket.instances[0]
+      socket.open()
+      await vi.waitFor(() => {
+        expect(socket.sentPayloads).toContain(
+          JSON.stringify({ type: 'list_modes' })
+        )
+      })
+      socket.receive({
+        conversation_id: { conversation_id: 'conversation-id' },
+      })
+
+      await waitFor(actor, (state) =>
+        state.matches(ZookeeperManagerStates.WaitForContinueCheck)
+      )
+      actor.send({
+        type: ZookeeperManagerStates.ContinueCheck,
+        projectName: 'zoo-project',
+        projectFiles: [],
+      })
+      await waitFor(actor, (state) =>
+        state.matches(ZookeeperManagerStates.Ready)
+      )
+
+      socket.receive({ error: { detail: billingError } })
+
+      await waitFor(actor, (state) => state.matches(S.Await))
+
+      expect(actor.getSnapshot().context).toMatchObject({
+        abruptlyClosed: true,
+        setupFailed: false,
+        closeReason: billingError,
+        conversation: { exchanges: [] },
+        conversationId: 'conversation-id',
+      })
+      expect(socket.close).toHaveBeenCalledOnce()
 
       actor.stop()
     })

--- a/src/lib/zookeeper/zookeeperManagerMachine.test.ts
+++ b/src/lib/zookeeper/zookeeperManagerMachine.test.ts
@@ -115,8 +115,7 @@ type SetupActorInput = {
 
 const completedConversationStartedAt = new Date('2026-07-15T12:00:00.000Z')
 
-const billingError =
-  'This request is not included in your current plan, and your account has no API credits available. Enable pay as you go or update your plan in your account: https://dev.zoo.dev/account/billing'
+const billingError = 'no API credits available'
 
 describe('createZookeeperCorrelation', () => {
   it('creates a unique correlation ID and includes the Engine API call ID', () => {

--- a/src/lib/zookeeper/zookeeperManagerMachine.ts
+++ b/src/lib/zookeeper/zookeeperManagerMachine.ts
@@ -23,6 +23,7 @@ import { getKclVersion } from '@src/lib/kclVersion'
 import { S, transitions, xstateEventError } from '@src/machines/utils'
 
 import { Socket, SocketConnectionError } from '@src/lib/socket'
+import { isZookeeperBillingError } from '@src/lib/zookeeper/zookeeperBilling'
 
 // Uncomment and switch WebSocket below with this MockSocket for development.
 // import { MockSocket } from '@src/mocks/copilot'
@@ -722,7 +723,7 @@ export const zookeeperManagerMachine = setup({
         closeReason: event.closeReason,
         ...zookeeperErrorContext(context),
       })
-      if (event.closeReason) {
+      if (event.closeReason && !isZookeeperBillingError(event.closeReason)) {
         toast.error(event.closeReason)
       }
       return {
@@ -1079,6 +1080,27 @@ export const zookeeperManagerMachine = setup({
 
             // Ignore pong
             if ('pong' in response) {
+              return
+            }
+
+            if (
+              'error' in response &&
+              isZookeeperBillingError(response.error.detail)
+            ) {
+              if (setupResolved) {
+                theRefParentSend({
+                  type: ZookeeperManagerTransitions.AbruptClose,
+                  closeReason: response.error.detail,
+                })
+              } else {
+                cancelSetupAttempt()
+                onRejected(
+                  new ZookeeperSetupConnectionError(
+                    response.error.detail,
+                    response.error.detail
+                  )
+                )
+              }
               return
             }
 


### PR DESCRIPTION
Fixes #13082. As reported today by a user.

Ideally we should also let the user view the past conversation, but that would need API changes.

I moved the existing banner into a component so it's cleaner with the added cases.

New billing-related error case:

<img width="1138" height="1078" alt="image" src="https://github.com/user-attachments/assets/c370ab3a-e1f6-43cb-a5f6-d84efe6b6c41" />


Non-billing case:

<img width="1036" height="1166" alt="image" src="https://github.com/user-attachments/assets/84c7781d-809a-43dc-b4f4-67127e93a797" />