### PR TITLE
Move conflict-copy telemetry to legacy cleanup

### DIFF
--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -2,7 +2,6 @@ import { signal } from '@preact/signals-core'
 import env, { getEnvironmentNameFromEnv } from '@src/env'
 import {
   reportCloudSyncConflict,
-  reportCloudSyncConflictCopyDetected,
   reportCloudSyncFailure,
 } from '@src/lib/cloudSync/clientErrorReporting'
 import {
@@ -2422,7 +2421,6 @@ async function markProjectConflict(
   }
   await putProjectMetadata(nextMetadata)
   publishScopedProjectCloudProjectId(nextMetadata)
-  reportCloudSyncConflictCopyDetected()
   if (projectPathMatchesSyncScope(metadata.localProjectPath)) {
     updateStatus({
       state: 'conflict',

--- a/src/lib/cloudSync/liveConflicts.test.ts
+++ b/src/lib/cloudSync/liveConflicts.test.ts
@@ -211,9 +211,9 @@ describe('cloud sync live conflicts', () => {
     await vi.waitFor(() =>
       expect(clientErrorsMock.reportClientError).toHaveBeenCalledWith(
         expect.objectContaining({
-          code: 'cloud_sync_conflict_copy_detected',
-          errorName: 'CloudSyncConflictCopyDetected',
-          message: 'Cloud sync "conflict copy" folder detected',
+          code: 'cloud_sync_conflict',
+          errorName: 'CloudSyncConflict',
+          message: 'Cloud sync conflict: local and remote both changed.',
           route: '/cloud-sync',
           extra: {
             source: 'CloudSyncEngine',
@@ -221,6 +221,11 @@ describe('cloud sync live conflicts', () => {
           },
         })
       )
+    )
+    expect(clientErrorsMock.reportClientError).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'cloud_sync_conflict_copy_detected',
+      })
     )
     const metadata = await getCloudSyncProjectMetadata(projectPath)
     expect(metadata?.conflict?.conflictProjectPath).toBeUndefined()

--- a/src/lib/projectLibraries/directoryScanner.test.ts
+++ b/src/lib/projectLibraries/directoryScanner.test.ts
@@ -57,6 +57,9 @@ const mocks = vi.hoisted(() => {
       clearOutboxEntriesTouchingProject: vi.fn(),
       deleteProjectMetadata: vi.fn(),
     },
+    clientErrorReporting: {
+      reportCloudSyncConflictCopyDetected: vi.fn(),
+    },
     fsZds: {
       cp: vi.fn(),
       dirname: vi.fn(dirname),
@@ -84,6 +87,11 @@ vi.mock('@src/lib/cloudSync', () => ({
 }))
 
 vi.mock('@src/lib/cloudSync/syncDb', () => mocks.cloudSyncDb)
+
+vi.mock(
+  '@src/lib/cloudSync/clientErrorReporting',
+  () => mocks.clientErrorReporting
+)
 
 vi.mock('@src/lib/desktop', () => mocks.desktop)
 
@@ -305,6 +313,9 @@ describe('directory project scanner', () => {
     expect(mocks.cloudSyncDb.deleteProjectMetadata).toHaveBeenCalledWith(
       conflictCopyPath
     )
+    expect(
+      mocks.clientErrorReporting.reportCloudSyncConflictCopyDetected
+    ).toHaveBeenCalledTimes(1)
   })
 
   it('keeps legacy cloud conflict-copy metadata when folder deletion fails', async () => {
@@ -354,6 +365,9 @@ describe('directory project scanner', () => {
       mocks.cloudSyncDb.clearLegacyConflictCopyReferences
     ).not.toHaveBeenCalled()
     expect(mocks.cloudSyncDb.deleteProjectMetadata).not.toHaveBeenCalled()
+    expect(
+      mocks.clientErrorReporting.reportCloudSyncConflictCopyDetected
+    ).not.toHaveBeenCalled()
   })
 
   it('batches scheduled directory name sync refreshes', async () => {

--- a/src/lib/projectLibraries/directoryScanner.ts
+++ b/src/lib/projectLibraries/directoryScanner.ts
@@ -3,6 +3,7 @@ import {
   getCloudSyncProjectMetadataIndex,
   getCloudSyncProjectModifiedTime,
 } from '@src/lib/cloudSync'
+import { reportCloudSyncConflictCopyDetected } from '@src/lib/cloudSync/clientErrorReporting'
 import {
   clearLegacyConflictCopyReferences,
   clearOutboxEntriesTouchingProject,
@@ -232,6 +233,7 @@ async function deleteLegacyCloudConflictCopyProject(projectPath: string) {
   await clearOutboxEntriesTouchingProject(projectPath)
   await clearLegacyConflictCopyReferences(projectPath)
   await deleteProjectMetadata(projectPath)
+  reportCloudSyncConflictCopyDetected()
 }
 
 export function shouldSendProjectFolderReadProgress(


### PR DESCRIPTION
I put this error type's logging in the wrong place in #12868, so it's been reported in Axiom in lock step with `CloudSyncConflict` errors, when it should be *far* more niche.