### PR TITLE
Remove stale Yarn postinstall shim

### DIFF
--- a/.github/workflows/kcl-wasm-lib-build-publish.yml
+++ b/.github/workflows/kcl-wasm-lib-build-publish.yml
@@ -26,9 +26,6 @@ jobs:
           cache: "npm"
 
       - run: npm install
-        env:
-          # Yarn reads the setup-node npmrc during postinstall and requires this placeholder to exist.
-          NODE_AUTH_TOKEN: ""
 
       - name: Use correct Rust toolchain
         shell: bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -146,7 +146,6 @@
         "pixelmatch": "^5.3.0",
         "pngjs": "^7.0.0",
         "postcss": "^8.5.14",
-        "postinstall-postinstall": "^2.1.0",
         "setimmediate": "^1.0.5",
         "tailwindcss": "^3.4.17",
         "ts-node": "^10.0.0",
@@ -26760,14 +26759,6 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
-    },
-    "node_modules/postinstall-postinstall": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/postinstall-postinstall/-/postinstall-postinstall-2.1.0.tgz",
-      "integrity": "sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT"
     },
     "node_modules/postject": {
       "version": "1.0.0-alpha.6",

--- a/package.json
+++ b/package.json
@@ -225,7 +225,6 @@
     "pixelmatch": "^5.3.0",
     "pngjs": "^7.0.0",
     "postcss": "^8.5.14",
-    "postinstall-postinstall": "^2.1.0",
     "setimmediate": "^1.0.5",
     "tailwindcss": "^3.4.17",
     "ts-node": "^10.0.0",


### PR DESCRIPTION
Follow-up to #13257.

Stacked on #13257.

## Summary

- remove `postinstall-postinstall` from the package manifests
- rely on npm's native root `postinstall` lifecycle to run `electron-rebuild`
- remove the empty `NODE_AUTH_TOKEN` workaround because the install no longer crosses into Yarn

`postinstall-postinstall` chooses Yarn whenever `yarnpkg` exists on `PATH`, regardless of whether npm started the install. GitHub-hosted runners include Yarn v1.22.22, which is why an npm workflow was unexpectedly invoking Yarn.

## Validation

- `npm install --package-lock-only --ignore-scripts --offline`
- clean `npm ci --offline --foreground-scripts --loglevel=error` with Yarn v1.22.22 on `PATH`, a setup-node-style npmrc containing `${NODE_AUTH_TOKEN}`, and `NODE_AUTH_TOKEN` unset
  - completed successfully
  - ran the root `electron-rebuild` postinstall
  - did not invoke Yarn
- `git diff --check`
