### PR TITLE
Migrate verified KCL samples to Sketch v2

### DIFF
--- a/public/kcl-samples/car-wheel-assembly/car-tire.kcl
+++ b/public/kcl-samples/car-wheel-assembly/car-tire.kcl
@@ -2,7 +2,7 @@
 // Solver sketch version of the full tire profile.
 
 // Set units and version
-@settings(defaultLengthUnit = in, kclVersion = 1.0)
+@settings(defaultLengthUnit = in, kclVersion = 2.0)
 
 // Import parameters
 import * from "parameters.kcl"

--- a/public/kcl-samples/car-wheel-assembly/car-wheel.kcl
+++ b/public/kcl-samples/car-wheel-assembly/car-wheel.kcl
@@ -2,7 +2,7 @@
 // A sports car wheel with a circular lug pattern and spokes.
 
 // Set units and version
-@settings(defaultLengthUnit = in, kclVersion = 1.0)
+@settings(defaultLengthUnit = in, kclVersion = 2.0)
 
 // Import parameters
 import * from "parameters.kcl"

--- a/public/kcl-samples/car-wheel-assembly/lug-nut.kcl
+++ b/public/kcl-samples/car-wheel-assembly/lug-nut.kcl
@@ -2,7 +2,7 @@
 // Solver sketch version of the lug nut profile.
 
 // Set units and version
-@settings(defaultLengthUnit = in, kclVersion = 1.0)
+@settings(defaultLengthUnit = in, kclVersion = 2.0)
 
 // Import parameters
 import * from "parameters.kcl"

--- a/public/kcl-samples/car-wheel-assembly/main.kcl
+++ b/public/kcl-samples/car-wheel-assembly/main.kcl
@@ -3,7 +3,7 @@
 // Categories: Automotive
 
 // Set units and version
-@settings(defaultLengthUnit = in, kclVersion = 1.0)
+@settings(defaultLengthUnit = in, kclVersion = 2.0)
 
 // Import parameters
 import * from "parameters.kcl"

--- a/public/kcl-samples/car-wheel-assembly/parameters.kcl
+++ b/public/kcl-samples/car-wheel-assembly/parameters.kcl
@@ -1,7 +1,7 @@
 // Car wheel assembly parameters
 
 // Set units
-@settings(defaultLengthUnit = in, kclVersion = 1.0)
+@settings(defaultLengthUnit = in, kclVersion = 2.0)
 
 // Lugs
 export lugCount = 5

--- a/public/kcl-samples/engine-valve/main.kcl
+++ b/public/kcl-samples/engine-valve/main.kcl
@@ -2,7 +2,7 @@
 // A mechanical valve used in internal combustion engines to control intake or exhaust flow
 // Categories: Automotive
 
-@settings(defaultLengthUnit = mm, kclVersion = 1.0)
+@settings(defaultLengthUnit = mm, kclVersion = 2.0)
 
 // Define parameters
 valveDiameter = 30

--- a/public/kcl-samples/golf-tee/main.kcl
+++ b/public/kcl-samples/golf-tee/main.kcl
@@ -2,7 +2,7 @@
 // A parametric model of a golf tee with realistic proportions, including a pointed tip, cylindrical shaft, and flared cup to hold the ball. Designed for prototyping, printing, or sports equipment simulations.
 // Categories: Maker
 
-@settings(defaultLengthUnit = mm, kclVersion = 1.0)
+@settings(defaultLengthUnit = mm, kclVersion = 2.0)
 
 // Primary dimensions
 teeHeight = 70

--- a/public/kcl-samples/i-beam/main.kcl
+++ b/public/kcl-samples/i-beam/main.kcl
@@ -3,7 +3,7 @@
 // Categories: Construction
 
 // Set units
-@settings(defaultLengthUnit = in, kclVersion = 1.0)
+@settings(defaultLengthUnit = in, kclVersion = 2.0)
 
 // Define parameters
 beamLength = 6ft

--- a/public/kcl-samples/lego/main.kcl
+++ b/public/kcl-samples/lego/main.kcl
@@ -3,7 +3,7 @@
 // Categories: Maker
 
 // Set Units
-@settings(defaultLengthUnit = in, kclVersion = 1.0)
+@settings(defaultLengthUnit = in, kclVersion = 2.0)
 
 // Define parameters
 lbumps = 3 // number of bumps long

--- a/public/kcl-samples/parametric-shelf-unit/main.kcl
+++ b/public/kcl-samples/parametric-shelf-unit/main.kcl
@@ -9,7 +9,7 @@
 // - Optional top board acting as a cover
 // All elements are parametric and adaptable through clearly named variables.
 
-@settings(defaultLengthUnit = m, kclVersion = 1.0)
+@settings(defaultLengthUnit = m, kclVersion = 2.0)
 
 // --- Global Dimensions ---
 unitWidth = 1 // overall external width of the shelf

--- a/public/kcl-samples/planetary-gearset/main.kcl
+++ b/public/kcl-samples/planetary-gearset/main.kcl
@@ -2,7 +2,7 @@
 // A helical planetary gearset is a type of planetary gear system where the teeth of the sun gear, planet gears, and/or ring gear are helical rather than straight. This design allows for smoother, quieter operation, greater load-carrying capacity, and more flexible shaft alignment.
 // Categories: Automotive, Aerospace
 
-@settings(defaultLengthUnit = mm, kclVersion = 1.0, experimentalFeatures = allow)
+@settings(defaultLengthUnit = mm, kclVersion = 2.0, experimentalFeatures = allow)
 
 // Create the outer ring gear for the planetary gearset
 gear::ring(

--- a/public/kcl-samples/radial-flow-centrifugal-impeller/main.kcl
+++ b/public/kcl-samples/radial-flow-centrifugal-impeller/main.kcl
@@ -2,7 +2,7 @@
 // Radial-flow impeller for centrifugal pumps—designed as a parametric base for blade and housing experiments.
 // Categories: Automotive, Aerospace
 
-@settings(defaultLengthUnit = mm, kclVersion = 1.0)
+@settings(defaultLengthUnit = mm, kclVersion = 2.0)
 
 // parameters
 bladeCount = 12 // number of blades

--- a/public/kcl-samples/router-template-cross-bar/main.kcl
+++ b/public/kcl-samples/router-template-cross-bar/main.kcl
@@ -2,7 +2,7 @@
 // A guide for routing a slate for a cross bar.
 // Categories: Construction
 
-@settings(defaultLengthUnit = mm, kclVersion = 1.0)
+@settings(defaultLengthUnit = mm, kclVersion = 2.0)
 
 routerDiameter = 12.7
 templateDiameter = (11 / 16): in

--- a/public/kcl-samples/router-template-slate/main.kcl
+++ b/public/kcl-samples/router-template-slate/main.kcl
@@ -3,7 +3,7 @@
 // Categories: Construction
 
 // Set units
-@settings(defaultLengthUnit = mm, kclVersion = 1.0)
+@settings(defaultLengthUnit = mm, kclVersion = 2.0)
 
 // Define parameters
 routerDiameter = 12.7

--- a/public/kcl-samples/single-impeller-blade/main.kcl
+++ b/public/kcl-samples/single-impeller-blade/main.kcl
@@ -2,7 +2,7 @@
 // A solid impeller blade created by lofting a root and a twisted tip profile. Useful for analyzing blade geometry, airflow shaping, or preparing for radial array placement.
 // Categories: Automotive, Aerospace
 
-@settings(defaultLengthUnit = mm, kclVersion = 1.0)
+@settings(defaultLengthUnit = mm, kclVersion = 2.0)
 
 // parameters
 bladeHeight = 60 // height from base (root) to top (tip)

--- a/public/kcl-samples/snowman/main.kcl
+++ b/public/kcl-samples/snowman/main.kcl
@@ -2,7 +2,7 @@
 // Three stacked spheres with simple facial features and a top hat standing on a small platform
 // Categories: Maker
 
-@settings(defaultLengthUnit = mm, kclVersion = 1.0)
+@settings(defaultLengthUnit = mm, kclVersion = 2.0)
 
 // Parameters
 rBottom = 40

--- a/public/kcl-samples/socket-head-cap-screw/main.kcl
+++ b/public/kcl-samples/socket-head-cap-screw/main.kcl
@@ -3,7 +3,7 @@
 // Categories: Fasteners
 
 // Set units
-@settings(defaultLengthUnit = in, kclVersion = 1.0)
+@settings(defaultLengthUnit = in, kclVersion = 2.0)
 
 // Define parameters
 boltDiameter = 0.190

--- a/public/kcl-samples/spinning-highrise-tower/main.kcl
+++ b/public/kcl-samples/spinning-highrise-tower/main.kcl
@@ -3,7 +3,7 @@
 // Categories: Maker
 
 // Declare units and version
-@settings(defaultLengthUnit = m, kclVersion = 1.0)
+@settings(defaultLengthUnit = m, kclVersion = 2.0)
 
 // Define global parameters for floor geometry and building layout
 floorCount = 17_

--- a/rust/kcl-lib/tests/kcl_samples/car-wheel-assembly/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/car-wheel-assembly/artifact_commands.snap
@@ -2200,7 +2200,8 @@ description: Artifact commands car-wheel-assembly.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -2497,7 +2498,8 @@ description: Artifact commands car-wheel-assembly.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -2835,7 +2837,8 @@ description: Artifact commands car-wheel-assembly.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -3412,7 +3415,8 @@ description: Artifact commands car-wheel-assembly.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -3697,7 +3701,8 @@ description: Artifact commands car-wheel-assembly.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -4166,7 +4171,8 @@ description: Artifact commands car-wheel-assembly.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -4591,7 +4597,8 @@ description: Artifact commands car-wheel-assembly.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {

--- a/rust/kcl-lib/tests/kcl_samples/car-wheel-assembly/ast.snap
+++ b/rust/kcl-lib/tests/kcl_samples/car-wheel-assembly/ast.snap
@@ -380,12 +380,12 @@ description: Result of parsing car-wheel-assembly.kcl
               "commentStart": 0,
               "end": 0,
               "moduleId": 0,
-              "raw": "1.0",
+              "raw": "2.0",
               "start": 0,
               "type": "Literal",
               "type": "Literal",
               "value": {
-                "value": 1.0,
+                "value": 2.0,
                 "suffix": "None"
               }
             }

--- a/rust/kcl-lib/tests/kcl_samples/engine-valve/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/engine-valve/artifact_commands.snap
@@ -505,7 +505,8 @@ description: Artifact commands engine-valve.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {

--- a/rust/kcl-lib/tests/kcl_samples/engine-valve/ast.snap
+++ b/rust/kcl-lib/tests/kcl_samples/engine-valve/ast.snap
@@ -11938,12 +11938,12 @@ description: Result of parsing engine-valve.kcl
               "commentStart": 0,
               "end": 0,
               "moduleId": 0,
-              "raw": "1.0",
+              "raw": "2.0",
               "start": 0,
               "type": "Literal",
               "type": "Literal",
               "value": {
-                "value": 1.0,
+                "value": 2.0,
                 "suffix": "None"
               }
             }

--- a/rust/kcl-lib/tests/kcl_samples/engine-valve/program_memory.snap
+++ b/rust/kcl-lib/tests/kcl_samples/engine-valve/program_memory.snap
@@ -162,12 +162,12 @@ description: Variables in memory after executing engine-valve.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
-            "commentStart": 1284,
-            "end": 1289,
+            "commentStart": 1435,
+            "end": 1440,
             "moduleId": 0,
-            "start": 1284,
+            "start": 1435,
             "type": "TagDeclarator",
-            "value": "line7"
+            "value": "line8"
           },
           "type": "extrudePlane"
         },

--- a/rust/kcl-lib/tests/kcl_samples/golf-tee/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/golf-tee/artifact_commands.snap
@@ -183,7 +183,8 @@ description: Artifact commands golf-tee.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {

--- a/rust/kcl-lib/tests/kcl_samples/golf-tee/ast.snap
+++ b/rust/kcl-lib/tests/kcl_samples/golf-tee/ast.snap
@@ -4126,12 +4126,12 @@ description: Result of parsing golf-tee.kcl
               "commentStart": 0,
               "end": 0,
               "moduleId": 0,
-              "raw": "1.0",
+              "raw": "2.0",
               "start": 0,
               "type": "Literal",
               "type": "Literal",
               "value": {
-                "value": 1.0,
+                "value": 2.0,
                 "suffix": "None"
               }
             }

--- a/rust/kcl-lib/tests/kcl_samples/golf-tee/program_memory.snap
+++ b/rust/kcl-lib/tests/kcl_samples/golf-tee/program_memory.snap
@@ -112,6 +112,20 @@ description: Variables in memory after executing golf-tee.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
+            "commentStart": 691,
+            "end": 700,
+            "moduleId": 0,
+            "start": 691,
+            "type": "TagDeclarator",
+            "value": "shaftEdge"
+          },
+          "type": "extrudePlane"
+        },
+        {
+          "faceId": "[uuid]",
+          "id": "[uuid]",
+          "sourceRange": [],
+          "tag": {
             "commentStart": 820,
             "end": 829,
             "moduleId": 0,
@@ -134,20 +148,6 @@ description: Variables in memory after executing golf-tee.kcl
             "value": "cupLipArc"
           },
           "type": "extrudeArc"
-        },
-        {
-          "faceId": "[uuid]",
-          "id": "[uuid]",
-          "sourceRange": [],
-          "tag": {
-            "commentStart": 1105,
-            "end": 1113,
-            "moduleId": 0,
-            "start": 1105,
-            "type": "TagDeclarator",
-            "value": "axisEdge"
-          },
-          "type": "extrudePlane"
         }
       ],
       "sketch": {

--- a/rust/kcl-lib/tests/kcl_samples/i-beam/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/i-beam/artifact_commands.snap
@@ -498,7 +498,8 @@ description: Artifact commands i-beam.kcl
         "query_point": {
           "x": 0.0,
           "y": 0.0
-        }
+        },
+        "version": "V1"
       }
     },
     {

--- a/rust/kcl-lib/tests/kcl_samples/i-beam/ast.snap
+++ b/rust/kcl-lib/tests/kcl_samples/i-beam/ast.snap
@@ -15116,12 +15116,12 @@ description: Result of parsing i-beam.kcl
               "commentStart": 0,
               "end": 0,
               "moduleId": 0,
-              "raw": "1.0",
+              "raw": "2.0",
               "start": 0,
               "type": "Literal",
               "type": "Literal",
               "value": {
-                "value": 1.0,
+                "value": 2.0,
                 "suffix": "None"
               }
             }

--- a/rust/kcl-lib/tests/kcl_samples/lego/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/lego/artifact_commands.snap
@@ -158,7 +158,8 @@ description: Artifact commands lego.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -348,7 +349,8 @@ description: Artifact commands lego.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -491,7 +493,8 @@ description: Artifact commands lego.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -812,7 +815,8 @@ description: Artifact commands lego.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {

--- a/rust/kcl-lib/tests/kcl_samples/lego/ast.snap
+++ b/rust/kcl-lib/tests/kcl_samples/lego/ast.snap
@@ -8095,12 +8095,12 @@ description: Result of parsing lego.kcl
               "commentStart": 0,
               "end": 0,
               "moduleId": 0,
-              "raw": "1.0",
+              "raw": "2.0",
               "start": 0,
               "type": "Literal",
               "type": "Literal",
               "value": {
-                "value": 1.0,
+                "value": 2.0,
                 "suffix": "None"
               }
             }

--- a/rust/kcl-lib/tests/kcl_samples/parametric-shelf-unit/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/parametric-shelf-unit/artifact_commands.snap
@@ -158,7 +158,8 @@ description: Artifact commands parametric-shelf-unit.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -417,7 +418,8 @@ description: Artifact commands parametric-shelf-unit.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -650,7 +652,8 @@ description: Artifact commands parametric-shelf-unit.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {

--- a/rust/kcl-lib/tests/kcl_samples/parametric-shelf-unit/ast.snap
+++ b/rust/kcl-lib/tests/kcl_samples/parametric-shelf-unit/ast.snap
@@ -7529,12 +7529,12 @@ description: Result of parsing parametric-shelf-unit.kcl
               "commentStart": 0,
               "end": 0,
               "moduleId": 0,
-              "raw": "1.0",
+              "raw": "2.0",
               "start": 0,
               "type": "Literal",
               "type": "Literal",
               "value": {
-                "value": 1.0,
+                "value": 2.0,
                 "suffix": "None"
               }
             }

--- a/rust/kcl-lib/tests/kcl_samples/planetary-gearset/ast.snap
+++ b/rust/kcl-lib/tests/kcl_samples/planetary-gearset/ast.snap
@@ -1088,12 +1088,12 @@ description: Result of parsing planetary-gearset.kcl
               "commentStart": 0,
               "end": 0,
               "moduleId": 0,
-              "raw": "1.0",
+              "raw": "2.0",
               "start": 0,
               "type": "Literal",
               "type": "Literal",
               "value": {
-                "value": 1.0,
+                "value": 2.0,
                 "suffix": "None"
               }
             }

--- a/rust/kcl-lib/tests/kcl_samples/radial-flow-centrifugal-impeller/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/radial-flow-centrifugal-impeller/artifact_commands.snap
@@ -508,7 +508,8 @@ description: Artifact commands radial-flow-centrifugal-impeller.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -646,7 +647,8 @@ description: Artifact commands radial-flow-centrifugal-impeller.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -832,7 +834,8 @@ description: Artifact commands radial-flow-centrifugal-impeller.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {

--- a/rust/kcl-lib/tests/kcl_samples/radial-flow-centrifugal-impeller/ast.snap
+++ b/rust/kcl-lib/tests/kcl_samples/radial-flow-centrifugal-impeller/ast.snap
@@ -6613,12 +6613,12 @@ description: Result of parsing radial-flow-centrifugal-impeller.kcl
               "commentStart": 0,
               "end": 0,
               "moduleId": 0,
-              "raw": "1.0",
+              "raw": "2.0",
               "start": 0,
               "type": "Literal",
               "type": "Literal",
               "value": {
-                "value": 1.0,
+                "value": 2.0,
                 "suffix": "None"
               }
             }

--- a/rust/kcl-lib/tests/kcl_samples/router-template-cross-bar/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/router-template-cross-bar/artifact_commands.snap
@@ -446,7 +446,8 @@ description: Artifact commands router-template-cross-bar.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -627,7 +628,8 @@ description: Artifact commands router-template-cross-bar.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -804,7 +806,8 @@ description: Artifact commands router-template-cross-bar.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -981,7 +984,8 @@ description: Artifact commands router-template-cross-bar.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {

--- a/rust/kcl-lib/tests/kcl_samples/router-template-cross-bar/ast.snap
+++ b/rust/kcl-lib/tests/kcl_samples/router-template-cross-bar/ast.snap
@@ -16289,12 +16289,12 @@ description: Result of parsing router-template-cross-bar.kcl
               "commentStart": 0,
               "end": 0,
               "moduleId": 0,
-              "raw": "1.0",
+              "raw": "2.0",
               "start": 0,
               "type": "Literal",
               "type": "Literal",
               "value": {
-                "value": 1.0,
+                "value": 2.0,
                 "suffix": "None"
               }
             }

--- a/rust/kcl-lib/tests/kcl_samples/router-template-slate/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/router-template-slate/artifact_commands.snap
@@ -310,7 +310,8 @@ description: Artifact commands router-template-slate.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -491,7 +492,8 @@ description: Artifact commands router-template-slate.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -668,7 +670,8 @@ description: Artifact commands router-template-slate.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {

--- a/rust/kcl-lib/tests/kcl_samples/router-template-slate/ast.snap
+++ b/rust/kcl-lib/tests/kcl_samples/router-template-slate/ast.snap
@@ -9563,12 +9563,12 @@ description: Result of parsing router-template-slate.kcl
               "commentStart": 0,
               "end": 0,
               "moduleId": 0,
-              "raw": "1.0",
+              "raw": "2.0",
               "start": 0,
               "type": "Literal",
               "type": "Literal",
               "value": {
-                "value": 1.0,
+                "value": 2.0,
                 "suffix": "None"
               }
             }

--- a/rust/kcl-lib/tests/kcl_samples/single-impeller-blade/ast.snap
+++ b/rust/kcl-lib/tests/kcl_samples/single-impeller-blade/ast.snap
@@ -3057,12 +3057,12 @@ description: Result of parsing single-impeller-blade.kcl
               "commentStart": 0,
               "end": 0,
               "moduleId": 0,
-              "raw": "1.0",
+              "raw": "2.0",
               "start": 0,
               "type": "Literal",
               "type": "Literal",
               "value": {
-                "value": 1.0,
+                "value": 2.0,
                 "suffix": "None"
               }
             }

--- a/rust/kcl-lib/tests/kcl_samples/snowman/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/snowman/artifact_commands.snap
@@ -132,7 +132,8 @@ description: Artifact commands snowman.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -367,7 +368,8 @@ description: Artifact commands snowman.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -602,7 +604,8 @@ description: Artifact commands snowman.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -837,7 +840,8 @@ description: Artifact commands snowman.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -1055,7 +1059,8 @@ description: Artifact commands snowman.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -1273,7 +1278,8 @@ description: Artifact commands snowman.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -1542,7 +1548,8 @@ description: Artifact commands snowman.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -1760,7 +1767,8 @@ description: Artifact commands snowman.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -2088,7 +2096,8 @@ description: Artifact commands snowman.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -2320,7 +2329,8 @@ description: Artifact commands snowman.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -2467,7 +2477,8 @@ description: Artifact commands snowman.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -2665,7 +2676,8 @@ description: Artifact commands snowman.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -2893,7 +2905,8 @@ description: Artifact commands snowman.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -3121,7 +3134,8 @@ description: Artifact commands snowman.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {

--- a/rust/kcl-lib/tests/kcl_samples/snowman/ast.snap
+++ b/rust/kcl-lib/tests/kcl_samples/snowman/ast.snap
@@ -18017,12 +18017,12 @@ description: Result of parsing snowman.kcl
               "commentStart": 0,
               "end": 0,
               "moduleId": 0,
-              "raw": "1.0",
+              "raw": "2.0",
               "start": 0,
               "type": "Literal",
               "type": "Literal",
               "value": {
-                "value": 1.0,
+                "value": 2.0,
                 "suffix": "None"
               }
             }

--- a/rust/kcl-lib/tests/kcl_samples/socket-head-cap-screw/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/socket-head-cap-screw/artifact_commands.snap
@@ -115,7 +115,8 @@ description: Artifact commands socket-head-cap-screw.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -372,7 +373,8 @@ description: Artifact commands socket-head-cap-screw.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -506,7 +508,8 @@ description: Artifact commands socket-head-cap-screw.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {

--- a/rust/kcl-lib/tests/kcl_samples/socket-head-cap-screw/ast.snap
+++ b/rust/kcl-lib/tests/kcl_samples/socket-head-cap-screw/ast.snap
@@ -3812,12 +3812,12 @@ description: Result of parsing socket-head-cap-screw.kcl
               "commentStart": 0,
               "end": 0,
               "moduleId": 0,
-              "raw": "1.0",
+              "raw": "2.0",
               "start": 0,
               "type": "Literal",
               "type": "Literal",
               "value": {
-                "value": 1.0,
+                "value": 2.0,
                 "suffix": "None"
               }
             }

--- a/rust/kcl-lib/tests/kcl_samples/spinning-highrise-tower/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/spinning-highrise-tower/artifact_commands.snap
@@ -158,7 +158,8 @@ description: Artifact commands spinning-highrise-tower.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -417,7 +418,8 @@ description: Artifact commands spinning-highrise-tower.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -662,7 +664,8 @@ description: Artifact commands spinning-highrise-tower.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -921,7 +924,8 @@ description: Artifact commands spinning-highrise-tower.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -1111,7 +1115,8 @@ description: Artifact commands spinning-highrise-tower.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -1352,7 +1357,8 @@ description: Artifact commands spinning-highrise-tower.kcl
         "segment": "[uuid]",
         "intersection_segment": "[uuid]",
         "intersection_index": -1,
-        "curve_clockwise": false
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {

--- a/rust/kcl-lib/tests/kcl_samples/spinning-highrise-tower/ast.snap
+++ b/rust/kcl-lib/tests/kcl_samples/spinning-highrise-tower/ast.snap
@@ -17206,12 +17206,12 @@ description: Result of parsing spinning-highrise-tower.kcl
               "commentStart": 0,
               "end": 0,
               "moduleId": 0,
-              "raw": "1.0",
+              "raw": "2.0",
               "start": 0,
               "type": "Literal",
               "type": "Literal",
               "value": {
-                "value": 1.0,
+                "value": 2.0,
                 "suffix": "None"
               }
             }


### PR DESCRIPTION
## Summary

- migrate 14 verified public KCL sample projects from `kclVersion = 1.0` to `2.0`
- regenerate the corresponding KCL AST snapshots
- keep the blocked Shelf Bracket, Sheet Metal Bracket, and Robot J3 migrations out of this change

The Planetary Gearset caller is included because its v2 behavior was verified across a six-case gear matrix. The shared `std::gear` implementation still uses Sketch v1 internally and remains tracked separately in #13109.

## Why

These public samples are retrieval context for Zookeeper. Moving verified samples to Sketch v2 reduces the chance that retrieved examples reinforce legacy sketch behavior while preserving their existing geometry and constraint state.

## Validation

- current KCL binding mock-executed every changed project with zero issues
- `cargo test -p kcl-lib --lib 'simulation_tests::kcl_samples::parse_' -- --nocapture`: 100 passed
- before/after constraint status matched exactly for every changed sample
- before/after render similarity exceeded 99.94% for every changed sample
- 13/14 projects matched exactly for mass, volume, surface area, center of mass, and bounding box
- Car Wheel Assembly matched exactly for mass, volume, and bounding box; surface area differed by approximately `9.3e-10 mm²`, and repeated center-of-mass measurements showed only micron-scale analysis nondeterminism
- six representative spur, helical, herringbone, and ring gear cases matched exactly on all physical-analysis metrics; their render similarities exceeded 99.982%

## Known holds

- Sketch v2 native involute support / `std::gear` migration: #13109
- post-subtract edge-cut failures blocking the two bracket samples: [KittyCAD/engine#4818](https://github.com/KittyCAD/engine/issues/4818)
- degenerate segment-selected J3 region: [KittyCAD/engine#4926](https://github.com/KittyCAD/engine/issues/4926)