### PR TITLE
Show actionable warning for unavailable Zookeeper attachments

### DIFF
--- a/src/lib/zookeeper/zookeeperManagerMachine.test.ts
+++ b/src/lib/zookeeper/zookeeperManagerMachine.test.ts
@@ -133,14 +133,15 @@ describe('toMlCopilotFile', () => {
         ),
     } as unknown as File
 
-    const result = toMlCopilotFile(file)
+    const result = await toMlCopilotFile(file)
 
-    await expect(result).rejects.toMatchObject({
+    expect(result).toMatchObject({
       name: 'ZookeeperAttachmentReadError',
       message:
         "We couldn't read the attachment. It may have been moved, deleted, or become unavailable. Reattach it and try again.",
     })
-    await expect(result).rejects.not.toThrow(file.name)
+    expect(result).toBeInstanceOf(Error)
+    expect((result as Error).message).not.toContain(file.name)
   })
 
   it('preserves unexpected attachment read errors', async () => {
@@ -151,7 +152,7 @@ describe('toMlCopilotFile', () => {
       arrayBuffer: vi.fn().mockRejectedValue(readError),
     } as unknown as File
 
-    await expect(toMlCopilotFile(file)).rejects.toBe(readError)
+    await expect(toMlCopilotFile(file)).resolves.toBe(readError)
   })
 })
 

--- a/src/lib/zookeeper/zookeeperManagerMachine.test.ts
+++ b/src/lib/zookeeper/zookeeperManagerMachine.test.ts
@@ -8,6 +8,7 @@ import {
   type MlCopilotModeOption,
   NUMBER_OF_ZOOKEEPER_SETUP_ATTEMPTS,
   parseMlCopilotModesResult,
+  toMlCopilotFile,
   ZOOKEEPER_HEARTBEAT_INTERVAL_MS,
   ZOOKEEPER_HEARTBEAT_TIMEOUT_MS,
   ZOOKEEPER_SETUP_ATTEMPT_TIMEOUT_MS,
@@ -116,6 +117,43 @@ type SetupActorInput = {
 }
 
 const completedConversationStartedAt = new Date('2026-07-15T12:00:00.000Z')
+
+describe('toMlCopilotFile', () => {
+  it('turns missing attachment reads into an actionable privacy-safe error', async () => {
+    const file = {
+      name: 'private-customer-file.step',
+      type: 'application/step',
+      arrayBuffer: vi
+        .fn()
+        .mockRejectedValue(
+          new DOMException(
+            'A requested file could not be found',
+            'NotFoundError'
+          )
+        ),
+    } as unknown as File
+
+    const result = toMlCopilotFile(file)
+
+    await expect(result).rejects.toMatchObject({
+      name: 'ZookeeperAttachmentReadError',
+      message:
+        "We couldn't read the attachment. It may have been moved, deleted, or become unavailable. Reattach it and try again.",
+    })
+    await expect(result).rejects.not.toThrow(file.name)
+  })
+
+  it('preserves unexpected attachment read errors', async () => {
+    const readError = new Error('Unexpected read failure')
+    const file = {
+      name: 'attachment.step',
+      type: 'application/step',
+      arrayBuffer: vi.fn().mockRejectedValue(readError),
+    } as unknown as File
+
+    await expect(toMlCopilotFile(file)).rejects.toBe(readError)
+  })
+})
 
 describe('createZookeeperCorrelation', () => {
   it('creates a unique correlation ID and includes the Engine API call ID', () => {

--- a/src/lib/zookeeper/zookeeperManagerMachine.ts
+++ b/src/lib/zookeeper/zookeeperManagerMachine.ts
@@ -611,11 +611,36 @@ function isAttachmentsLoadedMessage(
   )
 }
 
-async function toMlCopilotFile(file: File): Promise<MlCopilotFile> {
+const ZOOKEEPER_ATTACHMENT_READ_ERROR_MESSAGE =
+  "We couldn't read the attachment. It may have been moved, deleted, or become unavailable. Reattach it and try again."
+
+class ZookeeperAttachmentReadError extends Error {
+  constructor(cause: unknown) {
+    super(ZOOKEEPER_ATTACHMENT_READ_ERROR_MESSAGE, { cause })
+    this.name = 'ZookeeperAttachmentReadError'
+  }
+}
+
+export async function toMlCopilotFile(file: File): Promise<MlCopilotFile> {
+  let data: ArrayBuffer
+  try {
+    data = await file.arrayBuffer()
+  } catch (error) {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'name' in error &&
+      error.name === 'NotFoundError'
+    ) {
+      throw new ZookeeperAttachmentReadError(error)
+    }
+    throw error
+  }
+
   return {
     name: file.name,
     mimetype: file.type || 'application/octet-stream',
-    data: Array.from(new Uint8Array(await file.arrayBuffer())),
+    data: Array.from(new Uint8Array(data)),
   }
 }
 

--- a/src/lib/zookeeper/zookeeperManagerMachine.ts
+++ b/src/lib/zookeeper/zookeeperManagerMachine.ts
@@ -628,15 +628,10 @@ export async function toMlCopilotFile(
   try {
     data = await file.arrayBuffer()
   } catch (error) {
-    if (
-      typeof error === 'object' &&
-      error !== null &&
-      'name' in error &&
-      error.name === 'NotFoundError'
-    ) {
+    if (isErr(error) && error.name === 'NotFoundError') {
       return new ZookeeperAttachmentReadError(error)
     }
-    return error instanceof Error
+    return isErr(error)
       ? error
       : new Error('Unknown attachment read error', { cause: error })
   }

--- a/src/lib/zookeeper/zookeeperManagerMachine.ts
+++ b/src/lib/zookeeper/zookeeperManagerMachine.ts
@@ -12,7 +12,7 @@ import {
 import { ClientErrorCode, reportClientError } from '@src/lib/clientErrors'
 import { getKclVersion } from '@src/lib/kclVersion'
 import { Socket, SocketConnectionError } from '@src/lib/socket'
-import { isErr } from '@src/lib/trap'
+import { cleanErrs, isErr } from '@src/lib/trap'
 import { isArray, isRecord, uuidv4 } from '@src/lib/utils'
 import { withZookeeperWebSocketURL } from '@src/lib/withBaseURL'
 import { S, transitions, xstateEventError } from '@src/machines/utils'
@@ -621,7 +621,9 @@ class ZookeeperAttachmentReadError extends Error {
   }
 }
 
-export async function toMlCopilotFile(file: File): Promise<MlCopilotFile> {
+export async function toMlCopilotFile(
+  file: File
+): Promise<MlCopilotFile | Error> {
   let data: ArrayBuffer
   try {
     data = await file.arrayBuffer()
@@ -632,9 +634,11 @@ export async function toMlCopilotFile(file: File): Promise<MlCopilotFile> {
       'name' in error &&
       error.name === 'NotFoundError'
     ) {
-      throw new ZookeeperAttachmentReadError(error)
+      return new ZookeeperAttachmentReadError(error)
     }
-    throw error
+    return error instanceof Error
+      ? error
+      : new Error('Unknown attachment read error', { cause: error })
   }
 
   return {
@@ -1478,10 +1482,15 @@ export const zookeeperManagerMachine = setup({
         )
       }
 
-      const additionalFiles =
-        event.additionalFiles && event.additionalFiles.length > 0
-          ? await Promise.all(event.additionalFiles.map(toMlCopilotFile))
-          : undefined
+      let additionalFiles: MlCopilotFile[] | undefined
+      if (event.additionalFiles && event.additionalFiles.length > 0) {
+        const [, convertedFiles, conversionErrors] = cleanErrs(
+          await Promise.all(event.additionalFiles.map(toMlCopilotFile))
+        )
+        const conversionError = conversionErrors[0]
+        if (conversionError) return Promise.reject(conversionError)
+        additionalFiles = convertedFiles
+      }
 
       const request: MlCopilotUserRequest = {
         type: 'user',


### PR DESCRIPTION
## Summary

- translate attachment `File.arrayBuffer()` `NotFoundError` failures into an actionable reattachment message
- preserve the original browser error as the cause while keeping filenames and paths out of the reported error
- leave unexpected attachment-read errors unchanged
- add focused regression coverage for both branches

The existing actor-error toast now tells the user:

> We couldn't read the attachment. It may have been moved, deleted, or become unavailable. Reattach it and try again.

## Testing

- `vitest run --mode=development --project=unit src/lib/zookeeper/zookeeperManagerMachine.test.ts` — 28 passed
- Biome formatting check on both changed files
- `git diff --check`

Repository-wide lint/typecheck could not be evaluated locally because current `main` has an out-of-sync npm lockfile and the no-lock fallback resolves TypeScript 7 without the generated Rust bindings. The focused unit test is green; draft CI is authoritative for the full matrix.

## Scope

This warning-only patch does not yet preserve the cleared composer or snapshot attachment bytes before queueing. Those broader recovery/prevention changes remain documented in the issue.

Closes #13324
