### PR TITLE
Gate linked directory deletes on cloud sync

### DIFF
--- a/src/lib/cloudSync/registry/constants.ts
+++ b/src/lib/cloudSync/registry/constants.ts
@@ -1,0 +1,1 @@
+export const CLOUD_SYNC_PLUGIN_ID = 'cloud-sync'

--- a/src/lib/cloudSync/registry/extension.ts
+++ b/src/lib/cloudSync/registry/extension.ts
@@ -24,6 +24,7 @@ import {
   startCloudSyncProject,
 } from '@src/lib/cloudSync'
 import { getCloudProjectLibraryMaterializationDirectoryPath } from '@src/lib/cloudSync/paths'
+import { CLOUD_SYNC_PLUGIN_ID } from '@src/lib/cloudSync/registry/constants'
 import {
   type CloudSyncRegistryRuntimeConfig,
   type CloudSyncRegistryService,
@@ -47,8 +48,6 @@ import {
   settingsService,
 } from '@src/registry/contracts/settings'
 import { userFeaturesService } from '@src/registry/contracts/userFeatures'
-
-const CLOUD_SYNC_PLUGIN_ID = 'cloud-sync'
 
 type SettingsSnapshot = ReturnType<
   SettingsRegistryService['actor']['getSnapshot']

--- a/src/lib/cloudSync/registry/plugin.tsx
+++ b/src/lib/cloudSync/registry/plugin.tsx
@@ -44,6 +44,7 @@ import {
   getCloudProjectLibraryMaterializationDirectoryPath,
   normalizePathForSync,
 } from '@src/lib/cloudSync/paths'
+import { CLOUD_SYNC_PLUGIN_ID } from '@src/lib/cloudSync/registry/constants'
 import {
   type CloudProjectLocalManifestComparison,
   classifyCloudProjectDuplicateRisk,
@@ -108,7 +109,6 @@ import { wasmPromiseValueSpec } from '@src/registry/contracts/wasm'
 import { createZdsPlugin } from '@src/registry/createZdsPlugin'
 import { useEffect, useState } from 'react'
 
-const CLOUD_SYNC_PLUGIN_ID = 'cloud-sync'
 const CLOUD_SYNC_STALLED_AFTER_MS = 5 * 60_000
 
 function cloudSyncProjectIsStalled(

--- a/src/lib/projectLibraries/registry/index.ts
+++ b/src/lib/projectLibraries/registry/index.ts
@@ -2,17 +2,19 @@ import {
   defineRegistryItem,
   defineRegistryItemFactory,
   defineRuntimeRegistryItem,
+  pluginsValueSpec,
   provide,
   provideService,
 } from '@kittycad/registry'
 import { effect, signal } from '@preact/signals-core'
+import { CLOUD_SYNC_PLUGIN_ID } from '@src/lib/cloudSync/registry/constants'
 import { writeProjectTitleToProjectToml } from '@src/lib/desktop'
 import fsZds from '@src/lib/fs-zds'
 import { getHomeProjectDisplayName } from '@src/lib/homeProjects'
 import { duplicateProjectInDirectory } from '@src/lib/projectDuplication'
 import {
-  DIRECTORY_PROJECT_LIBRARY_TYPE,
   DEFAULT_PROJECT_LIBRARY_TITLE,
+  DIRECTORY_PROJECT_LIBRARY_TYPE,
   getDefaultProjectLibrarySettings,
   NEW_PROJECT_LIBRARY_TITLE,
   type ProjectLibrary,
@@ -29,9 +31,9 @@ import {
 import { projectLibraryRealizationFromProject } from '@src/lib/projectLibraries/realizations'
 import {
   invalidateProjectLibraryRealizations,
+  type ProjectLibraryRealizationsInvalidationSnapshot,
   readProjectLibraryRealizationInvalidationForLibrary,
   readProjectLibraryRealizationsInvalidation,
-  type ProjectLibraryRealizationsInvalidationSnapshot,
 } from '@src/lib/projectLibraries/registry/invalidation'
 import { DirectoryProjectLibrarySettingsDetails } from '@src/lib/projectLibraries/settings/ProjectLibrariesSettingInput'
 import { projectLibrariesSettingsContribution } from '@src/lib/projectLibraries/settings/setting'
@@ -619,6 +621,13 @@ function reportDirectoryProjectStatFailures({
 
 const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
   const cloudSync = ctx.services.signal(cloudSyncService)
+  const plugins = ctx.valueSpecs.signal(pluginsValueSpec)
+  const isCloudSyncPluginActive = () => {
+    const plugin = plugins.value.find(
+      (candidate) => candidate.id === CLOUD_SYNC_PLUGIN_ID
+    )
+    return plugin ? ctx.services.get(plugin.service).active.value : false
+  }
   const getWasmPromise = () =>
     ctx.valueSpecs.get(wasmPromiseValueSpec) ??
     new ExpectedSystemIOError('Missing WASM promise registry value.')
@@ -714,11 +723,17 @@ const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
           return
         }
 
-        const cloudSyncActions = project.remoteProjectId
+        // A cloud ID can outlive access to the plugin that manages it. Only an
+        // active cloudSync plugin owns relationship-aware local cleanup;
+        // otherwise this remains an ordinary directory-library delete.
+        const useCloudSyncDelete = Boolean(
+          project.remoteProjectId && isCloudSyncPluginActive()
+        )
+        const cloudSyncActions = useCloudSyncDelete
           ? cloudSync.value
           : undefined
         if (
-          project.remoteProjectId &&
+          useCloudSyncDelete &&
           cloudSyncActions?.status.value.enabled !== true
         ) {
           return Promise.reject(
@@ -726,7 +741,7 @@ const directoryProjectLibraryType = defineRegistryItemFactory((ctx) => {
           )
         }
 
-        if (project.remoteProjectId) {
+        if (useCloudSyncDelete && project.remoteProjectId) {
           await cloudSyncActions?.deleteLocalProjectRealizations(
             project.remoteProjectId,
             project.localProjectPath

--- a/src/registry/extensions/homeProjects/index.test.ts
+++ b/src/registry/extensions/homeProjects/index.test.ts
@@ -1,4 +1,5 @@
 import {
+  createPlugin,
   defineRegistryItem,
   provide,
   provideService,
@@ -6,6 +7,7 @@ import {
 } from '@kittycad/registry'
 import { signal } from '@preact/signals-core'
 import type * as ClientErrors from '@src/lib/clientErrors'
+import { CLOUD_SYNC_PLUGIN_ID } from '@src/lib/cloudSync/registry/constants'
 import fsZds from '@src/lib/fs-zds'
 import { fsZdsConstants } from '@src/lib/fs-zds/constants'
 import type { Project } from '@src/lib/project'
@@ -908,9 +910,24 @@ describe('home project actions', () => {
     expect(systemIO.send).not.toHaveBeenCalled()
   })
 
-  it('deletes only local state for a cloud-backed project outside a cloud-type library', async () => {
+  it.each([
+    {
+      name: 'uses cloudSync cleanup for a linked directory project when the plugin is active',
+      pluginActive: true,
+    },
+    {
+      name: 'deletes a linked directory project normally when the plugin is inactive',
+      pluginActive: false,
+    },
+  ])('$name', async ({ pluginActive }) => {
     const systemIO = createSystemIOService()
-    const cloudSync = createCloudSyncService()
+    const cloudSync = createCloudSyncService({
+      status: signal(
+        pluginActive
+          ? { enabled: true, state: 'idle', pendingCount: 0 }
+          : { enabled: false, state: 'disabled', pendingCount: 0 }
+      ),
+    })
     const removeProjectDirectory = vi
       .spyOn(fsZds, 'rm')
       .mockResolvedValue(undefined)
@@ -941,6 +958,13 @@ describe('home project actions', () => {
       defineRegistryItem({
         id: 'test.cloud-sync',
         providesServices: [provideService(cloudSyncService, cloudSync)],
+      }),
+      createPlugin({
+        id: CLOUD_SYNC_PLUGIN_ID,
+        title: 'Cloud sync',
+        description: 'Test cloud sync plugin.',
+        items: [],
+        enabledByDefault: pluginActive,
       }),
       projectLibrariesExtension,
       homeProjectsExtension,
@@ -976,11 +1000,18 @@ describe('home project actions', () => {
       },
     })
 
-    expect(cloudSync.deleteLocalProjectRealizations).toHaveBeenCalledWith(
-      'remote-123',
-      '/projects/bracket'
-    )
+    if (pluginActive) {
+      expect(cloudSync.deleteLocalProjectRealizations).toHaveBeenCalledWith(
+        'remote-123',
+        '/projects/bracket'
+      )
+      expect(removeProjectDirectory).not.toHaveBeenCalled()
+    } else {
+      expect(cloudSync.deleteLocalProjectRealizations).not.toHaveBeenCalled()
+      expect(removeProjectDirectory).toHaveBeenCalledWith('/projects/bracket', {
+        recursive: true,
+      })
+    }
     expect(cloudSync.deleteRemoteProject).not.toHaveBeenCalled()
-    expect(removeProjectDirectory).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Addresses directory-library deletion incorrectly entering cloudSync behavior solely because project.toml contains a cloud project ID, even when the cloudSync plugin is inactive.

1. Uses relationship-aware deletion for linked directory projects only while the cloudSync plugin is active.
2. Falls back to ordinary recursive local deletion when the plugin is inactive.
3. Retains the cloudSync runtime safety check when the plugin is active.
4. Centralizes the cloudSync plugin identifier used by activation checks.
5. Adds regression coverage for active and inactive plugin states.

## How to test

Disable cloudSync and delete a writable project from a directory-type library whose project.toml contains a cloud project ID. Confirm the local directory is deleted without a Cloud sync is not enabled error. Re-enable cloudSync and confirm the same kind of linked directory project still uses relationship-aware local cleanup.