### PR TITLE
Update kcl-lib to KittyCAD SDK 0.5

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2612,9 +2612,9 @@ dependencies = [
 
 [[package]]
 name = "kittycad"
-version = "0.4.14"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7973e7ac46b7d00b4cce721d6c414a602447ddff305126ddea8cf43144832d97"
+checksum = "09e616688e500d5d2273d98a80bdbeb2b9c783e217efb693e83ebfb70def7209"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,7 +25,7 @@ dashmap = { version = "6.2.1" }
 http = "1"
 indexmap = "2.13.1"
 ezpz = "0.2.29"
-kittycad = { version = "0.4.13", default-features = false, features = [
+kittycad = { version = "0.5.0", default-features = false, features = [
   "js",
   "requests",
 ] }


### PR DESCRIPTION
`zoo-cli` needs a new kittycad crate update, but the mismatch in kcl-lib creating a weird ass depedency to an older kcl-lib. This re-aligns things. I'm sure people familiar with this know the pain