### PR TITLE
Fix cloud conflict title flicker and project count link

### DIFF
--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -593,6 +593,63 @@ describe('cloud sync library home summary', () => {
     }
   })
 
+  test('keeps the project title when conflict metadata uses the directory name', async () => {
+    const projectPath = projectWellFormed.path
+    cloudSyncStatus.value = {
+      enabled: true,
+      state: 'conflict',
+      pendingCount: 0,
+      activeProjectPath: projectPath,
+    }
+    cloudConflictDialogMocks.conflicts = [
+      {
+        localProjectPath: projectPath,
+        projectName: projectWellFormed.name,
+      },
+    ]
+    const registry = new Registry()
+
+    registry.configure([cloudSyncProjectLibraryType, cloudSyncPlugin])
+    enableCloudSyncPlugin(registry)
+
+    try {
+      const cloudLibraryType = registry
+        .get(projectLibraryTypesValueSpec)
+        .get(CLOUD_PROJECT_LIBRARY_TYPE)
+      const HomeSummary = cloudLibraryType?.homeSummary
+      expect(HomeSummary).toBeDefined()
+      if (!HomeSummary) {
+        return
+      }
+
+      const cloudLibrary = {
+        ...getDefaultCloudProjectLibrarySetting(),
+        id: PERSONAL_CLOUD_PROJECT_LIBRARY_ID,
+      }
+      const project = {
+        ...homeProjectEntryFromProject(projectWellFormed),
+        id: `local:${projectPath}`,
+        libraryIds: [PERSONAL_CLOUD_PROJECT_LIBRARY_ID],
+        status: 'conflicted',
+        conflict: {},
+      } satisfies HomeProjectEntry
+      renderWithRouter(
+        <HomeSummary library={cloudLibrary} projects={[project]} />
+      )
+
+      fireEvent.click(screen.getByTestId('cloud-library-sync-status'))
+
+      expect(
+        await screen.findByRole('button', { name: projectWellFormed.title })
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: projectWellFormed.name })
+      ).not.toBeInTheDocument()
+    } finally {
+      registry[Symbol.dispose]()
+    }
+  })
+
   test('uses destroy styling for library sync failure status', () => {
     const projectPath = projectWellFormed.path
     cloudSyncStatus.value = {

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -312,6 +312,7 @@ function getCloudSyncLibraryConflictIssues(
   conflictMetadataList: readonly CloudSyncConflictMetadata[] | undefined
 ) {
   const libraryProjectPaths = getCloudSyncLibraryProjectPathSet(projects)
+  const projectsByPath = getCloudSyncLibraryProjectByPath(projects)
   const conflictIssuesByPath = new Map<string, CloudSyncLibraryProjectIssue>()
 
   for (const project of projects) {
@@ -331,10 +332,13 @@ function getCloudSyncLibraryConflictIssues(
     if (!projectPath || !libraryProjectPaths.has(projectPath)) {
       continue
     }
+    const project = projectsByPath.get(projectPath)
 
     conflictIssuesByPath.set(projectPath, {
       projectPath: metadata.localProjectPath,
-      projectName: metadata.projectName,
+      projectName: project
+        ? getHomeProjectDisplayName(project)
+        : metadata.projectName,
     })
   }
 

--- a/src/routes/HomeProjectCards.tsx
+++ b/src/routes/HomeProjectCards.tsx
@@ -139,9 +139,12 @@ export function ProjectLibraryPreviewRow({
           projects={libraryProjects}
           projectLibraryTypes={projectLibraryTypes}
         />
-        <span className="hidden flex-none text-xs text-chalkboard-70 dark:text-chalkboard-30 sm:block">
+        <Link
+          to={getProjectLibraryRoute(library)}
+          className="hidden flex-none select-none text-xs text-chalkboard-70 !no-underline dark:text-chalkboard-30 sm:block"
+        >
           {projectCountLabel(projects.length)}
-        </span>
+        </Link>
         <Link
           to={getProjectLibraryRoute(library)}
           aria-label={`Open ${library.title} library`}


### PR DESCRIPTION
Addresses two Home library overview interaction issues: cloud conflict labels could flicker between a project title and its local directory name, and the project count looked clickable but did not open its library.

1. Keeps the matching Home project entry as the authority for the user-visible conflict label.
2. Uses durable conflict metadata only as a fallback when no Home entry is available.
3. Makes the library project count a non-selectable navigation link.
4. Adds regression coverage for both behaviors.

## How to test

1. Create or use a cloud project whose title differs from its local directory name, put it into conflict, and open the Cloud conflict popover on Home. Confirm the conflict row consistently shows the project title while cloud sync status refreshes.
2. From the all-libraries Home overview, click the project count in a library header. Confirm it opens that library and does not select the count text.