### PR TITLE
Fix logo tab hover styling

### DIFF
--- a/src/components/ProjectSidebarMenu.tsx
+++ b/src/components/ProjectSidebarMenu.tsx
@@ -177,7 +177,7 @@ function AppLogoLink({
   onHomeNavigate: () => void
 }) {
   const wrapperClassName =
-    "cursor-pointer relative group-hover/home:before:outline h-full grid flex-none place-content-center group p-1.5 before:block before:content-[''] before:absolute before:inset-0 before:bottom-1 before:z-[-1] before:bg-primary before:rounded-b-sm"
+    "cursor-pointer relative group-hover/home:before:outline h-full grid flex-none place-content-center group p-1.5 before:block before:content-[''] before:absolute before:inset-0 before:bottom-1 before:z-[-1] before:bg-primary before:rounded-b-sm before:transition-[filter] before:duration-100 before:ease-out"
   const logoClassName = 'w-auto h-4 text-chalkboard-10'
 
   if (!enabled) {
@@ -200,7 +200,7 @@ function AppLogoLink({
         onHomeNavigate()
       }}
       to={PATHS.HOME}
-      className={`${wrapperClassName} hover:before:brightness-110`}
+      className={`${wrapperClassName} hover:hue-rotate-0 dark:hover:brightness-100 hover:before:drop-shadow-tab-sm`}
     >
       <Logo data-onboarding-id="app-logo" className={logoClassName} />
       <span className="sr-only">{APP_NAME}</span>

--- a/src/index.css
+++ b/src/index.css
@@ -581,6 +581,13 @@ code,
     which lets you use them with @apply in your CSS, and get
     autocomplete in classNames in your JSX.
   */
+  .drop-shadow-tab-sm {
+    --tw-drop-shadow: drop-shadow(0 2px 4px rgb(0 0 0 / 0.24));
+    filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast)
+      var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert)
+      var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+  }
+
   .parsed-markdown ul,
   .parsed-markdown ol {
     @apply list-outside pl-4 lg:pl-8 my-2;


### PR DESCRIPTION
Users find this hue-rotate hover styling, which the home button inherits from our default link styling, to be a bad look. This PR switches the indication that the pointer can have some interaction with the link to be a drop-shadow filter added underneath the button.

https://github.com/user-attachments/assets/1be60413-d6b5-4491-8e54-017c61e4ba8d

