### PR TITLE
KCL: Pattern3D should support imported geometry

### DIFF
--- a/docs/kcl-std/functions/std-solid-patternCircular3d.md
+++ b/docs/kcl-std/functions/std-solid-patternCircular3d.md
@@ -1,22 +1,22 @@
 ---
 title: "patternCircular3d"
 subtitle: "Function in std::solid"
-excerpt: "Repeat a 3-dimensional solid some number of times along a partial or complete circle some specified number of times. Each object may additionally be rotated along the circle, ensuring orientation of the solid with respect to the center of the circle is maintained."
+excerpt: "Repeat a 3-dimensional solid or imported geometry some number of times along a partial or complete circle some specified number of times. Each object may additionally be rotated along the circle, ensuring orientation of the solid with respect to the center of the circle is maintained."
 layout: manual
 ---
 
-Repeat a 3-dimensional solid some number of times along a partial or complete circle some specified number of times. Each object may additionally be rotated along the circle, ensuring orientation of the solid with respect to the center of the circle is maintained.
+Repeat a 3-dimensional solid or imported geometry some number of times along a partial or complete circle some specified number of times. Each object may additionally be rotated along the circle, ensuring orientation of the solid with respect to the center of the circle is maintained.
 
 ```kcl
 patternCircular3d(
-  @solids: [Solid; 1+],
+  @solids: [Solid; 1+] | ImportedGeometry,
   instances: number(_),
   axis: Axis3d | Point3d,
   center?: Point3d,
   arcDegrees?: number(deg),
   rotateDuplicates?: bool,
   useOriginal?: bool,
-): [Solid; 1+]
+): [Solid | ImportedGeometry; 1+]
 ```
 
 
@@ -25,7 +25,7 @@ patternCircular3d(
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `solids` | [[`Solid`](/docs/kcl-std/types/std-types-Solid); 1+] | The solid(s) to pattern. | Yes |
+| `solids` | [[`Solid`](/docs/kcl-std/types/std-types-Solid); 1+] or [`ImportedGeometry`](/docs/kcl-std/types/std-types-ImportedGeometry) | The solid(s) or imported geometry to pattern. | Yes |
 | `instances` | [`number(_)`](/docs/kcl-std/types/std-types-number) | The number of total instances. Must be greater than or equal to 1. This includes the original entity. For example, if instances is 2, there will be two copies -- the original, and one new copy. If instances is 1, this has no effect. | Yes |
 | `axis` | [`Axis3d`](/docs/kcl-std/types/std-types-Axis3d) or [`Point3d`](/docs/kcl-std/types/std-types-Point3d) | The axis of the pattern. A 3D vector. | Yes |
 | `center` | [`Point3d`](/docs/kcl-std/types/std-types-Point3d) | The center about which to make the pattern. This is a 3D vector. If not given, defaults to `[0, 0, 0]`. | No |
@@ -35,7 +35,7 @@ patternCircular3d(
 
 ### Returns
 
-[[`Solid`](/docs/kcl-std/types/std-types-Solid); 1+]
+[[`Solid`](/docs/kcl-std/types/std-types-Solid) or [`ImportedGeometry`](/docs/kcl-std/types/std-types-ImportedGeometry); 1+]
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-solid-patternCircular3d.md
+++ b/docs/kcl-std/functions/std-solid-patternCircular3d.md
@@ -1,11 +1,11 @@
 ---
 title: "patternCircular3d"
 subtitle: "Function in std::solid"
-excerpt: "Repeat a 3-dimensional solid or imported geometry some number of times along a partial or complete circle some specified number of times. Each object may additionally be rotated along the circle, ensuring orientation of the solid with respect to the center of the circle is maintained."
+excerpt: "Repeat a 3-dimensional body or imported geometry some number of times along a partial or complete circle some specified number of times. Each object may additionally be rotated along the circle, ensuring orientation of the solid with respect to the center of the circle is maintained."
 layout: manual
 ---
 
-Repeat a 3-dimensional solid or imported geometry some number of times along a partial or complete circle some specified number of times. Each object may additionally be rotated along the circle, ensuring orientation of the solid with respect to the center of the circle is maintained.
+Repeat a 3-dimensional body or imported geometry some number of times along a partial or complete circle some specified number of times. Each object may additionally be rotated along the circle, ensuring orientation of the solid with respect to the center of the circle is maintained.
 
 ```kcl
 patternCircular3d(

--- a/docs/kcl-std/functions/std-solid-patternLinear3d.md
+++ b/docs/kcl-std/functions/std-solid-patternLinear3d.md
@@ -1,20 +1,20 @@
 ---
 title: "patternLinear3d"
 subtitle: "Function in std::solid"
-excerpt: "Repeat a 3-dimensional solid along a linear path, with a dynamic amount of distance between each repetition, some specified number of times."
+excerpt: "Repeat a 3-dimensional solid or imported geometry along a linear path, with a dynamic amount of distance between each repetition, some specified number of times."
 layout: manual
 ---
 
-Repeat a 3-dimensional solid along a linear path, with a dynamic amount of distance between each repetition, some specified number of times.
+Repeat a 3-dimensional solid or imported geometry along a linear path, with a dynamic amount of distance between each repetition, some specified number of times.
 
 ```kcl
 patternLinear3d(
-  @solids: [Solid; 1+],
+  @solids: [Solid; 1+] | ImportedGeometry,
   instances: number(_),
   distance: number(Length),
   axis: Axis3d | Point3d,
   useOriginal?: bool,
-): [Solid; 1+]
+): [Solid | ImportedGeometry; 1+]
 ```
 
 
@@ -23,7 +23,7 @@ patternLinear3d(
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `solids` | [[`Solid`](/docs/kcl-std/types/std-types-Solid); 1+] | The solid(s) to duplicate. | Yes |
+| `solids` | [[`Solid`](/docs/kcl-std/types/std-types-Solid); 1+] or [`ImportedGeometry`](/docs/kcl-std/types/std-types-ImportedGeometry) | The solid(s) or imported geometry to duplicate. | Yes |
 | `instances` | [`number(_)`](/docs/kcl-std/types/std-types-number) | The number of total instances. Must be greater than or equal to 1. This includes the original entity. For example, if instances is 2, there will be two copies -- the original, and one new copy. If instances is 1, this has no effect. | Yes |
 | `distance` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | Distance between each repetition. Also known as 'spacing'. | Yes |
 | `axis` | [`Axis3d`](/docs/kcl-std/types/std-types-Axis3d) or [`Point3d`](/docs/kcl-std/types/std-types-Point3d) | The axis of the pattern. A 3D vector. | Yes |
@@ -31,7 +31,7 @@ patternLinear3d(
 
 ### Returns
 
-[[`Solid`](/docs/kcl-std/types/std-types-Solid); 1+]
+[[`Solid`](/docs/kcl-std/types/std-types-Solid) or [`ImportedGeometry`](/docs/kcl-std/types/std-types-ImportedGeometry); 1+]
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-solid-patternLinear3d.md
+++ b/docs/kcl-std/functions/std-solid-patternLinear3d.md
@@ -1,11 +1,11 @@
 ---
 title: "patternLinear3d"
 subtitle: "Function in std::solid"
-excerpt: "Repeat a 3-dimensional solid or imported geometry along a linear path, with a dynamic amount of distance between each repetition, some specified number of times."
+excerpt: "Repeat a 3-dimensional body or imported geometry along a linear path, with a dynamic amount of distance between each repetition, some specified number of times."
 layout: manual
 ---
 
-Repeat a 3-dimensional solid or imported geometry along a linear path, with a dynamic amount of distance between each repetition, some specified number of times.
+Repeat a 3-dimensional body or imported geometry along a linear path, with a dynamic amount of distance between each repetition, some specified number of times.
 
 ```kcl
 patternLinear3d(

--- a/docs/kcl-std/functions/std-solid-patternTransform.md
+++ b/docs/kcl-std/functions/std-solid-patternTransform.md
@@ -1,11 +1,11 @@
 ---
 title: "patternTransform"
 subtitle: "Function in std::solid"
-excerpt: "Repeat a 3-dimensional solid or imported geometry, changing it each time."
+excerpt: "Repeat a 3-dimensional body or imported geometry, changing it each time."
 layout: manual
 ---
 
-Repeat a 3-dimensional solid or imported geometry, changing it each time.
+Repeat a 3-dimensional body or imported geometry, changing it each time.
 
 ```kcl
 patternTransform(

--- a/docs/kcl-std/functions/std-solid-patternTransform.md
+++ b/docs/kcl-std/functions/std-solid-patternTransform.md
@@ -1,22 +1,22 @@
 ---
 title: "patternTransform"
 subtitle: "Function in std::solid"
-excerpt: "Repeat a 3-dimensional solid, changing it each time."
+excerpt: "Repeat a 3-dimensional solid or imported geometry, changing it each time."
 layout: manual
 ---
 
-Repeat a 3-dimensional solid, changing it each time.
+Repeat a 3-dimensional solid or imported geometry, changing it each time.
 
 ```kcl
 patternTransform(
-  @solids: [Solid; 1+],
+  @solids: [Solid; 1+] | ImportedGeometry,
   instances: number(_),
   transform: fn(number(_)): { },
   useOriginal?: bool,
-): [Solid; 1+]
+): [Solid | ImportedGeometry; 1+]
 ```
 
-Replicates the 3D solid, applying a transformation function to each replica.
+Replicates the 3D solid or imported geometry, applying a transformation function to each replica.
 Transformation function could alter rotation, scale, visibility, position, etc.
 
 The `patternTransform` call itself takes a number for how many total instances of
@@ -58,14 +58,14 @@ Its properties are:
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `solids` | [[`Solid`](/docs/kcl-std/types/std-types-Solid); 1+] | The solid(s) to duplicate. | Yes |
+| `solids` | [[`Solid`](/docs/kcl-std/types/std-types-Solid); 1+] or [`ImportedGeometry`](/docs/kcl-std/types/std-types-ImportedGeometry) | The solid(s) or imported geometry to duplicate. | Yes |
 | `instances` | [`number(_)`](/docs/kcl-std/types/std-types-number) | The number of total instances. Must be greater than or equal to 1. This includes the original entity. For example, if instances is 2, there will be two copies -- the original, and one new copy. If instances is 1, this has no effect. | Yes |
 | `transform` | [`fn(number(_)): { }`](/docs/kcl-std/types/std-types-fn) | How each replica should be transformed. The transform function takes a single parameter: an integer representing which number replication the transform is for. E.g. the first replica to be transformed will be passed the argument `1`. This simplifies your math: the transform function can rely on id `0` being the original instance passed into the `patternTransform`. See the examples. | Yes |
 | `useOriginal` | [`bool`](/docs/kcl-std/types/std-types-bool) | If the target was sketched on an extrusion, setting this will use the original sketch as the target, not the entire joined solid. | No |
 
 ### Returns
 
-[[`Solid`](/docs/kcl-std/types/std-types-Solid); 1+]
+[[`Solid`](/docs/kcl-std/types/std-types-Solid) or [`ImportedGeometry`](/docs/kcl-std/types/std-types-ImportedGeometry); 1+]
 
 
 ### Examples

--- a/rust/kcl-lib/expected-bindings/ts-rs/StdLibCommands.ts
+++ b/rust/kcl-lib/expected-bindings/ts-rs/StdLibCommands.ts
@@ -5772,7 +5772,7 @@ export default {
     "preferredName": "patternCircular3d",
     "qualName": "std::solid::patternCircular3d",
     "moduleName": "solid",
-    "returnType": "[Solid; 1+]",
+    "returnType": "[Solid | ImportedGeometry; 1+]",
     "deprecated": false,
     "deprecatedSince": null,
     "experimental": false,
@@ -5780,8 +5780,8 @@ export default {
     "args": [
       {
         "name": "solids",
-        "ty": "[Solid; 1+]",
-        "docs": "The solid(s) to pattern.",
+        "ty": "[Solid; 1+] | ImportedGeometry",
+        "docs": "The solid(s) or imported geometry to pattern.",
         "required": true,
         "special": true,
         "experimental": false,
@@ -5918,7 +5918,7 @@ export default {
     "preferredName": "patternLinear3d",
     "qualName": "std::solid::patternLinear3d",
     "moduleName": "solid",
-    "returnType": "[Solid; 1+]",
+    "returnType": "[Solid | ImportedGeometry; 1+]",
     "deprecated": false,
     "deprecatedSince": null,
     "experimental": false,
@@ -5926,8 +5926,8 @@ export default {
     "args": [
       {
         "name": "solids",
-        "ty": "[Solid; 1+]",
-        "docs": "The solid(s) to duplicate.",
+        "ty": "[Solid; 1+] | ImportedGeometry",
+        "docs": "The solid(s) or imported geometry to duplicate.",
         "required": true,
         "special": true,
         "experimental": false,
@@ -5981,7 +5981,7 @@ export default {
     "preferredName": "patternTransform",
     "qualName": "std::solid::patternTransform",
     "moduleName": "solid",
-    "returnType": "[Solid; 1+]",
+    "returnType": "[Solid | ImportedGeometry; 1+]",
     "deprecated": false,
     "deprecatedSince": null,
     "experimental": false,
@@ -5989,8 +5989,8 @@ export default {
     "args": [
       {
         "name": "solids",
-        "ty": "[Solid; 1+]",
-        "docs": "The solid(s) to duplicate.",
+        "ty": "[Solid; 1+] | ImportedGeometry",
+        "docs": "The solid(s) or imported geometry to duplicate.",
         "required": true,
         "special": true,
         "experimental": false,

--- a/rust/kcl-lib/src/execution/kcl_value.rs
+++ b/rust/kcl-lib/src/execution/kcl_value.rs
@@ -930,6 +930,14 @@ impl KclValue {
         }
     }
 
+    pub fn from_imported_geometries(geometries: Vec<ImportedGeometry>) -> Self {
+        geometries
+            .into_iter()
+            .map(|geometry| GeometryWithImportedGeometry::ImportedGeometry(Box::new(geometry)))
+            .collect::<Vec<_>>()
+            .into()
+    }
+
     /// Put the point into a KCL value.
     pub fn from_point3d(p: [f64; 3], ty: NumericType, meta: Vec<Metadata>) -> Self {
         let [x, y, z] = p;

--- a/rust/kcl-lib/src/execution/machine.rs
+++ b/rust/kcl-lib/src/execution/machine.rs
@@ -1937,8 +1937,8 @@ async fn resumable_entry(
                 crate::std::patterns::pattern_transform_parse_args(&args, exec_state)?;
             crate::std::patterns::pattern_check_instances(instances, source_range)?;
             let geometry = match geometry {
-                crate::std::patterns::PatternGeometry3d::Solids(solids) => PatternGeometry::Solids(solids),
-                crate::std::patterns::PatternGeometry3d::ImportedGeometry(geometry) => {
+                crate::std::patterns::Patternable3d::Solids(solids) => PatternGeometry::Solids(solids),
+                crate::std::patterns::Patternable3d::ImportedGeometry(geometry) => {
                     PatternGeometry::ImportedGeometry(geometry)
                 }
             };

--- a/rust/kcl-lib/src/execution/machine.rs
+++ b/rust/kcl-lib/src/execution/machine.rs
@@ -534,6 +534,7 @@ struct PatternTransformResume {
 enum PatternGeometry {
     Solids(Vec<crate::execution::Solid>),
     Sketches(Vec<crate::execution::Sketch>),
+    ImportedGeometry(crate::execution::ImportedGeometry),
 }
 
 /// Argument-evaluation state for a call: mirrors the argument loop of
@@ -1932,15 +1933,21 @@ async fn resumable_entry(
             return resume_drive(Feed::Callback(Some(initial)), konts, exec_state, ctx).await;
         }
         crate::std::ResumableKind::PatternTransform => {
-            let (solids, instances, transform, use_original) =
+            let (geometry, instances, transform, use_original) =
                 crate::std::patterns::pattern_transform_parse_args(&args, exec_state)?;
             crate::std::patterns::pattern_check_instances(instances, source_range)?;
+            let geometry = match geometry {
+                crate::std::patterns::PatternGeometry3d::Solids(solids) => PatternGeometry::Solids(solids),
+                crate::std::patterns::PatternGeometry3d::ImportedGeometry(geometry) => {
+                    PatternGeometry::ImportedGeometry(geometry)
+                }
+            };
             ResumeState::PatternTransform(PatternTransformResume {
                 transform,
                 instances,
                 next_i: 1,
                 transforms: Vec::with_capacity(usize::try_from(instances).unwrap_or_default()),
-                geometry: PatternGeometry::Solids(solids),
+                geometry,
                 use_original: use_original.unwrap_or_default(),
                 source_range,
                 node_path,
@@ -2049,6 +2056,9 @@ async fn resume_step(
                 PatternGeometry::Sketches(_) => crate::std::patterns::transforms_from_callback_value::<
                     crate::execution::Sketch,
                 >(value, p.source_range, exec_state)?,
+                PatternGeometry::ImportedGeometry(_) => crate::std::patterns::transforms_from_callback_value::<
+                    crate::execution::ImportedGeometry,
+                >(value, p.source_range, exec_state)?,
             };
             p.transforms.push(transforms);
             p.next_i += 1;
@@ -2118,6 +2128,24 @@ async fn resume_next(
                         )
                         .await?;
                         KclValue::from(out)
+                    }
+                    PatternGeometry::ImportedGeometry(geometry) => {
+                        let out =
+                            crate::std::patterns::execute_pattern_transform::<crate::execution::ImportedGeometry>(
+                                p.transforms,
+                                vec![geometry],
+                                p.use_original,
+                                exec_state,
+                                &p.args,
+                            )
+                            .await?;
+                        KclValue::from(
+                            out.into_iter()
+                                .map(|geometry| {
+                                    crate::execution::GeometryWithImportedGeometry::ImportedGeometry(Box::new(geometry))
+                                })
+                                .collect::<Vec<_>>(),
+                        )
                     }
                 };
                 Ok(ResumeOutcome::Control(Control::Apply(Applied::Value(value))))

--- a/rust/kcl-lib/src/std/patterns.rs
+++ b/rust/kcl-lib/src/std/patterns.rs
@@ -27,7 +27,6 @@ use crate::execution::EarlyReturn;
 use crate::execution::ExecState;
 use crate::execution::Geometries;
 use crate::execution::Geometry;
-use crate::execution::GeometryWithImportedGeometry;
 use crate::execution::ImportedGeometry;
 use crate::execution::KclObjectFields;
 use crate::execution::KclValue;
@@ -67,22 +66,17 @@ pub const POINT_ZERO_ZERO_ZERO: [TyF64; 3] = [
 
 const MUST_HAVE_ONE_INSTANCE: &str = "There must be at least 1 instance of your geometry";
 
+/// Something that can be 3D patterned, e.g. a 3D body.
 #[derive(Debug)]
-pub(crate) enum PatternGeometry3d {
+pub(crate) enum Patternable3d {
     Solids(Vec<Solid>),
     ImportedGeometry(ImportedGeometry),
 }
 
+/// Runtime type of [`Patternable3d`], i.e. something that can be replicated
+/// in a 3D pattern.
 fn pattern_geometry_3d_type() -> RuntimeType {
     RuntimeType::Union(vec![RuntimeType::solids(), RuntimeType::imported()])
-}
-
-fn imported_geometries_to_kcl_value(geometries: Vec<ImportedGeometry>) -> KclValue {
-    geometries
-        .into_iter()
-        .map(|geometry| GeometryWithImportedGeometry::ImportedGeometry(Box::new(geometry)))
-        .collect::<Vec<_>>()
-        .into()
 }
 
 /// Repeat some 3D geometry, changing each repetition slightly.
@@ -115,12 +109,12 @@ pub async fn pattern_transform_2d(exec_state: &mut ExecState, args: Args) -> Res
 pub(crate) fn pattern_transform_parse_args(
     args: &Args,
     exec_state: &mut ExecState,
-) -> Result<(PatternGeometry3d, u32, FunctionSource, Option<bool>), KclError> {
+) -> Result<(Patternable3d, u32, FunctionSource, Option<bool>), KclError> {
     let geometry: SolidOrImportedGeometry =
         args.get_unlabeled_kw_arg("solids", &pattern_geometry_3d_type(), exec_state)?;
     let geometry = match geometry {
-        SolidOrImportedGeometry::SolidSet(solids) => PatternGeometry3d::Solids(solids),
-        SolidOrImportedGeometry::ImportedGeometry(geometry) => PatternGeometry3d::ImportedGeometry(*geometry),
+        SolidOrImportedGeometry::SolidSet(solids) => Patternable3d::Solids(solids),
+        SolidOrImportedGeometry::ImportedGeometry(geometry) => Patternable3d::ImportedGeometry(*geometry),
     };
     let instances: u32 = args.get_kw_arg("instances", &RuntimeType::count(), exec_state)?;
     let transform: FunctionSource = args.get_kw_arg("transform", &RuntimeType::function(), exec_state)?;
@@ -224,7 +218,7 @@ pub(crate) fn transforms_from_callback_value<T: GeometryTrait>(
 }
 
 async fn inner_pattern_transform(
-    geometry: PatternGeometry3d,
+    geometry: Patternable3d,
     instances: u32,
     transform: FunctionSource,
     use_original: Option<bool>,
@@ -236,7 +230,7 @@ async fn inner_pattern_transform(
     pattern_check_instances(instances, args.source_range)?;
     for i in 1..instances {
         let t = match &geometry {
-            PatternGeometry3d::Solids(_) => {
+            Patternable3d::Solids(_) => {
                 make_transform::<Solid>(
                     i,
                     &transform,
@@ -247,7 +241,7 @@ async fn inner_pattern_transform(
                 )
                 .await?
             }
-            PatternGeometry3d::ImportedGeometry(_) => {
+            Patternable3d::ImportedGeometry(_) => {
                 make_transform::<ImportedGeometry>(
                     i,
                     &transform,
@@ -262,7 +256,7 @@ async fn inner_pattern_transform(
         transform_vec.push(t);
     }
     match geometry {
-        PatternGeometry3d::Solids(solids) => Ok(execute_pattern_transform::<Solid>(
+        Patternable3d::Solids(solids) => Ok(execute_pattern_transform::<Solid>(
             transform_vec,
             solids,
             use_original.unwrap_or_default(),
@@ -271,7 +265,7 @@ async fn inner_pattern_transform(
         )
         .await?
         .into()),
-        PatternGeometry3d::ImportedGeometry(geometry) => Ok(imported_geometries_to_kcl_value(
+        Patternable3d::ImportedGeometry(geometry) => Ok(KclValue::from_imported_geometries(
             execute_pattern_transform(
                 transform_vec,
                 vec![geometry],
@@ -904,7 +898,7 @@ pub async fn pattern_linear_3d(exec_state: &mut ExecState, args: Args) -> Result
                     .into(),
             )
         }
-        SolidOrImportedGeometry::ImportedGeometry(geometry) => Ok(imported_geometries_to_kcl_value(
+        SolidOrImportedGeometry::ImportedGeometry(geometry) => Ok(KclValue::from_imported_geometries(
             inner_pattern_linear_3d(
                 vec![*geometry],
                 instances,
@@ -1190,7 +1184,7 @@ pub async fn pattern_circular_3d(exec_state: &mut ExecState, args: Args) -> Resu
         )
         .await?
         .into()),
-        SolidOrImportedGeometry::ImportedGeometry(geometry) => Ok(imported_geometries_to_kcl_value(
+        SolidOrImportedGeometry::ImportedGeometry(geometry) => Ok(KclValue::from_imported_geometries(
             inner_pattern_circular_3d(
                 vec![*geometry],
                 instances,

--- a/rust/kcl-lib/src/std/patterns.rs
+++ b/rust/kcl-lib/src/std/patterns.rs
@@ -27,12 +27,15 @@ use crate::execution::EarlyReturn;
 use crate::execution::ExecState;
 use crate::execution::Geometries;
 use crate::execution::Geometry;
+use crate::execution::GeometryWithImportedGeometry;
+use crate::execution::ImportedGeometry;
 use crate::execution::KclObjectFields;
 use crate::execution::KclValue;
 use crate::execution::KclValueControlFlow;
 use crate::execution::ModelingCmdMeta;
 use crate::execution::Sketch;
 use crate::execution::Solid;
+use crate::execution::SolidOrImportedGeometry;
 use crate::execution::early_return;
 use crate::execution::fn_call::Arg;
 use crate::execution::fn_call::Args;
@@ -64,12 +67,30 @@ pub const POINT_ZERO_ZERO_ZERO: [TyF64; 3] = [
 
 const MUST_HAVE_ONE_INSTANCE: &str = "There must be at least 1 instance of your geometry";
 
-/// Repeat some 3D solid, changing each repetition slightly.
-pub async fn pattern_transform(exec_state: &mut ExecState, args: Args) -> Result<KclValueControlFlow, KclError> {
-    let (solids, instances, transform, use_original) = pattern_transform_parse_args(&args, exec_state)?;
+#[derive(Debug)]
+pub(crate) enum PatternGeometry3d {
+    Solids(Vec<Solid>),
+    ImportedGeometry(ImportedGeometry),
+}
 
-    match inner_pattern_transform(solids, instances, transform, use_original, exec_state, &args).await {
-        Ok(solids) => Ok(KclValue::continue_(solids.into())),
+fn pattern_geometry_3d_type() -> RuntimeType {
+    RuntimeType::Union(vec![RuntimeType::solids(), RuntimeType::imported()])
+}
+
+fn imported_geometries_to_kcl_value(geometries: Vec<ImportedGeometry>) -> KclValue {
+    geometries
+        .into_iter()
+        .map(|geometry| GeometryWithImportedGeometry::ImportedGeometry(Box::new(geometry)))
+        .collect::<Vec<_>>()
+        .into()
+}
+
+/// Repeat some 3D geometry, changing each repetition slightly.
+pub async fn pattern_transform(exec_state: &mut ExecState, args: Args) -> Result<KclValueControlFlow, KclError> {
+    let (geometry, instances, transform, use_original) = pattern_transform_parse_args(&args, exec_state)?;
+
+    match inner_pattern_transform(geometry, instances, transform, use_original, exec_state, &args).await {
+        Ok(geometry) => Ok(KclValue::continue_(geometry)),
         // The callback exited, e.g. by calling exit(). Propagate the exit so
         // that it terminates the enclosing module.
         Err(EarlyReturn::Value(cf)) => Ok(cf),
@@ -94,12 +115,17 @@ pub async fn pattern_transform_2d(exec_state: &mut ExecState, args: Args) -> Res
 pub(crate) fn pattern_transform_parse_args(
     args: &Args,
     exec_state: &mut ExecState,
-) -> Result<(Vec<Solid>, u32, FunctionSource, Option<bool>), KclError> {
-    let solids = args.get_unlabeled_kw_arg("solids", &RuntimeType::solids(), exec_state)?;
+) -> Result<(PatternGeometry3d, u32, FunctionSource, Option<bool>), KclError> {
+    let geometry: SolidOrImportedGeometry =
+        args.get_unlabeled_kw_arg("solids", &pattern_geometry_3d_type(), exec_state)?;
+    let geometry = match geometry {
+        SolidOrImportedGeometry::SolidSet(solids) => PatternGeometry3d::Solids(solids),
+        SolidOrImportedGeometry::ImportedGeometry(geometry) => PatternGeometry3d::ImportedGeometry(*geometry),
+    };
     let instances: u32 = args.get_kw_arg("instances", &RuntimeType::count(), exec_state)?;
     let transform: FunctionSource = args.get_kw_arg("transform", &RuntimeType::function(), exec_state)?;
     let use_original = args.get_kw_arg_opt("useOriginal", &RuntimeType::bool(), exec_state)?;
-    Ok((solids, instances, transform, use_original))
+    Ok((geometry, instances, transform, use_original))
 }
 
 /// Parse patternTransform2d's arguments. Shared by both executors.
@@ -198,36 +224,64 @@ pub(crate) fn transforms_from_callback_value<T: GeometryTrait>(
 }
 
 async fn inner_pattern_transform(
-    solids: Vec<Solid>,
+    geometry: PatternGeometry3d,
     instances: u32,
     transform: FunctionSource,
     use_original: Option<bool>,
     exec_state: &mut ExecState,
     args: &Args,
-) -> Result<Vec<Solid>, EarlyReturn> {
+) -> Result<KclValue, EarlyReturn> {
     // Build the vec of transforms, one for each repetition.
     let mut transform_vec = Vec::with_capacity(usize::try_from(instances).unwrap());
     pattern_check_instances(instances, args.source_range)?;
     for i in 1..instances {
-        let t = make_transform::<Solid>(
-            i,
-            &transform,
-            args.source_range,
-            args.node_path.clone(),
-            exec_state,
-            &args.ctx,
-        )
-        .await?;
+        let t = match &geometry {
+            PatternGeometry3d::Solids(_) => {
+                make_transform::<Solid>(
+                    i,
+                    &transform,
+                    args.source_range,
+                    args.node_path.clone(),
+                    exec_state,
+                    &args.ctx,
+                )
+                .await?
+            }
+            PatternGeometry3d::ImportedGeometry(_) => {
+                make_transform::<ImportedGeometry>(
+                    i,
+                    &transform,
+                    args.source_range,
+                    args.node_path.clone(),
+                    exec_state,
+                    &args.ctx,
+                )
+                .await?
+            }
+        };
         transform_vec.push(t);
     }
-    Ok(execute_pattern_transform(
-        transform_vec,
-        solids,
-        use_original.unwrap_or_default(),
-        exec_state,
-        args,
-    )
-    .await?)
+    match geometry {
+        PatternGeometry3d::Solids(solids) => Ok(execute_pattern_transform::<Solid>(
+            transform_vec,
+            solids,
+            use_original.unwrap_or_default(),
+            exec_state,
+            args,
+        )
+        .await?
+        .into()),
+        PatternGeometry3d::ImportedGeometry(geometry) => Ok(imported_geometries_to_kcl_value(
+            execute_pattern_transform(
+                transform_vec,
+                vec![geometry],
+                use_original.unwrap_or_default(),
+                exec_state,
+                args,
+            )
+            .await?,
+        )),
+    }
 }
 
 async fn inner_pattern_transform_2d(
@@ -277,8 +331,8 @@ pub(crate) async fn execute_pattern_transform<T: GeometryTrait>(
     let starting: Vec<T> = geo_set.into();
 
     let mut output = Vec::new();
-    for geo in starting {
-        let new = send_pattern_transform(transforms.clone(), &geo, use_original, exec_state, args).await?;
+    for mut geo in starting {
+        let new = send_pattern_transform(transforms.clone(), &mut geo, use_original, exec_state, args).await?;
         output.extend(new)
     }
     Ok(output)
@@ -288,19 +342,25 @@ async fn send_pattern_transform<T: GeometryTrait>(
     // This should be passed via reference, see
     // https://github.com/KittyCAD/modeling-app/issues/2821
     transforms: Vec<Vec<Transform>>,
-    solid: &T,
+    geometry: &mut T,
     use_original: bool,
     exec_state: &mut ExecState,
     args: &Args,
 ) -> Result<Vec<T>, KclError> {
     let extra_instances = transforms.len();
+    let geometry_id = geometry.id(&args.ctx).await?;
+    let entity_id = if use_original {
+        geometry.topology_id()
+    } else {
+        geometry_id
+    };
 
     let resp = exec_state
         .send_modeling_cmd(
             ModelingCmdMeta::from_args(exec_state, args),
             ModelingCmd::from(
                 mcmd::EntityLinearPatternTransform::builder()
-                    .entity_id(if use_original { solid.topology_id() } else { solid.id() })
+                    .entity_id(entity_id)
                     .transform(Default::default())
                     .transforms(transforms)
                     .build(),
@@ -327,12 +387,12 @@ async fn send_pattern_transform<T: GeometryTrait>(
         )));
     };
 
-    let mut geometries = vec![solid.clone()];
+    let mut geometries = vec![geometry.clone()];
     for id in entity_ids.iter().copied() {
-        let mut new_solid = solid.clone();
-        new_solid.set_id(id);
-        new_solid.set_artifact_id(id);
-        geometries.push(new_solid);
+        let mut new_geometry = geometry.clone();
+        new_geometry.set_id(id);
+        new_geometry.set_artifact_id(id);
+        geometries.push(new_geometry);
     }
     Ok(geometries)
 }
@@ -500,7 +560,8 @@ fn array_to_point2d(
 
 pub trait GeometryTrait: Clone {
     type Set: Into<Vec<Self>> + Clone;
-    fn id(&self) -> Uuid;
+    #[allow(async_fn_in_trait)]
+    async fn id(&mut self, ctx: &ExecutorContext) -> Result<Uuid, KclError>;
     fn topology_id(&self) -> Uuid;
     fn set_id(&mut self, id: Uuid);
     fn set_artifact_id(&mut self, id: Uuid);
@@ -521,8 +582,8 @@ impl GeometryTrait for Sketch {
     fn set_artifact_id(&mut self, id: Uuid) {
         self.artifact_id = ArtifactId::new(id);
     }
-    fn id(&self) -> Uuid {
-        self.id
+    async fn id(&mut self, _: &ExecutorContext) -> Result<Uuid, KclError> {
+        Ok(self.id)
     }
     fn topology_id(&self) -> Uuid {
         self.original_id
@@ -557,8 +618,8 @@ impl GeometryTrait for Solid {
         self.become_pattern_copy(id);
     }
 
-    fn id(&self) -> Uuid {
-        self.id
+    async fn id(&mut self, _: &ExecutorContext) -> Result<Uuid, KclError> {
+        Ok(self.id)
     }
 
     fn topology_id(&self) -> Uuid {
@@ -580,11 +641,109 @@ impl GeometryTrait for Solid {
     }
 }
 
+impl GeometryTrait for ImportedGeometry {
+    type Set = Vec<ImportedGeometry>;
+
+    async fn id(&mut self, ctx: &ExecutorContext) -> Result<Uuid, KclError> {
+        ImportedGeometry::id(self, ctx).await
+    }
+
+    fn topology_id(&self) -> Uuid {
+        self.id
+    }
+
+    fn set_id(&mut self, id: Uuid) {
+        self.id = id;
+    }
+
+    fn set_artifact_id(&mut self, _: Uuid) {}
+
+    fn array_to_point3d(
+        val: &KclValue,
+        source_ranges: Vec<SourceRange>,
+        exec_state: &mut ExecState,
+    ) -> Result<[TyF64; 3], KclError> {
+        array_to_point3d(val, source_ranges, exec_state)
+    }
+
+    async fn flush_batch(_: &Args, _: &mut ExecState, _: &Self::Set) -> Result<(), KclError> {
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::execution::KclValueView;
     use crate::execution::types::NumericType;
     use crate::execution::types::PrimitiveType;
+
+    async fn assert_imported_pattern_executes(code: &str) {
+        let current_file = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("inputs")
+            .join("main.kcl");
+        let ctx = crate::test_server::new_context(true, Some(current_file)).await.unwrap();
+        let program = crate::Program::parse_no_errs(code).unwrap();
+        let result = ctx.run_with_caching(program).await.unwrap();
+
+        let KclValueView::HomArray { value } = result.variables.get("patterned").unwrap() else {
+            panic!("Expected the imported geometry pattern to return an array");
+        };
+        assert_eq!(value.len(), 3);
+        assert!(
+            value
+                .iter()
+                .all(|value| matches!(value, KclValueView::ImportedGeometry(_)))
+        );
+        let ids = value
+            .iter()
+            .map(|value| match value {
+                KclValueView::ImportedGeometry(geometry) => geometry.id,
+                _ => unreachable!(),
+            })
+            .collect::<std::collections::HashSet<_>>();
+        assert_eq!(ids.len(), 3);
+
+        ctx.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn imported_geometry_pattern_linear_3d() {
+        assert_imported_pattern_executes(
+            r#"import "cube.step" as cube
+
+patterned = patternLinear3d(cube, instances = 3, distance = 20, axis = X)
+"#,
+        )
+        .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn imported_geometry_pattern_circular_3d() {
+        assert_imported_pattern_executes(
+            r#"import "cube.step" as cube
+
+patterned = patternCircular3d(cube, instances = 3, axis = Z, center = [20, 0, 0])
+"#,
+        )
+        .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn imported_geometry_pattern_transform() {
+        assert_imported_pattern_executes(
+            r#"import "cube.step" as cube
+
+fn shift(@i) {
+  return { translate = [20 * i, 0, 0] }
+}
+
+patterned = patternTransform(cube, instances = 3, transform = shift)
+"#,
+        )
+        .await;
+    }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_array_to_point3d() {
@@ -714,7 +873,8 @@ async fn inner_pattern_linear_2d(
 
 /// A linear pattern on a 3D model.
 pub async fn pattern_linear_3d(exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
-    let solids = args.get_unlabeled_kw_arg("solids", &RuntimeType::solids(), exec_state)?;
+    let geometry: SolidOrImportedGeometry =
+        args.get_unlabeled_kw_arg("solids", &pattern_geometry_3d_type(), exec_state)?;
     let instances: u32 = args.get_kw_arg("instances", &RuntimeType::count(), exec_state)?;
     let distance: TyF64 = args.get_kw_arg("distance", &RuntimeType::length(), exec_state)?;
     let axis: Axis3dOrPoint3d = args.get_kw_arg(
@@ -736,19 +896,38 @@ pub async fn pattern_linear_3d(exec_state: &mut ExecState, args: Args) -> Result
         )));
     }
 
-    let solids = inner_pattern_linear_3d(solids, instances, distance, axis, use_original, exec_state, args).await?;
-    Ok(solids.into())
+    match geometry {
+        SolidOrImportedGeometry::SolidSet(solids) => {
+            Ok(
+                inner_pattern_linear_3d(solids, instances, distance, axis, use_original, exec_state, args)
+                    .await?
+                    .into(),
+            )
+        }
+        SolidOrImportedGeometry::ImportedGeometry(geometry) => Ok(imported_geometries_to_kcl_value(
+            inner_pattern_linear_3d(
+                vec![*geometry],
+                instances,
+                distance,
+                axis,
+                use_original,
+                exec_state,
+                args,
+            )
+            .await?,
+        )),
+    }
 }
 
-async fn inner_pattern_linear_3d(
-    solids: Vec<Solid>,
+async fn inner_pattern_linear_3d<T: GeometryTrait<Set = Vec<T>>>(
+    geometry: Vec<T>,
     instances: u32,
     distance: TyF64,
     axis: [TyF64; 3],
     use_original: Option<bool>,
     exec_state: &mut ExecState,
     args: Args,
-) -> Result<Vec<Solid>, KclError> {
+) -> Result<Vec<T>, KclError> {
     let [x, y, z] = point_3d_to_mm(axis);
     let axis_len = f64::sqrt(x * x + y * y + z * z);
     let normalized_axis = kcmc::shared::Point3d::from([x / axis_len, y / axis_len, z / axis_len]);
@@ -759,7 +938,14 @@ async fn inner_pattern_linear_3d(
             vec![Transform::builder().translate(translate).build()]
         })
         .collect();
-    execute_pattern_transform(transforms, solids, use_original.unwrap_or_default(), exec_state, &args).await
+    execute_pattern_transform(
+        transforms,
+        geometry,
+        use_original.unwrap_or_default(),
+        exec_state,
+        &args,
+    )
+    .await
 }
 
 /// Data for a circular pattern on a 2D sketch.
@@ -808,6 +994,7 @@ struct CircularPattern3dData {
 }
 
 #[allow(clippy::large_enum_variant)]
+#[derive(Clone)]
 enum CircularPattern {
     ThreeD(CircularPattern3dData),
     TwoD(CircularPattern2dData),
@@ -927,13 +1114,8 @@ async fn inner_pattern_circular_2d(
 
     let mut sketches = Vec::new();
     for sketch in starting_sketches.iter() {
-        let geometries = pattern_circular(
-            CircularPattern::TwoD(data.clone()),
-            Geometry::Sketch(sketch.clone()),
-            exec_state,
-            args.clone(),
-        )
-        .await?;
+        let geometries =
+            pattern_circular_sketch(data.clone(), Geometry::Sketch(sketch.clone()), exec_state, args.clone()).await?;
 
         let Geometries::Sketches(new_sketches) = geometries else {
             return Err(KclError::new_semantic(KclErrorDetails::new(
@@ -948,9 +1130,26 @@ async fn inner_pattern_circular_2d(
     Ok(sketches)
 }
 
+async fn pattern_circular_sketch(
+    data: CircularPattern2dData,
+    geometry: Geometry,
+    exec_state: &mut ExecState,
+    args: Args,
+) -> Result<Geometries, KclError> {
+    let Geometry::Sketch(mut sketch) = geometry else {
+        return Err(KclError::new_internal(KclErrorDetails::new(
+            "A 2D circular pattern requires a sketch".to_owned(),
+            vec![args.source_range],
+        )));
+    };
+    let geometries = pattern_circular(&CircularPattern::TwoD(data), &mut sketch, exec_state, &args).await?;
+    Ok(Geometries::Sketches(geometries))
+}
+
 /// A circular pattern on a 3D model.
 pub async fn pattern_circular_3d(exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
-    let solids = args.get_unlabeled_kw_arg("solids", &RuntimeType::solids(), exec_state)?;
+    let geometry: SolidOrImportedGeometry =
+        args.get_unlabeled_kw_arg("solids", &pattern_geometry_3d_type(), exec_state)?;
     // The number of total instances. Must be greater than or equal to 1.
     // This includes the original entity. For example, if instances is 2,
     // there will be two copies -- the original, and one new copy.
@@ -977,24 +1176,40 @@ pub async fn pattern_circular_3d(exec_state: &mut ExecState, args: Args) -> Resu
     // or the pattern?
     let use_original = args.get_kw_arg_opt("useOriginal", &RuntimeType::bool(), exec_state)?;
 
-    let solids = inner_pattern_circular_3d(
-        solids,
-        instances,
-        [axis[0].n, axis[1].n, axis[2].n],
-        center,
-        arc_degrees.map(|x| x.n),
-        rotate_duplicates,
-        use_original,
-        exec_state,
-        args,
-    )
-    .await?;
-    Ok(solids.into())
+    match geometry {
+        SolidOrImportedGeometry::SolidSet(solids) => Ok(inner_pattern_circular_3d(
+            solids,
+            instances,
+            [axis[0].n, axis[1].n, axis[2].n],
+            center,
+            arc_degrees.map(|x| x.n),
+            rotate_duplicates,
+            use_original,
+            exec_state,
+            args,
+        )
+        .await?
+        .into()),
+        SolidOrImportedGeometry::ImportedGeometry(geometry) => Ok(imported_geometries_to_kcl_value(
+            inner_pattern_circular_3d(
+                vec![*geometry],
+                instances,
+                [axis[0].n, axis[1].n, axis[2].n],
+                center,
+                arc_degrees.map(|x| x.n),
+                rotate_duplicates,
+                use_original,
+                exec_state,
+                args,
+            )
+            .await?,
+        )),
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn inner_pattern_circular_3d(
-    solids: Vec<Solid>,
+async fn inner_pattern_circular_3d<T: GeometryTrait<Set = Vec<T>>>(
+    geometry: Vec<T>,
     instances: u32,
     axis: [f64; 3],
     center: Option<[TyF64; 3]>,
@@ -1003,21 +1218,7 @@ async fn inner_pattern_circular_3d(
     use_original: Option<bool>,
     exec_state: &mut ExecState,
     args: Args,
-) -> Result<Vec<Solid>, KclError> {
-    // Flush the batch for our fillets/chamfers if there are any.
-    // If we do not flush these, then you won't be able to pattern something with fillets.
-    // Flush just the fillets/chamfers that apply to these solids.
-    exec_state
-        .flush_batch_for_solids(ModelingCmdMeta::from_args(exec_state, &args), &solids)
-        .await?;
-
-    let starting_solids = solids;
-
-    if args.ctx.context_type == crate::execution::ContextType::Mock {
-        return Ok(starting_solids);
-    }
-
-    let mut solids = Vec::new();
+) -> Result<Vec<T>, KclError> {
     let center = center.unwrap_or(POINT_ZERO_ZERO_ZERO);
     let data = CircularPattern3dData {
         instances,
@@ -1027,38 +1228,38 @@ async fn inner_pattern_circular_3d(
         rotate_duplicates,
         use_original,
     };
-    for solid in starting_solids.iter() {
-        let geometries = pattern_circular(
-            CircularPattern::ThreeD(data.clone()),
-            Geometry::Solid(solid.clone()),
-            exec_state,
-            args.clone(),
-        )
-        .await?;
-
-        let Geometries::Solids(new_solids) = geometries else {
-            return Err(KclError::new_semantic(KclErrorDetails::new(
-                "Expected a vec of solids".to_string(),
-                vec![args.source_range],
-            )));
-        };
-
-        solids.extend(new_solids);
-    }
-
-    Ok(solids)
+    execute_pattern_circular(CircularPattern::ThreeD(data), geometry, exec_state, args).await
 }
 
-async fn pattern_circular(
+async fn execute_pattern_circular<T: GeometryTrait>(
     data: CircularPattern,
-    geometry: Geometry,
+    geometry_set: T::Set,
     exec_state: &mut ExecState,
     args: Args,
-) -> Result<Geometries, KclError> {
+) -> Result<Vec<T>, KclError> {
+    T::flush_batch(&args, exec_state, &geometry_set).await?;
+    let starting: Vec<T> = geometry_set.into();
+    if args.ctx.context_type == crate::execution::ContextType::Mock {
+        return Ok(starting);
+    }
+
+    let mut output = Vec::new();
+    for mut geometry in starting {
+        output.extend(pattern_circular(&data, &mut geometry, exec_state, &args).await?);
+    }
+    Ok(output)
+}
+
+async fn pattern_circular<T: GeometryTrait>(
+    data: &CircularPattern,
+    geometry: &mut T,
+    exec_state: &mut ExecState,
+    args: &Args,
+) -> Result<Vec<T>, KclError> {
     let num_repetitions = match data.repetitions() {
         RepetitionsNeeded::More(n) => n,
         RepetitionsNeeded::None => {
-            return Ok(Geometries::from(geometry));
+            return Ok(vec![geometry.clone()]);
         }
         RepetitionsNeeded::Invalid => {
             return Err(KclError::new_semantic(KclErrorDetails::new(
@@ -1068,17 +1269,18 @@ async fn pattern_circular(
         }
     };
 
+    let geometry_id = geometry.id(&args.ctx).await?;
     let center = data.center_mm();
     let resp = exec_state
         .send_modeling_cmd(
-            ModelingCmdMeta::from_args(exec_state, &args),
+            ModelingCmdMeta::from_args(exec_state, args),
             ModelingCmd::from(
                 mcmd::EntityCircularPattern::builder()
                     .axis(kcmc::shared::Point3d::from(data.axis()))
                     .entity_id(if data.use_original() {
-                        geometry.pattern_source_id()
+                        geometry.topology_id()
                     } else {
-                        geometry.id()
+                        geometry_id
                     })
                     .center(kcmc::shared::Point3d {
                         x: LengthUnit(center[0]),
@@ -1114,28 +1316,12 @@ async fn pattern_circular(
         )));
     };
 
-    let geometries = match geometry {
-        Geometry::Sketch(sketch) => {
-            let mut geometries = vec![sketch.clone()];
-            for id in entity_ids.iter().copied() {
-                let mut new_sketch = sketch.clone();
-                new_sketch.id = id;
-                new_sketch.artifact_id = ArtifactId::new(id);
-                geometries.push(new_sketch);
-            }
-            Geometries::Sketches(geometries)
-        }
-        Geometry::Solid(solid) => {
-            let mut geometries = vec![solid.clone()];
-            for id in entity_ids.iter().copied() {
-                let mut new_solid = solid.clone();
-                new_solid.id = id;
-                new_solid.become_pattern_copy(id);
-                geometries.push(new_solid);
-            }
-            Geometries::Solids(geometries)
-        }
-    };
-
+    let mut geometries = vec![geometry.clone()];
+    for id in entity_ids.iter().copied() {
+        let mut new_geometry = geometry.clone();
+        new_geometry.set_id(id);
+        new_geometry.set_artifact_id(id);
+        geometries.push(new_geometry);
+    }
     Ok(geometries)
 }

--- a/rust/kcl-lib/std/solid.kcl
+++ b/rust/kcl-lib/std/solid.kcl
@@ -648,9 +648,9 @@ export fn hollow(
   thickness: number(Length),
 ): Solid {}
 
-/// Repeat a 3-dimensional solid, changing it each time.
+/// Repeat a 3-dimensional solid or imported geometry, changing it each time.
 ///
-/// Replicates the 3D solid, applying a transformation function to each replica.
+/// Replicates the 3D solid or imported geometry, applying a transformation function to each replica.
 /// Transformation function could alter rotation, scale, visibility, position, etc.
 ///
 /// The `patternTransform` call itself takes a number for how many total instances of
@@ -856,17 +856,17 @@ export fn hollow(
 /// ```
 @(impl = std_rust, feature_tree = true)
 export fn patternTransform(
-  /// The solid(s) to duplicate.
-  @solids: [Solid; 1+],
+  /// The solid(s) or imported geometry to duplicate.
+  @solids: [Solid; 1+] | ImportedGeometry,
   /// The number of total instances. Must be greater than or equal to 1. This includes the original entity. For example, if instances is 2, there will be two copies -- the original, and one new copy. If instances is 1, this has no effect.
   instances: number(Count),
   /// How each replica should be transformed. The transform function takes a single parameter: an integer representing which number replication the transform is for. E.g. the first replica to be transformed will be passed the argument `1`. This simplifies your math: the transform function can rely on id `0` being the original instance passed into the `patternTransform`. See the examples.
   transform: fn(number(Count)): {},
   /// If the target was sketched on an extrusion, setting this will use the original sketch as the target, not the entire joined solid.
   useOriginal?: bool = false,
-): [Solid; 1+] {}
+): [Solid | ImportedGeometry; 1+] {}
 
-/// Repeat a 3-dimensional solid along a linear path, with a dynamic amount
+/// Repeat a 3-dimensional solid or imported geometry along a linear path, with a dynamic amount
 /// of distance between each repetition, some specified number of times.
 ///
 /// ```kcl,legacySketch
@@ -958,8 +958,8 @@ export fn patternTransform(
 /// ```
 @(impl = std_rust, feature_tree = true)
 export fn patternLinear3d(
-  /// The solid(s) to duplicate.
-  @solids: [Solid; 1+],
+  /// The solid(s) or imported geometry to duplicate.
+  @solids: [Solid; 1+] | ImportedGeometry,
   /// The number of total instances. Must be greater than or equal to 1. This includes the original entity. For example, if instances is 2, there will be two copies -- the original, and one new copy. If instances is 1, this has no effect.
   instances: number(Count),
   /// Distance between each repetition. Also known as 'spacing'.
@@ -969,9 +969,9 @@ export fn patternLinear3d(
   axis: Axis3d | Point3d,
   /// If the target was sketched on an extrusion, setting this will use the original sketch as the target, not the entire joined solid.
   useOriginal?: bool = false,
-): [Solid; 1+] {}
+): [Solid | ImportedGeometry; 1+] {}
 
-/// Repeat a 3-dimensional solid some number of times along a partial or
+/// Repeat a 3-dimensional solid or imported geometry some number of times along a partial or
 /// complete circle some specified number of times. Each object may
 /// additionally be rotated along the circle, ensuring orientation of the
 /// solid with respect to the center of the circle is maintained.
@@ -1009,8 +1009,8 @@ export fn patternLinear3d(
 /// ```
 @(impl = std_rust, feature_tree = true)
 export fn patternCircular3d(
-  /// The solid(s) to pattern.
-  @solids: [Solid; 1+],
+  /// The solid(s) or imported geometry to pattern.
+  @solids: [Solid; 1+] | ImportedGeometry,
   /// The number of total instances. Must be greater than or equal to 1. This includes the original entity. For example, if instances is 2, there will be two copies -- the original, and one new copy. If instances is 1, this has no effect.
   instances: number(Count),
   /// The axis of the pattern. A 3D vector.
@@ -1026,7 +1026,7 @@ export fn patternCircular3d(
   rotateDuplicates?: bool = true,
   /// If the target was sketched on an extrusion, setting this will use the original sketch as the target, not the entire joined solid.
   useOriginal?: bool = false,
-): [Solid; 1+] {}
+): [Solid | ImportedGeometry; 1+] {}
 
 /// Union two or more solids into a single solid.
 ///

--- a/rust/kcl-lib/std/solid.kcl
+++ b/rust/kcl-lib/std/solid.kcl
@@ -648,7 +648,7 @@ export fn hollow(
   thickness: number(Length),
 ): Solid {}
 
-/// Repeat a 3-dimensional solid or imported geometry, changing it each time.
+/// Repeat a 3-dimensional body or imported geometry, changing it each time.
 ///
 /// Replicates the 3D solid or imported geometry, applying a transformation function to each replica.
 /// Transformation function could alter rotation, scale, visibility, position, etc.
@@ -866,7 +866,7 @@ export fn patternTransform(
   useOriginal?: bool = false,
 ): [Solid | ImportedGeometry; 1+] {}
 
-/// Repeat a 3-dimensional solid or imported geometry along a linear path, with a dynamic amount
+/// Repeat a 3-dimensional body or imported geometry along a linear path, with a dynamic amount
 /// of distance between each repetition, some specified number of times.
 ///
 /// ```kcl,legacySketch
@@ -971,7 +971,7 @@ export fn patternLinear3d(
   useOriginal?: bool = false,
 ): [Solid | ImportedGeometry; 1+] {}
 
-/// Repeat a 3-dimensional solid or imported geometry some number of times along a partial or
+/// Repeat a 3-dimensional body or imported geometry some number of times along a partial or
 /// complete circle some specified number of times. Each object may
 /// additionally be rotated along the circle, ensuring orientation of the
 /// solid with respect to the center of the circle is maintained.


### PR DESCRIPTION
The engine already supports this, KCL didn't. Fairly straightforward to add support, just a matter of getting the right types piped through and extracting the right IDs.