### PR TITLE
test: Display KCL file path or test name when PNG diff fails

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5743,11 +5743,10 @@ dependencies = [
 
 [[package]]
 name = "twenty-twenty"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40badf08ea9162f080ee79ef4411b1a91919b44a01a3035c004a080dac39494"
+checksum = "6d411234fb5018ad8a6cc99279143ad57dfd5179a593394a9f76e5d7df9a6071"
 dependencies = [
- "anyhow",
  "image",
  "image-compare 0.4.2",
  "uuid",

--- a/rust/kcl-lib/Cargo.toml
+++ b/rust/kcl-lib/Cargo.toml
@@ -162,7 +162,7 @@ miette = { version = "7.6.0", features = ["fancy"] }
 pretty_assertions = "1.4.1"
 proptest = { workspace = true }
 tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "time"] }
-twenty-twenty = "0.8.3"
+twenty-twenty = "0.8.4"
 
 [lints]
 workspace = true

--- a/rust/kcl-lib/e2e/executor/main.rs
+++ b/rust/kcl-lib/e2e/executor/main.rs
@@ -22,7 +22,9 @@ macro_rules! kcl_input {
 
 pub(crate) fn assert_out(test_name: &str, result: &image::DynamicImage) -> String {
     let path = format!("e2e/executor/outputs/{test_name}.png");
-    twenty_twenty::assert_image(&path, result, MIN_DIFF);
+    if let Err(err) = twenty_twenty::try_assert_image(&path, result, MIN_DIFF) {
+        panic!("Image assertion failed for test {test_name}: {err}");
+    }
 
     path
 }

--- a/rust/kcl-lib/src/docs/kcl_doc.rs
+++ b/rust/kcl-lib/src/docs/kcl_doc.rs
@@ -1775,14 +1775,19 @@ mod test {
             if eg.1.norun {
                 return;
             }
-            twenty_twenty::assert_image(
+            if let Err(err) = twenty_twenty::try_assert_image(
                 format!(
                     "tests/outputs/serial_test_example_fn_{}{i}.png",
                     qualname.replace("::", "-")
                 ),
                 &result.image,
                 0.99,
-            );
+            ) {
+                panic!(
+                    "Image assertion failed for example {NAME} for {owner_name} in {}: {err}",
+                    source_path.display()
+                );
+            }
             // Doc generation omits the model viewer for a `no3d` example, so
             // writing its glTF would produce a file no page can ever link to.
             // Keep this in step with the `gltf_path` rule in `gen_std_tests`.

--- a/rust/kcl-lib/src/simulation_tests.rs
+++ b/rust/kcl-lib/src/simulation_tests.rs
@@ -331,8 +331,13 @@ async fn execute_test(test: &Test, render_to_png: bool, export_step: bool) {
                     fail_path.to_string_lossy()
                 )
             }
-            if render_to_png {
-                twenty_twenty::assert_image(test.output_dir.join(RENDERED_MODEL_NAME), &png, 0.99);
+            if render_to_png
+                && let Err(err) = twenty_twenty::try_assert_image(test.output_dir.join(RENDERED_MODEL_NAME), &png, 0.99)
+            {
+                panic!(
+                    "Image assertion failed: {err}; input KCL file: {}",
+                    test.entry_point.display()
+                );
             }
 
             // Ensure the step has data.


### PR DESCRIPTION
This is just to help developers track down the cause of test failures easier.