### PR TITLE
Enforce command availability by app context

### DIFF
--- a/e2e/playwright/command-bar-tests.spec.ts
+++ b/e2e/playwright/command-bar-tests.spec.ts
@@ -13,6 +13,58 @@ test.describe('Command bar tests', { tag: '@desktop' }, () => {
   // Some of these sketches are KCL 1.0, so editing them needs the legacy sketch flag.
   test.use({ userFeatures: [LEGACY_SKETCH_MODE_FEATURE_FLAG] })
 
+  test('Command palette scopes Home, modeling, editor, and Settings commands', async ({
+    page,
+    homePage,
+    scene,
+  }) => {
+    await page.setBodyDimensions({ width: 1200, height: 500 })
+    await expect(page.getByPlaceholder('Search projects')).toBeVisible()
+
+    const cmdSearchBar = page.getByPlaceholder('Search commands')
+    const command = (name: string) =>
+      page.getByRole('option', { name, exact: false })
+    const telemetryCommand = command('Go to Telemetry')
+    const resetViewCommand = command('Reset view')
+    const formatCodeCommand = command('Format Code')
+    const extrudeCommand = command('Pull a sketch into 3D')
+    const settingsHeading = page.getByRole('heading', {
+      name: 'Settings',
+      exact: true,
+    })
+    const openCommandPalette = async () => {
+      await page.keyboard.press('ControlOrMeta+K')
+      await expect(cmdSearchBar).toBeFocused()
+    }
+
+    await openCommandPalette()
+    await expect(telemetryCommand).toBeVisible()
+    await expect(resetViewCommand).toHaveCount(0)
+    await page.keyboard.press('Escape')
+
+    await homePage.goToModelingScene()
+    await scene.settled()
+    await scene.clickNoWhere()
+
+    await openCommandPalette()
+    await expect(resetViewCommand).toBeVisible()
+    await expect(extrudeCommand).toBeVisible()
+    await page.keyboard.press('Escape')
+
+    await page.locator('.cm-content').click()
+    await openCommandPalette()
+    await expect(formatCodeCommand).toBeVisible()
+    await expect(resetViewCommand).toHaveCount(0)
+    await page.keyboard.press('Escape')
+
+    await page.getByRole('link', { name: 'Settings' }).last().click()
+    await expect(settingsHeading).toBeVisible()
+    await openCommandPalette()
+    await expect(command('Settings · app · theme')).toBeVisible()
+    await expect(resetViewCommand).toHaveCount(0)
+    await page.keyboard.press('Escape')
+  })
+
   test('Extrude from command bar selects extrude line after', async ({
     page,
     homePage,
@@ -415,6 +467,19 @@ test.describe('Command bar tests', { tag: '@desktop' }, () => {
 
     await page.mouse.click(700, 200)
     await expect(toolbar.exitSketchBtn).toBeVisible()
+
+    await page.keyboard.press('ControlOrMeta+K')
+    await expect(page.getByPlaceholder('Search commands')).toBeFocused()
+    await expect(
+      page.getByRole('option', { name: 'Reset view', exact: false })
+    ).toBeVisible()
+    await expect(
+      page.getByRole('option', {
+        name: 'Pull a sketch into 3D',
+        exact: false,
+      })
+    ).toHaveCount(0)
+    await page.keyboard.press('Escape')
 
     // Switch between sketch tools via the command bar
     if ((await lineToolButton.getAttribute('aria-pressed')) !== 'true') {

--- a/e2e/playwright/command-bar-tests.spec.ts
+++ b/e2e/playwright/command-bar-tests.spec.ts
@@ -52,7 +52,8 @@ test.describe('Command bar tests', { tag: '@desktop' }, () => {
     await page.keyboard.press('Escape')
 
     await page.locator('.cm-content').click()
-    await openCommandPalette()
+    await page.getByRole('button', { name: 'Commands' }).click()
+    await expect(cmdSearchBar).toBeFocused()
     await expect(formatCodeCommand).toBeVisible()
     await expect(resetViewCommand).toHaveCount(0)
     await page.keyboard.press('Escape')
@@ -467,6 +468,8 @@ test.describe('Command bar tests', { tag: '@desktop' }, () => {
 
     await page.mouse.click(700, 200)
     await expect(toolbar.exitSketchBtn).toBeVisible()
+    await rectangleToolButton.click()
+    await expect(rectangleToolButton).toHaveAttribute('aria-pressed', 'true')
 
     await page.keyboard.press('ControlOrMeta+K')
     await expect(page.getByPlaceholder('Search commands')).toBeFocused()
@@ -480,6 +483,9 @@ test.describe('Command bar tests', { tag: '@desktop' }, () => {
       })
     ).toHaveCount(0)
     await page.keyboard.press('Escape')
+    await expect(page.getByPlaceholder('Search commands')).not.toBeVisible()
+    await page.keyboard.press('l')
+    await expect(lineToolButton).toHaveAttribute('aria-pressed', 'true')
 
     // Switch between sketch tools via the command bar
     if ((await lineToolButton.getAttribute('aria-pressed')) !== 'true') {

--- a/src/components/CommandBar/CommandBar.test.ts
+++ b/src/components/CommandBar/CommandBar.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { isCommandVisibleInSearch } from '@src/components/CommandBar/commandSearchVisibility'
 import type { Command } from '@src/lib/commandTypes'
+import { GLOBAL_COMMAND_SCOPES } from '@src/registry/contracts/commands'
 
 function command(overrides: Partial<Command> = {}): Command {
   return {
@@ -10,6 +11,7 @@ function command(overrides: Partial<Command> = {}): Command {
     needsReview: false,
     onSubmit: () => undefined,
     ...overrides,
+    scopes: overrides.scopes ?? GLOBAL_COMMAND_SCOPES,
   }
 }
 

--- a/src/components/CommandBar/CommandBar.tsx
+++ b/src/components/CommandBar/CommandBar.tsx
@@ -197,9 +197,10 @@ export const CommandBar = () => {
           >
             {commandBarState.matches('Selecting command') ? (
               <CommandComboBox
-                options={commands.filter((command: Command) =>
-                  isCommandVisibleInSearch(command) &&
-                  isCommandSearchable(command, effectiveCommandScopes)
+                options={commands.filter(
+                  (command: Command) =>
+                    isCommandVisibleInSearch(command) &&
+                    isCommandSearchable(command, effectiveCommandScopes)
                 )}
               />
             ) : commandBarState.matches('Gathering arguments') ? (

--- a/src/components/CommandBar/CommandBar.tsx
+++ b/src/components/CommandBar/CommandBar.tsx
@@ -1,5 +1,5 @@
 import { Dialog, Popover, Transition } from '@headlessui/react'
-import { Fragment, useEffect } from 'react'
+import { Fragment, useEffect, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 
 import CommandBarArgument from '@src/components/CommandBar/CommandBarArgument'
@@ -15,6 +15,10 @@ import useHotkeyWrapper from '@src/lib/hotkeyWrapper'
 import {
   COMMAND_PALETTE_OPEN_COMMAND_SCOPE,
   commandScopeService,
+  commandScopesValueSpec,
+  getCommandPaletteScopes,
+  getEffectiveCommandScopeSet,
+  isCommandSearchable,
 } from '@src/registry/contracts/commands'
 import { isCommandVisibleInSearch } from '@src/components/CommandBar/commandSearchVisibility'
 
@@ -26,6 +30,28 @@ export const CommandBar = () => {
   const commandScopes = registry.optional(commandScopeService)
   const commandBarState = cmd.useState()
   const isCommandBarOpen = !commandBarState.matches('Closed')
+  const [commandPaletteSession, setCommandPaletteSession] = useState(() => ({
+    isOpen: isCommandBarOpen,
+    scopes: isCommandBarOpen
+      ? getCommandPaletteScopes(commandScopes?.getCurrentScopes() ?? [])
+      : [],
+  }))
+  let commandPaletteScopes = commandPaletteSession.scopes
+  if (commandPaletteSession.isOpen !== isCommandBarOpen) {
+    // Capture the launch context before the palette input's autofocus changes
+    // the active focus scope. React applies this update before committing.
+    commandPaletteScopes = isCommandBarOpen
+      ? getCommandPaletteScopes(commandScopes?.getCurrentScopes() ?? [])
+      : []
+    setCommandPaletteSession({
+      isOpen: isCommandBarOpen,
+      scopes: commandPaletteScopes,
+    })
+  }
+  const effectiveCommandScopes = getEffectiveCommandScopeSet(
+    commandPaletteScopes,
+    registry.signal(commandScopesValueSpec).value
+  )
   const {
     context: {
       selectedCommand,
@@ -174,7 +200,8 @@ export const CommandBar = () => {
             {commandBarState.matches('Selecting command') ? (
               <CommandComboBox
                 options={commands.filter((command: Command) =>
-                  isCommandVisibleInSearch(command)
+                  isCommandVisibleInSearch(command) &&
+                  isCommandSearchable(command, effectiveCommandScopes)
                 )}
               />
             ) : commandBarState.matches('Gathering arguments') ? (

--- a/src/components/CommandBar/CommandBar.tsx
+++ b/src/components/CommandBar/CommandBar.tsx
@@ -1,5 +1,6 @@
 import { Dialog, Popover, Transition } from '@headlessui/react'
 import { Fragment, useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { useLocation } from 'react-router-dom'
 
 import CommandBarArgument from '@src/components/CommandBar/CommandBarArgument'
@@ -13,7 +14,6 @@ import { useApp } from '@src/lib/boot'
 import type { Command, CommandArgument } from '@src/lib/commandTypes'
 import useHotkeyWrapper from '@src/lib/hotkeyWrapper'
 import {
-  COMMAND_PALETTE_OPEN_COMMAND_SCOPE,
   commandScopeService,
   commandScopesValueSpec,
   getCommandPaletteScopes,
@@ -30,6 +30,8 @@ export const CommandBar = () => {
   const commandScopes = registry.optional(commandScopeService)
   const commandBarState = cmd.useState()
   const isCommandBarOpen = !commandBarState.matches('Closed')
+  const [modalCommandBarHost, setModalCommandBarHost] =
+    useState<HTMLElement | null>(null)
   const [commandPaletteSession, setCommandPaletteSession] = useState(() => ({
     isOpen: isCommandBarOpen,
     scopes: isCommandBarOpen
@@ -75,6 +77,14 @@ export const CommandBar = () => {
     ? Popover
     : Dialog
 
+  // Keep the global command bar inside the active route modal's focus boundary.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: pathname changes which modal host is mounted.
+  useEffect(() => {
+    setModalCommandBarHost(
+      document.querySelector<HTMLElement>('[data-command-bar-host]')
+    )
+  }, [pathname])
+
   // Close the command bar when navigating
   // but importantly not when the query parameters change
   // biome-ignore lint/correctness/useExhaustiveDependencies: this intentionally reacts only to path changes.
@@ -85,18 +95,6 @@ export const CommandBar = () => {
     cmd.send({ type: 'Close' })
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
   }, [pathname])
-
-  useEffect(() => {
-    if (!commandScopes || !isCommandBarOpen) {
-      return
-    }
-
-    commandScopes.applyScope(COMMAND_PALETTE_OPEN_COMMAND_SCOPE)
-
-    return () => {
-      commandScopes.removeScope(COMMAND_PALETTE_OPEN_COMMAND_SCOPE)
-    }
-  }, [commandScopes, isCommandBarOpen])
 
   // Hook up keyboard shortcuts
   useHotkeyWrapper(
@@ -163,7 +161,7 @@ export const CommandBar = () => {
     }
   }
 
-  return (
+  const commandBar = (
     <Transition.Root
       show={isCommandBarOpen || false}
       afterLeave={() => {
@@ -243,4 +241,8 @@ export const CommandBar = () => {
       </WrapperComponent>
     </Transition.Root>
   )
+
+  return modalCommandBarHost
+    ? createPortal(commandBar, modalCommandBarHost)
+    : commandBar
 }

--- a/src/components/CommandBarOpenButton.tsx
+++ b/src/components/CommandBarOpenButton.tsx
@@ -41,6 +41,8 @@ export const CommandBarOpenButton = memo(function CommandBarOpenButton({
     <button
       type="button"
       className="flex gap-1 items-center py-0 pl-0.5 pr-1 sm:pr-0.5 m-0 text-primary dark:text-inherit bg-chalkboard-10/80 dark:bg-chalkboard-100/50 hover:bg-chalkboard-10 dark:hover:bg-chalkboard-100 border border-solid border-primary/50 hover:border-primary active:border-primary"
+      data-command-scope-preserve-focus="true"
+      onPointerDown={(event) => event.preventDefault()}
       onClick={() => commands.send({ type: 'Open' })}
       data-testid="command-bar-open-button"
       data-onboarding-id="command-bar-open-button"

--- a/src/components/CommandComboBox.test.tsx
+++ b/src/components/CommandComboBox.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, expect, test, vi } from 'vitest'
 
 import { COMMAND_PALETTE_USAGE_STORAGE_KEY } from '@src/lib/commandPaletteUsage'
 import type { Command } from '@src/lib/commandTypes'
+import { GLOBAL_COMMAND_SCOPES } from '@src/registry/contracts/commands'
 
 const mocks = vi.hoisted(() => ({
   send: vi.fn(),
@@ -20,6 +21,7 @@ function command(id: string, displayName: string): Command {
     name: id,
     groupId: 'test',
     displayName,
+    scopes: GLOBAL_COMMAND_SCOPES,
     needsReview: false,
     onSubmit: () => {},
   }

--- a/src/components/Explorer/ProjectExplorer.tsx
+++ b/src/components/Explorer/ProjectExplorer.tsx
@@ -41,8 +41,8 @@ import {
   SystemIOMachineEvents,
   SystemIOMachineStates,
 } from '@src/machines/systemIO/utils'
+import { PROJECT_EXPLORER_FOCUSED_COMMAND_SCOPE } from '@src/registry/contracts/commands'
 import {
-  PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE,
   PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE,
   keymapService,
 } from '@src/registry/contracts/keymap'
@@ -392,7 +392,7 @@ export const ProjectExplorer = ({
   )
 
   const focusProjectExplorer = useCallback(() => {
-    keymap?.applyScope(PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE)
+    keymap?.applyScope(PROJECT_EXPLORER_FOCUSED_COMMAND_SCOPE)
     fileExplorerContainer.current?.focus()
   }, [keymap])
 
@@ -618,6 +618,7 @@ export const ProjectExplorer = ({
     () => [
       {
         id: PROJECT_EXPLORER_COMMAND_IDS.arrowLeft,
+        scopes: [PROJECT_EXPLORER_FOCUSED_COMMAND_SCOPE],
         name: 'arrow-left',
         groupId: 'project-explorer',
         displayName: 'Close selected project explorer row',
@@ -627,6 +628,7 @@ export const ProjectExplorer = ({
       },
       {
         id: PROJECT_EXPLORER_COMMAND_IDS.arrowRight,
+        scopes: [PROJECT_EXPLORER_FOCUSED_COMMAND_SCOPE],
         name: 'arrow-right',
         groupId: 'project-explorer',
         displayName: 'Open selected project explorer row',
@@ -636,6 +638,7 @@ export const ProjectExplorer = ({
       },
       {
         id: PROJECT_EXPLORER_COMMAND_IDS.arrowUp,
+        scopes: [PROJECT_EXPLORER_FOCUSED_COMMAND_SCOPE],
         name: 'arrow-up',
         groupId: 'project-explorer',
         displayName: 'Move project explorer selection up',
@@ -645,6 +648,7 @@ export const ProjectExplorer = ({
       },
       {
         id: PROJECT_EXPLORER_COMMAND_IDS.arrowDown,
+        scopes: [PROJECT_EXPLORER_FOCUSED_COMMAND_SCOPE],
         name: 'arrow-down',
         groupId: 'project-explorer',
         displayName: 'Move project explorer selection down',
@@ -654,6 +658,7 @@ export const ProjectExplorer = ({
       },
       {
         id: PROJECT_EXPLORER_COMMAND_IDS.enter,
+        scopes: [PROJECT_EXPLORER_FOCUSED_COMMAND_SCOPE],
         name: 'enter',
         groupId: 'project-explorer',
         displayName: 'Open selected project explorer file',
@@ -663,6 +668,7 @@ export const ProjectExplorer = ({
       },
       {
         id: PROJECT_EXPLORER_COMMAND_IDS.rename,
+        scopes: [PROJECT_EXPLORER_FOCUSED_COMMAND_SCOPE],
         name: 'rename',
         groupId: 'project-explorer',
         displayName: 'Rename selected project explorer row',
@@ -672,6 +678,7 @@ export const ProjectExplorer = ({
       },
       {
         id: PROJECT_EXPLORER_COMMAND_IDS.delete,
+        scopes: [PROJECT_EXPLORER_FOCUSED_COMMAND_SCOPE],
         name: 'delete',
         groupId: 'project-explorer',
         displayName: 'Delete selected project explorer row',
@@ -681,6 +688,7 @@ export const ProjectExplorer = ({
       },
       {
         id: PROJECT_EXPLORER_COMMAND_IDS.copy,
+        scopes: [PROJECT_EXPLORER_FOCUSED_COMMAND_SCOPE],
         name: 'copy',
         groupId: 'project-explorer',
         displayName: 'Copy selected project explorer row',
@@ -690,6 +698,7 @@ export const ProjectExplorer = ({
       },
       {
         id: PROJECT_EXPLORER_COMMAND_IDS.paste,
+        scopes: [PROJECT_EXPLORER_FOCUSED_COMMAND_SCOPE],
         name: 'paste',
         groupId: 'project-explorer',
         displayName: 'Paste into selected project explorer row',
@@ -717,7 +726,7 @@ export const ProjectExplorer = ({
 
   useEffect(() => {
     return () => {
-      keymap?.removeScope(PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE)
+      keymap?.removeScope(PROJECT_EXPLORER_FOCUSED_COMMAND_SCOPE)
       keymap?.removeScope(PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE)
     }
   }, [keymap])
@@ -858,7 +867,7 @@ export const ProjectExplorer = ({
       setIsRenaming(false)
       setIsDeleting(false)
       lastSyncedFilePathRef.current = undefined
-      keymap?.removeScope(PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE)
+      keymap?.removeScope(PROJECT_EXPLORER_FOCUSED_COMMAND_SCOPE)
       keymap?.removeScope(PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE)
     }
 
@@ -1423,12 +1432,12 @@ export const ProjectExplorer = ({
   useEffect(() => {
     if (isRenaming) {
       const fileExplorerContainerElement = fileExplorerContainer.current
-      keymap?.removeScope(PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE)
+      keymap?.removeScope(PROJECT_EXPLORER_FOCUSED_COMMAND_SCOPE)
       keymap?.applyScope(PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE)
       return () => {
         keymap?.removeScope(PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE)
         if (fileExplorerContainerElement?.contains(document.activeElement)) {
-          keymap?.applyScope(PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE)
+          keymap?.applyScope(PROJECT_EXPLORER_FOCUSED_COMMAND_SCOPE)
         }
       }
     }
@@ -1445,7 +1454,7 @@ export const ProjectExplorer = ({
         projectExplorerRef.current &&
         !path.includes(projectExplorerRef.current)
       ) {
-        keymap?.removeScope(PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE)
+        keymap?.removeScope(PROJECT_EXPLORER_FOCUSED_COMMAND_SCOPE)
         keymap?.removeScope(PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE)
         setActiveIndexWrapper(NOTHING_IS_SELECTED)
       }
@@ -1476,7 +1485,7 @@ export const ProjectExplorer = ({
 
   const handleExplorerFocus = useCallback(
     (event: ReactFocusEvent<HTMLDivElement>) => {
-      keymap?.applyScope(PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE)
+      keymap?.applyScope(PROJECT_EXPLORER_FOCUSED_COMMAND_SCOPE)
       if (
         event.target === fileExplorerContainer.current &&
         activeIndexRef.current === NOTHING_IS_SELECTED
@@ -1497,7 +1506,7 @@ export const ProjectExplorer = ({
         return
       }
 
-      keymap?.removeScope(PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE)
+      keymap?.removeScope(PROJECT_EXPLORER_FOCUSED_COMMAND_SCOPE)
       keymap?.removeScope(PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE)
       setActiveIndexWrapper(NOTHING_IS_SELECTED)
     },

--- a/src/components/ModelingMachineProvider.tsx
+++ b/src/components/ModelingMachineProvider.tsx
@@ -30,7 +30,10 @@ import {
   EngineConnectionEvents,
   EngineConnectionStateType,
 } from '@src/lib/engineConnection/utils'
+import { MODE_MODELING_COMMAND_SCOPE } from '@src/registry/contracts/commands'
 import { keymapService } from '@src/registry/contracts/keymap'
+
+const MODELING_COMMAND_SCOPES = [MODE_MODELING_COMMAND_SCOPE] as const
 
 export const ModelingMachineContext = createContext(
   {} as {
@@ -346,6 +349,7 @@ export const ModelingMachineProvider = ({
     send: modelingSend,
     actor: modelingActor,
     commandBarConfig,
+    scopes: MODELING_COMMAND_SCOPES,
     isExecuting: kclManager.isExecutingSignal.value,
     // TODO for when sketch tools are in the toolbar: This was added when we used one "Cancel" event,
     // but we need to support "SketchCancel" and basically

--- a/src/components/ModelingPageProvider.tsx
+++ b/src/components/ModelingPageProvider.tsx
@@ -22,6 +22,7 @@ import { PATHS } from '@src/lib/paths'
 import { markOnce } from '@src/lib/performance'
 import { isArray } from '@src/lib/utils'
 import { modelingMenuCallbackMostActions } from '@src/menu/register'
+import { FILE_AND_CODE_EDITOR_COMMAND_SCOPES } from '@src/registry/contracts/commands'
 
 function isNumberArray(value: unknown): value is number[] {
   return isArray(value) && value.every((item) => typeof item === 'number')
@@ -169,7 +170,12 @@ export const ModelingPageProvider = ({
     const filePath = PATHS.FILE + '/' + encodeURIComponent(file?.path)
 
     const { RouteTelemetryCommand, RouteHomeCommand, RouteSettingsCommand } =
-      createRouteCommands(navigate, location, filePath)
+      createRouteCommands(
+        navigate,
+        location,
+        filePath,
+        FILE_AND_CODE_EDITOR_COMMAND_SCOPES
+      )
     commands.send({
       type: 'Add commands',
       data: {

--- a/src/hooks/useStateMachineCommands.ts
+++ b/src/hooks/useStateMachineCommands.ts
@@ -24,6 +24,7 @@ interface UseStateMachineCommandsArgs<
   send: (event: EventFrom<T>) => void
   actor: Actor<T>
   commandBarConfig?: StateMachineCommandSetConfig<T, S>
+  scopes: Command['scopes']
   isExecuting: boolean
   onCancel?: () => void
 }
@@ -44,6 +45,7 @@ export default function useStateMachineCommands<
   send,
   actor,
   commandBarConfig,
+  scopes,
   onCancel,
   isExecuting,
 }: UseStateMachineCommandsArgs<T, S>) {
@@ -83,6 +85,7 @@ export default function useStateMachineCommands<
           send,
           actor,
           commandBarConfig,
+          defaultScopes: scopes,
           onCancel,
           forceDisable: shouldDisableEngineCommands,
           showExperimentalCommands,
@@ -102,5 +105,10 @@ export default function useStateMachineCommands<
       })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
-  }, [shouldDisableEngineCommands, showExperimentalCommands, commandBarConfig])
+  }, [
+    shouldDisableEngineCommands,
+    showExperimentalCommands,
+    commandBarConfig,
+    scopes,
+  ])
 }

--- a/src/lib/commandBarConfigs/applicationCommandConfig.ts
+++ b/src/lib/commandBarConfigs/applicationCommandConfig.ts
@@ -33,6 +33,11 @@ import { getAllSubDirectoriesAtProjectRoot } from '@src/machines/systemIO/snapsh
 import type { systemIOMachine } from '@src/machines/systemIO/systemIOMachine'
 import type { RequestedKCLFile } from '@src/machines/systemIO/utils'
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
+import {
+  FILE_AND_CODE_EDITOR_COMMAND_SCOPES,
+  GLOBAL_COMMAND_SCOPES,
+  HOME_COMMAND_SCOPE,
+} from '@src/registry/contracts/commands'
 import toast from 'react-hot-toast'
 import type { ActorRefFrom } from 'xstate'
 
@@ -113,6 +118,7 @@ export function createApplicationCommands({
   wasmInstance: ModuleType
 }) {
   const addKCLFileToProject: Command = {
+    scopes: GLOBAL_COMMAND_SCOPES,
     name: 'add-kcl-file-to-project',
     displayName: 'Add file to project',
     description:
@@ -343,6 +349,7 @@ export function createApplicationCommands({
    * Desktop only command for now!
    */
   const createASampleDesktopOnly: Command = {
+    scopes: [HOME_COMMAND_SCOPE],
     name: 'create-a-sample',
     displayName: 'Create a sample',
     description: 'Create a new project from a Zoo Sample',
@@ -410,6 +417,7 @@ export function createApplicationCommands({
   }
 
   const switchEnvironmentsCommand: Command = {
+    scopes: GLOBAL_COMMAND_SCOPES,
     name: 'switch-environments',
     displayName: 'Switch Environments',
     description: 'Connect the application runtime to a different environment',
@@ -439,6 +447,7 @@ export function createApplicationCommands({
   }
 
   const overrideEngineCommand: Command = {
+    scopes: GLOBAL_COMMAND_SCOPES,
     name: 'override-engine',
     displayName: 'Override Engine',
     description: 'Connect the scene to a custom Engine WebSocket URL',
@@ -485,6 +494,7 @@ export function createApplicationCommands({
   }
 
   const overrideZookeeperCommand: Command = {
+    scopes: GLOBAL_COMMAND_SCOPES,
     name: 'override-zookeeper',
     displayName: 'Override Zookeeper',
     description: 'Connect to a custom Zookeeper WebSocket URL',
@@ -529,6 +539,7 @@ export function createApplicationCommands({
   }
 
   const resetLayoutCommand: Command = {
+    scopes: FILE_AND_CODE_EDITOR_COMMAND_SCOPES,
     name: 'reset-layout',
     displayName: 'Reset layout',
     description: 'Reset layout to the default configuration',
@@ -539,6 +550,7 @@ export function createApplicationCommands({
   }
 
   const setLayoutCommand: Command = {
+    scopes: FILE_AND_CODE_EDITOR_COMMAND_SCOPES,
     name: 'set-layout',
     hideFromSearch: true,
     displayName: 'Set layout',
@@ -582,6 +594,7 @@ export function createApplicationCommands({
   }
 
   const checkForUpdatesCommand: Command = {
+    scopes: GLOBAL_COMMAND_SCOPES,
     name: 'check-for-updates',
     displayName: 'Check for updates',
     description: 'Check for a newer desktop app version.',
@@ -600,6 +613,7 @@ export function createApplicationCommands({
   }
 
   const exportProjectZipCommand: Command = {
+    scopes: FILE_AND_CODE_EDITOR_COMMAND_SCOPES,
     name: 'export-project-zip',
     displayName: 'Download project files',
     description: 'Download every file in the current project as a ZIP archive.',

--- a/src/lib/commandBarConfigs/authCommandConfig.ts
+++ b/src/lib/commandBarConfigs/authCommandConfig.ts
@@ -2,6 +2,7 @@ import type { Command } from '@src/lib/commandTypes'
 import { reportRejection } from '@src/lib/trap'
 import { refreshPage } from '@src/lib/utils'
 import type { authMachine } from '@src/machines/authMachine'
+import { GLOBAL_COMMAND_SCOPES } from '@src/registry/contracts/commands'
 import type { ActorRefFrom } from 'xstate'
 
 export function createAuthCommands({
@@ -11,6 +12,7 @@ export function createAuthCommands({
 }) {
   const authCommands: Command[] = [
     {
+      scopes: GLOBAL_COMMAND_SCOPES,
       groupId: 'auth',
       name: 'log-out',
       displayName: 'Log out',
@@ -20,6 +22,7 @@ export function createAuthCommands({
       onSubmit: () => authActor.send({ type: 'Log out' }),
     },
     {
+      scopes: GLOBAL_COMMAND_SCOPES,
       groupId: 'auth',
       name: 'refresh',
       displayName: 'Reload app',

--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -61,6 +61,7 @@ import type {
 import { getNextAvailableDatumName } from '@src/lang/modifyAst/gdt'
 import type { StdLibModelingCommandSchema } from '@src/lib/commandBarConfigs/modelingCommandStdLibTypes'
 import { capitaliseFC, isArray } from '@src/lib/utils'
+import { MODE_SKETCHING_COMMAND_SCOPE } from '@src/registry/contracts/commands'
 
 export type { HelixModes } from '@src/lib/commandBarConfigs/modelingCommandStdLibTypes'
 
@@ -378,6 +379,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
   },
   'change tool': [
     {
+      scopes: [MODE_SKETCHING_COMMAND_SCOPE],
       description: 'Start drawing straight lines.',
       icon: 'line',
       displayName: 'Line',
@@ -391,6 +393,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       },
     },
     {
+      scopes: [MODE_SKETCHING_COMMAND_SCOPE],
       description: 'Start drawing an arc tangent to the current segment.',
       icon: 'arc',
       displayName: 'Tangential Arc',
@@ -404,6 +407,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       },
     },
     {
+      scopes: [MODE_SKETCHING_COMMAND_SCOPE],
       description: 'Start drawing a rectangle.',
       icon: 'rectangle',
       displayName: 'Rectangle',
@@ -1399,6 +1403,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
     ),
   },
   'Constrain length': {
+    scopes: [MODE_SKETCHING_COMMAND_SCOPE],
     description: 'Constrain the length of one or more segments.',
     icon: 'dimension',
     args: {
@@ -1442,6 +1447,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
     },
   },
   'Constrain with named value': {
+    scopes: [MODE_SKETCHING_COMMAND_SCOPE],
     description: 'Constrain a value by making it a named constant.',
     icon: 'make-variable',
     args: {

--- a/src/lib/commandBarConfigs/namedViewsConfig.ts
+++ b/src/lib/commandBarConfigs/namedViewsConfig.ts
@@ -16,6 +16,7 @@ import { err, reportRejection } from '@src/lib/trap'
 import { uuidv4 } from '@src/lib/utils'
 import type { SettingsActorType } from '@src/machines/settingsMachine'
 import type { ConnectionManager } from '@src/lib/engineConnection/connectionManager'
+import { MODE_MODELING_COMMAND_SCOPE } from '@src/registry/contracts/commands'
 
 function isWorldCoordinateSystemType(x: string): x is WorldCoordinateSystem {
   return x === 'right_handed_up_z' || x === 'right_handed_up_y'
@@ -109,6 +110,7 @@ export function createNamedViewsCommand(
   // hit the engine for the camera properties and write them back to disk
   // in project.toml.
   const createNamedViewCommand: Command = {
+    scopes: [MODE_MODELING_COMMAND_SCOPE],
     name: 'Create named view',
     displayName: `Create named view`,
     description:
@@ -192,6 +194,7 @@ export function createNamedViewsCommand(
   // find it in the setting state, remove it from the array and
   // rewrite the project.toml settings to disk to delete the named view
   const deleteNamedViewCommand: Command = {
+    scopes: [MODE_MODELING_COMMAND_SCOPE],
     name: 'Delete named view',
     displayName: `Delete named view`,
     description: 'Deletes the named view from settings',
@@ -256,6 +259,7 @@ export function createNamedViewsCommand(
 
   // Read the named view from settings state and pass that camera information to the engine command to set the view of the engine camera
   const loadNamedViewCommand: Command = {
+    scopes: [MODE_MODELING_COMMAND_SCOPE],
     name: 'Load named view',
     displayName: `Load named view`,
     description: 'Loads your camera to the named view',

--- a/src/lib/commandBarConfigs/projectsCommandConfig.ts
+++ b/src/lib/commandBarConfigs/projectsCommandConfig.ts
@@ -22,6 +22,7 @@ import type {
   HomeProjectActionsService,
   HomeProjectEntry,
 } from '@src/registry/contracts/homeProjects'
+import { GLOBAL_COMMAND_SCOPES } from '@src/registry/contracts/commands'
 import type {
   ProjectLibraryCreateProjectInput,
   ProjectLibraryOperation,
@@ -300,6 +301,7 @@ export function createProjectCommands({
     )
 
   const openProjectCommand: Command = {
+    scopes: GLOBAL_COMMAND_SCOPES,
     icon: 'folder',
     name: 'Open project',
     displayName: `Open project`,
@@ -333,6 +335,7 @@ export function createProjectCommands({
   }
 
   const createProjectCommand: Command = {
+    scopes: GLOBAL_COMMAND_SCOPES,
     icon: 'folder',
     name: 'Create project',
     displayName: `Create project`,
@@ -412,6 +415,7 @@ export function createProjectCommands({
   }
 
   const moveToLibraryCommand: Command = {
+    scopes: GLOBAL_COMMAND_SCOPES,
     icon: 'folder',
     name: 'Move project',
     displayName: 'Move project',
@@ -488,6 +492,7 @@ export function createProjectCommands({
   }
 
   const deleteProjectCommand: Command = {
+    scopes: GLOBAL_COMMAND_SCOPES,
     icon: 'folder',
     name: 'Delete project',
     displayName: `Delete project`,
@@ -534,6 +539,7 @@ export function createProjectCommands({
   }
 
   const renameProjectCommand: Command = {
+    scopes: GLOBAL_COMMAND_SCOPES,
     icon: 'folder',
     name: 'Rename project',
     displayName: `Rename project`,
@@ -599,6 +605,7 @@ export function createProjectCommands({
   }
 
   const importFileFromURL: Command = {
+    scopes: GLOBAL_COMMAND_SCOPES,
     name: 'Import file from URL',
     groupId: 'projects',
     icon: 'file',

--- a/src/lib/commandBarConfigs/routeCommandConfig.ts
+++ b/src/lib/commandBarConfigs/routeCommandConfig.ts
@@ -6,9 +6,11 @@ import { PATHS, webSafeJoin } from '@src/lib/paths'
 export function createRouteCommands(
   navigate: NavigateFunction,
   location: Location,
-  filePath: string
+  filePath: string,
+  scopes: Command['scopes']
 ) {
   const RouteTelemetryCommand: Command = {
+    scopes,
     name: 'Go to Telemetry',
     displayName: `Go to Telemetry`,
     description: 'View the Telemetry metrics',
@@ -25,6 +27,7 @@ export function createRouteCommands(
   }
 
   const RouteHomeCommand: Command = {
+    scopes,
     name: 'Go to Home',
     displayName: `Go to Home`,
     description: 'Go to the home page',
@@ -37,6 +40,7 @@ export function createRouteCommands(
   }
 
   const RouteSettingsCommand: Command = {
+    scopes,
     name: 'Go to Settings',
     displayName: `Go to Settings`,
     description: 'Go to the settings page',

--- a/src/lib/commandBarConfigs/settingsCommandConfig.ts
+++ b/src/lib/commandBarConfigs/settingsCommandConfig.ts
@@ -20,6 +20,7 @@ import {
 } from '@src/lib/settings/settingsUtils'
 import type { PathValue } from '@src/lib/types'
 import type { settingsMachine } from '@src/machines/settingsMachine'
+import { GLOBAL_COMMAND_SCOPES } from '@src/registry/contracts/commands'
 
 // An array of the paths to all of the settings that have commandConfigs
 export const settingsWithCommandConfigs = (s: SettingsType) =>
@@ -114,6 +115,7 @@ export function createSettingsCommand({ type, actor }: CreateSettingsArgs) {
   const valueArg = buildCommandArgument(valueArgConfig, context, actor)
 
   const command: Command = {
+    scopes: GLOBAL_COMMAND_SCOPES,
     name: type,
     displayName: `Settings · ${type
       .split('.')

--- a/src/lib/commandBarConfigs/standardViewsConfig.ts
+++ b/src/lib/commandBarConfigs/standardViewsConfig.ts
@@ -3,10 +3,12 @@ import type { Command } from '@src/lib/commandTypes'
 import { AxisNames } from '@src/lib/constants'
 import { reportRejection } from '@src/lib/trap'
 import { engineStreamZoomToFit } from '@src/lib/utils'
+import { MODE_MODELING_COMMAND_SCOPE } from '@src/registry/contracts/commands'
 
 export function createStandardViewsCommands(kclManager: KclManager) {
   const { engineCommandManager, sceneInfra } = kclManager
   const topViewCommand: Command = {
+    scopes: [MODE_MODELING_COMMAND_SCOPE],
     name: 'Top view',
     displayName: `Top view`,
     description: 'Set to top view',
@@ -20,6 +22,7 @@ export function createStandardViewsCommands(kclManager: KclManager) {
     },
   }
   const rightViewCommand: Command = {
+    scopes: [MODE_MODELING_COMMAND_SCOPE],
     name: 'Right view',
     displayName: `Right view`,
     description: 'Set to right view',
@@ -33,6 +36,7 @@ export function createStandardViewsCommands(kclManager: KclManager) {
     },
   }
   const frontViewCommand: Command = {
+    scopes: [MODE_MODELING_COMMAND_SCOPE],
     name: 'Front view',
     displayName: `Front view`,
     description: 'Set to front view',
@@ -47,6 +51,7 @@ export function createStandardViewsCommands(kclManager: KclManager) {
   }
 
   const backViewCommand: Command = {
+    scopes: [MODE_MODELING_COMMAND_SCOPE],
     name: 'Back view',
     displayName: `Back view`,
     description: 'Set to back view',
@@ -61,6 +66,7 @@ export function createStandardViewsCommands(kclManager: KclManager) {
   }
 
   const bottomViewCommand: Command = {
+    scopes: [MODE_MODELING_COMMAND_SCOPE],
     name: 'Bottom view',
     displayName: `Bottom view`,
     description: 'Set to bottom view',
@@ -75,6 +81,7 @@ export function createStandardViewsCommands(kclManager: KclManager) {
   }
 
   const leftViewCommand: Command = {
+    scopes: [MODE_MODELING_COMMAND_SCOPE],
     name: 'Left view',
     displayName: `Left view`,
     description: 'Set to left view',
@@ -89,6 +96,7 @@ export function createStandardViewsCommands(kclManager: KclManager) {
   }
 
   const zoomToFitCommand: Command = {
+    scopes: [MODE_MODELING_COMMAND_SCOPE],
     name: 'Zoom to fit',
     displayName: `Zoom to fit`,
     description: 'Fits the model in the camera view',

--- a/src/lib/commandPaletteUsage.test.ts
+++ b/src/lib/commandPaletteUsage.test.ts
@@ -8,6 +8,7 @@ import {
 } from '@src/lib/commandPaletteUsage'
 import type { Command } from '@src/lib/commandTypes'
 import { commandKey } from '@src/lib/commandUtils'
+import { GLOBAL_COMMAND_SCOPES } from '@src/registry/contracts/commands'
 import { describe, expect, it, vi } from 'vitest'
 
 const DAY_MS = 24 * 60 * 60 * 1000
@@ -19,6 +20,7 @@ function command(name: string, overrides: Partial<Command> = {}): Command {
     needsReview: false,
     onSubmit: () => {},
     ...overrides,
+    scopes: overrides.scopes ?? GLOBAL_COMMAND_SCOPES,
   }
 }
 

--- a/src/lib/commandTypes.ts
+++ b/src/lib/commandTypes.ts
@@ -145,8 +145,8 @@ export type Command<
   icon?: Icon
   hide?: TARGET[number]
   hideFromSearch?: boolean
-  /** App contexts where the command may be exposed and invoked. */
-  scopes?: CommandScopes
+  /** App contexts where the command palette and keymap may expose this command. */
+  scopes: CommandScopes
   disabled?: boolean
   status?: CommandStatus
 }
@@ -158,10 +158,17 @@ export type CommandConfig<
     StateMachineCommandSetSchema<T>[CommandName] = StateMachineCommandSetSchema<T>[CommandName],
 > = Omit<
   Command<T, CommandName, CommandSchema>,
-  'name' | 'groupId' | 'onSubmit' | 'onCancel' | 'args' | 'needsReview'
+  | 'name'
+  | 'groupId'
+  | 'onSubmit'
+  | 'onCancel'
+  | 'args'
+  | 'needsReview'
+  | 'scopes'
 > & {
   needsReview?: boolean
   status?: CommandStatus
+  scopes?: CommandScopes
   args?: {
     [ArgName in keyof CommandSchema]: CommandArgumentConfig<
       CommandSchema[ArgName],

--- a/src/lib/commandUtils.test.ts
+++ b/src/lib/commandUtils.test.ts
@@ -1,5 +1,6 @@
 import type { CommandWithDisabledState } from '@src/lib/commandUtils'
 import { commandKey, sortCommands } from '@src/lib/commandUtils'
+import { GLOBAL_COMMAND_SCOPES } from '@src/registry/contracts/commands'
 import { describe, expect, it } from 'vitest'
 
 function commandWithDisabled(
@@ -9,6 +10,7 @@ function commandWithDisabled(
 ): CommandWithDisabledState {
   return {
     command: {
+      scopes: GLOBAL_COMMAND_SCOPES,
       name,
       groupId,
       needsReview: false,

--- a/src/lib/createMachineCommand.spec.ts
+++ b/src/lib/createMachineCommand.spec.ts
@@ -3,6 +3,10 @@ import { createActor, createMachine } from 'xstate'
 
 import type { StateMachineCommandSetConfig } from '@src/lib/commandTypes'
 import { createMachineCommand } from '@src/lib/createMachineCommand'
+import {
+  GLOBAL_COMMAND_SCOPES,
+  MODE_SKETCHING_COMMAND_SCOPE,
+} from '@src/registry/contracts/commands'
 
 const testMachine = createMachine({
   id: 'testMachine',
@@ -45,6 +49,7 @@ const commandBarConfig = {
     {
       displayName: 'Available child',
       description: 'Available child command',
+      scopes: [MODE_SKETCHING_COMMAND_SCOPE],
     },
   ],
   WithArguments: {
@@ -80,6 +85,7 @@ describe('createMachineCommand', () => {
         send: vi.fn(),
         actor,
         commandBarConfig,
+        defaultScopes: GLOBAL_COMMAND_SCOPES,
       }
     )
 
@@ -99,6 +105,7 @@ describe('createMachineCommand', () => {
         send: vi.fn(),
         actor,
         commandBarConfig,
+        defaultScopes: GLOBAL_COMMAND_SCOPES,
         showExperimentalCommands: true,
       }
     )
@@ -122,6 +129,7 @@ describe('createMachineCommand', () => {
         send: vi.fn(),
         actor,
         commandBarConfig,
+        defaultScopes: GLOBAL_COMMAND_SCOPES,
       }
     )
 
@@ -130,6 +138,7 @@ describe('createMachineCommand', () => {
     expect(command).toMatchObject({
       name: 'Deprecated',
       status: 'deprecated',
+      scopes: GLOBAL_COMMAND_SCOPES,
     })
   })
 
@@ -146,6 +155,7 @@ describe('createMachineCommand', () => {
       send: vi.fn(),
       actor,
       commandBarConfig,
+      defaultScopes: GLOBAL_COMMAND_SCOPES,
     })
 
     actor.stop()
@@ -154,6 +164,7 @@ describe('createMachineCommand', () => {
       expect.objectContaining({
         name: 'ManyCommands',
         displayName: 'Available child',
+        scopes: [MODE_SKETCHING_COMMAND_SCOPE],
       }),
     ])
   })
@@ -169,6 +180,7 @@ describe('createMachineCommand', () => {
         send: vi.fn(),
         actor,
         commandBarConfig,
+        defaultScopes: GLOBAL_COMMAND_SCOPES,
       }
     )
 
@@ -202,6 +214,7 @@ describe('createMachineCommand', () => {
         send: vi.fn(),
         actor,
         commandBarConfig,
+        defaultScopes: GLOBAL_COMMAND_SCOPES,
         showExperimentalCommands: true,
       }
     )

--- a/src/lib/createMachineCommand.ts
+++ b/src/lib/createMachineCommand.ts
@@ -27,6 +27,7 @@ interface CreateMachineCommandProps<
   send: Function
   actor: Actor<T>
   commandBarConfig?: StateMachineCommandSetConfig<T, S>
+  defaultScopes: Command['scopes']
   onCancel?: () => void
   forceDisable?: boolean
   showExperimentalCommands?: boolean
@@ -44,6 +45,7 @@ export function createMachineCommand<
   send,
   actor,
   commandBarConfig,
+  defaultScopes,
   onCancel,
   forceDisable = false,
   showExperimentalCommands = false,
@@ -73,6 +75,7 @@ export function createMachineCommand<
           send,
           actor,
           commandBarConfig: recursiveCommandBarConfig,
+          defaultScopes,
           onCancel,
           forceDisable,
           showExperimentalCommands,
@@ -102,6 +105,7 @@ export function createMachineCommand<
     groupId,
     icon,
     description: commandConfig.description,
+    scopes: commandConfig.scopes ?? defaultScopes,
     needsReview: commandConfig.needsReview || false,
     machineActor: actor,
     onSubmit: (data?: S[typeof type]) => {

--- a/src/lib/kclCommands.ts
+++ b/src/lib/kclCommands.ts
@@ -38,6 +38,7 @@ import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { CommandBarContext } from '@src/machines/commandBarMachine'
 import { listAllImportFilesWithinProject } from '@src/machines/systemIO/snapshotContext'
 import type { SystemIOActor } from '@src/machines/systemIO/utils'
+import { FILE_AND_CODE_EDITOR_COMMAND_SCOPES } from '@src/registry/contracts/commands'
 
 interface KclCommandConfig {
   // TODO: find a different approach that doesn't require
@@ -63,6 +64,7 @@ const DEFAULT_IMPORT_REPRESENTATION = 'mesh' as const
 export function kclCommands(commandProps: KclCommandConfig): Command[] {
   return [
     {
+      scopes: FILE_AND_CODE_EDITOR_COMMAND_SCOPES,
       name: 'set-file-units',
       displayName: 'Set file units',
       description:
@@ -114,6 +116,7 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
       },
     },
     {
+      scopes: FILE_AND_CODE_EDITOR_COMMAND_SCOPES,
       name: 'set-file-experimental-features',
       displayName: 'Set experimental features flag',
       description: 'Set the experimental features flag in the current file.',
@@ -187,6 +190,7 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
       },
     },
     {
+      scopes: FILE_AND_CODE_EDITOR_COMMAND_SCOPES,
       name: 'Insert',
       description: 'Insert from a file in the current project directory',
       icon: 'import',
@@ -334,6 +338,7 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
       },
     },
     {
+      scopes: FILE_AND_CODE_EDITOR_COMMAND_SCOPES,
       name: 'format-code',
       displayName: 'Format Code',
       description: 'Nicely formats the KCL code in the editor.',
@@ -345,6 +350,7 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
       },
     },
     {
+      scopes: FILE_AND_CODE_EDITOR_COMMAND_SCOPES,
       name: 'parameter.create',
       displayName: 'Create parameter',
       description: 'Add a named constant to use in geometry',
@@ -409,6 +415,7 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
       },
     },
     {
+      scopes: FILE_AND_CODE_EDITOR_COMMAND_SCOPES,
       name: 'parameter.edit',
       displayName: 'Edit parameter',
       description: 'Edit the value of a named constant',

--- a/src/machines/commandBarMachine.spec.ts
+++ b/src/machines/commandBarMachine.spec.ts
@@ -5,10 +5,12 @@ import type { MachineManager } from '@src/lib/MachineManager'
 import type { Command } from '@src/lib/commandTypes'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { commandBarMachine } from '@src/machines/commandBarMachine'
+import { GLOBAL_COMMAND_SCOPES } from '@src/registry/contracts/commands'
 
 describe('commandBarMachine', () => {
   it('preserves hidden default values that are not declared command args', () => {
     const command = {
+      scopes: GLOBAL_COMMAND_SCOPES,
       name: 'Test command',
       groupId: 'test',
       needsReview: false,
@@ -60,6 +62,7 @@ describe('commandBarMachine', () => {
       reviewDetails,
     })
     const command = {
+      scopes: GLOBAL_COMMAND_SCOPES,
       name: 'Test codemod',
       groupId: 'test',
       needsReview: true,

--- a/src/registry/contracts/commands.test.ts
+++ b/src/registry/contracts/commands.test.ts
@@ -2,7 +2,14 @@ import {
   BASE_COMMAND_SCOPE,
   CODE_EDITOR_FOCUSED_COMMAND_SCOPE,
   DEFAULT_COMMAND_SCOPES,
+  EDITABLE_FOCUSED_COMMAND_SCOPE,
+  FILE_AND_CODE_EDITOR_COMMAND_SCOPES,
+  FILE_COMMAND_SCOPES,
+  GLOBAL_COMMAND_SCOPES,
+  HOME_COMMAND_SCOPE,
   MODE_MODELING_COMMAND_SCOPE,
+  SETTINGS_COMMAND_SCOPE,
+  getCommandPaletteScopes,
   getEffectiveCommandScopeSet,
   getEffectiveCommandScopes,
   isCommandAvailable,
@@ -12,10 +19,10 @@ import {
 import { describe, expect, it } from 'vitest'
 
 describe('command scopes', () => {
-  it('treats omitted and empty command scopes as global', () => {
-    expect(normalizeCommandScopeIds(undefined)).toEqual([BASE_COMMAND_SCOPE])
-    expect(normalizeCommandScopeIds([])).toEqual([BASE_COMMAND_SCOPE])
-    expect(normalizeCommandScopeIds(['   '])).toEqual([BASE_COMMAND_SCOPE])
+  it('fails closed when command scopes are omitted or empty', () => {
+    expect(normalizeCommandScopeIds(undefined)).toEqual([])
+    expect(normalizeCommandScopeIds([])).toEqual([])
+    expect(normalizeCommandScopeIds(['   '])).toEqual([])
   })
 
   it('normalizes and deduplicates explicit command scopes', () => {
@@ -34,6 +41,13 @@ describe('command scopes', () => {
         DEFAULT_COMMAND_SCOPES
       )
     ).toEqual([BASE_COMMAND_SCOPE, CODE_EDITOR_FOCUSED_COMMAND_SCOPE])
+
+    expect(
+      getEffectiveCommandScopes(
+        [MODE_MODELING_COMMAND_SCOPE, SETTINGS_COMMAND_SCOPE],
+        DEFAULT_COMMAND_SCOPES
+      )
+    ).toEqual([BASE_COMMAND_SCOPE, SETTINGS_COMMAND_SCOPE])
   })
 
   it('uses OR semantics within command scopes', () => {
@@ -42,7 +56,7 @@ describe('command scopes', () => {
       DEFAULT_COMMAND_SCOPES
     )
 
-    expect(isCommandAvailable({}, effectiveScopes)).toBe(true)
+    expect(isCommandAvailable({}, effectiveScopes)).toBe(false)
     expect(
       isCommandAvailable(
         {
@@ -60,6 +74,44 @@ describe('command scopes', () => {
         effectiveScopes
       )
     ).toBe(false)
+    expect(
+      isCommandAvailable({ scopes: GLOBAL_COMMAND_SCOPES }, effectiveScopes)
+    ).toBe(true)
+  })
+
+  it('keeps file commands out of Home and generic editable contexts', () => {
+    for (const activeScopes of [
+      [HOME_COMMAND_SCOPE],
+      [MODE_MODELING_COMMAND_SCOPE, EDITABLE_FOCUSED_COMMAND_SCOPE],
+    ]) {
+      const effectiveScopes = getEffectiveCommandScopeSet(
+        activeScopes,
+        DEFAULT_COMMAND_SCOPES
+      )
+      expect(
+        isCommandAvailable({ scopes: FILE_COMMAND_SCOPES }, effectiveScopes)
+      ).toBe(false)
+    }
+
+    const editorScopes = getEffectiveCommandScopeSet(
+      [MODE_MODELING_COMMAND_SCOPE, CODE_EDITOR_FOCUSED_COMMAND_SCOPE],
+      DEFAULT_COMMAND_SCOPES
+    )
+    expect(
+      isCommandAvailable(
+        { scopes: FILE_AND_CODE_EDITOR_COMMAND_SCOPES },
+        editorScopes
+      )
+    ).toBe(true)
+  })
+
+  it('removes only transient editable focus from palette discovery', () => {
+    expect(
+      getCommandPaletteScopes([
+        SETTINGS_COMMAND_SCOPE,
+        EDITABLE_FOCUSED_COMMAND_SCOPE,
+      ])
+    ).toEqual([SETTINGS_COMMAND_SCOPE])
   })
 
   it('combines availability with command palette visibility', () => {
@@ -68,7 +120,12 @@ describe('command scopes', () => {
       DEFAULT_COMMAND_SCOPES
     )
 
-    expect(isCommandSearchable({}, effectiveScopes)).toBe(true)
+    expect(
+      isCommandSearchable(
+        { scopes: [MODE_MODELING_COMMAND_SCOPE] },
+        effectiveScopes
+      )
+    ).toBe(true)
     expect(isCommandSearchable({ hideFromSearch: true }, effectiveScopes)).toBe(
       false
     )

--- a/src/registry/contracts/commands.ts
+++ b/src/registry/contracts/commands.ts
@@ -16,6 +16,7 @@ export { commandKey } from '@src/lib/commandUtils'
 export const BASE_COMMAND_SCOPE = 'base'
 export const CODE_EDITOR_FOCUSED_COMMAND_SCOPE = 'code-editor-focused'
 export const CODE_EDITOR_NOT_FOCUSED_COMMAND_SCOPE = 'code-editor-not-focused'
+export const EDITABLE_FOCUSED_COMMAND_SCOPE = 'editable-focused'
 export const MODE_MODELING_COMMAND_SCOPE = 'mode-modeling'
 export const MODE_SKETCHING_COMMAND_SCOPE = 'mode-sketching'
 export const MODE_SKETCH_NO_FACE_COMMAND_SCOPE = 'mode-sketch-no-face'
@@ -29,6 +30,24 @@ export const PROJECT_EXPLORER_RENAMING_COMMAND_SCOPE =
 
 const COMMAND_CONTEXT_SCOPE_GROUP = 'context'
 const COMMAND_PROJECT_EXPLORER_SCOPE_GROUP = 'project-explorer'
+
+export const GLOBAL_COMMAND_SCOPES = [BASE_COMMAND_SCOPE] as const
+
+export const SKETCH_COMMAND_SCOPES = [
+  MODE_SKETCHING_COMMAND_SCOPE,
+  MODE_SKETCH_NO_FACE_COMMAND_SCOPE,
+  MODE_SKETCH_SOLVE_COMMAND_SCOPE,
+] as const
+
+export const FILE_COMMAND_SCOPES = [
+  MODE_MODELING_COMMAND_SCOPE,
+  ...SKETCH_COMMAND_SCOPES,
+] as const
+
+export const FILE_AND_CODE_EDITOR_COMMAND_SCOPES = [
+  ...FILE_COMMAND_SCOPES,
+  CODE_EDITOR_FOCUSED_COMMAND_SCOPE,
+] as const
 
 export type CommandScope = {
   id: string
@@ -54,12 +73,14 @@ export const DEFAULT_COMMAND_SCOPES: readonly CommandScope[] = [
   {
     id: SETTINGS_COMMAND_SCOPE,
     displayName: 'Settings open',
+    group: COMMAND_CONTEXT_SCOPE_GROUP,
     priority: 1900,
     userEditable: false,
   },
   {
     id: HOME_COMMAND_SCOPE,
     displayName: 'Home',
+    group: COMMAND_CONTEXT_SCOPE_GROUP,
     priority: 50,
     userEditable: false,
   },
@@ -106,6 +127,13 @@ export const DEFAULT_COMMAND_SCOPES: readonly CommandScope[] = [
     userEditable: false,
   },
   {
+    id: EDITABLE_FOCUSED_COMMAND_SCOPE,
+    displayName: 'Editable control focused',
+    group: COMMAND_CONTEXT_SCOPE_GROUP,
+    priority: 1100,
+    userEditable: false,
+  },
+  {
     id: PROJECT_EXPLORER_FOCUSED_COMMAND_SCOPE,
     displayName: 'Project explorer focused',
     group: COMMAND_PROJECT_EXPLORER_SCOPE_GROUP,
@@ -141,10 +169,15 @@ export type CommandSystemService = {
 export function normalizeCommandScopeIds(
   scopes: readonly string[] | undefined
 ): readonly string[] {
-  const normalizedScopes = [
+  return [
     ...new Set((scopes ?? []).map((scope) => scope.trim()).filter(Boolean)),
   ]
-  return normalizedScopes.length > 0 ? normalizedScopes : [BASE_COMMAND_SCOPE]
+}
+
+export function getCommandPaletteScopes(activeScopes: readonly string[]) {
+  return activeScopes.filter(
+    (scope) => scope !== EDITABLE_FOCUSED_COMMAND_SCOPE
+  )
 }
 
 export function getEffectiveCommandScopeSet(
@@ -158,8 +191,10 @@ export function isCommandAvailable(
   command: Partial<Pick<Command, 'scopes'>>,
   effectiveScopes: ReadonlySet<string>
 ) {
-  return normalizeCommandScopeIds(command.scopes).some((scope) =>
-    effectiveScopes.has(scope)
+  const commandScopes = normalizeCommandScopeIds(command.scopes)
+  return (
+    commandScopes.length > 0 &&
+    commandScopes.some((scope) => effectiveScopes.has(scope))
   )
 }
 

--- a/src/registry/contracts/keymap.test.ts
+++ b/src/registry/contracts/keymap.test.ts
@@ -129,6 +129,48 @@ describe('keymap contract', () => {
     })
   })
 
+  it('falls back to an available binding without consuming the unavailable one', () => {
+    const baseItem = createKeymapItem({
+      id: 'base-command',
+      keystrokes: ['mod+k'],
+    })
+    const scopedItem = createKeymapItem({
+      id: 'scoped-command',
+      scopes: ['test-scope'],
+      keystrokes: ['mod+k'],
+    })
+    const tree = createKeymapTree([baseItem, scopedItem])
+
+    expect(
+      matchKeymapKeystrokes(
+        tree,
+        ['test-scope'],
+        ['mod+k'],
+        [],
+        (item) => item !== scopedItem
+      )
+    ).toEqual({ type: 'full', item: baseItem })
+  })
+
+  it('does not return a prefix for unavailable bindings', () => {
+    const item = createKeymapItem({
+      id: 'unavailable-command',
+      keystrokes: ['v', '1'],
+      scopes: [CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE],
+    })
+    const tree = createKeymapTree([item])
+
+    expect(
+      matchKeymapKeystrokes(
+        tree,
+        [CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE],
+        ['v'],
+        [],
+        () => false
+      )
+    ).toEqual({ type: 'none' })
+  })
+
   it('matches scoped items from a single prefix tree', () => {
     const baseItem = createKeymapItem({
       id: 'command-palette.open',

--- a/src/registry/contracts/keymap.ts
+++ b/src/registry/contracts/keymap.ts
@@ -10,7 +10,12 @@ import {
   BASE_COMMAND_SCOPE,
   CODE_EDITOR_FOCUSED_COMMAND_SCOPE,
   CODE_EDITOR_NOT_FOCUSED_COMMAND_SCOPE,
+  COMMAND_PALETTE_OPEN_COMMAND_SCOPE,
   DEFAULT_COMMAND_SCOPES,
+  EDITABLE_FOCUSED_COMMAND_SCOPE,
+  FILE_AND_CODE_EDITOR_COMMAND_SCOPES,
+  FILE_COMMAND_SCOPES,
+  GLOBAL_COMMAND_SCOPES,
   HOME_COMMAND_SCOPE,
   MODE_MODELING_COMMAND_SCOPE,
   MODE_SKETCHING_COMMAND_SCOPE,
@@ -18,6 +23,8 @@ import {
   MODE_SKETCH_SOLVE_COMMAND_SCOPE,
   PROJECT_EXPLORER_FOCUSED_COMMAND_SCOPE,
   PROJECT_EXPLORER_RENAMING_COMMAND_SCOPE,
+  SETTINGS_COMMAND_SCOPE,
+  SKETCH_COMMAND_SCOPES,
   commandScopesValueSpec,
   getCommandScopePriority,
   getEffectiveCommandScopes,
@@ -30,17 +37,26 @@ export const CODE_EDITOR_FOCUSED_KEYMAP_SCOPE =
   CODE_EDITOR_FOCUSED_COMMAND_SCOPE
 export const CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE =
   CODE_EDITOR_NOT_FOCUSED_COMMAND_SCOPE
+export const EDITABLE_FOCUSED_KEYMAP_SCOPE = EDITABLE_FOCUSED_COMMAND_SCOPE
 export const MODE_MODELING_KEYMAP_SCOPE = MODE_MODELING_COMMAND_SCOPE
 export const MODE_SKETCHING_KEYMAP_SCOPE = MODE_SKETCHING_COMMAND_SCOPE
 export const MODE_SKETCH_NO_FACE_KEYMAP_SCOPE =
   MODE_SKETCH_NO_FACE_COMMAND_SCOPE
 export const MODE_SKETCH_SOLVE_KEYMAP_SCOPE = MODE_SKETCH_SOLVE_COMMAND_SCOPE
 export const HOME_KEYMAP_SCOPE = HOME_COMMAND_SCOPE
+export const COMMAND_PALETTE_OPEN_KEYMAP_SCOPE =
+  COMMAND_PALETTE_OPEN_COMMAND_SCOPE
+export const SETTINGS_KEYMAP_SCOPE = SETTINGS_COMMAND_SCOPE
 export const PROJECT_EXPLORER_FOCUSED_KEYMAP_SCOPE =
   PROJECT_EXPLORER_FOCUSED_COMMAND_SCOPE
 export const PROJECT_EXPLORER_RENAMING_KEYMAP_SCOPE =
   PROJECT_EXPLORER_RENAMING_COMMAND_SCOPE
 export const DEFAULT_KEYMAP_SCOPES = DEFAULT_COMMAND_SCOPES
+export const GLOBAL_KEYMAP_SCOPES = GLOBAL_COMMAND_SCOPES
+export const SKETCH_KEYMAP_SCOPES = SKETCH_COMMAND_SCOPES
+export const FILE_KEYMAP_SCOPES = FILE_COMMAND_SCOPES
+export const FILE_AND_CODE_EDITOR_KEYMAP_SCOPES =
+  FILE_AND_CODE_EDITOR_COMMAND_SCOPES
 export const KEYMAP_SCHEMA_VERSION = 1
 export const USER_KEYMAP_SOURCE = 'User'
 
@@ -103,6 +119,8 @@ export type KeymapMatch =
   | { type: 'none' }
   | { type: 'prefix' }
   | { type: 'full'; item: KeymapItem }
+
+export type KeymapItemAvailability = (item: KeymapItem) => boolean
 
 export type KeymapSource = 'global' | 'codeMirror'
 
@@ -593,7 +611,8 @@ export function matchKeymapKeystrokes(
   tree: KeymapTree,
   scopes: readonly string[],
   keystrokes: readonly string[],
-  keymapScopes: readonly KeymapScope[] = []
+  keymapScopes: readonly KeymapScope[] = [],
+  isItemAvailable: KeymapItemAvailability = () => true
 ): KeymapMatch {
   const normalizedKeystrokes = keystrokes.map(normalizeKeymapChord)
   const activeScopes = getEffectiveKeymapScopes(scopes, keymapScopes)
@@ -602,18 +621,18 @@ export function matchKeymapKeystrokes(
   let node = tree.root
   for (const chord of normalizedKeystrokes) {
     const child = node.children.get(chord)
-    if (!child || !nodeHasActiveItems(child, activeScopeSet)) {
+    if (!child || !nodeHasActiveItems(child, activeScopeSet, isItemAvailable)) {
       return { type: 'none' }
     }
     node = child
   }
 
-  const item = getActiveKeymapItem(node.items, activeScopes)
+  const item = getActiveKeymapItem(node.items, activeScopes, isItemAvailable)
   if (item) {
     return { type: 'full', item }
   }
 
-  if (nodeHasActiveItems(node, activeScopeSet)) {
+  if (nodeHasActiveItems(node, activeScopeSet, isItemAvailable)) {
     return { type: 'prefix' }
   }
 
@@ -622,31 +641,39 @@ export function matchKeymapKeystrokes(
 
 function nodeHasActiveItems(
   node: KeymapTreeNode,
-  activeScopes: ReadonlySet<string>
+  activeScopes: ReadonlySet<string>,
+  isItemAvailable: KeymapItemAvailability
 ): boolean {
   return (
-    node.items.some((item) => isKeymapItemActive(item, activeScopes)) ||
+    node.items.some(
+      (item) => isItemAvailable(item) && isKeymapItemActive(item, activeScopes)
+    ) ||
     [...node.children.values()].some((child) =>
-      nodeHasActiveItems(child, activeScopes)
+      nodeHasActiveItems(child, activeScopes, isItemAvailable)
     )
   )
 }
 
 function getActiveKeymapItem(
   items: readonly KeymapItem[],
-  activeScopes: readonly string[]
+  activeScopes: readonly string[],
+  isItemAvailable: KeymapItemAvailability
 ) {
   for (const scope of [...activeScopes].toReversed()) {
-    const item = items.find((candidate) =>
-      isKeymapItemActiveForScope(candidate, scope)
+    const item = items.find(
+      (candidate) =>
+        isItemAvailable(candidate) &&
+        isKeymapItemActiveForScope(candidate, scope)
     )
     if (item) {
       return item
     }
   }
 
-  return items.find((item) =>
-    isKeymapItemActiveForScope(item, BASE_KEYMAP_SCOPE)
+  return items.find(
+    (item) =>
+      isItemAvailable(item) &&
+      isKeymapItemActiveForScope(item, BASE_KEYMAP_SCOPE)
   )
 }
 

--- a/src/registry/extensions/commands/appCommands.ts
+++ b/src/registry/extensions/commands/appCommands.ts
@@ -9,6 +9,13 @@ import { selectAllInCurrentSketch } from '@src/lib/selections'
 import { reportRejection } from '@src/lib/trap'
 import type { CommandBarContext } from '@src/machines/commandBarMachine'
 import type { ModelingMachineEvent } from '@src/machines/modelingMachine'
+import {
+  FILE_AND_CODE_EDITOR_COMMAND_SCOPES,
+  FILE_COMMAND_SCOPES,
+  HOME_COMMAND_SCOPE,
+  SETTINGS_COMMAND_SCOPE,
+  SKETCH_COMMAND_SCOPES,
+} from '@src/registry/contracts/commands'
 import toast from 'react-hot-toast'
 
 const APP_COMMAND_GROUP_ID = 'zds'
@@ -73,6 +80,7 @@ function createAppCommand({
   description,
   icon,
   hideFromSearch = true,
+  scopes,
   onSubmit,
 }: {
   id: string
@@ -80,6 +88,7 @@ function createAppCommand({
   description?: Command['description']
   icon?: Command['icon']
   hideFromSearch?: boolean
+  scopes: Command['scopes']
   onSubmit: Command['onSubmit']
 }): Command {
   return {
@@ -90,6 +99,7 @@ function createAppCommand({
     description,
     icon,
     hideFromSearch,
+    scopes,
     needsReview: false,
     onSubmit,
   }
@@ -198,31 +208,37 @@ export const appCommands: readonly Command[] = [
   createAppCommand({
     id: APP_COMMAND_IDS.editor.undo,
     displayName: 'Undo',
+    scopes: FILE_AND_CODE_EDITOR_COMMAND_SCOPES,
     onSubmit: (input) => getKclManager(input)?.undo(),
   }),
   createAppCommand({
     id: APP_COMMAND_IDS.editor.redo,
     displayName: 'Redo',
+    scopes: FILE_AND_CODE_EDITOR_COMMAND_SCOPES,
     onSubmit: (input) => getKclManager(input)?.redo(),
   }),
   createAppCommand({
     id: APP_COMMAND_IDS.editor.format,
     displayName: 'Format code',
+    scopes: FILE_AND_CODE_EDITOR_COMMAND_SCOPES,
     onSubmit: (input) => getKclManager(input)?.format().catch(reportRejection),
   }),
   createAppCommand({
     id: APP_COMMAND_IDS.editor.convertToVariable,
     displayName: 'Convert to variable',
+    scopes: FILE_AND_CODE_EDITOR_COMMAND_SCOPES,
     onSubmit: (input) => getKclManager(input)?.convertToVariable(),
   }),
   createAppCommand({
     id: APP_COMMAND_IDS.editor.render,
     displayName: 'Render code',
+    scopes: FILE_AND_CODE_EDITOR_COMMAND_SCOPES,
     onSubmit: reexecuteOrToastAutosaveBehavior,
   }),
   createAppCommand({
     id: APP_COMMAND_IDS.modeling.deleteSelection,
     displayName: 'Delete selection',
+    scopes: FILE_COMMAND_SCOPES,
     onSubmit: deleteSelection,
   }),
   createAppCommand({
@@ -231,17 +247,20 @@ export const appCommands: readonly Command[] = [
     description: 'Center the camera on the current selection.',
     icon: 'camera',
     hideFromSearch: false,
+    scopes: FILE_COMMAND_SCOPES,
     onSubmit: (input) =>
       sendModelingEvent(input, { type: 'Center camera on selection' }),
   }),
   createAppCommand({
     id: APP_COMMAND_IDS.modeling.selectAllInCurrentSketch,
     displayName: 'Select all in current sketch',
+    scopes: SKETCH_COMMAND_SCOPES,
     onSubmit: selectAllInCurrentSketchCommand,
   }),
   createAppCommand({
     id: APP_COMMAND_IDS.modeling.toggleSnapToGrid,
     displayName: 'Toggle snap to grid',
+    scopes: FILE_COMMAND_SCOPES,
     onSubmit: toggleSnapToGrid,
   }),
   createAppCommand({
@@ -250,11 +269,13 @@ export const appCommands: readonly Command[] = [
     description: 'Restore the default camera position and view.',
     icon: 'refresh',
     hideFromSearch: false,
+    scopes: FILE_COMMAND_SCOPES,
     onSubmit: resetView,
   }),
   createAppCommand({
     id: APP_COMMAND_IDS.search.focusProjects,
     displayName: 'Focus project search',
+    scopes: [HOME_COMMAND_SCOPE],
     onSubmit: () => {
       projectSearchFocusRequest.value += 1
     },
@@ -262,6 +283,7 @@ export const appCommands: readonly Command[] = [
   createAppCommand({
     id: APP_COMMAND_IDS.search.focusSettings,
     displayName: 'Focus settings search',
+    scopes: [SETTINGS_COMMAND_SCOPE],
     onSubmit: () => {
       settingsSearchFocusRequest.value += 1
     },

--- a/src/registry/extensions/commands/index.spec.ts
+++ b/src/registry/extensions/commands/index.spec.ts
@@ -4,12 +4,14 @@ import {
   defineRegistryItem,
   provideService,
 } from '@kittycad/registry'
+import { signal } from '@preact/signals-core'
 import type { KclManager } from '@src/lang/KclManager'
 import { MachineManager } from '@src/lib/MachineManager'
 import type { Command } from '@src/lib/commandTypes'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { CommandBarContext } from '@src/machines/commandBarMachine'
 import {
+  COMMAND_PALETTE_OPEN_COMMAND_SCOPE,
   FILE_AND_CODE_EDITOR_COMMAND_SCOPES,
   FILE_COMMAND_SCOPES,
   GLOBAL_COMMAND_SCOPES,
@@ -20,6 +22,7 @@ import {
   MODE_SKETCH_SOLVE_COMMAND_SCOPE,
   SETTINGS_COMMAND_SCOPE,
   SKETCH_COMMAND_SCOPES,
+  commandScopeService,
   commandSystemService,
   provideCommand,
 } from '@src/registry/contracts/commands'
@@ -103,6 +106,76 @@ describe('commands extension', () => {
     expect(commandSystem.actor.getSnapshot().context.commands).toEqual([])
 
     registry[Symbol.dispose]()
+  })
+
+  it('syncs the command palette scope with command machine state', () => {
+    const activeScopes = signal<readonly string[]>([])
+    const applyScope = (scope: string) => {
+      if (!activeScopes.value.includes(scope)) {
+        activeScopes.value = [...activeScopes.value, scope]
+      }
+    }
+    const removeScope = (scope: string) => {
+      activeScopes.value = activeScopes.value.filter(
+        (activeScope) => activeScope !== scope
+      )
+    }
+    const registry = new Registry()
+    registry.configure([
+      defineRegistryItem({
+        id: 'test-wasm-promise',
+        provides: [provideWasmPromise(Promise.resolve({} as ModuleType))],
+      }),
+      defineRegistryItem({
+        id: 'test-machine-manager',
+        providesServices: [
+          provideService(machineManagerService, {
+            manager: new MachineManager(),
+          }),
+        ],
+      }),
+      defineRegistryItem({
+        id: 'test-command-scopes',
+        providesServices: [
+          provideService(commandScopeService, {
+            activeScopes,
+            applyScope,
+            removeScope,
+            getCurrentScopes: () => activeScopes.value,
+            focusScope: (scope) => ({
+              onFocus: () => applyScope(scope),
+              onBlur: () => removeScope(scope),
+            }),
+          }),
+        ],
+      }),
+      commandsExtension,
+      defineRegistryItem({
+        id: 'test-command',
+        provides: [
+          provideCommand({
+            scopes: GLOBAL_COMMAND_SCOPES,
+            groupId: 'test',
+            name: 'test-command',
+            needsReview: false,
+            onSubmit: vi.fn(),
+          }),
+        ],
+      }),
+    ])
+
+    const commandSystem = registry.get(commandSystemService)
+    expect(activeScopes.value).not.toContain(COMMAND_PALETTE_OPEN_COMMAND_SCOPE)
+
+    commandSystem.send({ type: 'Open' })
+    expect(activeScopes.value).toContain(COMMAND_PALETTE_OPEN_COMMAND_SCOPE)
+
+    commandSystem.send({ type: 'Close' })
+    expect(activeScopes.value).not.toContain(COMMAND_PALETTE_OPEN_COMMAND_SCOPE)
+
+    commandSystem.send({ type: 'Open' })
+    registry[Symbol.dispose]()
+    expect(activeScopes.value).not.toContain(COMMAND_PALETTE_OPEN_COMMAND_SCOPE)
   })
 
   it('provides a toolbar command for every toolbar command id', () => {

--- a/src/registry/extensions/commands/index.spec.ts
+++ b/src/registry/extensions/commands/index.spec.ts
@@ -10,11 +10,23 @@ import type { Command } from '@src/lib/commandTypes'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { CommandBarContext } from '@src/machines/commandBarMachine'
 import {
+  FILE_AND_CODE_EDITOR_COMMAND_SCOPES,
+  FILE_COMMAND_SCOPES,
+  GLOBAL_COMMAND_SCOPES,
+  HOME_COMMAND_SCOPE,
+  MODE_MODELING_COMMAND_SCOPE,
+  MODE_SKETCHING_COMMAND_SCOPE,
+  MODE_SKETCH_NO_FACE_COMMAND_SCOPE,
+  MODE_SKETCH_SOLVE_COMMAND_SCOPE,
+  SETTINGS_COMMAND_SCOPE,
+  SKETCH_COMMAND_SCOPES,
   commandSystemService,
   provideCommand,
 } from '@src/registry/contracts/commands'
+import { getKeymapItemScopes } from '@src/registry/contracts/keymap'
 import { machineManagerService } from '@src/registry/contracts/machineManager'
 import { provideWasmPromise } from '@src/registry/contracts/wasm'
+import { defaultKeymap } from '@src/registry/extensions/keymap/defaultKeymap'
 import { describe, expect, it, vi } from 'vitest'
 import { commandsExtension } from '.'
 import { APP_COMMAND_IDS, appCommands } from './appCommands'
@@ -42,10 +54,17 @@ function createCommandBarContext({
   return context
 }
 
+function commandIds(
+  groups: Readonly<Record<string, Readonly<Record<string, string>>>>
+) {
+  return Object.values(groups).flatMap((group) => Object.values(group))
+}
+
 describe('commands extension', () => {
   it('syncs registry command contributions into the command system service', () => {
     const commandsSlot = new Slot()
     const command: Command = {
+      scopes: GLOBAL_COMMAND_SCOPES,
       groupId: 'test',
       name: 'test-command',
       needsReview: false,
@@ -86,20 +105,96 @@ describe('commands extension', () => {
     registry[Symbol.dispose]()
   })
 
-  it('provides toolbar commands for keymap-backed tool selection', () => {
-    expect(toolbarCommands.map((command) => command.id)).toContain(
-      TOOLBAR_COMMAND_IDS.sketchSolve.vertical
+  it('provides a toolbar command for every toolbar command id', () => {
+    expect(toolbarCommands.map((command) => command.id).toSorted()).toEqual(
+      commandIds(TOOLBAR_COMMAND_IDS).toSorted()
     )
   })
 
   it('provides an app command for every app command id', () => {
-    const appCommandIds = Object.values(APP_COMMAND_IDS).flatMap((group) =>
-      Object.values(group)
-    )
-
     expect(appCommands.map((command) => command.id).toSorted()).toEqual(
-      appCommandIds.toSorted()
+      commandIds(APP_COMMAND_IDS).toSorted()
     )
+  })
+
+  it('gives every static command a non-empty scope list', () => {
+    for (const command of [...appCommands, ...toolbarCommands]) {
+      expect(command.scopes.length, command.id).toBeGreaterThan(0)
+    }
+  })
+
+  it.each([
+    [APP_COMMAND_IDS.editor.undo, FILE_AND_CODE_EDITOR_COMMAND_SCOPES],
+    [APP_COMMAND_IDS.editor.redo, FILE_AND_CODE_EDITOR_COMMAND_SCOPES],
+    [APP_COMMAND_IDS.editor.format, FILE_AND_CODE_EDITOR_COMMAND_SCOPES],
+    [
+      APP_COMMAND_IDS.editor.convertToVariable,
+      FILE_AND_CODE_EDITOR_COMMAND_SCOPES,
+    ],
+    [APP_COMMAND_IDS.editor.render, FILE_AND_CODE_EDITOR_COMMAND_SCOPES],
+    [APP_COMMAND_IDS.modeling.deleteSelection, FILE_COMMAND_SCOPES],
+    [APP_COMMAND_IDS.modeling.toggleSnapToGrid, FILE_COMMAND_SCOPES],
+    [APP_COMMAND_IDS.modeling.selectAllInCurrentSketch, SKETCH_COMMAND_SCOPES],
+    [APP_COMMAND_IDS.search.focusProjects, [HOME_COMMAND_SCOPE]],
+    [APP_COMMAND_IDS.search.focusSettings, [SETTINGS_COMMAND_SCOPE]],
+  ] as const)('scopes representative app command %s', (commandId, scopes) => {
+    expect(
+      appCommands.find((command) => command.id === commandId)?.scopes
+    ).toEqual(scopes)
+  })
+
+  it('scopes toolbar command families to their owning mode', () => {
+    expect(
+      toolbarCommands.find(
+        (command) => command.id === TOOLBAR_COMMAND_IDS.modeling.sketch
+      )?.scopes
+    ).toEqual([MODE_MODELING_COMMAND_SCOPE])
+    expect(
+      toolbarCommands.find(
+        (command) => command.id === TOOLBAR_COMMAND_IDS.sketching.exit
+      )?.scopes
+    ).toEqual([MODE_SKETCHING_COMMAND_SCOPE, MODE_SKETCH_NO_FACE_COMMAND_SCOPE])
+    expect(
+      toolbarCommands
+        .filter(
+          (command) =>
+            command.id?.startsWith('zds.toolbar.sketchLegacy.') &&
+            command.id !== TOOLBAR_COMMAND_IDS.sketching.exit
+        )
+        .every(
+          (command) =>
+            command.scopes.length === 1 &&
+            command.scopes[0] === MODE_SKETCHING_COMMAND_SCOPE
+        )
+    ).toBe(true)
+    expect(
+      toolbarCommands
+        .filter((command) => command.id?.startsWith('zds.toolbar.sketch.'))
+        .every(
+          (command) =>
+            command.scopes.length === 1 &&
+            command.scopes[0] === MODE_SKETCH_SOLVE_COMMAND_SCOPE
+        )
+    ).toBe(true)
+  })
+
+  it('allows reset view across files while keeping its mnemonic modeling-only', () => {
+    expect(
+      appCommands.find((command) => command.id === APP_COMMAND_IDS.view.reset)
+        ?.scopes
+    ).toEqual(FILE_COMMAND_SCOPES)
+    expect(
+      getKeymapItemScopes(
+        defaultKeymap.bindings.find((binding) => binding.id === 'view.reset')!
+      )
+    ).toEqual([MODE_MODELING_COMMAND_SCOPE])
+    expect(
+      getKeymapItemScopes(
+        defaultKeymap.bindings.find(
+          (binding) => binding.id === 'view.reset-with-modifier'
+        )!
+      )
+    ).toEqual(FILE_COMMAND_SCOPES)
   })
 
   it('exposes view commands with command palette metadata', () => {
@@ -115,12 +210,14 @@ describe('commands extension', () => {
           displayName: 'Center camera on selection',
           description: 'Center the camera on the current selection.',
           icon: 'camera',
+          scopes: FILE_COMMAND_SCOPES,
         }),
         expect.objectContaining({
           id: APP_COMMAND_IDS.view.reset,
           displayName: 'Reset view',
           description: 'Restore the default camera position and view.',
           icon: 'refresh',
+          scopes: FILE_COMMAND_SCOPES,
         }),
       ])
     )

--- a/src/registry/extensions/commands/index.ts
+++ b/src/registry/extensions/commands/index.ts
@@ -5,12 +5,14 @@ import {
   provide,
   provideService,
 } from '@kittycad/registry'
-import { effect } from '@preact/signals-core'
+import { effect, untracked } from '@preact/signals-core'
 import type { Command } from '@src/lib/commandTypes'
 import { commandBarMachine } from '@src/machines/commandBarMachine'
 import {
+  COMMAND_PALETTE_OPEN_COMMAND_SCOPE,
   type CommandSystemService,
   commandKey,
+  commandScopeService,
   commandSystemService,
   commandsValueSpec,
 } from '@src/registry/contracts/commands'
@@ -25,6 +27,7 @@ export const commandsExtension = defineRegistryItemFactory((ctx) => {
   const commandsSignal = ctx.valueSpecs.signal(commandsValueSpec)
 
   let commandBarActor: CommandSystemService['actor'] | undefined
+  let stopCommandPaletteScopeSync: (() => void) | undefined
   let stopCommandsEffect: (() => void) | undefined
   let registeredCommands: readonly Command[] = []
 
@@ -45,6 +48,26 @@ export const commandsExtension = defineRegistryItemFactory((ctx) => {
         machineManager,
       },
     }).start()
+
+    const syncCommandPaletteScope = () => {
+      const commandScopes = ctx.services.optional(commandScopeService)
+      if (!commandScopes || !commandBarActor) {
+        return
+      }
+
+      if (commandBarActor.getSnapshot().matches('Closed')) {
+        commandScopes.removeScope(COMMAND_PALETTE_OPEN_COMMAND_SCOPE)
+      } else {
+        commandScopes.applyScope(COMMAND_PALETTE_OPEN_COMMAND_SCOPE)
+      }
+    }
+
+    syncCommandPaletteScope()
+    const commandPaletteScopeSubscription = commandBarActor.subscribe(() =>
+      untracked(syncCommandPaletteScope)
+    )
+    stopCommandPaletteScopeSync = () =>
+      commandPaletteScopeSubscription.unsubscribe()
 
     stopCommandsEffect = effect(() => {
       const nextCommands = commandsSignal.value
@@ -83,6 +106,10 @@ export const commandsExtension = defineRegistryItemFactory((ctx) => {
       id: 'commands-extension',
       providesServices: [provideService(commandSystemService, serviceImpl)],
       dispose: () => {
+        stopCommandPaletteScopeSync?.()
+        ctx.services
+          .optional(commandScopeService)
+          ?.removeScope(COMMAND_PALETTE_OPEN_COMMAND_SCOPE)
         stopCommandsEffect?.()
         commandBarActor?.stop()
       },

--- a/src/registry/extensions/commands/toolbarCommands.ts
+++ b/src/registry/extensions/commands/toolbarCommands.ts
@@ -22,6 +22,12 @@ import {
   isSketchBlockSelected,
 } from '@src/machines/sketchSolve/sketchSolveImpl'
 import type { ConstraintToolName } from '@src/machines/sketchSolve/tools/constraintToolModel'
+import {
+  MODE_MODELING_COMMAND_SCOPE,
+  MODE_SKETCH_NO_FACE_COMMAND_SCOPE,
+  MODE_SKETCH_SOLVE_COMMAND_SCOPE,
+  MODE_SKETCHING_COMMAND_SCOPE,
+} from '@src/registry/contracts/commands'
 import type { StateFrom } from 'xstate'
 
 const TOOLBAR_COMMAND_GROUP_ID = 'toolbar'
@@ -80,6 +86,7 @@ type ToolbarCommandConfig = {
   displayName: string
   description: string
   icon?: Command['icon']
+  scopes: Command['scopes']
   onSubmit: Command['onSubmit']
 }
 
@@ -126,6 +133,7 @@ const createToolbarCommand = ({
   displayName,
   description,
   icon,
+  scopes,
   onSubmit,
 }: ToolbarCommandConfig): Command => ({
   id,
@@ -134,6 +142,7 @@ const createToolbarCommand = ({
   displayName,
   description,
   icon,
+  scopes,
   hideFromSearch: true,
   needsReview: false,
   onSubmit,
@@ -206,6 +215,7 @@ function createLegacySketchToolCommand({
     displayName,
     description,
     icon,
+    scopes: [MODE_SKETCHING_COMMAND_SCOPE],
     onSubmit: (input) => {
       const state = getModelingState(input)
       if (!state || state.matches('Sketch no face')) {
@@ -233,6 +243,7 @@ function createSketchSolveToolCommand({
     displayName,
     description,
     icon,
+    scopes: [MODE_SKETCH_SOLVE_COMMAND_SCOPE],
     onSubmit: (input) => {
       if (experimental && !hasSketchExperimentalFeatures(input)) {
         return
@@ -285,6 +296,7 @@ function createSketchSolveActionCommand({
     displayName,
     description,
     icon,
+    scopes: [MODE_SKETCH_SOLVE_COMMAND_SCOPE],
     onSubmit: (input) => sendModelingEvent(input, { type: event }),
   })
 }
@@ -383,6 +395,7 @@ export const toolbarCommands: readonly Command[] = [
     displayName: 'Start or edit sketch',
     description: 'Start drawing a 2D sketch.',
     icon: 'sketch',
+    scopes: [MODE_MODELING_COMMAND_SCOPE],
     onSubmit: enterSketch,
   }),
   createToolbarCommand({
@@ -390,12 +403,14 @@ export const toolbarCommands: readonly Command[] = [
     displayName: 'Exit sketch',
     description: 'Exit the current sketch.',
     icon: 'arrowShortLeft',
+    scopes: [MODE_SKETCHING_COMMAND_SCOPE, MODE_SKETCH_NO_FACE_COMMAND_SCOPE],
     onSubmit: exitSketch,
   }),
   createToolbarCommand({
     id: TOOLBAR_COMMAND_IDS.sketching.cancelTool,
     displayName: 'Cancel sketch tool',
     description: 'Cancel the active sketch tool.',
+    scopes: [MODE_SKETCHING_COMMAND_SCOPE],
     onSubmit: cancelLegacySketchTool,
   }),
   createLegacySketchToolCommand({
@@ -459,18 +474,21 @@ export const toolbarCommands: readonly Command[] = [
     displayName: 'Exit sketch',
     description: 'Exit the current sketch.',
     icon: 'arrowShortLeft',
+    scopes: [MODE_SKETCH_SOLVE_COMMAND_SCOPE],
     onSubmit: (input) => sendModelingEvent(input, { type: 'Exit sketch' }),
   }),
   createToolbarCommand({
     id: TOOLBAR_COMMAND_IDS.sketchSolve.cancel,
     displayName: 'Cancel sketch solve action',
     description: 'Cancel the active sketch solve action.',
+    scopes: [MODE_SKETCH_SOLVE_COMMAND_SCOPE],
     onSubmit: (input) => sendModelingEvent(input, { type: 'Cancel' }),
   }),
   createToolbarCommand({
     id: TOOLBAR_COMMAND_IDS.sketchSolve.toolPicker,
     displayName: 'Pick hovered sketch tool',
     description: 'Equip the sketch tool matching the object under the cursor.',
+    scopes: [MODE_SKETCH_SOLVE_COMMAND_SCOPE],
     onSubmit: (input) =>
       sendModelingEvent(input, { type: 'pick hovered tool' }),
   }),

--- a/src/registry/extensions/engineScene/index.spec.ts
+++ b/src/registry/extensions/engineScene/index.spec.ts
@@ -6,7 +6,11 @@ import {
 } from '@kittycad/registry'
 import { signal } from '@preact/signals-core'
 import type { modelingMachine } from '@src/machines/modelingMachine'
-import { commandsValueSpec } from '@src/registry/contracts/commands'
+import {
+  FILE_COMMAND_SCOPES,
+  MODE_MODELING_COMMAND_SCOPE,
+  commandsValueSpec,
+} from '@src/registry/contracts/commands'
 import {
   type EngineSceneExtensionContext,
   engineSceneStreamClassNamesValueSpec,
@@ -17,10 +21,7 @@ import {
 } from '@src/registry/contracts/engineScene'
 import type { ExecutingEditorService } from '@src/registry/contracts/executingEditor'
 import { executingEditorService } from '@src/registry/contracts/executingEditor'
-import {
-  MODE_MODELING_KEYMAP_SCOPE,
-  keymapValueSpec,
-} from '@src/registry/contracts/keymap'
+import { keymapValueSpec } from '@src/registry/contracts/keymap'
 import { settingsValueSpec } from '@src/registry/contracts/settings'
 import {
   statusBarGlobalItemsValueSpec,
@@ -155,10 +156,11 @@ describe('engineScene extension', () => {
       displayName: 'Open measure tool',
       icon: 'ruler',
       needsReview: false,
+      scopes: [MODE_MODELING_COMMAND_SCOPE],
     })
     expect(keymapItem).toMatchObject({
       title: 'Open measure tool',
-      scopes: [MODE_MODELING_KEYMAP_SCOPE],
+      scopes: [MODE_MODELING_COMMAND_SCOPE],
       keystrokes: ['shift+m'],
       command: ENGINE_SCENE_COMMAND_IDS.openMeasureTool,
     })
@@ -189,10 +191,11 @@ describe('engineScene extension', () => {
       displayName: 'Open physical analysis tool',
       icon: 'scales',
       needsReview: false,
+      scopes: [MODE_MODELING_COMMAND_SCOPE],
     })
     expect(keymapItem).toMatchObject({
       title: 'Open physical analysis tool',
-      scopes: [MODE_MODELING_KEYMAP_SCOPE],
+      scopes: [MODE_MODELING_COMMAND_SCOPE],
       keystrokes: ['shift+p'],
       command: ENGINE_SCENE_COMMAND_IDS.openPhysicalAnalysisTool,
     })
@@ -220,6 +223,7 @@ describe('engineScene extension', () => {
       description: 'Save the current modeling viewport as a PNG image.',
       icon: 'camera',
       needsReview: false,
+      scopes: FILE_COMMAND_SCOPES,
       onSubmit: saveViewportScreenshot,
     })
     expect(command?.hideFromSearch).not.toBe(true)

--- a/src/registry/extensions/engineScene/index.ts
+++ b/src/registry/extensions/engineScene/index.ts
@@ -5,7 +5,11 @@ import {
 } from '@kittycad/registry'
 import { computed } from '@preact/signals-core'
 import type { Command } from '@src/lib/commandTypes'
-import { provideCommand } from '@src/registry/contracts/commands'
+import {
+  FILE_COMMAND_SCOPES,
+  MODE_MODELING_COMMAND_SCOPE,
+  provideCommand,
+} from '@src/registry/contracts/commands'
 import {
   type EngineSceneExtensionContext,
   defineEngineSceneStreamClassName,
@@ -16,7 +20,6 @@ import {
 import { executingEditorService } from '@src/registry/contracts/executingEditor'
 import {
   type KeymapItem,
-  MODE_MODELING_KEYMAP_SCOPE,
   provideKeymapItem,
 } from '@src/registry/contracts/keymap'
 import {
@@ -46,6 +49,7 @@ export const ENGINE_SCENE_COMMAND_IDS = Object.freeze({
 } as const)
 
 const captureScreenshotCommand: Command = {
+  scopes: FILE_COMMAND_SCOPES,
   id: ENGINE_SCENE_COMMAND_IDS.captureScreenshot,
   name: ENGINE_SCENE_COMMAND_IDS.captureScreenshot,
   groupId: ENGINE_SCENE_COMMAND_GROUP_ID,
@@ -57,6 +61,7 @@ const captureScreenshotCommand: Command = {
 }
 
 const openMeasureToolCommand: Command = {
+  scopes: [MODE_MODELING_COMMAND_SCOPE],
   id: ENGINE_SCENE_COMMAND_IDS.openMeasureTool,
   name: ENGINE_SCENE_COMMAND_IDS.openMeasureTool,
   groupId: ENGINE_SCENE_COMMAND_GROUP_ID,
@@ -71,6 +76,7 @@ const openMeasureToolCommand: Command = {
 }
 
 const openPhysicalAnalysisToolCommand: Command = {
+  scopes: [MODE_MODELING_COMMAND_SCOPE],
   id: ENGINE_SCENE_COMMAND_IDS.openPhysicalAnalysisTool,
   name: ENGINE_SCENE_COMMAND_IDS.openPhysicalAnalysisTool,
   groupId: ENGINE_SCENE_COMMAND_GROUP_ID,
@@ -88,7 +94,7 @@ const openMeasureToolKeymapItem: KeymapItem = {
   id: 'engine-scene.measure.open',
   title: 'Open measure tool',
   source: ENGINE_SCENE_KEYMAP_SOURCE,
-  scopes: [MODE_MODELING_KEYMAP_SCOPE],
+  scopes: [MODE_MODELING_COMMAND_SCOPE],
   keystrokes: ['shift+m'],
   command: ENGINE_SCENE_COMMAND_IDS.openMeasureTool,
 }
@@ -97,7 +103,7 @@ const openPhysicalAnalysisToolKeymapItem: KeymapItem = {
   id: 'engine-scene.physical-analysis.open',
   title: 'Open physical analysis tool',
   source: ENGINE_SCENE_KEYMAP_SOURCE,
-  scopes: [MODE_MODELING_KEYMAP_SCOPE],
+  scopes: [MODE_MODELING_COMMAND_SCOPE],
   keystrokes: ['shift+p'],
   command: ENGINE_SCENE_COMMAND_IDS.openPhysicalAnalysisTool,
 }

--- a/src/registry/extensions/keymap/index.spec.ts
+++ b/src/registry/extensions/keymap/index.spec.ts
@@ -650,7 +650,7 @@ describe('keymap extension', () => {
     registry[Symbol.dispose]()
   })
 
-  it('keeps editor focus priority while typing in the CodeMirror search field', () => {
+  it('reconciles stale editable focus before matching a global keydown', () => {
     const registry = createRegistryWithKeymapItems([
       {
         id: 'test.sketch-solve-line',
@@ -662,27 +662,115 @@ describe('keymap extension', () => {
       },
     ])
     const keymap = registry.get(keymapService)
-    const editor = document.createElement('div')
-    const searchPanel = document.createElement('div')
-    const searchInput = document.createElement('input')
-
-    editor.className = 'cm-editor'
-    searchPanel.className = 'cm-panel cm-search'
-    searchPanel.append(searchInput)
-    editor.append(searchPanel)
-    document.body.append(editor)
+    const input = document.createElement('input')
+    document.body.append(input)
 
     keymap.applyScope(MODE_SKETCH_SOLVE_KEYMAP_SCOPE)
-    searchInput.dispatchEvent(new FocusEvent('focusin', { bubbles: true }))
+    input.dispatchEvent(new FocusEvent('focusin', { bubbles: true }))
+    input.remove()
+
+    expect(keymap.getCurrentScopes()).toContain(EDITABLE_FOCUSED_KEYMAP_SCOPE)
+    expect(
+      keymap.handleKeyDown(createKeyboardEventWithTarget('l', document.body), {
+        source: 'global',
+      })
+    ).toBe(true)
+    expect(keymap.getCurrentScopes()).not.toContain(
+      EDITABLE_FOCUSED_KEYMAP_SCOPE
+    )
+    expect(keymap.getCurrentScopes()).toContain(
+      CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE
+    )
+
+    registry[Symbol.dispose]()
+  })
+
+  it('preserves editor scope for command palette trigger pointerdown', () => {
+    const registry = createRegistryWithKeymapItems([])
+    const keymap = registry.get(keymapService)
+    const editor = document.createElement('div')
+    const content = document.createElement('div')
+    const commandPaletteTrigger = document.createElement('button')
+
+    editor.className = 'cm-editor'
+    content.className = 'cm-content'
+    content.contentEditable = 'true'
+    editor.append(content)
+    commandPaletteTrigger.dataset.commandScopePreserveFocus = 'true'
+    document.body.append(editor, commandPaletteTrigger)
+
+    content.dispatchEvent(new FocusEvent('focusin', { bubbles: true }))
+    commandPaletteTrigger.dispatchEvent(
+      new PointerEvent('pointerdown', { bubbles: true })
+    )
 
     expect(keymap.getCurrentScopes()).toContain(
       CODE_EDITOR_FOCUSED_KEYMAP_SCOPE
     )
-    expect(
-      keymap.handleKeyDown(createKeyboardEventWithTarget('l', searchInput), {
-        source: 'global',
-      })
-    ).toBe(false)
+    expect(keymap.getCurrentScopes()).not.toContain(
+      CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE
+    )
+
+    editor.remove()
+    commandPaletteTrigger.remove()
+    registry[Symbol.dispose]()
+  })
+
+  it('treats CodeMirror form controls as editable, not editor content', () => {
+    const send = vi.fn()
+    const registry = createRegistryWithKeymapItems(
+      [
+        {
+          id: 'test.code-editor-undo',
+          title: 'Test code editor undo',
+          command: 'test.code-editor-undo',
+          source: 'test',
+          keystrokes: ['mod+z'],
+          scopes: [CODE_EDITOR_FOCUSED_KEYMAP_SCOPE],
+        },
+      ],
+      {
+        commands: [
+          createTestCommand('test.code-editor-undo', [
+            CODE_EDITOR_FOCUSED_KEYMAP_SCOPE,
+          ]),
+        ],
+        send,
+      }
+    )
+    const keymap = registry.get(keymapService)
+    const editor = document.createElement('div')
+    const content = document.createElement('div')
+    const searchPanel = document.createElement('div')
+    const searchInput = document.createElement('input')
+
+    editor.className = 'cm-editor'
+    content.className = 'cm-content'
+    content.contentEditable = 'true'
+    searchPanel.className = 'cm-panel cm-search'
+    searchPanel.append(searchInput)
+    editor.append(content, searchPanel)
+    document.body.append(editor)
+
+    content.dispatchEvent(new FocusEvent('focusin', { bubbles: true }))
+    expect(keymap.getCurrentScopes()).toContain(
+      CODE_EDITOR_FOCUSED_KEYMAP_SCOPE
+    )
+
+    searchInput.dispatchEvent(new FocusEvent('focusin', { bubbles: true }))
+
+    expect(keymap.getCurrentScopes()).not.toContain(
+      CODE_EDITOR_FOCUSED_KEYMAP_SCOPE
+    )
+    expect(keymap.getCurrentScopes()).toContain(EDITABLE_FOCUSED_KEYMAP_SCOPE)
+    const undoEvent = createKeyboardEventWithTarget('z', searchInput, {
+      ctrlKey: true,
+      metaKey: true,
+      cancelable: true,
+    })
+    expect(keymap.handleKeyDown(undoEvent, { source: 'global' })).toBe(false)
+    expect(undoEvent.defaultPrevented).toBe(false)
+    expect(send).not.toHaveBeenCalled()
 
     editor.remove()
     registry[Symbol.dispose]()

--- a/src/registry/extensions/keymap/index.spec.ts
+++ b/src/registry/extensions/keymap/index.spec.ts
@@ -4,7 +4,13 @@ import {
   defineRegistryItem,
   provideService,
 } from '@kittycad/registry'
+import type { Command } from '@src/lib/commandTypes'
 import {
+  FILE_COMMAND_SCOPES,
+  GLOBAL_COMMAND_SCOPES,
+  HOME_COMMAND_SCOPE,
+  MODE_MODELING_COMMAND_SCOPE,
+  SETTINGS_COMMAND_SCOPE,
   type CommandSystemService,
   commandScopeService,
   commandScopesValueSpec,
@@ -13,6 +19,7 @@ import {
 import {
   CODE_EDITOR_FOCUSED_KEYMAP_SCOPE,
   CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE,
+  EDITABLE_FOCUSED_KEYMAP_SCOPE,
   KEYMAP_SCHEMA_VERSION,
   MODE_SKETCHING_KEYMAP_SCOPE,
   MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
@@ -165,7 +172,7 @@ describe('keymap extension', () => {
       {
         id: 'test.full',
         title: 'Test full',
-        command: 'zds.settings.tab',
+        command: 'test.full',
         source: 'test',
         keystrokes: ['x'],
         scopes: [CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE],
@@ -232,6 +239,34 @@ describe('keymap extension', () => {
     registry[Symbol.dispose]()
   })
 
+  it('does not let a user binding broaden a built-in action context', () => {
+    window.history.replaceState(null, '', '/settings?tab=user')
+    const registry = createRegistryWithKeymapItems([
+      {
+        id: 'test.user-settings-tab',
+        title: 'Test user settings tab',
+        command: 'zds.settings.tab',
+        source: 'User',
+        keystrokes: ['mod+u'],
+        arguments: { tab: 'keybindings' },
+      },
+    ])
+    const keymap = registry.get(keymapService)
+
+    const outsideSettingsEvent = createModUEvent()
+    expect(
+      keymap.handleKeyDown(outsideSettingsEvent, { source: 'global' })
+    ).toBe(false)
+    expect(outsideSettingsEvent.defaultPrevented).toBe(false)
+
+    keymap.applyScope(SETTINGS_COMMAND_SCOPE)
+    const settingsEvent = createModUEvent()
+    expect(keymap.handleKeyDown(settingsEvent, { source: 'global' })).toBe(true)
+    expect(settingsEvent.defaultPrevented).toBe(true)
+
+    registry[Symbol.dispose]()
+  })
+
   it('selects non-built-in command IDs through the command system', () => {
     const onSubmit = vi.fn()
     const send = vi.fn()
@@ -246,38 +281,21 @@ describe('keymap extension', () => {
           arguments: { value: 'abc' },
         },
       ],
-      [
-        defineRegistryItem({
-          id: 'test-command-system',
-          providesServices: [
-            provideService(commandSystemService, {
-              actor: {
-                getSnapshot: () => ({
-                  context: {
-                    commands: [
-                      {
-                        id: 'test.command',
-                        groupId: 'test',
-                        name: 'Run test command',
-                        needsReview: false,
-                        args: {
-                          value: {
-                            inputType: 'string',
-                            required: true,
-                          },
-                        },
-                        onSubmit,
-                      },
-                    ],
-                  },
-                }),
+      {
+        commands: [
+          createTestCommand('test.command', GLOBAL_COMMAND_SCOPES, {
+            name: 'Run test command',
+            args: {
+              value: {
+                inputType: 'string',
+                required: true,
               },
-              send,
-              useState: vi.fn(),
-            } as unknown as CommandSystemService),
-          ],
-        }),
-      ]
+            },
+            onSubmit,
+          }),
+        ],
+        send,
+      }
     )
 
     const keymap = registry.get(keymapService)
@@ -301,6 +319,73 @@ describe('keymap extension', () => {
     registry[Symbol.dispose]()
   })
 
+  it('does not let a user binding broaden a command context', () => {
+    const send = vi.fn()
+    const registry = createRegistryWithKeymapItems(
+      [
+        {
+          id: 'test.file-command-keymap',
+          title: 'Test file command keymap',
+          command: 'test.file-command',
+          source: 'User',
+          keystrokes: ['mod+u'],
+        },
+      ],
+      {
+        commands: [createTestCommand('test.file-command', FILE_COMMAND_SCOPES)],
+        send,
+      }
+    )
+    const keymap = registry.get(keymapService)
+
+    keymap.applyScope(HOME_COMMAND_SCOPE)
+    const homeEvent = createModUEvent()
+    expect(keymap.handleKeyDown(homeEvent, { source: 'global' })).toBe(false)
+    expect(homeEvent.defaultPrevented).toBe(false)
+    expect(send).not.toHaveBeenCalled()
+
+    keymap.applyScope(MODE_MODELING_COMMAND_SCOPE)
+    const modelingEvent = createModUEvent()
+    expect(keymap.handleKeyDown(modelingEvent, { source: 'global' })).toBe(true)
+    expect(modelingEvent.defaultPrevented).toBe(true)
+    expect(send).toHaveBeenCalledOnce()
+
+    keymap.applyScope(SETTINGS_COMMAND_SCOPE)
+    const settingsEvent = createModUEvent()
+    expect(keymap.handleKeyDown(settingsEvent, { source: 'global' })).toBe(
+      false
+    )
+    expect(settingsEvent.defaultPrevented).toBe(false)
+    expect(send).toHaveBeenCalledOnce()
+
+    registry[Symbol.dispose]()
+  })
+
+  it.each(['test.command-that-no-longer-exists', 'toString'])(
+    'does not consume a shortcut for unknown command %s',
+    (command) => {
+      const registry = createRegistryWithKeymapItems(
+        [
+          {
+            id: 'test.stale-command-keymap',
+            title: 'Stale command keymap',
+            command,
+            source: 'User',
+            keystrokes: ['mod+u'],
+          },
+        ],
+        { commands: [] }
+      )
+      const keymap = registry.get(keymapService)
+      const event = createModUEvent()
+
+      expect(keymap.handleKeyDown(event, { source: 'global' })).toBe(false)
+      expect(event.defaultPrevented).toBe(false)
+
+      registry[Symbol.dispose]()
+    }
+  )
+
   it('waits for the initial persisted keymap load before saving overrides', async () => {
     let resolveInitialRead: ((keymap: PersistedKeymap) => void) | undefined
     persistenceMocks.readUserKeymapFile.mockReturnValueOnce(
@@ -308,7 +393,16 @@ describe('keymap extension', () => {
         resolveInitialRead = resolve
       })
     )
-    const registry = createRegistryWithKeymapItems([])
+    const registry = createRegistryWithKeymapItems([], {
+      commands: [
+        createTestCommand('zds.toolbar.sketchLegacy.line', [
+          MODE_SKETCHING_KEYMAP_SCOPE,
+        ]),
+        createTestCommand('zds.toolbar.sketch.line', [
+          MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
+        ]),
+      ],
+    })
 
     const keymap = registry.get(keymapService)
     keymap.applyScope(MODE_SKETCHING_KEYMAP_SCOPE)
@@ -350,7 +444,7 @@ describe('keymap extension', () => {
       {
         id: 'test.code-mirror',
         title: 'Test CodeMirror',
-        command: 'zds.settings.tab',
+        command: 'test.code-mirror',
         source: 'test',
         keystrokes: ['escape'],
       },
@@ -377,7 +471,7 @@ describe('keymap extension', () => {
       {
         id: 'test.sketch-solve-line',
         title: 'Test sketch solve line',
-        command: 'zds.settings.tab',
+        command: 'test.sketch-solve-line',
         source: 'test',
         keystrokes: ['l'],
         scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
@@ -390,6 +484,12 @@ describe('keymap extension', () => {
     keymap.applyScope(MODE_SKETCH_SOLVE_KEYMAP_SCOPE)
     keymap.removeScope(CODE_EDITOR_FOCUSED_KEYMAP_SCOPE)
     keymap.applyScope(CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE)
+    input.dispatchEvent(new FocusEvent('focusin', { bubbles: true }))
+
+    expect(keymap.getCurrentScopes()).not.toContain(
+      CODE_EDITOR_FOCUSED_KEYMAP_SCOPE
+    )
+    expect(keymap.getCurrentScopes()).toContain(EDITABLE_FOCUSED_KEYMAP_SCOPE)
 
     expect(
       keymap.handleKeyDown(createKeyboardEventWithTarget('l', input), {
@@ -401,12 +501,55 @@ describe('keymap extension', () => {
     registry[Symbol.dispose]()
   })
 
+  it('does not run modified mode shortcuts from input targets', () => {
+    const send = vi.fn()
+    const registry = createRegistryWithKeymapItems(
+      [
+        {
+          id: 'test.sketch-select-all-keymap',
+          title: 'Test sketch select all',
+          command: 'test.sketch-select-all',
+          source: 'test',
+          keystrokes: ['mod+a'],
+          scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
+        },
+      ],
+      {
+        commands: [
+          createTestCommand('test.sketch-select-all', [
+            MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
+          ]),
+        ],
+        send,
+      }
+    )
+    const keymap = registry.get(keymapService)
+    const input = document.createElement('input')
+    document.body.append(input)
+
+    keymap.applyScope(MODE_SKETCH_SOLVE_KEYMAP_SCOPE)
+    input.dispatchEvent(new FocusEvent('focusin', { bubbles: true }))
+
+    const event = createKeyboardEventWithTarget('a', input, {
+      ctrlKey: true,
+      metaKey: true,
+      cancelable: true,
+    })
+    expect(keymap.getCurrentScopes()).toContain(EDITABLE_FOCUSED_KEYMAP_SCOPE)
+    expect(keymap.handleKeyDown(event, { source: 'global' })).toBe(false)
+    expect(event.defaultPrevented).toBe(false)
+    expect(send).not.toHaveBeenCalled()
+
+    input.remove()
+    registry[Symbol.dispose]()
+  })
+
   it('does not run mode keybindings from CodeMirror while the editor is focused', () => {
     const registry = createRegistryWithKeymapItems([
       {
         id: 'test.sketch-solve-line',
         title: 'Test sketch solve line',
-        command: 'zds.settings.tab',
+        command: 'test.sketch-solve-line',
         source: 'test',
         keystrokes: ['l'],
         scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
@@ -425,7 +568,11 @@ describe('keymap extension', () => {
   })
 
   it('handles default undo and redo keybindings from CodeMirror while the editor is focused', () => {
-    const registry = createRegistryWithKeymapItems([])
+    const registry = createRegistryWithKeymapItems([], {
+      commands: ['zds.editor.undo', 'zds.editor.redo'].map((id) =>
+        createTestCommand(id, [CODE_EDITOR_FOCUSED_KEYMAP_SCOPE])
+      ),
+    })
     const keymap = registry.get(keymapService)
 
     keymap.removeScope(CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE)
@@ -456,12 +603,12 @@ describe('keymap extension', () => {
     registry[Symbol.dispose]()
   })
 
-  it('keeps editor focus priority until focus moves outside editable content', () => {
+  it('does not treat arbitrary editable content as the code editor', () => {
     const registry = createRegistryWithKeymapItems([
       {
         id: 'test.sketch-solve-line',
         title: 'Test sketch solve line',
-        command: 'zds.settings.tab',
+        command: 'test.sketch-solve-line',
         source: 'test',
         keystrokes: ['l'],
         scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
@@ -475,9 +622,10 @@ describe('keymap extension', () => {
     keymap.applyScope(MODE_SKETCH_SOLVE_KEYMAP_SCOPE)
     editableTarget.dispatchEvent(new FocusEvent('focusin', { bubbles: true }))
 
-    expect(keymap.getCurrentScopes()).toContain(
+    expect(keymap.getCurrentScopes()).not.toContain(
       CODE_EDITOR_FOCUSED_KEYMAP_SCOPE
     )
+    expect(keymap.getCurrentScopes()).toContain(EDITABLE_FOCUSED_KEYMAP_SCOPE)
     expect(
       keymap.handleKeyDown(createKeyboardEventWithTarget('l', editableTarget), {
         source: 'global',
@@ -486,11 +634,14 @@ describe('keymap extension', () => {
 
     document.body.dispatchEvent(new Event('pointerdown', { bubbles: true }))
 
+    expect(keymap.getCurrentScopes()).not.toContain(
+      EDITABLE_FOCUSED_KEYMAP_SCOPE
+    )
     expect(keymap.getCurrentScopes()).toContain(
       CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE
     )
     expect(
-      keymap.handleKeyDown(createKeyboardEventWithTarget('l', editableTarget), {
+      keymap.handleKeyDown(createKeyboardEventWithTarget('l', document.body), {
         source: 'global',
       })
     ).toBe(true)
@@ -504,7 +655,7 @@ describe('keymap extension', () => {
       {
         id: 'test.sketch-solve-line',
         title: 'Test sketch solve line',
-        command: 'zds.settings.tab',
+        command: 'test.sketch-solve-line',
         source: 'test',
         keystrokes: ['l'],
         scopes: [MODE_SKETCH_SOLVE_KEYMAP_SCOPE],
@@ -578,13 +729,24 @@ describe('keymap extension', () => {
 
 function createRegistryWithKeymapItems(
   items: Parameters<typeof provideKeymapItem>[0][],
-  extraItems: Parameters<Registry['configure']>[0] = []
+  options: {
+    commands?: Command[]
+    send?: CommandSystemService['send']
+    extraItems?: Parameters<Registry['configure']>[0]
+  } = {}
 ) {
+  const inferredCommands = [...new Set(items.map((item) => item.command))].map(
+    (id) => createTestCommand(id, GLOBAL_COMMAND_SCOPES)
+  )
+  const commands = options.commands ?? inferredCommands
   const keymapSlot = new Slot()
   const registry = new Registry()
   registry.configure([
     keymapExtension,
-    ...extraItems,
+    ...(commands.length > 0
+      ? [createTestCommandSystemItem(commands, options.send ?? vi.fn())]
+      : []),
+    ...(options.extraItems ?? []),
     keymapSlot.of(
       defineRegistryItem({
         id: 'test-keymap-items',
@@ -595,8 +757,55 @@ function createRegistryWithKeymapItems(
   return registry
 }
 
-function createKeyboardEventWithTarget(key: string, target: EventTarget) {
-  const event = new KeyboardEvent('keydown', { key })
+function createTestCommandSystemItem(
+  commands: Command[],
+  send: CommandSystemService['send']
+) {
+  return defineRegistryItem({
+    id: 'test-command-system',
+    providesServices: [
+      provideService(commandSystemService, {
+        actor: {
+          getSnapshot: () => ({ context: { commands } }),
+        },
+        send,
+        useState: vi.fn(),
+      } as unknown as CommandSystemService),
+    ],
+  })
+}
+
+function createTestCommand(
+  id: string,
+  scopes: Command['scopes'],
+  overrides: Partial<Omit<Command, 'id' | 'scopes'>> = {}
+): Command {
+  return {
+    id,
+    scopes,
+    groupId: 'test',
+    name: id,
+    needsReview: false,
+    onSubmit: vi.fn(),
+    ...overrides,
+  }
+}
+
+function createKeyboardEventWithTarget(
+  key: string,
+  target: EventTarget,
+  init: KeyboardEventInit = {}
+) {
+  const event = new KeyboardEvent('keydown', { ...init, key })
   Object.defineProperty(event, 'target', { value: target })
   return event
+}
+
+function createModUEvent() {
+  return new KeyboardEvent('keydown', {
+    key: 'u',
+    ctrlKey: true,
+    metaKey: true,
+    cancelable: true,
+  })
 }

--- a/src/registry/extensions/keymap/index.ts
+++ b/src/registry/extensions/keymap/index.ts
@@ -130,6 +130,38 @@ const keymapExtension = defineRegistryItemFactory((ctx) => {
     }),
   }
 
+  const focusScopes = new Set([
+    CODE_EDITOR_FOCUSED_KEYMAP_SCOPE,
+    CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE,
+    EDITABLE_FOCUSED_COMMAND_SCOPE,
+  ])
+
+  const syncFocusScopeFromEventTarget = (target: EventTarget | null) => {
+    let nextFocusScope = CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE
+    if (isEventFromFormControl(target)) {
+      nextFocusScope = EDITABLE_FOCUSED_COMMAND_SCOPE
+    } else if (isEventFromCodeEditor(target)) {
+      nextFocusScope = CODE_EDITOR_FOCUSED_KEYMAP_SCOPE
+    } else if (isEventFromContentEditableTarget(target)) {
+      nextFocusScope = EDITABLE_FOCUSED_COMMAND_SCOPE
+    }
+
+    const currentFocusScopes = activeScopes.value.filter((scope) =>
+      focusScopes.has(scope)
+    )
+    if (
+      currentFocusScopes.length === 1 &&
+      currentFocusScopes[0] === nextFocusScope
+    ) {
+      return
+    }
+
+    activeScopes.value = [
+      ...activeScopes.value.filter((scope) => !focusScopes.has(scope)),
+      nextFocusScope,
+    ]
+  }
+
   const pendingKeystrokesBySource: Record<KeymapSource, string[]> = {
     global: [],
     codeMirror: [],
@@ -205,6 +237,12 @@ const keymapExtension = defineRegistryItemFactory((ctx) => {
   const handleKeyDown: KeymapService['handleKeyDown'] = (event, { source }) => {
     if (suspendListeningCount > 0) {
       return false
+    }
+
+    if (source === 'global') {
+      // A focused editable can be removed without another focusin event. Use
+      // the event target to reconcile focus before checking availability.
+      syncFocusScopeFromEventTarget(event.target)
     }
 
     const chord = keyboardEventToKeymapChord(event)
@@ -425,30 +463,14 @@ const keymapExtension = defineRegistryItemFactory((ctx) => {
     handleKeyDown(event, { source: 'global' })
   }
 
-  const syncFocusScopeFromEventTarget = (target: EventTarget | null) => {
-    if (isEventFromCodeEditor(target)) {
-      scopeServiceImpl.removeScope(CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE)
-      scopeServiceImpl.removeScope(EDITABLE_FOCUSED_COMMAND_SCOPE)
-      scopeServiceImpl.applyScope(CODE_EDITOR_FOCUSED_KEYMAP_SCOPE)
-      return
-    }
-
-    scopeServiceImpl.removeScope(CODE_EDITOR_FOCUSED_KEYMAP_SCOPE)
-    if (isEventFromEditableTarget(target)) {
-      scopeServiceImpl.removeScope(CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE)
-      scopeServiceImpl.applyScope(EDITABLE_FOCUSED_COMMAND_SCOPE)
-      return
-    }
-
-    scopeServiceImpl.removeScope(EDITABLE_FOCUSED_COMMAND_SCOPE)
-    scopeServiceImpl.applyScope(CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE)
-  }
-
   const handleGlobalFocusIn = (event: FocusEvent) => {
     syncFocusScopeFromEventTarget(event.target)
   }
 
   const handleGlobalPointerDown = (event: PointerEvent) => {
+    if (shouldPreserveFocusScope(event.target)) {
+      return
+    }
     syncFocusScopeFromEventTarget(event.target)
   }
 
@@ -573,12 +595,6 @@ function isEventFromCodeEditor(target: EventTarget | null) {
   return target instanceof Element && target.closest('.cm-editor') !== null
 }
 
-function isEventFromEditableTarget(target: EventTarget | null) {
-  return (
-    isEventFromContentEditableTarget(target) || isEventFromFormControl(target)
-  )
-}
-
 function isEventFromContentEditableTarget(target: EventTarget | null) {
   if (!(target instanceof HTMLElement)) {
     return false
@@ -592,6 +608,13 @@ function isEventFromFormControl(target: EventTarget | null) {
     target instanceof HTMLInputElement ||
     target instanceof HTMLTextAreaElement ||
     target instanceof HTMLSelectElement
+  )
+}
+
+function shouldPreserveFocusScope(target: EventTarget | null) {
+  return (
+    target instanceof Element &&
+    target.closest('[data-command-scope-preserve-focus="true"]') !== null
   )
 }
 

--- a/src/registry/extensions/keymap/index.ts
+++ b/src/registry/extensions/keymap/index.ts
@@ -8,16 +8,23 @@ import {
 import { computed, signal } from '@preact/signals-core'
 import { useSignals } from '@preact/signals-react/runtime'
 import type { StatusBarItemType } from '@src/components/StatusBar/statusBarTypes'
+import type { Command, CommandScopes } from '@src/lib/commandTypes'
 import makeUrlPathRelative from '@src/lib/makeUrlPathRelative'
 import { PATHS, webSafeJoin } from '@src/lib/paths'
 import { reportRejection } from '@src/lib/trap'
 import { isArray } from '@src/lib/utils'
 import {
+  COMMAND_PALETTE_OPEN_COMMAND_SCOPE,
+  DEFAULT_COMMAND_SCOPES,
+  EDITABLE_FOCUSED_COMMAND_SCOPE,
+  GLOBAL_COMMAND_SCOPES,
+  SETTINGS_COMMAND_SCOPE,
   commandKey,
   commandScopeService,
   commandScopesValueSpec,
   commandSystemService,
-  DEFAULT_COMMAND_SCOPES,
+  getEffectiveCommandScopeSet,
+  isCommandAvailable,
   type CommandScopeService,
 } from '@src/registry/contracts/commands'
 import {
@@ -47,6 +54,11 @@ import { createElement } from 'react'
 const PARTIAL_MATCH_TIMEOUT_MS = 1500
 type SettingsKeymapTab = 'project' | 'user' | 'keybindings' | 'plugins'
 
+type BuiltInKeymapCommand = {
+  scopes: CommandScopes
+  run: (item: KeymapItem) => unknown
+}
+
 const keymapExtension = defineRegistryItemFactory((ctx) => {
   const contributedKeymapSignal = ctx.valueSpecs.signal(keymapValueSpec)
   const commandScopesSignal = ctx.valueSpecs.signal(commandScopesValueSpec)
@@ -64,6 +76,39 @@ const keymapExtension = defineRegistryItemFactory((ctx) => {
   ])
   const partialMatch = signal(false)
   const partialMatchProgress = signal(0)
+  const builtInKeymapCommands = new Map<string, BuiltInKeymapCommand>([
+    [
+      'zds.commandPalette.open',
+      {
+        scopes: GLOBAL_COMMAND_SCOPES,
+        run: () =>
+          ctx.services.optional(commandSystemService)?.send({ type: 'Open' }),
+      },
+    ],
+    [
+      'zds.commandPalette.close',
+      {
+        scopes: [COMMAND_PALETTE_OPEN_COMMAND_SCOPE],
+        run: () =>
+          ctx.services.optional(commandSystemService)?.send({ type: 'Close' }),
+      },
+    ],
+    [
+      'zds.settings.open',
+      {
+        scopes: GLOBAL_COMMAND_SCOPES,
+        run: openSettings,
+      },
+    ],
+    [
+      'zds.settings.tab',
+      {
+        scopes: [SETTINGS_COMMAND_SCOPE],
+        run: (item) =>
+          updateSettingsTab(getSettingsTabArgument(item.arguments)),
+      },
+    ],
+  ])
 
   const scopeServiceImpl: CommandScopeService = {
     activeScopes,
@@ -167,20 +212,41 @@ const keymapExtension = defineRegistryItemFactory((ctx) => {
     if (
       !chord ||
       (source === 'global' &&
-        shouldIgnoreKeyboardEvent(
-          event,
-          pendingKeystrokes.length > 0,
-          activeScopes.value
-        ))
+        shouldIgnoreKeyboardEvent(event, pendingKeystrokes.length > 0))
     ) {
       return false
+    }
+
+    const commandSystem = ctx.services.optional(commandSystemService)
+    const registeredCommands =
+      commandSystem?.actor.getSnapshot().context.commands ?? []
+    const commandsByKey = new Map<string, Command>()
+    for (const command of registeredCommands) {
+      const key = commandKey(command)
+      if (!commandsByKey.has(key)) {
+        commandsByKey.set(key, command)
+      }
+    }
+    const effectiveCommandScopes = getEffectiveCommandScopeSet(
+      activeScopes.value,
+      commandScopesSignal.value
+    )
+    const isItemAvailable = (item: KeymapItem) => {
+      const command =
+        builtInKeymapCommands.get(item.command) ??
+        commandsByKey.get(item.command)
+      return (
+        command !== undefined &&
+        isCommandAvailable(command, effectiveCommandScopes)
+      )
     }
 
     const match = matchKeymapKeystrokes(
       keymapSignal.value,
       activeScopes.value,
       [...pendingKeystrokes, chord],
-      commandScopesSignal.value
+      commandScopesSignal.value,
+      isItemAvailable
     )
 
     if (match.type === 'prefix') {
@@ -198,7 +264,7 @@ const keymapExtension = defineRegistryItemFactory((ctx) => {
       event.stopPropagation()
       event.stopImmediatePropagation()
       clearPendingKeystrokes()
-      runKeymapItem(match.item)
+      runKeymapItem(match.item, commandsByKey, isItemAvailable(match.item))
       return true
     }
 
@@ -212,7 +278,8 @@ const keymapExtension = defineRegistryItemFactory((ctx) => {
       keymapSignal.value,
       activeScopes.value,
       [chord],
-      commandScopesSignal.value
+      commandScopesSignal.value,
+      isItemAvailable
     )
 
     if (retryMatch.type === 'prefix') {
@@ -229,7 +296,11 @@ const keymapExtension = defineRegistryItemFactory((ctx) => {
       event.preventDefault()
       event.stopPropagation()
       event.stopImmediatePropagation()
-      runKeymapItem(retryMatch.item)
+      runKeymapItem(
+        retryMatch.item,
+        commandsByKey,
+        isItemAvailable(retryMatch.item)
+      )
       return true
     }
 
@@ -284,37 +355,30 @@ const keymapExtension = defineRegistryItemFactory((ctx) => {
     focusScope: scopeServiceImpl.focusScope,
   }
 
-  function runKeymapItem(item: KeymapItem) {
-    const result = runBuiltInKeymapCommand(item)
+  function runKeymapItem(
+    item: KeymapItem,
+    commandsByKey: ReadonlyMap<string, Command>,
+    isAvailable: boolean
+  ) {
+    if (!isAvailable) {
+      return
+    }
+
+    const builtInCommand = builtInKeymapCommands.get(item.command)
+    const result = builtInCommand
+      ? builtInCommand.run(item)
+      : runCommandById(item, commandsByKey)
     if (result instanceof Promise) {
       result.catch(reportRejection)
     }
   }
 
-  function runBuiltInKeymapCommand(item: KeymapItem): unknown {
-    switch (item.command) {
-      case 'zds.commandPalette.open':
-        return ctx.services
-          .optional(commandSystemService)
-          ?.send({ type: 'Open' })
-      case 'zds.commandPalette.close':
-        return ctx.services
-          .optional(commandSystemService)
-          ?.send({ type: 'Close' })
-      case 'zds.settings.open':
-        return openSettings()
-      case 'zds.settings.tab':
-        return updateSettingsTab(getSettingsTabArgument(item.arguments))
-      default:
-        return runCommandById(item)
-    }
-  }
-
-  function runCommandById(item: KeymapItem) {
+  function runCommandById(
+    item: KeymapItem,
+    commandsByKey: ReadonlyMap<string, Command>
+  ) {
     const commandSystem = ctx.services.optional(commandSystemService)
-    const command = commandSystem?.actor
-      .getSnapshot()
-      .context.commands.find((cmd) => commandKey(cmd) === item.command)
+    const command = commandsByKey.get(item.command)
     if (!command || !commandSystem) {
       return
     }
@@ -361,23 +425,31 @@ const keymapExtension = defineRegistryItemFactory((ctx) => {
     handleKeyDown(event, { source: 'global' })
   }
 
-  const syncEditorFocusScopeFromEventTarget = (target: EventTarget | null) => {
-    if (isEventFromEditableTarget(target)) {
+  const syncFocusScopeFromEventTarget = (target: EventTarget | null) => {
+    if (isEventFromCodeEditor(target)) {
       scopeServiceImpl.removeScope(CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE)
+      scopeServiceImpl.removeScope(EDITABLE_FOCUSED_COMMAND_SCOPE)
       scopeServiceImpl.applyScope(CODE_EDITOR_FOCUSED_KEYMAP_SCOPE)
       return
     }
 
     scopeServiceImpl.removeScope(CODE_EDITOR_FOCUSED_KEYMAP_SCOPE)
+    if (isEventFromEditableTarget(target)) {
+      scopeServiceImpl.removeScope(CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE)
+      scopeServiceImpl.applyScope(EDITABLE_FOCUSED_COMMAND_SCOPE)
+      return
+    }
+
+    scopeServiceImpl.removeScope(EDITABLE_FOCUSED_COMMAND_SCOPE)
     scopeServiceImpl.applyScope(CODE_EDITOR_NOT_FOCUSED_KEYMAP_SCOPE)
   }
 
   const handleGlobalFocusIn = (event: FocusEvent) => {
-    syncEditorFocusScopeFromEventTarget(event.target)
+    syncFocusScopeFromEventTarget(event.target)
   }
 
   const handleGlobalPointerDown = (event: PointerEvent) => {
-    syncEditorFocusScopeFromEventTarget(event.target)
+    syncFocusScopeFromEventTarget(event.target)
   }
 
   if (typeof window !== 'undefined') {
@@ -485,8 +557,7 @@ function isMacPlatform() {
 
 function shouldIgnoreKeyboardEvent(
   event: KeyboardEvent,
-  hasPendingKeystrokes: boolean,
-  scopes: readonly string[]
+  hasPendingKeystrokes: boolean
 ) {
   if (event.metaKey || event.ctrlKey || event.altKey || hasPendingKeystrokes) {
     return false
@@ -494,9 +565,12 @@ function shouldIgnoreKeyboardEvent(
 
   return (
     isEventFromFormControl(event.target) ||
-    (scopes.includes(CODE_EDITOR_FOCUSED_KEYMAP_SCOPE) &&
-      isEventFromContentEditableTarget(event.target))
+    isEventFromContentEditableTarget(event.target)
   )
+}
+
+function isEventFromCodeEditor(target: EventTarget | null) {
+  return target instanceof Element && target.closest('.cm-editor') !== null
 }
 
 function isEventFromEditableTarget(target: EventTarget | null) {

--- a/src/registry/extensions/markdownEditor/index.ts
+++ b/src/registry/extensions/markdownEditor/index.ts
@@ -8,11 +8,13 @@ import type {
   MarkdownEditorActions,
 } from '@kittycad/ui-components'
 import type { Command } from '@src/lib/commandTypes'
-import { provideCommand } from '@src/registry/contracts/commands'
+import {
+  provideCommand,
+  provideCommandScope,
+} from '@src/registry/contracts/commands'
 import {
   type KeymapItem,
   provideKeymapItem,
-  provideKeymapScope,
 } from '@src/registry/contracts/keymap'
 import {
   MARKDOWN_EDITOR_FOCUSED_KEYMAP_SCOPE,
@@ -173,6 +175,7 @@ const markdownEditorCommands: readonly Command[] = Object.values(
 
   return {
     id: commandId,
+    scopes: [MARKDOWN_EDITOR_FOCUSED_KEYMAP_SCOPE],
     name: commandId,
     groupId: MARKDOWN_EDITOR_COMMAND_GROUP_ID,
     displayName: keymap?.title ?? commandId,
@@ -230,7 +233,7 @@ const markdownEditorExtension = defineRegistryItemFactory(() => {
       provides: [
         ...commands.map(provideCommand),
         ...markdownEditorKeymapItems.map(provideKeymapItem),
-        provideKeymapScope({
+        provideCommandScope({
           id: MARKDOWN_EDITOR_FOCUSED_KEYMAP_SCOPE,
           displayName: 'Markdown editor focused',
           priority: 1200,

--- a/src/registry/plugins/slicer/index.ts
+++ b/src/registry/plugins/slicer/index.ts
@@ -20,6 +20,7 @@ import {
   layoutActionLibraryValueSpec,
   layoutContributionsValueSpec,
 } from '@src/lib/layout/registry/contract'
+import { MODE_MODELING_COMMAND_SCOPE } from '@src/registry/contracts/commands'
 import { createZdsPlugin } from '@src/registry/createZdsPlugin'
 import {
   EXPORT_TO_SLICER_ACTION_TYPE,
@@ -78,6 +79,7 @@ function createExportToSlicerCommand({
   getKclManager: () => KclManager | undefined
 }): Command {
   return {
+    scopes: [MODE_MODELING_COMMAND_SCOPE],
     id: EXPORT_TO_SLICER_COMMAND_ID,
     name: EXPORT_TO_SLICER_COMMAND_NAME,
     displayName: EXPORT_TO_SLICER_COMMAND_NAME,

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -56,9 +56,9 @@ import {
   homeProjectEntriesValueSpec,
 } from '@src/registry/contracts/homeProjects'
 import { homeSidebarItemsValueSpec } from '@src/registry/contracts/homeSidebar'
+import { HOME_COMMAND_SCOPE } from '@src/registry/contracts/commands'
 import {
   findKeymapItemForCommand,
-  HOME_KEYMAP_SCOPE,
   keymapKeystrokesDisplay,
   keymapScopesValueSpec,
   keymapService,
@@ -299,10 +299,10 @@ const Home = () => {
       return
     }
 
-    keymap.applyScope(HOME_KEYMAP_SCOPE)
+    keymap.applyScope(HOME_COMMAND_SCOPE)
 
     return () => {
-      keymap.removeScope(HOME_KEYMAP_SCOPE)
+      keymap.removeScope(HOME_COMMAND_SCOPE)
     }
   }, [keymap])
 
@@ -371,7 +371,7 @@ const Home = () => {
       ? findKeymapItemForCommand(
           keymap.keymap.value,
           APP_COMMAND_IDS.search.focusProjects,
-          [HOME_KEYMAP_SCOPE],
+          [HOME_COMMAND_SCOPE],
           registry.signal(keymapScopesValueSpec).value
         )?.keystrokes
       : undefined,
@@ -430,7 +430,8 @@ const Home = () => {
     const { RouteTelemetryCommand, RouteSettingsCommand } = createRouteCommands(
       navigate,
       location,
-      ''
+      '',
+      [HOME_COMMAND_SCOPE]
     )
 
     commands.send({

--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -159,6 +159,7 @@ export const Settings = () => {
         >
           <Dialog.Panel
             data-testid="settings-dialog-panel"
+            data-command-bar-host
             className="rounded relative mx-auto bg-chalkboard-10 dark:bg-chalkboard-100 border dark:border-chalkboard-70 w-[90vw] h-[80vh] max-h-[calc(100vh-2rem)] shadow-lg flex flex-col gap-8"
           >
             <div className="p-5 pb-0 flex justify-between items-center">


### PR DESCRIPTION
## Problem

Commands can show up or run where they do not apply. Hiding the two Home entries would fix the palette, but shortcuts could still disagree.

## Solution

Use command scopes as the source of truth for both the palette and shortcut dispatch. Commands set the availability ceiling; keybindings can narrow it in #13307, but never widen it.

The palette keeps the context it opened from, so focusing its search box does not change the results.

2 of 3, on top of #13305. Closes #12815. #12835 is separate.