### PR TITLE
KCL: preserve sketch block members through scale

### DIFF
--- a/docs/kcl-std/functions/std-transform-scale.md
+++ b/docs/kcl-std/functions/std-transform-scale.md
@@ -9,13 +9,13 @@ Scale a solid, a sketch, or a helix.
 
 ```kcl
 scale(
-  @objects: [Solid; 1+] | [Sketch; 1+] | [Helix; 1+] | ImportedGeometry,
+  @objects: [SketchBlock; 1+] | [Solid; 1+] | [Sketch; 1+] | [Helix; 1+] | ImportedGeometry,
   x?: number(_),
   y?: number(_),
   z?: number(_),
   global?: bool,
   factor?: number(_),
-): [Solid; 1+] | [Sketch; 1+] | [Helix; 1+] | ImportedGeometry
+): [SketchBlock; 1+] | [Solid; 1+] | [Sketch; 1+] | [Helix; 1+] | ImportedGeometry
 ```
 
 This is really useful for resizing parts. You can create a part and then scale it to the
@@ -39,11 +39,18 @@ look like the model moves and gets bigger at the same time. Say you have a squar
 **NOTE:** Currently,, revolved bodies don't support being scaled in a non-uniform
 way (i.e. scaled differently along each axis).
 
+
+
+
+When the input is a KCL 2 sketch block result, `scale` preserves its
+block-local members. The scale is an object transform, so segment values
+continue to describe the sketch's local coordinates.
+
 ### Arguments
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `objects` | [[`Solid`](/docs/kcl-std/types/std-types-Solid); 1+] or [[`Sketch`](/docs/kcl-std/types/std-types-Sketch); 1+] or [[`Helix`](/docs/kcl-std/types/std-types-Helix); 1+] or [`ImportedGeometry`](/docs/kcl-std/types/std-types-ImportedGeometry) | The solid, sketch, helix, or set of solids, sketches, or helices to scale. | Yes |
+| `objects` | [[`SketchBlock`](/docs/kcl-std/types/std-types-SketchBlock); 1+] or [[`Solid`](/docs/kcl-std/types/std-types-Solid); 1+] or [[`Sketch`](/docs/kcl-std/types/std-types-Sketch); 1+] or [[`Helix`](/docs/kcl-std/types/std-types-Helix); 1+] or [`ImportedGeometry`](/docs/kcl-std/types/std-types-ImportedGeometry) | The solid, sketch, sketch block result, helix, or set of them to scale. | Yes |
 | `x` | [`number(_)`](/docs/kcl-std/types/std-types-number) | The dimensionless scale factor for the x axis. | No |
 | `y` | [`number(_)`](/docs/kcl-std/types/std-types-number) | The dimensionless scale factor for the y axis. | No |
 | `z` | [`number(_)`](/docs/kcl-std/types/std-types-number) | The dimensionless scale factor for the z axis. | No |
@@ -52,7 +59,7 @@ way (i.e. scaled differently along each axis).
 
 ### Returns
 
-[[`Solid`](/docs/kcl-std/types/std-types-Solid); 1+] or [[`Sketch`](/docs/kcl-std/types/std-types-Sketch); 1+] or [[`Helix`](/docs/kcl-std/types/std-types-Helix); 1+] or [`ImportedGeometry`](/docs/kcl-std/types/std-types-ImportedGeometry)
+[[`SketchBlock`](/docs/kcl-std/types/std-types-SketchBlock); 1+] or [[`Solid`](/docs/kcl-std/types/std-types-Solid); 1+] or [[`Sketch`](/docs/kcl-std/types/std-types-Sketch); 1+] or [[`Helix`](/docs/kcl-std/types/std-types-Helix); 1+] or [`ImportedGeometry`](/docs/kcl-std/types/std-types-ImportedGeometry)
 
 
 ### Examples

--- a/docs/kcl-std/index.md
+++ b/docs/kcl-std/index.md
@@ -286,6 +286,7 @@ See also the [types overview](/docs/kcl-lang/types)
   * [`Point3d`](/docs/kcl-std/types/std-types-Point3d)
   * [`Segment`](/docs/kcl-std/types/std-types-Segment) Experimental
   * [`Sketch`](/docs/kcl-std/types/std-types-Sketch)
+  * [`SketchBlock`](/docs/kcl-std/types/std-types-SketchBlock)
   * [`Solid`](/docs/kcl-std/types/std-types-Solid)
   * [`TaggedEdge`](/docs/kcl-std/types/std-types-TaggedEdge)
   * [`TaggedFace`](/docs/kcl-std/types/std-types-TaggedFace)

--- a/docs/kcl-std/modules/std-types.md
+++ b/docs/kcl-std/modules/std-types.md
@@ -29,6 +29,7 @@ does.
 * [`Point3d`](/docs/kcl-std/types/std-types-Point3d)
 * [`Segment`](/docs/kcl-std/types/std-types-Segment)
 * [`Sketch`](/docs/kcl-std/types/std-types-Sketch)
+* [`SketchBlock`](/docs/kcl-std/types/std-types-SketchBlock)
 * [`Solid`](/docs/kcl-std/types/std-types-Solid)
 * [`TagDecl`](/docs/kcl-std/types/std-types-TagDecl)
 * [`TaggedEdge`](/docs/kcl-std/types/std-types-TaggedEdge)

--- a/docs/kcl-std/types/std-types-SketchBlock.md
+++ b/docs/kcl-std/types/std-types-SketchBlock.md
@@ -1,0 +1,19 @@
+---
+title: "SketchBlock"
+subtitle: "Type in std::types"
+excerpt: "The result of a KCL 2 sketch block."
+layout: manual
+---
+
+The result of a KCL 2 sketch block.
+
+```kcl
+type SketchBlock = { meta: { sketch: Sketch } }
+```
+
+A sketch block result contains the underlying sketch geometry together with
+the block-local members declared while constructing it. Functions that
+preserve this type also preserve access to those members.
+
+
+

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -2994,6 +2994,43 @@ sketch001 = sketch(on = -YZ) {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn scale_preserves_sketch_block_members() {
+        let code = r#"@settings(defaultLengthUnit = mm, kclVersion = 2.0)
+
+profile = sketch(on = XY) {
+  bottom = line(start = [var 0mm, var 0mm], end = [var 30mm, var 0mm])
+  right = line(start = [var 30mm, var 0mm], end = [var 30mm, var 20mm])
+  top = line(start = [var 30mm, var 20mm], end = [var 0mm, var 20mm])
+  left = line(start = [var 0mm, var 20mm], end = [var 0mm, var 0mm])
+}
+
+originalBottom = profile.bottom
+scaledProfile = scale(profile, x = 2, y = 2)
+scaledBottom = scaledProfile.bottom
+scaledProfiles = scale([profile, profile], factor = 1.5)
+scaledArrayBottom = scaledProfiles[0].bottom
+"#;
+
+        let result = parse_execute(code).await.unwrap();
+        assert!(matches!(
+            mem_get_json(result.exec_state.stack(), result.mem_env, "originalBottom"),
+            KclValue::Segment { .. }
+        ));
+        assert!(matches!(
+            mem_get_json(result.exec_state.stack(), result.mem_env, "scaledProfile"),
+            KclValue::Object { .. }
+        ));
+        assert!(matches!(
+            mem_get_json(result.exec_state.stack(), result.mem_env, "scaledBottom"),
+            KclValue::Segment { .. }
+        ));
+        assert!(matches!(
+            mem_get_json(result.exec_state.stack(), result.mem_env, "scaledArrayBottom"),
+            KclValue::Segment { .. }
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn issue_10639_blend_example_with_two_sketch_blocks_executes() {
         let code = r#"
 sketch001 = sketch(on = YZ) {

--- a/rust/kcl-lib/src/std/transform.rs
+++ b/rust/kcl-lib/src/std/transform.rs
@@ -47,6 +47,11 @@ fn validate_rotation_angle(angle: &Option<TyF64>, argument_name: &str, args: &Ar
 
 /// Scale a solid, a sketch, or a helix.
 pub async fn scale(exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
+    // Keep the sketch-block wrapper that the KCL signature deliberately
+    // preserves. Geometry coercion below extracts its hidden Sketch so the
+    // engine transform can run, but returning that extracted value would drop
+    // every block-local segment member.
+    let original_objects = args.unlabeled_kw_arg_unconverted().map(|arg| arg.value.clone());
     let objects = args.get_unlabeled_kw_arg(
         "objects",
         &RuntimeType::Union(vec![
@@ -100,6 +105,13 @@ pub async fn scale(exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
         args,
     )
     .await?;
+    if let Some(original_objects) = original_objects
+        && (matches!(original_objects, KclValue::Object { .. })
+            || matches!(&original_objects, KclValue::HomArray { value, .. } if value.iter().all(|value| matches!(value, KclValue::Object { .. }))))
+    {
+        return Ok(original_objects);
+    }
+
     Ok(objects.into())
 }
 

--- a/rust/kcl-lib/std/transform.kcl
+++ b/rust/kcl-lib/std/transform.kcl
@@ -3,7 +3,7 @@
 @no_std
 @settings(defaultLengthUnit = mm, kclVersion = 1.0, experimentalFeatures = allow)
 
-import Axis2d, Axis3d, Edge, GdtAnnotation, Helix, Plane, Point3d, Segment, Sketch, Solid from "std::types"
+import Axis2d, Axis3d, Edge, GdtAnnotation, Helix, Plane, Point3d, Segment, Sketch, SketchBlock, Solid from "std::types"
 
 /// Mirror a sketch.
 ///
@@ -735,10 +735,14 @@ export fn rotate(
 ///   z = targetHeight / seedSize,
 /// )
 /// ```
+///
+/// When the input is a KCL 2 sketch block result, `scale` preserves its
+/// block-local members. The scale is an object transform, so segment values
+/// continue to describe the sketch's local coordinates.
 @(impl = std_rust, feature_tree = true)
 export fn scale(
-  /// The solid, sketch, helix, or set of solids, sketches, or helices to scale.
-  @objects: [Solid; 1+] | [Sketch; 1+] | [Helix; 1+] | ImportedGeometry,
+  /// The solid, sketch, sketch block result, helix, or set of them to scale.
+  @objects: [SketchBlock; 1+] | [Solid; 1+] | [Sketch; 1+] | [Helix; 1+] | ImportedGeometry,
   /// The dimensionless scale factor for the x axis.
   @(includeInSnippet = true)
   x?: number(Count) = 1,
@@ -754,7 +758,7 @@ export fn scale(
   /// Equivalent to setting `x`, `y` and `z` all to this number.
   /// Incompatible with `x`, `y` or `z`.
   factor?: number(Count),
-): [Solid; 1+] | [Sketch; 1+] | [Helix; 1+] | ImportedGeometry {}
+): [SketchBlock; 1+] | [Solid; 1+] | [Sketch; 1+] | [Helix; 1+] | ImportedGeometry {}
 
 /// Hide solids, planes, sketches, helices, or imported objects.
 ///

--- a/rust/kcl-lib/std/types.kcl
+++ b/rust/kcl-lib/std/types.kcl
@@ -283,6 +283,13 @@ export type Segment
 @(impl = std_rust)
 export type Sketch
 
+/// The result of a KCL 2 sketch block.
+///
+/// A sketch block result contains the underlying sketch geometry together with
+/// the block-local members declared while constructing it. Functions that
+/// preserve this type also preserve access to those members.
+export type SketchBlock = { meta: { sketch: Sketch } }
+
 /// A solid is a collection of extruded surfaces.
 ///
 /// When you define a solid to a variable like:


### PR DESCRIPTION
## Summary

- introduce a `SketchBlock` structural type for KCL 2 sketch-block results
- preserve the original sketch-block wrapper while `scale()` transforms its hidden engine sketch
- cover single and multi-value inputs and regenerate the stdlib docs

Because `scale()` is an object transform, segment members continue to describe the same local sketch coordinates instead of becoming stale copies.

## Testing

- `cargo nextest run --no-fail-fast -p kcl-lib scale_preserves_sketch_block_members`
- `cargo nextest run --no-fail-fast -p kcl-lib docs::kcl_doc::test::missing_test_examples`
- `cargo nextest run --no-fail-fast -p kcl-lib --features artifact-graph docs::gen_std_tests::test_generate_stdlib`
- `cargo clippy -p kcl-lib --lib -- -D warnings`

Engine-backed scale examples require `ZOO_API_TOKEN`, which was not available in the local shell.

Closes #13294