### PR TITLE
Fix Zookeeper happy path completion race

### DIFF
--- a/e2e/playwright/zookeeper.spec.ts
+++ b/e2e/playwright/zookeeper.spec.ts
@@ -32,9 +32,11 @@ test.describe('Zookeeper tests', { tag: ['@desktop', '@web'] }, () => {
         timeout: 30_000,
       })
 
-      await toolbar.closePane(DefaultLayoutPaneID.Zookeeper)
       await toolbar.openPane(DefaultLayoutPaneID.Code)
-      await expect(editor.codeContent).toContainText('sketch')
+      await expect(editor.codeContent).toContainText('sketch', {
+        timeout: 30_000,
+      })
+      await toolbar.closePane(DefaultLayoutPaneID.Zookeeper)
 
       await toolbar.closePane(DefaultLayoutPaneID.Code)
       await toolbar.openPane(DefaultLayoutPaneID.FeatureTree)


### PR DESCRIPTION
## Summary

- keep the Zookeeper pane mounted until generated KCL is visible in CodeMirror
- use the generated code as the completion signal, with the existing 30-second async budget
- close Zookeeper only after its tool output has been processed

## Why

The response placeholder disappears on the first response delta, before the later `tool_output` is handled. Closing Zookeeper at that point unmounts its file-request subscriber, so the generated KCL can be dropped and the editor remains at its starter content.

## Testing

- `biome check` for `e2e/playwright/zookeeper.spec.ts`
- `eslint --max-warnings 0 e2e/playwright/zookeeper.spec.ts`
- targeted Playwright run attempted, but the local July dependency/generated-WASM cache cannot load current `main` (`@codemirror/merge` and generated `StdLibCommands` are absent); the test body was not reached