### PR TITLE
[1/3] Add imported geometry point-and-click foundations

### DIFF
--- a/e2e/playwright/point-click-assemblies.spec.ts
+++ b/e2e/playwright/point-click-assemblies.spec.ts
@@ -7,6 +7,7 @@ import type { HomePageFixture } from '@e2e/playwright/fixtures/homePageFixture'
 import type { SceneFixture } from '@e2e/playwright/fixtures/sceneFixture'
 import type { ToolbarFixture } from '@e2e/playwright/fixtures/toolbarFixture'
 import {
+  closeOnboardingModalIfPresent,
   doAndWaitForImageDiff,
   executorInputPath,
   testsInputPath,
@@ -678,6 +679,111 @@ test.describe(
       )
     })
 
+    test(`Set appearance and toggle visibility on foreign part from feature tree`, async ({
+      folderSetupFn,
+      page,
+      homePage,
+      scene,
+      editor,
+      toolbar,
+      cmdBar,
+      fs,
+    }) => {
+      const waitForExecution = () =>
+        expect
+          .poll(
+            () =>
+              page.evaluate(() => window.app.singletons.kclManager.isExecuting),
+            { timeout: 60_000 }
+          )
+          .toBe(false)
+      const projectName = 'foreign-part-appearance'
+      await folderSetupFn(async (dir) => {
+        const projectDir = await fs.join(dir, projectName)
+        await fs.mkdir(projectDir, { recursive: true })
+        const cubeData = await fsp.readFile(testsInputPath('cube.step'))
+        await Promise.all([
+          fs.writeFile(
+            await fs.join(projectDir, 'cube.step'),
+            Uint8Array.from(cubeData)
+          ),
+          fs.writeFile(
+            await fs.join(projectDir, 'main.kcl'),
+            new TextEncoder().encode(`@settings(kclVersion = 2.0)
+
+@(targetRepresentation = mesh)
+import "cube.step" as cube`)
+          ),
+        ])
+      })
+      await homePage.openProject(projectName)
+      await scene.connectionEstablished()
+      await closeOnboardingModalIfPresent(page)
+      await editor.expectEditor.toContain('import "cube.step" as cube')
+
+      await toolbar.openPane(DefaultLayoutPaneID.FeatureTree)
+      const op = await toolbar.getFeatureTreeOperation('cube', 0)
+      await expect(op).toBeVisible({ timeout: 60_000 })
+      await waitForExecution()
+      await op.click({ button: 'right' })
+      await page.getByTestId('context-menu-set-appearance').click()
+      await cmdBar.progressCmdBar()
+      await cmdBar.currentArgumentInput.fill('#ff0000')
+      await cmdBar.progressCmdBar()
+      await cmdBar.expectState({
+        commandName: 'Appearance',
+        headerArguments: {
+          Objects: '1 importedGeometry',
+          Color: '#ff0000',
+        },
+        stage: 'review',
+      })
+      const codeChanges = page.getByRole('button', { name: 'Code changes' })
+      await expect(codeChanges).toBeVisible()
+      await expect(codeChanges).toHaveAttribute('aria-expanded', 'false')
+      await codeChanges.click()
+      await expect(codeChanges).toHaveAttribute('aria-expanded', 'true')
+      await expect(page.getByTestId('cmd-bar-codemod-diff')).toBeVisible()
+      await expect(
+        page.getByRole('textbox', { name: 'Proposed file' })
+      ).toContainText('appearance(cube, color = "#ff0000")')
+
+      await cmdBar.submit()
+      await editor.expectEditor.toContain('appearance(cube, color = "#ff0000")')
+      await waitForExecution()
+      await toolbar.openPane(DefaultLayoutPaneID.FeatureTree)
+      const visibleOp = await toolbar.getFeatureTreeOperation('cube', 0)
+      const visibleRow = visibleOp.locator('..')
+      await visibleRow.hover()
+      const visibleToggle = visibleRow.getByTestId(
+        'feature-tree-visibility-toggle'
+      )
+      await expect(
+        visibleToggle.locator('svg[aria-label="eye open"]')
+      ).toBeVisible()
+      await visibleToggle.click()
+      await editor.expectEditor.toContain(/hide\(\s*cube\s*\)/)
+      await waitForExecution()
+
+      const hiddenOp = await toolbar.getFeatureTreeOperation('cube', 0)
+      const hiddenToggle = hiddenOp
+        .locator('..')
+        .getByTestId('feature-tree-visibility-toggle')
+      await expect(
+        hiddenToggle.locator('svg[aria-label="eye crossed out"]')
+      ).toBeVisible()
+      await hiddenToggle.click()
+      await editor.expectEditor.not.toContain(/hide\(\s*cube\s*\)/)
+      await waitForExecution()
+      const shownOp = await toolbar.getFeatureTreeOperation('cube', 0)
+      await expect(
+        shownOp
+          .locator('..')
+          .getByTestId('feature-tree-visibility-toggle')
+          .locator('svg[aria-label="eye open"]')
+      ).toBeVisible()
+    })
+
     test(`Insert foreign parts into assembly and delete them`, async ({
       folderSetupFn,
       page,
@@ -770,12 +876,36 @@ test.describe(
         await expect(page.locator('.cm-lint-marker-error')).not.toBeVisible()
       })
 
-      await test.step('Module feature tree items do not offer delete', async () => {
+      await test.step('Delete first part using the feature tree', async () => {
         await toolbar.openPane(DefaultLayoutPaneID.FeatureTree)
-        const cubeOp = await toolbar.getFeatureTreeOperation('cube', 0)
-        await cubeOp.click({ button: 'right' })
-        await expect(page.getByText('View KCL source code')).toBeVisible()
-        await expect(page.getByTestId('context-menu-delete')).not.toBeVisible()
+        const op = await toolbar.getFeatureTreeOperation('cube', 0)
+        await op.click({ button: 'right' })
+        await page.getByTestId('context-menu-delete').click()
+        await scene.settled()
+        await toolbar.closePane(DefaultLayoutPaneID.FeatureTree)
+
+        await toolbar.openPane(DefaultLayoutPaneID.Code)
+        await editor.expectEditor.not.toContain(`import "cube.step" as cube`)
+        await editor.expectEditor.toContain(
+          `import "${complexPlmFileName}" as cubeSw`,
+          { shouldNormalise: true }
+        )
+        await toolbar.closePane(DefaultLayoutPaneID.Code)
+      })
+
+      await test.step('Delete second part using the feature tree', async () => {
+        await toolbar.openPane(DefaultLayoutPaneID.FeatureTree)
+        const op = await toolbar.getFeatureTreeOperation('cubeSw', 0)
+        await op.click({ button: 'right' })
+        await page.getByTestId('context-menu-delete').click()
+        await scene.settled()
+        await toolbar.closePane(DefaultLayoutPaneID.FeatureTree)
+
+        await toolbar.openPane(DefaultLayoutPaneID.Code)
+        await editor.expectEditor.not.toContain(
+          `import "${complexPlmFileName}" as cubeSw`
+        )
+        await toolbar.closePane(DefaultLayoutPaneID.Code)
       })
     })
 

--- a/rust/kcl-api/src/cad_op.rs
+++ b/rust/kcl-api/src/cad_op.rs
@@ -74,6 +74,17 @@ pub enum Operation {
         /// The source range of the operation in the source code.
         source_range: SourceRange,
     },
+    #[serde(rename_all = "camelCase")]
+    ImportedGeometry {
+        /// The name bound to the imported geometry.
+        name: String,
+        /// The ID of the foreign module backing the imported geometry.
+        module_id: ModuleId,
+        /// The node path of the import statement in the source code.
+        node_path: NodePath,
+        /// The source range of the import statement in the source code.
+        source_range: SourceRange,
+    },
     GroupEnd,
 }
 
@@ -85,6 +96,7 @@ impl Operation {
             Self::VariableDeclaration { .. }
             | Self::GroupBegin { .. }
             | Self::ModuleInstance { .. }
+            | Self::ImportedGeometry { .. }
             | Self::GroupEnd => {}
         }
     }

--- a/rust/kcl-lib/expected-bindings/ts-rs/Operation.ts
+++ b/rust/kcl-lib/expected-bindings/ts-rs/Operation.ts
@@ -148,4 +148,20 @@ nodePath: NodePath,
 /**
  * The source range of the operation in the source code.
  */
+sourceRange: SourceRange, } | { "type": "ImportedGeometry", 
+/**
+ * The name bound to the imported geometry.
+ */
+name: string, 
+/**
+ * The ID of the foreign module backing the imported geometry.
+ */
+moduleId: ModuleId, 
+/**
+ * The node path of the import statement in the source code.
+ */
+nodePath: NodePath, 
+/**
+ * The source range of the import statement in the source code.
+ */
 sourceRange: SourceRange, } | { "type": "GroupEnd" };

--- a/rust/kcl-lib/src/engine/engine_manager.rs
+++ b/rust/kcl-lib/src/engine/engine_manager.rs
@@ -194,6 +194,11 @@ impl EngineManager {
         std::mem::take(&mut *self.ids_of_async_commands().write().await)
     }
 
+    /// Whether an async command is still part of the current execution.
+    pub(crate) async fn has_pending_async_command(&self, id: Uuid) -> bool {
+        self.ids_of_async_commands().read().await.contains_key(&id)
+    }
+
     /// Take the responses that have accumulated so far and clear them.
     pub async fn take_responses(&self) -> IndexMap<Uuid, WebSocketResponse> {
         std::mem::take(&mut *self.responses().write().await)

--- a/rust/kcl-lib/src/execution/cad_op.rs
+++ b/rust/kcl-lib/src/execution/cad_op.rs
@@ -3,10 +3,39 @@ pub use kcl_api::OpKclValue;
 pub use kcl_api::OpSketch;
 pub use kcl_api::OpSolid;
 pub use kcl_api::Operation;
+use kcl_error::SourceRange;
 
 use super::ArtifactId;
 use super::KclValue;
+use crate::ModuleId;
 use crate::NodePathExt;
+use crate::parsing::ast::types::ImportPath;
+
+pub(crate) fn operation_from_import(
+    name: String,
+    module_id: ModuleId,
+    import_path: &ImportPath,
+    is_glob: bool,
+    source_range: SourceRange,
+) -> Option<Operation> {
+    let operation = match import_path {
+        ImportPath::Kcl { .. } => Operation::ModuleInstance {
+            name,
+            module_id,
+            glob: is_glob,
+            node_path: crate::NodePath::placeholder(),
+            source_range,
+        },
+        ImportPath::Foreign { .. } => Operation::ImportedGeometry {
+            name,
+            module_id,
+            node_path: crate::NodePath::placeholder(),
+            source_range,
+        },
+        ImportPath::Std { .. } => return None,
+    };
+    Some(operation)
+}
 
 pub trait OperationExt {
     fn fill_node_paths(&mut self, programs: &crate::execution::ProgramLookup, cached_body_items: usize);
@@ -39,6 +68,11 @@ impl OperationExt for Operation {
                 ..
             }
             | Operation::ModuleInstance {
+                node_path,
+                source_range,
+                ..
+            }
+            | Operation::ImportedGeometry {
                 node_path,
                 source_range,
                 ..
@@ -127,5 +161,38 @@ pub fn op_from_kcl_value(value: &KclValue) -> OpKclValue {
         KclValue::KclNone { .. } => OpKclValue::KclNone {},
         KclValue::Type { .. } => OpKclValue::Type {},
         KclValue::BoundedEdge { .. } => OpKclValue::BoundedEdge {},
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn import_operation_distinguishes_kcl_modules_from_imported_geometry() {
+        let module_id = ModuleId::default();
+        let source_range = SourceRange::default();
+
+        let kcl = operation_from_import(
+            "part".to_owned(),
+            module_id,
+            &ImportPath::Kcl {
+                filename: "part.kcl".into(),
+            },
+            true,
+            source_range,
+        );
+        assert!(matches!(kcl, Some(Operation::ModuleInstance { glob: true, .. })));
+
+        let foreign = operation_from_import(
+            "mesh".to_owned(),
+            module_id,
+            &ImportPath::Foreign {
+                path: "mesh.obj".into(),
+            },
+            false,
+            source_range,
+        );
+        assert!(matches!(foreign, Some(Operation::ImportedGeometry { .. })));
     }
 }

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -1295,13 +1295,15 @@ impl ExecutorContext {
             let name = import_stmt
                 .module_name()
                 .unwrap_or_else(|| value.file_name().unwrap_or_default());
-            exec_state.push_op(Operation::ModuleInstance {
+            if let Some(operation) = crate::execution::cad_op::operation_from_import(
                 name,
                 module_id,
-                glob: matches!(import_stmt.selector, ImportSelector::Glob(_)),
-                node_path: NodePath::placeholder(),
+                &import_stmt.path,
+                matches!(import_stmt.selector, ImportSelector::Glob(_)),
                 source_range,
-            });
+            ) {
+                exec_state.push_op(operation);
+            }
         }
 
         match &import_stmt.selector {

--- a/rust/kcl-lib/src/execution/geometry.rs
+++ b/rust/kcl-lib/src/execution/geometry.rs
@@ -181,9 +181,16 @@ impl ImportedGeometry {
             return Ok(());
         }
 
-        ctx.engine
-            .ensure_async_command_completed(self.id, self.meta.first().map(|m| m.source_range))
-            .await?;
+        // Incremental execution can reuse an imported geometry after the
+        // original execution has already awaited its import and consumed the
+        // engine response while building the artifact graph. The cached value
+        // does not serialize `completed`, so only wait when this execution
+        // actually has a pending import command for the geometry.
+        if ctx.engine.has_pending_async_command(self.id).await {
+            ctx.engine
+                .ensure_async_command_completed(self.id, self.meta.first().map(|m| m.source_range))
+                .await?;
+        }
 
         self.completed = true;
 
@@ -196,6 +203,31 @@ impl ImportedGeometry {
         }
 
         Ok(self.id)
+    }
+}
+
+#[cfg(test)]
+mod imported_geometry_tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use super::*;
+    use crate::engine::engine_manager::EngineManager;
+    use crate::execution::ExecutorSettings;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cached_import_without_a_pending_command_is_already_complete() {
+        let id = uuid::Uuid::new_v4();
+        let ctx = ExecutorContext::new_with_engine(Arc::new(EngineManager::new_mock()), ExecutorSettings::default());
+        let mut geometry = ImportedGeometry::new(id, Vec::new(), Vec::new());
+
+        let resolved_id = tokio::time::timeout(Duration::from_secs(1), geometry.id(&ctx))
+            .await
+            .expect("cached imported geometry should not wait for a consumed response")
+            .expect("cached imported geometry should resolve its id");
+
+        assert_eq!(resolved_id, id);
+        ctx.close().await;
     }
 }
 

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -79,6 +79,7 @@ pub(crate) use state::TangencyMode;
 use crate::CompilationIssue;
 use crate::ExecError;
 use crate::KclErrorWithOutputs;
+#[cfg(test)]
 use crate::NodePathExt;
 use crate::SourceRange;
 use crate::collections::AhashIndexSet;
@@ -1734,9 +1735,10 @@ impl ExecutorContext {
             self.get_universe(program, exec_state).await?
         };
 
-        // Push ModuleInstance ops for the root module's direct imports before
-        // child modules execute. This lets the live feature tree show module
-        // names immediately rather than waiting for the root module body to run.
+        // Push module/imported-geometry operations for the root module's direct
+        // imports before child modules execute. This lets the live feature tree
+        // show import names immediately rather than waiting for the root module
+        // body to run.
         // Sort by source position so they appear in source-code order (the
         // universe_map is a HashMap with non-deterministic iteration order).
         let mut sorted_imports: Vec<_> = universe_map.iter().collect();
@@ -1757,16 +1759,18 @@ impl ExecutorContext {
                     .module_name()
                     .unwrap_or_else(|| value.file_name().unwrap_or_default());
                 let source_range = SourceRange::from(import_stmt);
-                exec_state.push_op(crate::execution::cad_op::Operation::ModuleInstance {
+                if let Some(operation) = crate::execution::cad_op::operation_from_import(
                     name,
-                    module_id: *module_id,
-                    glob: matches!(
+                    *module_id,
+                    &import_stmt.path,
+                    matches!(
                         import_stmt.selector,
                         crate::parsing::ast::types::ImportSelector::Glob(_)
                     ),
-                    node_path: crate::NodePath::placeholder(),
                     source_range,
-                });
+                ) {
+                    exec_state.push_op(operation);
+                }
             }
         }
 
@@ -1931,8 +1935,8 @@ impl ExecutorContext {
             }
         }
 
-        // The early-pushed ModuleInstance operations have already served their
-        // purpose (firing onOperation callbacks for the live feature tree).
+        // The early-pushed import operations have already served their purpose
+        // (firing onOperation callbacks for the live feature tree).
         // Clear them so they don't duplicate the operations the root module
         // body will produce when it actually executes its import statements.
         exec_state.mod_local.artifacts.operations.clear();

--- a/rust/kcl-lib/tests/import_async/ops.snap
+++ b/rust/kcl-lib/tests/import_async/ops.snap
@@ -5,7 +5,7 @@ description: Operations executed import_async.kcl
 {
   "rust/kcl-lib/tests/import_async/input.kcl": [
     {
-      "type": "ModuleInstance",
+      "type": "ImportedGeometry",
       "name": "screw",
       "moduleId": 0,
       "nodePath": {

--- a/rust/kcl-lib/tests/import_foreign/ops.snap
+++ b/rust/kcl-lib/tests/import_foreign/ops.snap
@@ -5,7 +5,7 @@ description: Operations executed import_foreign.kcl
 {
   "rust/kcl-lib/tests/import_foreign/input.kcl": [
     {
-      "type": "ModuleInstance",
+      "type": "ImportedGeometry",
       "name": "cube",
       "moduleId": 0,
       "nodePath": {

--- a/rust/kcl-lib/tests/import_mesh_clone/ops.snap
+++ b/rust/kcl-lib/tests/import_mesh_clone/ops.snap
@@ -5,7 +5,7 @@ description: Operations executed import_mesh_clone.kcl
 {
   "rust/kcl-lib/tests/import_mesh_clone/input.kcl": [
     {
-      "type": "ModuleInstance",
+      "type": "ImportedGeometry",
       "name": "yellow",
       "moduleId": 0,
       "nodePath": {

--- a/rust/kcl-lib/tests/import_nested_foreign_error/ops.snap
+++ b/rust/kcl-lib/tests/import_nested_foreign_error/ops.snap
@@ -5,7 +5,7 @@ description: Operations executed import_nested_foreign_error.kcl
 {
   "rust/kcl-lib/tests/import_nested_foreign_error/assembly.kcl": [
     {
-      "type": "ModuleInstance",
+      "type": "ImportedGeometry",
       "name": "bad",
       "moduleId": 0,
       "nodePath": {

--- a/rust/kcl-lib/tests/import_transform/ops.snap
+++ b/rust/kcl-lib/tests/import_transform/ops.snap
@@ -5,7 +5,7 @@ description: Operations executed import_transform.kcl
 {
   "rust/kcl-lib/tests/import_transform/input.kcl": [
     {
-      "type": "ModuleInstance",
+      "type": "ImportedGeometry",
       "name": "screw",
       "moduleId": 0,
       "nodePath": {

--- a/rust/kcl-lib/tests/multiple-foreign-imports-all-render/ops.snap
+++ b/rust/kcl-lib/tests/multiple-foreign-imports-all-render/ops.snap
@@ -5,7 +5,7 @@ description: Operations executed multiple-foreign-imports-all-render.kcl
 {
   "rust/kcl-lib/tests/multiple-foreign-imports-all-render/anothercube.kcl": [
     {
-      "type": "ModuleInstance",
+      "type": "ImportedGeometry",
       "name": "cube",
       "moduleId": 0,
       "nodePath": {
@@ -45,7 +45,7 @@ description: Operations executed multiple-foreign-imports-all-render.kcl
   ],
   "rust/kcl-lib/tests/multiple-foreign-imports-all-render/input.kcl": [
     {
-      "type": "ModuleInstance",
+      "type": "ImportedGeometry",
       "name": "cube",
       "moduleId": 0,
       "nodePath": {
@@ -287,7 +287,7 @@ description: Operations executed multiple-foreign-imports-all-render.kcl
   ],
   "rust/kcl-lib/tests/multiple-foreign-imports-all-render/othercube.kcl": [
     {
-      "type": "ModuleInstance",
+      "type": "ImportedGeometry",
       "name": "cube",
       "moduleId": 0,
       "nodePath": {

--- a/rust/kcl-lib/tests/named_views_hide_imported/ops.snap
+++ b/rust/kcl-lib/tests/named_views_hide_imported/ops.snap
@@ -5,7 +5,7 @@ description: Operations executed named_views_hide_imported.kcl
 {
   "rust/kcl-lib/tests/named_views_hide_imported/input.kcl": [
     {
-      "type": "ModuleInstance",
+      "type": "ImportedGeometry",
       "name": "cube",
       "moduleId": 0,
       "nodePath": {

--- a/src/components/CommandBar/CodemodReviewDiff.test.tsx
+++ b/src/components/CommandBar/CodemodReviewDiff.test.tsx
@@ -54,7 +54,7 @@ vi.mock('@codemirror/merge', () => ({
 }))
 
 describe('CodemodReviewDiff', () => {
-  it('shows the failed codemod diff on demand', () => {
+  it('shows the codemod diff on demand', () => {
     render(
       <CodemodReviewDiff
         details={{

--- a/src/components/CommandBar/CommandBarReview.tsx
+++ b/src/components/CommandBar/CommandBarReview.tsx
@@ -225,42 +225,40 @@ function CommandBarReview({ stepBack }: { stepBack: () => void }) {
         </>
       )}
       {validationError && (
-        <>
-          <div
-            role="alert"
-            className="mx-4 my-3 flex items-start gap-3 rounded-md border border-destroy-30 bg-destroy-10/40 px-3 py-2.5 dark:border-destroy-70 dark:bg-destroy-80/15"
-          >
-            <span className="mt-0.5 grid h-6 w-6 shrink-0 place-items-center rounded-full bg-destroy-20/70 text-destroy-80 dark:bg-destroy-80/60 dark:text-destroy-20">
-              <CustomIcon name="triangleExclamation" className="h-4 w-4" />
-            </span>
-            <div className="min-w-0">
-              <p className="font-medium text-sm text-destroy-80 dark:text-destroy-20">
-                Check these arguments
-              </p>
-              <p
-                className="mt-0.5 break-words text-sm leading-5 text-chalkboard-80 dark:text-chalkboard-20"
-                data-testid="cmd-bar-review-validation-error"
-              >
-                {validationError.category && (
-                  <>
-                    <span className="mr-1 inline-flex rounded bg-destroy-20/60 px-1.5 py-0.5 text-[11px] font-medium leading-none capitalize text-destroy-80 dark:bg-destroy-80/50 dark:text-destroy-20">
-                      {validationError.category}:
-                    </span>{' '}
-                  </>
-                )}
-                {validationError.message}
-              </p>
-            </div>
+        <div
+          role="alert"
+          className="mx-4 my-3 flex items-start gap-3 rounded-md border border-destroy-30 bg-destroy-10/40 px-3 py-2.5 dark:border-destroy-70 dark:bg-destroy-80/15"
+        >
+          <span className="mt-0.5 grid h-6 w-6 shrink-0 place-items-center rounded-full bg-destroy-20/70 text-destroy-80 dark:bg-destroy-80/60 dark:text-destroy-20">
+            <CustomIcon name="triangleExclamation" className="h-4 w-4" />
+          </span>
+          <div className="min-w-0">
+            <p className="font-medium text-sm text-destroy-80 dark:text-destroy-20">
+              Check these arguments
+            </p>
+            <p
+              className="mt-0.5 break-words text-sm leading-5 text-chalkboard-80 dark:text-chalkboard-20"
+              data-testid="cmd-bar-review-validation-error"
+            >
+              {validationError.category && (
+                <>
+                  <span className="mr-1 inline-flex rounded bg-destroy-20/60 px-1.5 py-0.5 text-[11px] font-medium leading-none capitalize text-destroy-80 dark:bg-destroy-80/50 dark:text-destroy-20">
+                    {validationError.category}:
+                  </span>{' '}
+                </>
+              )}
+              {validationError.message}
+            </p>
           </div>
-          {reviewValidationDetails?.type === 'codemod' && (
-            <CodemodReviewDiff
-              details={reviewValidationDetails}
-              resolvedTheme={resolvedTheme}
-            />
-          )}
-          <CommandBarDivider />
-        </>
+        </div>
       )}
+      {reviewValidationDetails?.type === 'codemod' && (
+        <CodemodReviewDiff
+          details={reviewValidationDetails}
+          resolvedTheme={resolvedTheme}
+        />
+      )}
+      {(validationError || reviewValidationDetails) && <CommandBarDivider />}
       <form
         {...noAutofillFormProps}
         id="review-form"

--- a/src/components/layout/areas/FeatureTreePane.spec.ts
+++ b/src/components/layout/areas/FeatureTreePane.spec.ts
@@ -157,6 +157,26 @@ describe('FeatureTreePane', () => {
       })
     })
 
+    it('keeps imported geometry as a leaf instead of expanding its backing file', () => {
+      const importedGeometry: Operation = {
+        type: 'ImportedGeometry',
+        name: 'mesh',
+        moduleId: 1,
+        nodePath: defaultNodePath(),
+        sourceRange: [0, 10, 0],
+      }
+      const operationsByModule: OperationsByModule = {
+        map: {
+          0: [importedGeometry],
+          1: [createVariableDeclarationOperation([0, 11, 1], 'ignored')],
+        },
+      }
+
+      expect(buildOperationTree(operationsByModule, 0)).toEqual([
+        importedGeometry,
+      ])
+    })
+
     it('car wheel assembly: modules first, children nested, parameters deduped', () => {
       // Models the car-wheel-assembly import graph:
       //   main.kcl (module 0)

--- a/src/components/layout/areas/FeatureTreePane.tsx
+++ b/src/components/layout/areas/FeatureTreePane.tsx
@@ -32,6 +32,11 @@ import {
   type OperationTreeNode,
 } from '@src/lib/featureTreeOperationTree'
 import {
+  type FeatureTreeActionAvailability,
+  getFeatureTreeCapabilities,
+  resolveFeatureTreeTarget,
+} from '@src/lib/featureTreeTargets'
+import {
   getOperationCalculatedDisplay,
   getOperationIcon,
   getOperationLabel,
@@ -39,7 +44,6 @@ import {
   getOpTypeLabel,
   onHide,
   onUnhide,
-  stdLibMap,
 } from '@src/lib/operations'
 import { defaultPlaneNameToKcl } from '@src/lib/planes'
 import { getSelectedDefaultPlane, selectSketchPlane } from '@src/lib/selections'
@@ -403,6 +407,7 @@ export const FeatureTreePaneContents = memo(() => {
               engineCommandManager={engineCommandManager}
               onSelect={selectOperation}
               visibilityOperations={visibilityOperations}
+              editableModuleId={ROOT_MODULE_ID}
               liveActiveModuleId={liveActiveModuleId}
               liveLatestOperationKey={liveLatestOperationKey}
             />
@@ -431,11 +436,10 @@ function OperationItemGroup({
   engineCommandManager,
   onSelect,
   visibilityOperations,
-  isModuleOwned = false,
+  editableModuleId,
   liveLatestOperationKey,
 }: Omit<OperationProps, 'item'> & {
   items: Operation[]
-  isModuleOwned?: boolean
 }) {
   const contentItems = items.filter((item) => item.type !== 'GroupEnd')
   if (contentItems.length === 0) {
@@ -464,7 +468,7 @@ function OperationItemGroup({
           engineCommandManager={engineCommandManager}
           onSelect={onSelect}
           visibilityOperations={visibilityOperations}
-          isModuleOwned={isModuleOwned}
+          editableModuleId={editableModuleId}
           liveLatestOperationKey={liveLatestOperationKey}
         />
       )
@@ -494,7 +498,7 @@ function OperationItemGroup({
               engineCommandManager={engineCommandManager}
               onSelect={onSelect}
               visibilityOperations={visibilityOperations}
-              isModuleOwned={isModuleOwned}
+              editableModuleId={editableModuleId}
               liveLatestOperationKey={liveLatestOperationKey}
             />
           </div>
@@ -515,7 +519,7 @@ function OperationItemGroup({
                   onSelect={onSelect}
                   visibilityOperations={visibilityOperations}
                   size="sm"
-                  isModuleOwned={isModuleOwned}
+                  editableModuleId={editableModuleId}
                   liveLatestOperationKey={liveLatestOperationKey}
                 />
               )
@@ -554,7 +558,7 @@ function OperationItemGroup({
                 onSelect={onSelect}
                 visibilityOperations={visibilityOperations}
                 size="sm"
-                isModuleOwned={isModuleOwned}
+                editableModuleId={editableModuleId}
                 liveLatestOperationKey={liveLatestOperationKey}
               />
             )
@@ -576,13 +580,12 @@ function OperationBranchGroup({
   engineCommandManager,
   onSelect,
   visibilityOperations,
-  isModuleOwned = false,
+  editableModuleId,
   liveActiveModuleId,
   liveLatestOperationKey,
 }: Omit<OperationProps, 'item'> & {
   parentItem: ModuleInstanceOperation
   childItems: OperationTreeNode[]
-  isModuleOwned?: boolean
 }) {
   if (childItems.length === 0) {
     return (
@@ -596,7 +599,7 @@ function OperationBranchGroup({
         engineCommandManager={engineCommandManager}
         onSelect={onSelect}
         visibilityOperations={visibilityOperations}
-        isModuleOwned={true}
+        editableModuleId={editableModuleId}
         liveLatestOperationKey={liveLatestOperationKey}
       />
     )
@@ -639,7 +642,7 @@ function OperationBranchGroup({
             engineCommandManager={engineCommandManager}
             onSelect={onSelect}
             visibilityOperations={visibilityOperations}
-            isModuleOwned={true}
+            editableModuleId={editableModuleId}
             liveLatestOperationKey={liveLatestOperationKey}
           />
         </div>
@@ -659,7 +662,7 @@ function OperationBranchGroup({
                 engineCommandManager={engineCommandManager}
                 onSelect={onSelect}
                 visibilityOperations={visibilityOperations}
-                isModuleOwned={true}
+                editableModuleId={editableModuleId}
                 liveLatestOperationKey={liveLatestOperationKey}
               />
             )
@@ -675,7 +678,6 @@ function OperationTreeNodeItem({
   ...props
 }: Omit<OperationProps, 'item'> & {
   node: OperationTreeNode
-  isModuleOwned?: boolean
 }) {
   if (isArray(node)) {
     return <OperationItemGroup items={node} {...props} />
@@ -843,7 +845,8 @@ interface OperationProps {
   onSelect: (sourceRange: SourceRange) => void
   visibilityOperations: Operation[]
   size?: 'default' | 'sm'
-  isModuleOwned?: boolean
+  /** The module whose source can be changed from this feature tree. */
+  editableModuleId: number
   /** During live execution, the module that received the latest operation. */
   liveActiveModuleId?: number | null
   /** During live execution, the operation that was most recently added. */
@@ -978,7 +981,7 @@ const OperationItem = ({
   modelingActor,
   engineCommandManager,
   size,
-  isModuleOwned = false,
+  editableModuleId,
   referenceModuleId,
   visibilityOperations,
   liveLatestOperationKey,
@@ -995,19 +998,27 @@ const OperationItem = ({
   const ast = kclManager.hasParseErrors() ? kclManager.lastGoodAst : liveAst
   const wasmInstance = use(kclManager.wasmInstancePromise)
   const name = getOperationLabel(item)
+  const target = useMemo(
+    () => resolveFeatureTreeTarget(item, kclManager.artifactGraph),
+    [item, kclManager.artifactGraph]
+  )
+  const capabilities = useMemo(
+    () => getFeatureTreeCapabilities(target, editableModuleId),
+    [editableModuleId, target]
+  )
   const sourceRange =
     'sourceRange' in item &&
     sourceRangeToUtf16(sourceRangeFromRust(item.sourceRange), kclManager.code)
   const isLiveLatest = liveLatestOperationKey === getOperationKey(item)
   const isEditorSelected = useMemo(() => {
-    if (!sourceRange) {
+    if (!capabilities.canSelect || !sourceRange) {
       return false
     }
 
     return kclManager.editorState.selection.ranges.some(({ from, to }) => {
       return isOverlap(sourceRange, topLevelRange(from, to))
     })
-  }, [kclManager.editorState.selection, sourceRange])
+  }, [capabilities.canSelect, kclManager.editorState.selection, sourceRange])
   const isSelected = isLiveLatest || isEditorSelected
   const valueDetail = useMemo(() => {
     return getFeatureTreeValueDetail(item, code)
@@ -1016,17 +1027,20 @@ const OperationItem = ({
   const isNamedView = item.type === 'StdLibCall' && item.name === 'view::named'
 
   const variableName = useMemo(() => {
-    // Module-owned ModuleInstance operations have a nodePath relative to their
-    // own module's AST, not the currently open file.  Looking up the import
-    // alias in the wrong AST would return a bogus result (e.g. the parent
-    // module's alias).  Other operation types (VariableDeclaration, etc.)
-    // derive their name from the operation data directly, so they're safe.
-    if (isModuleOwned && item.type === 'ModuleInstance') return undefined
+    // Imports owned by another module have a nodePath relative to that
+    // module's AST. Looking their alias up in the editable AST would return a
+    // bogus result (for example, the parent module's alias).
+    if (
+      !capabilities.canSelect &&
+      (item.type === 'ModuleInstance' || item.type === 'ImportedGeometry')
+    ) {
+      return undefined
+    }
     return getOperationVariableName(item, ast, wasmInstance)
-  }, [item, ast, wasmInstance, isModuleOwned])
+  }, [ast, capabilities.canSelect, item, wasmInstance])
 
   const errors = useMemo(() => {
-    if (isStaleReference || isModuleOwned) {
+    if (isStaleReference || !capabilities.canSelect) {
       return []
     }
     return diagnostics.filter(
@@ -1037,11 +1051,11 @@ const OperationItem = ({
         diag.to <= toUtf16(item.sourceRange[1], code)
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
-  }, [diagnostics.length, isModuleOwned, isStaleReference])
+  }, [capabilities.canSelect, diagnostics.length, isStaleReference])
 
   const selectOperation = useCallback(
     async (providedSourceRange?: SourceRange) => {
-      if (isModuleOwned) {
+      if (!capabilities.canSelect) {
         return
       }
       const sketchSelectionContext = getFeatureTreeSketchSelectionContext({
@@ -1071,19 +1085,24 @@ const OperationItem = ({
         onSelect(sourceRangeFromRust(item.sourceRange))
       }
     },
-    [isModuleOwned, modelingActor, onSelect, item, kclManager]
+    [capabilities.canSelect, modelingActor, onSelect, item, kclManager]
   )
 
   const viewOperationSource = useCallback(
     async (providedSourceRange?: SourceRange) => {
-      if (item.type === 'GroupEnd') {
+      const sourceNavigation = providedSourceRange
+        ? { kind: 'source' as const, moduleId: providedSourceRange[2] }
+        : capabilities.sourceNavigation
+      if (!sourceNavigation || item.type === 'GroupEnd') {
         return
       }
 
-      const targetModuleId =
-        item.type === 'ModuleInstance'
-          ? item.moduleId
-          : (providedSourceRange?.[2] ?? item.sourceRange[2])
+      const targetModuleId = sourceNavigation.moduleId
+      const targetRange: SourceRange =
+        providedSourceRange ??
+        (sourceNavigation.kind === 'module'
+          ? [0, 0, targetModuleId]
+          : item.sourceRange)
       const targetModulePath = kclManager.execState.filenames[targetModuleId]
 
       const l = layout.signal.value
@@ -1096,25 +1115,28 @@ const OperationItem = ({
         if (app.project.executingPath !== targetPath) {
           kclManager.pendingFeatureTreeSourceSelection = {
             path: targetPath,
-            range: providedSourceRange ?? item.sourceRange,
+            range: targetRange,
           }
           await navigate(`${PATHS.FILE}/${encodeURIComponent(targetPath)}`)
           return
         }
       }
 
-      const moduleStartRange: SourceRange = [0, 0, targetModuleId]
-      const targetRange =
-        providedSourceRange ??
-        (item.type === 'ModuleInstance' ? moduleStartRange : item.sourceRange)
-
       onSelect(targetRange)
     },
-    [app, item, kclManager, layout, navigate, onSelect]
+    [
+      app,
+      capabilities.sourceNavigation,
+      item,
+      kclManager,
+      layout,
+      navigate,
+      onSelect,
+    ]
   )
 
   const enterEditFlow = useCallback(() => {
-    if (isModuleOwned) {
+    if (capabilities.edit !== 'enabled') {
       return
     }
     if (
@@ -1157,7 +1179,7 @@ const OperationItem = ({
       })
     }
   }, [
-    isModuleOwned,
+    capabilities.edit,
     item,
     modelingActor,
     commandBarActor,
@@ -1165,103 +1187,60 @@ const OperationItem = ({
     systemDeps,
   ])
 
-  function enterAppearanceFlow() {
-    if (isModuleOwned) return
+  function enterModelingCommandFlow(
+    availability: FeatureTreeActionAvailability,
+    name: 'Appearance' | 'Translate' | 'Rotate' | 'Scale' | 'Clone'
+  ) {
+    if (availability !== 'enabled') return
     selectOperation()
       .then(() => {
-        if (
-          item.type === 'StdLibCall' ||
-          (item.type === 'GroupBegin' && item.group.type === 'FunctionCall')
-        ) {
-          commandBarActor.send({
-            type: 'Find and select command',
-            data: { name: 'Appearance', groupId: 'modeling' },
-          })
-        }
+        commandBarActor.send({
+          type: 'Find and select command',
+          data: { name, groupId: 'modeling' },
+        })
       })
       .catch((e) => toast.error(e))
+  }
+
+  function enterAppearanceFlow() {
+    enterModelingCommandFlow(capabilities.appearance, 'Appearance')
   }
 
   function enterTranslateFlow() {
-    if (isModuleOwned) return
-    selectOperation()
-      .then(() => {
-        if (item.type === 'StdLibCall' || item.type === 'GroupBegin') {
-          commandBarActor.send({
-            type: 'Find and select command',
-            data: { name: 'Translate', groupId: 'modeling' },
-          })
-        }
-      })
-      .catch((e) => toast.error(e))
+    enterModelingCommandFlow(capabilities.translate, 'Translate')
   }
 
   function enterRotateFlow() {
-    if (isModuleOwned) return
-    selectOperation()
-      .then(() => {
-        if (item.type === 'StdLibCall' || item.type === 'GroupBegin') {
-          commandBarActor.send({
-            type: 'Find and select command',
-            data: { name: 'Rotate', groupId: 'modeling' },
-          })
-        }
-      })
-      .catch((e) => toast.error(e))
+    enterModelingCommandFlow(capabilities.rotate, 'Rotate')
   }
 
   function enterScaleFlow() {
-    if (isModuleOwned) return
-    selectOperation()
-      .then(() => {
-        if (item.type === 'StdLibCall' || item.type === 'GroupBegin') {
-          commandBarActor.send({
-            type: 'Find and select command',
-            data: { name: 'Scale', groupId: 'modeling' },
-          })
-        }
-      })
-      .catch((e) => toast.error(e))
+    enterModelingCommandFlow(capabilities.scale, 'Scale')
   }
 
   function enterCloneFlow() {
-    if (isModuleOwned) return
-    selectOperation()
-      .then(() => {
-        if (item.type === 'StdLibCall' || item.type === 'GroupBegin') {
-          commandBarActor.send({
-            type: 'Find and select command',
-            data: { name: 'Clone', groupId: 'modeling' },
-          })
-        }
-      })
-      .catch((e) => toast.error(e))
+    enterModelingCommandFlow(capabilities.clone, 'Clone')
   }
 
   function deleteOperation() {
-    if (isModuleOwned) {
+    if (capabilities.remove !== 'enabled' || item.type === 'GroupEnd') {
       return
     }
-    if (
-      item.type === 'StdLibCall' ||
-      item.type === 'GroupBegin' ||
-      item.type === 'VariableDeclaration'
-    ) {
-      const maybeArtifact =
-        getArtifactFromRange(item.sourceRange, kclManager.artifactGraph) ??
-        undefined
-      sendDeleteCommand({
-        artifact: maybeArtifact,
-        targetSourceRange: item.sourceRange,
-        systemDeps,
-      }).catch((e) => {
-        toast.error(isErr(e) ? e.message : JSON.stringify(e))
-      })
-    }
+    const artifact =
+      target.artifact ??
+      getArtifactFromRange(item.sourceRange, kclManager.artifactGraph) ??
+      undefined
+    sendDeleteCommand({
+      artifact,
+      targetSourceRange: item.sourceRange,
+      systemDeps,
+    }).catch((e) => {
+      toast.error(isErr(e) ? e.message : JSON.stringify(e))
+    })
   }
 
   function startSketchOnOffsetPlane() {
-    if (isModuleOwned) {
+    if (!capabilities.canSelect) {
       return
     }
     if (isOffsetPlane(item)) {
@@ -1306,29 +1285,74 @@ const OperationItem = ({
 
   const menuItems = useMemo(
     () => {
-      const viewSourceMenuItem = (
-        <ContextMenuItem
-          onClick={() => {
-            if (item.type === 'GroupEnd') {
-              return
-            }
-            void viewOperationSource().catch(reportRejection)
-          }}
-        >
-          View KCL source code
-        </ContextMenuItem>
-      )
+      const viewSourceMenuItems = capabilities.sourceNavigation
+        ? [
+            <ContextMenuItem
+              onClick={() => {
+                void viewOperationSource().catch(reportRejection)
+              }}
+            >
+              View KCL source code
+            </ContextMenuItem>,
+          ]
+        : []
 
       if (isStaleReference) {
         return []
       }
 
-      if (isModuleOwned) {
-        return [viewSourceMenuItem]
+      if (!capabilities.canSelect) {
+        return viewSourceMenuItems
       }
 
+      const modelingActionMenuItems = [
+        {
+          availability: capabilities.appearance,
+          label: 'Set appearance',
+          onClick: enterAppearanceFlow,
+          testId: 'context-menu-set-appearance',
+        },
+        {
+          availability: capabilities.translate,
+          label: 'Translate',
+          onClick: enterTranslateFlow,
+          testId: 'context-menu-set-translate',
+        },
+        {
+          availability: capabilities.rotate,
+          label: 'Rotate',
+          onClick: enterRotateFlow,
+          testId: 'context-menu-set-rotate',
+        },
+        {
+          availability: capabilities.scale,
+          label: 'Scale',
+          onClick: enterScaleFlow,
+          testId: 'context-menu-set-scale',
+        },
+        {
+          availability: capabilities.clone,
+          label: 'Clone',
+          onClick: enterCloneFlow,
+          testId: 'context-menu-clone',
+        },
+      ].flatMap(({ availability, label, onClick, testId }) =>
+        availability === 'hidden'
+          ? []
+          : [
+              <ContextMenuItem
+                key={testId}
+                disabled={availability === 'disabled'}
+                onClick={onClick}
+                data-testid={testId}
+              >
+                {label}
+              </ContextMenuItem>,
+            ]
+      )
+
       return [
-        viewSourceMenuItem,
+        ...viewSourceMenuItems,
         ...(item.type === 'GroupBegin' && item.group.type === 'FunctionCall'
           ? [
               <ContextMenuItem
@@ -1368,16 +1392,10 @@ const OperationItem = ({
               </ContextMenuItem>,
             ]
           : []),
-        ...(item.type === 'StdLibCall' ||
-        item.type === 'VariableDeclaration' ||
-        (item.type === 'GroupBegin' && item.group.type === 'SketchBlock')
+        ...(capabilities.edit !== 'hidden'
           ? [
               <ContextMenuItem
-                disabled={
-                  item.type !== 'VariableDeclaration' &&
-                  item.type === 'StdLibCall' &&
-                  stdLibMap[item.name]?.prepareToEdit === undefined
-                }
+                disabled={capabilities.edit === 'disabled'}
                 onClick={enterEditFlow}
                 hotkey="Double click"
               >
@@ -1385,78 +1403,12 @@ const OperationItem = ({
               </ContextMenuItem>,
             ]
           : []),
-        ...(item.type === 'StdLibCall' ||
-        (item.type === 'GroupBegin' && item.group.type === 'FunctionCall')
-          ? [
-              <ContextMenuItem
-                disabled={
-                  !(
-                    (item.type === 'GroupBegin' &&
-                      item.group.type === 'FunctionCall') ||
-                    (item.type === 'StdLibCall' &&
-                      stdLibMap[item.name]?.supportsAppearance)
-                  )
-                }
-                onClick={enterAppearanceFlow}
-                data-testid="context-menu-set-appearance"
-              >
-                Set appearance
-              </ContextMenuItem>,
-            ]
-          : []),
-        ...(item.type === 'StdLibCall' || item.type === 'GroupBegin'
-          ? [
-              <ContextMenuItem
-                onClick={enterTranslateFlow}
-                data-testid="context-menu-set-translate"
-                disabled={
-                  item.type !== 'GroupBegin' &&
-                  !stdLibMap[item.name]?.supportsTransform &&
-                  !stdLibMap[item.name]?.supportsTranslate
-                }
-              >
-                Translate
-              </ContextMenuItem>,
-              <ContextMenuItem
-                onClick={enterRotateFlow}
-                data-testid="context-menu-set-rotate"
-                disabled={
-                  item.type !== 'GroupBegin' &&
-                  !stdLibMap[item.name]?.supportsTransform &&
-                  !stdLibMap[item.name]?.supportsRotate
-                }
-              >
-                Rotate
-              </ContextMenuItem>,
-              <ContextMenuItem
-                onClick={enterScaleFlow}
-                data-testid="context-menu-set-scale"
-                disabled={
-                  item.type !== 'GroupBegin' &&
-                  !stdLibMap[item.name]?.supportsTransform &&
-                  !stdLibMap[item.name]?.supportsScale
-                }
-              >
-                Scale
-              </ContextMenuItem>,
-              <ContextMenuItem
-                onClick={enterCloneFlow}
-                data-testid="context-menu-clone"
-                disabled={
-                  item.type !== 'GroupBegin' &&
-                  !stdLibMap[item.name]?.supportsTransform
-                }
-              >
-                Clone
-              </ContextMenuItem>,
-            ]
-          : []),
-        ...(item.type === 'StdLibCall' ||
-        item.type === 'GroupBegin' ||
-        item.type === 'VariableDeclaration'
+        ...modelingActionMenuItems,
+        ...(capabilities.remove !== 'hidden'
           ? [
               <ContextMenuItem
                 onClick={deleteOperation}
+                disabled={capabilities.remove === 'disabled'}
                 hotkey="Delete"
                 data-testid="context-menu-delete"
               >
@@ -1468,8 +1420,8 @@ const OperationItem = ({
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
     [
+      capabilities,
       item,
-      isModuleOwned,
       isStaleReference,
       layout.signal.value,
       viewOperationSource,
@@ -1500,7 +1452,7 @@ const OperationItem = ({
         ) : undefined
       }
       Tooltip={
-        isModuleOwned ? undefined : (
+        !capabilities.canSelect ? undefined : (
           <Tooltip
             delay={500}
             position="bottom-left"
@@ -1541,21 +1493,21 @@ const OperationItem = ({
                 }
               }
             }
-          : isStaleReference || isModuleOwned
+          : isStaleReference || !capabilities.canSelect
             ? undefined
             : () => {
                 void selectOperation()
               }
       }
       onContextMenu={
-        isStaleReference || isModuleOwned
+        isStaleReference || !capabilities.canSelect
           ? undefined
           : () => {
               void selectOperation()
             }
       }
       onDoubleClick={
-        sketchNoFace || isStaleReference || isModuleOwned
+        sketchNoFace || isStaleReference || capabilities.edit !== 'enabled'
           ? undefined
           : enterEditFlow
       } // no double click in "Sketch no face" mode
@@ -1565,7 +1517,7 @@ const OperationItem = ({
       size={size}
       visibilityToggle={
         !isStaleReference &&
-        !isModuleOwned &&
+        capabilities.canSelect &&
         visibilityState.canToggleVisibility
           ? {
               visible: visibilityState.hideOperation === undefined,

--- a/src/lang/KclManager.spec.ts
+++ b/src/lang/KclManager.spec.ts
@@ -261,6 +261,27 @@ describe('KclManager file switching', () => {
   })
 })
 
+describe('KclManager mock execution', () => {
+  it('can execute a complete AST without reusing program memory', async () => {
+    const { kclManager } = createKclManagerTestHarness()
+    const executeMockSpy = vi
+      .spyOn(kclManager.rustContext, 'executeMock')
+      .mockResolvedValue(kclManager.execState)
+
+    await kclManager.executeAstMock(createEmptyAst(), {
+      usePrevMemory: false,
+    })
+
+    expect(executeMockSpy).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Object),
+      kclManager.path,
+      false,
+      undefined
+    )
+  })
+})
+
 describe('KclManager diagnostics', () => {
   it('filters out duplicated diagnostics', () => {
     const { kclManager } = createKclManagerTestHarness()

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -2699,7 +2699,10 @@ export class KclManager extends File {
   }
 
   // DO NOT CALL THIS from codemirror ever.
-  async executeAstMock(ast: Program): Promise<null | Error> {
+  async executeAstMock(
+    ast: Program,
+    options?: { usePrevMemory?: boolean }
+  ): Promise<null | Error> {
     const newCode = recast(ast, await this.wasmInstancePromise)
     if (err(newCode)) {
       console.error(newCode)
@@ -2719,6 +2722,8 @@ export class KclManager extends File {
     const { logs, errors, execState } = await executeAstMock({
       ast: newAst,
       rustContext: this.rustContext,
+      path: this.path,
+      usePrevMemory: options?.usePrevMemory,
     })
 
     this.logs = logs
@@ -2799,6 +2804,7 @@ export class KclManager extends File {
     execute: boolean,
     optionalParams?: {
       focusPath?: Array<PathToNode>
+      usePrevMemory?: boolean
     }
   ): Promise<{
     newAst: Node<Program>
@@ -2854,7 +2860,9 @@ export class KclManager extends File {
       // When we don't re-execute, we still want to update the program
       // memory with the new ast. So we will hit the mock executor
       // instead..
-      const didReParse = await this.executeAstMock(astWithUpdatedSource)
+      const didReParse = await this.executeAstMock(astWithUpdatedSource, {
+        usePrevMemory: optionalParams?.usePrevMemory,
+      })
       if (err(didReParse)) return Promise.reject(didReParse)
     }
 

--- a/src/lang/modelingWorkflows.test.ts
+++ b/src/lang/modelingWorkflows.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { Node } from '@rust/kcl-lib/bindings/Node'
+import type { KclManager } from '@src/lang/KclManager'
+import { executeAstMock } from '@src/lang/executeAstMock'
+import {
+  mockExecAstAndReportErrors,
+  updateModelingState,
+} from '@src/lang/modelingWorkflows'
+import type { ExecState, PathToNode, Program } from '@src/lang/wasm'
+import { EXECUTION_TYPE_NONE } from '@src/lib/constants'
+import type RustContext from '@src/lib/rustContext'
+
+vi.mock('@src/lang/executeAstMock', () => ({
+  executeAstMock: vi.fn(),
+}))
+
+describe('mockExecAstAndReportErrors', () => {
+  it('uses fresh mock memory for a complete proposed AST', async () => {
+    const ast = {} as Node<Program>
+    const rustContext = {} as RustContext
+    const path = 'project/main.kcl'
+    vi.mocked(executeAstMock).mockResolvedValueOnce({
+      logs: [],
+      errors: [],
+      execState: {} as ExecState,
+      isInterrupted: false,
+    })
+
+    await expect(
+      mockExecAstAndReportErrors(ast, rustContext, path)
+    ).resolves.toBeUndefined()
+    expect(executeAstMock).toHaveBeenCalledWith({
+      ast,
+      rustContext,
+      path,
+      usePrevMemory: false,
+    })
+  })
+})
+
+describe('updateModelingState', () => {
+  it('uses fresh memory when updating the KCL manager with a codemod AST', async () => {
+    const ast = {} as Node<Program>
+    const rustContext = {} as RustContext
+    const focusPath: PathToNode[] = [[['body', '']]]
+    const updateAst = vi.fn().mockResolvedValue({ newAst: ast })
+    const updateEditorWithAstAndWriteToFile = vi
+      .fn()
+      .mockResolvedValue(undefined)
+    const kclManager = {
+      rustContext,
+      path: 'project/main.kcl',
+      updateAst,
+      updateEditorWithAstAndWriteToFile,
+    } as unknown as KclManager
+    vi.mocked(executeAstMock).mockResolvedValueOnce({
+      logs: [],
+      errors: [],
+      execState: {} as ExecState,
+      isInterrupted: false,
+    })
+
+    await updateModelingState(ast, EXECUTION_TYPE_NONE, kclManager, {
+      focusPath,
+    })
+
+    expect(updateAst).toHaveBeenCalledWith(ast, false, {
+      focusPath,
+      usePrevMemory: false,
+    })
+    expect(updateEditorWithAstAndWriteToFile).toHaveBeenCalledWith(ast, {
+      isDeleting: undefined,
+      allowProgrammaticDocumentChanges: true,
+    })
+  })
+})

--- a/src/lang/modelingWorkflows.ts
+++ b/src/lang/modelingWorkflows.ts
@@ -22,9 +22,17 @@ import type { Selections } from '@src/machines/modelingSharedTypes'
 
 export async function mockExecAstAndReportErrors(
   ast: Node<Program>,
-  rustContext: RustContext
+  rustContext: RustContext,
+  path?: string
 ): Promise<undefined | Error> {
-  const { errors } = await executeAstMock({ ast, rustContext })
+  const { errors } = await executeAstMock({
+    ast,
+    rustContext,
+    path,
+    // Codemod validation executes a complete proposed AST. Reusing cached
+    // mock memory can deadlock when that program contains a foreign import.
+    usePrevMemory: false,
+  })
   if (errors.length > 0) {
     return new Error(errors.map((e) => e.message).join('\n'))
   }
@@ -71,7 +79,11 @@ export async function updateModelingState(
 
   // Step 0: Mock execute shit so we know it aint broke
   if (!options?.skipErrorsOnMockExecution) {
-    const res = await mockExecAstAndReportErrors(ast, kclManager.rustContext)
+    const res = await mockExecAstAndReportErrors(
+      ast,
+      kclManager.rustContext,
+      kclManager.path
+    )
     if (err(res)) {
       return Promise.reject(res)
     }
@@ -81,7 +93,12 @@ export async function updateModelingState(
   updatedAst = await kclManager.updateAst(
     ast,
     false, // Execution handled separately for error resilience
-    options
+    {
+      focusPath: options?.focusPath,
+      // Codemods provide a complete replacement AST. Reusing program memory
+      // can deadlock when the model imports foreign geometry.
+      usePrevMemory: false,
+    }
   )
 
   // Step 2: Update the code editor and save file

--- a/src/lang/modifyAst/modelingCodemod.test.ts
+++ b/src/lang/modifyAst/modelingCodemod.test.ts
@@ -33,6 +33,7 @@ describe('createModelingCodemodReviewValidation', () => {
     const wasmInstance = {
       recast_wasm: vi.fn().mockReturnValue(proposedCode),
     } as unknown as ModuleType
+    const currentPath = 'project/main.kcl'
     const kclManager = {
       get ast() {
         return currentAst
@@ -41,7 +42,9 @@ describe('createModelingCodemodReviewValidation', () => {
         return currentCode
       },
       fileSettings: {},
+      path: currentPath,
     } as KclManager
+    const rustContext = {} as RustContext
     const executionError = new Error('Mock execution failed')
     vi.mocked(mockExecAstAndReportErrors).mockResolvedValueOnce(executionError)
 
@@ -74,7 +77,7 @@ describe('createModelingCodemodReviewValidation', () => {
               connection: { connected: true },
             } as unknown as ConnectionManager,
             kclManager,
-            rustContext: {} as RustContext,
+            rustContext,
           },
         }),
       }
@@ -85,7 +88,15 @@ describe('createModelingCodemodReviewValidation', () => {
     const result = await resultPromise
 
     expect(run).toHaveBeenCalledOnce()
+    expect(mockExecAstAndReportErrors).toHaveBeenCalledWith(
+      modifiedAst,
+      rustContext,
+      currentPath
+    )
     expect(result).toBeInstanceOf(Error)
+    if (!(result instanceof Error)) {
+      throw new Error('Expected review validation to fail')
+    }
     expect(result?.message).toBe(executionError.message)
     expect(result?.cause).toBe(executionError)
     expect(result?.reviewDetails).toEqual({
@@ -96,5 +107,54 @@ describe('createModelingCodemodReviewValidation', () => {
     expect(wasmInstance.recast_wasm).toHaveBeenCalledWith(
       JSON.stringify(modifiedAst)
     )
+  })
+
+  it('returns the code diff when mock execution succeeds', async () => {
+    const currentCode = 'part = extrude(sketch, length = 10)'
+    const proposedCode = 'part = extrude(sketch, length = 20)'
+    const currentAst = { start: 0, end: currentCode.length } as Node<Program>
+    const modifiedAst = { start: 0, end: proposedCode.length } as Node<Program>
+    const wasmInstance = {
+      recast_wasm: vi.fn().mockReturnValue(proposedCode),
+    } as unknown as ModuleType
+    const rustContext = {} as RustContext
+    const kclManager = {
+      ast: currentAst,
+      code: currentCode,
+      fileSettings: {},
+      path: 'project/main.kcl',
+    } as KclManager
+    vi.mocked(mockExecAstAndReportErrors).mockResolvedValueOnce(undefined)
+
+    const validate = createModelingCodemodReviewValidation(
+      defineModelingCodemod({
+        run: () => ({ modifiedAst, pathToNode: [] }),
+      })
+    )
+    const result = await validate(
+      {
+        argumentsToSubmit: {},
+        wasmInstancePromise: Promise.resolve(wasmInstance),
+      },
+      {
+        getSnapshot: () => ({
+          context: {
+            engineCommandManager: {
+              connection: { connected: true },
+            } as unknown as ConnectionManager,
+            kclManager,
+            rustContext,
+          },
+        }),
+      }
+    )
+
+    expect(result).toEqual({
+      reviewDetails: {
+        type: 'codemod',
+        currentCode,
+        proposedCode,
+      },
+    })
   })
 })

--- a/src/lang/modifyAst/modelingCodemod.ts
+++ b/src/lang/modifyAst/modelingCodemod.ts
@@ -7,7 +7,7 @@ import {
 } from '@src/lang/modelingWorkflows'
 import { setExperimentalFeatures } from '@src/lang/modifyAst/settings'
 import { recast, type PathToNode, type Program } from '@src/lang/wasm'
-import type { CommandReviewValidationError } from '@src/lib/commandTypes'
+import type { CommandReviewValidationResult } from '@src/lib/commandTypes'
 import { EXECUTION_TYPE_REAL } from '@src/lib/constants'
 import type RustContext from '@src/lib/rustContext'
 import { err, isErr } from '@src/lib/trap'
@@ -148,7 +148,7 @@ export function createModelingCodemodReviewValidation<CommandArgs>(
         }
       }
     }
-  ): Promise<undefined | CommandReviewValidationError> => {
+  ): Promise<undefined | CommandReviewValidationResult> => {
     if (!modelingActor) {
       return new Error('modelingMachine not found')
     }
@@ -176,24 +176,28 @@ export function createModelingCodemodReviewValidation<CommandArgs>(
       return codemodResult
     }
 
+    const proposedCode = recast(codemodResult.modifiedAst, wasmInstance)
+    if (isErr(proposedCode)) {
+      return proposedCode
+    }
+    const reviewDetails = {
+      type: 'codemod' as const,
+      currentCode: sourceSnapshot.code,
+      proposedCode,
+    }
+
     const execRes = await mockExecAstAndReportErrors(
       codemodResult.modifiedAst,
-      rustContext
+      rustContext,
+      kclManager.path
     )
     if (isErr(execRes)) {
-      const proposedCode = recast(codemodResult.modifiedAst, wasmInstance)
-      if (isErr(proposedCode)) {
-        return execRes
-      }
-
       return Object.assign(new Error(execRes.message, { cause: execRes }), {
-        reviewDetails: {
-          type: 'codemod' as const,
-          currentCode: sourceSnapshot.code,
-          proposedCode,
-        },
+        reviewDetails,
       })
     }
+
+    return { reviewDetails }
   }
 }
 

--- a/src/lang/modifyAst/transforms.spec.ts
+++ b/src/lang/modifyAst/transforms.spec.ts
@@ -3,6 +3,7 @@ import {
   addAppearance,
   addClone,
   addDelete,
+  addHide,
   addMirror3D,
   addRotate,
   addScale,
@@ -1130,6 +1131,46 @@ extrude001 = extrude(profile001, length = 1)`
     })
   })
 
+  describe('Testing addHide', () => {
+    it('should add a standalone call on imported geometry selection', () => {
+      const code = `@settings(kclVersion = 2.0)
+
+@(targetRepresentation = mesh)
+import "cube.step" as cube`
+      const ast = assertParse(code, instanceInThisFile)
+      const importStatement = ast.body[0]
+      const sourceRange: [number, number, number] = [
+        importStatement.start,
+        importStatement.end,
+        0,
+      ]
+      const codeRef = {
+        range: sourceRange,
+        pathToNode: getNodePathFromSourceRange(ast, sourceRange),
+        nodePath: { steps: [] },
+      }
+      const importedGeometry: Artifact = {
+        type: 'importedGeometry',
+        id: 'imported-geometry-id',
+        codeRef,
+      }
+      const result = addHide({
+        ast,
+        artifactGraph: new Map([[importedGeometry.id, importedGeometry]]),
+        objects: {
+          graphSelections: [{ artifact: importedGeometry, codeRef }],
+          otherSelections: [],
+        },
+        wasmInstance: instanceInThisFile,
+      })
+      if (err(result)) throw result
+
+      expect(recast(result.modifiedAst, instanceInThisFile)).toContain(
+        `${code}\nhidden001 = hide(cube)`
+      )
+    })
+  })
+
   describe('Testing addAppearance', () => {
     async function runAddAppearanceTest(
       code: string,
@@ -1157,6 +1198,46 @@ extrude001 = extrude(profile001, length = 1)`
     const box = `sketch001 = startSketchOn(XY)
 profile001 = circle(sketch001, center = [0, 0], radius = 1)
 extrude001 = extrude(profile001, length = 1)`
+
+    it('should add a standalone call on imported geometry selection', () => {
+      const code = `@settings(kclVersion = 2.0)
+
+@(targetRepresentation = mesh)
+import "cube.step" as cube`
+      const ast = assertParse(code, instanceInThisFile)
+      const importStatement = ast.body[0]
+      const sourceRange: [number, number, number] = [
+        importStatement.start,
+        importStatement.end,
+        0,
+      ]
+      const codeRef = {
+        range: sourceRange,
+        pathToNode: getNodePathFromSourceRange(ast, sourceRange),
+        nodePath: { steps: [] },
+      }
+      const importedGeometry: Artifact = {
+        type: 'importedGeometry',
+        id: 'imported-geometry-id',
+        codeRef,
+      }
+      const result = addAppearance({
+        ast,
+        artifactGraph: new Map([[importedGeometry.id, importedGeometry]]),
+        objects: {
+          graphSelections: [{ artifact: importedGeometry, codeRef }],
+          otherSelections: [],
+        },
+        color: '#FF0000',
+        wasmInstance: instanceInThisFile,
+      })
+      if (err(result)) throw result
+
+      expect(recast(result.modifiedAst, instanceInThisFile)).toContain(
+        `${code}\nappearance(cube, color = "#FF0000")`
+      )
+    })
+
     it('should add a standalone call on sweep selection', async () => {
       const expectedNewLine = `appearance(extrude001, color = "#FF0000")`
       const newCode = await runAddAppearanceTest(

--- a/src/lang/std/artifactGraph.ts
+++ b/src/lang/std/artifactGraph.ts
@@ -869,7 +869,9 @@ export function getArtifactFromRange(
     const codeRef = getFaceCodeRef(artifact)
     if (codeRef) {
       const match =
-        codeRef?.range[0] === range[0] && codeRef.range[1] === range[1]
+        codeRef.range[0] === range[0] &&
+        codeRef.range[1] === range[1] &&
+        codeRef.range[2] === range[2]
       if (match) {
         // Favor the first sketch block artifact since multiple artifacts may be
         // created here.

--- a/src/lib/commandBarConfigs/modelingCommandConfig.integration.spec.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.integration.spec.ts
@@ -459,6 +459,58 @@ describe('Transform arguments', () => {
       }
     }
   })
+
+  it('accepts imported geometry only for operations supported by KCL', () => {
+    for (const [commandName, argName] of [
+      ['Appearance', 'objects'],
+      ['Delete', 'objects'],
+      ['Translate', 'objects'],
+      ['Rotate', 'objects'],
+      ['Scale', 'objects'],
+      ['Clone', 'objects'],
+      ['Pattern Circular 3D', 'solids'],
+      ['Pattern Linear 3D', 'solids'],
+    ] as const) {
+      const commandConfig = modelingMachineCommandConfig[commandName]
+      if (!commandConfig || isArray(commandConfig)) {
+        throw new Error(`${commandName} should have a single command config`)
+      }
+
+      const selectionTypes = (
+        commandConfig.args as unknown as Record<
+          string,
+          { selectionTypes?: string[] } | undefined
+        >
+      )?.[argName]?.selectionTypes
+      if (!selectionTypes) {
+        throw new Error(`${commandName}.${argName} should select geometry`)
+      }
+      expect(selectionTypes).toContain('importedGeometry')
+    }
+
+    for (const [commandName, argName] of [
+      ['Boolean Subtract', 'solids'],
+      ['Boolean Union', 'solids'],
+      ['Boolean Intersect', 'solids'],
+      ['Boolean Split', 'targets'],
+    ] as const) {
+      const commandConfig = modelingMachineCommandConfig[commandName]
+      if (!commandConfig || isArray(commandConfig)) {
+        throw new Error(`${commandName} should have a single command config`)
+      }
+
+      const selectionTypes = (
+        commandConfig.args as unknown as Record<
+          string,
+          { selectionTypes?: string[] } | undefined
+        >
+      )?.[argName]?.selectionTypes
+      if (!selectionTypes) {
+        throw new Error(`${commandName}.${argName} should select solids`)
+      }
+      expect(selectionTypes).not.toContain('importedGeometry')
+    }
+  })
 })
 
 const uniqueSorted = (values: string[]) => [...new Set(values)].sort()

--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -105,7 +105,7 @@ const FRAME_PLANE_OPTIONS = Object.freeze([
   Object.freeze({ name: 'YZ Plane', value: KCL_PLANE_YZ }),
 ] as const)
 
-// For all transforms and boolean commands
+// Common geometry selections for transforms, booleans, and surface commands.
 const objectsTypesAndFilters: {
   selectionTypes: Artifact['type'][]
   selectionFilter: EntityType[]
@@ -113,6 +113,18 @@ const objectsTypesAndFilters: {
   selectionTypes: ['path', 'sweep', 'compositeSolid'],
   selectionFilter: ['object'],
 }
+
+// Imported geometry is supported by only a subset of those KCL operations.
+// Keep it separate so solid-only commands such as booleans remain correctly
+// constrained by the command bar.
+const objectsWithImportedGeometryTypesAndFilters: typeof objectsTypesAndFilters =
+  {
+    ...objectsTypesAndFilters,
+    selectionTypes: [
+      ...objectsTypesAndFilters.selectionTypes,
+      'importedGeometry',
+    ],
+  }
 
 // For all surface modeling commands
 const kclBodyTypeOptions = KCL_PRELUDE_BODY_TYPE_VALUES.map((value) => ({
@@ -1493,7 +1505,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
   },
   Appearance: {
     description:
-      'Set the appearance of a solid. This only works on solids, not sketches or individual paths.',
+      'Set the appearance of a solid or imported geometry. This does not work on sketches or individual paths.',
     icon: 'extrude',
     needsReview: true,
     reviewValidation: createModelingCodemodReviewValidation(
@@ -1506,7 +1518,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
           objects: {
             // selectionMixed allows for feature tree selection of module imports
             inputType: 'selectionMixed',
-            selectionTypes: ['path', 'sweep', 'compositeSolid'],
+            selectionTypes:
+              objectsWithImportedGeometryTypesAndFilters.selectionTypes,
             selectionFilter: ['object'],
             multiple: true,
             hidden: isEditingNodeSelection,
@@ -1529,7 +1542,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
     args: modelingStdLibCommandArgs<ModelingCommandSchema['Delete']>('Delete', {
       overrides: {
         objects: {
-          ...objectsTypesAndFilters,
+          ...objectsWithImportedGeometryTypesAndFilters,
           inputType: 'selectionMixed',
           multiple: true,
         },
@@ -1537,7 +1550,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
     }),
   },
   Translate: {
-    description: 'Set translation on a solid, sketch, or helix.',
+    description:
+      'Set translation on a solid, sketch, helix, or imported geometry.',
     icon: 'move',
     needsReview: true,
     reviewValidation: createModelingCodemodReviewValidation(
@@ -1548,8 +1562,11 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       {
         overrides: {
           objects: {
-            ...objectsTypesAndFilters,
-            selectionTypes: [...objectsTypesAndFilters.selectionTypes, 'helix'],
+            ...objectsWithImportedGeometryTypesAndFilters,
+            selectionTypes: [
+              ...objectsWithImportedGeometryTypesAndFilters.selectionTypes,
+              'helix',
+            ],
             inputType: 'selectionMixed',
             multiple: true,
             hidden: isEditingNodeSelection,
@@ -1573,7 +1590,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
     ),
   },
   Rotate: {
-    description: 'Set rotation on a solid, sketch, or helix.',
+    description:
+      'Set rotation on a solid, sketch, helix, or imported geometry.',
     icon: 'rotate',
     needsReview: true,
     reviewValidation: createModelingCodemodReviewValidation(
@@ -1582,8 +1600,11 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
     args: modelingStdLibCommandArgs<ModelingCommandSchema['Rotate']>('Rotate', {
       overrides: {
         objects: {
-          ...objectsTypesAndFilters,
-          selectionTypes: [...objectsTypesAndFilters.selectionTypes, 'helix'],
+          ...objectsWithImportedGeometryTypesAndFilters,
+          selectionTypes: [
+            ...objectsWithImportedGeometryTypesAndFilters.selectionTypes,
+            'helix',
+          ],
           inputType: 'selectionMixed',
           multiple: true,
           hidden: isEditingNodeSelection,
@@ -1615,7 +1636,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
     }),
   },
   Scale: {
-    description: 'Set scale on a solid, sketch, or helix.',
+    description: 'Set scale on a solid, sketch, helix, or imported geometry.',
     icon: 'scale',
     needsReview: true,
     reviewValidation: createModelingCodemodReviewValidation(
@@ -1624,8 +1645,11 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
     args: modelingStdLibCommandArgs<ModelingCommandSchema['Scale']>('Scale', {
       overrides: {
         objects: {
-          ...objectsTypesAndFilters,
-          selectionTypes: [...objectsTypesAndFilters.selectionTypes, 'helix'],
+          ...objectsWithImportedGeometryTypesAndFilters,
+          selectionTypes: [
+            ...objectsWithImportedGeometryTypesAndFilters.selectionTypes,
+            'helix',
+          ],
           inputType: 'selectionMixed',
           multiple: true,
           hidden: isEditingNodeSelection,
@@ -1647,7 +1671,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
     }),
   },
   Clone: {
-    description: 'Clone a solid or sketch.',
+    description: 'Clone a solid, sketch, or imported geometry.',
     icon: 'clone',
     needsReview: true,
     reviewValidation: createModelingCodemodReviewValidation(
@@ -1656,7 +1680,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
     args: modelingStdLibCommandArgs<ModelingCommandSchema['Clone']>('Clone', {
       overrides: {
         objects: {
-          ...objectsTypesAndFilters,
+          ...objectsWithImportedGeometryTypesAndFilters,
           inputType: 'selectionMixed',
           multiple: false, // only one object can be cloned at this time
           hidden: isEditingNodeSelection,
@@ -1731,7 +1755,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
     ),
   },
   'Pattern Circular 3D': {
-    description: 'Create a circular pattern of 3D solids around an axis.',
+    description: 'Create a circular pattern of 3D geometry around an axis.',
     icon: 'patternCircular3d',
     needsReview: true,
     reviewValidation: createModelingCodemodReviewValidation(
@@ -1742,7 +1766,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
     >('Pattern Circular 3D', {
       overrides: {
         solids: {
-          ...objectsTypesAndFilters,
+          ...objectsWithImportedGeometryTypesAndFilters,
           inputType: 'selectionMixed',
           multiple: true,
           hidden: isEditingNodeSelection,
@@ -1770,7 +1794,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
     }),
   },
   'Pattern Linear 3D': {
-    description: 'Create a linear pattern of 3D solids along an axis.',
+    description: 'Create a linear pattern of 3D geometry along an axis.',
     icon: 'patternLinear3d',
     needsReview: true,
     reviewValidation: createModelingCodemodReviewValidation(
@@ -1781,7 +1805,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       {
         overrides: {
           solids: {
-            ...objectsTypesAndFilters,
+            ...objectsWithImportedGeometryTypesAndFilters,
             inputType: 'selectionMixed',
             multiple: true,
             hidden: isEditingNodeSelection,

--- a/src/lib/commandTypes.ts
+++ b/src/lib/commandTypes.ts
@@ -117,6 +117,12 @@ export type CommandReviewValidationError = Error & {
   reviewDetails?: CommandReviewValidationDetails
 }
 
+export type CommandReviewValidationResult =
+  | CommandReviewValidationError
+  | {
+      reviewDetails: CommandReviewValidationDetails
+    }
+
 export type Command<
   T extends AnyStateMachine = AnyStateMachine,
   CommandName extends EventFrom<T>['type'] = EventFrom<T>['type'],
@@ -133,7 +139,7 @@ export type Command<
   reviewValidation?: (
     context: CommandBarContext,
     machineActor?: ActorRefFrom<T>
-  ) => Promise<undefined | CommandReviewValidationError>
+  ) => Promise<undefined | CommandReviewValidationResult>
   machineActor?: Actor<T>
   onSubmit: (data?: CommandSchema, wasmInstance?: ModuleType) => unknown
   onCancel?: () => void

--- a/src/lib/featureTree.spec.ts
+++ b/src/lib/featureTree.spec.ts
@@ -35,6 +35,16 @@ function helixOperation(sourceRange: SourceRange): Operation {
   }
 }
 
+function importedGeometryOperation(sourceRange: SourceRange): Operation {
+  return {
+    type: 'ImportedGeometry',
+    name: 'cube',
+    moduleId: 1,
+    nodePath: defaultNodePath(),
+    sourceRange,
+  }
+}
+
 function hideOperation(sourceRange: SourceRange, value: OpKclValue): Operation {
   return {
     type: 'StdLibCall',
@@ -79,6 +89,21 @@ function helixArtifact(id: string, sourceRange: SourceRange): Artifact {
   }
 }
 
+function importedGeometryArtifact(
+  id: string,
+  sourceRange: SourceRange
+): Artifact {
+  return {
+    type: 'importedGeometry',
+    id,
+    codeRef: {
+      range: sourceRange,
+      nodePath: defaultNodePath(),
+      pathToNode: [],
+    },
+  }
+}
+
 function pathArtifact(id: string, sourceRange: SourceRange): Artifact {
   return {
     type: 'path',
@@ -115,6 +140,61 @@ function expectHidden(
 }
 
 describe('resolveFeatureTreeVisibility', () => {
+  it('enables the visibility toggle for imported geometry', () => {
+    const importRange = range(0, 28)
+    const item = importedGeometryOperation(importRange)
+    const artifact = importedGeometryArtifact(
+      'imported-geometry-artifact',
+      importRange
+    )
+
+    const visibilityState = resolveFeatureTreeVisibility({
+      item,
+      operations: [],
+      artifactGraph: toArtifactGraph([artifact]),
+    })
+
+    expect(visibilityState.canToggleVisibility).toBe(true)
+    expect(visibilityState.hideOperation).toBeUndefined()
+    expect(visibilityState.targetArtifact).toBe(artifact)
+  })
+
+  it('resolves imported geometry visibility using artifact-id hide matching', () => {
+    const importRange = range(0, 28)
+    const item = importedGeometryOperation(importRange)
+    const artifact = importedGeometryArtifact(
+      'imported-geometry-artifact',
+      importRange
+    )
+    const hideOp = hideOperation(range(29, 39), {
+      type: 'ImportedGeometry',
+      artifact_id: artifact.id,
+    })
+
+    const visibilityState = resolveFeatureTreeVisibility({
+      item,
+      operations: [hideOp],
+      artifactGraph: toArtifactGraph([artifact]),
+    })
+
+    expect(visibilityState.canToggleVisibility).toBe(true)
+    expectHidden(visibilityState)
+    expect(visibilityState.hideOperation).toBe(hideOp)
+    expect(visibilityState.targetArtifact).toBe(artifact)
+  })
+
+  it('disables imported geometry visibility without its artifact', () => {
+    const visibilityState = resolveFeatureTreeVisibility({
+      item: importedGeometryOperation(range(0, 28)),
+      operations: [],
+      artifactGraph: new Map(),
+    })
+
+    expect(visibilityState.canToggleVisibility).toBe(false)
+    expect(visibilityState.hideOperation).toBeUndefined()
+    expect(visibilityState.targetArtifact).toBeUndefined()
+  })
+
   it('resolves sketch visibility via artifact-id hide matching', () => {
     const sketchDeclaration = 'sketch001 = sketch(on = XY) {}'
     const code = `${sketchDeclaration}\nhide(sketch001)`

--- a/src/lib/featureTree.ts
+++ b/src/lib/featureTree.ts
@@ -39,6 +39,19 @@ export function resolveFeatureTreeVisibility(input: {
 }): FeatureTreeVisibilityState {
   const { item, operations, artifactGraph } = input
 
+  if (item.type === 'ImportedGeometry') {
+    const artifact = getArtifactFromRange(item.sourceRange, artifactGraph)
+    if (artifact?.type !== 'importedGeometry') {
+      return { canToggleVisibility: false }
+    }
+
+    return {
+      canToggleVisibility: true,
+      hideOperation: getHideOpByArtifactId(operations, artifact.id),
+      targetArtifact: artifact,
+    }
+  }
+
   if (item.type === 'StdLibCall' && item.name === 'helix') {
     const operationArtifact = findOperationArtifact(item, artifactGraph)
     const hideOperation = operationArtifact

--- a/src/lib/featureTreeTargets.spec.ts
+++ b/src/lib/featureTreeTargets.spec.ts
@@ -1,0 +1,125 @@
+import type { Operation } from '@rust/kcl-lib/bindings/Operation'
+import { defaultNodePath, type ArtifactGraph } from '@src/lang/wasm'
+import {
+  getFeatureTreeCapabilities,
+  resolveFeatureTreeTarget,
+} from '@src/lib/featureTreeTargets'
+import { describe, expect, it } from 'vitest'
+
+function importedGeometry(
+  sourceModuleId = 0
+): Extract<Operation, { type: 'ImportedGeometry' }> {
+  return {
+    type: 'ImportedGeometry',
+    name: 'mesh',
+    moduleId: 1,
+    nodePath: defaultNodePath(),
+    sourceRange: [10, 30, sourceModuleId],
+  }
+}
+
+function kclModule(
+  sourceModuleId = 0
+): Extract<Operation, { type: 'ModuleInstance' }> {
+  return {
+    type: 'ModuleInstance',
+    name: 'assembly',
+    moduleId: 2,
+    nodePath: defaultNodePath(),
+    sourceRange: [31, 50, sourceModuleId],
+  }
+}
+
+describe('feature-tree targets', () => {
+  it('resolves imported geometry semantically and attaches its artifact', () => {
+    const operation = importedGeometry()
+    const artifactGraph: ArtifactGraph = new Map([
+      [
+        'imported-geometry',
+        {
+          type: 'importedGeometry',
+          id: 'imported-geometry',
+          codeRef: {
+            range: operation.sourceRange,
+            nodePath: defaultNodePath(),
+            pathToNode: [],
+          },
+        },
+      ],
+    ])
+
+    expect(resolveFeatureTreeTarget(operation, artifactGraph)).toMatchObject({
+      kind: 'geometry',
+      geometryType: 'importedGeometry',
+      ownerModuleId: 0,
+      artifact: { id: 'imported-geometry' },
+    })
+  })
+
+  it('does not attach an artifact from another source module', () => {
+    const operation = importedGeometry()
+    const artifactGraph: ArtifactGraph = new Map([
+      [
+        'other-module-geometry',
+        {
+          type: 'importedGeometry',
+          id: 'other-module-geometry',
+          codeRef: {
+            range: [10, 30, 2],
+            nodePath: defaultNodePath(),
+            pathToNode: [],
+          },
+        },
+      ],
+    ])
+
+    expect(
+      resolveFeatureTreeTarget(operation, artifactGraph).artifact
+    ).toBeUndefined()
+  })
+
+  it('navigates KCL modules without treating them as editable geometry', () => {
+    const target = resolveFeatureTreeTarget(kclModule(), new Map())
+
+    expect(getFeatureTreeCapabilities(target, 0)).toMatchObject({
+      canSelect: false,
+      sourceNavigation: { kind: 'module', moduleId: 2 },
+      translate: 'hidden',
+      clone: 'hidden',
+    })
+  })
+
+  it('enables imported-geometry actions in the editable module', () => {
+    const target = resolveFeatureTreeTarget(importedGeometry(), new Map())
+
+    expect(getFeatureTreeCapabilities(target, 0)).toMatchObject({
+      canSelect: true,
+      sourceNavigation: { kind: 'source', moduleId: 0 },
+      appearance: 'enabled',
+      translate: 'enabled',
+      rotate: 'enabled',
+      scale: 'enabled',
+      clone: 'enabled',
+      remove: 'enabled',
+    })
+  })
+
+  it('keeps nested geometry read-only based on ownership, at any depth', () => {
+    const target = resolveFeatureTreeTarget(importedGeometry(7), new Map())
+
+    expect(getFeatureTreeCapabilities(target, 0)).toMatchObject({
+      canSelect: false,
+      sourceNavigation: { kind: 'source', moduleId: 7 },
+      appearance: 'hidden',
+      translate: 'hidden',
+      clone: 'hidden',
+      remove: 'hidden',
+    })
+
+    expect(getFeatureTreeCapabilities(target, 7)).toMatchObject({
+      canSelect: true,
+      translate: 'enabled',
+      clone: 'enabled',
+    })
+  })
+})

--- a/src/lib/featureTreeTargets.ts
+++ b/src/lib/featureTreeTargets.ts
@@ -1,0 +1,197 @@
+import type { Operation } from '@rust/kcl-lib/bindings/Operation'
+import { getArtifactFromRange } from '@src/lang/std/artifactGraph'
+import type { Artifact, ArtifactGraph } from '@src/lang/wasm'
+import { stdLibMap } from '@src/lib/operations'
+
+type ModuleInstanceOperation = Extract<Operation, { type: 'ModuleInstance' }>
+type ImportedGeometryOperation = Extract<
+  Operation,
+  { type: 'ImportedGeometry' }
+>
+
+export type FeatureTreeTarget =
+  | {
+      kind: 'kclModule'
+      operation: ModuleInstanceOperation
+      ownerModuleId: number
+      artifact?: undefined
+    }
+  | {
+      kind: 'geometry'
+      geometryType: 'importedGeometry'
+      operation: ImportedGeometryOperation
+      ownerModuleId: number
+      artifact?: Extract<Artifact, { type: 'importedGeometry' }>
+    }
+  | {
+      kind: 'operation'
+      operation: Exclude<
+        Operation,
+        ModuleInstanceOperation | ImportedGeometryOperation
+      >
+      ownerModuleId: number | null
+      artifact?: undefined
+    }
+
+export type FeatureTreeActionAvailability = 'hidden' | 'disabled' | 'enabled'
+
+export interface FeatureTreeCapabilities {
+  canSelect: boolean
+  sourceNavigation:
+    | { kind: 'module'; moduleId: number }
+    | { kind: 'source'; moduleId: number }
+    | null
+  edit: FeatureTreeActionAvailability
+  appearance: FeatureTreeActionAvailability
+  translate: FeatureTreeActionAvailability
+  rotate: FeatureTreeActionAvailability
+  scale: FeatureTreeActionAvailability
+  clone: FeatureTreeActionAvailability
+  remove: FeatureTreeActionAvailability
+}
+
+const HIDDEN_ACTIONS = {
+  edit: 'hidden',
+  appearance: 'hidden',
+  translate: 'hidden',
+  rotate: 'hidden',
+  scale: 'hidden',
+  clone: 'hidden',
+  remove: 'hidden',
+} as const
+
+export function resolveFeatureTreeTarget(
+  operation: Operation,
+  artifactGraph: ArtifactGraph
+): FeatureTreeTarget {
+  if (operation.type === 'ModuleInstance') {
+    return {
+      kind: 'kclModule',
+      operation,
+      ownerModuleId: operation.sourceRange[2],
+    }
+  }
+
+  if (operation.type === 'ImportedGeometry') {
+    const artifact = getArtifactFromRange(operation.sourceRange, artifactGraph)
+    return {
+      kind: 'geometry',
+      geometryType: 'importedGeometry',
+      operation,
+      ownerModuleId: operation.sourceRange[2],
+      artifact: artifact?.type === 'importedGeometry' ? artifact : undefined,
+    }
+  }
+
+  return {
+    kind: 'operation',
+    operation,
+    ownerModuleId:
+      operation.type === 'GroupEnd' ? null : operation.sourceRange[2],
+  }
+}
+
+/**
+ * Resolve every feature-tree interaction from the semantic target and the
+ * module currently being edited. This keeps nesting/ownership separate from
+ * operation type: adding a new target kind requires one resolver update rather
+ * than conditionals throughout the tree UI.
+ */
+export function getFeatureTreeCapabilities(
+  target: FeatureTreeTarget,
+  editableModuleId: number
+): FeatureTreeCapabilities {
+  const sourceNavigation = getSourceNavigation(target)
+  const isEditable =
+    target.kind !== 'kclModule' && target.ownerModuleId === editableModuleId
+
+  if (!isEditable) {
+    return {
+      canSelect: false,
+      sourceNavigation,
+      ...HIDDEN_ACTIONS,
+    }
+  }
+
+  if (target.kind === 'geometry') {
+    return {
+      canSelect: true,
+      sourceNavigation,
+      edit: 'hidden',
+      appearance: 'enabled',
+      translate: 'enabled',
+      rotate: 'enabled',
+      scale: 'enabled',
+      clone: 'enabled',
+      remove: 'enabled',
+    }
+  }
+
+  const operation = target.operation
+  if (operation.type === 'GroupEnd') {
+    return {
+      canSelect: false,
+      sourceNavigation,
+      ...HIDDEN_ACTIONS,
+    }
+  }
+
+  if (operation.type === 'VariableDeclaration') {
+    return {
+      canSelect: true,
+      sourceNavigation,
+      ...HIDDEN_ACTIONS,
+      edit: 'enabled',
+      remove: 'enabled',
+    }
+  }
+
+  if (operation.type === 'GroupBegin') {
+    const isFunctionCall = operation.group.type === 'FunctionCall'
+    return {
+      canSelect: true,
+      sourceNavigation,
+      edit: operation.group.type === 'SketchBlock' ? 'enabled' : 'hidden',
+      appearance: isFunctionCall ? 'enabled' : 'hidden',
+      translate: 'enabled',
+      rotate: 'enabled',
+      scale: 'enabled',
+      clone: 'enabled',
+      remove: 'enabled',
+    }
+  }
+
+  const stdLibInfo = stdLibMap[operation.name]
+  return {
+    canSelect: true,
+    sourceNavigation,
+    edit: stdLibInfo?.prepareToEdit ? 'enabled' : 'disabled',
+    appearance: stdLibInfo?.supportsAppearance ? 'enabled' : 'disabled',
+    translate:
+      stdLibInfo?.supportsTransform || stdLibInfo?.supportsTranslate
+        ? 'enabled'
+        : 'disabled',
+    rotate:
+      stdLibInfo?.supportsTransform || stdLibInfo?.supportsRotate
+        ? 'enabled'
+        : 'disabled',
+    scale:
+      stdLibInfo?.supportsTransform || stdLibInfo?.supportsScale
+        ? 'enabled'
+        : 'disabled',
+    clone: stdLibInfo?.supportsTransform ? 'enabled' : 'disabled',
+    remove: 'enabled',
+  }
+}
+
+function getSourceNavigation(
+  target: FeatureTreeTarget
+): FeatureTreeCapabilities['sourceNavigation'] {
+  if (target.kind === 'kclModule') {
+    return { kind: 'module', moduleId: target.operation.moduleId }
+  }
+  if (target.ownerModuleId === null) {
+    return null
+  }
+  return { kind: 'source', moduleId: target.ownerModuleId }
+}

--- a/src/lib/operations.ts
+++ b/src/lib/operations.ts
@@ -3602,6 +3602,7 @@ export function getOperationLabel(op: Operation): string {
         return '' // unreachable
       }
     case 'ModuleInstance':
+    case 'ImportedGeometry':
       return op.name
     case 'GroupEnd':
       return 'Group end'
@@ -3649,6 +3650,7 @@ export function getOperationIcon(op: Operation): CustomIconName {
       }
       return 'make-variable'
     case 'ModuleInstance':
+    case 'ImportedGeometry':
       return 'import' // TODO: Use insert icon.
     case 'GroupEnd':
       return 'questionMark'
@@ -3710,7 +3712,8 @@ export function getOperationVariableName(
     op.type !== 'StdLibCall' &&
     !(op.type === 'GroupBegin' && op.group.type === 'SketchBlock') &&
     !(op.type === 'GroupBegin' && op.group.type === 'FunctionCall') &&
-    op.type !== 'ModuleInstance'
+    op.type !== 'ModuleInstance' &&
+    op.type !== 'ImportedGeometry'
   ) {
     return undefined
   }
@@ -3722,8 +3725,8 @@ export function getOperationVariableName(
   // Find the AST node.
   const pathToNode = pathToNodeFromRustNodePath(op.nodePath)
 
-  // If this is a module instance, the variable name is the import alias.
-  if (op.type === 'ModuleInstance') {
+  // Imports use their alias as the variable name.
+  if (op.type === 'ModuleInstance' || op.type === 'ImportedGeometry') {
     const statement = getNodeFromPath<ImportStatement>(
       program,
       pathToNode,

--- a/src/lib/selections.spec.ts
+++ b/src/lib/selections.spec.ts
@@ -1858,6 +1858,44 @@ describe('pattern copy selection highlighting', () => {
   })
 })
 
+describe('imported geometry code selection', () => {
+  const codeRef = {
+    range: [10, 20, 0] as SourceRange,
+    pathToNode: [],
+    nodePath: { steps: [] },
+  }
+  const importedGeometry: Artifact = {
+    type: 'importedGeometry',
+    id: 'imported-geometry-id',
+    codeRef,
+  }
+  const artifactGraph: ArtifactGraph = new Map([
+    [importedGeometry.id, importedGeometry],
+  ])
+
+  test('preserves the artifact when the editor mirrors a feature-tree cursor', () => {
+    const result = codeToIdSelections(
+      [
+        {
+          codeRef: {
+            range: [codeRef.range[1], codeRef.range[1], 0],
+            pathToNode: [],
+          },
+        },
+      ],
+      artifactGraph,
+      buildArtifactIndex(artifactGraph)
+    )
+
+    expect(result).toEqual([
+      {
+        id: importedGeometry.id,
+        range: [codeRef.range[1], codeRef.range[1], 0],
+      },
+    ])
+  })
+})
+
 describe('getSelectionTypeDisplayText', () => {
   test('coalesces face-like selections under face', () => {
     const codeRef = { range: [0, 0, 0], pathToNode: [] } as any

--- a/src/lib/selections.ts
+++ b/src/lib/selections.ts
@@ -1954,7 +1954,9 @@ function getBestCandidates(
 
     // Other valid artifact types
     if (
-      ['plane', 'cap', 'wall', 'sweep', 'pattern'].includes(entry.artifact.type)
+      ['plane', 'cap', 'wall', 'sweep', 'pattern', 'importedGeometry'].includes(
+        entry.artifact.type
+      )
     ) {
       return [entry]
     }

--- a/src/machines/commandBarMachine.spec.ts
+++ b/src/machines/commandBarMachine.spec.ts
@@ -52,7 +52,7 @@ describe('commandBarMachine', () => {
     actor.stop()
   })
 
-  it('clears codemod review details when review is closed or submitted', async () => {
+  it('preserves codemod review details on errors and success until review closes', async () => {
     const reviewDetails = {
       type: 'codemod' as const,
       currentCode: 'x = 1',
@@ -66,7 +66,10 @@ describe('commandBarMachine', () => {
       name: 'Test codemod',
       groupId: 'test',
       needsReview: true,
-      reviewValidation: vi.fn().mockResolvedValue(reviewError),
+      reviewValidation: vi
+        .fn()
+        .mockResolvedValueOnce(reviewError)
+        .mockResolvedValueOnce({ reviewDetails }),
       onSubmit: vi.fn(),
       args: {
         optional: {
@@ -113,6 +116,7 @@ describe('commandBarMachine', () => {
     await vi.waitFor(() => {
       expect(actor.getSnapshot().matches('Review')).toBe(true)
     })
+    expect(actor.getSnapshot().context.reviewValidationError).toBeUndefined()
     expect(actor.getSnapshot().context.reviewValidationDetails).toEqual(
       reviewDetails
     )

--- a/src/machines/commandBarMachine.ts
+++ b/src/machines/commandBarMachine.ts
@@ -598,9 +598,11 @@ export const commandBarMachine = setup({
             input,
             input.selectedCommand?.machineActor
           )
+          if (result) {
+            reviewValidationDetails = result.reviewDetails
+          }
           if (isErr(result)) {
             reviewValidationError = result.message
-            reviewValidationDetails = result.reviewDetails
           }
         }
 


### PR DESCRIPTION
## Stack

- 1 of 3.
- Followed by #13771 and #13576.

## What changed

- Represent foreign imports as first-class `ImportedGeometry` execution operations and artifacts.
- Centralize Feature Tree target resolution so nested module content remains read-only while imported geometry remains an actionable leaf target.
- Drive the Feature Tree action menu from a data list with per-action visibility, which keeps future target capabilities from multiplying conditional UI blocks.
- Enable appearance, visibility, transforms, clone, patterns, and delete for imported geometry.
- Keep cached imported geometry from waiting on stale engine commands.

## Review notes

This PR is the generic imported-geometry and Feature Tree foundation. It intentionally excludes imported BREP face and edge topology:

- KCL/runtime topology support is in #13771.
- App selection and codemod wiring is in #13576.

The foreign-part appearance/visibility scenario is a desktop test because it exercises the native project and import flow.