### PR TITLE
Add cloud sync incident regression coverage

### DIFF
--- a/src/lib/cloudSync/incidentRegression.test.ts
+++ b/src/lib/cloudSync/incidentRegression.test.ts
@@ -1,0 +1,194 @@
+import 'fake-indexeddb/auto'
+import {
+  configureCloudSyncEngine,
+  configureCloudSyncLocalFileSystem,
+  filterCloudSyncProjectFilesForSync,
+  notifyCloudSyncWriteLikeMutation,
+  type ProjectArchiveFile,
+  setCloudSyncOpenedProject,
+} from '@src/lib/cloudSync'
+import { projectManifestFromFiles } from '@src/lib/cloudSync/projectArchive'
+import {
+  appendOutboxEntry,
+  getAllOutboxEntries,
+  putProjectMetadata,
+} from '@src/lib/cloudSync/syncDb'
+import {
+  createCloudSyncTestFs,
+  deleteCloudSyncTestDatabase,
+  getFetchMethod,
+  getFetchUrl,
+  jsonResponse,
+} from '@src/lib/cloudSync/testUtils'
+import type { OutboxEntry } from '@src/lib/cloudSync/types'
+import { PROJECT_SETTINGS_FILE_NAME } from '@src/lib/constants'
+import { CLOUD_PROJECT_LIBRARY_TYPE } from '@src/lib/projectLibraries'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const baseUrl = 'https://example.test'
+const environmentName = 'dev.zoo.dev'
+const projectDirectory = '/documents/Projects'
+const projectPath = `${projectDirectory}/bracket`
+const remoteProjectId = 'remote-project-123'
+const remoteRevision = 'revision-123'
+const updatedRemoteRevision = 'revision-124'
+const remoteProjectUrl = `${baseUrl}/user/projects/${remoteProjectId}`
+const encoder = new TextEncoder()
+const projectToml = `title = "Bracket"\n\n[cloud."${environmentName}"]\nproject_id = "${remoteProjectId}"\n`
+
+const fetchMock = vi.fn<typeof fetch>()
+
+function projectFile(
+  relativePath: string,
+  contents: string
+): ProjectArchiveFile {
+  return {
+    relativePath,
+    data: encoder.encode(contents),
+  }
+}
+
+function remoteProject(revision = remoteRevision) {
+  return {
+    id: remoteProjectId,
+    title: 'Bracket',
+    revision,
+  }
+}
+
+function installFetchMock(onUpdate?: (formData: FormData) => Promise<void>) {
+  fetchMock.mockImplementation(async (input, init) => {
+    const url = getFetchUrl(input)
+    const method = getFetchMethod(input, init)
+
+    if (url === remoteProjectUrl && method === 'GET') {
+      return jsonResponse(remoteProject())
+    }
+
+    if (url.startsWith(remoteProjectUrl) && method === 'PUT') {
+      await onUpdate?.(init?.body as FormData)
+      return jsonResponse(remoteProject(updatedRemoteRevision))
+    }
+
+    return jsonResponse({ message: `Unexpected fetch: ${method} ${url}` }, 500)
+  })
+  vi.stubGlobal('fetch', fetchMock)
+}
+
+async function seedSyncedProject(baseFiles: ProjectArchiveFile[]) {
+  await putProjectMetadata({
+    schemaVersion: 1,
+    localProjectPath: projectPath,
+    projectName: 'bracket',
+    remoteProjectId,
+    remoteRevision,
+    baseManifest: await projectManifestFromFiles(
+      filterCloudSyncProjectFilesForSync(baseFiles)
+    ),
+  })
+}
+
+describe('cloud sync incident regressions', () => {
+  beforeEach(async () => {
+    await deleteCloudSyncTestDatabase()
+    fetchMock.mockReset()
+  })
+
+  afterEach(async () => {
+    setCloudSyncOpenedProject(undefined)
+    configureCloudSyncEngine({ enabled: false })
+    vi.unstubAllGlobals()
+    await deleteCloudSyncTestDatabase()
+  })
+
+  it.skip('drains project writes when a direct file-route reload omitted library ownership', async () => {
+    const files = new Map([
+      [`${projectPath}/main.kcl`, 'local = 2\n'],
+      [`${projectPath}/${PROJECT_SETTINGS_FILE_NAME}`, projectToml],
+    ])
+    configureCloudSyncLocalFileSystem(
+      createCloudSyncTestFs(files, { projectDirectory })
+    )
+    await seedSyncedProject([
+      projectFile('main.kcl', 'base = 1\n'),
+      projectFile(PROJECT_SETTINGS_FILE_NAME, projectToml),
+    ])
+    installFetchMock()
+
+    // A direct browser reload can restore the project path before project
+    // library ownership has been resolved.
+    setCloudSyncOpenedProject({ projectPath })
+    configureCloudSyncEngine({
+      enabled: true,
+      baseUrl,
+      environmentName,
+      cloudProjectDirectoryPaths: [projectDirectory],
+      autoEnrollCloudLibraryProjects: true,
+    })
+
+    await notifyCloudSyncWriteLikeMutation(`${projectPath}/main.kcl`)
+
+    await vi.waitFor(() => {
+      expect(
+        fetchMock.mock.calls.filter(
+          ([input, init]) =>
+            getFetchUrl(input).startsWith(remoteProjectUrl) &&
+            getFetchMethod(input, init) === 'PUT'
+        )
+      ).toHaveLength(1)
+    })
+    await expect(getAllOutboxEntries()).resolves.toEqual([])
+  })
+
+  it.skip('declares observed local file deletions in a replacement upload', async () => {
+    const deletedFilePath = `${projectPath}/obsolete.kcl`
+    const files = new Map([
+      [`${projectPath}/main.kcl`, 'base = 1\n'],
+      [`${projectPath}/${PROJECT_SETTINGS_FILE_NAME}`, projectToml],
+    ])
+    configureCloudSyncLocalFileSystem(
+      createCloudSyncTestFs(files, { projectDirectory })
+    )
+    await seedSyncedProject([
+      projectFile('main.kcl', 'base = 1\n'),
+      projectFile('obsolete.kcl', 'obsolete = 1\n'),
+      projectFile(PROJECT_SETTINGS_FILE_NAME, projectToml),
+    ])
+    await appendOutboxEntry({
+      projectPath,
+      kind: 'upsert',
+      targetPath: deletedFilePath,
+      deletedPaths: ['obsolete.kcl'],
+      createdAt: '2026-08-24T12:00:00.000Z',
+    } as Omit<OutboxEntry, 'id'> & { deletedPaths: string[] })
+    installFetchMock(async (formData) => {
+      const body = JSON.parse(await (formData.get('body') as Blob).text()) as {
+        deleted_paths?: string[]
+      }
+      expect(body.deleted_paths).toEqual(['obsolete.kcl'])
+    })
+    setCloudSyncOpenedProject({
+      projectPath,
+      libraryPath: projectDirectory,
+      libraryType: CLOUD_PROJECT_LIBRARY_TYPE,
+    })
+
+    configureCloudSyncEngine({
+      enabled: true,
+      baseUrl,
+      environmentName,
+      cloudProjectDirectoryPaths: [projectDirectory],
+      autoEnrollCloudLibraryProjects: true,
+    })
+
+    await vi.waitFor(() => {
+      expect(
+        fetchMock.mock.calls.filter(
+          ([input, init]) =>
+            getFetchUrl(input).startsWith(remoteProjectUrl) &&
+            getFetchMethod(input, init) === 'PUT'
+        )
+      ).toHaveLength(1)
+    })
+  })
+})

--- a/src/lib/cloudSync/incidentRegression.test.ts
+++ b/src/lib/cloudSync/incidentRegression.test.ts
@@ -101,94 +101,104 @@ describe('cloud sync incident regressions', () => {
     await deleteCloudSyncTestDatabase()
   })
 
-  it.skip('drains project writes when a direct file-route reload omitted library ownership', async () => {
-    const files = new Map([
-      [`${projectPath}/main.kcl`, 'local = 2\n'],
-      [`${projectPath}/${PROJECT_SETTINGS_FILE_NAME}`, projectToml],
-    ])
-    configureCloudSyncLocalFileSystem(
-      createCloudSyncTestFs(files, { projectDirectory })
-    )
-    await seedSyncedProject([
-      projectFile('main.kcl', 'base = 1\n'),
-      projectFile(PROJECT_SETTINGS_FILE_NAME, projectToml),
-    ])
-    installFetchMock()
+  it.fails(
+    'drains project writes when a direct file-route reload omitted library ownership',
+    async () => {
+      const files = new Map([
+        [`${projectPath}/main.kcl`, 'local = 2\n'],
+        [`${projectPath}/${PROJECT_SETTINGS_FILE_NAME}`, projectToml],
+      ])
+      configureCloudSyncLocalFileSystem(
+        createCloudSyncTestFs(files, { projectDirectory })
+      )
+      await seedSyncedProject([
+        projectFile('main.kcl', 'base = 1\n'),
+        projectFile(PROJECT_SETTINGS_FILE_NAME, projectToml),
+      ])
+      installFetchMock()
 
-    // A direct browser reload can restore the project path before project
-    // library ownership has been resolved.
-    setCloudSyncOpenedProject({ projectPath })
-    configureCloudSyncEngine({
-      enabled: true,
-      baseUrl,
-      environmentName,
-      cloudProjectDirectoryPaths: [projectDirectory],
-      autoEnrollCloudLibraryProjects: true,
-    })
+      // A direct browser reload can restore the project path before project
+      // library ownership has been resolved.
+      setCloudSyncOpenedProject({ projectPath })
+      configureCloudSyncEngine({
+        enabled: true,
+        baseUrl,
+        environmentName,
+        cloudProjectDirectoryPaths: [projectDirectory],
+        autoEnrollCloudLibraryProjects: true,
+      })
 
-    await notifyCloudSyncWriteLikeMutation(`${projectPath}/main.kcl`)
+      await notifyCloudSyncWriteLikeMutation(`${projectPath}/main.kcl`)
 
-    await vi.waitFor(() => {
-      expect(
-        fetchMock.mock.calls.filter(
-          ([input, init]) =>
-            getFetchUrl(input).startsWith(remoteProjectUrl) &&
-            getFetchMethod(input, init) === 'PUT'
-        )
-      ).toHaveLength(1)
-    })
-    await expect(getAllOutboxEntries()).resolves.toEqual([])
-  })
+      await vi.waitFor(() => {
+        expect(
+          fetchMock.mock.calls.filter(
+            ([input, init]) =>
+              getFetchUrl(input).startsWith(remoteProjectUrl) &&
+              getFetchMethod(input, init) === 'PUT'
+          )
+        ).toHaveLength(1)
+      })
+      await expect(getAllOutboxEntries()).resolves.toEqual([])
+    }
+  )
 
-  it.skip('declares observed local file deletions in a replacement upload', async () => {
-    const deletedFilePath = `${projectPath}/obsolete.kcl`
-    const files = new Map([
-      [`${projectPath}/main.kcl`, 'base = 1\n'],
-      [`${projectPath}/${PROJECT_SETTINGS_FILE_NAME}`, projectToml],
-    ])
-    configureCloudSyncLocalFileSystem(
-      createCloudSyncTestFs(files, { projectDirectory })
-    )
-    await seedSyncedProject([
-      projectFile('main.kcl', 'base = 1\n'),
-      projectFile('obsolete.kcl', 'obsolete = 1\n'),
-      projectFile(PROJECT_SETTINGS_FILE_NAME, projectToml),
-    ])
-    await appendOutboxEntry({
-      projectPath,
-      kind: 'upsert',
-      targetPath: deletedFilePath,
-      deletedPaths: ['obsolete.kcl'],
-      createdAt: '2026-08-24T12:00:00.000Z',
-    } as Omit<OutboxEntry, 'id'> & { deletedPaths: string[] })
-    installFetchMock(async (formData) => {
-      const body = JSON.parse(await (formData.get('body') as Blob).text()) as {
-        deleted_paths?: string[]
-      }
-      expect(body.deleted_paths).toEqual(['obsolete.kcl'])
-    })
-    setCloudSyncOpenedProject({
-      projectPath,
-      libraryPath: projectDirectory,
-      libraryType: CLOUD_PROJECT_LIBRARY_TYPE,
-    })
+  it.fails(
+    'declares observed local file deletions in a replacement upload',
+    async () => {
+      const deletedFilePath = `${projectPath}/obsolete.kcl`
+      const files = new Map([
+        [`${projectPath}/main.kcl`, 'base = 1\n'],
+        [`${projectPath}/${PROJECT_SETTINGS_FILE_NAME}`, projectToml],
+      ])
+      configureCloudSyncLocalFileSystem(
+        createCloudSyncTestFs(files, { projectDirectory })
+      )
+      await seedSyncedProject([
+        projectFile('main.kcl', 'base = 1\n'),
+        projectFile('obsolete.kcl', 'obsolete = 1\n'),
+        projectFile(PROJECT_SETTINGS_FILE_NAME, projectToml),
+      ])
+      await appendOutboxEntry({
+        projectPath,
+        kind: 'upsert',
+        targetPath: deletedFilePath,
+        deletedPaths: ['obsolete.kcl'],
+        createdAt: '2026-08-24T12:00:00.000Z',
+      } as Omit<OutboxEntry, 'id'> & { deletedPaths: string[] })
+      let uploadedDeletedPaths: string[] | undefined
+      installFetchMock(async (formData) => {
+        const body = JSON.parse(
+          await (formData.get('body') as Blob).text()
+        ) as {
+          deleted_paths?: string[]
+        }
+        uploadedDeletedPaths = body.deleted_paths
+      })
+      setCloudSyncOpenedProject({
+        projectPath,
+        libraryPath: projectDirectory,
+        libraryType: CLOUD_PROJECT_LIBRARY_TYPE,
+      })
 
-    configureCloudSyncEngine({
-      enabled: true,
-      baseUrl,
-      environmentName,
-      cloudProjectDirectoryPaths: [projectDirectory],
-      autoEnrollCloudLibraryProjects: true,
-    })
+      configureCloudSyncEngine({
+        enabled: true,
+        baseUrl,
+        environmentName,
+        cloudProjectDirectoryPaths: [projectDirectory],
+        autoEnrollCloudLibraryProjects: true,
+      })
 
-    await vi.waitFor(() => {
-      expect(
-        fetchMock.mock.calls.filter(
-          ([input, init]) =>
-            getFetchUrl(input).startsWith(remoteProjectUrl) &&
-            getFetchMethod(input, init) === 'PUT'
-        )
-      ).toHaveLength(1)
-    })
-  })
+      await vi.waitFor(() => {
+        expect(
+          fetchMock.mock.calls.filter(
+            ([input, init]) =>
+              getFetchUrl(input).startsWith(remoteProjectUrl) &&
+              getFetchMethod(input, init) === 'PUT'
+          )
+        ).toHaveLength(1)
+      })
+      expect(uploadedDeletedPaths).toEqual(['obsolete.kcl'])
+    }
+  )
 })

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -149,8 +149,7 @@ vi.mock('@src/components/CloudConflictDialog', async () => {
     },
     useCloudSyncProjectConflict: () => cloudConflictDialogMocks.conflict,
     useCloudSyncProjectConflicts: () => [],
-    useCloudSyncProjectMetadata: () =>
-      cloudConflictDialogMocks.projectMetadata,
+    useCloudSyncProjectMetadata: () => cloudConflictDialogMocks.projectMetadata,
   }
 })
 
@@ -595,65 +594,79 @@ describe('cloud sync status bar conflict dialog', () => {
 })
 
 describe('cloud sync project menu item', () => {
-  test.skip('keeps a durable project failure visible after runtime status resets', () => {
-    cloudSyncStatus.value = {
-      enabled: true,
-      state: 'idle',
-      pendingCount: 0,
-      scopedProjectCloudProjectId: 'remote-123',
-    }
-    cloudConflictDialogMocks.projectMetadata = {
-      localProjectPath: projectWellFormed.path,
-      remoteProjectId: 'remote-123',
-      lastFailure: {
-        message: 'Cloud sync stopped before local changes were uploaded.',
-        at: new Date(now - 60_000).toISOString(),
-      },
-    }
-    const cloudSync = createCloudSyncService()
-    const { app, dispose } = createProjectMenuApp(cloudSync)
+  test.fails(
+    'keeps a durable project failure visible after runtime status resets',
+    () => {
+      cloudSyncStatus.value = {
+        enabled: true,
+        state: 'idle',
+        pendingCount: 0,
+        scopedProjectCloudProjectId: 'remote-123',
+      }
+      cloudConflictDialogMocks.projectMetadata = {
+        localProjectPath: projectWellFormed.path,
+        remoteProjectId: 'remote-123',
+        lastFailure: {
+          message: 'Cloud sync stopped before local changes were uploaded.',
+          at: new Date(now - 60_000).toISOString(),
+        },
+      }
+      const cloudSync = createCloudSyncService()
+      const { app, dispose } = createProjectMenuApp(cloudSync)
 
-    try {
-      renderWithRouter(
-        <ProjectSidebarMenu app={app} enableMenu project={projectWellFormed} />
-      )
+      try {
+        renderWithRouter(
+          <ProjectSidebarMenu
+            app={app}
+            enableMenu
+            project={projectWellFormed}
+          />
+        )
 
-      expect(
-        screen.getByTestId('project-sidebar-cloud-error-badge')
-      ).toHaveTextContent('Cloud error')
-    } finally {
-      dispose()
+        expect(
+          screen.getByTestId('project-sidebar-cloud-error-badge')
+        ).toHaveTextContent('Cloud error')
+      } finally {
+        dispose()
+      }
     }
-  })
+  )
 
-  test.skip('shows a persistent badge when durable project work is stalled', () => {
-    cloudSyncStatus.value = {
-      enabled: true,
-      state: 'idle',
-      pendingCount: 0,
-      scopedProjectCloudProjectId: 'remote-123',
-    }
-    cloudConflictDialogMocks.projectMetadata = {
-      localProjectPath: projectWellFormed.path,
-      remoteProjectId: 'remote-123',
-      hasPendingChanges: true,
-      pendingSince: new Date(now - 5 * 60_000).toISOString(),
-    }
-    const cloudSync = createCloudSyncService()
-    const { app, dispose } = createProjectMenuApp(cloudSync)
+  test.fails(
+    'shows a persistent badge when durable project work is stalled',
+    () => {
+      cloudSyncStatus.value = {
+        enabled: true,
+        state: 'idle',
+        pendingCount: 0,
+        scopedProjectCloudProjectId: 'remote-123',
+      }
+      cloudConflictDialogMocks.projectMetadata = {
+        localProjectPath: projectWellFormed.path,
+        remoteProjectId: 'remote-123',
+        hasPendingChanges: true,
+        pendingSince: new Date(now - 5 * 60_000).toISOString(),
+      }
+      const cloudSync = createCloudSyncService()
+      const { app, dispose } = createProjectMenuApp(cloudSync)
 
-    try {
-      renderWithRouter(
-        <ProjectSidebarMenu app={app} enableMenu project={projectWellFormed} />
-      )
+      try {
+        renderWithRouter(
+          <ProjectSidebarMenu
+            app={app}
+            enableMenu
+            project={projectWellFormed}
+          />
+        )
 
-      expect(
-        screen.getByTestId('project-sidebar-cloud-stalled-badge')
-      ).toHaveTextContent('Cloud sync stalled')
-    } finally {
-      dispose()
+        expect(
+          screen.getByTestId('project-sidebar-cloud-stalled-badge')
+        ).toHaveTextContent('Cloud sync stalled')
+      } finally {
+        dispose()
+      }
     }
-  })
+  )
 
   test('shows synced state from the project sidebar menu', async () => {
     cloudSyncStatus.value = {

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -64,6 +64,7 @@ const cloudConflictDialogMocks = vi.hoisted(
     conflictDialogProjectPath?: string
     dialogProjectPaths: string[]
     errorDialogMessage?: string
+    projectMetadata?: unknown
     listeners: Set<() => void>
     notify: () => void
   } => ({
@@ -71,6 +72,7 @@ const cloudConflictDialogMocks = vi.hoisted(
     conflictDialogProjectPath: undefined,
     dialogProjectPaths: [],
     errorDialogMessage: undefined,
+    projectMetadata: undefined,
     listeners: new Set(),
     notify: () => {
       for (const listener of cloudConflictDialogMocks.listeners) {
@@ -147,6 +149,8 @@ vi.mock('@src/components/CloudConflictDialog', async () => {
     },
     useCloudSyncProjectConflict: () => cloudConflictDialogMocks.conflict,
     useCloudSyncProjectConflicts: () => [],
+    useCloudSyncProjectMetadata: () =>
+      cloudConflictDialogMocks.projectMetadata,
   }
 })
 
@@ -433,6 +437,7 @@ afterEach(() => {
   cloudConflictDialogMocks.conflictDialogProjectPath = undefined
   cloudConflictDialogMocks.dialogProjectPaths = []
   cloudConflictDialogMocks.errorDialogMessage = undefined
+  cloudConflictDialogMocks.projectMetadata = undefined
   cloudSyncStatus.value = {
     enabled: false,
     state: 'disabled',
@@ -590,6 +595,66 @@ describe('cloud sync status bar conflict dialog', () => {
 })
 
 describe('cloud sync project menu item', () => {
+  test.skip('keeps a durable project failure visible after runtime status resets', () => {
+    cloudSyncStatus.value = {
+      enabled: true,
+      state: 'idle',
+      pendingCount: 0,
+      scopedProjectCloudProjectId: 'remote-123',
+    }
+    cloudConflictDialogMocks.projectMetadata = {
+      localProjectPath: projectWellFormed.path,
+      remoteProjectId: 'remote-123',
+      lastFailure: {
+        message: 'Cloud sync stopped before local changes were uploaded.',
+        at: new Date(now - 60_000).toISOString(),
+      },
+    }
+    const cloudSync = createCloudSyncService()
+    const { app, dispose } = createProjectMenuApp(cloudSync)
+
+    try {
+      renderWithRouter(
+        <ProjectSidebarMenu app={app} enableMenu project={projectWellFormed} />
+      )
+
+      expect(
+        screen.getByTestId('project-sidebar-cloud-error-badge')
+      ).toHaveTextContent('Cloud error')
+    } finally {
+      dispose()
+    }
+  })
+
+  test.skip('shows a persistent badge when durable project work is stalled', () => {
+    cloudSyncStatus.value = {
+      enabled: true,
+      state: 'idle',
+      pendingCount: 0,
+      scopedProjectCloudProjectId: 'remote-123',
+    }
+    cloudConflictDialogMocks.projectMetadata = {
+      localProjectPath: projectWellFormed.path,
+      remoteProjectId: 'remote-123',
+      hasPendingChanges: true,
+      pendingSince: new Date(now - 5 * 60_000).toISOString(),
+    }
+    const cloudSync = createCloudSyncService()
+    const { app, dispose } = createProjectMenuApp(cloudSync)
+
+    try {
+      renderWithRouter(
+        <ProjectSidebarMenu app={app} enableMenu project={projectWellFormed} />
+      )
+
+      expect(
+        screen.getByTestId('project-sidebar-cloud-stalled-badge')
+      ).toHaveTextContent('Cloud sync stalled')
+    } finally {
+      dispose()
+    }
+  })
+
   test('shows synced state from the project sidebar menu', async () => {
     cloudSyncStatus.value = {
       enabled: true,

--- a/src/lib/cloudSync/syncDb.test.ts
+++ b/src/lib/cloudSync/syncDb.test.ts
@@ -8,6 +8,7 @@ import {
   putProjectMetadata,
 } from '@src/lib/cloudSync/syncDb'
 import { deleteCloudSyncTestDatabase } from '@src/lib/cloudSync/testUtils'
+import type { OutboxEntry } from '@src/lib/cloudSync/types'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 describe('cloud sync outbox persistence', () => {
@@ -75,6 +76,31 @@ describe('cloud sync outbox persistence', () => {
         kind: 'upsert',
         targetPath: '/projects/bracket/main.kcl',
         createdAt: '2026-07-28T12:00:00.000Z',
+      },
+    ])
+  })
+
+  it.skip('coalesces explicit file deletions without losing their paths', async () => {
+    await appendOutboxEntry({
+      projectPath: '/projects/bracket',
+      kind: 'upsert',
+      targetPath: '/projects/bracket/first.kcl',
+      deletedPaths: ['first.kcl'],
+      createdAt: '2026-08-24T12:00:00.000Z',
+    } as Omit<OutboxEntry, 'id'> & { deletedPaths: string[] })
+    await appendOutboxEntry({
+      projectPath: '/projects/bracket',
+      kind: 'upsert',
+      targetPath: '/projects/bracket/second.kcl',
+      deletedPaths: ['second.kcl'],
+      createdAt: '2026-08-24T12:01:00.000Z',
+    } as Omit<OutboxEntry, 'id'> & { deletedPaths: string[] })
+
+    await expect(getAllOutboxEntries()).resolves.toMatchObject([
+      {
+        projectPath: '/projects/bracket',
+        kind: 'upsert',
+        deletedPaths: ['first.kcl', 'second.kcl'],
       },
     ])
   })

--- a/src/lib/cloudSync/syncDb.test.ts
+++ b/src/lib/cloudSync/syncDb.test.ts
@@ -80,30 +80,33 @@ describe('cloud sync outbox persistence', () => {
     ])
   })
 
-  it.skip('coalesces explicit file deletions without losing their paths', async () => {
-    await appendOutboxEntry({
-      projectPath: '/projects/bracket',
-      kind: 'upsert',
-      targetPath: '/projects/bracket/first.kcl',
-      deletedPaths: ['first.kcl'],
-      createdAt: '2026-08-24T12:00:00.000Z',
-    } as Omit<OutboxEntry, 'id'> & { deletedPaths: string[] })
-    await appendOutboxEntry({
-      projectPath: '/projects/bracket',
-      kind: 'upsert',
-      targetPath: '/projects/bracket/second.kcl',
-      deletedPaths: ['second.kcl'],
-      createdAt: '2026-08-24T12:01:00.000Z',
-    } as Omit<OutboxEntry, 'id'> & { deletedPaths: string[] })
-
-    await expect(getAllOutboxEntries()).resolves.toMatchObject([
-      {
+  it.fails(
+    'coalesces explicit file deletions without losing their paths',
+    async () => {
+      await appendOutboxEntry({
         projectPath: '/projects/bracket',
         kind: 'upsert',
-        deletedPaths: ['first.kcl', 'second.kcl'],
-      },
-    ])
-  })
+        targetPath: '/projects/bracket/first.kcl',
+        deletedPaths: ['first.kcl'],
+        createdAt: '2026-08-24T12:00:00.000Z',
+      } as Omit<OutboxEntry, 'id'> & { deletedPaths: string[] })
+      await appendOutboxEntry({
+        projectPath: '/projects/bracket',
+        kind: 'upsert',
+        targetPath: '/projects/bracket/second.kcl',
+        deletedPaths: ['second.kcl'],
+        createdAt: '2026-08-24T12:01:00.000Z',
+      } as Omit<OutboxEntry, 'id'> & { deletedPaths: string[] })
+
+      await expect(getAllOutboxEntries()).resolves.toMatchObject([
+        {
+          projectPath: '/projects/bracket',
+          kind: 'upsert',
+          deletedPaths: ['first.kcl', 'second.kcl'],
+        },
+      ])
+    }
+  )
 
   it('keeps project delete work when a later upsert is registered for the tombstoned project', async () => {
     await appendOutboxEntry({

--- a/src/lib/cloudSync/syncReliability.test.ts
+++ b/src/lib/cloudSync/syncReliability.test.ts
@@ -88,7 +88,7 @@ async function seedSyncedProject(baseFiles: ProjectArchiveFile[]) {
   })
 }
 
-describe('cloud sync incident regressions', () => {
+describe('cloud sync reliability', () => {
   beforeEach(async () => {
     await deleteCloudSyncTestDatabase()
     fetchMock.mockReset()


### PR DESCRIPTION
Adds regression coverage for the silent cloud-sync stall and destructive replacement conditions observed in the August support incident. The new cases run as Vitest expected failures here, so CI proves the bugs are reproducible while remaining green; each follow-up PR converts the tests it satisfies into ordinary passing tests.

1. Recreates a direct file-route reload whose project-library ownership is missing, causing queued work to be excluded from sync.
2. Specifies durable project failure and stalled-work badges after ephemeral runtime state resets.
3. Specifies explicit deletion paths on replacement uploads and verifies deletion intent survives outbox coalescing.

## How to test

Run the focused cloud-sync unit and registry integration suites and confirm they report five expected failures rather than skipped tests. Follow-up PRs convert the relevant cases to ordinary passing tests as the engine, deletion-intent, and UI behavior lands.