### PR TITLE
Fixes for proprietary CAD import extensions

### DIFF
--- a/rust/kcl-lib/src/execution/import.rs
+++ b/rust/kcl-lib/src/execution/import.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use anyhow::Result;
 use kcmc::ImportFile;
 use kcmc::ModelingCmd;
@@ -50,18 +48,13 @@ pub async fn import_foreign(
         )));
     }
 
-    let ext_format = get_import_format_from_extension(file_path.extension().ok_or_else(|| {
-        KclError::new_semantic(KclErrorDetails::new(
-            format!("No file extension found for `{}`", file_path.display()),
-            vec![source_range],
-        ))
-    })?)
-    .map_err(|e| KclError::new_semantic(KclErrorDetails::new(e.to_string(), vec![source_range])))?;
+    let ext_format = get_import_format_from_extension(&file_path.to_string_lossy())
+        .map_err(|e| KclError::new_semantic(KclErrorDetails::new(e.to_string(), vec![source_range])))?;
 
     // Get the format type from the extension of the file.
     let format = if let Some(format) = format {
         // Validate the given format with the extension format.
-        validate_extension_format(ext_format, format.clone())
+        validate_extension_format(&file_path.to_string_lossy(), ext_format, format.clone())
             .map_err(|e| KclError::new_semantic(KclErrorDetails::new(e.to_string(), vec![source_range])))?;
         format
     } else {
@@ -161,10 +154,7 @@ pub(super) fn format_from_annotations(
     }
 
     let mut result = result
-        .or_else(|| {
-            path.extension()
-                .and_then(|ext| get_import_format_from_extension(ext).ok())
-        })
+        .or_else(|| get_import_format_from_extension(&path.to_string_lossy()).ok())
         .ok_or(KclError::new_semantic(KclErrorDetails::new(
             "Unknown or missing extension, and no specified format for imported file".to_owned(),
             vec![import_source_range],
@@ -326,23 +316,15 @@ pub async fn send_to_engine(
     Ok(imported_geometry)
 }
 
-/// Get the source format from the extension.
+/// Get the source format from a file path, extension, or canonical format name.
 fn get_import_format_from_extension(ext: &str) -> Result<InputFormat3d> {
-    let ext = ext.to_lowercase();
-    let format = match FileImportFormat::from_str(&ext) {
-        Ok(format) => format,
-        Err(_) => {
-            if ext == "stp" {
-                FileImportFormat::Step
-            } else if ext == "glb" {
-                FileImportFormat::Gltf
-            } else {
-                anyhow::bail!(
-                    "unknown source format for file extension: {ext}. Try setting the `--src-format` flag explicitly or use a valid format."
-                )
-            }
-        }
-    };
+    let format = crate::import_format::import_format_from_path(ext)
+        .or_else(|| crate::import_format::import_format_from_name(ext))
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "unknown source format for file extension: {ext}. Try setting the `--src-format` flag explicitly or use a valid format."
+            )
+        })?;
 
     // Make the default units millimeters.
     let ul = UnitLength::Millimeters;
@@ -353,6 +335,9 @@ fn get_import_format_from_extension(ext: &str) -> Result<InputFormat3d> {
     // * Up: +Z
     // * Handedness: Right
     match format {
+        FileImportFormat::Acis => Ok(InputFormat3d::Acis(kcmc::format::acis::import::Options::default())),
+        FileImportFormat::Catia => Ok(InputFormat3d::Catia(kcmc::format::catia::import::Options::default())),
+        FileImportFormat::Creo => Ok(InputFormat3d::Creo(kcmc::format::creo::import::Options::default())),
         FileImportFormat::Step => Ok(InputFormat3d::Step(
             kcmc::format::step::import::Options::builder()
                 .coords(ZOO_COORD_SYSTEM)
@@ -372,6 +357,10 @@ fn get_import_format_from_extension(ext: &str) -> Result<InputFormat3d> {
                 .build(),
         )),
         FileImportFormat::Gltf => Ok(InputFormat3d::Gltf(kcmc::format::gltf::import::Options::default())),
+        FileImportFormat::Inventor => Ok(InputFormat3d::Inventor(
+            kcmc::format::inventor::import::Options::default(),
+        )),
+        FileImportFormat::Nx => Ok(InputFormat3d::Nx(kcmc::format::nx::import::Options::default())),
         FileImportFormat::Ply => Ok(InputFormat3d::Ply(
             kcmc::format::ply::import::Options::builder()
                 .coords(ZOO_COORD_SYSTEM)
@@ -379,6 +368,9 @@ fn get_import_format_from_extension(ext: &str) -> Result<InputFormat3d> {
                 .build(),
         )),
         FileImportFormat::Fbx => Ok(InputFormat3d::Fbx(kcmc::format::fbx::import::Options::default())),
+        FileImportFormat::Parasolid => Ok(InputFormat3d::Parasolid(
+            kcmc::format::parasolid::import::Options::default(),
+        )),
         FileImportFormat::Sldprt => Ok(InputFormat3d::Sldprt(
             kcmc::format::sldprt::import::Options::builder()
                 .split_closed_faces(false)
@@ -388,32 +380,8 @@ fn get_import_format_from_extension(ext: &str) -> Result<InputFormat3d> {
     }
 }
 
-fn validate_extension_format(ext: InputFormat3d, given: InputFormat3d) -> Result<()> {
-    if let InputFormat3d::Stl(_) = ext
-        && let InputFormat3d::Stl(_) = given
-    {
-        return Ok(());
-    }
-
-    if let InputFormat3d::Obj(_) = ext
-        && let InputFormat3d::Obj(_) = given
-    {
-        return Ok(());
-    }
-
-    if let InputFormat3d::Ply(_) = ext
-        && let InputFormat3d::Ply(_) = given
-    {
-        return Ok(());
-    }
-
-    if let InputFormat3d::Step(_) = ext
-        && let InputFormat3d::Step(_) = given
-    {
-        return Ok(());
-    }
-
-    if ext == given {
+fn validate_extension_format(path: &str, ext: InputFormat3d, given: InputFormat3d) -> Result<()> {
+    if crate::import_format::import_path_supports_format(path, given.clone().into()) {
         return Ok(());
     }
 
@@ -444,10 +412,39 @@ mod test {
     test_import_format_from_extension!(test_xtn_step_spongebob, "STeP", InputFormat3d::Step);
     test_import_format_from_extension!(test_xtn_fbx, "fbx", InputFormat3d::Fbx);
     test_import_format_from_extension!(test_xtn_gltf, "gltf", InputFormat3d::Gltf);
+    test_import_format_from_extension!(test_xtn_sat, "sat", InputFormat3d::Acis);
+    test_import_format_from_extension!(test_xtn_sab, "sab", InputFormat3d::Acis);
+    test_import_format_from_extension!(test_xtn_catpart, "catpart", InputFormat3d::Catia);
+    test_import_format_from_extension!(test_xtn_ipt, "ipt", InputFormat3d::Inventor);
+    test_import_format_from_extension!(test_xtn_prt, "prt", InputFormat3d::Nx);
     test_import_format_from_extension!(test_xtn_obj, "obj", InputFormat3d::Obj);
+    test_import_format_from_extension!(test_xtn_x_t, "x_t", InputFormat3d::Parasolid);
+    test_import_format_from_extension!(test_xtn_x_b, "x_b", InputFormat3d::Parasolid);
     test_import_format_from_extension!(test_xtn_ply, "ply", InputFormat3d::Ply);
     test_import_format_from_extension!(test_xtn_sldprt, "sldprt", InputFormat3d::Sldprt);
     test_import_format_from_extension!(test_xtn_stl, "stl", InputFormat3d::Stl);
+    test_import_format_from_extension!(test_format_creo, "creo", InputFormat3d::Creo);
+
+    #[test]
+    fn versioned_creo_import_format_from_path() {
+        for path in ["part.prt.1", "nested/part.PRT.23"] {
+            let format = get_import_format_from_extension(path).unwrap();
+            assert_eq!(
+                format,
+                InputFormat3d::Creo(kcmc::format::creo::import::Options::default())
+            );
+        }
+    }
+
+    #[test]
+    fn unversioned_prt_accepts_explicit_creo_format() {
+        validate_extension_format(
+            "part.prt",
+            InputFormat3d::Nx(kcmc::format::nx::import::Options::default()),
+            InputFormat3d::Creo(kcmc::format::creo::import::Options::default()),
+        )
+        .unwrap();
+    }
 
     #[test]
     fn annotations() {
@@ -475,6 +472,24 @@ mod test {
             .unwrap()
             .unwrap();
         assert_eq!(fmt, InputFormat3d::Gltf(kcmc::format::gltf::import::Options::default()));
+
+        // Creo format inferred from a versioned part path.
+        let text = "@()\nimport '../foo.prt.3' as foo";
+        let parsed = crate::Program::parse_no_errs(text).unwrap().ast;
+        let attrs = parsed.body[0].get_attrs();
+        let fmt = format_from_annotations(attrs, &TypedPath::from("../foo.prt.3"), SourceRange::default())
+            .unwrap()
+            .unwrap();
+        assert_eq!(fmt, InputFormat3d::Creo(kcmc::format::creo::import::Options::default()));
+
+        // Creo's canonical format name remains valid in annotations.
+        let text = "@(format = creo)\nimport '../foo.prt.3' as foo";
+        let parsed = crate::Program::parse_no_errs(text).unwrap().ast;
+        let attrs = parsed.body[0].get_attrs();
+        let fmt = format_from_annotations(attrs, &TypedPath::from("../foo.prt.3"), SourceRange::default())
+            .unwrap()
+            .unwrap();
+        assert_eq!(fmt, InputFormat3d::Creo(kcmc::format::creo::import::Options::default()));
 
         // format, no options
         let text = "@(format = gltf)\nimport '../foo.txt' as foo";

--- a/rust/kcl-lib/src/import_format.rs
+++ b/rust/kcl-lib/src/import_format.rs
@@ -1,0 +1,184 @@
+use std::str::FromStr;
+
+use kittycad_modeling_cmds::shared::FileImportFormat;
+
+/// Supported file extensions and the import formats they may contain.
+///
+/// Creo and NX both use `.prt`. NX is listed first so it is the default when the
+/// format is inferred from an unversioned file path. Creo can be selected
+/// explicitly with an import annotation, and versioned `.prt.N` paths are always
+/// Creo.
+pub(crate) const IMPORT_FILE_EXTENSION_FORMATS: &[(&str, &[FileImportFormat])] = &[
+    ("sat", &[FileImportFormat::Acis]),
+    ("sab", &[FileImportFormat::Acis]),
+    ("catpart", &[FileImportFormat::Catia]),
+    ("prt", &[FileImportFormat::Nx, FileImportFormat::Creo]),
+    ("fbx", &[FileImportFormat::Fbx]),
+    ("fbxb", &[FileImportFormat::Fbx]),
+    ("gltf", &[FileImportFormat::Gltf]),
+    ("glb", &[FileImportFormat::Gltf]),
+    ("ipt", &[FileImportFormat::Inventor]),
+    ("obj", &[FileImportFormat::Obj]),
+    ("x_t", &[FileImportFormat::Parasolid]),
+    ("x_b", &[FileImportFormat::Parasolid]),
+    ("ply", &[FileImportFormat::Ply]),
+    ("sldprt", &[FileImportFormat::Sldprt]),
+    ("step", &[FileImportFormat::Step]),
+    ("stp", &[FileImportFormat::Step]),
+    ("stl", &[FileImportFormat::Stl]),
+];
+
+fn formats_for_extension(extension: &str) -> Option<&'static [FileImportFormat]> {
+    IMPORT_FILE_EXTENSION_FORMATS
+        .iter()
+        .find_map(|(candidate, formats)| (*candidate == extension).then_some(*formats))
+}
+
+fn extension_from_path(path: &str) -> Option<String> {
+    let file_name = path.rsplit(['/', '\\']).next()?;
+    let (stem, extension) = file_name.rsplit_once('.')?;
+    (!stem.is_empty()).then(|| extension.to_ascii_lowercase())
+}
+
+/// Parse a canonical import format identifier or a supported file extension.
+pub fn import_format_from_name(name: &str) -> Option<FileImportFormat> {
+    let name = name.to_ascii_lowercase();
+    formats_for_extension(&name)
+        .and_then(|formats| formats.first().copied())
+        .or_else(|| FileImportFormat::from_str(&name).ok())
+}
+
+/// Whether a path names a Creo part file.
+///
+/// Creo part files end in `.prt` or a positive numeric version such as
+/// `.prt.1`. Matching is case-insensitive and applies to the complete basename,
+/// rather than only the final path extension.
+pub fn is_creo_import_path(path: &str) -> bool {
+    let Some(file_name) = path.rsplit(['/', '\\']).next() else {
+        return false;
+    };
+    let file_name = file_name.to_ascii_lowercase();
+    let Some((stem, suffix)) = file_name.rsplit_once(".prt") else {
+        return false;
+    };
+    if stem.is_empty() {
+        return false;
+    }
+    if suffix.is_empty() {
+        return true;
+    }
+
+    let Some(version) = suffix.strip_prefix('.') else {
+        return false;
+    };
+    let mut digits = version.chars();
+    digits.next().is_some_and(|first| matches!(first, '1'..='9')) && digits.all(|digit| digit.is_ascii_digit())
+}
+
+/// Classify an import path by its complete filename.
+pub fn import_format_from_path(path: &str) -> Option<FileImportFormat> {
+    if let Some(format) = extension_from_path(path)
+        .and_then(|extension| formats_for_extension(&extension))
+        .and_then(|formats| formats.first().copied())
+    {
+        return Some(format);
+    }
+
+    is_creo_import_path(path).then_some(FileImportFormat::Creo)
+}
+
+/// Whether a file path can contain the given import format.
+pub(crate) fn import_path_supports_format(path: &str, format: FileImportFormat) -> bool {
+    if format == FileImportFormat::Creo && is_creo_import_path(path) {
+        return true;
+    }
+
+    extension_from_path(path)
+        .and_then(|extension| formats_for_extension(&extension))
+        .is_some_and(|formats| formats.contains(&format))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_creo_part_paths() {
+        for path in [
+            "part.prt",
+            "part.prt.1",
+            "part.prt.23",
+            "parts/nested/part.PRT",
+            r"C:\parts\nested\part.PrT.3",
+        ] {
+            assert!(is_creo_import_path(path), "expected `{path}` to match");
+        }
+    }
+
+    #[test]
+    fn rejects_non_creo_part_paths() {
+        for path in [
+            "partprt",
+            "partprt.1",
+            ".prt",
+            ".prt.1",
+            "part.prt.0",
+            "part.prt.01",
+            "part.prt.-1",
+            "part.prt.foo",
+            "part.prt.1.bak",
+        ] {
+            assert!(!is_creo_import_path(path), "expected `{path}` not to match");
+        }
+    }
+
+    #[test]
+    fn recognizes_creo_format_name_and_import_paths() {
+        assert_eq!(import_format_from_name("creo"), Some(FileImportFormat::Creo));
+        assert_eq!(import_format_from_path("part.prt.42"), Some(FileImportFormat::Creo));
+    }
+
+    #[test]
+    fn classifies_existing_import_extensions_and_aliases() {
+        for (path, expected) in [
+            ("part.step", FileImportFormat::Step),
+            ("part.stp", FileImportFormat::Step),
+            ("part.glb", FileImportFormat::Gltf),
+            ("part.fbxb", FileImportFormat::Fbx),
+            ("part.sldprt", FileImportFormat::Sldprt),
+        ] {
+            assert_eq!(
+                import_format_from_path(path),
+                Some(expected),
+                "unexpected format for `{path}`"
+            );
+        }
+    }
+
+    #[test]
+    fn classifies_proprietary_part_extensions() {
+        for (path, expected) in [
+            ("part.sat", FileImportFormat::Acis),
+            ("part.sab", FileImportFormat::Acis),
+            ("part.CATPart", FileImportFormat::Catia),
+            ("part.ipt", FileImportFormat::Inventor),
+            ("part.x_t", FileImportFormat::Parasolid),
+            ("part.x_b", FileImportFormat::Parasolid),
+            ("part.sldprt", FileImportFormat::Sldprt),
+        ] {
+            assert_eq!(
+                import_format_from_path(path),
+                Some(expected),
+                "unexpected format for `{path}`"
+            );
+        }
+    }
+
+    #[test]
+    fn unversioned_prt_supports_creo_and_nx() {
+        assert_eq!(import_format_from_path("part.prt"), Some(FileImportFormat::Nx));
+        assert!(import_path_supports_format("part.prt", FileImportFormat::Creo));
+        assert!(import_path_supports_format("part.prt", FileImportFormat::Nx));
+        assert!(!import_path_supports_format("part.prt.1", FileImportFormat::Nx));
+    }
+}

--- a/rust/kcl-lib/src/import_format.rs
+++ b/rust/kcl-lib/src/import_format.rs
@@ -41,7 +41,7 @@ fn extension_from_path(path: &str) -> Option<String> {
 }
 
 /// Parse a canonical import format identifier or a supported file extension.
-pub fn import_format_from_name(name: &str) -> Option<FileImportFormat> {
+pub(crate) fn import_format_from_name(name: &str) -> Option<FileImportFormat> {
     let name = name.to_ascii_lowercase();
     formats_for_extension(&name)
         .and_then(|formats| formats.first().copied())
@@ -53,7 +53,7 @@ pub fn import_format_from_name(name: &str) -> Option<FileImportFormat> {
 /// Creo part files end in `.prt` or a positive numeric version such as
 /// `.prt.1`. Matching is case-insensitive and applies to the complete basename,
 /// rather than only the final path extension.
-pub fn is_creo_import_path(path: &str) -> bool {
+fn is_creo_import_path(path: &str) -> bool {
     let Some(file_name) = path.rsplit(['/', '\\']).next() else {
         return false;
     };
@@ -76,7 +76,7 @@ pub fn is_creo_import_path(path: &str) -> bool {
 }
 
 /// Classify an import path by its complete filename.
-pub fn import_format_from_path(path: &str) -> Option<FileImportFormat> {
+pub(crate) fn import_format_from_path(path: &str) -> Option<FileImportFormat> {
     if let Some(format) = extension_from_path(path)
         .and_then(|extension| formats_for_extension(&extension))
         .and_then(|formats| formats.first().copied())

--- a/rust/kcl-lib/src/lib.rs
+++ b/rust/kcl-lib/src/lib.rs
@@ -65,7 +65,7 @@ mod fmt;
 mod frontend;
 mod fs;
 pub(crate) mod id;
-pub mod import_format;
+mod import_format;
 pub mod lint;
 mod log;
 mod lsp;

--- a/rust/kcl-lib/src/lib.rs
+++ b/rust/kcl-lib/src/lib.rs
@@ -65,6 +65,7 @@ mod fmt;
 mod frontend;
 mod fs;
 pub(crate) mod id;
+pub mod import_format;
 pub mod lint;
 mod log;
 mod lsp;
@@ -248,8 +249,6 @@ pub mod front {
     };
 }
 
-#[cfg(feature = "cli")]
-use clap::ValueEnum;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -262,17 +261,10 @@ use crate::log::logln;
 lazy_static::lazy_static! {
 
     pub static ref IMPORT_FILE_EXTENSIONS: Vec<String> = {
-        let mut import_file_extensions = vec!["stp".to_string(), "glb".to_string(), "fbxb".to_string()];
-        #[cfg(feature = "cli")]
-        let named_extensions = kittycad::types::FileImportFormat::value_variants()
+        import_format::IMPORT_FILE_EXTENSION_FORMATS
             .iter()
-            .map(|x| format!("{x}"))
-            .collect::<Vec<String>>();
-        #[cfg(not(feature = "cli"))]
-        let named_extensions = vec![]; // We don't really need this outside of the CLI.
-        // Add all the default import formats.
-        import_file_extensions.extend_from_slice(&named_extensions);
-        import_file_extensions
+            .map(|(extension, _)| (*extension).to_owned())
+            .collect()
     };
 
     pub static ref RELEVANT_FILE_EXTENSIONS: Vec<String> = {
@@ -439,6 +431,13 @@ pub fn version() -> &'static str {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn proprietary_file_extensions_use_real_suffixes() {
+        for extension in ["sat", "sab", "catpart", "prt", "ipt", "x_t", "x_b", "sldprt"] {
+            assert!(IMPORT_FILE_EXTENSIONS.iter().any(|candidate| candidate == extension));
+        }
+    }
 
     #[test]
     fn convert_int() {

--- a/rust/kcl-lib/src/parsing/parser.rs
+++ b/rust/kcl-lib/src/parsing/parser.rs
@@ -45,6 +45,7 @@ use crate::execution::annotations::EXPERIMENTAL;
 use crate::execution::annotations::VersionConstraint;
 use crate::execution::annotations::{self};
 use crate::execution::types::ArrayLen;
+use crate::import_format::import_format_from_path;
 use crate::parsing::PIPE_OPERATOR;
 use crate::parsing::PIPE_SUBSTITUTION_OPERATOR;
 use crate::parsing::ast::types::Annotation;
@@ -2523,8 +2524,7 @@ fn validate_path_string(path_string: String, var_name: bool, path_range: SourceR
 
         ImportPath::Std { path: segments }
     } else if path_string.contains('.') {
-        let extn = std::path::Path::new(&path_string).extension().unwrap_or_default();
-        if !IMPORT_FILE_EXTENSIONS.contains(&extn.to_string_lossy().to_lowercase()) {
+        if import_format_from_path(&path_string).is_none() {
             ParseContext::warn(CompilationIssue::err(
                 path_range,
                 format!(
@@ -6255,6 +6255,13 @@ e
             "Import path is not a valid identifier and must be aliased using `as someName`. For example: `import \"my-part.kcl\" as myPart`",
             [7, 20],
         );
+    }
+
+    #[test]
+    fn creo_import_paths() {
+        for path in ["part.prt", "part.prt.1", "parts/part.PRT.23"] {
+            assert_no_err(&format!(r#"import "{path}" as part"#));
+        }
     }
 
     #[test]

--- a/src/components/layout/areas/ProjectExplorerPane.tsx
+++ b/src/components/layout/areas/ProjectExplorerPane.tsx
@@ -21,7 +21,6 @@ import {
   togglePaneLayoutNode,
 } from '@src/lib/layout'
 import {
-  getEXTNoPeriod,
   isExtensionARelevantExtension,
   parentPathRelativeToProject,
 } from '@src/lib/paths'
@@ -127,14 +126,7 @@ export function ProjectExplorerPane(props: AreaTypeComponentProps) {
 
       const RELEVANT_FILE_EXTENSIONS = relevantFileExtensions(wasmInstance)
       const isRelevantFile = (filename: string): boolean => {
-        const extension = getEXTNoPeriod(filename)
-        if (!extension) {
-          return false
-        }
-        return isExtensionARelevantExtension(
-          extension,
-          RELEVANT_FILE_EXTENSIONS
-        )
+        return isExtensionARelevantExtension(filename, RELEVANT_FILE_EXTENSIONS)
       }
 
       // Only open the file if it is a kcl file.

--- a/src/lang/wasm.spec.ts
+++ b/src/lang/wasm.spec.ts
@@ -368,6 +368,11 @@ describe('relevantFileExtensions', () => {
       expect(actual).toBe(expected)
     })
 
+    it('contains prt', () => {
+      const extensions = relevantFileExtensions(instanceInThisFile)
+      expect(extensions).toContain('prt')
+    })
+
     it('contains stl', () => {
       const expected = true
       const actual = relevantFileExtensions(instanceInThisFile).some(
@@ -401,6 +406,13 @@ describe('importFileExtensions', () => {
   })
 
   describe('check for each known extension', () => {
+    it.each(['sat', 'sab', 'catpart', 'prt', 'ipt', 'x_t', 'x_b', 'sldprt'])(
+      'contains proprietary part extension %s',
+      (extension) => {
+        expect(importFileExtensions(instanceInThisFile)).toContain(extension)
+      }
+    )
+
     it('contains stp', () => {
       const expected = true
       const actual = importFileExtensions(instanceInThisFile).some(
@@ -489,6 +501,11 @@ describe('importFileExtensions', () => {
       expect(actual).toBe(expected)
     })
 
+    it('contains prt', () => {
+      const extensions = importFileExtensions(instanceInThisFile)
+      expect(extensions).toContain('prt')
+    })
+
     it('contains stl', () => {
       const expected = true
       const actual = importFileExtensions(instanceInThisFile).some(
@@ -526,6 +543,26 @@ describe('isExtensionAnImportExtension', () => {
     const actual = isExtensionAnImportExtension('steP', extensions)
     expect(actual).toBe(expected)
   })
+
+  it.each([
+    'bracket.prt',
+    'bracket.prt.1',
+    'parts/bracket.PRT.23',
+    String.raw`parts\bracket.PrT.3`,
+  ])('recognizes Creo import path %s', (filePath) => {
+    const extensions = importFileExtensions(instanceInThisFile)
+    expect(isExtensionAnImportExtension(filePath, extensions)).toBe(true)
+  })
+
+  it.each([
+    'bracket.prt.0',
+    'bracket.prt.01',
+    'bracket.prt.-1',
+    'bracket.prt.1.bak',
+  ])('rejects invalid Creo import path %s', (filePath) => {
+    const extensions = importFileExtensions(instanceInThisFile)
+    expect(isExtensionAnImportExtension(filePath, extensions)).toBe(false)
+  })
 })
 
 describe('isExtensionARelevantExtension', () => {
@@ -552,6 +589,13 @@ describe('isExtensionARelevantExtension', () => {
     const expected = true
     const actual = isExtensionARelevantExtension('steP', extensions)
     expect(actual).toBe(expected)
+  })
+
+  it('recognizes a versioned Creo path', () => {
+    const extensions = relevantFileExtensions(instanceInThisFile)
+    expect(isExtensionARelevantExtension('bracket.prt.2', extensions)).toBe(
+      true
+    )
   })
 })
 

--- a/src/lib/desktopFS.spec.ts
+++ b/src/lib/desktopFS.spec.ts
@@ -13,7 +13,7 @@ beforeAll(async () => {
 })
 
 const wasmInstance = {
-  relevant_file_extensions: () => ['kcl', 'stp', 'step'],
+  relevant_file_extensions: () => ['kcl', 'prt', 'stp', 'step'],
 } as ModuleType
 
 /** Create a dummy project */
@@ -89,6 +89,28 @@ describe(`Getting unique project names`, () => {
       })
 
       expect(nextFile.name).toBe('notes-1.pdf')
+    } finally {
+      await fsZds.rm(baseDir, { recursive: true, force: true })
+    }
+  })
+
+  it('preserves a versioned Creo extension when resolving a collision', async () => {
+    const baseDir = `/tmp/opencode/desktopfs-${crypto.randomUUID()}`
+    await fsZds.mkdir(baseDir, { recursive: true })
+
+    try {
+      await fsZds.writeFile(
+        fsZds.join(baseDir, 'bracket.prt.2'),
+        new TextEncoder().encode('a')
+      )
+
+      const nextFile = await getNextFileName({
+        entryName: 'bracket.prt.2',
+        baseDir,
+        wasmInstance,
+      })
+
+      expect(nextFile.name).toBe('bracket-1.prt.2')
     } finally {
       await fsZds.rm(baseDir, { recursive: true, force: true })
     }

--- a/src/lib/desktopFS.ts
+++ b/src/lib/desktopFS.ts
@@ -2,8 +2,8 @@ import { relevantFileExtensions } from '@src/lang/wasmUtils'
 import { FILE_EXT, INDEX_IDENTIFIER, MAX_PADDING } from '@src/lib/constants'
 import fsZds from '@src/lib/fs-zds'
 import {
-  getEXTNoPeriod,
   getEXTWithPeriod,
+  getVersionedCreoExtensionWithPeriod,
   isExtensionARelevantExtension,
 } from '@src/lib/paths'
 import type { FileEntry } from '@src/lib/project'
@@ -137,15 +137,13 @@ export async function getNextFileName({
   wasmInstance: ModuleType
   preserveUnknownExtension?: boolean
 }) {
-  // Check if the file is relevantFile by not using the period
-  const extensionNoPeriod = getEXTNoPeriod(entryName)
   const extensions = relevantFileExtensions(wasmInstance)
-  const isRelevantFile =
-    extensionNoPeriod &&
-    isExtensionARelevantExtension(extensionNoPeriod, extensions)
+  const isRelevantFile = isExtensionARelevantExtension(entryName, extensions)
 
   // Do the following business logic with the period in the extension
-  let extension = getEXTWithPeriod(entryName)
+  let extension =
+    getVersionedCreoExtensionWithPeriod(entryName) ||
+    getEXTWithPeriod(entryName)
   if (!preserveUnknownExtension && (!isRelevantFile || !extension)) {
     extension = FILE_EXT
   }

--- a/src/lib/getCurrentProjectFile.spec.ts
+++ b/src/lib/getCurrentProjectFile.spec.ts
@@ -44,6 +44,28 @@ describe('getCurrentProjectFile', () => {
     await fs.rm(tmpProjectDir, { recursive: true, force: true })
   })
 
+  test('wraps a versioned Creo part file', async () => {
+    const { instance } = await buildTheWorldAndNoEngineConnection()
+    const name = `kittycad-modeling-projects-${uuidv4()}`
+    const tmpProjectDir = path.join(os.tmpdir(), name)
+    const creoFile = path.join(tmpProjectDir, 'bracket.prt.2')
+    const wrapperFile = `${creoFile}.kcl`
+
+    await fs.mkdir(tmpProjectDir, { recursive: true })
+    await fs.writeFile(creoFile, '')
+
+    try {
+      const state = await getCurrentProjectFile(creoFile, instance)
+
+      expect(state).toBe(wrapperFile)
+      await expect(fs.readFile(wrapperFile, 'utf8')).resolves.toContain(
+        'import "bracket.prt.2"'
+      )
+    } finally {
+      await fs.rm(tmpProjectDir, { recursive: true, force: true })
+    }
+  })
+
   test('with source path dot', async () => {
     const { instance } = await buildTheWorldAndNoEngineConnection()
     const name = `kittycad-modeling-projects-${uuidv4()}`

--- a/src/lib/getCurrentProjectFile.ts
+++ b/src/lib/getCurrentProjectFile.ts
@@ -9,7 +9,10 @@ import * as fs from 'fs/promises'
 
 import { changeKclVersion } from '@src/lang/wasm'
 import { DEFAULT_KCL_VERSION, PROJECT_ENTRYPOINT } from '@src/lib/constants'
-import { isExtensionAnImportExtension } from '@src/lib/paths'
+import {
+  isExtensionARelevantExtension,
+  isExtensionAnImportExtension,
+} from '@src/lib/paths'
 import { err } from '@src/lib/trap'
 import { getInVariableCase } from '@src/lib/utils'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
@@ -24,8 +27,8 @@ export default async function getCurrentProjectFile(
   // Extract the values into an array
   const allFileImportFormats: string[] = importFileExtensions(wasmInstance)
   const relevantExtensions: string[] = relevantFileExtensions(wasmInstance)
-  const shouldWrapExtension = (extension: string) => {
-    return isExtensionAnImportExtension(extension, allFileImportFormats)
+  const shouldWrapExtension = (filePath: string) => {
+    return isExtensionAnImportExtension(filePath, allFileImportFormats)
   }
 
   // Fix for "." path, which is the current directory.
@@ -86,7 +89,10 @@ export default async function getCurrentProjectFile(
   // Check if the extension on what we are trying to open is a relevant file type.
   const extension = path.extname(sourcePath).slice(1).toLowerCase()
 
-  if (!relevantExtensions.includes(extension) && extension !== 'toml') {
+  if (
+    !isExtensionARelevantExtension(sourcePath, relevantExtensions) &&
+    extension !== 'toml'
+  ) {
     return new Error(
       `File type (${extension}) cannot be opened with this app: '${sourcePath}', try opening one of the following file types: ${relevantExtensions.join(
         ', '
@@ -102,7 +108,7 @@ export default async function getCurrentProjectFile(
   // this import model.
   // TODO: once we have some sort of a load file into project it would make sense to stop creating these wrapper files
   // and let people save their own kcl file importing
-  if (shouldWrapExtension(extension)) {
+  if (shouldWrapExtension(sourcePath)) {
     const importFileName = path.basename(sourcePath)
     // Check if we have a file in the project for this import model.
     const kclWrapperFilename = `${importFileName}.kcl`

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -375,6 +375,32 @@ export const getEXTWithPeriod = (filePath: string) => {
   return extension
 }
 
+export const getVersionedCreoExtensionWithPeriod = (filePath: string) => {
+  const lastSeparatorIndex = Math.max(
+    filePath.lastIndexOf('/'),
+    filePath.lastIndexOf('\\')
+  )
+  const fileName = filePath.slice(lastSeparatorIndex + 1)
+  const normalizedFileName = fileName.toLowerCase()
+  const marker = '.prt.'
+  const markerIndex = normalizedFileName.lastIndexOf(marker)
+  if (markerIndex <= 0) {
+    return null
+  }
+
+  const version = normalizedFileName.slice(markerIndex + marker.length)
+  if (version.length === 0 || version[0] < '1' || version[0] > '9') {
+    return null
+  }
+  for (const digit of version) {
+    if (digit < '0' || digit > '9') {
+      return null
+    }
+  }
+
+  return fileName.slice(markerIndex)
+}
+
 export const getParentAbsolutePath = (absolutePath: string) => {
   const split = desktopSafePathSplit(absolutePath)
   split.pop()
@@ -383,20 +409,41 @@ export const getParentAbsolutePath = (absolutePath: string) => {
 }
 
 /**
- * Helper function to detect if an extension is an import extension
+ * Match a raw extension or complete file path against supported extensions.
  */
+const isExtensionOrPathInList = (
+  extensionOrPath: string,
+  extensions: string[]
+) => {
+  const normalized = extensionOrPath.toLowerCase()
+  if (extensions.includes(normalized)) {
+    return true
+  }
+
+  const extension = getEXTNoPeriod(normalized)
+  if (extension && extensions.includes(extension)) {
+    return true
+  }
+
+  if (!extensions.includes('prt')) {
+    return false
+  }
+
+  return getVersionedCreoExtensionWithPeriod(normalized) !== null
+}
+
 export const isExtensionAnImportExtension = (
   extension: string,
   importExtensions: string[]
 ) => {
-  return importExtensions.includes(extension.toLowerCase())
+  return isExtensionOrPathInList(extension, importExtensions)
 }
 
 export const isExtensionARelevantExtension = (
   extension: string,
   relevantExtensions: string[]
 ) => {
-  return relevantExtensions.includes(extension.toLowerCase())
+  return isExtensionOrPathInList(extension, relevantExtensions)
 }
 
 /**

--- a/src/machines/systemIO/snapshotContext.ts
+++ b/src/machines/systemIO/snapshotContext.ts
@@ -1,5 +1,5 @@
 import fsZds from '@src/lib/fs-zds'
-import { getEXTNoPeriod, isExtensionAnImportExtension } from '@src/lib/paths'
+import { isExtensionAnImportExtension } from '@src/lib/paths'
 import type { FileEntry } from '@src/lib/project'
 import { isArray } from '@src/lib/utils'
 import type { SystemIOContext } from '@src/machines/systemIO/utils'
@@ -65,11 +65,7 @@ export function listAllImportFilesWithinProject(
       }
 
       const relativeFilePath = v.path.replace(projectPath + fsZds.sep, '')
-      const extension = getEXTNoPeriod(relativeFilePath)
-      if (
-        extension &&
-        isExtensionAnImportExtension(extension, importExtensions)
-      ) {
+      if (isExtensionAnImportExtension(relativeFilePath, importExtensions)) {
         relativeFilePaths.push(relativeFilePath)
       }
     }


### PR DESCRIPTION
Fixes proprietary CAD import extensions and Creo versioned filenames.

- Replaces placeholder extensions such as .catia and .inventor with real file extensions.
- Supports Creo files named .prt.N (unversioned .prt is treated as NX by default but allows explicit Creo imports with attribute)
- Derives the file picker’s supported extensions from the same mapping used by import detection.

How to add a new extension:

1. Add the extension and corresponding FileImportFormat to IMPORT_FILE_EXTENSION_FORMATS in rust/kcl-lib/src/import_format.rs.
2. If introducing a new format, add its InputFormat3d construction in get_import_format_from_extension.
3. Add extension resolution and generated list test coverage.