### PR TITLE
Make unresolved Zookeeper selections dismissible

### DIFF
--- a/src/components/SelectionReferencesPopover.test.tsx
+++ b/src/components/SelectionReferencesPopover.test.tsx
@@ -1,0 +1,125 @@
+import { Suspense } from 'react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+  const unresolvedFace = {
+    type: 'enginePrimitive' as const,
+    entityId: 'unresolved-face',
+    parentEntityId: 'body',
+    primitiveIndex: 1,
+    primitiveType: 'face' as const,
+  }
+  const wasmInstancePromise = Promise.resolve({})
+
+  return {
+    getSelectionReferences: vi.fn(),
+    send: vi.fn(),
+    selectionRanges: {
+      graphSelections: [],
+      otherSelections: [unresolvedFace],
+    },
+    unresolvedFace,
+    wasmInstancePromise,
+    kclManager: {
+      artifactGraph: new Map(),
+      engineCommandManager: {},
+      wasmInstancePromise,
+    },
+  }
+})
+
+vi.mock('react-hot-toast', () => ({
+  default: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+vi.mock('@src/components/CustomIcon', () => ({
+  CustomIcon: () => null,
+}))
+
+vi.mock('@src/components/Tooltip', () => ({
+  default: () => null,
+}))
+
+vi.mock('@src/hooks/useModelingContext', () => ({
+  useModelingContext: () => ({
+    context: { selectionRanges: mocks.selectionRanges },
+    send: mocks.send,
+  }),
+}))
+
+vi.mock('@src/lib/boot', () => ({
+  useSingletons: () => ({
+    kclManager: mocks.kclManager,
+  }),
+}))
+
+vi.mock('@src/lib/selections', () => ({
+  getSelectionReferences: mocks.getSelectionReferences,
+  getUnresolvedEnginePrimitiveSelections: (
+    enginePrimitives: typeof mocks.selectionRanges.otherSelections,
+    references: Array<{ enginePrimitiveSelection?: { entityId: string } }>
+  ) =>
+    enginePrimitives.filter(
+      (selection) =>
+        !references.some(
+          (reference) =>
+            reference.enginePrimitiveSelection?.entityId === selection.entityId
+        )
+    ),
+  isDefaultPlaneSelection: () => false,
+  isEnginePrimitiveSelection: (selection: { type?: string }) =>
+    selection.type === 'enginePrimitive',
+  removeEnginePrimitiveSelectionFromSelections: (
+    selections: typeof mocks.selectionRanges,
+    selectionToRemove: typeof mocks.unresolvedFace
+  ) => ({
+    graphSelections: selections.graphSelections,
+    otherSelections: selections.otherSelections.filter(
+      (selection) => selection.entityId !== selectionToRemove.entityId
+    ),
+  }),
+  removeReferenceFromSelections: vi.fn(),
+}))
+
+import { SelectionReferencesPopover } from '@src/components/SelectionReferencesPopover'
+
+describe('SelectionReferencesPopover', () => {
+  beforeEach(() => {
+    mocks.getSelectionReferences.mockReset()
+    mocks.getSelectionReferences.mockResolvedValue([])
+    mocks.send.mockReset()
+  })
+
+  test('shows and removes an engine primitive that has no KCL reference', async () => {
+    await act(async () => {
+      render(
+        <Suspense fallback={<div>Loading Wasm...</div>}>
+          <SelectionReferencesPopover />
+        </Suspense>
+      )
+      await mocks.wasmInstancePromise
+    })
+
+    const removeButton = await screen.findByRole('button', {
+      name: 'Remove unresolved face from selection',
+    })
+    expect(screen.getByText('Unresolved face')).toBeInTheDocument()
+
+    fireEvent.click(removeButton)
+
+    expect(mocks.send).toHaveBeenCalledWith({
+      type: 'Set selection',
+      data: {
+        selectionType: 'completeSelection',
+        selection: {
+          graphSelections: [],
+          otherSelections: [],
+        },
+      },
+    })
+  })
+})

--- a/src/components/SelectionReferencesPopover.tsx
+++ b/src/components/SelectionReferencesPopover.tsx
@@ -9,10 +9,13 @@ import { useSingletons } from '@src/lib/boot'
 import {
   type SelectionReference,
   getSelectionReferences,
+  getUnresolvedEnginePrimitiveSelections,
   isDefaultPlaneSelection,
   isEnginePrimitiveSelection,
+  removeEnginePrimitiveSelectionFromSelections,
   removeReferenceFromSelections,
 } from '@src/lib/selections'
+import type { EnginePrimitiveSelection } from '@src/machines/modelingSharedTypes'
 import { reportRejection } from '@src/lib/trap'
 
 type SelectionReferenceState =
@@ -97,7 +100,21 @@ export function SelectionReferencesPopover() {
     )
   }
 
-  if (state.references.length === 0) {
+  const enginePrimitives = selectionRanges.otherSelections.filter(
+    isEnginePrimitiveSelection
+  )
+  const unresolvedEnginePrimitives =
+    state.status === 'ready'
+      ? getUnresolvedEnginePrimitiveSelections(
+          enginePrimitives,
+          state.references
+        )
+      : []
+
+  if (
+    state.references.length === 0 &&
+    unresolvedEnginePrimitives.length === 0
+  ) {
     return (
       <div className="p-2 text-xs text-chalkboard-70 dark:text-chalkboard-30">
         No selection references for the current selection.
@@ -111,6 +128,21 @@ export function SelectionReferencesPopover() {
       data: {
         selectionType: 'completeSelection',
         selection: removeReferenceFromSelections(selectionRanges, reference),
+      },
+    })
+  }
+
+  const removeUnresolvedEnginePrimitive = (
+    selection: EnginePrimitiveSelection
+  ) => {
+    send({
+      type: 'Set selection',
+      data: {
+        selectionType: 'completeSelection',
+        selection: removeEnginePrimitiveSelectionFromSelections(
+          selectionRanges,
+          selection
+        ),
       },
     })
   }
@@ -156,6 +188,30 @@ export function SelectionReferencesPopover() {
               contentClassName="max-w-64 text-xs text-left"
             >
               Remove this item from the selection.
+            </Tooltip>
+          </button>
+        </div>
+      ))}
+      {unresolvedEnginePrimitives.map((selection) => (
+        <div
+          key={`unresolved:${selection.primitiveType}:${selection.entityId}`}
+          className="grid grid-cols-[minmax(0,1fr),auto] items-center gap-2 rounded-sm px-2 py-1 text-xs"
+        >
+          <span className="truncate text-destroy-80 dark:text-destroy-40">
+            Unresolved {selection.primitiveType}
+          </span>
+          <button
+            type="button"
+            className="relative p-0.5 rounded-sm text-2 hover:bg-destroy-80 focus:bg-destroy-80 !border-none"
+            aria-label={`Remove unresolved ${selection.primitiveType} from selection`}
+            onClick={() => removeUnresolvedEnginePrimitive(selection)}
+          >
+            <CustomIcon name="close" className="h-4 w-4" />
+            <Tooltip
+              position="left"
+              contentClassName="max-w-64 text-xs text-left"
+            >
+              Remove this unresolved item from the selection.
             </Tooltip>
           </button>
         </div>

--- a/src/lib/selections.spec.ts
+++ b/src/lib/selections.spec.ts
@@ -14,13 +14,16 @@ import {
   getSelectionReferences,
   getSelectionTypeDisplayText,
   getStableOffsetPlaneData,
+  getUnresolvedEnginePrimitiveSelections,
   handleSelectionBatch,
+  removeEnginePrimitiveSelectionFromSelections,
   removeReferenceFromSelections,
   selectSketchPlane,
 } from '@src/lib/selections'
 import { enginelessExecutor } from '@src/lib/testHelpers'
 import type {
   DefaultPlaneSelection,
+  EnginePrimitiveSelection,
   Selection,
 } from '@src/machines/modelingSharedTypes'
 import { buildTheWorldAndNoEngineConnection } from '@src/unitTestUtils'
@@ -1656,6 +1659,50 @@ cube = extrude(cubeRegion, length = 10)
     ).toEqual({
       graphSelections: [],
       otherSelections: ['x-axis'],
+    })
+  })
+
+  test('identifies and removes engine primitives without KCL references', () => {
+    const unresolvedFace: EnginePrimitiveSelection = {
+      type: 'enginePrimitive',
+      entityId: 'unresolved-face',
+      parentEntityId: 'body',
+      primitiveIndex: 1,
+      primitiveType: 'face',
+    }
+    const resolvedEdge: EnginePrimitiveSelection = {
+      type: 'enginePrimitive',
+      entityId: 'resolved-edge',
+      parentEntityId: 'body',
+      primitiveIndex: 2,
+      primitiveType: 'edge',
+    }
+
+    expect(
+      getUnresolvedEnginePrimitiveSelections(
+        [unresolvedFace, resolvedEdge],
+        [
+          {
+            id: 'edge:resolved-edge',
+            label: 'Edge',
+            code: 'getEdge(body, 2)',
+            enginePrimitiveSelection: resolvedEdge,
+          },
+        ]
+      )
+    ).toEqual([unresolvedFace])
+
+    expect(
+      removeEnginePrimitiveSelectionFromSelections(
+        {
+          graphSelections: [],
+          otherSelections: [unresolvedFace, resolvedEdge, 'x-axis'],
+        },
+        unresolvedFace
+      )
+    ).toEqual({
+      graphSelections: [],
+      otherSelections: [resolvedEdge, 'x-axis'],
     })
   })
 })

--- a/src/lib/selections.ts
+++ b/src/lib/selections.ts
@@ -323,7 +323,7 @@ const BODY_REFERENCE_ARTIFACT_TYPES: Artifact['type'][] = [
   'helix',
 ]
 
-function isReferenceablePrimitiveSelection(
+export function isReferenceableEnginePrimitiveSelection(
   selection: EnginePrimitiveSelection
 ): selection is ReferenceablePrimitiveSelection {
   return (
@@ -1013,7 +1013,7 @@ export async function getSelectionReferences({
     )
     if (
       primitiveSelection &&
-      isReferenceablePrimitiveSelection(primitiveSelection)
+      isReferenceableEnginePrimitiveSelection(primitiveSelection)
     ) {
       primitiveSelections.push({
         ...primitiveSelection,
@@ -1023,7 +1023,7 @@ export async function getSelectionReferences({
   }
 
   for (const selection of enginePrimitives) {
-    if (isReferenceablePrimitiveSelection(selection)) {
+    if (isReferenceableEnginePrimitiveSelection(selection)) {
       primitiveSelections.push({
         ...selection,
         graphSelection: graphSelectionByEntityId.get(selection.entityId),
@@ -1072,6 +1072,20 @@ export async function getSelectionReferences({
   ]
 }
 
+export function getUnresolvedEnginePrimitiveSelections(
+  enginePrimitives: EnginePrimitiveSelection[],
+  references: SelectionReference[]
+): EnginePrimitiveSelection[] {
+  return enginePrimitives.filter(
+    (selection) =>
+      isReferenceableEnginePrimitiveSelection(selection) &&
+      !references.some(
+        (reference) =>
+          reference.enginePrimitiveSelection?.entityId === selection.entityId
+      )
+  )
+}
+
 function isSameCodeRange(left: Selection, right: Selection) {
   return (
     left.codeRef.range[0] === right.codeRef.range[0] &&
@@ -1103,6 +1117,25 @@ function isSameDefaultPlaneSelection(
   right: DefaultPlaneSelection
 ) {
   return left.id === right.id
+}
+
+export function removeEnginePrimitiveSelectionFromSelections(
+  selections: Selections,
+  enginePrimitiveSelectionToRemove: EnginePrimitiveSelection
+): Selections {
+  return {
+    graphSelections: selections.graphSelections,
+    otherSelections: selections.otherSelections.filter(
+      (selection) =>
+        !(
+          isEnginePrimitiveSelection(selection) &&
+          isSameEnginePrimitiveSelection(
+            selection,
+            enginePrimitiveSelectionToRemove
+          )
+        )
+    ),
+  }
 }
 
 export function removeReferenceFromSelections(

--- a/src/lib/zookeeper/zookeeperPromptRequest.ts
+++ b/src/lib/zookeeper/zookeeperPromptRequest.ts
@@ -11,17 +11,15 @@ import { parentPathRelativeToProject, toWebSafePath } from '@src/lib/paths'
 import type { FileEntry } from '@src/lib/project'
 import {
   getSelectionReferences,
+  getUnresolvedEnginePrimitiveSelections,
   isEnginePrimitiveSelection,
+  isReferenceableEnginePrimitiveSelection,
   type SelectionReference,
 } from '@src/lib/selections'
 import type { FileMeta } from '@src/lib/types'
 import { isErr, reportRejection } from '@src/lib/trap'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
-import type {
-  EnginePrimitiveSelection,
-  Selection,
-  Selections,
-} from '@src/machines/modelingSharedTypes'
+import type { Selection, Selections } from '@src/machines/modelingSharedTypes'
 
 export type KittyCadLibFile = { name: string; data: Blob }
 
@@ -404,14 +402,6 @@ export function buildZookeeperSourceRangePromptsForSelection({
   return prompts
 }
 
-function isReferenceableEnginePrimitiveSelection(
-  selection: EnginePrimitiveSelection
-): boolean {
-  return (
-    selection.primitiveType === 'face' || selection.primitiveType === 'edge'
-  )
-}
-
 function formatSelectionReferencePrompt(
   references: SelectionReference[]
 ): string | null {
@@ -477,12 +467,9 @@ async function buildSelectionReferencePrompt({
     wasmInstance,
   })
 
-  const unresolvedSelections = referenceableEnginePrimitives.filter(
-    (selection) =>
-      !references.some(
-        (reference) =>
-          reference.enginePrimitiveSelection?.entityId === selection.entityId
-      )
+  const unresolvedSelections = getUnresolvedEnginePrimitiveSelections(
+    referenceableEnginePrimitives,
+    references
   )
   if (unresolvedSelections.length > 0) {
     return new Error(


### PR DESCRIPTION
## Summary

- show selected faces and edges that could not be resolved to KCL references in the Selection References popover
- let users remove an unresolved primitive while preserving unrelated graph and non-code selections
- share the unresolved-selection predicate with Zookeeper prompt construction so the UI identifies exactly the selections that block sending
- add component and selection-helper regression coverage for the customer-reported deadlock

## Testing

- `npm run test:unit -- src/components/SelectionReferencesPopover.test.tsx`
- `npm run test:integration -- src/lib/selections.spec.ts -t 'identifies and removes engine primitives without KCL references'`
- `make check`

Closes #13351

Related: #13047
