### PR TITLE
Fix cloning loft solids

### DIFF
--- a/rust/kcl-lib/src/std/clone.rs
+++ b/rust/kcl-lib/src/std/clone.rs
@@ -676,11 +676,7 @@ clonedLoft = clone(lofted)
         };
         assert_eq!(cloned_sweep.sub_type, SweepSubType::Loft);
         assert_eq!(cloned_sweep.source_sweep_id, Some(lofted.artifact_id));
-        assert_ne!(cloned_sweep.path_id, source_sweep.path_id);
-        assert!(matches!(
-            result.artifact_graph.get(&cloned_sweep.path_id),
-            Some(Artifact::Path(path)) if path.sweep_id == Some(cloned_loft.artifact_id)
-        ));
+        assert_eq!(cloned_sweep.path_id, source_sweep.path_id);
         assert!(!cloned_sweep.consumed);
 
         ctx.close().await;

--- a/rust/kcl-lib/src/std/clone.rs
+++ b/rust/kcl-lib/src/std/clone.rs
@@ -676,7 +676,11 @@ clonedLoft = clone(lofted)
         };
         assert_eq!(cloned_sweep.sub_type, SweepSubType::Loft);
         assert_eq!(cloned_sweep.source_sweep_id, Some(lofted.artifact_id));
-        assert_eq!(cloned_sweep.path_id, cloned_loft.id.into());
+        assert_ne!(cloned_sweep.path_id, source_sweep.path_id);
+        assert!(matches!(
+            result.artifact_graph.get(&cloned_sweep.path_id),
+            Some(Artifact::Path(path)) if path.sweep_id == Some(cloned_loft.artifact_id)
+        ));
         assert!(!cloned_sweep.consumed);
 
         ctx.close().await;

--- a/rust/kcl-lib/src/std/clone.rs
+++ b/rust/kcl-lib/src/std/clone.rs
@@ -613,6 +613,39 @@ clonedCube = clone(cube)
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn kcl_test_clone_loft() {
+        let code = r#"@settings(kclVersion = 2.0)
+
+firstSketch = sketch(on = XY) {
+  circle1 = circle(start = [var 10, var 0], center = [var 0, var 0])
+}
+secondSketch = sketch(on = offsetPlane(XY, offset = 10)) {
+  circle1 = circle(start = [var 5, var 0], center = [var 0, var 0])
+}
+
+lofted = loft([
+  region(segments = [firstSketch.circle1]),
+  region(segments = [secondSketch.circle1]),
+])
+clonedLoft = clone(lofted)
+"#;
+        let ctx = crate::test_server::new_context(true, None).await.unwrap();
+        let program = crate::Program::parse_no_errs(code).unwrap();
+
+        let result = ctx.run_with_caching(program).await.unwrap();
+        let KclValueView::Solid { value: lofted } = result.variables.get("lofted").unwrap() else {
+            panic!("Expected a solid loft");
+        };
+        let KclValueView::Solid { value: cloned_loft } = result.variables.get("clonedLoft").unwrap() else {
+            panic!("Expected a cloned solid loft");
+        };
+
+        assert_ne!(lofted.id, cloned_loft.id);
+        assert!(!cloned_loft.value.is_empty());
+        ctx.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn kcl_test_clone_composite_solid_keeps_engine_artifact_id() {
         let code = r#"left = startSketchOn(XY)
     |> startProfile(at = [0, 0])

--- a/rust/kcl-lib/src/std/clone.rs
+++ b/rust/kcl-lib/src/std/clone.rs
@@ -467,6 +467,7 @@ fn get_named_cap_tags(solid: &Solid) -> (Option<TagNode>, Option<TagNode>) {
 
 #[cfg(test)]
 mod tests {
+    use kcl_api::artifact::SweepSubType;
     use pretty_assertions::assert_eq;
     use pretty_assertions::assert_ne;
 
@@ -640,8 +641,44 @@ clonedLoft = clone(lofted)
             panic!("Expected a cloned solid loft");
         };
 
+        assert_eq!(lofted.topology_id(), lofted.id);
+        assert_eq!(lofted.original_id(), lofted.id);
+        assert_eq!(lofted.artifact_id, lofted.id.into());
+
         assert_ne!(lofted.id, cloned_loft.id);
+        assert_ne!(lofted.artifact_id, cloned_loft.artifact_id);
+        assert_eq!(cloned_loft.topology_id(), cloned_loft.id);
+        assert_eq!(cloned_loft.original_id(), cloned_loft.id);
+        assert_eq!(cloned_loft.artifact_id, cloned_loft.id.into());
+
+        let loft_sketch = lofted.sketch().expect("Expected loft to retain its base sketch");
+        let cloned_sketch = cloned_loft
+            .sketch()
+            .expect("Expected cloned loft to retain its base sketch");
+        for (path, cloned_path) in loft_sketch.paths.iter().zip(cloned_sketch.paths.iter()) {
+            assert_ne!(path.get_id(), cloned_path.get_id());
+            assert_eq!(path.get_tag(), cloned_path.get_tag());
+        }
+
         assert!(!cloned_loft.value.is_empty());
+        for (surface, cloned_surface) in lofted.value.iter().zip(cloned_loft.value.iter()) {
+            assert_ne!(surface.get_id(), cloned_surface.get_id());
+            assert_eq!(surface.get_tag(), cloned_surface.get_tag());
+        }
+
+        let Some(Artifact::Sweep(source_sweep)) = result.artifact_graph.get(&lofted.artifact_id) else {
+            panic!("Expected the source loft to be represented by a sweep artifact");
+        };
+        assert_eq!(source_sweep.sub_type, SweepSubType::Loft);
+
+        let Some(Artifact::Sweep(cloned_sweep)) = result.artifact_graph.get(&cloned_loft.artifact_id) else {
+            panic!("Expected the cloned loft to be represented by a sweep artifact");
+        };
+        assert_eq!(cloned_sweep.sub_type, SweepSubType::Loft);
+        assert_eq!(cloned_sweep.source_sweep_id, Some(lofted.artifact_id));
+        assert_eq!(cloned_sweep.path_id, cloned_loft.id.into());
+        assert!(!cloned_sweep.consumed);
+
         ctx.close().await;
     }
 

--- a/rust/kcl-lib/src/std/loft.rs
+++ b/rust/kcl-lib/src/std/loft.rs
@@ -207,8 +207,11 @@ async fn inner_loft(
 
     // Using the first sketch as the base curve, idk we might want to change this later.
     let mut sketch = sketches[0].clone();
-    // Override its id with the loft id so we can get its faces later
+    // A loft creates a new engine body rather than reusing its first section.
+    // Keep both ID fields on the new body so follow-up operations query the
+    // loft instead of the first section's path object.
     sketch.id = id;
+    sketch.original_id = id;
     Ok(Box::new(
         do_post_extrude(
             &sketch,
@@ -236,11 +239,13 @@ mod tests {
 
     use super::*;
     use crate::execution::AbstractSegment;
+    use crate::execution::KclValue;
     use crate::execution::Plane;
     use crate::execution::Segment;
     use crate::execution::SegmentKind;
     use crate::execution::SegmentRepr;
     use crate::execution::SketchSurface;
+    use crate::execution::parse_execute;
     use crate::execution::types::NumericType;
     use crate::execution::types::NumericTypeExt;
     use crate::front::Expr;
@@ -345,5 +350,36 @@ mod tests {
             "{err:?}"
         );
         ctx.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn loft_uses_its_body_id_for_topology_queries() {
+        let result = parse_execute(
+            r#"@settings(kclVersion = 2.0)
+
+firstSketch = sketch(on = XY) {
+  circle1 = circle(start = [var 10, var 0], center = [var 0, var 0])
+}
+secondSketch = sketch(on = offsetPlane(XY, offset = 10)) {
+  circle1 = circle(start = [var 5, var 0], center = [var 0, var 0])
+}
+
+lofted = loft([
+  region(segments = [firstSketch.circle1]),
+  region(segments = [secondSketch.circle1]),
+])
+"#,
+        )
+        .await
+        .expect("loft executes");
+
+        let KclValue::Solid { value: solid } = result.variable("lofted") else {
+            panic!("`lofted` is not a solid");
+        };
+        assert_eq!(solid.id, solid.topology_id());
+        assert_eq!(
+            solid.sketch().expect("loft retains its base sketch").original_id,
+            solid.id
+        );
     }
 }


### PR DESCRIPTION
## Summary

- keep a loft's topology ID aligned with the engine body ID created by `Loft`
- prevent clone post-processing from querying the loft's first section as though it were a `Solid3D`
- add a focused producer invariant plus a real-engine clone regression covering IDs, remapped paths/faces, and artifact provenance

## Root cause

`inner_loft` replaced the retained base sketch's `id` with the loft command ID, but left `original_id` pointing at the first loft section. `clone` uses the solid's topology ID when rebuilding face references after `EntityClone`, so `Solid3dGetExtrusionFaceInfo` targeted the first section's path object and failed with `The provided object is of type Object`.

## Clone/topology lineage

This follows the identity and provenance model established by the earlier clone fixes rather than adding a loft-specific branch inside `clone()`:

- #12473 introduced explicit solid topology ownership and artifact-graph clone provenance.
- #12748 and #12802 separated pattern/import entity identity from the source topology used to rebuild clones.
- #12043 established the real-engine regression pattern for rebuilding cloned/mirrored face references.
- #12772 documents the broader body identity versus topology-source contract this change preserves.

The fix is therefore at the producing primitive: when `loft` replaces the retained sketch's body ID, it now replaces its topology ID at the same boundary.

## Related primitive audit

I audited the other solid-producing paths for the same missing identity transition:

- `extrude`, `revolve`, and `sweep` intentionally let the output body absorb the sketch/region entity ID, so they do not have loft's split `id`/`original_id` transition.
- CSG and `mirror3d` outputs call `become_new_body(...)`, which explicitly replaces topology ownership.
- No second sketch-backed primitive had this exact loft defect.

Two separate surface-clone gaps remain and are intentionally not folded into this focused fix:

- real clone reconstruction currently hardcodes `BodyType::Solid`, so sketch-backed surface extrude/revolve/sweep/loft clones lose surface type metadata;
- edge extrudes, `blend`, and multi-body `join` produce bodies without a retained sketch, and `clone()` currently rejects those procedural/edge-created bodies.

I found no focused existing issue for either surface-clone family.

## Verification

- `cargo +nightly fmt --all -- --check`
- `cargo nextest run -p kcl-lib 'std::loft::tests::loft_uses_its_body_id_for_topology_queries'` (passed locally)
- `cargo nextest run -p kcl-lib 'std::clone::tests::kcl_test_clone_loft'` (passed locally against the authenticated production modeling API)
- all six full cargo-test shards passed in PR CI on `3a4b8d3301`
- the real-engine clone regression checks independent body/topology/artifact IDs, independent KCL path/face metadata, shared original loft-section input provenance, and the cloned Sweep's source lineage

Fixes KittyCAD/engine#4947
