### PR TITLE
Show Zookeeper export downloads without refresh

### DIFF
--- a/src/components/ExchangeCard.tsx
+++ b/src/components/ExchangeCard.tsx
@@ -2,7 +2,11 @@ import type { MlCopilotServerMessage } from '@kittycad/lib'
 import { CustomIcon } from '@src/components/CustomIcon'
 import { MarkdownText } from '@src/components/MarkdownText'
 import { PlaceholderLine } from '@src/components/PlaceholderLine'
-import { Thinking } from '@src/components/Thinking'
+import {
+  ExportDownloadFiles,
+  isExportDownloadFile,
+  Thinking,
+} from '@src/components/Thinking'
 import Tooltip from '@src/components/Tooltip'
 import {
   type Exchange,
@@ -389,15 +393,29 @@ export const ResponsesCard = (props: ResponsesCardProp) => {
   const deltasAggregatedMarkdown = useMemo(() => {
     return props.deltasAggregated !== '' ? (
       <MarkdownText
+        key="response"
         text={props.deltasAggregated}
         className="whitespace-normal"
       />
     ) : null
   }, [props.deltasAggregated])
 
+  const exportDownloadFiles = useMemo(
+    () =>
+      props.items.flatMap((response) =>
+        'files' in response
+          ? response.files.files.filter(isExportDownloadFile)
+          : []
+      ),
+    [props.items]
+  )
+
   const children = [
     maybeError ? <MaybeError key="error" maybeError={maybeError} /> : null,
     deltasAggregatedMarkdown,
+    exportDownloadFiles.length > 0 ? (
+      <ExportDownloadFiles key="downloads" files={exportDownloadFiles} />
+    ) : null,
   ].filter((x: ReactNode) => x !== null)
 
   const shouldShowResponseBubble =

--- a/src/components/ExchangeCard.tsx
+++ b/src/components/ExchangeCard.tsx
@@ -400,14 +400,8 @@ export const ResponsesCard = (props: ResponsesCardProp) => {
     ) : null
   }, [props.deltasAggregated])
 
-  const exportDownloadFiles = useMemo(
-    () =>
-      props.items.flatMap((response) =>
-        'files' in response
-          ? response.files.files.filter(isExportDownloadFile)
-          : []
-      ),
-    [props.items]
+  const exportDownloadFiles = props.items.flatMap((response) =>
+    'files' in response ? response.files.files.filter(isExportDownloadFile) : []
   )
 
   const children = [

--- a/src/components/ExportDownloadFiles.test.tsx
+++ b/src/components/ExportDownloadFiles.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import type { MlCopilotFile, MlCopilotServerMessage } from '@kittycad/lib'
+import { ResponsesCard } from '@src/components/ExchangeCard'
+import { ExportDownloadFiles, Thinking } from '@src/components/Thinking'
+
+describe('export download files', () => {
+  beforeEach(() => {
+    global.URL.createObjectURL = vi.fn(() => 'blob:export-download')
+    global.URL.revokeObjectURL = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('keeps export downloads out of the reasoning view', () => {
+    const exportFile: MlCopilotFile = {
+      name: 'model.step',
+      mimetype: 'application/step',
+      data: [1, 2, 3],
+      metadata: { export_format: 'step' },
+    }
+
+    render(
+      <Thinking
+        thoughts={[{ files: { files: [exportFile] } }]}
+        isDone={false}
+        onlyShowImmediateThought={false}
+      />
+    )
+
+    expect(screen.queryByText('model.step')).not.toBeInTheDocument()
+    expect(screen.queryByText('Zookeeper File')).not.toBeInTheDocument()
+  })
+
+  test('keeps non-export files in reasoning when a message is mixed', () => {
+    const exportFile: MlCopilotFile = {
+      name: 'model.step',
+      mimetype: 'application/step',
+      data: [1, 2, 3],
+      metadata: { export_format: 'step' },
+    }
+    const snapshotFile: MlCopilotFile = {
+      name: 'snapshot.png',
+      mimetype: 'image/png',
+      data: [1, 2, 3],
+    }
+
+    render(
+      <Thinking
+        thoughts={[{ files: { files: [snapshotFile, exportFile] } }]}
+        isDone={false}
+        onlyShowImmediateThought={false}
+      />
+    )
+
+    expect(screen.getByText('snapshot.png')).toBeInTheDocument()
+    expect(screen.queryByText('model.step')).not.toBeInTheDocument()
+  })
+
+  test('renders an export download without reasoning decoration', () => {
+    const exportFile: MlCopilotFile = {
+      name: 'model.stl',
+      mimetype: 'model/stl',
+      data: [1, 2, 3],
+      metadata: { export_format: 'stl' },
+    }
+
+    render(<ExportDownloadFiles files={[exportFile]} />)
+
+    expect(screen.getByTestId('ml-response-download-files')).toHaveTextContent(
+      'model.stl'
+    )
+    expect(screen.queryByText('Zookeeper File')).not.toBeInTheDocument()
+  })
+
+  test('shows exported files with the final response', () => {
+    const items: MlCopilotServerMessage[] = [
+      {
+        files: {
+          files: [
+            {
+              name: 'model.step',
+              mimetype: 'application/step',
+              data: [1, 2, 3],
+              metadata: { export_format: 'step' },
+            },
+          ],
+        },
+      },
+    ]
+
+    render(
+      <ResponsesCard
+        items={items}
+        deltasAggregated="Exported successfully. The download is ready here."
+        isLastResponse={true}
+        onClickClearChat={vi.fn()}
+      />
+    )
+
+    const responseBubble = screen.getByTestId('ml-response-chat-bubble')
+    expect(responseBubble).toHaveTextContent(
+      'Exported successfully. The download is ready here.'
+    )
+    expect(within(responseBubble).getByText('model.step')).toBeInTheDocument()
+    expect(screen.queryByText('Zookeeper File')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/ExportDownloadFiles.test.tsx
+++ b/src/components/ExportDownloadFiles.test.tsx
@@ -108,4 +108,36 @@ describe('export download files', () => {
     expect(within(responseBubble).getByText('model.step')).toBeInTheDocument()
     expect(screen.queryByText('Zookeeper File')).not.toBeInTheDocument()
   })
+
+  test('shows an export added to the existing response list', () => {
+    const items: MlCopilotServerMessage[] = []
+    const onClickClearChat = vi.fn()
+    const responseCard = () => (
+      <ResponsesCard
+        items={items}
+        deltasAggregated="Exported successfully. The download is ready here."
+        isLastResponse={true}
+        onClickClearChat={onClickClearChat}
+      />
+    )
+    const { rerender } = render(responseCard())
+
+    expect(screen.queryByText('model.step')).not.toBeInTheDocument()
+
+    items.push({
+      files: {
+        files: [
+          {
+            name: 'model.step',
+            mimetype: 'application/step',
+            data: [1, 2, 3],
+            metadata: { export_format: 'step' },
+          },
+        ],
+      },
+    })
+    rerender(responseCard())
+
+    expect(screen.getByText('model.step')).toBeInTheDocument()
+  })
 })

--- a/src/components/Thinking.tsx
+++ b/src/components/Thinking.tsx
@@ -378,6 +378,10 @@ const isImageMimetype = (mimetype: string): boolean => {
   return mimetype.startsWith('image/')
 }
 
+export const isExportDownloadFile = (file: MlCopilotFile): boolean => {
+  return file.metadata?.export_format !== undefined
+}
+
 /**
  * Component for displaying an image file with error handling
  */
@@ -426,7 +430,7 @@ const ImageFileItem = (props: {
   )
 }
 
-export const FilesSnapshot = (props: { files: MlCopilotFile[] }) => {
+const FileList = (props: { files: MlCopilotFile[] }) => {
   const [objectUrls, setObjectUrls] = useState<string[]>([])
 
   useEffect(() => {
@@ -459,6 +463,44 @@ export const FilesSnapshot = (props: { files: MlCopilotFile[] }) => {
   )
 
   return (
+    <div className="flex max-w-full min-w-0 flex-col gap-3">
+      {imageFiles.map((file, index) => {
+        const fileIndex = props.files.indexOf(file)
+        const url = objectUrls[fileIndex]
+        return (
+          <ImageFileItem
+            key={`${file.name}-${index}`}
+            file={file}
+            url={url}
+            onDownload={handleDownload}
+          />
+        )
+      })}
+      {otherFiles.map((file, index) => {
+        const fileIndex = props.files.indexOf(file)
+        const url = objectUrls[fileIndex]
+        return (
+          <button
+            key={`${file.name}-${index}`}
+            onClick={() => url && handleDownload(url, file.name)}
+            className="flex flex-row gap-2 items-center cursor-pointer hover:bg-chalkboard-20 dark:hover:bg-chalkboard-90 p-2 rounded transition-colors text-left w-full"
+            title={`Click to download ${file.name}`}
+          >
+            <CustomIcon name="file" className="w-5 h-5 flex-shrink-0" />
+            <span className="text-sm truncate">{file.name}</span>
+            <CustomIcon
+              name="download"
+              className="w-4 h-4 ml-auto flex-shrink-0"
+            />
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+export const FilesSnapshot = (props: { files: MlCopilotFile[] }) => {
+  return (
     <ThoughtContainer
       heading={
         <ThoughtHeader icon={<CustomIcon name="file" className="w-6 h-6" />}>
@@ -470,41 +512,20 @@ export const FilesSnapshot = (props: { files: MlCopilotFile[] }) => {
     >
       {/* Using a custom content wrapper without height restriction for images */}
       <div className="min-w-0 max-w-full pt-4 pb-4 border-l pl-5 ml-3 b-3">
-        <div className="flex max-w-full min-w-0 flex-col gap-3">
-          {imageFiles.map((file, index) => {
-            const fileIndex = props.files.indexOf(file)
-            const url = objectUrls[fileIndex]
-            return (
-              <ImageFileItem
-                key={index}
-                file={file}
-                url={url}
-                onDownload={handleDownload}
-              />
-            )
-          })}
-          {otherFiles.map((file, index) => {
-            const fileIndex = props.files.indexOf(file)
-            const url = objectUrls[fileIndex]
-            return (
-              <button
-                key={`other-${index}`}
-                onClick={() => url && handleDownload(url, file.name)}
-                className="flex flex-row gap-2 items-center cursor-pointer hover:bg-chalkboard-20 dark:hover:bg-chalkboard-90 p-2 rounded transition-colors text-left w-full"
-                title={`Click to download ${file.name}`}
-              >
-                <CustomIcon name="file" className="w-5 h-5 flex-shrink-0" />
-                <span className="text-sm truncate">{file.name}</span>
-                <CustomIcon
-                  name="download"
-                  className="w-4 h-4 ml-auto flex-shrink-0"
-                />
-              </button>
-            )
-          })}
-        </div>
+        <FileList files={props.files} />
       </div>
     </ThoughtContainer>
+  )
+}
+
+export const ExportDownloadFiles = (props: { files: MlCopilotFile[] }) => {
+  return (
+    <div
+      className="mt-3 min-w-0 max-w-full rounded-sm border b-4"
+      data-testid="ml-response-download-files"
+    >
+      <FileList files={props.files} />
+    </div>
   )
 }
 
@@ -695,7 +716,12 @@ const fromDataToComponent = (
   }
 
   if ('files' in thought) {
-    return <FilesSnapshot key={options.key} files={thought.files.files} />
+    const reasoningFiles = thought.files.files.filter(
+      (file) => !isExportDownloadFile(file)
+    )
+    return reasoningFiles.length > 0 ? (
+      <FilesSnapshot key={options.key} files={reasoningFiles} />
+    ) : null
   }
 
   return null
@@ -720,7 +746,11 @@ export const Thinking = (props: {
 
   const reasoningThoughts =
     props.thoughts?.filter((x: MlCopilotServerMessage) => {
-      return 'reasoning' in x || 'files' in x
+      return (
+        'reasoning' in x ||
+        ('files' in x &&
+          x.files.files.some((file) => !isExportDownloadFile(file)))
+      )
     }) ?? []
 
   // Resume reasoning autoscroll when a new prompt is sent

--- a/src/lib/zookeeper/zookeeperManagerMachine.test.ts
+++ b/src/lib/zookeeper/zookeeperManagerMachine.test.ts
@@ -824,6 +824,85 @@ describe('zookeeperManagerMachine', () => {
 
       actor.stop()
     })
+
+    it('stores file responses in the current exchange', async () => {
+      const ws: TestWebSocket = new TestSocket() as TestWebSocket
+      const conversation: Conversation = {
+        exchanges: [
+          {
+            request: {
+              type: 'user',
+              content: 'export this in step',
+            },
+            responses: [],
+            deltasAggregated:
+              'Exported successfully. The download is ready here.',
+          },
+        ],
+      }
+      const machine = zookeeperManagerMachine.provide({
+        actors: {
+          [ZookeeperManagerStates.Setup]: fromPromise<
+            Partial<ZookeeperManagerContext>,
+            SetupActorInput
+          >(async () => ({ ws, conversation })),
+        },
+      })
+      const actor = createActor(machine, {
+        input: { apiToken: '' },
+      }).start()
+
+      actor.send({
+        type: ZookeeperManagerTransitions.CacheSetupAndConnect,
+        refParentSend: vi.fn(),
+      })
+      await waitFor(actor, (state) =>
+        state.matches(ZookeeperManagerStates.WaitForContinueCheck)
+      )
+
+      actor.send({
+        type: ZookeeperManagerStates.ContinueCheck,
+        projectName: 'zoo-project',
+        projectFiles: [],
+      })
+      await waitFor(actor, (state) =>
+        state.matches(ZookeeperManagerStates.Ready)
+      )
+
+      actor.send({
+        type: ZookeeperManagerTransitions.ResponseReceive,
+        response: {
+          files: {
+            files: [
+              {
+                name: 'model.step',
+                mimetype: 'model/step',
+                data: [1, 2, 3],
+                metadata: { export_format: 'step' },
+              },
+            ],
+          },
+        },
+      })
+
+      await waitFor(actor, (state) => state.context.lastMessageType === 'files')
+      expect(
+        actor.getSnapshot().context.conversation?.exchanges[0]?.responses
+      ).toContainEqual({
+        files: {
+          files: [
+            {
+              name: 'model.step',
+              mimetype: 'model/step',
+              data: [1, 2, 3],
+              metadata: { export_format: 'step' },
+            },
+          ],
+        },
+      })
+
+      actor.stop()
+    })
   })
 
   describe('ConversationClose', () => {

--- a/src/lib/zookeeper/zookeeperManagerMachine.ts
+++ b/src/lib/zookeeper/zookeeperManagerMachine.ts
@@ -1733,6 +1733,7 @@ export const zookeeperManagerMachine = setup({
                       'delta',
                       'tool_output',
                       'reasoning',
+                      'files',
                       'replay',
                     ]
                     const lastMessageType:


### PR DESCRIPTION
## What changed

- Render Zookeeper STEP/STL export downloads inside the final response card.
- Keep exported downloads out of the collapsible reasoning view while preserving ordinary screenshots and working files there.
- Recompute the export download list during render so a newly appended file appears immediately.
- Add regression coverage for export files appended to the existing response list.

## Why

The Zookeeper state machine appends file messages to the existing `responses` array. The UI memoized its derived export list using that array's identity, so it kept the earlier empty result even after React rendered the new conversation state. Refreshing rebuilt the response array and made the download appear.

Users now see the download as soon as the export file arrives, without refreshing the page.

Supersedes #13073.

## Validation

- `npm run test:unit -- src/components/ExportDownloadFiles.test.tsx src/lib/zookeeper/zookeeperManagerMachine.test.ts` (29 tests passed)
- Full Biome formatting check (1,135 files checked)
