### PR TITLE
KCL: Mock exec circularPattern3d should create expected number of instances

### DIFF
--- a/rust/kcl-lib/e2e/executor/inputs/repro_mock_pattern_circular.kcl
+++ b/rust/kcl-lib/e2e/executor/inputs/repro_mock_pattern_circular.kcl
@@ -1,0 +1,19 @@
+@settings(kclVersion = 2.0)
+
+sketch001 = sketch(on = XY) {
+  line1 = line(start = [var -3.63mm, var 2.64mm], end = [var -2.28mm, var 2.64mm])
+  line2 = line(start = [var -2.28mm, var 2.64mm], end = [var -2.28mm, var 1.3mm])
+  line3 = line(start = [var -2.28mm, var 1.3mm], end = [var -3.63mm, var 1.3mm])
+  line4 = line(start = [var -3.63mm, var 1.3mm], end = [var -3.63mm, var 2.64mm])
+  coincident([line1.end, line2.start])
+  coincident([line2.end, line3.start])
+  coincident([line3.end, line4.start])
+  coincident([line4.end, line1.start])
+  parallel([line2, line4])
+  parallel([line3, line1])
+  perpendicular([line1, line2])
+  horizontal(line3)
+}
+
+extrude001 = extrude(region(segments = [sketch001.line1, sketch001.line2], direction = CW), length = 1)
+copies = patternCircular3d(extrude001, instances = 10, axis = Z)

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -4273,6 +4273,32 @@ w = f() + f()
         };
     }
 
+    /// Regression test for https://github.com/KittyCAD/modeling-app/issues/13103
+    /// i.e.
+    /// If you do a pattern circular 3d in mock execution mode,
+    /// and you ask for 10 instances, you should get 10 instances.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn mock_execution_pattern_circular_number() {
+        let code = kcl_input!("repro_mock_pattern_circular");
+        let ctx = ExecutorContext::new_mock(None).await;
+        let program = crate::Program::parse_no_errs(code).unwrap();
+        let result = ctx.run_mock(&program, &MockConfig::default()).await.unwrap();
+        let copies = result
+            .variables
+            .get("copies")
+            .expect("no variable called 'copies' found");
+        let value = match copies {
+            KclValueView::Solid { .. } => {
+                panic!("One solid?");
+            }
+            KclValueView::HomArray { value } => value,
+            other => panic!("{other:#?}"),
+        };
+        let actual_instances = value.len();
+        let expected_instances = 10; // from the KCL `instances = `
+        assert_eq!(actual_instances, expected_instances);
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn mock_then_add_extrude_then_mock_again() {
         let code = "s = sketch(on = XY) {

--- a/rust/kcl-lib/src/std/patterns.rs
+++ b/rust/kcl-lib/src/std/patterns.rs
@@ -1258,6 +1258,7 @@ async fn execute_pattern_circular<T: GeometryTrait>(
             let new_id = exec_state.next_uuid();
             let mut new_geometry = seed.clone();
             new_geometry.set_id(new_id);
+            new_geometry.set_artifact_id(new_id);
             mock_responses.push(new_geometry);
         }
 

--- a/rust/kcl-lib/src/std/patterns.rs
+++ b/rust/kcl-lib/src/std/patterns.rs
@@ -1234,7 +1234,34 @@ async fn execute_pattern_circular<T: GeometryTrait>(
     T::flush_batch(&args, exec_state, &geometry_set).await?;
     let starting: Vec<T> = geometry_set.into();
     if args.ctx.context_type == crate::execution::ContextType::Mock {
-        return Ok(starting);
+        let seed = starting
+            .first()
+            .cloned()
+            .ok_or(KclError::new_internal(KclErrorDetails::new(
+                "Unexpected empty set".to_owned(),
+                vec![args.source_range],
+            )))?;
+        let mut mock_responses = starting;
+        let num_repetitions = match data.repetitions() {
+            RepetitionsNeeded::More(n) => n,
+            RepetitionsNeeded::None => {
+                return Ok(mock_responses);
+            }
+            RepetitionsNeeded::Invalid => {
+                return Err(KclError::new_semantic(KclErrorDetails::new(
+                    MUST_HAVE_ONE_INSTANCE.to_owned(),
+                    vec![args.source_range],
+                )));
+            }
+        };
+        for _ in 0..num_repetitions {
+            let new_id = exec_state.next_uuid();
+            let mut new_geometry = seed.clone();
+            new_geometry.set_id(new_id);
+            mock_responses.push(new_geometry);
+        }
+
+        return Ok(mock_responses);
     }
 
     let mut output = Vec::new();


### PR DESCRIPTION
Closes https://github.com/KittyCAD/modeling-app/issues/13103