### PR TITLE
chore(kcl): increase stack size for wasm builds

### DIFF
--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -2,4 +2,11 @@
 kcl-language-server-release = "run --manifest-path ./kcl-language-server-release/Cargo.toml --"
 
 [target.wasm32-unknown-unknown]
-rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]
+rustflags = [
+  "--cfg",
+  "getrandom_backend=\"wasm_js\"",
+  "-C",
+  "link-arg=-z",
+  "-C",
+  "link-arg=stack-size=16777216",
+]


### PR DESCRIPTION
WASM dev build is too large and with the CEK code we seem to be hitting the limit. MacOS sets 8MB by default (I think) so set to 16MB. 

This affects release as well as dev! 