### PR TITLE
Move project opening into project session

### DIFF
--- a/src/hooks/useAbsoluteFilePath.ts
+++ b/src/hooks/useAbsoluteFilePath.ts
@@ -1,12 +1,15 @@
 import { useApp } from '@src/lib/boot'
 import { PATHS } from '@src/lib/paths'
 import { projectSession } from '@src/registry/contracts/projectSession'
+import { useSignals } from '@preact/signals-react/runtime'
 
 const defaultOptions = {
   warnIfNoExecutingPath: true,
 }
 
 export function useAbsoluteFilePath(options = defaultOptions) {
+  useSignals()
+
   const app = useApp()
   const session = app.registry.get(projectSession)
 

--- a/src/lang/KclManager.spec.ts
+++ b/src/lang/KclManager.spec.ts
@@ -4,9 +4,18 @@ import type {
   SourceDelta,
 } from '@rust/kcl-lib/bindings/FrontendApi'
 import type { Operation } from '@rust/kcl-lib/bindings/Operation'
+import { signal } from '@preact/signals-core'
 import { createEmptyAst } from '@src/editor/plugins/ast'
-import { File, KclManager } from '@src/lang/KclManager'
+import {
+  File,
+  KclManager,
+  ZDSProject,
+  type ZDSProjectFileSystemOperationProvider,
+  type ZDSProjectFileSystemOperations,
+  type ZDSProjectRuntime,
+} from '@src/lang/KclManager'
 import { DEFAULT_KCL_VERSION } from '@src/lib/constants'
+import type { Project } from '@src/lib/project'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const clientErrorMocks = vi.hoisted(() => ({
@@ -104,6 +113,39 @@ function enableSketchSolveEditorExecution(kclManager: KclManager) {
   } as unknown as typeof kclManager.engineCommandManager.connection
 }
 
+function createProjectFileListTestProject() {
+  const projectRef = signal<Project>({
+    name: 'project',
+    path: '/tmp/project',
+    default_file: '/tmp/project/main.kcl',
+    directory_count: 0,
+    kcl_file_count: 2,
+    metadata: null,
+    readWriteAccess: true,
+    children: [
+      {
+        name: 'main.kcl',
+        path: '/tmp/project/main.kcl',
+        children: null,
+      },
+      {
+        name: 'deleted.kcl',
+        path: '/tmp/project/deleted.kcl',
+        children: null,
+      },
+    ],
+  })
+  const fileSystemOperationProvider: ZDSProjectFileSystemOperationProvider = {
+    getFileSystemOperations: () => ({}) as ZDSProjectFileSystemOperations,
+  }
+
+  return new ZDSProject(
+    projectRef,
+    {} as ZDSProjectRuntime,
+    fileSystemOperationProvider
+  )
+}
+
 afterEach(() => {
   vi.clearAllMocks()
   vi.clearAllTimers()
@@ -167,6 +209,35 @@ describe('KclManager live operation updates', () => {
       expect.stringContaining('Live operation updates failed')
     )
     consoleErrorSpy.mockRestore()
+  })
+})
+
+describe('ZDSProject project files', () => {
+  it('prunes stale project files when serializing files for Rust', async () => {
+    const project = createProjectFileListTestProject()
+    const readSpy = vi
+      .spyOn(File.ioImplementations, 'read')
+      .mockImplementation(async (path) => {
+        if (path === '/tmp/project/deleted.kcl') {
+          return Promise.reject('ENOENT')
+        }
+        return 'cube(1)'
+      })
+
+    const files = await (
+      project as unknown as {
+        getAllKclFiles: () => Promise<{ path: string; text: string }[]>
+      }
+    ).getAllKclFiles()
+
+    expect(files).toEqual([
+      { id: 0, path: '/tmp/project/main.kcl', text: 'cube(1)' },
+    ])
+    expect(project.files.map((file) => file.path)).toEqual([
+      '/tmp/project/main.kcl',
+    ])
+
+    readSpy.mockRestore()
   })
 })
 

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -1001,7 +1001,26 @@ export class ZDSProject {
 
   /** Get all the KCL files in this project as a flat array. */
   private async getAllKclFiles(): Promise<ApiFile[]> {
-    return Promise.all(this.files.map((file) => file.asRustApiFile()))
+    const files = await Promise.all(
+      this.files.map(async (file): Promise<ApiFile | undefined> => {
+        try {
+          return await file.asRustApiFile()
+        } catch (error) {
+          if (isPathNotFoundError(error)) {
+            return undefined
+          }
+          return Promise.reject(error)
+        }
+      })
+    )
+    const existingFiles = files.filter((file): file is ApiFile => Boolean(file))
+
+    if (existingFiles.length !== this.files.length) {
+      const existingFilePaths = new Set(existingFiles.map((file) => file.path))
+      this.files = this.files.filter((file) => existingFilePaths.has(file.path))
+    }
+
+    return existingFiles
   }
 
   /**

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -162,7 +162,6 @@ import {
 import { requestWriteToFile } from '@src/editor/plugins/write'
 import { zookeeperHistoryExtension } from '@src/lib/zookeeper/editorPlugin'
 import { projectFsManager } from '@src/lang/std/fileSystemManager'
-import type { App } from '@src/lib/app'
 import { getAutomaticallyRenderEnabledFromSettings } from '@src/lib/automaticRendering'
 import { isCodeTheSame, normalizeLineEndings } from '@src/lib/codeEditor'
 import {
@@ -316,6 +315,21 @@ interface SystemDeps {
   keymap?: KeymapService
 }
 
+/**
+ * Runtime collaborators needed to open project editors and hydrate project
+ * files. The project session service owns this wiring so ZDSProject does not
+ * need to depend on the App shell directly.
+ */
+export interface ZDSProjectRuntime {
+  wasmPromise: Promise<ModuleType>
+  settings: SettingsActorType
+  commandBar: CommandBarActorType
+  engineCommandManager: ConnectionManager
+  rustContext: RustContext
+  userFeatures: UserFeaturesSettleService
+  keymap?: KeymapService
+}
+
 export enum KclManagerEvents {
   LongExecution = 'long-execution',
 }
@@ -410,7 +424,7 @@ export class ZDSProject {
 
   constructor(
     public projectIORefSignal: Signal<Project>,
-    private app: App,
+    private projectRuntime: ZDSProjectRuntime,
     fileSystemOperationProvider: ZDSProjectFileSystemOperationProvider
   ) {
     this.fileSystemOperations =
@@ -435,10 +449,14 @@ export class ZDSProject {
   /** Open a project, with the option to open an initial editor too */
   static async open(
     projectRef: Signal<Project>,
-    app: App,
+    projectRuntime: ZDSProjectRuntime,
     fileSystemOperationProvider: ZDSProjectFileSystemOperationProvider
   ) {
-    return new ZDSProject(projectRef, app, fileSystemOperationProvider)
+    return new ZDSProject(
+      projectRef,
+      projectRuntime,
+      fileSystemOperationProvider
+    )
   }
 
   get executingPath() {
@@ -494,12 +512,13 @@ export class ZDSProject {
     }
 
     const systemDeps: SystemDeps = {
-      wasmInstancePromise: this.app.wasmPromise,
-      commandBar: this.app.commands.actor,
-      settings: this.app.settings.actor,
-      engineCommandManager: this.app.engineCommandManager,
-      rustContext: this.app.rustContext,
-      userFeatures: this.app.userFeatures,
+      wasmInstancePromise: this.projectRuntime.wasmPromise,
+      commandBar: this.projectRuntime.commandBar,
+      settings: this.projectRuntime.settings,
+      engineCommandManager: this.projectRuntime.engineCommandManager,
+      rustContext: this.projectRuntime.rustContext,
+      userFeatures: this.projectRuntime.userFeatures,
+      keymap: this.projectRuntime.keymap,
       projectPath: computed(() => this.projectIORefSignal.value.path),
     }
 
@@ -545,7 +564,8 @@ export class ZDSProject {
     // TODO: Disassemble onSettingsUpdate, subscribe to changes from subsystems
     newEditor
       .updateTheme(
-        getSettingsFromActorContext(this.app.settings.actor).app.theme.current
+        getSettingsFromActorContext(this.projectRuntime.settings).app.theme
+          .current
       )
       .catch(reportRejection)
 
@@ -664,7 +684,7 @@ export class ZDSProject {
       return new Uint8Array(File.encoder.encode(textContents))
     }
 
-    const wasmInstance = await this.app.wasmPromise
+    const wasmInstance = await this.projectRuntime.wasmPromise
     const configuration = await readAppSettingsFile(wasmInstance)
     if (err(configuration)) {
       return Promise.reject(configuration)
@@ -746,7 +766,7 @@ export class ZDSProject {
   async refreshProjectTree() {
     const refreshedProject = await getProjectInfo(
       this.path,
-      await this.app.wasmPromise
+      await this.projectRuntime.wasmPromise
     )
     const currentProject = this.projectIORefSignal.value
     const ownedProject = {

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -970,7 +970,26 @@ export class ZDSProject {
 
   /** Get all the KCL files in this project as a flat array. */
   private async getAllKclFiles(): Promise<ApiFile[]> {
-    return Promise.all(this.files.map((file) => file.asRustApiFile()))
+    const files = await Promise.all(
+      this.files.map(async (file): Promise<ApiFile | undefined> => {
+        try {
+          return await file.asRustApiFile()
+        } catch (error) {
+          if (isPathNotFoundError(error)) {
+            return undefined
+          }
+          return Promise.reject(error)
+        }
+      })
+    )
+    const existingFiles = files.filter((file): file is ApiFile => Boolean(file))
+
+    if (existingFiles.length !== this.files.length) {
+      const existingFilePaths = new Set(existingFiles.map((file) => file.path))
+      this.files = this.files.filter((file) => existingFilePaths.has(file.path))
+    }
+
+    return existingFiles
   }
 
   /**

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -162,7 +162,6 @@ import {
 import { requestWriteToFile } from '@src/editor/plugins/write'
 import { zookeeperHistoryExtension } from '@src/lib/zookeeper/editorPlugin'
 import { projectFsManager } from '@src/lang/std/fileSystemManager'
-import type { App } from '@src/lib/app'
 import { getAutomaticallyRenderEnabledFromSettings } from '@src/lib/automaticRendering'
 import { isCodeTheSame, normalizeLineEndings } from '@src/lib/codeEditor'
 import {
@@ -316,6 +315,21 @@ interface SystemDeps {
   keymap?: KeymapService
 }
 
+/**
+ * Runtime collaborators needed to open project editors and hydrate project
+ * files. The project session service owns this wiring so ZDSProject does not
+ * need to depend on the App shell directly.
+ */
+export interface ZDSProjectRuntime {
+  wasmPromise: Promise<ModuleType>
+  settings: SettingsActorType
+  commandBar: CommandBarActorType
+  engineCommandManager: ConnectionManager
+  rustContext: RustContext
+  userFeatures: UserFeaturesSettleService
+  keymap?: KeymapService
+}
+
 export enum KclManagerEvents {
   LongExecution = 'long-execution',
 }
@@ -413,7 +427,7 @@ export class ZDSProject {
 
   constructor(
     public projectIORefSignal: Signal<Project>,
-    private app: App,
+    private projectRuntime: ZDSProjectRuntime,
     fileSystemOperationProvider: ZDSProjectFileSystemOperationProvider
   ) {
     this.fileSystemOperations =
@@ -438,10 +452,14 @@ export class ZDSProject {
   /** Open a project, with the option to open an initial editor too */
   static async open(
     projectRef: Signal<Project>,
-    app: App,
+    projectRuntime: ZDSProjectRuntime,
     fileSystemOperationProvider: ZDSProjectFileSystemOperationProvider
   ) {
-    return new ZDSProject(projectRef, app, fileSystemOperationProvider)
+    return new ZDSProject(
+      projectRef,
+      projectRuntime,
+      fileSystemOperationProvider
+    )
   }
 
   get executingPath() {
@@ -500,12 +518,13 @@ export class ZDSProject {
     }
 
     const systemDeps: SystemDeps = {
-      wasmInstancePromise: this.app.wasmPromise,
-      commandBar: this.app.commands.actor,
-      settings: this.app.settings.actor,
-      engineCommandManager: this.app.engineCommandManager,
-      rustContext: this.app.rustContext,
-      userFeatures: this.app.userFeatures,
+      wasmInstancePromise: this.projectRuntime.wasmPromise,
+      commandBar: this.projectRuntime.commandBar,
+      settings: this.projectRuntime.settings,
+      engineCommandManager: this.projectRuntime.engineCommandManager,
+      rustContext: this.projectRuntime.rustContext,
+      userFeatures: this.projectRuntime.userFeatures,
+      keymap: this.projectRuntime.keymap,
       projectPath: computed(() => this.projectIORefSignal.value.path),
     }
 
@@ -551,7 +570,8 @@ export class ZDSProject {
     // TODO: Disassemble onSettingsUpdate, subscribe to changes from subsystems
     newEditor
       .updateTheme(
-        getSettingsFromActorContext(this.app.settings.actor).app.theme.current
+        getSettingsFromActorContext(this.projectRuntime.settings).app.theme
+          .current
       )
       .catch(reportRejection)
 
@@ -670,7 +690,7 @@ export class ZDSProject {
       return new Uint8Array(File.encoder.encode(textContents))
     }
 
-    const wasmInstance = await this.app.wasmPromise
+    const wasmInstance = await this.projectRuntime.wasmPromise
     const configuration = await readAppSettingsFile(wasmInstance)
     if (err(configuration)) {
       return Promise.reject(configuration)
@@ -750,7 +770,7 @@ export class ZDSProject {
   async refreshProjectTree() {
     const refreshedProject = await getProjectInfo(
       this.path,
-      await this.app.wasmPromise
+      await this.projectRuntime.wasmPromise
     )
     const currentProject = this.projectIORefSignal.value
     const ownedProject = {

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -332,7 +332,7 @@ describe('project system', () => {
       }
 
       const projectPath = fsZds.join(library.path, 'bracket')
-      const openedProject = await app.openProject({
+      const openedProject = await app.registry.get(projectSession).openProject({
         ...mockProject,
         name: 'bracket',
         path: projectPath,
@@ -812,7 +812,9 @@ describe('project system', () => {
           },
         ],
       }
-      const openedProject = await app.openProject(project)
+      const openedProject = await app.registry
+        .get(projectSession)
+        .openProject(project)
       const kclManager = await openedProject.openEditor(mainPath)
       await Promise.resolve()
 
@@ -865,7 +867,9 @@ describe('project system', () => {
     const app = createAppForTest()
 
     try {
-      const project = await app.openProject(mockProject)
+      const project = await app.registry
+        .get(projectSession)
+        .openProject(mockProject)
       const session = app.registry.get(projectSession)
       const openedProject = session.getProject()
 
@@ -921,7 +925,9 @@ describe('project system', () => {
         ],
       }
 
-      const openedProject = await app.openProject(project)
+      const openedProject = await app.registry
+        .get(projectSession)
+        .openProject(project)
       const session = app.registry.get(projectSession)
       const queue = app.registry.get(fsOperationQueue)
       queue.clearJournal()

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -963,19 +963,37 @@ describe('project system', () => {
       await expect(fsZds.readFile(renamedPath, 'utf8')).resolves.toBe(
         'created = true\n'
       )
-      expect(queue.getJournal()).toEqual([
+      const journal = queue.getJournal()
+      const writeBatch = journal[0]
+      const renameBatch = journal[3]
+      expect(journal).toEqual([
+        expect.objectContaining({
+          kind: 'write-file',
+          metadata: { service: 'projectSession' },
+          status: 'completed',
+          targetPath: createdPath,
+        }),
         expect.objectContaining({
           kind: 'mkdir',
+          parentId: writeBatch.id,
           status: 'completed',
           targetPath: fsZds.dirname(createdPath),
         }),
         expect.objectContaining({
           kind: 'write-file',
+          parentId: writeBatch.id,
           status: 'completed',
           targetPath: createdPath,
         }),
         expect.objectContaining({
+          kind: 'rename-entry',
+          metadata: { service: 'projectSession' },
+          status: 'completed',
+          targetPath: renamedPath,
+        }),
+        expect.objectContaining({
           kind: 'rename',
+          parentId: renameBatch.id,
           sourcePath: createdPath,
           status: 'completed',
           targetPath: renamedPath,

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -6,9 +6,8 @@ import {
   type RegistryItem,
   Slot,
 } from '@kittycad/registry'
-import { effect, signal } from '@preact/signals-core'
-import { buildFSHistoryExtension } from '@src/editor/plugins/fs'
-import { KclManager, ZDSProject } from '@src/lang/KclManager'
+import { signal } from '@preact/signals-core'
+import { KclManager } from '@src/lang/KclManager'
 import { lspService } from '@src/lang/lsp/registry/contract'
 import { type BillingRegistryService, billingService } from '@src/lib/billing'
 import { createAuthCommands } from '@src/lib/commandBarConfigs/authCommandConfig'
@@ -21,8 +20,6 @@ import { setKclRuntimeFlagsOnWasm } from '@src/lib/kclRuntimeFlags'
 import { layoutService } from '@src/lib/layout/registry/contract'
 import type { LayoutService } from '@src/lib/layout/types'
 import type { MachineManager } from '@src/lib/MachineManager'
-import type { Project } from '@src/lib/project'
-import { projectWithLibraryOwnership } from '@src/lib/projectLibraryOwnership'
 import { projectLibrariesFromSettings } from '@src/lib/projectLibraries'
 import type RustContext from '@src/lib/rustContext'
 import { rustContextService } from '@src/lib/rustContext/registry/contract'
@@ -35,17 +32,10 @@ import { reportRejection } from '@src/lib/trap'
 import { uuidv4 } from '@src/lib/utils'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { onActiveWasmInstance } from '@src/lib/wasmLifecycle'
-import {
-  buildZookeeperHistoryExtension,
-  type PreparedZookeeperPatchFileReplay,
-} from '@src/lib/zookeeper/editorPlugin'
 import type { ZookeeperManagerActor } from '@src/lib/zookeeper/zookeeperManagerMachine'
 import { getOnlySettingsFromContext } from '@src/machines/settingsMachine'
 import { systemIOMachineImpl } from '@src/machines/systemIO/systemIOMachineImpl'
-import {
-  type SystemIOActor,
-  SystemIOMachineEvents,
-} from '@src/machines/systemIO/utils'
+import { type SystemIOActor } from '@src/machines/systemIO/utils'
 import {
   UserFeaturesTransition,
   userFeaturesContextHas,
@@ -54,7 +44,6 @@ import {
   type AuthRegistryService,
   authService,
 } from '@src/registry/contracts/auth'
-import { cloudSyncService } from '@src/registry/contracts/cloudSync'
 import {
   type CommandSystemService,
   commandSystemService,
@@ -100,28 +89,6 @@ const appCommandsSlot = new Slot()
 
 type AppRegistryOptions = {
   registryOverrides?: readonly RegistryItem[]
-}
-
-function zookeeperReplayChangesProjectFileSet(
-  replayFiles: readonly PreparedZookeeperPatchFileReplay[]
-) {
-  return replayFiles.some(
-    (replayFile) =>
-      replayFile.previousContent === null || replayFile.nextContent === null
-  )
-}
-
-function getZookeeperReplayFallbackFilePath(
-  project: ZDSProject,
-  deletedPaths: Set<string>
-) {
-  const defaultFile = project.projectIORefSignal.value.default_file
-  const candidates = [
-    defaultFile,
-    ...project.files.map((file) => file.path),
-  ].filter((path, index, paths) => paths.indexOf(path) === index)
-
-  return candidates.find((path) => path && !deletedPaths.has(path))
 }
 
 // We set some of our singletons on the window for debugging and E2E tests
@@ -255,6 +222,9 @@ export class App implements AppSubsystems {
     this.lastSettings = getAllCurrentSettings(
       getOnlySettingsFromContext(this.settings.actor.getSnapshot().context)
     )
+    this.unsubscribeFromSettings = this.settings.actor.subscribe(
+      this.onSettingsUpdate
+    )
     this.settings.actor.subscribe(this.syncPluginSettings)
     this.syncPluginSettingsFromCurrent()
   }
@@ -325,123 +295,13 @@ export class App implements AppSubsystems {
     return new App(combined)
   }
 
-  private setCloudSyncOpenedProject(project?: Project) {
-    this.registry.get(cloudSyncService).setOpenedProject(
-      project
-        ? {
-            projectPath: project.path,
-            ...(project.libraryPath
-              ? { libraryPath: project.libraryPath }
-              : {}),
-            ...(project.libraryType
-              ? { libraryType: project.libraryType }
-              : {}),
-          }
-        : undefined
-    )
-  }
-
-  async openProject(projectIORef: Project) {
-    this.disposeProjectHistoryExtensions?.()
-    const session = this.registry.get(projectSession)
-    const ownedProject = await projectWithLibraryOwnership(
-      projectIORef,
-      this.settings.get().app.libraries.current
-    )
-    const projectIORefSignal = signal(ownedProject)
-    const openedProject = await ZDSProject.open(
-      projectIORefSignal,
-      this,
-      session
-    )
-    session.setProject(openedProject)
-    this.setCloudSyncOpenedProject(ownedProject)
-
-    // These extensions make global project operations un/redoable.
-    this.disposeProjectHistoryExtensions = effect(() => {
-      const project = session.project.value
-      const executingEditor = project?.executingEditor.value
-      if (!project || !executingEditor) {
-        return
-      }
-
-      const disposeFSHistory = buildFSHistoryExtension(
-        this.systemIOActor,
-        executingEditor
-      )
-      const disposeZookeeperHistory = buildZookeeperHistoryExtension({
-        kclManager: executingEditor,
-        onCurrentFileDelete: async (deletedPaths) => {
-          const fallbackPath = getZookeeperReplayFallbackFilePath(
-            project,
-            deletedPaths
-          )
-          if (!fallbackPath) {
-            return Promise.reject(
-              new Error(
-                'Cannot replay this Zookeeper edit because no fallback KCL file is available.'
-              )
-            )
-          }
-
-          await project.openEditor(fallbackPath, executingEditor)
-        },
-        onActiveFileRestore: async (restoredPath, restoredContents) => {
-          await project.openEditor(
-            restoredPath,
-            executingEditor,
-            restoredContents
-          )
-        },
-        onProjectFilesReplay: async (replayFiles) => {
-          await project.syncReplayedFilesToRust(replayFiles)
-          if (zookeeperReplayChangesProjectFileSet(replayFiles)) {
-            this.systemIOActor.send({
-              type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
-            })
-          }
-        },
-      })
-
-      return () => {
-        disposeFSHistory()
-        disposeZookeeperHistory()
-      }
-    })
-
-    // TODO: Rework the systemIOActor to fit into the system better,
-    // so that the project doesn't need to subscribe to it.
-    this.systemIOActor.subscribe(({ context }) => {
-      const foundProject = (context.folders ?? []).find(
-        (p) =>
-          p.name === projectIORefSignal.value.name &&
-          p.path === projectIORefSignal.value.path
-      )
-      if (foundProject && projectIORefSignal.value !== foundProject) {
-        projectIORefSignal.value = {
-          ...foundProject,
-          ...(projectIORefSignal.value.libraryPath
-            ? { libraryPath: projectIORefSignal.value.libraryPath }
-            : {}),
-          ...(projectIORefSignal.value.libraryType
-            ? { libraryType: projectIORefSignal.value.libraryType }
-            : {}),
-        }
-      }
-    })
-
-    this.unsubscribeFromSettings = this.settings.actor.subscribe(
-      this.onSettingsUpdate
-    )
-
-    return openedProject
-  }
   private unsubscribeFromSettings: Subscription | undefined = undefined
-  private disposeProjectHistoryExtensions: (() => void) | undefined = undefined
   dispose() {
     this.closeProject()
     this.unsubscribeFromActiveWasmInstance?.()
     this.unsubscribeFromActiveWasmInstance = undefined
+    this.unsubscribeFromSettings?.unsubscribe()
+    this.unsubscribeFromSettings = undefined
     this.systemIOActor.stop()
     this.settings.actor.stop()
     this.commands.actor.stop()
@@ -452,13 +312,7 @@ export class App implements AppSubsystems {
   }
 
   closeProject() {
-    this.disposeProjectHistoryExtensions?.()
-    this.disposeProjectHistoryExtensions = undefined
-    this.unsubscribeFromSettings?.unsubscribe()
-    this.unsubscribeFromSettings = undefined
     const session = this.registry.get(projectSession)
-    this.setCloudSyncOpenedProject(undefined)
-    session.getProject()?.close()
     session.clearProject()
   }
 

--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -3562,8 +3562,9 @@ function scheduleRemoteIndexSync(delay = 0) {
   scheduleSync(delay)
 }
 
-// With no opened project, Home syncs the full cloud index. App.openProject()
-// passes ownership context so file-route status and retries stay project-local.
+// With no opened project, Home syncs the full cloud index.
+// projectSession.openProject() passes ownership context so file-route status
+// and retries stay project-local.
 export function setCloudSyncOpenedProject(
   openedProject?: CloudSyncOpenedProject
 ) {

--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -3634,8 +3634,9 @@ function scheduleRemoteIndexSync(delay = 0) {
   scheduleSync(delay)
 }
 
-// With no opened project, Home syncs the full cloud index. App.openProject()
-// passes ownership context so file-route status and retries stay project-local.
+// With no opened project, Home syncs the full cloud index.
+// projectSession.openProject() passes ownership context so file-route status
+// and retries stay project-local.
 export function setCloudSyncOpenedProject(
   openedProject?: CloudSyncOpenedProject
 ) {

--- a/src/lib/routeLoaders.ts
+++ b/src/lib/routeLoaders.ts
@@ -300,7 +300,9 @@ export const fileLoader =
     })
     await waitFor(settingsActor, (state) => state.matches('idle'))
 
-    const projectRef = await app.openProject(project)
+    const projectRef = await app.registry
+      .get(projectSession)
+      .openProject(project)
     const editor = await projectRef.openEditor(
       currentFilePath || PROJECT_ENTRYPOINT,
       app.singletons.kclManager,

--- a/src/lib/routeLoaders.ts
+++ b/src/lib/routeLoaders.ts
@@ -5,7 +5,11 @@ import {
   DEFAULT_DEFAULT_LENGTH_UNIT,
   PROJECT_ENTRYPOINT,
 } from '@src/lib/constants'
-import { getInitialDefaultDir, getProjectInfo } from '@src/lib/desktop'
+import {
+  getInitialDefaultDir,
+  getProjectInfo,
+  isPathNotFoundError,
+} from '@src/lib/desktop'
 import fsZds from '@src/lib/fs-zds'
 import {
   getParentAbsolutePath,
@@ -231,7 +235,7 @@ export const fileLoader =
         try {
           await fsZds.stat(currentFilePath)
         } catch (e) {
-          if (e === 'ENOENT') {
+          if (isPathNotFoundError(e)) {
             fileExists = false
           }
         }
@@ -287,18 +291,22 @@ export const fileLoader =
     })
     await waitFor(settingsActor, (state) => state.matches('idle'))
 
-    const projectRef = await app.registry
-      .get(projectSession)
-      .openProject(project)
-    const editor = await projectRef.openEditor(
-      currentFilePath || PROJECT_ENTRYPOINT,
-      app.singletons.kclManager,
+    const session = app.registry.get(projectSession)
+    await session.openProject(project)
+    const openFilePath =
+      currentFilePath ||
+      project.default_file ||
+      fsZds.join(project.path, PROJECT_ENTRYPOINT)
+    const editor = await session.openEditor({
+      path: openFilePath,
+      editor: app.singletons.kclManager,
       // If persistCode in localStorage is present, it'll persist that code
       // through *anything*. INTENDED FOR TESTS.
-      window.electron?.process.env.NODE_ENV === 'test'
-        ? kclManager.localStoragePersistCode()
-        : undefined
-    )
+      code:
+        window.electron?.process.env.NODE_ENV === 'test'
+          ? kclManager.localStoragePersistCode()
+          : undefined,
+    })
 
     const requestedFileName =
       app.systemIOActor.getSnapshot().context.requestedFileName
@@ -327,8 +335,8 @@ export const fileLoader =
       code: editor.code,
       project,
       file: {
-        name: currentFileName || '',
-        path: currentFilePath || '',
+        name: currentFileName || fsZds.basename(openFilePath),
+        path: openFilePath,
         children: [],
       },
     }

--- a/src/lib/routeLoaders.ts
+++ b/src/lib/routeLoaders.ts
@@ -5,7 +5,11 @@ import {
   DEFAULT_DEFAULT_LENGTH_UNIT,
   PROJECT_ENTRYPOINT,
 } from '@src/lib/constants'
-import { getInitialDefaultDir, getProjectInfo } from '@src/lib/desktop'
+import {
+  getInitialDefaultDir,
+  getProjectInfo,
+  isPathNotFoundError,
+} from '@src/lib/desktop'
 import fsZds from '@src/lib/fs-zds'
 import {
   getParentAbsolutePath,
@@ -244,7 +248,7 @@ export const fileLoader =
         try {
           await fsZds.stat(currentFilePath)
         } catch (e) {
-          if (e === 'ENOENT') {
+          if (isPathNotFoundError(e)) {
             fileExists = false
           }
         }
@@ -300,18 +304,22 @@ export const fileLoader =
     })
     await waitFor(settingsActor, (state) => state.matches('idle'))
 
-    const projectRef = await app.registry
-      .get(projectSession)
-      .openProject(project)
-    const editor = await projectRef.openEditor(
-      currentFilePath || PROJECT_ENTRYPOINT,
-      app.singletons.kclManager,
+    const session = app.registry.get(projectSession)
+    const projectRef = await session.openProject(project)
+    const openFilePath =
+      currentFilePath ||
+      project.default_file ||
+      fsZds.join(project.path, PROJECT_ENTRYPOINT)
+    const editor = await session.openEditor({
+      path: openFilePath,
+      editor: app.singletons.kclManager,
       // If persistCode in localStorage is present, it'll persist that code
       // through *anything*. INTENDED FOR TESTS.
-      window.electron?.process.env.NODE_ENV === 'test'
-        ? kclManager.localStoragePersistCode()
-        : undefined
-    )
+      code:
+        window.electron?.process.env.NODE_ENV === 'test'
+          ? kclManager.localStoragePersistCode()
+          : undefined,
+    })
 
     const requestedFileName =
       app.systemIOActor.getSnapshot().context.requestedFileName
@@ -343,8 +351,8 @@ export const fileLoader =
       code: editor.code,
       project,
       file: {
-        name: currentFileName || '',
-        path: currentFilePath || '',
+        name: currentFileName || fsZds.basename(openFilePath),
+        path: openFilePath,
         children: [],
       },
     }

--- a/src/lib/routeLoaders.ts
+++ b/src/lib/routeLoaders.ts
@@ -40,6 +40,7 @@ import {
   projectLibrarySettingDefaultPoliciesValueSpec,
   projectLibrarySettingDefaultsValueSpec,
 } from '@src/registry/contracts/projectLibraries'
+import { projectSession } from '@src/registry/contracts/projectSession'
 import { settingsValueSpec } from '@src/registry/contracts/settings'
 import type { LoaderFunction } from 'react-router-dom'
 import { redirect } from 'react-router-dom'
@@ -286,7 +287,9 @@ export const fileLoader =
     })
     await waitFor(settingsActor, (state) => state.matches('idle'))
 
-    const projectRef = await app.openProject(project)
+    const projectRef = await app.registry
+      .get(projectSession)
+      .openProject(project)
     const editor = await projectRef.openEditor(
       currentFilePath || PROJECT_ENTRYPOINT,
       app.singletons.kclManager,

--- a/src/lib/zookeeper/editorPlugin.integration.spec.ts
+++ b/src/lib/zookeeper/editorPlugin.integration.spec.ts
@@ -1390,7 +1390,9 @@ async function createProjectHarness(files: Record<string, string>) {
     registryOverrides: [createTestWasmRegistryItem()],
   })
   apps.push(app)
-  const openedProject = await app.openProject(project)
+  const openedProject = await app.registry
+    .get(projectSession)
+    .openProject(project)
   const kclManager = await openedProject.openEditor(
     fsZds.join(projectPath, 'main.kcl')
   )

--- a/src/registry/contracts/projectSession.ts
+++ b/src/registry/contracts/projectSession.ts
@@ -8,6 +8,7 @@ import type {
 import type { Project } from '@src/lib/project'
 
 export type ProjectSessionMutationOperation =
+  | 'open-project'
   | 'refresh-project-tree'
   | 'open-editor'
   | 'close-editor'
@@ -83,6 +84,7 @@ export interface ProjectSessionService {
   readonly mutation: Signal<ProjectSessionMutationState>
   getProject: () => ZDSProject | undefined
   getFileSystemOperations: () => ZDSProjectFileSystemOperations
+  openProject: (project: Project) => Promise<ZDSProject>
   setProject: (project: ZDSProject | undefined) => void
   clearProject: () => void
   getProjectTree: () => Project | undefined

--- a/src/registry/extensions/projectSession/index.test.ts
+++ b/src/registry/extensions/projectSession/index.test.ts
@@ -1,11 +1,21 @@
-import { Registry } from '@kittycad/registry'
+import {
+  Registry,
+  defineRegistryItem,
+  provideService,
+} from '@kittycad/registry'
 import { signal } from '@preact/signals-core'
 import type { KclManager, ZDSProject } from '@src/lang/KclManager'
 import type { Project } from '@src/lib/project'
+import {
+  cloudSyncService,
+  type CloudSyncRegistryService,
+} from '@src/registry/contracts/cloudSync'
 import { fsOperationQueue } from '@src/registry/contracts/fsOperationQueue'
 import { projectSession } from '@src/registry/contracts/projectSession'
 import projectSessionRegistryItem from '@src/registry/extensions/projectSession'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@src/lib/wasm_lib_wrapper', () => ({}))
 
 describe('project session extension', () => {
   let registry: Registry | undefined
@@ -15,10 +25,20 @@ describe('project session extension', () => {
     registry = undefined
   })
 
-  function configureProjectSession() {
+  function configureProjectSession(
+    extraItems: Parameters<Registry['configure']>[0] = []
+  ) {
     registry = new Registry()
-    registry.configure([projectSessionRegistryItem])
+    registry.configure([...extraItems, projectSessionRegistryItem])
     return registry.get(projectSession)
+  }
+
+  function createCloudSyncService() {
+    return {
+      setOpenedProject: vi.fn(),
+    } as unknown as CloudSyncRegistryService & {
+      setOpenedProject: ReturnType<typeof vi.fn>
+    }
   }
 
   async function flushMicrotasks() {
@@ -150,6 +170,43 @@ describe('project session extension', () => {
         writeFile: expect.any(Function),
       })
     )
+  })
+
+  it('reuses the opened project when opening the same project path', async () => {
+    const cloudSync = createCloudSyncService()
+    const projectSession = configureProjectSession([
+      defineRegistryItem({
+        id: 'test-cloud-sync',
+        providesServices: [provideService(cloudSyncService, cloudSync)],
+      }),
+    ])
+    const projectTree = {
+      ...createProjectTree(),
+      libraryPath: '/projects',
+    }
+    const project = createFakeProject(projectTree)
+    projectSession.setProject(project)
+
+    const reseededProject = {
+      ...createProjectTree(),
+      title: 'Bracket',
+      default_file: '/projects/bracket/other.kcl',
+    }
+    const openedProject = await projectSession.openProject(reseededProject)
+
+    expect(openedProject).toBe(project)
+    expect(project.mocks.closeAllEditors).not.toHaveBeenCalled()
+    expect(project.projectIORefSignal.value).toEqual(
+      expect.objectContaining({
+        title: 'Bracket',
+        default_file: '/projects/bracket/other.kcl',
+        libraryPath: '/projects',
+      })
+    )
+    expect(cloudSync.setOpenedProject).toHaveBeenCalledWith({
+      projectPath: '/projects/bracket',
+      libraryPath: '/projects',
+    })
   })
 
   it('refreshes the hydrated project tree through the opened project', async () => {

--- a/src/registry/extensions/projectSession/index.test.ts
+++ b/src/registry/extensions/projectSession/index.test.ts
@@ -1,11 +1,21 @@
-import { Registry } from '@kittycad/registry'
+import {
+  Registry,
+  defineRegistryItem,
+  provideService,
+} from '@kittycad/registry'
 import { signal } from '@preact/signals-core'
 import type { KclManager } from '@src/lang/KclManager'
 import type { ZDSProject } from '@src/lang/KclManager'
 import type { Project } from '@src/lib/project'
+import {
+  cloudSyncService,
+  type CloudSyncRegistryService,
+} from '@src/registry/contracts/cloudSync'
 import { projectSession } from '@src/registry/contracts/projectSession'
 import projectSessionRegistryItem from '@src/registry/extensions/projectSession'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@src/lib/wasm_lib_wrapper', () => ({}))
 
 describe('project session extension', () => {
   let registry: Registry | undefined
@@ -15,10 +25,20 @@ describe('project session extension', () => {
     registry = undefined
   })
 
-  function configureProjectSession() {
+  function configureProjectSession(
+    extraItems: Parameters<Registry['configure']>[0] = []
+  ) {
     registry = new Registry()
-    registry.configure([projectSessionRegistryItem])
+    registry.configure([...extraItems, projectSessionRegistryItem])
     return registry.get(projectSession)
+  }
+
+  function createCloudSyncService() {
+    return {
+      setOpenedProject: vi.fn(),
+    } as unknown as CloudSyncRegistryService & {
+      setOpenedProject: ReturnType<typeof vi.fn>
+    }
   }
 
   async function flushMicrotasks() {
@@ -149,6 +169,43 @@ describe('project session extension', () => {
         writeFile: expect.any(Function),
       })
     )
+  })
+
+  it('reuses the opened project when opening the same project path', async () => {
+    const cloudSync = createCloudSyncService()
+    const projectSession = configureProjectSession([
+      defineRegistryItem({
+        id: 'test-cloud-sync',
+        providesServices: [provideService(cloudSyncService, cloudSync)],
+      }),
+    ])
+    const projectTree = {
+      ...createProjectTree(),
+      libraryPath: '/projects',
+    }
+    const project = createFakeProject(projectTree)
+    projectSession.setProject(project)
+
+    const reseededProject = {
+      ...createProjectTree(),
+      title: 'Bracket',
+      default_file: '/projects/bracket/other.kcl',
+    }
+    const openedProject = await projectSession.openProject(reseededProject)
+
+    expect(openedProject).toBe(project)
+    expect(project.mocks.closeAllEditors).not.toHaveBeenCalled()
+    expect(project.projectIORefSignal.value).toEqual(
+      expect.objectContaining({
+        title: 'Bracket',
+        default_file: '/projects/bracket/other.kcl',
+        libraryPath: '/projects',
+      })
+    )
+    expect(cloudSync.setOpenedProject).toHaveBeenCalledWith({
+      projectPath: '/projects/bracket',
+      libraryPath: '/projects',
+    })
   })
 
   it('refreshes the hydrated project tree through the opened project', async () => {

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -6,7 +6,7 @@ import {
 } from '@kittycad/registry'
 import { effect, signal, type Signal } from '@preact/signals-core'
 import { buildFSHistoryExtension } from '@src/editor/plugins/fs'
-import { ZDSProject, type ZDSProjectRuntime } from '@src/lang/KclManager'
+import type { ZDSProject, ZDSProjectRuntime } from '@src/lang/KclManager'
 import { projectWithLibraryOwnership } from '@src/lib/projectLibraryOwnership'
 import type { Project } from '@src/lib/project'
 import { rustContextService } from '@src/lib/rustContext/registry/contract'
@@ -262,7 +262,6 @@ export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
   }
 
   const openProject = async (projectIORef: Project) => {
-    serviceImpl.clearProject()
     setMutation({
       pending: true,
       operation: 'open-project',
@@ -271,11 +270,36 @@ export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
     })
 
     try {
+      const currentProject = project.value
+      if (currentProject?.path === projectIORef.path) {
+        const currentProjectIORef = currentProject.projectIORefSignal.value
+        const reseededProject = {
+          ...projectIORef,
+          ...(currentProjectIORef.libraryPath
+            ? { libraryPath: currentProjectIORef.libraryPath }
+            : {}),
+          ...(currentProjectIORef.libraryType
+            ? { libraryType: currentProjectIORef.libraryType }
+            : {}),
+        }
+        currentProject.projectIORefSignal.value = reseededProject
+        syncProjectTree()
+        setCloudSyncOpenedProject(reseededProject)
+        setMutation({
+          pending: false,
+          operation: 'open-project',
+          lastTargetPath: currentProject.path,
+        })
+        return currentProject
+      }
+
+      serviceImpl.clearProject()
       const ownedProject = await projectWithLibraryOwnership(
         projectIORef,
         ctx.services.get(settingsService).get().app.libraries.current
       )
       const projectIORefSignal = signal(ownedProject)
+      const { ZDSProject } = await import('@src/lang/KclManager')
       const openedProject = await ZDSProject.open(
         projectIORefSignal,
         createProjectRuntime(),

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -4,12 +4,25 @@ import {
   defineRuntimeRegistryItem,
   provideService,
 } from '@kittycad/registry'
-import { effect, signal } from '@preact/signals-core'
-import type { ZDSProject } from '@src/lang/KclManager'
+import { effect, signal, type Signal } from '@preact/signals-core'
+import { buildFSHistoryExtension } from '@src/editor/plugins/fs'
+import { ZDSProject, type ZDSProjectRuntime } from '@src/lang/KclManager'
+import { projectWithLibraryOwnership } from '@src/lib/projectLibraryOwnership'
+import type { Project } from '@src/lib/project'
+import { rustContextService } from '@src/lib/rustContext/registry/contract'
+import {
+  buildZookeeperHistoryExtension,
+  type PreparedZookeeperPatchFileReplay,
+} from '@src/lib/zookeeper/editorPlugin'
+import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
+import { cloudSyncService } from '@src/registry/contracts/cloudSync'
+import { commandSystemService } from '@src/registry/contracts/commands'
+import { engineConnectionService } from '@src/registry/contracts/engineConnection'
 import {
   type FsOperationBatch,
   fsOperationQueue,
 } from '@src/registry/contracts/fsOperationQueue'
+import { keymapService } from '@src/registry/contracts/keymap'
 import {
   type ProjectSessionApplyFilePatchInput,
   type ProjectSessionEntryCopyMoveInput,
@@ -22,7 +35,34 @@ import {
   type ProjectSessionService,
   projectSession,
 } from '@src/registry/contracts/projectSession'
+import { settingsService } from '@src/registry/contracts/settings'
+import { systemIOService } from '@src/registry/contracts/systemIO'
+import { userFeaturesService } from '@src/registry/contracts/userFeatures'
+import { wasmPromiseValueSpec } from '@src/registry/contracts/wasm'
 import fsOperationQueueRegistryItem from '@src/registry/extensions/fsOperationQueue'
+import type { Subscription } from 'xstate'
+
+function zookeeperReplayChangesProjectFileSet(
+  replayFiles: readonly PreparedZookeeperPatchFileReplay[]
+) {
+  return replayFiles.some(
+    (replayFile) =>
+      replayFile.previousContent === null || replayFile.nextContent === null
+  )
+}
+
+function getZookeeperReplayFallbackFilePath(
+  project: ZDSProject,
+  deletedPaths: Set<string>
+) {
+  const defaultFile = project.projectIORefSignal.value.default_file
+  const candidates = [
+    defaultFile,
+    ...project.files.map((file) => file.path),
+  ].filter((path, index, paths) => paths.indexOf(path) === index)
+
+  return candidates.find((path) => path && !deletedPaths.has(path))
+}
 
 export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
   const project = signal<ZDSProject | undefined>(undefined)
@@ -30,6 +70,9 @@ export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
   const currentProjectLibraryId = signal<string | undefined>(undefined)
   const mutation = signal<ProjectSessionMutationState>({ pending: false })
   let disposeProjectTreeSync: (() => void) | undefined
+  let disposeProjectHistoryExtensions: (() => void) | undefined
+  let projectFoldersSubscription: Subscription | undefined
+  let seededCloudSyncOpenedProject = false
 
   const setMutation = ({
     pending,
@@ -51,6 +94,48 @@ export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
       return new Error('No project is currently open.')
     }
     return currentProject
+  }
+
+  const setCloudSyncOpenedProject = (nextProject?: Project) => {
+    ctx.services.get(cloudSyncService).setOpenedProject(
+      nextProject
+        ? {
+            projectPath: nextProject.path,
+            ...(nextProject.libraryPath
+              ? { libraryPath: nextProject.libraryPath }
+              : {}),
+            ...(nextProject.libraryType
+              ? { libraryType: nextProject.libraryType }
+              : {}),
+          }
+        : undefined
+    )
+    seededCloudSyncOpenedProject = Boolean(nextProject)
+  }
+
+  const clearCloudSyncOpenedProject = () => {
+    if (!seededCloudSyncOpenedProject) {
+      return
+    }
+    setCloudSyncOpenedProject(undefined)
+  }
+
+  const createProjectRuntime = (): ZDSProjectRuntime => {
+    const wasmPromise =
+      ctx.valueSpecs.get(wasmPromiseValueSpec) ??
+      Promise.reject(new Error('Missing WASM promise registry value.'))
+    const settings = ctx.services.get(settingsService)
+    const commands = ctx.services.get(commandSystemService)
+
+    return {
+      wasmPromise,
+      settings: settings.actor,
+      commandBar: commands.actor,
+      engineCommandManager: ctx.services.get(engineConnectionService).manager,
+      rustContext: ctx.services.get(rustContextService).context,
+      userFeatures: ctx.services.get(userFeaturesService),
+      keymap: ctx.services.get(keymapService),
+    }
   }
 
   const syncProjectTree = () => {
@@ -93,6 +178,127 @@ export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
         operation: 'refresh-project-tree',
         lastTargetPath: currentProject.path,
       })
+    }
+  }
+
+  const watchSystemIOProjectTree = (projectIORefSignal: Signal<Project>) => {
+    projectFoldersSubscription?.unsubscribe()
+    projectFoldersSubscription = ctx.services
+      .get(systemIOService)
+      .actor.subscribe(({ context }) => {
+        const foundProject = (context.folders ?? []).find(
+          (candidate) =>
+            candidate.name === projectIORefSignal.value.name &&
+            candidate.path === projectIORefSignal.value.path
+        )
+        if (foundProject && projectIORefSignal.value !== foundProject) {
+          projectIORefSignal.value = {
+            ...foundProject,
+            ...(projectIORefSignal.value.libraryPath
+              ? { libraryPath: projectIORefSignal.value.libraryPath }
+              : {}),
+            ...(projectIORefSignal.value.libraryType
+              ? { libraryType: projectIORefSignal.value.libraryType }
+              : {}),
+          }
+        }
+      })
+  }
+
+  const watchProjectHistoryExtensions = () => {
+    const systemIOActor = ctx.services.get(systemIOService).actor
+
+    disposeProjectHistoryExtensions?.()
+    disposeProjectHistoryExtensions = effect(() => {
+      const currentProject = project.value
+      const executingEditor = currentProject?.executingEditor.value
+      if (!currentProject || !executingEditor) {
+        return
+      }
+
+      const disposeFSHistory = buildFSHistoryExtension(
+        systemIOActor,
+        executingEditor
+      )
+      const disposeZookeeperHistory = buildZookeeperHistoryExtension({
+        kclManager: executingEditor,
+        onCurrentFileDelete: async (deletedPaths) => {
+          const fallbackPath = getZookeeperReplayFallbackFilePath(
+            currentProject,
+            deletedPaths
+          )
+          if (!fallbackPath) {
+            return Promise.reject(
+              new Error(
+                'Cannot replay this Zookeeper edit because no fallback KCL file is available.'
+              )
+            )
+          }
+
+          await currentProject.openEditor(fallbackPath, executingEditor)
+        },
+        onActiveFileRestore: async (restoredPath, restoredContents) => {
+          await currentProject.openEditor(
+            restoredPath,
+            executingEditor,
+            restoredContents
+          )
+        },
+        onProjectFilesReplay: async (replayFiles) => {
+          await currentProject.syncReplayedFilesToRust(replayFiles)
+          if (zookeeperReplayChangesProjectFileSet(replayFiles)) {
+            systemIOActor.send({
+              type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
+            })
+          }
+        },
+      })
+
+      return () => {
+        disposeFSHistory()
+        disposeZookeeperHistory()
+      }
+    })
+  }
+
+  const openProject = async (projectIORef: Project) => {
+    serviceImpl.clearProject()
+    setMutation({
+      pending: true,
+      operation: 'open-project',
+      targetPath: projectIORef.path,
+      lastTargetPath: mutation.value.lastTargetPath,
+    })
+
+    try {
+      const ownedProject = await projectWithLibraryOwnership(
+        projectIORef,
+        ctx.services.get(settingsService).get().app.libraries.current
+      )
+      const projectIORefSignal = signal(ownedProject)
+      const openedProject = await ZDSProject.open(
+        projectIORefSignal,
+        createProjectRuntime(),
+        serviceImpl
+      )
+      serviceImpl.setProject(openedProject)
+      setCloudSyncOpenedProject(ownedProject)
+      watchProjectHistoryExtensions()
+      watchSystemIOProjectTree(projectIORefSignal)
+      setMutation({
+        pending: false,
+        operation: 'open-project',
+        lastTargetPath: openedProject.path,
+      })
+      return openedProject
+    } catch (error) {
+      serviceImpl.clearProject()
+      setMutation({
+        pending: false,
+        operation: 'open-project',
+        lastTargetPath: projectIORef.path,
+      })
+      return Promise.reject(error)
     }
   }
 
@@ -167,13 +373,20 @@ export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
     mutation,
     getProject: () => project.value,
     getFileSystemOperations: () => ctx.services.get(fsOperationQueue),
+    openProject,
     setProject: (nextProject) => {
       project.value = nextProject
       watchProjectTree(nextProject)
     },
     clearProject: () => {
+      disposeProjectHistoryExtensions?.()
+      disposeProjectHistoryExtensions = undefined
+      projectFoldersSubscription?.unsubscribe()
+      projectFoldersSubscription = undefined
+      project.value?.close?.()
       project.value = undefined
       watchProjectTree(undefined)
+      clearCloudSyncOpenedProject()
     },
     getProjectTree: () => projectTree.value,
     refreshProjectTree,
@@ -284,8 +497,7 @@ export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
       id: 'project-session-extension',
       providesServices: [provideService(projectSession, serviceImpl)],
       dispose: () => {
-        disposeProjectTreeSync?.()
-        disposeProjectTreeSync = undefined
+        serviceImpl.clearProject()
       },
     }),
   }

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -6,7 +6,7 @@ import {
 } from '@kittycad/registry'
 import { effect, signal, type Signal } from '@preact/signals-core'
 import { buildFSHistoryExtension } from '@src/editor/plugins/fs'
-import { ZDSProject, type ZDSProjectRuntime } from '@src/lang/KclManager'
+import type { ZDSProject, ZDSProjectRuntime } from '@src/lang/KclManager'
 import { projectWithLibraryOwnership } from '@src/lib/projectLibraryOwnership'
 import type { Project } from '@src/lib/project'
 import { rustContextService } from '@src/lib/rustContext/registry/contract'
@@ -259,7 +259,6 @@ export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
   }
 
   const openProject = async (projectIORef: Project) => {
-    serviceImpl.clearProject()
     setMutation({
       pending: true,
       operation: 'open-project',
@@ -268,11 +267,36 @@ export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
     })
 
     try {
+      const currentProject = project.value
+      if (currentProject?.path === projectIORef.path) {
+        const currentProjectIORef = currentProject.projectIORefSignal.value
+        const reseededProject = {
+          ...projectIORef,
+          ...(currentProjectIORef.libraryPath
+            ? { libraryPath: currentProjectIORef.libraryPath }
+            : {}),
+          ...(currentProjectIORef.libraryType
+            ? { libraryType: currentProjectIORef.libraryType }
+            : {}),
+        }
+        currentProject.projectIORefSignal.value = reseededProject
+        syncProjectTree()
+        setCloudSyncOpenedProject(reseededProject)
+        setMutation({
+          pending: false,
+          operation: 'open-project',
+          lastTargetPath: currentProject.path,
+        })
+        return currentProject
+      }
+
+      serviceImpl.clearProject()
       const ownedProject = await projectWithLibraryOwnership(
         projectIORef,
         ctx.services.get(settingsService).get().app.libraries.current
       )
       const projectIORefSignal = signal(ownedProject)
+      const { ZDSProject } = await import('@src/lang/KclManager')
       const openedProject = await ZDSProject.open(
         projectIORefSignal,
         createProjectRuntime(),

--- a/src/registry/extensions/projectSession/index.ts
+++ b/src/registry/extensions/projectSession/index.ts
@@ -4,9 +4,22 @@ import {
   defineRuntimeRegistryItem,
   provideService,
 } from '@kittycad/registry'
-import { effect, signal } from '@preact/signals-core'
-import type { ZDSProject } from '@src/lang/KclManager'
+import { effect, signal, type Signal } from '@preact/signals-core'
+import { buildFSHistoryExtension } from '@src/editor/plugins/fs'
+import { ZDSProject, type ZDSProjectRuntime } from '@src/lang/KclManager'
+import { projectWithLibraryOwnership } from '@src/lib/projectLibraryOwnership'
+import type { Project } from '@src/lib/project'
+import { rustContextService } from '@src/lib/rustContext/registry/contract'
+import {
+  buildZookeeperHistoryExtension,
+  type PreparedZookeeperPatchFileReplay,
+} from '@src/lib/zookeeper/editorPlugin'
+import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
+import { cloudSyncService } from '@src/registry/contracts/cloudSync'
+import { commandSystemService } from '@src/registry/contracts/commands'
+import { engineConnectionService } from '@src/registry/contracts/engineConnection'
 import { fsOperationQueue } from '@src/registry/contracts/fsOperationQueue'
+import { keymapService } from '@src/registry/contracts/keymap'
 import {
   type ProjectSessionApplyFilePatchInput,
   type ProjectSessionEntryCopyMoveInput,
@@ -19,7 +32,34 @@ import {
   type ProjectSessionService,
   projectSession,
 } from '@src/registry/contracts/projectSession'
+import { settingsService } from '@src/registry/contracts/settings'
+import { systemIOService } from '@src/registry/contracts/systemIO'
+import { userFeaturesService } from '@src/registry/contracts/userFeatures'
+import { wasmPromiseValueSpec } from '@src/registry/contracts/wasm'
 import fsOperationQueueRegistryItem from '@src/registry/extensions/fsOperationQueue'
+import type { Subscription } from 'xstate'
+
+function zookeeperReplayChangesProjectFileSet(
+  replayFiles: readonly PreparedZookeeperPatchFileReplay[]
+) {
+  return replayFiles.some(
+    (replayFile) =>
+      replayFile.previousContent === null || replayFile.nextContent === null
+  )
+}
+
+function getZookeeperReplayFallbackFilePath(
+  project: ZDSProject,
+  deletedPaths: Set<string>
+) {
+  const defaultFile = project.projectIORefSignal.value.default_file
+  const candidates = [
+    defaultFile,
+    ...project.files.map((file) => file.path),
+  ].filter((path, index, paths) => paths.indexOf(path) === index)
+
+  return candidates.find((path) => path && !deletedPaths.has(path))
+}
 
 export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
   const project = signal<ZDSProject | undefined>(undefined)
@@ -27,6 +67,9 @@ export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
   const currentProjectLibraryId = signal<string | undefined>(undefined)
   const mutation = signal<ProjectSessionMutationState>({ pending: false })
   let disposeProjectTreeSync: (() => void) | undefined
+  let disposeProjectHistoryExtensions: (() => void) | undefined
+  let projectFoldersSubscription: Subscription | undefined
+  let seededCloudSyncOpenedProject = false
 
   const setMutation = ({
     pending,
@@ -48,6 +91,48 @@ export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
       return new Error('No project is currently open.')
     }
     return currentProject
+  }
+
+  const setCloudSyncOpenedProject = (nextProject?: Project) => {
+    ctx.services.get(cloudSyncService).setOpenedProject(
+      nextProject
+        ? {
+            projectPath: nextProject.path,
+            ...(nextProject.libraryPath
+              ? { libraryPath: nextProject.libraryPath }
+              : {}),
+            ...(nextProject.libraryType
+              ? { libraryType: nextProject.libraryType }
+              : {}),
+          }
+        : undefined
+    )
+    seededCloudSyncOpenedProject = Boolean(nextProject)
+  }
+
+  const clearCloudSyncOpenedProject = () => {
+    if (!seededCloudSyncOpenedProject) {
+      return
+    }
+    setCloudSyncOpenedProject(undefined)
+  }
+
+  const createProjectRuntime = (): ZDSProjectRuntime => {
+    const wasmPromise =
+      ctx.valueSpecs.get(wasmPromiseValueSpec) ??
+      Promise.reject(new Error('Missing WASM promise registry value.'))
+    const settings = ctx.services.get(settingsService)
+    const commands = ctx.services.get(commandSystemService)
+
+    return {
+      wasmPromise,
+      settings: settings.actor,
+      commandBar: commands.actor,
+      engineCommandManager: ctx.services.get(engineConnectionService).manager,
+      rustContext: ctx.services.get(rustContextService).context,
+      userFeatures: ctx.services.get(userFeaturesService),
+      keymap: ctx.services.get(keymapService),
+    }
   }
 
   const syncProjectTree = () => {
@@ -90,6 +175,127 @@ export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
         operation: 'refresh-project-tree',
         lastTargetPath: currentProject.path,
       })
+    }
+  }
+
+  const watchSystemIOProjectTree = (projectIORefSignal: Signal<Project>) => {
+    projectFoldersSubscription?.unsubscribe()
+    projectFoldersSubscription = ctx.services
+      .get(systemIOService)
+      .actor.subscribe(({ context }) => {
+        const foundProject = (context.folders ?? []).find(
+          (candidate) =>
+            candidate.name === projectIORefSignal.value.name &&
+            candidate.path === projectIORefSignal.value.path
+        )
+        if (foundProject && projectIORefSignal.value !== foundProject) {
+          projectIORefSignal.value = {
+            ...foundProject,
+            ...(projectIORefSignal.value.libraryPath
+              ? { libraryPath: projectIORefSignal.value.libraryPath }
+              : {}),
+            ...(projectIORefSignal.value.libraryType
+              ? { libraryType: projectIORefSignal.value.libraryType }
+              : {}),
+          }
+        }
+      })
+  }
+
+  const watchProjectHistoryExtensions = () => {
+    const systemIOActor = ctx.services.get(systemIOService).actor
+
+    disposeProjectHistoryExtensions?.()
+    disposeProjectHistoryExtensions = effect(() => {
+      const currentProject = project.value
+      const executingEditor = currentProject?.executingEditor.value
+      if (!currentProject || !executingEditor) {
+        return
+      }
+
+      const disposeFSHistory = buildFSHistoryExtension(
+        systemIOActor,
+        executingEditor
+      )
+      const disposeZookeeperHistory = buildZookeeperHistoryExtension({
+        kclManager: executingEditor,
+        onCurrentFileDelete: async (deletedPaths) => {
+          const fallbackPath = getZookeeperReplayFallbackFilePath(
+            currentProject,
+            deletedPaths
+          )
+          if (!fallbackPath) {
+            return Promise.reject(
+              new Error(
+                'Cannot replay this Zookeeper edit because no fallback KCL file is available.'
+              )
+            )
+          }
+
+          await currentProject.openEditor(fallbackPath, executingEditor)
+        },
+        onActiveFileRestore: async (restoredPath, restoredContents) => {
+          await currentProject.openEditor(
+            restoredPath,
+            executingEditor,
+            restoredContents
+          )
+        },
+        onProjectFilesReplay: async (replayFiles) => {
+          await currentProject.syncReplayedFilesToRust(replayFiles)
+          if (zookeeperReplayChangesProjectFileSet(replayFiles)) {
+            systemIOActor.send({
+              type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
+            })
+          }
+        },
+      })
+
+      return () => {
+        disposeFSHistory()
+        disposeZookeeperHistory()
+      }
+    })
+  }
+
+  const openProject = async (projectIORef: Project) => {
+    serviceImpl.clearProject()
+    setMutation({
+      pending: true,
+      operation: 'open-project',
+      targetPath: projectIORef.path,
+      lastTargetPath: mutation.value.lastTargetPath,
+    })
+
+    try {
+      const ownedProject = await projectWithLibraryOwnership(
+        projectIORef,
+        ctx.services.get(settingsService).get().app.libraries.current
+      )
+      const projectIORefSignal = signal(ownedProject)
+      const openedProject = await ZDSProject.open(
+        projectIORefSignal,
+        createProjectRuntime(),
+        serviceImpl
+      )
+      serviceImpl.setProject(openedProject)
+      setCloudSyncOpenedProject(ownedProject)
+      watchProjectHistoryExtensions()
+      watchSystemIOProjectTree(projectIORefSignal)
+      setMutation({
+        pending: false,
+        operation: 'open-project',
+        lastTargetPath: openedProject.path,
+      })
+      return openedProject
+    } catch (error) {
+      serviceImpl.clearProject()
+      setMutation({
+        pending: false,
+        operation: 'open-project',
+        lastTargetPath: projectIORef.path,
+      })
+      return Promise.reject(error)
     }
   }
 
@@ -140,13 +346,20 @@ export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
     mutation,
     getProject: () => project.value,
     getFileSystemOperations: () => ctx.services.get(fsOperationQueue),
+    openProject,
     setProject: (nextProject) => {
       project.value = nextProject
       watchProjectTree(nextProject)
     },
     clearProject: () => {
+      disposeProjectHistoryExtensions?.()
+      disposeProjectHistoryExtensions = undefined
+      projectFoldersSubscription?.unsubscribe()
+      projectFoldersSubscription = undefined
+      project.value?.close?.()
       project.value = undefined
       watchProjectTree(undefined)
+      clearCloudSyncOpenedProject()
     },
     getProjectTree: () => projectTree.value,
     refreshProjectTree,
@@ -251,8 +464,7 @@ export const projectSessionExtension = defineRegistryItemFactory((ctx) => {
       id: 'project-session-extension',
       providesServices: [provideService(projectSession, serviceImpl)],
       dispose: () => {
-        disposeProjectTreeSync?.()
-        disposeProjectTreeSync = undefined
+        serviceImpl.clearProject()
       },
     }),
   }


### PR DESCRIPTION
Addresses the project-session ownership follow-up by moving project opening behind the registry service.

1. Adds projectSession.openProject(project) and moves library ownership, cloud-sync scope seeding, project-tree subscription, and history extension setup into the projectSession extension.
2. Removes App.openProject and updates route loading/tests to call app.registry.get(projectSession).openProject(...).
3. Changes ZDSProject to receive explicit runtime collaborators instead of depending on App directly.

How to test:
Open a local project through the file route and confirm the editor opens, project tree updates, undo/redo history still works, and closing the project tears down the session.