### PR TITLE
Correlate resumed Zookeeper turns

### DIFF
--- a/src/lib/zookeeper/components/ZookeeperConversationPane.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPane.tsx
@@ -508,6 +508,8 @@ export const ZookeeperConversationPane = (props: {
               type: ZookeeperManagerStates.ContinueCheck,
               projectName: project.name,
               projectFiles,
+              engineApiCallId:
+                props.contextModeling.engineCommandManager.apiCallId,
               activeFile: currentLoaderFile
                 ? activeFileRelativeToProject({
                     currentFileEntry: currentLoaderFile,

--- a/src/lib/zookeeper/zookeeperManagerMachine.test.ts
+++ b/src/lib/zookeeper/zookeeperManagerMachine.test.ts
@@ -792,6 +792,7 @@ describe('zookeeperManagerMachine', () => {
         projectName: 'zoo-project',
         projectFiles,
         activeFile: 'newFile.kcl',
+        engineApiCallId: 'engine-api-call-id',
       })
 
       await waitFor(actor, (state) =>
@@ -802,21 +803,24 @@ describe('zookeeperManagerMachine', () => {
       expect(actor.getSnapshot().context.projectNameCurrentlyOpened).toBe(
         'zoo-project'
       )
-      expect(ws.sentPayloads).toStrictEqual([
-        JSON.stringify({
-          type: 'system',
-          command: 'continue',
-        }),
-        JSON.stringify({
-          type: 'project_context',
-          project_name: 'zoo-project',
-          current_files: {
-            'main.kcl': Array.from(new TextEncoder().encode('cube()')),
-            'notes.txt': Array.from(new TextEncoder().encode('notes')),
-          },
-          active_file: 'newFile.kcl',
-        }),
-      ])
+      expect(ws.sentPayloads).toHaveLength(2)
+      expect(JSON.parse(ws.sentPayloads[0])).toStrictEqual({
+        type: 'system',
+        command: 'continue',
+      })
+      expect(JSON.parse(ws.sentPayloads[1])).toStrictEqual({
+        type: 'project_context',
+        correlation_id: expect.stringMatching(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+        ),
+        engine_api_call_id: 'engine-api-call-id',
+        project_name: 'zoo-project',
+        current_files: {
+          'main.kcl': Array.from(new TextEncoder().encode('cube()')),
+          'notes.txt': Array.from(new TextEncoder().encode('notes')),
+        },
+        active_file: 'newFile.kcl',
+      })
 
       actor.stop()
     })

--- a/src/lib/zookeeper/zookeeperManagerMachine.ts
+++ b/src/lib/zookeeper/zookeeperManagerMachine.ts
@@ -78,6 +78,8 @@ type MlCopilotProjectContextRequest = Extract<
   { type: 'project_context' }
 > & {
   active_file?: string
+  correlation_id?: string
+  engine_api_call_id?: string
 }
 
 type MlCopilotClientMessageWithDiscoveredMode =
@@ -288,6 +290,7 @@ export type ZookeeperManagerEvents =
       projectName: string
       projectFiles: FileMeta[]
       activeFile?: string
+      engineApiCallId?: string
     }
   | {
       type: ZookeeperManagerTransitions.ResponseReceive
@@ -1391,6 +1394,7 @@ export const zookeeperManagerMachine = setup({
 
       const requestProjectContext: MlCopilotProjectContextRequest = {
         type: 'project_context',
+        ...createZookeeperCorrelation(event.engineApiCallId),
         project_name: event.projectName,
         current_files: filesAsByteArrays,
         ...(event.activeFile ? { active_file: event.activeFile } : {}),


### PR DESCRIPTION
Issue:
this [4:24 PM reconnect/resume trace](https://www.comet.com/opik/zookeeper/projects/019bb36a-9d1d-7612-8127-0918162e8217/logs?time_range=past30days&trace=01a01c58-3efb-7081-90cd-1cfb062ee4c2&span=) has neither ID. Its input is:
`[The user had disconnected during the previous run, continue processing using the current context]
`
- attach a fresh correlation ID and the active Engine API call ID to resumed Zookeeper project-context requests
- pass the current Engine session ID into the reconnect state transition
- cover the reconnect payload with a regression test

Normal Zookeeper prompts included both IDs, but the reconnect path sent `continue` and updated project context without them. As a result, a resumed turn could not be linked back to the Engine session involved in that continuation.

