### PR TITLE
Track engine FPS in network health

### DIFF
--- a/src/components/NetworkHealthIndicator.tsx
+++ b/src/components/NetworkHealthIndicator.tsx
@@ -3,9 +3,9 @@ import { ActionIcon } from '@src/components/ActionIcon'
 import type { StatusBarItemType } from '@src/components/StatusBar/statusBarTypes'
 import { useNetworkContext } from '@src/hooks/useNetworkContext'
 import { NetworkHealthState } from '@src/hooks/useNetworkStatus'
+import type { ConnectingTypeGroup } from '@src/lib/engineConnection/utils'
 import { reportRejection } from '@src/lib/trap'
 import { toSync } from '@src/lib/utils'
-import type { ConnectingTypeGroup } from '@src/lib/engineConnection/utils'
 
 export const NETWORK_HEALTH_TEXT: Record<NetworkHealthState, string> = {
   [NetworkHealthState.Ok]: 'Strong',
@@ -72,14 +72,15 @@ const overallConnectionStateIcon = {
 } as const
 
 export const useNetworkHealthStatus = (): StatusBarItemType => {
-  const { overallState } = useNetworkContext()
+  const { overallState, fps } = useNetworkContext()
+  const fpsLabel = fps === undefined ? '' : `, ${fps} FPS`
 
   return {
     id: 'network-health',
     'data-testid': `network-toggle-${
       overallState === NetworkHealthState.Ok ? 'ok' : 'other'
     }`,
-    label: `Network health (${NETWORK_HEALTH_TEXT[overallState]})`,
+    label: `Network health (${NETWORK_HEALTH_TEXT[overallState]}${fpsLabel})`,
     hideLabel: true,
     element: 'popover',
     className: overallConnectionStateColor[overallState].icon,
@@ -98,6 +99,7 @@ function NetworkHealthPopoverContent() {
     ping,
     setHasCopied,
     hasCopied,
+    fps,
   } = useNetworkContext()
 
   return (
@@ -127,6 +129,19 @@ function NetworkHealthPopoverContent() {
           className={`font-bold text-xs uppercase px-2 py-1 rounded-sm ${overallConnectionStateColor[overallState].icon}`}
         >
           {ping ?? 'N/A'}
+        </p>
+      </div>
+      <div className="flex items-center justify-between p-2 rounded-t-sm">
+        <h2
+          className={`text-xs font-sans font-normal ${overallConnectionStateColor[overallState].icon}`}
+        >
+          FPS
+        </h2>
+        <p
+          data-testid="network-fps"
+          className={`font-bold text-xs uppercase px-2 py-1 rounded-sm ${overallConnectionStateColor[overallState].icon}`}
+        >
+          {fps ?? 'N/A'}
         </p>
       </div>
       <ul className="divide-y divide-chalkboard-20 dark:divide-chalkboard-80">

--- a/src/hooks/useNetworkContext.tsx
+++ b/src/hooks/useNetworkContext.tsx
@@ -1,5 +1,3 @@
-import { createContext, useContext } from 'react'
-
 import type { NetworkStatus } from '@src/hooks/useNetworkStatus'
 import { NetworkHealthState } from '@src/hooks/useNetworkStatus'
 import {
@@ -7,6 +5,7 @@ import {
   EngineConnectionStateType,
   initialConnectingTypeGroupState,
 } from '@src/lib/engineConnection/utils'
+import { createContext, useContext } from 'react'
 
 export const NetworkContext = createContext<NetworkStatus>({
   immediateState: {
@@ -22,9 +21,10 @@ export const NetworkContext = createContext<NetworkStatus>({
     [ConnectingTypeGroup.WebRTC]: undefined,
   },
   error: undefined,
-  setHasCopied: (b: boolean) => {},
+  setHasCopied: (_b: boolean) => {},
   hasCopied: false,
   ping: undefined,
+  fps: undefined,
 })
 export const useNetworkContext = () => {
   return useContext(NetworkContext)

--- a/src/hooks/useNetworkStatus.test.tsx
+++ b/src/hooks/useNetworkStatus.test.tsx
@@ -1,0 +1,103 @@
+import {
+  NetworkHealthState,
+  useNetworkStatus,
+} from '@src/hooks/useNetworkStatus'
+import type { ConnectionManager } from '@src/lib/engineConnection/connectionManager'
+import {
+  EngineConnectionEvents,
+  EngineConnectionManagerEvents,
+  EngineConnectionStateType,
+  initialConnectingTypeGroupState,
+} from '@src/lib/engineConnection/utils'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+function createTestConnectionManager() {
+  const connection = new EventTarget()
+  const manager = new EventTarget() as EventTarget & {
+    connection: EventTarget
+  }
+  manager.connection = connection
+
+  return {
+    connection,
+    manager: manager as unknown as ConnectionManager,
+  }
+}
+
+function publishEngineAvailable({
+  connection,
+  manager,
+}: {
+  connection: EventTarget
+  manager: ConnectionManager
+}) {
+  manager.dispatchEvent(
+    new CustomEvent(EngineConnectionManagerEvents.EngineAvailable, {
+      detail: connection,
+    })
+  )
+}
+
+function publishHealthyConnectionSteps(connection: EventTarget) {
+  for (const [connectingType] of Object.values(
+    initialConnectingTypeGroupState
+  ).flat()) {
+    connection.dispatchEvent(
+      new CustomEvent(EngineConnectionEvents.ConnectionStateChanged, {
+        detail: {
+          type: EngineConnectionStateType.Connecting,
+          value: {
+            type: connectingType,
+          },
+        },
+      })
+    )
+  }
+}
+
+describe('useNetworkStatus', () => {
+  it('exposes frames per second from the engine connection', async () => {
+    const { connection, manager } = createTestConnectionManager()
+    const { result } = renderHook(() => useNetworkStatus(manager))
+
+    act(() => {
+      publishEngineAvailable({ connection, manager })
+      connection.dispatchEvent(
+        new CustomEvent(EngineConnectionEvents.FramesPerSecondChanged, {
+          detail: 59.6,
+        })
+      )
+    })
+
+    await waitFor(() => {
+      expect(result.current.fps).toBe(60)
+    })
+  })
+
+  it('reports weak health when an otherwise healthy stream has low FPS', async () => {
+    const { connection, manager } = createTestConnectionManager()
+    const { result } = renderHook(() => useNetworkStatus(manager))
+
+    act(() => {
+      publishEngineAvailable({ connection, manager })
+      publishHealthyConnectionSteps(connection)
+    })
+
+    await waitFor(() => {
+      expect(result.current.hasIssues).toBe(false)
+    })
+
+    act(() => {
+      connection.dispatchEvent(
+        new CustomEvent(EngineConnectionEvents.FramesPerSecondChanged, {
+          detail: 12,
+        })
+      )
+    })
+
+    await waitFor(() => {
+      expect(result.current.overallState).toBe(NetworkHealthState.Weak)
+    })
+  })
+})

--- a/src/hooks/useNetworkStatus.tsx
+++ b/src/hooks/useNetworkStatus.tsx
@@ -32,7 +32,11 @@ export interface NetworkStatus {
   setHasCopied: (b: boolean) => void
   hasCopied: boolean
   ping: undefined | number
+  fps: undefined | number
 }
+
+const hasIssue = (i: [ConnectingType, boolean | undefined]) =>
+  i[1] === undefined ? i[1] : !i[1]
 
 // Must be called from one place in the application.
 // We've chosen the <Router /> component for this.
@@ -49,12 +53,11 @@ export function useNetworkStatus(engineCommandManager?: ConnectionManager) {
   )
   const [pingRaw, setPingRaw] = useState<undefined | number>(undefined)
   const [pingEMA, setPingEMA] = useState<undefined | number>(undefined)
+  const [fpsRaw, setFpsRaw] = useState<undefined | number>(undefined)
+  const [fpsEMA, setFpsEMA] = useState<undefined | number>(undefined)
   const [hasCopied, setHasCopied] = useState<boolean>(false)
 
   const [error, setError] = useState<IErrorType | undefined>(undefined)
-
-  const hasIssue = (i: [ConnectingType, boolean | undefined]) =>
-    i[1] === undefined ? i[1] : !i[1]
 
   const [issues, setIssues] = useState<
     Record<ConnectingTypeGroup, boolean | undefined>
@@ -66,29 +69,54 @@ export function useNetworkStatus(engineCommandManager?: ConnectionManager) {
 
   const [hasIssues, setHasIssues] = useState<boolean | undefined>(undefined)
   useEffect(() => {
-    if (immediateState.type === EngineConnectionStateType.Disconnecting) {
+    if (
+      immediateState.type === EngineConnectionStateType.Disconnecting ||
+      immediateState.type === EngineConnectionStateType.Disconnected
+    ) {
       // Reset our running average.
       setPingRaw(undefined)
       setPingEMA(undefined)
+      setFpsRaw(undefined)
+      setFpsEMA(undefined)
     }
   }, [immediateState])
 
   useEffect(() => {
-    if (!pingRaw) return
+    if (!pingRaw) {
+      return
+    }
 
     // We use an exponential running average to smooth out ping values.
     const pingDataPointsToConsider = 10
     const multiplier = 2 / (pingDataPointsToConsider + 1)
-    let pingEMANext = ((pingEMA ?? 0) + pingRaw) / 2
-    pingEMANext = pingEMANext * multiplier + (pingEMA ?? 0) * (1 - multiplier)
-    setPingEMA(pingEMANext)
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
+    setPingEMA((currentPingEMA) => {
+      let pingEMANext = ((currentPingEMA ?? 0) + pingRaw) / 2
+      pingEMANext =
+        pingEMANext * multiplier + (currentPingEMA ?? 0) * (1 - multiplier)
+      return pingEMANext
+    })
   }, [pingRaw])
+
+  useEffect(() => {
+    if (fpsRaw === undefined) {
+      return
+    }
+
+    // We use an exponential running average to smooth out short frame drops.
+    const fpsDataPointsToConsider = 5
+    const multiplier = 2 / (fpsDataPointsToConsider + 1)
+    setFpsEMA((currentFpsEMA) =>
+      currentFpsEMA === undefined
+        ? fpsRaw
+        : fpsRaw * multiplier + currentFpsEMA * (1 - multiplier)
+    )
+  }, [fpsRaw])
 
   useEffect(() => {
     // We consider ping longer than 3 frames as weak
     const WEAK_PING = 16.6 * 3
     const OK_PING = 16.6 * 2
+    const WEAK_FPS = 24
 
     // A is used in the literature to specify the "window" of switching
     const A = 1.25
@@ -103,6 +131,8 @@ export function useNetworkStatus(engineCommandManager?: ConnectionManager) {
       nextOverallState = NetworkHealthState.Disconnected
     } else if (hasIssues || hasIssues === undefined) {
       nextOverallState = NetworkHealthState.Issue
+    } else if (fpsEMA !== undefined && fpsEMA < WEAK_FPS) {
+      nextOverallState = NetworkHealthState.Weak
     } else if (pingEMA && pingEMA < THRESHOLD_GOOD) {
       nextOverallState = NetworkHealthState.Ok
     } else if (pingEMA && pingEMA > THRESHOLD_WEAK) {
@@ -111,10 +141,12 @@ export function useNetworkStatus(engineCommandManager?: ConnectionManager) {
       nextOverallState = NetworkHealthState.Ok
     }
 
-    if (nextOverallState === overallState) return
+    if (nextOverallState === overallState) {
+      return
+    }
 
     setOverallState(nextOverallState)
-  }, [hasIssues, internetConnected, pingEMA, overallState])
+  }, [fpsEMA, hasIssues, internetConnected, pingEMA, overallState])
 
   useEffect(() => {
     const offlineCallback = () => {
@@ -169,6 +201,14 @@ export function useNetworkStatus(engineCommandManager?: ConnectionManager) {
       setPingRaw(state)
     }
 
+    const onFramesPerSecondChange = ({
+      detail: state,
+    }: CustomEvent<number | undefined>) => {
+      setFpsRaw(
+        typeof state === 'number' && Number.isFinite(state) ? state : undefined
+      )
+    }
+
     const onConnectionStateChange = ({
       detail: engineConnectionState,
     }: CustomEvent) => {
@@ -183,7 +223,9 @@ export function useNetworkStatus(engineCommandManager?: ConnectionManager) {
           const groups = Object.values(nextSteps)
           for (const group of groups) {
             for (const step of group) {
-              if (step[0] !== engineConnectionState.value.type) continue
+              if (step[0] !== engineConnectionState.value.type) {
+                continue
+              }
               step[1] = true
             }
           }
@@ -237,6 +279,10 @@ export function useNetworkStatus(engineCommandManager?: ConnectionManager) {
         EngineConnectionEvents.ConnectionStateChanged,
         onConnectionStateChange as EventListener
       )
+      connection.addEventListener(
+        EngineConnectionEvents.FramesPerSecondChanged,
+        onFramesPerSecondChange as EventListener
+      )
     }
 
     engineCommandManager?.addEventListener(
@@ -260,6 +306,10 @@ export function useNetworkStatus(engineCommandManager?: ConnectionManager) {
         EngineConnectionEvents.ConnectionStateChanged,
         onConnectionStateChange as EventListener
       )
+      engineCommandManager?.connection?.removeEventListener(
+        EngineConnectionEvents.FramesPerSecondChanged,
+        onFramesPerSecondChange as EventListener
+      )
     }
   }, [engineCommandManager])
 
@@ -274,5 +324,6 @@ export function useNetworkStatus(engineCommandManager?: ConnectionManager) {
     setHasCopied,
     hasCopied,
     ping: pingEMA !== undefined ? Math.trunc(pingEMA) : pingEMA,
+    fps: fpsEMA !== undefined ? Math.round(fpsEMA) : fpsEMA,
   }
 }

--- a/src/lib/engineConnection/connection.test.ts
+++ b/src/lib/engineConnection/connection.test.ts
@@ -1,0 +1,89 @@
+import type { ClientMetrics } from '@kittycad/lib/dist/types/src'
+import { Connection } from '@src/lib/engineConnection/connection'
+import { FPS_TRACKER_INTERVAL_MS } from '@src/lib/engineConnection/fpsTracker'
+import { EngineConnectionEvents } from '@src/lib/engineConnection/utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+function createConnection() {
+  return new Connection({
+    url: 'wss://example.test',
+    token: '',
+    handleOnDataChannelMessage: () => {},
+    tearDownManager: () => {},
+    rejectPendingCommand: () => {},
+    handleMessage: () => {},
+  })
+}
+
+async function flushPromises() {
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve()
+  }
+}
+
+describe('Connection FPS tracking', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('reuses an in-flight WebRTC stats collection', async () => {
+    const connection = createConnection()
+    const collector = vi
+      .fn<() => Promise<ClientMetrics>>()
+      .mockResolvedValue({ rtc_frames_per_second: 30 } satisfies ClientMetrics)
+    connection.webrtcStatsCollector = collector
+
+    const firstMetricsPromise = connection.collectClientMetrics()
+    const secondMetricsPromise = connection.collectClientMetrics()
+
+    expect(firstMetricsPromise).toBe(secondMetricsPromise)
+    expect(collector).toHaveBeenCalledTimes(1)
+
+    await firstMetricsPromise
+
+    const thirdMetricsPromise = connection.collectClientMetrics()
+
+    expect(thirdMetricsPromise).not.toBe(firstMetricsPromise)
+    expect(collector).toHaveBeenCalledTimes(2)
+  })
+
+  it('publishes FPS only when the rounded value changes', async () => {
+    vi.useFakeTimers()
+    const connection = createConnection()
+    const framesPerSecond: Array<number | undefined> = []
+    const collector = vi
+      .fn<() => Promise<ClientMetrics>>()
+      .mockResolvedValueOnce({
+        rtc_frames_per_second: 59.4,
+      } satisfies ClientMetrics)
+      .mockResolvedValueOnce({
+        rtc_frames_per_second: 59.49,
+      } satisfies ClientMetrics)
+      .mockResolvedValueOnce({
+        rtc_frames_per_second: 60.4,
+      } satisfies ClientMetrics)
+
+    connection.addEventListener(
+      EngineConnectionEvents.FramesPerSecondChanged,
+      (({ detail }: CustomEvent<number | undefined>) => {
+        framesPerSecond.push(detail)
+      }) as EventListener
+    )
+    connection.setWebrtcStatsCollector(collector)
+    await flushPromises()
+
+    expect(framesPerSecond).toEqual([59])
+
+    await vi.advanceTimersByTimeAsync(FPS_TRACKER_INTERVAL_MS)
+    await flushPromises()
+
+    expect(framesPerSecond).toEqual([59])
+
+    await vi.advanceTimersByTimeAsync(FPS_TRACKER_INTERVAL_MS)
+    await flushPromises()
+
+    expect(framesPerSecond).toEqual([59, 60])
+
+    connection.stopFpsTracker()
+  })
+})

--- a/src/lib/engineConnection/connection.ts
+++ b/src/lib/engineConnection/connection.ts
@@ -4,10 +4,11 @@ import type {
   WebSocketResponse,
 } from '@kittycad/lib/dist/types/src'
 import { EngineDebugger } from '@src/lib/debugger'
-import { markOnce } from '@src/lib/performance'
-import { notifySessionExpired } from '@src/lib/sessionExpired'
-import { promiseFactory, uuidv4 } from '@src/lib/utils'
-import { withKittycadWebSocketURL } from '@src/lib/withBaseURL'
+import {
+  FPS_TRACKER_INTERVAL_MS,
+  type FpsTrackerSample,
+  getFramesPerSecondFromClientMetrics,
+} from '@src/lib/engineConnection/fpsTracker'
 import {
   createOnConnectionStateChange,
   createOnDataChannel,
@@ -37,6 +38,11 @@ import {
   createOnWebSocketMessage,
   createOnWebSocketOpen,
 } from '@src/lib/engineConnection/websocketConnection'
+import { markOnce } from '@src/lib/performance'
+import { notifySessionExpired } from '@src/lib/sessionExpired'
+import { reportRejection } from '@src/lib/trap'
+import { promiseFactory, uuidv4 } from '@src/lib/utils'
+import { withKittycadWebSocketURL } from '@src/lib/withBaseURL'
 
 // An interface for a promise that needs to be awaited and pass the resolve reject to
 // other dependencies. We do not need to pass values between these. It is mainly
@@ -58,6 +64,10 @@ export class Connection extends EventTarget {
     pong: number | undefined
   }
   private _pingIntervalId: ReturnType<typeof setInterval> | undefined
+  private _fpsIntervalId: ReturnType<typeof setInterval> | undefined
+  private _fpsTrackerSample: FpsTrackerSample | undefined
+  private _clientMetricsCollectionPromise: Promise<ClientMetrics> | undefined
+  private _lastPublishedFramesPerSecond: number | undefined
   timeoutToForceConnectId: ReturnType<typeof setTimeout> | undefined
 
   peerConnection: RTCPeerConnection | undefined
@@ -186,9 +196,11 @@ export class Connection extends EventTarget {
         }
       }
 
-      if (!('resp' in message)) return
+      if (!('resp' in message)) {
+        return
+      }
 
-      let resp = message.resp
+      const resp = message.resp
 
       // If there's no body to the response, we can bail here.
       if (!resp || !resp.type) {
@@ -259,6 +271,94 @@ export class Connection extends EventTarget {
     })
     clearInterval(this._pingIntervalId)
     this._pingIntervalId = undefined
+  }
+
+  startFpsTracker() {
+    if (this._fpsIntervalId !== undefined) {
+      return
+    }
+
+    const collectFramesPerSecond = () => {
+      const clientMetricsPromise = this.collectClientMetrics()
+      if (!clientMetricsPromise) {
+        return
+      }
+
+      void clientMetricsPromise
+        .then((clientMetrics) => {
+          if (this._fpsIntervalId === undefined) {
+            return
+          }
+
+          this.updateFramesPerSecondFromClientMetrics(clientMetrics)
+        })
+        .catch(reportRejection)
+    }
+
+    this._fpsIntervalId = setInterval(
+      collectFramesPerSecond,
+      FPS_TRACKER_INTERVAL_MS
+    )
+    collectFramesPerSecond()
+  }
+
+  stopFpsTracker() {
+    clearInterval(this._fpsIntervalId)
+    this._fpsIntervalId = undefined
+    this._fpsTrackerSample = undefined
+    this._clientMetricsCollectionPromise = undefined
+    this._lastPublishedFramesPerSecond = undefined
+  }
+
+  collectClientMetrics() {
+    const collector = this.webrtcStatsCollector
+    if (!collector) {
+      return undefined
+    }
+
+    if (this._clientMetricsCollectionPromise) {
+      return this._clientMetricsCollectionPromise
+    }
+
+    const clientMetricsPromise = collector()
+    const trackedClientMetricsPromise = clientMetricsPromise.finally(() => {
+      if (
+        this._clientMetricsCollectionPromise === trackedClientMetricsPromise
+      ) {
+        this._clientMetricsCollectionPromise = undefined
+      }
+    })
+
+    this._clientMetricsCollectionPromise = trackedClientMetricsPromise
+
+    return trackedClientMetricsPromise
+  }
+
+  updateFramesPerSecondFromClientMetrics(clientMetrics: ClientMetrics) {
+    if (this._fpsIntervalId === undefined) {
+      return
+    }
+
+    const { framesPerSecond, sample } = getFramesPerSecondFromClientMetrics({
+      metrics: clientMetrics,
+      previousSample: this._fpsTrackerSample,
+      timestampMs: Date.now(),
+    })
+    this._fpsTrackerSample = sample
+
+    const roundedFramesPerSecond =
+      framesPerSecond === undefined ? undefined : Math.round(framesPerSecond)
+
+    if (roundedFramesPerSecond === this._lastPublishedFramesPerSecond) {
+      return
+    }
+
+    this._lastPublishedFramesPerSecond = roundedFramesPerSecond
+    this.dispatchEvent(
+      new CustomEvent(EngineConnectionEvents.FramesPerSecondChanged, {
+        detail: roundedFramesPerSecond,
+      })
+    )
   }
 
   /**
@@ -619,7 +719,9 @@ export class Connection extends EventTarget {
       setSdpAnswer: this.setSdpAnswer.bind(this),
       initiateConnectionExclusive: this.initiateConnectionExclusive.bind(this),
       addIceCandidate: this.addIceCandidate.bind(this),
-      webrtcStatsCollector: () => this.webrtcStatsCollector?.bind(this),
+      collectClientMetrics: this.collectClientMetrics.bind(this),
+      updateFramesPerSecondFromClientMetrics:
+        this.updateFramesPerSecondFromClientMetrics.bind(this),
       sdpAnswerResolve: this.deferredSdpAnswer.resolve,
       sdpAnswerReject: this.deferredSdpAnswer.reject,
       setApiCallId: (apiCallId) => {
@@ -692,6 +794,7 @@ export class Connection extends EventTarget {
       metadata: { id: this.id },
     })
     this.webrtcStatsCollector = webrtcStatsCollector
+    this.startFpsTracker()
   }
 
   setUnreliableDataChannel(channel: RTCDataChannel) {
@@ -732,6 +835,7 @@ export class Connection extends EventTarget {
     this.disconnectUnreliableDataChannel()
     this.disconnectPeerConnection()
     // Function generated from createPeerConnection workflow
+    this.stopFpsTracker()
     this.webrtcStatsCollector = undefined
     this.cleanUpTimeouts()
     this.stopPingPong()

--- a/src/lib/engineConnection/fpsTracker.test.ts
+++ b/src/lib/engineConnection/fpsTracker.test.ts
@@ -1,0 +1,64 @@
+import type { ClientMetrics } from '@kittycad/lib/dist/types/src'
+import {
+  FPS_TRACKER_INTERVAL_MS,
+  getFramesPerSecondFromClientMetrics,
+} from '@src/lib/engineConnection/fpsTracker'
+import { describe, expect, it } from 'vitest'
+
+describe('getFramesPerSecondFromClientMetrics', () => {
+  it('uses a low-frequency tracker interval', () => {
+    expect(FPS_TRACKER_INTERVAL_MS).toBe(5_000)
+  })
+
+  it('uses the browser-reported frames per second when available', () => {
+    const result = getFramesPerSecondFromClientMetrics({
+      metrics: {
+        rtc_frames_decoded: 120,
+        rtc_frames_per_second: 59.8,
+      } satisfies ClientMetrics,
+      previousSample: undefined,
+      timestampMs: 1_000,
+    })
+
+    expect(result.framesPerSecond).toBe(59.8)
+    expect(result.sample).toEqual({
+      timestampMs: 1_000,
+      framesDecoded: 120,
+    })
+  })
+
+  it('falls back to decoded frame deltas', () => {
+    const first = getFramesPerSecondFromClientMetrics({
+      metrics: {
+        rtc_frames_decoded: 120,
+      } satisfies ClientMetrics,
+      previousSample: undefined,
+      timestampMs: 1_000,
+    })
+    const second = getFramesPerSecondFromClientMetrics({
+      metrics: {
+        rtc_frames_decoded: 168,
+      } satisfies ClientMetrics,
+      previousSample: first.sample,
+      timestampMs: 3_000,
+    })
+
+    expect(first.framesPerSecond).toBeUndefined()
+    expect(second.framesPerSecond).toBe(24)
+  })
+
+  it('ignores unusable frame deltas', () => {
+    const result = getFramesPerSecondFromClientMetrics({
+      metrics: {
+        rtc_frames_decoded: 110,
+      } satisfies ClientMetrics,
+      previousSample: {
+        timestampMs: 1_000,
+        framesDecoded: 120,
+      },
+      timestampMs: 2_000,
+    })
+
+    expect(result.framesPerSecond).toBeUndefined()
+  })
+})

--- a/src/lib/engineConnection/fpsTracker.ts
+++ b/src/lib/engineConnection/fpsTracker.ts
@@ -1,0 +1,63 @@
+import type { ClientMetrics } from '@kittycad/lib/dist/types/src'
+
+export const FPS_TRACKER_INTERVAL_MS = 5_000
+
+export interface FpsTrackerSample {
+  timestampMs: number
+  framesDecoded: number | undefined
+}
+
+export function getFramesPerSecondFromClientMetrics({
+  metrics,
+  previousSample,
+  timestampMs,
+}: {
+  metrics: ClientMetrics
+  previousSample: FpsTrackerSample | undefined
+  timestampMs: number
+}) {
+  const reportedFramesPerSecond = metrics.rtc_frames_per_second
+  const framesDecoded = metrics.rtc_frames_decoded
+  const sample = {
+    timestampMs,
+    framesDecoded:
+      typeof framesDecoded === 'number' && Number.isFinite(framesDecoded)
+        ? framesDecoded
+        : undefined,
+  }
+
+  if (
+    typeof reportedFramesPerSecond === 'number' &&
+    Number.isFinite(reportedFramesPerSecond)
+  ) {
+    return {
+      framesPerSecond: Math.max(0, reportedFramesPerSecond),
+      sample,
+    }
+  }
+
+  if (
+    sample.framesDecoded === undefined ||
+    previousSample?.framesDecoded === undefined
+  ) {
+    return {
+      framesPerSecond: undefined,
+      sample,
+    }
+  }
+
+  const elapsedSeconds = (timestampMs - previousSample.timestampMs) / 1_000
+  const framesDecodedDelta = sample.framesDecoded - previousSample.framesDecoded
+
+  if (elapsedSeconds <= 0 || framesDecodedDelta < 0) {
+    return {
+      framesPerSecond: undefined,
+      sample,
+    }
+  }
+
+  return {
+    framesPerSecond: framesDecodedDelta / elapsedSeconds,
+    sample,
+  }
+}

--- a/src/lib/engineConnection/peerConnection.ts
+++ b/src/lib/engineConnection/peerConnection.ts
@@ -1,10 +1,8 @@
-import {
-  type ClientMetrics,
-  type WebSocketRequest,
+import type {
+  ClientMetrics,
+  WebSocketRequest,
 } from '@kittycad/lib/dist/types/src'
 import { EngineDebugger } from '@src/lib/debugger'
-import { markOnce } from '@src/lib/performance'
-import { reportRejection } from '@src/lib/trap'
 import type { Connection } from '@src/lib/engineConnection/connection'
 import type {
   IEventListenerTracked,
@@ -15,6 +13,8 @@ import {
   EngineConnectionEvents,
   EngineConnectionStateType,
 } from '@src/lib/engineConnection/utils'
+import { markOnce } from '@src/lib/performance'
+import { reportRejection } from '@src/lib/trap'
 
 export function createOnIceCandidate({
   initiateConnectionExclusive,
@@ -263,9 +263,9 @@ export function createWebrtcStatsCollector({
         .then((stats) => {
           const metrics: ClientMetrics = {}
 
-          stats.forEach((report, id) => {
+          stats.forEach((report) => {
             if (report.type === 'candidate-pair') {
-              if (report.state == 'succeeded') {
+              if (report.state === 'succeeded') {
                 const rtt = report.currentRoundTripTime
                 metrics.rtc_stun_rtt_sec = rtt
               }
@@ -300,7 +300,10 @@ export function createWebrtcStatsCollector({
 
           resolve(metrics)
         })
-        .catch(reportRejection)
+        .catch((error) => {
+          reportRejection(error)
+          reject(error)
+        })
     })
   }
 

--- a/src/lib/engineConnection/utils.ts
+++ b/src/lib/engineConnection/utils.ts
@@ -199,6 +199,9 @@ export enum EngineConnectionEvents {
   // Fires for each ping-pong success or failure.
   PingPongChanged = 'ping-pong-changed', // (state: PingPongState) => void
 
+  // Fires when the engine media stream has a new measured frames-per-second value.
+  FramesPerSecondChanged = 'frames-per-second-changed', // (state: number | undefined) => void
+
   // For now, this is only used by the NetworkHealthIndicator.
   // We can eventually use it for more, but one step at a time.
   ConnectionStateChanged = 'connection-state-changed', // (state: EngineConnectionState) => void

--- a/src/lib/engineConnection/websocketConnection.ts
+++ b/src/lib/engineConnection/websocketConnection.ts
@@ -5,9 +5,6 @@ import type {
   WebSocketResponse,
 } from '@kittycad/lib/dist/types/src'
 import { EngineDebugger } from '@src/lib/debugger'
-import { mark } from '@src/lib/performance'
-import { notifySessionExpired } from '@src/lib/sessionExpired'
-import { reportRejection } from '@src/lib/trap'
 import {
   ConnectingType,
   EngineConnectionEvents,
@@ -15,6 +12,9 @@ import {
   type ManagerTearDown,
   toRTCSessionDescriptionInit,
 } from '@src/lib/engineConnection/utils'
+import { mark } from '@src/lib/performance'
+import { notifySessionExpired } from '@src/lib/sessionExpired'
+import { reportRejection } from '@src/lib/trap'
 
 /**
  * 4 different event listeners to clean up
@@ -94,7 +94,8 @@ export const createOnWebSocketMessage = ({
   setSdpAnswer,
   initiateConnectionExclusive,
   addIceCandidate,
-  webrtcStatsCollector,
+  collectClientMetrics,
+  updateFramesPerSecondFromClientMetrics,
   sdpAnswerResolve,
   sdpAnswerReject,
   setApiCallId,
@@ -109,7 +110,8 @@ export const createOnWebSocketMessage = ({
   setSdpAnswer: (answer: RTCSessionDescriptionInit) => void
   initiateConnectionExclusive: () => Promise<unknown>
   addIceCandidate: (candidate: RTCIceCandidateInit) => void
-  webrtcStatsCollector: () => (() => Promise<ClientMetrics>) | undefined
+  collectClientMetrics: () => Promise<ClientMetrics> | undefined
+  updateFramesPerSecondFromClientMetrics: (clientMetrics: ClientMetrics) => void
   sdpAnswerResolve: (value: any) => void
   sdpAnswerReject: (value: any) => void
   setApiCallId: (apiCallId: string) => void
@@ -172,7 +174,7 @@ export const createOnWebSocketMessage = ({
 
     // Message is successful, lets process the websocket message
     switch (resp.type) {
-      case 'pong':
+      case 'pong': {
         const pong = Date.now()
         setPong(pong)
         dispatchEvent(
@@ -182,7 +184,8 @@ export const createOnWebSocketMessage = ({
         )
         setPing(undefined)
         break
-      case 'modeling_session_data':
+      }
+      case 'modeling_session_data': {
         const apiCallId = resp.data.session.api_call_id
         setApiCallId(apiCallId)
         mark('code/apiCallId', {
@@ -201,8 +204,9 @@ export const createOnWebSocketMessage = ({
         })
 
         break
+      }
       // Only fires on successful authentication.
-      case 'ice_server_info':
+      case 'ice_server_info': {
         const iceServers = resp.data.ice_servers
         // Now that we have some ICE servers it makes sense
         // to start initializing the RTCPeerConnection. RTCPeerConnection
@@ -329,7 +333,8 @@ export const createOnWebSocketMessage = ({
             disconnectAll()
           })
         break
-      case 'sdp_answer':
+      }
+      case 'sdp_answer': {
         const answer = resp.data.answer
         if (!answer || answer.type === 'unspecified') {
           return
@@ -360,18 +365,20 @@ export const createOnWebSocketMessage = ({
         // Make sure we attempt to connect when we do.
         initiateConnectionExclusive().catch(reportRejection)
         break
-      case 'trickle_ice':
+      }
+      case 'trickle_ice': {
         const candidate = resp.data.candidate
         addIceCandidate(candidate)
         break
-      case 'metrics_request':
+      }
+      case 'metrics_request': {
         /**
-         * Gotcha, metrics_request can be called before the webrtcStatsCollector
+         * Gotcha, metrics_request can be called before the WebRTC stats collector
          * is initialized from the ice_server_info workflow. This means we need to drop these requests
          * until the function is initialized
          */
-        const collector = webrtcStatsCollector()
-        if (!collector) {
+        const clientMetricsPromise = collectClientMetrics()
+        if (!clientMetricsPromise) {
           EngineDebugger.addLog({
             label: 'onWebSocketMessage',
             message:
@@ -384,8 +391,9 @@ export const createOnWebSocketMessage = ({
         // which is an event within this switch case so it is not easy
         // to have this be a sync workflow? You could have two onMessageHandlers
         // once the other one is created but that could be more confusing.
-        collector()
+        clientMetricsPromise
           .then((clientMetrics) => {
+            updateFramesPerSecondFromClientMetrics(clientMetrics)
             send({
               type: 'metrics_response',
               metrics: clientMetrics,
@@ -396,6 +404,7 @@ export const createOnWebSocketMessage = ({
           })
 
         break
+      }
     }
   }
 


### PR DESCRIPTION
Closes #444. This adds client-side FPS as an input to the existing network health indicator so stream quality is reflected alongside connection setup and ping.

1. Adds an engine-connection FPS tracker that samples the existing WebRTC stats collector every 5 seconds, preferring `rtc_frames_per_second` and falling back to decoded-frame deltas.
2. Shares in-flight WebRTC metrics collection between FPS polling and server `metrics_request` handling, so concurrent paths do not double-call `getStats()`.
3. Publishes only rounded FPS changes through the network status context and treats an otherwise healthy stream below 24 FPS as weak.
4. Shows FPS in the network health status label/popover and covers the FPS calculation, collection sharing, publish suppression, and hook behavior with focused unit tests.

## How to test

Open a modeling session and check the network health popover after the stream starts; it should show an FPS row once WebRTC stats arrive. To smoke test the weak-state behavior, force or simulate a low-FPS stream and confirm the indicator moves to the weak state only after connection steps are otherwise healthy.