### PR TITLE
Confirm the cloud feature is properly enabled in tests

### DIFF
--- a/e2e/playwright/cloud-sync.spec.ts
+++ b/e2e/playwright/cloud-sync.spec.ts
@@ -10,7 +10,11 @@ import {
   seedCloudSyncState,
   zipProject,
 } from '@e2e/playwright/lib/cloudSyncTestUtils'
-import { mockClientErrorReports, setup } from '@e2e/playwright/test-utils'
+import {
+  expectCloudFeatureEnabled,
+  mockClientErrorReports,
+  setup,
+} from '@e2e/playwright/test-utils'
 import { expect, type Page, test } from '@playwright/test'
 import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
 
@@ -74,6 +78,7 @@ test(
       `&ttc-prompt=${encodeURIComponent(prompt)}`
 
     await setup(context, page, testInfo, [OPFS_CLOUD_FEATURE_FLAG])
+    await expectCloudFeatureEnabled(page)
 
     for (const [index, projectName] of [
       'demo-project',
@@ -169,7 +174,7 @@ test(
     })
 
     await setup(context, page, testInfo, [OPFS_CLOUD_FEATURE_FLAG])
-    await page.goto('/')
+    await expectCloudFeatureEnabled(page)
     await expectCloudSyncHomeReady(page)
     await expect(
       page.getByTestId('project-library-empty').first()
@@ -299,6 +304,7 @@ test(
     })
 
     await setup(context, page, testInfo, [OPFS_CLOUD_FEATURE_FLAG])
+    await expectCloudFeatureEnabled(page)
     await page.goto(`/?project-id=${publicProjectId}&ask-open-desktop=true`)
     await page.getByTestId('continue-to-web-app-button').click()
 
@@ -416,7 +422,7 @@ test(
 
     await mockClientErrorReports(context)
     await setup(context, page, testInfo, [OPFS_CLOUD_FEATURE_FLAG])
-    await page.goto('/')
+    await expectCloudFeatureEnabled(page)
     await expectCloudSyncHomeReady(page)
 
     const localOnlyFiles = {

--- a/e2e/playwright/onboarding-web.spec.ts
+++ b/e2e/playwright/onboarding-web.spec.ts
@@ -6,7 +6,7 @@ import {
   readOpfsTextFiles,
   routeCloudProjects,
 } from '@e2e/playwright/lib/cloudSyncTestUtils'
-import { setup } from '@e2e/playwright/test-utils'
+import { expectCloudFeatureEnabled, setup } from '@e2e/playwright/test-utils'
 import { expect, type Page, test } from '@playwright/test'
 import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
 
@@ -92,6 +92,7 @@ test(
       },
     })
     await setup(context, page, testInfo, [OPFS_CLOUD_FEATURE_FLAG])
+    await expectCloudFeatureEnabled(page)
 
     await replayOnboardingFromSettings(page, 'tutorial-project')
     await expect

--- a/e2e/playwright/test-utils.ts
+++ b/e2e/playwright/test-utils.ts
@@ -45,6 +45,7 @@ import {
 import { test } from '@e2e/playwright/zoo-test'
 import { createLayoutWithMetadata } from '@src/lib/layout'
 import { playwrightLayoutConfig } from '@src/lib/layout/configs/playwright'
+import { PERSONAL_CLOUD_PROJECT_LIBRARY_TITLE } from '@src/lib/projectLibraries'
 
 export const PLAYWRIGHT_LAYOUT_CONFIG_NAME = 'test'
 
@@ -942,6 +943,19 @@ export async function mockClientErrorReports(context: BrowserContext) {
       body: JSON.stringify({}),
     })
   })
+}
+
+// Temporary function to confirm the feature flag is enabled
+export async function expectCloudFeatureEnabled(page: Page) {
+  await page.goto('/')
+  await expect(
+    page,
+    `'${OPFS_CLOUD_FEATURE_FLAG}' feature not enabled: / did not redirect to /home`
+  ).toHaveURL(/\/home$/)
+  await expect(
+    page.getByText(PERSONAL_CLOUD_PROJECT_LIBRARY_TITLE, { exact: true }),
+    `'${OPFS_CLOUD_FEATURE_FLAG}' feature not enabled: "${PERSONAL_CLOUD_PROJECT_LIBRARY_TITLE}" not visible`
+  ).toBeVisible()
 }
 
 // settingsOverrides may need to be augmented to take more generic items,


### PR DESCRIPTION
There might be a race condition between fetching auth and the enabled features in tests. If that's happening, it will show up in these tests:

https://test-analysis-bot.corp.zoo.dev/projects/KittyCAD/modeling-app/tests/27460?branch=confirm-cloud-feature

https://test-analysis-bot.corp.zoo.dev/projects/KittyCAD/modeling-app/tests/26573?branch=confirm-cloud-feature