### PR TITLE
KCL: Migrate rack blanking panel off legacy subtract

### DIFF
--- a/public/kcl-samples/rack-blanking-panel/main.kcl
+++ b/public/kcl-samples/rack-blanking-panel/main.kcl
@@ -113,4 +113,4 @@ extrudeHoles = extrude([region001, region002], length = 5, symmetric = true)
   |> patternCircular3d(instances = 2, axis = Z, center = [0, 0, 0])
 
 // Cut the holes from the blanking plate
-holesCut = subtract(baseExtrusion, tools = extrudeHoles, legacyMethod = true)
+holesCut = subtract(baseExtrusion, tools = extrudeHoles)

--- a/rust/kcl-lib/src/simulation_tests/kcl_samples.rs
+++ b/rust/kcl-lib/src/simulation_tests/kcl_samples.rs
@@ -152,14 +152,6 @@ fn test(test_name: &str, entry_point: std::path::PathBuf) -> Test {
     if !relative_output_dir.exists() {
         std::fs::create_dir_all(&relative_output_dir).unwrap();
     }
-    // The current boolean implementation cannot subtract the lower-left rack
-    // mounting hole. Keep the legacy method until the engine supports it, but
-    // require exactly one warning so additional deprecations still fail and
-    // removing the workaround makes this exception fail too.
-    let expected_deprecation_warnings = match test_name {
-        "rack-blanking-panel" => 1,
-        _ => 0,
-    };
     Test {
         name: test_name.to_owned(),
         entry_point,
@@ -167,7 +159,7 @@ fn test(test_name: &str, entry_point: std::path::PathBuf) -> Test {
         output_dir: relative_output_dir,
         // Skip is temporary while we have non-deterministic output.
         skip_assert_artifact_graph: true,
-        expected_deprecation_warnings: Some(expected_deprecation_warnings),
+        expected_deprecation_warnings: Some(0),
     }
 }
 

--- a/rust/kcl-lib/tests/kcl_samples/rack-blanking-panel/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/rack-blanking-panel/artifact_commands.snap
@@ -765,7 +765,6 @@ description: Artifact commands rack-blanking-panel.kcl
           "[uuid]"
         ],
         "separate_bodies": false,
-        "use_legacy": true,
         "tolerance": 0.0000001
       }
     }

--- a/rust/kcl-lib/tests/kcl_samples/rack-blanking-panel/ast.snap
+++ b/rust/kcl-lib/tests/kcl_samples/rack-blanking-panel/ast.snap
@@ -11878,27 +11878,6 @@ description: Result of parsing rack-blanking-panel.kcl
                   "type": "Name",
                   "type": "Name"
                 }
-              },
-              {
-                "type": "LabeledArg",
-                "label": {
-                  "commentStart": 0,
-                  "end": 0,
-                  "moduleId": 0,
-                  "name": "legacyMethod",
-                  "start": 0,
-                  "type": "Identifier"
-                },
-                "arg": {
-                  "commentStart": 0,
-                  "end": 0,
-                  "moduleId": 0,
-                  "raw": "true",
-                  "start": 0,
-                  "type": "Literal",
-                  "type": "Literal",
-                  "value": true
-                }
               }
             ],
             "callee": {

--- a/rust/kcl-lib/tests/kcl_samples/rack-blanking-panel/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/rack-blanking-panel/ops.snap
@@ -5385,13 +5385,6 @@ description: Operations executed rack-blanking-panel.kcl
         "sourceRange": []
       },
       "labeledArgs": {
-        "legacyMethod": {
-          "value": {
-            "type": "Bool",
-            "value": true
-          },
-          "sourceRange": []
-        },
         "tools": {
           "value": {
             "type": "Array",


### PR DESCRIPTION
## Summary

- remove `legacyMethod = true` from the Rack Blanking Panel sample now that the modern boolean succeeds
- remove the Rack-specific expected deprecation warning
- refresh the affected parser, operation, and artifact-command snapshots

This unblocks the sample's final deprecated CSG usage after KittyCAD/engine#4932. The rendered model remains unchanged, including all four mounting holes.

## Verification

- current KCL 178 standalone execution against `api.dev.zoo.dev`: passed
- `simulation_tests::kcl_samples::kcl_test_execute_rack_blanking_panel` against dev: passed twice
- `simulation_tests::kcl_samples::parse_rack_blanking_panel`: passed
- `simulation_tests::kcl_samples::unparse_rack_blanking_panel`: passed
- `cargo fmt --all -- --check`: passed
- `git diff --check`: passed

Related: KittyCAD/engine#4818
