### PR TITLE
Fix KCL WASM workflow after setup-node v7

### DIFF
--- a/.github/workflows/kcl-wasm-lib-build-publish.yml
+++ b/.github/workflows/kcl-wasm-lib-build-publish.yml
@@ -26,6 +26,9 @@ jobs:
           cache: "npm"
 
       - run: npm install
+        env:
+          # Yarn reads the setup-node npmrc during postinstall and requires this placeholder to exist.
+          NODE_AUTH_TOKEN: ""
 
       - name: Use correct Rust toolchain
         shell: bash


### PR DESCRIPTION
## Summary

- define an empty NODE_AUTH_TOKEN only during npm install
- keep the later npm publish step tokenless for trusted publishing with OIDC

## Why

actions/setup-node v7 no longer exports a dummy NODE_AUTH_TOKEN. The npmrc created by registry-url still references ${NODE_AUTH_TOKEN}, and postinstall-postinstall invokes Yarn 1, which exits when that variable is unset. This has caused every KCL WASM publish workflow run to fail during npm install since the v7 upgrade.

## Validation

- parsed the modified workflow with Ruby YAML
- reproduced the Yarn failure with NODE_AUTH_TOKEN unset
- confirmed Yarn reads the same npmrc successfully when NODE_AUTH_TOKEN is defined as an empty string
- git diff --check