### PR TITLE
Handle superseded Zookeeper resumes by socket

### DIFF
--- a/src/lib/zookeeper/zookeeperManagerMachine.test.ts
+++ b/src/lib/zookeeper/zookeeperManagerMachine.test.ts
@@ -18,6 +18,7 @@ import {
   ZookeeperManagerTransitions,
   ZookeeperSetupErrors,
   zookeeperManagerMachine,
+  ZOOKEEPER_RESUME_SUPERSEDED_CLOSE_CODE,
 } from '@src/lib/zookeeper/zookeeperManagerMachine'
 import { S } from '@src/machines/utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -987,6 +988,115 @@ describe('zookeeperManagerMachine', () => {
   })
 
   describe('ConversationClose', () => {
+    it('silently makes the current socket recoverable when its resume is superseded', async () => {
+      const { fetchMock } = stubClientErrorFetch()
+      vi.stubGlobal('WebSocket', ControllableSetupWebSocket)
+      const actor = createActor(zookeeperManagerMachine, {
+        input: {
+          apiToken: 'token',
+        },
+      }).start()
+
+      actor.send({
+        type: ZookeeperManagerTransitions.CacheSetupAndConnect,
+        refParentSend: vi.fn(),
+      })
+
+      const socket = ControllableSetupWebSocket.instances[0]
+      socket.open()
+      await vi.waitFor(() => {
+        expect(socket.sentPayloads).toContain(
+          JSON.stringify({ type: 'list_modes' })
+        )
+      })
+      socket.receive({
+        conversation_id: { conversation_id: 'conversation-id' },
+      })
+      await waitFor(actor, (state) =>
+        state.matches(ZookeeperManagerStates.WaitForContinueCheck)
+      )
+
+      actor.send({
+        type: ZookeeperManagerStates.ContinueCheck,
+        projectName: 'zoo-project',
+        projectFiles: [],
+      })
+      await waitFor(actor, (state) =>
+        state.matches(ZookeeperManagerStates.Ready)
+      )
+
+      socket.closeWithCode(
+        ZOOKEEPER_RESUME_SUPERSEDED_CLOSE_CODE,
+        'zookeeper_resume_superseded'
+      )
+      await waitFor(actor, (state) => state.matches(S.Await))
+
+      expect(actor.getSnapshot().context).toMatchObject({
+        abruptlyClosed: true,
+        setupFailed: false,
+        closeReason: undefined,
+        conversation: { exchanges: [] },
+        conversationId: 'conversation-id',
+      })
+      expect(fetchMock).not.toHaveBeenCalled()
+
+      actor.stop()
+    })
+
+    it('ignores a superseded close from an obsolete socket', async () => {
+      const currentSocket = new TestSocket() as TestWebSocket
+      const obsoleteSocket = new TestSocket() as TestWebSocket
+      const machine = zookeeperManagerMachine.provide({
+        actors: {
+          [ZookeeperManagerStates.Setup]: fromPromise<
+            Partial<ZookeeperManagerContext>,
+            SetupActorInput
+          >(async () => ({
+            ws: currentSocket,
+            conversation: completedConversation,
+            conversationId: 'conversation-id',
+          })),
+        },
+      })
+      const actor = createActor(machine, {
+        input: {
+          apiToken: 'token',
+        },
+      }).start()
+
+      actor.send({
+        type: ZookeeperManagerTransitions.CacheSetupAndConnect,
+        refParentSend: vi.fn(),
+      })
+      await waitFor(actor, (state) =>
+        state.matches(ZookeeperManagerStates.WaitForContinueCheck)
+      )
+      actor.send({
+        type: ZookeeperManagerStates.ContinueCheck,
+        projectName: 'zoo-project',
+        projectFiles: [],
+      })
+      await waitFor(actor, (state) =>
+        state.matches(ZookeeperManagerStates.Ready)
+      )
+
+      actor.send({
+        type: ZookeeperManagerTransitions.ResumeSuperseded,
+        webSocket: obsoleteSocket,
+      })
+
+      expect(actor.getSnapshot().matches(ZookeeperManagerStates.Ready)).toBe(
+        true
+      )
+      expect(actor.getSnapshot().context).toMatchObject({
+        ws: currentSocket,
+        abruptlyClosed: false,
+        conversationId: 'conversation-id',
+      })
+
+      actor.stop()
+    })
+
     it('stops setup without retrying when the browser goes offline', async () => {
       let setupAttempts = 0
       const machine = zookeeperManagerMachine.provide({

--- a/src/lib/zookeeper/zookeeperManagerMachine.ts
+++ b/src/lib/zookeeper/zookeeperManagerMachine.ts
@@ -196,6 +196,7 @@ export enum ZookeeperManagerTransitions {
   Cancel = 'cancel',
   Interrupt = 'interrupt',
   AbruptClose = 'abrupt-close',
+  ResumeSuperseded = 'resume-superseded',
   NetworkOffline = 'network-offline',
   CacheSetupAndConnect = 'cache-setup-and-connect',
   BackendShutdown = 'backend-shutdown',
@@ -207,6 +208,7 @@ export const ZOOKEEPER_SETUP_INACTIVITY_TIMEOUT_MS = 60_000
 export const ZOOKEEPER_SETUP_ATTEMPT_TIMEOUT_MS = 120_000
 export const ZOOKEEPER_HEARTBEAT_INTERVAL_MS = 4_000
 export const ZOOKEEPER_HEARTBEAT_TIMEOUT_MS = 30_000
+export const ZOOKEEPER_RESUME_SUPERSEDED_CLOSE_CODE = 4409
 const ZOOKEEPER_HEARTBEAT_TIMER_DRIFT_GRACE_MS = 5_000
 
 const ZOOKEEPER_PROJECT_TOO_LARGE_CLOSE_REASON =
@@ -313,6 +315,10 @@ export type ZookeeperManagerEvents =
   | {
       type: ZookeeperManagerTransitions.AbruptClose
       closeReason?: string
+    }
+  | {
+      type: ZookeeperManagerTransitions.ResumeSuperseded
+      webSocket: WebSocket
     }
   | {
       type: ZookeeperManagerTransitions.NetworkOffline
@@ -691,6 +697,10 @@ export const zookeeperManagerMachine = setup({
       assertEvent(event, ZookeeperManagerTransitions.AuthTokenChanged)
       return event.apiToken.trim().length === 0
     },
+    isCurrentZookeeperWebSocket: ({ context, event }) => {
+      assertEvent(event, ZookeeperManagerTransitions.ResumeSuperseded)
+      return context.ws === event.webSocket
+    },
   },
   actions: {
     assignApiToken: assign(({ event }) => {
@@ -740,19 +750,28 @@ export const zookeeperManagerMachine = setup({
       })
     },
     handleAbruptClose: assign(({ event, context }) => {
-      assertEvent(event, ZookeeperManagerTransitions.AbruptClose)
+      assertEvent(event, [
+        ZookeeperManagerTransitions.AbruptClose,
+        ZookeeperManagerTransitions.ResumeSuperseded,
+      ])
+      const closeReason =
+        event.type === ZookeeperManagerTransitions.AbruptClose
+          ? event.closeReason
+          : undefined
       logZookeeperDisconnect('machine handling abrupt websocket close', {
-        closeReason: event.closeReason,
+        closeReason,
+        resumeSuperseded:
+          event.type === ZookeeperManagerTransitions.ResumeSuperseded,
         ...zookeeperErrorContext(context),
       })
-      if (event.closeReason && !isZookeeperBillingError(event.closeReason)) {
-        toast.error(event.closeReason)
+      if (closeReason && !isZookeeperBillingError(closeReason)) {
+        toast.error(closeReason)
       }
       return {
         abruptlyClosed: true,
         setupFailed: false,
         setupFailureReason: undefined,
-        closeReason: event.closeReason,
+        closeReason,
       }
     }),
     handleNetworkOffline: assign(({ context }) => {
@@ -1284,6 +1303,14 @@ export const zookeeperManagerMachine = setup({
             }
 
             if (theRefParentSend !== undefined) {
+              if (event.code === ZOOKEEPER_RESUME_SUPERSEDED_CLOSE_CODE) {
+                theRefParentSend({
+                  type: ZookeeperManagerTransitions.ResumeSuperseded,
+                  webSocket: ws,
+                })
+                return
+              }
+
               const closeReason =
                 event.code === 1009
                   ? ZOOKEEPER_PROJECT_TOO_LARGE_CLOSE_REASON
@@ -1485,6 +1512,11 @@ export const zookeeperManagerMachine = setup({
       actions: ['assignModeOptions'],
     },
     [ZookeeperManagerTransitions.AbruptClose]: {
+      target: '#zookeeper-abrupt-close',
+      actions: ['handleAbruptClose'],
+    },
+    [ZookeeperManagerTransitions.ResumeSuperseded]: {
+      guard: 'isCurrentZookeeperWebSocket',
       target: '#zookeeper-abrupt-close',
       actions: ['handleAbruptClose'],
     },


### PR DESCRIPTION
## Why

[API PR #4431](https://github.com/KittyCAD/api/pull/4431) gives one WebSocket ownership of an interrupted Zookeeper turn. When reconnects race, API closes the loser with code 4409 without showing a client error.

A delayed close from an obsolete socket must not disconnect a newer active socket. If it did, the active client could reconnect and claim ownership again, causing avoidable reconnect churn.

## What

- Recognize the API 4409 resume-superseded close.
- Send the source WebSocket through the internal state-machine event.
- Use the existing silent reconnect path only when that WebSocket is still current.
- Ignore the event when it came from an obsolete socket.
- Cover both cases with focused unit tests.

This does not add a new retry policy or UI behavior. It can deploy before 
[API PR #4431](https://github.com/KittyCAD/api/pull/4431) and remains dormant until API sends code 4409.

Related: [text-to-cad #4097](https://github.com/KittyCAD/text-to-cad/pull/4097), [text-to-cad #4081](https://github.com/KittyCAD/text-to-cad/issues/4081).