### PR TITLE
Preserve multi-selected variable-less transform inputs

### DIFF
--- a/src/lang/modifyAst.ts
+++ b/src/lang/modifyAst.ts
@@ -1280,12 +1280,14 @@ export function getSelectionVarsForCall({
   modifiedAst,
   wasmInstance,
   nodeToEdit,
+  options = { lastChildLookup: true },
 }: {
   selection: Selections
   artifactGraph: ArtifactGraph
   modifiedAst: Node<Program>
   wasmInstance: ModuleType
   nodeToEdit?: PathToNode
+  options?: NonNullable<Parameters<typeof getVariableExprsFromSelection>[5]>
 }) {
   // Edit codemods preserve the existing selection argument, so only rebuild
   // selection expressions when creating a new call.
@@ -1293,14 +1295,97 @@ export function getSelectionVarsForCall({
     return { exprs: [] }
   }
 
-  return getVariableExprsFromSelection(
+  const vars = getVariableExprsFromSelection(
     selection,
     artifactGraph,
     modifiedAst,
     wasmInstance,
     undefined,
-    { lastChildLookup: true }
+    options
   )
+  if (err(vars) || selection.graphSelections.length < 2) {
+    return vars
+  }
+
+  const selections: Array<{
+    exprs: Expr[]
+    pathIfPipe?: PathToNode
+    pipeBodyIndex?: number
+  }> = []
+  const pipeBodyIndexes = new Set<number>()
+
+  for (const graphSelection of selection.graphSelections) {
+    const selectionVars = getVariableExprsFromSelection(
+      { graphSelections: [graphSelection], otherSelections: [] },
+      artifactGraph,
+      modifiedAst,
+      wasmInstance,
+      undefined,
+      options
+    )
+    if (err(selectionVars)) {
+      return selectionVars
+    }
+
+    let pipeBodyIndex: number | undefined
+    if (selectionVars.pathIfPipe) {
+      const expression = getNodeFromPath<ExpressionStatement>(
+        modifiedAst,
+        selectionVars.pathIfPipe,
+        wasmInstance,
+        'ExpressionStatement'
+      )
+      if (!err(expression)) {
+        const bodyIndex = getBodyIndex(expression.shallowPath)
+        if (err(bodyIndex)) {
+          return bodyIndex
+        }
+        pipeBodyIndex = bodyIndex
+        pipeBodyIndexes.add(bodyIndex)
+      }
+    }
+
+    selections.push({ ...selectionVars, pipeBodyIndex })
+  }
+
+  // A call cannot use `%` for two different source pipes. Give each pipe a
+  // name, then pass those names to the new call.
+  if (pipeBodyIndexes.size <= 1) {
+    return vars
+  }
+
+  const variableByBodyIndex = new Map<number, string>()
+  for (const bodyIndex of pipeBodyIndexes) {
+    const statement = modifiedAst.body[bodyIndex]
+    if (!statement || statement.type !== 'ExpressionStatement') {
+      return new Error('Expected a variable-less source pipe')
+    }
+
+    const variableName = findUniqueName(
+      modifiedAst,
+      KCL_DEFAULT_CONSTANT_PREFIXES.SOLID
+    )
+    const declaration = createVariableDeclaration(
+      variableName,
+      statement.expression
+    )
+    declaration.preComments = statement.preComments
+    modifiedAst.body[bodyIndex] = declaration
+    variableByBodyIndex.set(bodyIndex, variableName)
+  }
+
+  return {
+    exprs: selections.flatMap(({ exprs, pathIfPipe, pipeBodyIndex }) => {
+      if (!pathIfPipe) {
+        return exprs
+      }
+      const variableName =
+        pipeBodyIndex === undefined
+          ? undefined
+          : variableByBodyIndex.get(pipeBodyIndex)
+      return variableName ? [createLocalName(variableName)] : []
+    }),
+  }
 }
 
 // Create a path to node to the last variable declaroator of an ast

--- a/src/lang/modifyAst/multiVariablelessSelectionTransforms.spec.ts
+++ b/src/lang/modifyAst/multiVariablelessSelectionTransforms.spec.ts
@@ -1,0 +1,145 @@
+import type { Node } from '@rust/kcl-lib/bindings/Node'
+import {
+  addAppearance,
+  addMirror3D,
+  addRotate,
+  addScale,
+  addTranslate,
+} from '@src/lang/modifyAst/transforms'
+import type { Program } from '@src/lang/wasm'
+import { assertParse, recast } from '@src/lang/wasm'
+import {
+  createSelectionFromArtifacts,
+  enginelessExecutor,
+  getKclCommandValue,
+} from '@src/lib/testHelpers'
+import { err } from '@src/lib/trap'
+import { buildTheWorldAndNoEngineConnection } from '@src/unitTestUtils'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@src/lib/commandBarConfigs/modelingCommandStdLibCommands', () => ({
+  STD_LIB_COMMANDS: {},
+}))
+
+describe('transforms on multiple variable-less pipes', () => {
+  async function expectValidTransformOutput(
+    result: Error | { modifiedAst: Node<Program> },
+    expectedCall: string,
+    instance: Awaited<
+      ReturnType<typeof buildTheWorldAndNoEngineConnection>
+    >['instance'],
+    rustContext: Awaited<
+      ReturnType<typeof buildTheWorldAndNoEngineConnection>
+    >['rustContext']
+  ) {
+    if (err(result)) {
+      throw result
+    }
+
+    const output = recast(result.modifiedAst, instance)
+    expect(output).toContain('solid001 = startSketchOn(XY)')
+    expect(output).toContain('solid002 = startSketchOn(XZ)')
+    expect(output).toContain(expectedCall)
+    expect(output).not.toContain('[%, %]')
+
+    const execution = await enginelessExecutor(result.modifiedAst, rustContext)
+    expect(execution.issues).toEqual([])
+  }
+
+  it('keeps every selected source body for multi-object transforms', async () => {
+    const { instance, rustContext } = await buildTheWorldAndNoEngineConnection()
+    const code = `@settings(experimentalFeatures = allow)
+
+startSketchOn(XY)
+  |> circle(center = [0, 0], radius = 2)
+  |> extrude(length = 2)
+startSketchOn(XZ)
+  |> circle(center = [0, 0], radius = 2)
+  |> extrude(length = 2)
+plane001 = offsetPlane(YZ, offset = 1)`
+    const ast = assertParse(code, instance)
+    const { artifactGraph, variables } = await enginelessExecutor(
+      ast,
+      rustContext
+    )
+    const sweeps = [...artifactGraph.values()].filter(
+      (artifact) => artifact.type === 'sweep'
+    )
+    expect(sweeps).toHaveLength(2)
+    const objects = createSelectionFromArtifacts(sweeps, artifactGraph)
+    const planes = [...artifactGraph.values()].filter(
+      (artifact) => artifact.type === 'plane'
+    )
+    const plane = planes.at(-1)
+    if (!plane) {
+      throw new Error('Expected an offset plane for mirror3d')
+    }
+    const across = createSelectionFromArtifacts([plane], artifactGraph)
+
+    await expectValidTransformOutput(
+      addTranslate({
+        ast,
+        artifactGraph,
+        objects,
+        x: await getKclCommandValue('1', instance, rustContext),
+        wasmInstance: instance,
+      }),
+      'translate([solid001, solid002], x = 1)',
+      instance,
+      rustContext
+    )
+
+    await expectValidTransformOutput(
+      addRotate({
+        ast,
+        artifactGraph,
+        objects,
+        roll: await getKclCommandValue('10', instance, rustContext),
+        wasmInstance: instance,
+      }),
+      'rotate([solid001, solid002], roll = 10)',
+      instance,
+      rustContext
+    )
+
+    await expectValidTransformOutput(
+      addScale({
+        ast,
+        artifactGraph,
+        objects,
+        factor: await getKclCommandValue('2', instance, rustContext),
+        wasmInstance: instance,
+      }),
+      'scale([solid001, solid002], factor = 2)',
+      instance,
+      rustContext
+    )
+
+    await expectValidTransformOutput(
+      addAppearance({
+        ast,
+        artifactGraph,
+        objects,
+        color: '#ff0000',
+        wasmInstance: instance,
+      }),
+      'appearance([solid001, solid002], color = "#ff0000")',
+      instance,
+      rustContext
+    )
+
+    await expectValidTransformOutput(
+      addMirror3D({
+        ast,
+        artifactGraph,
+        variables,
+        bodies: objects,
+        across,
+        wasmInstance: instance,
+      }),
+      'solid003 = mirror3d([solid001, solid002], across = plane001)',
+      instance,
+      rustContext
+    )
+  })
+})

--- a/src/lang/modifyAst/transforms.ts
+++ b/src/lang/modifyAst/transforms.ts
@@ -6,7 +6,6 @@ import {
   createLiteral,
   createLocalName,
   createVariableDeclaration,
-  findUniqueName,
 } from '@src/lang/create'
 import {
   createPathToNodeForLastVariable,
@@ -18,15 +17,12 @@ import {
 import { getPlaneExprFromSelection } from '@src/lang/modifyAst/faces'
 import { getAxisExpression } from '@src/lang/modifyAst/geometry'
 import {
-  getBodyIndex,
-  getNodeFromPath,
   getVariableExprsFromSelection,
   valueOrVariable,
 } from '@src/lang/queryAst'
 import type {
   ArtifactGraph,
   Expr,
-  ExpressionStatement,
   PathToNode,
   Program,
   VariableMap,
@@ -473,117 +469,6 @@ export function addAppearance({
 
 type ObjectTransformName = 'hide' | 'delete'
 
-type VariableExprsOptions = NonNullable<
-  Parameters<typeof getVariableExprsFromSelection>[5]
->
-
-type ObjectTransformSelectionRecord = {
-  exprs: Expr[]
-  pathIfPipe?: PathToNode
-  pipeBodyIndex?: number
-}
-
-function getObjectTransformVariableExprsFromSelection(
-  selection: Selections,
-  artifactGraph: ArtifactGraph,
-  ast: Node<Program>,
-  wasmInstance: ModuleType,
-  options: VariableExprsOptions = {}
-): Error | { exprs: Expr[]; pathIfPipe?: PathToNode } {
-  const vars = getVariableExprsFromSelection(
-    selection,
-    artifactGraph,
-    ast,
-    wasmInstance,
-    undefined,
-    options
-  )
-  if (err(vars)) {
-    return vars
-  }
-
-  if (selection.graphSelections.length < 2) {
-    return vars
-  }
-
-  const records: ObjectTransformSelectionRecord[] = []
-  const pipeBodyIndexes = new Set<number>()
-
-  for (const graphSelection of selection.graphSelections) {
-    const singleSelectionVars = getVariableExprsFromSelection(
-      {
-        graphSelections: [graphSelection],
-        otherSelections: [],
-      },
-      artifactGraph,
-      ast,
-      wasmInstance,
-      undefined,
-      options
-    )
-    if (err(singleSelectionVars)) {
-      return singleSelectionVars
-    }
-
-    let pipeBodyIndex: number | undefined
-    if (singleSelectionVars.pathIfPipe) {
-      const expression = getNodeFromPath<ExpressionStatement>(
-        ast,
-        singleSelectionVars.pathIfPipe,
-        wasmInstance,
-        'ExpressionStatement'
-      )
-      if (!err(expression) && expression.node.type === 'ExpressionStatement') {
-        const bodyIndex = getBodyIndex(expression.shallowPath)
-        if (err(bodyIndex)) {
-          return bodyIndex
-        }
-        pipeBodyIndex = bodyIndex
-        pipeBodyIndexes.add(bodyIndex)
-      }
-    }
-
-    records.push({ ...singleSelectionVars, pipeBodyIndex })
-  }
-
-  if (pipeBodyIndexes.size <= 1) {
-    return vars
-  }
-
-  const variableByBodyIndex = new Map<number, string>()
-  for (const bodyIndex of pipeBodyIndexes) {
-    const statement = ast.body[bodyIndex]
-    if (!statement || statement.type !== 'ExpressionStatement') {
-      return new Error('Expected a variable-less object transform source pipe')
-    }
-
-    const variableName = findUniqueName(
-      ast,
-      KCL_DEFAULT_CONSTANT_PREFIXES.SOLID
-    )
-    const declaration = createVariableDeclaration(
-      variableName,
-      statement.expression
-    )
-    declaration.preComments = statement.preComments
-    ast.body[bodyIndex] = declaration
-    variableByBodyIndex.set(bodyIndex, variableName)
-  }
-
-  return {
-    exprs: records.flatMap(({ exprs, pathIfPipe, pipeBodyIndex }) => {
-      if (!pathIfPipe) {
-        return exprs
-      }
-      if (pipeBodyIndex === undefined) {
-        return []
-      }
-      const variableName = variableByBodyIndex.get(pipeBodyIndex)
-      return variableName ? [createLocalName(variableName)] : []
-    }),
-  }
-}
-
 function addObjectTransform({
   ast,
   artifactGraph,
@@ -607,15 +492,15 @@ function addObjectTransform({
   const artifact = objects.graphSelections[0].artifact
   const lastChildLookup =
     artifact?.type !== 'helix' && artifact?.type !== 'sketchBlock'
-  const vars = getObjectTransformVariableExprsFromSelection(
-    objects,
+  const vars = getSelectionVarsForCall({
+    selection: objects,
     artifactGraph,
     modifiedAst,
     wasmInstance,
-    {
+    options: {
       lastChildLookup,
-    }
-  )
+    },
+  })
 
   if (err(vars)) {
     return vars
@@ -708,17 +593,16 @@ export function addMirror3D({
   let vars: { exprs: Expr[]; pathIfPipe?: PathToNode } = { exprs: [] }
   let acrossArg: Expr | undefined
   if (!mNodeToEdit) {
-    const selectionVars = getVariableExprsFromSelection(
-      bodies,
+    const selectionVars = getSelectionVarsForCall({
+      selection: bodies,
       artifactGraph,
       modifiedAst,
       wasmInstance,
-      undefined,
-      {
+      options: {
         lastChildLookup: true,
         artifactTypeFilter: ['compositeSolid', 'sweep'],
-      }
-    )
+      },
+    })
     if (err(selectionVars)) {
       return selectionVars
     }


### PR DESCRIPTION
Preserve every selected variable-less source pipeline when Translate, Rotate, Scale, Appearance, or Mirror 3D receives multiple bodies. Reuse the shared selection-to-call helper instead of carrying a second materialization path.\n\nFixes #13416. The focused engineless regressions pass (5/5); formatting and diff checks pass.