### PR TITLE
Use explicit solid selection for KCL physical analysis

### DIFF
--- a/rust/kcl-lib/src/execution/state.rs
+++ b/rust/kcl-lib/src/execution/state.rs
@@ -8,6 +8,7 @@ use indexmap::IndexMap;
 pub use kcl_api::KclVersion;
 use kcl_api::UnitAngle;
 use kcl_api::UnitLength;
+use kittycad_modeling_cmds::ModelingCmd;
 use serde::Deserialize;
 use serde::Serialize;
 use uuid::Uuid;
@@ -625,6 +626,56 @@ impl ExecState {
 
     pub fn issues(&self) -> &[CompilationIssue] {
         &self.global.issues
+    }
+
+    /// Return the explicit Engine solid ids that represent the complete visible
+    /// procedural model for physical-property measurements.
+    ///
+    /// `None` means the execution contains geometry that cannot yet be mapped
+    /// conservatively to explicit solid ids, such as foreign imported geometry
+    /// or an unbound body. Callers should retain their legacy Engine selection
+    /// in that case rather than risk measuring an incomplete model.
+    pub fn physical_property_entity_ids(&self, main_ref: EnvironmentRef) -> Result<Option<Vec<Uuid>>, KclError> {
+        let graph = &self.global.artifacts.graph;
+        let candidate_artifact_ids = graph
+            .values()
+            .filter_map(|artifact| match artifact {
+                Artifact::Sweep(sweep) if !sweep.consumed => Some(sweep.id),
+                Artifact::CompositeSolid(composite) if !composite.consumed => Some(composite.id),
+                _ => None,
+            })
+            .collect::<AhashIndexSet<_>>();
+
+        let mut visibility_by_engine_id = AHashMap::new();
+        for artifact_command in &self.global.root_module_artifacts.commands {
+            if let ModelingCmd::ObjectVisible(visibility) = &artifact_command.command {
+                visibility_by_engine_id.insert(visibility.object_id, visibility.hidden);
+            }
+        }
+
+        let variables = self.mod_local.variables(main_ref)?;
+        let mut mapped_artifact_ids = AhashIndexSet::default();
+        let mut entity_ids = AhashIndexSet::default();
+        let mut unsupported_geometry = false;
+        for value in variables.into_values().map(KclValueView::from) {
+            collect_physical_property_entity_ids(
+                &value,
+                graph,
+                &visibility_by_engine_id,
+                &mut mapped_artifact_ids,
+                &mut entity_ids,
+                &mut unsupported_geometry,
+            );
+        }
+
+        let all_candidates_mapped = candidate_artifact_ids
+            .iter()
+            .all(|artifact_id| mapped_artifact_ids.contains(artifact_id));
+        if unsupported_geometry || !all_candidates_mapped {
+            return Ok(None);
+        }
+
+        Ok(Some(entity_ids.into_iter().collect()))
     }
 
     pub(crate) fn deprecation_version(&self) -> &str {
@@ -1463,6 +1514,65 @@ impl ExecState {
     }
 }
 
+fn collect_physical_property_entity_ids(
+    value: &KclValueView,
+    graph: &ArtifactGraph,
+    visibility_by_engine_id: &AHashMap<Uuid, bool>,
+    mapped_artifact_ids: &mut AhashIndexSet<ArtifactId>,
+    entity_ids: &mut AhashIndexSet<Uuid>,
+    unsupported_geometry: &mut bool,
+) {
+    match value {
+        KclValueView::Solid { value } => match graph.get(&value.artifact_id) {
+            Some(Artifact::Sweep(sweep)) if !sweep.consumed => {
+                mapped_artifact_ids.insert(value.artifact_id);
+                if !visibility_by_engine_id.get(&value.id).copied().unwrap_or(false) {
+                    entity_ids.insert(value.id);
+                }
+            }
+            Some(Artifact::CompositeSolid(composite)) if !composite.consumed => {
+                mapped_artifact_ids.insert(value.artifact_id);
+                if !visibility_by_engine_id.get(&value.id).copied().unwrap_or(false) {
+                    entity_ids.insert(value.id);
+                }
+            }
+            Some(Artifact::Sweep(_) | Artifact::CompositeSolid(_)) => {
+                // Consumed solids remain in KCL memory but no longer represent
+                // measurable Engine bodies.
+            }
+            _ => *unsupported_geometry = true,
+        },
+        KclValueView::Tuple { value } | KclValueView::HomArray { value } => {
+            for value in value {
+                collect_physical_property_entity_ids(
+                    value,
+                    graph,
+                    visibility_by_engine_id,
+                    mapped_artifact_ids,
+                    entity_ids,
+                    unsupported_geometry,
+                );
+            }
+        }
+        KclValueView::Object { value, .. } => {
+            let mut keys = value.keys().collect::<Vec<_>>();
+            keys.sort();
+            for key in keys {
+                collect_physical_property_entity_ids(
+                    &value[key],
+                    graph,
+                    visibility_by_engine_id,
+                    mapped_artifact_ids,
+                    entity_ids,
+                    unsupported_geometry,
+                );
+            }
+        }
+        KclValueView::ImportedGeometry(_) => *unsupported_geometry = true,
+        _ => {}
+    }
+}
+
 /// The kclVersion that a program's `@settings` annotations declare, with the
 /// source range of the declaring property, or `None` when the program does not
 /// declare one. The last declaration wins, as in
@@ -1837,6 +1947,7 @@ mod tests {
 
     use uuid::Uuid;
 
+    use super::ExecState;
     use super::KclVersion;
     use super::ModuleArtifactState;
     use crate::NodePath;
@@ -1848,6 +1959,134 @@ mod tests {
     use crate::front::ObjectKind;
     use crate::front::Plane;
     use crate::front::SourceRef;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn physical_property_entity_ids_select_only_visible_procedural_solids() {
+        let code = r#"
+finalSketch = startSketchOn(XY)
+  |> startProfile(at = [0, 0])
+  |> xLine(length = 10)
+  |> yLine(length = 10)
+  |> xLine(endAbsolute = profileStartX(%))
+  |> close()
+finalSolid = extrude(finalSketch, length = 10)
+
+constructionSketch = startSketchOn(XY)
+  |> startProfile(at = [1000, 0])
+  |> xLine(length = 100)
+  |> yLine(length = 100)
+  |> xLine(endAbsolute = profileStartX(%))
+  |> close()
+
+hiddenSketch = startSketchOn(XY)
+  |> startProfile(at = [2000, 0])
+  |> xLine(length = 20)
+  |> yLine(length = 20)
+  |> xLine(endAbsolute = profileStartX(%))
+  |> close()
+hiddenSolid = extrude(hiddenSketch, length = 20)
+hide(hiddenSolid)
+"#;
+        let program = crate::Program::parse_no_errs(code).unwrap();
+        let ctx = crate::ExecutorContext::new_mock(None).await;
+        let mut state = ExecState::new(&ctx);
+        let (env_ref, _) = ctx.run(&program, &mut state).await.unwrap();
+
+        let variables = state.mod_local.variables(env_ref).unwrap();
+        let crate::execution::KclValue::Solid { value: final_solid } = &variables["finalSolid"] else {
+            panic!("finalSolid should be a solid");
+        };
+        let entity_ids = state
+            .physical_property_entity_ids(env_ref)
+            .unwrap()
+            .expect("procedural solids should have a complete explicit selection");
+
+        assert_eq!(entity_ids, vec![final_solid.id]);
+        ctx.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn physical_property_entity_ids_exclude_consumed_boolean_operands() {
+        let code = r#"
+targetSketch = startSketchOn(XY)
+  |> startProfile(at = [0, 0])
+  |> xLine(length = 10)
+  |> yLine(length = 10)
+  |> xLine(endAbsolute = profileStartX(%))
+  |> close()
+target = extrude(targetSketch, length = 10)
+
+toolSketch = startSketchOn(XY)
+  |> startProfile(at = [5, -100])
+  |> xLine(length = 100)
+  |> yLine(length = 200)
+  |> xLine(endAbsolute = profileStartX(%))
+  |> close()
+tool = extrude(toolSketch, length = 20)
+
+result = subtract(target, tools = [tool])
+"#;
+        let program = crate::Program::parse_no_errs(code).unwrap();
+        let ctx = crate::ExecutorContext::new_mock(None).await;
+        let mut state = ExecState::new(&ctx);
+        let (env_ref, _) = ctx.run(&program, &mut state).await.unwrap();
+
+        let variables = state.mod_local.variables(env_ref).unwrap();
+        let crate::execution::KclValue::Solid { value: target } = &variables["target"] else {
+            panic!("target should be a solid");
+        };
+        let crate::execution::KclValue::Solid { value: tool } = &variables["tool"] else {
+            panic!("tool should be a solid");
+        };
+        let crate::execution::KclValue::Solid { value: result } = &variables["result"] else {
+            panic!("result should be a solid");
+        };
+        let target_artifact_id = target.artifact_id;
+        let tool_artifact_id = tool.artifact_id;
+        let result_artifact_id = result.artifact_id;
+        let result_id = result.id;
+        drop(variables);
+
+        // Mock execution does not receive the Engine responses that turn the
+        // source sweeps into a composite artifact, so model that final graph
+        // state directly for the selector regression.
+        let item_count = state.global.artifacts.graph.item_count();
+        let (mut graph, _) = std::mem::take(&mut state.global.artifacts.graph).into_parts();
+        let crate::execution::Artifact::Sweep(target_sweep) =
+            graph.get_mut(&target_artifact_id).expect("target sweep artifact")
+        else {
+            panic!("target artifact should be a sweep");
+        };
+        target_sweep.consumed = true;
+        let crate::execution::Artifact::Sweep(tool_sweep) =
+            graph.get_mut(&tool_artifact_id).expect("tool sweep artifact")
+        else {
+            panic!("tool artifact should be a sweep");
+        };
+        tool_sweep.consumed = true;
+        graph.insert(
+            result_artifact_id,
+            crate::execution::Artifact::CompositeSolid(kcl_api::artifact::CompositeSolid {
+                id: result_artifact_id,
+                consumed: false,
+                sub_type: kcl_api::artifact::CompositeSolidSubType::Subtract,
+                output_index: None,
+                solid_ids: vec![target_artifact_id],
+                tool_ids: vec![tool_artifact_id],
+                code_ref: crate::execution::CodeRef::placeholder(SourceRange::synthetic()),
+                composite_solid_id: None,
+                pattern_ids: Vec::new(),
+            }),
+        );
+        state.global.artifacts.graph = crate::execution::ArtifactGraph::from_parts(graph, item_count);
+        let entity_ids = state
+            .physical_property_entity_ids(env_ref)
+            .unwrap()
+            .expect("procedural solids should have a complete explicit selection");
+
+        assert_eq!(entity_ids, vec![result_id]);
+        ctx.close().await;
+    }
 
     #[test]
     fn declared_kcl_version_finds_the_setting_and_its_range() {

--- a/rust/kcl-python-bindings/src/bridge/physical_properties.rs
+++ b/rust/kcl-python-bindings/src/bridge/physical_properties.rs
@@ -11,6 +11,7 @@ use pyo3::PyResult;
 use pyo3::exceptions::PyException;
 use pyo3::pyclass;
 use pyo3::pymethods;
+use uuid::Uuid;
 
 use crate::bridge::bounding_box::BoundingBoxResponse;
 
@@ -25,6 +26,38 @@ pub struct PhysicalPropertiesRequest {
     pub surface_area: Option<kcmc::SurfaceArea>,
     pub density: Option<kcmc::Density>,
     pub bounding_box: Option<kcmc::BoundingBox>,
+}
+
+impl PhysicalPropertiesRequest {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.volume.is_none()
+            && self.mass.is_none()
+            && self.center_of_mass.is_none()
+            && self.surface_area.is_none()
+            && self.density.is_none()
+            && self.bounding_box.is_none()
+    }
+
+    pub(crate) fn set_entity_ids(&mut self, entity_ids: &[Uuid]) {
+        if let Some(request) = &mut self.volume {
+            request.entity_ids = entity_ids.to_vec();
+        }
+        if let Some(request) = &mut self.mass {
+            request.entity_ids = entity_ids.to_vec();
+        }
+        if let Some(request) = &mut self.center_of_mass {
+            request.entity_ids = entity_ids.to_vec();
+        }
+        if let Some(request) = &mut self.surface_area {
+            request.entity_ids = entity_ids.to_vec();
+        }
+        if let Some(request) = &mut self.density {
+            request.entity_ids = entity_ids.to_vec();
+        }
+        if let Some(request) = &mut self.bounding_box {
+            request.entity_ids = entity_ids.to_vec();
+        }
+    }
 }
 
 /// Resulting data from a `PhysicalPropertiesRequest`.

--- a/rust/kcl-python-bindings/src/lib.rs
+++ b/rust/kcl-python-bindings/src/lib.rs
@@ -446,9 +446,27 @@ async fn execute_and_snapshot_views_impl(
 
 async fn execute_and_measure_impl(
     input: KclInput,
-    request: PhysicalPropertiesRequest,
+    mut request: PhysicalPropertiesRequest,
 ) -> PyResult<PhysicalPropertiesResponse> {
-    let ExecutedKcl { ctx, .. } = run_kcl(input, false, None).await?;
+    let ExecutedKcl {
+        ctx, state, env_ref, ..
+    } = run_kcl(input, false, None).await?;
+    let entity_ids = match state.physical_property_entity_ids(env_ref) {
+        Ok(entity_ids) => entity_ids,
+        Err(err) => {
+            ctx.close().await;
+            return Err(to_py_exception(err));
+        }
+    };
+    if let Some(entity_ids) = entity_ids {
+        if entity_ids.is_empty() && !request.is_empty() {
+            ctx.close().await;
+            return Err(PyException::new_err(
+                "KCL execution produced no visible solid bodies to measure",
+            ));
+        }
+        request.set_entity_ids(&entity_ids);
+    }
     let result = measure_model_properties(&ctx, request).await;
     ctx.close().await;
     result

--- a/rust/kcl-python-bindings/tests/tests.py
+++ b/rust/kcl-python-bindings/tests/tests.py
@@ -45,6 +45,42 @@ box_sketch = startSketchOn(XY)
 box3D = extrude(box_sketch, length = box_height)
 """
 
+box_with_construction_sketch_code = f"""
+{box_code}
+
+construction_sketch = startSketchOn(XY)
+  |> startProfile(at = [1000, 0])
+  |> xLine(length = 100)
+  |> yLine(length = 100)
+  |> xLine(endAbsolute = profileStartX(%))
+  |> close()
+"""
+
+box_with_hidden_solid_code = f"""
+{box_code}
+
+hidden_sketch = startSketchOn(XY)
+  |> startProfile(at = [1000, 0])
+  |> xLine(length = 100)
+  |> yLine(length = 100)
+  |> xLine(endAbsolute = profileStartX(%))
+  |> close()
+hidden_solid = extrude(hidden_sketch, length = 100)
+hide(hidden_solid)
+"""
+
+two_visible_boxes_code = f"""
+{box_code}
+
+second_sketch = startSketchOn(XY)
+  |> startProfile(at = [100, 0])
+  |> xLine(length = 10)
+  |> yLine(length = 10)
+  |> xLine(endAbsolute = profileStartX(%))
+  |> close()
+second_solid = extrude(second_sketch, length = 10)
+"""
+
 requires_engine = pytest.mark.skipif(
     "ZOO_API_TOKEN" not in os.environ, reason="requires ZOO_API_TOKEN"
 )
@@ -508,6 +544,86 @@ async def test_kcl_execute_code_and_measure_bounding_box_mm():
     assert dimensions.x == pytest.approx(25, rel=0, abs=1e-5)
     assert dimensions.y == pytest.approx(25, rel=0, abs=1e-5)
     assert dimensions.z == pytest.approx(50, rel=0, abs=1e-5)
+
+
+@requires_engine
+@pytest.mark.asyncio
+async def test_kcl_measure_ignores_unextruded_construction_sketch():
+    request = kcl.PhysicalPropertiesRequest()
+    request.set_volume(kcl.UnitVolume.CubicMillimeters)
+    request.set_bounding_box(kcl.UnitLength.Millimeters)
+    response = await execute_with_retries(
+        kcl.execute_code_and_measure, box_with_construction_sketch_code, request
+    )
+
+    assert response.get_volume() == pytest.approx(31250, rel=0, abs=1e-2)
+    bounding_box = response.get_bounding_box()
+    center = bounding_box.get_center()
+    dimensions = bounding_box.get_dimensions()
+    assert center.x == pytest.approx(12.5, rel=0, abs=1e-5)
+    assert center.y == pytest.approx(12.5, rel=0, abs=1e-5)
+    assert center.z == pytest.approx(25, rel=0, abs=1e-5)
+    assert dimensions.x == pytest.approx(25, rel=0, abs=1e-5)
+    assert dimensions.y == pytest.approx(25, rel=0, abs=1e-5)
+    assert dimensions.z == pytest.approx(50, rel=0, abs=1e-5)
+
+
+@requires_engine
+@pytest.mark.asyncio
+async def test_kcl_measure_ignores_hidden_solid():
+    request = kcl.PhysicalPropertiesRequest()
+    request.set_volume(kcl.UnitVolume.CubicMillimeters)
+    request.set_bounding_box(kcl.UnitLength.Millimeters)
+    response = await execute_with_retries(
+        kcl.execute_code_and_measure, box_with_hidden_solid_code, request
+    )
+
+    assert response.get_volume() == pytest.approx(31250, rel=0, abs=1e-2)
+    bounding_box = response.get_bounding_box()
+    center = bounding_box.get_center()
+    dimensions = bounding_box.get_dimensions()
+    assert center.x == pytest.approx(12.5, rel=0, abs=1e-5)
+    assert center.y == pytest.approx(12.5, rel=0, abs=1e-5)
+    assert center.z == pytest.approx(25, rel=0, abs=1e-5)
+    assert dimensions.x == pytest.approx(25, rel=0, abs=1e-5)
+    assert dimensions.y == pytest.approx(25, rel=0, abs=1e-5)
+    assert dimensions.z == pytest.approx(50, rel=0, abs=1e-5)
+
+
+@requires_engine
+@pytest.mark.asyncio
+async def test_kcl_measure_includes_multiple_visible_solids():
+    request = kcl.PhysicalPropertiesRequest()
+    request.set_volume(kcl.UnitVolume.CubicMillimeters)
+    request.set_bounding_box(kcl.UnitLength.Millimeters)
+    response = await execute_with_retries(
+        kcl.execute_code_and_measure, two_visible_boxes_code, request
+    )
+
+    assert response.get_volume() == pytest.approx(32250, rel=0, abs=1e-2)
+    bounding_box = response.get_bounding_box()
+    center = bounding_box.get_center()
+    dimensions = bounding_box.get_dimensions()
+    assert center.x == pytest.approx(55, rel=0, abs=1e-5)
+    assert center.y == pytest.approx(12.5, rel=0, abs=1e-5)
+    assert center.z == pytest.approx(25, rel=0, abs=1e-5)
+    assert dimensions.x == pytest.approx(110, rel=0, abs=1e-5)
+    assert dimensions.y == pytest.approx(25, rel=0, abs=1e-5)
+    assert dimensions.z == pytest.approx(50, rel=0, abs=1e-5)
+
+
+@requires_engine
+@pytest.mark.asyncio
+async def test_kcl_measure_requires_a_visible_solid():
+    request = kcl.PhysicalPropertiesRequest()
+    request.set_bounding_box(kcl.UnitLength.Millimeters)
+
+    with pytest.raises(Exception, match="no visible solid bodies"):
+        await execute_with_retries(
+            kcl.execute_code_and_measure,
+            "startSketchOn(XY) |> startProfile(at = [0, 0]) |> xLine(length = 10)",
+            request,
+        )
 
 
 @requires_engine


### PR DESCRIPTION
Send one explicit, deterministic set of visible procedural solid IDs to every KCL physical-property command. Hidden and consumed solids are excluded; sketch-only programs report no visible solid, while imported or unmappable geometry retains the existing empty-selection fallback.

Fixes #13375. Focused selector, binding, lint, and live-Engine tests pass. Engine still reports a separate incorrect per-entity bound for one subtraction result.