### PR TITLE
Revise CONTRIBUTING.md

### DIFF
--- a/.github/workflows/kcl-python-bindings.yml
+++ b/.github/workflows/kcl-python-bindings.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v7.0.1
       - uses: actions/setup-python@v7.0.0
         with:
-          python-version: 3.x
+          python-version-file: .tool-versions
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@v7.0.1
       - uses: actions/setup-python@v7.0.0
         with:
-          python-version: 3.x
+          python-version-file: .tool-versions
           architecture: ${{ matrix.target }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
@@ -101,7 +101,7 @@ jobs:
       - uses: actions/checkout@v7.0.1
       - uses: actions/setup-python@v7.0.0
         with:
-          python-version: 3.x
+          python-version-file: .tool-versions
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/publish-apps.yml
+++ b/.github/workflows/publish-apps.yml
@@ -139,7 +139,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7.0.0
         with:
-          python-version: '3.x'
+          python-version-file: .tool-versions
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/update-python-stubs.yml
+++ b/.github/workflows/update-python-stubs.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7.0.0
         with:
-          python-version: "3.x"
+          python-version-file: .tool-versions
       - name: Install toolchain + maturin
         uses: PyO3/maturin-action@v1 # Rust + Python + maturin
         with:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,3 @@
-just 1.42.4
+just 1.58.0
 nodejs 24.11.0
-python 3.11.14
-rust system  # via rustup
+python 3.14.6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,7 @@ Integration tests will be slower, require more dependencies, and could be flaky.
 
 Prepare these system dependencies:
 
-- Set `$VITE_ZOO_API_TOKEN` from https://zoo.dev/account/api-tokens
+- Set `$VITE_ZOO_API_TOKEN` from https://zoo.dev/account/developer
 
 #### Desktop tests (Electron on all platforms)
 
@@ -243,14 +243,15 @@ Which will run our suite of [Vitest unit](https://vitest.dev/) and [React Testin
 
 Prepare these system dependencies:
 
-- Set `$ZOO_API_TOKEN` from https://zoo.dev/account/api-tokens
-- Install `just` following [these instructions](https://just.systems/man/en/packages.html)
+- Set `$ZOO_API_TOKEN` from https://zoo.dev/account/developer
+- Confirm that `just` is installed via the asdf instructions earlier.
 
 then run tests that target the KCL language:
 
 ```
 npm run test:e2e:kcl
 ```
+Note that the `TS-RS` typescript bindings generation runs as a series of "test" jobs alongside other Rust tests and under the multithreaded conditions of this command these jobs are expected to result in failures or flakiness. You may disregard test failures whose names start with `export_bindings`.
 
 ### Fuzzing the parser
 


### PR DESCRIPTION
Update links to the API token page to reflect the current location. Also explain the binding generation "test" failures and flakiness that result from the way nextest triggers ts-rs binding generation.