### PR TITLE
Preserve mock 3D circular pattern cardinality

### DIFF
--- a/rust/kcl-lib/src/std/patterns.rs
+++ b/rust/kcl-lib/src/std/patterns.rs
@@ -587,6 +587,45 @@ mod tests {
     use crate::execution::types::PrimitiveType;
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn mock_circular_patterns_preserve_requested_cardinality() {
+        let code = r#"
+profile = startSketchOn(XZ)
+  |> startProfile(at = [1, 0])
+  |> line(end = [1, 0])
+  |> line(end = [0, 1])
+  |> line(end = [-1, 0])
+  |> close()
+
+sketchCopies = patternCircular2d(
+  profile,
+  center = [0, 0],
+  instances = 3,
+  arcDegrees = 360,
+  rotateDuplicates = true,
+)
+secondSketch = sketchCopies[1]
+
+seed = extrude(profile, length = 5)
+solidCopies = patternCircular3d(
+  seed,
+  axis = X,
+  center = [0, 0, 0],
+  instances = 3,
+  arcDegrees = 360,
+  rotateDuplicates = true,
+)
+secondSolid = solidCopies[1]
+"#;
+
+        let ctx = crate::ExecutorContext::new_mock(None).await;
+        let program = crate::Program::parse_no_errs(code).unwrap();
+        ctx.run_mock(&program, &crate::execution::MockConfig::default())
+            .await
+            .unwrap();
+        ctx.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_array_to_point3d() {
         let ctx = ExecutorContext::new_mock(None).await;
         let mut exec_state = ExecState::new(&ctx);
@@ -912,10 +951,6 @@ async fn inner_pattern_circular_2d(
     args: Args,
 ) -> Result<Vec<Sketch>, KclError> {
     let starting_sketches = sketch_set;
-
-    if args.ctx.context_type == crate::execution::ContextType::Mock {
-        return Ok(starting_sketches);
-    }
     let center = center.unwrap_or(POINT_ZERO_ZERO);
     let data = CircularPattern2dData {
         instances,
@@ -1012,10 +1047,6 @@ async fn inner_pattern_circular_3d(
         .await?;
 
     let starting_solids = solids;
-
-    if args.ctx.context_type == crate::execution::ContextType::Mock {
-        return Ok(starting_solids);
-    }
 
     let mut solids = Vec::new();
     let center = center.unwrap_or(POINT_ZERO_ZERO_ZERO);

--- a/rust/kcl-lib/src/std/patterns.rs
+++ b/rust/kcl-lib/src/std/patterns.rs
@@ -587,25 +587,11 @@ mod tests {
     use crate::execution::types::PrimitiveType;
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn mock_circular_patterns_preserve_requested_cardinality() {
+    async fn mock_circular_3d_preserves_requested_cardinality() {
         let code = r#"
-profile = startSketchOn(XZ)
-  |> startProfile(at = [1, 0])
-  |> line(end = [1, 0])
-  |> line(end = [0, 1])
-  |> line(end = [-1, 0])
-  |> close()
-
-sketchCopies = patternCircular2d(
-  profile,
-  center = [0, 0],
-  instances = 3,
-  arcDegrees = 360,
-  rotateDuplicates = true,
-)
-secondSketch = sketchCopies[1]
-
-seed = extrude(profile, length = 5)
+seed = startSketchOn(XZ)
+  |> circle(center = [0, 0], radius = 1)
+  |> extrude(length = 5)
 solidCopies = patternCircular3d(
   seed,
   axis = X,
@@ -951,6 +937,10 @@ async fn inner_pattern_circular_2d(
     args: Args,
 ) -> Result<Vec<Sketch>, KclError> {
     let starting_sketches = sketch_set;
+
+    if args.ctx.context_type == crate::execution::ContextType::Mock {
+        return Ok(starting_sketches);
+    }
     let center = center.unwrap_or(POINT_ZERO_ZERO);
     let data = CircularPattern2dData {
         instances,


### PR DESCRIPTION
## Summary

- remove the mock-only early return from `patternCircular3d`
- reuse the existing pattern response path, which synthesizes one distinct mock result per requested 3D instance when no engine geometry is available
- add regression coverage that indexes the second of three requested solid instances
- retain the `patternCircular2d` mock shortcut because real 2D result cardinality depends on engine path chaining

This preserves the public 3D collection/cardinality contract during mock execution instead of collapsing a one-element seed vector into a scalar.

The initial revision also changed `patternCircular2d`. CI correctly caught a legacy engine behavior: connected open-path patterns, including the experimental stdlib gear implementations, are appended into one engine path and therefore remain a scalar `Sketch`; disconnected 2D regions return separate sketches. Mock execution intentionally stays geometry-agnostic, so 2D path/region cardinality parity is out of scope and #13108 was closed as not planned.

Fixes #13103

## Testing

- `cargo +nightly fmt --all -- --check`
- `cargo test -p kcl-lib mock_circular_3d_preserves_requested_cardinality --lib`
- `cargo test -p kcl-lib std::patterns::tests --lib`
- `npm run build:wasm`

The exact `gears.spec.ts` integration command could not run locally because this clean worktree does not have Node dependencies installed. The WASM build succeeded; CI will rerun the integration suite.