### PR TITLE
chore(CI): run kcl-python-bindings jobs only when they answer something

### DIFF
--- a/.github/workflows/kcl-python-bindings.yml
+++ b/.github/workflows/kcl-python-bindings.yml
@@ -30,7 +30,6 @@ concurrency:
   cancel-in-progress: true
 jobs:
   changes:
-    name: kcl-python-bindings (changes)
     runs-on: namespace-profile-ubuntu-2-cores
     if: github.event_name != 'schedule'
     outputs:

--- a/.github/workflows/kcl-python-bindings.yml
+++ b/.github/workflows/kcl-python-bindings.yml
@@ -29,9 +29,56 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
+  changes:
+    name: kcl-python-bindings (changes)
+    runs-on: namespace-profile-ubuntu-2-cores
+    if: github.event_name != 'schedule'
+    outputs:
+      packaging: ${{ steps.filter.outputs.packaging == 'true' || steps.gates.outputs.found == 'true' }}
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - id: filter
+        name: Check for packaging changes
+        uses: dorny/paths-filter@v4.0.3
+        # A tag push has no previous ref to diff against, so this step can
+        # fail there. A tag forces the full matrix on its own.
+        continue-on-error: true
+        with:
+          # These inputs decide whether a wheel builds and links on one
+          # architecture but not another.
+          filters: |
+            packaging:
+              - 'rust/kcl-python-bindings/**'
+              - 'rust/Cargo.lock'
+              - 'rust/**/Cargo.toml'
+              - 'rust/rust-toolchain.toml'
+              - '.tool-versions'
+              - '.github/workflows/kcl-python-bindings.yml'
+      - id: gates
+        name: Check for platform-gated code
+        shell: bash
+        # Linux stands in for Windows and macOS only while no crate in the
+        # wheel compiles differently per platform. This step tests that
+        # premise on every run instead of assuming it. A hit forces the full
+        # matrix. Unlisted crates are scanned, so a new crate fails safe.
+        # kcl-language-server is excluded because it is not in the wheel, and
+        # wasm32 gates are excluded because no wheel targets wasm.
+        run: |
+          if rg -n 'cfg\([^)]*target_(os|family|env|arch)' \
+               --glob '*.rs' \
+               --glob '!rust/kcl-language-server/**' \
+               rust/ | rg -v wasm32; then
+            echo 'Platform-gated code found; building every architecture.'
+            echo 'found=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'found=false' >> "$GITHUB_OUTPUT"
+          fi
   linux-x86_64:
     name: kcl-python-bindings (linux-x86_64)
     runs-on: namespace-profile-ubuntu-8-cores
+    # The hourly schedule exists to observe flaky tests. It runs the test job
+    # and nothing else.
+    if: github.event_name != 'schedule'
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: actions/setup-python@v7.0.0
@@ -90,6 +137,9 @@ jobs:
   windows:
     name: kcl-python-bindings (windows)
     runs-on: namespace-profile-windows-8-cores
+    needs: changes
+    # Linux is the representative target on every other run.
+    if: needs.changes.outputs.packaging == 'true' || startsWith(github.ref, 'refs/tags/')
     strategy:
       matrix:
         target:
@@ -138,6 +188,8 @@ jobs:
           path: rust/kcl-python-bindings/dist
   macos:
     name: kcl-python-bindings (macos)
+    needs: changes
+    if: needs.changes.outputs.packaging == 'true' || startsWith(github.ref, 'refs/tags/')
     runs-on: namespace-profile-macos-6-cores
     strategy:
       matrix:
@@ -242,6 +294,7 @@ jobs:
   sdist:
     name: kcl-python-bindings (sdist)
     runs-on: namespace-profile-ubuntu-8-cores
+    if: github.event_name != 'schedule'
     steps:
       - uses: actions/checkout@v7.0.1
       - name: Install the latest version of uv


### PR DESCRIPTION
Pure addition, +53/−0. Every `if:` in the original #13244 lives here and nowhere else.

- The hourly cron exists to observe flaky tests, but was also building three wheel platforms and an sdist 24 times a day. It now runs the test job only.
- Windows and macOS wheels build on tags, when a packaging input changes, or when a scan finds platform-gated code. Linux is representative otherwise: every `target_arch` cfg in the tree is wasm32, the one `target_os` gate is in `kcl-language-server` which isn't in the wheel, and all three targets are 64-bit.
- The scan re-tests that premise every run instead of assuming it, and unlisted crates are scanned, so a new crate fails safe.
- Nothing here gates a merge: of ruleset 5324149's 34 required contexts, the only python one is `python-codespell`.