### PR TITLE
Document region consumption and reuse

### DIFF
--- a/docs/kcl-std/functions/std-sketch-region.md
+++ b/docs/kcl-std/functions/std-sketch-region.md
@@ -35,6 +35,14 @@ To make a fallback point move with a parametric sketch, consider creating a
 construction point in the sketch and constraining it into place. You can then
 refer to that point to create the region.
 
+Operations such as `extrude`, `revolve`, and `sweep` consume the region
+passed to them. Each region can be used by only one consuming operation. To
+reuse the same profile, call `region(...)` again with the original sketch
+segments instead of cloning the sketch. For example, create
+`firstRegion = region(segments = [profile.circle])` and
+`secondRegion = region(segments = [profile.circle])`, then pass each region
+to a different consuming operation.
+
 ### Arguments
 
 | Name | Type | Description | Required |

--- a/rust/kcl-lib/std/sketch.kcl
+++ b/rust/kcl-lib/std/sketch.kcl
@@ -3352,6 +3352,14 @@ export fn faceOf(
 /// construction point in the sketch and constraining it into place. You can then
 /// refer to that point to create the region.
 ///
+/// Operations such as `extrude`, `revolve`, and `sweep` consume the region
+/// passed to them. Each region can be used by only one consuming operation. To
+/// reuse the same profile, call `region(...)` again with the original sketch
+/// segments instead of cloning the sketch. For example, create
+/// `firstRegion = region(segments = [profile.circle])` and
+/// `secondRegion = region(segments = [profile.circle])`, then pass each region
+/// to a different consuming operation.
+///
 /// ```kcl,sketchSolve
 /// @settings(kclVersion = 2.0)
 ///


### PR DESCRIPTION
## Summary

- document that `extrude`, `revolve`, and `sweep` consume their input region
- explain that each consuming operation needs its own `region(...)` result
- show how to reuse the original sketch segments and clarify that the sketch should not be cloned
- regenerate the public `region()` reference page from the KCL stdlib source

## Why

The runtime diagnostic added in #12779 explains the recovery after a consumed-region error, but the `region()` reference did not explain the ownership rule proactively. This brings the reference documentation in line with that diagnostic and the behavior tracked in #12685.

## Testing

- `EXPECTORATE=overwrite cargo nextest run --retries 3 --no-fail-fast -p kcl-lib --features artifact-graph docs::gen_std_tests::test_generate_stdlib`
- `cargo nextest run --retries 3 --no-fail-fast -p kcl-lib --features artifact-graph docs::kcl_doc::test::missing_test_examples`
- `git diff --cached --check`
