### PR TITLE
Scope Playwright client error mocks

### DIFF
--- a/e2e/playwright/cloud-sync.spec.ts
+++ b/e2e/playwright/cloud-sync.spec.ts
@@ -10,7 +10,7 @@ import {
   seedCloudSyncState,
   zipProject,
 } from '@e2e/playwright/lib/cloudSyncTestUtils'
-import { setup } from '@e2e/playwright/test-utils'
+import { mockClientErrorReports, setup } from '@e2e/playwright/test-utils'
 import { expect, type Page, test } from '@playwright/test'
 import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
 
@@ -414,6 +414,7 @@ test(
         (update) => update.projectId === staleDirtyProject.id
       )
 
+    await mockClientErrorReports(context)
     await setup(context, page, testInfo, [OPFS_CLOUD_FEATURE_FLAG])
     await page.goto('/')
     await expectCloudSyncHomeReady(page)

--- a/e2e/playwright/test-utils.ts
+++ b/e2e/playwright/test-utils.ts
@@ -932,6 +932,18 @@ export async function tearDown(page: Page, testInfo: TestInfo) {
   })
 }
 
+export async function mockClientErrorReports(context: BrowserContext) {
+  await context.unroute('**/user/client-errors')
+  await context.route('**/user/client-errors', async (route) => {
+    // Keep intentionally simulated failures from polluting real dev telemetry.
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({}),
+    })
+  })
+}
+
 // settingsOverrides may need to be augmented to take more generic items,
 // but we'll be strict for now
 export async function setup(


### PR DESCRIPTION
Axiom showed that the CI Service Account is dominating recent `cloud_sync_failure` client-error telemetry from Windows Chrome Playwright runs, including `localhost:3000` referers and cloud-sync fixture project ids. We still want real client-error reporting to work in CI so new reports can be validated before landing on `main`; this PR only suppresses telemetry for a cloud-sync test that intentionally drives a failure path.

1. Adds an opt-in Playwright helper for mocking `**/user/client-errors`.
2. Uses that helper only in the cloud-sync scenario that deliberately simulates a stale remote update with a 409 response.
3. Leaves default Playwright setup and other web E2E tests able to report real client errors to dev.

How to test

Review the scoped helper call in the stale-update cloud-sync E2E scenario. Other Playwright tests should continue using real client-error reporting unless they explicitly opt into this mock.
