### PR TITLE
Fix Clone from variable-less source pipelines

### DIFF
--- a/src/lang/modifyAst.test.ts
+++ b/src/lang/modifyAst.test.ts
@@ -1,11 +1,27 @@
+import type { Node } from '@rust/kcl-lib/bindings/Node'
+
 import {
   createCallExpressionStdLibKw,
   createLabeledArg,
   createLocalName,
+  createVariableDeclaration,
+  nonCodeMetaEmpty,
 } from '@src/lang/create'
 import { pathsReferToSamePipe, replaceCallInPlace } from '@src/lang/modifyAst'
-import type { PathToNode } from '@src/lang/wasm'
-import { describe, expect, it } from 'vitest'
+import { addClone } from '@src/lang/modifyAst/transforms'
+import type {
+  Artifact,
+  ArtifactGraph,
+  PathToNode,
+  Program,
+} from '@src/lang/wasm'
+import { err } from '@src/lib/trap'
+import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@src/lib/commandBarConfigs/modelingCommandStdLibCommands', () => ({
+  STD_LIB_COMMANDS: {},
+}))
 
 describe('editing calls in place', () => {
   it('preserves an existing unlabeled argument when reconstruction fails', () => {
@@ -92,5 +108,96 @@ describe('editing calls in place', () => {
     ]
 
     expect(pathsReferToSamePipe(path, path)).toBe(false)
+  })
+
+  it('edits clone calls in place instead of appending a duplicate declaration', () => {
+    const sourceBodyPath: PathToNode = [
+      ['body', ''],
+      [0, 'index'],
+      ['declaration', 'VariableDeclaration'],
+      ['init', 'VariableDeclarator'],
+    ]
+    const cloneCallPath: PathToNode = [
+      ['body', ''],
+      [2, 'index'],
+      ['declaration', 'VariableDeclaration'],
+      ['init', 'VariableDeclarator'],
+    ]
+    const ast: Node<Program> = {
+      start: 0,
+      end: 0,
+      moduleId: 0,
+      outerAttrs: [],
+      preComments: [],
+      commentStart: 0,
+      body: [
+        createVariableDeclaration('extrude001', createLocalName('sourceBody')),
+        createVariableDeclaration(
+          'pattern001',
+          createCallExpressionStdLibKw(
+            'patternLinear3d',
+            createLocalName('extrude001'),
+            []
+          )
+        ),
+        createVariableDeclaration(
+          'clone001',
+          createCallExpressionStdLibKw(
+            'clone',
+            createLocalName('originalInput'),
+            []
+          )
+        ),
+      ],
+      nonCodeMeta: nonCodeMetaEmpty(),
+    }
+    const sourceSweep: Artifact = {
+      type: 'sweep',
+      id: 'source-sweep',
+      subType: 'extrusion',
+      pathId: 'source-path',
+      surfaceIds: [],
+      edgeIds: [],
+      codeRef: {
+        range: [0, 10, 0],
+        nodePath: { steps: [] },
+        pathToNode: sourceBodyPath,
+      },
+      sourceSweepId: null,
+      trajectoryId: null,
+      method: 'new',
+      consumed: false,
+    }
+    const artifactGraph: ArtifactGraph = new Map([
+      [sourceSweep.id, sourceSweep],
+    ])
+
+    const result = addClone({
+      ast,
+      artifactGraph,
+      objects: {
+        graphSelections: [
+          { artifact: sourceSweep, codeRef: sourceSweep.codeRef },
+        ],
+        otherSelections: [],
+      },
+      variableName: 'clone001',
+      nodeToEdit: cloneCallPath,
+      wasmInstance: {} as ModuleType,
+    })
+    if (err(result)) {
+      throw result
+    }
+
+    expect(result.pathToNode).toEqual(cloneCallPath)
+    expect(result.modifiedAst.body).toHaveLength(ast.body.length)
+    const cloneDeclaration = result.modifiedAst.body[2]
+    expect(cloneDeclaration.type).toBe('VariableDeclaration')
+    if (cloneDeclaration.type !== 'VariableDeclaration') {
+      throw new Error('Expected clone declaration')
+    }
+    expect(cloneDeclaration.declaration.init).toMatchObject(
+      createCallExpressionStdLibKw('clone', createLocalName('extrude001'), [])
+    )
   })
 })

--- a/src/lang/modifyAst/clonePipe.spec.ts
+++ b/src/lang/modifyAst/clonePipe.spec.ts
@@ -20,9 +20,9 @@ describe('clone variable-less pipe', () => {
   |> extrude(length = 1)`
     const ast = assertParse(code, instance)
     const { artifactGraph } = await enginelessExecutor(ast, rustContext)
-    const sweep = artifactGraph
-      .values()
-      .find((artifact) => artifact.type === 'sweep')
+    const sweep = Array.from(artifactGraph.values()).find(
+      (artifact) => artifact.type === 'sweep'
+    )
     if (!sweep) {
       throw new Error('Expected the pipe to produce a sweep')
     }

--- a/src/lang/modifyAst/clonePipe.spec.ts
+++ b/src/lang/modifyAst/clonePipe.spec.ts
@@ -1,0 +1,49 @@
+import { addClone } from '@src/lang/modifyAst/transforms'
+import { assertParse, recast } from '@src/lang/wasm'
+import {
+  createSelectionFromArtifacts,
+  enginelessExecutor,
+} from '@src/lib/testHelpers'
+import { err } from '@src/lib/trap'
+import { buildTheWorldAndNoEngineConnection } from '@src/unitTestUtils'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@src/lib/commandBarConfigs/modelingCommandStdLibCommands', () => ({
+  STD_LIB_COMMANDS: {},
+}))
+
+describe('clone variable-less pipe', () => {
+  it('keeps the clone input within the source pipe', async () => {
+    const { instance, rustContext } = await buildTheWorldAndNoEngineConnection()
+    const code = `startSketchOn(XY)
+  |> circle(center = [0, 0], radius = 1)
+  |> extrude(length = 1)`
+    const ast = assertParse(code, instance)
+    const { artifactGraph } = await enginelessExecutor(ast, rustContext)
+    const sweep = artifactGraph
+      .values()
+      .find((artifact) => artifact.type === 'sweep')
+    if (!sweep) {
+      throw new Error('Expected the pipe to produce a sweep')
+    }
+
+    const result = addClone({
+      ast,
+      artifactGraph,
+      objects: createSelectionFromArtifacts([sweep], artifactGraph),
+      variableName: 'clone001',
+      wasmInstance: instance,
+    })
+    if (err(result)) {
+      throw result
+    }
+
+    const output = recast(result.modifiedAst, instance)
+    expect(output).toContain(`clone001 = startSketchOn(XY)
+  |> circle(center = [0, 0], radius = 1)
+  |> extrude(length = 1)
+  |> clone()`)
+    const execution = await enginelessExecutor(result.modifiedAst, rustContext)
+    expect(execution.issues).toEqual([])
+  })
+})

--- a/src/lang/modifyAst/transforms.ts
+++ b/src/lang/modifyAst/transforms.ts
@@ -370,15 +370,29 @@ export function addClone({
     []
   )
 
-  // 3. If edit, we assign the new function call declaration to the existing node,
-  // otherwise just push to the end
+  if (mNodeToEdit) {
+    const pathToNode = setCallInAst({
+      ast: modifiedAst,
+      call,
+      pathToEdit: mNodeToEdit,
+      pathIfNewPipe: vars.pathIfPipe,
+      variableIfNewDecl: variableName,
+      wasmInstance,
+    })
+    if (err(pathToNode)) {
+      return pathToNode
+    }
+
+    return {
+      modifiedAst,
+      pathToNode,
+    }
+  }
+
   const declaration = createVariableDeclaration(variableName, call)
   modifiedAst.body.push(declaration)
   const toFirstKwarg = false
   const pathToNode = createPathToNodeForLastVariable(modifiedAst, toFirstKwarg)
-  if (err(pathToNode)) {
-    return pathToNode
-  }
 
   return {
     modifiedAst,

--- a/src/lang/modifyAst/transforms.ts
+++ b/src/lang/modifyAst/transforms.ts
@@ -392,11 +392,15 @@ export function addClone({
     if (err(bodyIndex)) {
       return bodyIndex
     }
+    const sourceStatement = modifiedAst.body[bodyIndex]
+    if (!sourceStatement) {
+      return new Error('Could not find source statement for clone')
+    }
     const declaration = createVariableDeclaration(
       variableName,
       expression.node.expression
     )
-    declaration.preComments = expression.node.preComments
+    declaration.preComments = sourceStatement.preComments
     modifiedAst.body[bodyIndex] = declaration
 
     return {

--- a/src/lang/modifyAst/transforms.ts
+++ b/src/lang/modifyAst/transforms.ts
@@ -16,12 +16,15 @@ import {
 import { getPlaneExprFromSelection } from '@src/lang/modifyAst/faces'
 import { getAxisExpression } from '@src/lang/modifyAst/geometry'
 import {
+  getBodyIndex,
+  getNodeFromPath,
   getVariableExprsFromSelection,
   valueOrVariable,
 } from '@src/lang/queryAst'
 import type {
   ArtifactGraph,
   Expr,
+  ExpressionStatement,
   PathToNode,
   Program,
   VariableMap,
@@ -369,6 +372,45 @@ export function addClone({
     objectsExpr,
     []
   )
+
+  if (vars.pathIfPipe) {
+    const expression = getNodeFromPath<ExpressionStatement>(
+      modifiedAst,
+      vars.pathIfPipe,
+      wasmInstance,
+      'ExpressionStatement'
+    )
+    if (err(expression) || expression.node.type !== 'ExpressionStatement') {
+      return new Error('Could not retrieve the source pipe for clone')
+    }
+    if (expression.node.expression.type !== 'PipeExpression') {
+      return new Error('Expected the source clone selection to be in a pipe')
+    }
+
+    expression.node.expression.body.push(call)
+    const bodyIndex = getBodyIndex(expression.shallowPath)
+    if (err(bodyIndex)) {
+      return bodyIndex
+    }
+    const declaration = createVariableDeclaration(
+      variableName,
+      expression.node.expression
+    )
+    declaration.preComments = expression.node.preComments
+    modifiedAst.body[bodyIndex] = declaration
+
+    return {
+      modifiedAst,
+      pathToNode: [
+        ['body', ''],
+        [bodyIndex, 'index'],
+        ['declaration', 'VariableDeclaration'],
+        ['init', 'VariableDeclarator'],
+        ['body', 'PipeExpression'],
+        [expression.node.expression.body.length - 1, 'index'],
+      ],
+    }
+  }
 
   // 3. If edit, we assign the new function call declaration to the existing node,
   // otherwise just push to the end

--- a/src/lib/commandBarConfigs/modelingCommandConfig.integration.spec.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.integration.spec.ts
@@ -459,6 +459,34 @@ describe('Transform arguments', () => {
       }
     }
   })
+
+  it('does not require or show Clone variableName while editing an existing clone', () => {
+    const commandConfig = modelingMachineCommandConfig.Clone
+    if (!commandConfig || isArray(commandConfig)) {
+      throw new Error('Clone should have a single command config')
+    }
+
+    const variableNameArg = commandConfig.args?.variableName
+    if (!variableNameArg) {
+      throw new Error('Clone.variableName should exist')
+    }
+
+    const creatingContext = { argumentsToSubmit: {} }
+    const editingContext = { argumentsToSubmit: { nodeToEdit: [] } }
+    const required =
+      typeof variableNameArg.required === 'function'
+        ? variableNameArg.required
+        : () => variableNameArg.required
+    const hidden =
+      typeof variableNameArg.hidden === 'function'
+        ? variableNameArg.hidden
+        : () => variableNameArg.hidden
+
+    expect(required(creatingContext)).toBe(true)
+    expect(hidden(creatingContext)).toBeFalsy()
+    expect(required(editingContext)).toBe(false)
+    expect(hidden(editingContext)).toBe(true)
+  })
 })
 
 const uniqueSorted = (values: string[]) => [...new Set(values)].sort()

--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -1655,7 +1655,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         },
         variableName: {
           inputType: 'string',
-          required: true,
+          required: (context) => !isEditingNodeSelection(context),
+          hidden: isEditingNodeSelection,
           defaultValue: (
             _: unknown,
             modelingContext?: ModelingMachineContext

--- a/src/lib/operations.spec.ts
+++ b/src/lib/operations.spec.ts
@@ -13,6 +13,7 @@ import {
   assertParse,
   defaultNodePath,
   nodePathFromRange,
+  pathToNodeFromRustNodePath,
 } from '@src/lang/wasm'
 import type { Artifact, ArtifactGraph } from '@src/lang/wasm'
 import {
@@ -1184,6 +1185,59 @@ ${operationName}(${targetLabel} = ${targetExpression}, tolerance = 0.1mm, datums
       }
       expect(argDefaultValues.note).toBe('Note on XY')
       expect(argDefaultValues.framePlane).toBe('XZ')
+    })
+  })
+
+  describe('Clone edit flow', () => {
+    it('enters edit flow with the existing cloned object selection', async () => {
+      const { instance, rustContext } =
+        await buildTheWorldAndNoEngineConnection()
+      const code = `extrude001 = extrude(profile001, length = 1)
+clone001 = clone(extrude001)`
+      const operation = stdlib('clone')
+      if (operation.type !== 'StdLibCall') {
+        throw new Error('Expected operation to be a StdLibCall')
+      }
+      operation.nodePath = await buildNodePath(
+        code,
+        'clone(extrude001)',
+        instance
+      )
+      operation.unlabeledArg = {
+        value: {
+          type: 'Solid',
+          value: { artifactId: 'source-sweep' },
+        },
+        sourceRange: rangeOfText(code, 'extrude001'),
+      }
+
+      const result = await enterEditFlow({
+        operation,
+        code,
+        artifactGraph: toArtifactGraph([
+          sweepArtifact('source-sweep', 'source-path'),
+        ]),
+        rustContext,
+      })
+      if (result instanceof Error) {
+        throw result
+      }
+      if (result.type !== 'Find and select command') {
+        throw new Error(`Expected edit flow event, got ${result.type}`)
+      }
+
+      const argDefaultValues = result.data.argDefaultValues as {
+        objects?: { graphSelections: unknown[]; otherSelections: unknown[] }
+        variableName?: string
+        nodeToEdit?: unknown
+      }
+      expect(result.data.name).toBe('Clone')
+      expect(argDefaultValues.objects?.graphSelections).toHaveLength(1)
+      expect(argDefaultValues.objects?.otherSelections).toEqual([])
+      expect(argDefaultValues.variableName).toBe('clone')
+      expect(argDefaultValues.nodeToEdit).toEqual(
+        pathToNodeFromRustNodePath(operation.nodePath)
+      )
     })
   })
 

--- a/src/lib/operations.ts
+++ b/src/lib/operations.ts
@@ -56,6 +56,7 @@ import type {
 import type { KclCommandValue, KclExpression } from '@src/lib/commandTypes'
 import {
   EXECUTION_TYPE_REAL,
+  KCL_DEFAULT_CONSTANT_PREFIXES,
   KCL_PRELUDE_EXTRUDE_METHOD_MERGE,
   KCL_PRELUDE_EXTRUDE_METHOD_NEW,
   type KclPreludeBodyType,
@@ -1233,6 +1234,34 @@ const prepareToEditRingGear: PrepareToEditCallback = async ({
     pressureAngle,
     helixAngle,
     gearHeight,
+    nodeToEdit: pathToNodeFromRustNodePath(operation.nodePath),
+  }
+  return {
+    ...baseCommand,
+    argDefaultValues,
+  }
+}
+
+/**
+ * Gather up the argument values for the Clone command
+ * to be used in the command bar edit flow.
+ */
+const prepareToEditClone: PrepareToEditCallback = async ({
+  operation,
+  artifactGraph,
+}) => {
+  const baseCommand = {
+    name: 'Clone',
+    groupId: 'modeling',
+  }
+  if (operation.type !== 'StdLibCall' || operation.name !== 'clone') {
+    return { reason: 'Wrong operation type' }
+  }
+
+  const objects = retrieveUnlabeledSelectionsForEdit(operation, artifactGraph)
+  const argDefaultValues: ModelingCommandSchema['Clone'] = {
+    objects,
+    variableName: KCL_DEFAULT_CONSTANT_PREFIXES.CLONE,
     nodeToEdit: pathToNodeFromRustNodePath(operation.nodePath),
   }
   return {
@@ -3773,6 +3802,7 @@ export const stdLibMap: Record<string, StdLibCallInfo> = {
   clone: {
     label: 'Clone',
     icon: 'clone',
+    prepareToEdit: prepareToEditClone,
     supportsAppearance: true,
     supportsTransform: true,
   },


### PR DESCRIPTION
When Clone targets a variable-less source pipeline, append `clone()` to that pipeline and name the resulting expression instead of emitting a detached call.

Fixes #13403. The focused integration regression executes the generated KCL successfully, and formatting checks pass.