### PR TITLE
[Testing- Do not Merge] camera positioning for ZK

### DIFF
--- a/src/components/OpenedProject.tsx
+++ b/src/components/OpenedProject.tsx
@@ -34,7 +34,6 @@ import { useDefaultAreaLibrary } from '@src/lib/layout/defaultAreaLibrary'
 import { lspService } from '@src/lang/lsp/registry/contract'
 import { PATHS } from '@src/lib/paths'
 import type { Project } from '@src/lib/project'
-import { resetCameraPosition } from '@src/lib/resetCameraPosition'
 import { maybeWriteToDisk } from '@src/lib/telemetry'
 import { reportRejection } from '@src/lib/trap'
 import { withSiteBaseURL } from '@src/lib/withBaseURL'
@@ -70,7 +69,6 @@ export function OpenedProject() {
   const { auth, billing, settings, layout, project, systemIOActor, registry } =
     app
   const { kclManager } = useSingletons()
-  const settingsActor = settings.actor
   const defaultAreaLibrary = useDefaultAreaLibrary()
   const defaultActionLibrary = useDefaultActionLibrary()
   const { state: modelingState, send: modelingSend } = useModelingContext()
@@ -145,19 +143,8 @@ export function OpenedProject() {
       return
     }
 
-    kclManager
-      .executeCode()
-      .then(async () => {
-        if (reloadBehavior === 'execute-and-reset-camera') {
-          await resetCameraPosition({
-            sceneInfra: kclManager.sceneInfra,
-            engineCommandManager: kclManager.engineCommandManager,
-            settingsActor,
-          })
-        }
-      })
-      .catch(reportRejection)
-  }, [systemIOState, kclManager, modelingState, modelingSend, settingsActor])
+    kclManager.executeCode().catch(reportRejection)
+  }, [systemIOState, kclManager, modelingState, modelingSend])
 
   // Run LSP file open hook when navigating between projects or files
   useEffect(() => {

--- a/src/components/openedProjectUtils.spec.ts
+++ b/src/components/openedProjectUtils.spec.ts
@@ -19,11 +19,11 @@ describe('getZookeeperProjectReloadBehavior', () => {
     ).toBe('execute-without-camera-reset')
   })
 
-  it('keeps the current behavior outside sketch mode', () => {
+  it('preserves the camera outside sketch mode', () => {
     expect(
       getZookeeperProjectReloadBehavior({
         matches: () => false,
       })
-    ).toBe('execute-and-reset-camera')
+    ).toBe('execute-without-camera-reset')
   })
 })

--- a/src/components/openedProjectUtils.ts
+++ b/src/components/openedProjectUtils.ts
@@ -5,7 +5,6 @@ export interface ModelingStateMatcher {
 export type ZookeeperProjectReloadBehavior =
   | 'exit-sketch-solve'
   | 'execute-without-camera-reset'
-  | 'execute-and-reset-camera'
 
 export function getZookeeperProjectReloadBehavior(
   modelingState?: ModelingStateMatcher | null
@@ -14,9 +13,5 @@ export function getZookeeperProjectReloadBehavior(
     return 'exit-sketch-solve'
   }
 
-  if (modelingState?.matches('Sketch')) {
-    return 'execute-without-camera-reset'
-  }
-
-  return 'execute-and-reset-camera'
+  return 'execute-without-camera-reset'
 }

--- a/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.spec.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.spec.tsx
@@ -231,7 +231,7 @@ describe('ZookeeperConversationPaneWrapper', () => {
         shouldAddToHistory: false,
         shouldClearHistory: false,
         shouldExecute: true,
-        shouldResetCamera: true,
+        shouldResetCamera: false,
         shouldWriteToDisk: false,
       }
     )

--- a/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.tsx
@@ -357,7 +357,7 @@ function ZookeeperConversationPaneInner(props: AreaTypeComponentProps) {
                                   shouldClearHistory:
                                     !shouldRecordZookeeperHistory,
                                   shouldExecute: true,
-                                  shouldResetCamera: true,
+                                  shouldResetCamera: false,
                                   shouldWriteToDisk:
                                     !shouldRecordZookeeperHistory,
                                 }


### PR DESCRIPTION
## Summary

- preserve the current camera when Zookeeper refreshes the active editor
- execute Zookeeper filesystem reloads without forcing an isometric camera fit
- update the existing regression expectations for both reset paths

## Context

This is an exploratory draft that reverses the forced post-execution camera resets added in #9864. It is intentionally marked do not merge while we compare viewport preservation against automatic model discoverability.

The minimal implementation disables automatic fitting for all normal Zookeeper writes, including first generation and edits that move or greatly rescale geometry. Those cases must be tested before deciding on the final policy.

## Automated checks

- [x] make check
- [x] npm run test:integration -- src/components/openedProjectUtils.spec.ts
- [x] npm run test:integration -- src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.spec.tsx

## Manual test plan

- [ ] Set a distinctive orbit, pan, and zoom, then edit the active main.kcl through Zookeeper. Geometry should update without moving the camera.
- [ ] Repeat with an imported or inactive part.kcl edit to exercise the post-filesystem reload path.
- [ ] Generate the first model from a blank project and judge whether it remains discoverable without automatic fitting.
- [ ] Make a large or off-origin geometry change and judge the preserve-view tradeoff.
- [ ] Verify sketch solve mode still exits safely when Zookeeper updates the project.
- [ ] Verify explicit Reset View and Zoom to Fit commands still work.

## Related

- #9864
- #9595