### PR TITLE
Defer cloud sync until Zookeeper edit checkpoints

### DIFF
--- a/src/lib/cloudSync/disconnect.spec.ts
+++ b/src/lib/cloudSync/disconnect.spec.ts
@@ -1,5 +1,6 @@
 import 'fake-indexeddb/auto'
 import {
+  beginCloudSyncProjectMutationBatch,
   cloudSyncRemoteProjects,
   cloudSyncStatus,
   configureCloudSyncEngine,
@@ -230,6 +231,98 @@ describe('cloud sync upload failures', () => {
     configureCloudSyncEngine({ enabled: false })
     vi.unstubAllGlobals()
     await deleteCloudSyncTestDatabase()
+  })
+
+  it('defers a project upload until its semantic mutation batch is released', async () => {
+    const files = new Map([
+      [`${projectPath}/main.kcl`, 'coherent = final'],
+      [
+        projectTomlPath,
+        `title = "Bracket"\n\n[cloud."dev.zoo.dev"]\nproject_id = "${remoteProjectId}"\n`,
+      ],
+    ])
+    configureCloudSyncLocalFileSystem(
+      createCloudSyncTestFs(files, { projectDirectory })
+    )
+    await seedLinkedProject()
+    await appendOutboxEntry({
+      projectPath,
+      kind: 'upsert',
+      targetPath: `${projectPath}/main.kcl`,
+      createdAt: '2026-07-08T12:00:00.000Z',
+    })
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = getFetchUrl(input)
+      const method = getFetchMethod(input, init)
+
+      if (url === remoteProjectUrl && method === 'GET') {
+        return jsonResponse({
+          id: remoteProjectId,
+          title: 'Bracket',
+          description: '',
+          category_ids: [],
+          revision: remoteRevision,
+        })
+      }
+
+      if (
+        url === `${remoteProjectUrl}?expected_revision=${remoteRevision}` &&
+        method === 'PUT'
+      ) {
+        return jsonResponse({
+          id: remoteProjectId,
+          title: 'Bracket',
+          revision: 'revision-124',
+        })
+      }
+
+      return jsonResponse(
+        { message: `Unexpected fetch: ${method} ${url}` },
+        500
+      )
+    })
+
+    configureCloudSyncEngine({
+      enabled: false,
+      baseUrl: 'https://example.test',
+      environmentName: 'dev.zoo.dev',
+      cloudProjectDirectoryPaths: ['/documents/Projects'],
+    })
+    setCloudSyncOpenedProject({
+      projectPath,
+      libraryPath: projectDirectory,
+      libraryType: CLOUD_PROJECT_LIBRARY_TYPE,
+    })
+    const releaseMutationBatch = beginCloudSyncProjectMutationBatch(projectPath)
+    configureCloudSyncEngine({ enabled: true })
+
+    await vi.waitFor(() => {
+      expect(cloudSyncStatus.value).toMatchObject({
+        state: 'idle',
+        pendingCount: 1,
+      })
+    })
+    expect(
+      fetchMock.mock.calls.some(
+        ([input, init]) =>
+          getFetchUrl(input) ===
+            `${remoteProjectUrl}?expected_revision=${remoteRevision}` &&
+          getFetchMethod(input, init) === 'PUT'
+      )
+    ).toBe(false)
+
+    releaseMutationBatch()
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${remoteProjectUrl}?expected_revision=${remoteRevision}`,
+        expect.objectContaining({
+          credentials: 'include',
+          method: 'PUT',
+        })
+      )
+      expect(cloudSyncStatus.value.pendingCount).toBe(0)
+    })
   })
 
   it('records a blocked upload failure when the remote project is readable but not writable', async () => {

--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -155,6 +155,7 @@ let detachVisibilityChangeListener: (() => void) | undefined
 let syncScopeProjectPath: string | undefined
 let syncScopeSyncable = false
 const scheduledProjectDirectoryNameSyncs = new Set<string>()
+const projectMutationBatchDepth = new Map<string, number>()
 
 /**
  * Per-run throttle for automatic full-library syncs. It spaces project API
@@ -353,12 +354,63 @@ export function shouldScheduleCloudSyncPendingWork({
   pendingCount,
   state,
   failureRetryScheduled,
+  hasUndeferredPendingWork = true,
 }: {
   pendingCount: number
   state: CloudSyncStatus['state']
   failureRetryScheduled: boolean
+  hasUndeferredPendingWork?: boolean
 }) {
-  return pendingCount > 0 && state !== 'conflict' && !failureRetryScheduled
+  return (
+    pendingCount > 0 &&
+    hasUndeferredPendingWork &&
+    state !== 'conflict' &&
+    !failureRetryScheduled
+  )
+}
+
+function isCloudSyncProjectMutationBatchOpen(projectPath: string) {
+  return (
+    (projectMutationBatchDepth.get(normalizePathForSync(projectPath)) ?? 0) > 0
+  )
+}
+
+/**
+ * Defer cloud publication for one project while a logical multi-file mutation
+ * is in progress. Local filesystem writes and durable outbox entries continue
+ * normally; releasing the outermost batch flushes the coherent snapshot.
+ */
+export function beginCloudSyncProjectMutationBatch(projectPath: string) {
+  const normalizedProjectPath = normalizePathForSync(projectPath)
+  projectMutationBatchDepth.set(
+    normalizedProjectPath,
+    (projectMutationBatchDepth.get(normalizedProjectPath) ?? 0) + 1
+  )
+
+  let released = false
+  return () => {
+    if (released) {
+      return
+    }
+    released = true
+
+    const nextDepth =
+      (projectMutationBatchDepth.get(normalizedProjectPath) ?? 1) - 1
+    if (nextDepth > 0) {
+      projectMutationBatchDepth.set(normalizedProjectPath, nextDepth)
+      return
+    }
+
+    projectMutationBatchDepth.delete(normalizedProjectPath)
+    scheduleSync(0)
+  }
+}
+
+async function hasUndeferredPendingOutboxEntries() {
+  const entries = await getAllOutboxEntries()
+  return entries.some(
+    (entry) => !isCloudSyncProjectMutationBatchOpen(entry.projectPath)
+  )
 }
 
 export function getCloudSyncProjectRootInDirectory(
@@ -2766,6 +2818,10 @@ async function syncProject(
   entries: OutboxEntry[],
   throttleProjectApiRequest: CloudSyncProjectApiRequestThrottle = unthrottledCloudSyncProjectApiRequest
 ) {
+  if (isCloudSyncProjectMutationBatchOpen(projectPath)) {
+    return
+  }
+
   let metadata = await getOrCreateProjectMetadata(projectPath)
   if (isProjectSyncExcluded(metadata)) {
     await clearOutboxEntriesForProject(metadata.localProjectPath)
@@ -3470,6 +3526,7 @@ async function runCloudSync() {
     }
 
     await refreshPendingCount()
+    const hasUndeferredPendingWork = await hasUndeferredPendingOutboxEntries()
     const syncedAt = pendingStatusSyncedAt
     if (syncedAt && cloudSyncStatus.value.state === 'conflict') {
       updateStatus({ lastSyncedAt: syncedAt })
@@ -3505,6 +3562,7 @@ async function runCloudSync() {
         pendingCount: cloudSyncStatus.value.pendingCount,
         state: cloudSyncStatus.value.state,
         failureRetryScheduled,
+        hasUndeferredPendingWork,
       })
     ) {
       scheduleSync(SYNC_DEBOUNCE_MS)
@@ -3526,11 +3584,14 @@ async function runCloudSync() {
   } finally {
     syncInProgress = false
     pendingStatusSyncedAt = undefined
+    const hasUndeferredPendingWork =
+      await hasUndeferredPendingOutboxEntries().catch(() => true)
     if (
       shouldScheduleCloudSyncPendingWork({
         pendingCount: cloudSyncStatus.value.pendingCount,
         state: cloudSyncStatus.value.state,
         failureRetryScheduled,
+        hasUndeferredPendingWork,
       })
     ) {
       scheduleSync(SYNC_DEBOUNCE_MS)
@@ -3891,7 +3952,9 @@ async function registerProjectMutation(
     sourcePath: sourcePath ? normalizePathForSync(sourcePath) : undefined,
     createdAt: nowIso(),
   })
-  scheduleSync()
+  if (!isCloudSyncProjectMutationBatchOpen(normalizedProjectPath)) {
+    scheduleSync()
+  }
 }
 
 async function registerProjectRename(sourcePath: string, targetPath: string) {
@@ -4017,6 +4080,7 @@ export function configureCloudSyncEngine(nextConfig: CloudSyncConfig) {
     initialLocalScanComplete = false
     lastRemoteIndexSyncAt = 0
     resetSyncRetryBackoff()
+    projectMutationBatchDepth.clear()
     cloudSyncRemoteProjects.value = []
     updateStatus({
       enabled: false,

--- a/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.spec.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.spec.tsx
@@ -1,13 +1,39 @@
-import { ZookeeperConversationPaneWrapper } from '@src/lib/zookeeper/components/ZookeeperConversationPaneWrapper'
 import { AreaType, LayoutType } from '@src/lib/layout/types'
-import type * as SystemIOUtils from '@src/machines/systemIO/utils'
+import { ZookeeperConversationPaneWrapper } from '@src/lib/zookeeper/components/ZookeeperConversationPaneWrapper'
 import { render, waitFor } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => {
   const systemIOSend = vi.fn()
   const useWatchForNewFileRequestsFromZookeeper = vi.fn()
-  const zookeeperSubscribe = vi.fn(() => ({ unsubscribe: vi.fn() }))
+  type ZookeeperSnapshot = {
+    context: {
+      awaitingResponse?: boolean
+      conversation?: { exchanges: unknown[] }
+      lastMessageId?: number
+      lastMessageType?: string
+    }
+  }
+  const zookeeperSubscribers: ((snapshot: ZookeeperSnapshot) => void)[] = []
+  const zookeeperSubscribe = vi.fn(
+    (subscriber: (snapshot: ZookeeperSnapshot) => void) => {
+      zookeeperSubscribers.push(subscriber)
+      return {
+        unsubscribe: vi.fn(() => {
+          const index = zookeeperSubscribers.indexOf(subscriber)
+          if (index >= 0) {
+            zookeeperSubscribers.splice(index, 1)
+          }
+        }),
+      }
+    }
+  )
+  const cloudSyncBatchReleases: ReturnType<typeof vi.fn>[] = []
+  const beginCloudSyncProjectMutationBatch = vi.fn(() => {
+    const release = vi.fn()
+    cloudSyncBatchReleases.push(release)
+    return release
+  })
   const kclManager = {
     captureEditorHistoryState: vi.fn(() => ({
       doc: { toString: () => 'initial code' },
@@ -18,12 +44,16 @@ const mocks = vi.hoisted(() => {
     zookeeperHistoryRecordingInProgress: false,
     addGlobalHistoryEvent: vi.fn(),
     addGlobalHistoryEventWithCodeChange: vi.fn(),
+    restoreEditorHistoryState: vi.fn(),
     updateCodeEditor: vi.fn(),
   }
 
   return {
     kclManager,
+    beginCloudSyncProjectMutationBatch,
+    cloudSyncBatchReleases,
     zookeeperSubscribe,
+    zookeeperSubscribers,
     systemIOSend,
     useWatchForNewFileRequestsFromZookeeper,
     watchCallback: undefined as
@@ -42,6 +72,10 @@ vi.mock('@src/components/layout/Panel', () => ({
     <div>{children}</div>
   ),
   LayoutPanelHeader: () => null,
+}))
+
+vi.mock('@src/lib/cloudSync', () => ({
+  beginCloudSyncProjectMutationBatch: mocks.beginCloudSyncProjectMutationBatch,
 }))
 
 vi.mock('@src/components/layout/Panel/HeaderMenu', () => ({
@@ -126,14 +160,34 @@ vi.mock('@src/lib/zookeeper/components/ZookeeperConversationPaneHooks', () => ({
   },
 }))
 
-vi.mock('@src/machines/systemIO/utils', async (importOriginal) => {
-  const original = await importOriginal<typeof SystemIOUtils>()
-
-  return {
-    ...original,
-    waitForIdleState: vi.fn(async () => undefined),
-  }
-})
+vi.mock('@src/machines/systemIO/utils', () => ({
+  normalizeKCLFileDeletePath: (path: string) =>
+    path.replaceAll('\\', '/').replace(/^\.\//, ''),
+  prepareZookeeperNewFileRequest: ({
+    toolOutput,
+  }: {
+    toolOutput: {
+      outputs?: Record<string, string>
+      project_name?: string
+      zookeeper_edit_patch?: unknown
+    }
+  }) => ({
+    files: Object.entries(toolOutput.outputs ?? {}).map(
+      ([requestedFileName, requestedCode]) => ({
+        requestedFileName,
+        requestedCode,
+      })
+    ),
+    filesToDelete: [],
+    requestedFileNameWithExtension: 'main.kcl',
+    requestedProjectName: toolOutput.project_name,
+    zookeeperEditPatch: toolOutput.zookeeper_edit_patch,
+  }),
+  SystemIOMachineEvents: {
+    bulkCreateAndDeleteKCLFilesAndNavigateToFile: 'bulkCreateAndDelete',
+  },
+  waitForIdleState: vi.fn(async () => undefined),
+}))
 
 vi.mock('@src/routes/utils', () => ({
   IS_STAGING_OR_DEBUG: false,
@@ -179,7 +233,58 @@ async function flushQueuedWork() {
   await new Promise((resolve) => setTimeout(resolve, 0))
 }
 
+function finishZookeeperExchange() {
+  for (const subscriber of mocks.zookeeperSubscribers) {
+    subscriber({
+      context: {
+        awaitingResponse: false,
+        conversation: { exchanges: [{}] },
+        lastMessageId: 2,
+        lastMessageType: 'end_of_stream',
+      },
+    })
+  }
+}
+
 describe('ZookeeperConversationPaneWrapper', () => {
+  test('releases one cloud sync checkpoint only after the exchange and queued writes finish', async () => {
+    mocks.systemIOSend.mockClear()
+    mocks.beginCloudSyncProjectMutationBatch.mockClear()
+    mocks.cloudSyncBatchReleases.length = 0
+    mocks.watchCallback = undefined
+
+    render(
+      <ZookeeperConversationPaneWrapper
+        areaConfig={{ hide: () => false }}
+        layout={{
+          areaType: AreaType.Zookeeper,
+          id: 'zookeeper',
+          label: 'Zookeeper',
+          type: LayoutType.Simple,
+        }}
+        onClose={vi.fn()}
+      />
+    )
+
+    emitZookeeperFileRequest('coherent final code')
+    await waitFor(() => expect(mocks.systemIOSend).toHaveBeenCalledTimes(1))
+
+    expect(mocks.beginCloudSyncProjectMutationBatch).toHaveBeenCalledWith(
+      '/workspace/demo'
+    )
+    expect(mocks.cloudSyncBatchReleases).toHaveLength(1)
+
+    finishZookeeperExchange()
+    expect(mocks.cloudSyncBatchReleases[0]).not.toHaveBeenCalled()
+
+    const request = mocks.systemIOSend.mock.calls[0][0].data
+    request.onFileSystemSuccess()
+    request.onSuccess()
+    await flushQueuedWork()
+
+    expect(mocks.cloudSyncBatchReleases[0]).toHaveBeenCalledTimes(1)
+  })
+
   test('does not start the next patch-backed Zookeeper edit until the previous editor refresh completes', async () => {
     mocks.systemIOSend.mockClear()
     mocks.kclManager.updateCodeEditor.mockClear()

--- a/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.tsx
@@ -8,6 +8,7 @@ import type { KclManager } from '@src/lang/KclManager'
 import { BillingTransition } from '@src/lib/billing'
 import { useApp, useSingletons } from '@src/lib/boot'
 import { browserSaveFile } from '@src/lib/browserSaveFile'
+import { beginCloudSyncProjectMutationBatch } from '@src/lib/cloudSync'
 import { isCodeTheSame } from '@src/lib/codeEditor'
 import { isPathNotFoundError } from '@src/lib/desktop'
 import fsZds from '@src/lib/fs-zds'
@@ -21,11 +22,6 @@ import {
   type ZookeeperSnapshotFileReplay,
   zookeeperEditPatchHistoryEvent,
 } from '@src/lib/zookeeper/editorPlugin'
-import {
-  ZookeeperConversationToMarkdown,
-  type ZookeeperManagerActor,
-  ZookeeperManagerReactContext,
-} from '@src/lib/zookeeper/zookeeperManagerMachine'
 import { zookeeperConversationStore } from '@src/lib/zookeeper/zookeeperConversationStore'
 import {
   mergeZookeeperEditPatches,
@@ -33,6 +29,11 @@ import {
   type ZookeeperEditPatch,
   type ZookeeperEditPatchFile,
 } from '@src/lib/zookeeper/zookeeperEditPatch'
+import {
+  ZookeeperConversationToMarkdown,
+  type ZookeeperManagerActor,
+  ZookeeperManagerReactContext,
+} from '@src/lib/zookeeper/zookeeperManagerMachine'
 import { zookeeperPromptRunningSignal } from '@src/lib/zookeeper/zookeeperPromptState'
 import {
   normalizeKCLFileDeletePath,
@@ -459,6 +460,9 @@ function useZookeeperEditPatchHistory({
   useEffect(() => {
     const pendingZookeeperHistories = pendingZookeeperHistoryByExchange.current
     return () => {
+      for (const pending of pendingZookeeperHistories.values()) {
+        releaseZookeeperCloudSyncBatch(pending)
+      }
       pendingZookeeperHistories.clear()
       kclManager.zookeeperHistoryRecordingInProgress = false
     }
@@ -532,30 +536,31 @@ function useZookeeperEditPatchHistory({
   const tryFlushPendingZookeeperHistory = useCallback(
     (exchangeId: number) => {
       const pending = pendingZookeeperHistoryByExchange.current.get(exchangeId)
-      if (
-        !pending?.streamEnded ||
-        pending.outstandingWrites > 0 ||
-        !pending.projectPath ||
-        !pending.patch?.changed_files?.length ||
-        !pending.activeFilePath
-      ) {
+      if (!pending?.streamEnded || pending.outstandingWrites > 0) {
         return
       }
 
       pendingZookeeperHistoryByExchange.current.delete(exchangeId)
       try {
-        recordZookeeperHistory({
-          activeFileDeleted: pending.activeFileDeleted,
-          activeFilePath: pending.activeFilePath,
-          activeEditorState: pending.activeEditorState,
-          activeFileRequestedCode: pending.activeFileRequestedCode,
-          currentFilePath: pending.currentFilePath,
-          currentFileRequestedCode: pending.currentFileRequestedCode,
-          patch: pending.patch,
-          projectPath: pending.projectPath,
-          snapshotFiles: getReadyZookeeperSnapshotFiles(pending),
-        })
+        if (
+          pending.projectPath &&
+          pending.patch?.changed_files?.length &&
+          pending.activeFilePath
+        ) {
+          recordZookeeperHistory({
+            activeFileDeleted: pending.activeFileDeleted,
+            activeFilePath: pending.activeFilePath,
+            activeEditorState: pending.activeEditorState,
+            activeFileRequestedCode: pending.activeFileRequestedCode,
+            currentFilePath: pending.currentFilePath,
+            currentFileRequestedCode: pending.currentFileRequestedCode,
+            patch: pending.patch,
+            projectPath: pending.projectPath,
+            snapshotFiles: getReadyZookeeperSnapshotFiles(pending),
+          })
+        }
       } finally {
+        releaseZookeeperCloudSyncBatch(pending)
         if (pendingZookeeperHistoryByExchange.current.size === 0) {
           kclManager.zookeeperHistoryRecordingInProgress = false
         }
@@ -575,6 +580,8 @@ function useZookeeperEditPatchHistory({
         createPendingZookeeperHistory()
       pending.outstandingWrites += 1
       pending.projectPath ??= projectPath
+      pending.releaseCloudSyncBatch ??=
+        beginCloudSyncProjectMutationBatch(projectPath)
       if (
         !pending.activeEditorState &&
         activeFilePath &&
@@ -603,6 +610,8 @@ function useZookeeperEditPatchHistory({
         pending.outstandingWrites += 1
       }
       pending.projectPath ??= projectPath
+      pending.releaseCloudSyncBatch ??=
+        beginCloudSyncProjectMutationBatch(projectPath)
       if (
         !pending.activeEditorState &&
         activeFilePath &&
@@ -644,6 +653,7 @@ function useZookeeperEditPatchHistory({
         !pending.patch?.changed_files?.length
       ) {
         pendingZookeeperHistoryByExchange.current.delete(exchangeId)
+        releaseZookeeperCloudSyncBatch(pending)
       } else {
         pendingZookeeperHistoryByExchange.current.set(exchangeId, pending)
         tryFlushPendingZookeeperHistory(exchangeId)
@@ -904,6 +914,7 @@ type PendingZookeeperHistory = {
   outstandingWrites: number
   patch?: ZookeeperEditPatch
   projectPath?: string
+  releaseCloudSyncBatch?: () => void
   snapshotFilesByRelativePath: Map<string, PendingZookeeperSnapshotFile>
   streamEnded: boolean
 }
@@ -958,6 +969,11 @@ function createPendingZookeeperHistory(): PendingZookeeperHistory {
   }
 }
 
+function releaseZookeeperCloudSyncBatch(pending: PendingZookeeperHistory) {
+  pending.releaseCloudSyncBatch?.()
+  pending.releaseCloudSyncBatch = undefined
+}
+
 function useFlushZookeeperHistoryOnResponseEnd(
   zookeeperManagerActor: ZookeeperManagerActor,
   pendingZookeeperHistoryByExchange: MutableRefObject<
@@ -966,18 +982,22 @@ function useFlushZookeeperHistoryOnResponseEnd(
   tryFlushPendingZookeeperHistory: (exchangeId: number) => void
 ) {
   useEffect(() => {
-    let lastId: number | undefined
+    const completedExchanges = new Set<number>()
     const subscription = zookeeperManagerActor.subscribe((next) => {
-      if (next.context.lastMessageId === lastId) return
-      lastId = next.context.lastMessageId
-
-      if (next.context.lastMessageType !== 'end_of_stream') return
+      if (next.context.awaitingResponse) {
+        return
+      }
       const exchangeId = (next.context.conversation?.exchanges.length ?? 0) - 1
-      if (exchangeId < 0) return
+      if (exchangeId < 0 || completedExchanges.has(exchangeId)) {
+        return
+      }
 
       const pending = pendingZookeeperHistoryByExchange.current.get(exchangeId)
-      if (!pending) return
+      if (!pending) {
+        return
+      }
 
+      completedExchanges.add(exchangeId)
       pending.streamEnded = true
       pendingZookeeperHistoryByExchange.current.set(exchangeId, pending)
       tryFlushPendingZookeeperHistory(exchangeId)


### PR DESCRIPTION
## Summary

- add a nestable, project-scoped cloud publication batch while logical edits are in progress
- keep filesystem writes and durable outbox entries active, but defer that project's cloud PUT until the outer batch is released
- have patch-backed Zookeeper exchanges release their batch only after the response ends and all queued filesystem/editor work completes
- avoid timer churn when every pending outbox entry is intentionally deferred

Closes #13261.

## Validation

- `npm run test:integration -- src/lib/cloudSync/disconnect.spec.ts src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.spec.tsx` (8 passed)
- Biome formatting check on the four changed files
- ESLint on the four changed files
- repository-wide `npm run tsc` is blocked in the isolated clone by ungenerated Rust/WASM bindings; filtering its output found no errors in the changed files

## Draft review focus

- decide whether a never-terminating Zookeeper exchange needs a bounded fallback timeout in addition to error completion and component-unmount cleanup
- confirm whether an already-started upload needs an explicit generation fence when a new mutation batch opens
