### PR TITLE
Fix imported-module issues to render with correct source

### DIFF
--- a/rust/kcl-lib/src/errors.rs
+++ b/rust/kcl-lib/src/errors.rs
@@ -238,7 +238,7 @@ impl KclErrorWithOutputs {
             refactor_metadata: outcome.refactor_metadata,
             scene_graph: Default::default(),
             filenames: outcome.filenames,
-            source_files: Default::default(),
+            source_files: outcome.source_files,
             default_planes: outcome.default_planes,
         }
     }
@@ -587,6 +587,32 @@ pub fn render_compilation_issue_miette(filename: &str, source: &str, issue: Comp
     };
     let report = miette::Report::new(report);
     format!("{report:?}")
+}
+
+/// Render a [`CompilationIssue`] as a miette report string against the module
+/// its source range points into. Issues from imported modules are rendered
+/// with the imported module's filename and source; the top-level filename and
+/// source are used for top-level issues and as a fallback when the module is
+/// missing from `source_files`.
+pub fn render_compilation_issue_miette_with_sources(
+    top_level_filename: &str,
+    top_level_source: &str,
+    source_files: &IndexMap<ModuleId, ModuleSource>,
+    issue: CompilationIssue,
+) -> String {
+    let module_id = issue.source_range.module_id();
+    // Callers know the real top-level filename (e.g. an absolute path), while
+    // `source_files` only records the module path, so prefer the caller's
+    // top-level pair.
+    let module_source = (!module_id.is_top_level())
+        .then(|| source_files.get(&module_id))
+        .flatten();
+    match module_source {
+        Some(module_source) => {
+            render_compilation_issue_miette(&module_source.path.to_string(), &module_source.source, issue)
+        }
+        None => render_compilation_issue_miette(top_level_filename, top_level_source, issue),
+    }
 }
 
 impl IntoDiagnostic for KclError {

--- a/rust/kcl-lib/src/errors.rs
+++ b/rust/kcl-lib/src/errors.rs
@@ -578,41 +578,35 @@ impl miette::Diagnostic for CompilationIssueReport {
 }
 
 /// Render a [`CompilationIssue`] as a miette report string, mirroring the
-/// formatting used for [`Report`].
-pub fn render_compilation_issue_miette(filename: &str, source: &str, issue: CompilationIssue) -> String {
-    let report = CompilationIssueReport {
-        issue,
-        kcl_source: source.to_owned(),
-        filename: filename.to_owned(),
-    };
-    let report = miette::Report::new(report);
-    format!("{report:?}")
-}
-
-/// Render a [`CompilationIssue`] as a miette report string against the module
-/// its source range points into. Issues from imported modules are rendered
-/// with the imported module's filename and source; the top-level filename and
-/// source are used for top-level issues and as a fallback when the module is
-/// missing from `source_files`.
-pub fn render_compilation_issue_miette_with_sources(
+/// formatting used for [`Report`]. The issue is rendered against the module
+/// its source range points into: issues from imported modules use their
+/// entry in `source_files`, while top-level issues use `top_level_filename`
+/// and `top_level_source`, since callers know the real top-level filename
+/// (e.g. an absolute path) while `source_files` only records the module
+/// path. The top-level pair is also the fallback when the module is missing
+/// from `source_files`, so callers without a source map can pass an empty
+/// one.
+pub fn render_compilation_issue_miette(
     top_level_filename: &str,
     top_level_source: &str,
     source_files: &IndexMap<ModuleId, ModuleSource>,
     issue: CompilationIssue,
 ) -> String {
     let module_id = issue.source_range.module_id();
-    // Callers know the real top-level filename (e.g. an absolute path), while
-    // `source_files` only records the module path, so prefer the caller's
-    // top-level pair.
     let module_source = (!module_id.is_top_level())
         .then(|| source_files.get(&module_id))
         .flatten();
-    match module_source {
-        Some(module_source) => {
-            render_compilation_issue_miette(&module_source.path.to_string(), &module_source.source, issue)
-        }
-        None => render_compilation_issue_miette(top_level_filename, top_level_source, issue),
-    }
+    let (filename, kcl_source) = match module_source {
+        Some(module_source) => (module_source.path.to_string(), module_source.source.clone()),
+        None => (top_level_filename.to_owned(), top_level_source.to_owned()),
+    };
+    let report = CompilationIssueReport {
+        issue,
+        kcl_source,
+        filename,
+    };
+    let report = miette::Report::new(report);
+    format!("{report:?}")
 }
 
 impl IntoDiagnostic for KclError {
@@ -788,5 +782,63 @@ mod tests {
 
         assert_eq!(report.primary_labels.len(), 1);
         assert_eq!(report.related.len(), 2);
+    }
+
+    #[test]
+    fn compilation_issues_render_against_the_module_their_range_points_into() {
+        let imported_module = ModuleId::from_usize(1);
+        // Long enough that ranges into it lie past the end of the top-level
+        // source below.
+        let imported_code = "// enough leading padding to push the range out of the top level\nexport value = 1 * 2\n";
+        let mul_start = imported_code.find("1 * 2").unwrap();
+        let mut source_files = IndexMap::new();
+        source_files.insert(
+            imported_module,
+            ModuleSource {
+                source: imported_code.to_owned(),
+                path: ModulePath::Local {
+                    value: "/project/derived.kcl".into(),
+                    original_import_path: None,
+                },
+            },
+        );
+        let issue_at = |source_range| CompilationIssue {
+            source_range,
+            message: "unknown units".to_owned(),
+            suggestion: None,
+            severity: Severity::Warning,
+            tag: Tag::UnknownNumericUnits,
+        };
+
+        // Imported ranges render the imported module's filename and source.
+        let report = render_compilation_issue_miette(
+            "/project/main.kcl",
+            "top",
+            &source_files,
+            issue_at(SourceRange::new(mul_start, mul_start + 5, imported_module)),
+        );
+        assert!(report.contains("derived.kcl"), "{report}");
+        assert!(report.contains("1 * 2"), "{report}");
+        assert!(!report.contains("OutOfBounds"), "{report}");
+
+        // Top-level ranges use the caller's filename and source, not the
+        // module path recorded in `source_files`.
+        let report = render_compilation_issue_miette(
+            "/project/main.kcl",
+            "top",
+            &source_files,
+            issue_at(SourceRange::new(0, 3, ModuleId::default())),
+        );
+        assert!(report.contains("main.kcl"), "{report}");
+
+        // Modules missing from the map fall back to the top-level pair, for
+        // callers that have no source map.
+        let report = render_compilation_issue_miette(
+            "/project/main.kcl",
+            "top",
+            &source_files,
+            issue_at(SourceRange::new(0, 3, ModuleId::from_usize(9))),
+        );
+        assert!(report.contains("main.kcl"), "{report}");
     }
 }

--- a/rust/kcl-lib/src/execution/cache.rs
+++ b/rust/kcl-lib/src/execution/cache.rs
@@ -135,6 +135,7 @@ impl GlobalState {
             var_solutions: self.exec_state.root_module_artifacts.var_solutions,
             refactor_metadata: self.exec_state.root_module_artifacts.refactor_metadata.clone(),
             issues: self.exec_state.issues,
+            source_files: self.exec_state.id_to_source,
             default_planes: ctx.engine.get_default_planes().read().await.clone(),
         })
     }

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -103,6 +103,7 @@ use crate::modules::ModuleExecutionOutcome;
 use crate::modules::ModuleId;
 use crate::modules::ModulePath;
 use crate::modules::ModuleRepr;
+use crate::modules::ModuleSource;
 use crate::parsing::ast::types::Expr;
 use crate::parsing::ast::types::ImportPath;
 use crate::parsing::ast::types::NodeRef;
@@ -342,6 +343,12 @@ pub struct ExecOutcome {
     pub issues: Vec<CompilationIssue>,
     /// File Names in module Id array index order
     pub filenames: IndexMap<ModuleId, ModulePath>,
+    /// Source code of each module, for rendering issues against the module
+    /// their source range points into. Not serialized to keep the WASM
+    /// payload small; native callers (e.g. the Python bindings) read it
+    /// directly.
+    #[serde(skip)]
+    pub source_files: IndexMap<ModuleId, ModuleSource>,
     /// The default planes.
     pub default_planes: Option<DefaultPlanes>,
 }

--- a/rust/kcl-lib/src/execution/state.rs
+++ b/rust/kcl-lib/src/execution/state.rs
@@ -654,6 +654,7 @@ impl ExecState {
             var_solutions: self.global.root_module_artifacts.var_solutions,
             refactor_metadata: self.global.root_module_artifacts.refactor_metadata.clone(),
             issues: self.global.issues,
+            source_files: self.global.id_to_source,
             default_planes: ctx.engine.get_default_planes().read().await.clone(),
         })
     }

--- a/rust/kcl-lib/src/frontend.rs
+++ b/rust/kcl-lib/src/frontend.rs
@@ -2053,6 +2053,7 @@ impl FrontendState {
             var_solutions,
             refactor_metadata,
             filenames,
+            source_files,
             default_planes,
             ..
         } = err;
@@ -2069,6 +2070,7 @@ impl FrontendState {
             var_solutions,
             refactor_metadata,
             issues: non_fatal,
+            source_files,
             default_planes,
         })
     }
@@ -9334,6 +9336,7 @@ cylinder = startSketchOn(XY)
             refactor_metadata: Default::default(),
             issues: Default::default(),
             filenames: Default::default(),
+            source_files: Default::default(),
             default_planes: Default::default(),
         };
 
@@ -9488,6 +9491,7 @@ sketch(on = XY) {
             refactor_metadata: Default::default(),
             issues: Default::default(),
             filenames: Default::default(),
+            source_files: Default::default(),
             default_planes: Default::default(),
         }
     }

--- a/rust/kcl-lib/src/lib.rs
+++ b/rust/kcl-lib/src/lib.rs
@@ -105,6 +105,7 @@ pub use errors::KclErrorWithOutputs;
 pub use errors::Report;
 pub use errors::ReportWithOutputs;
 pub use errors::render_compilation_issue_miette;
+pub use errors::render_compilation_issue_miette_with_sources;
 pub use execution::ConstraintKind;
 pub use execution::EdgeRefactorMeta;
 pub use execution::EnvironmentRef;

--- a/rust/kcl-lib/src/lib.rs
+++ b/rust/kcl-lib/src/lib.rs
@@ -105,7 +105,6 @@ pub use errors::KclErrorWithOutputs;
 pub use errors::Report;
 pub use errors::ReportWithOutputs;
 pub use errors::render_compilation_issue_miette;
-pub use errors::render_compilation_issue_miette_with_sources;
 pub use execution::ConstraintKind;
 pub use execution::EdgeRefactorMeta;
 pub use execution::EnvironmentRef;

--- a/rust/kcl-lib/src/simulation_tests.rs
+++ b/rust/kcl-lib/src/simulation_tests.rs
@@ -7567,3 +7567,24 @@ mod import_nested_foreign_error {
         super::execute(TEST_NAME, true).await
     }
 }
+mod import_error_in_other_module_with_overflow {
+    const TEST_NAME: &str = "import_error_in_other_module_with_overflow";
+
+    /// Test parsing KCL.
+    #[test]
+    fn parse() {
+        super::parse(TEST_NAME)
+    }
+
+    /// Test that parsing and unparsing KCL produces the original KCL input.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unparse() {
+        super::unparse(TEST_NAME).await
+    }
+
+    /// Test that KCL is executed correctly.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn kcl_test_execute() {
+        super::execute(TEST_NAME, true).await
+    }
+}

--- a/rust/kcl-lib/tests/import_error_in_other_module_with_overflow/artifact_commands.snap
+++ b/rust/kcl-lib/tests/import_error_in_other_module_with_overflow/artifact_commands.snap
@@ -1,0 +1,5 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Artifact commands import_error_in_other_module_with_overflow.kcl
+---
+{}

--- a/rust/kcl-lib/tests/import_error_in_other_module_with_overflow/artifact_graph_flowchart.snap
+++ b/rust/kcl-lib/tests/import_error_in_other_module_with_overflow/artifact_graph_flowchart.snap
@@ -1,0 +1,6 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Artifact graph flowchart import_error_in_other_module_with_overflow.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/rust/kcl-lib/tests/import_error_in_other_module_with_overflow/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/import_error_in_other_module_with_overflow/artifact_graph_flowchart.snap.md
@@ -1,0 +1,3 @@
+```mermaid
+flowchart LR
+```

--- a/rust/kcl-lib/tests/import_error_in_other_module_with_overflow/ast.snap
+++ b/rust/kcl-lib/tests/import_error_in_other_module_with_overflow/ast.snap
@@ -1,0 +1,115 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Result of parsing import_error_in_other_module_with_overflow.kcl
+---
+{
+  "Ok": {
+    "body": [
+      {
+        "commentStart": 0,
+        "end": 0,
+        "moduleId": 0,
+        "path": {
+          "type": "Kcl",
+          "filename": "derived.kcl"
+        },
+        "selector": {
+          "type": "List",
+          "items": [
+            {
+              "alias": null,
+              "commentStart": 0,
+              "end": 0,
+              "moduleId": 0,
+              "name": {
+                "commentStart": 0,
+                "end": 0,
+                "moduleId": 0,
+                "name": "derived",
+                "start": 0,
+                "type": "Identifier"
+              },
+              "start": 0,
+              "type": "ImportItem"
+            }
+          ]
+        },
+        "start": 0,
+        "type": "ImportStatement",
+        "type": "ImportStatement"
+      },
+      {
+        "commentStart": 0,
+        "declaration": {
+          "commentStart": 0,
+          "end": 0,
+          "id": {
+            "commentStart": 0,
+            "end": 0,
+            "moduleId": 0,
+            "name": "result",
+            "start": 0,
+            "type": "Identifier"
+          },
+          "init": {
+            "arguments": [],
+            "callee": {
+              "abs_path": false,
+              "commentStart": 0,
+              "end": 0,
+              "moduleId": 0,
+              "name": {
+                "commentStart": 0,
+                "end": 0,
+                "moduleId": 0,
+                "name": "derived",
+                "start": 0,
+                "type": "Identifier"
+              },
+              "path": [],
+              "start": 0,
+              "type": "Name"
+            },
+            "commentStart": 0,
+            "end": 0,
+            "moduleId": 0,
+            "start": 0,
+            "type": "CallExpressionKw",
+            "type": "CallExpressionKw",
+            "unlabeled": null
+          },
+          "moduleId": 0,
+          "start": 0,
+          "type": "VariableDeclarator"
+        },
+        "end": 0,
+        "kind": "const",
+        "moduleId": 0,
+        "start": 0,
+        "type": "VariableDeclaration",
+        "type": "VariableDeclaration"
+      }
+    ],
+    "commentStart": 0,
+    "end": 0,
+    "moduleId": 0,
+    "nonCodeMeta": {
+      "nonCodeNodes": {
+        "0": [
+          {
+            "commentStart": 0,
+            "end": 0,
+            "moduleId": 0,
+            "start": 0,
+            "type": "NonCodeNode",
+            "value": {
+              "type": "newLine"
+            }
+          }
+        ]
+      },
+      "startNodes": []
+    },
+    "start": 0
+  }
+}

--- a/rust/kcl-lib/tests/import_error_in_other_module_with_overflow/derived.kcl
+++ b/rust/kcl-lib/tests/import_error_in_other_module_with_overflow/derived.kcl
@@ -1,0 +1,9 @@
+// Repeat this padding comment until the function starts after byte 100.
+// imported-module padding
+// imported-module padding
+// imported-module padding
+// imported-module padding
+// imported-module padding
+export fn derived() {
+  return PI * 2
+}

--- a/rust/kcl-lib/tests/import_error_in_other_module_with_overflow/execution_success.snap
+++ b/rust/kcl-lib/tests/import_error_in_other_module_with_overflow/execution_success.snap
@@ -1,0 +1,5 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Execution success import_error_in_other_module_with_overflow.kcl
+---
+null

--- a/rust/kcl-lib/tests/import_error_in_other_module_with_overflow/input.kcl
+++ b/rust/kcl-lib/tests/import_error_in_other_module_with_overflow/input.kcl
@@ -1,0 +1,3 @@
+import derived from "derived.kcl"
+
+result = derived()

--- a/rust/kcl-lib/tests/import_error_in_other_module_with_overflow/ops.snap
+++ b/rust/kcl-lib/tests/import_error_in_other_module_with_overflow/ops.snap
@@ -1,0 +1,356 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Operations executed import_error_in_other_module_with_overflow.kcl
+---
+{
+  "rust/kcl-lib/tests/import_error_in_other_module_with_overflow/input.kcl": [
+    {
+      "type": "ModuleInstance",
+      "name": "derived",
+      "moduleId": 0,
+      "nodePath": {
+        "steps": [
+          {
+            "type": "ProgramBodyItem",
+            "index": 0
+          }
+        ]
+      },
+      "sourceRange": []
+    },
+    {
+      "type": "GroupBegin",
+      "group": {
+        "type": "FunctionCall",
+        "name": "derived",
+        "functionSourceRange": [],
+        "unlabeledArg": null,
+        "labeledArgs": {}
+      },
+      "nodePath": {
+        "steps": [
+          {
+            "type": "ProgramBodyItem",
+            "index": 1
+          },
+          {
+            "type": "VariableDeclarationDeclaration"
+          },
+          {
+            "type": "VariableDeclarationInit"
+          }
+        ]
+      },
+      "sourceRange": []
+    },
+    {
+      "type": "GroupEnd"
+    },
+    {
+      "type": "VariableDeclaration",
+      "name": "result",
+      "value": {
+        "type": "Number",
+        "value": 6.283185307179586,
+        "ty": {
+          "type": "Unknown"
+        }
+      },
+      "visibility": "default",
+      "nodePath": {
+        "steps": [
+          {
+            "type": "ProgramBodyItem",
+            "index": 1
+          },
+          {
+            "type": "VariableDeclarationDeclaration"
+          },
+          {
+            "type": "VariableDeclarationInit"
+          }
+        ]
+      },
+      "sourceRange": []
+    }
+  ],
+  "std::math": [
+    {
+      "type": "VariableDeclaration",
+      "name": "PI",
+      "value": {
+        "type": "Number",
+        "value": 3.141592653589793,
+        "ty": {
+          "type": "Unknown"
+        }
+      },
+      "visibility": "export",
+      "nodePath": {
+        "steps": [
+          {
+            "type": "ProgramBodyItem",
+            "index": 1
+          },
+          {
+            "type": "VariableDeclarationDeclaration"
+          },
+          {
+            "type": "VariableDeclarationInit"
+          }
+        ]
+      },
+      "sourceRange": []
+    },
+    {
+      "type": "VariableDeclaration",
+      "name": "E",
+      "value": {
+        "type": "Number",
+        "value": 2.718281828459045,
+        "ty": {
+          "type": "Known",
+          "type": "Count"
+        }
+      },
+      "visibility": "export",
+      "nodePath": {
+        "steps": [
+          {
+            "type": "ProgramBodyItem",
+            "index": 2
+          },
+          {
+            "type": "VariableDeclarationDeclaration"
+          },
+          {
+            "type": "VariableDeclarationInit"
+          }
+        ]
+      },
+      "sourceRange": []
+    },
+    {
+      "type": "VariableDeclaration",
+      "name": "TAU",
+      "value": {
+        "type": "Number",
+        "value": 6.283185307179586,
+        "ty": {
+          "type": "Known",
+          "type": "Count"
+        }
+      },
+      "visibility": "export",
+      "nodePath": {
+        "steps": [
+          {
+            "type": "ProgramBodyItem",
+            "index": 3
+          },
+          {
+            "type": "VariableDeclarationDeclaration"
+          },
+          {
+            "type": "VariableDeclarationInit"
+          }
+        ]
+      },
+      "sourceRange": []
+    }
+  ],
+  "std::prelude": [
+    {
+      "type": "VariableDeclaration",
+      "name": "START",
+      "value": {
+        "type": "String",
+        "value": "start"
+      },
+      "visibility": "export",
+      "nodePath": {
+        "steps": [
+          {
+            "type": "ProgramBodyItem",
+            "index": 23
+          },
+          {
+            "type": "VariableDeclarationDeclaration"
+          },
+          {
+            "type": "VariableDeclarationInit"
+          }
+        ]
+      },
+      "sourceRange": []
+    },
+    {
+      "type": "VariableDeclaration",
+      "name": "END",
+      "value": {
+        "type": "String",
+        "value": "end"
+      },
+      "visibility": "export",
+      "nodePath": {
+        "steps": [
+          {
+            "type": "ProgramBodyItem",
+            "index": 24
+          },
+          {
+            "type": "VariableDeclarationDeclaration"
+          },
+          {
+            "type": "VariableDeclarationInit"
+          }
+        ]
+      },
+      "sourceRange": []
+    },
+    {
+      "type": "VariableDeclaration",
+      "name": "NEW",
+      "value": {
+        "type": "String",
+        "value": "new"
+      },
+      "visibility": "export",
+      "nodePath": {
+        "steps": [
+          {
+            "type": "ProgramBodyItem",
+            "index": 25
+          },
+          {
+            "type": "VariableDeclarationDeclaration"
+          },
+          {
+            "type": "VariableDeclarationInit"
+          }
+        ]
+      },
+      "sourceRange": []
+    },
+    {
+      "type": "VariableDeclaration",
+      "name": "MERGE",
+      "value": {
+        "type": "String",
+        "value": "merge"
+      },
+      "visibility": "export",
+      "nodePath": {
+        "steps": [
+          {
+            "type": "ProgramBodyItem",
+            "index": 26
+          },
+          {
+            "type": "VariableDeclarationDeclaration"
+          },
+          {
+            "type": "VariableDeclarationInit"
+          }
+        ]
+      },
+      "sourceRange": []
+    },
+    {
+      "type": "VariableDeclaration",
+      "name": "SOLID",
+      "value": {
+        "type": "String",
+        "value": "solid"
+      },
+      "visibility": "export",
+      "nodePath": {
+        "steps": [
+          {
+            "type": "ProgramBodyItem",
+            "index": 27
+          },
+          {
+            "type": "VariableDeclarationDeclaration"
+          },
+          {
+            "type": "VariableDeclarationInit"
+          }
+        ]
+      },
+      "sourceRange": []
+    },
+    {
+      "type": "VariableDeclaration",
+      "name": "SURFACE",
+      "value": {
+        "type": "String",
+        "value": "surface"
+      },
+      "visibility": "export",
+      "nodePath": {
+        "steps": [
+          {
+            "type": "ProgramBodyItem",
+            "index": 28
+          },
+          {
+            "type": "VariableDeclarationDeclaration"
+          },
+          {
+            "type": "VariableDeclarationInit"
+          }
+        ]
+      },
+      "sourceRange": []
+    },
+    {
+      "type": "VariableDeclaration",
+      "name": "CCW",
+      "value": {
+        "type": "String",
+        "value": "ccw"
+      },
+      "visibility": "export",
+      "nodePath": {
+        "steps": [
+          {
+            "type": "ProgramBodyItem",
+            "index": 29
+          },
+          {
+            "type": "VariableDeclarationDeclaration"
+          },
+          {
+            "type": "VariableDeclarationInit"
+          }
+        ]
+      },
+      "sourceRange": []
+    },
+    {
+      "type": "VariableDeclaration",
+      "name": "CW",
+      "value": {
+        "type": "String",
+        "value": "cw"
+      },
+      "visibility": "export",
+      "nodePath": {
+        "steps": [
+          {
+            "type": "ProgramBodyItem",
+            "index": 30
+          },
+          {
+            "type": "VariableDeclarationDeclaration"
+          },
+          {
+            "type": "VariableDeclarationInit"
+          }
+        ]
+      },
+      "sourceRange": []
+    }
+  ]
+}

--- a/rust/kcl-lib/tests/import_error_in_other_module_with_overflow/program_memory.snap
+++ b/rust/kcl-lib/tests/import_error_in_other_module_with_overflow/program_memory.snap
@@ -1,0 +1,16 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Variables in memory after executing import_error_in_other_module_with_overflow.kcl
+---
+{
+  "derived": {
+    "type": "Function"
+  },
+  "result": {
+    "type": "Number",
+    "value": 6.283185307179586,
+    "ty": {
+      "type": "Unknown"
+    }
+  }
+}

--- a/rust/kcl-lib/tests/import_error_in_other_module_with_overflow/unparsed.snap
+++ b/rust/kcl-lib/tests/import_error_in_other_module_with_overflow/unparsed.snap
@@ -1,0 +1,7 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Result of unparsing import_error_in_other_module_with_overflow.kcl
+---
+import derived from "derived.kcl"
+
+result = derived()

--- a/rust/kcl-lib/tests/import_error_in_other_module_with_overflow/unparsed@derived.kcl.snap
+++ b/rust/kcl-lib/tests/import_error_in_other_module_with_overflow/unparsed@derived.kcl.snap
@@ -1,0 +1,13 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Result of unparsing tests/import_error_in_other_module_with_overflow/derived.kcl
+---
+// Repeat this padding comment until the function starts after byte 100.
+// imported-module padding
+// imported-module padding
+// imported-module padding
+// imported-module padding
+// imported-module padding
+export fn derived() {
+  return PI * 2
+}

--- a/rust/kcl-python-bindings/files/imported_warning/derived.kcl
+++ b/rust/kcl-python-bindings/files/imported_warning/derived.kcl
@@ -1,0 +1,9 @@
+// Repeat this padding comment until the function starts after byte 100.
+// imported-module padding
+// imported-module padding
+// imported-module padding
+// imported-module padding
+// imported-module padding
+export fn derived() {
+  return PI * 2
+}

--- a/rust/kcl-python-bindings/files/imported_warning/main.kcl
+++ b/rust/kcl-python-bindings/files/imported_warning/main.kcl
@@ -1,0 +1,3 @@
+import derived from "derived.kcl"
+
+result = derived()

--- a/rust/kcl-python-bindings/kcl.pyi
+++ b/rust/kcl-python-bindings/kcl.pyi
@@ -192,7 +192,7 @@ class ExecOutcome:
     def report(self, issue: CompilationIssue) -> builtins.str:
         r"""
         Render the given compilation issue as a miette report string, using
-        the source code and filename captured at execution time.
+        the source code and filenames captured at execution time.
         """
     def sketch_constraint_report(self) -> SketchConstraintReport:
         r"""

--- a/rust/kcl-python-bindings/src/lib.rs
+++ b/rust/kcl-python-bindings/src/lib.rs
@@ -1391,4 +1391,58 @@ result = subtract(cube, tools = [cylinder])
             "report should include a line:column marker for the source span: {report}"
         );
     }
+
+    /// A short top-level file that calls a function defined in a longer
+    /// imported module. Evaluating the function body multiplies numbers with
+    /// unknown units, so execution emits an `unknown-numeric-units` warning
+    /// whose source range points into the imported module, past the end of
+    /// the top-level source. The report must render that range against the
+    /// imported module's source, not the top-level file.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn mock_exec_outcome_report_renders_imported_module_warning_against_imported_source() {
+        let project_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/files/imported_warning");
+        let outcome = execute_impl(KclInput::Path(project_dir.to_owned()), true)
+            .await
+            .expect("mock execute_impl should succeed for a project that only warns");
+
+        let issues = outcome.issues().expect("issues should convert");
+        let warning = issues
+            .iter()
+            .find(|issue| issue.is_warning() && issue.message().contains("unknown or incompatible units"))
+            .unwrap_or_else(|| panic!("expected an unknown-numeric-units warning, got: {issues:?}"));
+
+        let report = outcome.report(warning);
+
+        assert!(
+            !report.contains("Failed to read contents") && !report.contains("OutOfBounds"),
+            "imported range should not be read against the top-level source: {report}"
+        );
+        assert!(
+            report.contains("derived.kcl"),
+            "report should name the imported file: {report}"
+        );
+        assert!(
+            report.contains("PI * 2"),
+            "report should include the offending line from the imported source snippet: {report}"
+        );
+
+        // The sketch constraint report renders the same issues through the
+        // shared helper; it must also resolve the imported module's source.
+        let constraint_report = outcome.sketch_constraint_report();
+        assert!(
+            !constraint_report.warnings.is_empty(),
+            "constraint report should carry the rendered execution warning"
+        );
+        for rendered in &constraint_report.warnings {
+            assert!(
+                !rendered.contains("Failed to read contents") && !rendered.contains("OutOfBounds"),
+                "constraint report warning should render against the imported source: {rendered}"
+            );
+        }
+        assert!(
+            constraint_report.warnings.iter().any(|w| w.contains("PI * 2")),
+            "a constraint report warning should include the imported source snippet: {:?}",
+            constraint_report.warnings
+        );
+    }
 }

--- a/rust/kcl-python-bindings/src/lib.rs
+++ b/rust/kcl-python-bindings/src/lib.rs
@@ -279,12 +279,7 @@ impl ExecOutcome {
     /// Render the issue against the module source its range points into,
     /// falling back to the top-level source captured at execution time.
     fn render_issue(&self, issue: kcl_lib::CompilationIssue) -> String {
-        kcl_lib::render_compilation_issue_miette_with_sources(
-            &self.filename,
-            &self.code,
-            &self.inner.source_files,
-            issue,
-        )
+        kcl_lib::render_compilation_issue_miette(&self.filename, &self.code, &self.inner.source_files, issue)
     }
 }
 
@@ -411,7 +406,7 @@ async fn sketch_constraint_report_impl(input: KclInput) -> PyResult<SketchConstr
             let outcome = state.into_exec_outcome(env_ref, &ctx).await.map_err(to_py_exception)?;
             let mut report: SketchConstraintReport = outcome.sketch_constraint_report().into();
             add_execution_issues(&mut report, outcome.issues, |issue| {
-                kcl_lib::render_compilation_issue_miette_with_sources(&filename, &code, &outcome.source_files, issue)
+                kcl_lib::render_compilation_issue_miette(&filename, &code, &outcome.source_files, issue)
             });
             Ok(report)
         }
@@ -422,7 +417,7 @@ async fn sketch_constraint_report_impl(input: KclInput) -> PyResult<SketchConstr
             let error_text = render_miette(err.clone(), &code);
             let mut report: SketchConstraintReport = err.sketch_constraint_report().into();
             add_execution_issues(&mut report, err.non_fatal, |issue| {
-                kcl_lib::render_compilation_issue_miette_with_sources(&filename, &code, &err.source_files, issue)
+                kcl_lib::render_compilation_issue_miette(&filename, &code, &err.source_files, issue)
             });
             report.is_complete = false;
             report.kcl_error = Some(KclErrorInfo {

--- a/rust/kcl-python-bindings/src/lib.rs
+++ b/rust/kcl-python-bindings/src/lib.rs
@@ -98,13 +98,12 @@ fn render_miette_for_parse(filename: &str, input: &str, error: kcl_lib::KclError
 
 fn add_execution_issues(
     report: &mut SketchConstraintReport,
-    filename: &str,
-    code: &str,
     issues: Vec<kcl_lib::CompilationIssue>,
+    render: impl Fn(kcl_lib::CompilationIssue) -> String,
 ) {
     for issue in issues {
         let severity = issue.severity;
-        let rendered = kcl_lib::render_compilation_issue_miette(filename, code, issue);
+        let rendered = render(issue);
         if severity.is_fatal() {
             report.execution_fatals.push(rendered);
         } else if severity.is_err() {
@@ -276,6 +275,19 @@ struct ExecOutcome {
     filename: String,
 }
 
+impl ExecOutcome {
+    /// Render the issue against the module source its range points into,
+    /// falling back to the top-level source captured at execution time.
+    fn render_issue(&self, issue: kcl_lib::CompilationIssue) -> String {
+        kcl_lib::render_compilation_issue_miette_with_sources(
+            &self.filename,
+            &self.code,
+            &self.inner.source_files,
+            issue,
+        )
+    }
+}
+
 #[pyo3_stub_gen::derive::gen_stub_pymethods]
 #[pymethods]
 impl ExecOutcome {
@@ -284,16 +296,16 @@ impl ExecOutcome {
     }
 
     /// Render the given compilation issue as a miette report string, using
-    /// the source code and filename captured at execution time.
+    /// the source code and filenames captured at execution time.
     fn report(&self, issue: &CompilationIssue) -> String {
-        kcl_lib::render_compilation_issue_miette(&self.filename, &self.code, issue.inner.clone())
+        self.render_issue(issue.inner.clone())
     }
 
     /// Analyze all sketches from this execution and group them by constraint
     /// status.
     fn sketch_constraint_report(&self) -> SketchConstraintReport {
         let mut report: SketchConstraintReport = self.inner.sketch_constraint_report().into();
-        add_execution_issues(&mut report, &self.filename, &self.code, self.inner.issues.clone());
+        add_execution_issues(&mut report, self.inner.issues.clone(), |issue| self.render_issue(issue));
         report
     }
 
@@ -398,7 +410,9 @@ async fn sketch_constraint_report_impl(input: KclInput) -> PyResult<SketchConstr
         Ok((env_ref, _)) => {
             let outcome = state.into_exec_outcome(env_ref, &ctx).await.map_err(to_py_exception)?;
             let mut report: SketchConstraintReport = outcome.sketch_constraint_report().into();
-            add_execution_issues(&mut report, &filename, &code, outcome.issues);
+            add_execution_issues(&mut report, outcome.issues, |issue| {
+                kcl_lib::render_compilation_issue_miette_with_sources(&filename, &code, &outcome.source_files, issue)
+            });
             Ok(report)
         }
         Err(err) => {
@@ -407,7 +421,9 @@ async fn sketch_constraint_report_impl(input: KclInput) -> PyResult<SketchConstr
             }
             let error_text = render_miette(err.clone(), &code);
             let mut report: SketchConstraintReport = err.sketch_constraint_report().into();
-            add_execution_issues(&mut report, &filename, &code, err.non_fatal);
+            add_execution_issues(&mut report, err.non_fatal, |issue| {
+                kcl_lib::render_compilation_issue_miette_with_sources(&filename, &code, &err.source_files, issue)
+            });
             report.is_complete = false;
             report.kcl_error = Some(KclErrorInfo {
                 phase: "execution".to_string(),


### PR DESCRIPTION
Fixes #13368.

Keep KCL source around so that rendering errors in other files works in the Python bindings.