### PR TITLE
Fix Settings status-bar route normalization

### DIFF
--- a/src/registry/extensions/settings/index.test.ts
+++ b/src/registry/extensions/settings/index.test.ts
@@ -1,5 +1,6 @@
 import { Registry } from '@kittycad/registry'
 import { statusBarGlobalItemsValueSpec } from '@src/registry/contracts/statusBar'
+import type { Location } from 'react-router-dom'
 import { describe, expect, it } from 'vitest'
 import settingsRegistryItem from '.'
 
@@ -17,6 +18,33 @@ describe('settings extension', () => {
         'data-testid': 'settings-link',
       }),
     ])
+
+    registry[Symbol.dispose]()
+  })
+
+  it('builds a stable settings link for project file routes', () => {
+    const registry = new Registry()
+    registry.configure([settingsRegistryItem])
+    const [settingsItem] = registry.get(statusBarGlobalItemsValueSpec)
+
+    if (
+      !settingsItem ||
+      'component' in settingsItem ||
+      settingsItem.element !== 'link' ||
+      typeof settingsItem.href !== 'function'
+    ) {
+      throw new Error('Expected the settings item to provide a link function')
+    }
+
+    const filePath = '/file/%2Fdocuments%2Fdemo-project%2Fmain.kcl'
+    const location = (pathname: string) => ({ pathname }) as Location
+
+    expect(settingsItem.href(location(filePath))).toBe(
+      `${filePath}/settings?tab=project`
+    )
+    expect(settingsItem.href(location(`${filePath}/settings`))).toBe(
+      `${filePath}/settings?tab=project`
+    )
 
     registry[Symbol.dispose]()
   })

--- a/src/registry/extensions/settings/index.ts
+++ b/src/registry/extensions/settings/index.ts
@@ -6,6 +6,7 @@ import {
   provideService,
 } from '@kittycad/registry'
 import { signal } from '@preact/signals-core'
+import makeUrlPathRelative from '@src/lib/makeUrlPathRelative'
 import { PATHS, webSafeJoin } from '@src/lib/paths'
 import type { SettingsType } from '@src/lib/settings/initialSettings'
 import { createSettings } from '@src/lib/settings/initialSettings'
@@ -111,10 +112,14 @@ const settingsRegistryItem = defineRegistryItem({
       id: 'settings',
       element: 'link',
       icon: 'settings',
-      href: (location) =>
-        `${webSafeJoin([location.pathname, PATHS.SETTINGS])}${
-          location.pathname.includes(PATHS.FILE) ? '?tab=project' : ''
-        }`,
+      href: (location) => {
+        const pathname = location.pathname
+        const settingsPath = pathname.includes(PATHS.SETTINGS)
+          ? pathname
+          : webSafeJoin([pathname, makeUrlPathRelative(PATHS.SETTINGS)])
+
+        return `${settingsPath}${pathname.includes(PATHS.FILE) ? '?tab=project' : ''}`
+      },
       'data-testid': 'settings-link',
       order: 1,
       label: 'Settings',


### PR DESCRIPTION
## Summary

- build the Settings status-bar link with a relative route segment
- preserve the existing pathname when the Settings route is already open
- add a unit regression for both the file route and its open-Settings route

Fixes #13251.

## Why

A Codex GUI-fuzz reload scenario found that the status-bar contribution first
generated `/main.kcl//settings`, which React Router normalized, and then
rendered `/main.kcl/settings/settings?tab=project` while the Settings dialog was
open. The visible dialog continued to work, but the focused production run
captured seven route-normalization warnings and the incorrect self-link.

The Settings keymap command already uses the intended behavior: keep an
existing Settings pathname, otherwise join a relative `settings` segment. This
change applies the same behavior to the status-bar contribution.

## Testing

- `npm run test:unit -- src/registry/extensions/settings/index.test.ts` (2
  passed)
- `npx biome format src/registry/extensions/settings/index.ts
  src/registry/extensions/settings/index.test.ts` (passed)
- `git diff --check` (passed)
- Full `tsc` remains blocked by unrelated generated Rust/Wasm binding drift on
  current `main`; it reports existing `BacktraceItem`, sketch constraint,
  `edit_constraint_value`, and `importedGeometry` errors, with no errors in the
  changed Settings files.
- Targeted ESLint is blocked during tool startup by
  `TypeError: Cannot read properties of undefined (reading 'Cjs')` in
  `@typescript-eslint/typescript-estree`.

## QA provenance

Codex GUI-fuzzer-derived. The pre-fix production reproduction used discrete
Playwright screenshots, DOM href attachments, runtime-event logs, and a passing
rectangle control. Recovered authentication and ICE/connection warnings were
classified separately as infrastructure noise.
