### PR TITLE
Recover cloud sync after direct route reloads

### DIFF
--- a/src/lib/clientErrors.ts
+++ b/src/lib/clientErrors.ts
@@ -23,6 +23,7 @@ export enum ClientErrorCode {
   CloudSyncConflict = 'cloud_sync_conflict',
   CloudSyncConflictCopyDetected = 'cloud_sync_conflict_copy_detected',
   CloudSyncFailure = 'cloud_sync_failure',
+  CloudSyncUntrackedLocalChanges = 'cloud_sync_untracked_local_changes',
   DesktopChildProcessGone = 'desktop_child_process_gone',
   DesktopRendererUnresponsive = 'desktop_renderer_unresponsive',
   DesktopRenderProcessGone = 'desktop_render_process_gone',

--- a/src/lib/cloudSync/clientErrorReporting.test.ts
+++ b/src/lib/cloudSync/clientErrorReporting.test.ts
@@ -14,6 +14,7 @@ vi.mock('@src/lib/clientErrors', () => ({
     CloudSyncConflict: 'cloud_sync_conflict',
     CloudSyncConflictCopyDetected: 'cloud_sync_conflict_copy_detected',
     CloudSyncFailure: 'cloud_sync_failure',
+    CloudSyncUntrackedLocalChanges: 'cloud_sync_untracked_local_changes',
   },
   reportClientError: mocks.reportClientError,
 }))
@@ -26,6 +27,7 @@ import {
   reportCloudSyncConflict,
   reportCloudSyncConflictCopyDetected,
   reportCloudSyncFailure,
+  reportCloudSyncUntrackedLocalChanges,
 } from '@src/lib/cloudSync/clientErrorReporting'
 
 describe('cloud sync client error reporting', () => {
@@ -117,6 +119,32 @@ describe('cloud sync client error reporting', () => {
       extra: {
         source: 'CloudSyncEngine',
         operation: 'reconcile-project',
+      },
+    })
+  })
+
+  it('reports recovery of local changes that were missing queued work', () => {
+    reportCloudSyncUntrackedLocalChanges({
+      remoteProjectId: 'remote-123',
+      remoteRevision: 'rev-1',
+      baseFileCount: 4,
+      localFileCount: 5,
+    })
+
+    expect(mocks.reportClientError).toHaveBeenCalledWith({
+      code: 'cloud_sync_untracked_local_changes',
+      errorName: 'CloudSyncUntrackedLocalChanges',
+      message: 'Cloud sync detected local changes without queued work.',
+      route: '/cloud-sync',
+      dedupeKey: 'CloudSync:untracked-local-changes:remote-123:rev-1',
+      extra: {
+        source: 'CloudSyncEngine',
+        operation: 'reconcile-project',
+        remoteProjectId: 'remote-123',
+        remoteRevision: 'rev-1',
+        baseFileCount: 4,
+        localFileCount: 5,
+        recoveryAction: 'sync-project',
       },
     })
   })

--- a/src/lib/cloudSync/clientErrorReporting.ts
+++ b/src/lib/cloudSync/clientErrorReporting.ts
@@ -241,6 +241,35 @@ export function reportCloudSyncConflictCopyDetected() {
   })
 }
 
+export function reportCloudSyncUntrackedLocalChanges({
+  remoteProjectId,
+  remoteRevision,
+  baseFileCount,
+  localFileCount,
+}: {
+  remoteProjectId: string
+  remoteRevision?: Revision
+  baseFileCount: number
+  localFileCount: number
+}) {
+  submit({
+    code: ClientErrorCode.CloudSyncUntrackedLocalChanges,
+    errorName: 'CloudSyncUntrackedLocalChanges',
+    message: 'Cloud sync detected local changes without queued work.',
+    route,
+    dedupeKey: `CloudSync:untracked-local-changes:${remoteProjectId}:${remoteRevision ?? 'none'}`,
+    extra: {
+      source: 'CloudSyncEngine',
+      operation: 'reconcile-project',
+      remoteProjectId,
+      remoteRevision,
+      baseFileCount,
+      localFileCount,
+      recoveryAction: 'sync-project',
+    },
+  })
+}
+
 export type CloudSyncFailureOperation =
   | 'conflict-resolution'
   | 'mutation'

--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -3,6 +3,7 @@ import env, { getEnvironmentNameFromEnv } from '@src/env'
 import {
   reportCloudSyncConflict,
   reportCloudSyncFailure,
+  reportCloudSyncUntrackedLocalChanges,
 } from '@src/lib/cloudSync/clientErrorReporting'
 import {
   CloudApiError,
@@ -152,6 +153,7 @@ let lastRemoteIndexSyncAt = 0
 let initialLocalScanComplete = false
 let pendingStatusSyncedAt: string | undefined
 let detachVisibilityChangeListener: (() => void) | undefined
+let openedProjectContext: CloudSyncOpenedProject | undefined
 let syncScopeProjectPath: string | undefined
 let syncScopeSyncable = false
 const scheduledProjectDirectoryNameSyncs = new Set<string>()
@@ -581,8 +583,9 @@ function normalizeCloudSyncOpenedProject(
   return {
     projectPath: normalizedProjectPath,
     syncable:
-      openedProject.libraryType === CLOUD_PROJECT_LIBRARY_TYPE &&
-      Boolean(openedProject.libraryPath?.trim()),
+      (openedProject.libraryType === CLOUD_PROJECT_LIBRARY_TYPE &&
+        Boolean(openedProject.libraryPath?.trim())) ||
+      Boolean(getCloudLibraryProjectRoot(normalizedProjectPath)),
   }
 }
 
@@ -2869,6 +2872,20 @@ async function syncProject(
         : true
     }
 
+    if (
+      entries.length === 0 &&
+      metadata.remoteProjectId &&
+      metadata.baseManifest &&
+      localChanged
+    ) {
+      reportCloudSyncUntrackedLocalChanges({
+        remoteProjectId: metadata.remoteProjectId,
+        remoteRevision: metadata.remoteRevision,
+        baseFileCount: Object.keys(metadata.baseManifest.files).length,
+        localFileCount: Object.keys(localManifest.files).length,
+      })
+    }
+
     const preflightAction = getCloudSyncProjectSyncPreflightAction({
       latestKind,
       tombstone: metadata.tombstone,
@@ -3567,6 +3584,7 @@ function scheduleRemoteIndexSync(delay = 0) {
 export function setCloudSyncOpenedProject(
   openedProject?: CloudSyncOpenedProject
 ) {
+  openedProjectContext = openedProject
   const nextScope = normalizeCloudSyncOpenedProject(openedProject)
   const nextSyncScopeProjectPath = nextScope?.projectPath
   const nextSyncScopeSyncable = nextScope?.syncable ?? false
@@ -4006,6 +4024,10 @@ export function configureCloudSyncEngine(nextConfig: CloudSyncConfig) {
     lastRemoteIndexSyncAt = 0
     initialLocalScanComplete = false
     resetSyncRetryBackoff()
+  }
+
+  if (projectDirectoryChanged && openedProjectContext) {
+    setCloudSyncOpenedProject(openedProjectContext)
   }
 
   if (!config.enabled) {

--- a/src/lib/cloudSync/syncReliability.test.ts
+++ b/src/lib/cloudSync/syncReliability.test.ts
@@ -107,47 +107,44 @@ describe('cloud sync reliability', () => {
     await deleteCloudSyncTestDatabase()
   })
 
-  it(
-    'drains project writes when a direct file-route reload omitted library ownership',
-    async () => {
-      const files = new Map([
-        [`${projectPath}/main.kcl`, 'local = 2\n'],
-        [`${projectPath}/${PROJECT_SETTINGS_FILE_NAME}`, projectToml],
-      ])
-      configureCloudSyncLocalFileSystem(
-        createCloudSyncTestFs(files, { projectDirectory })
-      )
-      await seedSyncedProject([
-        projectFile('main.kcl', 'base = 1\n'),
-        projectFile(PROJECT_SETTINGS_FILE_NAME, projectToml),
-      ])
-      installFetchMock()
+  it('drains project writes when a direct file-route reload omitted library ownership', async () => {
+    const files = new Map([
+      [`${projectPath}/main.kcl`, 'local = 2\n'],
+      [`${projectPath}/${PROJECT_SETTINGS_FILE_NAME}`, projectToml],
+    ])
+    configureCloudSyncLocalFileSystem(
+      createCloudSyncTestFs(files, { projectDirectory })
+    )
+    await seedSyncedProject([
+      projectFile('main.kcl', 'base = 1\n'),
+      projectFile(PROJECT_SETTINGS_FILE_NAME, projectToml),
+    ])
+    installFetchMock()
 
-      // A direct browser reload can restore the project path before project
-      // library ownership has been resolved.
-      setCloudSyncOpenedProject({ projectPath })
-      configureCloudSyncEngine({
-        enabled: true,
-        baseUrl,
-        environmentName,
-        cloudProjectDirectoryPaths: [projectDirectory],
-        autoEnrollCloudLibraryProjects: true,
-      })
+    // A direct browser reload can restore the project path before project
+    // library ownership has been resolved.
+    setCloudSyncOpenedProject({ projectPath })
+    configureCloudSyncEngine({
+      enabled: true,
+      baseUrl,
+      environmentName,
+      cloudProjectDirectoryPaths: [projectDirectory],
+      autoEnrollCloudLibraryProjects: true,
+    })
 
-      await notifyCloudSyncWriteLikeMutation(`${projectPath}/main.kcl`)
+    await notifyCloudSyncWriteLikeMutation(`${projectPath}/main.kcl`)
 
-      await vi.waitFor(() => {
-        expect(
-          fetchMock.mock.calls.filter(
-            ([input, init]) =>
-              getFetchUrl(input).startsWith(remoteProjectUrl) &&
-              getFetchMethod(input, init) === 'PUT'
-          )
-        ).toHaveLength(1)
-      })
-      await expect(getAllOutboxEntries()).resolves.toEqual([])
-    }
-  )
+    await vi.waitFor(() => {
+      expect(
+        fetchMock.mock.calls.filter(
+          ([input, init]) =>
+            getFetchUrl(input).startsWith(remoteProjectUrl) &&
+            getFetchMethod(input, init) === 'PUT'
+        )
+      ).toHaveLength(1)
+    })
+    await expect(getAllOutboxEntries()).resolves.toEqual([])
+  })
 
   it.fails(
     'declares observed local file deletions in a replacement upload',

--- a/src/lib/cloudSync/syncReliability.test.ts
+++ b/src/lib/cloudSync/syncReliability.test.ts
@@ -50,6 +50,8 @@ function projectFile(
 
 function remoteProject(revision = remoteRevision) {
   return {
+    category_ids: [],
+    description: '',
     id: remoteProjectId,
     title: 'Bracket',
     revision,
@@ -68,6 +70,10 @@ function installFetchMock(onUpdate?: (formData: FormData) => Promise<void>) {
     if (url.startsWith(remoteProjectUrl) && method === 'PUT') {
       await onUpdate?.(init?.body as FormData)
       return jsonResponse(remoteProject(updatedRemoteRevision))
+    }
+
+    if (url.endsWith('/user/client-errors') && method === 'POST') {
+      return jsonResponse({})
     }
 
     return jsonResponse({ message: `Unexpected fetch: ${method} ${url}` }, 500)
@@ -101,7 +107,7 @@ describe('cloud sync reliability', () => {
     await deleteCloudSyncTestDatabase()
   })
 
-  it.fails(
+  it(
     'drains project writes when a direct file-route reload omitted library ownership',
     async () => {
       const files = new Map([


### PR DESCRIPTION
Builds on #13289 and restores cloud-sync eligibility when a cloud project is reopened through a direct file route before its library ownership is available.

1. Recomputes the active project scope when the configured cloud library arrives.
2. Recognizes paths inside the configured cloud materialization as syncable even without route ownership metadata.
3. Reports privacy-safe telemetry when manifest drift exists without queued work.
4. Activates the regression that proves the local write reaches the API and drains.

## How to test

Open a cloud project through a direct file URL after a fresh application load, edit its KCL file before library metadata is populated, then confirm the update reaches the cloud and the pending state drains. Also verify an untracked-local-change report contains counts and project/revision identifiers, but no paths or file contents.