### PR TITLE
Fix Clone edits and variable-less pipelines

### DIFF
--- a/src/lang/modifyAst.ts
+++ b/src/lang/modifyAst.ts
@@ -1372,6 +1372,7 @@ export function setCallInAst({
   pathToEdit,
   pathIfNewPipe,
   variableIfNewDecl,
+  variableIfNewPipe,
   labeledSelectionArgNames,
   wasmInstance,
 }: {
@@ -1380,6 +1381,7 @@ export function setCallInAst({
   pathToEdit?: PathToNode
   pathIfNewPipe?: PathToNode
   variableIfNewDecl?: string
+  variableIfNewPipe?: string
   labeledSelectionArgNames?: readonly string[]
   wasmInstance: ModuleType
 }): Error | PathToNode {
@@ -1405,7 +1407,7 @@ export function setCallInAst({
     replaceCallInPlace(result.node, call, labeledSelectionArgNames)
     pathToNode = pathToEdit
   } else if (pathIfNewPipe) {
-    const pipe = getNodeFromPath<PipeExpression>(
+    const pipe = getNodeFromPath<Node<PipeExpression> | Node<CallExpressionKw>>(
       ast,
       pathIfNewPipe,
       wasmInstance,
@@ -1414,8 +1416,10 @@ export function setCallInAst({
     if (err(pipe)) {
       return pipe
     }
+    let pipeExpression: Node<PipeExpression>
     if (pipe.node.type === 'PipeExpression') {
       pipe.node.body.push(call)
+      pipeExpression = pipe.node
     } else if (pipe.node.type === 'CallExpressionKw') {
       const expression = getNodeFromPath<ExpressionStatement>(
         ast,
@@ -1427,16 +1431,46 @@ export function setCallInAst({
         return new Error('Could not retrieve ExpressionStatement')
       }
 
-      expression.node.expression = createPipeExpression([
-        expression.node.expression,
-        call,
-      ])
+      pipeExpression = createPipeExpression([expression.node.expression, call])
+      expression.node.expression = pipeExpression
     } else {
       return new Error(
         'Expected pipeIfPipe to be a PipeExpression or CallExpressionKw'
       )
     }
-    pathToNode = pathIfNewPipe
+    if (variableIfNewPipe) {
+      const expression = getNodeFromPath<ExpressionStatement>(
+        ast,
+        pathIfNewPipe,
+        wasmInstance,
+        'ExpressionStatement'
+      )
+      if (err(expression) || expression.node.type !== 'ExpressionStatement') {
+        return new Error('Could not retrieve ExpressionStatement')
+      }
+      const bodyIndex = getBodyIndex(expression.shallowPath)
+      if (err(bodyIndex)) {
+        return bodyIndex
+      }
+      const sourceStatement = ast.body[bodyIndex]
+      if (!sourceStatement) {
+        return new Error('Could not find source statement')
+      }
+      const name = findUniqueName(ast, variableIfNewPipe)
+      const declaration = createVariableDeclaration(name, pipeExpression)
+      declaration.preComments = sourceStatement.preComments
+      ast.body[bodyIndex] = declaration
+      pathToNode = [
+        ['body', ''],
+        [bodyIndex, 'index'],
+        ['declaration', 'VariableDeclaration'],
+        ['init', 'VariableDeclarator'],
+        ['body', 'PipeExpression'],
+        [pipeExpression.body.length - 1, 'index'],
+      ]
+    } else {
+      pathToNode = pathIfNewPipe
+    }
   } else if (variableIfNewDecl) {
     const name = findUniqueName(ast, variableIfNewDecl)
     const declaration = createVariableDeclaration(name, call)

--- a/src/lang/modifyAst/clonePipe.spec.ts
+++ b/src/lang/modifyAst/clonePipe.spec.ts
@@ -1,0 +1,87 @@
+import { addClone } from '@src/lang/modifyAst/transforms'
+import { getNodePathFromSourceRange } from '@src/lang/queryAstNodePathUtils'
+import { assertParse, recast } from '@src/lang/wasm'
+import {
+  createSelectionFromArtifacts,
+  enginelessExecutor,
+} from '@src/lib/testHelpers'
+import { err } from '@src/lib/trap'
+import { buildTheWorldAndNoEngineConnection } from '@src/unitTestUtils'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@src/lib/commandBarConfigs/modelingCommandStdLibCommands', () => ({
+  STD_LIB_COMMANDS: {},
+}))
+
+describe('clone variable-less pipe', () => {
+  it('keeps the clone input within the source pipe', async () => {
+    const { instance, rustContext } = await buildTheWorldAndNoEngineConnection()
+    const code = `startSketchOn(XY)
+  |> circle(center = [0, 0], radius = 1)
+  |> extrude(length = 1)`
+    const ast = assertParse(code, instance)
+    const { artifactGraph } = await enginelessExecutor(ast, rustContext)
+    const sweep = Array.from(artifactGraph.values()).find(
+      (artifact) => artifact.type === 'sweep'
+    )
+    if (!sweep) {
+      throw new Error('Expected the pipe to produce a sweep')
+    }
+
+    const result = addClone({
+      ast,
+      artifactGraph,
+      objects: createSelectionFromArtifacts([sweep], artifactGraph),
+      variableName: 'clone001',
+      wasmInstance: instance,
+    })
+    if (err(result)) {
+      throw result
+    }
+
+    const output = recast(result.modifiedAst, instance)
+    expect(output).toContain(`clone001 = startSketchOn(XY)
+  |> circle(center = [0, 0], radius = 1)
+  |> extrude(length = 1)
+  |> clone()`)
+    const execution = await enginelessExecutor(result.modifiedAst, rustContext)
+    expect(execution.issues).toEqual([])
+  })
+
+  it('edits an existing clone without appending a second declaration', async () => {
+    const { instance, rustContext } = await buildTheWorldAndNoEngineConnection()
+    const code = `sketch001 = startSketchOn(XY)
+profile001 = circle(sketch001, center = [0, 0], radius = 1)
+extrude001 = extrude(profile001, length = 1)
+clone001 = clone(extrude001)`
+    const ast = assertParse(code, instance)
+    const { artifactGraph } = await enginelessExecutor(ast, rustContext)
+    const sweep = Array.from(artifactGraph.values()).find(
+      (artifact) => artifact.type === 'sweep'
+    )
+    if (!sweep) {
+      throw new Error('Expected an extrusion sweep')
+    }
+    const cloneStart = code.indexOf('clone(extrude001)')
+    const nodeToEdit = getNodePathFromSourceRange(ast, [
+      cloneStart,
+      cloneStart + 'clone(extrude001)'.length,
+      0,
+    ])
+
+    const result = addClone({
+      ast,
+      artifactGraph,
+      objects: createSelectionFromArtifacts([sweep], artifactGraph),
+      variableName: 'clone001',
+      nodeToEdit,
+      wasmInstance: instance,
+    })
+    if (err(result)) {
+      throw result
+    }
+
+    expect(recast(result.modifiedAst, instance)).toBe(`${code}\n`)
+    expect(result.modifiedAst.body).toHaveLength(ast.body.length)
+  })
+})

--- a/src/lang/modifyAst/transforms.ts
+++ b/src/lang/modifyAst/transforms.ts
@@ -362,12 +362,20 @@ export function addClone({
     []
   )
 
-  // 3. If edit, we assign the new function call declaration to the existing node,
-  // otherwise just push to the end
-  const declaration = createVariableDeclaration(variableName, call)
-  modifiedAst.body.push(declaration)
-  const toFirstKwarg = false
-  const pathToNode = createPathToNodeForLastVariable(modifiedAst, toFirstKwarg)
+  let pathToNode: PathToNode | Error
+  if (!mNodeToEdit && !vars.pathIfPipe) {
+    modifiedAst.body.push(createVariableDeclaration(variableName, call))
+    pathToNode = createPathToNodeForLastVariable(modifiedAst, false)
+  } else {
+    pathToNode = setCallInAst({
+      ast: modifiedAst,
+      call,
+      pathToEdit: mNodeToEdit,
+      pathIfNewPipe: vars.pathIfPipe,
+      variableIfNewPipe: variableName,
+      wasmInstance,
+    })
+  }
   if (err(pathToNode)) {
     return pathToNode
   }

--- a/src/lib/commandBarConfigs/modelingCommandConfig.integration.spec.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.integration.spec.ts
@@ -459,6 +459,34 @@ describe('Transform arguments', () => {
       }
     }
   })
+
+  it('does not require or show Clone variableName while editing an existing clone', () => {
+    const commandConfig = modelingMachineCommandConfig.Clone
+    if (!commandConfig || isArray(commandConfig)) {
+      throw new Error('Clone should have a single command config')
+    }
+
+    const variableNameArg = commandConfig.args?.variableName
+    if (!variableNameArg) {
+      throw new Error('Clone.variableName should exist')
+    }
+
+    const creatingContext = { argumentsToSubmit: {} }
+    const editingContext = { argumentsToSubmit: { nodeToEdit: [] } }
+    const required =
+      typeof variableNameArg.required === 'function'
+        ? variableNameArg.required
+        : () => variableNameArg.required
+    const hidden =
+      typeof variableNameArg.hidden === 'function'
+        ? variableNameArg.hidden
+        : () => variableNameArg.hidden
+
+    expect(required(creatingContext)).toBe(true)
+    expect(hidden(creatingContext)).toBeFalsy()
+    expect(required(editingContext)).toBe(false)
+    expect(hidden(editingContext)).toBe(true)
+  })
 })
 
 const uniqueSorted = (values: string[]) => [...new Set(values)].sort()

--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -1663,7 +1663,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         },
         variableName: {
           inputType: 'string',
-          required: true,
+          required: (context) => !isEditingNodeSelection(context),
+          hidden: isEditingNodeSelection,
           defaultValue: (
             _: unknown,
             modelingContext?: ModelingMachineContext

--- a/src/lib/operations.spec.ts
+++ b/src/lib/operations.spec.ts
@@ -13,6 +13,7 @@ import {
   assertParse,
   defaultNodePath,
   nodePathFromRange,
+  pathToNodeFromRustNodePath,
 } from '@src/lang/wasm'
 import type { Artifact, ArtifactGraph } from '@src/lang/wasm'
 import {
@@ -1347,6 +1348,59 @@ ${operationName}(${targetLabel} = ${targetExpression}, tolerance = 0.1mm, datums
       }
       expect(argDefaultValues.note).toBe('Note on XY')
       expect(argDefaultValues.framePlane).toBe('XZ')
+    })
+  })
+
+  describe('Clone edit flow', () => {
+    it('enters edit flow with the existing cloned object selection', async () => {
+      const { instance, rustContext } =
+        await buildTheWorldAndNoEngineConnection()
+      const code = `extrude001 = extrude(profile001, length = 1)
+clone001 = clone(extrude001)`
+      const operation = stdlib('clone')
+      if (operation.type !== 'StdLibCall') {
+        throw new Error('Expected operation to be a StdLibCall')
+      }
+      operation.nodePath = await buildNodePath(
+        code,
+        'clone(extrude001)',
+        instance
+      )
+      operation.unlabeledArg = {
+        value: {
+          type: 'Solid',
+          value: { artifactId: 'source-sweep' },
+        },
+        sourceRange: rangeOfText(code, 'extrude001'),
+      }
+
+      const result = await enterEditFlow({
+        operation,
+        code,
+        artifactGraph: toArtifactGraph([
+          sweepArtifact('source-sweep', 'source-path'),
+        ]),
+        rustContext,
+      })
+      if (result instanceof Error) {
+        throw result
+      }
+      if (result.type !== 'Find and select command') {
+        throw new Error(`Expected edit flow event, got ${result.type}`)
+      }
+
+      const argDefaultValues = result.data.argDefaultValues as {
+        objects?: { graphSelections: unknown[]; otherSelections: unknown[] }
+        variableName?: string
+        nodeToEdit?: unknown
+      }
+      expect(result.data.name).toBe('Clone')
+      expect(argDefaultValues.objects?.graphSelections).toHaveLength(1)
+      expect(argDefaultValues.objects?.otherSelections).toEqual([])
+      expect(argDefaultValues.variableName).toBe('clone')
+      expect(argDefaultValues.nodeToEdit).toEqual(
+        pathToNodeFromRustNodePath(operation.nodePath)
+      )
     })
   })
 

--- a/src/lib/operations.ts
+++ b/src/lib/operations.ts
@@ -56,6 +56,7 @@ import type {
 import type { KclCommandValue, KclExpression } from '@src/lib/commandTypes'
 import {
   EXECUTION_TYPE_REAL,
+  KCL_DEFAULT_CONSTANT_PREFIXES,
   KCL_PRELUDE_EXTRUDE_METHOD_MERGE,
   KCL_PRELUDE_EXTRUDE_METHOD_NEW,
   type KclPreludeBodyType,
@@ -1266,6 +1267,34 @@ const prepareToEditRingGear: PrepareToEditCallback = async ({
     pressureAngle,
     helixAngle,
     gearHeight,
+    nodeToEdit: pathToNodeFromRustNodePath(operation.nodePath),
+  }
+  return {
+    ...baseCommand,
+    argDefaultValues,
+  }
+}
+
+/**
+ * Gather up the argument values for the Clone command
+ * to be used in the command bar edit flow.
+ */
+const prepareToEditClone: PrepareToEditCallback = async ({
+  operation,
+  artifactGraph,
+}) => {
+  const baseCommand = {
+    name: 'Clone',
+    groupId: 'modeling',
+  }
+  if (operation.type !== 'StdLibCall' || operation.name !== 'clone') {
+    return { reason: 'Wrong operation type' }
+  }
+
+  const objects = retrieveUnlabeledSelectionsForEdit(operation, artifactGraph)
+  const argDefaultValues: ModelingCommandSchema['Clone'] = {
+    objects,
+    variableName: KCL_DEFAULT_CONSTANT_PREFIXES.CLONE,
     nodeToEdit: pathToNodeFromRustNodePath(operation.nodePath),
   }
   return {
@@ -3574,6 +3603,7 @@ export const stdLibMap: Record<string, StdLibCallInfo> = {
   clone: {
     label: 'Clone',
     icon: 'clone',
+    prepareToEdit: prepareToEditClone,
     supportsAppearance: true,
     supportsTransform: true,
   },


### PR DESCRIPTION
Fix Clone edits by replacing the existing call instead of appending a duplicate declaration. When Clone targets a variable-less source pipeline, name that pipeline and keep `clone()` attached; other codemods retain their current output.

Fixes #13398.
Fixes #13403.

Validation: focused Clone tests pass (2/2); formatting and diff checks pass.