### PR TITLE
Fix false file conflict toast during Zookeeper writes

### DIFF
--- a/src/lang/KclManager.spec.ts
+++ b/src/lang/KclManager.spec.ts
@@ -12,15 +12,16 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 const clientErrorMocks = vi.hoisted(() => ({
   reportSystemIOError: vi.fn(),
 }))
+const toastMocks = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+}))
 
 vi.mock('@src/machines/systemIO/errorReporting', () => ({
   reportSystemIOError: clientErrorMocks.reportSystemIOError,
 }))
 vi.mock('react-hot-toast', () => ({
-  default: {
-    success: vi.fn(),
-    error: vi.fn(),
-  },
+  default: toastMocks,
 }))
 
 import {
@@ -623,8 +624,63 @@ describe('KclManager diagnostics', () => {
     expect(kclManager.code).toBe('from disk')
   })
 
+  it('does not report Zookeeper disk writes as conflicts when the editor snapshot is stale', async () => {
+    const { kclManager } = createKclManagerTestHarness('zookeeper edit')
+    const updateCodeEditorSpy = vi.spyOn(kclManager, 'updateCodeEditor')
+    const testInternals = kclManager as unknown as {
+      markFileCodeAsSynced(code: string): void
+      systemDeps: { projectPath: { value: string } }
+    }
+
+    kclManager.path = '/tmp/kcl-manager-zookeeper-watch-test.kcl'
+    kclManager.zookeeperManagerMachineBulkManipulatingFileSystem = true
+    testInternals.systemDeps.projectPath.value = '/tmp/project'
+    testInternals.markFileCodeAsSynced('from disk')
+
+    vi.spyOn(File.ioImplementations, 'read').mockResolvedValue(
+      'newer zookeeper edit'
+    )
+
+    const watchHandler = kclManager.onWatchEvent.at(-1)
+    expect(watchHandler).toBeDefined()
+
+    watchHandler?.('change', kclManager.path)
+    await flushPromises()
+
+    expect(toastMocks.error).not.toHaveBeenCalled()
+    expect(updateCodeEditorSpy).not.toHaveBeenCalled()
+    expect(kclManager.code).toBe('zookeeper edit')
+  })
+
+  it('reports external disk conflicts when the editor has unsaved changes', async () => {
+    const { kclManager } = createKclManagerTestHarness('local edit')
+    const updateCodeEditorSpy = vi.spyOn(kclManager, 'updateCodeEditor')
+    const testInternals = kclManager as unknown as {
+      markFileCodeAsSynced(code: string): void
+      systemDeps: { projectPath: { value: string } }
+    }
+
+    kclManager.path = '/tmp/kcl-manager-external-watch-test.kcl'
+    testInternals.systemDeps.projectPath.value = '/tmp/project'
+    testInternals.markFileCodeAsSynced('from disk')
+
+    vi.spyOn(File.ioImplementations, 'read').mockResolvedValue('external edit')
+
+    const watchHandler = kclManager.onWatchEvent.at(-1)
+    expect(watchHandler).toBeDefined()
+
+    watchHandler?.('change', kclManager.path)
+    await flushPromises()
+
+    expect(toastMocks.error).toHaveBeenCalledWith(
+      'File changed on disk while this editor has unsaved changes. Reload was skipped to protect your work.'
+    )
+    expect(updateCodeEditorSpy).not.toHaveBeenCalled()
+    expect(kclManager.code).toBe('local edit')
+  })
+
   it('does not reload active editor disk updates while Zookeeper history is pending', async () => {
-    const { kclManager } = createKclManagerTestHarness('from disk')
+    const { kclManager } = createKclManagerTestHarness('zookeeper edit')
     const updateCodeEditorSpy = vi.spyOn(kclManager, 'updateCodeEditor')
     const testInternals = kclManager as unknown as {
       markFileCodeAsSynced(code: string): void
@@ -636,7 +692,9 @@ describe('KclManager diagnostics', () => {
     testInternals.systemDeps.projectPath.value = '/tmp/project'
     testInternals.markFileCodeAsSynced('from disk')
 
-    vi.spyOn(File.ioImplementations, 'read').mockResolvedValue('zookeeper edit')
+    vi.spyOn(File.ioImplementations, 'read').mockResolvedValue(
+      'newer zookeeper edit'
+    )
 
     const watchHandler = kclManager.onWatchEvent.at(-1)
     expect(watchHandler).toBeDefined()
@@ -644,8 +702,9 @@ describe('KclManager diagnostics', () => {
     watchHandler?.('change', kclManager.path)
     await flushPromises()
 
+    expect(toastMocks.error).not.toHaveBeenCalled()
     expect(updateCodeEditorSpy).not.toHaveBeenCalled()
-    expect(kclManager.code).toBe('from disk')
+    expect(kclManager.code).toBe('zookeeper edit')
   })
 
   it('arms disk watcher when reusing the singleton editor for an opened file', async () => {

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -1050,6 +1050,16 @@ export class KclManager extends File {
           return
         }
 
+        // Zookeeper history needs to record the active-file edit against the
+        // editor's pre-write text, so don't let the watcher preemptively reload
+        // it or report its intermediate editor state as an unsaved local edit.
+        if (
+          this.zookeeperManagerMachineBulkManipulatingFileSystem ||
+          this.zookeeperHistoryRecordingInProgress
+        ) {
+          return
+        }
+
         if (this.hasUnsavedLocalChanges()) {
           console.warn(
             'External file change detected while local edits are unsaved. Skipping automatic reload to avoid overwriting the editor buffer.'
@@ -1057,15 +1067,6 @@ export class KclManager extends File {
           toast.error(
             'File changed on disk while this editor has unsaved changes. Reload was skipped to protect your work.'
           )
-          return
-        }
-
-        // Zookeeper history needs to record the active-file edit against the
-        // editor's pre-write text, so don't let the watcher preemptively reload it.
-        if (
-          this.zookeeperManagerMachineBulkManipulatingFileSystem ||
-          this.zookeeperHistoryRecordingInProgress
-        ) {
           return
         }
 


### PR DESCRIPTION
## Summary

- ignore Zookeeper-owned active-file watcher events before evaluating the generic unsaved-change conflict warning
- cover stale editor snapshots during both Zookeeper bulk file writes and pending Zookeeper history writes
- preserve the existing warning and editor-buffer protection for genuine external disk conflicts

Closes #13376.

## Root cause

`KclManager` defines an unsaved edit as any difference between the editor buffer and its last known file snapshot. Zookeeper updates the on-disk file, active editor, and undo history through separate asynchronous steps, so that snapshot can legitimately lag during streamed cumulative file updates.

The watcher previously evaluated the generic dirty-buffer branch first. That branch returned after displaying an external-write error, before the watcher reached the Zookeeper ownership guards.

## Fix

Move the existing Zookeeper bulk/history guard ahead of the generic dirty-buffer check. Both branches already return without reloading the active editor, so this changes the classification and notification only; it does not introduce a new file-write or reload path.

## Verification

- New regression test failed on unmodified `origin/main` with the exact reported toast.
- `npm run test:integration -- src/lang/KclManager.spec.ts` — 35 passed.
- Targeted ESLint on `KclManager.ts` and `KclManager.spec.ts` — passed.
- `npm run fmt:check -- src/lang/KclManager.ts src/lang/KclManager.spec.ts` — passed.
- `git diff --check` — passed.
- `npm run check` — repository baseline failure: the command reports thousands of unrelated diagnostics in untouched files, beginning with legacy Node import and unused-parameter findings under `e2e/playwright`. No diagnostics from this patch were identified by the targeted formatter or ESLint checks.

## Smoke test

In the desktop app, run a Zookeeper request that streams multiple active-file updates and confirm that:

1. the returned KCL continues to load and execute;
2. the false `File changed on disk` toast does not appear; and
3. a real external edit to a dirty active file still preserves the editor buffer and displays the warning.
