### PR TITLE
Clarify cylindrical shaft edge selection

### DIFF
--- a/docs/kcl-std/functions/std-solid-chamfer.md
+++ b/docs/kcl-std/functions/std-solid-chamfer.md
@@ -241,20 +241,17 @@ leftShaft = extrude(leftRegion, length = 20mm)
        ],
      )
 
-// Extrude the other circle into a shaft, tagging the top face,
-// then use `getCommonEdge` to select the shared edge
-// between the top and the extruded side face created from extruding `rightCircle`.
-// Then chamfer it.
-rightShaft = extrude(rightRegion, length = 20mm, tagEnd = $rightShaftTop)
-  |> chamfer(
-       length = 1mm,
-       tags = [
-         getCommonEdge(faces = [
-           rightRegion.tags.rightCircle,
-           rightShaftTop
-         ])
-       ],
-     )
+// Extrude the other circle into a shaft and tag its top end face.
+rightShaftBase = extrude(rightRegion, length = 20mm, tagEnd = $rightShaftTop)
+
+// After extrusion, the circle identifies the cylindrical side face.
+// `getCommonEdge` selects the top rim shared by that face and the top end face.
+rightTopEdge = getCommonEdge(faces = [
+  rightShaftBase.sketch.tags.rightCircle,
+  rightShaftBase.faces.rightShaftTop
+])
+
+rightShaft = chamfer(rightShaftBase, length = 1mm, tags = [rightTopEdge])
 
 ```
 

--- a/rust/kcl-lib/std/solid.kcl
+++ b/rust/kcl-lib/std/solid.kcl
@@ -399,20 +399,17 @@ export fn fillet(
 ///        ],
 ///      )
 /// 
-/// // Extrude the other circle into a shaft, tagging the top face,
-/// // then use `getCommonEdge` to select the shared edge
-/// // between the top and the extruded side face created from extruding `rightCircle`.
-/// // Then chamfer it.
-/// rightShaft = extrude(rightRegion, length = 20mm, tagEnd = $rightShaftTop)
-///   |> chamfer(
-///        length = 1mm,
-///        tags = [
-///          getCommonEdge(faces = [
-///            rightRegion.tags.rightCircle,
-///            rightShaftTop
-///          ])
-///        ],
-///      )
+/// // Extrude the other circle into a shaft and tag its top end face.
+/// rightShaftBase = extrude(rightRegion, length = 20mm, tagEnd = $rightShaftTop)
+///
+/// // After extrusion, the circle identifies the cylindrical side face.
+/// // `getCommonEdge` selects the top rim shared by that face and the top end face.
+/// rightTopEdge = getCommonEdge(faces = [
+///   rightShaftBase.sketch.tags.rightCircle,
+///   rightShaftBase.faces.rightShaftTop
+/// ])
+///
+/// rightShaft = chamfer(rightShaftBase, length = 1mm, tags = [rightTopEdge])
 /// ```
 @(impl = std_rust, feature_tree = true)
 export fn chamfer(


### PR DESCRIPTION
## Summary

- follow up on #13089 by making the `getCommonEdge` example bind the unchamfered shaft first
- select the cylindrical side face and top end face through explicit body-scoped paths
- name the resulting top rim before passing it to `chamfer`
- regenerate the published stdlib Markdown from the canonical `solid.kcl` documentation

## Why

The previous piped form was valid, but `rightRegion.tags.rightCircle` and the global `rightShaftTop` tag made the two `getCommonEdge` inputs look like the same object or like implicit tag rebinding. The revised example visibly supplies two distinct faces:

- `rightShaftBase.sketch.tags.rightCircle` — the cylindrical side face created from the circle
- `rightShaftBase.faces.rightShaftTop` — the tagged planar top end face

Their common edge is the top circular rim. This keeps the example focused on the topology transition that caused the original agent failure.

## Validation

- `git diff --check origin/main...HEAD`
- `cargo +nightly fmt --all --check`
- `cargo nextest run --retries 3 --no-fail-fast -p kcl-lib --features artifact-graph docs::gen_std_tests::test_generate_stdlib`
- `cargo nextest run --retries 3 --no-fail-fast -p kcl-lib --features artifact-graph docs::kcl_doc::test::missing_test_examples`
- `cargo nextest run --retries 3 --no-fail-fast -p kcl-lib --features artifact-graph docs::kcl_doc::test::kcl_test_examples_std_solid_chamfer_4`
