### PR TITLE
Guard modeling stream dimensions

### DIFF
--- a/src/lib/engineConnection/connectionManager.test.ts
+++ b/src/lib/engineConnection/connectionManager.test.ts
@@ -1,0 +1,65 @@
+import { ConnectionManager } from '@src/lib/engineConnection/connectionManager'
+import type { SettingsActorType } from '@src/machines/settingsMachine'
+import { describe, expect, it, vi } from 'vitest'
+
+function createConnectionManager() {
+  return new ConnectionManager({
+    settingsActor: {
+      getSnapshot: () => ({ context: {} }),
+    } as unknown as SettingsActorType,
+  })
+}
+
+function startConnectionManager(
+  manager: ConnectionManager,
+  { width, height }: { width: number; height: number }
+) {
+  return manager.start({
+    width,
+    height,
+    token: 'token',
+    setStreamIsReady: vi.fn(),
+  })
+}
+
+describe('ConnectionManager', () => {
+  it.each([
+    [{ width: 240, height: 256 }, 'width must be between 256 and 2160, 240'],
+    [{ width: 256, height: 240 }, 'height must be between 256 and 2160, 240'],
+    [{ width: 258, height: 256 }, 'width must be a multiple of 4, 258'],
+    [{ width: Number.NaN, height: 256 }, 'width must be finite, NaN'],
+  ])(
+    'rejects unsupported stream dimensions before mutating connection state',
+    async (dimensions, errorMessage) => {
+      const manager = createConnectionManager()
+      const rejectAllPendingCommands = vi.spyOn(
+        manager,
+        'rejectAllPendingCommands'
+      )
+
+      await expect(startConnectionManager(manager, dimensions)).rejects.toThrow(
+        errorMessage
+      )
+
+      expect(manager.started).toBe(false)
+      expect(manager.connection).toBeUndefined()
+      expect(rejectAllPendingCommands).not.toHaveBeenCalled()
+    }
+  )
+
+  it('does not send unsupported resize dimensions', async () => {
+    const manager = createConnectionManager()
+    const send = vi.fn()
+    manager.connection = {
+      deferredConnection: { promise: Promise.resolve() },
+      send,
+    } as unknown as NonNullable<ConnectionManager['connection']>
+
+    await expect(
+      manager.handleResize({ width: 256, height: 240 })
+    ).rejects.toThrow('height must be between 256 and 2160, 240')
+
+    expect(manager.streamDimensions).toEqual({ width: 256, height: 256 })
+    expect(send).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/engineConnection/connectionManager.ts
+++ b/src/lib/engineConnection/connectionManager.ts
@@ -44,6 +44,7 @@ import {
   EngineConnectionManagerEvents,
   EngineConnectionStateType,
   REJECTED_TOO_EARLY_WEBSOCKET_MESSAGE,
+  validateStreamDimensions,
 } from '@src/lib/engineConnection/utils'
 import {
   isExportResponse,
@@ -196,8 +197,6 @@ export class ConnectionManager extends EventTarget {
         )
       )
     }
-    this.started = true
-    this.rejectAllPendingCommands()
 
     if (this.connection) {
       return Promise.reject(
@@ -205,13 +204,13 @@ export class ConnectionManager extends EventTarget {
       )
     }
 
-    if (width <= 0) {
-      return Promise.reject(new Error(`width is <=0, ${width}`))
+    const invalidStreamDimensions = validateStreamDimensions({ width, height })
+    if (invalidStreamDimensions) {
+      return Promise.reject(invalidStreamDimensions)
     }
 
-    if (height <= 0) {
-      return Promise.reject(new Error(`height is <=0, ${height}`))
-    }
+    this.started = true
+    this.rejectAllPendingCommands()
 
     this.streamDimensions = {
       width,
@@ -1013,6 +1012,11 @@ export class ConnectionManager extends EventTarget {
     if (!this.connection) {
       console.warn('unable to resize, connection is not found')
       return
+    }
+
+    const invalidStreamDimensions = validateStreamDimensions({ width, height })
+    if (invalidStreamDimensions) {
+      return Promise.reject(invalidStreamDimensions)
     }
 
     // Make sure the connection is ready otherwise you are sending the events too early.

--- a/src/lib/engineConnection/utils.test.ts
+++ b/src/lib/engineConnection/utils.test.ts
@@ -1,0 +1,69 @@
+import {
+  getDimensions,
+  MAX_STREAM_DIMENSION,
+  MIN_STREAM_DIMENSION,
+  STREAM_DIMENSION_FACTOR,
+} from '@src/lib/engineConnection/utils'
+import { describe, expect, it } from 'vitest'
+
+function expectSupportedStreamDimensions({
+  width,
+  height,
+}: {
+  width: number
+  height: number
+}) {
+  expect(width).toBeGreaterThanOrEqual(MIN_STREAM_DIMENSION)
+  expect(height).toBeGreaterThanOrEqual(MIN_STREAM_DIMENSION)
+  expect(width).toBeLessThanOrEqual(MAX_STREAM_DIMENSION)
+  expect(height).toBeLessThanOrEqual(MAX_STREAM_DIMENSION)
+  expect(width % STREAM_DIMENSION_FACTOR).toBe(0)
+  expect(height % STREAM_DIMENSION_FACTOR).toBe(0)
+}
+
+describe('getDimensions', () => {
+  it.each([
+    [240, { width: 852, height: 256 }],
+    [164, { width: 1248, height: 256 }],
+    [112, { width: 1828, height: 256 }],
+    [232, { width: 884, height: 256 }],
+    [100, { width: 2048, height: 256 }],
+  ])('scales observed undersized height %ipx', (height, expected) => {
+    const dimensions = getDimensions(800, height)
+
+    expect(dimensions).toEqual(expected)
+    expectSupportedStreamDimensions(dimensions)
+  })
+
+  it('scales an undersized width with an otherwise valid height', () => {
+    const dimensions = getDimensions(240, 800)
+
+    expect(dimensions).toEqual({ width: 256, height: 852 })
+    expectSupportedStreamDimensions(dimensions)
+  })
+
+  it('keeps a normal viewport unchanged', () => {
+    const dimensions = getDimensions(1280, 720)
+
+    expect(dimensions).toEqual({ width: 1280, height: 720 })
+    expectSupportedStreamDimensions(dimensions)
+  })
+
+  it('preserves maximum-resolution downscaling', () => {
+    const dimensions = getDimensions(4000, 3000)
+
+    expect(dimensions).toEqual({ width: 2160, height: 1620 })
+    expectSupportedStreamDimensions(dimensions)
+  })
+
+  it('keeps extreme aspect ratios inside the supported range', () => {
+    const dimensions = getDimensions(5000, 100)
+
+    expect(dimensions).toEqual({ width: 2160, height: 256 })
+    expectSupportedStreamDimensions(dimensions)
+  })
+
+  it('leaves zero dimensions invalid for the connection guard', () => {
+    expect(getDimensions(0, 800)).toEqual({ width: 0, height: 800 })
+  })
+})

--- a/src/lib/engineConnection/utils.ts
+++ b/src/lib/engineConnection/utils.ts
@@ -302,16 +302,87 @@ export interface IEventListenerTracked {
   type: EventSource
 }
 
+export const MIN_STREAM_DIMENSION = 256
+export const MAX_STREAM_DIMENSION = 2160
+export const STREAM_DIMENSION_FACTOR = 4
+
 export function getDimensions(streamWidth: number, streamHeight: number) {
-  const factorOf = 4
-  const maxResolution = 2160
-  const ratio = Math.min(
-    Math.min(maxResolution / streamWidth, maxResolution / streamHeight),
-    1.0
+  const ratio = getStreamDimensionScale(streamWidth, streamHeight)
+  const width = normalizeStreamDimension(streamWidth * ratio)
+  const height = normalizeStreamDimension(streamHeight * ratio)
+  return { width, height }
+}
+
+export function validateStreamDimensions({
+  width,
+  height,
+}: {
+  width: number
+  height: number
+}): Error | undefined {
+  const invalidDimension = validateStreamDimension(width, 'width')
+  if (invalidDimension) {
+    return invalidDimension
+  }
+
+  return validateStreamDimension(height, 'height')
+}
+
+function getStreamDimensionScale(streamWidth: number, streamHeight: number) {
+  if (
+    !Number.isFinite(streamWidth) ||
+    !Number.isFinite(streamHeight) ||
+    streamWidth <= 0 ||
+    streamHeight <= 0
+  ) {
+    return 1
+  }
+
+  const minScale = Math.max(
+    MIN_STREAM_DIMENSION / streamWidth,
+    MIN_STREAM_DIMENSION / streamHeight,
+    1
   )
-  const quadWidth = Math.round((streamWidth * ratio) / factorOf) * factorOf
-  const quadHeight = Math.round((streamHeight * ratio) / factorOf) * factorOf
-  return { width: quadWidth, height: quadHeight }
+  const maxScale = Math.min(
+    MAX_STREAM_DIMENSION / streamWidth,
+    MAX_STREAM_DIMENSION / streamHeight
+  )
+
+  return Math.min(minScale, maxScale)
+}
+
+function normalizeStreamDimension(dimension: number) {
+  if (!Number.isFinite(dimension)) {
+    return dimension
+  }
+
+  const rounded =
+    Math.round(dimension / STREAM_DIMENSION_FACTOR) * STREAM_DIMENSION_FACTOR
+  if (rounded <= 0) {
+    return rounded
+  }
+
+  return Math.min(Math.max(rounded, MIN_STREAM_DIMENSION), MAX_STREAM_DIMENSION)
+}
+
+function validateStreamDimension(dimension: number, label: string) {
+  if (!Number.isFinite(dimension)) {
+    return new Error(`${label} must be finite, ${dimension}`)
+  }
+
+  if (dimension < MIN_STREAM_DIMENSION || dimension > MAX_STREAM_DIMENSION) {
+    return new Error(
+      `${label} must be between ${MIN_STREAM_DIMENSION} and ${MAX_STREAM_DIMENSION}, ${dimension}`
+    )
+  }
+
+  if (dimension % STREAM_DIMENSION_FACTOR !== 0) {
+    return new Error(
+      `${label} must be a multiple of ${STREAM_DIMENSION_FACTOR}, ${dimension}`
+    )
+  }
+
+  return undefined
 }
 
 export interface ManagerTearDown {

--- a/src/lib/layout/defaultAreaLibrary.tsx
+++ b/src/lib/layout/defaultAreaLibrary.tsx
@@ -54,7 +54,7 @@ function ModelingArea() {
   )
 
   return (
-    <div className="relative z-0 min-w-64 flex flex-col flex-1 items-center overflow-hidden">
+    <div className="relative z-0 min-w-64 min-h-64 flex flex-col flex-1 items-center overflow-hidden">
       <ConnectionStream
         authToken={authToken}
         sketchSolveStreamDimming={sketchSolveStreamDimming}


### PR DESCRIPTION
Closes #13228. This prevents undersized modeling stream dimensions from triggering repeated invalid engine connection attempts. Positive but undersized stream sizes are normalized up to the engine-supported 256px minimum before startup or resize, so users should continue into the scene normally. If the DOM somehow reports a truly invalid size such as 0 or NaN, startup stops client-side after the normal retries with the existing reconnect UI, while resize rejects without tearing down the current stream.

1. Adds a minimum height to the modeling area to match the existing minimum width guard.
2. Normalizes stream dimensions into the engine-supported 256-2160px range on multiples of 4.
3. Adds ConnectionManager guards and regression coverage for the observed undersized heights plus invalid direct startup/resize dimensions.

## How to test

Shrink the modeling viewport before startup and confirm the scene connects without a stream-too-small reconnect loop.

Resize an already connected scene down and back up, and confirm the existing stream remains active and resizing resumes when dimensions are valid.