### PR TITLE
Add elision of the middle of long KCL error backtraces

### DIFF
--- a/src/lang/errors.test.ts
+++ b/src/lang/errors.test.ts
@@ -1,3 +1,4 @@
+import type { BacktraceItem } from '@rust/kcl-lib/bindings/BacktraceItem'
 import type { KCLError } from '@src/lang/errors'
 import { kclErrorsToDiagnostics, toUtf8, toUtf16 } from '@src/lang/errors'
 import { defaultArtifactGraph } from '@src/lang/std/artifactGraph'
@@ -240,6 +241,110 @@ describe('test kclErrToDiagnostic', () => {
         to: 41,
         message:
           '`missingName` is not defined\n\nBacktrace:\ninner()\nouter()\nimport assembly.kcl',
+        severity: 'error',
+      },
+    ])
+  })
+
+  // A recursive function whose backtrace has `namedFrames` frames named `f`,
+  // ending at the unnamed top-level call.
+  const recursiveSourceCode =
+    'fn f(@n) {\n  assert(n, isGreaterThan = 0)\n  return f(n - 1)\n}\n\nf(40)\n'
+  function recursiveError(namedFrames: number): KCLError {
+    const recursiveCallSite: BacktraceItem = {
+      sourceRange: [51, 59, 0],
+      fnName: 'f',
+      kind: 'call',
+    }
+    return {
+      name: '',
+      message: '',
+      kind: 'user_defined',
+      msg: 'assert failed',
+      sourceRange: [13, 41, 0],
+      kclBacktrace: [
+        { sourceRange: [13, 41, 0], fnName: 'f', kind: 'call' },
+        ...Array(namedFrames - 1).fill(recursiveCallSite),
+        { sourceRange: [63, 68, 0], fnName: null, kind: 'call' },
+      ],
+      nonFatal: [],
+      variables: {},
+      operations: emptyOperationsByModule(),
+      artifactGraph: defaultArtifactGraph(),
+      filenames: {},
+      defaultPlanes: null,
+    }
+  }
+  // Every recursive frame repeats the same call site, so it produces one
+  // deduped hint, plus one for the top-level call.
+  const recursiveHints = [
+    {
+      from: 51,
+      to: 59,
+      message: 'Part of the error backtrace',
+      severity: 'hint',
+    },
+    {
+      from: 63,
+      to: 68,
+      message: 'Part of the error backtrace',
+      severity: 'hint',
+    },
+  ]
+
+  it('shows a 30-frame backtrace in full', () => {
+    const diagnostics = kclErrorsToDiagnostics(
+      [recursiveError(30)],
+      recursiveSourceCode
+    )
+    expect(diagnostics).toEqual([
+      ...recursiveHints,
+      {
+        from: 13,
+        to: 41,
+        message: `assert failed\n\nBacktrace:\n${Array(30).fill('f()').join('\n')}`,
+        severity: 'error',
+      },
+    ])
+  })
+
+  it('elides the middle of a backtrace just over the limit', () => {
+    const diagnostics = kclErrorsToDiagnostics(
+      [recursiveError(31)],
+      recursiveSourceCode
+    )
+    const lines = [
+      ...Array(15).fill('f()'),
+      '(1 frame omitted)',
+      ...Array(15).fill('f()'),
+    ]
+    expect(diagnostics).toEqual([
+      ...recursiveHints,
+      {
+        from: 13,
+        to: 41,
+        message: `assert failed\n\nBacktrace:\n${lines.join('\n')}`,
+        severity: 'error',
+      },
+    ])
+  })
+
+  it('elides the middle of a deep backtrace', () => {
+    const diagnostics = kclErrorsToDiagnostics(
+      [recursiveError(40)],
+      recursiveSourceCode
+    )
+    const lines = [
+      ...Array(15).fill('f()'),
+      '(10 frames omitted)',
+      ...Array(15).fill('f()'),
+    ]
+    expect(diagnostics).toEqual([
+      ...recursiveHints,
+      {
+        from: 13,
+        to: 41,
+        message: `assert failed\n\nBacktrace:\n${lines.join('\n')}`,
         severity: 'error',
       },
     ])

--- a/src/lang/errors.ts
+++ b/src/lang/errors.ts
@@ -99,6 +99,10 @@ export function sourceRangeToUtf16(
   return [t(s[0]), t(s[1]), t(s[2])]
 }
 
+// When a backtrace has more than twice this many lines, elide the middle,
+// keeping this many innermost and outermost frames.
+const BACKTRACE_EDGE_LINES = 15
+
 /**
  * Maps the KCL errors to an array of CodeMirror diagnostics.
  * Currently the diagnostics are all errors, but in the future they could include lints.
@@ -116,6 +120,9 @@ export function kclErrorsToDiagnostics(
       if (err.kclBacktrace.length > 0) {
         // Show the backtrace in the error message.
         const backtraceLines: Array<string> = []
+        // Recursive calls repeat the same call site; one hint diagnostic per
+        // source range is enough.
+        const hintRanges = new Set<string>()
         for (let i = 0; i < err.kclBacktrace.length; i++) {
           const item = err.kclBacktrace[i]
           if (
@@ -123,12 +130,16 @@ export function kclErrorsToDiagnostics(
             isTopLevelModule(item.sourceRange) &&
             !sourceRangeContains(item.sourceRange, err.sourceRange)
           ) {
-            diagnostics.push({
-              from: toUtf16(item.sourceRange[0], sourceCode),
-              to: toUtf16(item.sourceRange[1], sourceCode),
-              message: 'Part of the error backtrace',
-              severity: 'hint',
-            })
+            const rangeKey = `${item.sourceRange[0]}:${item.sourceRange[1]}`
+            if (!hintRanges.has(rangeKey)) {
+              hintRanges.add(rangeKey)
+              diagnostics.push({
+                from: toUtf16(item.sourceRange[0], sourceCode),
+                to: toUtf16(item.sourceRange[1], sourceCode),
+                message: 'Part of the error backtrace',
+                severity: 'hint',
+              })
+            }
           }
           if (i === err.kclBacktrace.length - 1 && !item.fnName) {
             // The top-level doesn't have a name.
@@ -150,6 +161,16 @@ export function kclErrorsToDiagnostics(
               break
           }
           backtraceLines.push(name)
+        }
+        // Deep recursion can produce a huge backtrace. The innermost and
+        // outermost frames are the informative ones, so elide the middle.
+        if (backtraceLines.length > 2 * BACKTRACE_EDGE_LINES) {
+          const omitted = backtraceLines.length - 2 * BACKTRACE_EDGE_LINES
+          backtraceLines.splice(
+            BACKTRACE_EDGE_LINES,
+            omitted,
+            `(${omitted} ${omitted === 1 ? 'frame' : 'frames'} omitted)`
+          )
         }
         // A single function frame repeats what the squiggle already points
         // at, so it's not helpful to show. But a lone import frame is the


### PR DESCRIPTION
Resolves #13172

The CEK executor raised the call depth limit from 50 to 1000, so a deep-recursion error can produce a backtrace far too long to display.

- Backtraces over 30 lines now show only the 15 innermost and 15 outermost frames, with `(N frames omitted)` between them.
- Backtrace hint diagnostics are now deduped by source range.

<img width="1397" height="946" alt="Screenshot 2026-08-21 at 4 24 45 PM" src="https://github.com/user-attachments/assets/93a307bf-249f-42a7-8595-6cd2dfb3cee8" />
