### PR TITLE
Update kcl version autocomplete

### DIFF
--- a/rust/kcl-lib/src/execution/annotations.rs
+++ b/rust/kcl-lib/src/execution/annotations.rs
@@ -164,7 +164,7 @@ impl FromStr for Impl {
 }
 
 pub(crate) fn settings_completion_text() -> String {
-    format!("@{SETTINGS}({SETTINGS_UNIT_LENGTH} = mm, {SETTINGS_VERSION} = 1.0)")
+    format!("@{SETTINGS}({SETTINGS_UNIT_LENGTH} = mm, {SETTINGS_VERSION} = 2.0)")
 }
 
 pub(super) fn is_significant(attr: &&Node<Annotation>) -> bool {


### PR DESCRIPTION
Seems like this should be changed? Codex couldn't seem to find a default version available in rust that this could be set to to make this not need to be manually updated in the future.