### PR TITLE
Skip empty Zookeeper delete workflows

### DIFF
--- a/src/machines/systemIO/systemIOMachine.spec.ts
+++ b/src/machines/systemIO/systemIOMachine.spec.ts
@@ -6,12 +6,14 @@ import type { Project } from '@src/lib/project'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { systemIOMachine } from '@src/machines/systemIO/systemIOMachine'
 import {
+  sharedBulkDeleteWorkflow,
   shouldSendProjectFolderReadProgress,
   sortProjectDirectoryEntriesByModifiedDesc,
   systemIOMachineImpl,
 } from '@src/machines/systemIO/systemIOMachineImpl'
 import {
   NO_PROJECT_DIRECTORY,
+  type SystemIOContext,
   SystemIOMachineActors,
   SystemIOMachineEvents,
   SystemIOMachineStates,
@@ -328,6 +330,22 @@ describe('systemIOMachine - XState', () => {
         )
         actor.stop()
       })
+      it.each([undefined, []])(
+        'skips project lookup when filesToDelete is %j',
+        async (filesToDelete) => {
+          const totalDeleted = await sharedBulkDeleteWorkflow({
+            input: {
+              requestedProjectName: 'project-not-in-folder-snapshot',
+              context: { folders: undefined } as SystemIOContext,
+              files: [],
+              filesToDelete,
+              wasmInstance: instanceInThisFile,
+            },
+          })
+
+          expect(totalDeleted).toBe(0)
+        }
+      )
     })
     describe('when reading projects', () => {
       it('should exit early when project directory is empty string', async () => {

--- a/src/machines/systemIO/systemIOMachineImpl.ts
+++ b/src/machines/systemIO/systemIOMachineImpl.ts
@@ -346,7 +346,7 @@ const sharedBulkWriteImportedProjectFilesWorkflow = async ({
   }
 }
 
-const sharedBulkDeleteWorkflow = async ({
+export const sharedBulkDeleteWorkflow = async ({
   input,
 }: {
   input: {
@@ -357,6 +357,10 @@ const sharedBulkDeleteWorkflow = async ({
     wasmInstance: ModuleType
   }
 }) => {
+  if (!input.filesToDelete?.length) {
+    return 0
+  }
+
   if (!input.context.folders) {
     console.warn('no folders')
     return


### PR DESCRIPTION
Closes #13253

## Summary

- return `0` before project lookup when a Zookeeper bulk edit has no files to delete
- preserve create-before-delete behavior for requests that explicitly include deletions
- cover both omitted and empty `filesToDelete` inputs with a regression test

## Testing

- `npm run test:integration -- src/machines/systemIO/systemIOMachine.spec.ts` (30 passed)
- Biome formatter check on the two changed files
- ESLint on the two changed files
