### PR TITLE
Avoid project.toml pre-read for new projects

### DIFF
--- a/src/lib/desktop.test.ts
+++ b/src/lib/desktop.test.ts
@@ -133,6 +133,9 @@ describe('createNewProjectDirectory', () => {
   it('treats serialized ENOENT strings as missing project.toml metadata', async () => {
     const projectDirectoryPath = createTempDirectoryPath()
     createdProjectDirectoryPaths.push(projectDirectoryPath)
+    await fsZds.mkdir(fsZds.join(projectDirectoryPath, 'Serialized ENOENT'), {
+      recursive: true,
+    })
 
     const originalReadFile = fsZds.readFile
     let hasThrownSerializedEnoent = false
@@ -180,6 +183,9 @@ describe('createNewProjectDirectory', () => {
   it('treats Electron ENOENT errors as missing project.toml metadata', async () => {
     const projectDirectoryPath = createTempDirectoryPath()
     createdProjectDirectoryPaths.push(projectDirectoryPath)
+    await fsZds.mkdir(fsZds.join(projectDirectoryPath, 'Electron ENOENT'), {
+      recursive: true,
+    })
 
     const originalReadFile = fsZds.readFile
     let hasThrownElectronEnoent = false
@@ -222,6 +228,53 @@ describe('createNewProjectDirectory', () => {
     } finally {
       fsZds.readFile = originalReadFile
     }
+  })
+
+  it('does not read project.toml before writing metadata for newly created project directories', async () => {
+    const projectDirectoryPath = createTempDirectoryPath()
+    createdProjectDirectoryPaths.push(projectDirectoryPath)
+
+    const originalReadFile = fsZds.readFile
+    let attemptedProjectTomlRead = false
+    fsZds.readFile = (async (filePath: string, options?: unknown) => {
+      if (fsZds.basename(filePath) === PROJECT_SETTINGS_FILE_NAME) {
+        attemptedProjectTomlRead = true
+        return Promise.reject(
+          new Error(`UNKNOWN: unknown error, open '${filePath}'`)
+        )
+      }
+
+      return originalReadFile(filePath, options as never)
+    }) as typeof fsZds.readFile
+
+    let projectPath = ''
+    try {
+      const project = await createNewProjectDirectory(
+        'Windows Dropbox',
+        wasmInstance,
+        undefined,
+        {
+          settings: {
+            project: {
+              directory: projectDirectoryPath,
+            },
+          },
+        }
+      )
+      projectPath = project.path
+
+      expect(attemptedProjectTomlRead).toBe(false)
+      expect(project.title).toBe('Windows Dropbox')
+    } finally {
+      fsZds.readFile = originalReadFile
+    }
+
+    const projectToml = await fsZds.readFile(
+      fsZds.join(projectPath, PROJECT_SETTINGS_FILE_NAME),
+      { encoding: 'utf-8' }
+    )
+
+    expect(projectToml).toContain('title = "Windows Dropbox"')
   })
 
   it('preserves project metadata when writing project settings', async () => {

--- a/src/lib/desktop.ts
+++ b/src/lib/desktop.ts
@@ -139,20 +139,24 @@ async function ensureProjectTomlTitle({
   projectPath,
   title,
   defaultFile,
+  readExistingProjectToml = true,
 }: {
   projectPath: string
   title: string
   defaultFile: string
+  readExistingProjectToml?: boolean
 }) {
   const projectTomlPath = fsZds.join(projectPath, PROJECT_SETTINGS_FILE_NAME)
   let projectToml = ''
-  try {
-    projectToml = await fsZds.readFile(projectTomlPath, {
-      encoding: 'utf-8',
-    })
-  } catch (error) {
-    if (!isPathNotFoundError(error)) {
-      return Promise.reject(error)
+  if (readExistingProjectToml) {
+    try {
+      projectToml = await fsZds.readFile(projectTomlPath, {
+        encoding: 'utf-8',
+      })
+    } catch (error) {
+      if (!isPathNotFoundError(error)) {
+        return Promise.reject(error)
+      }
     }
   }
 
@@ -272,11 +276,13 @@ export async function createNewProjectDirectory(
   }
   const projectDir = fsZds.join(mainDir, projectName)
 
+  let projectDirectoryCreated = false
   try {
     await fsZds.stat(projectDir)
   } catch (e) {
     if (isPathNotFoundError(e)) {
       await fsZds.mkdir(projectDir, { recursive: true })
+      projectDirectoryCreated = true
     }
   }
 
@@ -303,6 +309,7 @@ export async function createNewProjectDirectory(
     projectPath: projectDir,
     title: projectTitle,
     defaultFile: kclFileName,
+    readExistingProjectToml: !projectDirectoryCreated,
   })
   let metadata: FileMetadata | null = null
   try {


### PR DESCRIPTION
Fixes a flaky project creation failure where Windows/Dropbox could report `UNKNOWN: unknown error, open ...project.toml` while creating a new project. So far only @jacebrowning has hit this, but it's likely been in the app since #12461. The root cause was that project creation read `project.toml` before writing it, even when the project directory had just been created and there could not be existing metadata to preserve.

1. Tracks whether `createNewProjectDirectory` created the project directory in the current operation.
2. Skips the initial `project.toml` read for freshly created directories and writes synthesized metadata directly.
3. Keeps the existing read-before-write behavior for pre-existing project directories so metadata preservation still works.
4. Adds regression coverage for the Windows-style `UNKNOWN` open error and keeps the existing missing-file behavior covered.

## How to test
Create a new project in a Personal Cloud library, especially from a Windows or Dropbox-backed folder a bunch, and confirm it opens without a console error and writes `project.toml` with the title/default file metadata. The focused desktop project creation tests cover the missing-file and Windows-style error cases.