### PR TITLE
Close mock subtract executor context

### DIFF
--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -4534,7 +4534,9 @@ w = f() + f()
         let code = kcl_input!("repro_mock_subtract");
         let ctx = ExecutorContext::new_mock(None).await;
         let program = crate::Program::parse_no_errs(code).unwrap();
-        let result = match ctx.run_mock(&program, &MockConfig::default()).await {
+        let result = ctx.run_mock(&program, &MockConfig::default()).await;
+        ctx.close().await;
+        let result = match result {
             Ok(x) => x,
             Err(e) => {
                 let error = e.error;


### PR DESCRIPTION
## Summary
- ensure the mock subtract regression test closes its ExecutorContext before handling the execution result
- follow up on https://github.com/KittyCAD/modeling-app/pull/13203#discussion_r3831411770

## Test plan
- cargo +nightly fmt --check
- cargo test -p kcl-lib mock_execution_subtract --lib