### PR TITLE
Gate measurement requests for stale graph selections

### DIFF
--- a/src/registry/extensions/engineScene/MeasurementTool.test.ts
+++ b/src/registry/extensions/engineScene/MeasurementTool.test.ts
@@ -18,6 +18,7 @@ import {
   getMeasurementEntities,
   getMeasurementEntityIds,
   getVolumeUnit,
+  graphSelectionsReferenceCurrentArtifacts,
   type MeasurementEntity,
   unitAreaLabels,
   unitVolumeLabels,
@@ -192,6 +193,51 @@ describe('MeasurementTool helpers', () => {
       { id: 'region-id', kind: 'other' },
       { id: 'plane-id', kind: 'other' },
     ])
+  })
+
+  it('detects graph selections whose artifacts were replaced after regeneration', () => {
+    const currentBody = artifact({
+      id: 'body-id',
+      type: 'sweep',
+    })
+    const staleBody = artifact({
+      id: 'body-id',
+      type: 'sweep',
+    })
+    const currentArtifactGraph = new Map([[currentBody.id, currentBody]])
+    const codeRef = {
+      range: [0, 1, 0] as [number, number, number],
+      pathToNode: [],
+    }
+
+    expect(
+      graphSelectionsReferenceCurrentArtifacts(
+        {
+          graphSelections: [
+            {
+              artifact: currentBody,
+              codeRef,
+            },
+          ],
+          otherSelections: [],
+        },
+        currentArtifactGraph
+      )
+    ).toBe(true)
+    expect(
+      graphSelectionsReferenceCurrentArtifacts(
+        {
+          graphSelections: [
+            {
+              artifact: staleBody,
+              codeRef,
+            },
+          ],
+          otherSelections: [],
+        },
+        currentArtifactGraph
+      )
+    ).toBe(false)
   })
 
   it('classifies non-code faces and bodies', () => {

--- a/src/registry/extensions/engineScene/MeasurementTool.tsx
+++ b/src/registry/extensions/engineScene/MeasurementTool.tsx
@@ -49,6 +49,7 @@ import {
   getDistanceTypeForMode,
   getMeasurementEntities,
   getVolumeUnit,
+  graphSelectionsReferenceCurrentArtifacts,
   type MeasurementEntity,
   unitAreaLabels,
   unitVolumeLabels,
@@ -471,6 +472,14 @@ export function MeasurementTool() {
   const areaUnit = getAreaUnit(unit)
   const volumeUnit = getVolumeUnit(unit)
   const isIdle = state.matches('idle')
+  const graphSelectionsAreCurrent = useMemo(
+    () =>
+      graphSelectionsReferenceCurrentArtifacts(
+        state.context.selectionRanges,
+        kclManager.artifactGraph
+      ),
+    [state.context.selectionRanges, kclManager.artifactGraph]
+  )
 
   const sendModelingCommand = useCallback(
     (cmd: ModelingCmd) =>
@@ -489,7 +498,7 @@ export function MeasurementTool() {
     setResult(null)
     setErrorMessage(null)
 
-    if (!isIdle) {
+    if (!isIdle || !graphSelectionsAreCurrent) {
       return
     }
 
@@ -535,6 +544,7 @@ export function MeasurementTool() {
   }, [
     areaUnit,
     distanceMode,
+    graphSelectionsAreCurrent,
     isIdle,
     measurementInputKey,
     measurementTarget,
@@ -544,7 +554,7 @@ export function MeasurementTool() {
     volumeUnit,
   ])
 
-  if (!isIdle) {
+  if (!isIdle || !graphSelectionsAreCurrent) {
     return null
   }
 
@@ -706,6 +716,14 @@ export function MeasurementStatusBarItem() {
     () => getMeasurementEntities(state.context.selectionRanges),
     [state.context.selectionRanges]
   )
+  const graphSelectionsAreCurrent = useMemo(
+    () =>
+      graphSelectionsReferenceCurrentArtifacts(
+        state.context.selectionRanges,
+        kclManager.artifactGraph
+      ),
+    [state.context.selectionRanges, kclManager.artifactGraph]
+  )
   const selectedEntityIdsKey = selectedEntities
     .map((entity) => `${entity.kind}:${entity.id}`)
     .join(':')
@@ -744,7 +762,7 @@ export function MeasurementStatusBarItem() {
     latestRequestKey.current = measurementInputKey
     setResult(null)
 
-    if (!isIdle || !measurementTarget) {
+    if (!isIdle || !measurementTarget || !graphSelectionsAreCurrent) {
       return
     }
 
@@ -777,6 +795,7 @@ export function MeasurementStatusBarItem() {
   }, [
     areaUnit,
     defaultStatusDistanceMode,
+    graphSelectionsAreCurrent,
     isIdle,
     measurementInputKey,
     measurementTarget,

--- a/src/registry/extensions/engineScene/measurementUtils.ts
+++ b/src/registry/extensions/engineScene/measurementUtils.ts
@@ -6,6 +6,7 @@ import type {
   UnitVolume,
 } from '@kittycad/lib'
 import type { Artifact } from '@src/lang/std/artifactGraph'
+import type { ArtifactGraph } from '@src/lang/wasm'
 import {
   isDefaultPlaneSelection,
   isEnginePrimitiveSelection,
@@ -190,6 +191,19 @@ export function getMeasurementEntities(
       }
     ),
   ])
+}
+
+export function graphSelectionsReferenceCurrentArtifacts(
+  selectionRanges: Selections,
+  artifactGraph: ArtifactGraph
+): boolean {
+  return selectionRanges.graphSelections.every((selection) => {
+    if (!selection.artifact) {
+      return true
+    }
+
+    return artifactGraph.get(selection.artifact.id) === selection.artifact
+  })
 }
 
 export function getMeasurementEntityIds(selectionRanges: Selections): string[] {


### PR DESCRIPTION
## Summary

- Add a measurement helper that detects graph selections still pointing at artifact objects from an older artifact graph.
- Skip automatic measurement requests while the selected graph artifacts are stale.
- Apply the guard to both the explicit measurement panel and the status-bar measurement path.
- Add regression coverage for current versus stale graph-selection artifacts.

Closes #13380.

## Why

Codex GUI-fuzzer runs against production reproduced valid Sweep/Helix geometry and KCL, but each repeat logged stale-BRep body-detail errors after regeneration. The status-bar request key only prevented stale responses from updating UI; it did not prevent stale requests from reaching the engine.

This is a narrow client-side guard to avoid sending automatic `volume`, `surface_area`, and `center_of_mass` requests when the current selection still references an artifact object replaced by regeneration.

## Tests

- `biome check src/registry/extensions/engineScene/measurementUtils.ts src/registry/extensions/engineScene/MeasurementTool.tsx src/registry/extensions/engineScene/MeasurementTool.test.ts`
- `npm run test:unit -- src/registry/extensions/engineScene/MeasurementTool.test.ts`

Also attempted `npm run tsc -- --noEmit --pretty false` after copying generated Rust/Wasm bindings into the clean worktree. It still fails on existing generated-binding/API drift outside this diff, with no measurement-file errors remaining in the filtered output.
