### PR TITLE
Codemod: One big parallel call for many lines

### DIFF
--- a/src/machines/sketchSolve/tools/constraintToolHelpers.spec.ts
+++ b/src/machines/sketchSolve/tools/constraintToolHelpers.spec.ts
@@ -455,7 +455,7 @@ describe('constraintToolHelpers', () => {
     })
   })
 
-  it('prepares one payload per additional line for parallel area selection', () => {
+  it('prepares one grouped payload for parallel area selection', () => {
     const pointA = createPointApiObject({ id: 1 })
     const pointB = createPointApiObject({ id: 2 })
     const pointC = createPointApiObject({ id: 3 })
@@ -487,16 +487,12 @@ describe('constraintToolHelpers', () => {
     expect(apply?.payloads).toEqual([
       {
         type: 'Parallel',
-        lines: [10, 11],
-      },
-      {
-        type: 'Parallel',
-        lines: [10, 12],
+        lines: [10, 11, 12],
       },
     ])
     expect(apply?.payload).toEqual({
       type: 'Parallel',
-      lines: [10, 11],
+      lines: [10, 11, 12],
     })
   })
 
@@ -568,11 +564,7 @@ describe('constraintToolHelpers', () => {
       expect(areaSelection.apply.payloads).toEqual([
         {
           type: 'Parallel',
-          lines: [10, 11],
-        },
-        {
-          type: 'Parallel',
-          lines: [10, 12],
+          lines: [10, 11, 12],
         },
       ])
     }

--- a/src/machines/sketchSolve/tools/constraintToolHelpers.ts
+++ b/src/machines/sketchSolve/tools/constraintToolHelpers.ts
@@ -296,15 +296,16 @@ function buildConstraintToolPayloads(
       return [symmetricInput]
     }
     case 'parallelConstraintTool': {
-      const [anchorLineId, ...otherLineIds] = objectSelectionIds
-      if (anchorLineId === undefined || otherLineIds.length === 0) {
+      if (objectSelectionIds.length < 2) {
         return null
       }
 
-      return otherLineIds.map((lineId) => ({
-        type: 'Parallel',
-        lines: [anchorLineId, lineId],
-      }))
+      return [
+        {
+          type: 'Parallel',
+          lines: objectSelectionIds,
+        },
+      ]
     }
     case 'equalLengthConstraintTool': {
       const equalLengthInput = buildEqualLengthConstraintInput(

--- a/src/machines/sketchSolve/tools/constraintToolMachine.spec.ts
+++ b/src/machines/sketchSolve/tools/constraintToolMachine.spec.ts
@@ -275,6 +275,62 @@ describe('constraintToolMachine', () => {
     )
   })
 
+  it('applies one grouped parallel constraint for an area selection', async () => {
+    const pointA = createPointApiObject({ id: 1 })
+    const pointB = createPointApiObject({ id: 2 })
+    const pointC = createPointApiObject({ id: 3 })
+    const pointD = createPointApiObject({ id: 4 })
+    const pointE = createPointApiObject({ id: 5 })
+    const pointF = createPointApiObject({ id: 6 })
+    const lineA = createLineApiObject({ id: 10, start: 1, end: 2 })
+    const lineB = createLineApiObject({ id: 11, start: 3, end: 4 })
+    const lineC = createLineApiObject({ id: 12, start: 5, end: 6 })
+    const objects = [
+      pointA,
+      pointB,
+      pointC,
+      pointD,
+      pointE,
+      pointF,
+      lineA,
+      lineB,
+      lineC,
+    ]
+    const { child, rustContext } = createHarness({
+      childMachine: parallelConstraintTool,
+      objects,
+    })
+    const addConstraintMock = vi.spyOn(rustContext, 'addConstraint')
+
+    addConstraintMock.mockResolvedValue({
+      kclSource: { text: 'parallel' },
+      sceneGraphDelta: createSceneGraphDelta(objects),
+      checkpointId: 1,
+    })
+
+    child.send({
+      type: 'commit area selection',
+      currentSelectionIds: [],
+      candidateSelectionIds: [10, 11, 12],
+      objects: createSceneGraphDelta(objects).new_graph.objects,
+      modifierKeepSelection: false,
+    })
+
+    await waitFor(child, () => addConstraintMock.mock.calls.length > 0)
+
+    expect(addConstraintMock).toHaveBeenCalledOnce()
+    expect(addConstraintMock).toHaveBeenCalledWith(
+      0,
+      0,
+      {
+        type: 'Parallel',
+        lines: [10, 11, 12],
+      },
+      expect.anything(),
+      true
+    )
+  })
+
   it('applies one horizontal constraint per selected line in an area selection', async () => {
     const pointA = createPointApiObject({ id: 1 })
     const pointB = createPointApiObject({ id: 2 })


### PR DESCRIPTION
Closes issue #11302.

Entirely written by Codex, given the issue linked above. It added unit tests, and I tested it manually.

Instead of generating
```
parallel([line1, line2])
parallel([line1, line3])
parallel([line1, line4])
parallel([line1, line5])
```
it now generates
```
parallel([line1, line2, line3, line4, line5])
```
This makes the UI better: previously you had many separate parallel constraints to mouse over, each of which only shows 2 lines. Like this:
<img width="608" height="777" alt="Screenshot 2026-08-21 at 4 59 17 PM" src="https://github.com/user-attachments/assets/5bba59c8-38ae-47bd-adae-649fc71a602b" />
Now you get one big parallel constraint for all your lines, like this:
<img width="651" height="718" alt="Screenshot 2026-08-21 at 4 58 37 PM" src="https://github.com/user-attachments/assets/aced7078-c42d-40fb-ab8c-29a423714a5c" />
