### PR TITLE
Add fs operation queue service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -137,6 +137,7 @@
         "eslint-plugin-testing-library": "^7.16.2",
         "eslint-plugin-vitest": "^0.5.4",
         "fake-indexeddb": "^6.2.5",
+        "fast-check": "^4.9.0",
         "happy-dom": "^20.9.0",
         "http-server": "^14.1.1",
         "husky": "^9.1.7",
@@ -20206,6 +20207,29 @@
         "node": ">=18"
       }
     },
+    "node_modules/fast-check": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -27150,6 +27174,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.15.2",

--- a/package.json
+++ b/package.json
@@ -216,6 +216,7 @@
     "eslint-plugin-testing-library": "^7.16.2",
     "eslint-plugin-vitest": "^0.5.4",
     "fake-indexeddb": "^6.2.5",
+    "fast-check": "^4.9.0",
     "happy-dom": "^20.9.0",
     "http-server": "^14.1.1",
     "husky": "^9.1.7",

--- a/src/registry/contracts/fsOperationQueue.ts
+++ b/src/registry/contracts/fsOperationQueue.ts
@@ -1,0 +1,63 @@
+import { defineContract, defineService } from '@kittycad/registry'
+import type { Signal } from '@preact/signals-core'
+import type { IZooDesignStudioFS } from '@src/lib/fs-zds/interface'
+
+export type FsOperationQueueStatus =
+  | 'queued'
+  | 'running'
+  | 'completed'
+  | 'failed'
+
+export interface FsOperationQueueOperation {
+  readonly kind: string
+  readonly sourcePath?: string
+  readonly targetPath?: string
+  readonly metadata?: Readonly<Record<string, unknown>>
+}
+
+export interface FsOperationQueueRecord extends FsOperationQueueOperation {
+  readonly id: string
+  readonly sequence: number
+  readonly status: FsOperationQueueStatus
+  readonly enqueuedAt: number
+  readonly startedAt?: number
+  readonly completedAt?: number
+  readonly error?: unknown
+}
+
+export interface FsOperationQueueState {
+  readonly pending: boolean
+  readonly current?: FsOperationQueueRecord
+  readonly queued: readonly FsOperationQueueRecord[]
+  readonly journal: readonly FsOperationQueueRecord[]
+}
+
+/**
+ * Serializes mutating filesystem work through one observable chokepoint.
+ *
+ * Domain services should expose domain-specific operations, but mutating
+ * filesystem effects should run through this queue so ordering and error
+ * reporting can be tested independently of those domains.
+ */
+export interface FsOperationQueueService {
+  readonly state: Signal<FsOperationQueueState>
+  run: <Result>(
+    operation: FsOperationQueueOperation,
+    run: () => Promise<Result>
+  ) => Promise<Result>
+  waitForIdle: () => Promise<void>
+  getJournal: () => readonly FsOperationQueueRecord[]
+  clearJournal: () => void
+  cp: IZooDesignStudioFS['cp']
+  mkdir: IZooDesignStudioFS['mkdir']
+  rename: IZooDesignStudioFS['rename']
+  rm: IZooDesignStudioFS['rm']
+  writeFile: IZooDesignStudioFS['writeFile']
+}
+
+export const fsOperationQueueContract = defineContract({
+  fsOperationQueue:
+    defineService<FsOperationQueueService>('fs-operation-queue'),
+})
+
+export const { fsOperationQueue } = fsOperationQueueContract

--- a/src/registry/contracts/fsOperationQueue.ts
+++ b/src/registry/contracts/fsOperationQueue.ts
@@ -17,12 +17,37 @@ export interface FsOperationQueueOperation {
 
 export interface FsOperationQueueRecord extends FsOperationQueueOperation {
   readonly id: string
+  readonly parentId?: string
   readonly sequence: number
   readonly status: FsOperationQueueStatus
   readonly enqueuedAt: number
   readonly startedAt?: number
   readonly completedAt?: number
   readonly error?: unknown
+}
+
+/** Mutating filesystem operations that can run alone or within a batch. */
+export interface FsMutationOperations {
+  cp: IZooDesignStudioFS['cp']
+  mkdir: IZooDesignStudioFS['mkdir']
+  rename: IZooDesignStudioFS['rename']
+  rm: IZooDesignStudioFS['rm']
+  writeFile: IZooDesignStudioFS['writeFile']
+}
+
+/**
+ * Filesystem facade bound to one exclusively scheduled batch.
+ *
+ * Calls made through this facade are serialized inside the batch without
+ * re-entering the top-level queue. A batch provides scheduling atomicity only;
+ * it does not roll back filesystem effects when a later operation fails.
+ */
+export interface FsOperationBatch extends FsMutationOperations {
+  readonly id: string
+  run: <Result>(
+    operation: FsOperationQueueOperation,
+    run: () => Promise<Result>
+  ) => Promise<Result>
 }
 
 export interface FsOperationQueueState {
@@ -39,20 +64,19 @@ export interface FsOperationQueueState {
  * filesystem effects should run through this queue so ordering and error
  * reporting can be tested independently of those domains.
  */
-export interface FsOperationQueueService {
+export interface FsOperationQueueService extends FsMutationOperations {
   readonly state: Signal<FsOperationQueueState>
   run: <Result>(
     operation: FsOperationQueueOperation,
     run: () => Promise<Result>
   ) => Promise<Result>
+  batch: <Result>(
+    operation: FsOperationQueueOperation,
+    run: (batch: FsOperationBatch) => Promise<Result>
+  ) => Promise<Result>
   waitForIdle: () => Promise<void>
   getJournal: () => readonly FsOperationQueueRecord[]
   clearJournal: () => void
-  cp: IZooDesignStudioFS['cp']
-  mkdir: IZooDesignStudioFS['mkdir']
-  rename: IZooDesignStudioFS['rename']
-  rm: IZooDesignStudioFS['rm']
-  writeFile: IZooDesignStudioFS['writeFile']
 }
 
 export const fsOperationQueueContract = defineContract({

--- a/src/registry/extensions/fsOperationQueue/index.property.test.ts
+++ b/src/registry/extensions/fsOperationQueue/index.property.test.ts
@@ -1,0 +1,292 @@
+import type {
+  FsMutationOperations,
+  FsOperationBatch,
+} from '@src/registry/contracts/fsOperationQueue'
+import { createFsOperationQueueService } from '@src/registry/extensions/fsOperationQueue'
+import fc, { type Scheduler } from 'fast-check'
+import { describe, expect, it } from 'vitest'
+
+type Mutation =
+  | {
+      readonly kind: 'copy'
+      readonly sourcePath: string
+      readonly targetPath: string
+    }
+  | {
+      readonly kind: 'remove'
+      readonly targetPath: string
+    }
+  | {
+      readonly kind: 'rename'
+      readonly sourcePath: string
+      readonly targetPath: string
+    }
+  | {
+      readonly kind: 'write'
+      readonly targetPath: string
+      readonly value: string
+    }
+
+interface FileSystemModel {
+  readonly files: Map<string, string>
+  readonly attempted: Mutation[]
+}
+
+const projectPath = fc.constantFrom(
+  '/project/a.kcl',
+  '/project/b.kcl',
+  '/project/c.kcl',
+  '/project/d.kcl'
+)
+
+const mutationArbitrary: fc.Arbitrary<Mutation> = fc.oneof(
+  fc.tuple(projectPath, projectPath).map(([sourcePath, targetPath]) => ({
+    kind: 'copy' as const,
+    sourcePath,
+    targetPath,
+  })),
+  projectPath.map((targetPath) => ({
+    kind: 'remove' as const,
+    targetPath,
+  })),
+  fc.tuple(projectPath, projectPath).map(([sourcePath, targetPath]) => ({
+    kind: 'rename' as const,
+    sourcePath,
+    targetPath,
+  })),
+  fc
+    .tuple(projectPath, fc.string({ maxLength: 8 }))
+    .map(([targetPath, value]) => ({
+      kind: 'write' as const,
+      targetPath,
+      value,
+    }))
+)
+
+const batchPlansArbitrary = fc.array(
+  fc.array(mutationArbitrary, { minLength: 1, maxLength: 5 }),
+  { minLength: 1, maxLength: 4 }
+)
+
+function applyMutation(files: Map<string, string>, mutation: Mutation) {
+  switch (mutation.kind) {
+    case 'copy':
+      files.set(mutation.targetPath, files.get(mutation.sourcePath) ?? '')
+      break
+    case 'remove':
+      files.delete(mutation.targetPath)
+      break
+    case 'rename': {
+      const contents = files.get(mutation.sourcePath) ?? ''
+      files.delete(mutation.sourcePath)
+      files.set(mutation.targetPath, contents)
+      break
+    }
+    case 'write':
+      files.set(mutation.targetPath, mutation.value)
+      break
+  }
+}
+
+function createScheduledFileSystem(
+  scheduler: Scheduler,
+  failureAt?: number
+): FileSystemModel & { readonly operations: FsMutationOperations } {
+  const files = new Map<string, string>()
+  const attempted: Mutation[] = []
+  let invocation = 0
+
+  const mutate = scheduler.scheduleFunction(async (mutation: Mutation) => {
+    const currentInvocation = invocation++
+    attempted.push(mutation)
+    if (currentInvocation === failureAt) {
+      throw new Error(`injected filesystem failure at ${currentInvocation}`)
+    }
+    applyMutation(files, mutation)
+  })
+
+  return {
+    files,
+    attempted,
+    operations: {
+      cp: (sourcePath, targetPath) =>
+        mutate({ kind: 'copy', sourcePath, targetPath }),
+      mkdir: async () => undefined,
+      rename: (sourcePath, targetPath) =>
+        mutate({ kind: 'rename', sourcePath, targetPath }),
+      rm: (targetPath) => mutate({ kind: 'remove', targetPath }),
+      writeFile: (targetPath, data) =>
+        mutate({
+          kind: 'write',
+          targetPath,
+          value: new TextDecoder().decode(data),
+        }),
+    },
+  }
+}
+
+function executeMutation(batch: FsOperationBatch, mutation: Mutation) {
+  switch (mutation.kind) {
+    case 'copy':
+      return Promise.resolve(batch.cp(mutation.sourcePath, mutation.targetPath))
+    case 'remove':
+      return batch.rm(mutation.targetPath)
+    case 'rename':
+      return batch.rename(mutation.sourcePath, mutation.targetPath)
+    case 'write':
+      return batch.writeFile(
+        mutation.targetPath,
+        new TextEncoder().encode(mutation.value)
+      )
+  }
+}
+
+function modelSequentialBatches(
+  plans: readonly (readonly Mutation[])[],
+  failureAt?: number
+) {
+  const files = new Map<string, string>()
+  const attempted: Mutation[] = []
+  const failedBatches = new Set<number>()
+  let invocation = 0
+
+  plans.forEach((plan, batchIndex) => {
+    for (const mutation of plan) {
+      attempted.push(mutation)
+      if (invocation++ === failureAt) {
+        failedBatches.add(batchIndex)
+        break
+      }
+      applyMutation(files, mutation)
+    }
+  })
+
+  return { files, attempted, failedBatches }
+}
+
+function sortedEntries(files: ReadonlyMap<string, string>) {
+  return [...files.entries()].sort(([left], [right]) =>
+    left.localeCompare(right)
+  )
+}
+
+describe('fs operation queue properties', () => {
+  it('matches a serial model across generated batches and failures', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        batchPlansArbitrary,
+        fc.option(fc.nat({ max: 20 }), { nil: undefined }),
+        fc.scheduler(),
+        async (plans, failureAt, scheduler) => {
+          const fileSystem = createScheduledFileSystem(scheduler, failureAt)
+          const queue = createFsOperationQueueService(fileSystem.operations)
+          const batchEvents: string[] = []
+          const expected = modelSequentialBatches(plans, failureAt)
+
+          const batches = plans.map((plan, batchIndex) =>
+            queue.batch({ kind: `batch-${batchIndex}` }, async (batch) => {
+              batchEvents.push(`${batchIndex}:start`)
+              try {
+                for (const mutation of plan) {
+                  await executeMutation(batch, mutation)
+                }
+              } finally {
+                batchEvents.push(`${batchIndex}:end`)
+              }
+            })
+          )
+
+          const results = await scheduler.waitFor(Promise.allSettled(batches))
+          await queue.waitForIdle()
+
+          expect(batchEvents).toEqual(
+            plans.flatMap((_, batchIndex) => [
+              `${batchIndex}:start`,
+              `${batchIndex}:end`,
+            ])
+          )
+          expect(fileSystem.attempted).toEqual(expected.attempted)
+          expect(sortedEntries(fileSystem.files)).toEqual(
+            sortedEntries(expected.files)
+          )
+          expect(results.map((result) => result.status)).toEqual(
+            plans.map((_, batchIndex) =>
+              expected.failedBatches.has(batchIndex) ? 'rejected' : 'fulfilled'
+            )
+          )
+
+          const journal = queue.getJournal()
+          expect(journal).toHaveLength(plans.length + expected.attempted.length)
+          expect(new Set(journal.map((record) => record.id)).size).toBe(
+            journal.length
+          )
+          expect(
+            journal.every(
+              (record) =>
+                record.status === 'completed' || record.status === 'failed'
+            )
+          ).toBe(true)
+          expect(
+            journal
+              .filter((record) => record.parentId)
+              .every((record) =>
+                journal.some((parent) => parent.id === record.parentId)
+              )
+          ).toBe(true)
+          expect(
+            journal
+              .filter((record) => !record.parentId)
+              .map((record) => record.status)
+          ).toEqual(
+            plans.map((_, batchIndex) =>
+              expected.failedBatches.has(batchIndex) ? 'failed' : 'completed'
+            )
+          )
+          expect(
+            journal.filter(
+              (record) => record.parentId && record.status === 'failed'
+            )
+          ).toHaveLength(expected.failedBatches.size)
+          expect(queue.state.value).toMatchObject({
+            pending: false,
+            queued: [],
+          })
+          expect(queue.state.value.current).toBeUndefined()
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+
+  it('serializes concurrently requested children in generated batches', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        batchPlansArbitrary,
+        fc.scheduler(),
+        async (plans, scheduler) => {
+          const fileSystem = createScheduledFileSystem(scheduler)
+          const queue = createFsOperationQueueService(fileSystem.operations)
+          const expected = modelSequentialBatches(plans)
+
+          const batches = plans.map((plan, batchIndex) =>
+            queue.batch({ kind: `batch-${batchIndex}` }, async (batch) => {
+              await Promise.all(
+                plan.map((mutation) => executeMutation(batch, mutation))
+              )
+            })
+          )
+
+          await scheduler.waitFor(Promise.all(batches))
+          await queue.waitForIdle()
+
+          expect(fileSystem.attempted).toEqual(expected.attempted)
+          expect(sortedEntries(fileSystem.files)).toEqual(
+            sortedEntries(expected.files)
+          )
+          expect(queue.state.value.pending).toBe(false)
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+})

--- a/src/registry/extensions/fsOperationQueue/index.test.ts
+++ b/src/registry/extensions/fsOperationQueue/index.test.ts
@@ -103,6 +103,144 @@ describe('fs operation queue extension', () => {
     ])
   })
 
+  it('keeps batch operations exclusive from top-level queue work', async () => {
+    registry = new Registry()
+    registry.configure([fsOperationQueueRegistryItem])
+    const queue = registry.get(fsOperationQueue)
+    const mkdirGate = createDeferred<void>()
+    const order: string[] = []
+
+    fsZdsMocks.mkdir.mockImplementationOnce(async () => {
+      order.push('batch:mkdir:start')
+      await mkdirGate.promise
+      order.push('batch:mkdir:end')
+    })
+    fsZdsMocks.cp.mockImplementationOnce(async () => {
+      order.push('batch:cp')
+    })
+    fsZdsMocks.writeFile.mockImplementationOnce(async () => {
+      order.push('external:write')
+    })
+
+    const batched = queue.batch(
+      {
+        kind: 'move-entry',
+        sourcePath: '/project/source',
+        targetPath: '/project/target',
+      },
+      async (batch) => {
+        order.push('batch:start')
+        await batch.mkdir('/project/target', { recursive: true })
+        await batch.cp('/project/source', '/project/target', {
+          recursive: true,
+        })
+        order.push('batch:end')
+      }
+    )
+    const external = queue.writeFile(
+      '/project/external.kcl',
+      new Uint8Array([1])
+    )
+
+    await flushMicrotasks()
+
+    expect(order).toEqual(['batch:start', 'batch:mkdir:start'])
+    expect(queue.state.value.current).toMatchObject({
+      kind: 'move-entry',
+      status: 'running',
+    })
+    expect(queue.state.value.queued).toEqual([
+      expect.objectContaining({ kind: 'write-file', status: 'queued' }),
+    ])
+
+    mkdirGate.resolve()
+    await batched
+    await external
+
+    expect(order).toEqual([
+      'batch:start',
+      'batch:mkdir:start',
+      'batch:mkdir:end',
+      'batch:cp',
+      'batch:end',
+      'external:write',
+    ])
+    const journal = queue.getJournal()
+    const batchRecord = journal.find((record) => record.kind === 'move-entry')
+    expect(batchRecord).toMatchObject({ status: 'completed' })
+    expect(
+      journal.filter((record) => record.parentId === batchRecord?.id)
+    ).toEqual([
+      expect.objectContaining({ kind: 'mkdir', status: 'completed' }),
+      expect.objectContaining({ kind: 'cp', status: 'completed' }),
+    ])
+  })
+
+  it('serializes concurrently requested operations within a batch', async () => {
+    registry = new Registry()
+    registry.configure([fsOperationQueueRegistryItem])
+    const queue = registry.get(fsOperationQueue)
+    const firstGate = createDeferred<void>()
+    const order: string[] = []
+
+    await queue.batch({ kind: 'parallel-request' }, async (batch) => {
+      const first = batch.run({ kind: 'first-child' }, async () => {
+        order.push('first:start')
+        await firstGate.promise
+        order.push('first:end')
+      })
+      const second = batch.run({ kind: 'second-child' }, async () => {
+        order.push('second:start')
+      })
+
+      await flushMicrotasks()
+      expect(order).toEqual(['first:start'])
+      firstGate.resolve()
+      await Promise.all([first, second])
+    })
+
+    expect(order).toEqual(['first:start', 'first:end', 'second:start'])
+  })
+
+  it('records a caught child failure while allowing batch fallback work', async () => {
+    registry = new Registry()
+    registry.configure([fsOperationQueueRegistryItem])
+    const queue = registry.get(fsOperationQueue)
+    const renameError = new Error('cross-device rename')
+    fsZdsMocks.rename.mockRejectedValueOnce(renameError)
+    fsZdsMocks.cp.mockResolvedValueOnce(undefined)
+    fsZdsMocks.rm.mockResolvedValueOnce(undefined)
+
+    await expect(
+      queue.batch({ kind: 'move-entry' }, async (batch) => {
+        try {
+          await batch.rename('/project/source', '/project/target')
+        } catch {
+          await batch.cp('/project/source', '/project/target', {
+            recursive: true,
+          })
+          await batch.rm('/project/source', { recursive: true })
+        }
+        return 'moved'
+      })
+    ).resolves.toBe('moved')
+
+    const journal = queue.getJournal()
+    const batchRecord = journal.find((record) => record.kind === 'move-entry')
+    expect(batchRecord).toMatchObject({ status: 'completed' })
+    expect(
+      journal.filter((record) => record.parentId === batchRecord?.id)
+    ).toEqual([
+      expect.objectContaining({
+        kind: 'rename',
+        status: 'failed',
+        error: renameError,
+      }),
+      expect.objectContaining({ kind: 'cp', status: 'completed' }),
+      expect.objectContaining({ kind: 'rm', status: 'completed' }),
+    ])
+  })
+
   it('keeps draining after a queued operation fails', async () => {
     registry = new Registry()
     registry.configure([fsOperationQueueRegistryItem])

--- a/src/registry/extensions/fsOperationQueue/index.test.ts
+++ b/src/registry/extensions/fsOperationQueue/index.test.ts
@@ -1,0 +1,197 @@
+import { Registry } from '@kittycad/registry'
+import { fsOperationQueue } from '@src/registry/contracts/fsOperationQueue'
+import fsOperationQueueRegistryItem from '@src/registry/extensions/fsOperationQueue'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const fsZdsMocks = vi.hoisted(() => ({
+  cp: vi.fn(),
+  mkdir: vi.fn(),
+  rename: vi.fn(),
+  rm: vi.fn(),
+  writeFile: vi.fn(),
+}))
+
+vi.mock('@src/lib/fs-zds', () => ({
+  default: fsZdsMocks,
+}))
+
+function createDeferred<Result>() {
+  let resolve!: (value: Result | PromiseLike<Result>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<Result>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+
+  return { promise, resolve, reject }
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('fs operation queue extension', () => {
+  let registry: Registry | undefined
+
+  afterEach(() => {
+    registry?.[Symbol.dispose]()
+    registry = undefined
+    vi.clearAllMocks()
+  })
+
+  it('serializes queued filesystem operations', async () => {
+    registry = new Registry()
+    registry.configure([fsOperationQueueRegistryItem])
+    const queue = registry.get(fsOperationQueue)
+    const firstGate = createDeferred<string>()
+    const order: string[] = []
+
+    const first = queue.run(
+      {
+        kind: 'first',
+        targetPath: '/project/first.kcl',
+      },
+      async () => {
+        order.push('first:start')
+        const result = await firstGate.promise
+        order.push('first:end')
+        return result
+      }
+    )
+    const second = queue.run(
+      {
+        kind: 'second',
+        targetPath: '/project/second.kcl',
+      },
+      async () => {
+        order.push('second:start')
+        return 'second result'
+      }
+    )
+
+    await flushMicrotasks()
+
+    expect(order).toEqual(['first:start'])
+    expect(queue.state.value.pending).toBe(true)
+    expect(queue.state.value.current).toMatchObject({
+      kind: 'first',
+      status: 'running',
+      targetPath: '/project/first.kcl',
+    })
+    expect(queue.state.value.queued).toEqual([
+      expect.objectContaining({
+        kind: 'second',
+        status: 'queued',
+        targetPath: '/project/second.kcl',
+      }),
+    ])
+
+    firstGate.resolve('first result')
+
+    await expect(first).resolves.toBe('first result')
+    await expect(second).resolves.toBe('second result')
+    await queue.waitForIdle()
+
+    expect(order).toEqual(['first:start', 'first:end', 'second:start'])
+    expect(queue.state.value.pending).toBe(false)
+    expect(queue.state.value.current).toBeUndefined()
+    expect(queue.state.value.queued).toEqual([])
+    expect(queue.getJournal()).toEqual([
+      expect.objectContaining({ kind: 'first', status: 'completed' }),
+      expect.objectContaining({ kind: 'second', status: 'completed' }),
+    ])
+  })
+
+  it('keeps draining after a queued operation fails', async () => {
+    registry = new Registry()
+    registry.configure([fsOperationQueueRegistryItem])
+    const queue = registry.get(fsOperationQueue)
+    const error = new Error('write failed')
+    const order: string[] = []
+
+    const failed = queue.run(
+      {
+        kind: 'write-file',
+        targetPath: '/project/main.kcl',
+      },
+      async () => {
+        order.push('failed:start')
+        return Promise.reject(error)
+      }
+    )
+    const completed = queue.run(
+      {
+        kind: 'rm',
+        targetPath: '/project/old.kcl',
+      },
+      async () => {
+        order.push('completed:start')
+        return 'done'
+      }
+    )
+
+    await expect(failed).rejects.toBe(error)
+    await expect(completed).resolves.toBe('done')
+    await queue.waitForIdle()
+
+    expect(order).toEqual(['failed:start', 'completed:start'])
+    expect(queue.state.value.pending).toBe(false)
+    expect(queue.getJournal()).toEqual([
+      expect.objectContaining({
+        kind: 'write-file',
+        status: 'failed',
+        error,
+      }),
+      expect.objectContaining({ kind: 'rm', status: 'completed' }),
+    ])
+  })
+
+  it('wraps mutating fsZds operations', async () => {
+    registry = new Registry()
+    registry.configure([fsOperationQueueRegistryItem])
+    const queue = registry.get(fsOperationQueue)
+    const fileData = new Uint8Array([1, 2, 3])
+
+    fsZdsMocks.mkdir.mockResolvedValueOnce(undefined)
+    fsZdsMocks.writeFile.mockResolvedValueOnce(undefined)
+    fsZdsMocks.rename.mockResolvedValueOnce(undefined)
+    fsZdsMocks.cp.mockResolvedValueOnce(undefined)
+    fsZdsMocks.rm.mockResolvedValueOnce(undefined)
+
+    await queue.mkdir('/project', { recursive: true })
+    await queue.writeFile('/project/main.kcl', fileData)
+    await queue.rename('/project/main.kcl', '/project/renamed.kcl')
+    await queue.cp('/project/renamed.kcl', '/project/copy.kcl')
+    await queue.rm('/project/copy.kcl', { force: true })
+
+    expect(fsZdsMocks.mkdir).toHaveBeenCalledWith('/project', {
+      recursive: true,
+    })
+    expect(fsZdsMocks.writeFile).toHaveBeenCalledWith(
+      '/project/main.kcl',
+      fileData,
+      undefined
+    )
+    expect(fsZdsMocks.rename).toHaveBeenCalledWith(
+      '/project/main.kcl',
+      '/project/renamed.kcl',
+      undefined
+    )
+    expect(fsZdsMocks.cp).toHaveBeenCalledWith(
+      '/project/renamed.kcl',
+      '/project/copy.kcl',
+      undefined
+    )
+    expect(fsZdsMocks.rm).toHaveBeenCalledWith('/project/copy.kcl', {
+      force: true,
+    })
+    expect(queue.getJournal().map((record) => record.kind)).toEqual([
+      'mkdir',
+      'write-file',
+      'rename',
+      'cp',
+      'rm',
+    ])
+  })
+})

--- a/src/registry/extensions/fsOperationQueue/index.ts
+++ b/src/registry/extensions/fsOperationQueue/index.ts
@@ -29,7 +29,8 @@ function sortedBySequence(records: readonly FsOperationQueueRecord[]) {
 }
 
 function createFileSystemOperations(
-  run: FsOperationBatch['run']
+  run: FsOperationBatch['run'],
+  fileSystem: FsMutationOperations
 ): FsMutationOperations {
   return {
     cp: (src, dest, options) =>
@@ -39,7 +40,7 @@ function createFileSystemOperations(
           sourcePath: src,
           targetPath: dest,
         },
-        () => Promise.resolve(fsZds.cp(src, dest, options))
+        () => Promise.resolve(fileSystem.cp(src, dest, options))
       ),
     mkdir: (path, options) =>
       run(
@@ -47,7 +48,7 @@ function createFileSystemOperations(
           kind: 'mkdir',
           targetPath: path,
         },
-        () => fsZds.mkdir(path, options)
+        () => fileSystem.mkdir(path, options)
       ),
     rename: (src, dest, options) =>
       run(
@@ -56,7 +57,7 @@ function createFileSystemOperations(
           sourcePath: src,
           targetPath: dest,
         },
-        () => fsZds.rename(src, dest, options)
+        () => fileSystem.rename(src, dest, options)
       ),
     rm: (path, options) =>
       run(
@@ -64,7 +65,7 @@ function createFileSystemOperations(
           kind: 'rm',
           targetPath: path,
         },
-        () => fsZds.rm(path, options)
+        () => fileSystem.rm(path, options)
       ),
     writeFile: (path, data, options) =>
       run(
@@ -72,12 +73,15 @@ function createFileSystemOperations(
           kind: 'write-file',
           targetPath: path,
         },
-        () => fsZds.writeFile(path, data, options)
+        () => fileSystem.writeFile(path, data, options)
       ),
   }
 }
 
-export const fsOperationQueueExtension = defineRegistryItemFactory(() => {
+/** Create an isolated queue over a supplied filesystem mutation adapter. */
+export function createFsOperationQueueService(
+  fileSystem: FsMutationOperations = fsZds
+): FsOperationQueueService {
   const state = signal<FsOperationQueueState>(emptyQueueState)
   let queueTail: Promise<unknown> = Promise.resolve()
   let nextSequence = 0
@@ -210,7 +214,7 @@ export const fsOperationQueueExtension = defineRegistryItemFactory(() => {
       const batchFacade: FsOperationBatch = {
         id: batchRecord.id,
         run: runInBatch,
-        ...createFileSystemOperations(runInBatch),
+        ...createFileSystemOperations(runInBatch, fileSystem),
       }
 
       try {
@@ -220,7 +224,7 @@ export const fsOperationQueueExtension = defineRegistryItemFactory(() => {
       }
     })
 
-  const fileSystemOperations = createFileSystemOperations(run)
+  const fileSystemOperations = createFileSystemOperations(run, fileSystem)
 
   const serviceImpl: FsOperationQueueService = {
     state,
@@ -250,6 +254,12 @@ export const fsOperationQueueExtension = defineRegistryItemFactory(() => {
     },
     ...fileSystemOperations,
   }
+
+  return serviceImpl
+}
+
+export const fsOperationQueueExtension = defineRegistryItemFactory(() => {
+  const serviceImpl = createFsOperationQueueService()
 
   return {
     item: defineRuntimeRegistryItem({

--- a/src/registry/extensions/fsOperationQueue/index.ts
+++ b/src/registry/extensions/fsOperationQueue/index.ts
@@ -7,11 +7,13 @@ import {
 import { signal } from '@preact/signals-core'
 import fsZds from '@src/lib/fs-zds'
 import {
-  fsOperationQueue,
+  type FsMutationOperations,
+  type FsOperationBatch,
   type FsOperationQueueOperation,
   type FsOperationQueueRecord,
   type FsOperationQueueService,
   type FsOperationQueueState,
+  fsOperationQueue,
 } from '@src/registry/contracts/fsOperationQueue'
 
 const maxJournalEntries = 200
@@ -26,111 +28,10 @@ function sortedBySequence(records: readonly FsOperationQueueRecord[]) {
   return [...records].sort((a, b) => a.sequence - b.sequence)
 }
 
-export const fsOperationQueueExtension = defineRegistryItemFactory(() => {
-  const state = signal<FsOperationQueueState>(emptyQueueState)
-  let queueTail: Promise<unknown> = Promise.resolve()
-  let nextSequence = 0
-
-  const publishRecord = (record: FsOperationQueueRecord) => {
-    const previous = state.value
-    const queued =
-      record.status === 'queued'
-        ? sortedBySequence([
-            ...previous.queued.filter((item) => item.id !== record.id),
-            record,
-          ])
-        : previous.queued.filter((item) => item.id !== record.id)
-    const current =
-      record.status === 'running'
-        ? record
-        : previous.current?.id === record.id
-          ? undefined
-          : previous.current
-    const journal = sortedBySequence([
-      ...previous.journal.filter((item) => item.id !== record.id),
-      record,
-    ]).slice(-maxJournalEntries)
-
-    state.value = {
-      pending: Boolean(current || queued.length),
-      ...(current ? { current } : {}),
-      queued,
-      journal,
-    }
-  }
-
-  const createRecord = (
-    operation: FsOperationQueueOperation
-  ): FsOperationQueueRecord => {
-    const sequence = nextSequence++
-    return {
-      ...operation,
-      id: `fs-operation-${sequence}`,
-      sequence,
-      status: 'queued',
-      enqueuedAt: Date.now(),
-    }
-  }
-
-  const run: FsOperationQueueService['run'] = (operation, operationRun) => {
-    const queuedRecord = createRecord(operation)
-    publishRecord(queuedRecord)
-
-    const runQueued = () => {
-      const runningRecord: FsOperationQueueRecord = {
-        ...queuedRecord,
-        status: 'running',
-        startedAt: Date.now(),
-      }
-      publishRecord(runningRecord)
-
-      return operationRun().then(
-        (result) => {
-          publishRecord({
-            ...runningRecord,
-            status: 'completed',
-            completedAt: Date.now(),
-          })
-          return result
-        },
-        (error: unknown) => {
-          publishRecord({
-            ...runningRecord,
-            status: 'failed',
-            completedAt: Date.now(),
-            error,
-          })
-          return Promise.reject(error)
-        }
-      )
-    }
-
-    const queued = queueTail.then(runQueued, runQueued)
-    queueTail = queued.then(
-      () => undefined,
-      () => undefined
-    )
-
-    return queued
-  }
-
-  const serviceImpl: FsOperationQueueService = {
-    state,
-    run,
-    waitForIdle: async () => {
-      await queueTail.catch(() => undefined)
-    },
-    getJournal: () => state.value.journal,
-    clearJournal: () => {
-      const activeRecords = [
-        ...(state.value.current ? [state.value.current] : []),
-        ...state.value.queued,
-      ]
-      state.value = {
-        ...state.value,
-        journal: sortedBySequence(activeRecords),
-      }
-    },
+function createFileSystemOperations(
+  run: FsOperationBatch['run']
+): FsMutationOperations {
+  return {
     cp: (src, dest, options) =>
       run(
         {
@@ -173,6 +74,181 @@ export const fsOperationQueueExtension = defineRegistryItemFactory(() => {
         },
         () => fsZds.writeFile(path, data, options)
       ),
+  }
+}
+
+export const fsOperationQueueExtension = defineRegistryItemFactory(() => {
+  const state = signal<FsOperationQueueState>(emptyQueueState)
+  let queueTail: Promise<unknown> = Promise.resolve()
+  let nextSequence = 0
+
+  const publishRecord = (record: FsOperationQueueRecord) => {
+    const previous = state.value
+    const queued =
+      record.status === 'queued'
+        ? sortedBySequence([
+            ...previous.queued.filter((item) => item.id !== record.id),
+            record,
+          ])
+        : previous.queued.filter((item) => item.id !== record.id)
+    const current =
+      record.status === 'running'
+        ? record
+        : previous.current?.id === record.id
+          ? undefined
+          : previous.current
+    const journal = sortedBySequence([
+      ...previous.journal.filter((item) => item.id !== record.id),
+      record,
+    ]).slice(-maxJournalEntries)
+
+    state.value = {
+      pending: Boolean(current || queued.length),
+      ...(current ? { current } : {}),
+      queued,
+      journal,
+    }
+  }
+
+  const publishBatchRecord = (record: FsOperationQueueRecord) => {
+    const previous = state.value
+    state.value = {
+      ...previous,
+      journal: sortedBySequence([
+        ...previous.journal.filter((item) => item.id !== record.id),
+        record,
+      ]).slice(-maxJournalEntries),
+    }
+  }
+
+  const createRecord = (
+    operation: FsOperationQueueOperation,
+    parentId?: string
+  ): FsOperationQueueRecord => {
+    const sequence = nextSequence++
+    return {
+      ...operation,
+      id: `fs-operation-${sequence}`,
+      ...(parentId ? { parentId } : {}),
+      sequence,
+      status: 'queued',
+      enqueuedAt: Date.now(),
+    }
+  }
+
+  const executeRecord = async <Result>(
+    queuedRecord: FsOperationQueueRecord,
+    operationRun: (runningRecord: FsOperationQueueRecord) => Promise<Result>,
+    publish: (record: FsOperationQueueRecord) => void
+  ) => {
+    const runningRecord: FsOperationQueueRecord = {
+      ...queuedRecord,
+      status: 'running',
+      startedAt: Date.now(),
+    }
+    publish(runningRecord)
+
+    try {
+      const result = await operationRun(runningRecord)
+      publish({
+        ...runningRecord,
+        status: 'completed',
+        completedAt: Date.now(),
+      })
+      return result
+    } catch (error: unknown) {
+      publish({
+        ...runningRecord,
+        status: 'failed',
+        completedAt: Date.now(),
+        error,
+      })
+      return Promise.reject(error)
+    }
+  }
+
+  const enqueue = <Result>(
+    operation: FsOperationQueueOperation,
+    operationRun: (runningRecord: FsOperationQueueRecord) => Promise<Result>
+  ) => {
+    const queuedRecord = createRecord(operation)
+    publishRecord(queuedRecord)
+
+    const runQueued = () =>
+      executeRecord(queuedRecord, operationRun, publishRecord)
+
+    const queued = queueTail.then(runQueued, runQueued)
+    queueTail = queued.then(
+      () => undefined,
+      () => undefined
+    )
+
+    return queued
+  }
+
+  const run: FsOperationQueueService['run'] = (operation, operationRun) =>
+    enqueue(operation, operationRun)
+
+  const batch: FsOperationQueueService['batch'] = (operation, batchRun) =>
+    enqueue(operation, async (batchRecord) => {
+      let batchTail: Promise<unknown> = Promise.resolve()
+      const runInBatch: FsOperationBatch['run'] = (
+        childOperation,
+        childOperationRun
+      ) => {
+        const queuedRecord = createRecord(childOperation, batchRecord.id)
+        publishBatchRecord(queuedRecord)
+        const runChild = () =>
+          executeRecord(queuedRecord, childOperationRun, publishBatchRecord)
+        const child = batchTail.then(runChild, runChild)
+        batchTail = child.then(
+          () => undefined,
+          () => undefined
+        )
+        return child
+      }
+      const batchFacade: FsOperationBatch = {
+        id: batchRecord.id,
+        run: runInBatch,
+        ...createFileSystemOperations(runInBatch),
+      }
+
+      try {
+        return await batchRun(batchFacade)
+      } finally {
+        await batchTail
+      }
+    })
+
+  const fileSystemOperations = createFileSystemOperations(run)
+
+  const serviceImpl: FsOperationQueueService = {
+    state,
+    run,
+    batch,
+    waitForIdle: async () => {
+      await queueTail.catch(() => undefined)
+    },
+    getJournal: () => state.value.journal,
+    clearJournal: () => {
+      const activeRecords = [
+        ...state.value.journal.filter(
+          (record) => record.status === 'queued' || record.status === 'running'
+        ),
+        ...(state.value.current ? [state.value.current] : []),
+        ...state.value.queued,
+      ]
+      state.value = {
+        ...state.value,
+        journal: sortedBySequence(
+          activeRecords.filter(
+            (record, index, records) =>
+              records.findIndex((item) => item.id === record.id) === index
+          )
+        ),
+      }
+    },
+    ...fileSystemOperations,
   }
 
   return {

--- a/src/registry/extensions/fsOperationQueue/index.ts
+++ b/src/registry/extensions/fsOperationQueue/index.ts
@@ -1,0 +1,189 @@
+import {
+  defineRegistryItem,
+  defineRegistryItemFactory,
+  defineRuntimeRegistryItem,
+  provideService,
+} from '@kittycad/registry'
+import { signal } from '@preact/signals-core'
+import fsZds from '@src/lib/fs-zds'
+import {
+  fsOperationQueue,
+  type FsOperationQueueOperation,
+  type FsOperationQueueRecord,
+  type FsOperationQueueService,
+  type FsOperationQueueState,
+} from '@src/registry/contracts/fsOperationQueue'
+
+const maxJournalEntries = 200
+
+const emptyQueueState: FsOperationQueueState = {
+  pending: false,
+  queued: [],
+  journal: [],
+}
+
+function sortedBySequence(records: readonly FsOperationQueueRecord[]) {
+  return [...records].sort((a, b) => a.sequence - b.sequence)
+}
+
+export const fsOperationQueueExtension = defineRegistryItemFactory(() => {
+  const state = signal<FsOperationQueueState>(emptyQueueState)
+  let queueTail: Promise<unknown> = Promise.resolve()
+  let nextSequence = 0
+
+  const publishRecord = (record: FsOperationQueueRecord) => {
+    const previous = state.value
+    const queued =
+      record.status === 'queued'
+        ? sortedBySequence([
+            ...previous.queued.filter((item) => item.id !== record.id),
+            record,
+          ])
+        : previous.queued.filter((item) => item.id !== record.id)
+    const current =
+      record.status === 'running'
+        ? record
+        : previous.current?.id === record.id
+          ? undefined
+          : previous.current
+    const journal = sortedBySequence([
+      ...previous.journal.filter((item) => item.id !== record.id),
+      record,
+    ]).slice(-maxJournalEntries)
+
+    state.value = {
+      pending: Boolean(current || queued.length),
+      ...(current ? { current } : {}),
+      queued,
+      journal,
+    }
+  }
+
+  const createRecord = (
+    operation: FsOperationQueueOperation
+  ): FsOperationQueueRecord => {
+    const sequence = nextSequence++
+    return {
+      ...operation,
+      id: `fs-operation-${sequence}`,
+      sequence,
+      status: 'queued',
+      enqueuedAt: Date.now(),
+    }
+  }
+
+  const run: FsOperationQueueService['run'] = (operation, operationRun) => {
+    const queuedRecord = createRecord(operation)
+    publishRecord(queuedRecord)
+
+    const runQueued = () => {
+      const runningRecord: FsOperationQueueRecord = {
+        ...queuedRecord,
+        status: 'running',
+        startedAt: Date.now(),
+      }
+      publishRecord(runningRecord)
+
+      return operationRun().then(
+        (result) => {
+          publishRecord({
+            ...runningRecord,
+            status: 'completed',
+            completedAt: Date.now(),
+          })
+          return result
+        },
+        (error: unknown) => {
+          publishRecord({
+            ...runningRecord,
+            status: 'failed',
+            completedAt: Date.now(),
+            error,
+          })
+          return Promise.reject(error)
+        }
+      )
+    }
+
+    const queued = queueTail.then(runQueued, runQueued)
+    queueTail = queued.then(
+      () => undefined,
+      () => undefined
+    )
+
+    return queued
+  }
+
+  const serviceImpl: FsOperationQueueService = {
+    state,
+    run,
+    waitForIdle: async () => {
+      await queueTail.catch(() => undefined)
+    },
+    getJournal: () => state.value.journal,
+    clearJournal: () => {
+      const activeRecords = [
+        ...(state.value.current ? [state.value.current] : []),
+        ...state.value.queued,
+      ]
+      state.value = {
+        ...state.value,
+        journal: sortedBySequence(activeRecords),
+      }
+    },
+    cp: (src, dest, options) =>
+      run(
+        {
+          kind: 'cp',
+          sourcePath: src,
+          targetPath: dest,
+        },
+        () => Promise.resolve(fsZds.cp(src, dest, options))
+      ),
+    mkdir: (path, options) =>
+      run(
+        {
+          kind: 'mkdir',
+          targetPath: path,
+        },
+        () => fsZds.mkdir(path, options)
+      ),
+    rename: (src, dest, options) =>
+      run(
+        {
+          kind: 'rename',
+          sourcePath: src,
+          targetPath: dest,
+        },
+        () => fsZds.rename(src, dest, options)
+      ),
+    rm: (path, options) =>
+      run(
+        {
+          kind: 'rm',
+          targetPath: path,
+        },
+        () => fsZds.rm(path, options)
+      ),
+    writeFile: (path, data, options) =>
+      run(
+        {
+          kind: 'write-file',
+          targetPath: path,
+        },
+        () => fsZds.writeFile(path, data, options)
+      ),
+  }
+
+  return {
+    item: defineRuntimeRegistryItem({
+      id: 'fs-operation-queue-extension',
+      providesServices: [provideService(fsOperationQueue, serviceImpl)],
+    }),
+  }
+}, 'fs-operation-queue-extension')
+
+export default defineRegistryItem({
+  id: 'fs-operation-queue',
+  uses: [fsOperationQueueExtension],
+})


### PR DESCRIPTION
Adds a centralized `fsOperationQueue` registry service as the filesystem mutation chokepoint for the project-session stack. This is what will replace `systemIOActor`.

1. Introduces the `fsOperationQueue` contract and always-on extension.
2. Serializes queued filesystem mutation work and exposes observable queue state.
3. Journals recent operation records with status, path metadata, timing, and errors.
4. Provides queued wrappers for mutating `fsZds` operations: `cp`, `mkdir`, `rename`, `rm`, and `writeFile`.
5. Adds focused unit coverage for ordering, error recovery, journaling, and direct mutation wrappers.

How to test:
Exercise project file creation, rename, move, delete, and Zookeeper patch flows from the stack above this PR, then confirm queued operations complete in order and leave the project tree current.
