### PR TITLE
Fix point-and-click editing for chained holes

### DIFF
--- a/src/lang/modifyAst/faces.test.ts
+++ b/src/lang/modifyAst/faces.test.ts
@@ -1,0 +1,126 @@
+import type { Artifact, CodeRef } from '@rust/kcl-lib/bindings/Artifact'
+import type { OpArg } from '@rust/kcl-lib/bindings/Operation'
+
+import { retrieveFaceSelectionsFromOpArgs } from '@src/lang/modifyAst/faces'
+import type { ArtifactGraph } from '@src/lang/wasm'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@src/lib/commandBarConfigs/modelingCommandStdLib', () => ({
+  modelingStdLibCall: vi.fn(),
+  modelingStdLibCommandName: vi.fn(),
+}))
+
+const codeRef: CodeRef = {
+  range: [0, 0, 0],
+  pathToNode: [['body', 'Program']],
+  nodePath: { steps: [] },
+}
+
+describe('retrieveFaceSelectionsFromOpArgs', () => {
+  it('retrieves a tagged wall when editing chained holes', () => {
+    const path: Artifact = {
+      type: 'path',
+      id: 'region-1',
+      subType: 'region',
+      planeId: 'plane-1',
+      segIds: ['segment-1'],
+      consumed: true,
+      sweepId: 'sweep-1',
+      trajectorySweepId: null,
+      codeRef,
+    }
+    const segment: Artifact = {
+      type: 'segment',
+      id: 'segment-1',
+      pathId: path.id,
+      edgeIds: [],
+      commonSurfaceIds: ['wall-1'],
+      codeRef,
+    }
+    const sweep: Artifact = {
+      type: 'sweep',
+      id: 'sweep-1',
+      subType: 'extrusion',
+      pathId: path.id,
+      surfaceIds: ['wall-1'],
+      edgeIds: [],
+      codeRef,
+      trajectoryId: null,
+      method: 'merge',
+      consumed: true,
+    }
+    const wall: Artifact = {
+      type: 'wall',
+      id: 'wall-1',
+      segId: segment.id,
+      sweepId: sweep.id,
+      pathIds: [],
+      edgeCutEdgeIds: [],
+      faceCodeRef: codeRef,
+      cmdId: 'wall-command-1',
+    }
+    const holeTool: Artifact = {
+      type: 'sweep',
+      id: 'hole-tool',
+      subType: 'extrusion',
+      pathId: 'hole-tool-path',
+      surfaceIds: [],
+      edgeIds: [],
+      codeRef,
+      trajectoryId: null,
+      method: 'new',
+      consumed: true,
+    }
+    const firstHole: Artifact = {
+      type: 'compositeSolid',
+      id: 'hole-1',
+      consumed: true,
+      subType: 'subtract',
+      solidIds: [path.id],
+      toolIds: [holeTool.id],
+      codeRef,
+      compositeSolidId: 'hole-2',
+    }
+    const secondHole: Artifact = {
+      type: 'compositeSolid',
+      id: 'hole-2',
+      consumed: true,
+      subType: 'subtract',
+      solidIds: [firstHole.id],
+      toolIds: [holeTool.id],
+      codeRef,
+      compositeSolidId: 'hole-3',
+    }
+    const artifactGraph: ArtifactGraph = new Map(
+      [path, segment, sweep, wall, holeTool, firstHole, secondHole].map(
+        (artifact) => [artifact.id, artifact]
+      )
+    )
+    const faceArg: OpArg = {
+      value: {
+        type: 'TagIdentifier',
+        value: 'line1',
+        artifact_id: segment.id,
+      },
+      sourceRange: [0, 0, 0],
+    }
+
+    for (const hole of [firstHole, secondHole]) {
+      const solidArg: OpArg = {
+        value: { type: 'Solid', value: { artifactId: hole.id } },
+        sourceRange: [0, 0, 0],
+      }
+      const result = retrieveFaceSelectionsFromOpArgs(
+        solidArg,
+        faceArg,
+        artifactGraph
+      )
+
+      if (result instanceof Error) {
+        throw result
+      }
+      expect(result.solids.graphSelections[0].artifact).toBe(hole)
+      expect(result.faces.graphSelections[0].artifact).toBe(wall)
+    }
+  })
+})

--- a/src/lang/modifyAst/faces.ts
+++ b/src/lang/modifyAst/faces.ts
@@ -30,6 +30,7 @@ import {
   getArtifactOfTypes,
   getCapCodeRef,
   getFaceCodeRef,
+  getSweepArtifactsFromBodyArtifact,
   getSweepFromSuspectedSweepSurface,
 } from '@src/lang/std/artifactGraph'
 import {
@@ -1058,8 +1059,10 @@ export function retrieveFaceSelectionsFromOpArgs(
     return solids
   }
 
-  const sweepIds = solids.graphSelections.flatMap((s) =>
-    s.artifact?.type === 'sweep' ? s.artifact.id : []
+  const sweepIds = solids.graphSelections.flatMap((selection) =>
+    getSweepArtifactsFromBodyArtifact(selection.artifact, artifactGraph).map(
+      (sweep) => sweep.id
+    )
   )
   if (sweepIds.length === 0) {
     return new Error('No sweep artifact found in solids selection')

--- a/src/lang/modifyAst/faces.ts
+++ b/src/lang/modifyAst/faces.ts
@@ -30,7 +30,6 @@ import {
   getArtifactOfTypes,
   getCapCodeRef,
   getFaceCodeRef,
-  getSweepArtifactsFromBodyArtifact,
   getSweepFromSuspectedSweepSurface,
 } from '@src/lang/std/artifactGraph'
 import {
@@ -1060,9 +1059,7 @@ export function retrieveFaceSelectionsFromOpArgs(
   }
 
   const sweepIds = solids.graphSelections.flatMap((selection) =>
-    getSweepArtifactsFromBodyArtifact(selection.artifact, artifactGraph).map(
-      (sweep) => sweep.id
-    )
+    getTargetSweepIdsFromBodyArtifact(selection.artifact, artifactGraph)
   )
   if (sweepIds.length === 0) {
     return new Error('No sweep artifact found in solids selection')
@@ -1148,6 +1145,33 @@ export function retrieveFaceSelectionsFromOpArgs(
 
   const faces = { graphSelections, otherSelections: [] }
   return { solids, faces }
+}
+
+function getTargetSweepIdsFromBodyArtifact(
+  artifact: Artifact | undefined,
+  artifactGraph: ArtifactGraph
+): string[] {
+  const sweepIds = new Set<string>()
+  const visited = new Set<string>()
+
+  const visit = (candidate: Artifact | undefined) => {
+    if (!candidate || visited.has(candidate.id)) return
+    visited.add(candidate.id)
+
+    if (candidate.type === 'sweep') {
+      sweepIds.add(candidate.id)
+    } else if (candidate.type === 'path' && candidate.sweepId) {
+      const sweep = artifactGraph.get(candidate.sweepId)
+      if (sweep?.type === 'sweep') {
+        sweepIds.add(sweep.id)
+      }
+    } else if (candidate.type === 'compositeSolid') {
+      candidate.solidIds.forEach((id) => visit(artifactGraph.get(id)))
+    }
+  }
+
+  visit(artifact)
+  return [...sweepIds]
 }
 
 export function retrieveNonDefaultPlaneSelectionFromOpArg(

--- a/src/lang/std/artifactGraph.ts
+++ b/src/lang/std/artifactGraph.ts
@@ -418,34 +418,6 @@ export function getCommonFacesForEdge(
   return commonFaces ?? new Error('No common face found')
 }
 
-/** Resolve source sweeps through body targets, excluding CSG cutter ancestry. */
-export function getSweepArtifactsFromBodyArtifact(
-  artifact: Artifact | undefined,
-  artifactGraph: ArtifactGraph
-): SweepArtifact[] {
-  const sweeps = new Map<ArtifactId, SweepArtifact>()
-  const visited = new Set<ArtifactId>()
-
-  const visit = (candidate: Artifact | undefined) => {
-    if (!candidate || visited.has(candidate.id)) return
-    visited.add(candidate.id)
-
-    if (candidate.type === 'sweep') {
-      sweeps.set(candidate.id, candidate)
-    } else if (candidate.type === 'path' && candidate.sweepId) {
-      const sweep = artifactGraph.get(candidate.sweepId)
-      if (sweep?.type === 'sweep') {
-        sweeps.set(sweep.id, sweep)
-      }
-    } else if (candidate.type === 'compositeSolid') {
-      candidate.solidIds.forEach((id) => visit(artifactGraph.get(id)))
-    }
-  }
-
-  visit(artifact)
-  return [...sweeps.values()]
-}
-
 export function getSweepArtifactFromSelection(
   selection: Selection,
   artifactGraph: ArtifactGraph

--- a/src/lang/std/artifactGraph.ts
+++ b/src/lang/std/artifactGraph.ts
@@ -418,6 +418,34 @@ export function getCommonFacesForEdge(
   return commonFaces ?? new Error('No common face found')
 }
 
+/** Resolve source sweeps through body targets, excluding CSG cutter ancestry. */
+export function getSweepArtifactsFromBodyArtifact(
+  artifact: Artifact | undefined,
+  artifactGraph: ArtifactGraph
+): SweepArtifact[] {
+  const sweeps = new Map<ArtifactId, SweepArtifact>()
+  const visited = new Set<ArtifactId>()
+
+  const visit = (candidate: Artifact | undefined) => {
+    if (!candidate || visited.has(candidate.id)) return
+    visited.add(candidate.id)
+
+    if (candidate.type === 'sweep') {
+      sweeps.set(candidate.id, candidate)
+    } else if (candidate.type === 'path' && candidate.sweepId) {
+      const sweep = artifactGraph.get(candidate.sweepId)
+      if (sweep?.type === 'sweep') {
+        sweeps.set(sweep.id, sweep)
+      }
+    } else if (candidate.type === 'compositeSolid') {
+      candidate.solidIds.forEach((id) => visit(artifactGraph.get(id)))
+    }
+  }
+
+  visit(artifact)
+  return [...sweeps.values()]
+}
+
 export function getSweepArtifactFromSelection(
   selection: Selection,
   artifactGraph: ArtifactGraph


### PR DESCRIPTION


https://github.com/user-attachments/assets/528be380-ae01-4bd7-9c96-656d4c4ece39



## Problem

can't edit the second hole



```
@settings(kclVersion = 2.0)

sketch001 = sketch(on = XY) {
  line1 = line(start = [var -3.73mm, var -4.32mm], end = [var 4.14mm, var -4.32mm])
  line2 = line(start = [var 4.14mm, var -4.32mm], end = [var 4.14mm, var 4.54mm])
  line3 = line(start = [var 4.14mm, var 4.54mm], end = [var -3.73mm, var 4.54mm])
  line4 = line(start = [var -3.73mm, var 4.54mm], end = [var -3.73mm, var -4.32mm])
  coincident([line1.end, line2.start])
  coincident([line2.end, line3.start])
  coincident([line3.end, line4.start])
  coincident([line4.end, line1.start])
  parallel([line2, line4])
  parallel([line3, line1])
  perpendicular([line1, line2])
  horizontal(line3)
}
hidden001 = hide(sketch001)
region001 = region(segments = [sketch001.line4, sketch001.line1])
extrude001 = extrude(
  region001,
  length = 5,
  symmetric = true,
  tagEnd = $capEnd001,
)
hole001 = hole::hole(
  extrude001,
  face = capEnd001,
  cutAt = [0, 0],
  holeBottom = hole::flat(),
  holeBody = hole::blind(depth = 2, diameter = 1),
  holeType = hole::simple(),
)
hole002 = hole::hole(
  hole001,
  face = region001.tags.line1,
  cutAt = [0, 0],
  holeBottom = hole::flat(),
  holeBody = hole::blind(depth = 2, diameter = 1),
  holeType = hole::simple(),
)

```

Fixes #13265.

Related to the add-another-hole flow in #9371 and the broader work in #11245.
