### PR TITLE
Clarify project library summaries

### DIFF
--- a/e2e/playwright/file-tree.spec.ts
+++ b/e2e/playwright/file-tree.spec.ts
@@ -1,14 +1,13 @@
-import { FILE_EXT, PROJECT_SETTINGS_FILE_NAME } from '@src/lib/constants'
-import type { PromisifiedZooDesignStudioFS } from '@src/lib/fs-zds/interface'
-import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
-import * as nodeFsP from 'fs/promises'
-
 import {
   createProject,
   executorInputPath,
   getUtils,
 } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
+import { FILE_EXT, PROJECT_SETTINGS_FILE_NAME } from '@src/lib/constants'
+import type { PromisifiedZooDesignStudioFS } from '@src/lib/fs-zds/interface'
+import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
+import * as nodeFsP from 'fs/promises'
 
 const exists = async (
   fs: PromisifiedZooDesignStudioFS,
@@ -1119,7 +1118,9 @@ test(
     })
 
     await test.step('Check the app is back on the home view', async () => {
-      const projectsDirLink = page.getByText('Loaded from')
+      const projectsDirLink = page.getByTestId(
+        'project-directory-settings-link'
+      )
       await expect(projectsDirLink).toBeVisible()
     })
   }

--- a/e2e/playwright/testing-settings.spec.ts
+++ b/e2e/playwright/testing-settings.spec.ts
@@ -1,9 +1,3 @@
-import { join } from 'path'
-import path from 'path'
-import { PROJECT_SETTINGS_FILE_NAME } from '@src/lib/constants'
-import type { SettingsLevel } from '@src/lib/settings/settingsTypes'
-import * as fsp from 'fs/promises'
-
 import {
   TEST_SETTINGS,
   TEST_SETTINGS_CORRUPTED,
@@ -20,8 +14,12 @@ import {
 import { expect, test } from '@e2e/playwright/zoo-test'
 import type { UnitLength } from '@kittycad/lib/dist/types/src'
 import type { Page } from '@playwright/test'
+import { PROJECT_SETTINGS_FILE_NAME } from '@src/lib/constants'
+import type { SettingsLevel } from '@src/lib/settings/settingsTypes'
 import { Themes } from '@src/lib/theme'
 import { isArray, uuidv4 } from '@src/lib/utils'
+import * as fsp from 'fs/promises'
+import path, { join } from 'path'
 
 const settingsSwitchTab = (page: Page) => async (tab: 'user' | 'proj') => {
   const projectSettingsTab = page.getByRole('radio', { name: 'Project' })
@@ -297,7 +295,9 @@ test.describe(
         const errorHeading = page.getByRole('heading', {
           name: 'An unexpected error occurred',
         })
-        const projectDirLink = page.getByText('Loaded from')
+        const projectDirLink = page.getByTestId(
+          'project-directory-settings-link'
+        )
 
         // If the app loads without exploding we're in the clear
         await expect(errorHeading).not.toBeVisible()
@@ -323,7 +323,9 @@ test.describe(
         const errorHeading = page.getByRole('heading', {
           name: 'An unexpected error occurred',
         })
-        const projectDirLink = page.getByText('Loaded from')
+        const projectDirLink = page.getByTestId(
+          'project-directory-settings-link'
+        )
 
         // If the app loads without exploding we're in the clear
         await expect(errorHeading).not.toBeVisible()
@@ -339,7 +341,9 @@ test.describe(
 
         await page.setBodyDimensions({ width: 1200, height: 500 })
 
-        const projectDirLink = page.getByText('Loaded from')
+        const projectDirLink = page.getByTestId(
+          'project-directory-settings-link'
+        )
 
         await test.step('Wait for project view', async () => {
           await expect(projectDirLink).toBeVisible()

--- a/src/components/CustomIcon.tsx
+++ b/src/components/CustomIcon.tsx
@@ -440,6 +440,22 @@ const CustomIconMap = Object.freeze({
       />
     </svg>
   ),
+  caretLeft: (
+    <svg
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-label="caret left"
+    >
+      <title>caret left</title>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M8.70709 10.0001L12.3536 6.35352L11.6465 5.64642L7.64642 9.64655L7.64643 10.3537L11.6465 14.3535L12.3536 13.6464L8.70709 10.0001Z"
+        fill="currentColor"
+      />
+    </svg>
+  ),
   caretUp: (
     <svg
       viewBox="0 0 20 20"

--- a/src/lib/projectLibraries/index.ts
+++ b/src/lib/projectLibraries/index.ts
@@ -39,24 +39,46 @@ export function getProjectLibrarySummaryDescription(
   return formatProjectLibraryPathForDisplay(library)
 }
 
-export function getProjectLibrarySummaryTooltip(
+export function getProjectLibraryDetailsDescription(
   library: Pick<ProjectLibrarySetting, 'path' | 'source' | 'type'>
 ) {
-  const technicalLocation = formatProjectLibraryPathForDisplay(library)
-
   if (library.type === CLOUD_PROJECT_LIBRARY_TYPE) {
     return [
       'Projects in this library sync to your Zoo account.',
       'Storage type and model-training controls depend on your plan.',
-      `Technical source: ${technicalLocation}`,
     ].join(' ')
   }
 
   if (library.type === DIRECTORY_PROJECT_LIBRARY_TYPE) {
-    return [
-      'Projects in this library are saved only on this computer.',
-      `Folder: ${technicalLocation}`,
-    ].join(' ')
+    return 'Projects in this library are saved only on this computer.'
+  }
+
+  return undefined
+}
+
+export function getProjectLibraryLocationLabel(
+  library: Pick<ProjectLibrarySetting, 'path' | 'source' | 'type'>
+) {
+  if (library.type === CLOUD_PROJECT_LIBRARY_TYPE) {
+    return 'Technical source'
+  }
+
+  if (library.type === DIRECTORY_PROJECT_LIBRARY_TYPE) {
+    return 'Folder'
+  }
+
+  return 'Location'
+}
+
+export function getProjectLibrarySummaryTooltip(
+  library: Pick<ProjectLibrarySetting, 'path' | 'source' | 'type'>
+) {
+  const description = getProjectLibraryDetailsDescription(library)
+  const locationLabel = getProjectLibraryLocationLabel(library)
+  const technicalLocation = formatProjectLibraryPathForDisplay(library)
+
+  if (description) {
+    return `${description} ${locationLabel}: ${technicalLocation}`
   }
 
   return technicalLocation

--- a/src/lib/projectLibraries/index.ts
+++ b/src/lib/projectLibraries/index.ts
@@ -25,6 +25,43 @@ export function formatProjectLibraryPathForDisplay(
   return `${CLOUD_PROJECT_LIBRARY_PATH_DISPLAY_PREFIX}${cloudSource.replace(/^\/+/, '')}`
 }
 
+export function getProjectLibrarySummaryDescription(
+  library: Pick<ProjectLibrarySetting, 'path' | 'source' | 'type'>
+) {
+  if (library.type === CLOUD_PROJECT_LIBRARY_TYPE) {
+    return 'Projects in this library sync to your Zoo account'
+  }
+
+  if (library.type === DIRECTORY_PROJECT_LIBRARY_TYPE) {
+    return 'Projects in this library are saved only on this computer'
+  }
+
+  return formatProjectLibraryPathForDisplay(library)
+}
+
+export function getProjectLibrarySummaryTooltip(
+  library: Pick<ProjectLibrarySetting, 'path' | 'source' | 'type'>
+) {
+  const technicalLocation = formatProjectLibraryPathForDisplay(library)
+
+  if (library.type === CLOUD_PROJECT_LIBRARY_TYPE) {
+    return [
+      'Projects in this library sync to your Zoo account.',
+      'Storage type and model-training controls depend on your plan.',
+      `Technical source: ${technicalLocation}`,
+    ].join(' ')
+  }
+
+  if (library.type === DIRECTORY_PROJECT_LIBRARY_TYPE) {
+    return [
+      'Projects in this library are saved only on this computer.',
+      `Folder: ${technicalLocation}`,
+    ].join(' ')
+  }
+
+  return technicalLocation
+}
+
 export type ProjectLibraryType = string
 
 export interface ProjectLibrarySetting {

--- a/src/registry/contracts/projectLibraries.test.ts
+++ b/src/registry/contracts/projectLibraries.test.ts
@@ -8,6 +8,8 @@ import {
   getDefaultDirectoryProjectLibraryPath,
   getDefaultDirectoryProjectLibrarySetting,
   getProjectLibraryIdFromSetting,
+  getProjectLibrarySummaryDescription,
+  getProjectLibrarySummaryTooltip,
   LEGACY_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH,
   moveProjectLibrarySetting,
   normalizeProjectLibrarySetting,
@@ -179,6 +181,30 @@ describe('project library settings', () => {
         type: 'directory',
       })
     ).toBe('/projects')
+  })
+
+  test('summarizes project library storage in plain language', () => {
+    const cloudLibrary = {
+      path: DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_LOCAL_PATH,
+      type: 'cloud',
+    }
+    const directoryLibrary = {
+      path: '/projects',
+      type: 'directory',
+    }
+
+    expect(getProjectLibrarySummaryDescription(cloudLibrary)).toBe(
+      'Projects in this library sync to your Zoo account'
+    )
+    expect(getProjectLibrarySummaryTooltip(cloudLibrary)).toContain(
+      'Technical source: zoo://personal'
+    )
+    expect(getProjectLibrarySummaryDescription(directoryLibrary)).toBe(
+      'Projects in this library are saved only on this computer'
+    )
+    expect(getProjectLibrarySummaryTooltip(directoryLibrary)).toContain(
+      'Folder: /projects'
+    )
   })
 
   test('treats the first directory library as the default local project target', () => {

--- a/src/registry/contracts/projectLibraries.test.ts
+++ b/src/registry/contracts/projectLibraries.test.ts
@@ -7,7 +7,9 @@ import {
   getDefaultCloudProjectLibrarySetting,
   getDefaultDirectoryProjectLibraryPath,
   getDefaultDirectoryProjectLibrarySetting,
+  getProjectLibraryDetailsDescription,
   getProjectLibraryIdFromSetting,
+  getProjectLibraryLocationLabel,
   getProjectLibrarySummaryDescription,
   getProjectLibrarySummaryTooltip,
   LEGACY_PERSONAL_CLOUD_PROJECT_LIBRARY_PATH,
@@ -199,12 +201,22 @@ describe('project library settings', () => {
     expect(getProjectLibrarySummaryTooltip(cloudLibrary)).toContain(
       'Technical source: zoo://personal'
     )
+    expect(getProjectLibraryDetailsDescription(cloudLibrary)).toBe(
+      'Projects in this library sync to your Zoo account. Storage type and model-training controls depend on your plan.'
+    )
+    expect(getProjectLibraryLocationLabel(cloudLibrary)).toBe(
+      'Technical source'
+    )
     expect(getProjectLibrarySummaryDescription(directoryLibrary)).toBe(
       'Projects in this library are saved only on this computer'
     )
     expect(getProjectLibrarySummaryTooltip(directoryLibrary)).toContain(
       'Folder: /projects'
     )
+    expect(getProjectLibraryDetailsDescription(directoryLibrary)).toBe(
+      'Projects in this library are saved only on this computer.'
+    )
+    expect(getProjectLibraryLocationLabel(directoryLibrary)).toBe('Folder')
   })
 
   test('treats the first directory library as the default local project target', () => {

--- a/src/routes/Home.test.tsx
+++ b/src/routes/Home.test.tsx
@@ -3,7 +3,9 @@ import {
   FREE_CLOUD_PROJECT_TRAINING_POLICY_URL,
   shouldShowFreeCloudProjectTrainingDisclosure,
 } from '@src/lib/projectLibraries/trainingDisclosure'
+import type { HomeProjectActionsService } from '@src/registry/contracts/homeProjects'
 import { HomeHeader } from '@src/routes/HomeHeader'
+import { ProjectLibraryPreviewRow } from '@src/routes/HomeProjectCards'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, expect, it, vi } from 'vitest'
@@ -14,6 +16,22 @@ const cloudLibrary = {
   path: '/documents/Zoo Projects',
   type: 'cloud',
 } satisfies ProjectLibrary
+
+const projectActions = {
+  canOpen: vi.fn(() => false),
+  canDuplicate: vi.fn(() => false),
+  canRename: vi.fn(() => false),
+  canDelete: vi.fn(() => false),
+  canMoveToLibrary: vi.fn(() => false),
+  canReviewDuplicateRealizations: vi.fn(() => false),
+  open: vi.fn(async () => undefined),
+  duplicate: vi.fn(async () => undefined),
+  rename: vi.fn(async () => undefined),
+  delete: vi.fn(async () => undefined),
+  getMoveToLibraryTargets: vi.fn(() => []),
+  moveToLibrary: vi.fn(async () => undefined),
+  deleteDuplicateRealizations: vi.fn(async () => undefined),
+} satisfies HomeProjectActionsService
 
 function renderHomeHeader({
   showFreeCloudProjectTrainingDisclosure,
@@ -32,6 +50,22 @@ function renderHomeHeader({
         showFreeCloudProjectTrainingDisclosure={
           showFreeCloudProjectTrainingDisclosure
         }
+      />
+    </MemoryRouter>
+  )
+}
+
+function renderProjectLibraryPreviewRow(library: ProjectLibrary) {
+  render(
+    <MemoryRouter>
+      <ProjectLibraryPreviewRow
+        library={library}
+        projects={[]}
+        query=""
+        projectStatuses={new Map()}
+        projectActions={projectActions}
+        showCloudSyncUi={true}
+        onMoveToLibrary={vi.fn()}
       />
     </MemoryRouter>
   )
@@ -63,5 +97,21 @@ describe('HomeHeader', () => {
     expect(
       screen.queryByText(/Zoo trains on Free user cloud projects/)
     ).not.toBeInTheDocument()
+  })
+})
+
+describe('ProjectLibraryPreviewRow', () => {
+  it('shows cloud library helper text instead of the technical zoo source', () => {
+    renderProjectLibraryPreviewRow(cloudLibrary)
+
+    const libraryLink = screen.getByTestId('project-library-link')
+    expect(libraryLink).toHaveTextContent('Personal Cloud')
+    expect(libraryLink).toHaveTextContent(
+      'Projects in this library sync to your Zoo account'
+    )
+    expect(libraryLink).not.toHaveTextContent('zoo://personal')
+    expect(
+      screen.getByTitle(/Technical source: zoo:\/\/personal/)
+    ).toBeInTheDocument()
   })
 })

--- a/src/routes/Home.test.tsx
+++ b/src/routes/Home.test.tsx
@@ -35,8 +35,10 @@ const projectActions = {
 
 function renderHomeHeader({
   showFreeCloudProjectTrainingDisclosure,
+  showLibraryBackLink = false,
 }: {
   showFreeCloudProjectTrainingDisclosure: boolean
+  showLibraryBackLink?: boolean
 }) {
   render(
     <MemoryRouter>
@@ -50,6 +52,7 @@ function renderHomeHeader({
         showFreeCloudProjectTrainingDisclosure={
           showFreeCloudProjectTrainingDisclosure
         }
+        showLibraryBackLink={showLibraryBackLink}
       />
     </MemoryRouter>
   )
@@ -97,6 +100,23 @@ describe('HomeHeader', () => {
     expect(
       screen.queryByText(/Zoo trains on Free user cloud projects/)
     ).not.toBeInTheDocument()
+  })
+
+  it('shows the selected library type icon and caret back link', () => {
+    renderHomeHeader({
+      showFreeCloudProjectTrainingDisclosure: false,
+      showLibraryBackLink: true,
+    })
+
+    const backLink = screen.getByRole('link', { name: 'All libraries' })
+    expect(backLink).toHaveAttribute('href', '/home')
+    expect(backLink.querySelector('svg')).toHaveAttribute('aria-hidden', 'true')
+
+    const detailsIcon = screen.getByTestId('project-library-details-icon')
+    expect(detailsIcon.querySelector('svg')).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    )
   })
 })
 

--- a/src/routes/Home.test.tsx
+++ b/src/routes/Home.test.tsx
@@ -102,6 +102,25 @@ describe('HomeHeader', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('shows details copy with the linked library path', () => {
+    renderHomeHeader({
+      showFreeCloudProjectTrainingDisclosure: false,
+    })
+
+    expect(
+      screen.getByText(/Projects in this library sync to your Zoo account/)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        /Storage type and model-training controls depend on your plan/
+      )
+    ).toBeInTheDocument()
+    expect(screen.getByText(/Technical source:/)).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: 'zoo://personal' })
+    ).toHaveAttribute('href', '/home/settings?tab=user#libraries')
+  })
+
   it('shows the selected library type icon and caret back link', () => {
     renderHomeHeader({
       showFreeCloudProjectTrainingDisclosure: false,

--- a/src/routes/Home.test.tsx
+++ b/src/routes/Home.test.tsx
@@ -105,13 +105,17 @@ describe('ProjectLibraryPreviewRow', () => {
     renderProjectLibraryPreviewRow(cloudLibrary)
 
     const libraryLink = screen.getByTestId('project-library-link')
+    const summaryDescription = screen.getByTestId(
+      'project-library-summary-description'
+    )
     expect(libraryLink).toHaveTextContent('Personal Cloud')
-    expect(libraryLink).toHaveTextContent(
+    expect(summaryDescription).toHaveTextContent(
       'Projects in this library sync to your Zoo account'
     )
-    expect(libraryLink).not.toHaveTextContent('zoo://personal')
-    expect(
-      screen.getByTitle(/Technical source: zoo:\/\/personal/)
-    ).toBeInTheDocument()
+    expect(summaryDescription).not.toHaveTextContent('zoo://personal')
+    expect(screen.getByRole('tooltip', { hidden: true })).toBeInTheDocument()
+    expect(screen.getByRole('tooltip', { hidden: true })).toHaveTextContent(
+      'Technical source: zoo://personal'
+    )
   })
 })

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -3,8 +3,7 @@ import { useSignals } from '@preact/signals-react/runtime'
 import { ActionButton } from '@src/components/ActionButton'
 import { Announcements } from '@src/components/Announcements'
 import { AppHeader } from '@src/components/AppHeader'
-import AppProjectCard from '@src/components/AppProjectCard/AppProjectCard'
-import { CustomIcon, type CustomIconName } from '@src/components/CustomIcon'
+import { CustomIcon } from '@src/components/CustomIcon'
 import Loading from '@src/components/Loading'
 import { useNetworkMachineStatus } from '@src/components/NetworkMachineIndicator'
 import { useProjectSearch } from '@src/components/ProjectSearchBar'
@@ -35,7 +34,6 @@ import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
 import { PATHS } from '@src/lib/paths'
 import { markOnce } from '@src/lib/performance'
 import {
-  formatProjectLibraryPathForDisplay,
   type ProjectLibrary,
   projectLibrariesFromSettings,
 } from '@src/lib/projectLibraries'
@@ -78,6 +76,13 @@ import {
 import { APP_COMMAND_IDS } from '@src/registry/extensions/commands/appCommands'
 import { HomeHeader } from '@src/routes/HomeHeader'
 import {
+  type ProjectCardDragProps,
+  ProjectCardList,
+  type ProjectLibraryDragController,
+  type ProjectLibraryDropTargetProps,
+  ProjectLibraryPreviewRow,
+} from '@src/routes/HomeProjectCards'
+import {
   acceptOnboarding,
   needsToOnboard,
   onDismissOnboardingInvite,
@@ -87,14 +92,12 @@ import type { HTMLProps } from 'react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 import {
-  Link,
   useLocation,
   useNavigate,
   useParams,
   useSearchParams,
 } from 'react-router-dom'
 
-const PROJECT_LIBRARY_PREVIEW_LIMIT = 6
 const HOME_PROJECT_CARD_DRAG_MIME = 'application/x-zoo-home-project'
 const HOME_PROJECT_CARD_DRAG_PREVIEW_ID = 'home-project-card-drag-preview'
 
@@ -133,24 +136,6 @@ function readHomeProjectCardDragData(
   } catch {
     return undefined
   }
-}
-
-type ProjectCardDragProps = Pick<
-  HTMLProps<HTMLLIElement>,
-  'draggable' | 'onDragStart' | 'onDragEnd'
->
-
-type ProjectLibraryDropTargetProps = Pick<
-  HTMLProps<HTMLElement>,
-  'onDragOver' | 'onDragLeave' | 'onDrop'
->
-
-interface ProjectLibraryDragController {
-  getProjectCardDragProps: (project: HomeProjectEntry) => ProjectCardDragProps
-  getLibraryDropTargetProps: (
-    library: ProjectLibrary
-  ) => ProjectLibraryDropTargetProps
-  isLibraryDragOver: (library: ProjectLibrary) => boolean
 }
 
 interface UseProjectLibraryDragOptions {
@@ -837,26 +822,6 @@ interface ProjectLibraryOverviewProps extends HTMLProps<HTMLDivElement> {
   projectLibraryDrag?: ProjectLibraryDragController
 }
 
-function getProjectLibraryRoute(library: ProjectLibrary) {
-  return `${PATHS.LIBRARY}/${encodeURIComponent(library.id)}`
-}
-
-function getProjectLibraryIconName(library: ProjectLibrary): CustomIconName {
-  if (library.type === 'cloud' || library.icon === 'cloud') {
-    return 'cloud'
-  }
-
-  if (library.icon === 'network') {
-    return 'network'
-  }
-
-  return 'folder'
-}
-
-function projectCountLabel(count: number) {
-  return `${count} project${count === 1 ? '' : 's'}`
-}
-
 function shouldShowLoadingMoreProjects(
   state: ReturnType<typeof useSystemIOState>
 ) {
@@ -972,99 +937,6 @@ function ProjectLibrariesEmptyState(props: HTMLProps<HTMLDivElement>) {
   )
 }
 
-interface ProjectLibraryPreviewRowProps {
-  library: ProjectLibrary
-  projects: HomeProjectEntry[]
-  query: string
-  projectStatuses: Map<string, ProjectStatus>
-  projectActions: HomeProjectActionsService
-  showCloudSyncUi: boolean
-  onMoveToLibrary: (project: HomeProjectEntry) => void
-  projectLibraryDrag?: ProjectLibraryDragController
-}
-
-function ProjectLibraryPreviewRow({
-  library,
-  projects,
-  query,
-  projectStatuses,
-  projectActions,
-  showCloudSyncUi,
-  onMoveToLibrary,
-  projectLibraryDrag,
-}: ProjectLibraryPreviewRowProps) {
-  const previewProjects =
-    query.length > 0
-      ? projects
-      : projects.slice(0, PROJECT_LIBRARY_PREVIEW_LIMIT)
-  const libraryDropTargetProps =
-    projectLibraryDrag?.getLibraryDropTargetProps(library)
-  const isActiveDropTarget =
-    projectLibraryDrag?.isLibraryDragOver(library) ?? false
-  const sectionClassName = `mx-1 flex flex-col gap-3 rounded-sm border p-2 transition-colors ${
-    isActiveDropTarget
-      ? 'border-primary bg-primary/5 ring-2 ring-primary/30 dark:bg-primary/10'
-      : 'border-transparent'
-  }`
-
-  return (
-    <section
-      className={sectionClassName}
-      data-testid="project-library-drop-target"
-      aria-label={`${library.title} library`}
-      {...libraryDropTargetProps}
-    >
-      <Link
-        to={getProjectLibraryRoute(library)}
-        className="group flex items-center gap-3 rounded-sm border border-transparent p-1 !no-underline hover:border-primary/30 hover:bg-primary/5"
-        data-testid="project-library-link"
-      >
-        <span className="grid h-8 w-8 flex-none place-content-center rounded-sm bg-primary/10 text-primary dark:bg-chalkboard-90 dark:text-chalkboard-20">
-          <CustomIcon
-            name={getProjectLibraryIconName(library)}
-            className="h-5 w-5"
-          />
-        </span>
-        <span className="min-w-0 flex-1">
-          <span className="block truncate text-base font-semibold text-chalkboard-100 dark:text-chalkboard-10">
-            {library.title}
-          </span>
-          <span className="block truncate text-xs text-chalkboard-70 dark:text-chalkboard-30">
-            {formatProjectLibraryPathForDisplay(library)}
-          </span>
-        </span>
-        <span className="hidden flex-none text-xs text-chalkboard-70 dark:text-chalkboard-30 sm:block">
-          {projectCountLabel(projects.length)}
-        </span>
-        <CustomIcon
-          name="arrowRight"
-          className="h-5 w-5 flex-none text-chalkboard-60 group-hover:text-primary"
-        />
-      </Link>
-      {previewProjects.length > 0 ? (
-        <ProjectCardList
-          projects={previewProjects}
-          projectStatuses={projectStatuses}
-          projectActions={projectActions}
-          showCloudSyncUi={showCloudSyncUi}
-          showSourceStatusBadges={false}
-          onMoveToLibrary={onMoveToLibrary}
-          projectLibraryDrag={projectLibraryDrag}
-          density="compact"
-          className="grid w-full grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6"
-        />
-      ) : (
-        <p
-          className="rounded-sm border border-dashed border-chalkboard-30 p-4 text-sm text-chalkboard-70 dark:border-chalkboard-70 dark:text-chalkboard-30"
-          data-testid="project-library-empty"
-        >
-          No projects
-        </p>
-      )}
-    </section>
-  )
-}
-
 interface ProjectGridProps extends HTMLProps<HTMLDivElement> {
   searchResults: HomeProjectEntry[]
   projects: HomeProjectEntry[]
@@ -1133,60 +1005,6 @@ function ProjectGrid({
         </>
       )}
     </section>
-  )
-}
-
-interface ProjectCardListProps {
-  projects: HomeProjectEntry[]
-  projectStatuses: Map<string, ProjectStatus>
-  projectActions: HomeProjectActionsService
-  showCloudSyncUi: boolean
-  onMoveToLibrary: (project: HomeProjectEntry) => void
-  projectLibraryDrag?: ProjectLibraryDragController
-  density?: 'default' | 'compact'
-  showDetails?: boolean
-  showSourceStatusBadges?: boolean
-  className?: string
-}
-
-function ProjectCardList({
-  projects,
-  projectStatuses,
-  projectActions,
-  showCloudSyncUi,
-  onMoveToLibrary,
-  projectLibraryDrag,
-  density = 'default',
-  showDetails = true,
-  showSourceStatusBadges = true,
-  className = 'grid w-full sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4',
-}: ProjectCardListProps) {
-  return (
-    <ul className={className}>
-      {projects.map((project) => {
-        const projectDragProps =
-          projectLibraryDrag?.getProjectCardDragProps(project)
-
-        return (
-          <AppProjectCard
-            key={project.id}
-            project={project}
-            projectActions={projectActions}
-            projectStatus={
-              project.remoteProjectId
-                ? projectStatuses.get(project.remoteProjectId)
-                : undefined
-            }
-            density={density}
-            showDetails={showDetails}
-            showCloudSyncUi={showCloudSyncUi}
-            showSourceStatusBadges={showSourceStatusBadges}
-            onMoveToLibrary={onMoveToLibrary}
-            {...projectDragProps}
-          />
-        )
-      })}
-    </ul>
   )
 }
 

--- a/src/routes/HomeHeader.tsx
+++ b/src/routes/HomeHeader.tsx
@@ -11,9 +11,9 @@ import {
 } from '@src/lib/projectLibraries'
 import { FREE_CLOUD_PROJECT_TRAINING_POLICY_URL } from '@src/lib/projectLibraries/trainingDisclosure'
 import { getNextSearchParams, getSortIcon } from '@src/lib/sorting'
+import { getProjectLibraryIconName } from '@src/routes/projectLibraryIcons'
 import type { HTMLProps } from 'react'
 import { Link } from 'react-router-dom'
-import { getProjectLibraryIconName } from './projectLibraryIcons'
 
 type ReadWriteProjectState = {
   value: boolean

--- a/src/routes/HomeHeader.tsx
+++ b/src/routes/HomeHeader.tsx
@@ -1,4 +1,5 @@
 import { ActionButton } from '@src/components/ActionButton'
+import { CustomIcon } from '@src/components/CustomIcon'
 import { ProjectSearchBar } from '@src/components/ProjectSearchBar'
 import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
 import { PATHS } from '@src/lib/paths'
@@ -10,6 +11,7 @@ import { FREE_CLOUD_PROJECT_TRAINING_POLICY_URL } from '@src/lib/projectLibrarie
 import { getNextSearchParams, getSortIcon } from '@src/lib/sorting'
 import type { HTMLProps } from 'react'
 import { Link } from 'react-router-dom'
+import { getProjectLibraryIconName } from './projectLibraryIcons'
 
 type ReadWriteProjectState = {
   value: boolean
@@ -50,12 +52,31 @@ export function HomeHeader({
             {library && showLibraryBackLink && (
               <Link
                 to={PATHS.HOME}
-                className="text-sm text-chalkboard-70 underline underline-offset-2 dark:text-chalkboard-30"
+                className="inline-flex items-center gap-1 text-sm text-chalkboard-70 underline underline-offset-2 dark:text-chalkboard-30"
               >
+                <CustomIcon
+                  name="caretLeft"
+                  className="h-4 w-4"
+                  aria-hidden="true"
+                />
                 All libraries
               </Link>
             )}
-            <h1 className="text-3xl font-bold">{title}</h1>
+            <div className="flex items-center gap-3">
+              {library && (
+                <span
+                  className="grid h-12 w-12 flex-none place-content-center rounded-sm bg-primary/10 text-primary dark:bg-chalkboard-90 dark:text-chalkboard-20"
+                  data-testid="project-library-details-icon"
+                >
+                  <CustomIcon
+                    name={getProjectLibraryIconName(library)}
+                    className="h-7 w-7"
+                    aria-hidden="true"
+                  />
+                </span>
+              )}
+              <h1 className="text-3xl font-bold">{title}</h1>
+            </div>
           </div>
         </div>
         <div className="flex flex-col sm:flex-row gap-2 sm:items-center">

--- a/src/routes/HomeHeader.tsx
+++ b/src/routes/HomeHeader.tsx
@@ -5,6 +5,8 @@ import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
 import { PATHS } from '@src/lib/paths'
 import {
   formatProjectLibraryPathForDisplay,
+  getProjectLibraryDetailsDescription,
+  getProjectLibraryLocationLabel,
   type ProjectLibrary,
 } from '@src/lib/projectLibraries'
 import { FREE_CLOUD_PROJECT_TRAINING_POLICY_URL } from '@src/lib/projectLibraries/trainingDisclosure'
@@ -43,6 +45,9 @@ export function HomeHeader({
   ...rest
 }: HomeHeaderProps) {
   const isSortByModified = sort?.includes('modified') || !sort || sort === null
+  const libraryDetailsDescription = library
+    ? getProjectLibraryDetailsDescription(library)
+    : undefined
 
   return (
     <section {...rest}>
@@ -131,7 +136,9 @@ export function HomeHeader({
       </div>
       {library ? (
         <p className="my-4 break-words text-sm text-chalkboard-80 dark:text-chalkboard-30">
-          Loaded from{' '}
+          {libraryDetailsDescription
+            ? `${libraryDetailsDescription} ${getProjectLibraryLocationLabel(library)}: `
+            : 'Loaded from '}
           <Link
             data-testid="project-directory-settings-link"
             to={`${PATHS.HOME + PATHS.SETTINGS_USER}#libraries`}

--- a/src/routes/HomeHeader.tsx
+++ b/src/routes/HomeHeader.tsx
@@ -136,16 +136,19 @@ export function HomeHeader({
       </div>
       {library ? (
         <p className="my-4 break-words text-sm text-chalkboard-80 dark:text-chalkboard-30">
-          {libraryDetailsDescription
-            ? `${libraryDetailsDescription} ${getProjectLibraryLocationLabel(library)}: `
-            : 'Loaded from '}
-          <Link
-            data-testid="project-directory-settings-link"
-            to={`${PATHS.HOME + PATHS.SETTINGS_USER}#libraries`}
-            className="text-chalkboard-90 dark:text-chalkboard-20 underline underline-offset-2"
-          >
-            {formatProjectLibraryPathForDisplay(library)}
-          </Link>
+          {libraryDetailsDescription ? `${libraryDetailsDescription} ` : null}
+          <span className="whitespace-nowrap">
+            {libraryDetailsDescription
+              ? `${getProjectLibraryLocationLabel(library)}: `
+              : 'Loaded from '}
+            <Link
+              data-testid="project-directory-settings-link"
+              to={`${PATHS.HOME + PATHS.SETTINGS_USER}#libraries`}
+              className="text-chalkboard-90 dark:text-chalkboard-20 underline underline-offset-2"
+            >
+              {formatProjectLibraryPathForDisplay(library)}
+            </Link>
+          </span>
           {showFreeCloudProjectTrainingDisclosure && (
             <>
               . Zoo trains on Free user cloud projects.{' '}

--- a/src/routes/HomeProjectCards.tsx
+++ b/src/routes/HomeProjectCards.tsx
@@ -12,9 +12,9 @@ import type {
   HomeProjectActionsService,
   HomeProjectEntry,
 } from '@src/registry/contracts/homeProjects'
+import { getProjectLibraryIconName } from '@src/routes/projectLibraryIcons'
 import type { HTMLProps } from 'react'
 import { Link } from 'react-router-dom'
-import { getProjectLibraryIconName } from './projectLibraryIcons'
 
 const PROJECT_LIBRARY_PREVIEW_LIMIT = 6
 

--- a/src/routes/HomeProjectCards.tsx
+++ b/src/routes/HomeProjectCards.tsx
@@ -1,0 +1,205 @@
+import AppProjectCard from '@src/components/AppProjectCard/AppProjectCard'
+import { CustomIcon, type CustomIconName } from '@src/components/CustomIcon'
+import type { ProjectStatus } from '@src/hooks/useProjectStatus'
+import { PATHS } from '@src/lib/paths'
+import {
+  getProjectLibrarySummaryDescription,
+  getProjectLibrarySummaryTooltip,
+  type ProjectLibrary,
+} from '@src/lib/projectLibraries'
+import type {
+  HomeProjectActionsService,
+  HomeProjectEntry,
+} from '@src/registry/contracts/homeProjects'
+import type { HTMLProps } from 'react'
+import { Link } from 'react-router-dom'
+
+const PROJECT_LIBRARY_PREVIEW_LIMIT = 6
+
+export type ProjectCardDragProps = Pick<
+  HTMLProps<HTMLLIElement>,
+  'draggable' | 'onDragStart' | 'onDragEnd'
+>
+
+export type ProjectLibraryDropTargetProps = Pick<
+  HTMLProps<HTMLElement>,
+  'onDragOver' | 'onDragLeave' | 'onDrop'
+>
+
+export interface ProjectLibraryDragController {
+  getProjectCardDragProps: (project: HomeProjectEntry) => ProjectCardDragProps
+  getLibraryDropTargetProps: (
+    library: ProjectLibrary
+  ) => ProjectLibraryDropTargetProps
+  isLibraryDragOver: (library: ProjectLibrary) => boolean
+}
+
+interface ProjectLibraryPreviewRowProps {
+  library: ProjectLibrary
+  projects: HomeProjectEntry[]
+  query: string
+  projectStatuses: Map<string, ProjectStatus>
+  projectActions: HomeProjectActionsService
+  showCloudSyncUi: boolean
+  onMoveToLibrary: (project: HomeProjectEntry) => void
+  projectLibraryDrag?: ProjectLibraryDragController
+}
+
+function getProjectLibraryRoute(library: ProjectLibrary) {
+  return `${PATHS.LIBRARY}/${encodeURIComponent(library.id)}`
+}
+
+function getProjectLibraryIconName(library: ProjectLibrary): CustomIconName {
+  if (library.type === 'cloud' || library.icon === 'cloud') {
+    return 'cloud'
+  }
+
+  if (library.icon === 'network') {
+    return 'network'
+  }
+
+  return 'folder'
+}
+
+function projectCountLabel(count: number) {
+  return `${count} project${count === 1 ? '' : 's'}`
+}
+
+export function ProjectLibraryPreviewRow({
+  library,
+  projects,
+  query,
+  projectStatuses,
+  projectActions,
+  showCloudSyncUi,
+  onMoveToLibrary,
+  projectLibraryDrag,
+}: ProjectLibraryPreviewRowProps) {
+  const previewProjects =
+    query.length > 0
+      ? projects
+      : projects.slice(0, PROJECT_LIBRARY_PREVIEW_LIMIT)
+  const libraryDropTargetProps =
+    projectLibraryDrag?.getLibraryDropTargetProps(library)
+  const isActiveDropTarget =
+    projectLibraryDrag?.isLibraryDragOver(library) ?? false
+  const sectionClassName = `mx-1 flex flex-col gap-3 rounded-sm border p-2 transition-colors ${
+    isActiveDropTarget
+      ? 'border-primary bg-primary/5 ring-2 ring-primary/30 dark:bg-primary/10'
+      : 'border-transparent'
+  }`
+
+  return (
+    <section
+      className={sectionClassName}
+      data-testid="project-library-drop-target"
+      aria-label={`${library.title} library`}
+      {...libraryDropTargetProps}
+    >
+      <Link
+        to={getProjectLibraryRoute(library)}
+        className="group flex items-center gap-3 rounded-sm border border-transparent p-1 !no-underline hover:border-primary/30 hover:bg-primary/5"
+        data-testid="project-library-link"
+      >
+        <span
+          className="grid h-8 w-8 flex-none place-content-center rounded-sm bg-primary/10 text-primary dark:bg-chalkboard-90 dark:text-chalkboard-20"
+          title={getProjectLibrarySummaryTooltip(library)}
+        >
+          <CustomIcon
+            name={getProjectLibraryIconName(library)}
+            className="h-5 w-5"
+          />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-base font-semibold text-chalkboard-100 dark:text-chalkboard-10">
+            {library.title}
+          </span>
+          <span className="block truncate text-xs text-chalkboard-70 dark:text-chalkboard-30">
+            {getProjectLibrarySummaryDescription(library)}
+          </span>
+        </span>
+        <span className="hidden flex-none text-xs text-chalkboard-70 dark:text-chalkboard-30 sm:block">
+          {projectCountLabel(projects.length)}
+        </span>
+        <CustomIcon
+          name="arrowRight"
+          className="h-5 w-5 flex-none text-chalkboard-60 group-hover:text-primary"
+        />
+      </Link>
+      {previewProjects.length > 0 ? (
+        <ProjectCardList
+          projects={previewProjects}
+          projectStatuses={projectStatuses}
+          projectActions={projectActions}
+          showCloudSyncUi={showCloudSyncUi}
+          showSourceStatusBadges={false}
+          onMoveToLibrary={onMoveToLibrary}
+          projectLibraryDrag={projectLibraryDrag}
+          density="compact"
+          className="grid w-full grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6"
+        />
+      ) : (
+        <p
+          className="rounded-sm border border-dashed border-chalkboard-30 p-4 text-sm text-chalkboard-70 dark:border-chalkboard-70 dark:text-chalkboard-30"
+          data-testid="project-library-empty"
+        >
+          No projects
+        </p>
+      )}
+    </section>
+  )
+}
+
+interface ProjectCardListProps {
+  projects: HomeProjectEntry[]
+  projectStatuses: Map<string, ProjectStatus>
+  projectActions: HomeProjectActionsService
+  showCloudSyncUi: boolean
+  onMoveToLibrary: (project: HomeProjectEntry) => void
+  projectLibraryDrag?: ProjectLibraryDragController
+  density?: 'default' | 'compact'
+  showDetails?: boolean
+  showSourceStatusBadges?: boolean
+  className?: string
+}
+
+export function ProjectCardList({
+  projects,
+  projectStatuses,
+  projectActions,
+  showCloudSyncUi,
+  onMoveToLibrary,
+  projectLibraryDrag,
+  density = 'default',
+  showDetails = true,
+  showSourceStatusBadges = true,
+  className = 'grid w-full sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4',
+}: ProjectCardListProps) {
+  return (
+    <ul className={className}>
+      {projects.map((project) => {
+        const projectDragProps =
+          projectLibraryDrag?.getProjectCardDragProps(project)
+
+        return (
+          <AppProjectCard
+            key={project.id}
+            project={project}
+            projectActions={projectActions}
+            projectStatus={
+              project.remoteProjectId
+                ? projectStatuses.get(project.remoteProjectId)
+                : undefined
+            }
+            density={density}
+            showDetails={showDetails}
+            showCloudSyncUi={showCloudSyncUi}
+            showSourceStatusBadges={showSourceStatusBadges}
+            onMoveToLibrary={onMoveToLibrary}
+            {...projectDragProps}
+          />
+        )
+      })}
+    </ul>
+  )
+}

--- a/src/routes/HomeProjectCards.tsx
+++ b/src/routes/HomeProjectCards.tsx
@@ -1,5 +1,6 @@
 import AppProjectCard from '@src/components/AppProjectCard/AppProjectCard'
 import { CustomIcon, type CustomIconName } from '@src/components/CustomIcon'
+import Tooltip from '@src/components/Tooltip'
 import type { ProjectStatus } from '@src/hooks/useProjectStatus'
 import { PATHS } from '@src/lib/paths'
 import {
@@ -101,20 +102,23 @@ export function ProjectLibraryPreviewRow({
         className="group flex items-center gap-3 rounded-sm border border-transparent p-1 !no-underline hover:border-primary/30 hover:bg-primary/5"
         data-testid="project-library-link"
       >
-        <span
-          className="grid h-8 w-8 flex-none place-content-center rounded-sm bg-primary/10 text-primary dark:bg-chalkboard-90 dark:text-chalkboard-20"
-          title={getProjectLibrarySummaryTooltip(library)}
-        >
+        <div className="grid h-8 w-8 flex-none place-content-center rounded-sm bg-primary/10 text-primary dark:bg-chalkboard-90 dark:text-chalkboard-20">
           <CustomIcon
             name={getProjectLibraryIconName(library)}
             className="h-5 w-5"
           />
-        </span>
+          <Tooltip position="right" contentClassName="max-w-xs text-xs">
+            {getProjectLibrarySummaryTooltip(library)}
+          </Tooltip>
+        </div>
         <span className="min-w-0 flex-1">
           <span className="block truncate text-base font-semibold text-chalkboard-100 dark:text-chalkboard-10">
             {library.title}
           </span>
-          <span className="block truncate text-xs text-chalkboard-70 dark:text-chalkboard-30">
+          <span
+            className="block truncate text-xs text-chalkboard-70 dark:text-chalkboard-30"
+            data-testid="project-library-summary-description"
+          >
             {getProjectLibrarySummaryDescription(library)}
           </span>
         </span>

--- a/src/routes/HomeProjectCards.tsx
+++ b/src/routes/HomeProjectCards.tsx
@@ -1,5 +1,5 @@
 import AppProjectCard from '@src/components/AppProjectCard/AppProjectCard'
-import { CustomIcon, type CustomIconName } from '@src/components/CustomIcon'
+import { CustomIcon } from '@src/components/CustomIcon'
 import Tooltip from '@src/components/Tooltip'
 import type { ProjectStatus } from '@src/hooks/useProjectStatus'
 import { PATHS } from '@src/lib/paths'
@@ -14,6 +14,7 @@ import type {
 } from '@src/registry/contracts/homeProjects'
 import type { HTMLProps } from 'react'
 import { Link } from 'react-router-dom'
+import { getProjectLibraryIconName } from './projectLibraryIcons'
 
 const PROJECT_LIBRARY_PREVIEW_LIMIT = 6
 
@@ -48,18 +49,6 @@ interface ProjectLibraryPreviewRowProps {
 
 function getProjectLibraryRoute(library: ProjectLibrary) {
   return `${PATHS.LIBRARY}/${encodeURIComponent(library.id)}`
-}
-
-function getProjectLibraryIconName(library: ProjectLibrary): CustomIconName {
-  if (library.type === 'cloud' || library.icon === 'cloud') {
-    return 'cloud'
-  }
-
-  if (library.icon === 'network') {
-    return 'network'
-  }
-
-  return 'folder'
 }
 
 function projectCountLabel(count: number) {

--- a/src/routes/projectLibraryIcons.ts
+++ b/src/routes/projectLibraryIcons.ts
@@ -1,0 +1,16 @@
+import type { CustomIconName } from '@src/components/CustomIcon'
+import type { ProjectLibrary } from '@src/lib/projectLibraries'
+
+export function getProjectLibraryIconName(
+  library: Pick<ProjectLibrary, 'icon' | 'type'>
+): CustomIconName {
+  if (library.type === 'cloud' || library.icon === 'cloud') {
+    return 'cloud'
+  }
+
+  if (library.icon === 'network') {
+    return 'network'
+  }
+
+  return 'folder'
+}


### PR DESCRIPTION
Closes #13062 by replacing the raw cloud source shown in the Home library overview with plain-language storage context, while keeping the technical source available in a hover tooltip.

<img width="1042" height="712" alt="Screenshot 2026-08-20 at 3 58 19 PM" src="https://github.com/user-attachments/assets/36c6354e-74b0-4a99-8ad4-ffb7a19749e0" />
<img width="626" height="174" alt="Screenshot 2026-08-20 at 3 58 24 PM" src="https://github.com/user-attachments/assets/27da663f-282c-4476-ab12-713eeace8366" />
<img width="1071" height="396" alt="Screenshot 2026-08-20 at 3 58 30 PM" src="https://github.com/user-attachments/assets/f5a2377e-19ba-480e-b21f-180412a7ea49" />

## How to test

Open Home and confirm the Project Libraries overview shows plain-language text under Personal Cloud instead of `zoo://personal`, with the technical source available from the icon tooltip.

Open a specific library and confirm the page header shows the larger library type icon, and the “All libraries” link includes the left caret while still navigating back to the libraries overview.