### PR TITLE
KCL: Mock subtract should return multiple bodies

### DIFF
--- a/rust/kcl-lib/e2e/executor/inputs/repro_mock_subtract.kcl
+++ b/rust/kcl-lib/e2e/executor/inputs/repro_mock_subtract.kcl
@@ -1,14 +1,33 @@
-left = startSketchOn(XY)
-  |> circle(center = [-4, 0], radius = 3)
-  |> extrude(length = 5)
+@settings(kclVersion = 2.0)
 
-right = startSketchOn(XY)
-  |> circle(center = [4, 0], radius = 3)
-  |> extrude(length = 5)
+sketch001 = sketch(on = XY) {
+  circle1 = circle(start = [var -3.35mm, var -0.7mm], center = [var -5.74mm, var 1.39mm])
+}
 
-tool = startSketchOn(XY)
-  |> circle(center = [0, 0], radius = 2)
-  |> extrude(length = 5)
+sketch002 = sketch(on = XY) {
+  circle1 = circle(start = [var 3.47mm, var -1.07mm], center = [var 4.76mm, var 1.86mm])
+}
+sketch003 = sketch(on = XY) {
+  line1 = line(start = [var -4.05mm, var 2.82mm], end = [var 3.62mm, var 2.82mm])
+  line2 = line(start = [var 3.62mm, var 2.82mm], end = [var 3.62mm, var 0.54mm])
+  line3 = line(start = [var 3.62mm, var 0.54mm], end = [var -4.05mm, var 0.54mm])
+  line4 = line(start = [var -4.05mm, var 0.54mm], end = [var -4.05mm, var 2.82mm])
+  coincident([line1.end, line2.start])
+  coincident([line2.end, line3.start])
+  coincident([line3.end, line4.start])
+  coincident([line4.end, line1.start])
+  parallel([line2, line4])
+  parallel([line3, line1])
+  perpendicular([line1, line2])
+  horizontal(line3)
+}
 
-subtracted_parts = subtract([left, right], tools = tool)
-secondResult = subtracted_parts[1]
+region001 = region(segments = [sketch001.circle1])
+left = extrude(region001, length = 0.5)
+region002 = region(segments = [sketch002.circle1])
+right = extrude(region002, length = 0.5)
+region003 = region(segments = [sketch003.line1, sketch003.line2], direction = CW)
+tool = extrude(region003, length = 2, symmetric = true)
+
+subtractedParts = subtract([left, right], tools = [tool])
+output = subtractedParts[1]

--- a/rust/kcl-lib/e2e/executor/inputs/repro_mock_subtract.kcl
+++ b/rust/kcl-lib/e2e/executor/inputs/repro_mock_subtract.kcl
@@ -1,0 +1,14 @@
+left = startSketchOn(XY)
+  |> circle(center = [-4, 0], radius = 3)
+  |> extrude(length = 5)
+
+right = startSketchOn(XY)
+  |> circle(center = [4, 0], radius = 3)
+  |> extrude(length = 5)
+
+tool = startSketchOn(XY)
+  |> circle(center = [0, 0], radius = 2)
+  |> extrude(length = 5)
+
+subtracted_parts = subtract([left, right], tools = tool)
+secondResult = subtracted_parts[1]

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -4320,7 +4320,7 @@ w = f() + f()
         // Get the variable we're interested in, from KCL program memory.
         let subtracted_parts = result
             .variables
-            .get("subtracted_parts")
+            .get("subtractedParts")
             .expect("no variable called 'subtracted_parts' found");
         let subtracted_parts = match subtracted_parts {
             KclValueView::Solid { .. } => {

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -4299,6 +4299,44 @@ w = f() + f()
         assert_eq!(actual_instances, expected_instances);
     }
 
+    /// Regression test for https://github.com/KittyCAD/modeling-app/issues/13103
+    /// i.e.
+    /// If you do a pattern circular 3d in mock execution mode,
+    /// and you ask for 10 instances, you should get 10 instances.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn mock_execution_subtract() {
+        // Run this KCL file, in mock execution.
+        let code = kcl_input!("repro_mock_subtract");
+        let ctx = ExecutorContext::new_mock(None).await;
+        let program = crate::Program::parse_no_errs(code).unwrap();
+        let result = match ctx.run_mock(&program, &MockConfig::default()).await {
+            Ok(x) => x,
+            Err(e) => {
+                let error = e.error;
+                panic!("{error}");
+            }
+        };
+
+        // Get the variable we're interested in, from KCL program memory.
+        let subtracted_parts = result
+            .variables
+            .get("subtracted_parts")
+            .expect("no variable called 'subtracted_parts' found");
+        let subtracted_parts = match subtracted_parts {
+            KclValueView::Solid { .. } => {
+                panic!("One solid?");
+            }
+            KclValueView::HomArray { value } => value,
+            other => panic!("{other:#?}"),
+        };
+
+        // Validate the variable.
+        // from the KCL, there's 2 parts being subtracted from.
+        let expected_number_of_parts = 2;
+        let actual_number_of_parts = subtracted_parts.len();
+        assert_eq!(actual_number_of_parts, expected_number_of_parts);
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn mock_then_add_extrude_then_mock_again() {
         let code = "s = sketch(on = XY) {

--- a/rust/kcl-lib/src/std/csg.rs
+++ b/rust/kcl-lib/src/std/csg.rs
@@ -289,10 +289,24 @@ pub(crate) async fn inner_subtract(
     let tool_ids = tools.iter().map(|s| s.id).collect::<Vec<_>>();
 
     if args.ctx.no_engine_commands().await {
-        let mut solid = solids[0].clone();
-        solid.set_id(solid_out_id);
-        solid.become_new_body(solid_out_id, solid_out_id.into());
-        let new_solids = vec![solid];
+        // Output N new bodies, where N is the number of input target bodies.
+        let new_solids = solids
+            .iter()
+            .enumerate()
+            .map(|(index, solid)| {
+                // The first ID is set by the user, subsequent IDs are not.
+                // This matches the usual production normal execution path.
+                let output_id = if index == 0 {
+                    solid_out_id
+                } else {
+                    exec_state.next_uuid()
+                };
+                let mut new_solid = solid.clone();
+                new_solid.set_id(output_id);
+                new_solid.become_new_body(output_id, output_id.into());
+                new_solid
+            })
+            .collect::<Vec<_>>();
         record_consumed_solids(exec_state, &solids, ConsumedSolidOperation::Subtract, &new_solids);
         record_consumed_solids(exec_state, &tools, ConsumedSolidOperation::Subtract, &[]);
         return Ok(new_solids);


### PR DESCRIPTION
Mock executing subtract should return N output bodies, where N is the number of input target bodies.

Closes https://github.com/KittyCAD/modeling-app/issues/13167