### PR TITLE
Ignore non-measurable selections for measurement distance

### DIFF
--- a/src/registry/extensions/engineScene/MeasurementTool.test.ts
+++ b/src/registry/extensions/engineScene/MeasurementTool.test.ts
@@ -223,6 +223,7 @@ describe('MeasurementTool helpers', () => {
     const edge = measurementEntity('edge')
     const face = measurementEntity('face')
     const body = measurementEntity('body')
+    const other = measurementEntity('other')
 
     expect(
       measurementCapabilities.map((capability) => ({
@@ -251,6 +252,9 @@ describe('MeasurementTool helpers', () => {
       type: 'distance',
       entities: [body, face],
     })
+    expect(getMeasurementTarget([body, other])).toBeNull()
+    expect(getMeasurementTarget([edge, other])).toBeNull()
+    expect(getMeasurementTarget([other, other])).toBeNull()
     expect(getMeasurementTarget([body, face, edge])).toBeNull()
   })
 

--- a/src/registry/extensions/engineScene/measurementCapabilities.ts
+++ b/src/registry/extensions/engineScene/measurementCapabilities.ts
@@ -25,6 +25,10 @@ export type MeasurementCapability = {
 
 const defaultDistanceMode: DistanceMode = 'euclidean'
 
+function canMeasureDistance(entity: MeasurementEntity): boolean {
+  return entity.kind !== 'other'
+}
+
 /** User-facing explanation for a known endpoint gap: body area works, face area does not. */
 export const unsupportedFaceSurfaceAreaMessage =
   'Face surface area is not supported by the current engine endpoint. Select the body to measure total surface area, volume, and center of mass.'
@@ -44,6 +48,9 @@ export const measurementCapabilities: readonly MeasurementCapability[] = [
     label: 'Distance',
     getTarget(selectedEntities) {
       if (selectedEntities.length !== 2) {
+        return null
+      }
+      if (!selectedEntities.every(canMeasureDistance)) {
         return null
       }
 


### PR DESCRIPTION
## Summary

- Prevent the measurement capability layer from building distance targets for selections classified as `kind: "other"`.
- Add regression coverage for `body + other`, `edge + other`, and `other + other` selections.

Closes #13379.

## Why

Codex GUI-fuzzer follow-up found that regions/default planes/unknown scene selections are normalized to `other`, but the distance capability accepted any two entities and could pass them through to `entity_get_distance`.

## Tests

- `biome check src/registry/extensions/engineScene/measurementCapabilities.ts src/registry/extensions/engineScene/MeasurementTool.test.ts`
- `npm run test:unit -- src/registry/extensions/engineScene/MeasurementTool.test.ts`

Also attempted `npm run tsc -- --noEmit --pretty false` after copying generated Rust/Wasm bindings into the clean worktree. It still fails on existing generated-binding/API drift outside this diff, with no measurement-file errors remaining in the filtered output.
