### PR TITLE
Label subtract2d documentation as KCL 1

### DIFF
--- a/docs/kcl-std/functions/std-sketch-circle.md
+++ b/docs/kcl-std/functions/std-sketch-circle.md
@@ -22,6 +22,9 @@ circle(
 This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
 
+
+**Legacy KCL 1 example:** The next example uses deprecated `subtract2d`.
+
 ### Arguments
 
 | Name | Type | Description | Required |
@@ -62,6 +65,8 @@ example = extrude(exampleSketch, length = 5)
 </model-viewer>
 
 ```kcl
+@settings(kclVersion = 1.0)
+
 exampleSketch = startSketchOn(XZ)
   |> startProfile(at = [-15, 0])
   |> line(end = [30, 0])

--- a/docs/kcl-std/functions/std-sketch-subtract2d.md
+++ b/docs/kcl-std/functions/std-sketch-subtract2d.md
@@ -34,6 +34,8 @@ This is part of sketch v1 and is deprecated in favor of
 ### Examples
 
 ```kcl
+@settings(kclVersion = 1.0)
+
 exampleSketch = startSketchOn(XY)
   |> startProfile(at = [0, 0])
   |> line(end = [0, 5])
@@ -62,6 +64,8 @@ example = extrude(exampleSketch, length = 1)
 </model-viewer>
 
 ```kcl
+@settings(kclVersion = 1.0)
+
 fn squareHoleSketch() {
   squareSketch = startSketchOn(-XZ)
     |> startProfile(at = [-1, -1])

--- a/docs/kcl-std/functions/std-sketch-sweep.md
+++ b/docs/kcl-std/functions/std-sketch-sweep.md
@@ -32,6 +32,8 @@ extrusion.
 You can provide more than one sketch to sweep, and they will all be
 swept along the same path.
 
+**Legacy KCL 1 example:** This pipe example uses deprecated `subtract2d`.
+
 ### Arguments
 
 | Name | Type | Description | Required |
@@ -56,6 +58,8 @@ swept along the same path.
 ### Examples
 
 ```kcl
+@settings(kclVersion = 1.0)
+
 // Create a pipe using a sweep.
 
 // Create a path for the sweep.

--- a/docs/kcl-std/functions/std-solid-appearance.md
+++ b/docs/kcl-std/functions/std-solid-appearance.md
@@ -20,6 +20,16 @@ appearance(
 This will work on any solid, including extruded solids, revolved solids, and shelled solids.
 For planes, only `color` is used.
 
+
+
+
+
+
+
+
+
+**Legacy KCL 1 example:** The next pipe example uses deprecated `subtract2d`.
+
 ### Arguments
 
 | Name | Type | Description | Required |
@@ -289,6 +299,8 @@ example = extrude(exampleSketch, length = 1)
 </model-viewer>
 
 ```kcl
+@settings(kclVersion = 1.0)
+
 // Color the result of a sweep.
 
 // Create a path for the sweep.

--- a/docs/kcl-std/functions/std-solid-subtract.md
+++ b/docs/kcl-std/functions/std-solid-subtract.md
@@ -28,6 +28,10 @@ operation. Assign the returned solid or solids to a new variable and use that
 result for subsequent operations. For multiple cuts, pass each `subtract`
 result into the next call instead of reusing the original base solid.
 
+
+
+**Legacy KCL 1 example:** The next example uses deprecated `subtract2d`.
+
 ### Arguments
 
 | Name | Type | Description | Required |
@@ -118,7 +122,7 @@ subtractedPart = part001 - part002
 </model-viewer>
 
 ```kcl
-@settings(defaultLengthUnit = in)
+@settings(defaultLengthUnit = in, kclVersion = 1.0)
 
 height = 2.5
 width = 2.5

--- a/docs/kcl-std/functions/std-transform-rotate.md
+++ b/docs/kcl-std/functions/std-transform-rotate.md
@@ -49,6 +49,8 @@ So, in the context of a 3D model:
 When rotating a part around an axis, you specify the axis of rotation and the angle of
 rotation.
 
+**Legacy KCL 1 examples:** The pipe examples below use deprecated `subtract2d`.
+
 ### Arguments
 
 | Name | Type | Description | Required |
@@ -69,6 +71,8 @@ rotation.
 ### Examples
 
 ```kcl
+@settings(kclVersion = 1.0)
+
 // Rotate a pipe with roll, pitch, and yaw.
 
 // Create a path for the sweep.
@@ -107,6 +111,8 @@ sweepSketch = startSketchOn(XY)
 </model-viewer>
 
 ```kcl
+@settings(kclVersion = 1.0)
+
 // Rotate a pipe with just roll.
 
 // Create a path for the sweep.
@@ -145,6 +151,8 @@ sweepSketch = startSketchOn(XY)
 </model-viewer>
 
 ```kcl
+@settings(kclVersion = 1.0)
+
 // Rotate a pipe about a named axis with an angle.
 
 // Create a path for the sweep.
@@ -207,6 +215,8 @@ cube
 </model-viewer>
 
 ```kcl
+@settings(kclVersion = 1.0)
+
 // Rotate a pipe about a raw axis with an angle.
 
 // Create a path for the sweep.

--- a/docs/kcl-std/functions/std-transform-scale.md
+++ b/docs/kcl-std/functions/std-transform-scale.md
@@ -39,6 +39,8 @@ look like the model moves and gets bigger at the same time. Say you have a squar
 **NOTE:** Currently,, revolved bodies don't support being scaled in a non-uniform
 way (i.e. scaled differently along each axis).
 
+**Legacy KCL 1 example:** This pipe example uses deprecated `subtract2d`.
+
 ### Arguments
 
 | Name | Type | Description | Required |
@@ -58,6 +60,8 @@ way (i.e. scaled differently along each axis).
 ### Examples
 
 ```kcl
+@settings(kclVersion = 1.0)
+
 // Scale a pipe.
 
 // Create a path for the sweep.

--- a/docs/kcl-std/functions/std-transform-translate.md
+++ b/docs/kcl-std/functions/std-transform-translate.md
@@ -27,6 +27,8 @@ To translate around the global scene coordinate system, use `global = true`.
 Translate is really useful for sketches if you want to move a sketch
 and then rotate it using the `rotate` function to create a loft.
 
+**Legacy KCL 1 example:** This pipe example uses deprecated `subtract2d`.
+
 ### Arguments
 
 | Name | Type | Description | Required |
@@ -46,6 +48,8 @@ and then rotate it using the `rotate` function to create a loft.
 ### Examples
 
 ```kcl
+@settings(kclVersion = 1.0)
+
 // Move a pipe.
 
 // Create a path for the sweep.

--- a/rust/kcl-lib/std/sketch.kcl
+++ b/rust/kcl-lib/std/sketch.kcl
@@ -405,7 +405,11 @@ export fn rectangle(
 /// example = extrude(exampleSketch, length = 5)
 /// ```
 ///
+/// **Legacy KCL 1 example:** The next example uses deprecated `subtract2d`.
+///
 /// ```kcl,legacySketch
+/// @settings(kclVersion = 1.0)
+///
 /// exampleSketch = startSketchOn(XZ)
 ///   |> startProfile(at = [-15, 0])
 ///   |> line(end = [30, 0])
@@ -1526,7 +1530,11 @@ export fn polygon(
 /// You can provide more than one sketch to sweep, and they will all be
 /// swept along the same path.
 ///
+/// **Legacy KCL 1 example:** This pipe example uses deprecated `subtract2d`.
+///
 /// ```kcl,legacySketch
+/// @settings(kclVersion = 1.0)
+///
 /// // Create a pipe using a sweep.
 ///
 /// // Create a path for the sweep.
@@ -2989,6 +2997,8 @@ export fn bezierCurve(
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
 ///
 /// ```kcl,legacySketch
+/// @settings(kclVersion = 1.0)
+///
 /// exampleSketch = startSketchOn(XY)
 ///   |> startProfile(at = [0, 0])
 ///   |> line(end = [0, 5])
@@ -3002,6 +3012,8 @@ export fn bezierCurve(
 /// ```
 ///
 /// ```kcl,legacySketch
+/// @settings(kclVersion = 1.0)
+///
 /// fn squareHoleSketch() {
 ///   squareSketch = startSketchOn(-XZ)
 ///     |> startProfile(at = [-1, -1])

--- a/rust/kcl-lib/std/solid.kcl
+++ b/rust/kcl-lib/std/solid.kcl
@@ -1289,8 +1289,10 @@ export fn intersect(
 /// // This is the equivalent of: subtract([part001], tools=[part002])
 /// subtractedPart = part001 - part002
 /// ```
+///
+/// **Legacy KCL 1 example:** The next example uses deprecated `subtract2d`.
 /// ```kcl,legacySketch
-/// @settings(defaultLengthUnit = in)
+/// @settings(defaultLengthUnit = in, kclVersion = 1.0)
 /// 
 /// height = 2.5
 /// width = 2.5
@@ -1565,7 +1567,11 @@ export fn subtract(
 ///     )
 /// ```
 ///
+/// **Legacy KCL 1 example:** The next pipe example uses deprecated `subtract2d`.
+///
 /// ```kcl,legacySketch
+/// @settings(kclVersion = 1.0)
+///
 /// // Color the result of a sweep.
 ///
 /// // Create a path for the sweep.

--- a/rust/kcl-lib/std/transform.kcl
+++ b/rust/kcl-lib/std/transform.kcl
@@ -227,7 +227,11 @@ export fn mirror3d(
 /// Translate is really useful for sketches if you want to move a sketch
 /// and then rotate it using the `rotate` function to create a loft.
 ///
+/// **Legacy KCL 1 example:** This pipe example uses deprecated `subtract2d`.
+///
 /// ```kcl,legacySketch
+/// @settings(kclVersion = 1.0)
+///
 /// // Move a pipe.
 ///
 /// // Create a path for the sweep.
@@ -433,7 +437,11 @@ export fn translate(
 /// When rotating a part around an axis, you specify the axis of rotation and the angle of
 /// rotation.
 ///
+/// **Legacy KCL 1 examples:** The pipe examples below use deprecated `subtract2d`.
+///
 /// ```kcl,legacySketch
+/// @settings(kclVersion = 1.0)
+///
 /// // Rotate a pipe with roll, pitch, and yaw.
 ///
 /// // Create a path for the sweep.
@@ -467,6 +475,8 @@ export fn translate(
 /// ```
 ///
 /// ```kcl,legacySketch
+/// @settings(kclVersion = 1.0)
+///
 /// // Rotate a pipe with just roll.
 ///
 /// // Create a path for the sweep.
@@ -498,6 +508,8 @@ export fn translate(
 /// ```
 ///
 /// ```kcl,legacySketch
+/// @settings(kclVersion = 1.0)
+///
 /// // Rotate a pipe about a named axis with an angle.
 ///
 /// // Create a path for the sweep.
@@ -542,6 +554,8 @@ export fn translate(
 /// ```
 ///
 /// ```kcl,legacySketch
+/// @settings(kclVersion = 1.0)
+///
 /// // Rotate a pipe about a raw axis with an angle.
 ///
 /// // Create a path for the sweep.
@@ -669,7 +683,11 @@ export fn rotate(
 /// **NOTE:** Currently,, revolved bodies don't support being scaled in a non-uniform
 /// way (i.e. scaled differently along each axis).
 ///
+/// **Legacy KCL 1 example:** This pipe example uses deprecated `subtract2d`.
+///
 /// ```kcl,legacySketch
+/// @settings(kclVersion = 1.0)
+///
 /// // Scale a pipe.
 ///
 /// // Create a path for the sweep.


### PR DESCRIPTION
## Summary

- explicitly label every standard-library example that uses `subtract2d` as legacy KCL 1
- pin those executable examples to `kclVersion = 1.0`
- regenerate the affected canonical function pages

This keeps the deprecated API reference available for existing KCL 1 models without presenting incidental examples as current KCL 2 guidance.

## Verification

- `cargo +nightly fmt --all`
- `cargo nextest run --retries 0 --no-fail-fast -p kcl-lib --features artifact-graph docs::gen_std_tests::test_generate_stdlib_markdown_docs`
- 12 affected executable documentation examples run against the real modeling endpoint (12 passed)
- `git diff --check`
