### PR TITLE
Preserve explicit cloud deletion intent

### DIFF
--- a/src/lib/cloudSync/README.md
+++ b/src/lib/cloudSync/README.md
@@ -186,4 +186,6 @@ Remote hydration is only allowed to replace OPFS when the local project is clean
 
 This implementation is whole-project archive based. It can auto-reconcile independent file-level changes by comparing local and remote manifests to `baseManifest`, but it does not attempt same-file line or syntax merges because the base stores file fingerprints instead of file contents. A remote revision must therefore change on every successful project archive update; otherwise a remote change can be missed.
 
+Whole-project updates include `deleted_paths`, derived from acknowledged files removed by observed local filesystem mutations. The outbox preserves this intent while writes coalesce, and the upload filters out paths that were recreated before synchronization. This lets the API distinguish an intentional background deletion from an incomplete or stale replacement archive.
+
 When a cloud title changes, the title is written into `project.toml` only when that can be done without overwriting local edits. The local project directory name is treated as an implementation detail and may differ from the cloud title when uniqueness requires it.

--- a/src/lib/cloudSync/cloudApi.spec.ts
+++ b/src/lib/cloudSync/cloudApi.spec.ts
@@ -110,7 +110,37 @@ describe('remote project uploads', () => {
       entrypoint_path: 'main.kcl',
       project_toml_path: 'project.toml',
       expected_revision: 'rev-1',
+      deleted_paths: [],
     })
+  })
+
+  test('declares explicit deletion intent when replacing a cloud project', async () => {
+    let uploadedBody: Record<string, unknown> | undefined
+    vi.stubGlobal(
+      'fetch',
+      vi.fn<typeof fetch>(async (_input, init) => {
+        uploadedBody = await uploadBodyFromRequest(init)
+        return projectResponse('project-existing', 'rev-2')
+      })
+    )
+
+    await updateRemoteProject({
+      config: { enabled: true, baseUrl: 'https://api.dev.zoo.dev' },
+      projectPath: '/projects/bracket',
+      project: {
+        id: 'project-existing',
+        description: '',
+        category_ids: [],
+      },
+      files: [projectFile('main.kcl')],
+      expectedRevision: 'rev-1',
+      deletedPaths: ['old/part.kcl', 'obsolete.kcl', 'obsolete.kcl'],
+    })
+
+    expect(uploadedBody?.deleted_paths).toEqual([
+      'obsolete.kcl',
+      'old/part.kcl',
+    ])
   })
 })
 

--- a/src/lib/cloudSync/cloudApi.ts
+++ b/src/lib/cloudSync/cloudApi.ts
@@ -389,6 +389,7 @@ export async function updateRemoteProject({
   files,
   expectedRevision,
   entrypointPath,
+  deletedPaths = [],
 }: {
   config: CloudSyncConfig
   projectPath: string
@@ -396,6 +397,7 @@ export async function updateRemoteProject({
   files: ProjectArchiveFile[]
   expectedRevision?: Revision
   entrypointPath?: string
+  deletedPaths?: string[]
 }) {
   const publicationMetadata = getProjectUploadPublicationMetadata(project)
 
@@ -411,6 +413,7 @@ export async function updateRemoteProject({
         expectedRevision,
         entrypointPath,
         publicationMetadata,
+        deletedPaths,
       }),
     }
   )
@@ -420,6 +423,7 @@ type BuildProjectFormDataOptions = {
   expectedRevision?: Revision
   entrypointPath?: string
   publicationMetadata?: ProjectUploadPublicationMetadata
+  deletedPaths?: string[]
 }
 
 function buildProjectFormData(

--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -2261,6 +2261,11 @@ async function applyLocalDataForConflict(
 
   const localFiles = await collectLocalProjectFiles(metadata.localProjectPath)
   const localManifest = await projectManifestFromFiles(localFiles)
+  const remoteFiles = filterCloudSyncProjectFilesForSync(
+    await parseProjectArchive(
+      await downloadRemoteProjectArchive(config, metadata.remoteProjectId)
+    )
+  )
   const updated = await updateRemoteProject({
     config,
     projectPath: metadata.localProjectPath,
@@ -2268,6 +2273,7 @@ async function applyLocalDataForConflict(
     files: localFiles,
     expectedRevision,
     entrypointPath: getRemoteProjectEntrypointPath(remoteProject),
+    deletedPaths: getRemovedProjectFilePaths(remoteFiles, localFiles),
   }).catch(rejectRemoteUploadFailure)
   await clearOutboxEntriesForProject(metadata.localProjectPath)
   await deleteLegacyConflictCopy(conflict)
@@ -2452,6 +2458,45 @@ async function markProjectConflict(
 
 function latestOutboxKind(entries: OutboxEntry[]) {
   return entries.toSorted((a, b) => (a.id ?? 0) - (b.id ?? 0)).at(-1)?.kind
+}
+
+function getOutboxDeletedPaths(
+  entries: OutboxEntry[],
+  uploadedFiles: ProjectArchiveFile[],
+  currentPaths?: Iterable<string>
+) {
+  const uploadedPaths = new Set(
+    uploadedFiles.map((file) => normalizeRelativePath(file.relativePath))
+  )
+  const currentPathSet = currentPaths
+    ? new Set(Array.from(currentPaths, normalizeRelativePath))
+    : undefined
+  return Array.from(
+    new Set(
+      entries
+        .flatMap((entry) => entry.deletedPaths ?? [])
+        .map(normalizeRelativePath)
+        .filter(
+          (path) =>
+            Boolean(path) &&
+            !uploadedPaths.has(path) &&
+            (!currentPathSet || currentPathSet.has(path))
+        )
+    )
+  ).sort()
+}
+
+function getRemovedProjectFilePaths(
+  previousFiles: ProjectArchiveFile[],
+  nextFiles: ProjectArchiveFile[]
+) {
+  const nextPaths = new Set(
+    nextFiles.map((file) => normalizeRelativePath(file.relativePath))
+  )
+  return previousFiles
+    .map((file) => normalizeRelativePath(file.relativePath))
+    .filter((path) => !nextPaths.has(path))
+    .sort()
 }
 
 function projectManifestEntryEqual(
@@ -2951,6 +2996,11 @@ async function syncProject(
             files: localFiles,
             expectedRevision: metadata.remoteRevision,
             entrypointPath: getRemoteProjectEntrypointPath(remoteProject),
+            deletedPaths: getOutboxDeletedPaths(
+              entries,
+              localFiles,
+              Object.keys(metadata.baseManifest?.files ?? {})
+            ),
           })
       ).catch(rejectRemoteUploadFailure)
       await clearOutboxEntriesForProject(metadata.localProjectPath)
@@ -3037,6 +3087,11 @@ async function syncProject(
             project: remoteProject,
             files: autoReconciledFiles,
             expectedRevision: remoteRevision,
+            deletedPaths: getOutboxDeletedPaths(
+              entries,
+              autoReconciledFiles,
+              remoteFiles.map((file) => file.relativePath)
+            ),
           })
       ).catch(rejectRemoteUploadFailure)
       await replaceLocalProjectWithFiles(
@@ -3830,7 +3885,8 @@ async function registerProjectMutation(
   projectPath: string,
   kind: OutboxEntry['kind'],
   targetPath: string,
-  sourcePath?: string
+  sourcePath?: string,
+  deletedPaths?: string[]
 ) {
   if (!isConfiguredForCloud() || isCloudSyncExcludedPath(targetPath)) {
     return
@@ -3907,6 +3963,7 @@ async function registerProjectMutation(
     kind,
     targetPath: normalizedTargetPath,
     sourcePath: sourcePath ? normalizePathForSync(sourcePath) : undefined,
+    deletedPaths: deletedPaths?.length ? deletedPaths : undefined,
     createdAt: nowIso(),
   })
   scheduleSync()
@@ -3944,11 +4001,18 @@ async function registerProjectRename(sourcePath: string, targetPath: string) {
     }
   }
 
+  const deletedPaths =
+    sourceProjectRoot &&
+    normalizePathForSync(sourceProjectRoot) ===
+      normalizePathForSync(targetProjectRoot)
+      ? await getObservedDeletedPaths(sourceProjectRoot, sourcePath)
+      : undefined
   await registerProjectMutation(
     targetProjectRoot,
     'upsert',
     targetPath,
-    sourcePath
+    sourcePath,
+    deletedPaths
   )
 }
 
@@ -3970,11 +4034,36 @@ async function afterRemoveMutation(targetPath: string) {
     return
   }
 
+  const deletingProject = isProjectRootPath(targetPath, projectRoot)
   await registerProjectMutation(
     projectRoot,
-    isProjectRootPath(targetPath, projectRoot) ? 'delete' : 'upsert',
-    targetPath
+    deletingProject ? 'delete' : 'upsert',
+    targetPath,
+    undefined,
+    deletingProject
+      ? undefined
+      : await getObservedDeletedPaths(projectRoot, targetPath)
   )
+}
+
+async function getObservedDeletedPaths(
+  projectRoot: string,
+  targetPath: string
+) {
+  const metadata = await getProjectMetadata(projectRoot)
+  const relativeTargetPath = normalizeRelativePath(
+    localFs.relative(projectRoot, targetPath)
+  )
+  if (!metadata?.baseManifest || !relativeTargetPath) {
+    return []
+  }
+
+  return Object.keys(metadata.baseManifest.files)
+    .filter(
+      (path) =>
+        path === relativeTargetPath || path.startsWith(`${relativeTargetPath}/`)
+    )
+    .sort()
 }
 
 export function configureCloudSyncLocalFileSystem(

--- a/src/lib/cloudSync/policy.spec.ts
+++ b/src/lib/cloudSync/policy.spec.ts
@@ -4,6 +4,7 @@ import {
   configureCloudSyncEngine,
   configureCloudSyncLocalFileSystem,
   filterCloudSyncProjectFilesForSync,
+  notifyCloudSyncRemoveMutation,
   notifyCloudSyncRenameMutation,
   notifyCloudSyncWriteLikeMutation,
   type ProjectArchiveFile,
@@ -439,6 +440,46 @@ describe('cloud sync file policy', () => {
     )
 
     expect(await getAllOutboxEntries()).toEqual([])
+  })
+
+  it('records acknowledged files removed by a local mutation', async () => {
+    const obsoletePath = `${projectPath}/old/obsolete.kcl`
+    const files = new Map([
+      [`${projectPath}/main.kcl`, 'cube = 1\n'],
+      [`${projectPath}/${PROJECT_SETTINGS_FILE_NAME}`, projectToml],
+    ])
+    configureCloudSyncLocalFileSystem(
+      createCloudSyncTestFs(files, { projectDirectory })
+    )
+    await putProjectMetadata({
+      schemaVersion: 1,
+      localProjectPath: projectPath,
+      projectName: 'bracket',
+      remoteProjectId,
+      remoteRevision,
+      baseManifest: await projectManifestFromFiles([
+        projectFile('main.kcl', 'cube = 1\n'),
+        projectFile('old/obsolete.kcl', 'obsolete = 1\n'),
+        projectFile(PROJECT_SETTINGS_FILE_NAME, projectToml),
+      ]),
+    })
+    configureCloudSyncEngine({
+      enabled: true,
+      baseUrl,
+      environmentName: 'dev.zoo.dev',
+      cloudProjectDirectoryPaths: [projectDirectory],
+      autoEnrollCloudLibraryProjects: false,
+    })
+
+    await notifyCloudSyncRemoveMutation(obsoletePath)
+
+    await expect(getAllOutboxEntries()).resolves.toMatchObject([
+      {
+        kind: 'upsert',
+        projectPath,
+        deletedPaths: ['old/obsolete.kcl'],
+      },
+    ])
   })
 
   it('clears ignored-file-only pending work without uploading a new revision', async () => {

--- a/src/lib/cloudSync/projectArchive.ts
+++ b/src/lib/cloudSync/projectArchive.ts
@@ -32,6 +32,7 @@ type PrepareProjectFilesForCloudUploadOptions = {
   expectedRevision?: Revision
   entrypointPath?: string
   publicationMetadata?: ProjectUploadPublicationMetadata
+  deletedPaths?: string[]
 }
 
 export function prepareProjectFilesForCloudUpload(
@@ -88,6 +89,14 @@ export function prepareProjectFilesForCloudUpload(
   }
   if (expectedRevision) {
     body.expected_revision = expectedRevision
+  }
+  if (
+    typeof optionsOrExpectedRevision !== 'string' &&
+    optionsOrExpectedRevision?.deletedPaths
+  ) {
+    body.deleted_paths = Array.from(
+      new Set(optionsOrExpectedRevision.deletedPaths.map(normalizeRelativePath))
+    ).sort()
   }
 
   return {

--- a/src/lib/cloudSync/syncDb.test.ts
+++ b/src/lib/cloudSync/syncDb.test.ts
@@ -8,7 +8,6 @@ import {
   putProjectMetadata,
 } from '@src/lib/cloudSync/syncDb'
 import { deleteCloudSyncTestDatabase } from '@src/lib/cloudSync/testUtils'
-import type { OutboxEntry } from '@src/lib/cloudSync/types'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 describe('cloud sync outbox persistence', () => {
@@ -80,33 +79,30 @@ describe('cloud sync outbox persistence', () => {
     ])
   })
 
-  it.fails(
-    'coalesces explicit file deletions without losing their paths',
-    async () => {
-      await appendOutboxEntry({
-        projectPath: '/projects/bracket',
-        kind: 'upsert',
-        targetPath: '/projects/bracket/first.kcl',
-        deletedPaths: ['first.kcl'],
-        createdAt: '2026-08-24T12:00:00.000Z',
-      } as Omit<OutboxEntry, 'id'> & { deletedPaths: string[] })
-      await appendOutboxEntry({
-        projectPath: '/projects/bracket',
-        kind: 'upsert',
-        targetPath: '/projects/bracket/second.kcl',
-        deletedPaths: ['second.kcl'],
-        createdAt: '2026-08-24T12:01:00.000Z',
-      } as Omit<OutboxEntry, 'id'> & { deletedPaths: string[] })
+  it('coalesces explicit file deletions without losing their paths', async () => {
+    await appendOutboxEntry({
+      projectPath: '/projects/bracket',
+      kind: 'upsert',
+      targetPath: '/projects/bracket/first.kcl',
+      deletedPaths: ['first.kcl'],
+      createdAt: '2026-08-24T12:00:00.000Z',
+    })
+    await appendOutboxEntry({
+      projectPath: '/projects/bracket',
+      kind: 'upsert',
+      targetPath: '/projects/bracket/second.kcl',
+      deletedPaths: ['second.kcl'],
+      createdAt: '2026-08-24T12:01:00.000Z',
+    })
 
-      await expect(getAllOutboxEntries()).resolves.toMatchObject([
-        {
-          projectPath: '/projects/bracket',
-          kind: 'upsert',
-          deletedPaths: ['first.kcl', 'second.kcl'],
-        },
-      ])
-    }
-  )
+    await expect(getAllOutboxEntries()).resolves.toMatchObject([
+      {
+        projectPath: '/projects/bracket',
+        kind: 'upsert',
+        deletedPaths: ['first.kcl', 'second.kcl'],
+      },
+    ])
+  })
 
   it('keeps project delete work when a later upsert is registered for the tombstoned project', async () => {
     await appendOutboxEntry({

--- a/src/lib/cloudSync/syncDb.ts
+++ b/src/lib/cloudSync/syncDb.ts
@@ -151,7 +151,10 @@ export async function appendOutboxEntry(entry: Omit<OutboxEntry, 'id'>) {
     const store = transaction.objectStore(OUTBOX_STORE)
     const request = store.openCursor()
     const matchingDeleteEntryKeys: IDBValidKey[] = []
-    const matchingUpsertEntryKeys: IDBValidKey[] = []
+    const matchingUpsertEntries: Array<{
+      key: IDBValidKey
+      entry: OutboxEntry
+    }> = []
 
     request.onsuccess = () => {
       const cursor = request.result
@@ -159,7 +162,7 @@ export async function appendOutboxEntry(entry: Omit<OutboxEntry, 'id'>) {
         if (nextEntry.kind === 'delete') {
           for (const key of [
             ...matchingDeleteEntryKeys,
-            ...matchingUpsertEntryKeys,
+            ...matchingUpsertEntries.map(({ key }) => key),
           ]) {
             store.delete(key)
           }
@@ -171,16 +174,27 @@ export async function appendOutboxEntry(entry: Omit<OutboxEntry, 'id'>) {
         if (retainedDeleteEntryKey !== undefined) {
           for (const key of [
             ...matchingDeleteEntryKeys.slice(1),
-            ...matchingUpsertEntryKeys,
+            ...matchingUpsertEntries.map(({ key }) => key),
           ]) {
             store.delete(key)
           }
           return
         }
 
-        const retainedUpsertEntryKey = matchingUpsertEntryKeys[0]
-        if (retainedUpsertEntryKey !== undefined) {
-          for (const key of matchingUpsertEntryKeys.slice(1)) {
+        const retainedUpsertEntry = matchingUpsertEntries[0]
+        if (retainedUpsertEntry !== undefined) {
+          const deletedPaths = Array.from(
+            new Set(
+              [...matchingUpsertEntries.map(({ entry }) => entry), nextEntry]
+                .flatMap((entry) => entry.deletedPaths ?? [])
+                .map(normalizePathForSync)
+            )
+          ).sort()
+          store.put({
+            ...retainedUpsertEntry.entry,
+            deletedPaths: deletedPaths.length ? deletedPaths : undefined,
+          })
+          for (const { key } of matchingUpsertEntries.slice(1)) {
             store.delete(key)
           }
           return
@@ -198,7 +212,10 @@ export async function appendOutboxEntry(entry: Omit<OutboxEntry, 'id'>) {
         if (existingEntry.kind === 'delete') {
           matchingDeleteEntryKeys.push(cursor.primaryKey)
         } else {
-          matchingUpsertEntryKeys.push(cursor.primaryKey)
+          matchingUpsertEntries.push({
+            key: cursor.primaryKey,
+            entry: existingEntry,
+          })
         }
       }
       cursor.continue()

--- a/src/lib/cloudSync/syncReliability.test.ts
+++ b/src/lib/cloudSync/syncReliability.test.ts
@@ -20,7 +20,6 @@ import {
   getFetchUrl,
   jsonResponse,
 } from '@src/lib/cloudSync/testUtils'
-import type { OutboxEntry } from '@src/lib/cloudSync/types'
 import { PROJECT_SETTINGS_FILE_NAME } from '@src/lib/constants'
 import { CLOUD_PROJECT_LIBRARY_TYPE } from '@src/lib/projectLibraries'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -146,62 +145,57 @@ describe('cloud sync reliability', () => {
     await expect(getAllOutboxEntries()).resolves.toEqual([])
   })
 
-  it.fails(
-    'declares observed local file deletions in a replacement upload',
-    async () => {
-      const deletedFilePath = `${projectPath}/obsolete.kcl`
-      const files = new Map([
-        [`${projectPath}/main.kcl`, 'base = 1\n'],
-        [`${projectPath}/${PROJECT_SETTINGS_FILE_NAME}`, projectToml],
-      ])
-      configureCloudSyncLocalFileSystem(
-        createCloudSyncTestFs(files, { projectDirectory })
-      )
-      await seedSyncedProject([
-        projectFile('main.kcl', 'base = 1\n'),
-        projectFile('obsolete.kcl', 'obsolete = 1\n'),
-        projectFile(PROJECT_SETTINGS_FILE_NAME, projectToml),
-      ])
-      await appendOutboxEntry({
-        projectPath,
-        kind: 'upsert',
-        targetPath: deletedFilePath,
-        deletedPaths: ['obsolete.kcl'],
-        createdAt: '2026-08-24T12:00:00.000Z',
-      } as Omit<OutboxEntry, 'id'> & { deletedPaths: string[] })
-      let uploadedDeletedPaths: string[] | undefined
-      installFetchMock(async (formData) => {
-        const body = JSON.parse(
-          await (formData.get('body') as Blob).text()
-        ) as {
-          deleted_paths?: string[]
-        }
-        uploadedDeletedPaths = body.deleted_paths
-      })
-      setCloudSyncOpenedProject({
-        projectPath,
-        libraryPath: projectDirectory,
-        libraryType: CLOUD_PROJECT_LIBRARY_TYPE,
-      })
+  it('declares observed local file deletions in a replacement upload', async () => {
+    const deletedFilePath = `${projectPath}/obsolete.kcl`
+    const files = new Map([
+      [`${projectPath}/main.kcl`, 'base = 1\n'],
+      [`${projectPath}/${PROJECT_SETTINGS_FILE_NAME}`, projectToml],
+    ])
+    configureCloudSyncLocalFileSystem(
+      createCloudSyncTestFs(files, { projectDirectory })
+    )
+    await seedSyncedProject([
+      projectFile('main.kcl', 'base = 1\n'),
+      projectFile('obsolete.kcl', 'obsolete = 1\n'),
+      projectFile(PROJECT_SETTINGS_FILE_NAME, projectToml),
+    ])
+    await appendOutboxEntry({
+      projectPath,
+      kind: 'upsert',
+      targetPath: deletedFilePath,
+      deletedPaths: ['obsolete.kcl'],
+      createdAt: '2026-08-24T12:00:00.000Z',
+    })
+    let uploadedDeletedPaths: string[] | undefined
+    installFetchMock(async (formData) => {
+      const body = JSON.parse(await (formData.get('body') as Blob).text()) as {
+        deleted_paths?: string[]
+      }
+      uploadedDeletedPaths = body.deleted_paths
+    })
+    setCloudSyncOpenedProject({
+      projectPath,
+      libraryPath: projectDirectory,
+      libraryType: CLOUD_PROJECT_LIBRARY_TYPE,
+    })
 
-      configureCloudSyncEngine({
-        enabled: true,
-        baseUrl,
-        environmentName,
-        cloudProjectDirectoryPaths: [projectDirectory],
-        autoEnrollCloudLibraryProjects: true,
-      })
+    configureCloudSyncEngine({
+      enabled: true,
+      baseUrl,
+      environmentName,
+      cloudProjectDirectoryPaths: [projectDirectory],
+      autoEnrollCloudLibraryProjects: true,
+    })
 
-      await vi.waitFor(() => {
-        expect(
-          fetchMock.mock.calls.filter(
-            ([input, init]) =>
-              getFetchUrl(input).startsWith(remoteProjectUrl) &&
-              getFetchMethod(input, init) === 'PUT'
-          )
-        ).toHaveLength(1)
-      })
-      expect(uploadedDeletedPaths).toEqual(['obsolete.kcl'])
-    }
-  )
+    await vi.waitFor(() => {
+      expect(
+        fetchMock.mock.calls.filter(
+          ([input, init]) =>
+            getFetchUrl(input).startsWith(remoteProjectUrl) &&
+            getFetchMethod(input, init) === 'PUT'
+        )
+      ).toHaveLength(1)
+    })
+    expect(uploadedDeletedPaths).toEqual(['obsolete.kcl'])
+  })
 })

--- a/src/lib/cloudSync/types.ts
+++ b/src/lib/cloudSync/types.ts
@@ -66,6 +66,7 @@ export type OutboxEntry = {
   kind: 'upsert' | 'delete'
   targetPath: string
   sourcePath?: string
+  deletedPaths?: string[]
   createdAt: string
 }
 
@@ -89,6 +90,7 @@ export type ProjectUploadBody = {
   entrypoint_path: string
   project_toml_path: string
   expected_revision?: Revision
+  deleted_paths?: string[]
 }
 
 /** Publication metadata that whole-project replacements must preserve. */


### PR DESCRIPTION
Builds on #13290 and carries intentional file removals through background whole-project synchronization without introducing user prompts.

1. Records acknowledged paths removed by filesystem delete and rename mutations.
2. Preserves and deduplicates deletion intent when durable outbox writes coalesce.
3. Adds sorted deleted_paths to update payloads while filtering files recreated before upload.
4. Computes the complete deletion set when the user explicitly resolves a conflict in favor of local data.
5. Activates the deletion regressions and adds mutation-policy and request-contract coverage.

## How to test

Delete and rename files in a synced cloud project while offline, make additional edits, then reconnect and verify the replacement request declares only files that remain deleted. Recreate a deleted file before reconnecting and verify it is uploaded without deletion intent. Resolve a local-wins conflict and confirm all remote files omitted by the chosen local snapshot are declared.