### PR TITLE
KCL release instructions: use new branch

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -9,6 +9,7 @@
     ```
 3. Commit the changes:
     ```bash
+    git checkout -b "release/VERSION_GOES_HERE"
     git add .
     git commit -m "Bump versions"
     ```


### PR DESCRIPTION
Without this instruction, people would push a new commit on main.