### PR TITLE
KCL: Default appearance autocomplete snippet should be rose gold

### DIFF
--- a/rust/kcl-lib/src/docs/kcl_doc.rs
+++ b/rust/kcl-lib/src/docs/kcl_doc.rs
@@ -1010,6 +1010,8 @@ impl ArgData {
                     "angle" => "180deg",
                     "arcDegrees" => "360deg",
                     "sector" => "1",
+                    "metalness" => "90",
+                    "roughness" => "50",
                     _ => "10",
                 };
                 Some((index, format!(r#"{label}${{{index}:{value}}}"#)))
@@ -1045,7 +1047,7 @@ impl ArgData {
 
             Some("string") => {
                 if self.name == "color" {
-                    Some((index, format!(r"{label}${{{}:{}}}", index, "\"#ff0000\"")))
+                    Some((index, format!(r"{label}${{{}:{}}}", index, "\"#da4333\"")))
                 } else {
                     Some((index, format!(r#"{label}${{{index}:"string"}}"#)))
                 }

--- a/rust/kcl-lib/src/docs/mod.rs
+++ b/rust/kcl-lib/src/docs/mod.rs
@@ -143,7 +143,10 @@ mod tests {
             panic!();
         };
         let snippet = helix_fn.to_autocomplete_snippet();
-        assert_eq!(snippet, "appearance(color = ${0:\"#ff0000\"})");
+        assert_eq!(
+            snippet,
+            "appearance(color = ${0:\"#da4333\"}, metalness = ${1:90}, roughness = ${2:50})"
+        );
     }
 
     #[test]

--- a/rust/kcl-lib/std/solid.kcl
+++ b/rust/kcl-lib/std/solid.kcl
@@ -1620,8 +1620,10 @@ export fn appearance(
   /// Color of the new material, a hex string like '#ff0000'.
   color: string,
   /// Metalness of the new material, a percentage like 95.7.
+  @(includeInSnippet = true)
   metalness?: number(Count),
   /// Roughness of the new material, a percentage like 95.7.
+  @(includeInSnippet = true)
   roughness?: number(Count),
   /// Opacity. Defaults to 100 (totally opaque). 0 would be totally transparent.
   opacity?: number(Count),


### PR DESCRIPTION
I just think this looks a lot nicer, it matches the texture of the default silver a lot better. The default red we suggest for appearance looks like an error state.

Before:
<img width="577" height="650" alt="Screenshot 2026-08-20 at 4 13 58 PM" src="https://github.com/user-attachments/assets/98eeb1c5-a86d-499b-b0fe-61063cf5d5bd" />

After:
<img width="596" height="656" alt="Screenshot 2026-08-20 at 4 13 37 PM" src="https://github.com/user-attachments/assets/135aaf96-da47-4b4d-8b4f-572a0324f94b" />

After, light mode:
<img width="1840" height="1196" alt="Screenshot 2026-08-21 at 9 24 44 AM" src="https://github.com/user-attachments/assets/71d326fd-1adf-4133-9f90-660a59f7af92" />
