### PR TITLE
Fix desktop nested file route roots

### DIFF
--- a/src/lib/paths.test.ts
+++ b/src/lib/paths.test.ts
@@ -8,6 +8,7 @@ import {
   parentPathRelativeToApplicationDirectory,
   parentPathRelativeToProject,
   parseProjectRoute,
+  parseProjectRouteFromProject,
   toProjectRelativePath,
   toWebSafePath,
 } from '@src/lib/paths'
@@ -126,6 +127,45 @@ describe('testing parseProjectRoute', () => {
     })
   })
 
+  it('should parse a project file using the configured library that contains the route', async () => {
+    const defaultProjectDirectory = absolutePath(
+      'home',
+      'somebody',
+      'default-projects'
+    )
+    const clientProjectDirectory = absolutePath(
+      'home',
+      'somebody',
+      'client-projects'
+    )
+    const config = {
+      settings: {
+        app: {
+          libraries: [
+            {
+              title: 'Default Projects',
+              path: defaultProjectDirectory,
+              type: 'directory',
+            },
+            {
+              title: 'Client Projects',
+              path: clientProjectDirectory,
+              type: 'directory',
+            },
+          ],
+        },
+      },
+    }
+    const projectPath = fsZds.join(clientProjectDirectory, 'assembly')
+    const route = fsZds.join(projectPath, 'parts', 'main.kcl')
+    expect(parseProjectRoute(config, route)).toEqual({
+      projectName: 'assembly',
+      projectPath,
+      currentFileName: 'main.kcl',
+      currentFilePath: route,
+    })
+  })
+
   it('should respect an explicit empty libraries setting', async () => {
     const legacyProjectDirectory = absolutePath(
       'home',
@@ -197,6 +237,44 @@ describe('testing parseProjectRoute', () => {
       currentFileName: 'main.kcl',
       currentFilePath: route,
     })
+  })
+
+  it('should preserve the already-open project root for nested file routes', async () => {
+    const projectPath = absolutePath(
+      'home',
+      'somebody',
+      'CloudStorage',
+      'Zoo',
+      'personal',
+      'assembly'
+    )
+    const route = fsZds.join(projectPath, 'parts', 'main.kcl')
+    expect(
+      parseProjectRouteFromProject(
+        {
+          name: 'assembly',
+          path: projectPath,
+        },
+        route
+      )
+    ).toEqual({
+      projectName: 'assembly',
+      projectPath,
+      currentFileName: 'main.kcl',
+      currentFilePath: route,
+    })
+  })
+
+  it('should ignore already-open projects that do not contain the route', async () => {
+    expect(
+      parseProjectRouteFromProject(
+        {
+          name: 'assembly',
+          path: absolutePath('home', 'somebody', 'projects', 'assembly'),
+        },
+        absolutePath('home', 'somebody', 'other-projects', 'assembly.kcl')
+      )
+    ).toBeUndefined()
   })
 })
 

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -3,6 +3,7 @@ import { APP_NAME, ARCHIVE_DIR, IS_PLAYWRIGHT_KEY } from '@src/lib/constants'
 import fsZds from '@src/lib/fs-zds'
 import { webSafeJoin } from '@src/lib/pathUtils'
 import {
+  getContainingDirectoryProjectLibraryPath,
   getDefaultDirectoryProjectLibraryPath,
   isProjectLibrarySettings,
 } from '@src/lib/projectLibraries'
@@ -25,11 +26,14 @@ export type ProjectRoute = {
 }
 
 function getProjectDirectorySetting(
-  configuration: DeepPartial<Configuration>
+  configuration: DeepPartial<Configuration>,
+  targetPath?: string
 ): string | undefined {
   const libraries = configuration.settings?.app?.libraries
   if (isProjectLibrarySettings(libraries)) {
-    return getDefaultDirectoryProjectLibraryPath(libraries)
+    return targetPath
+      ? getContainingDirectoryProjectLibraryPath(libraries, targetPath)
+      : getDefaultDirectoryProjectLibraryPath(libraries)
   }
 
   const projectSettings = configuration.settings?.project
@@ -141,7 +145,7 @@ export function parseProjectRoute(
   let projectPath = ''
   let currentFileName = null
   let currentFilePath = null
-  const projectDirectory = getProjectDirectorySetting(configuration)
+  const projectDirectory = getProjectDirectorySetting(configuration, id)
   const relativeToRoot = projectDirectory
     ? getRelativePathIfContained(projectDirectory, id)
     : undefined
@@ -169,6 +173,29 @@ export function parseProjectRoute(
     projectPath: projectPath,
     currentFileName: currentFileName,
     currentFilePath: currentFilePath,
+  }
+}
+
+/** Parse a file route by preserving an already-open project as the root. */
+export function parseProjectRouteFromProject(
+  project: Pick<Project, 'name' | 'path'> | undefined,
+  id: string
+): ProjectRoute | undefined {
+  if (!project?.path) {
+    return undefined
+  }
+
+  const relativeToProject = getRelativePathIfContained(project.path, id)
+  if (relativeToProject === undefined) {
+    return undefined
+  }
+
+  const isProjectRoot = relativeToProject === ''
+  return {
+    projectName: project.name || fsZds.basename(project.path) || null,
+    projectPath: project.path,
+    currentFileName: isProjectRoot ? null : fsZds.basename(id),
+    currentFilePath: isProjectRoot ? null : id,
   }
 }
 

--- a/src/lib/routeLoaders.ts
+++ b/src/lib/routeLoaders.ts
@@ -12,14 +12,13 @@ import {
   getRouterSearchFromRequestUrl,
   PATHS,
   parseProjectRoute,
+  parseProjectRouteFromProject,
   safeEncodeForRouterPaths,
 } from '@src/lib/paths'
 import {
   DEFAULT_PROJECT_LIBRARY_TITLE,
   DIRECTORY_PROJECT_LIBRARY_TYPE,
-  getDefaultDirectoryProjectLibraryPath,
   getDefaultDirectoryProjectLibrarySetting,
-  isPathInDirectoryProjectLibrary,
   type ProjectLibrarySetting,
 } from '@src/lib/projectLibraries'
 import {
@@ -201,8 +200,10 @@ export const fileLoader =
     // settings from a selected file's parent folder creates project.toml in
     // nested folders and makes them look like project roots.
     const appSettings = await loadRouteSettings(app, wasmInstance)
+    const currentProject = settingsActor.getSnapshot().context.currentProject
     const projectPathData = params.id
-      ? parseProjectRoute(appSettings.configuration, params.id)
+      ? (parseProjectRouteFromProject(currentProject, params.id) ??
+        parseProjectRoute(appSettings.configuration, params.id))
       : undefined
 
     if (!projectPathData) {
@@ -211,11 +212,7 @@ export const fileLoader =
       )
     }
 
-    const settings = await loadRouteSettings(
-      app,
-      wasmInstance,
-      projectPathData.projectPath
-    )
+    await loadRouteSettings(app, wasmInstance, projectPathData.projectPath)
 
     const { projectName, projectPath, currentFileName, currentFilePath } =
       projectPathData
@@ -303,16 +300,9 @@ export const fileLoader =
       requestedFileName.onProjectLoaderComplete?.()
     }
 
-    const appProjectDir =
-      getDefaultDirectoryProjectLibraryPath(
-        settings.settings.app.libraries?.current
-      ) ?? ''
-    const requestedProjectDirectoryPath = isPathInDirectoryProjectLibrary(
-      project.path,
-      appProjectDir
-    )
-      ? appProjectDir
-      : getParentAbsolutePath(project.path) // Fallback to parent directory if foreign to app project dir.
+    const openedProject = projectRef.projectIORefSignal.value
+    const requestedProjectDirectoryPath =
+      openedProject.libraryPath ?? getParentAbsolutePath(openedProject.path)
     app.systemIOActor.send({
       type: SystemIOMachineEvents.setProjectDirectoryPath,
       data: {


### PR DESCRIPTION
Addresses #13206 by preserving the real project root when desktop opens a nested KCL file from routes that are not covered by the default project directory fix.

1. Resolves file routes against the configured directory library that actually contains the target path, instead of always using the first/default directory library.
2. Preserves the already-open project root when navigating to a nested file inside that project, which covers cloud/local desktop projects whose materialized root is outside the default library.
3. Uses the opened project's resolved library ownership when updating System.IO's project directory context after the loader finishes.
4. Adds focused route parsing regressions for non-default directory libraries and active nested project roots.

How to test:
Open staging desktop with a project that has a nested KCL file. From both a Personal Cloud project and a local project outside the default library, single-click the nested file in the file explorer and confirm the project remains rooted at the project folder rather than the subdirectory.