### PR TITLE
Clarify signed distance constraint conflicts

### DIFF
--- a/docs/kcl-std/functions/std-solver-horizontalDistance.md
+++ b/docs/kcl-std/functions/std-solver-horizontalDistance.md
@@ -20,6 +20,8 @@ X coordinate. A positive value places the second point at a greater X
 than the first, and swapping the points negates the sign. For example,
 `horizontalDistance([ORIGIN, point]) == 5mm` places `point` at X = 5mm,
 while `horizontalDistance([point, ORIGIN]) == 5mm` places it at X = -5mm.
+Negative values are valid: if the second point is left of the first, use a
+negative value (or swap the points and use the corresponding positive value).
 
 ### Arguments
 

--- a/docs/kcl-std/functions/std-solver-verticalDistance.md
+++ b/docs/kcl-std/functions/std-solver-verticalDistance.md
@@ -20,6 +20,8 @@ Y coordinate. A positive value places the second point at a greater Y
 than the first, and swapping the points negates the sign. For example,
 `verticalDistance([ORIGIN, point]) == 5mm` places `point` at Y = 5mm,
 while `verticalDistance([point, ORIGIN]) == 5mm` places it at Y = -5mm.
+Negative values are valid: if the second point is below the first, use a
+negative value (or swap the points and use the corresponding positive value).
 
 ### Arguments
 

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -74,6 +74,7 @@ use crate::execution::memory::{self};
 use crate::execution::sketch_constraint_status_for_sketch;
 use crate::execution::sketch_solve::FreedomAnalysis;
 use crate::execution::sketch_solve::Solved;
+use crate::execution::sketch_solve::UnsatisfiedDirectionalConstraint;
 use crate::execution::sketch_solve::create_segment_scene_objects;
 use crate::execution::sketch_solve::normalize_to_solver_angle_unit;
 use crate::execution::sketch_solve::normalize_to_solver_distance_unit;
@@ -145,6 +146,39 @@ use crate::walk::Visitable;
 
 fn internal_err(message: impl Into<String>, range: impl Into<SourceRange>) -> KclError {
     KclError::new_internal(KclErrorDetails::new(message.into(), vec![range.into()]))
+}
+
+fn signed_distance_conflict_hint(solve_outcome: &Solved) -> String {
+    let hints = solve_outcome
+        .unsatisfied_directional_constraints
+        .iter()
+        .map(|constraint| match constraint {
+            UnsatisfiedDirectionalConstraint::Horizontal(expected) if *expected > 0.0 => {
+                "Unsatisfied signed horizontalDistance constraint: a positive right-hand side requires the second point to be right of the first (second.x - first.x > 0)."
+            }
+            UnsatisfiedDirectionalConstraint::Horizontal(expected) if *expected < 0.0 => {
+                "Unsatisfied signed horizontalDistance constraint: a negative right-hand side requires the second point to be left of the first (second.x - first.x < 0)."
+            }
+            UnsatisfiedDirectionalConstraint::Horizontal(_) => {
+                "Unsatisfied signed horizontalDistance constraint: a zero right-hand side requires both points to have the same X coordinate."
+            }
+            UnsatisfiedDirectionalConstraint::Vertical(expected) if *expected > 0.0 => {
+                "Unsatisfied signed verticalDistance constraint: a positive right-hand side requires the second point to be above the first (second.y - first.y > 0)."
+            }
+            UnsatisfiedDirectionalConstraint::Vertical(expected) if *expected < 0.0 => {
+                "Unsatisfied signed verticalDistance constraint: a negative right-hand side requires the second point to be below the first (second.y - first.y < 0)."
+            }
+            UnsatisfiedDirectionalConstraint::Vertical(_) => {
+                "Unsatisfied signed verticalDistance constraint: a zero right-hand side requires both points to have the same Y coordinate."
+            }
+        })
+        .collect::<Vec<_>>();
+
+    if hints.is_empty() {
+        String::new()
+    } else {
+        format!(" {}", hints.join(" "))
+    }
 }
 
 fn datum_point_from_constrainable(
@@ -2835,6 +2869,7 @@ impl Node<SketchBlock> {
                                 warnings: failure.warnings,
                                 priority_solved: Default::default(),
                                 variables_in_conflicts: Default::default(),
+                                unsatisfied_directional_constraints: Default::default(),
                                 converged: false,
                             },
                             None,
@@ -3002,8 +3037,9 @@ impl Node<SketchBlock> {
                     "segments have"
                 };
                 let message = format!(
-                    "Sketch is over-constrained: {} {description} conflicting constraints",
+                    "Sketch is over-constrained: {} {description} conflicting constraints.{}",
                     status.conflict_count,
+                    signed_distance_conflict_hint(&solve_outcome),
                 );
                 exec_state.warn(
                     CompilationIssue::err(range, message),

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -4999,6 +4999,29 @@ sketch001 = sketch(on = XY) {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn over_constrained_warning_identifies_signed_vertical_distance_direction() {
+        let code = r#"
+sketch001 = sketch(on = XY) {
+  line1 = line(start = [var 0mm, var 10mm], end = [var 0mm, var 0mm])
+  fixed([line1.start, [0mm, 10mm]])
+  fixed([line1.end, ORIGIN])
+  verticalDistance([line1.start, line1.end]) == 10mm
+}
+"#;
+        let result = parse_execute(code).await.unwrap();
+        let issues = result.exec_state.issues();
+        let Some(warning) = issues.iter().find(|issue| issue.message.contains("over-constrained")) else {
+            panic!("expected over-constrained warning; found {issues:#?}");
+        };
+        assert!(
+            warning.message.contains(
+                "Unsatisfied signed verticalDistance constraint: a positive right-hand side requires the second point to be above the first"
+            ),
+            "expected signed-direction diagnostic; found {warning:#?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn no_warning_when_sketch_is_not_over_constrained() {
         // Under-constrained sketch should not emit the over-constrained warning.
         let code = r#"

--- a/rust/kcl-lib/src/execution/sketch_solve.rs
+++ b/rust/kcl-lib/src/execution/sketch_solve.rs
@@ -507,8 +507,17 @@ pub(crate) struct Solved {
     pub(crate) priority_solved: u32,
     /// Variables involved in unsatisfied constraints (for conflict detection)
     pub(crate) variables_in_conflicts: AHashSet<ezpz::Id>,
+    /// Signed distance constraints the solver could not satisfy. Retain their
+    /// right-hand-side values so diagnostics can explain the required direction.
+    pub(crate) unsatisfied_directional_constraints: Vec<UnsatisfiedDirectionalConstraint>,
     /// Did the solver converge on a solution?
     pub(crate) converged: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum UnsatisfiedDirectionalConstraint {
+    Horizontal(f64),
+    Vertical(f64),
 }
 
 impl Solved {
@@ -523,12 +532,23 @@ impl Solved {
         // Build a set of variables involved in unsatisfied constraints
         // Only include required constraints (not optional ones like from dragging)
         let mut variables_in_conflicts = AHashSet::new();
+        let mut unsatisfied_directional_constraints = Vec::new();
         for &constraint_idx in value.unsatisfied() {
             // Only mark as conflicted if it's a required constraint, not an optional one
             if constraint_idx < num_required_constraints
                 && let Some(constraint) = constraints.get(constraint_idx)
             {
                 constraint.extend_associated_variable_ids(&mut variables_in_conflicts);
+                match constraint {
+                    ezpz::Constraint::HorizontalDistance(_, _, expected) => {
+                        unsatisfied_directional_constraints
+                            .push(UnsatisfiedDirectionalConstraint::Horizontal(*expected));
+                    }
+                    ezpz::Constraint::VerticalDistance(_, _, expected) => {
+                        unsatisfied_directional_constraints.push(UnsatisfiedDirectionalConstraint::Vertical(*expected));
+                    }
+                    _ => {}
+                }
             }
         }
 
@@ -538,6 +558,7 @@ impl Solved {
             warnings: value.warnings().to_owned(),
             priority_solved: value.priority_solved(),
             variables_in_conflicts,
+            unsatisfied_directional_constraints,
             converged: value.converged(),
         }
     }
@@ -1117,6 +1138,7 @@ mod tests {
             warnings: vec![],
             priority_solved: 0,
             variables_in_conflicts: AHashSet::new(),
+            unsatisfied_directional_constraints: vec![],
             converged: true,
         };
 

--- a/rust/kcl-lib/std/solver.kcl
+++ b/rust/kcl-lib/std/solver.kcl
@@ -340,6 +340,8 @@ export fn diameter(
 /// than the first, and swapping the points negates the sign. For example,
 /// `horizontalDistance([ORIGIN, point]) == 5mm` places `point` at X = 5mm,
 /// while `horizontalDistance([point, ORIGIN]) == 5mm` places it at X = -5mm.
+/// Negative values are valid: if the second point is left of the first, use a
+/// negative value (or swap the points and use the corresponding positive value).
 ///
 /// ```kcl,sketchSolve
 /// profile = sketch(on = XY) {
@@ -374,6 +376,8 @@ export fn horizontalDistance(
 /// than the first, and swapping the points negates the sign. For example,
 /// `verticalDistance([ORIGIN, point]) == 5mm` places `point` at Y = 5mm,
 /// while `verticalDistance([point, ORIGIN]) == 5mm` places it at Y = -5mm.
+/// Negative values are valid: if the second point is below the first, use a
+/// negative value (or swap the points and use the corresponding positive value).
 ///
 /// ```kcl,sketchSolve
 /// profile = sketch(on = XY) {


### PR DESCRIPTION
Closes #13269.

## What changed

- retain unsatisfied horizontal/vertical distance kinds and RHS signs from the constraint solver outcome
- append a direction-specific explanation to over-constraint warnings when a signed distance is unsatisfied
- explicitly document that negative `horizontalDistance` and `verticalDistance` values are valid for leftward/downward direction
- add a regression test for a reversed positive vertical-distance constraint

For the reproduction in #13269, the warning now includes:

```text
Unsatisfied signed verticalDistance constraint: a positive right-hand side requires the second point to be above the first (second.y - first.y > 0).
```

The existing affected-segment count remains in place for broader context. Negative values are not rejected.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo test -p kcl-lib over_constrained_warning_identifies_signed_vertical_distance_direction -- --nocapture`
- `cargo clippy -p kcl-lib --lib -- -D warnings`
