### PR TITLE
KCL: reject zero-length revolve axes

### DIFF
--- a/rust/kcl-lib/src/lint/checks/chained_profiles.rs
+++ b/rust/kcl-lib/src/lint/checks/chained_profiles.rs
@@ -386,7 +386,7 @@ extrude([profile1, profile2], length = 1)
 sketch1 = startSketchOn(XY)
 profile1 = circle(sketch1, center = [0, 0], radius = 5)
   |> circle(center = [0, 0], radius = 5)
-revolve(profile1, axis = Z)
+revolve(profile1, axis = X)
 ",
         "Profiles should not be chained together in a pipeline.",
         Some(
@@ -394,7 +394,7 @@ revolve(profile1, axis = Z)
 sketch1 = startSketchOn(XY)
 profile1 = circle(sketch1, center = [0, 0], radius = 5)
 profile2 = circle(sketch1, center = [0, 0], radius = 5)
-revolve([profile1, profile2], axis = Z)
+revolve([profile1, profile2], axis = X)
 "
             .to_owned()
         )

--- a/rust/kcl-lib/src/std/revolve.rs
+++ b/rust/kcl-lib/src/std/revolve.rs
@@ -112,6 +112,16 @@ async fn inner_revolve(
     exec_state: &mut ExecState,
     args: Args,
 ) -> Result<Vec<Solid>, KclError> {
+    if let Axis2dOrEdgeReference::Axis { direction, .. } = &axis
+        && direction[0].to_mm() == 0.0
+        && direction[1].to_mm() == 0.0
+    {
+        return Err(KclError::new_semantic(KclErrorDetails::new(
+            "The axis of revolution cannot be the zero vector.".to_owned(),
+            vec![args.source_range],
+        )));
+    }
+
     if let Some(angle) = angle {
         // Return an error if the angle is zero.
         // We don't use validate() here because we want to return a specific error message that is
@@ -363,6 +373,7 @@ mod tests {
 
     use super::*;
     use crate::execution::AbstractSegment;
+    use crate::execution::MockConfig;
     use crate::execution::Plane;
     use crate::execution::Segment;
     use crate::execution::SegmentKind;
@@ -436,5 +447,48 @@ mod tests {
             "{err:?}"
         );
         ctx.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn mock_revolve_rejects_axis_that_collapses_to_zero_in_2d() {
+        let code = r#"
+profile = startSketchOn(XZ)
+  |> startProfile(at = [10, 0])
+  |> line(end = [0, 10])
+  |> line(end = [-10, 0])
+  |> close()
+
+body = revolve(profile, axis = Z, angle = 90deg)
+"#;
+        let program = crate::Program::parse_no_errs(code).unwrap();
+        let ctx = ExecutorContext::new_mock(None).await;
+        let err = ctx.run_mock(&program, &MockConfig::default()).await.unwrap_err();
+        ctx.close().await;
+
+        assert!(
+            err.error
+                .message()
+                .contains("axis of revolution cannot be the zero vector"),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn mock_revolve_accepts_nonzero_2d_axis() {
+        let code = r#"
+profile = startSketchOn(XZ)
+  |> startProfile(at = [10, 0])
+  |> line(end = [0, 10])
+  |> line(end = [-10, 0])
+  |> close()
+
+body = revolve(profile, axis = Y, angle = 90deg)
+"#;
+        let program = crate::Program::parse_no_errs(code).unwrap();
+        let ctx = ExecutorContext::new_mock(None).await;
+        let outcome = ctx.run_mock(&program, &MockConfig::default()).await;
+        ctx.close().await;
+
+        outcome.unwrap();
     }
 }


### PR DESCRIPTION
## Summary

- reject explicit `Axis2d` zero vectors before mock or real revolve execution
- catch `axis = Z`, which becomes `[0, 0]` when an `Axis3d` is coerced to `Axis2d`
- add mock regression coverage for rejected Z and accepted nonzero Y axes

Closes #13317.

## Testing

- `cargo +nightly fmt --all`
- `cargo test -p kcl-lib mock_revolve_ --lib`
