### PR TITLE
KCL: warn on geometry-dependent mock cardinality

### DIFF
--- a/rust/kcl-lib/src/execution/annotations.rs
+++ b/rust/kcl-lib/src/execution/annotations.rs
@@ -81,7 +81,8 @@ pub(crate) const WARN_UNUSED_TAGS: &str = "unusedTags";
 pub(crate) const WARN_NOT_YET_SUPPORTED: &str = "notYetSupported";
 pub(crate) const WARN_OVER_CONSTRAINED_SKETCH: &str = "overConstrainedSketch";
 pub(crate) const WARN_REGION_LIVENESS: &str = "regionLiveness";
-pub(super) const WARN_VALUES: [&str; 14] = [
+pub(crate) const WARN_MOCK_GEOMETRY_CARDINALITY: &str = "mockGeometryCardinality";
+pub(super) const WARN_VALUES: [&str; 15] = [
     WARN_UNKNOWN_UNITS,
     WARN_ANGLE_UNITS,
     WARN_UNKNOWN_ATTR,
@@ -96,6 +97,7 @@ pub(super) const WARN_VALUES: [&str; 14] = [
     WARN_CSG_NO_INTERSECTION,
     WARN_OVER_CONSTRAINED_SKETCH,
     WARN_REGION_LIVENESS,
+    WARN_MOCK_GEOMETRY_CARDINALITY,
 ];
 
 #[derive(Clone, Copy, Eq, PartialEq, Debug, Deserialize, Serialize, ts_rs::TS)]

--- a/rust/kcl-lib/src/std/csg.rs
+++ b/rust/kcl-lib/src/std/csg.rs
@@ -430,6 +430,14 @@ pub(crate) async fn inner_imprint(
 
     if args.ctx.no_engine_commands().await {
         if separate_bodies {
+            exec_state.warn(
+                CompilationIssue::err(
+                    args.source_range,
+                    "Mock execution cannot determine how many bodies `split(..., merge = false)` produces. The returned mock bodies are placeholders; use real execution before relying on their count or indexing them."
+                        .to_owned(),
+                ),
+                annotations::WARN_MOCK_GEOMETRY_CARDINALITY,
+            );
             let extra_solid_id = exec_state.next_uuid();
             let mut new_solid = body.clone();
             new_solid.set_id(extra_solid_id);
@@ -844,6 +852,13 @@ second = subtract(first, tools = [tool])
         ctx.close().await;
 
         assert!(outcome.variables.contains_key("second"));
+        assert!(
+            outcome.issues.iter().any(|issue| issue
+                .message
+                .contains("Mock execution cannot determine how many bodies `split")),
+            "expected mock cardinality warning, got: {:#?}",
+            outcome.issues
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/rust/kcl-lib/src/std/patterns.rs
+++ b/rust/kcl-lib/src/std/patterns.rs
@@ -746,6 +746,40 @@ patterned = patternTransform(cube, instances = 3, transform = shift)
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn mock_pattern_circular_2d_warns_that_cardinality_is_geometry_dependent() {
+        let code = r#"
+@settings(kclVersion = 2.0)
+
+profile = sketch(on = XY) {
+  line1 = line(start = [var 10, var 0], end = [var 11, var 0])
+}
+
+patterned = patternCircular2d(
+  profile,
+  instances = 3,
+  center = [0, 0],
+  arcDegrees = 360deg,
+  rotateDuplicates = true,
+)
+"#;
+        let program = crate::Program::parse_no_errs(code).unwrap();
+        let ctx = ExecutorContext::new_mock(None).await;
+        let outcome = ctx
+            .run_mock(&program, &crate::execution::MockConfig::default())
+            .await
+            .unwrap();
+        ctx.close().await;
+
+        assert!(
+            outcome.issues.iter().any(|issue| issue
+                .message
+                .contains("Mock execution cannot determine whether `patternCircular2d` repetitions")),
+            "expected mock cardinality warning, got: {:#?}",
+            outcome.issues
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_array_to_point3d() {
         let ctx = ExecutorContext::new_mock(None).await;
         let mut exec_state = ExecState::new(&ctx);
@@ -1214,6 +1248,14 @@ async fn inner_pattern_circular_2d(
     let starting_sketches = sketch_set;
 
     if args.ctx.context_type == crate::execution::ContextType::Mock {
+        exec_state.warn(
+            CompilationIssue::err(
+                args.source_range,
+                "Mock execution cannot determine whether `patternCircular2d` repetitions form one connected sketch or multiple sketches. The returned mock sketch is a placeholder; use real execution before relying on result cardinality or indexing it."
+                    .to_owned(),
+            ),
+            annotations::WARN_MOCK_GEOMETRY_CARDINALITY,
+        );
         return Ok(starting_sketches);
     }
     let center = center.unwrap_or(POINT_ZERO_ZERO);


### PR DESCRIPTION
Warn when mock execution returns placeholder cardinality for `patternCircular2d` and `split(..., merge = false)`. The stable `mockGeometryCardinality` annotation tells downstream callers to use real execution before trusting count or indexing.

This is the KCL-side first step for #13318; downstream handling remains separate.

Focused validation on current `main`:
- `cargo +nightly fmt --all -- --check`
- `cargo test -p kcl-lib mock_pattern_circular_2d_warns_that_cardinality_is_geometry_dependent --lib`
- `cargo test -p kcl-lib split_keep_tools_does_not_consume_tools --lib`