### PR TITLE
Handle stale and retired categories in the publish dialog

### DIFF
--- a/src/components/PublishDialog.test.tsx
+++ b/src/components/PublishDialog.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const category = {
   id: 'robotics',
+  slug: 'robotics',
   display_name: 'Robotics',
   description: 'Robotics projects',
   sort_order: 1,
@@ -89,6 +90,131 @@ describe('PublishDialog', () => {
     await waitFor(() => {
       expect(unregisterActions).toHaveBeenCalledTimes(1)
       expect(focusScope.onBlur).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('shows every active category and hides inactive categories', async () => {
+    const categories = Array.from({ length: 18 }, (_, index) => ({
+      ...category,
+      id: `category-${index}`,
+      slug: `category-${index}`,
+      display_name: `Category ${index}`,
+      sort_order: index,
+      is_active: true,
+    }))
+    categories.push({
+      ...category,
+      id: 'inactive-makeathon',
+      slug: 'makeathon',
+      display_name: 'Inactive Makeathon',
+      sort_order: 19,
+      is_active: false,
+    })
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue(categories),
+    } as unknown as Response)
+
+    render(
+      <Popover>
+        <PublishDialog
+          onSubmit={vi.fn()}
+          accountUrl="https://zoo.dev/account"
+        />
+      </Popover>
+    )
+
+    expect(await screen.findByText('Category 17')).toBeVisible()
+    expect(screen.getAllByRole('checkbox')).toHaveLength(18)
+    expect(screen.queryByText('Inactive Makeathon')).not.toBeInTheDocument()
+    expect(fetch).toHaveBeenCalledWith(expect.any(String), {
+      cache: 'no-cache',
+      signal: expect.any(AbortSignal),
+    })
+  })
+
+  it('keeps Makeathon available only when it is already assigned', async () => {
+    render(
+      <Popover>
+        <PublishDialog
+          onSubmit={vi.fn()}
+          accountUrl="https://zoo.dev/account"
+          publicationDetails={{
+            projectId: 'project-id',
+            publicationStatus: 'published',
+            title: 'Makeathon project',
+            description: 'An existing entry.',
+            categoryIds: ['3bd6fb75-c6f6-413e-83f6-e93b6076ae0c'],
+            updatedAt: '2026-04-30T00:00:00Z',
+          }}
+        />
+      </Popover>
+    )
+
+    expect(await screen.findByText('Makeathon')).toBeVisible()
+    expect(screen.getByRole('checkbox', { name: /Makeathon/ })).toBeChecked()
+  })
+
+  it('allows an existing Makeathon category to be removed', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(true)
+    render(
+      <Popover>
+        <PublishDialog
+          onSubmit={onSubmit}
+          accountUrl="https://zoo.dev/account"
+          publicationDetails={{
+            projectId: 'project-id',
+            publicationStatus: 'published',
+            title: 'Makeathon project',
+            description: 'An existing entry.',
+            categoryIds: ['3bd6fb75-c6f6-413e-83f6-e93b6076ae0c', category.id],
+            updatedAt: '2026-04-30T00:00:00Z',
+          }}
+        />
+      </Popover>
+    )
+
+    await screen.findByText('Robotics')
+    fireEvent.click(screen.getByRole('checkbox', { name: /Makeathon/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Update submission' }))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({
+        title: 'Makeathon project',
+        description: 'An existing entry.',
+        categoryIds: [category.id],
+      })
+    })
+  })
+
+  it('does not resubmit inactive categories from an existing project', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(true)
+    render(
+      <Popover>
+        <PublishDialog
+          onSubmit={onSubmit}
+          accountUrl="https://zoo.dev/account"
+          publicationDetails={{
+            projectId: 'project-id',
+            publicationStatus: 'published',
+            title: 'Existing project',
+            description: 'Existing description.',
+            categoryIds: ['retired-category', category.id],
+            updatedAt: '2026-04-30T00:00:00Z',
+          }}
+        />
+      </Popover>
+    )
+
+    await screen.findByText('Robotics')
+    fireEvent.click(screen.getByRole('button', { name: 'Update submission' }))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({
+        title: 'Existing project',
+        description: 'Existing description.',
+        categoryIds: [category.id],
+      })
     })
   })
 })

--- a/src/components/PublishDialog.tsx
+++ b/src/components/PublishDialog.tsx
@@ -39,6 +39,19 @@ type PublishDialogProps = {
 }
 
 const AQUARIUM_TERMS_URL = 'https://zoo.dev/aquarium-terms-of-use'
+// The active-only categories endpoint omits this retired category. Keep it
+// available when already assigned so users may retain or remove it while editing.
+const MAKEATHON_CATEGORY: ProjectCategoryResponse = {
+  id: '3bd6fb75-c6f6-413e-83f6-e93b6076ae0c',
+  slug: 'makeathon',
+  display_name: 'Makeathon',
+  description: 'Entries from the April-May 2026 Makeathon event',
+  sort_order: 220,
+}
+
+type ProjectCategoryWithStatus = ProjectCategoryResponse & {
+  is_active?: boolean
+}
 
 export function PublishDialog({
   onSubmit,
@@ -59,7 +72,7 @@ export function PublishDialog({
   const [hasEditedCategories, setHasEditedCategories] = useState(false)
   const [hasTriedSubmit, setHasTriedSubmit] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [categories, setCategories] = useState<ProjectCategoryResponse[]>([])
+  const [categories, setCategories] = useState<ProjectCategoryWithStatus[]>([])
   const [isLoadingCategories, setIsLoadingCategories] = useState(true)
   const [categoriesError, setCategoriesError] = useState<string | null>(null)
   const [descriptionEditorActions, setDescriptionEditorActions] =
@@ -97,6 +110,7 @@ export function PublishDialog({
       const response = await fetchWithSessionExpiration(
         withAPIBaseURL('/projects/categories'),
         {
+          cache: 'no-cache',
           signal,
         }
       )
@@ -108,7 +122,7 @@ export function PublishDialog({
       }
 
       const nextCategories =
-        (await response.json()) as ProjectCategoryResponse[]
+        (await response.json()) as ProjectCategoryWithStatus[]
       setCategories(
         [...nextCategories].sort((a, b) => a.sort_order - b.sort_order)
       )
@@ -166,9 +180,36 @@ export function PublishDialog({
     () => normalizeMarkdownEditorValue(description),
     [description]
   )
+  const availableCategories = useMemo(() => {
+    const assignedCategoryIds = new Set(publicationDetails?.categoryIds ?? [])
+    const activeCategories = categories.filter(
+      (category) =>
+        category.is_active !== false ||
+        (category.slug === MAKEATHON_CATEGORY.slug &&
+          assignedCategoryIds.has(category.id))
+    )
+
+    if (
+      assignedCategoryIds.has(MAKEATHON_CATEGORY.id) &&
+      !activeCategories.some(
+        (category) => category.id === MAKEATHON_CATEGORY.id
+      )
+    ) {
+      activeCategories.push(MAKEATHON_CATEGORY)
+    }
+
+    return activeCategories.sort((a, b) => a.sort_order - b.sort_order)
+  }, [categories, publicationDetails?.categoryIds])
+  const availableCategoryIds = useMemo(
+    () => new Set(availableCategories.map((category) => category.id)),
+    [availableCategories]
+  )
+  const validSelectedCategoryIds = selectedCategoryIds.filter((categoryId) =>
+    availableCategoryIds.has(categoryId)
+  )
   const titleIsValid = title.trim().length > 0
   const descriptionIsValid = normalizedDescription.trim().length > 0
-  const categoriesIsValid = selectedCategoryIds.length > 0
+  const categoriesIsValid = validSelectedCategoryIds.length > 0
   const lastSubmittedText = useMemo(
     () => getLastSubmittedText(publicationDetails),
     [publicationDetails]
@@ -192,7 +233,7 @@ export function PublishDialog({
       await onSubmit({
         title: title.trim(),
         description: normalizedDescription.trim(),
-        categoryIds: selectedCategoryIds,
+        categoryIds: validSelectedCategoryIds,
       })
     } finally {
       setIsSubmitting(false)
@@ -211,8 +252,8 @@ export function PublishDialog({
       leaveFrom="opacity-100 translate-y-0 scale-100"
       leaveTo="opacity-0 translate-y-1 scale-[0.98]"
     >
-      <Popover.Panel className="absolute right-0 top-full z-20 mt-3 flex max-h-[calc(100vh-5rem)] w-[30rem] max-w-[calc(100vw-2rem)] flex-col overflow-y-auto overscroll-contain rounded border border-chalkboard-30/80 bg-chalkboard-10/95 text-sm text-chalkboard-100 shadow-2xl backdrop-blur-sm dark:border-chalkboard-80/60 dark:bg-chalkboard-90/95 dark:text-chalkboard-10">
-        <div className="border-b border-chalkboard-20/70 bg-chalkboard-20/70 px-4 py-4 text-chalkboard-100 dark:border-chalkboard-80/70 dark:bg-chalkboard-80/70 dark:text-chalkboard-10">
+      <Popover.Panel className="fixed bottom-4 right-4 top-16 z-20 flex w-[30rem] max-w-[calc(100vw-2rem)] flex-col overflow-hidden rounded border border-chalkboard-30/80 bg-chalkboard-10/95 text-sm text-chalkboard-100 shadow-2xl backdrop-blur-sm dark:border-chalkboard-80/60 dark:bg-chalkboard-90/95 dark:text-chalkboard-10">
+        <div className="shrink-0 border-b border-chalkboard-20/70 bg-chalkboard-20/70 px-4 py-4 text-chalkboard-100 dark:border-chalkboard-80/70 dark:bg-chalkboard-80/70 dark:text-chalkboard-10">
           <div className="min-w-0">
             <h2 className="text-base font-medium leading-none">
               Publish project
@@ -225,7 +266,7 @@ export function PublishDialog({
 
         <form
           {...noAutofillFormProps}
-          className="flex flex-col gap-4 px-4 py-4"
+          className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto overscroll-contain px-4 py-4"
           onSubmit={(event) => {
             event.preventDefault()
             void handleSubmit()
@@ -313,7 +354,7 @@ export function PublishDialog({
 
               <div
                 aria-invalid={hasTriedSubmit && !categoriesIsValid}
-                className={`max-h-64 overflow-y-auto rounded-lg border bg-chalkboard-10/70 p-1.5 dark:bg-chalkboard-100/40 ${
+                className={`max-h-[19rem] overflow-y-auto overscroll-contain rounded-lg border bg-chalkboard-10/70 p-1.5 dark:bg-chalkboard-100/40 ${
                   hasTriedSubmit && !categoriesIsValid
                     ? 'border-destroy-60'
                     : 'border-chalkboard-20/80 dark:border-chalkboard-80/70'
@@ -339,13 +380,13 @@ export function PublishDialog({
                       </ActionButton>
                     </div>
                   </div>
-                ) : categories.length === 0 ? (
+                ) : availableCategories.length === 0 ? (
                   <div className="px-2 py-6 text-xs leading-5 text-chalkboard-60 dark:text-chalkboard-40">
                     No Aquarium categories are currently available.
                   </div>
                 ) : (
                   <div className="flex flex-col gap-1.5">
-                    {categories.map((category) => {
+                    {availableCategories.map((category) => {
                       const isSelected = selectedCategoryIds.includes(
                         category.id
                       )
@@ -406,7 +447,7 @@ export function PublishDialog({
             </div>
           </section>
 
-          <section className="border-t border-chalkboard-20/70 pt-4 dark:border-chalkboard-80/70">
+          <section className="sticky -bottom-4 z-10 -mx-4 -mb-4 border-t border-chalkboard-20/70 bg-chalkboard-10/95 px-4 pb-4 pt-4 backdrop-blur-sm dark:border-chalkboard-80/70 dark:bg-chalkboard-90/95">
             <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between sm:gap-4 md:gap-6">
               <div className="min-w-0 flex-1">
                 <p className="text-xs leading-5 text-chalkboard-60 dark:text-chalkboard-40">

--- a/src/lib/share.test.ts
+++ b/src/lib/share.test.ts
@@ -216,6 +216,34 @@ describe('publishCurrentProject', () => {
       { duration: 5000 }
     )
   })
+
+  it('shows a useful error when a category is rejected', async () => {
+    mockState.createProject.mockResolvedValueOnce(
+      new Error(
+        'category `retired-category` is not active or does not exist'
+      ) as never
+    )
+
+    const published = await publishCurrentProject({
+      token: 'token-123',
+      project: makeProject(),
+      currentFilePath: '/projects/bracket/main.kcl',
+      currentFileContents: 'part001 = startSketchOn(XY)',
+      wasmInstance: {} as never,
+      submission: {
+        title: 'Bracket',
+        description: 'A mounting bracket.',
+        categoryIds: ['retired-category'],
+      },
+    })
+
+    expect(published).toBe(false)
+    expect(mockState.toastError).toHaveBeenCalledWith(
+      'One or more selected categories are no longer available. Choose an active category and try again.',
+      { duration: 5000 }
+    )
+    expect(mockState.publishProject).not.toHaveBeenCalled()
+  })
 })
 
 describe('getCurrentProjectPublicationDetails', () => {

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -80,7 +80,7 @@ export async function publishCurrentProject(
     project: args.project,
   })
   if (err(uploadedProject)) {
-    toast.error(uploadedProject.message, {
+    toast.error(getPublishErrorMessage(uploadedProject), {
       duration: 5000,
     })
     return false
@@ -93,7 +93,7 @@ export async function publishCurrentProject(
     })
   )
   if (err(publishedProject)) {
-    toast.error(publishedProject.message, {
+    toast.error(getPublishErrorMessage(publishedProject), {
       duration: 5000,
     })
     return false
@@ -109,6 +109,17 @@ export async function publishCurrentProject(
   )
 
   return true
+}
+
+function getPublishErrorMessage(error: Error) {
+  if (
+    /categor(?:y|ies)/i.test(error.message) &&
+    /not active|inactive|does not exist|invalid/i.test(error.message)
+  ) {
+    return 'One or more selected categories are no longer available. Choose an active category and try again.'
+  }
+
+  return error.message
 }
 
 export async function getCurrentProjectPublicationDetails({

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -113,7 +113,7 @@ export async function publishCurrentProject(
 
 function getPublishErrorMessage(error: Error) {
   if (
-    /categor(?:y|ies)/i.test(error.message) &&
+    /(?:category|categories)/i.test(error.message) &&
     /not active|inactive|does not exist|invalid/i.test(error.message)
   ) {
     return 'One or more selected categories are no longer available. Choose an active category and try again.'


### PR DESCRIPTION
- Revalidate the active category list whenever the publish dialog opens.
- Prevent retired category IDs from being silently resubmitted from existing projects.
- Keep Makeathon available when already assigned, while allowing users to remove it.
- Show a clear error if the API rejects an unavailable category.
- Keep the category list independently scrollable and the dialog footer within the viewport.
- Defensively filter categories explicitly marked inactive if the API includes status metadata.
- Tests: Added coverage for active and inactive categories, long category lists, retaining and removing Makeathon category,  excluding retired category IDs from submissions, and category rejection messaging.

Follow-up
The API must allow an inactive category to remain assigned when it already belongs to the project for retained Makeathon submissions to succeed. (will do this separately)