### PR TITLE
Fix Zookeeper auth token hydration

### DIFF
--- a/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.spec.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.spec.tsx
@@ -104,6 +104,9 @@ vi.mock('@src/lib/fs-zds', () => ({
 
 vi.mock('@src/lib/zookeeper/zookeeperManagerMachine', () => ({
   ZookeeperConversationToMarkdown: vi.fn(() => ''),
+  ZookeeperManagerTransitions: {
+    AuthTokenChanged: 'auth-token-changed',
+  },
   ZookeeperManagerReactContext: {
     Provider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
     useActorRef: () => ({

--- a/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.tsx
@@ -21,11 +21,6 @@ import {
   type ZookeeperSnapshotFileReplay,
   zookeeperEditPatchHistoryEvent,
 } from '@src/lib/zookeeper/editorPlugin'
-import {
-  ZookeeperConversationToMarkdown,
-  type ZookeeperManagerActor,
-  ZookeeperManagerReactContext,
-} from '@src/lib/zookeeper/zookeeperManagerMachine'
 import { zookeeperConversationStore } from '@src/lib/zookeeper/zookeeperConversationStore'
 import {
   mergeZookeeperEditPatches,
@@ -33,6 +28,12 @@ import {
   type ZookeeperEditPatch,
   type ZookeeperEditPatchFile,
 } from '@src/lib/zookeeper/zookeeperEditPatch'
+import {
+  ZookeeperConversationToMarkdown,
+  type ZookeeperManagerActor,
+  ZookeeperManagerReactContext,
+  ZookeeperManagerTransitions,
+} from '@src/lib/zookeeper/zookeeperManagerMachine'
 import { zookeeperPromptRunningSignal } from '@src/lib/zookeeper/zookeeperPromptState'
 import {
   normalizeKCLFileDeletePath,
@@ -122,6 +123,13 @@ function ZookeeperConversationPaneInner(props: AreaTypeComponentProps) {
   } = useModelingContext()
   const loaderFile = project?.executingFileEntry.value
   const zookeeperManagerActor = ZookeeperManagerReactContext.useActorRef()
+
+  useEffect(() => {
+    zookeeperManagerActor.send({
+      type: ZookeeperManagerTransitions.AuthTokenChanged,
+      apiToken: token,
+    })
+  }, [token, zookeeperManagerActor])
 
   useEffect(() => {
     const updatePromptRunning = (

--- a/src/lib/zookeeper/zookeeperManagerMachine.test.ts
+++ b/src/lib/zookeeper/zookeeperManagerMachine.test.ts
@@ -5,6 +5,12 @@ import {
   type Conversation,
   createZookeeperCorrelation,
   type MlCopilotModeOption,
+  NUMBER_OF_ZOOKEEPER_SETUP_ATTEMPTS,
+  parseMlCopilotModesResult,
+  ZOOKEEPER_HEARTBEAT_INTERVAL_MS,
+  ZOOKEEPER_HEARTBEAT_TIMEOUT_MS,
+  ZOOKEEPER_SETUP_ATTEMPT_TIMEOUT_MS,
+  ZOOKEEPER_SETUP_INACTIVITY_TIMEOUT_MS,
   ZookeeperConversationToMarkdown,
   type ZookeeperManagerContext,
   type ZookeeperManagerEvents,
@@ -12,12 +18,6 @@ import {
   ZookeeperManagerTransitions,
   ZookeeperSetupErrors,
   zookeeperManagerMachine,
-  NUMBER_OF_ZOOKEEPER_SETUP_ATTEMPTS,
-  parseMlCopilotModesResult,
-  ZOOKEEPER_HEARTBEAT_INTERVAL_MS,
-  ZOOKEEPER_HEARTBEAT_TIMEOUT_MS,
-  ZOOKEEPER_SETUP_ATTEMPT_TIMEOUT_MS,
-  ZOOKEEPER_SETUP_INACTIVITY_TIMEOUT_MS,
 } from '@src/lib/zookeeper/zookeeperManagerMachine'
 import { S } from '@src/machines/utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -257,7 +257,7 @@ describe('zookeeperManagerMachine', () => {
       })
       const actor = createActor(machine, {
         input: {
-          apiToken: '',
+          apiToken: 'token',
         },
       }).start()
 
@@ -288,6 +288,87 @@ describe('zookeeperManagerMachine', () => {
       stubClientErrorFetch()
     })
 
+    it('waits for auth hydration before opening the setup websocket', async () => {
+      vi.stubGlobal('WebSocket', ControllableSetupWebSocket)
+      const actor = createActor(zookeeperManagerMachine, {
+        input: { apiToken: '' },
+      }).start()
+
+      actor.send({
+        type: ZookeeperManagerTransitions.CacheSetupAndConnect,
+        refParentSend: vi.fn(),
+        conversationId: 'conversation-id',
+      })
+
+      expect(ControllableSetupWebSocket.instances).toHaveLength(0)
+
+      actor.send({
+        type: ZookeeperManagerTransitions.AuthTokenChanged,
+        apiToken: 'hydrated-token',
+      })
+
+      await vi.waitFor(() => {
+        expect(ControllableSetupWebSocket.instances).toHaveLength(1)
+      })
+      const socket = ControllableSetupWebSocket.instances[0]
+      socket.open()
+
+      await vi.waitFor(() => {
+        expect(socket.sentPayloads).toContain(
+          JSON.stringify({
+            type: 'headers',
+            headers: { Authorization: 'Bearer hydrated-token' },
+          })
+        )
+      })
+
+      actor.stop()
+    })
+
+    it('restarts an in-flight setup with a rotated auth token', async () => {
+      vi.stubGlobal('WebSocket', ControllableSetupWebSocket)
+      const actor = createActor(zookeeperManagerMachine, {
+        input: { apiToken: 'old-token' },
+      }).start()
+
+      actor.send({
+        type: ZookeeperManagerTransitions.CacheSetupAndConnect,
+        refParentSend: vi.fn(),
+        conversationId: 'conversation-id',
+      })
+
+      await vi.waitFor(() => {
+        expect(ControllableSetupWebSocket.instances).toHaveLength(1)
+      })
+      const oldSocket = ControllableSetupWebSocket.instances[0]
+
+      actor.send({
+        type: ZookeeperManagerTransitions.AuthTokenChanged,
+        apiToken: 'new-token',
+      })
+
+      await vi.waitFor(() => {
+        expect(ControllableSetupWebSocket.instances).toHaveLength(2)
+      })
+      const newSocket = ControllableSetupWebSocket.instances[1]
+      newSocket.open()
+
+      await vi.waitFor(() => {
+        expect(newSocket.sentPayloads).toContain(
+          JSON.stringify({
+            type: 'headers',
+            headers: { Authorization: 'Bearer new-token' },
+          })
+        )
+      })
+      expect(oldSocket.close).toHaveBeenCalledOnce()
+      expect(oldSocket.sentPayloads).not.toContain(
+        expect.stringContaining('old-token')
+      )
+
+      actor.stop()
+    })
+
     it('stops retrying and exposes a recoverable failure after repeated setup errors', async () => {
       const { fetchMock, reports } = stubClientErrorFetch()
       let setupAttempts = 0
@@ -310,7 +391,7 @@ describe('zookeeperManagerMachine', () => {
       })
       const actor = createActor(machine, {
         input: {
-          apiToken: '',
+          apiToken: 'token',
         },
       }).start()
 
@@ -508,7 +589,7 @@ describe('zookeeperManagerMachine', () => {
       })
       const actor = createActor(machine, {
         input: {
-          apiToken: '',
+          apiToken: 'token',
         },
       }).start()
 
@@ -557,7 +638,7 @@ describe('zookeeperManagerMachine', () => {
       })
       const actor = createActor(machine, {
         input: {
-          apiToken: '',
+          apiToken: 'token',
         },
       }).start()
 
@@ -606,7 +687,7 @@ describe('zookeeperManagerMachine', () => {
       })
       const actor = createActor(machine, {
         input: {
-          apiToken: '',
+          apiToken: 'token',
         },
       }).start()
 
@@ -774,7 +855,7 @@ describe('zookeeperManagerMachine', () => {
       })
       const actor = createActor(machine, {
         input: {
-          apiToken: '',
+          apiToken: 'token',
         },
       }).start()
 
@@ -849,7 +930,7 @@ describe('zookeeperManagerMachine', () => {
         },
       })
       const actor = createActor(machine, {
-        input: { apiToken: '' },
+        input: { apiToken: 'token' },
       }).start()
 
       actor.send({
@@ -921,7 +1002,7 @@ describe('zookeeperManagerMachine', () => {
       })
       const actor = createActor(machine, {
         input: {
-          apiToken: '',
+          apiToken: 'token',
         },
       }).start()
 
@@ -966,7 +1047,7 @@ describe('zookeeperManagerMachine', () => {
       })
       const actor = createActor(machine, {
         input: {
-          apiToken: '',
+          apiToken: 'token',
         },
       }).start()
 
@@ -1022,7 +1103,7 @@ describe('zookeeperManagerMachine', () => {
       })
       const actor = createActor(machine, {
         input: {
-          apiToken: '',
+          apiToken: 'token',
         },
       }).start()
 
@@ -1081,7 +1162,7 @@ describe('zookeeperManagerMachine', () => {
       })
       const actor = createActor(machine, {
         input: {
-          apiToken: '',
+          apiToken: 'token',
         },
       }).start()
 
@@ -1151,7 +1232,7 @@ describe('zookeeperManagerMachine', () => {
       })
       const actor = createActor(machine, {
         input: {
-          apiToken: '',
+          apiToken: 'token',
         },
       }).start()
 

--- a/src/lib/zookeeper/zookeeperManagerMachine.ts
+++ b/src/lib/zookeeper/zookeeperManagerMachine.ts
@@ -1618,9 +1618,6 @@ export const zookeeperManagerMachine = setup({
             actions: ['assignApiToken'],
             reenter: true,
           },
-          {
-            actions: ['assignApiToken'],
-          },
         ],
         ...transitions([ZookeeperManagerTransitions.ConversationClose]),
         [ZookeeperManagerTransitions.AbruptClose]: [

--- a/src/lib/zookeeper/zookeeperManagerMachine.ts
+++ b/src/lib/zookeeper/zookeeperManagerMachine.ts
@@ -4,26 +4,22 @@ import type {
   MlCopilotServerMessage,
 } from '@kittycad/lib'
 import { decode as msgpackDecode } from '@msgpack/msgpack'
-import { withZookeeperWebSocketURL } from '@src/lib/withBaseURL'
-import { createActorContext } from '@xstate/react'
-import ms from 'ms'
-import { assertEvent, assign, fromPromise, setup } from 'xstate'
-import type { ActorRefFrom } from 'xstate'
-
 import {
   type CustomIconName,
   isCustomIconName,
 } from '@src/components/CustomIcon'
-
 import { ClientErrorCode, reportClientError } from '@src/lib/clientErrors'
+import { getKclVersion } from '@src/lib/kclVersion'
+import { Socket, SocketConnectionError } from '@src/lib/socket'
 import { isErr } from '@src/lib/trap'
 import { isArray, uuidv4 } from '@src/lib/utils'
-
-import { getKclVersion } from '@src/lib/kclVersion'
-import { S, transitions, xstateEventError } from '@src/machines/utils'
-
-import { Socket, SocketConnectionError } from '@src/lib/socket'
+import { withZookeeperWebSocketURL } from '@src/lib/withBaseURL'
 import { isZookeeperBillingError } from '@src/lib/zookeeper/zookeeperBilling'
+import { S, transitions, xstateEventError } from '@src/machines/utils'
+import { createActorContext } from '@xstate/react'
+import ms from 'ms'
+import type { ActorRefFrom } from 'xstate'
+import { assertEvent, assign, fromPromise, setup } from 'xstate'
 
 // Uncomment and switch WebSocket below with this MockSocket for development.
 // import { MockSocket } from '@src/mocks/copilot'
@@ -34,12 +30,11 @@ import type { ConnectionManager } from '@src/lib/engineConnection/connectionMana
 import type { FileEntry, Project } from '@src/lib/project'
 import type { FileMeta } from '@src/lib/types'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
-import type { Selections } from '@src/machines/modelingSharedTypes'
-
 import {
-  type KittyCadLibFile,
   constructZookeeperUserPromptRequest,
+  type KittyCadLibFile,
 } from '@src/lib/zookeeper/zookeeperPromptRequest'
+import type { Selections } from '@src/machines/modelingSharedTypes'
 
 import toast from 'react-hot-toast'
 
@@ -193,6 +188,7 @@ export enum ZookeeperManagerStates {
 }
 
 export enum ZookeeperManagerTransitions {
+  AuthTokenChanged = 'auth-token-changed',
   MessageSend = 'message-send',
   ResponseReceive = 'response-receive',
   ModesReceive = 'modes-receive',
@@ -250,6 +246,10 @@ function getSetupFailureReason(event: unknown): string | undefined {
 }
 
 export type ZookeeperManagerEvents =
+  | {
+      type: ZookeeperManagerTransitions.AuthTokenChanged
+      apiToken: string
+    }
   | {
       type: 'xstate.done.state.(machine).ready'
       conversationId: undefined
@@ -676,8 +676,27 @@ export const zookeeperManagerMachine = setup({
   guards: {
     canRetrySetup: ({ context }) =>
       context.setupAttempt < NUMBER_OF_ZOOKEEPER_SETUP_ATTEMPTS,
+    hasApiToken: ({ context }) => context.apiToken.trim().length > 0,
+    canResumeSetupWithApiToken: ({ context, event }) => {
+      assertEvent(event, ZookeeperManagerTransitions.AuthTokenChanged)
+      return (
+        context.cachedSetup !== undefined && event.apiToken.trim().length > 0
+      )
+    },
+    apiTokenChanged: ({ context, event }) => {
+      assertEvent(event, ZookeeperManagerTransitions.AuthTokenChanged)
+      return event.apiToken !== context.apiToken
+    },
+    apiTokenCleared: ({ event }) => {
+      assertEvent(event, ZookeeperManagerTransitions.AuthTokenChanged)
+      return event.apiToken.trim().length === 0
+    },
   },
   actions: {
+    assignApiToken: assign(({ event }) => {
+      assertEvent(event, ZookeeperManagerTransitions.AuthTokenChanged)
+      return { apiToken: event.apiToken }
+    }),
     toastError: ({ event, context }) => {
       console.error(event)
       const error = xstateEventError(event)
@@ -1459,6 +1478,9 @@ export const zookeeperManagerMachine = setup({
     closeZookeeperWebSocket(args.context?.ws)
   },
   on: {
+    [ZookeeperManagerTransitions.AuthTokenChanged]: {
+      actions: ['assignApiToken'],
+    },
     [ZookeeperManagerTransitions.ModesReceive]: {
       actions: ['assignModeOptions'],
     },
@@ -1474,10 +1496,26 @@ export const zookeeperManagerMachine = setup({
   states: {
     [S.Await]: {
       on: {
-        [ZookeeperManagerTransitions.CacheSetupAndConnect]: {
-          target: ZookeeperManagerStates.Setup,
-          actions: ['prepareSetup'],
-        },
+        [ZookeeperManagerTransitions.CacheSetupAndConnect]: [
+          {
+            guard: 'hasApiToken',
+            target: ZookeeperManagerStates.Setup,
+            actions: ['prepareSetup'],
+          },
+          {
+            actions: ['prepareSetup'],
+          },
+        ],
+        [ZookeeperManagerTransitions.AuthTokenChanged]: [
+          {
+            guard: 'canResumeSetupWithApiToken',
+            target: ZookeeperManagerStates.Setup,
+            actions: ['assignApiToken'],
+          },
+          {
+            actions: ['assignApiToken'],
+          },
+        ],
         ...transitions([ZookeeperManagerStates.Setup]),
       },
     },
@@ -1568,6 +1606,22 @@ export const zookeeperManagerMachine = setup({
         ],
       },
       on: {
+        [ZookeeperManagerTransitions.AuthTokenChanged]: [
+          {
+            guard: 'apiTokenCleared',
+            target: S.Await,
+            actions: ['assignApiToken'],
+          },
+          {
+            guard: 'apiTokenChanged',
+            target: ZookeeperManagerStates.Setup,
+            actions: ['assignApiToken'],
+            reenter: true,
+          },
+          {
+            actions: ['assignApiToken'],
+          },
+        ],
         ...transitions([ZookeeperManagerTransitions.ConversationClose]),
         [ZookeeperManagerTransitions.AbruptClose]: [
           {

--- a/src/lib/zookeeper/zookeeperPromptRequest.integration.spec.ts
+++ b/src/lib/zookeeper/zookeeperPromptRequest.integration.spec.ts
@@ -143,7 +143,7 @@ describe('Zookeeper prompt selections from modelingMachine', () => {
         })),
       },
     })
-    const actor = createActor(machine, { input: { apiToken: '' } }).start()
+    const actor = createActor(machine, { input: { apiToken: 'token' } }).start()
     const projectFiles: FileMeta[] = [
       {
         type: 'kcl',


### PR DESCRIPTION
## Summary

- propagate the live application auth token into the long-lived Zookeeper manager actor
- defer setup while the token is empty and resume automatically after auth hydration
- cancel and re-enter an in-flight setup when the token rotates, so retries cannot keep using the captured credential
- cover empty-at-mount hydration and active token rotation with state-machine tests

Closes #13296.

## Validation

- `npx vitest run --mode=development src/lib/zookeeper/zookeeperManagerMachine.test.ts` — 26 passed
- Biome formatter and import-assist checks pass for all four changed files
- `git diff --check`

The adjacent prompt-request integration suite could not start in the local clone because the generated `@rust/kcl-lib/bindings/StdLibCommands` artifact was absent. The modified fixture is limited to supplying the nonempty token now required by setup; CI's normal generated-bindings environment will exercise it.
