### PR TITLE
KCL: validate getCommonEdge provenance in mock execution

### DIFF
--- a/rust/kcl-lib/src/execution/geometry.rs
+++ b/rust/kcl-lib/src/execution/geometry.rs
@@ -1410,6 +1410,45 @@ impl Solid {
         self.topology_id = engine_id;
         self.pattern_source_artifact_id = None;
         self.artifact_id = artifact_id;
+        self.retarget_current_tags_to_self();
+    }
+
+    /// Keep carried tags owned by this body after an operation creates a new
+    /// topological body from an existing [`Solid`] value.
+    ///
+    /// Clone, CSG, and mirror start from a copy of an input solid. Without
+    /// retargeting, some tags retain the source body's geometry while other
+    /// tags already point at the result body. That makes same-body validation
+    /// unreliable and can also make tags from two cloned bodies appear to
+    /// share an owner.
+    fn retarget_current_tags_to_self(&mut self) {
+        let mut owner = self.clone();
+        if let Some(sketch) = owner.sketch_mut() {
+            sketch.tags.clear();
+        }
+        owner.faces.clear();
+        let owner = Geometry::Solid(owner);
+
+        fn retarget(tag: &mut TagIdentifier, owner: &Geometry) {
+            let Some(current_epoch) = tag.info.last().map(|(epoch, _)| *epoch) else {
+                return;
+            };
+            for (epoch, info) in tag.info.iter_mut().rev() {
+                if *epoch != current_epoch {
+                    break;
+                }
+                info.geometry = owner.clone();
+            }
+        }
+
+        if let Some(sketch) = self.sketch_mut() {
+            for tag in sketch.tags.values_mut() {
+                retarget(tag, &owner);
+            }
+        }
+        for tag in self.faces.values_mut() {
+            retarget(tag, &owner);
+        }
     }
 
     /// Make this solid a pattern copy. It gets a new top-level entity artifact

--- a/rust/kcl-lib/src/std/edge.rs
+++ b/rust/kcl-lib/src/std/edge.rs
@@ -438,16 +438,9 @@ async fn inner_get_common_edge(
 ) -> Result<Uuid, KclError> {
     check_tag_not_ambiguous(&face1, &args)?;
     check_tag_not_ambiguous(&face2, &args)?;
-    let id = exec_state.next_uuid();
-    if args.ctx.no_engine_commands().await {
-        return Ok(id);
-    }
-
-    let first_face_id = args.get_adjacent_face_to_tag(exec_state, &face1, false).await?;
-    let second_face_id = args.get_adjacent_face_to_tag(exec_state, &face2, false).await?;
 
     let first_tagged_path = args.get_tag_engine_info(exec_state, &face1)?.clone();
-    let second_tagged_path = args.get_tag_engine_info(exec_state, &face2)?;
+    let second_tagged_path = args.get_tag_engine_info(exec_state, &face2)?.clone();
 
     if first_tagged_path.geometry.id() != second_tagged_path.geometry.id() {
         return Err(KclError::new_type(KclErrorDetails::new(
@@ -455,6 +448,14 @@ async fn inner_get_common_edge(
             vec![args.source_range],
         )));
     }
+
+    let id = exec_state.next_uuid();
+    if args.ctx.no_engine_commands().await {
+        return Ok(id);
+    }
+
+    let first_face_id = args.get_adjacent_face_to_tag(exec_state, &face1, false).await?;
+    let second_face_id = args.get_adjacent_face_to_tag(exec_state, &face2, false).await?;
 
     // Flush the batch for our fillets/chamfers if there are any.
     // If we have a chamfer/fillet, flush the batch.
@@ -1017,6 +1018,47 @@ mod tests {
     use super::combination_count;
     use super::edge_combinations_exceed_limit;
     use super::face_id_combinations;
+    use crate::errors::KclError;
+    use crate::execution::MockConfig;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn mock_get_common_edge_rejects_faces_from_different_sketches() {
+        let code = r#"
+@settings(kclVersion = 2.0)
+
+firstSketch = sketch(on = XY) {
+  line1 = line(start = [var 0mm, var 0mm], end = [var 10mm, var 0mm])
+  line2 = line(start = [var 10mm, var 0mm], end = [var 10mm, var 10mm])
+  line3 = line(start = [var 10mm, var 10mm], end = [var 0mm, var 10mm])
+  line4 = line(start = [var 0mm, var 10mm], end = [var 0mm, var 0mm])
+}
+firstRegion = region(point = [5mm, 0.0025mm], sketch = firstSketch)
+firstSolid = extrude(firstRegion, length = 5mm, tagEnd = $firstEnd)
+
+secondSketch = sketch(on = XZ) {
+  line1 = line(start = [var 0mm, var 0mm], end = [var 10mm, var 0mm])
+  line2 = line(start = [var 10mm, var 0mm], end = [var 10mm, var 10mm])
+  line3 = line(start = [var 10mm, var 10mm], end = [var 0mm, var 10mm])
+  line4 = line(start = [var 0mm, var 10mm], end = [var 0mm, var 0mm])
+}
+secondRegion = region(point = [5mm, 0.0025mm], sketch = secondSketch)
+secondSolid = extrude(secondRegion, length = 5mm, tagEnd = $secondEnd)
+
+edge = getCommonEdge(faces = [firstEnd, secondEnd])
+"#;
+        let ctx = crate::ExecutorContext::new_mock(None).await;
+        let program = crate::Program::parse_no_errs(code).unwrap();
+
+        let err = ctx.run_mock(&program, &MockConfig::default()).await.unwrap_err();
+        ctx.close().await;
+
+        assert!(matches!(&err.error, KclError::Type { .. }), "{:?}", err.error);
+        let message = err.error.message();
+        assert!(
+            message.contains("getCommonEdge requires the faces to be in the same original sketch"),
+            "{message}"
+        );
+    }
 
     #[test]
     fn face_id_combinations_empty_input_is_one_empty_combination() {

--- a/rust/kcl-lib/src/std/edge.rs
+++ b/rust/kcl-lib/src/std/edge.rs
@@ -440,7 +440,7 @@ async fn inner_get_common_edge(
     check_tag_not_ambiguous(&face2, &args)?;
 
     let first_tagged_path = args.get_tag_engine_info(exec_state, &face1)?.clone();
-    let second_tagged_path = args.get_tag_engine_info(exec_state, &face2)?.clone();
+    let second_tagged_path = args.get_tag_engine_info(exec_state, &face2)?;
 
     if first_tagged_path.geometry.id() != second_tagged_path.geometry.id() {
         return Err(KclError::new_type(KclErrorDetails::new(

--- a/rust/kcl-lib/src/std/edge.rs
+++ b/rust/kcl-lib/src/std/edge.rs
@@ -442,22 +442,15 @@ async fn inner_get_common_edge(
     let first_tagged_path = args.get_tag_engine_info(exec_state, &face1)?.clone();
     let second_tagged_path = args.get_tag_engine_info(exec_state, &face2)?;
 
-    let no_engine_commands = args.ctx.no_engine_commands().await;
-    // Clone and CSG mock execution can retain different current geometry IDs
-    // for tags on the same derived body. Their source sketch remains stable.
-    let shared_mock_origin = no_engine_commands
-        && original_sketch_id(&first_tagged_path.geometry)
-            .is_some_and(|first_origin| original_sketch_id(&second_tagged_path.geometry) == Some(first_origin));
-
-    if first_tagged_path.geometry.id() != second_tagged_path.geometry.id() && !shared_mock_origin {
+    if first_tagged_path.geometry.id() != second_tagged_path.geometry.id() {
         return Err(KclError::new_type(KclErrorDetails::new(
-            "getCommonEdge requires the faces to be in the same original sketch".to_string(),
+            "getCommonEdge requires both faces to belong to the same body".to_string(),
             vec![args.source_range],
         )));
     }
 
     let id = exec_state.next_uuid();
-    if no_engine_commands {
+    if args.ctx.no_engine_commands().await {
         return Ok(id);
     }
 
@@ -517,13 +510,6 @@ async fn inner_get_common_edge(
         stdlib_fn: EdgeRefactorStdlibFn::GetCommonEdge,
     });
     Ok(edge_id)
-}
-
-fn original_sketch_id(geometry: &crate::execution::Geometry) -> Option<Uuid> {
-    match geometry {
-        crate::execution::Geometry::Sketch(sketch) => sketch.origin_sketch_id,
-        crate::execution::Geometry::Solid(solid) => solid.sketch().and_then(|sketch| sketch.origin_sketch_id),
-    }
 }
 
 pub async fn get_bounded_edge(exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
@@ -1069,7 +1055,7 @@ edge = getCommonEdge(faces = [firstEnd, secondEnd])
         assert!(matches!(&err.error, KclError::Type { .. }), "{:?}", err.error);
         let message = err.error.message();
         assert!(
-            message.contains("getCommonEdge requires the faces to be in the same original sketch"),
+            message.contains("getCommonEdge requires both faces to belong to the same body"),
             "{message}"
         );
     }
@@ -1098,6 +1084,38 @@ edge = getCommonEdge(faces = [clonedSolid.sketch.tags.line2, clonedSolid.faces.e
         ctx.close().await;
 
         result.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn mock_get_common_edge_rejects_faces_from_different_cloned_bodies() {
+        let code = r#"
+@settings(kclVersion = 2.0)
+
+rectangleSketch = sketch(on = XY) {
+  line1 = line(start = [var 0mm, var 0mm], end = [var 10mm, var 0mm])
+  line2 = line(start = [var 10mm, var 0mm], end = [var 10mm, var 10mm])
+  line3 = line(start = [var 10mm, var 10mm], end = [var 0mm, var 10mm])
+  line4 = line(start = [var 0mm, var 10mm], end = [var 0mm, var 0mm])
+}
+rectangleRegion = region(point = [5mm, 5mm], sketch = rectangleSketch)
+firstSolid = extrude(rectangleRegion, length = 5mm, tagEnd = $endFace)
+clonedSolid = clone(firstSolid)
+  |> translate(x = 20mm)
+
+edge = getCommonEdge(faces = [firstSolid.sketch.tags.line2, clonedSolid.faces.endFace])
+"#;
+        let ctx = crate::ExecutorContext::new_mock(None).await;
+        let program = crate::Program::parse_no_errs(code).unwrap();
+
+        let err = ctx.run_mock(&program, &MockConfig::default()).await.unwrap_err();
+        ctx.close().await;
+
+        assert!(matches!(&err.error, KclError::Type { .. }), "{:?}", err.error);
+        let message = err.error.message();
+        assert!(
+            message.contains("getCommonEdge requires both faces to belong to the same body"),
+            "{message}"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/rust/kcl-lib/src/std/edge.rs
+++ b/rust/kcl-lib/src/std/edge.rs
@@ -442,7 +442,14 @@ async fn inner_get_common_edge(
     let first_tagged_path = args.get_tag_engine_info(exec_state, &face1)?.clone();
     let second_tagged_path = args.get_tag_engine_info(exec_state, &face2)?;
 
-    if first_tagged_path.geometry.id() != second_tagged_path.geometry.id() {
+    let no_engine_commands = args.ctx.no_engine_commands().await;
+    // Clone and CSG mock execution can retain different current geometry IDs
+    // for tags on the same derived body. Their source sketch remains stable.
+    let shared_mock_origin = no_engine_commands
+        && original_sketch_id(&first_tagged_path.geometry)
+            .is_some_and(|first_origin| original_sketch_id(&second_tagged_path.geometry) == Some(first_origin));
+
+    if first_tagged_path.geometry.id() != second_tagged_path.geometry.id() && !shared_mock_origin {
         return Err(KclError::new_type(KclErrorDetails::new(
             "getCommonEdge requires the faces to be in the same original sketch".to_string(),
             vec![args.source_range],
@@ -450,7 +457,7 @@ async fn inner_get_common_edge(
     }
 
     let id = exec_state.next_uuid();
-    if args.ctx.no_engine_commands().await {
+    if no_engine_commands {
         return Ok(id);
     }
 
@@ -510,6 +517,13 @@ async fn inner_get_common_edge(
         stdlib_fn: EdgeRefactorStdlibFn::GetCommonEdge,
     });
     Ok(edge_id)
+}
+
+fn original_sketch_id(geometry: &crate::execution::Geometry) -> Option<Uuid> {
+    match geometry {
+        crate::execution::Geometry::Sketch(sketch) => sketch.origin_sketch_id,
+        crate::execution::Geometry::Solid(solid) => solid.sketch().and_then(|sketch| sketch.origin_sketch_id),
+    }
 }
 
 pub async fn get_bounded_edge(exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
@@ -1058,6 +1072,64 @@ edge = getCommonEdge(faces = [firstEnd, secondEnd])
             message.contains("getCommonEdge requires the faces to be in the same original sketch"),
             "{message}"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn mock_get_common_edge_accepts_faces_on_a_cloned_body() {
+        let code = r#"
+@settings(kclVersion = 2.0)
+
+rectangleSketch = sketch(on = XY) {
+  line1 = line(start = [var 0mm, var 0mm], end = [var 10mm, var 0mm])
+  line2 = line(start = [var 10mm, var 0mm], end = [var 10mm, var 10mm])
+  line3 = line(start = [var 10mm, var 10mm], end = [var 0mm, var 10mm])
+  line4 = line(start = [var 0mm, var 10mm], end = [var 0mm, var 0mm])
+}
+rectangleRegion = region(point = [5mm, 5mm], sketch = rectangleSketch)
+firstSolid = extrude(rectangleRegion, length = 5mm, tagEnd = $endFace)
+clonedSolid = clone(firstSolid)
+
+edge = getCommonEdge(faces = [clonedSolid.sketch.tags.line2, clonedSolid.faces.endFace])
+"#;
+        let ctx = crate::ExecutorContext::new_mock(None).await;
+        let program = crate::Program::parse_no_errs(code).unwrap();
+
+        let result = ctx.run_mock(&program, &MockConfig::default()).await;
+        ctx.close().await;
+
+        result.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn mock_get_common_edge_accepts_faces_on_a_csg_result() {
+        let code = r#"
+@settings(kclVersion = 2.0)
+
+boxSketch = sketch(on = XY) {
+  line1 = line(start = [var 0mm, var 0mm], end = [var 10mm, var 0mm])
+  line2 = line(start = [var 10mm, var 0mm], end = [var 10mm, var 10mm])
+  line3 = line(start = [var 10mm, var 10mm], end = [var 0mm, var 10mm])
+  line4 = line(start = [var 0mm, var 10mm], end = [var 0mm, var 0mm])
+}
+boxRegion = region(point = [5mm, 5mm], sketch = boxSketch)
+boxSolid = extrude(boxRegion, length = 5mm, tagEnd = $boxEnd)
+
+toolSketch = sketch(on = XY) {
+  circle1 = circle(start = [var 7mm, var 5mm], center = [var 5mm, var 5mm])
+}
+toolRegion = region(segments = [toolSketch.circle1])
+toolSolid = extrude(toolRegion, length = 5mm)
+part = subtract(boxSolid, tools = [toolSolid])
+
+edge = getCommonEdge(faces = [boxRegion.tags.line2, part.faces.boxEnd])
+"#;
+        let ctx = crate::ExecutorContext::new_mock(None).await;
+        let program = crate::Program::parse_no_errs(code).unwrap();
+
+        let result = ctx.run_mock(&program, &MockConfig::default()).await;
+        ctx.close().await;
+
+        result.unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- validate `getCommonEdge` face-tag provenance before the mock-execution early return
- preserve engine-only adjacent-face resolution and modeling commands on the real-execution path
- add a mock regression test for face tags created by different sketches

This makes mock execution return the same deterministic type error that real execution already returns, instead of a synthetic edge UUID.

Closes #13303.

## Tests

- `cargo +nightly fmt --all -- --check`
- `cargo test -p kcl-lib mock_get_common_edge_rejects_faces_from_different_sketches --lib`
- `cargo test -p kcl-lib std::edge::tests --lib`
- `git diff --check`
