### PR TITLE
chore(CI): enable Namespace caching for LSP builds

### DIFF
--- a/.github/workflows/kcl-language-server.yml
+++ b/.github/workflows/kcl-language-server.yml
@@ -115,32 +115,17 @@ jobs:
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1.17.0
         with:
-          cache: ${{ runner.os != 'Linux' }}
-          cache-workspaces: rust
+          cache: false
           components: rust-src
           rustflags: "" # Use .cargo/config.toml
           target: ${{ matrix.target }}
       - name: Rust cache on the Namespace volume
-        if: runner.os == 'Linux'
         uses: namespacelabs/nscloud-cache-action@v1
         with:
           path: |
             rust/target
             ~/.cargo/registry
             ~/.cargo/git
-      - name: TEMPORARY probe - does this profile have a cache volume?
-        # Remove once the answer is recorded. The Windows and macOS profiles
-        # are unverified. This action fails the job when no volume is attached,
-        # so the probe sets continue-on-error and mounts a throwaway directory
-        # that no other step reads or writes. Success means a volume exists and
-        # the real cache can be switched over; failure prints
-        # "requires a cache volume to be configured" and the build continues on
-        # the GitHub cache.
-        if: runner.os != 'Linux'
-        continue-on-error: true
-        uses: namespacelabs/nscloud-cache-action@v1
-        with:
-          path: .nscloud-volume-probe
       - name: Install Node.js
         uses: actions/setup-node@v7.0.0
         with:

--- a/.github/workflows/kcl-language-server.yml
+++ b/.github/workflows/kcl-language-server.yml
@@ -205,15 +205,22 @@ jobs:
           path: ./rust/build
   build-release-x86_64-unknown-linux-musl:
     name: kcl-language-server build-release (x86_64-unknown-linux-musl)
-    runs-on: namespace-profile-ubuntu-2-cores
+    runs-on: namespace-profile-ubuntu-8-cores
     env:
       RA_TARGET: x86_64-unknown-linux-musl
       # For some reason `-crt-static` is not working for clang without lld
       RUSTFLAGS: "-C link-arg=-fuse-ld=lld -C target-feature=-crt-static"
     container:
       image: alpine:latest
+      # The cache volume lives on the host. Three things carry it into the
+      # container: NSC_CACHE_PATH, which is the only variable the cache action
+      # reads to locate the volume; the bind mount of the volume itself; and
+      # SYS_ADMIN, which the action needs to mount the cached paths.
+      env:
+        NSC_CACHE_PATH: ${{ env.NSC_CACHE_PATH }}
       volumes:
-        - /usr/local/cargo/registry:/usr/local/cargo/registry
+        - /cache:/cache
+      options: --cap-add=SYS_ADMIN
     steps:
       - name: Install dependencies
         run: |
@@ -226,7 +233,8 @@ jobs:
             build-base \
             musl-dev \
             nodejs \
-            npm
+            npm \
+            sudo
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
         with:
@@ -238,10 +246,22 @@ jobs:
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1.17.0
         with:
-          cache-workspaces: rust
+          # Caching is handled by the Namespace cache volume below. The
+          # built-in cache cannot work in this container
+          cache: false
           components: rust-src
           rustflags: "" # Use .cargo/config.toml
-          target: ${{ matrix.target }}
+      - name: Rust cache on the Namespace volume
+        # The cargo paths are absolute rather than `~/.cargo/...` because this
+        # container has two candidate home directories. HOME is /github/home,
+        # which is where cargo reads and writes, while the effective user id
+        # resolves to /root.
+        uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          path: |
+            rust/target
+            /github/home/.cargo/registry
+            /github/home/.cargo/git
       - name: build
         env:
           GITHUB_RUN_NUMBER: ${{ github.run_number }}

--- a/.github/workflows/kcl-language-server.yml
+++ b/.github/workflows/kcl-language-server.yml
@@ -126,23 +126,6 @@ jobs:
             rust/target
             ~/.cargo/registry
             ~/.cargo/git
-      # TEMPORARY. Every job on a runner profile caches the same `rust/target`
-      # on one shared volume, and warm runs still rebuild every crate. These
-      # two steps record which jobs' artifacts survive there. Each job drops a
-      # marker after building. A later run listing more than one marker means
-      # the volume merges commits; exactly one means the last writer wins.
-      - name: Diagnostic, cache contents after mount
-        shell: bash
-        # Every command tolerates failure. An absent path is a result here,
-        # not an error.
-        run: |
-          echo "== markers left by earlier runs =="
-          ls -la rust/target/.cache-marker-* 2>&1 | head -20 || true
-          echo "== target subdirectories =="
-          ls -la rust/target 2>&1 | head -30 || true
-          echo "== sizes =="
-          du -sh rust/target 2>&1 || true
-          du -sh rust/target/* 2>&1 | head -20 || true
       - name: Install Node.js
         uses: actions/setup-node@v7.0.0
         with:
@@ -172,8 +155,6 @@ jobs:
             mingw-w64 \
             wget \
             zlib1g-dev
-
-          cargo install cross
       - name: Install AArch64 target toolchain
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: sudo apt-get install gcc-aarch64-linux-gnu
@@ -186,18 +167,6 @@ jobs:
         run: |
           cd rust
           cargo kcl-language-server-release build --client-patch-version "${GITHUB_RUN_NUMBER}"
-      # TEMPORARY. See the note on the diagnostic step above.
-      - name: Diagnostic, mark and list after build
-        shell: bash
-        run: |
-          mkdir -p rust/target
-          date -u > "rust/target/.cache-marker-${{ matrix.target }}-run${{ github.run_number }}-attempt${{ github.run_attempt }}"
-          echo "== markers present now =="
-          ls -la rust/target/.cache-marker-* 2>&1 | head -20 || true
-          echo "== target subdirectories =="
-          ls -la rust/target 2>&1 | head -30 || true
-          echo "== sizes =="
-          du -sh rust/target 2>&1 || true
       - name: Install dependencies
         run: |
           cd rust/kcl-language-server
@@ -281,43 +250,18 @@ jobs:
           components: rust-src
           rustflags: "" # Use .cargo/config.toml
       - name: Rust cache on the Namespace volume
-        # `~` is ambiguous here. Cargo uses HOME, /github/home, but the
-        # effective user id resolves to /root.
         uses: namespacelabs/nscloud-cache-action@v1
         with:
           path: |
             rust/target
             /github/home/.cargo/registry
             /github/home/.cargo/git
-      # TEMPORARY. See the note on the diagnostic step in build-release.
-      - name: Diagnostic, cache contents after mount
-        shell: bash
-        run: |
-          echo "== markers left by earlier runs =="
-          ls -la rust/target/.cache-marker-* 2>&1 | head -20 || true
-          echo "== target subdirectories =="
-          ls -la rust/target 2>&1 | head -30 || true
-          echo "== sizes =="
-          du -sh rust/target 2>&1 || true
-          du -sh rust/target/* 2>&1 | head -20 || true
       - name: build
         env:
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
           cd rust
           cargo kcl-language-server-release build --client-patch-version "${GITHUB_RUN_NUMBER}"
-      # TEMPORARY. See the note on the diagnostic step in build-release.
-      - name: Diagnostic, mark and list after build
-        shell: bash
-        run: |
-          mkdir -p rust/target
-          date -u > "rust/target/.cache-marker-x86_64-unknown-linux-musl-run${{ github.run_number }}-attempt${{ github.run_attempt }}"
-          echo "== markers present now =="
-          ls -la rust/target/.cache-marker-* 2>&1 | head -20 || true
-          echo "== target subdirectories =="
-          ls -la rust/target 2>&1 | head -30 || true
-          echo "== sizes =="
-          du -sh rust/target 2>&1 || true
       - name: Install dependencies
         run: |
           cd rust/kcl-language-server

--- a/.github/workflows/kcl-language-server.yml
+++ b/.github/workflows/kcl-language-server.yml
@@ -73,26 +73,26 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: namespace-profile-windows-2-cores
+          - os: namespace-profile-windows-8-cores
             target: x86_64-pc-windows-msvc
             code-target: win32-x64
-            #- os: namespace-profile-windows-2-cores
+            #- os: namespace-profile-windows-8-cores
             #target: i686-pc-windows-msvc
             #code-target:
             #win32-ia32
-            #- os: namespace-profile-windows-2-cores
+            #- os: namespace-profile-windows-8-cores
             #target: aarch64-pc-windows-msvc
             #code-target: win32-arm64
-          - os: namespace-profile-ubuntu-2-cores
+          - os: namespace-profile-ubuntu-8-cores
             target: x86_64-unknown-linux-gnu
             code-target: linux-x64
-            #- os: namespace-profile-ubuntu-2-cores
+            #- os: namespace-profile-ubuntu-8-cores
             #target: aarch64-unknown-linux-musl
             #code-target: linux-arm64
-          - os: namespace-profile-ubuntu-2-cores
+          - os: namespace-profile-ubuntu-8-cores
             target: aarch64-unknown-linux-gnu
             code-target: linux-arm64
-          - os: namespace-profile-ubuntu-2-cores
+          - os: namespace-profile-ubuntu-8-cores
             target: arm-unknown-linux-gnueabihf
             code-target: linux-armhf
           - os: namespace-profile-macos-6-cores
@@ -115,18 +115,40 @@ jobs:
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1.17.0
         with:
+          cache: ${{ runner.os != 'Linux' }}
           cache-workspaces: rust
           components: rust-src
           rustflags: "" # Use .cargo/config.toml
           target: ${{ matrix.target }}
+      - name: Rust cache on the Namespace volume
+        if: runner.os == 'Linux'
+        uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          path: |
+            rust/target
+            ~/.cargo/registry
+            ~/.cargo/git
+      - name: TEMPORARY probe - does this profile have a cache volume?
+        # Remove once the answer is recorded. The Windows and macOS profiles
+        # are unverified. This action fails the job when no volume is attached,
+        # so the probe sets continue-on-error and mounts a throwaway directory
+        # that no other step reads or writes. Success means a volume exists and
+        # the real cache can be switched over; failure prints
+        # "requires a cache volume to be configured" and the build continues on
+        # the GitHub cache.
+        if: runner.os != 'Linux'
+        continue-on-error: true
+        uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          path: .nscloud-volume-probe
       - name: Install Node.js
         uses: actions/setup-node@v7.0.0
         with:
           node-version-file: .nvmrc
       - name: Update apt repositories
-        if: matrix.target == 'aarch64-unknown-linux-gnu' || matrix.target == 'arm-unknown-linux-gnueabihf' || matrix.os == 'namespace-profile-ubuntu-2-cores'
+        if: runner.os == 'Linux'
         run: sudo apt-get update
-      - if: ${{ matrix.os == 'namespace-profile-ubuntu-2-cores' }}
+      - if: runner.os == 'Linux'
         name: Install deps
         shell: bash
         run: |

--- a/.github/workflows/kcl-language-server.yml
+++ b/.github/workflows/kcl-language-server.yml
@@ -126,6 +126,23 @@ jobs:
             rust/target
             ~/.cargo/registry
             ~/.cargo/git
+      # TEMPORARY. Every job on a runner profile caches the same `rust/target`
+      # on one shared volume, and warm runs still rebuild every crate. These
+      # two steps record which jobs' artifacts survive there. Each job drops a
+      # marker after building. A later run listing more than one marker means
+      # the volume merges commits; exactly one means the last writer wins.
+      - name: Diagnostic, cache contents after mount
+        shell: bash
+        # Every command tolerates failure. An absent path is a result here,
+        # not an error.
+        run: |
+          echo "== markers left by earlier runs =="
+          ls -la rust/target/.cache-marker-* 2>&1 | head -20 || true
+          echo "== target subdirectories =="
+          ls -la rust/target 2>&1 | head -30 || true
+          echo "== sizes =="
+          du -sh rust/target 2>&1 || true
+          du -sh rust/target/* 2>&1 | head -20 || true
       - name: Install Node.js
         uses: actions/setup-node@v7.0.0
         with:
@@ -169,6 +186,18 @@ jobs:
         run: |
           cd rust
           cargo kcl-language-server-release build --client-patch-version "${GITHUB_RUN_NUMBER}"
+      # TEMPORARY. See the note on the diagnostic step above.
+      - name: Diagnostic, mark and list after build
+        shell: bash
+        run: |
+          mkdir -p rust/target
+          date -u > "rust/target/.cache-marker-${{ matrix.target }}-run${{ github.run_number }}-attempt${{ github.run_attempt }}"
+          echo "== markers present now =="
+          ls -la rust/target/.cache-marker-* 2>&1 | head -20 || true
+          echo "== target subdirectories =="
+          ls -la rust/target 2>&1 | head -30 || true
+          echo "== sizes =="
+          du -sh rust/target 2>&1 || true
       - name: Install dependencies
         run: |
           cd rust/kcl-language-server
@@ -212,10 +241,10 @@ jobs:
       RUSTFLAGS: "-C link-arg=-fuse-ld=lld -C target-feature=-crt-static"
     container:
       image: alpine:latest
-      # The cache volume lives on the host. Three things carry it into the
-      # container: NSC_CACHE_PATH, which is the only variable the cache action
-      # reads to locate the volume; the bind mount of the volume itself; and
-      # SYS_ADMIN, which the action needs to mount the cached paths.
+      # Reaching the host cache volume from a container requires all three:
+      # - NSC_CACHE_PATH, the only variable the action reads to find it.
+      # - The /cache bind mount.
+      # - SYS_ADMIN, for the action's mount calls.
       env:
         NSC_CACHE_PATH: ${{ env.NSC_CACHE_PATH }}
       volumes:
@@ -246,28 +275,49 @@ jobs:
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1.17.0
         with:
-          # Caching is handled by the Namespace cache volume below. The
-          # built-in cache cannot work in this container
+          # The Namespace volume below handles caching. This cache cannot:
+          # it runs `tar --posix`, which Alpine's BusyBox tar rejects.
           cache: false
           components: rust-src
           rustflags: "" # Use .cargo/config.toml
       - name: Rust cache on the Namespace volume
-        # The cargo paths are absolute rather than `~/.cargo/...` because this
-        # container has two candidate home directories. HOME is /github/home,
-        # which is where cargo reads and writes, while the effective user id
-        # resolves to /root.
+        # `~` is ambiguous here. Cargo uses HOME, /github/home, but the
+        # effective user id resolves to /root.
         uses: namespacelabs/nscloud-cache-action@v1
         with:
           path: |
             rust/target
             /github/home/.cargo/registry
             /github/home/.cargo/git
+      # TEMPORARY. See the note on the diagnostic step in build-release.
+      - name: Diagnostic, cache contents after mount
+        shell: bash
+        run: |
+          echo "== markers left by earlier runs =="
+          ls -la rust/target/.cache-marker-* 2>&1 | head -20 || true
+          echo "== target subdirectories =="
+          ls -la rust/target 2>&1 | head -30 || true
+          echo "== sizes =="
+          du -sh rust/target 2>&1 || true
+          du -sh rust/target/* 2>&1 | head -20 || true
       - name: build
         env:
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
           cd rust
           cargo kcl-language-server-release build --client-patch-version "${GITHUB_RUN_NUMBER}"
+      # TEMPORARY. See the note on the diagnostic step in build-release.
+      - name: Diagnostic, mark and list after build
+        shell: bash
+        run: |
+          mkdir -p rust/target
+          date -u > "rust/target/.cache-marker-x86_64-unknown-linux-musl-run${{ github.run_number }}-attempt${{ github.run_attempt }}"
+          echo "== markers present now =="
+          ls -la rust/target/.cache-marker-* 2>&1 | head -20 || true
+          echo "== target subdirectories =="
+          ls -la rust/target 2>&1 | head -30 || true
+          echo "== sizes =="
+          du -sh rust/target 2>&1 || true
       - name: Install dependencies
         run: |
           cd rust/kcl-language-server


### PR DESCRIPTION


- `build-release` matrix: 2-core → 8-core namespace profiles.
- two step conditions test `runner.os == 'linux'`, replacing a match on the old profile string.
- musl job reaches the cache volume from its container: `nsc_cache_path`, `/cache:/cache`, `--cap-add=sys_admin`. drops `swatinem/rust-cache`, which never worked there — busybox tar rejects `tar --posix`.
- removed `cargo install cross`: 73 crates per linux job, nothing invokes it.

## timing

run `32539310624` on `main` against run `32542154277` here.

| job | before | after |
|---|---|---|
| `x86_64-unknown-linux-musl` | 17.9 | 8.8 |
| `x86_64-pc-windows-msvc` | 15.8 | 6.2 |
| `x86_64-unknown-linux-gnu` | 11.3 | 5.5 |
| `aarch64-unknown-linux-gnu` | 10.8 | 4.6 |
| `arm-unknown-linux-gnueabihf` | 10.7 | 5.0 |
| `aarch64-apple-darwin` | 3.8 | 3.6 |

workflow: ~18 min → ~9 min.

## caching

still none, and none before this pr either — 489 crates compiled in the `build` step on every run measured. pull-request branches cannot persist cache writes, and eight jobs across five workflows share one `rust/target` on `namespace-profile-ubuntu-8-cores`.

## after merge

1. count `compiling` lines in the `build` step over two `main` runs. cold is 489.
2. windows and macos have one cache writer each, linux has eight. expect the first two to drop.
3. if they do, give each linux build job its own `cargo_target_dir`. if they do not, remove the cache action.
