### PR TITLE
Surface durable cloud sync problems

### DIFF
--- a/src/components/CloudConflictDialog.tsx
+++ b/src/components/CloudConflictDialog.tsx
@@ -10,14 +10,15 @@ import { CustomIcon } from '@src/components/CustomIcon'
 import {
   type CloudSyncConflictResolution,
   type CloudSyncProjectMetadata,
+  type CloudSyncProjectMetadataIndexEntry,
   cloudSyncStatus,
-  getCloudSyncProjectMetadata,
   getCloudSyncProjectMetadataIndex,
   isCloudSyncConflictRevisionChangedError,
   loadCloudSyncProjectConflictInspection,
   retryCloudSync,
   resolveCloudSyncProjectConflict,
 } from '@src/lib/cloudSync'
+import { normalizePathForSync } from '@src/lib/cloudSync/paths'
 import {
   type ConflictFileComparison,
   type ConflictFileStatus,
@@ -241,14 +242,14 @@ function ChangedFilesList({
   )
 }
 
-export function useCloudSyncProjectConflict(projectPath?: string) {
+export function useCloudSyncProjectMetadata(projectPath?: string) {
   useSignals()
   const status = cloudSyncStatus.value
   const [metadata, setMetadata] = useState<
-    CloudSyncProjectMetadata | undefined
+    CloudSyncProjectMetadataIndexEntry | undefined
   >()
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: cloud sync status changes intentionally refresh conflict metadata.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: cloud sync status changes intentionally refresh durable project metadata.
   useEffect(() => {
     let cancelled = false
 
@@ -257,10 +258,10 @@ export function useCloudSyncProjectConflict(projectPath?: string) {
       return
     }
 
-    getCloudSyncProjectMetadata(projectPath)
-      .then((nextMetadata) => {
+    getCloudSyncProjectMetadataIndex()
+      .then((metadataIndex) => {
         if (!cancelled) {
-          setMetadata(nextMetadata?.conflict ? nextMetadata : undefined)
+          setMetadata(metadataIndex.get(normalizePathForSync(projectPath)))
         }
       })
       .catch((error: unknown) => {
@@ -283,6 +284,11 @@ export function useCloudSyncProjectConflict(projectPath?: string) {
   ])
 
   return metadata
+}
+
+export function useCloudSyncProjectConflict(projectPath?: string) {
+  const metadata = useCloudSyncProjectMetadata(projectPath)
+  return metadata?.conflict ? metadata : undefined
 }
 
 export function useCloudSyncProjectConflicts() {

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -594,79 +594,65 @@ describe('cloud sync status bar conflict dialog', () => {
 })
 
 describe('cloud sync project menu item', () => {
-  test.fails(
-    'keeps a durable project failure visible after runtime status resets',
-    () => {
-      cloudSyncStatus.value = {
-        enabled: true,
-        state: 'idle',
-        pendingCount: 0,
-        scopedProjectCloudProjectId: 'remote-123',
-      }
-      cloudConflictDialogMocks.projectMetadata = {
-        localProjectPath: projectWellFormed.path,
-        remoteProjectId: 'remote-123',
-        lastFailure: {
-          message: 'Cloud sync stopped before local changes were uploaded.',
-          at: new Date(now - 60_000).toISOString(),
-        },
-      }
-      const cloudSync = createCloudSyncService()
-      const { app, dispose } = createProjectMenuApp(cloudSync)
-
-      try {
-        renderWithRouter(
-          <ProjectSidebarMenu
-            app={app}
-            enableMenu
-            project={projectWellFormed}
-          />
-        )
-
-        expect(
-          screen.getByTestId('project-sidebar-cloud-error-badge')
-        ).toHaveTextContent('Cloud error')
-      } finally {
-        dispose()
-      }
+  test('keeps a durable project failure visible after runtime status resets', () => {
+    cloudSyncStatus.value = {
+      enabled: true,
+      state: 'idle',
+      pendingCount: 0,
+      scopedProjectCloudProjectId: 'remote-123',
     }
-  )
-
-  test.fails(
-    'shows a persistent badge when durable project work is stalled',
-    () => {
-      cloudSyncStatus.value = {
-        enabled: true,
-        state: 'idle',
-        pendingCount: 0,
-        scopedProjectCloudProjectId: 'remote-123',
-      }
-      cloudConflictDialogMocks.projectMetadata = {
-        localProjectPath: projectWellFormed.path,
-        remoteProjectId: 'remote-123',
-        hasPendingChanges: true,
-        pendingSince: new Date(now - 5 * 60_000).toISOString(),
-      }
-      const cloudSync = createCloudSyncService()
-      const { app, dispose } = createProjectMenuApp(cloudSync)
-
-      try {
-        renderWithRouter(
-          <ProjectSidebarMenu
-            app={app}
-            enableMenu
-            project={projectWellFormed}
-          />
-        )
-
-        expect(
-          screen.getByTestId('project-sidebar-cloud-stalled-badge')
-        ).toHaveTextContent('Cloud sync stalled')
-      } finally {
-        dispose()
-      }
+    cloudConflictDialogMocks.projectMetadata = {
+      localProjectPath: projectWellFormed.path,
+      remoteProjectId: 'remote-123',
+      lastFailure: {
+        message: 'Cloud sync stopped before local changes were uploaded.',
+        at: new Date(now - 60_000).toISOString(),
+      },
     }
-  )
+    const cloudSync = createCloudSyncService()
+    const { app, dispose } = createProjectMenuApp(cloudSync)
+
+    try {
+      renderWithRouter(
+        <ProjectSidebarMenu app={app} enableMenu project={projectWellFormed} />
+      )
+
+      expect(
+        screen.getByTestId('project-sidebar-cloud-error-badge')
+      ).toHaveTextContent('Cloud error')
+    } finally {
+      dispose()
+    }
+  })
+
+  test('shows a persistent badge when durable project work is stalled', () => {
+    cloudSyncStatus.value = {
+      enabled: true,
+      state: 'idle',
+      pendingCount: 0,
+      scopedProjectCloudProjectId: 'remote-123',
+    }
+    cloudConflictDialogMocks.projectMetadata = {
+      localProjectPath: projectWellFormed.path,
+      remoteProjectId: 'remote-123',
+      hasPendingChanges: true,
+      pendingSince: new Date(now - 5 * 60_000).toISOString(),
+    }
+    const cloudSync = createCloudSyncService()
+    const { app, dispose } = createProjectMenuApp(cloudSync)
+
+    try {
+      renderWithRouter(
+        <ProjectSidebarMenu app={app} enableMenu project={projectWellFormed} />
+      )
+
+      expect(
+        screen.getByTestId('project-sidebar-cloud-stalled-badge')
+      ).toHaveTextContent('Cloud sync stalled')
+    } finally {
+      dispose()
+    }
+  })
 
   test('shows synced state from the project sidebar menu', async () => {
     cloudSyncStatus.value = {

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -23,6 +23,7 @@ import {
   openCloudSyncErrorDialog,
   useCloudSyncProjectConflicts,
   useCloudSyncProjectConflict,
+  useCloudSyncProjectMetadata,
 } from '@src/components/CloudConflictDialog'
 import type { CustomIconName } from '@src/components/CustomIcon'
 import { defaultStatusBarItemClassNames } from '@src/components/StatusBar/StatusBar'
@@ -111,6 +112,43 @@ import { Fragment, useEffect, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 
 const CLOUD_SYNC_PLUGIN_ID = 'cloud-sync'
+const CLOUD_SYNC_STALLED_AFTER_MS = 5 * 60_000
+
+function cloudSyncProjectIsStalled(
+  metadata: CloudSyncProjectMetadataIndexEntry | undefined,
+  now = Date.now()
+) {
+  if (!metadata?.hasPendingChanges || !metadata.pendingSince) {
+    return false
+  }
+  const pendingSince = Date.parse(metadata.pendingSince)
+  return Number.isFinite(pendingSince)
+    ? now - pendingSince >= CLOUD_SYNC_STALLED_AFTER_MS
+    : false
+}
+
+function useCloudSyncProjectIsStalled(
+  metadata: CloudSyncProjectMetadataIndexEntry | undefined
+) {
+  const [now, setNow] = useState(Date.now)
+
+  useEffect(() => {
+    if (!metadata?.hasPendingChanges || !metadata.pendingSince) {
+      return
+    }
+    const pendingSince = Date.parse(metadata.pendingSince)
+    if (!Number.isFinite(pendingSince)) {
+      return
+    }
+    const timeout = setTimeout(
+      () => setNow(Date.now()),
+      Math.max(0, CLOUD_SYNC_STALLED_AFTER_MS - (Date.now() - pendingSince))
+    )
+    return () => clearTimeout(timeout)
+  }, [metadata?.hasPendingChanges, metadata?.pendingSince])
+
+  return cloudSyncProjectIsStalled(metadata, now)
+}
 
 type CloudSyncStatusBarPresentation = {
   label: string
@@ -394,20 +432,30 @@ function CloudSyncProjectMenuItem({
   useSignals()
   const status = cloudSyncStatus.value
   const conflictMetadata = useCloudSyncProjectConflict(context.projectPath)
+  const projectMetadata = useCloudSyncProjectMetadata(context.projectPath)
   const projectName = getProjectDisplayName(context.project)
   const presentation = getCloudSyncStatusBarPresentation(status)
   const isActiveProjectStatus = cloudSyncStatusAppliesToProject(
     status,
     context.projectPath
   )
+  const durableFailure = projectMetadata?.lastFailure
+  const hasStalledProjectWork = useCloudSyncProjectIsStalled(projectMetadata)
   const isError =
     status.enabled &&
-    status.state !== 'conflict' &&
-    cloudSyncFailureAppliesToProject(status, context.projectPath)
+    !conflictMetadata &&
+    (Boolean(durableFailure) ||
+      (status.state !== 'conflict' &&
+        cloudSyncFailureAppliesToProject(status, context.projectPath)))
+  const isStalled =
+    status.enabled && !isError && !conflictMetadata && hasStalledProjectWork
   const errorMessage = isError
-    ? status.lastFailure ||
+    ? durableFailure?.message ||
+      status.lastFailure ||
       'Cloud sync failed without a reported error message.'
-    : undefined
+    : isStalled
+      ? 'Cloud sync has local changes that have not reached the cloud after several retries.'
+      : undefined
 
   if (!status.enabled) {
     return null
@@ -419,6 +467,7 @@ function CloudSyncProjectMenuItem({
   const hasCloudSyncProjectStatus =
     isConflict ||
     isError ||
+    isStalled ||
     Boolean(status.scopedProjectCloudProjectId) ||
     (isActiveProjectStatus &&
       (status.state === 'syncing' || status.pendingCount > 0))
@@ -433,23 +482,32 @@ function CloudSyncProjectMenuItem({
       ? status.lastFailureKind === 'remote-upload-forbidden'
         ? 'Cloud sync blocked'
         : 'Cloud sync failed'
-      : presentation.label
-  const icon = isConflict ? 'triangleExclamation' : presentation.icon
+      : isStalled
+        ? 'Cloud sync stalled'
+        : presentation.label
+  const icon =
+    isConflict || isStalled ? 'triangleExclamation' : presentation.icon
   const iconClassName = isConflict
     ? '!text-warn-80 dark:!text-warn-10'
     : isError
       ? '!text-destroy-80 dark:!text-destroy-20'
-      : `!text-chalkboard-60 dark:!text-chalkboard-40 ${presentation.iconClassName}`
+      : isStalled
+        ? '!text-warn-80 dark:!text-warn-10'
+        : `!text-chalkboard-60 dark:!text-chalkboard-40 ${presentation.iconClassName}`
   const statusClassName = isConflict
     ? 'bg-warn-10/60 text-warn-90 hover:!bg-warn-20 focus:!bg-warn-20 dark:bg-warn-80/20 dark:text-warn-10 dark:hover:!bg-warn-80/30 dark:focus:!bg-warn-80/30'
     : isError
       ? 'bg-destroy-10/60 text-destroy-80 hover:!bg-destroy-10 focus:!bg-destroy-10 dark:bg-destroy-80/20 dark:text-destroy-20 dark:hover:!bg-destroy-80/30 dark:focus:!bg-destroy-80/30'
-      : 'hover:!bg-chalkboard-20 focus:!bg-chalkboard-20 dark:hover:!bg-chalkboard-80 dark:focus:!bg-chalkboard-80'
+      : isStalled
+        ? 'bg-warn-10/60 text-warn-90 hover:!bg-warn-20 focus:!bg-warn-20 dark:bg-warn-80/20 dark:text-warn-10 dark:hover:!bg-warn-80/30 dark:focus:!bg-warn-80/30'
+        : 'hover:!bg-chalkboard-20 focus:!bg-chalkboard-20 dark:hover:!bg-chalkboard-80 dark:focus:!bg-chalkboard-80'
   const dataTestId = isConflict
     ? 'project-sidebar-inspect-cloud-conflicts'
     : isError
       ? 'project-sidebar-inspect-cloud-sync-error'
-      : 'project-sidebar-cloud-sync-status'
+      : isStalled
+        ? 'project-sidebar-inspect-cloud-sync-stalled'
+        : 'project-sidebar-cloud-sync-status'
 
   return (
     <li className="contents">
@@ -473,10 +531,13 @@ function CloudSyncProjectMenuItem({
           }
           if (errorMessage) {
             openCloudSyncErrorDialog({
-              title: presentation.label,
+              title: label,
               message: errorMessage,
               projectName,
-              occurredAt: status.lastFailureAt,
+              occurredAt:
+                durableFailure?.at ||
+                status.lastFailureAt ||
+                projectMetadata?.pendingSince,
             })
             close()
             return
@@ -500,6 +561,8 @@ function CloudSyncProjectBreadcrumbBadge({
 }: ProjectExplorerProjectBreadcrumbBadgeComponentProps) {
   useSignals()
   const conflictMetadata = useCloudSyncProjectConflict(context.projectPath)
+  const projectMetadata = useCloudSyncProjectMetadata(context.projectPath)
+  const hasStalledProjectWork = useCloudSyncProjectIsStalled(projectMetadata)
   const status = cloudSyncStatus.value
   const isActiveProjectStatus = cloudSyncStatusAppliesToProject(
     status,
@@ -510,10 +573,14 @@ function CloudSyncProjectBreadcrumbBadge({
     (status.enabled && status.state === 'conflict' && isActiveProjectStatus)
   const isError =
     status.enabled &&
-    status.state !== 'conflict' &&
-    cloudSyncFailureAppliesToProject(status, context.projectPath)
+    !isConflict &&
+    (Boolean(projectMetadata?.lastFailure) ||
+      (status.state !== 'conflict' &&
+        cloudSyncFailureAppliesToProject(status, context.projectPath)))
+  const isStalled =
+    status.enabled && !isConflict && !isError && hasStalledProjectWork
 
-  if (!isConflict && !isError) {
+  if (!isConflict && !isError && !isStalled) {
     return null
   }
 
@@ -523,12 +590,19 @@ function CloudSyncProjectBreadcrumbBadge({
         className: 'bg-warn-20 text-warn-90 dark:bg-warn-80 dark:text-warn-10',
         dataTestId: 'project-sidebar-cloud-conflict-badge',
       }
-    : {
-        label: 'Cloud error',
-        className:
-          'bg-destroy-10 text-destroy-80 ring-1 ring-inset ring-destroy-40 dark:bg-destroy-80 dark:text-destroy-10 dark:ring-destroy-70',
-        dataTestId: 'project-sidebar-cloud-error-badge',
-      }
+    : isError
+      ? {
+          label: 'Cloud error',
+          className:
+            'bg-destroy-10 text-destroy-80 ring-1 ring-inset ring-destroy-40 dark:bg-destroy-80 dark:text-destroy-10 dark:ring-destroy-70',
+          dataTestId: 'project-sidebar-cloud-error-badge',
+        }
+      : {
+          label: 'Cloud sync stalled',
+          className:
+            'bg-warn-20 text-warn-90 ring-1 ring-inset ring-warn-40 dark:bg-warn-80 dark:text-warn-10 dark:ring-warn-70',
+          dataTestId: 'project-sidebar-cloud-stalled-badge',
+        }
 
   return (
     <span

--- a/src/lib/cloudSync/syncDb.test.ts
+++ b/src/lib/cloudSync/syncDb.test.ts
@@ -4,6 +4,7 @@ import {
   clearLegacyConflictCopyReferences,
   clearOutboxEntriesTouchingProject,
   getAllOutboxEntries,
+  getCloudSyncProjectMetadataIndex,
   getProjectMetadata,
   putProjectMetadata,
 } from '@src/lib/cloudSync/syncDb'
@@ -102,6 +103,34 @@ describe('cloud sync outbox persistence', () => {
         deletedPaths: ['first.kcl', 'second.kcl'],
       },
     ])
+  })
+
+  it('exposes the oldest durable pending time in the project metadata index', async () => {
+    await putProjectMetadata({
+      schemaVersion: 1,
+      localProjectPath: '/projects/bracket',
+      projectName: 'bracket',
+    })
+    await appendOutboxEntry({
+      projectPath: '/projects/bracket',
+      kind: 'upsert',
+      targetPath: '/projects/bracket/main.kcl',
+      createdAt: '2026-08-24T12:00:00.000Z',
+    })
+    await appendOutboxEntry({
+      projectPath: '/projects/bracket',
+      kind: 'upsert',
+      targetPath: '/projects/bracket/other.kcl',
+      createdAt: '2026-08-24T12:01:00.000Z',
+    })
+
+    const metadata = (await getCloudSyncProjectMetadataIndex()).get(
+      '/projects/bracket'
+    )
+    expect(metadata).toMatchObject({
+      hasPendingChanges: true,
+      pendingSince: '2026-08-24T12:00:00.000Z',
+    })
   })
 
   it('keeps project delete work when a later upsert is registered for the tombstoned project', async () => {

--- a/src/lib/cloudSync/syncDb.ts
+++ b/src/lib/cloudSync/syncDb.ts
@@ -100,9 +100,14 @@ export async function getCloudSyncProjectMetadataIndex() {
     getAllProjectMetadata(),
     getAllOutboxEntries(),
   ])
-  const pendingProjectPaths = new Set(
-    outboxEntries.map((entry) => normalizePathForSync(entry.projectPath))
-  )
+  const pendingSinceByProjectPath = new Map<string, string>()
+  for (const entry of outboxEntries) {
+    const projectPath = normalizePathForSync(entry.projectPath)
+    const pendingSince = pendingSinceByProjectPath.get(projectPath)
+    if (!pendingSince || entry.createdAt < pendingSince) {
+      pendingSinceByProjectPath.set(projectPath, entry.createdAt)
+    }
+  }
 
   return new Map<string, CloudSyncProjectMetadataIndexEntry>(
     metadata.map((entry) => [
@@ -110,9 +115,12 @@ export async function getCloudSyncProjectMetadataIndex() {
       {
         ...entry,
         hasPendingChanges:
-          pendingProjectPaths.has(
+          pendingSinceByProjectPath.has(
             normalizePathForSync(entry.localProjectPath)
           ) || Boolean(entry.tombstone),
+        pendingSince: pendingSinceByProjectPath.get(
+          normalizePathForSync(entry.localProjectPath)
+        ),
       },
     ])
   )

--- a/src/lib/cloudSync/types.ts
+++ b/src/lib/cloudSync/types.ts
@@ -150,6 +150,7 @@ export type CloudSyncLocalProject = {
 /** Project metadata index entry enriched with pending local-change state. */
 export type CloudSyncProjectMetadataIndexEntry = ProjectMetadata & {
   hasPendingChanges: boolean
+  pendingSince?: string
 }
 
 /** Remote revision/update metadata extracted from cloud API responses. */


### PR DESCRIPTION
Builds on #13291 and makes project-level cloud-sync failures survive transient runtime status changes without adding a new warning pattern.

1. Exposes the oldest durable outbox timestamp with per-project metadata.
2. Reads durable failure and pending state through the existing project metadata hook.
3. Shows existing breadcrumb badges only for conflicts, failures, or work stalled for five minutes.
4. Keeps healthy Cloud synced state in the existing project menu.
5. Activates the durable-failure and stalled-work UI regressions.

## How to test

Cause an upload failure, let the aggregate runtime status return to idle or enter a retry pulse, and verify the Cloud error breadcrumb badge remains. Leave local work pending for five minutes and verify the existing warning-style breadcrumb badge says Cloud sync stalled. Open the project menu to inspect details or retry, and confirm a healthy cloud project has no breadcrumb badge.