### PR TITLE
KCL: Derive more traits on Cad Operation

### DIFF
--- a/rust/kcl-api/src/ast.rs
+++ b/rust/kcl-api/src/ast.rs
@@ -1,11 +1,12 @@
 use parse_display::Display;
 use parse_display::FromStr;
+use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 
 pub mod node_path;
 
-#[derive(Debug, Default, Clone, Copy, Deserialize, Serialize, PartialEq, ts_rs::TS, FromStr, Display)]
+#[derive(Debug, Default, Clone, Copy, Deserialize, Serialize, PartialEq, ts_rs::TS, FromStr, Display, JsonSchema)]
 #[ts(export)]
 #[serde(rename_all = "snake_case")]
 #[display(style = "snake_case")]

--- a/rust/kcl-api/src/cad_op.rs
+++ b/rust/kcl-api/src/cad_op.rs
@@ -1,5 +1,7 @@
 use indexmap::IndexMap;
 use kcl_error::SourceRange;
+use schemars::JsonSchema;
+use serde::Deserialize;
 use serde::Serialize;
 
 use super::ArtifactId;
@@ -12,7 +14,7 @@ use crate::front::ObjectId;
 /// A CAD modeling operation for display in the feature tree, AKA operations
 /// timeline.
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
+#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS, JsonSchema, Deserialize)]
 #[ts(export_to = "Operation.ts")]
 #[serde(tag = "type")]
 pub enum Operation {
@@ -88,7 +90,7 @@ impl Operation {
     }
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export_to = "Operation.ts")]
 #[serde(tag = "type")]
 #[cfg_attr(not(target_arch = "wasm32"), expect(clippy::large_enum_variant))]
@@ -117,7 +119,7 @@ pub enum Group {
 }
 
 /// An argument to a CAD modeling operation.
-#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export_to = "Operation.ts")]
 #[serde(rename_all = "camelCase")]
 pub struct OpArg {
@@ -141,7 +143,7 @@ fn is_false(b: &bool) -> bool {
 
 /// A KCL value used in Operations.  `ArtifactId`s are used to refer to the
 /// actual scene objects.  Any data not needed in the UI may be omitted.
-#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export_to = "Operation.ts")]
 #[serde(tag = "type")]
 pub enum OpKclValue {
@@ -219,7 +221,7 @@ pub enum OpKclValue {
 
 pub type OpKclObjectFields = IndexMap<String, OpKclValue>;
 
-#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
+#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS, Deserialize, JsonSchema)]
 #[ts(export_to = "Operation.ts")]
 #[serde(rename_all = "camelCase")]
 pub struct OpSketch {
@@ -232,7 +234,7 @@ impl OpSketch {
     }
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export_to = "Operation.ts")]
 #[serde(rename_all = "camelCase")]
 pub struct OpSolid {
@@ -245,7 +247,7 @@ impl OpSolid {
     }
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export_to = "Operation.ts")]
 #[serde(rename_all = "camelCase")]
 pub struct OpHelix {

--- a/rust/kcl-api/src/numeric_type.rs
+++ b/rust/kcl-api/src/numeric_type.rs
@@ -1,10 +1,11 @@
+use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::UnitAngle;
 use crate::UnitLength;
 
-#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, ts_rs::TS)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, ts_rs::TS, JsonSchema)]
 #[ts(export)]
 #[serde(tag = "type")]
 pub enum UnitType {
@@ -46,7 +47,7 @@ impl std::fmt::Display for UnitType {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, ts_rs::TS)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export)]
 #[serde(tag = "type")]
 pub enum NumericType {

--- a/rust/kcl-error/src/source_range.rs
+++ b/rust/kcl-error/src/source_range.rs
@@ -5,7 +5,9 @@ use serde::Deserialize;
 use serde::Serialize;
 
 /// Identifier of a source file.  Uses a u32 to keep the size small.
-#[derive(Debug, Default, Ord, PartialOrd, Eq, PartialEq, Clone, Copy, Hash, Deserialize, Serialize, ts_rs::TS)]
+#[derive(
+    Debug, Default, Ord, PartialOrd, Eq, PartialEq, Clone, Copy, Hash, Deserialize, Serialize, ts_rs::TS, JsonSchema,
+)]
 #[ts(export)]
 pub struct ModuleId(u32);
 


### PR DESCRIPTION
These will be used to pull CadOperation into the modeling-cmds API, so it can be returned during engine execution.

Part of https://github.com/KittyCAD/modeling-app/issues/12500
Used in https://github.com/KittyCAD/modeling-api/pull/1348