### PR TITLE
Document patternLinear2d with KCL 2 examples

### DIFF
--- a/docs/kcl-std/functions/std-sketch-patternLinear2d.md
+++ b/docs/kcl-std/functions/std-sketch-patternLinear2d.md
@@ -17,10 +17,12 @@ patternLinear2d(
 ): [Sketch; 1+]
 ```
 
-This function returns raw [`Sketch`](/docs/kcl-std/types/std-types-Sketch) values. If a KCL 2 sketch block is passed
-directly, its named members are not copied to the returned sketches. Create
-a region from the named segments before patterning, as shown below, or
-consume the returned sketches without accessing sketch-block members.
+Currently, KCL's type system limitations make the type signature here misleading.
+This function works with Regions from the new sketch blocks (that use constraint solvers),
+or the old, deprecated, imperative sketch/profile syntax from older versions of KCL.
+It does _not_ work as expected with sketch blocks, only with the regions that can be
+created from sketch blocks. In the following examples, a region is passed into the pattern
+function, which creates new regions in a pattern. You should _not_ pass a sketch block in.
 
 ### Arguments
 

--- a/docs/kcl-std/functions/std-sketch-patternLinear2d.md
+++ b/docs/kcl-std/functions/std-sketch-patternLinear2d.md
@@ -17,7 +17,10 @@ patternLinear2d(
 ): [Sketch; 1+]
 ```
 
-
+This function returns raw [`Sketch`](/docs/kcl-std/types/std-types-Sketch) values. If a KCL 2 sketch block is passed
+directly, its named members are not copied to the returned sketches. Create
+a region from the named segments before patterning, as shown below, or
+consume the returned sketches without accessing sketch-block members.
 
 ### Arguments
 
@@ -39,11 +42,17 @@ patternLinear2d(
 ```kcl
 // / Pattern using a named axis.
 
-exampleSketch = startSketchOn(XZ)
-  |> circle(center = [0, 0], radius = 1)
-  |> patternLinear2d(axis = X, instances = 7, distance = 4)
+exampleSketch = sketch(on = XZ) {
+  circle1 = circle(start = [var 1mm, var 0mm], center = [var 0mm, var 0mm])
+  fixed([circle1.center, ORIGIN])
+  radius(circle1) == 1mm
+}
 
-example = extrude(exampleSketch, length = 1)
+exampleProfiles = region(segments = [exampleSketch.circle1])
+  |> patternLinear2d(axis = X, instances = 7, distance = 4mm)
+
+example = extrude(exampleProfiles, length = 1mm)
+hide(exampleSketch)
 
 ```
 
@@ -64,11 +73,17 @@ example = extrude(exampleSketch, length = 1)
 ```kcl
 // / Pattern using a raw axis.
 
-exampleSketch = startSketchOn(XZ)
-  |> circle(center = [0, 0], radius = 1)
-  |> patternLinear2d(axis = [1, 0], instances = 7, distance = 4)
+exampleSketch = sketch(on = XZ) {
+  circle1 = circle(start = [var 1mm, var 0mm], center = [var 0mm, var 0mm])
+  fixed([circle1.center, ORIGIN])
+  radius(circle1) == 1mm
+}
 
-example = extrude(exampleSketch, length = 1)
+exampleProfiles = region(segments = [exampleSketch.circle1])
+  |> patternLinear2d(axis = [1, 0], instances = 7, distance = 4mm)
+
+example = extrude(exampleProfiles, length = 1mm)
+hide(exampleSketch)
 
 ```
 

--- a/docs/kcl-std/functions/std-sketch-patternLinear2d.md
+++ b/docs/kcl-std/functions/std-sketch-patternLinear2d.md
@@ -42,7 +42,9 @@ function, which creates new regions in a pattern. You should _not_ pass a sketch
 ### Examples
 
 ```kcl
-// / Pattern using a named axis.
+// Example of pattern using a named axis.
+
+@settings(kclVersion = 2.0)
 
 exampleSketch = sketch(on = XZ) {
   circle1 = circle(start = [var 1mm, var 0mm], center = [var 0mm, var 0mm])
@@ -73,7 +75,9 @@ hide(exampleSketch)
 </model-viewer>
 
 ```kcl
-// / Pattern using a raw axis.
+// Example of pattern using a raw axis.
+
+@settings(kclVersion = 2.0)
 
 exampleSketch = sketch(on = XZ) {
   circle1 = circle(start = [var 1mm, var 0mm], center = [var 0mm, var 0mm])

--- a/public/kcl-samples/utility-sink/main.kcl
+++ b/public/kcl-samples/utility-sink/main.kcl
@@ -48,7 +48,10 @@ legProfile = sketch(on = XY) {
 }
 
 legProfiles = patternLinear2d(
-  legProfile,
+  region(segments = [
+    legProfile.leftEdge,
+    legProfile.topEdge
+  ]),
   instances = legCount,
   distance = blockWidth,
   axis = [1, 0],
@@ -94,7 +97,10 @@ lowerBeltXProfile = sketch(on = lowerBeltPlane) {
 }
 
 lowerBeltXProfiles = patternLinear2d(
-  lowerBeltXProfile,
+  region(segments = [
+    lowerBeltXProfile.leftEdge,
+    lowerBeltXProfile.topEdge
+  ]),
   instances = blockCount,
   distance = blockWidth,
   axis = [1, 0],
@@ -136,7 +142,10 @@ lowerBeltYProfile = sketch(on = lowerBeltPlane) {
 }
 
 lowerBeltYProfileArray = patternLinear2d(
-  lowerBeltYProfile,
+  region(segments = [
+    lowerBeltYProfile.leftEdge,
+    lowerBeltYProfile.topEdge
+  ]),
   instances = 2,
   distance = tableWidth - profileThickness,
   axis = [1, 0],
@@ -220,7 +229,10 @@ upperBeltXProfile = sketch(on = upperBeltPlane) {
 }
 
 upperBeltXProfileArray = patternLinear2d(
-  upperBeltXProfile,
+  region(segments = [
+    upperBeltXProfile.leftEdge,
+    upperBeltXProfile.topEdge
+  ]),
   instances = 2,
   distance = blockDepth,
   axis = [0, 1],
@@ -256,7 +268,10 @@ upperBeltYProfile = sketch(on = upperBeltPlane) {
 }
 
 upperBeltYProfileArray = patternLinear2d(
-  upperBeltYProfile,
+  region(segments = [
+    upperBeltYProfile.leftEdge,
+    upperBeltYProfile.topEdge
+  ]),
   instances = 2,
   distance = tableWidth - profileThickness,
   axis = [1, 0],

--- a/rust/kcl-lib/src/execution/state.rs
+++ b/rust/kcl-lib/src/execution/state.rs
@@ -991,6 +991,17 @@ impl ExecState {
         self.mod_local.artifacts.artifacts.get_mut(&id)
     }
 
+    pub(crate) fn is_sketch_block_path(&self, path_id: ArtifactId) -> bool {
+        self.mod_local
+            .artifacts
+            .artifacts
+            .values()
+            .chain(self.global.artifacts.artifacts.values())
+            .any(|artifact| {
+                matches!(artifact, Artifact::SketchBlock(sketch_block) if sketch_block.path_id == Some(path_id))
+            })
+    }
+
     pub(crate) fn push_op(&mut self, op: Operation) {
         let index = self.mod_local.artifacts.operations.len();
         self.mod_local.artifacts.operations.push(op);

--- a/rust/kcl-lib/src/std/patterns.rs
+++ b/rust/kcl-lib/src/std/patterns.rs
@@ -17,11 +17,15 @@ use serde::Serialize;
 use uuid::Uuid;
 
 use super::axis_or_reference::Axis3dOrPoint3d;
+use crate::CompilationIssue;
 use crate::ExecutorContext;
+use crate::KclVersion;
 use crate::NodePath;
 use crate::SourceRange;
 use crate::errors::KclError;
 use crate::errors::KclErrorDetails;
+use crate::errors::Severity;
+use crate::errors::Tag;
 use crate::execution::ArtifactId;
 use crate::execution::EarlyReturn;
 use crate::execution::ExecState;
@@ -35,6 +39,7 @@ use crate::execution::ModelingCmdMeta;
 use crate::execution::Sketch;
 use crate::execution::Solid;
 use crate::execution::SolidOrImportedGeometry;
+use crate::execution::annotations;
 use crate::execution::early_return;
 use crate::execution::fn_call::Arg;
 use crate::execution::fn_call::Args;
@@ -65,6 +70,7 @@ pub const POINT_ZERO_ZERO_ZERO: [TyF64; 3] = [
 ];
 
 const MUST_HAVE_ONE_INSTANCE: &str = "There must be at least 1 instance of your geometry";
+const PATTERN_LINEAR_2D_REGIONS_ONLY: &str = "patternLinear2d should only be used with regions";
 
 /// Something that can be 3D patterned, e.g. a 3D body.
 #[derive(Debug)]
@@ -806,11 +812,79 @@ patterned = patternTransform(cube, instances = 3, transform = shift)
         assert_eq!(actual.unwrap(), expected);
         ctx.close().await;
     }
+
+    fn pattern_linear_2d_code(kcl_version: &str, input: &str) -> String {
+        format!(
+            r#"@settings(kclVersion = {kcl_version}, defaultLengthUnit = mm, experimentalFeatures = allow)
+
+profile = sketch(on = XY) {{
+  circle1 = circle(start = [var 10mm, var 0mm], center = [var 0mm, var 0mm])
+}}
+patterned = patternLinear2d({input}, instances = 2, distance = 20mm, axis = X)
+"#
+        )
+    }
+
+    async fn run_mock(code: &str) -> Result<crate::ExecOutcome, crate::KclErrorWithOutputs> {
+        let program = crate::Program::parse_no_errs(code).unwrap();
+        let ctx = ExecutorContext::new_mock(None).await;
+        let result = ctx.run_mock(&program, &crate::execution::MockConfig::default()).await;
+        ctx.close().await;
+        result
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn pattern_linear_2d_with_sketch_warns_before_v3() {
+        for version in ["1.0", "2.0"] {
+            let code = pattern_linear_2d_code(version, "profile");
+            let outcome = run_mock(&code).await.unwrap();
+            let warnings = outcome
+                .issues
+                .iter()
+                .filter(|issue| issue.message == PATTERN_LINEAR_2D_REGIONS_ONLY)
+                .collect::<Vec<_>>();
+
+            assert_eq!(
+                warnings.len(),
+                1,
+                "unexpected issues for KCL {version}: {:#?}",
+                outcome.issues
+            );
+            assert_eq!(warnings[0].severity, Severity::Warning);
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn pattern_linear_2d_with_sketch_is_an_error_in_v3() {
+        let code = pattern_linear_2d_code(r#""3.0-preview""#, "profile");
+        let error = run_mock(&code).await.unwrap_err();
+
+        assert!(matches!(error.error, KclError::Semantic { .. }));
+        assert_eq!(error.error.message(), PATTERN_LINEAR_2D_REGIONS_ONLY);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn pattern_linear_2d_with_region_is_allowed_in_v3() {
+        let code = pattern_linear_2d_code(r#""3.0-preview""#, "region(segments = [profile.circle1])");
+        let outcome = run_mock(&code).await.unwrap();
+
+        assert!(
+            outcome
+                .issues
+                .iter()
+                .all(|issue| issue.message != PATTERN_LINEAR_2D_REGIONS_ONLY),
+            "unexpected regions-only issue: {:#?}",
+            outcome.issues
+        );
+    }
 }
 
 /// A linear pattern on a 2D sketch.
 pub async fn pattern_linear_2d(exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
-    let sketches = args.get_unlabeled_kw_arg("sketches", &RuntimeType::sketches(), exec_state)?;
+    let sketches_source_range = args
+        .unlabeled_kw_arg_unconverted()
+        .map_or(args.source_range, |arg| arg.source_range);
+    let sketches: Vec<Sketch> = args.get_unlabeled_kw_arg("sketches", &RuntimeType::sketches(), exec_state)?;
     let instances: u32 = args.get_kw_arg("instances", &RuntimeType::count(), exec_state)?;
     let distance: TyF64 = args.get_kw_arg("distance", &RuntimeType::length(), exec_state)?;
     let axis: Axis2dOrPoint2d = args.get_kw_arg(
@@ -822,6 +896,26 @@ pub async fn pattern_linear_2d(exec_state: &mut ExecState, args: Args) -> Result
         exec_state,
     )?;
     let use_original = args.get_kw_arg_opt("useOriginal", &RuntimeType::bool(), exec_state)?;
+
+    if sketches.iter().any(|sketch| sketch.origin_sketch_id.is_none()) {
+        if exec_state.kcl_version() >= KclVersion::V3Preview {
+            return Err(KclError::new_semantic(KclErrorDetails::new(
+                PATTERN_LINEAR_2D_REGIONS_ONLY.to_owned(),
+                vec![sketches_source_range],
+            )));
+        }
+
+        exec_state.warn(
+            CompilationIssue {
+                source_range: sketches_source_range,
+                message: PATTERN_LINEAR_2D_REGIONS_ONLY.to_owned(),
+                suggestion: None,
+                severity: Severity::Warning,
+                tag: Tag::Deprecated,
+            },
+            annotations::WARN_DEPRECATED,
+        );
+    }
 
     let axis = axis.to_point2d();
     if axis[0].n == 0.0 && axis[1].n == 0.0 {

--- a/rust/kcl-lib/src/std/patterns.rs
+++ b/rust/kcl-lib/src/std/patterns.rs
@@ -877,6 +877,26 @@ patterned = patternLinear2d({input}, instances = 2, distance = 20mm, axis = X)
             outcome.issues
         );
     }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn pattern_linear_2d_with_sketch_v1_profile_is_allowed() {
+        let code = r#"@settings(kclVersion = 2.0, defaultLengthUnit = mm, experimentalFeatures = allow)
+
+patterned = startSketchOn(XY)
+  |> rectangle(width = 4mm, height = 3mm, center = [0mm, 0mm])
+  |> patternLinear2d(instances = 10, distance = 10mm, axis = [1, 0])
+"#;
+        let outcome = run_mock(code).await.unwrap();
+
+        assert!(
+            outcome
+                .issues
+                .iter()
+                .all(|issue| issue.message != PATTERN_LINEAR_2D_REGIONS_ONLY),
+            "unexpected regions-only issue: {:#?}",
+            outcome.issues
+        );
+    }
 }
 
 /// A linear pattern on a 2D sketch.
@@ -897,7 +917,12 @@ pub async fn pattern_linear_2d(exec_state: &mut ExecState, args: Args) -> Result
     )?;
     let use_original = args.get_kw_arg_opt("useOriginal", &RuntimeType::bool(), exec_state)?;
 
-    if sketches.iter().any(|sketch| sketch.origin_sketch_id.is_none()) {
+    let has_sketch_solver_block = sketches.iter().any(|sketch| {
+        sketch.origin_sketch_id.is_none()
+            && (exec_state.is_sketch_block_path(sketch.artifact_id)
+                || exec_state.is_sketch_block_path(sketch.original_id.into()))
+    });
+    if has_sketch_solver_block {
         if exec_state.kcl_version() >= KclVersion::V3Preview {
             return Err(KclError::new_semantic(KclErrorDetails::new(
                 PATTERN_LINEAR_2D_REGIONS_ONLY.to_owned(),

--- a/rust/kcl-lib/std/sketch.kcl
+++ b/rust/kcl-lib/std/sketch.kcl
@@ -2078,32 +2078,49 @@ export fn loft(
 /// Repeat a 2-dimensional sketch along some dimension, with a dynamic amount
 /// of distance between each repetition, some specified number of times.
 ///
-/// ```kcl,legacySketch
+/// This function returns raw `Sketch` values. If a KCL 2 sketch block is passed
+/// directly, its named members are not copied to the returned sketches. Create
+/// a region from the named segments before patterning, as shown below, or
+/// consume the returned sketches without accessing sketch-block members.
+///
+/// ```kcl
 /// /// Pattern using a named axis.
 ///
-/// exampleSketch = startSketchOn(XZ)
-///   |> circle(center = [0, 0], radius = 1)
+/// exampleSketch = sketch(on = XZ) {
+///   circle1 = circle(start = [var 1mm, var 0mm], center = [var 0mm, var 0mm])
+///   fixed([circle1.center, ORIGIN])
+///   radius(circle1) == 1mm
+/// }
+///
+/// exampleProfiles = region(segments = [exampleSketch.circle1])
 ///   |> patternLinear2d(
 ///        axis = X,
 ///        instances = 7,
-///        distance = 4
+///        distance = 4mm
 ///      )
 ///
-/// example = extrude(exampleSketch, length = 1)
+/// example = extrude(exampleProfiles, length = 1mm)
+/// hide(exampleSketch)
 /// ```
 ///
-/// ```kcl,legacySketch
+/// ```kcl
 /// /// Pattern using a raw axis.
 ///
-/// exampleSketch = startSketchOn(XZ)
-///   |> circle(center = [0, 0], radius = 1)
+/// exampleSketch = sketch(on = XZ) {
+///   circle1 = circle(start = [var 1mm, var 0mm], center = [var 0mm, var 0mm])
+///   fixed([circle1.center, ORIGIN])
+///   radius(circle1) == 1mm
+/// }
+///
+/// exampleProfiles = region(segments = [exampleSketch.circle1])
 ///   |> patternLinear2d(
 ///        axis = [1, 0],
 ///        instances = 7,
-///        distance = 4
+///        distance = 4mm
 ///      )
 ///
-/// example = extrude(exampleSketch, length = 1)
+/// example = extrude(exampleProfiles, length = 1mm)
+/// hide(exampleSketch)
 /// ```
 @(impl = std_rust, feature_tree = false)
 export fn patternLinear2d(

--- a/rust/kcl-lib/std/sketch.kcl
+++ b/rust/kcl-lib/std/sketch.kcl
@@ -2078,10 +2078,12 @@ export fn loft(
 /// Repeat a 2-dimensional sketch along some dimension, with a dynamic amount
 /// of distance between each repetition, some specified number of times.
 ///
-/// This function returns raw `Sketch` values. If a KCL 2 sketch block is passed
-/// directly, its named members are not copied to the returned sketches. Create
-/// a region from the named segments before patterning, as shown below, or
-/// consume the returned sketches without accessing sketch-block members.
+/// Currently, KCL's type system limitations make the type signature here misleading.
+/// This function works with Regions from the new sketch blocks (that use constraint solvers),
+/// or the old, deprecated, imperative sketch/profile syntax from older versions of KCL.
+/// It does _not_ work as expected with sketch blocks, only with the regions that can be
+/// created from sketch blocks. In the following examples, a region is passed into the pattern
+/// function, which creates new regions in a pattern. You should _not_ pass a sketch block in.
 ///
 /// ```kcl
 /// /// Pattern using a named axis.

--- a/rust/kcl-lib/std/sketch.kcl
+++ b/rust/kcl-lib/std/sketch.kcl
@@ -2086,7 +2086,9 @@ export fn loft(
 /// function, which creates new regions in a pattern. You should _not_ pass a sketch block in.
 ///
 /// ```kcl
-/// /// Pattern using a named axis.
+/// // Example of pattern using a named axis.
+///
+/// @settings(kclVersion = 2.0)
 ///
 /// exampleSketch = sketch(on = XZ) {
 ///   circle1 = circle(start = [var 1mm, var 0mm], center = [var 0mm, var 0mm])
@@ -2106,7 +2108,9 @@ export fn loft(
 /// ```
 ///
 /// ```kcl
-/// /// Pattern using a raw axis.
+/// // Example of pattern using a raw axis.
+///
+/// @settings(kclVersion = 2.0)
 ///
 /// exampleSketch = sketch(on = XZ) {
 ///   circle1 = circle(start = [var 1mm, var 0mm], center = [var 0mm, var 0mm])

--- a/rust/kcl-lib/tests/kcl_samples/utility-sink/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/utility-sink/artifact_commands.snap
@@ -153,6 +153,19 @@ description: Artifact commands utility-sink.kcl
       "cmdId": "[uuid]",
       "range": [],
       "command": {
+        "type": "create_region",
+        "object_id": "[uuid]",
+        "segment": "[uuid]",
+        "intersection_segment": "[uuid]",
+        "intersection_index": -1,
+        "curve_clockwise": false,
+        "version": "V1"
+      }
+    },
+    {
+      "cmdId": "[uuid]",
+      "range": [],
+      "command": {
         "type": "entity_linear_pattern_transform",
         "entity_id": "[uuid]",
         "transform": [],
@@ -680,6 +693,19 @@ description: Artifact commands utility-sink.kcl
       "cmdId": "[uuid]",
       "range": [],
       "command": {
+        "type": "create_region",
+        "object_id": "[uuid]",
+        "segment": "[uuid]",
+        "intersection_segment": "[uuid]",
+        "intersection_index": -1,
+        "curve_clockwise": false,
+        "version": "V1"
+      }
+    },
+    {
+      "cmdId": "[uuid]",
+      "range": [],
+      "command": {
         "type": "entity_linear_pattern_transform",
         "entity_id": "[uuid]",
         "transform": [],
@@ -968,6 +994,19 @@ description: Artifact commands utility-sink.kcl
           },
           "relative": false
         }
+      }
+    },
+    {
+      "cmdId": "[uuid]",
+      "range": [],
+      "command": {
+        "type": "create_region",
+        "object_id": "[uuid]",
+        "segment": "[uuid]",
+        "intersection_segment": "[uuid]",
+        "intersection_index": -1,
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {
@@ -1653,6 +1692,19 @@ description: Artifact commands utility-sink.kcl
       "cmdId": "[uuid]",
       "range": [],
       "command": {
+        "type": "create_region",
+        "object_id": "[uuid]",
+        "segment": "[uuid]",
+        "intersection_segment": "[uuid]",
+        "intersection_index": -1,
+        "curve_clockwise": false,
+        "version": "V1"
+      }
+    },
+    {
+      "cmdId": "[uuid]",
+      "range": [],
+      "command": {
         "type": "entity_linear_pattern_transform",
         "entity_id": "[uuid]",
         "transform": [],
@@ -1931,6 +1983,19 @@ description: Artifact commands utility-sink.kcl
           },
           "relative": false
         }
+      }
+    },
+    {
+      "cmdId": "[uuid]",
+      "range": [],
+      "command": {
+        "type": "create_region",
+        "object_id": "[uuid]",
+        "segment": "[uuid]",
+        "intersection_segment": "[uuid]",
+        "intersection_index": -1,
+        "curve_clockwise": false,
+        "version": "V1"
       }
     },
     {

--- a/rust/kcl-lib/tests/kcl_samples/utility-sink/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/utility-sink/artifact_graph_flowchart.snap.md
@@ -1,7 +1,7 @@
 ```mermaid
 flowchart LR
   subgraph path2 [Path]
-    2["Path<br>[755, 1530, 0]<br>Consumed: true"]
+    2["Path<br>[755, 1530, 0]<br>Consumed: false"]
       %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit]
     3["Segment<br>[786, 845, 0]"]
       %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit]
@@ -12,476 +12,514 @@ flowchart LR
     6["Segment<br>[1011, 1070, 0]"]
       %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 3 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   end
-  subgraph path29 [Path]
-    29["Path<br>[2031, 3077, 0]<br>Consumed: true"]
+  subgraph path7 [Path]
+    7["Path Region<br>[1565, 1637, 0]<br>Consumed: true"]
+      %% [ProgramBodyItem { index: 14 }, VariableDeclarationDeclaration, VariableDeclarationInit, CallKwUnlabeledArg]
+    8["Segment<br>[1565, 1637, 0]"]
+      %% [ProgramBodyItem { index: 14 }, VariableDeclarationDeclaration, VariableDeclarationInit, CallKwUnlabeledArg]
+    9["Segment<br>[1565, 1637, 0]"]
+      %% [ProgramBodyItem { index: 14 }, VariableDeclarationDeclaration, VariableDeclarationInit, CallKwUnlabeledArg]
+    10["Segment<br>[1565, 1637, 0]"]
+      %% [ProgramBodyItem { index: 14 }, VariableDeclarationDeclaration, VariableDeclarationInit, CallKwUnlabeledArg]
+    11["Segment<br>[1565, 1637, 0]"]
+      %% [ProgramBodyItem { index: 14 }, VariableDeclarationDeclaration, VariableDeclarationInit, CallKwUnlabeledArg]
+  end
+  subgraph path34 [Path]
+    34["Path<br>[2093, 3139, 0]<br>Consumed: false"]
       %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    30["Segment<br>[2170, 2231, 0]"]
+    35["Segment<br>[2232, 2293, 0]"]
       %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 1 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    31["Segment<br>[2244, 2308, 0]"]
+    36["Segment<br>[2306, 2370, 0]"]
       %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 2 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    32["Segment<br>[2323, 2388, 0]"]
+    37["Segment<br>[2385, 2450, 0]"]
       %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 3 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    33["Segment<br>[2404, 2466, 0]"]
+    38["Segment<br>[2466, 2528, 0]"]
       %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 4 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   end
-  subgraph path52 [Path]
-    52["Path<br>[3507, 4545, 0]<br>Consumed: true"]
+  subgraph path39 [Path]
+    39["Path Region<br>[3181, 3267, 0]<br>Consumed: true"]
+      %% [ProgramBodyItem { index: 21 }, VariableDeclarationDeclaration, VariableDeclarationInit, CallKwUnlabeledArg]
+    40["Segment<br>[3181, 3267, 0]"]
+      %% [ProgramBodyItem { index: 21 }, VariableDeclarationDeclaration, VariableDeclarationInit, CallKwUnlabeledArg]
+    41["Segment<br>[3181, 3267, 0]"]
+      %% [ProgramBodyItem { index: 21 }, VariableDeclarationDeclaration, VariableDeclarationInit, CallKwUnlabeledArg]
+    42["Segment<br>[3181, 3267, 0]"]
+      %% [ProgramBodyItem { index: 21 }, VariableDeclarationDeclaration, VariableDeclarationInit, CallKwUnlabeledArg]
+    43["Segment<br>[3181, 3267, 0]"]
+      %% [ProgramBodyItem { index: 21 }, VariableDeclarationDeclaration, VariableDeclarationInit, CallKwUnlabeledArg]
+  end
+  subgraph path62 [Path]
+    62["Path<br>[3638, 4676, 0]<br>Consumed: false"]
       %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    53["Segment<br>[3646, 3707, 0]"]
+    63["Segment<br>[3777, 3838, 0]"]
       %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 1 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    54["Segment<br>[3720, 3783, 0]"]
+    64["Segment<br>[3851, 3914, 0]"]
       %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 2 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    55["Segment<br>[3798, 3861, 0]"]
+    65["Segment<br>[3929, 3992, 0]"]
       %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 3 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    56["Segment<br>[3877, 3938, 0]"]
+    66["Segment<br>[4008, 4069, 0]"]
       %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 4 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   end
-  subgraph path75 [Path]
-    75["Path<br>[5048, 6097, 0]<br>Consumed: false"]
+  subgraph path67 [Path]
+    67["Path Region<br>[4722, 4808, 0]<br>Consumed: true"]
+      %% [ProgramBodyItem { index: 26 }, VariableDeclarationDeclaration, VariableDeclarationInit, CallKwUnlabeledArg]
+    68["Segment<br>[4722, 4808, 0]"]
+      %% [ProgramBodyItem { index: 26 }, VariableDeclarationDeclaration, VariableDeclarationInit, CallKwUnlabeledArg]
+    69["Segment<br>[4722, 4808, 0]"]
+      %% [ProgramBodyItem { index: 26 }, VariableDeclarationDeclaration, VariableDeclarationInit, CallKwUnlabeledArg]
+    70["Segment<br>[4722, 4808, 0]"]
+      %% [ProgramBodyItem { index: 26 }, VariableDeclarationDeclaration, VariableDeclarationInit, CallKwUnlabeledArg]
+    71["Segment<br>[4722, 4808, 0]"]
+      %% [ProgramBodyItem { index: 26 }, VariableDeclarationDeclaration, VariableDeclarationInit, CallKwUnlabeledArg]
+  end
+  subgraph path90 [Path]
+    90["Path<br>[5248, 6297, 0]<br>Consumed: false"]
       %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    76["Segment<br>[5185, 5248, 0]"]
+    91["Segment<br>[5385, 5448, 0]"]
       %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 1 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    77["Segment<br>[5261, 5325, 0]"]
+    92["Segment<br>[5461, 5525, 0]"]
       %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 2 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    78["Segment<br>[5340, 5403, 0]"]
+    93["Segment<br>[5540, 5603, 0]"]
       %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 3 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    79["Segment<br>[5419, 5481, 0]"]
+    94["Segment<br>[5619, 5681, 0]"]
       %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 4 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   end
-  subgraph path80 [Path]
-    80["Path Region<br>[6135, 6248, 0]<br>Consumed: true"]
+  subgraph path95 [Path]
+    95["Path Region<br>[6335, 6448, 0]<br>Consumed: true"]
       %% [ProgramBodyItem { index: 32 }, VariableDeclarationDeclaration, VariableDeclarationInit, CallKwUnlabeledArg]
-    81["Segment<br>[6135, 6248, 0]"]
+    96["Segment<br>[6335, 6448, 0]"]
       %% [ProgramBodyItem { index: 32 }, VariableDeclarationDeclaration, VariableDeclarationInit, CallKwUnlabeledArg]
-    82["Segment<br>[6135, 6248, 0]"]
+    97["Segment<br>[6335, 6448, 0]"]
       %% [ProgramBodyItem { index: 32 }, VariableDeclarationDeclaration, VariableDeclarationInit, CallKwUnlabeledArg]
-    83["Segment<br>[6135, 6248, 0]"]
+    98["Segment<br>[6335, 6448, 0]"]
       %% [ProgramBodyItem { index: 32 }, VariableDeclarationDeclaration, VariableDeclarationInit, CallKwUnlabeledArg]
-    84["Segment<br>[6135, 6248, 0]"]
+    99["Segment<br>[6335, 6448, 0]"]
       %% [ProgramBodyItem { index: 32 }, VariableDeclarationDeclaration, VariableDeclarationInit, CallKwUnlabeledArg]
   end
-  subgraph path105 [Path]
-    105["Path<br>[6611, 7400, 0]<br>Consumed: true"]
+  subgraph path120 [Path]
+    120["Path<br>[6811, 7600, 0]<br>Consumed: false"]
       %% [ProgramBodyItem { index: 36 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    106["Segment<br>[6654, 6713, 0]"]
+    121["Segment<br>[6854, 6913, 0]"]
       %% [ProgramBodyItem { index: 36 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    107["Segment<br>[6726, 6789, 0]"]
+    122["Segment<br>[6926, 6989, 0]"]
       %% [ProgramBodyItem { index: 36 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 1 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    108["Segment<br>[6804, 6869, 0]"]
+    123["Segment<br>[7004, 7069, 0]"]
       %% [ProgramBodyItem { index: 36 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 2 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    109["Segment<br>[6885, 6946, 0]"]
+    124["Segment<br>[7085, 7146, 0]"]
       %% [ProgramBodyItem { index: 36 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 3 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   end
-  subgraph path127 [Path]
-    127["Path<br>[7701, 8739, 0]<br>Consumed: true"]
+  subgraph path125 [Path]
+    125["Path Region<br>[7646, 7732, 0]<br>Consumed: true"]
+      %% [ProgramBodyItem { index: 37 }, VariableDeclarationDeclaration, VariableDeclarationInit, CallKwUnlabeledArg]
+    126["Segment<br>[7646, 7732, 0]"]
+      %% [ProgramBodyItem { index: 37 }, VariableDeclarationDeclaration, VariableDeclarationInit, CallKwUnlabeledArg]
+    127["Segment<br>[7646, 7732, 0]"]
+      %% [ProgramBodyItem { index: 37 }, VariableDeclarationDeclaration, VariableDeclarationInit, CallKwUnlabeledArg]
+    128["Segment<br>[7646, 7732, 0]"]
+      %% [ProgramBodyItem { index: 37 }, VariableDeclarationDeclaration, VariableDeclarationInit, CallKwUnlabeledArg]
+    129["Segment<br>[7646, 7732, 0]"]
+      %% [ProgramBodyItem { index: 37 }, VariableDeclarationDeclaration, VariableDeclarationInit, CallKwUnlabeledArg]
+  end
+  subgraph path147 [Path]
+    147["Path<br>[7970, 9008, 0]<br>Consumed: false"]
       %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    128["Segment<br>[7840, 7901, 0]"]
+    148["Segment<br>[8109, 8170, 0]"]
       %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 1 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    129["Segment<br>[7914, 7977, 0]"]
+    149["Segment<br>[8183, 8246, 0]"]
       %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 2 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    130["Segment<br>[7992, 8055, 0]"]
+    150["Segment<br>[8261, 8324, 0]"]
       %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 3 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    131["Segment<br>[8071, 8132, 0]"]
+    151["Segment<br>[8340, 8401, 0]"]
       %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 4 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   end
-  subgraph path150 [Path]
-    150["Path<br>[9061, 9847, 0]<br>Consumed: false"]
-      %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    151["Segment<br>[9103, 9163, 0]"]
-      %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    152["Segment<br>[9176, 9241, 0]"]
-      %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 1 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    153["Segment<br>[9256, 9322, 0]"]
-      %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 2 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    154["Segment<br>[9338, 9399, 0]"]
-      %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 3 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  end
-  subgraph path155 [Path]
-    155["Path Region<br>[9866, 9971, 0]<br>Consumed: true"]
-      %% [ProgramBodyItem { index: 45 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    156["Segment<br>[9866, 9971, 0]"]
-      %% [ProgramBodyItem { index: 45 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    157["Segment<br>[9866, 9971, 0]"]
-      %% [ProgramBodyItem { index: 45 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    158["Segment<br>[9866, 9971, 0]"]
-      %% [ProgramBodyItem { index: 45 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    159["Segment<br>[9866, 9971, 0]"]
-      %% [ProgramBodyItem { index: 45 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  subgraph path152 [Path]
+    152["Path Region<br>[9054, 9140, 0]<br>Consumed: true"]
+      %% [ProgramBodyItem { index: 41 }, VariableDeclarationDeclaration, VariableDeclarationInit, CallKwUnlabeledArg]
+    153["Segment<br>[9054, 9140, 0]"]
+      %% [ProgramBodyItem { index: 41 }, VariableDeclarationDeclaration, VariableDeclarationInit, CallKwUnlabeledArg]
+    154["Segment<br>[9054, 9140, 0]"]
+      %% [ProgramBodyItem { index: 41 }, VariableDeclarationDeclaration, VariableDeclarationInit, CallKwUnlabeledArg]
+    155["Segment<br>[9054, 9140, 0]"]
+      %% [ProgramBodyItem { index: 41 }, VariableDeclarationDeclaration, VariableDeclarationInit, CallKwUnlabeledArg]
+    156["Segment<br>[9054, 9140, 0]"]
+      %% [ProgramBodyItem { index: 41 }, VariableDeclarationDeclaration, VariableDeclarationInit, CallKwUnlabeledArg]
   end
   subgraph path175 [Path]
-    175["Path<br>[10386, 11689, 0]<br>Consumed: false"]
-      %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    176["Segment<br>[10628, 10695, 0]"]
-      %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 2 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    177["Segment<br>[10708, 10776, 0]"]
-      %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 3 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    178["Segment<br>[10791, 10858, 0]"]
-      %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 4 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    179["Segment<br>[10874, 10940, 0]"]
-      %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 5 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+    175["Path<br>[9399, 10185, 0]<br>Consumed: false"]
+      %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+    176["Segment<br>[9441, 9501, 0]"]
+      %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+    177["Segment<br>[9514, 9579, 0]"]
+      %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 1 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+    178["Segment<br>[9594, 9660, 0]"]
+      %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 2 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+    179["Segment<br>[9676, 9737, 0]"]
+      %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 3 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   end
   subgraph path180 [Path]
-    180["Path Region<br>[11711, 11793, 0]<br>Consumed: true"]
-      %% [ProgramBodyItem { index: 57 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    181["Segment<br>[11711, 11793, 0]"]
-      %% [ProgramBodyItem { index: 57 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    182["Segment<br>[11711, 11793, 0]"]
-      %% [ProgramBodyItem { index: 57 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    183["Segment<br>[11711, 11793, 0]"]
-      %% [ProgramBodyItem { index: 57 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    184["Segment<br>[11711, 11793, 0]"]
-      %% [ProgramBodyItem { index: 57 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+    180["Path Region<br>[10204, 10309, 0]<br>Consumed: true"]
+      %% [ProgramBodyItem { index: 45 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+    181["Segment<br>[10204, 10309, 0]"]
+      %% [ProgramBodyItem { index: 45 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+    182["Segment<br>[10204, 10309, 0]"]
+      %% [ProgramBodyItem { index: 45 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+    183["Segment<br>[10204, 10309, 0]"]
+      %% [ProgramBodyItem { index: 45 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+    184["Segment<br>[10204, 10309, 0]"]
+      %% [ProgramBodyItem { index: 45 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   end
-  subgraph path199 [Path]
-    199["Path<br>[11983, 13354, 0]<br>Consumed: false"]
-      %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    200["Segment<br>[12223, 12288, 0]"]
-      %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 2 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    201["Segment<br>[12301, 12367, 0]"]
-      %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 3 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    202["Segment<br>[12382, 12447, 0]"]
-      %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 4 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    203["Segment<br>[12463, 12527, 0]"]
-      %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 5 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  subgraph path200 [Path]
+    200["Path<br>[10724, 12027, 0]<br>Consumed: false"]
+      %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+    201["Segment<br>[10966, 11033, 0]"]
+      %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 2 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+    202["Segment<br>[11046, 11114, 0]"]
+      %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 3 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+    203["Segment<br>[11129, 11196, 0]"]
+      %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 4 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+    204["Segment<br>[11212, 11278, 0]"]
+      %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 5 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   end
-  subgraph path204 [Path]
-    204["Path Region<br>[13375, 13484, 0]<br>Consumed: true"]
-      %% [ProgramBodyItem { index: 62 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    205["Segment<br>[13375, 13484, 0]"]
-      %% [ProgramBodyItem { index: 62 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    206["Segment<br>[13375, 13484, 0]"]
-      %% [ProgramBodyItem { index: 62 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    207["Segment<br>[13375, 13484, 0]"]
-      %% [ProgramBodyItem { index: 62 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    208["Segment<br>[13375, 13484, 0]"]
-      %% [ProgramBodyItem { index: 62 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  subgraph path205 [Path]
+    205["Path Region<br>[12049, 12131, 0]<br>Consumed: true"]
+      %% [ProgramBodyItem { index: 57 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+    206["Segment<br>[12049, 12131, 0]"]
+      %% [ProgramBodyItem { index: 57 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+    207["Segment<br>[12049, 12131, 0]"]
+      %% [ProgramBodyItem { index: 57 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+    208["Segment<br>[12049, 12131, 0]"]
+      %% [ProgramBodyItem { index: 57 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+    209["Segment<br>[12049, 12131, 0]"]
+      %% [ProgramBodyItem { index: 57 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   end
   subgraph path224 [Path]
-    224["Path<br>[13617, 14663, 0]<br>Consumed: false"]
+    224["Path<br>[12321, 13692, 0]<br>Consumed: false"]
+      %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+    225["Segment<br>[12561, 12626, 0]"]
+      %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 2 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+    226["Segment<br>[12639, 12705, 0]"]
+      %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 3 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+    227["Segment<br>[12720, 12785, 0]"]
+      %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 4 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+    228["Segment<br>[12801, 12865, 0]"]
+      %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 5 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  end
+  subgraph path229 [Path]
+    229["Path Region<br>[13713, 13822, 0]<br>Consumed: true"]
+      %% [ProgramBodyItem { index: 62 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+    230["Segment<br>[13713, 13822, 0]"]
+      %% [ProgramBodyItem { index: 62 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+    231["Segment<br>[13713, 13822, 0]"]
+      %% [ProgramBodyItem { index: 62 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+    232["Segment<br>[13713, 13822, 0]"]
+      %% [ProgramBodyItem { index: 62 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+    233["Segment<br>[13713, 13822, 0]"]
+      %% [ProgramBodyItem { index: 62 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  end
+  subgraph path249 [Path]
+    249["Path<br>[13955, 15001, 0]<br>Consumed: false"]
       %% [ProgramBodyItem { index: 65 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    225["Segment<br>[13891, 13962, 0]"]
+    250["Segment<br>[14229, 14300, 0]"]
       %% [ProgramBodyItem { index: 65 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 2 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   end
-  subgraph path226 [Path]
-    226["Path Region<br>[14682, 14732, 0]<br>Consumed: true"]
+  subgraph path251 [Path]
+    251["Path Region<br>[15020, 15070, 0]<br>Consumed: true"]
       %% [ProgramBodyItem { index: 66 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    227["Segment<br>[14682, 14732, 0]"]
+    252["Segment<br>[15020, 15070, 0]"]
       %% [ProgramBodyItem { index: 66 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   end
-  subgraph path236 [Path]
-    236["Path<br>[14955, 16007, 0]<br>Consumed: false"]
+  subgraph path261 [Path]
+    261["Path<br>[15293, 16345, 0]<br>Consumed: false"]
       %% [ProgramBodyItem { index: 70 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    237["Segment<br>[15230, 15301, 0]"]
+    262["Segment<br>[15568, 15639, 0]"]
       %% [ProgramBodyItem { index: 70 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 2 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   end
-  subgraph path238 [Path]
-    238["Path Region<br>[16027, 16079, 0]<br>Consumed: true"]
+  subgraph path263 [Path]
+    263["Path Region<br>[16365, 16417, 0]<br>Consumed: true"]
       %% [ProgramBodyItem { index: 71 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    239["Segment<br>[16027, 16079, 0]"]
+    264["Segment<br>[16365, 16417, 0]"]
       %% [ProgramBodyItem { index: 71 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   end
-  subgraph path248 [Path]
-    248["Path<br>[16306, 17334, 0]<br>Consumed: false"]
+  subgraph path273 [Path]
+    273["Path<br>[16644, 17672, 0]<br>Consumed: false"]
       %% [ProgramBodyItem { index: 75 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    249["Segment<br>[16582, 16653, 0]"]
+    274["Segment<br>[16920, 16991, 0]"]
       %% [ProgramBodyItem { index: 75 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 2 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   end
-  subgraph path250 [Path]
-    250["Path Region<br>[17352, 17400, 0]<br>Consumed: true"]
+  subgraph path275 [Path]
+    275["Path Region<br>[17690, 17738, 0]<br>Consumed: true"]
       %% [ProgramBodyItem { index: 76 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    251["Segment<br>[17352, 17400, 0]"]
+    276["Segment<br>[17690, 17738, 0]"]
       %% [ProgramBodyItem { index: 76 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   end
-  subgraph path260 [Path]
-    260["Path<br>[17637, 18695, 0]<br>Consumed: false"]
+  subgraph path285 [Path]
+    285["Path<br>[17975, 19033, 0]<br>Consumed: false"]
       %% [ProgramBodyItem { index: 80 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    261["Segment<br>[17918, 17991, 0]"]
+    286["Segment<br>[18256, 18329, 0]"]
       %% [ProgramBodyItem { index: 80 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 2 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   end
-  subgraph path262 [Path]
-    262["Path Region<br>[18715, 18767, 0]<br>Consumed: true"]
+  subgraph path287 [Path]
+    287["Path Region<br>[19053, 19105, 0]<br>Consumed: true"]
       %% [ProgramBodyItem { index: 81 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    263["Segment<br>[18715, 18767, 0]"]
+    288["Segment<br>[19053, 19105, 0]"]
       %% [ProgramBodyItem { index: 81 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   end
-  subgraph path272 [Path]
-    272["Path<br>[19548, 20571, 0]<br>Consumed: false"]
+  subgraph path297 [Path]
+    297["Path<br>[19886, 20909, 0]<br>Consumed: false"]
       %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    273["Segment<br>[19682, 19743, 0]"]
+    298["Segment<br>[20020, 20081, 0]"]
       %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 1 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    274["Segment<br>[19756, 19819, 0]"]
+    299["Segment<br>[20094, 20157, 0]"]
       %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 2 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    275["Segment<br>[19834, 19897, 0]"]
+    300["Segment<br>[20172, 20235, 0]"]
       %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 3 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    276["Segment<br>[19913, 19974, 0]"]
+    301["Segment<br>[20251, 20312, 0]"]
       %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 4 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   end
-  subgraph path277 [Path]
-    277["Path Region<br>[20686, 20783, 0]<br>Consumed: true"]
+  subgraph path302 [Path]
+    302["Path Region<br>[21024, 21121, 0]<br>Consumed: true"]
       %% [ProgramBodyItem { index: 93 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    278["Segment<br>[20686, 20783, 0]"]
+    303["Segment<br>[21024, 21121, 0]"]
       %% [ProgramBodyItem { index: 93 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    279["Segment<br>[20686, 20783, 0]"]
+    304["Segment<br>[21024, 21121, 0]"]
       %% [ProgramBodyItem { index: 93 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    280["Segment<br>[20686, 20783, 0]"]
+    305["Segment<br>[21024, 21121, 0]"]
       %% [ProgramBodyItem { index: 93 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    281["Segment<br>[20686, 20783, 0]"]
+    306["Segment<br>[21024, 21121, 0]"]
       %% [ProgramBodyItem { index: 93 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   end
-  subgraph path300 [Path]
-    300["Path<br>[21354, 22374, 0]<br>Consumed: false"]
+  subgraph path325 [Path]
+    325["Path<br>[21692, 22712, 0]<br>Consumed: false"]
       %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    301["Segment<br>[21488, 21549, 0]"]
+    326["Segment<br>[21826, 21887, 0]"]
       %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 1 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    302["Segment<br>[21562, 21625, 0]"]
+    327["Segment<br>[21900, 21963, 0]"]
       %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 2 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    303["Segment<br>[21640, 21703, 0]"]
+    328["Segment<br>[21978, 22041, 0]"]
       %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 3 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    304["Segment<br>[21719, 21780, 0]"]
+    329["Segment<br>[22057, 22118, 0]"]
       %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 4 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   end
-  subgraph path305 [Path]
-    305["Path Region<br>[22390, 22489, 0]<br>Consumed: true"]
+  subgraph path330 [Path]
+    330["Path Region<br>[22728, 22827, 0]<br>Consumed: true"]
       %% [ProgramBodyItem { index: 102 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    306["Segment<br>[22390, 22489, 0]"]
+    331["Segment<br>[22728, 22827, 0]"]
       %% [ProgramBodyItem { index: 102 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    307["Segment<br>[22390, 22489, 0]"]
+    332["Segment<br>[22728, 22827, 0]"]
       %% [ProgramBodyItem { index: 102 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    308["Segment<br>[22390, 22489, 0]"]
+    333["Segment<br>[22728, 22827, 0]"]
       %% [ProgramBodyItem { index: 102 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    309["Segment<br>[22390, 22489, 0]"]
+    334["Segment<br>[22728, 22827, 0]"]
       %% [ProgramBodyItem { index: 102 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   end
-  subgraph path327 [Path]
-    327["Path<br>[23038, 25421, 0]<br>Consumed: true"]
+  subgraph path352 [Path]
+    352["Path<br>[23376, 25759, 0]<br>Consumed: true"]
       %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    328["Segment<br>[23183, 23253, 0]"]
+    353["Segment<br>[23521, 23591, 0]"]
       %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 1 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    329["Segment<br>[23380, 23487, 0]"]
+    354["Segment<br>[23718, 23825, 0]"]
       %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 3 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    330["Segment<br>[23497, 23569, 0]"]
+    355["Segment<br>[23835, 23907, 0]"]
       %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 4 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    331["Segment<br>[23698, 23805, 0]"]
+    356["Segment<br>[24036, 24143, 0]"]
       %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    332["Segment<br>[23819, 23889, 0]"]
+    357["Segment<br>[24157, 24227, 0]"]
       %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   end
-  subgraph path334 [Path]
-    334["Path<br>[25446, 26455, 0]<br>Consumed: false"]
+  subgraph path359 [Path]
+    359["Path<br>[25784, 26793, 0]<br>Consumed: false"]
       %% [ProgramBodyItem { index: 115 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    335["Segment<br>[25686, 25763, 0]"]
+    360["Segment<br>[26024, 26101, 0]"]
       %% [ProgramBodyItem { index: 115 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 2 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   end
-  subgraph path336 [Path]
-    336["Path Region<br>[26473, 26528, 0]<br>Consumed: true"]
+  subgraph path361 [Path]
+    361["Path Region<br>[26811, 26866, 0]<br>Consumed: true"]
       %% [ProgramBodyItem { index: 116 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-    337["Segment<br>[26473, 26528, 0]"]
+    362["Segment<br>[26811, 26866, 0]"]
       %% [ProgramBodyItem { index: 116 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   end
   1["Plane<br>[755, 1530, 0]"]
     %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  7["Pattern Transform<br>[1546, 1644, 0]<br>Copies: 1<br>Faces: 0<br>Edges: 4"]
+  12["Pattern Transform<br>[1546, 1706, 0]<br>Copies: 1<br>Faces: 0<br>Edges: 4"]
     %% [ProgramBodyItem { index: 14 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  8["Pattern Transform<br>[1663, 1755, 0]<br>Copies: 1<br>Faces: 0<br>Edges: 4"]
+  13["Pattern Transform<br>[1725, 1817, 0]<br>Copies: 1<br>Faces: 0<br>Edges: 4"]
     %% [ProgramBodyItem { index: 15 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  9["Pattern Transform<br>[1663, 1755, 0]<br>Copies: 1<br>Faces: 0<br>Edges: 4"]
+  14["Pattern Transform<br>[1725, 1817, 0]<br>Copies: 1<br>Faces: 0<br>Edges: 4"]
     %% [ProgramBodyItem { index: 15 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  10["Sweep Extrusion<br>[1766, 1810, 0]<br>Consumed: false"]
+  15["Sweep Extrusion<br>[1828, 1872, 0]<br>Consumed: false"]
     %% [ProgramBodyItem { index: 16 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  11[Wall]
+  16[Wall]
     %% face_code_ref=Missing NodePath
-  12[Wall]
+  17[Wall]
     %% face_code_ref=Missing NodePath
-  13[Wall]
+  18[Wall]
     %% face_code_ref=Missing NodePath
-  14[Wall]
+  19[Wall]
     %% face_code_ref=Missing NodePath
-  15["Cap Start"]
+  20["Cap Start"]
     %% face_code_ref=Missing NodePath
-  16["Cap End"]
+  21["Cap End"]
     %% face_code_ref=Missing NodePath
-  17["SweepEdge Opposite"]
-  18["SweepEdge Adjacent"]
-  19["SweepEdge Opposite"]
-  20["SweepEdge Adjacent"]
-  21["SweepEdge Opposite"]
-  22["SweepEdge Adjacent"]
-  23["SweepEdge Opposite"]
-  24["SweepEdge Adjacent"]
-  25["Sweep Extrusion<br>[1766, 1810, 0]<br>Consumed: false"]
+  22["SweepEdge Opposite"]
+  23["SweepEdge Adjacent"]
+  24["SweepEdge Opposite"]
+  25["SweepEdge Adjacent"]
+  26["SweepEdge Opposite"]
+  27["SweepEdge Adjacent"]
+  28["SweepEdge Opposite"]
+  29["SweepEdge Adjacent"]
+  30["Sweep Extrusion<br>[1828, 1872, 0]<br>Consumed: false"]
     %% [ProgramBodyItem { index: 16 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  26["Sweep Extrusion<br>[1766, 1810, 0]<br>Consumed: false"]
+  31["Sweep Extrusion<br>[1828, 1872, 0]<br>Consumed: false"]
     %% [ProgramBodyItem { index: 16 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  27["Sweep Extrusion<br>[1766, 1810, 0]<br>Consumed: false"]
+  32["Sweep Extrusion<br>[1828, 1872, 0]<br>Consumed: false"]
     %% [ProgramBodyItem { index: 16 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  28["Plane<br>[1928, 1982, 0]"]
+  33["Plane<br>[1990, 2044, 0]"]
     %% [ProgramBodyItem { index: 19 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  34["Pattern Transform<br>[3100, 3207, 0]<br>Copies: 0<br>Faces: 0<br>Edges: 0"]
+  44["Pattern Transform<br>[3162, 3338, 0]<br>Copies: 0<br>Faces: 0<br>Edges: 0"]
     %% [ProgramBodyItem { index: 21 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  35["Pattern Transform<br>[3233, 3332, 0]<br>Copies: 1<br>Faces: 0<br>Edges: 4"]
+  45["Pattern Transform<br>[3364, 3463, 0]<br>Copies: 1<br>Faces: 0<br>Edges: 4"]
     %% [ProgramBodyItem { index: 22 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  36["Sweep Extrusion<br>[3350, 3408, 0]<br>Consumed: false"]
+  46["Sweep Extrusion<br>[3481, 3539, 0]<br>Consumed: false"]
     %% [ProgramBodyItem { index: 23 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  37[Wall]
+  47[Wall]
     %% face_code_ref=Missing NodePath
-  38[Wall]
+  48[Wall]
     %% face_code_ref=Missing NodePath
-  39[Wall]
+  49[Wall]
     %% face_code_ref=Missing NodePath
-  40[Wall]
+  50[Wall]
     %% face_code_ref=Missing NodePath
-  41["Cap Start"]
+  51["Cap Start"]
     %% face_code_ref=Missing NodePath
-  42["Cap End"]
+  52["Cap End"]
     %% face_code_ref=Missing NodePath
-  43["SweepEdge Opposite"]
-  44["SweepEdge Adjacent"]
-  45["SweepEdge Opposite"]
-  46["SweepEdge Adjacent"]
-  47["SweepEdge Opposite"]
-  48["SweepEdge Adjacent"]
-  49["SweepEdge Opposite"]
-  50["SweepEdge Adjacent"]
-  51["Sweep Extrusion<br>[3350, 3408, 0]<br>Consumed: false"]
+  53["SweepEdge Opposite"]
+  54["SweepEdge Adjacent"]
+  55["SweepEdge Opposite"]
+  56["SweepEdge Adjacent"]
+  57["SweepEdge Opposite"]
+  58["SweepEdge Adjacent"]
+  59["SweepEdge Opposite"]
+  60["SweepEdge Adjacent"]
+  61["Sweep Extrusion<br>[3481, 3539, 0]<br>Consumed: false"]
     %% [ProgramBodyItem { index: 23 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  57["Pattern Transform<br>[4572, 4689, 0]<br>Copies: 1<br>Faces: 0<br>Edges: 4"]
+  72["Pattern Transform<br>[4703, 4889, 0]<br>Copies: 1<br>Faces: 0<br>Edges: 4"]
     %% [ProgramBodyItem { index: 26 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  58["Sweep Extrusion<br>[4707, 4765, 0]<br>Consumed: false"]
+  73["Sweep Extrusion<br>[4907, 4965, 0]<br>Consumed: false"]
     %% [ProgramBodyItem { index: 27 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  59[Wall]
+  74[Wall]
     %% face_code_ref=Missing NodePath
-  60[Wall]
+  75[Wall]
     %% face_code_ref=Missing NodePath
-  61[Wall]
+  76[Wall]
     %% face_code_ref=Missing NodePath
-  62[Wall]
+  77[Wall]
     %% face_code_ref=Missing NodePath
-  63["Cap Start"]
+  78["Cap Start"]
     %% face_code_ref=Missing NodePath
-  64["Cap End"]
+  79["Cap End"]
     %% face_code_ref=Missing NodePath
-  65["SweepEdge Opposite"]
-  66["SweepEdge Adjacent"]
-  67["SweepEdge Opposite"]
-  68["SweepEdge Adjacent"]
-  69["SweepEdge Opposite"]
-  70["SweepEdge Adjacent"]
-  71["SweepEdge Opposite"]
-  72["SweepEdge Adjacent"]
-  73["Sweep Extrusion<br>[4707, 4765, 0]<br>Consumed: false"]
+  80["SweepEdge Opposite"]
+  81["SweepEdge Adjacent"]
+  82["SweepEdge Opposite"]
+  83["SweepEdge Adjacent"]
+  84["SweepEdge Opposite"]
+  85["SweepEdge Adjacent"]
+  86["SweepEdge Opposite"]
+  87["SweepEdge Adjacent"]
+  88["Sweep Extrusion<br>[4907, 4965, 0]<br>Consumed: false"]
     %% [ProgramBodyItem { index: 27 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  74["Plane<br>[4868, 4919, 0]"]
+  89["Plane<br>[5068, 5119, 0]"]
     %% [ProgramBodyItem { index: 29 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  85["Pattern Transform<br>[6116, 6310, 0]<br>Copies: 1<br>Faces: 0<br>Edges: 4"]
+  100["Pattern Transform<br>[6316, 6510, 0]<br>Copies: 1<br>Faces: 0<br>Edges: 4"]
     %% [ProgramBodyItem { index: 32 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  86["Sweep Extrusion<br>[6324, 6375, 0]<br>Consumed: false"]
+  101["Sweep Extrusion<br>[6524, 6575, 0]<br>Consumed: false"]
     %% [ProgramBodyItem { index: 33 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  87[Wall]
+  102[Wall]
     %% face_code_ref=Missing NodePath
-  88[Wall]
+  103[Wall]
     %% face_code_ref=Missing NodePath
-  89[Wall]
+  104[Wall]
     %% face_code_ref=Missing NodePath
-  90[Wall]
+  105[Wall]
     %% face_code_ref=Missing NodePath
-  91["Cap Start"]
+  106["Cap Start"]
     %% face_code_ref=Missing NodePath
-  92["Cap End"]
+  107["Cap End"]
     %% face_code_ref=Missing NodePath
-  93["SweepEdge Opposite"]
-  94["SweepEdge Adjacent"]
-  95["SweepEdge Opposite"]
-  96["SweepEdge Adjacent"]
-  97["SweepEdge Opposite"]
-  98["SweepEdge Adjacent"]
-  99["SweepEdge Opposite"]
-  100["SweepEdge Adjacent"]
-  101["Sweep Extrusion<br>[6324, 6375, 0]<br>Consumed: false"]
+  108["SweepEdge Opposite"]
+  109["SweepEdge Adjacent"]
+  110["SweepEdge Opposite"]
+  111["SweepEdge Adjacent"]
+  112["SweepEdge Opposite"]
+  113["SweepEdge Adjacent"]
+  114["SweepEdge Opposite"]
+  115["SweepEdge Adjacent"]
+  116["Sweep Extrusion<br>[6524, 6575, 0]<br>Consumed: false"]
     %% [ProgramBodyItem { index: 33 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  102["Pattern Transform<br>[6389, 6492, 0]<br>Copies: 0<br>Faces: 0<br>Edges: 0"]
+  117["Pattern Transform<br>[6589, 6692, 0]<br>Copies: 0<br>Faces: 0<br>Edges: 0"]
     %% [ProgramBodyItem { index: 34 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  103["Pattern Transform<br>[6389, 6492, 0]<br>Copies: 0<br>Faces: 0<br>Edges: 0"]
+  118["Pattern Transform<br>[6589, 6692, 0]<br>Copies: 0<br>Faces: 0<br>Edges: 0"]
     %% [ProgramBodyItem { index: 34 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  104["Plane<br>[6525, 6562, 0]"]
+  119["Plane<br>[6725, 6762, 0]"]
     %% [ProgramBodyItem { index: 35 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  110["Pattern Transform<br>[7427, 7525, 0]<br>Copies: 1<br>Faces: 0<br>Edges: 4"]
+  130["Pattern Transform<br>[7627, 7794, 0]<br>Copies: 1<br>Faces: 0<br>Edges: 4"]
     %% [ProgramBodyItem { index: 37 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  111["Sweep Extrusion<br>[7543, 7602, 0]<br>Consumed: false"]
+  131["Sweep Extrusion<br>[7812, 7871, 0]<br>Consumed: false"]
     %% [ProgramBodyItem { index: 38 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  112[Wall]
+  132[Wall]
     %% face_code_ref=Missing NodePath
-  113[Wall]
+  133[Wall]
     %% face_code_ref=Missing NodePath
-  114[Wall]
-    %% face_code_ref=Missing NodePath
-  115[Wall]
-    %% face_code_ref=Missing NodePath
-  116["Cap Start"]
-    %% face_code_ref=Missing NodePath
-  117["Cap End"]
-    %% face_code_ref=Missing NodePath
-  118["SweepEdge Opposite"]
-  119["SweepEdge Adjacent"]
-  120["SweepEdge Opposite"]
-  121["SweepEdge Adjacent"]
-  122["SweepEdge Opposite"]
-  123["SweepEdge Adjacent"]
-  124["SweepEdge Opposite"]
-  125["SweepEdge Adjacent"]
-  126["Sweep Extrusion<br>[7543, 7602, 0]<br>Consumed: false"]
-    %% [ProgramBodyItem { index: 38 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  132["Pattern Transform<br>[8766, 8883, 0]<br>Copies: 1<br>Faces: 0<br>Edges: 4"]
-    %% [ProgramBodyItem { index: 41 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  133["Sweep Extrusion<br>[8901, 8960, 0]<br>Consumed: false"]
-    %% [ProgramBodyItem { index: 42 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   134[Wall]
     %% face_code_ref=Missing NodePath
   135[Wall]
     %% face_code_ref=Missing NodePath
-  136[Wall]
+  136["Cap Start"]
     %% face_code_ref=Missing NodePath
-  137[Wall]
+  137["Cap End"]
     %% face_code_ref=Missing NodePath
-  138["Cap Start"]
-    %% face_code_ref=Missing NodePath
-  139["Cap End"]
-    %% face_code_ref=Missing NodePath
+  138["SweepEdge Opposite"]
+  139["SweepEdge Adjacent"]
   140["SweepEdge Opposite"]
   141["SweepEdge Adjacent"]
   142["SweepEdge Opposite"]
   143["SweepEdge Adjacent"]
   144["SweepEdge Opposite"]
   145["SweepEdge Adjacent"]
-  146["SweepEdge Opposite"]
-  147["SweepEdge Adjacent"]
-  148["Sweep Extrusion<br>[8901, 8960, 0]<br>Consumed: false"]
+  146["Sweep Extrusion<br>[7812, 7871, 0]<br>Consumed: false"]
+    %% [ProgramBodyItem { index: 38 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  157["Pattern Transform<br>[9035, 9221, 0]<br>Copies: 1<br>Faces: 0<br>Edges: 4"]
+    %% [ProgramBodyItem { index: 41 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  158["Sweep Extrusion<br>[9239, 9298, 0]<br>Consumed: false"]
     %% [ProgramBodyItem { index: 42 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  149["Plane<br>[8986, 9023, 0]"]
-    %% [ProgramBodyItem { index: 43 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  160["Sweep Extrusion<br>[9987, 10036, 0]<br>Consumed: false"]
-    %% [ProgramBodyItem { index: 46 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  159[Wall]
+    %% face_code_ref=Missing NodePath
+  160[Wall]
+    %% face_code_ref=Missing NodePath
   161[Wall]
     %% face_code_ref=Missing NodePath
   162[Wall]
     %% face_code_ref=Missing NodePath
-  163[Wall]
+  163["Cap Start"]
     %% face_code_ref=Missing NodePath
-  164[Wall]
+  164["Cap End"]
     %% face_code_ref=Missing NodePath
-  165["Cap Start"]
-    %% face_code_ref=Missing NodePath
-  166["Cap End"]
-    %% face_code_ref=Missing NodePath
+  165["SweepEdge Opposite"]
+  166["SweepEdge Adjacent"]
   167["SweepEdge Opposite"]
   168["SweepEdge Adjacent"]
   169["SweepEdge Opposite"]
   170["SweepEdge Adjacent"]
   171["SweepEdge Opposite"]
   172["SweepEdge Adjacent"]
-  173["SweepEdge Opposite"]
-  174["SweepEdge Adjacent"]
-  185["Sweep Extrusion<br>[11812, 11858, 0]<br>Consumed: false"]
-    %% [ProgramBodyItem { index: 58 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  173["Sweep Extrusion<br>[9239, 9298, 0]<br>Consumed: false"]
+    %% [ProgramBodyItem { index: 42 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  174["Plane<br>[9324, 9361, 0]"]
+    %% [ProgramBodyItem { index: 43 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  185["Sweep Extrusion<br>[10325, 10374, 0]<br>Consumed: false"]
+    %% [ProgramBodyItem { index: 46 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   186[Wall]
     %% face_code_ref=Missing NodePath
   187[Wall]
@@ -490,152 +528,152 @@ flowchart LR
     %% face_code_ref=Missing NodePath
   189[Wall]
     %% face_code_ref=Missing NodePath
-  190["Cap End"]
+  190["Cap Start"]
     %% face_code_ref=Missing NodePath
-  191["SweepEdge Opposite"]
-  192["SweepEdge Adjacent"]
-  193["SweepEdge Opposite"]
-  194["SweepEdge Adjacent"]
-  195["SweepEdge Opposite"]
-  196["SweepEdge Adjacent"]
-  197["SweepEdge Opposite"]
-  198["SweepEdge Adjacent"]
-  209["Sweep Extrusion<br>[13502, 13548, 0]<br>Consumed: false"]
-    %% [ProgramBodyItem { index: 63 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  210[Wall]
+  191["Cap End"]
     %% face_code_ref=Missing NodePath
+  192["SweepEdge Opposite"]
+  193["SweepEdge Adjacent"]
+  194["SweepEdge Opposite"]
+  195["SweepEdge Adjacent"]
+  196["SweepEdge Opposite"]
+  197["SweepEdge Adjacent"]
+  198["SweepEdge Opposite"]
+  199["SweepEdge Adjacent"]
+  210["Sweep Extrusion<br>[12150, 12196, 0]<br>Consumed: false"]
+    %% [ProgramBodyItem { index: 58 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   211[Wall]
     %% face_code_ref=Missing NodePath
   212[Wall]
     %% face_code_ref=Missing NodePath
   213[Wall]
     %% face_code_ref=Missing NodePath
-  214["Cap Start"]
+  214[Wall]
     %% face_code_ref=Missing NodePath
-  215["SweepEdge Opposite"]
-  216["SweepEdge Adjacent"]
-  217["SweepEdge Opposite"]
-  218["SweepEdge Adjacent"]
-  219["SweepEdge Opposite"]
-  220["SweepEdge Adjacent"]
-  221["SweepEdge Opposite"]
-  222["SweepEdge Adjacent"]
-  223["Plane<br>[13629, 13666, 0]"]
-    %% [ProgramBodyItem { index: 65 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockArgs]
-  228["Sweep Extrusion<br>[14748, 14783, 0]<br>Consumed: false"]
-    %% [ProgramBodyItem { index: 67 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  229[Wall]
+  215["Cap End"]
     %% face_code_ref=Missing NodePath
-  230["Cap Start"]
+  216["SweepEdge Opposite"]
+  217["SweepEdge Adjacent"]
+  218["SweepEdge Opposite"]
+  219["SweepEdge Adjacent"]
+  220["SweepEdge Opposite"]
+  221["SweepEdge Adjacent"]
+  222["SweepEdge Opposite"]
+  223["SweepEdge Adjacent"]
+  234["Sweep Extrusion<br>[13840, 13886, 0]<br>Consumed: false"]
+    %% [ProgramBodyItem { index: 63 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  235[Wall]
     %% face_code_ref=Missing NodePath
-  231["Cap End"]
+  236[Wall]
     %% face_code_ref=Missing NodePath
-  232["SweepEdge Opposite"]
-  233["SweepEdge Adjacent"]
-  234["Pattern Transform<br>[14795, 14900, 0]<br>Copies: 0<br>Faces: 0<br>Edges: 0"]
-    %% [ProgramBodyItem { index: 68 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  235["Plane<br>[14967, 15004, 0]"]
-    %% [ProgramBodyItem { index: 70 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockArgs]
-  240["Sweep Extrusion<br>[16096, 16134, 0]<br>Consumed: false"]
-    %% [ProgramBodyItem { index: 72 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  241[Wall]
+  237[Wall]
     %% face_code_ref=Missing NodePath
-  242["Cap Start"]
+  238[Wall]
     %% face_code_ref=Missing NodePath
-  243["Cap End"]
+  239["Cap Start"]
     %% face_code_ref=Missing NodePath
+  240["SweepEdge Opposite"]
+  241["SweepEdge Adjacent"]
+  242["SweepEdge Opposite"]
+  243["SweepEdge Adjacent"]
   244["SweepEdge Opposite"]
   245["SweepEdge Adjacent"]
-  246["Pattern Transform<br>[16147, 16253, 0]<br>Copies: 0<br>Faces: 0<br>Edges: 0"]
+  246["SweepEdge Opposite"]
+  247["SweepEdge Adjacent"]
+  248["Plane<br>[13967, 14004, 0]"]
+    %% [ProgramBodyItem { index: 65 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockArgs]
+  253["Sweep Extrusion<br>[15086, 15121, 0]<br>Consumed: false"]
+    %% [ProgramBodyItem { index: 67 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  254[Wall]
+    %% face_code_ref=Missing NodePath
+  255["Cap Start"]
+    %% face_code_ref=Missing NodePath
+  256["Cap End"]
+    %% face_code_ref=Missing NodePath
+  257["SweepEdge Opposite"]
+  258["SweepEdge Adjacent"]
+  259["Pattern Transform<br>[15133, 15238, 0]<br>Copies: 0<br>Faces: 0<br>Edges: 0"]
+    %% [ProgramBodyItem { index: 68 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  260["Plane<br>[15305, 15342, 0]"]
+    %% [ProgramBodyItem { index: 70 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockArgs]
+  265["Sweep Extrusion<br>[16434, 16472, 0]<br>Consumed: false"]
+    %% [ProgramBodyItem { index: 72 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  266[Wall]
+    %% face_code_ref=Missing NodePath
+  267["Cap Start"]
+    %% face_code_ref=Missing NodePath
+  268["Cap End"]
+    %% face_code_ref=Missing NodePath
+  269["SweepEdge Opposite"]
+  270["SweepEdge Adjacent"]
+  271["Pattern Transform<br>[16485, 16591, 0]<br>Copies: 0<br>Faces: 0<br>Edges: 0"]
     %% [ProgramBodyItem { index: 73 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  247["Plane<br>[16318, 16359, 0]"]
+  272["Plane<br>[16656, 16697, 0]"]
     %% [ProgramBodyItem { index: 75 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockArgs]
-  252["Sweep Extrusion<br>[17415, 17463, 0]<br>Consumed: false"]
+  277["Sweep Extrusion<br>[17753, 17801, 0]<br>Consumed: false"]
     %% [ProgramBodyItem { index: 77 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  253[Wall]
+  278[Wall]
     %% face_code_ref=Missing NodePath
-  254["Cap Start"]
+  279["Cap Start"]
     %% face_code_ref=Missing NodePath
-  255["Cap End"]
+  280["Cap End"]
     %% face_code_ref=Missing NodePath
-  256["SweepEdge Opposite"]
-  257["SweepEdge Adjacent"]
-  258["Pattern Transform<br>[17474, 17578, 0]<br>Copies: 0<br>Faces: 0<br>Edges: 0"]
+  281["SweepEdge Opposite"]
+  282["SweepEdge Adjacent"]
+  283["Pattern Transform<br>[17812, 17916, 0]<br>Copies: 0<br>Faces: 0<br>Edges: 0"]
     %% [ProgramBodyItem { index: 78 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  259["Plane<br>[17649, 17690, 0]"]
+  284["Plane<br>[17987, 18028, 0]"]
     %% [ProgramBodyItem { index: 80 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockArgs]
-  264["Sweep Extrusion<br>[18784, 18821, 0]<br>Consumed: false"]
+  289["Sweep Extrusion<br>[19122, 19159, 0]<br>Consumed: false"]
     %% [ProgramBodyItem { index: 82 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  265[Wall]
+  290[Wall]
     %% face_code_ref=Missing NodePath
-  266["Cap Start"]
+  291["Cap Start"]
     %% face_code_ref=Missing NodePath
-  267["Cap End"]
+  292["Cap End"]
     %% face_code_ref=Missing NodePath
-  268["SweepEdge Opposite"]
-  269["SweepEdge Adjacent"]
-  270["Pattern Transform<br>[18834, 18940, 0]<br>Copies: 0<br>Faces: 0<br>Edges: 0"]
-    %% [ProgramBodyItem { index: 83 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  271["Plane<br>[19301, 19350, 0]"]
-    %% [ProgramBodyItem { index: 91 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  282["Sweep Extrusion<br>[20795, 20835, 0]<br>Consumed: false"]
-    %% [ProgramBodyItem { index: 94 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  283[Wall]
-    %% face_code_ref=Missing NodePath
-  284[Wall]
-    %% face_code_ref=Missing NodePath
-  285[Wall]
-    %% face_code_ref=Missing NodePath
-  286[Wall]
-    %% face_code_ref=Missing NodePath
-  287["Cap Start"]
-    %% face_code_ref=Missing NodePath
-  288["Cap End"]
-    %% face_code_ref=Missing NodePath
-  289["SweepEdge Opposite"]
-  290["SweepEdge Adjacent"]
-  291["SweepEdge Opposite"]
-  292["SweepEdge Adjacent"]
   293["SweepEdge Opposite"]
   294["SweepEdge Adjacent"]
-  295["SweepEdge Opposite"]
-  296["SweepEdge Adjacent"]
-  297["Pattern Transform<br>[20846, 20957, 0]<br>Copies: 1<br>Faces: 6<br>Edges: 12"]
-    %% [ProgramBodyItem { index: 95 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  298["Pattern Transform<br>[20969, 21060, 0]<br>Copies: 1<br>Faces: 6<br>Edges: 12"]
-    %% [ProgramBodyItem { index: 96 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  299["Pattern Transform<br>[20969, 21060, 0]<br>Copies: 1<br>Faces: 6<br>Edges: 12"]
-    %% [ProgramBodyItem { index: 96 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  310["Sweep Extrusion<br>[22502, 22543, 0]<br>Consumed: false"]
-    %% [ProgramBodyItem { index: 103 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  295["Pattern Transform<br>[19172, 19278, 0]<br>Copies: 0<br>Faces: 0<br>Edges: 0"]
+    %% [ProgramBodyItem { index: 83 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  296["Plane<br>[19639, 19688, 0]"]
+    %% [ProgramBodyItem { index: 91 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  307["Sweep Extrusion<br>[21133, 21173, 0]<br>Consumed: false"]
+    %% [ProgramBodyItem { index: 94 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  308[Wall]
+    %% face_code_ref=Missing NodePath
+  309[Wall]
+    %% face_code_ref=Missing NodePath
+  310[Wall]
+    %% face_code_ref=Missing NodePath
   311[Wall]
     %% face_code_ref=Missing NodePath
-  312[Wall]
+  312["Cap Start"]
     %% face_code_ref=Missing NodePath
-  313[Wall]
+  313["Cap End"]
     %% face_code_ref=Missing NodePath
-  314[Wall]
+  314["SweepEdge Opposite"]
+  315["SweepEdge Adjacent"]
+  316["SweepEdge Opposite"]
+  317["SweepEdge Adjacent"]
+  318["SweepEdge Opposite"]
+  319["SweepEdge Adjacent"]
+  320["SweepEdge Opposite"]
+  321["SweepEdge Adjacent"]
+  322["Pattern Transform<br>[21184, 21295, 0]<br>Copies: 1<br>Faces: 6<br>Edges: 12"]
+    %% [ProgramBodyItem { index: 95 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  323["Pattern Transform<br>[21307, 21398, 0]<br>Copies: 1<br>Faces: 6<br>Edges: 12"]
+    %% [ProgramBodyItem { index: 96 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  324["Pattern Transform<br>[21307, 21398, 0]<br>Copies: 1<br>Faces: 6<br>Edges: 12"]
+    %% [ProgramBodyItem { index: 96 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  335["Sweep Extrusion<br>[22840, 22881, 0]<br>Consumed: false"]
+    %% [ProgramBodyItem { index: 103 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  336[Wall]
     %% face_code_ref=Missing NodePath
-  315["Cap Start"]
+  337[Wall]
     %% face_code_ref=Missing NodePath
-  316["Cap End"]
+  338[Wall]
     %% face_code_ref=Missing NodePath
-  317["SweepEdge Opposite"]
-  318["SweepEdge Adjacent"]
-  319["SweepEdge Opposite"]
-  320["SweepEdge Adjacent"]
-  321["SweepEdge Opposite"]
-  322["SweepEdge Adjacent"]
-  323["SweepEdge Opposite"]
-  324["SweepEdge Adjacent"]
-  325["Pattern Transform<br>[22556, 22651, 0]<br>Copies: 1<br>Faces: 6<br>Edges: 12"]
-    %% [ProgramBodyItem { index: 104 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  326["Plane<br>[22949, 23000, 0]"]
-    %% [ProgramBodyItem { index: 113 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  333["Plane<br>[25446, 26455, 0]"]
-    %% [ProgramBodyItem { index: 115 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  338["Sweep Sweep<br>[26542, 26588, 0]<br>Consumed: false"]
-    %% [ProgramBodyItem { index: 117 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   339[Wall]
     %% face_code_ref=Missing NodePath
   340["Cap Start"]
@@ -644,947 +682,944 @@ flowchart LR
     %% face_code_ref=Missing NodePath
   342["SweepEdge Opposite"]
   343["SweepEdge Adjacent"]
-  344["Pattern Transform<br>[26602, 26715, 0]<br>Copies: 1<br>Faces: 3<br>Edges: 3"]
-    %% [ProgramBodyItem { index: 118 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  345["SketchBlock<br>[755, 1530, 0]"]
-    %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  346["SketchBlockConstraint Coincident<br>[1074, 1110, 0]"]
-    %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 4 }, ExpressionStatementExpr]
-  347["SketchBlockConstraint Coincident<br>[1113, 1154, 0]"]
-    %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 5 }, ExpressionStatementExpr]
-  348["SketchBlockConstraint Coincident<br>[1157, 1199, 0]"]
-    %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, ExpressionStatementExpr]
-  349["SketchBlockConstraint Coincident<br>[1202, 1247, 0]"]
-    %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, ExpressionStatementExpr]
-  350["SketchBlockConstraint Coincident<br>[1250, 1294, 0]"]
-    %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 8 }, ExpressionStatementExpr]
-  351["SketchBlockConstraint Vertical<br>[1298, 1316, 0]"]
-    %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
-  352["SketchBlockConstraint Horizontal<br>[1319, 1338, 0]"]
-    %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
-  353["SketchBlockConstraint Vertical<br>[1341, 1360, 0]"]
-    %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
-  354["SketchBlockConstraint Horizontal<br>[1363, 1385, 0]"]
-    %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
-  355["SketchBlockConstraint VerticalDistance<br>[1389, 1457, 0]"]
-    %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
-  356["SketchBlockConstraint HorizontalDistance<br>[1460, 1528, 0]"]
-    %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
-  357["SketchBlock<br>[2031, 3077, 0]"]
-    %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  358["SketchBlockConstraint Coincident<br>[2470, 2508, 0]"]
-    %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 5 }, ExpressionStatementExpr]
-  359["SketchBlockConstraint Coincident<br>[2511, 2555, 0]"]
-    %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, ExpressionStatementExpr]
-  360["SketchBlockConstraint Coincident<br>[2558, 2599, 0]"]
-    %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, ExpressionStatementExpr]
-  361["SketchBlockConstraint Coincident<br>[2602, 2644, 0]"]
-    %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 8 }, ExpressionStatementExpr]
-  362["SketchBlockConstraint Coincident<br>[2647, 2692, 0]"]
-    %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
-  363["SketchBlockConstraint Coincident<br>[2695, 2739, 0]"]
-    %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
-  364["SketchBlockConstraint Horizontal<br>[2743, 2765, 0]"]
-    %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
-  365["SketchBlockConstraint Vertical<br>[2768, 2786, 0]"]
-    %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
-  366["SketchBlockConstraint Horizontal<br>[2789, 2808, 0]"]
-    %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
-  367["SketchBlockConstraint Vertical<br>[2811, 2830, 0]"]
-    %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
-  368["SketchBlockConstraint Horizontal<br>[2833, 2855, 0]"]
-    %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 15 }, ExpressionStatementExpr]
-  369["SketchBlockConstraint HorizontalDistance<br>[2859, 2933, 0]"]
-    %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 16 }, ExpressionStatementExpr]
-  370["SketchBlockConstraint VerticalDistance<br>[2936, 3004, 0]"]
-    %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 17 }, ExpressionStatementExpr]
-  371["SketchBlockConstraint HorizontalDistance<br>[3007, 3075, 0]"]
-    %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 18 }, ExpressionStatementExpr]
-  372["SketchBlock<br>[3507, 4545, 0]"]
-    %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  373["SketchBlockConstraint Coincident<br>[3942, 3980, 0]"]
-    %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 5 }, ExpressionStatementExpr]
-  374["SketchBlockConstraint Coincident<br>[3983, 4027, 0]"]
-    %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, ExpressionStatementExpr]
-  375["SketchBlockConstraint Coincident<br>[4030, 4071, 0]"]
-    %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, ExpressionStatementExpr]
-  376["SketchBlockConstraint Coincident<br>[4074, 4116, 0]"]
-    %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 8 }, ExpressionStatementExpr]
-  377["SketchBlockConstraint Coincident<br>[4119, 4164, 0]"]
-    %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
-  378["SketchBlockConstraint Coincident<br>[4167, 4211, 0]"]
-    %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
-  379["SketchBlockConstraint Vertical<br>[4215, 4235, 0]"]
-    %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
-  380["SketchBlockConstraint Vertical<br>[4238, 4256, 0]"]
-    %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
-  381["SketchBlockConstraint Horizontal<br>[4259, 4278, 0]"]
-    %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
-  382["SketchBlockConstraint Vertical<br>[4281, 4300, 0]"]
-    %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
-  383["SketchBlockConstraint Horizontal<br>[4303, 4325, 0]"]
-    %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 15 }, ExpressionStatementExpr]
-  384["SketchBlockConstraint VerticalDistance<br>[4329, 4401, 0]"]
-    %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 16 }, ExpressionStatementExpr]
-  385["SketchBlockConstraint VerticalDistance<br>[4404, 4472, 0]"]
-    %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 17 }, ExpressionStatementExpr]
-  386["SketchBlockConstraint HorizontalDistance<br>[4475, 4543, 0]"]
-    %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 18 }, ExpressionStatementExpr]
-  387["SketchBlock<br>[5048, 6097, 0]"]
-    %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  388["SketchBlockConstraint Coincident<br>[5485, 5523, 0]"]
-    %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 5 }, ExpressionStatementExpr]
-  389["SketchBlockConstraint Coincident<br>[5526, 5570, 0]"]
-    %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, ExpressionStatementExpr]
-  390["SketchBlockConstraint Coincident<br>[5573, 5614, 0]"]
-    %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, ExpressionStatementExpr]
-  391["SketchBlockConstraint Coincident<br>[5617, 5659, 0]"]
-    %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 8 }, ExpressionStatementExpr]
-  392["SketchBlockConstraint Coincident<br>[5662, 5707, 0]"]
-    %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
-  393["SketchBlockConstraint Coincident<br>[5710, 5754, 0]"]
-    %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
-  394["SketchBlockConstraint Horizontal<br>[5758, 5780, 0]"]
-    %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
-  395["SketchBlockConstraint Vertical<br>[5783, 5801, 0]"]
-    %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
-  396["SketchBlockConstraint Horizontal<br>[5804, 5823, 0]"]
-    %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
-  397["SketchBlockConstraint Vertical<br>[5826, 5845, 0]"]
-    %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
-  398["SketchBlockConstraint Horizontal<br>[5848, 5870, 0]"]
-    %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 15 }, ExpressionStatementExpr]
-  399["SketchBlockConstraint HorizontalDistance<br>[5874, 5953, 0]"]
-    %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 16 }, ExpressionStatementExpr]
-  400["SketchBlockConstraint VerticalDistance<br>[5956, 6024, 0]"]
-    %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 17 }, ExpressionStatementExpr]
-  401["SketchBlockConstraint HorizontalDistance<br>[6027, 6095, 0]"]
-    %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 18 }, ExpressionStatementExpr]
-  402["SketchBlock<br>[6611, 7400, 0]"]
-    %% [ProgramBodyItem { index: 36 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  403["SketchBlockConstraint Coincident<br>[6950, 6986, 0]"]
-    %% [ProgramBodyItem { index: 36 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 4 }, ExpressionStatementExpr]
-  404["SketchBlockConstraint Coincident<br>[6989, 7030, 0]"]
-    %% [ProgramBodyItem { index: 36 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 5 }, ExpressionStatementExpr]
-  405["SketchBlockConstraint Coincident<br>[7033, 7075, 0]"]
-    %% [ProgramBodyItem { index: 36 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, ExpressionStatementExpr]
-  406["SketchBlockConstraint Coincident<br>[7078, 7123, 0]"]
-    %% [ProgramBodyItem { index: 36 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, ExpressionStatementExpr]
-  407["SketchBlockConstraint Coincident<br>[7126, 7170, 0]"]
-    %% [ProgramBodyItem { index: 36 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 8 }, ExpressionStatementExpr]
-  408["SketchBlockConstraint Vertical<br>[7174, 7192, 0]"]
-    %% [ProgramBodyItem { index: 36 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
-  409["SketchBlockConstraint Horizontal<br>[7195, 7214, 0]"]
-    %% [ProgramBodyItem { index: 36 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
-  410["SketchBlockConstraint Vertical<br>[7217, 7236, 0]"]
-    %% [ProgramBodyItem { index: 36 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
-  411["SketchBlockConstraint Horizontal<br>[7239, 7261, 0]"]
-    %% [ProgramBodyItem { index: 36 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
-  412["SketchBlockConstraint VerticalDistance<br>[7265, 7333, 0]"]
-    %% [ProgramBodyItem { index: 36 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
-  413["SketchBlockConstraint HorizontalDistance<br>[7336, 7398, 0]"]
-    %% [ProgramBodyItem { index: 36 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
-  414["SketchBlock<br>[7701, 8739, 0]"]
-    %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  415["SketchBlockConstraint Coincident<br>[8136, 8174, 0]"]
-    %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 5 }, ExpressionStatementExpr]
-  416["SketchBlockConstraint Coincident<br>[8177, 8221, 0]"]
-    %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, ExpressionStatementExpr]
-  417["SketchBlockConstraint Coincident<br>[8224, 8265, 0]"]
-    %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, ExpressionStatementExpr]
-  418["SketchBlockConstraint Coincident<br>[8268, 8310, 0]"]
-    %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 8 }, ExpressionStatementExpr]
-  419["SketchBlockConstraint Coincident<br>[8313, 8358, 0]"]
-    %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
-  420["SketchBlockConstraint Coincident<br>[8361, 8405, 0]"]
-    %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
-  421["SketchBlockConstraint Vertical<br>[8409, 8429, 0]"]
-    %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
-  422["SketchBlockConstraint Vertical<br>[8432, 8450, 0]"]
-    %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
-  423["SketchBlockConstraint Horizontal<br>[8453, 8472, 0]"]
-    %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
-  424["SketchBlockConstraint Vertical<br>[8475, 8494, 0]"]
-    %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
-  425["SketchBlockConstraint Horizontal<br>[8497, 8519, 0]"]
-    %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 15 }, ExpressionStatementExpr]
-  426["SketchBlockConstraint VerticalDistance<br>[8523, 8595, 0]"]
-    %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 16 }, ExpressionStatementExpr]
-  427["SketchBlockConstraint VerticalDistance<br>[8598, 8666, 0]"]
-    %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 17 }, ExpressionStatementExpr]
-  428["SketchBlockConstraint HorizontalDistance<br>[8669, 8737, 0]"]
-    %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 18 }, ExpressionStatementExpr]
-  429["SketchBlock<br>[9061, 9847, 0]"]
-    %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  430["SketchBlockConstraint Coincident<br>[9403, 9439, 0]"]
-    %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 4 }, ExpressionStatementExpr]
-  431["SketchBlockConstraint Coincident<br>[9442, 9483, 0]"]
-    %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 5 }, ExpressionStatementExpr]
-  432["SketchBlockConstraint Coincident<br>[9486, 9528, 0]"]
-    %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, ExpressionStatementExpr]
-  433["SketchBlockConstraint Coincident<br>[9531, 9576, 0]"]
-    %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, ExpressionStatementExpr]
-  434["SketchBlockConstraint Coincident<br>[9579, 9623, 0]"]
-    %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 8 }, ExpressionStatementExpr]
-  435["SketchBlockConstraint Vertical<br>[9627, 9645, 0]"]
-    %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
-  436["SketchBlockConstraint Horizontal<br>[9648, 9667, 0]"]
-    %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
-  437["SketchBlockConstraint Vertical<br>[9670, 9689, 0]"]
-    %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
-  438["SketchBlockConstraint Horizontal<br>[9692, 9714, 0]"]
-    %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
-  439["SketchBlockConstraint VerticalDistance<br>[9718, 9780, 0]"]
-    %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
-  440["SketchBlockConstraint HorizontalDistance<br>[9783, 9845, 0]"]
-    %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
-  441["SketchBlock<br>[10386, 11689, 0]"]
-    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  442["SketchBlockConstraint Coincident<br>[10944, 10982, 0]"]
-    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, ExpressionStatementExpr]
-  443["SketchBlockConstraint Coincident<br>[10985, 11032, 0]"]
-    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, ExpressionStatementExpr]
-  444["SketchBlockConstraint Coincident<br>[11035, 11080, 0]"]
-    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 8 }, ExpressionStatementExpr]
-  445["SketchBlockConstraint Coincident<br>[11083, 11124, 0]"]
-    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
-  446["SketchBlockConstraint Coincident<br>[11127, 11169, 0]"]
-    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
-  447["SketchBlockConstraint Coincident<br>[11172, 11217, 0]"]
-    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
-  448["SketchBlockConstraint Coincident<br>[11220, 11264, 0]"]
-    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
-  449["SketchBlockConstraint Vertical<br>[11268, 11288, 0]"]
-    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
-  450["SketchBlockConstraint Horizontal<br>[11291, 11314, 0]"]
-    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
-  451["SketchBlockConstraint Vertical<br>[11317, 11335, 0]"]
-    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 15 }, ExpressionStatementExpr]
-  452["SketchBlockConstraint Horizontal<br>[11338, 11357, 0]"]
-    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 16 }, ExpressionStatementExpr]
-  453["SketchBlockConstraint Vertical<br>[11360, 11379, 0]"]
-    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 17 }, ExpressionStatementExpr]
-  454["SketchBlockConstraint Horizontal<br>[11382, 11404, 0]"]
-    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 18 }, ExpressionStatementExpr]
-  455["SketchBlockConstraint VerticalDistance<br>[11408, 11479, 0]"]
-    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 19 }, ExpressionStatementExpr]
-  456["SketchBlockConstraint HorizontalDistance<br>[11482, 11557, 0]"]
-    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 20 }, ExpressionStatementExpr]
-  457["SketchBlockConstraint VerticalDistance<br>[11560, 11622, 0]"]
-    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 21 }, ExpressionStatementExpr]
-  458["SketchBlockConstraint HorizontalDistance<br>[11625, 11687, 0]"]
-    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 22 }, ExpressionStatementExpr]
-  459["SketchBlock<br>[11983, 13354, 0]"]
-    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  460["SketchBlockConstraint Coincident<br>[12531, 12569, 0]"]
-    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, ExpressionStatementExpr]
-  461["SketchBlockConstraint Coincident<br>[12572, 12619, 0]"]
-    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, ExpressionStatementExpr]
-  462["SketchBlockConstraint Coincident<br>[12622, 12667, 0]"]
-    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 8 }, ExpressionStatementExpr]
-  463["SketchBlockConstraint Coincident<br>[12670, 12711, 0]"]
-    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
-  464["SketchBlockConstraint Coincident<br>[12714, 12756, 0]"]
-    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
-  465["SketchBlockConstraint Coincident<br>[12759, 12804, 0]"]
-    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
-  466["SketchBlockConstraint Coincident<br>[12807, 12851, 0]"]
-    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
-  467["SketchBlockConstraint Vertical<br>[12855, 12875, 0]"]
-    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
-  468["SketchBlockConstraint Horizontal<br>[12878, 12901, 0]"]
-    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
-  469["SketchBlockConstraint Vertical<br>[12904, 12922, 0]"]
-    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 15 }, ExpressionStatementExpr]
-  470["SketchBlockConstraint Horizontal<br>[12925, 12944, 0]"]
-    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 16 }, ExpressionStatementExpr]
-  471["SketchBlockConstraint Vertical<br>[12947, 12966, 0]"]
-    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 17 }, ExpressionStatementExpr]
-  472["SketchBlockConstraint Horizontal<br>[12969, 12991, 0]"]
-    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 18 }, ExpressionStatementExpr]
-  473["SketchBlockConstraint VerticalDistance<br>[12995, 13083, 0]"]
-    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 19 }, ExpressionStatementExpr]
-  474["SketchBlockConstraint HorizontalDistance<br>[13086, 13177, 0]"]
-    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 20 }, ExpressionStatementExpr]
-  475["SketchBlockConstraint VerticalDistance<br>[13180, 13264, 0]"]
-    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 21 }, ExpressionStatementExpr]
-  476["SketchBlockConstraint HorizontalDistance<br>[13268, 13351, 0]"]
-    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 22 }, ExpressionStatementExpr]
-  477["SketchBlock<br>[13617, 14663, 0]"]
-    %% [ProgramBodyItem { index: 65 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  478["SketchBlockConstraint Coincident<br>[14070, 14110, 0]"]
-    %% [ProgramBodyItem { index: 65 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 4 }, ExpressionStatementExpr]
-  479["SketchBlockConstraint Coincident<br>[14113, 14163, 0]"]
-    %% [ProgramBodyItem { index: 65 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 5 }, ExpressionStatementExpr]
-  480["SketchBlockConstraint Coincident<br>[14166, 14231, 0]"]
-    %% [ProgramBodyItem { index: 65 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, ExpressionStatementExpr]
-  481["SketchBlockConstraint Coincident<br>[14234, 14300, 0]"]
-    %% [ProgramBodyItem { index: 65 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, ExpressionStatementExpr]
-  482["SketchBlockConstraint Coincident<br>[14303, 14354, 0]"]
-    %% [ProgramBodyItem { index: 65 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 8 }, ExpressionStatementExpr]
-  483["SketchBlockConstraint Vertical<br>[14358, 14380, 0]"]
-    %% [ProgramBodyItem { index: 65 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
-  484["SketchBlockConstraint Horizontal<br>[14383, 14407, 0]"]
-    %% [ProgramBodyItem { index: 65 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
-  485["SketchBlockConstraint Horizontal<br>[14410, 14433, 0]"]
-    %% [ProgramBodyItem { index: 65 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
-  486["SketchBlockConstraint VerticalDistance<br>[14437, 14512, 0]"]
-    %% [ProgramBodyItem { index: 65 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
-  487["SketchBlockConstraint HorizontalDistance<br>[14515, 14591, 0]"]
-    %% [ProgramBodyItem { index: 65 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
-  488["SketchBlockConstraint Distance<br>[14594, 14661, 0]"]
-    %% [ProgramBodyItem { index: 65 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
-  489["SketchBlock<br>[14955, 16007, 0]"]
-    %% [ProgramBodyItem { index: 70 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  490["SketchBlockConstraint Coincident<br>[15409, 15449, 0]"]
-    %% [ProgramBodyItem { index: 70 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 4 }, ExpressionStatementExpr]
-  491["SketchBlockConstraint Coincident<br>[15452, 15502, 0]"]
-    %% [ProgramBodyItem { index: 70 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 5 }, ExpressionStatementExpr]
-  492["SketchBlockConstraint Coincident<br>[15505, 15571, 0]"]
-    %% [ProgramBodyItem { index: 70 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, ExpressionStatementExpr]
-  493["SketchBlockConstraint Coincident<br>[15574, 15641, 0]"]
-    %% [ProgramBodyItem { index: 70 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, ExpressionStatementExpr]
-  494["SketchBlockConstraint Coincident<br>[15644, 15696, 0]"]
-    %% [ProgramBodyItem { index: 70 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 8 }, ExpressionStatementExpr]
-  495["SketchBlockConstraint Vertical<br>[15700, 15722, 0]"]
-    %% [ProgramBodyItem { index: 70 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
-  496["SketchBlockConstraint Horizontal<br>[15725, 15749, 0]"]
-    %% [ProgramBodyItem { index: 70 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
-  497["SketchBlockConstraint Horizontal<br>[15752, 15775, 0]"]
-    %% [ProgramBodyItem { index: 70 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
-  498["SketchBlockConstraint VerticalDistance<br>[15779, 15854, 0]"]
-    %% [ProgramBodyItem { index: 70 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
-  499["SketchBlockConstraint HorizontalDistance<br>[15857, 15933, 0]"]
-    %% [ProgramBodyItem { index: 70 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
-  500["SketchBlockConstraint Distance<br>[15936, 16005, 0]"]
-    %% [ProgramBodyItem { index: 70 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
-  501["SketchBlock<br>[16306, 17334, 0]"]
-    %% [ProgramBodyItem { index: 75 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  502["SketchBlockConstraint Coincident<br>[16761, 16800, 0]"]
-    %% [ProgramBodyItem { index: 75 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 4 }, ExpressionStatementExpr]
-  503["SketchBlockConstraint Coincident<br>[16803, 16852, 0]"]
-    %% [ProgramBodyItem { index: 75 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 5 }, ExpressionStatementExpr]
-  504["SketchBlockConstraint Coincident<br>[16855, 16907, 0]"]
-    %% [ProgramBodyItem { index: 75 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, ExpressionStatementExpr]
-  505["SketchBlockConstraint Coincident<br>[16910, 16975, 0]"]
-    %% [ProgramBodyItem { index: 75 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, ExpressionStatementExpr]
-  506["SketchBlockConstraint Coincident<br>[16978, 17028, 0]"]
-    %% [ProgramBodyItem { index: 75 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 8 }, ExpressionStatementExpr]
-  507["SketchBlockConstraint Vertical<br>[17032, 17053, 0]"]
-    %% [ProgramBodyItem { index: 75 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
-  508["SketchBlockConstraint Horizontal<br>[17056, 17080, 0]"]
-    %% [ProgramBodyItem { index: 75 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
-  509["SketchBlockConstraint Horizontal<br>[17083, 17106, 0]"]
-    %% [ProgramBodyItem { index: 75 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
-  510["SketchBlockConstraint VerticalDistance<br>[17110, 17185, 0]"]
-    %% [ProgramBodyItem { index: 75 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
-  511["SketchBlockConstraint HorizontalDistance<br>[17188, 17264, 0]"]
-    %% [ProgramBodyItem { index: 75 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
-  512["SketchBlockConstraint Distance<br>[17267, 17332, 0]"]
-    %% [ProgramBodyItem { index: 75 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
-  513["SketchBlock<br>[17637, 18695, 0]"]
-    %% [ProgramBodyItem { index: 80 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  514["SketchBlockConstraint Coincident<br>[18101, 18140, 0]"]
-    %% [ProgramBodyItem { index: 80 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 4 }, ExpressionStatementExpr]
-  515["SketchBlockConstraint Coincident<br>[18143, 18192, 0]"]
-    %% [ProgramBodyItem { index: 80 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 5 }, ExpressionStatementExpr]
-  516["SketchBlockConstraint Coincident<br>[18195, 18261, 0]"]
-    %% [ProgramBodyItem { index: 80 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, ExpressionStatementExpr]
-  517["SketchBlockConstraint Coincident<br>[18264, 18331, 0]"]
-    %% [ProgramBodyItem { index: 80 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, ExpressionStatementExpr]
-  518["SketchBlockConstraint Coincident<br>[18334, 18386, 0]"]
-    %% [ProgramBodyItem { index: 80 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 8 }, ExpressionStatementExpr]
-  519["SketchBlockConstraint Vertical<br>[18390, 18411, 0]"]
-    %% [ProgramBodyItem { index: 80 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
-  520["SketchBlockConstraint Horizontal<br>[18414, 18438, 0]"]
-    %% [ProgramBodyItem { index: 80 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
-  521["SketchBlockConstraint Horizontal<br>[18441, 18464, 0]"]
-    %% [ProgramBodyItem { index: 80 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
-  522["SketchBlockConstraint VerticalDistance<br>[18468, 18543, 0]"]
-    %% [ProgramBodyItem { index: 80 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
-  523["SketchBlockConstraint HorizontalDistance<br>[18546, 18622, 0]"]
-    %% [ProgramBodyItem { index: 80 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
-  524["SketchBlockConstraint Distance<br>[18625, 18693, 0]"]
-    %% [ProgramBodyItem { index: 80 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
-  525["SketchBlock<br>[19548, 20571, 0]"]
-    %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  526["SketchBlockConstraint Coincident<br>[19978, 20016, 0]"]
-    %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 5 }, ExpressionStatementExpr]
-  527["SketchBlockConstraint Coincident<br>[20019, 20063, 0]"]
-    %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, ExpressionStatementExpr]
-  528["SketchBlockConstraint Coincident<br>[20066, 20107, 0]"]
-    %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, ExpressionStatementExpr]
-  529["SketchBlockConstraint Coincident<br>[20110, 20152, 0]"]
-    %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 8 }, ExpressionStatementExpr]
-  530["SketchBlockConstraint Coincident<br>[20155, 20200, 0]"]
-    %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
-  531["SketchBlockConstraint Coincident<br>[20203, 20247, 0]"]
-    %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
-  532["SketchBlockConstraint Horizontal<br>[20251, 20273, 0]"]
-    %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
-  533["SketchBlockConstraint Vertical<br>[20276, 20294, 0]"]
-    %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
-  534["SketchBlockConstraint Horizontal<br>[20297, 20316, 0]"]
-    %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
-  535["SketchBlockConstraint Vertical<br>[20319, 20338, 0]"]
-    %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
-  536["SketchBlockConstraint Horizontal<br>[20341, 20363, 0]"]
-    %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 15 }, ExpressionStatementExpr]
-  537["SketchBlockConstraint HorizontalDistance<br>[20367, 20434, 0]"]
-    %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 16 }, ExpressionStatementExpr]
-  538["SketchBlockConstraint VerticalDistance<br>[20437, 20505, 0]"]
-    %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 17 }, ExpressionStatementExpr]
-  539["SketchBlockConstraint HorizontalDistance<br>[20508, 20569, 0]"]
-    %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 18 }, ExpressionStatementExpr]
-  540["SketchBlock<br>[21354, 22374, 0]"]
-    %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  541["SketchBlockConstraint Coincident<br>[21784, 21822, 0]"]
-    %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 5 }, ExpressionStatementExpr]
-  542["SketchBlockConstraint Coincident<br>[21825, 21869, 0]"]
-    %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, ExpressionStatementExpr]
-  543["SketchBlockConstraint Coincident<br>[21872, 21913, 0]"]
-    %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, ExpressionStatementExpr]
-  544["SketchBlockConstraint Coincident<br>[21916, 21958, 0]"]
-    %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 8 }, ExpressionStatementExpr]
-  545["SketchBlockConstraint Coincident<br>[21961, 22006, 0]"]
-    %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
-  546["SketchBlockConstraint Coincident<br>[22009, 22053, 0]"]
-    %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
-  547["SketchBlockConstraint Vertical<br>[22057, 22077, 0]"]
-    %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
-  548["SketchBlockConstraint Vertical<br>[22080, 22098, 0]"]
-    %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
-  549["SketchBlockConstraint Horizontal<br>[22101, 22120, 0]"]
-    %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
-  550["SketchBlockConstraint Vertical<br>[22123, 22142, 0]"]
-    %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
-  551["SketchBlockConstraint Horizontal<br>[22145, 22167, 0]"]
-    %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 15 }, ExpressionStatementExpr]
-  552["SketchBlockConstraint VerticalDistance<br>[22171, 22236, 0]"]
-    %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 16 }, ExpressionStatementExpr]
-  553["SketchBlockConstraint VerticalDistance<br>[22239, 22301, 0]"]
-    %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 17 }, ExpressionStatementExpr]
-  554["SketchBlockConstraint HorizontalDistance<br>[22304, 22372, 0]"]
-    %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 18 }, ExpressionStatementExpr]
-  555["SketchBlock<br>[23038, 25421, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  556["SketchBlockConstraint Coincident<br>[24000, 24044, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
-  557["SketchBlockConstraint Coincident<br>[24047, 24096, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
-  558["SketchBlockConstraint Coincident<br>[24099, 24147, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
-  559["SketchBlockConstraint Coincident<br>[24150, 24190, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
-  560["SketchBlockConstraint Coincident<br>[24193, 24242, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
-  561["SketchBlockConstraint Coincident<br>[24245, 24282, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
-  562["SketchBlockConstraint Coincident<br>[24285, 24331, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 15 }, ExpressionStatementExpr]
-  563["SketchBlockConstraint Coincident<br>[24334, 24372, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 16 }, ExpressionStatementExpr]
-  564["SketchBlockConstraint Coincident<br>[24375, 24426, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 17 }, ExpressionStatementExpr]
-  565["SketchBlockConstraint Coincident<br>[24429, 24471, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 18 }, ExpressionStatementExpr]
-  566["SketchBlockConstraint Coincident<br>[24474, 24521, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 19 }, ExpressionStatementExpr]
-  567["SketchBlockConstraint Coincident<br>[24524, 24568, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 20 }, ExpressionStatementExpr]
-  568["SketchBlockConstraint Horizontal<br>[24572, 24600, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 21 }, ExpressionStatementExpr]
-  569["SketchBlockConstraint Vertical<br>[24603, 24620, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 22 }, ExpressionStatementExpr]
-  570["SketchBlockConstraint Horizontal<br>[24623, 24650, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 23 }, ExpressionStatementExpr]
-  571["SketchBlockConstraint Horizontal<br>[24653, 24669, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 24 }, ExpressionStatementExpr]
-  572["SketchBlockConstraint Vertical<br>[24672, 24698, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 25 }, ExpressionStatementExpr]
-  573["SketchBlockConstraint Vertical<br>[24701, 24719, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 26 }, ExpressionStatementExpr]
-  574["SketchBlockConstraint Horizontal<br>[24722, 24746, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 27 }, ExpressionStatementExpr]
-  575["SketchBlockConstraint HorizontalDistance<br>[24750, 24838, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 28 }, ExpressionStatementExpr]
-  576["SketchBlockConstraint Distance<br>[24841, 24903, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 29 }, ExpressionStatementExpr]
-  577["SketchBlockConstraint LinesEqualLength<br>[24906, 24938, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 30 }, ExpressionStatementExpr]
-  578["SketchBlockConstraint Distance<br>[24941, 25017, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 31 }, ExpressionStatementExpr]
-  579["SketchBlockConstraint Distance<br>[25020, 25098, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 32 }, ExpressionStatementExpr]
-  580["SketchBlockConstraint Distance<br>[25101, 25157, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 33 }, ExpressionStatementExpr]
-  581["SketchBlockConstraint HorizontalDistance<br>[25160, 25233, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 34 }, ExpressionStatementExpr]
-  582["SketchBlockConstraint Radius<br>[25236, 25267, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 35 }, ExpressionStatementExpr]
-  583["SketchBlockConstraint Radius<br>[25270, 25302, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 36 }, ExpressionStatementExpr]
-  584["SketchBlockConstraint Tangent<br>[25305, 25332, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 37 }, ExpressionStatementExpr]
-  585["SketchBlockConstraint Tangent<br>[25335, 25359, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 38 }, ExpressionStatementExpr]
-  586["SketchBlockConstraint Tangent<br>[25362, 25387, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 39 }, ExpressionStatementExpr]
-  587["SketchBlockConstraint Tangent<br>[25390, 25419, 0]"]
-    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 40 }, ExpressionStatementExpr]
-  588["SketchBlock<br>[25446, 26455, 0]"]
+  344["SweepEdge Opposite"]
+  345["SweepEdge Adjacent"]
+  346["SweepEdge Opposite"]
+  347["SweepEdge Adjacent"]
+  348["SweepEdge Opposite"]
+  349["SweepEdge Adjacent"]
+  350["Pattern Transform<br>[22894, 22989, 0]<br>Copies: 1<br>Faces: 6<br>Edges: 12"]
+    %% [ProgramBodyItem { index: 104 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  351["Plane<br>[23287, 23338, 0]"]
+    %% [ProgramBodyItem { index: 113 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  358["Plane<br>[25784, 26793, 0]"]
     %% [ProgramBodyItem { index: 115 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  589["SketchBlockConstraint Coincident<br>[25877, 25916, 0]"]
+  363["Sweep Sweep<br>[26880, 26926, 0]<br>Consumed: false"]
+    %% [ProgramBodyItem { index: 117 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  364[Wall]
+    %% face_code_ref=Missing NodePath
+  365["Cap Start"]
+    %% face_code_ref=Missing NodePath
+  366["Cap End"]
+    %% face_code_ref=Missing NodePath
+  367["SweepEdge Opposite"]
+  368["SweepEdge Adjacent"]
+  369["Pattern Transform<br>[26940, 27053, 0]<br>Copies: 1<br>Faces: 3<br>Edges: 3"]
+    %% [ProgramBodyItem { index: 118 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  370["SketchBlock<br>[755, 1530, 0]"]
+    %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  371["SketchBlockConstraint Coincident<br>[1074, 1110, 0]"]
+    %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 4 }, ExpressionStatementExpr]
+  372["SketchBlockConstraint Coincident<br>[1113, 1154, 0]"]
+    %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 5 }, ExpressionStatementExpr]
+  373["SketchBlockConstraint Coincident<br>[1157, 1199, 0]"]
+    %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, ExpressionStatementExpr]
+  374["SketchBlockConstraint Coincident<br>[1202, 1247, 0]"]
+    %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, ExpressionStatementExpr]
+  375["SketchBlockConstraint Coincident<br>[1250, 1294, 0]"]
+    %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 8 }, ExpressionStatementExpr]
+  376["SketchBlockConstraint Vertical<br>[1298, 1316, 0]"]
+    %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
+  377["SketchBlockConstraint Horizontal<br>[1319, 1338, 0]"]
+    %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
+  378["SketchBlockConstraint Vertical<br>[1341, 1360, 0]"]
+    %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
+  379["SketchBlockConstraint Horizontal<br>[1363, 1385, 0]"]
+    %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
+  380["SketchBlockConstraint VerticalDistance<br>[1389, 1457, 0]"]
+    %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
+  381["SketchBlockConstraint HorizontalDistance<br>[1460, 1528, 0]"]
+    %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
+  382["SketchBlock<br>[2093, 3139, 0]"]
+    %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  383["SketchBlockConstraint Coincident<br>[2532, 2570, 0]"]
+    %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 5 }, ExpressionStatementExpr]
+  384["SketchBlockConstraint Coincident<br>[2573, 2617, 0]"]
+    %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, ExpressionStatementExpr]
+  385["SketchBlockConstraint Coincident<br>[2620, 2661, 0]"]
+    %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, ExpressionStatementExpr]
+  386["SketchBlockConstraint Coincident<br>[2664, 2706, 0]"]
+    %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 8 }, ExpressionStatementExpr]
+  387["SketchBlockConstraint Coincident<br>[2709, 2754, 0]"]
+    %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
+  388["SketchBlockConstraint Coincident<br>[2757, 2801, 0]"]
+    %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
+  389["SketchBlockConstraint Horizontal<br>[2805, 2827, 0]"]
+    %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
+  390["SketchBlockConstraint Vertical<br>[2830, 2848, 0]"]
+    %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
+  391["SketchBlockConstraint Horizontal<br>[2851, 2870, 0]"]
+    %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
+  392["SketchBlockConstraint Vertical<br>[2873, 2892, 0]"]
+    %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
+  393["SketchBlockConstraint Horizontal<br>[2895, 2917, 0]"]
+    %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 15 }, ExpressionStatementExpr]
+  394["SketchBlockConstraint HorizontalDistance<br>[2921, 2995, 0]"]
+    %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 16 }, ExpressionStatementExpr]
+  395["SketchBlockConstraint VerticalDistance<br>[2998, 3066, 0]"]
+    %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 17 }, ExpressionStatementExpr]
+  396["SketchBlockConstraint HorizontalDistance<br>[3069, 3137, 0]"]
+    %% [ProgramBodyItem { index: 20 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 18 }, ExpressionStatementExpr]
+  397["SketchBlock<br>[3638, 4676, 0]"]
+    %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  398["SketchBlockConstraint Coincident<br>[4073, 4111, 0]"]
+    %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 5 }, ExpressionStatementExpr]
+  399["SketchBlockConstraint Coincident<br>[4114, 4158, 0]"]
+    %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, ExpressionStatementExpr]
+  400["SketchBlockConstraint Coincident<br>[4161, 4202, 0]"]
+    %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, ExpressionStatementExpr]
+  401["SketchBlockConstraint Coincident<br>[4205, 4247, 0]"]
+    %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 8 }, ExpressionStatementExpr]
+  402["SketchBlockConstraint Coincident<br>[4250, 4295, 0]"]
+    %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
+  403["SketchBlockConstraint Coincident<br>[4298, 4342, 0]"]
+    %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
+  404["SketchBlockConstraint Vertical<br>[4346, 4366, 0]"]
+    %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
+  405["SketchBlockConstraint Vertical<br>[4369, 4387, 0]"]
+    %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
+  406["SketchBlockConstraint Horizontal<br>[4390, 4409, 0]"]
+    %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
+  407["SketchBlockConstraint Vertical<br>[4412, 4431, 0]"]
+    %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
+  408["SketchBlockConstraint Horizontal<br>[4434, 4456, 0]"]
+    %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 15 }, ExpressionStatementExpr]
+  409["SketchBlockConstraint VerticalDistance<br>[4460, 4532, 0]"]
+    %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 16 }, ExpressionStatementExpr]
+  410["SketchBlockConstraint VerticalDistance<br>[4535, 4603, 0]"]
+    %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 17 }, ExpressionStatementExpr]
+  411["SketchBlockConstraint HorizontalDistance<br>[4606, 4674, 0]"]
+    %% [ProgramBodyItem { index: 25 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 18 }, ExpressionStatementExpr]
+  412["SketchBlock<br>[5248, 6297, 0]"]
+    %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  413["SketchBlockConstraint Coincident<br>[5685, 5723, 0]"]
+    %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 5 }, ExpressionStatementExpr]
+  414["SketchBlockConstraint Coincident<br>[5726, 5770, 0]"]
+    %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, ExpressionStatementExpr]
+  415["SketchBlockConstraint Coincident<br>[5773, 5814, 0]"]
+    %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, ExpressionStatementExpr]
+  416["SketchBlockConstraint Coincident<br>[5817, 5859, 0]"]
+    %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 8 }, ExpressionStatementExpr]
+  417["SketchBlockConstraint Coincident<br>[5862, 5907, 0]"]
+    %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
+  418["SketchBlockConstraint Coincident<br>[5910, 5954, 0]"]
+    %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
+  419["SketchBlockConstraint Horizontal<br>[5958, 5980, 0]"]
+    %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
+  420["SketchBlockConstraint Vertical<br>[5983, 6001, 0]"]
+    %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
+  421["SketchBlockConstraint Horizontal<br>[6004, 6023, 0]"]
+    %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
+  422["SketchBlockConstraint Vertical<br>[6026, 6045, 0]"]
+    %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
+  423["SketchBlockConstraint Horizontal<br>[6048, 6070, 0]"]
+    %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 15 }, ExpressionStatementExpr]
+  424["SketchBlockConstraint HorizontalDistance<br>[6074, 6153, 0]"]
+    %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 16 }, ExpressionStatementExpr]
+  425["SketchBlockConstraint VerticalDistance<br>[6156, 6224, 0]"]
+    %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 17 }, ExpressionStatementExpr]
+  426["SketchBlockConstraint HorizontalDistance<br>[6227, 6295, 0]"]
+    %% [ProgramBodyItem { index: 31 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 18 }, ExpressionStatementExpr]
+  427["SketchBlock<br>[6811, 7600, 0]"]
+    %% [ProgramBodyItem { index: 36 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  428["SketchBlockConstraint Coincident<br>[7150, 7186, 0]"]
+    %% [ProgramBodyItem { index: 36 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 4 }, ExpressionStatementExpr]
+  429["SketchBlockConstraint Coincident<br>[7189, 7230, 0]"]
+    %% [ProgramBodyItem { index: 36 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 5 }, ExpressionStatementExpr]
+  430["SketchBlockConstraint Coincident<br>[7233, 7275, 0]"]
+    %% [ProgramBodyItem { index: 36 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, ExpressionStatementExpr]
+  431["SketchBlockConstraint Coincident<br>[7278, 7323, 0]"]
+    %% [ProgramBodyItem { index: 36 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, ExpressionStatementExpr]
+  432["SketchBlockConstraint Coincident<br>[7326, 7370, 0]"]
+    %% [ProgramBodyItem { index: 36 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 8 }, ExpressionStatementExpr]
+  433["SketchBlockConstraint Vertical<br>[7374, 7392, 0]"]
+    %% [ProgramBodyItem { index: 36 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
+  434["SketchBlockConstraint Horizontal<br>[7395, 7414, 0]"]
+    %% [ProgramBodyItem { index: 36 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
+  435["SketchBlockConstraint Vertical<br>[7417, 7436, 0]"]
+    %% [ProgramBodyItem { index: 36 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
+  436["SketchBlockConstraint Horizontal<br>[7439, 7461, 0]"]
+    %% [ProgramBodyItem { index: 36 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
+  437["SketchBlockConstraint VerticalDistance<br>[7465, 7533, 0]"]
+    %% [ProgramBodyItem { index: 36 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
+  438["SketchBlockConstraint HorizontalDistance<br>[7536, 7598, 0]"]
+    %% [ProgramBodyItem { index: 36 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
+  439["SketchBlock<br>[7970, 9008, 0]"]
+    %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  440["SketchBlockConstraint Coincident<br>[8405, 8443, 0]"]
+    %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 5 }, ExpressionStatementExpr]
+  441["SketchBlockConstraint Coincident<br>[8446, 8490, 0]"]
+    %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, ExpressionStatementExpr]
+  442["SketchBlockConstraint Coincident<br>[8493, 8534, 0]"]
+    %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, ExpressionStatementExpr]
+  443["SketchBlockConstraint Coincident<br>[8537, 8579, 0]"]
+    %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 8 }, ExpressionStatementExpr]
+  444["SketchBlockConstraint Coincident<br>[8582, 8627, 0]"]
+    %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
+  445["SketchBlockConstraint Coincident<br>[8630, 8674, 0]"]
+    %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
+  446["SketchBlockConstraint Vertical<br>[8678, 8698, 0]"]
+    %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
+  447["SketchBlockConstraint Vertical<br>[8701, 8719, 0]"]
+    %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
+  448["SketchBlockConstraint Horizontal<br>[8722, 8741, 0]"]
+    %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
+  449["SketchBlockConstraint Vertical<br>[8744, 8763, 0]"]
+    %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
+  450["SketchBlockConstraint Horizontal<br>[8766, 8788, 0]"]
+    %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 15 }, ExpressionStatementExpr]
+  451["SketchBlockConstraint VerticalDistance<br>[8792, 8864, 0]"]
+    %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 16 }, ExpressionStatementExpr]
+  452["SketchBlockConstraint VerticalDistance<br>[8867, 8935, 0]"]
+    %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 17 }, ExpressionStatementExpr]
+  453["SketchBlockConstraint HorizontalDistance<br>[8938, 9006, 0]"]
+    %% [ProgramBodyItem { index: 40 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 18 }, ExpressionStatementExpr]
+  454["SketchBlock<br>[9399, 10185, 0]"]
+    %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  455["SketchBlockConstraint Coincident<br>[9741, 9777, 0]"]
+    %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 4 }, ExpressionStatementExpr]
+  456["SketchBlockConstraint Coincident<br>[9780, 9821, 0]"]
+    %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 5 }, ExpressionStatementExpr]
+  457["SketchBlockConstraint Coincident<br>[9824, 9866, 0]"]
+    %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, ExpressionStatementExpr]
+  458["SketchBlockConstraint Coincident<br>[9869, 9914, 0]"]
+    %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, ExpressionStatementExpr]
+  459["SketchBlockConstraint Coincident<br>[9917, 9961, 0]"]
+    %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 8 }, ExpressionStatementExpr]
+  460["SketchBlockConstraint Vertical<br>[9965, 9983, 0]"]
+    %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
+  461["SketchBlockConstraint Horizontal<br>[9986, 10005, 0]"]
+    %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
+  462["SketchBlockConstraint Vertical<br>[10008, 10027, 0]"]
+    %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
+  463["SketchBlockConstraint Horizontal<br>[10030, 10052, 0]"]
+    %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
+  464["SketchBlockConstraint VerticalDistance<br>[10056, 10118, 0]"]
+    %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
+  465["SketchBlockConstraint HorizontalDistance<br>[10121, 10183, 0]"]
+    %% [ProgramBodyItem { index: 44 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
+  466["SketchBlock<br>[10724, 12027, 0]"]
+    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  467["SketchBlockConstraint Coincident<br>[11282, 11320, 0]"]
+    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, ExpressionStatementExpr]
+  468["SketchBlockConstraint Coincident<br>[11323, 11370, 0]"]
+    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, ExpressionStatementExpr]
+  469["SketchBlockConstraint Coincident<br>[11373, 11418, 0]"]
+    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 8 }, ExpressionStatementExpr]
+  470["SketchBlockConstraint Coincident<br>[11421, 11462, 0]"]
+    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
+  471["SketchBlockConstraint Coincident<br>[11465, 11507, 0]"]
+    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
+  472["SketchBlockConstraint Coincident<br>[11510, 11555, 0]"]
+    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
+  473["SketchBlockConstraint Coincident<br>[11558, 11602, 0]"]
+    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
+  474["SketchBlockConstraint Vertical<br>[11606, 11626, 0]"]
+    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
+  475["SketchBlockConstraint Horizontal<br>[11629, 11652, 0]"]
+    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
+  476["SketchBlockConstraint Vertical<br>[11655, 11673, 0]"]
+    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 15 }, ExpressionStatementExpr]
+  477["SketchBlockConstraint Horizontal<br>[11676, 11695, 0]"]
+    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 16 }, ExpressionStatementExpr]
+  478["SketchBlockConstraint Vertical<br>[11698, 11717, 0]"]
+    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 17 }, ExpressionStatementExpr]
+  479["SketchBlockConstraint Horizontal<br>[11720, 11742, 0]"]
+    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 18 }, ExpressionStatementExpr]
+  480["SketchBlockConstraint VerticalDistance<br>[11746, 11817, 0]"]
+    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 19 }, ExpressionStatementExpr]
+  481["SketchBlockConstraint HorizontalDistance<br>[11820, 11895, 0]"]
+    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 20 }, ExpressionStatementExpr]
+  482["SketchBlockConstraint VerticalDistance<br>[11898, 11960, 0]"]
+    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 21 }, ExpressionStatementExpr]
+  483["SketchBlockConstraint HorizontalDistance<br>[11963, 12025, 0]"]
+    %% [ProgramBodyItem { index: 56 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 22 }, ExpressionStatementExpr]
+  484["SketchBlock<br>[12321, 13692, 0]"]
+    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  485["SketchBlockConstraint Coincident<br>[12869, 12907, 0]"]
+    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, ExpressionStatementExpr]
+  486["SketchBlockConstraint Coincident<br>[12910, 12957, 0]"]
+    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, ExpressionStatementExpr]
+  487["SketchBlockConstraint Coincident<br>[12960, 13005, 0]"]
+    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 8 }, ExpressionStatementExpr]
+  488["SketchBlockConstraint Coincident<br>[13008, 13049, 0]"]
+    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
+  489["SketchBlockConstraint Coincident<br>[13052, 13094, 0]"]
+    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
+  490["SketchBlockConstraint Coincident<br>[13097, 13142, 0]"]
+    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
+  491["SketchBlockConstraint Coincident<br>[13145, 13189, 0]"]
+    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
+  492["SketchBlockConstraint Vertical<br>[13193, 13213, 0]"]
+    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
+  493["SketchBlockConstraint Horizontal<br>[13216, 13239, 0]"]
+    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
+  494["SketchBlockConstraint Vertical<br>[13242, 13260, 0]"]
+    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 15 }, ExpressionStatementExpr]
+  495["SketchBlockConstraint Horizontal<br>[13263, 13282, 0]"]
+    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 16 }, ExpressionStatementExpr]
+  496["SketchBlockConstraint Vertical<br>[13285, 13304, 0]"]
+    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 17 }, ExpressionStatementExpr]
+  497["SketchBlockConstraint Horizontal<br>[13307, 13329, 0]"]
+    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 18 }, ExpressionStatementExpr]
+  498["SketchBlockConstraint VerticalDistance<br>[13333, 13421, 0]"]
+    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 19 }, ExpressionStatementExpr]
+  499["SketchBlockConstraint HorizontalDistance<br>[13424, 13515, 0]"]
+    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 20 }, ExpressionStatementExpr]
+  500["SketchBlockConstraint VerticalDistance<br>[13518, 13602, 0]"]
+    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 21 }, ExpressionStatementExpr]
+  501["SketchBlockConstraint HorizontalDistance<br>[13606, 13689, 0]"]
+    %% [ProgramBodyItem { index: 61 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 22 }, ExpressionStatementExpr]
+  502["SketchBlock<br>[13955, 15001, 0]"]
+    %% [ProgramBodyItem { index: 65 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  503["SketchBlockConstraint Coincident<br>[14408, 14448, 0]"]
+    %% [ProgramBodyItem { index: 65 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 4 }, ExpressionStatementExpr]
+  504["SketchBlockConstraint Coincident<br>[14451, 14501, 0]"]
+    %% [ProgramBodyItem { index: 65 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 5 }, ExpressionStatementExpr]
+  505["SketchBlockConstraint Coincident<br>[14504, 14569, 0]"]
+    %% [ProgramBodyItem { index: 65 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, ExpressionStatementExpr]
+  506["SketchBlockConstraint Coincident<br>[14572, 14638, 0]"]
+    %% [ProgramBodyItem { index: 65 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, ExpressionStatementExpr]
+  507["SketchBlockConstraint Coincident<br>[14641, 14692, 0]"]
+    %% [ProgramBodyItem { index: 65 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 8 }, ExpressionStatementExpr]
+  508["SketchBlockConstraint Vertical<br>[14696, 14718, 0]"]
+    %% [ProgramBodyItem { index: 65 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
+  509["SketchBlockConstraint Horizontal<br>[14721, 14745, 0]"]
+    %% [ProgramBodyItem { index: 65 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
+  510["SketchBlockConstraint Horizontal<br>[14748, 14771, 0]"]
+    %% [ProgramBodyItem { index: 65 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
+  511["SketchBlockConstraint VerticalDistance<br>[14775, 14850, 0]"]
+    %% [ProgramBodyItem { index: 65 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
+  512["SketchBlockConstraint HorizontalDistance<br>[14853, 14929, 0]"]
+    %% [ProgramBodyItem { index: 65 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
+  513["SketchBlockConstraint Distance<br>[14932, 14999, 0]"]
+    %% [ProgramBodyItem { index: 65 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
+  514["SketchBlock<br>[15293, 16345, 0]"]
+    %% [ProgramBodyItem { index: 70 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  515["SketchBlockConstraint Coincident<br>[15747, 15787, 0]"]
+    %% [ProgramBodyItem { index: 70 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 4 }, ExpressionStatementExpr]
+  516["SketchBlockConstraint Coincident<br>[15790, 15840, 0]"]
+    %% [ProgramBodyItem { index: 70 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 5 }, ExpressionStatementExpr]
+  517["SketchBlockConstraint Coincident<br>[15843, 15909, 0]"]
+    %% [ProgramBodyItem { index: 70 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, ExpressionStatementExpr]
+  518["SketchBlockConstraint Coincident<br>[15912, 15979, 0]"]
+    %% [ProgramBodyItem { index: 70 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, ExpressionStatementExpr]
+  519["SketchBlockConstraint Coincident<br>[15982, 16034, 0]"]
+    %% [ProgramBodyItem { index: 70 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 8 }, ExpressionStatementExpr]
+  520["SketchBlockConstraint Vertical<br>[16038, 16060, 0]"]
+    %% [ProgramBodyItem { index: 70 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
+  521["SketchBlockConstraint Horizontal<br>[16063, 16087, 0]"]
+    %% [ProgramBodyItem { index: 70 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
+  522["SketchBlockConstraint Horizontal<br>[16090, 16113, 0]"]
+    %% [ProgramBodyItem { index: 70 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
+  523["SketchBlockConstraint VerticalDistance<br>[16117, 16192, 0]"]
+    %% [ProgramBodyItem { index: 70 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
+  524["SketchBlockConstraint HorizontalDistance<br>[16195, 16271, 0]"]
+    %% [ProgramBodyItem { index: 70 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
+  525["SketchBlockConstraint Distance<br>[16274, 16343, 0]"]
+    %% [ProgramBodyItem { index: 70 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
+  526["SketchBlock<br>[16644, 17672, 0]"]
+    %% [ProgramBodyItem { index: 75 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  527["SketchBlockConstraint Coincident<br>[17099, 17138, 0]"]
+    %% [ProgramBodyItem { index: 75 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 4 }, ExpressionStatementExpr]
+  528["SketchBlockConstraint Coincident<br>[17141, 17190, 0]"]
+    %% [ProgramBodyItem { index: 75 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 5 }, ExpressionStatementExpr]
+  529["SketchBlockConstraint Coincident<br>[17193, 17245, 0]"]
+    %% [ProgramBodyItem { index: 75 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, ExpressionStatementExpr]
+  530["SketchBlockConstraint Coincident<br>[17248, 17313, 0]"]
+    %% [ProgramBodyItem { index: 75 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, ExpressionStatementExpr]
+  531["SketchBlockConstraint Coincident<br>[17316, 17366, 0]"]
+    %% [ProgramBodyItem { index: 75 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 8 }, ExpressionStatementExpr]
+  532["SketchBlockConstraint Vertical<br>[17370, 17391, 0]"]
+    %% [ProgramBodyItem { index: 75 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
+  533["SketchBlockConstraint Horizontal<br>[17394, 17418, 0]"]
+    %% [ProgramBodyItem { index: 75 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
+  534["SketchBlockConstraint Horizontal<br>[17421, 17444, 0]"]
+    %% [ProgramBodyItem { index: 75 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
+  535["SketchBlockConstraint VerticalDistance<br>[17448, 17523, 0]"]
+    %% [ProgramBodyItem { index: 75 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
+  536["SketchBlockConstraint HorizontalDistance<br>[17526, 17602, 0]"]
+    %% [ProgramBodyItem { index: 75 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
+  537["SketchBlockConstraint Distance<br>[17605, 17670, 0]"]
+    %% [ProgramBodyItem { index: 75 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
+  538["SketchBlock<br>[17975, 19033, 0]"]
+    %% [ProgramBodyItem { index: 80 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  539["SketchBlockConstraint Coincident<br>[18439, 18478, 0]"]
+    %% [ProgramBodyItem { index: 80 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 4 }, ExpressionStatementExpr]
+  540["SketchBlockConstraint Coincident<br>[18481, 18530, 0]"]
+    %% [ProgramBodyItem { index: 80 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 5 }, ExpressionStatementExpr]
+  541["SketchBlockConstraint Coincident<br>[18533, 18599, 0]"]
+    %% [ProgramBodyItem { index: 80 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, ExpressionStatementExpr]
+  542["SketchBlockConstraint Coincident<br>[18602, 18669, 0]"]
+    %% [ProgramBodyItem { index: 80 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, ExpressionStatementExpr]
+  543["SketchBlockConstraint Coincident<br>[18672, 18724, 0]"]
+    %% [ProgramBodyItem { index: 80 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 8 }, ExpressionStatementExpr]
+  544["SketchBlockConstraint Vertical<br>[18728, 18749, 0]"]
+    %% [ProgramBodyItem { index: 80 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
+  545["SketchBlockConstraint Horizontal<br>[18752, 18776, 0]"]
+    %% [ProgramBodyItem { index: 80 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
+  546["SketchBlockConstraint Horizontal<br>[18779, 18802, 0]"]
+    %% [ProgramBodyItem { index: 80 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
+  547["SketchBlockConstraint VerticalDistance<br>[18806, 18881, 0]"]
+    %% [ProgramBodyItem { index: 80 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
+  548["SketchBlockConstraint HorizontalDistance<br>[18884, 18960, 0]"]
+    %% [ProgramBodyItem { index: 80 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
+  549["SketchBlockConstraint Distance<br>[18963, 19031, 0]"]
+    %% [ProgramBodyItem { index: 80 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
+  550["SketchBlock<br>[19886, 20909, 0]"]
+    %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  551["SketchBlockConstraint Coincident<br>[20316, 20354, 0]"]
+    %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 5 }, ExpressionStatementExpr]
+  552["SketchBlockConstraint Coincident<br>[20357, 20401, 0]"]
+    %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, ExpressionStatementExpr]
+  553["SketchBlockConstraint Coincident<br>[20404, 20445, 0]"]
+    %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, ExpressionStatementExpr]
+  554["SketchBlockConstraint Coincident<br>[20448, 20490, 0]"]
+    %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 8 }, ExpressionStatementExpr]
+  555["SketchBlockConstraint Coincident<br>[20493, 20538, 0]"]
+    %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
+  556["SketchBlockConstraint Coincident<br>[20541, 20585, 0]"]
+    %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
+  557["SketchBlockConstraint Horizontal<br>[20589, 20611, 0]"]
+    %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
+  558["SketchBlockConstraint Vertical<br>[20614, 20632, 0]"]
+    %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
+  559["SketchBlockConstraint Horizontal<br>[20635, 20654, 0]"]
+    %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
+  560["SketchBlockConstraint Vertical<br>[20657, 20676, 0]"]
+    %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
+  561["SketchBlockConstraint Horizontal<br>[20679, 20701, 0]"]
+    %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 15 }, ExpressionStatementExpr]
+  562["SketchBlockConstraint HorizontalDistance<br>[20705, 20772, 0]"]
+    %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 16 }, ExpressionStatementExpr]
+  563["SketchBlockConstraint VerticalDistance<br>[20775, 20843, 0]"]
+    %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 17 }, ExpressionStatementExpr]
+  564["SketchBlockConstraint HorizontalDistance<br>[20846, 20907, 0]"]
+    %% [ProgramBodyItem { index: 92 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 18 }, ExpressionStatementExpr]
+  565["SketchBlock<br>[21692, 22712, 0]"]
+    %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  566["SketchBlockConstraint Coincident<br>[22122, 22160, 0]"]
+    %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 5 }, ExpressionStatementExpr]
+  567["SketchBlockConstraint Coincident<br>[22163, 22207, 0]"]
+    %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, ExpressionStatementExpr]
+  568["SketchBlockConstraint Coincident<br>[22210, 22251, 0]"]
+    %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, ExpressionStatementExpr]
+  569["SketchBlockConstraint Coincident<br>[22254, 22296, 0]"]
+    %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 8 }, ExpressionStatementExpr]
+  570["SketchBlockConstraint Coincident<br>[22299, 22344, 0]"]
+    %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
+  571["SketchBlockConstraint Coincident<br>[22347, 22391, 0]"]
+    %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
+  572["SketchBlockConstraint Vertical<br>[22395, 22415, 0]"]
+    %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
+  573["SketchBlockConstraint Vertical<br>[22418, 22436, 0]"]
+    %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
+  574["SketchBlockConstraint Horizontal<br>[22439, 22458, 0]"]
+    %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
+  575["SketchBlockConstraint Vertical<br>[22461, 22480, 0]"]
+    %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
+  576["SketchBlockConstraint Horizontal<br>[22483, 22505, 0]"]
+    %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 15 }, ExpressionStatementExpr]
+  577["SketchBlockConstraint VerticalDistance<br>[22509, 22574, 0]"]
+    %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 16 }, ExpressionStatementExpr]
+  578["SketchBlockConstraint VerticalDistance<br>[22577, 22639, 0]"]
+    %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 17 }, ExpressionStatementExpr]
+  579["SketchBlockConstraint HorizontalDistance<br>[22642, 22710, 0]"]
+    %% [ProgramBodyItem { index: 101 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 18 }, ExpressionStatementExpr]
+  580["SketchBlock<br>[23376, 25759, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  581["SketchBlockConstraint Coincident<br>[24338, 24382, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
+  582["SketchBlockConstraint Coincident<br>[24385, 24434, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
+  583["SketchBlockConstraint Coincident<br>[24437, 24485, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
+  584["SketchBlockConstraint Coincident<br>[24488, 24528, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
+  585["SketchBlockConstraint Coincident<br>[24531, 24580, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
+  586["SketchBlockConstraint Coincident<br>[24583, 24620, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
+  587["SketchBlockConstraint Coincident<br>[24623, 24669, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 15 }, ExpressionStatementExpr]
+  588["SketchBlockConstraint Coincident<br>[24672, 24710, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 16 }, ExpressionStatementExpr]
+  589["SketchBlockConstraint Coincident<br>[24713, 24764, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 17 }, ExpressionStatementExpr]
+  590["SketchBlockConstraint Coincident<br>[24767, 24809, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 18 }, ExpressionStatementExpr]
+  591["SketchBlockConstraint Coincident<br>[24812, 24859, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 19 }, ExpressionStatementExpr]
+  592["SketchBlockConstraint Coincident<br>[24862, 24906, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 20 }, ExpressionStatementExpr]
+  593["SketchBlockConstraint Horizontal<br>[24910, 24938, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 21 }, ExpressionStatementExpr]
+  594["SketchBlockConstraint Vertical<br>[24941, 24958, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 22 }, ExpressionStatementExpr]
+  595["SketchBlockConstraint Horizontal<br>[24961, 24988, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 23 }, ExpressionStatementExpr]
+  596["SketchBlockConstraint Horizontal<br>[24991, 25007, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 24 }, ExpressionStatementExpr]
+  597["SketchBlockConstraint Vertical<br>[25010, 25036, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 25 }, ExpressionStatementExpr]
+  598["SketchBlockConstraint Vertical<br>[25039, 25057, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 26 }, ExpressionStatementExpr]
+  599["SketchBlockConstraint Horizontal<br>[25060, 25084, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 27 }, ExpressionStatementExpr]
+  600["SketchBlockConstraint HorizontalDistance<br>[25088, 25176, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 28 }, ExpressionStatementExpr]
+  601["SketchBlockConstraint Distance<br>[25179, 25241, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 29 }, ExpressionStatementExpr]
+  602["SketchBlockConstraint LinesEqualLength<br>[25244, 25276, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 30 }, ExpressionStatementExpr]
+  603["SketchBlockConstraint Distance<br>[25279, 25355, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 31 }, ExpressionStatementExpr]
+  604["SketchBlockConstraint Distance<br>[25358, 25436, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 32 }, ExpressionStatementExpr]
+  605["SketchBlockConstraint Distance<br>[25439, 25495, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 33 }, ExpressionStatementExpr]
+  606["SketchBlockConstraint HorizontalDistance<br>[25498, 25571, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 34 }, ExpressionStatementExpr]
+  607["SketchBlockConstraint Radius<br>[25574, 25605, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 35 }, ExpressionStatementExpr]
+  608["SketchBlockConstraint Radius<br>[25608, 25640, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 36 }, ExpressionStatementExpr]
+  609["SketchBlockConstraint Tangent<br>[25643, 25670, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 37 }, ExpressionStatementExpr]
+  610["SketchBlockConstraint Tangent<br>[25673, 25697, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 38 }, ExpressionStatementExpr]
+  611["SketchBlockConstraint Tangent<br>[25700, 25725, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 39 }, ExpressionStatementExpr]
+  612["SketchBlockConstraint Tangent<br>[25728, 25757, 0]"]
+    %% [ProgramBodyItem { index: 114 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 40 }, ExpressionStatementExpr]
+  613["SketchBlock<br>[25784, 26793, 0]"]
+    %% [ProgramBodyItem { index: 115 }, VariableDeclarationDeclaration, VariableDeclarationInit]
+  614["SketchBlockConstraint Coincident<br>[26215, 26254, 0]"]
     %% [ProgramBodyItem { index: 115 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 4 }, ExpressionStatementExpr]
-  590["SketchBlockConstraint Coincident<br>[25919, 25968, 0]"]
+  615["SketchBlockConstraint Coincident<br>[26257, 26306, 0]"]
     %% [ProgramBodyItem { index: 115 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 5 }, ExpressionStatementExpr]
-  591["SketchBlockConstraint Coincident<br>[25971, 26023, 0]"]
+  616["SketchBlockConstraint Coincident<br>[26309, 26361, 0]"]
     %% [ProgramBodyItem { index: 115 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 6 }, ExpressionStatementExpr]
-  592["SketchBlockConstraint Coincident<br>[26026, 26091, 0]"]
+  617["SketchBlockConstraint Coincident<br>[26364, 26429, 0]"]
     %% [ProgramBodyItem { index: 115 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 7 }, ExpressionStatementExpr]
-  593["SketchBlockConstraint Coincident<br>[26094, 26144, 0]"]
+  618["SketchBlockConstraint Coincident<br>[26432, 26482, 0]"]
     %% [ProgramBodyItem { index: 115 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 8 }, ExpressionStatementExpr]
-  594["SketchBlockConstraint Vertical<br>[26148, 26169, 0]"]
+  619["SketchBlockConstraint Vertical<br>[26486, 26507, 0]"]
     %% [ProgramBodyItem { index: 115 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 9 }, ExpressionStatementExpr]
-  595["SketchBlockConstraint Horizontal<br>[26172, 26196, 0]"]
+  620["SketchBlockConstraint Horizontal<br>[26510, 26534, 0]"]
     %% [ProgramBodyItem { index: 115 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
-  596["SketchBlockConstraint Horizontal<br>[26199, 26222, 0]"]
+  621["SketchBlockConstraint Horizontal<br>[26537, 26560, 0]"]
     %% [ProgramBodyItem { index: 115 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
-  597["SketchBlockConstraint VerticalDistance<br>[26226, 26309, 0]"]
+  622["SketchBlockConstraint VerticalDistance<br>[26564, 26647, 0]"]
     %% [ProgramBodyItem { index: 115 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 12 }, ExpressionStatementExpr]
-  598["SketchBlockConstraint HorizontalDistance<br>[26312, 26386, 0]"]
+  623["SketchBlockConstraint HorizontalDistance<br>[26650, 26724, 0]"]
     %% [ProgramBodyItem { index: 115 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 13 }, ExpressionStatementExpr]
-  599["SketchBlockConstraint Distance<br>[26389, 26453, 0]"]
+  624["SketchBlockConstraint Distance<br>[26727, 26791, 0]"]
     %% [ProgramBodyItem { index: 115 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 14 }, ExpressionStatementExpr]
   1 --- 2
-  1 <--x 345
+  1 <--x 7
+  1 <--x 370
   2 --- 3
   2 --- 4
   2 --- 5
   2 --- 6
-  2 --- 7
-  2 --- 8
-  2 ---- 10
-  345 --- 2
-  3 --- 14
-  3 x--> 15
-  3 --- 23
-  3 --- 24
-  4 --- 13
-  4 x--> 15
-  4 --- 21
-  4 --- 22
-  5 --- 12
-  5 x--> 15
-  5 --- 19
-  5 --- 20
-  6 --- 11
-  6 x--> 15
-  6 --- 17
-  6 --- 18
-  10 --- 11
-  10 --- 12
-  10 --- 13
-  10 --- 14
-  10 --- 15
-  10 --- 16
-  10 --- 17
+  2 <--x 7
+  370 --- 2
+  3 <--x 8
+  4 <--x 9
+  5 <--x 10
+  6 <--x 11
+  7 --- 8
+  7 --- 9
+  7 --- 10
+  7 --- 11
+  7 --- 12
+  7 --- 13
+  7 ---- 15
+  8 --- 16
+  8 x--> 20
+  8 --- 22
+  8 --- 23
+  9 --- 17
+  9 x--> 20
+  9 --- 24
+  9 --- 25
   10 --- 18
-  10 --- 19
-  10 --- 20
-  10 --- 21
-  10 --- 22
-  10 --- 23
-  10 --- 24
-  11 --- 17
-  11 --- 18
-  20 <--x 11
-  12 --- 19
-  12 --- 20
-  22 <--x 12
-  13 --- 21
-  13 --- 22
-  24 <--x 13
-  18 <--x 14
-  14 --- 23
-  14 --- 24
-  17 <--x 16
-  19 <--x 16
-  21 <--x 16
-  23 <--x 16
-  28 --- 29
-  28 --- 52
-  28 <--x 357
-  28 <--x 372
-  29 --- 30
-  29 --- 31
-  29 --- 32
-  29 --- 33
-  29 --- 34
-  29 --- 35
-  29 ---- 36
-  357 --- 29
-  30 --- 40
-  30 x--> 41
-  30 --- 49
-  30 --- 50
-  31 --- 39
-  31 x--> 41
-  31 --- 47
-  31 --- 48
-  32 --- 38
-  32 x--> 41
-  32 --- 45
-  32 --- 46
-  33 --- 37
-  33 x--> 41
-  33 --- 43
-  33 --- 44
-  36 --- 37
-  36 --- 38
-  36 --- 39
-  36 --- 40
-  36 --- 41
-  36 --- 42
-  36 --- 43
-  36 --- 44
-  36 --- 45
-  36 --- 46
-  36 --- 47
-  36 --- 48
-  36 --- 49
-  36 --- 50
-  37 --- 43
-  37 --- 44
-  46 <--x 37
-  38 --- 45
-  38 --- 46
-  48 <--x 38
-  39 --- 47
-  39 --- 48
-  50 <--x 39
-  44 <--x 40
-  40 --- 49
-  40 --- 50
-  43 <--x 42
-  45 <--x 42
-  47 <--x 42
-  49 <--x 42
-  52 --- 53
-  52 --- 54
-  52 --- 55
-  52 --- 56
-  52 --- 57
-  52 ---- 58
-  372 --- 52
-  53 --- 62
-  53 x--> 63
-  53 --- 71
-  53 --- 72
-  54 --- 61
-  54 x--> 63
-  54 --- 69
-  54 --- 70
-  55 --- 60
-  55 x--> 63
-  55 --- 67
-  55 --- 68
-  56 --- 59
-  56 x--> 63
-  56 --- 65
-  56 --- 66
-  58 --- 59
-  58 --- 60
-  58 --- 61
-  58 --- 62
-  58 --- 63
-  58 --- 64
-  58 --- 65
-  58 --- 66
-  58 --- 67
-  58 --- 68
-  58 --- 69
-  58 --- 70
-  58 --- 71
-  58 --- 72
-  59 --- 65
-  59 --- 66
-  68 <--x 59
-  60 --- 67
-  60 --- 68
-  70 <--x 60
-  61 --- 69
-  61 --- 70
-  72 <--x 61
-  66 <--x 62
-  62 --- 71
-  62 --- 72
-  65 <--x 64
-  67 <--x 64
-  69 <--x 64
-  71 <--x 64
-  74 --- 75
-  74 <--x 80
-  74 <--x 387
-  75 --- 76
-  75 --- 77
-  75 --- 78
-  75 --- 79
-  75 <--x 80
-  387 --- 75
-  76 <--x 81
-  77 <--x 82
-  78 <--x 83
-  79 <--x 84
-  80 --- 81
-  80 --- 82
-  80 --- 83
-  80 --- 84
-  80 --- 85
-  80 ---- 86
-  80 --- 102
-  81 --- 90
-  81 x--> 91
-  81 --- 99
-  81 --- 100
-  82 --- 87
-  82 x--> 91
-  82 --- 93
-  82 --- 94
-  83 --- 88
-  83 x--> 91
-  83 --- 95
-  83 --- 96
-  84 --- 89
-  84 x--> 91
-  84 --- 97
-  84 --- 98
-  86 --- 87
-  86 --- 88
-  86 --- 89
-  86 --- 90
-  86 --- 91
-  86 --- 92
-  86 --- 93
-  86 --- 94
-  86 --- 95
-  86 --- 96
-  86 --- 97
-  86 --- 98
-  86 --- 99
-  86 --- 100
-  86 x--> 102
-  87 --- 93
-  87 --- 94
-  100 <--x 87
-  94 <--x 88
-  88 --- 95
-  88 --- 96
-  96 <--x 89
-  89 --- 97
-  89 --- 98
-  98 <--x 90
-  90 --- 99
-  90 --- 100
-  93 <--x 92
-  95 <--x 92
-  97 <--x 92
-  99 <--x 92
-  101 x--> 103
-  104 --- 105
-  104 --- 127
-  104 <--x 402
-  104 <--x 414
-  105 --- 106
-  105 --- 107
-  105 --- 108
-  105 --- 109
-  105 --- 110
-  105 ---- 111
-  402 --- 105
-  106 --- 115
-  106 x--> 117
-  106 --- 124
-  106 --- 125
-  107 --- 114
-  107 x--> 117
-  107 --- 122
-  107 --- 123
-  108 --- 113
-  108 x--> 117
-  108 --- 120
-  108 --- 121
-  109 --- 112
-  109 x--> 117
-  109 --- 118
-  109 --- 119
-  111 --- 112
-  111 --- 113
-  111 --- 114
-  111 --- 115
-  111 --- 116
-  111 --- 117
-  111 --- 118
-  111 --- 119
-  111 --- 120
-  111 --- 121
-  111 --- 122
-  111 --- 123
-  111 --- 124
-  111 --- 125
-  112 --- 118
-  112 --- 119
-  121 <--x 112
-  113 --- 120
-  113 --- 121
-  123 <--x 113
-  114 --- 122
-  114 --- 123
-  125 <--x 114
-  119 <--x 115
-  115 --- 124
-  115 --- 125
-  118 <--x 116
-  120 <--x 116
-  122 <--x 116
-  124 <--x 116
-  127 --- 128
-  127 --- 129
-  127 --- 130
-  127 --- 131
-  127 --- 132
-  127 ---- 133
-  414 --- 127
-  128 --- 137
-  128 x--> 139
-  128 --- 146
-  128 --- 147
-  129 --- 136
-  129 x--> 139
+  10 x--> 20
+  10 --- 26
+  10 --- 27
+  11 --- 19
+  11 x--> 20
+  11 --- 28
+  11 --- 29
+  15 --- 16
+  15 --- 17
+  15 --- 18
+  15 --- 19
+  15 --- 20
+  15 --- 21
+  15 --- 22
+  15 --- 23
+  15 --- 24
+  15 --- 25
+  15 --- 26
+  15 --- 27
+  15 --- 28
+  15 --- 29
+  16 --- 22
+  16 --- 23
+  29 <--x 16
+  23 <--x 17
+  17 --- 24
+  17 --- 25
+  25 <--x 18
+  18 --- 26
+  18 --- 27
+  27 <--x 19
+  19 --- 28
+  19 --- 29
+  22 <--x 21
+  24 <--x 21
+  26 <--x 21
+  28 <--x 21
+  33 --- 34
+  33 <--x 39
+  33 --- 62
+  33 <--x 67
+  33 <--x 382
+  33 <--x 397
+  34 --- 35
+  34 --- 36
+  34 --- 37
+  34 --- 38
+  34 <--x 39
+  382 --- 34
+  35 <--x 40
+  36 <--x 41
+  37 <--x 42
+  38 <--x 43
+  39 --- 40
+  39 --- 41
+  39 --- 42
+  39 --- 43
+  39 --- 44
+  39 --- 45
+  39 ---- 46
+  40 --- 47
+  40 x--> 51
+  40 --- 53
+  40 --- 54
+  41 --- 48
+  41 x--> 51
+  41 --- 55
+  41 --- 56
+  42 --- 49
+  42 x--> 51
+  42 --- 57
+  42 --- 58
+  43 --- 50
+  43 x--> 51
+  43 --- 59
+  43 --- 60
+  46 --- 47
+  46 --- 48
+  46 --- 49
+  46 --- 50
+  46 --- 51
+  46 --- 52
+  46 --- 53
+  46 --- 54
+  46 --- 55
+  46 --- 56
+  46 --- 57
+  46 --- 58
+  46 --- 59
+  46 --- 60
+  47 --- 53
+  47 --- 54
+  60 <--x 47
+  54 <--x 48
+  48 --- 55
+  48 --- 56
+  56 <--x 49
+  49 --- 57
+  49 --- 58
+  58 <--x 50
+  50 --- 59
+  50 --- 60
+  53 <--x 52
+  55 <--x 52
+  57 <--x 52
+  59 <--x 52
+  62 --- 63
+  62 --- 64
+  62 --- 65
+  62 --- 66
+  62 <--x 67
+  397 --- 62
+  63 <--x 68
+  64 <--x 69
+  65 <--x 70
+  66 <--x 71
+  67 --- 68
+  67 --- 69
+  67 --- 70
+  67 --- 71
+  67 --- 72
+  67 ---- 73
+  68 --- 74
+  68 x--> 78
+  68 --- 80
+  68 --- 81
+  69 --- 75
+  69 x--> 78
+  69 --- 82
+  69 --- 83
+  70 --- 76
+  70 x--> 78
+  70 --- 84
+  70 --- 85
+  71 --- 77
+  71 x--> 78
+  71 --- 86
+  71 --- 87
+  73 --- 74
+  73 --- 75
+  73 --- 76
+  73 --- 77
+  73 --- 78
+  73 --- 79
+  73 --- 80
+  73 --- 81
+  73 --- 82
+  73 --- 83
+  73 --- 84
+  73 --- 85
+  73 --- 86
+  73 --- 87
+  74 --- 80
+  74 --- 81
+  87 <--x 74
+  81 <--x 75
+  75 --- 82
+  75 --- 83
+  83 <--x 76
+  76 --- 84
+  76 --- 85
+  85 <--x 77
+  77 --- 86
+  77 --- 87
+  80 <--x 79
+  82 <--x 79
+  84 <--x 79
+  86 <--x 79
+  89 --- 90
+  89 <--x 95
+  89 <--x 412
+  90 --- 91
+  90 --- 92
+  90 --- 93
+  90 --- 94
+  90 <--x 95
+  412 --- 90
+  91 <--x 96
+  92 <--x 97
+  93 <--x 98
+  94 <--x 99
+  95 --- 96
+  95 --- 97
+  95 --- 98
+  95 --- 99
+  95 --- 100
+  95 ---- 101
+  95 --- 117
+  96 --- 102
+  96 x--> 106
+  96 --- 108
+  96 --- 109
+  97 --- 103
+  97 x--> 106
+  97 --- 110
+  97 --- 111
+  98 --- 104
+  98 x--> 106
+  98 --- 112
+  98 --- 113
+  99 --- 105
+  99 x--> 106
+  99 --- 114
+  99 --- 115
+  101 --- 102
+  101 --- 103
+  101 --- 104
+  101 --- 105
+  101 --- 106
+  101 --- 107
+  101 --- 108
+  101 --- 109
+  101 --- 110
+  101 --- 111
+  101 --- 112
+  101 --- 113
+  101 --- 114
+  101 --- 115
+  101 x--> 117
+  102 --- 108
+  102 --- 109
+  115 <--x 102
+  109 <--x 103
+  103 --- 110
+  103 --- 111
+  111 <--x 104
+  104 --- 112
+  104 --- 113
+  113 <--x 105
+  105 --- 114
+  105 --- 115
+  108 <--x 107
+  110 <--x 107
+  112 <--x 107
+  114 <--x 107
+  116 x--> 118
+  119 --- 120
+  119 <--x 125
+  119 --- 147
+  119 <--x 152
+  119 <--x 427
+  119 <--x 439
+  120 --- 121
+  120 --- 122
+  120 --- 123
+  120 --- 124
+  120 <--x 125
+  427 --- 120
+  121 <--x 126
+  122 <--x 127
+  123 <--x 128
+  124 <--x 129
+  125 --- 126
+  125 --- 127
+  125 --- 128
+  125 --- 129
+  125 --- 130
+  125 ---- 131
+  126 --- 132
+  126 x--> 137
+  126 --- 138
+  126 --- 139
+  127 --- 133
+  127 x--> 137
+  127 --- 140
+  127 --- 141
+  128 --- 134
+  128 x--> 137
+  128 --- 142
+  128 --- 143
+  129 --- 135
+  129 x--> 137
   129 --- 144
   129 --- 145
-  130 --- 135
-  130 x--> 139
-  130 --- 142
-  130 --- 143
+  131 --- 132
+  131 --- 133
   131 --- 134
-  131 x--> 139
+  131 --- 135
+  131 --- 136
+  131 --- 137
+  131 --- 138
+  131 --- 139
   131 --- 140
   131 --- 141
-  133 --- 134
-  133 --- 135
-  133 --- 136
-  133 --- 137
-  133 --- 138
-  133 --- 139
+  131 --- 142
+  131 --- 143
+  131 --- 144
+  131 --- 145
+  132 --- 138
+  132 --- 139
+  145 <--x 132
+  139 <--x 133
   133 --- 140
   133 --- 141
-  133 --- 142
-  133 --- 143
-  133 --- 144
-  133 --- 145
-  133 --- 146
-  133 --- 147
-  134 --- 140
-  134 --- 141
-  143 <--x 134
-  135 --- 142
-  135 --- 143
-  145 <--x 135
-  136 --- 144
-  136 --- 145
-  147 <--x 136
-  141 <--x 137
-  137 --- 146
-  137 --- 147
-  140 <--x 138
-  142 <--x 138
-  144 <--x 138
-  146 <--x 138
-  149 --- 150
-  149 <--x 155
-  149 <--x 429
-  150 --- 151
-  150 --- 152
-  150 --- 153
-  150 --- 154
+  141 <--x 134
+  134 --- 142
+  134 --- 143
+  143 <--x 135
+  135 --- 144
+  135 --- 145
+  138 <--x 136
+  140 <--x 136
+  142 <--x 136
+  144 <--x 136
+  147 --- 148
+  147 --- 149
+  147 --- 150
+  147 --- 151
+  147 <--x 152
+  439 --- 147
+  148 <--x 153
+  149 <--x 154
   150 <--x 155
-  429 --- 150
   151 <--x 156
-  152 <--x 157
-  153 <--x 158
-  154 <--x 159
-  155 --- 156
-  155 --- 157
-  155 --- 158
-  155 --- 159
-  155 ---- 160
-  156 --- 161
-  156 x--> 166
-  156 --- 167
-  156 --- 168
-  157 --- 162
-  157 x--> 166
-  157 --- 169
-  157 --- 170
+  152 --- 153
+  152 --- 154
+  152 --- 155
+  152 --- 156
+  152 --- 157
+  152 ---- 158
+  153 --- 159
+  153 x--> 164
+  153 --- 165
+  153 --- 166
+  154 --- 160
+  154 x--> 164
+  154 --- 167
+  154 --- 168
+  155 --- 161
+  155 x--> 164
+  155 --- 169
+  155 --- 170
+  156 --- 162
+  156 x--> 164
+  156 --- 171
+  156 --- 172
+  158 --- 159
+  158 --- 160
+  158 --- 161
+  158 --- 162
   158 --- 163
-  158 x--> 166
+  158 --- 164
+  158 --- 165
+  158 --- 166
+  158 --- 167
+  158 --- 168
+  158 --- 169
+  158 --- 170
   158 --- 171
   158 --- 172
-  159 --- 164
-  159 x--> 166
-  159 --- 173
-  159 --- 174
-  160 --- 161
-  160 --- 162
-  160 --- 163
-  160 --- 164
-  160 --- 165
-  160 --- 166
+  159 --- 165
+  159 --- 166
+  172 <--x 159
+  166 <--x 160
   160 --- 167
   160 --- 168
-  160 --- 169
-  160 --- 170
-  160 --- 171
-  160 --- 172
-  160 --- 173
-  160 --- 174
-  161 --- 167
-  161 --- 168
-  174 <--x 161
-  168 <--x 162
-  162 --- 169
-  162 --- 170
-  170 <--x 163
-  163 --- 171
-  163 --- 172
-  172 <--x 164
-  164 --- 173
-  164 --- 174
-  167 <--x 165
-  169 <--x 165
-  171 <--x 165
-  173 <--x 165
-  165 --- 175
-  165 <--x 180
-  181 <--x 165
-  182 <--x 165
-  183 <--x 165
-  184 <--x 165
-  165 <--x 441
-  166 --- 199
-  166 <--x 204
-  205 <--x 166
-  206 <--x 166
-  207 <--x 166
-  208 <--x 166
-  166 <--x 459
+  168 <--x 161
+  161 --- 169
+  161 --- 170
+  170 <--x 162
+  162 --- 171
+  162 --- 172
+  165 <--x 163
+  167 <--x 163
+  169 <--x 163
+  171 <--x 163
+  174 --- 175
+  174 <--x 180
+  174 <--x 454
   175 --- 176
   175 --- 177
   175 --- 178
   175 --- 179
   175 <--x 180
-  441 --- 175
+  454 --- 175
   176 <--x 181
   177 <--x 182
   178 <--x 183
@@ -1595,17 +1630,21 @@ flowchart LR
   180 --- 184
   180 ---- 185
   181 --- 186
-  181 --- 191
+  181 x--> 191
   181 --- 192
+  181 --- 193
   182 --- 187
-  182 --- 193
+  182 x--> 191
   182 --- 194
+  182 --- 195
   183 --- 188
-  183 --- 195
+  183 x--> 191
   183 --- 196
+  183 --- 197
   184 --- 189
-  184 --- 197
+  184 x--> 191
   184 --- 198
+  184 --- 199
   185 --- 186
   185 --- 187
   185 --- 188
@@ -1619,334 +1658,405 @@ flowchart LR
   185 --- 196
   185 --- 197
   185 --- 198
-  186 --- 191
+  185 --- 199
   186 --- 192
-  194 <--x 186
-  187 --- 193
+  186 --- 193
+  199 <--x 186
+  193 <--x 187
   187 --- 194
-  196 <--x 187
-  188 --- 195
+  187 --- 195
+  195 <--x 188
   188 --- 196
-  198 <--x 188
-  192 <--x 189
-  189 --- 197
+  188 --- 197
+  197 <--x 189
   189 --- 198
-  191 <--x 190
-  193 <--x 190
-  195 <--x 190
-  197 <--x 190
-  199 --- 200
-  199 --- 201
-  199 --- 202
-  199 --- 203
-  199 <--x 204
-  459 --- 199
+  189 --- 199
+  192 <--x 190
+  194 <--x 190
+  196 <--x 190
+  198 <--x 190
+  190 --- 200
+  190 <--x 205
+  206 <--x 190
+  207 <--x 190
+  208 <--x 190
+  209 <--x 190
+  190 <--x 466
+  191 --- 224
+  191 <--x 229
+  230 <--x 191
+  231 <--x 191
+  232 <--x 191
+  233 <--x 191
+  191 <--x 484
+  200 --- 201
+  200 --- 202
+  200 --- 203
+  200 --- 204
   200 <--x 205
+  466 --- 200
   201 <--x 206
   202 <--x 207
   203 <--x 208
-  204 --- 205
-  204 --- 206
-  204 --- 207
-  204 --- 208
-  204 ---- 209
-  205 --- 210
-  205 --- 215
-  205 --- 216
+  204 <--x 209
+  205 --- 206
+  205 --- 207
+  205 --- 208
+  205 --- 209
+  205 ---- 210
   206 --- 211
+  206 --- 216
   206 --- 217
-  206 --- 218
   207 --- 212
+  207 --- 218
   207 --- 219
-  207 --- 220
   208 --- 213
+  208 --- 220
   208 --- 221
-  208 --- 222
-  209 --- 210
-  209 --- 211
-  209 --- 212
-  209 --- 213
   209 --- 214
-  209 --- 215
-  209 --- 216
-  209 --- 217
-  209 --- 218
-  209 --- 219
-  209 --- 220
-  209 --- 221
   209 --- 222
+  209 --- 223
+  210 --- 211
+  210 --- 212
+  210 --- 213
+  210 --- 214
   210 --- 215
   210 --- 216
-  222 <--x 210
-  216 <--x 211
+  210 --- 217
+  210 --- 218
+  210 --- 219
+  210 --- 220
+  210 --- 221
+  210 --- 222
+  210 --- 223
+  211 --- 216
   211 --- 217
-  211 --- 218
-  218 <--x 212
+  219 <--x 211
+  212 --- 218
   212 --- 219
-  212 --- 220
-  220 <--x 213
+  221 <--x 212
+  213 --- 220
   213 --- 221
-  213 --- 222
-  215 <--x 214
+  223 <--x 213
   217 <--x 214
-  219 <--x 214
-  221 <--x 214
-  223 --- 224
-  223 <--x 226
-  223 <--x 477
+  214 --- 222
+  214 --- 223
+  216 <--x 215
+  218 <--x 215
+  220 <--x 215
+  222 <--x 215
   224 --- 225
-  224 <--x 226
-  477 --- 224
-  225 <--x 227
-  226 --- 227
-  226 ---- 228
-  226 --- 234
-  227 --- 229
-  227 x--> 230
-  227 --- 232
-  227 --- 233
-  228 --- 229
-  228 --- 230
-  228 --- 231
-  228 --- 232
-  228 --- 233
-  228 x--> 234
+  224 --- 226
+  224 --- 227
+  224 --- 228
+  224 <--x 229
+  484 --- 224
+  225 <--x 230
+  226 <--x 231
+  227 <--x 232
+  228 <--x 233
+  229 --- 230
+  229 --- 231
   229 --- 232
   229 --- 233
-  232 <--x 231
-  235 --- 236
-  235 <--x 238
-  235 <--x 489
-  236 --- 237
-  236 <--x 238
-  489 --- 236
-  237 <--x 239
-  238 --- 239
-  238 ---- 240
+  229 ---- 234
+  230 --- 235
+  230 --- 240
+  230 --- 241
+  231 --- 236
+  231 --- 242
+  231 --- 243
+  232 --- 237
+  232 --- 244
+  232 --- 245
+  233 --- 238
+  233 --- 246
+  233 --- 247
+  234 --- 235
+  234 --- 236
+  234 --- 237
+  234 --- 238
+  234 --- 239
+  234 --- 240
+  234 --- 241
+  234 --- 242
+  234 --- 243
+  234 --- 244
+  234 --- 245
+  234 --- 246
+  234 --- 247
+  235 --- 240
+  235 --- 241
+  247 <--x 235
+  241 <--x 236
+  236 --- 242
+  236 --- 243
+  243 <--x 237
+  237 --- 244
+  237 --- 245
+  245 <--x 238
   238 --- 246
-  239 --- 241
-  239 x--> 242
-  239 --- 244
-  239 --- 245
-  240 --- 241
-  240 --- 242
-  240 --- 243
-  240 --- 244
-  240 --- 245
-  240 x--> 246
-  241 --- 244
-  241 --- 245
-  244 <--x 243
-  247 --- 248
-  247 <--x 250
-  247 <--x 501
+  238 --- 247
+  240 <--x 239
+  242 <--x 239
+  244 <--x 239
+  246 <--x 239
   248 --- 249
-  248 <--x 250
-  501 --- 248
+  248 <--x 251
+  248 <--x 502
+  249 --- 250
   249 <--x 251
-  250 --- 251
-  250 ---- 252
-  250 --- 258
-  251 --- 253
-  251 x--> 254
-  251 --- 256
-  251 --- 257
-  252 --- 253
+  502 --- 249
+  250 <--x 252
+  251 --- 252
+  251 ---- 253
+  251 --- 259
   252 --- 254
-  252 --- 255
-  252 --- 256
+  252 x--> 255
   252 --- 257
-  252 x--> 258
+  252 --- 258
+  253 --- 254
+  253 --- 255
   253 --- 256
   253 --- 257
-  256 <--x 255
-  259 --- 260
-  259 <--x 262
-  259 <--x 513
+  253 --- 258
+  253 x--> 259
+  254 --- 257
+  254 --- 258
+  257 <--x 256
   260 --- 261
-  260 <--x 262
-  513 --- 260
+  260 <--x 263
+  260 <--x 514
+  261 --- 262
   261 <--x 263
-  262 --- 263
-  262 ---- 264
-  262 --- 270
-  263 --- 265
-  263 x--> 266
-  263 --- 268
-  263 --- 269
-  264 --- 265
+  514 --- 261
+  262 <--x 264
+  263 --- 264
+  263 ---- 265
+  263 --- 271
   264 --- 266
-  264 --- 267
-  264 --- 268
+  264 x--> 267
   264 --- 269
-  264 x--> 270
+  264 --- 270
+  265 --- 266
+  265 --- 267
   265 --- 268
   265 --- 269
-  268 <--x 267
-  271 --- 272
-  271 <--x 277
-  271 --- 300
-  271 <--x 305
-  271 <--x 525
-  271 <--x 540
+  265 --- 270
+  265 x--> 271
+  266 --- 269
+  266 --- 270
+  269 <--x 268
   272 --- 273
-  272 --- 274
-  272 --- 275
-  272 --- 276
-  272 <--x 277
-  525 --- 272
-  273 <--x 278
-  274 <--x 279
-  275 <--x 280
-  276 <--x 281
+  272 <--x 275
+  272 <--x 526
+  273 --- 274
+  273 <--x 275
+  526 --- 273
+  274 <--x 276
+  275 --- 276
+  275 ---- 277
+  275 --- 283
+  276 --- 278
+  276 x--> 279
+  276 --- 281
+  276 --- 282
   277 --- 278
   277 --- 279
   277 --- 280
   277 --- 281
-  277 ---- 282
-  277 --- 297
-  277 --- 298
-  278 --- 283
-  278 x--> 287
-  278 --- 289
-  278 --- 290
-  279 --- 284
-  279 x--> 287
-  279 --- 291
-  279 --- 292
-  280 --- 285
-  280 x--> 287
-  280 --- 293
-  280 --- 294
-  281 --- 286
-  281 x--> 287
-  281 --- 295
-  281 --- 296
-  282 --- 283
-  282 --- 284
-  282 --- 285
-  282 --- 286
-  282 --- 287
-  282 --- 288
-  282 --- 289
-  282 --- 290
-  282 --- 291
-  282 --- 292
-  282 --- 293
-  282 --- 294
-  282 --- 295
-  282 --- 296
-  282 x--> 297
-  282 x--> 298
-  283 --- 289
-  283 --- 290
-  296 <--x 283
-  290 <--x 284
-  284 --- 291
-  284 --- 292
-  292 <--x 285
-  285 --- 293
-  285 --- 294
-  294 <--x 286
-  286 --- 295
-  286 --- 296
-  289 <--x 288
-  291 <--x 288
-  293 <--x 288
-  295 <--x 288
-  300 --- 301
-  300 --- 302
-  300 --- 303
-  300 --- 304
+  277 --- 282
+  277 x--> 283
+  278 --- 281
+  278 --- 282
+  281 <--x 280
+  284 --- 285
+  284 <--x 287
+  284 <--x 538
+  285 --- 286
+  285 <--x 287
+  538 --- 285
+  286 <--x 288
+  287 --- 288
+  287 ---- 289
+  287 --- 295
+  288 --- 290
+  288 x--> 291
+  288 --- 293
+  288 --- 294
+  289 --- 290
+  289 --- 291
+  289 --- 292
+  289 --- 293
+  289 --- 294
+  289 x--> 295
+  290 --- 293
+  290 --- 294
+  293 <--x 292
+  296 --- 297
+  296 <--x 302
+  296 --- 325
+  296 <--x 330
+  296 <--x 550
+  296 <--x 565
+  297 --- 298
+  297 --- 299
+  297 --- 300
+  297 --- 301
+  297 <--x 302
+  550 --- 297
+  298 <--x 303
+  299 <--x 304
   300 <--x 305
-  540 --- 300
   301 <--x 306
-  302 <--x 307
-  303 <--x 308
-  304 <--x 309
-  305 --- 306
-  305 --- 307
-  305 --- 308
-  305 --- 309
-  305 ---- 310
-  305 --- 325
+  302 --- 303
+  302 --- 304
+  302 --- 305
+  302 --- 306
+  302 ---- 307
+  302 --- 322
+  302 --- 323
+  303 --- 308
+  303 x--> 312
+  303 --- 314
+  303 --- 315
+  304 --- 309
+  304 x--> 312
+  304 --- 316
+  304 --- 317
+  305 --- 310
+  305 x--> 312
+  305 --- 318
+  305 --- 319
   306 --- 311
-  306 x--> 315
-  306 --- 317
-  306 --- 318
+  306 x--> 312
+  306 --- 320
+  306 --- 321
+  307 --- 308
+  307 --- 309
+  307 --- 310
+  307 --- 311
   307 --- 312
-  307 x--> 315
+  307 --- 313
+  307 --- 314
+  307 --- 315
+  307 --- 316
+  307 --- 317
+  307 --- 318
   307 --- 319
   307 --- 320
-  308 --- 313
-  308 x--> 315
-  308 --- 321
-  308 --- 322
-  309 --- 314
-  309 x--> 315
-  309 --- 323
-  309 --- 324
-  310 --- 311
-  310 --- 312
-  310 --- 313
-  310 --- 314
-  310 --- 315
-  310 --- 316
-  310 --- 317
+  307 --- 321
+  307 x--> 322
+  307 x--> 323
+  308 --- 314
+  308 --- 315
+  321 <--x 308
+  315 <--x 309
+  309 --- 316
+  309 --- 317
+  317 <--x 310
   310 --- 318
   310 --- 319
-  310 --- 320
-  310 --- 321
-  310 --- 322
-  310 --- 323
-  310 --- 324
-  310 x--> 325
-  311 --- 317
-  311 --- 318
-  324 <--x 311
-  318 <--x 312
-  312 --- 319
-  312 --- 320
+  319 <--x 311
+  311 --- 320
+  311 --- 321
+  314 <--x 313
+  316 <--x 313
+  318 <--x 313
   320 <--x 313
-  313 --- 321
-  313 --- 322
-  322 <--x 314
-  314 --- 323
-  314 --- 324
-  317 <--x 316
-  319 <--x 316
-  321 <--x 316
-  323 <--x 316
-  326 --- 327
-  326 <--x 555
-  327 --- 328
-  327 --- 329
-  327 --- 330
-  327 --- 331
-  327 --- 332
-  327 ---- 338
-  555 --- 327
-  333 --- 334
-  333 <--x 336
-  333 <--x 588
-  334 --- 335
-  334 <--x 336
-  588 --- 334
-  335 <--x 337
-  336 --- 337
-  336 ---- 338
-  336 --- 344
-  337 --- 339
-  337 x--> 340
-  337 --- 342
-  337 --- 343
-  338 --- 339
-  338 --- 340
-  338 --- 341
-  338 --- 342
-  338 --- 343
-  338 x--> 344
-  339 --- 342
-  339 --- 343
+  325 --- 326
+  325 --- 327
+  325 --- 328
+  325 --- 329
+  325 <--x 330
+  565 --- 325
+  326 <--x 331
+  327 <--x 332
+  328 <--x 333
+  329 <--x 334
+  330 --- 331
+  330 --- 332
+  330 --- 333
+  330 --- 334
+  330 ---- 335
+  330 --- 350
+  331 --- 336
+  331 x--> 340
+  331 --- 342
+  331 --- 343
+  332 --- 337
+  332 x--> 340
+  332 --- 344
+  332 --- 345
+  333 --- 338
+  333 x--> 340
+  333 --- 346
+  333 --- 347
+  334 --- 339
+  334 x--> 340
+  334 --- 348
+  334 --- 349
+  335 --- 336
+  335 --- 337
+  335 --- 338
+  335 --- 339
+  335 --- 340
+  335 --- 341
+  335 --- 342
+  335 --- 343
+  335 --- 344
+  335 --- 345
+  335 --- 346
+  335 --- 347
+  335 --- 348
+  335 --- 349
+  335 x--> 350
+  336 --- 342
+  336 --- 343
+  349 <--x 336
+  343 <--x 337
+  337 --- 344
+  337 --- 345
+  345 <--x 338
+  338 --- 346
+  338 --- 347
+  347 <--x 339
+  339 --- 348
+  339 --- 349
   342 <--x 341
+  344 <--x 341
+  346 <--x 341
+  348 <--x 341
+  351 --- 352
+  351 <--x 580
+  352 --- 353
+  352 --- 354
+  352 --- 355
+  352 --- 356
+  352 --- 357
+  352 ---- 363
+  580 --- 352
+  358 --- 359
+  358 <--x 361
+  358 <--x 613
+  359 --- 360
+  359 <--x 361
+  613 --- 359
+  360 <--x 362
+  361 --- 362
+  361 ---- 363
+  361 --- 369
+  362 --- 364
+  362 x--> 365
+  362 --- 367
+  362 --- 368
+  363 --- 364
+  363 --- 365
+  363 --- 366
+  363 --- 367
+  363 --- 368
+  363 x--> 369
+  364 --- 367
+  364 --- 368
+  367 <--x 366
 ```

--- a/rust/kcl-lib/tests/kcl_samples/utility-sink/ast.snap
+++ b/rust/kcl-lib/tests/kcl_samples/utility-sink/ast.snap
@@ -2826,22 +2826,143 @@ description: Result of parsing utility-sink.kcl
             "type": "CallExpressionKw",
             "type": "CallExpressionKw",
             "unlabeled": {
-              "abs_path": false,
-              "commentStart": 0,
-              "end": 0,
-              "moduleId": 0,
-              "name": {
+              "arguments": [
+                {
+                  "type": "LabeledArg",
+                  "label": {
+                    "commentStart": 0,
+                    "end": 0,
+                    "moduleId": 0,
+                    "name": "segments",
+                    "start": 0,
+                    "type": "Identifier"
+                  },
+                  "arg": {
+                    "commentStart": 0,
+                    "elements": [
+                      {
+                        "commentStart": 0,
+                        "computed": false,
+                        "end": 0,
+                        "moduleId": 0,
+                        "object": {
+                          "abs_path": false,
+                          "commentStart": 0,
+                          "end": 0,
+                          "moduleId": 0,
+                          "name": {
+                            "commentStart": 0,
+                            "end": 0,
+                            "moduleId": 0,
+                            "name": "legProfile",
+                            "start": 0,
+                            "type": "Identifier"
+                          },
+                          "path": [],
+                          "start": 0,
+                          "type": "Name",
+                          "type": "Name"
+                        },
+                        "property": {
+                          "abs_path": false,
+                          "commentStart": 0,
+                          "end": 0,
+                          "moduleId": 0,
+                          "name": {
+                            "commentStart": 0,
+                            "end": 0,
+                            "moduleId": 0,
+                            "name": "leftEdge",
+                            "start": 0,
+                            "type": "Identifier"
+                          },
+                          "path": [],
+                          "start": 0,
+                          "type": "Name",
+                          "type": "Name"
+                        },
+                        "start": 0,
+                        "type": "MemberExpression",
+                        "type": "MemberExpression"
+                      },
+                      {
+                        "commentStart": 0,
+                        "computed": false,
+                        "end": 0,
+                        "moduleId": 0,
+                        "object": {
+                          "abs_path": false,
+                          "commentStart": 0,
+                          "end": 0,
+                          "moduleId": 0,
+                          "name": {
+                            "commentStart": 0,
+                            "end": 0,
+                            "moduleId": 0,
+                            "name": "legProfile",
+                            "start": 0,
+                            "type": "Identifier"
+                          },
+                          "path": [],
+                          "start": 0,
+                          "type": "Name",
+                          "type": "Name"
+                        },
+                        "property": {
+                          "abs_path": false,
+                          "commentStart": 0,
+                          "end": 0,
+                          "moduleId": 0,
+                          "name": {
+                            "commentStart": 0,
+                            "end": 0,
+                            "moduleId": 0,
+                            "name": "topEdge",
+                            "start": 0,
+                            "type": "Identifier"
+                          },
+                          "path": [],
+                          "start": 0,
+                          "type": "Name",
+                          "type": "Name"
+                        },
+                        "start": 0,
+                        "type": "MemberExpression",
+                        "type": "MemberExpression"
+                      }
+                    ],
+                    "end": 0,
+                    "moduleId": 0,
+                    "start": 0,
+                    "type": "ArrayExpression",
+                    "type": "ArrayExpression"
+                  }
+                }
+              ],
+              "callee": {
+                "abs_path": false,
                 "commentStart": 0,
                 "end": 0,
                 "moduleId": 0,
-                "name": "legProfile",
+                "name": {
+                  "commentStart": 0,
+                  "end": 0,
+                  "moduleId": 0,
+                  "name": "region",
+                  "start": 0,
+                  "type": "Identifier"
+                },
+                "path": [],
                 "start": 0,
-                "type": "Identifier"
+                "type": "Name"
               },
-              "path": [],
+              "commentStart": 0,
+              "end": 0,
+              "moduleId": 0,
               "start": 0,
-              "type": "Name",
-              "type": "Name"
+              "type": "CallExpressionKw",
+              "type": "CallExpressionKw",
+              "unlabeled": null
             }
           },
           "moduleId": 0,
@@ -5961,22 +6082,143 @@ description: Result of parsing utility-sink.kcl
             "type": "CallExpressionKw",
             "type": "CallExpressionKw",
             "unlabeled": {
-              "abs_path": false,
-              "commentStart": 0,
-              "end": 0,
-              "moduleId": 0,
-              "name": {
+              "arguments": [
+                {
+                  "type": "LabeledArg",
+                  "label": {
+                    "commentStart": 0,
+                    "end": 0,
+                    "moduleId": 0,
+                    "name": "segments",
+                    "start": 0,
+                    "type": "Identifier"
+                  },
+                  "arg": {
+                    "commentStart": 0,
+                    "elements": [
+                      {
+                        "commentStart": 0,
+                        "computed": false,
+                        "end": 0,
+                        "moduleId": 0,
+                        "object": {
+                          "abs_path": false,
+                          "commentStart": 0,
+                          "end": 0,
+                          "moduleId": 0,
+                          "name": {
+                            "commentStart": 0,
+                            "end": 0,
+                            "moduleId": 0,
+                            "name": "lowerBeltXProfile",
+                            "start": 0,
+                            "type": "Identifier"
+                          },
+                          "path": [],
+                          "start": 0,
+                          "type": "Name",
+                          "type": "Name"
+                        },
+                        "property": {
+                          "abs_path": false,
+                          "commentStart": 0,
+                          "end": 0,
+                          "moduleId": 0,
+                          "name": {
+                            "commentStart": 0,
+                            "end": 0,
+                            "moduleId": 0,
+                            "name": "leftEdge",
+                            "start": 0,
+                            "type": "Identifier"
+                          },
+                          "path": [],
+                          "start": 0,
+                          "type": "Name",
+                          "type": "Name"
+                        },
+                        "start": 0,
+                        "type": "MemberExpression",
+                        "type": "MemberExpression"
+                      },
+                      {
+                        "commentStart": 0,
+                        "computed": false,
+                        "end": 0,
+                        "moduleId": 0,
+                        "object": {
+                          "abs_path": false,
+                          "commentStart": 0,
+                          "end": 0,
+                          "moduleId": 0,
+                          "name": {
+                            "commentStart": 0,
+                            "end": 0,
+                            "moduleId": 0,
+                            "name": "lowerBeltXProfile",
+                            "start": 0,
+                            "type": "Identifier"
+                          },
+                          "path": [],
+                          "start": 0,
+                          "type": "Name",
+                          "type": "Name"
+                        },
+                        "property": {
+                          "abs_path": false,
+                          "commentStart": 0,
+                          "end": 0,
+                          "moduleId": 0,
+                          "name": {
+                            "commentStart": 0,
+                            "end": 0,
+                            "moduleId": 0,
+                            "name": "topEdge",
+                            "start": 0,
+                            "type": "Identifier"
+                          },
+                          "path": [],
+                          "start": 0,
+                          "type": "Name",
+                          "type": "Name"
+                        },
+                        "start": 0,
+                        "type": "MemberExpression",
+                        "type": "MemberExpression"
+                      }
+                    ],
+                    "end": 0,
+                    "moduleId": 0,
+                    "start": 0,
+                    "type": "ArrayExpression",
+                    "type": "ArrayExpression"
+                  }
+                }
+              ],
+              "callee": {
+                "abs_path": false,
                 "commentStart": 0,
                 "end": 0,
                 "moduleId": 0,
-                "name": "lowerBeltXProfile",
+                "name": {
+                  "commentStart": 0,
+                  "end": 0,
+                  "moduleId": 0,
+                  "name": "region",
+                  "start": 0,
+                  "type": "Identifier"
+                },
+                "path": [],
                 "start": 0,
-                "type": "Identifier"
+                "type": "Name"
               },
-              "path": [],
+              "commentStart": 0,
+              "end": 0,
+              "moduleId": 0,
               "start": 0,
-              "type": "Name",
-              "type": "Name"
+              "type": "CallExpressionKw",
+              "type": "CallExpressionKw",
+              "unlabeled": null
             }
           },
           "moduleId": 0,
@@ -8980,22 +9222,143 @@ description: Result of parsing utility-sink.kcl
             "type": "CallExpressionKw",
             "type": "CallExpressionKw",
             "unlabeled": {
-              "abs_path": false,
-              "commentStart": 0,
-              "end": 0,
-              "moduleId": 0,
-              "name": {
+              "arguments": [
+                {
+                  "type": "LabeledArg",
+                  "label": {
+                    "commentStart": 0,
+                    "end": 0,
+                    "moduleId": 0,
+                    "name": "segments",
+                    "start": 0,
+                    "type": "Identifier"
+                  },
+                  "arg": {
+                    "commentStart": 0,
+                    "elements": [
+                      {
+                        "commentStart": 0,
+                        "computed": false,
+                        "end": 0,
+                        "moduleId": 0,
+                        "object": {
+                          "abs_path": false,
+                          "commentStart": 0,
+                          "end": 0,
+                          "moduleId": 0,
+                          "name": {
+                            "commentStart": 0,
+                            "end": 0,
+                            "moduleId": 0,
+                            "name": "lowerBeltYProfile",
+                            "start": 0,
+                            "type": "Identifier"
+                          },
+                          "path": [],
+                          "start": 0,
+                          "type": "Name",
+                          "type": "Name"
+                        },
+                        "property": {
+                          "abs_path": false,
+                          "commentStart": 0,
+                          "end": 0,
+                          "moduleId": 0,
+                          "name": {
+                            "commentStart": 0,
+                            "end": 0,
+                            "moduleId": 0,
+                            "name": "leftEdge",
+                            "start": 0,
+                            "type": "Identifier"
+                          },
+                          "path": [],
+                          "start": 0,
+                          "type": "Name",
+                          "type": "Name"
+                        },
+                        "start": 0,
+                        "type": "MemberExpression",
+                        "type": "MemberExpression"
+                      },
+                      {
+                        "commentStart": 0,
+                        "computed": false,
+                        "end": 0,
+                        "moduleId": 0,
+                        "object": {
+                          "abs_path": false,
+                          "commentStart": 0,
+                          "end": 0,
+                          "moduleId": 0,
+                          "name": {
+                            "commentStart": 0,
+                            "end": 0,
+                            "moduleId": 0,
+                            "name": "lowerBeltYProfile",
+                            "start": 0,
+                            "type": "Identifier"
+                          },
+                          "path": [],
+                          "start": 0,
+                          "type": "Name",
+                          "type": "Name"
+                        },
+                        "property": {
+                          "abs_path": false,
+                          "commentStart": 0,
+                          "end": 0,
+                          "moduleId": 0,
+                          "name": {
+                            "commentStart": 0,
+                            "end": 0,
+                            "moduleId": 0,
+                            "name": "topEdge",
+                            "start": 0,
+                            "type": "Identifier"
+                          },
+                          "path": [],
+                          "start": 0,
+                          "type": "Name",
+                          "type": "Name"
+                        },
+                        "start": 0,
+                        "type": "MemberExpression",
+                        "type": "MemberExpression"
+                      }
+                    ],
+                    "end": 0,
+                    "moduleId": 0,
+                    "start": 0,
+                    "type": "ArrayExpression",
+                    "type": "ArrayExpression"
+                  }
+                }
+              ],
+              "callee": {
+                "abs_path": false,
                 "commentStart": 0,
                 "end": 0,
                 "moduleId": 0,
-                "name": "lowerBeltYProfile",
+                "name": {
+                  "commentStart": 0,
+                  "end": 0,
+                  "moduleId": 0,
+                  "name": "region",
+                  "start": 0,
+                  "type": "Identifier"
+                },
+                "path": [],
                 "start": 0,
-                "type": "Identifier"
+                "type": "Name"
               },
-              "path": [],
+              "commentStart": 0,
+              "end": 0,
+              "moduleId": 0,
               "start": 0,
-              "type": "Name",
-              "type": "Name"
+              "type": "CallExpressionKw",
+              "type": "CallExpressionKw",
+              "unlabeled": null
             }
           },
           "moduleId": 0,
@@ -14658,22 +15021,143 @@ description: Result of parsing utility-sink.kcl
             "type": "CallExpressionKw",
             "type": "CallExpressionKw",
             "unlabeled": {
-              "abs_path": false,
-              "commentStart": 0,
-              "end": 0,
-              "moduleId": 0,
-              "name": {
+              "arguments": [
+                {
+                  "type": "LabeledArg",
+                  "label": {
+                    "commentStart": 0,
+                    "end": 0,
+                    "moduleId": 0,
+                    "name": "segments",
+                    "start": 0,
+                    "type": "Identifier"
+                  },
+                  "arg": {
+                    "commentStart": 0,
+                    "elements": [
+                      {
+                        "commentStart": 0,
+                        "computed": false,
+                        "end": 0,
+                        "moduleId": 0,
+                        "object": {
+                          "abs_path": false,
+                          "commentStart": 0,
+                          "end": 0,
+                          "moduleId": 0,
+                          "name": {
+                            "commentStart": 0,
+                            "end": 0,
+                            "moduleId": 0,
+                            "name": "upperBeltXProfile",
+                            "start": 0,
+                            "type": "Identifier"
+                          },
+                          "path": [],
+                          "start": 0,
+                          "type": "Name",
+                          "type": "Name"
+                        },
+                        "property": {
+                          "abs_path": false,
+                          "commentStart": 0,
+                          "end": 0,
+                          "moduleId": 0,
+                          "name": {
+                            "commentStart": 0,
+                            "end": 0,
+                            "moduleId": 0,
+                            "name": "leftEdge",
+                            "start": 0,
+                            "type": "Identifier"
+                          },
+                          "path": [],
+                          "start": 0,
+                          "type": "Name",
+                          "type": "Name"
+                        },
+                        "start": 0,
+                        "type": "MemberExpression",
+                        "type": "MemberExpression"
+                      },
+                      {
+                        "commentStart": 0,
+                        "computed": false,
+                        "end": 0,
+                        "moduleId": 0,
+                        "object": {
+                          "abs_path": false,
+                          "commentStart": 0,
+                          "end": 0,
+                          "moduleId": 0,
+                          "name": {
+                            "commentStart": 0,
+                            "end": 0,
+                            "moduleId": 0,
+                            "name": "upperBeltXProfile",
+                            "start": 0,
+                            "type": "Identifier"
+                          },
+                          "path": [],
+                          "start": 0,
+                          "type": "Name",
+                          "type": "Name"
+                        },
+                        "property": {
+                          "abs_path": false,
+                          "commentStart": 0,
+                          "end": 0,
+                          "moduleId": 0,
+                          "name": {
+                            "commentStart": 0,
+                            "end": 0,
+                            "moduleId": 0,
+                            "name": "topEdge",
+                            "start": 0,
+                            "type": "Identifier"
+                          },
+                          "path": [],
+                          "start": 0,
+                          "type": "Name",
+                          "type": "Name"
+                        },
+                        "start": 0,
+                        "type": "MemberExpression",
+                        "type": "MemberExpression"
+                      }
+                    ],
+                    "end": 0,
+                    "moduleId": 0,
+                    "start": 0,
+                    "type": "ArrayExpression",
+                    "type": "ArrayExpression"
+                  }
+                }
+              ],
+              "callee": {
+                "abs_path": false,
                 "commentStart": 0,
                 "end": 0,
                 "moduleId": 0,
-                "name": "upperBeltXProfile",
+                "name": {
+                  "commentStart": 0,
+                  "end": 0,
+                  "moduleId": 0,
+                  "name": "region",
+                  "start": 0,
+                  "type": "Identifier"
+                },
+                "path": [],
                 "start": 0,
-                "type": "Identifier"
+                "type": "Name"
               },
-              "path": [],
+              "commentStart": 0,
+              "end": 0,
+              "moduleId": 0,
               "start": 0,
-              "type": "Name",
-              "type": "Name"
+              "type": "CallExpressionKw",
+              "type": "CallExpressionKw",
+              "unlabeled": null
             }
           },
           "moduleId": 0,
@@ -17517,22 +18001,143 @@ description: Result of parsing utility-sink.kcl
             "type": "CallExpressionKw",
             "type": "CallExpressionKw",
             "unlabeled": {
-              "abs_path": false,
-              "commentStart": 0,
-              "end": 0,
-              "moduleId": 0,
-              "name": {
+              "arguments": [
+                {
+                  "type": "LabeledArg",
+                  "label": {
+                    "commentStart": 0,
+                    "end": 0,
+                    "moduleId": 0,
+                    "name": "segments",
+                    "start": 0,
+                    "type": "Identifier"
+                  },
+                  "arg": {
+                    "commentStart": 0,
+                    "elements": [
+                      {
+                        "commentStart": 0,
+                        "computed": false,
+                        "end": 0,
+                        "moduleId": 0,
+                        "object": {
+                          "abs_path": false,
+                          "commentStart": 0,
+                          "end": 0,
+                          "moduleId": 0,
+                          "name": {
+                            "commentStart": 0,
+                            "end": 0,
+                            "moduleId": 0,
+                            "name": "upperBeltYProfile",
+                            "start": 0,
+                            "type": "Identifier"
+                          },
+                          "path": [],
+                          "start": 0,
+                          "type": "Name",
+                          "type": "Name"
+                        },
+                        "property": {
+                          "abs_path": false,
+                          "commentStart": 0,
+                          "end": 0,
+                          "moduleId": 0,
+                          "name": {
+                            "commentStart": 0,
+                            "end": 0,
+                            "moduleId": 0,
+                            "name": "leftEdge",
+                            "start": 0,
+                            "type": "Identifier"
+                          },
+                          "path": [],
+                          "start": 0,
+                          "type": "Name",
+                          "type": "Name"
+                        },
+                        "start": 0,
+                        "type": "MemberExpression",
+                        "type": "MemberExpression"
+                      },
+                      {
+                        "commentStart": 0,
+                        "computed": false,
+                        "end": 0,
+                        "moduleId": 0,
+                        "object": {
+                          "abs_path": false,
+                          "commentStart": 0,
+                          "end": 0,
+                          "moduleId": 0,
+                          "name": {
+                            "commentStart": 0,
+                            "end": 0,
+                            "moduleId": 0,
+                            "name": "upperBeltYProfile",
+                            "start": 0,
+                            "type": "Identifier"
+                          },
+                          "path": [],
+                          "start": 0,
+                          "type": "Name",
+                          "type": "Name"
+                        },
+                        "property": {
+                          "abs_path": false,
+                          "commentStart": 0,
+                          "end": 0,
+                          "moduleId": 0,
+                          "name": {
+                            "commentStart": 0,
+                            "end": 0,
+                            "moduleId": 0,
+                            "name": "topEdge",
+                            "start": 0,
+                            "type": "Identifier"
+                          },
+                          "path": [],
+                          "start": 0,
+                          "type": "Name",
+                          "type": "Name"
+                        },
+                        "start": 0,
+                        "type": "MemberExpression",
+                        "type": "MemberExpression"
+                      }
+                    ],
+                    "end": 0,
+                    "moduleId": 0,
+                    "start": 0,
+                    "type": "ArrayExpression",
+                    "type": "ArrayExpression"
+                  }
+                }
+              ],
+              "callee": {
+                "abs_path": false,
                 "commentStart": 0,
                 "end": 0,
                 "moduleId": 0,
-                "name": "upperBeltYProfile",
+                "name": {
+                  "commentStart": 0,
+                  "end": 0,
+                  "moduleId": 0,
+                  "name": "region",
+                  "start": 0,
+                  "type": "Identifier"
+                },
+                "path": [],
                 "start": 0,
-                "type": "Identifier"
+                "type": "Name"
               },
-              "path": [],
+              "commentStart": 0,
+              "end": 0,
+              "moduleId": 0,
               "start": 0,
-              "type": "Name",
-              "type": "Name"
+              "type": "CallExpressionKw",
+              "type": "CallExpressionKw",
+              "unlabeled": null
             }
           },
           "moduleId": 0,

--- a/rust/kcl-lib/tests/kcl_samples/utility-sink/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/utility-sink/ops.snap
@@ -1234,6 +1234,47 @@ description: Operations executed utility-sink.kcl
     },
     {
       "type": "StdLibCall",
+      "name": "region",
+      "unlabeledArg": null,
+      "labeledArgs": {
+        "segments": {
+          "value": {
+            "type": "Array",
+            "value": [
+              {
+                "type": "Segment",
+                "artifact_id": "[uuid]"
+              },
+              {
+                "type": "Segment",
+                "artifact_id": "[uuid]"
+              }
+            ]
+          },
+          "sourceRange": []
+        }
+      },
+      "nodePath": {
+        "steps": [
+          {
+            "type": "ProgramBodyItem",
+            "index": 14
+          },
+          {
+            "type": "VariableDeclarationDeclaration"
+          },
+          {
+            "type": "VariableDeclarationInit"
+          },
+          {
+            "type": "CallKwUnlabeledArg"
+          }
+        ]
+      },
+      "sourceRange": []
+    },
+    {
+      "type": "StdLibCall",
       "name": "extrude",
       "unlabeledArg": {
         "value": {
@@ -2469,6 +2510,47 @@ description: Operations executed utility-sink.kcl
     },
     {
       "type": "StdLibCall",
+      "name": "region",
+      "unlabeledArg": null,
+      "labeledArgs": {
+        "segments": {
+          "value": {
+            "type": "Array",
+            "value": [
+              {
+                "type": "Segment",
+                "artifact_id": "[uuid]"
+              },
+              {
+                "type": "Segment",
+                "artifact_id": "[uuid]"
+              }
+            ]
+          },
+          "sourceRange": []
+        }
+      },
+      "nodePath": {
+        "steps": [
+          {
+            "type": "ProgramBodyItem",
+            "index": 21
+          },
+          {
+            "type": "VariableDeclarationDeclaration"
+          },
+          {
+            "type": "VariableDeclarationInit"
+          },
+          {
+            "type": "CallKwUnlabeledArg"
+          }
+        ]
+      },
+      "sourceRange": []
+    },
+    {
+      "type": "StdLibCall",
       "name": "extrude",
       "unlabeledArg": {
         "value": {
@@ -3620,6 +3702,47 @@ description: Operations executed utility-sink.kcl
     },
     {
       "type": "GroupEnd"
+    },
+    {
+      "type": "StdLibCall",
+      "name": "region",
+      "unlabeledArg": null,
+      "labeledArgs": {
+        "segments": {
+          "value": {
+            "type": "Array",
+            "value": [
+              {
+                "type": "Segment",
+                "artifact_id": "[uuid]"
+              },
+              {
+                "type": "Segment",
+                "artifact_id": "[uuid]"
+              }
+            ]
+          },
+          "sourceRange": []
+        }
+      },
+      "nodePath": {
+        "steps": [
+          {
+            "type": "ProgramBodyItem",
+            "index": 26
+          },
+          {
+            "type": "VariableDeclarationDeclaration"
+          },
+          {
+            "type": "VariableDeclarationInit"
+          },
+          {
+            "type": "CallKwUnlabeledArg"
+          }
+        ]
+      },
+      "sourceRange": []
     },
     {
       "type": "StdLibCall",
@@ -5937,6 +6060,47 @@ description: Operations executed utility-sink.kcl
     },
     {
       "type": "StdLibCall",
+      "name": "region",
+      "unlabeledArg": null,
+      "labeledArgs": {
+        "segments": {
+          "value": {
+            "type": "Array",
+            "value": [
+              {
+                "type": "Segment",
+                "artifact_id": "[uuid]"
+              },
+              {
+                "type": "Segment",
+                "artifact_id": "[uuid]"
+              }
+            ]
+          },
+          "sourceRange": []
+        }
+      },
+      "nodePath": {
+        "steps": [
+          {
+            "type": "ProgramBodyItem",
+            "index": 37
+          },
+          {
+            "type": "VariableDeclarationDeclaration"
+          },
+          {
+            "type": "VariableDeclarationInit"
+          },
+          {
+            "type": "CallKwUnlabeledArg"
+          }
+        ]
+      },
+      "sourceRange": []
+    },
+    {
+      "type": "StdLibCall",
       "name": "extrude",
       "unlabeledArg": {
         "value": {
@@ -7088,6 +7252,47 @@ description: Operations executed utility-sink.kcl
     },
     {
       "type": "GroupEnd"
+    },
+    {
+      "type": "StdLibCall",
+      "name": "region",
+      "unlabeledArg": null,
+      "labeledArgs": {
+        "segments": {
+          "value": {
+            "type": "Array",
+            "value": [
+              {
+                "type": "Segment",
+                "artifact_id": "[uuid]"
+              },
+              {
+                "type": "Segment",
+                "artifact_id": "[uuid]"
+              }
+            ]
+          },
+          "sourceRange": []
+        }
+      },
+      "nodePath": {
+        "steps": [
+          {
+            "type": "ProgramBodyItem",
+            "index": 41
+          },
+          {
+            "type": "VariableDeclarationDeclaration"
+          },
+          {
+            "type": "VariableDeclarationInit"
+          },
+          {
+            "type": "CallKwUnlabeledArg"
+          }
+        ]
+      },
+      "sourceRange": []
     },
     {
       "type": "StdLibCall",

--- a/rust/kcl-lib/tests/kcl_samples/utility-sink/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/utility-sink/physical_properties.snap
@@ -24,6 +24,6 @@ description: Physical properties utility-sink.kcl
     "material_density": 1000.0,
     "material_density_unit": "kg:m3",
     "unit": "g",
-    "value": 34383.194221199985
+    "value": 34383.10704067585
   }
 }

--- a/rust/kcl-lib/tests/kcl_samples/utility-sink/program_memory.snap
+++ b/rust/kcl-lib/tests/kcl_samples/utility-sink/program_memory.snap
@@ -624,10 +624,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 19671,
-                "end": 19679,
+                "commentStart": 20009,
+                "end": 20017,
                 "moduleId": 0,
-                "start": 19671,
+                "start": 20009,
                 "type": "TagDeclarator",
                 "value": "leftEdge"
               },
@@ -638,10 +638,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 19746,
-                "end": 19753,
+                "commentStart": 20084,
+                "end": 20091,
                 "moduleId": 0,
-                "start": 19746,
+                "start": 20084,
                 "type": "TagDeclarator",
                 "value": "topEdge"
               },
@@ -652,10 +652,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 19822,
-                "end": 19831,
+                "commentStart": 20160,
+                "end": 20169,
                 "moduleId": 0,
-                "start": 19822,
+                "start": 20160,
                 "type": "TagDeclarator",
                 "value": "rightEdge"
               },
@@ -666,10 +666,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 19900,
-                "end": 19910,
+                "commentStart": 20238,
+                "end": 20248,
                 "moduleId": 0,
-                "start": 19900,
+                "start": 20238,
                 "type": "TagDeclarator",
                 "value": "bottomEdge"
               },
@@ -691,10 +691,10 @@ description: Variables in memory after executing utility-sink.kcl
                   0.0
                 ],
                 "tag": {
-                  "commentStart": 19671,
-                  "end": 19679,
+                  "commentStart": 20009,
+                  "end": 20017,
                   "moduleId": 0,
-                  "start": 19671,
+                  "start": 20009,
                   "type": "TagDeclarator",
                   "value": "leftEdge"
                 },
@@ -715,10 +715,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 19746,
-                  "end": 19753,
+                  "commentStart": 20084,
+                  "end": 20091,
                   "moduleId": 0,
-                  "start": 19746,
+                  "start": 20084,
                   "type": "TagDeclarator",
                   "value": "topEdge"
                 },
@@ -739,10 +739,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 19822,
-                  "end": 19831,
+                  "commentStart": 20160,
+                  "end": 20169,
                   "moduleId": 0,
-                  "start": 19822,
+                  "start": 20160,
                   "type": "TagDeclarator",
                   "value": "rightEdge"
                 },
@@ -763,10 +763,10 @@ description: Variables in memory after executing utility-sink.kcl
                   0.0
                 ],
                 "tag": {
-                  "commentStart": 19900,
-                  "end": 19910,
+                  "commentStart": 20238,
+                  "end": 20248,
                   "moduleId": 0,
-                  "start": 19900,
+                  "start": 20238,
                   "type": "TagDeclarator",
                   "value": "bottomEdge"
                 },
@@ -866,10 +866,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 19671,
-                "end": 19679,
+                "commentStart": 20009,
+                "end": 20017,
                 "moduleId": 0,
-                "start": 19671,
+                "start": 20009,
                 "type": "TagDeclarator",
                 "value": "leftEdge"
               },
@@ -880,10 +880,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 19746,
-                "end": 19753,
+                "commentStart": 20084,
+                "end": 20091,
                 "moduleId": 0,
-                "start": 19746,
+                "start": 20084,
                 "type": "TagDeclarator",
                 "value": "topEdge"
               },
@@ -894,10 +894,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 19822,
-                "end": 19831,
+                "commentStart": 20160,
+                "end": 20169,
                 "moduleId": 0,
-                "start": 19822,
+                "start": 20160,
                 "type": "TagDeclarator",
                 "value": "rightEdge"
               },
@@ -908,10 +908,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 19900,
-                "end": 19910,
+                "commentStart": 20238,
+                "end": 20248,
                 "moduleId": 0,
-                "start": 19900,
+                "start": 20238,
                 "type": "TagDeclarator",
                 "value": "bottomEdge"
               },
@@ -933,10 +933,10 @@ description: Variables in memory after executing utility-sink.kcl
                   0.0
                 ],
                 "tag": {
-                  "commentStart": 19671,
-                  "end": 19679,
+                  "commentStart": 20009,
+                  "end": 20017,
                   "moduleId": 0,
-                  "start": 19671,
+                  "start": 20009,
                   "type": "TagDeclarator",
                   "value": "leftEdge"
                 },
@@ -957,10 +957,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 19746,
-                  "end": 19753,
+                  "commentStart": 20084,
+                  "end": 20091,
                   "moduleId": 0,
-                  "start": 19746,
+                  "start": 20084,
                   "type": "TagDeclarator",
                   "value": "topEdge"
                 },
@@ -981,10 +981,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 19822,
-                  "end": 19831,
+                  "commentStart": 20160,
+                  "end": 20169,
                   "moduleId": 0,
-                  "start": 19822,
+                  "start": 20160,
                   "type": "TagDeclarator",
                   "value": "rightEdge"
                 },
@@ -1005,10 +1005,10 @@ description: Variables in memory after executing utility-sink.kcl
                   0.0
                 ],
                 "tag": {
-                  "commentStart": 19900,
-                  "end": 19910,
+                  "commentStart": 20238,
+                  "end": 20248,
                   "moduleId": 0,
-                  "start": 19900,
+                  "start": 20238,
                   "type": "TagDeclarator",
                   "value": "bottomEdge"
                 },
@@ -1108,10 +1108,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 19671,
-                "end": 19679,
+                "commentStart": 20009,
+                "end": 20017,
                 "moduleId": 0,
-                "start": 19671,
+                "start": 20009,
                 "type": "TagDeclarator",
                 "value": "leftEdge"
               },
@@ -1122,10 +1122,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 19746,
-                "end": 19753,
+                "commentStart": 20084,
+                "end": 20091,
                 "moduleId": 0,
-                "start": 19746,
+                "start": 20084,
                 "type": "TagDeclarator",
                 "value": "topEdge"
               },
@@ -1136,10 +1136,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 19822,
-                "end": 19831,
+                "commentStart": 20160,
+                "end": 20169,
                 "moduleId": 0,
-                "start": 19822,
+                "start": 20160,
                 "type": "TagDeclarator",
                 "value": "rightEdge"
               },
@@ -1150,10 +1150,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 19900,
-                "end": 19910,
+                "commentStart": 20238,
+                "end": 20248,
                 "moduleId": 0,
-                "start": 19900,
+                "start": 20238,
                 "type": "TagDeclarator",
                 "value": "bottomEdge"
               },
@@ -1175,10 +1175,10 @@ description: Variables in memory after executing utility-sink.kcl
                   0.0
                 ],
                 "tag": {
-                  "commentStart": 19671,
-                  "end": 19679,
+                  "commentStart": 20009,
+                  "end": 20017,
                   "moduleId": 0,
-                  "start": 19671,
+                  "start": 20009,
                   "type": "TagDeclarator",
                   "value": "leftEdge"
                 },
@@ -1199,10 +1199,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 19746,
-                  "end": 19753,
+                  "commentStart": 20084,
+                  "end": 20091,
                   "moduleId": 0,
-                  "start": 19746,
+                  "start": 20084,
                   "type": "TagDeclarator",
                   "value": "topEdge"
                 },
@@ -1223,10 +1223,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 19822,
-                  "end": 19831,
+                  "commentStart": 20160,
+                  "end": 20169,
                   "moduleId": 0,
-                  "start": 19822,
+                  "start": 20160,
                   "type": "TagDeclarator",
                   "value": "rightEdge"
                 },
@@ -1247,10 +1247,10 @@ description: Variables in memory after executing utility-sink.kcl
                   0.0
                 ],
                 "tag": {
-                  "commentStart": 19900,
-                  "end": 19910,
+                  "commentStart": 20238,
+                  "end": 20248,
                   "moduleId": 0,
-                  "start": 19900,
+                  "start": 20238,
                   "type": "TagDeclarator",
                   "value": "bottomEdge"
                 },
@@ -1350,10 +1350,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 19671,
-                "end": 19679,
+                "commentStart": 20009,
+                "end": 20017,
                 "moduleId": 0,
-                "start": 19671,
+                "start": 20009,
                 "type": "TagDeclarator",
                 "value": "leftEdge"
               },
@@ -1364,10 +1364,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 19746,
-                "end": 19753,
+                "commentStart": 20084,
+                "end": 20091,
                 "moduleId": 0,
-                "start": 19746,
+                "start": 20084,
                 "type": "TagDeclarator",
                 "value": "topEdge"
               },
@@ -1378,10 +1378,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 19822,
-                "end": 19831,
+                "commentStart": 20160,
+                "end": 20169,
                 "moduleId": 0,
-                "start": 19822,
+                "start": 20160,
                 "type": "TagDeclarator",
                 "value": "rightEdge"
               },
@@ -1392,10 +1392,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 19900,
-                "end": 19910,
+                "commentStart": 20238,
+                "end": 20248,
                 "moduleId": 0,
-                "start": 19900,
+                "start": 20238,
                 "type": "TagDeclarator",
                 "value": "bottomEdge"
               },
@@ -1417,10 +1417,10 @@ description: Variables in memory after executing utility-sink.kcl
                   0.0
                 ],
                 "tag": {
-                  "commentStart": 19671,
-                  "end": 19679,
+                  "commentStart": 20009,
+                  "end": 20017,
                   "moduleId": 0,
-                  "start": 19671,
+                  "start": 20009,
                   "type": "TagDeclarator",
                   "value": "leftEdge"
                 },
@@ -1441,10 +1441,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 19746,
-                  "end": 19753,
+                  "commentStart": 20084,
+                  "end": 20091,
                   "moduleId": 0,
-                  "start": 19746,
+                  "start": 20084,
                   "type": "TagDeclarator",
                   "value": "topEdge"
                 },
@@ -1465,10 +1465,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 19822,
-                  "end": 19831,
+                  "commentStart": 20160,
+                  "end": 20169,
                   "moduleId": 0,
-                  "start": 19822,
+                  "start": 20160,
                   "type": "TagDeclarator",
                   "value": "rightEdge"
                 },
@@ -1489,10 +1489,10 @@ description: Variables in memory after executing utility-sink.kcl
                   0.0
                 ],
                 "tag": {
-                  "commentStart": 19900,
-                  "end": 19910,
+                  "commentStart": 20238,
+                  "end": 20248,
                   "moduleId": 0,
-                  "start": 19900,
+                  "start": 20238,
                   "type": "TagDeclarator",
                   "value": "bottomEdge"
                 },
@@ -1913,10 +1913,10 @@ description: Variables in memory after executing utility-sink.kcl
                     0.0
                   ],
                   "tag": {
-                    "commentStart": 19671,
-                    "end": 19679,
+                    "commentStart": 20009,
+                    "end": 20017,
                     "moduleId": 0,
-                    "start": 19671,
+                    "start": 20009,
                     "type": "TagDeclarator",
                     "value": "leftEdge"
                   },
@@ -1937,10 +1937,10 @@ description: Variables in memory after executing utility-sink.kcl
                     13.0
                   ],
                   "tag": {
-                    "commentStart": 19746,
-                    "end": 19753,
+                    "commentStart": 20084,
+                    "end": 20091,
                     "moduleId": 0,
-                    "start": 19746,
+                    "start": 20084,
                     "type": "TagDeclarator",
                     "value": "topEdge"
                   },
@@ -1961,10 +1961,10 @@ description: Variables in memory after executing utility-sink.kcl
                     13.0
                   ],
                   "tag": {
-                    "commentStart": 19822,
-                    "end": 19831,
+                    "commentStart": 20160,
+                    "end": 20169,
                     "moduleId": 0,
-                    "start": 19822,
+                    "start": 20160,
                     "type": "TagDeclarator",
                     "value": "rightEdge"
                   },
@@ -1985,10 +1985,10 @@ description: Variables in memory after executing utility-sink.kcl
                     0.0
                   ],
                   "tag": {
-                    "commentStart": 19900,
-                    "end": 19910,
+                    "commentStart": 20238,
+                    "end": 20248,
                     "moduleId": 0,
-                    "start": 19900,
+                    "start": 20238,
                     "type": "TagDeclarator",
                     "value": "bottomEdge"
                   },
@@ -2454,10 +2454,10 @@ description: Variables in memory after executing utility-sink.kcl
             0.0
           ],
           "tag": {
-            "commentStart": 19671,
-            "end": 19679,
+            "commentStart": 20009,
+            "end": 20017,
             "moduleId": 0,
-            "start": 19671,
+            "start": 20009,
             "type": "TagDeclarator",
             "value": "leftEdge"
           },
@@ -2478,10 +2478,10 @@ description: Variables in memory after executing utility-sink.kcl
             13.0
           ],
           "tag": {
-            "commentStart": 19746,
-            "end": 19753,
+            "commentStart": 20084,
+            "end": 20091,
             "moduleId": 0,
-            "start": 19746,
+            "start": 20084,
             "type": "TagDeclarator",
             "value": "topEdge"
           },
@@ -2502,10 +2502,10 @@ description: Variables in memory after executing utility-sink.kcl
             13.0
           ],
           "tag": {
-            "commentStart": 19822,
-            "end": 19831,
+            "commentStart": 20160,
+            "end": 20169,
             "moduleId": 0,
-            "start": 19822,
+            "start": 20160,
             "type": "TagDeclarator",
             "value": "rightEdge"
           },
@@ -2526,10 +2526,10 @@ description: Variables in memory after executing utility-sink.kcl
             0.0
           ],
           "tag": {
-            "commentStart": 19900,
-            "end": 19910,
+            "commentStart": 20238,
+            "end": 20248,
             "moduleId": 0,
-            "start": 19900,
+            "start": 20238,
             "type": "TagDeclarator",
             "value": "bottomEdge"
           },
@@ -2627,10 +2627,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 19671,
-                "end": 19679,
+                "commentStart": 20009,
+                "end": 20017,
                 "moduleId": 0,
-                "start": 19671,
+                "start": 20009,
                 "type": "TagDeclarator",
                 "value": "leftEdge"
               },
@@ -2641,10 +2641,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 19746,
-                "end": 19753,
+                "commentStart": 20084,
+                "end": 20091,
                 "moduleId": 0,
-                "start": 19746,
+                "start": 20084,
                 "type": "TagDeclarator",
                 "value": "topEdge"
               },
@@ -2655,10 +2655,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 19822,
-                "end": 19831,
+                "commentStart": 20160,
+                "end": 20169,
                 "moduleId": 0,
-                "start": 19822,
+                "start": 20160,
                 "type": "TagDeclarator",
                 "value": "rightEdge"
               },
@@ -2669,10 +2669,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 19900,
-                "end": 19910,
+                "commentStart": 20238,
+                "end": 20248,
                 "moduleId": 0,
-                "start": 19900,
+                "start": 20238,
                 "type": "TagDeclarator",
                 "value": "bottomEdge"
               },
@@ -2694,10 +2694,10 @@ description: Variables in memory after executing utility-sink.kcl
                   0.0
                 ],
                 "tag": {
-                  "commentStart": 19671,
-                  "end": 19679,
+                  "commentStart": 20009,
+                  "end": 20017,
                   "moduleId": 0,
-                  "start": 19671,
+                  "start": 20009,
                   "type": "TagDeclarator",
                   "value": "leftEdge"
                 },
@@ -2718,10 +2718,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 19746,
-                  "end": 19753,
+                  "commentStart": 20084,
+                  "end": 20091,
                   "moduleId": 0,
-                  "start": 19746,
+                  "start": 20084,
                   "type": "TagDeclarator",
                   "value": "topEdge"
                 },
@@ -2742,10 +2742,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 19822,
-                  "end": 19831,
+                  "commentStart": 20160,
+                  "end": 20169,
                   "moduleId": 0,
-                  "start": 19822,
+                  "start": 20160,
                   "type": "TagDeclarator",
                   "value": "rightEdge"
                 },
@@ -2766,10 +2766,10 @@ description: Variables in memory after executing utility-sink.kcl
                   0.0
                 ],
                 "tag": {
-                  "commentStart": 19900,
-                  "end": 19910,
+                  "commentStart": 20238,
+                  "end": 20248,
                   "moduleId": 0,
-                  "start": 19900,
+                  "start": 20238,
                   "type": "TagDeclarator",
                   "value": "bottomEdge"
                 },
@@ -2869,10 +2869,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 19671,
-                "end": 19679,
+                "commentStart": 20009,
+                "end": 20017,
                 "moduleId": 0,
-                "start": 19671,
+                "start": 20009,
                 "type": "TagDeclarator",
                 "value": "leftEdge"
               },
@@ -2883,10 +2883,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 19746,
-                "end": 19753,
+                "commentStart": 20084,
+                "end": 20091,
                 "moduleId": 0,
-                "start": 19746,
+                "start": 20084,
                 "type": "TagDeclarator",
                 "value": "topEdge"
               },
@@ -2897,10 +2897,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 19822,
-                "end": 19831,
+                "commentStart": 20160,
+                "end": 20169,
                 "moduleId": 0,
-                "start": 19822,
+                "start": 20160,
                 "type": "TagDeclarator",
                 "value": "rightEdge"
               },
@@ -2911,10 +2911,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 19900,
-                "end": 19910,
+                "commentStart": 20238,
+                "end": 20248,
                 "moduleId": 0,
-                "start": 19900,
+                "start": 20238,
                 "type": "TagDeclarator",
                 "value": "bottomEdge"
               },
@@ -2936,10 +2936,10 @@ description: Variables in memory after executing utility-sink.kcl
                   0.0
                 ],
                 "tag": {
-                  "commentStart": 19671,
-                  "end": 19679,
+                  "commentStart": 20009,
+                  "end": 20017,
                   "moduleId": 0,
-                  "start": 19671,
+                  "start": 20009,
                   "type": "TagDeclarator",
                   "value": "leftEdge"
                 },
@@ -2960,10 +2960,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 19746,
-                  "end": 19753,
+                  "commentStart": 20084,
+                  "end": 20091,
                   "moduleId": 0,
-                  "start": 19746,
+                  "start": 20084,
                   "type": "TagDeclarator",
                   "value": "topEdge"
                 },
@@ -2984,10 +2984,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 19822,
-                  "end": 19831,
+                  "commentStart": 20160,
+                  "end": 20169,
                   "moduleId": 0,
-                  "start": 19822,
+                  "start": 20160,
                   "type": "TagDeclarator",
                   "value": "rightEdge"
                 },
@@ -3008,10 +3008,10 @@ description: Variables in memory after executing utility-sink.kcl
                   0.0
                 ],
                 "tag": {
-                  "commentStart": 19900,
-                  "end": 19910,
+                  "commentStart": 20238,
+                  "end": 20248,
                   "moduleId": 0,
-                  "start": 19900,
+                  "start": 20238,
                   "type": "TagDeclarator",
                   "value": "bottomEdge"
                 },
@@ -3113,10 +3113,10 @@ description: Variables in memory after executing utility-sink.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
-            "commentStart": 19671,
-            "end": 19679,
+            "commentStart": 20009,
+            "end": 20017,
             "moduleId": 0,
-            "start": 19671,
+            "start": 20009,
             "type": "TagDeclarator",
             "value": "leftEdge"
           },
@@ -3127,10 +3127,10 @@ description: Variables in memory after executing utility-sink.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
-            "commentStart": 19746,
-            "end": 19753,
+            "commentStart": 20084,
+            "end": 20091,
             "moduleId": 0,
-            "start": 19746,
+            "start": 20084,
             "type": "TagDeclarator",
             "value": "topEdge"
           },
@@ -3141,10 +3141,10 @@ description: Variables in memory after executing utility-sink.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
-            "commentStart": 19822,
-            "end": 19831,
+            "commentStart": 20160,
+            "end": 20169,
             "moduleId": 0,
-            "start": 19822,
+            "start": 20160,
             "type": "TagDeclarator",
             "value": "rightEdge"
           },
@@ -3155,10 +3155,10 @@ description: Variables in memory after executing utility-sink.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
-            "commentStart": 19900,
-            "end": 19910,
+            "commentStart": 20238,
+            "end": 20248,
             "moduleId": 0,
-            "start": 19900,
+            "start": 20238,
             "type": "TagDeclarator",
             "value": "bottomEdge"
           },
@@ -3180,10 +3180,10 @@ description: Variables in memory after executing utility-sink.kcl
               0.0
             ],
             "tag": {
-              "commentStart": 19671,
-              "end": 19679,
+              "commentStart": 20009,
+              "end": 20017,
               "moduleId": 0,
-              "start": 19671,
+              "start": 20009,
               "type": "TagDeclarator",
               "value": "leftEdge"
             },
@@ -3204,10 +3204,10 @@ description: Variables in memory after executing utility-sink.kcl
               13.0
             ],
             "tag": {
-              "commentStart": 19746,
-              "end": 19753,
+              "commentStart": 20084,
+              "end": 20091,
               "moduleId": 0,
-              "start": 19746,
+              "start": 20084,
               "type": "TagDeclarator",
               "value": "topEdge"
             },
@@ -3228,10 +3228,10 @@ description: Variables in memory after executing utility-sink.kcl
               13.0
             ],
             "tag": {
-              "commentStart": 19822,
-              "end": 19831,
+              "commentStart": 20160,
+              "end": 20169,
               "moduleId": 0,
-              "start": 19822,
+              "start": 20160,
               "type": "TagDeclarator",
               "value": "rightEdge"
             },
@@ -3252,10 +3252,10 @@ description: Variables in memory after executing utility-sink.kcl
               0.0
             ],
             "tag": {
-              "commentStart": 19900,
-              "end": 19910,
+              "commentStart": 20238,
+              "end": 20248,
               "moduleId": 0,
-              "start": 19900,
+              "start": 20238,
               "type": "TagDeclarator",
               "value": "bottomEdge"
             },
@@ -3381,10 +3381,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 25670,
-                "end": 25683,
+                "commentStart": 26008,
+                "end": 26021,
                 "moduleId": 0,
-                "start": 25670,
+                "start": 26008,
                 "type": "TagDeclarator",
                 "value": "sectionCircle"
               },
@@ -3412,10 +3412,10 @@ description: Variables in memory after executing utility-sink.kcl
                 ],
                 "radius": 2.0,
                 "tag": {
-                  "commentStart": 25670,
-                  "end": 25683,
+                  "commentStart": 26008,
+                  "end": 26021,
                   "moduleId": 0,
-                  "start": 25670,
+                  "start": 26008,
                   "type": "TagDeclarator",
                   "value": "sectionCircle"
                 },
@@ -3503,10 +3503,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 25670,
-                "end": 25683,
+                "commentStart": 26008,
+                "end": 26021,
                 "moduleId": 0,
-                "start": 25670,
+                "start": 26008,
                 "type": "TagDeclarator",
                 "value": "sectionCircle"
               },
@@ -3534,10 +3534,10 @@ description: Variables in memory after executing utility-sink.kcl
                 ],
                 "radius": 2.0,
                 "tag": {
-                  "commentStart": 25670,
-                  "end": 25683,
+                  "commentStart": 26008,
+                  "end": 26021,
                   "moduleId": 0,
-                  "start": 25670,
+                  "start": 26008,
                   "type": "TagDeclarator",
                   "value": "sectionCircle"
                 },
@@ -4237,10 +4237,10 @@ description: Variables in memory after executing utility-sink.kcl
                     0.0
                   ],
                   "tag": {
-                    "commentStart": 23173,
-                    "end": 23180,
+                    "commentStart": 23511,
+                    "end": 23518,
                     "moduleId": 0,
-                    "start": 23173,
+                    "start": 23511,
                     "type": "TagDeclarator",
                     "value": "leftLeg"
                   },
@@ -4267,10 +4267,10 @@ description: Variables in memory after executing utility-sink.kcl
                   ],
                   "radius": 20.0,
                   "tag": {
-                    "commentStart": 23370,
-                    "end": 23377,
+                    "commentStart": 23708,
+                    "end": 23715,
                     "moduleId": 0,
-                    "start": 23370,
+                    "start": 23708,
                     "type": "TagDeclarator",
                     "value": "leftArc"
                   },
@@ -4291,10 +4291,10 @@ description: Variables in memory after executing utility-sink.kcl
                     -40.0
                   ],
                   "tag": {
-                    "commentStart": 23490,
-                    "end": 23494,
+                    "commentStart": 23828,
+                    "end": 23832,
                     "moduleId": 0,
-                    "start": 23490,
+                    "start": 23828,
                     "type": "TagDeclarator",
                     "value": "grip"
                   },
@@ -4321,10 +4321,10 @@ description: Variables in memory after executing utility-sink.kcl
                   ],
                   "radius": 20.0,
                   "tag": {
-                    "commentStart": 23687,
-                    "end": 23695,
+                    "commentStart": 24025,
+                    "end": 24033,
                     "moduleId": 0,
-                    "start": 23687,
+                    "start": 24025,
                     "type": "TagDeclarator",
                     "value": "rightArc"
                   },
@@ -4345,10 +4345,10 @@ description: Variables in memory after executing utility-sink.kcl
                     -20.0
                   ],
                   "tag": {
-                    "commentStart": 23808,
-                    "end": 23816,
+                    "commentStart": 24146,
+                    "end": 24154,
                     "moduleId": 0,
-                    "start": 23808,
+                    "start": 24146,
                     "type": "TagDeclarator",
                     "value": "rightLeg"
                   },
@@ -5098,10 +5098,10 @@ description: Variables in memory after executing utility-sink.kcl
           ],
           "radius": 2.0,
           "tag": {
-            "commentStart": 25670,
-            "end": 25683,
+            "commentStart": 26008,
+            "end": 26021,
             "moduleId": 0,
-            "start": 25670,
+            "start": 26008,
             "type": "TagDeclarator",
             "value": "sectionCircle"
           },
@@ -5442,10 +5442,10 @@ description: Variables in memory after executing utility-sink.kcl
                   ],
                   "radius": 2.0,
                   "tag": {
-                    "commentStart": 25670,
-                    "end": 25683,
+                    "commentStart": 26008,
+                    "end": 26021,
                     "moduleId": 0,
-                    "start": 25670,
+                    "start": 26008,
                     "type": "TagDeclarator",
                     "value": "sectionCircle"
                   },
@@ -5775,10 +5775,10 @@ description: Variables in memory after executing utility-sink.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
-            "commentStart": 25670,
-            "end": 25683,
+            "commentStart": 26008,
+            "end": 26021,
             "moduleId": 0,
-            "start": 25670,
+            "start": 26008,
             "type": "TagDeclarator",
             "value": "sectionCircle"
           },
@@ -5806,10 +5806,10 @@ description: Variables in memory after executing utility-sink.kcl
             ],
             "radius": 2.0,
             "tag": {
-              "commentStart": 25670,
-              "end": 25683,
+              "commentStart": 26008,
+              "end": 26021,
               "moduleId": 0,
-              "start": 25670,
+              "start": 26008,
               "type": "TagDeclarator",
               "value": "sectionCircle"
             },
@@ -6145,6 +6145,7 @@ description: Variables in memory after executing utility-sink.kcl
             },
             "artifactId": "[uuid]",
             "originalId": "[uuid]",
+            "originSketchId": "[uuid]",
             "units": "mm"
           },
           "startCapId": "[uuid]",
@@ -6329,6 +6330,7 @@ description: Variables in memory after executing utility-sink.kcl
             },
             "artifactId": "[uuid]",
             "originalId": "[uuid]",
+            "originSketchId": "[uuid]",
             "units": "mm"
           },
           "startCapId": "[uuid]",
@@ -6513,6 +6515,7 @@ description: Variables in memory after executing utility-sink.kcl
             },
             "artifactId": "[uuid]",
             "originalId": "[uuid]",
+            "originSketchId": "[uuid]",
             "units": "mm"
           },
           "startCapId": "[uuid]",
@@ -6697,6 +6700,7 @@ description: Variables in memory after executing utility-sink.kcl
             },
             "artifactId": "[uuid]",
             "originalId": "[uuid]",
+            "originSketchId": "[uuid]",
             "units": "mm"
           },
           "startCapId": "[uuid]",
@@ -7564,8 +7568,8 @@ description: Variables in memory after executing utility-sink.kcl
           },
           "artifactId": "[uuid]",
           "originalId": "[uuid]",
-          "units": "mm",
-          "isClosed": "implicitly"
+          "originSketchId": "[uuid]",
+          "units": "mm"
         }
       },
       {
@@ -7738,8 +7742,8 @@ description: Variables in memory after executing utility-sink.kcl
           },
           "artifactId": "[uuid]",
           "originalId": "[uuid]",
-          "units": "mm",
-          "isClosed": "implicitly"
+          "originSketchId": "[uuid]",
+          "units": "mm"
         }
       },
       {
@@ -7912,8 +7916,8 @@ description: Variables in memory after executing utility-sink.kcl
           },
           "artifactId": "[uuid]",
           "originalId": "[uuid]",
-          "units": "mm",
-          "isClosed": "implicitly"
+          "originSketchId": "[uuid]",
+          "units": "mm"
         }
       },
       {
@@ -8086,8 +8090,8 @@ description: Variables in memory after executing utility-sink.kcl
           },
           "artifactId": "[uuid]",
           "originalId": "[uuid]",
-          "units": "mm",
-          "isClosed": "implicitly"
+          "originSketchId": "[uuid]",
+          "units": "mm"
         }
       }
     ]
@@ -8265,8 +8269,8 @@ description: Variables in memory after executing utility-sink.kcl
           },
           "artifactId": "[uuid]",
           "originalId": "[uuid]",
-          "units": "mm",
-          "isClosed": "implicitly"
+          "originSketchId": "[uuid]",
+          "units": "mm"
         }
       },
       {
@@ -8439,8 +8443,8 @@ description: Variables in memory after executing utility-sink.kcl
           },
           "artifactId": "[uuid]",
           "originalId": "[uuid]",
-          "units": "mm",
-          "isClosed": "implicitly"
+          "originSketchId": "[uuid]",
+          "units": "mm"
         }
       }
     ]
@@ -8460,10 +8464,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 2159,
-                "end": 2167,
+                "commentStart": 2221,
+                "end": 2229,
                 "moduleId": 0,
-                "start": 2159,
+                "start": 2221,
                 "type": "TagDeclarator",
                 "value": "leftEdge"
               },
@@ -8474,10 +8478,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 2234,
-                "end": 2241,
+                "commentStart": 2296,
+                "end": 2303,
                 "moduleId": 0,
-                "start": 2234,
+                "start": 2296,
                 "type": "TagDeclarator",
                 "value": "topEdge"
               },
@@ -8488,10 +8492,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 2311,
-                "end": 2320,
+                "commentStart": 2373,
+                "end": 2382,
                 "moduleId": 0,
-                "start": 2311,
+                "start": 2373,
                 "type": "TagDeclarator",
                 "value": "rightEdge"
               },
@@ -8502,10 +8506,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 2391,
-                "end": 2401,
+                "commentStart": 2453,
+                "end": 2463,
                 "moduleId": 0,
-                "start": 2391,
+                "start": 2453,
                 "type": "TagDeclarator",
                 "value": "bottomEdge"
               },
@@ -8527,10 +8531,10 @@ description: Variables in memory after executing utility-sink.kcl
                   0.0
                 ],
                 "tag": {
-                  "commentStart": 2159,
-                  "end": 2167,
+                  "commentStart": 2221,
+                  "end": 2229,
                   "moduleId": 0,
-                  "start": 2159,
+                  "start": 2221,
                   "type": "TagDeclarator",
                   "value": "leftEdge"
                 },
@@ -8551,10 +8555,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 2234,
-                  "end": 2241,
+                  "commentStart": 2296,
+                  "end": 2303,
                   "moduleId": 0,
-                  "start": 2234,
+                  "start": 2296,
                   "type": "TagDeclarator",
                   "value": "topEdge"
                 },
@@ -8575,10 +8579,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 2311,
-                  "end": 2320,
+                  "commentStart": 2373,
+                  "end": 2382,
                   "moduleId": 0,
-                  "start": 2311,
+                  "start": 2373,
                   "type": "TagDeclarator",
                   "value": "rightEdge"
                 },
@@ -8599,10 +8603,10 @@ description: Variables in memory after executing utility-sink.kcl
                   0.0
                 ],
                 "tag": {
-                  "commentStart": 2391,
-                  "end": 2401,
+                  "commentStart": 2453,
+                  "end": 2463,
                   "moduleId": 0,
-                  "start": 2391,
+                  "start": 2453,
                   "type": "TagDeclarator",
                   "value": "bottomEdge"
                 },
@@ -8681,6 +8685,7 @@ description: Variables in memory after executing utility-sink.kcl
             },
             "artifactId": "[uuid]",
             "originalId": "[uuid]",
+            "originSketchId": "[uuid]",
             "units": "mm"
           },
           "startCapId": "[uuid]",
@@ -8711,10 +8716,10 @@ description: Variables in memory after executing utility-sink.kcl
                   0.0
                 ],
                 "tag": {
-                  "commentStart": 2159,
-                  "end": 2167,
+                  "commentStart": 2221,
+                  "end": 2229,
                   "moduleId": 0,
-                  "start": 2159,
+                  "start": 2221,
                   "type": "TagDeclarator",
                   "value": "leftEdge"
                 },
@@ -8735,10 +8740,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 2234,
-                  "end": 2241,
+                  "commentStart": 2296,
+                  "end": 2303,
                   "moduleId": 0,
-                  "start": 2234,
+                  "start": 2296,
                   "type": "TagDeclarator",
                   "value": "topEdge"
                 },
@@ -8759,10 +8764,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 2311,
-                  "end": 2320,
+                  "commentStart": 2373,
+                  "end": 2382,
                   "moduleId": 0,
-                  "start": 2311,
+                  "start": 2373,
                   "type": "TagDeclarator",
                   "value": "rightEdge"
                 },
@@ -8783,10 +8788,10 @@ description: Variables in memory after executing utility-sink.kcl
                   0.0
                 ],
                 "tag": {
-                  "commentStart": 2391,
-                  "end": 2401,
+                  "commentStart": 2453,
+                  "end": 2463,
                   "moduleId": 0,
-                  "start": 2391,
+                  "start": 2453,
                   "type": "TagDeclarator",
                   "value": "bottomEdge"
                 },
@@ -8865,6 +8870,7 @@ description: Variables in memory after executing utility-sink.kcl
             },
             "artifactId": "[uuid]",
             "originalId": "[uuid]",
+            "originSketchId": "[uuid]",
             "units": "mm"
           },
           "startCapId": "[uuid]",
@@ -8890,10 +8896,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 3635,
-                "end": 3643,
+                "commentStart": 3766,
+                "end": 3774,
                 "moduleId": 0,
-                "start": 3635,
+                "start": 3766,
                 "type": "TagDeclarator",
                 "value": "leftEdge"
               },
@@ -8904,10 +8910,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 3710,
-                "end": 3717,
+                "commentStart": 3841,
+                "end": 3848,
                 "moduleId": 0,
-                "start": 3710,
+                "start": 3841,
                 "type": "TagDeclarator",
                 "value": "topEdge"
               },
@@ -8918,10 +8924,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 3786,
-                "end": 3795,
+                "commentStart": 3917,
+                "end": 3926,
                 "moduleId": 0,
-                "start": 3786,
+                "start": 3917,
                 "type": "TagDeclarator",
                 "value": "rightEdge"
               },
@@ -8932,10 +8938,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 3864,
-                "end": 3874,
+                "commentStart": 3995,
+                "end": 4005,
                 "moduleId": 0,
-                "start": 3864,
+                "start": 3995,
                 "type": "TagDeclarator",
                 "value": "bottomEdge"
               },
@@ -8957,10 +8963,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 3635,
-                  "end": 3643,
+                  "commentStart": 3766,
+                  "end": 3774,
                   "moduleId": 0,
-                  "start": 3635,
+                  "start": 3766,
                   "type": "TagDeclarator",
                   "value": "leftEdge"
                 },
@@ -8981,10 +8987,10 @@ description: Variables in memory after executing utility-sink.kcl
                   587.0
                 ],
                 "tag": {
-                  "commentStart": 3710,
-                  "end": 3717,
+                  "commentStart": 3841,
+                  "end": 3848,
                   "moduleId": 0,
-                  "start": 3710,
+                  "start": 3841,
                   "type": "TagDeclarator",
                   "value": "topEdge"
                 },
@@ -9005,10 +9011,10 @@ description: Variables in memory after executing utility-sink.kcl
                   587.0
                 ],
                 "tag": {
-                  "commentStart": 3786,
-                  "end": 3795,
+                  "commentStart": 3917,
+                  "end": 3926,
                   "moduleId": 0,
-                  "start": 3786,
+                  "start": 3917,
                   "type": "TagDeclarator",
                   "value": "rightEdge"
                 },
@@ -9029,10 +9035,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 3864,
-                  "end": 3874,
+                  "commentStart": 3995,
+                  "end": 4005,
                   "moduleId": 0,
-                  "start": 3864,
+                  "start": 3995,
                   "type": "TagDeclarator",
                   "value": "bottomEdge"
                 },
@@ -9111,6 +9117,7 @@ description: Variables in memory after executing utility-sink.kcl
             },
             "artifactId": "[uuid]",
             "originalId": "[uuid]",
+            "originSketchId": "[uuid]",
             "units": "mm"
           },
           "startCapId": "[uuid]",
@@ -9141,10 +9148,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 3635,
-                  "end": 3643,
+                  "commentStart": 3766,
+                  "end": 3774,
                   "moduleId": 0,
-                  "start": 3635,
+                  "start": 3766,
                   "type": "TagDeclarator",
                   "value": "leftEdge"
                 },
@@ -9165,10 +9172,10 @@ description: Variables in memory after executing utility-sink.kcl
                   587.0
                 ],
                 "tag": {
-                  "commentStart": 3710,
-                  "end": 3717,
+                  "commentStart": 3841,
+                  "end": 3848,
                   "moduleId": 0,
-                  "start": 3710,
+                  "start": 3841,
                   "type": "TagDeclarator",
                   "value": "topEdge"
                 },
@@ -9189,10 +9196,10 @@ description: Variables in memory after executing utility-sink.kcl
                   587.0
                 ],
                 "tag": {
-                  "commentStart": 3786,
-                  "end": 3795,
+                  "commentStart": 3917,
+                  "end": 3926,
                   "moduleId": 0,
-                  "start": 3786,
+                  "start": 3917,
                   "type": "TagDeclarator",
                   "value": "rightEdge"
                 },
@@ -9213,10 +9220,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 3864,
-                  "end": 3874,
+                  "commentStart": 3995,
+                  "end": 4005,
                   "moduleId": 0,
-                  "start": 3864,
+                  "start": 3995,
                   "type": "TagDeclarator",
                   "value": "bottomEdge"
                 },
@@ -9295,6 +9302,7 @@ description: Variables in memory after executing utility-sink.kcl
             },
             "artifactId": "[uuid]",
             "originalId": "[uuid]",
+            "originSketchId": "[uuid]",
             "units": "mm"
           },
           "startCapId": "[uuid]",
@@ -9627,10 +9635,10 @@ description: Variables in memory after executing utility-sink.kcl
                     0.0
                   ],
                   "tag": {
-                    "commentStart": 2159,
-                    "end": 2167,
+                    "commentStart": 2221,
+                    "end": 2229,
                     "moduleId": 0,
-                    "start": 2159,
+                    "start": 2221,
                     "type": "TagDeclarator",
                     "value": "leftEdge"
                   },
@@ -9651,10 +9659,10 @@ description: Variables in memory after executing utility-sink.kcl
                     13.0
                   ],
                   "tag": {
-                    "commentStart": 2234,
-                    "end": 2241,
+                    "commentStart": 2296,
+                    "end": 2303,
                     "moduleId": 0,
-                    "start": 2234,
+                    "start": 2296,
                     "type": "TagDeclarator",
                     "value": "topEdge"
                   },
@@ -9675,10 +9683,10 @@ description: Variables in memory after executing utility-sink.kcl
                     13.0
                   ],
                   "tag": {
-                    "commentStart": 2311,
-                    "end": 2320,
+                    "commentStart": 2373,
+                    "end": 2382,
                     "moduleId": 0,
-                    "start": 2311,
+                    "start": 2373,
                     "type": "TagDeclarator",
                     "value": "rightEdge"
                   },
@@ -9699,10 +9707,10 @@ description: Variables in memory after executing utility-sink.kcl
                     0.0
                   ],
                   "tag": {
-                    "commentStart": 2391,
-                    "end": 2401,
+                    "commentStart": 2453,
+                    "end": 2463,
                     "moduleId": 0,
-                    "start": 2391,
+                    "start": 2453,
                     "type": "TagDeclarator",
                     "value": "bottomEdge"
                   },
@@ -10171,10 +10179,10 @@ description: Variables in memory after executing utility-sink.kcl
                 0.0
               ],
               "tag": {
-                "commentStart": 2159,
-                "end": 2167,
+                "commentStart": 2221,
+                "end": 2229,
                 "moduleId": 0,
-                "start": 2159,
+                "start": 2221,
                 "type": "TagDeclarator",
                 "value": "leftEdge"
               },
@@ -10195,10 +10203,10 @@ description: Variables in memory after executing utility-sink.kcl
                 13.0
               ],
               "tag": {
-                "commentStart": 2234,
-                "end": 2241,
+                "commentStart": 2296,
+                "end": 2303,
                 "moduleId": 0,
-                "start": 2234,
+                "start": 2296,
                 "type": "TagDeclarator",
                 "value": "topEdge"
               },
@@ -10219,10 +10227,10 @@ description: Variables in memory after executing utility-sink.kcl
                 13.0
               ],
               "tag": {
-                "commentStart": 2311,
-                "end": 2320,
+                "commentStart": 2373,
+                "end": 2382,
                 "moduleId": 0,
-                "start": 2311,
+                "start": 2373,
                 "type": "TagDeclarator",
                 "value": "rightEdge"
               },
@@ -10243,10 +10251,10 @@ description: Variables in memory after executing utility-sink.kcl
                 0.0
               ],
               "tag": {
-                "commentStart": 2391,
-                "end": 2401,
+                "commentStart": 2453,
+                "end": 2463,
                 "moduleId": 0,
-                "start": 2391,
+                "start": 2453,
                 "type": "TagDeclarator",
                 "value": "bottomEdge"
               },
@@ -10325,8 +10333,8 @@ description: Variables in memory after executing utility-sink.kcl
           },
           "artifactId": "[uuid]",
           "originalId": "[uuid]",
-          "units": "mm",
-          "isClosed": "implicitly"
+          "originSketchId": "[uuid]",
+          "units": "mm"
         }
       },
       {
@@ -10345,10 +10353,10 @@ description: Variables in memory after executing utility-sink.kcl
                 0.0
               ],
               "tag": {
-                "commentStart": 2159,
-                "end": 2167,
+                "commentStart": 2221,
+                "end": 2229,
                 "moduleId": 0,
-                "start": 2159,
+                "start": 2221,
                 "type": "TagDeclarator",
                 "value": "leftEdge"
               },
@@ -10369,10 +10377,10 @@ description: Variables in memory after executing utility-sink.kcl
                 13.0
               ],
               "tag": {
-                "commentStart": 2234,
-                "end": 2241,
+                "commentStart": 2296,
+                "end": 2303,
                 "moduleId": 0,
-                "start": 2234,
+                "start": 2296,
                 "type": "TagDeclarator",
                 "value": "topEdge"
               },
@@ -10393,10 +10401,10 @@ description: Variables in memory after executing utility-sink.kcl
                 13.0
               ],
               "tag": {
-                "commentStart": 2311,
-                "end": 2320,
+                "commentStart": 2373,
+                "end": 2382,
                 "moduleId": 0,
-                "start": 2311,
+                "start": 2373,
                 "type": "TagDeclarator",
                 "value": "rightEdge"
               },
@@ -10417,10 +10425,10 @@ description: Variables in memory after executing utility-sink.kcl
                 0.0
               ],
               "tag": {
-                "commentStart": 2391,
-                "end": 2401,
+                "commentStart": 2453,
+                "end": 2463,
                 "moduleId": 0,
-                "start": 2391,
+                "start": 2453,
                 "type": "TagDeclarator",
                 "value": "bottomEdge"
               },
@@ -10499,8 +10507,8 @@ description: Variables in memory after executing utility-sink.kcl
           },
           "artifactId": "[uuid]",
           "originalId": "[uuid]",
-          "units": "mm",
-          "isClosed": "implicitly"
+          "originSketchId": "[uuid]",
+          "units": "mm"
         }
       }
     ]
@@ -10521,10 +10529,10 @@ description: Variables in memory after executing utility-sink.kcl
             0.0
           ],
           "tag": {
-            "commentStart": 2159,
-            "end": 2167,
+            "commentStart": 2221,
+            "end": 2229,
             "moduleId": 0,
-            "start": 2159,
+            "start": 2221,
             "type": "TagDeclarator",
             "value": "leftEdge"
           },
@@ -10545,10 +10553,10 @@ description: Variables in memory after executing utility-sink.kcl
             13.0
           ],
           "tag": {
-            "commentStart": 2234,
-            "end": 2241,
+            "commentStart": 2296,
+            "end": 2303,
             "moduleId": 0,
-            "start": 2234,
+            "start": 2296,
             "type": "TagDeclarator",
             "value": "topEdge"
           },
@@ -10569,10 +10577,10 @@ description: Variables in memory after executing utility-sink.kcl
             13.0
           ],
           "tag": {
-            "commentStart": 2311,
-            "end": 2320,
+            "commentStart": 2373,
+            "end": 2382,
             "moduleId": 0,
-            "start": 2311,
+            "start": 2373,
             "type": "TagDeclarator",
             "value": "rightEdge"
           },
@@ -10593,10 +10601,10 @@ description: Variables in memory after executing utility-sink.kcl
             0.0
           ],
           "tag": {
-            "commentStart": 2391,
-            "end": 2401,
+            "commentStart": 2453,
+            "end": 2463,
             "moduleId": 0,
-            "start": 2391,
+            "start": 2453,
             "type": "TagDeclarator",
             "value": "bottomEdge"
           },
@@ -10675,8 +10683,8 @@ description: Variables in memory after executing utility-sink.kcl
       },
       "artifactId": "[uuid]",
       "originalId": "[uuid]",
-      "units": "mm",
-      "isClosed": "implicitly"
+      "originSketchId": "[uuid]",
+      "units": "mm"
     }
   },
   "lowerBeltYProfile": {
@@ -10941,10 +10949,10 @@ description: Variables in memory after executing utility-sink.kcl
                     13.0
                   ],
                   "tag": {
-                    "commentStart": 3635,
-                    "end": 3643,
+                    "commentStart": 3766,
+                    "end": 3774,
                     "moduleId": 0,
-                    "start": 3635,
+                    "start": 3766,
                     "type": "TagDeclarator",
                     "value": "leftEdge"
                   },
@@ -10965,10 +10973,10 @@ description: Variables in memory after executing utility-sink.kcl
                     587.0
                   ],
                   "tag": {
-                    "commentStart": 3710,
-                    "end": 3717,
+                    "commentStart": 3841,
+                    "end": 3848,
                     "moduleId": 0,
-                    "start": 3710,
+                    "start": 3841,
                     "type": "TagDeclarator",
                     "value": "topEdge"
                   },
@@ -10989,10 +10997,10 @@ description: Variables in memory after executing utility-sink.kcl
                     587.0
                   ],
                   "tag": {
-                    "commentStart": 3786,
-                    "end": 3795,
+                    "commentStart": 3917,
+                    "end": 3926,
                     "moduleId": 0,
-                    "start": 3786,
+                    "start": 3917,
                     "type": "TagDeclarator",
                     "value": "rightEdge"
                   },
@@ -11013,10 +11021,10 @@ description: Variables in memory after executing utility-sink.kcl
                     13.0
                   ],
                   "tag": {
-                    "commentStart": 3864,
-                    "end": 3874,
+                    "commentStart": 3995,
+                    "end": 4005,
                     "moduleId": 0,
-                    "start": 3864,
+                    "start": 3995,
                     "type": "TagDeclarator",
                     "value": "bottomEdge"
                   },
@@ -11485,10 +11493,10 @@ description: Variables in memory after executing utility-sink.kcl
                 13.0
               ],
               "tag": {
-                "commentStart": 3635,
-                "end": 3643,
+                "commentStart": 3766,
+                "end": 3774,
                 "moduleId": 0,
-                "start": 3635,
+                "start": 3766,
                 "type": "TagDeclarator",
                 "value": "leftEdge"
               },
@@ -11509,10 +11517,10 @@ description: Variables in memory after executing utility-sink.kcl
                 587.0
               ],
               "tag": {
-                "commentStart": 3710,
-                "end": 3717,
+                "commentStart": 3841,
+                "end": 3848,
                 "moduleId": 0,
-                "start": 3710,
+                "start": 3841,
                 "type": "TagDeclarator",
                 "value": "topEdge"
               },
@@ -11533,10 +11541,10 @@ description: Variables in memory after executing utility-sink.kcl
                 587.0
               ],
               "tag": {
-                "commentStart": 3786,
-                "end": 3795,
+                "commentStart": 3917,
+                "end": 3926,
                 "moduleId": 0,
-                "start": 3786,
+                "start": 3917,
                 "type": "TagDeclarator",
                 "value": "rightEdge"
               },
@@ -11557,10 +11565,10 @@ description: Variables in memory after executing utility-sink.kcl
                 13.0
               ],
               "tag": {
-                "commentStart": 3864,
-                "end": 3874,
+                "commentStart": 3995,
+                "end": 4005,
                 "moduleId": 0,
-                "start": 3864,
+                "start": 3995,
                 "type": "TagDeclarator",
                 "value": "bottomEdge"
               },
@@ -11639,8 +11647,8 @@ description: Variables in memory after executing utility-sink.kcl
           },
           "artifactId": "[uuid]",
           "originalId": "[uuid]",
-          "units": "mm",
-          "isClosed": "implicitly"
+          "originSketchId": "[uuid]",
+          "units": "mm"
         }
       },
       {
@@ -11659,10 +11667,10 @@ description: Variables in memory after executing utility-sink.kcl
                 13.0
               ],
               "tag": {
-                "commentStart": 3635,
-                "end": 3643,
+                "commentStart": 3766,
+                "end": 3774,
                 "moduleId": 0,
-                "start": 3635,
+                "start": 3766,
                 "type": "TagDeclarator",
                 "value": "leftEdge"
               },
@@ -11683,10 +11691,10 @@ description: Variables in memory after executing utility-sink.kcl
                 587.0
               ],
               "tag": {
-                "commentStart": 3710,
-                "end": 3717,
+                "commentStart": 3841,
+                "end": 3848,
                 "moduleId": 0,
-                "start": 3710,
+                "start": 3841,
                 "type": "TagDeclarator",
                 "value": "topEdge"
               },
@@ -11707,10 +11715,10 @@ description: Variables in memory after executing utility-sink.kcl
                 587.0
               ],
               "tag": {
-                "commentStart": 3786,
-                "end": 3795,
+                "commentStart": 3917,
+                "end": 3926,
                 "moduleId": 0,
-                "start": 3786,
+                "start": 3917,
                 "type": "TagDeclarator",
                 "value": "rightEdge"
               },
@@ -11731,10 +11739,10 @@ description: Variables in memory after executing utility-sink.kcl
                 13.0
               ],
               "tag": {
-                "commentStart": 3864,
-                "end": 3874,
+                "commentStart": 3995,
+                "end": 4005,
                 "moduleId": 0,
-                "start": 3864,
+                "start": 3995,
                 "type": "TagDeclarator",
                 "value": "bottomEdge"
               },
@@ -11813,8 +11821,8 @@ description: Variables in memory after executing utility-sink.kcl
           },
           "artifactId": "[uuid]",
           "originalId": "[uuid]",
-          "units": "mm",
-          "isClosed": "implicitly"
+          "originSketchId": "[uuid]",
+          "units": "mm"
         }
       }
     ]
@@ -11843,10 +11851,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 21477,
-                "end": 21485,
+                "commentStart": 21815,
+                "end": 21823,
                 "moduleId": 0,
-                "start": 21477,
+                "start": 21815,
                 "type": "TagDeclarator",
                 "value": "leftEdge"
               },
@@ -11857,10 +11865,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 21552,
-                "end": 21559,
+                "commentStart": 21890,
+                "end": 21897,
                 "moduleId": 0,
-                "start": 21552,
+                "start": 21890,
                 "type": "TagDeclarator",
                 "value": "topEdge"
               },
@@ -11871,10 +11879,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 21628,
-                "end": 21637,
+                "commentStart": 21966,
+                "end": 21975,
                 "moduleId": 0,
-                "start": 21628,
+                "start": 21966,
                 "type": "TagDeclarator",
                 "value": "rightEdge"
               },
@@ -11885,10 +11893,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 21706,
-                "end": 21716,
+                "commentStart": 22044,
+                "end": 22054,
                 "moduleId": 0,
-                "start": 21706,
+                "start": 22044,
                 "type": "TagDeclarator",
                 "value": "bottomEdge"
               },
@@ -11910,10 +11918,10 @@ description: Variables in memory after executing utility-sink.kcl
                   15.0
                 ],
                 "tag": {
-                  "commentStart": 21477,
-                  "end": 21485,
+                  "commentStart": 21815,
+                  "end": 21823,
                   "moduleId": 0,
-                  "start": 21477,
+                  "start": 21815,
                   "type": "TagDeclarator",
                   "value": "leftEdge"
                 },
@@ -11934,10 +11942,10 @@ description: Variables in memory after executing utility-sink.kcl
                   585.0
                 ],
                 "tag": {
-                  "commentStart": 21552,
-                  "end": 21559,
+                  "commentStart": 21890,
+                  "end": 21897,
                   "moduleId": 0,
-                  "start": 21552,
+                  "start": 21890,
                   "type": "TagDeclarator",
                   "value": "topEdge"
                 },
@@ -11958,10 +11966,10 @@ description: Variables in memory after executing utility-sink.kcl
                   585.0
                 ],
                 "tag": {
-                  "commentStart": 21628,
-                  "end": 21637,
+                  "commentStart": 21966,
+                  "end": 21975,
                   "moduleId": 0,
-                  "start": 21628,
+                  "start": 21966,
                   "type": "TagDeclarator",
                   "value": "rightEdge"
                 },
@@ -11982,10 +11990,10 @@ description: Variables in memory after executing utility-sink.kcl
                   15.0
                 ],
                 "tag": {
-                  "commentStart": 21706,
-                  "end": 21716,
+                  "commentStart": 22044,
+                  "end": 22054,
                   "moduleId": 0,
-                  "start": 21706,
+                  "start": 22044,
                   "type": "TagDeclarator",
                   "value": "bottomEdge"
                 },
@@ -12085,10 +12093,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 21477,
-                "end": 21485,
+                "commentStart": 21815,
+                "end": 21823,
                 "moduleId": 0,
-                "start": 21477,
+                "start": 21815,
                 "type": "TagDeclarator",
                 "value": "leftEdge"
               },
@@ -12099,10 +12107,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 21552,
-                "end": 21559,
+                "commentStart": 21890,
+                "end": 21897,
                 "moduleId": 0,
-                "start": 21552,
+                "start": 21890,
                 "type": "TagDeclarator",
                 "value": "topEdge"
               },
@@ -12113,10 +12121,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 21628,
-                "end": 21637,
+                "commentStart": 21966,
+                "end": 21975,
                 "moduleId": 0,
-                "start": 21628,
+                "start": 21966,
                 "type": "TagDeclarator",
                 "value": "rightEdge"
               },
@@ -12127,10 +12135,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 21706,
-                "end": 21716,
+                "commentStart": 22044,
+                "end": 22054,
                 "moduleId": 0,
-                "start": 21706,
+                "start": 22044,
                 "type": "TagDeclarator",
                 "value": "bottomEdge"
               },
@@ -12152,10 +12160,10 @@ description: Variables in memory after executing utility-sink.kcl
                   15.0
                 ],
                 "tag": {
-                  "commentStart": 21477,
-                  "end": 21485,
+                  "commentStart": 21815,
+                  "end": 21823,
                   "moduleId": 0,
-                  "start": 21477,
+                  "start": 21815,
                   "type": "TagDeclarator",
                   "value": "leftEdge"
                 },
@@ -12176,10 +12184,10 @@ description: Variables in memory after executing utility-sink.kcl
                   585.0
                 ],
                 "tag": {
-                  "commentStart": 21552,
-                  "end": 21559,
+                  "commentStart": 21890,
+                  "end": 21897,
                   "moduleId": 0,
-                  "start": 21552,
+                  "start": 21890,
                   "type": "TagDeclarator",
                   "value": "topEdge"
                 },
@@ -12200,10 +12208,10 @@ description: Variables in memory after executing utility-sink.kcl
                   585.0
                 ],
                 "tag": {
-                  "commentStart": 21628,
-                  "end": 21637,
+                  "commentStart": 21966,
+                  "end": 21975,
                   "moduleId": 0,
-                  "start": 21628,
+                  "start": 21966,
                   "type": "TagDeclarator",
                   "value": "rightEdge"
                 },
@@ -12224,10 +12232,10 @@ description: Variables in memory after executing utility-sink.kcl
                   15.0
                 ],
                 "tag": {
-                  "commentStart": 21706,
-                  "end": 21716,
+                  "commentStart": 22044,
+                  "end": 22054,
                   "moduleId": 0,
-                  "start": 21706,
+                  "start": 22044,
                   "type": "TagDeclarator",
                   "value": "bottomEdge"
                 },
@@ -12588,10 +12596,10 @@ description: Variables in memory after executing utility-sink.kcl
                     15.0
                   ],
                   "tag": {
-                    "commentStart": 21477,
-                    "end": 21485,
+                    "commentStart": 21815,
+                    "end": 21823,
                     "moduleId": 0,
-                    "start": 21477,
+                    "start": 21815,
                     "type": "TagDeclarator",
                     "value": "leftEdge"
                   },
@@ -12612,10 +12620,10 @@ description: Variables in memory after executing utility-sink.kcl
                     585.0
                   ],
                   "tag": {
-                    "commentStart": 21552,
-                    "end": 21559,
+                    "commentStart": 21890,
+                    "end": 21897,
                     "moduleId": 0,
-                    "start": 21552,
+                    "start": 21890,
                     "type": "TagDeclarator",
                     "value": "topEdge"
                   },
@@ -12636,10 +12644,10 @@ description: Variables in memory after executing utility-sink.kcl
                     585.0
                   ],
                   "tag": {
-                    "commentStart": 21628,
-                    "end": 21637,
+                    "commentStart": 21966,
+                    "end": 21975,
                     "moduleId": 0,
-                    "start": 21628,
+                    "start": 21966,
                     "type": "TagDeclarator",
                     "value": "rightEdge"
                   },
@@ -12660,10 +12668,10 @@ description: Variables in memory after executing utility-sink.kcl
                     15.0
                   ],
                   "tag": {
-                    "commentStart": 21706,
-                    "end": 21716,
+                    "commentStart": 22044,
+                    "end": 22054,
                     "moduleId": 0,
-                    "start": 21706,
+                    "start": 22044,
                     "type": "TagDeclarator",
                     "value": "bottomEdge"
                   },
@@ -13129,10 +13137,10 @@ description: Variables in memory after executing utility-sink.kcl
             15.0
           ],
           "tag": {
-            "commentStart": 21477,
-            "end": 21485,
+            "commentStart": 21815,
+            "end": 21823,
             "moduleId": 0,
-            "start": 21477,
+            "start": 21815,
             "type": "TagDeclarator",
             "value": "leftEdge"
           },
@@ -13153,10 +13161,10 @@ description: Variables in memory after executing utility-sink.kcl
             585.0
           ],
           "tag": {
-            "commentStart": 21552,
-            "end": 21559,
+            "commentStart": 21890,
+            "end": 21897,
             "moduleId": 0,
-            "start": 21552,
+            "start": 21890,
             "type": "TagDeclarator",
             "value": "topEdge"
           },
@@ -13177,10 +13185,10 @@ description: Variables in memory after executing utility-sink.kcl
             585.0
           ],
           "tag": {
-            "commentStart": 21628,
-            "end": 21637,
+            "commentStart": 21966,
+            "end": 21975,
             "moduleId": 0,
-            "start": 21628,
+            "start": 21966,
             "type": "TagDeclarator",
             "value": "rightEdge"
           },
@@ -13201,10 +13209,10 @@ description: Variables in memory after executing utility-sink.kcl
             15.0
           ],
           "tag": {
-            "commentStart": 21706,
-            "end": 21716,
+            "commentStart": 22044,
+            "end": 22054,
             "moduleId": 0,
-            "start": 21706,
+            "start": 22044,
             "type": "TagDeclarator",
             "value": "bottomEdge"
           },
@@ -13299,10 +13307,10 @@ description: Variables in memory after executing utility-sink.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
-            "commentStart": 21477,
-            "end": 21485,
+            "commentStart": 21815,
+            "end": 21823,
             "moduleId": 0,
-            "start": 21477,
+            "start": 21815,
             "type": "TagDeclarator",
             "value": "leftEdge"
           },
@@ -13313,10 +13321,10 @@ description: Variables in memory after executing utility-sink.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
-            "commentStart": 21552,
-            "end": 21559,
+            "commentStart": 21890,
+            "end": 21897,
             "moduleId": 0,
-            "start": 21552,
+            "start": 21890,
             "type": "TagDeclarator",
             "value": "topEdge"
           },
@@ -13327,10 +13335,10 @@ description: Variables in memory after executing utility-sink.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
-            "commentStart": 21628,
-            "end": 21637,
+            "commentStart": 21966,
+            "end": 21975,
             "moduleId": 0,
-            "start": 21628,
+            "start": 21966,
             "type": "TagDeclarator",
             "value": "rightEdge"
           },
@@ -13341,10 +13349,10 @@ description: Variables in memory after executing utility-sink.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
-            "commentStart": 21706,
-            "end": 21716,
+            "commentStart": 22044,
+            "end": 22054,
             "moduleId": 0,
-            "start": 21706,
+            "start": 22044,
             "type": "TagDeclarator",
             "value": "bottomEdge"
           },
@@ -13366,10 +13374,10 @@ description: Variables in memory after executing utility-sink.kcl
               15.0
             ],
             "tag": {
-              "commentStart": 21477,
-              "end": 21485,
+              "commentStart": 21815,
+              "end": 21823,
               "moduleId": 0,
-              "start": 21477,
+              "start": 21815,
               "type": "TagDeclarator",
               "value": "leftEdge"
             },
@@ -13390,10 +13398,10 @@ description: Variables in memory after executing utility-sink.kcl
               585.0
             ],
             "tag": {
-              "commentStart": 21552,
-              "end": 21559,
+              "commentStart": 21890,
+              "end": 21897,
               "moduleId": 0,
-              "start": 21552,
+              "start": 21890,
               "type": "TagDeclarator",
               "value": "topEdge"
             },
@@ -13414,10 +13422,10 @@ description: Variables in memory after executing utility-sink.kcl
               585.0
             ],
             "tag": {
-              "commentStart": 21628,
-              "end": 21637,
+              "commentStart": 21966,
+              "end": 21975,
               "moduleId": 0,
-              "start": 21628,
+              "start": 21966,
               "type": "TagDeclarator",
               "value": "rightEdge"
             },
@@ -13438,10 +13446,10 @@ description: Variables in memory after executing utility-sink.kcl
               15.0
             ],
             "tag": {
-              "commentStart": 21706,
-              "end": 21716,
+              "commentStart": 22044,
+              "end": 22054,
               "moduleId": 0,
-              "start": 21706,
+              "start": 22044,
               "type": "TagDeclarator",
               "value": "bottomEdge"
             },
@@ -13562,10 +13570,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 5174,
-                "end": 5182,
+                "commentStart": 5374,
+                "end": 5382,
                 "moduleId": 0,
-                "start": 5174,
+                "start": 5374,
                 "type": "TagDeclarator",
                 "value": "leftEdge"
               },
@@ -13576,10 +13584,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 5251,
-                "end": 5258,
+                "commentStart": 5451,
+                "end": 5458,
                 "moduleId": 0,
-                "start": 5251,
+                "start": 5451,
                 "type": "TagDeclarator",
                 "value": "topEdge"
               },
@@ -13590,10 +13598,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 5328,
-                "end": 5337,
+                "commentStart": 5528,
+                "end": 5537,
                 "moduleId": 0,
-                "start": 5328,
+                "start": 5528,
                 "type": "TagDeclarator",
                 "value": "rightEdge"
               },
@@ -13604,10 +13612,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 5406,
-                "end": 5416,
+                "commentStart": 5606,
+                "end": 5616,
                 "moduleId": 0,
-                "start": 5406,
+                "start": 5606,
                 "type": "TagDeclarator",
                 "value": "bottomEdge"
               },
@@ -13629,10 +13637,10 @@ description: Variables in memory after executing utility-sink.kcl
                   0.0
                 ],
                 "tag": {
-                  "commentStart": 5174,
-                  "end": 5182,
+                  "commentStart": 5374,
+                  "end": 5382,
                   "moduleId": 0,
-                  "start": 5174,
+                  "start": 5374,
                   "type": "TagDeclarator",
                   "value": "leftEdge"
                 },
@@ -13653,10 +13661,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 5251,
-                  "end": 5258,
+                  "commentStart": 5451,
+                  "end": 5458,
                   "moduleId": 0,
-                  "start": 5251,
+                  "start": 5451,
                   "type": "TagDeclarator",
                   "value": "topEdge"
                 },
@@ -13677,10 +13685,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 5328,
-                  "end": 5337,
+                  "commentStart": 5528,
+                  "end": 5537,
                   "moduleId": 0,
-                  "start": 5328,
+                  "start": 5528,
                   "type": "TagDeclarator",
                   "value": "rightEdge"
                 },
@@ -13701,10 +13709,10 @@ description: Variables in memory after executing utility-sink.kcl
                   0.0
                 ],
                 "tag": {
-                  "commentStart": 5406,
-                  "end": 5416,
+                  "commentStart": 5606,
+                  "end": 5616,
                   "moduleId": 0,
-                  "start": 5406,
+                  "start": 5606,
                   "type": "TagDeclarator",
                   "value": "bottomEdge"
                 },
@@ -13814,10 +13822,10 @@ description: Variables in memory after executing utility-sink.kcl
                   0.0
                 ],
                 "tag": {
-                  "commentStart": 5174,
-                  "end": 5182,
+                  "commentStart": 5374,
+                  "end": 5382,
                   "moduleId": 0,
-                  "start": 5174,
+                  "start": 5374,
                   "type": "TagDeclarator",
                   "value": "leftEdge"
                 },
@@ -13838,10 +13846,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 5251,
-                  "end": 5258,
+                  "commentStart": 5451,
+                  "end": 5458,
                   "moduleId": 0,
-                  "start": 5251,
+                  "start": 5451,
                   "type": "TagDeclarator",
                   "value": "topEdge"
                 },
@@ -13862,10 +13870,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 5328,
-                  "end": 5337,
+                  "commentStart": 5528,
+                  "end": 5537,
                   "moduleId": 0,
-                  "start": 5328,
+                  "start": 5528,
                   "type": "TagDeclarator",
                   "value": "rightEdge"
                 },
@@ -13886,10 +13894,10 @@ description: Variables in memory after executing utility-sink.kcl
                   0.0
                 ],
                 "tag": {
-                  "commentStart": 5406,
-                  "end": 5416,
+                  "commentStart": 5606,
+                  "end": 5616,
                   "moduleId": 0,
-                  "start": 5406,
+                  "start": 5606,
                   "type": "TagDeclarator",
                   "value": "bottomEdge"
                 },
@@ -14283,10 +14291,10 @@ description: Variables in memory after executing utility-sink.kcl
                     0.0
                   ],
                   "tag": {
-                    "commentStart": 5174,
-                    "end": 5182,
+                    "commentStart": 5374,
+                    "end": 5382,
                     "moduleId": 0,
-                    "start": 5174,
+                    "start": 5374,
                     "type": "TagDeclarator",
                     "value": "leftEdge"
                   },
@@ -14307,10 +14315,10 @@ description: Variables in memory after executing utility-sink.kcl
                     13.0
                   ],
                   "tag": {
-                    "commentStart": 5251,
-                    "end": 5258,
+                    "commentStart": 5451,
+                    "end": 5458,
                     "moduleId": 0,
-                    "start": 5251,
+                    "start": 5451,
                     "type": "TagDeclarator",
                     "value": "topEdge"
                   },
@@ -14331,10 +14339,10 @@ description: Variables in memory after executing utility-sink.kcl
                     13.0
                   ],
                   "tag": {
-                    "commentStart": 5328,
-                    "end": 5337,
+                    "commentStart": 5528,
+                    "end": 5537,
                     "moduleId": 0,
-                    "start": 5328,
+                    "start": 5528,
                     "type": "TagDeclarator",
                     "value": "rightEdge"
                   },
@@ -14355,10 +14363,10 @@ description: Variables in memory after executing utility-sink.kcl
                     0.0
                   ],
                   "tag": {
-                    "commentStart": 5406,
-                    "end": 5416,
+                    "commentStart": 5606,
+                    "end": 5616,
                     "moduleId": 0,
-                    "start": 5406,
+                    "start": 5606,
                     "type": "TagDeclarator",
                     "value": "bottomEdge"
                   },
@@ -14827,10 +14835,10 @@ description: Variables in memory after executing utility-sink.kcl
                 0.0
               ],
               "tag": {
-                "commentStart": 5174,
-                "end": 5182,
+                "commentStart": 5374,
+                "end": 5382,
                 "moduleId": 0,
-                "start": 5174,
+                "start": 5374,
                 "type": "TagDeclarator",
                 "value": "leftEdge"
               },
@@ -14851,10 +14859,10 @@ description: Variables in memory after executing utility-sink.kcl
                 13.0
               ],
               "tag": {
-                "commentStart": 5251,
-                "end": 5258,
+                "commentStart": 5451,
+                "end": 5458,
                 "moduleId": 0,
-                "start": 5251,
+                "start": 5451,
                 "type": "TagDeclarator",
                 "value": "topEdge"
               },
@@ -14875,10 +14883,10 @@ description: Variables in memory after executing utility-sink.kcl
                 13.0
               ],
               "tag": {
-                "commentStart": 5328,
-                "end": 5337,
+                "commentStart": 5528,
+                "end": 5537,
                 "moduleId": 0,
-                "start": 5328,
+                "start": 5528,
                 "type": "TagDeclarator",
                 "value": "rightEdge"
               },
@@ -14899,10 +14907,10 @@ description: Variables in memory after executing utility-sink.kcl
                 0.0
               ],
               "tag": {
-                "commentStart": 5406,
-                "end": 5416,
+                "commentStart": 5606,
+                "end": 5616,
                 "moduleId": 0,
-                "start": 5406,
+                "start": 5606,
                 "type": "TagDeclarator",
                 "value": "bottomEdge"
               },
@@ -15001,10 +15009,10 @@ description: Variables in memory after executing utility-sink.kcl
                 0.0
               ],
               "tag": {
-                "commentStart": 5174,
-                "end": 5182,
+                "commentStart": 5374,
+                "end": 5382,
                 "moduleId": 0,
-                "start": 5174,
+                "start": 5374,
                 "type": "TagDeclarator",
                 "value": "leftEdge"
               },
@@ -15025,10 +15033,10 @@ description: Variables in memory after executing utility-sink.kcl
                 13.0
               ],
               "tag": {
-                "commentStart": 5251,
-                "end": 5258,
+                "commentStart": 5451,
+                "end": 5458,
                 "moduleId": 0,
-                "start": 5251,
+                "start": 5451,
                 "type": "TagDeclarator",
                 "value": "topEdge"
               },
@@ -15049,10 +15057,10 @@ description: Variables in memory after executing utility-sink.kcl
                 13.0
               ],
               "tag": {
-                "commentStart": 5328,
-                "end": 5337,
+                "commentStart": 5528,
+                "end": 5537,
                 "moduleId": 0,
-                "start": 5328,
+                "start": 5528,
                 "type": "TagDeclarator",
                 "value": "rightEdge"
               },
@@ -15073,10 +15081,10 @@ description: Variables in memory after executing utility-sink.kcl
                 0.0
               ],
               "tag": {
-                "commentStart": 5406,
-                "end": 5416,
+                "commentStart": 5606,
+                "end": 5616,
                 "moduleId": 0,
-                "start": 5406,
+                "start": 5606,
                 "type": "TagDeclarator",
                 "value": "bottomEdge"
               },
@@ -15176,10 +15184,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 5174,
-                "end": 5182,
+                "commentStart": 5374,
+                "end": 5382,
                 "moduleId": 0,
-                "start": 5174,
+                "start": 5374,
                 "type": "TagDeclarator",
                 "value": "leftEdge"
               },
@@ -15190,10 +15198,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 5251,
-                "end": 5258,
+                "commentStart": 5451,
+                "end": 5458,
                 "moduleId": 0,
-                "start": 5251,
+                "start": 5451,
                 "type": "TagDeclarator",
                 "value": "topEdge"
               },
@@ -15204,10 +15212,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 5328,
-                "end": 5337,
+                "commentStart": 5528,
+                "end": 5537,
                 "moduleId": 0,
-                "start": 5328,
+                "start": 5528,
                 "type": "TagDeclarator",
                 "value": "rightEdge"
               },
@@ -15218,10 +15226,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 5406,
-                "end": 5416,
+                "commentStart": 5606,
+                "end": 5616,
                 "moduleId": 0,
-                "start": 5406,
+                "start": 5606,
                 "type": "TagDeclarator",
                 "value": "bottomEdge"
               },
@@ -15243,10 +15251,10 @@ description: Variables in memory after executing utility-sink.kcl
                   0.0
                 ],
                 "tag": {
-                  "commentStart": 5174,
-                  "end": 5182,
+                  "commentStart": 5374,
+                  "end": 5382,
                   "moduleId": 0,
-                  "start": 5174,
+                  "start": 5374,
                   "type": "TagDeclarator",
                   "value": "leftEdge"
                 },
@@ -15267,10 +15275,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 5251,
-                  "end": 5258,
+                  "commentStart": 5451,
+                  "end": 5458,
                   "moduleId": 0,
-                  "start": 5251,
+                  "start": 5451,
                   "type": "TagDeclarator",
                   "value": "topEdge"
                 },
@@ -15291,10 +15299,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 5328,
-                  "end": 5337,
+                  "commentStart": 5528,
+                  "end": 5537,
                   "moduleId": 0,
-                  "start": 5328,
+                  "start": 5528,
                   "type": "TagDeclarator",
                   "value": "rightEdge"
                 },
@@ -15315,10 +15323,10 @@ description: Variables in memory after executing utility-sink.kcl
                   0.0
                 ],
                 "tag": {
-                  "commentStart": 5406,
-                  "end": 5416,
+                  "commentStart": 5606,
+                  "end": 5616,
                   "moduleId": 0,
-                  "start": 5406,
+                  "start": 5606,
                   "type": "TagDeclarator",
                   "value": "bottomEdge"
                 },
@@ -15428,10 +15436,10 @@ description: Variables in memory after executing utility-sink.kcl
                   0.0
                 ],
                 "tag": {
-                  "commentStart": 5174,
-                  "end": 5182,
+                  "commentStart": 5374,
+                  "end": 5382,
                   "moduleId": 0,
-                  "start": 5174,
+                  "start": 5374,
                   "type": "TagDeclarator",
                   "value": "leftEdge"
                 },
@@ -15452,10 +15460,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 5251,
-                  "end": 5258,
+                  "commentStart": 5451,
+                  "end": 5458,
                   "moduleId": 0,
-                  "start": 5251,
+                  "start": 5451,
                   "type": "TagDeclarator",
                   "value": "topEdge"
                 },
@@ -15476,10 +15484,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 5328,
-                  "end": 5337,
+                  "commentStart": 5528,
+                  "end": 5537,
                   "moduleId": 0,
-                  "start": 5328,
+                  "start": 5528,
                   "type": "TagDeclarator",
                   "value": "rightEdge"
                 },
@@ -15500,10 +15508,10 @@ description: Variables in memory after executing utility-sink.kcl
                   0.0
                 ],
                 "tag": {
-                  "commentStart": 5406,
-                  "end": 5416,
+                  "commentStart": 5606,
+                  "end": 5616,
                   "moduleId": 0,
-                  "start": 5406,
+                  "start": 5606,
                   "type": "TagDeclarator",
                   "value": "bottomEdge"
                 },
@@ -15643,10 +15651,10 @@ description: Variables in memory after executing utility-sink.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
-            "commentStart": 12212,
-            "end": 12220,
+            "commentStart": 12550,
+            "end": 12558,
             "moduleId": 0,
-            "start": 12212,
+            "start": 12550,
             "type": "TagDeclarator",
             "value": "leftEdge"
           },
@@ -15657,10 +15665,10 @@ description: Variables in memory after executing utility-sink.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
-            "commentStart": 12291,
-            "end": 12298,
+            "commentStart": 12629,
+            "end": 12636,
             "moduleId": 0,
-            "start": 12291,
+            "start": 12629,
             "type": "TagDeclarator",
             "value": "topEdge"
           },
@@ -15671,10 +15679,10 @@ description: Variables in memory after executing utility-sink.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
-            "commentStart": 12370,
-            "end": 12379,
+            "commentStart": 12708,
+            "end": 12717,
             "moduleId": 0,
-            "start": 12370,
+            "start": 12708,
             "type": "TagDeclarator",
             "value": "rightEdge"
           },
@@ -15685,10 +15693,10 @@ description: Variables in memory after executing utility-sink.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
-            "commentStart": 12450,
-            "end": 12460,
+            "commentStart": 12788,
+            "end": 12798,
             "moduleId": 0,
-            "start": 12450,
+            "start": 12788,
             "type": "TagDeclarator",
             "value": "bottomEdge"
           },
@@ -15710,10 +15718,10 @@ description: Variables in memory after executing utility-sink.kcl
               42.0
             ],
             "tag": {
-              "commentStart": 12212,
-              "end": 12220,
+              "commentStart": 12550,
+              "end": 12558,
               "moduleId": 0,
-              "start": 12212,
+              "start": 12550,
               "type": "TagDeclarator",
               "value": "leftEdge"
             },
@@ -15734,10 +15742,10 @@ description: Variables in memory after executing utility-sink.kcl
               488.0
             ],
             "tag": {
-              "commentStart": 12291,
-              "end": 12298,
+              "commentStart": 12629,
+              "end": 12636,
               "moduleId": 0,
-              "start": 12291,
+              "start": 12629,
               "type": "TagDeclarator",
               "value": "topEdge"
             },
@@ -15758,10 +15766,10 @@ description: Variables in memory after executing utility-sink.kcl
               488.0
             ],
             "tag": {
-              "commentStart": 12370,
-              "end": 12379,
+              "commentStart": 12708,
+              "end": 12717,
               "moduleId": 0,
-              "start": 12370,
+              "start": 12708,
               "type": "TagDeclarator",
               "value": "rightEdge"
             },
@@ -15782,10 +15790,10 @@ description: Variables in memory after executing utility-sink.kcl
               42.0
             ],
             "tag": {
-              "commentStart": 12450,
-              "end": 12460,
+              "commentStart": 12788,
+              "end": 12798,
               "moduleId": 0,
-              "start": 12450,
+              "start": 12788,
               "type": "TagDeclarator",
               "value": "bottomEdge"
             },
@@ -15879,10 +15887,10 @@ description: Variables in memory after executing utility-sink.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
-            "commentStart": 10617,
-            "end": 10625,
+            "commentStart": 10955,
+            "end": 10963,
             "moduleId": 0,
-            "start": 10617,
+            "start": 10955,
             "type": "TagDeclarator",
             "value": "leftEdge"
           },
@@ -15893,10 +15901,10 @@ description: Variables in memory after executing utility-sink.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
-            "commentStart": 10698,
-            "end": 10705,
+            "commentStart": 11036,
+            "end": 11043,
             "moduleId": 0,
-            "start": 10698,
+            "start": 11036,
             "type": "TagDeclarator",
             "value": "topEdge"
           },
@@ -15907,10 +15915,10 @@ description: Variables in memory after executing utility-sink.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
-            "commentStart": 10779,
-            "end": 10788,
+            "commentStart": 11117,
+            "end": 11126,
             "moduleId": 0,
-            "start": 10779,
+            "start": 11117,
             "type": "TagDeclarator",
             "value": "rightEdge"
           },
@@ -15921,10 +15929,10 @@ description: Variables in memory after executing utility-sink.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
-            "commentStart": 10861,
-            "end": 10871,
+            "commentStart": 11199,
+            "end": 11209,
             "moduleId": 0,
-            "start": 10861,
+            "start": 11199,
             "type": "TagDeclarator",
             "value": "bottomEdge"
           },
@@ -15946,10 +15954,10 @@ description: Variables in memory after executing utility-sink.kcl
               40.0
             ],
             "tag": {
-              "commentStart": 10617,
-              "end": 10625,
+              "commentStart": 10955,
+              "end": 10963,
               "moduleId": 0,
-              "start": 10617,
+              "start": 10955,
               "type": "TagDeclarator",
               "value": "leftEdge"
             },
@@ -15970,10 +15978,10 @@ description: Variables in memory after executing utility-sink.kcl
               490.0
             ],
             "tag": {
-              "commentStart": 10698,
-              "end": 10705,
+              "commentStart": 11036,
+              "end": 11043,
               "moduleId": 0,
-              "start": 10698,
+              "start": 11036,
               "type": "TagDeclarator",
               "value": "topEdge"
             },
@@ -15994,10 +16002,10 @@ description: Variables in memory after executing utility-sink.kcl
               490.0
             ],
             "tag": {
-              "commentStart": 10779,
-              "end": 10788,
+              "commentStart": 11117,
+              "end": 11126,
               "moduleId": 0,
-              "start": 10779,
+              "start": 11117,
               "type": "TagDeclarator",
               "value": "rightEdge"
             },
@@ -16018,10 +16026,10 @@ description: Variables in memory after executing utility-sink.kcl
               40.0
             ],
             "tag": {
-              "commentStart": 10861,
-              "end": 10871,
+              "commentStart": 11199,
+              "end": 11209,
               "moduleId": 0,
-              "start": 10861,
+              "start": 11199,
               "type": "TagDeclarator",
               "value": "bottomEdge"
             },
@@ -16486,10 +16494,10 @@ description: Variables in memory after executing utility-sink.kcl
                     42.0
                   ],
                   "tag": {
-                    "commentStart": 12212,
-                    "end": 12220,
+                    "commentStart": 12550,
+                    "end": 12558,
                     "moduleId": 0,
-                    "start": 12212,
+                    "start": 12550,
                     "type": "TagDeclarator",
                     "value": "leftEdge"
                   },
@@ -16510,10 +16518,10 @@ description: Variables in memory after executing utility-sink.kcl
                     488.0
                   ],
                   "tag": {
-                    "commentStart": 12291,
-                    "end": 12298,
+                    "commentStart": 12629,
+                    "end": 12636,
                     "moduleId": 0,
-                    "start": 12291,
+                    "start": 12629,
                     "type": "TagDeclarator",
                     "value": "topEdge"
                   },
@@ -16534,10 +16542,10 @@ description: Variables in memory after executing utility-sink.kcl
                     488.0
                   ],
                   "tag": {
-                    "commentStart": 12370,
-                    "end": 12379,
+                    "commentStart": 12708,
+                    "end": 12717,
                     "moduleId": 0,
-                    "start": 12370,
+                    "start": 12708,
                     "type": "TagDeclarator",
                     "value": "rightEdge"
                   },
@@ -16558,10 +16566,10 @@ description: Variables in memory after executing utility-sink.kcl
                     42.0
                   ],
                   "tag": {
-                    "commentStart": 12450,
-                    "end": 12460,
+                    "commentStart": 12788,
+                    "end": 12798,
                     "moduleId": 0,
-                    "start": 12450,
+                    "start": 12788,
                     "type": "TagDeclarator",
                     "value": "bottomEdge"
                   },
@@ -17003,10 +17011,10 @@ description: Variables in memory after executing utility-sink.kcl
             42.0
           ],
           "tag": {
-            "commentStart": 12212,
-            "end": 12220,
+            "commentStart": 12550,
+            "end": 12558,
             "moduleId": 0,
-            "start": 12212,
+            "start": 12550,
             "type": "TagDeclarator",
             "value": "leftEdge"
           },
@@ -17027,10 +17035,10 @@ description: Variables in memory after executing utility-sink.kcl
             488.0
           ],
           "tag": {
-            "commentStart": 12291,
-            "end": 12298,
+            "commentStart": 12629,
+            "end": 12636,
             "moduleId": 0,
-            "start": 12291,
+            "start": 12629,
             "type": "TagDeclarator",
             "value": "topEdge"
           },
@@ -17051,10 +17059,10 @@ description: Variables in memory after executing utility-sink.kcl
             488.0
           ],
           "tag": {
-            "commentStart": 12370,
-            "end": 12379,
+            "commentStart": 12708,
+            "end": 12717,
             "moduleId": 0,
-            "start": 12370,
+            "start": 12708,
             "type": "TagDeclarator",
             "value": "rightEdge"
           },
@@ -17075,10 +17083,10 @@ description: Variables in memory after executing utility-sink.kcl
             42.0
           ],
           "tag": {
-            "commentStart": 12450,
-            "end": 12460,
+            "commentStart": 12788,
+            "end": 12798,
             "moduleId": 0,
-            "start": 12450,
+            "start": 12788,
             "type": "TagDeclarator",
             "value": "bottomEdge"
           },
@@ -17547,10 +17555,10 @@ description: Variables in memory after executing utility-sink.kcl
                     40.0
                   ],
                   "tag": {
-                    "commentStart": 10617,
-                    "end": 10625,
+                    "commentStart": 10955,
+                    "end": 10963,
                     "moduleId": 0,
-                    "start": 10617,
+                    "start": 10955,
                     "type": "TagDeclarator",
                     "value": "leftEdge"
                   },
@@ -17571,10 +17579,10 @@ description: Variables in memory after executing utility-sink.kcl
                     490.0
                   ],
                   "tag": {
-                    "commentStart": 10698,
-                    "end": 10705,
+                    "commentStart": 11036,
+                    "end": 11043,
                     "moduleId": 0,
-                    "start": 10698,
+                    "start": 11036,
                     "type": "TagDeclarator",
                     "value": "topEdge"
                   },
@@ -17595,10 +17603,10 @@ description: Variables in memory after executing utility-sink.kcl
                     490.0
                   ],
                   "tag": {
-                    "commentStart": 10779,
-                    "end": 10788,
+                    "commentStart": 11117,
+                    "end": 11126,
                     "moduleId": 0,
-                    "start": 10779,
+                    "start": 11117,
                     "type": "TagDeclarator",
                     "value": "rightEdge"
                   },
@@ -17619,10 +17627,10 @@ description: Variables in memory after executing utility-sink.kcl
                     40.0
                   ],
                   "tag": {
-                    "commentStart": 10861,
-                    "end": 10871,
+                    "commentStart": 11199,
+                    "end": 11209,
                     "moduleId": 0,
-                    "start": 10861,
+                    "start": 11199,
                     "type": "TagDeclarator",
                     "value": "bottomEdge"
                   },
@@ -18064,10 +18072,10 @@ description: Variables in memory after executing utility-sink.kcl
             40.0
           ],
           "tag": {
-            "commentStart": 10617,
-            "end": 10625,
+            "commentStart": 10955,
+            "end": 10963,
             "moduleId": 0,
-            "start": 10617,
+            "start": 10955,
             "type": "TagDeclarator",
             "value": "leftEdge"
           },
@@ -18088,10 +18096,10 @@ description: Variables in memory after executing utility-sink.kcl
             490.0
           ],
           "tag": {
-            "commentStart": 10698,
-            "end": 10705,
+            "commentStart": 11036,
+            "end": 11043,
             "moduleId": 0,
-            "start": 10698,
+            "start": 11036,
             "type": "TagDeclarator",
             "value": "topEdge"
           },
@@ -18112,10 +18120,10 @@ description: Variables in memory after executing utility-sink.kcl
             490.0
           ],
           "tag": {
-            "commentStart": 10779,
-            "end": 10788,
+            "commentStart": 11117,
+            "end": 11126,
             "moduleId": 0,
-            "start": 10779,
+            "start": 11117,
             "type": "TagDeclarator",
             "value": "rightEdge"
           },
@@ -18136,10 +18144,10 @@ description: Variables in memory after executing utility-sink.kcl
             40.0
           ],
           "tag": {
-            "commentStart": 10861,
-            "end": 10871,
+            "commentStart": 11199,
+            "end": 11209,
             "moduleId": 0,
-            "start": 10861,
+            "start": 11199,
             "type": "TagDeclarator",
             "value": "bottomEdge"
           },
@@ -18318,10 +18326,10 @@ description: Variables in memory after executing utility-sink.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
-            "commentStart": 9092,
-            "end": 9100,
+            "commentStart": 9430,
+            "end": 9438,
             "moduleId": 0,
-            "start": 9092,
+            "start": 9430,
             "type": "TagDeclarator",
             "value": "leftEdge"
           },
@@ -18332,10 +18340,10 @@ description: Variables in memory after executing utility-sink.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
-            "commentStart": 9166,
-            "end": 9173,
+            "commentStart": 9504,
+            "end": 9511,
             "moduleId": 0,
-            "start": 9166,
+            "start": 9504,
             "type": "TagDeclarator",
             "value": "topEdge"
           },
@@ -18346,10 +18354,10 @@ description: Variables in memory after executing utility-sink.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
-            "commentStart": 9244,
-            "end": 9253,
+            "commentStart": 9582,
+            "end": 9591,
             "moduleId": 0,
-            "start": 9244,
+            "start": 9582,
             "type": "TagDeclarator",
             "value": "rightEdge"
           },
@@ -18360,10 +18368,10 @@ description: Variables in memory after executing utility-sink.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
-            "commentStart": 9325,
-            "end": 9335,
+            "commentStart": 9663,
+            "end": 9673,
             "moduleId": 0,
-            "start": 9325,
+            "start": 9663,
             "type": "TagDeclarator",
             "value": "bottomEdge"
           },
@@ -18385,10 +18393,10 @@ description: Variables in memory after executing utility-sink.kcl
               0.0
             ],
             "tag": {
-              "commentStart": 9092,
-              "end": 9100,
+              "commentStart": 9430,
+              "end": 9438,
               "moduleId": 0,
-              "start": 9092,
+              "start": 9430,
               "type": "TagDeclarator",
               "value": "leftEdge"
             },
@@ -18409,10 +18417,10 @@ description: Variables in memory after executing utility-sink.kcl
               600.0
             ],
             "tag": {
-              "commentStart": 9166,
-              "end": 9173,
+              "commentStart": 9504,
+              "end": 9511,
               "moduleId": 0,
-              "start": 9166,
+              "start": 9504,
               "type": "TagDeclarator",
               "value": "topEdge"
             },
@@ -18433,10 +18441,10 @@ description: Variables in memory after executing utility-sink.kcl
               600.0
             ],
             "tag": {
-              "commentStart": 9244,
-              "end": 9253,
+              "commentStart": 9582,
+              "end": 9591,
               "moduleId": 0,
-              "start": 9244,
+              "start": 9582,
               "type": "TagDeclarator",
               "value": "rightEdge"
             },
@@ -18457,10 +18465,10 @@ description: Variables in memory after executing utility-sink.kcl
               0.0
             ],
             "tag": {
-              "commentStart": 9325,
-              "end": 9335,
+              "commentStart": 9663,
+              "end": 9673,
               "moduleId": 0,
-              "start": 9325,
+              "start": 9663,
               "type": "TagDeclarator",
               "value": "bottomEdge"
             },
@@ -18843,10 +18851,10 @@ description: Variables in memory after executing utility-sink.kcl
                     0.0
                   ],
                   "tag": {
-                    "commentStart": 9092,
-                    "end": 9100,
+                    "commentStart": 9430,
+                    "end": 9438,
                     "moduleId": 0,
-                    "start": 9092,
+                    "start": 9430,
                     "type": "TagDeclarator",
                     "value": "leftEdge"
                   },
@@ -18867,10 +18875,10 @@ description: Variables in memory after executing utility-sink.kcl
                     600.0
                   ],
                   "tag": {
-                    "commentStart": 9166,
-                    "end": 9173,
+                    "commentStart": 9504,
+                    "end": 9511,
                     "moduleId": 0,
-                    "start": 9166,
+                    "start": 9504,
                     "type": "TagDeclarator",
                     "value": "topEdge"
                   },
@@ -18891,10 +18899,10 @@ description: Variables in memory after executing utility-sink.kcl
                     600.0
                   ],
                   "tag": {
-                    "commentStart": 9244,
-                    "end": 9253,
+                    "commentStart": 9582,
+                    "end": 9591,
                     "moduleId": 0,
-                    "start": 9244,
+                    "start": 9582,
                     "type": "TagDeclarator",
                     "value": "rightEdge"
                   },
@@ -18915,10 +18923,10 @@ description: Variables in memory after executing utility-sink.kcl
                     0.0
                   ],
                   "tag": {
-                    "commentStart": 9325,
-                    "end": 9335,
+                    "commentStart": 9663,
+                    "end": 9673,
                     "moduleId": 0,
-                    "start": 9325,
+                    "start": 9663,
                     "type": "TagDeclarator",
                     "value": "bottomEdge"
                   },
@@ -19263,10 +19271,10 @@ description: Variables in memory after executing utility-sink.kcl
             0.0
           ],
           "tag": {
-            "commentStart": 9092,
-            "end": 9100,
+            "commentStart": 9430,
+            "end": 9438,
             "moduleId": 0,
-            "start": 9092,
+            "start": 9430,
             "type": "TagDeclarator",
             "value": "leftEdge"
           },
@@ -19287,10 +19295,10 @@ description: Variables in memory after executing utility-sink.kcl
             600.0
           ],
           "tag": {
-            "commentStart": 9166,
-            "end": 9173,
+            "commentStart": 9504,
+            "end": 9511,
             "moduleId": 0,
-            "start": 9166,
+            "start": 9504,
             "type": "TagDeclarator",
             "value": "topEdge"
           },
@@ -19311,10 +19319,10 @@ description: Variables in memory after executing utility-sink.kcl
             600.0
           ],
           "tag": {
-            "commentStart": 9244,
-            "end": 9253,
+            "commentStart": 9582,
+            "end": 9591,
             "moduleId": 0,
-            "start": 9244,
+            "start": 9582,
             "type": "TagDeclarator",
             "value": "rightEdge"
           },
@@ -19335,10 +19343,10 @@ description: Variables in memory after executing utility-sink.kcl
             0.0
           ],
           "tag": {
-            "commentStart": 9325,
-            "end": 9335,
+            "commentStart": 9663,
+            "end": 9673,
             "moduleId": 0,
-            "start": 9325,
+            "start": 9663,
             "type": "TagDeclarator",
             "value": "bottomEdge"
           },
@@ -19442,10 +19450,10 @@ description: Variables in memory after executing utility-sink.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
-            "commentStart": 17900,
-            "end": 17915,
+            "commentStart": 18238,
+            "end": 18253,
             "moduleId": 0,
-            "start": 17900,
+            "start": 18238,
             "type": "TagDeclarator",
             "value": "tapHandleCircle"
           },
@@ -19473,10 +19481,10 @@ description: Variables in memory after executing utility-sink.kcl
             ],
             "radius": 4.000000000999989,
             "tag": {
-              "commentStart": 17900,
-              "end": 17915,
+              "commentStart": 18238,
+              "end": 18253,
               "moduleId": 0,
-              "start": 17900,
+              "start": 18238,
               "type": "TagDeclarator",
               "value": "tapHandleCircle"
             },
@@ -19579,10 +19587,10 @@ description: Variables in memory after executing utility-sink.kcl
           ],
           "radius": 4.000000000999989,
           "tag": {
-            "commentStart": 17900,
-            "end": 17915,
+            "commentStart": 18238,
+            "end": 18253,
             "moduleId": 0,
-            "start": 17900,
+            "start": 18238,
             "type": "TagDeclarator",
             "value": "tapHandleCircle"
           },
@@ -19665,10 +19673,10 @@ description: Variables in memory after executing utility-sink.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
-            "commentStart": 17900,
-            "end": 17915,
+            "commentStart": 18238,
+            "end": 18253,
             "moduleId": 0,
-            "start": 17900,
+            "start": 18238,
             "type": "TagDeclarator",
             "value": "tapHandleCircle"
           },
@@ -19696,10 +19704,10 @@ description: Variables in memory after executing utility-sink.kcl
             ],
             "radius": 4.000000000999989,
             "tag": {
-              "commentStart": 17900,
-              "end": 17915,
+              "commentStart": 18238,
+              "end": 18253,
               "moduleId": 0,
-              "start": 17900,
+              "start": 18238,
               "type": "TagDeclarator",
               "value": "tapHandleCircle"
             },
@@ -20045,10 +20053,10 @@ description: Variables in memory after executing utility-sink.kcl
                   ],
                   "radius": 4.000000000999989,
                   "tag": {
-                    "commentStart": 17900,
-                    "end": 17915,
+                    "commentStart": 18238,
+                    "end": 18253,
                     "moduleId": 0,
-                    "start": 17900,
+                    "start": 18238,
                     "type": "TagDeclarator",
                     "value": "tapHandleCircle"
                   },
@@ -20378,10 +20386,10 @@ description: Variables in memory after executing utility-sink.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
-            "commentStart": 16566,
-            "end": 16579,
+            "commentStart": 16904,
+            "end": 16917,
             "moduleId": 0,
-            "start": 16566,
+            "start": 16904,
             "type": "TagDeclarator",
             "value": "tapNoseCircle"
           },
@@ -20409,10 +20417,10 @@ description: Variables in memory after executing utility-sink.kcl
             ],
             "radius": 10.00000000099999,
             "tag": {
-              "commentStart": 16566,
-              "end": 16579,
+              "commentStart": 16904,
+              "end": 16917,
               "moduleId": 0,
-              "start": 16566,
+              "start": 16904,
               "type": "TagDeclarator",
               "value": "tapNoseCircle"
             },
@@ -20515,10 +20523,10 @@ description: Variables in memory after executing utility-sink.kcl
           ],
           "radius": 10.00000000099999,
           "tag": {
-            "commentStart": 16566,
-            "end": 16579,
+            "commentStart": 16904,
+            "end": 16917,
             "moduleId": 0,
-            "start": 16566,
+            "start": 16904,
             "type": "TagDeclarator",
             "value": "tapNoseCircle"
           },
@@ -20601,10 +20609,10 @@ description: Variables in memory after executing utility-sink.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
-            "commentStart": 16566,
-            "end": 16579,
+            "commentStart": 16904,
+            "end": 16917,
             "moduleId": 0,
-            "start": 16566,
+            "start": 16904,
             "type": "TagDeclarator",
             "value": "tapNoseCircle"
           },
@@ -20632,10 +20640,10 @@ description: Variables in memory after executing utility-sink.kcl
             ],
             "radius": 10.00000000099999,
             "tag": {
-              "commentStart": 16566,
-              "end": 16579,
+              "commentStart": 16904,
+              "end": 16917,
               "moduleId": 0,
-              "start": 16566,
+              "start": 16904,
               "type": "TagDeclarator",
               "value": "tapNoseCircle"
             },
@@ -20981,10 +20989,10 @@ description: Variables in memory after executing utility-sink.kcl
                   ],
                   "radius": 10.00000000099999,
                   "tag": {
-                    "commentStart": 16566,
-                    "end": 16579,
+                    "commentStart": 16904,
+                    "end": 16917,
                     "moduleId": 0,
-                    "start": 16566,
+                    "start": 16904,
                     "type": "TagDeclarator",
                     "value": "tapNoseCircle"
                   },
@@ -21314,10 +21322,10 @@ description: Variables in memory after executing utility-sink.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
-            "commentStart": 15212,
-            "end": 15227,
+            "commentStart": 15550,
+            "end": 15565,
             "moduleId": 0,
-            "start": 15212,
+            "start": 15550,
             "type": "TagDeclarator",
             "value": "tapPillarCircle"
           },
@@ -21345,10 +21353,10 @@ description: Variables in memory after executing utility-sink.kcl
             ],
             "radius": 15.00000000099999,
             "tag": {
-              "commentStart": 15212,
-              "end": 15227,
+              "commentStart": 15550,
+              "end": 15565,
               "moduleId": 0,
-              "start": 15212,
+              "start": 15550,
               "type": "TagDeclarator",
               "value": "tapPillarCircle"
             },
@@ -21451,10 +21459,10 @@ description: Variables in memory after executing utility-sink.kcl
           ],
           "radius": 15.00000000099999,
           "tag": {
-            "commentStart": 15212,
-            "end": 15227,
+            "commentStart": 15550,
+            "end": 15565,
             "moduleId": 0,
-            "start": 15212,
+            "start": 15550,
             "type": "TagDeclarator",
             "value": "tapPillarCircle"
           },
@@ -21537,10 +21545,10 @@ description: Variables in memory after executing utility-sink.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
-            "commentStart": 15212,
-            "end": 15227,
+            "commentStart": 15550,
+            "end": 15565,
             "moduleId": 0,
-            "start": 15212,
+            "start": 15550,
             "type": "TagDeclarator",
             "value": "tapPillarCircle"
           },
@@ -21568,10 +21576,10 @@ description: Variables in memory after executing utility-sink.kcl
             ],
             "radius": 15.00000000099999,
             "tag": {
-              "commentStart": 15212,
-              "end": 15227,
+              "commentStart": 15550,
+              "end": 15565,
               "moduleId": 0,
-              "start": 15212,
+              "start": 15550,
               "type": "TagDeclarator",
               "value": "tapPillarCircle"
             },
@@ -21917,10 +21925,10 @@ description: Variables in memory after executing utility-sink.kcl
                   ],
                   "radius": 15.00000000099999,
                   "tag": {
-                    "commentStart": 15212,
-                    "end": 15227,
+                    "commentStart": 15550,
+                    "end": 15565,
                     "moduleId": 0,
-                    "start": 15212,
+                    "start": 15550,
                     "type": "TagDeclarator",
                     "value": "tapPillarCircle"
                   },
@@ -22250,10 +22258,10 @@ description: Variables in memory after executing utility-sink.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
-            "commentStart": 13874,
-            "end": 13888,
+            "commentStart": 14212,
+            "end": 14226,
             "moduleId": 0,
-            "start": 13874,
+            "start": 14212,
             "type": "TagDeclarator",
             "value": "tapPlateCircle"
           },
@@ -22281,10 +22289,10 @@ description: Variables in memory after executing utility-sink.kcl
             ],
             "radius": 40.00000000099999,
             "tag": {
-              "commentStart": 13874,
-              "end": 13888,
+              "commentStart": 14212,
+              "end": 14226,
               "moduleId": 0,
-              "start": 13874,
+              "start": 14212,
               "type": "TagDeclarator",
               "value": "tapPlateCircle"
             },
@@ -22387,10 +22395,10 @@ description: Variables in memory after executing utility-sink.kcl
           ],
           "radius": 40.00000000099999,
           "tag": {
-            "commentStart": 13874,
-            "end": 13888,
+            "commentStart": 14212,
+            "end": 14226,
             "moduleId": 0,
-            "start": 13874,
+            "start": 14212,
             "type": "TagDeclarator",
             "value": "tapPlateCircle"
           },
@@ -22473,10 +22481,10 @@ description: Variables in memory after executing utility-sink.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
-            "commentStart": 13874,
-            "end": 13888,
+            "commentStart": 14212,
+            "end": 14226,
             "moduleId": 0,
-            "start": 13874,
+            "start": 14212,
             "type": "TagDeclarator",
             "value": "tapPlateCircle"
           },
@@ -22504,10 +22512,10 @@ description: Variables in memory after executing utility-sink.kcl
             ],
             "radius": 40.00000000099999,
             "tag": {
-              "commentStart": 13874,
-              "end": 13888,
+              "commentStart": 14212,
+              "end": 14226,
               "moduleId": 0,
-              "start": 13874,
+              "start": 14212,
               "type": "TagDeclarator",
               "value": "tapPlateCircle"
             },
@@ -22853,10 +22861,10 @@ description: Variables in memory after executing utility-sink.kcl
                   ],
                   "radius": 40.00000000099999,
                   "tag": {
-                    "commentStart": 13874,
-                    "end": 13888,
+                    "commentStart": 14212,
+                    "end": 14226,
                     "moduleId": 0,
-                    "start": 13874,
+                    "start": 14212,
                     "type": "TagDeclarator",
                     "value": "tapPlateCircle"
                   },
@@ -23194,10 +23202,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 6643,
-                "end": 6651,
+                "commentStart": 6843,
+                "end": 6851,
                 "moduleId": 0,
-                "start": 6643,
+                "start": 6843,
                 "type": "TagDeclarator",
                 "value": "leftEdge"
               },
@@ -23208,10 +23216,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 6716,
-                "end": 6723,
+                "commentStart": 6916,
+                "end": 6923,
                 "moduleId": 0,
-                "start": 6716,
+                "start": 6916,
                 "type": "TagDeclarator",
                 "value": "topEdge"
               },
@@ -23222,10 +23230,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 6792,
-                "end": 6801,
+                "commentStart": 6992,
+                "end": 7001,
                 "moduleId": 0,
-                "start": 6792,
+                "start": 6992,
                 "type": "TagDeclarator",
                 "value": "rightEdge"
               },
@@ -23236,10 +23244,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 6872,
-                "end": 6882,
+                "commentStart": 7072,
+                "end": 7082,
                 "moduleId": 0,
-                "start": 6872,
+                "start": 7072,
                 "type": "TagDeclarator",
                 "value": "bottomEdge"
               },
@@ -23261,10 +23269,10 @@ description: Variables in memory after executing utility-sink.kcl
                   0.0
                 ],
                 "tag": {
-                  "commentStart": 6643,
-                  "end": 6651,
+                  "commentStart": 6843,
+                  "end": 6851,
                   "moduleId": 0,
-                  "start": 6643,
+                  "start": 6843,
                   "type": "TagDeclarator",
                   "value": "leftEdge"
                 },
@@ -23285,10 +23293,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 6716,
-                  "end": 6723,
+                  "commentStart": 6916,
+                  "end": 6923,
                   "moduleId": 0,
-                  "start": 6716,
+                  "start": 6916,
                   "type": "TagDeclarator",
                   "value": "topEdge"
                 },
@@ -23309,10 +23317,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 6792,
-                  "end": 6801,
+                  "commentStart": 6992,
+                  "end": 7001,
                   "moduleId": 0,
-                  "start": 6792,
+                  "start": 6992,
                   "type": "TagDeclarator",
                   "value": "rightEdge"
                 },
@@ -23333,10 +23341,10 @@ description: Variables in memory after executing utility-sink.kcl
                   0.0
                 ],
                 "tag": {
-                  "commentStart": 6872,
-                  "end": 6882,
+                  "commentStart": 7072,
+                  "end": 7082,
                   "moduleId": 0,
-                  "start": 6872,
+                  "start": 7072,
                   "type": "TagDeclarator",
                   "value": "bottomEdge"
                 },
@@ -23415,6 +23423,7 @@ description: Variables in memory after executing utility-sink.kcl
             },
             "artifactId": "[uuid]",
             "originalId": "[uuid]",
+            "originSketchId": "[uuid]",
             "units": "mm"
           },
           "startCapId": "[uuid]",
@@ -23445,10 +23454,10 @@ description: Variables in memory after executing utility-sink.kcl
                   0.0
                 ],
                 "tag": {
-                  "commentStart": 6643,
-                  "end": 6651,
+                  "commentStart": 6843,
+                  "end": 6851,
                   "moduleId": 0,
-                  "start": 6643,
+                  "start": 6843,
                   "type": "TagDeclarator",
                   "value": "leftEdge"
                 },
@@ -23469,10 +23478,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 6716,
-                  "end": 6723,
+                  "commentStart": 6916,
+                  "end": 6923,
                   "moduleId": 0,
-                  "start": 6716,
+                  "start": 6916,
                   "type": "TagDeclarator",
                   "value": "topEdge"
                 },
@@ -23493,10 +23502,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 6792,
-                  "end": 6801,
+                  "commentStart": 6992,
+                  "end": 7001,
                   "moduleId": 0,
-                  "start": 6792,
+                  "start": 6992,
                   "type": "TagDeclarator",
                   "value": "rightEdge"
                 },
@@ -23517,10 +23526,10 @@ description: Variables in memory after executing utility-sink.kcl
                   0.0
                 ],
                 "tag": {
-                  "commentStart": 6872,
-                  "end": 6882,
+                  "commentStart": 7072,
+                  "end": 7082,
                   "moduleId": 0,
-                  "start": 6872,
+                  "start": 7072,
                   "type": "TagDeclarator",
                   "value": "bottomEdge"
                 },
@@ -23599,6 +23608,7 @@ description: Variables in memory after executing utility-sink.kcl
             },
             "artifactId": "[uuid]",
             "originalId": "[uuid]",
+            "originSketchId": "[uuid]",
             "units": "mm"
           },
           "startCapId": "[uuid]",
@@ -23624,10 +23634,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 7829,
-                "end": 7837,
+                "commentStart": 8098,
+                "end": 8106,
                 "moduleId": 0,
-                "start": 7829,
+                "start": 8098,
                 "type": "TagDeclarator",
                 "value": "leftEdge"
               },
@@ -23638,10 +23648,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 7904,
-                "end": 7911,
+                "commentStart": 8173,
+                "end": 8180,
                 "moduleId": 0,
-                "start": 7904,
+                "start": 8173,
                 "type": "TagDeclarator",
                 "value": "topEdge"
               },
@@ -23652,10 +23662,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 7980,
-                "end": 7989,
+                "commentStart": 8249,
+                "end": 8258,
                 "moduleId": 0,
-                "start": 7980,
+                "start": 8249,
                 "type": "TagDeclarator",
                 "value": "rightEdge"
               },
@@ -23666,10 +23676,10 @@ description: Variables in memory after executing utility-sink.kcl
               "id": "[uuid]",
               "sourceRange": [],
               "tag": {
-                "commentStart": 8058,
-                "end": 8068,
+                "commentStart": 8327,
+                "end": 8337,
                 "moduleId": 0,
-                "start": 8058,
+                "start": 8327,
                 "type": "TagDeclarator",
                 "value": "bottomEdge"
               },
@@ -23691,10 +23701,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 7829,
-                  "end": 7837,
+                  "commentStart": 8098,
+                  "end": 8106,
                   "moduleId": 0,
-                  "start": 7829,
+                  "start": 8098,
                   "type": "TagDeclarator",
                   "value": "leftEdge"
                 },
@@ -23715,10 +23725,10 @@ description: Variables in memory after executing utility-sink.kcl
                   587.0
                 ],
                 "tag": {
-                  "commentStart": 7904,
-                  "end": 7911,
+                  "commentStart": 8173,
+                  "end": 8180,
                   "moduleId": 0,
-                  "start": 7904,
+                  "start": 8173,
                   "type": "TagDeclarator",
                   "value": "topEdge"
                 },
@@ -23739,10 +23749,10 @@ description: Variables in memory after executing utility-sink.kcl
                   587.0
                 ],
                 "tag": {
-                  "commentStart": 7980,
-                  "end": 7989,
+                  "commentStart": 8249,
+                  "end": 8258,
                   "moduleId": 0,
-                  "start": 7980,
+                  "start": 8249,
                   "type": "TagDeclarator",
                   "value": "rightEdge"
                 },
@@ -23763,10 +23773,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 8058,
-                  "end": 8068,
+                  "commentStart": 8327,
+                  "end": 8337,
                   "moduleId": 0,
-                  "start": 8058,
+                  "start": 8327,
                   "type": "TagDeclarator",
                   "value": "bottomEdge"
                 },
@@ -23845,6 +23855,7 @@ description: Variables in memory after executing utility-sink.kcl
             },
             "artifactId": "[uuid]",
             "originalId": "[uuid]",
+            "originSketchId": "[uuid]",
             "units": "mm"
           },
           "startCapId": "[uuid]",
@@ -23875,10 +23886,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 7829,
-                  "end": 7837,
+                  "commentStart": 8098,
+                  "end": 8106,
                   "moduleId": 0,
-                  "start": 7829,
+                  "start": 8098,
                   "type": "TagDeclarator",
                   "value": "leftEdge"
                 },
@@ -23899,10 +23910,10 @@ description: Variables in memory after executing utility-sink.kcl
                   587.0
                 ],
                 "tag": {
-                  "commentStart": 7904,
-                  "end": 7911,
+                  "commentStart": 8173,
+                  "end": 8180,
                   "moduleId": 0,
-                  "start": 7904,
+                  "start": 8173,
                   "type": "TagDeclarator",
                   "value": "topEdge"
                 },
@@ -23923,10 +23934,10 @@ description: Variables in memory after executing utility-sink.kcl
                   587.0
                 ],
                 "tag": {
-                  "commentStart": 7980,
-                  "end": 7989,
+                  "commentStart": 8249,
+                  "end": 8258,
                   "moduleId": 0,
-                  "start": 7980,
+                  "start": 8249,
                   "type": "TagDeclarator",
                   "value": "rightEdge"
                 },
@@ -23947,10 +23958,10 @@ description: Variables in memory after executing utility-sink.kcl
                   13.0
                 ],
                 "tag": {
-                  "commentStart": 8058,
-                  "end": 8068,
+                  "commentStart": 8327,
+                  "end": 8337,
                   "moduleId": 0,
-                  "start": 8058,
+                  "start": 8327,
                   "type": "TagDeclarator",
                   "value": "bottomEdge"
                 },
@@ -24029,6 +24040,7 @@ description: Variables in memory after executing utility-sink.kcl
             },
             "artifactId": "[uuid]",
             "originalId": "[uuid]",
+            "originSketchId": "[uuid]",
             "units": "mm"
           },
           "startCapId": "[uuid]",
@@ -24343,10 +24355,10 @@ description: Variables in memory after executing utility-sink.kcl
                     0.0
                   ],
                   "tag": {
-                    "commentStart": 6643,
-                    "end": 6651,
+                    "commentStart": 6843,
+                    "end": 6851,
                     "moduleId": 0,
-                    "start": 6643,
+                    "start": 6843,
                     "type": "TagDeclarator",
                     "value": "leftEdge"
                   },
@@ -24367,10 +24379,10 @@ description: Variables in memory after executing utility-sink.kcl
                     13.0
                   ],
                   "tag": {
-                    "commentStart": 6716,
-                    "end": 6723,
+                    "commentStart": 6916,
+                    "end": 6923,
                     "moduleId": 0,
-                    "start": 6716,
+                    "start": 6916,
                     "type": "TagDeclarator",
                     "value": "topEdge"
                   },
@@ -24391,10 +24403,10 @@ description: Variables in memory after executing utility-sink.kcl
                     13.0
                   ],
                   "tag": {
-                    "commentStart": 6792,
-                    "end": 6801,
+                    "commentStart": 6992,
+                    "end": 7001,
                     "moduleId": 0,
-                    "start": 6792,
+                    "start": 6992,
                     "type": "TagDeclarator",
                     "value": "rightEdge"
                   },
@@ -24415,10 +24427,10 @@ description: Variables in memory after executing utility-sink.kcl
                     0.0
                   ],
                   "tag": {
-                    "commentStart": 6872,
-                    "end": 6882,
+                    "commentStart": 7072,
+                    "end": 7082,
                     "moduleId": 0,
-                    "start": 6872,
+                    "start": 7072,
                     "type": "TagDeclarator",
                     "value": "bottomEdge"
                   },
@@ -24766,10 +24778,10 @@ description: Variables in memory after executing utility-sink.kcl
                 0.0
               ],
               "tag": {
-                "commentStart": 6643,
-                "end": 6651,
+                "commentStart": 6843,
+                "end": 6851,
                 "moduleId": 0,
-                "start": 6643,
+                "start": 6843,
                 "type": "TagDeclarator",
                 "value": "leftEdge"
               },
@@ -24790,10 +24802,10 @@ description: Variables in memory after executing utility-sink.kcl
                 13.0
               ],
               "tag": {
-                "commentStart": 6716,
-                "end": 6723,
+                "commentStart": 6916,
+                "end": 6923,
                 "moduleId": 0,
-                "start": 6716,
+                "start": 6916,
                 "type": "TagDeclarator",
                 "value": "topEdge"
               },
@@ -24814,10 +24826,10 @@ description: Variables in memory after executing utility-sink.kcl
                 13.0
               ],
               "tag": {
-                "commentStart": 6792,
-                "end": 6801,
+                "commentStart": 6992,
+                "end": 7001,
                 "moduleId": 0,
-                "start": 6792,
+                "start": 6992,
                 "type": "TagDeclarator",
                 "value": "rightEdge"
               },
@@ -24838,10 +24850,10 @@ description: Variables in memory after executing utility-sink.kcl
                 0.0
               ],
               "tag": {
-                "commentStart": 6872,
-                "end": 6882,
+                "commentStart": 7072,
+                "end": 7082,
                 "moduleId": 0,
-                "start": 6872,
+                "start": 7072,
                 "type": "TagDeclarator",
                 "value": "bottomEdge"
               },
@@ -24920,8 +24932,8 @@ description: Variables in memory after executing utility-sink.kcl
           },
           "artifactId": "[uuid]",
           "originalId": "[uuid]",
-          "units": "mm",
-          "isClosed": "implicitly"
+          "originSketchId": "[uuid]",
+          "units": "mm"
         }
       },
       {
@@ -24940,10 +24952,10 @@ description: Variables in memory after executing utility-sink.kcl
                 0.0
               ],
               "tag": {
-                "commentStart": 6643,
-                "end": 6651,
+                "commentStart": 6843,
+                "end": 6851,
                 "moduleId": 0,
-                "start": 6643,
+                "start": 6843,
                 "type": "TagDeclarator",
                 "value": "leftEdge"
               },
@@ -24964,10 +24976,10 @@ description: Variables in memory after executing utility-sink.kcl
                 13.0
               ],
               "tag": {
-                "commentStart": 6716,
-                "end": 6723,
+                "commentStart": 6916,
+                "end": 6923,
                 "moduleId": 0,
-                "start": 6716,
+                "start": 6916,
                 "type": "TagDeclarator",
                 "value": "topEdge"
               },
@@ -24988,10 +25000,10 @@ description: Variables in memory after executing utility-sink.kcl
                 13.0
               ],
               "tag": {
-                "commentStart": 6792,
-                "end": 6801,
+                "commentStart": 6992,
+                "end": 7001,
                 "moduleId": 0,
-                "start": 6792,
+                "start": 6992,
                 "type": "TagDeclarator",
                 "value": "rightEdge"
               },
@@ -25012,10 +25024,10 @@ description: Variables in memory after executing utility-sink.kcl
                 0.0
               ],
               "tag": {
-                "commentStart": 6872,
-                "end": 6882,
+                "commentStart": 7072,
+                "end": 7082,
                 "moduleId": 0,
-                "start": 6872,
+                "start": 7072,
                 "type": "TagDeclarator",
                 "value": "bottomEdge"
               },
@@ -25094,8 +25106,8 @@ description: Variables in memory after executing utility-sink.kcl
           },
           "artifactId": "[uuid]",
           "originalId": "[uuid]",
-          "units": "mm",
-          "isClosed": "implicitly"
+          "originSketchId": "[uuid]",
+          "units": "mm"
         }
       }
     ]
@@ -25362,10 +25374,10 @@ description: Variables in memory after executing utility-sink.kcl
                     13.0
                   ],
                   "tag": {
-                    "commentStart": 7829,
-                    "end": 7837,
+                    "commentStart": 8098,
+                    "end": 8106,
                     "moduleId": 0,
-                    "start": 7829,
+                    "start": 8098,
                     "type": "TagDeclarator",
                     "value": "leftEdge"
                   },
@@ -25386,10 +25398,10 @@ description: Variables in memory after executing utility-sink.kcl
                     587.0
                   ],
                   "tag": {
-                    "commentStart": 7904,
-                    "end": 7911,
+                    "commentStart": 8173,
+                    "end": 8180,
                     "moduleId": 0,
-                    "start": 7904,
+                    "start": 8173,
                     "type": "TagDeclarator",
                     "value": "topEdge"
                   },
@@ -25410,10 +25422,10 @@ description: Variables in memory after executing utility-sink.kcl
                     587.0
                   ],
                   "tag": {
-                    "commentStart": 7980,
-                    "end": 7989,
+                    "commentStart": 8249,
+                    "end": 8258,
                     "moduleId": 0,
-                    "start": 7980,
+                    "start": 8249,
                     "type": "TagDeclarator",
                     "value": "rightEdge"
                   },
@@ -25434,10 +25446,10 @@ description: Variables in memory after executing utility-sink.kcl
                     13.0
                   ],
                   "tag": {
-                    "commentStart": 8058,
-                    "end": 8068,
+                    "commentStart": 8327,
+                    "end": 8337,
                     "moduleId": 0,
-                    "start": 8058,
+                    "start": 8327,
                     "type": "TagDeclarator",
                     "value": "bottomEdge"
                   },
@@ -25906,10 +25918,10 @@ description: Variables in memory after executing utility-sink.kcl
                 13.0
               ],
               "tag": {
-                "commentStart": 7829,
-                "end": 7837,
+                "commentStart": 8098,
+                "end": 8106,
                 "moduleId": 0,
-                "start": 7829,
+                "start": 8098,
                 "type": "TagDeclarator",
                 "value": "leftEdge"
               },
@@ -25930,10 +25942,10 @@ description: Variables in memory after executing utility-sink.kcl
                 587.0
               ],
               "tag": {
-                "commentStart": 7904,
-                "end": 7911,
+                "commentStart": 8173,
+                "end": 8180,
                 "moduleId": 0,
-                "start": 7904,
+                "start": 8173,
                 "type": "TagDeclarator",
                 "value": "topEdge"
               },
@@ -25954,10 +25966,10 @@ description: Variables in memory after executing utility-sink.kcl
                 587.0
               ],
               "tag": {
-                "commentStart": 7980,
-                "end": 7989,
+                "commentStart": 8249,
+                "end": 8258,
                 "moduleId": 0,
-                "start": 7980,
+                "start": 8249,
                 "type": "TagDeclarator",
                 "value": "rightEdge"
               },
@@ -25978,10 +25990,10 @@ description: Variables in memory after executing utility-sink.kcl
                 13.0
               ],
               "tag": {
-                "commentStart": 8058,
-                "end": 8068,
+                "commentStart": 8327,
+                "end": 8337,
                 "moduleId": 0,
-                "start": 8058,
+                "start": 8327,
                 "type": "TagDeclarator",
                 "value": "bottomEdge"
               },
@@ -26060,8 +26072,8 @@ description: Variables in memory after executing utility-sink.kcl
           },
           "artifactId": "[uuid]",
           "originalId": "[uuid]",
-          "units": "mm",
-          "isClosed": "implicitly"
+          "originSketchId": "[uuid]",
+          "units": "mm"
         }
       },
       {
@@ -26080,10 +26092,10 @@ description: Variables in memory after executing utility-sink.kcl
                 13.0
               ],
               "tag": {
-                "commentStart": 7829,
-                "end": 7837,
+                "commentStart": 8098,
+                "end": 8106,
                 "moduleId": 0,
-                "start": 7829,
+                "start": 8098,
                 "type": "TagDeclarator",
                 "value": "leftEdge"
               },
@@ -26104,10 +26116,10 @@ description: Variables in memory after executing utility-sink.kcl
                 587.0
               ],
               "tag": {
-                "commentStart": 7904,
-                "end": 7911,
+                "commentStart": 8173,
+                "end": 8180,
                 "moduleId": 0,
-                "start": 7904,
+                "start": 8173,
                 "type": "TagDeclarator",
                 "value": "topEdge"
               },
@@ -26128,10 +26140,10 @@ description: Variables in memory after executing utility-sink.kcl
                 587.0
               ],
               "tag": {
-                "commentStart": 7980,
-                "end": 7989,
+                "commentStart": 8249,
+                "end": 8258,
                 "moduleId": 0,
-                "start": 7980,
+                "start": 8249,
                 "type": "TagDeclarator",
                 "value": "rightEdge"
               },
@@ -26152,10 +26164,10 @@ description: Variables in memory after executing utility-sink.kcl
                 13.0
               ],
               "tag": {
-                "commentStart": 8058,
-                "end": 8068,
+                "commentStart": 8327,
+                "end": 8337,
                 "moduleId": 0,
-                "start": 8058,
+                "start": 8327,
                 "type": "TagDeclarator",
                 "value": "bottomEdge"
               },
@@ -26234,8 +26246,8 @@ description: Variables in memory after executing utility-sink.kcl
           },
           "artifactId": "[uuid]",
           "originalId": "[uuid]",
-          "units": "mm",
-          "isClosed": "implicitly"
+          "originSketchId": "[uuid]",
+          "units": "mm"
         }
       }
     ]


### PR DESCRIPTION
KCL's `patternLinear2d` function was designed for sketch1, so it has surprising interactions with sketch blocks. If you pass a sketch block into `patternLinear2d`, it's accepted, but it downgrades it to a sketch 1 single-profile old `Sketch` instead of a sketch block. This should not be allowed -- let's make it a warning on KCL 2 and ban it in KCL 3.

(this _does_ work fine for regions, though, so you should be able to use patternLinear2d on regions, and sketch1-style profiles)



## Summary

- replace both Sketch V1-only `patternLinear2d` examples with executable KCL 2 sketch-solve examples
- select a `region` from the named circle before patterning, matching current production samples
- document that `patternLinear2d` returns raw `Sketch` values and does not preserve sketch-block member names
- regenerate the checked-in stdlib page from its canonical KCL source

## Why

The function is current KCL 2 and its declared contract is `[Sketch; 1+] -> [Sketch; 1+]`, but the published examples still used `startSketchOn`. The page also did not explain that passing a KCL 2 sketch-block object uses its underlying sketch and returns raw sketches. That omission contributed to generated code later attempting member access such as `.hole` on a patterned sketch.

This keeps `patternLinear2d` available as a current API while showing the safe KCL 2 workflow: use named sketch members to create a region before the pattern, then consume the returned sketches directly.

Related corpus tracking: KittyCAD/kcl-corpus#52

## Validation

- `cargo nextest run --no-fail-fast -p kcl-lib --features artifact-graph docs::kcl_doc::test::missing_test_examples`
- `EXPECTORATE=overwrite cargo nextest run --retries 3 --no-fail-fast -p kcl-lib --features artifact-graph docs::gen_std_tests::test_generate_stdlib`
- `git diff --check`

The two engine-backed example tests were invoked locally but could not connect because `ZOO_API_TOKEN` is not present in this shell. CI should execute and snapshot them with its configured credentials.
