### PR TITLE
Preserve Boolean Split inputs during edit

### DIFF
--- a/src/lang/modifyAst/boolean.ts
+++ b/src/lang/modifyAst/boolean.ts
@@ -5,6 +5,9 @@ import {
   createCallExpressionStdLibKw,
   createLabeledArg,
   createLiteral,
+  createLocalName,
+  createVariableDeclaration,
+  findUniqueName,
 } from '@src/lang/create'
 import {
   createVariableExpressionsArray,
@@ -12,11 +15,18 @@ import {
   setCallInAst,
 } from '@src/lang/modifyAst'
 import {
+  getBodyIndex,
+  getNodeFromPath,
   getVariableExprsFromSelection,
   stringifyPathToNode,
   valueOrVariable,
 } from '@src/lang/queryAst'
-import type { ArtifactGraph, PathToNode, Program } from '@src/lang/wasm'
+import type {
+  ArtifactGraph,
+  ExpressionStatement,
+  PathToNode,
+  Program,
+} from '@src/lang/wasm'
 import { modelingStdLibCommandName } from '@src/lib/commandBarConfigs/modelingCommandStdLib'
 import type { KclCommandValue } from '@src/lib/commandTypes'
 import { KCL_DEFAULT_CONSTANT_PREFIXES } from '@src/lib/constants'
@@ -31,6 +41,125 @@ type BooleanSelectionGroup = {
   selections: Selections
   exprs: Expr[]
   pathIfPipe?: PathToNode
+}
+
+type BooleanSelectionRecord = {
+  exprs: Expr[]
+  pathIfPipe?: PathToNode
+  pipeBodyIndex?: number
+}
+
+function resolveBooleanSelectionGroups({
+  selectionGroups,
+  artifactGraph,
+  ast,
+  wasmInstance,
+  nodeToEdit,
+}: {
+  selectionGroups: Array<{
+    selections: Selections
+    requiresExplicitExpr?: boolean
+  }>
+  artifactGraph: ArtifactGraph
+  ast: Node<Program>
+  wasmInstance: ModuleType
+  nodeToEdit?: PathToNode
+}): Error | BooleanSelectionGroup[] {
+  const recordsByGroup: BooleanSelectionRecord[][] = []
+  const pipeBodyIndexes = new Set<number>()
+  let mustMaterializePipes = false
+
+  for (const { selections, requiresExplicitExpr } of selectionGroups) {
+    const records: BooleanSelectionRecord[] = []
+    for (const selection of selections.graphSelections) {
+      const vars = getVariableExprsFromSelection(
+        {
+          graphSelections: [selection],
+          otherSelections: [],
+        },
+        artifactGraph,
+        ast,
+        wasmInstance,
+        nodeToEdit,
+        {
+          lastChildLookup: true,
+          artifactTypeFilter: ['compositeSolid', 'sweep'],
+        }
+      )
+      if (err(vars)) {
+        return vars
+      }
+
+      let pipeBodyIndex: number | undefined
+      if (vars.pathIfPipe) {
+        const expression = getNodeFromPath<ExpressionStatement>(
+          ast,
+          vars.pathIfPipe,
+          wasmInstance,
+          'ExpressionStatement'
+        )
+        if (
+          !err(expression) &&
+          expression.node.type === 'ExpressionStatement'
+        ) {
+          const bodyIndex = getBodyIndex(expression.shallowPath)
+          if (err(bodyIndex)) {
+            return bodyIndex
+          }
+          pipeBodyIndex = bodyIndex
+          pipeBodyIndexes.add(bodyIndex)
+          if (requiresExplicitExpr) {
+            mustMaterializePipes = true
+          }
+        }
+      }
+
+      records.push({ ...vars, pipeBodyIndex })
+    }
+    recordsByGroup.push(records)
+  }
+
+  mustMaterializePipes ||= pipeBodyIndexes.size > 1
+  if (!mustMaterializePipes) {
+    return recordsByGroup.map((records, index) => ({
+      selections: selectionGroups[index].selections,
+      exprs: records.flatMap(({ exprs }) => exprs),
+      pathIfPipe: records.find(({ pathIfPipe }) => pathIfPipe)?.pathIfPipe,
+    }))
+  }
+
+  const variableByBodyIndex = new Map<number, string>()
+  for (const bodyIndex of pipeBodyIndexes) {
+    const statement = ast.body[bodyIndex]
+    if (statement.type !== 'ExpressionStatement') {
+      return new Error('Expected a variable-less Boolean source pipe')
+    }
+    const variableName = findUniqueName(
+      ast,
+      KCL_DEFAULT_CONSTANT_PREFIXES.SOLID
+    )
+    const declaration = createVariableDeclaration(
+      variableName,
+      statement.expression
+    )
+    declaration.preComments = statement.preComments
+    ast.body[bodyIndex] = declaration
+    variableByBodyIndex.set(bodyIndex, variableName)
+  }
+
+  return recordsByGroup.map((records, index) => ({
+    selections: selectionGroups[index].selections,
+    exprs: records.flatMap(({ exprs, pathIfPipe, pipeBodyIndex }) => {
+      if (!pathIfPipe) {
+        return exprs
+      }
+      if (pipeBodyIndex === undefined) {
+        return []
+      }
+      const variableName = variableByBodyIndex.get(pipeBodyIndex)
+      return variableName ? [createLocalName(variableName)] : []
+    }),
+  }))
 }
 
 function booleanInputKey(expr: Expr, pathIfPipe?: PathToNode): string {
@@ -95,24 +224,19 @@ export function addUnion({
   const mNodeToEdit = structuredClone(nodeToEdit)
 
   // 2. Prepare unlabeled arguments (no exposed labeled arguments for boolean yet)
-  const vars = getVariableExprsFromSelection(
-    solids,
+  const selectionGroups = resolveBooleanSelectionGroups({
+    selectionGroups: [{ selections: solids }],
     artifactGraph,
-    modifiedAst,
+    ast: modifiedAst,
     wasmInstance,
-    mNodeToEdit,
-    {
-      lastChildLookup: true,
-      artifactTypeFilter: ['compositeSolid', 'sweep'],
-    }
-  )
-  if (err(vars)) {
-    return vars
+    nodeToEdit: mNodeToEdit,
+  })
+  if (err(selectionGroups)) {
+    return selectionGroups
   }
+  const [vars] = selectionGroups
 
-  const selectionError = validateBooleanSelections([
-    { selections: solids, ...vars },
-  ])
+  const selectionError = validateBooleanSelections(selectionGroups)
   if (selectionError) {
     return selectionError
   }
@@ -167,24 +291,19 @@ export function addIntersect({
   const mNodeToEdit = structuredClone(nodeToEdit)
 
   // 2. Prepare unlabeled arguments (no exposed labeled arguments for boolean yet)
-  const vars = getVariableExprsFromSelection(
-    solids,
+  const selectionGroups = resolveBooleanSelectionGroups({
+    selectionGroups: [{ selections: solids }],
     artifactGraph,
-    modifiedAst,
+    ast: modifiedAst,
     wasmInstance,
-    mNodeToEdit,
-    {
-      lastChildLookup: true,
-      artifactTypeFilter: ['compositeSolid', 'sweep'],
-    }
-  )
-  if (err(vars)) {
-    return vars
+    nodeToEdit: mNodeToEdit,
+  })
+  if (err(selectionGroups)) {
+    return selectionGroups
   }
+  const [vars] = selectionGroups
 
-  const selectionError = validateBooleanSelections([
-    { selections: solids, ...vars },
-  ])
+  const selectionError = validateBooleanSelections(selectionGroups)
   if (selectionError) {
     return selectionError
   }
@@ -241,40 +360,22 @@ export function addSubtract({
   const mNodeToEdit = structuredClone(nodeToEdit)
 
   // 2. Prepare unlabeled and labeled arguments
-  const vars = getVariableExprsFromSelection(
-    solids,
+  const selectionGroups = resolveBooleanSelectionGroups({
+    selectionGroups: [
+      { selections: solids },
+      { selections: tools, requiresExplicitExpr: true },
+    ],
     artifactGraph,
-    modifiedAst,
+    ast: modifiedAst,
     wasmInstance,
-    mNodeToEdit,
-    {
-      lastChildLookup: true,
-      artifactTypeFilter: ['compositeSolid', 'sweep'],
-    }
-  )
-  if (err(vars)) {
-    return vars
+    nodeToEdit: mNodeToEdit,
+  })
+  if (err(selectionGroups)) {
+    return selectionGroups
   }
+  const [vars, toolVars] = selectionGroups
 
-  const toolVars = getVariableExprsFromSelection(
-    tools,
-    artifactGraph,
-    modifiedAst,
-    wasmInstance,
-    mNodeToEdit,
-    {
-      lastChildLookup: true,
-      artifactTypeFilter: ['compositeSolid', 'sweep'],
-    }
-  )
-  if (err(toolVars)) {
-    return toolVars
-  }
-
-  const selectionError = validateBooleanSelections([
-    { selections: solids, ...vars },
-    { selections: tools, ...toolVars },
-  ])
+  const selectionError = validateBooleanSelections(selectionGroups)
   if (selectionError) {
     return selectionError
   }
@@ -350,57 +451,35 @@ export function addSplit({
   const mNodeToEdit = structuredClone(nodeToEdit)
 
   // 2. Prepare unlabeled and labeled arguments
-  const vars = getVariableExprsFromSelection(
-    targets,
-    artifactGraph,
-    modifiedAst,
-    wasmInstance,
-    mNodeToEdit,
-    {
-      lastChildLookup: true,
-      artifactTypeFilter: ['compositeSolid', 'sweep'],
-    }
-  )
-  if (err(vars)) {
-    return vars
-  }
-
   const hasTools = Boolean(
     tools &&
       (tools.graphSelections.length > 0 || tools.otherSelections.length > 0)
   )
-  const selectionGroups: BooleanSelectionGroup[] = [
-    { selections: targets, ...vars },
-  ]
-  const targetSelectionError = validateBooleanSelections(selectionGroups)
-  if (targetSelectionError) {
-    return targetSelectionError
+  const selectionGroups = resolveBooleanSelectionGroups({
+    selectionGroups: [
+      { selections: targets },
+      ...(hasTools && tools
+        ? [{ selections: tools, requiresExplicitExpr: true }]
+        : []),
+    ],
+    artifactGraph,
+    ast: modifiedAst,
+    wasmInstance,
+    nodeToEdit: mNodeToEdit,
+  })
+  if (err(selectionGroups)) {
+    return selectionGroups
+  }
+  const [vars, toolVars] = selectionGroups
+  const selectionError = validateBooleanSelections(selectionGroups)
+  if (selectionError) {
+    return selectionError
   }
 
   const labeledArgs: ReturnType<typeof createLabeledArg>[] = []
   let pathIfNewPipe = vars.pathIfPipe
 
-  if (hasTools && tools) {
-    const toolVars = getVariableExprsFromSelection(
-      tools,
-      artifactGraph,
-      modifiedAst,
-      wasmInstance,
-      mNodeToEdit,
-      {
-        lastChildLookup: true,
-        artifactTypeFilter: ['compositeSolid', 'sweep'],
-      }
-    )
-    if (err(toolVars)) {
-      return toolVars
-    }
-    selectionGroups.push({ selections: tools, ...toolVars })
-    const selectionError = validateBooleanSelections(selectionGroups)
-    if (selectionError) {
-      return selectionError
-    }
-
+  if (hasTools && toolVars) {
     const toolsExpr = createVariableExpressionsArray(toolVars.exprs)
     if (toolsExpr === null) {
       return new Error('No tools provided for split operation')

--- a/src/lang/modifyAst/boolean.ts
+++ b/src/lang/modifyAst/boolean.ts
@@ -12,11 +12,17 @@ import {
   setCallInAst,
 } from '@src/lang/modifyAst'
 import {
+  getNodeFromPath,
   getVariableExprsFromSelection,
   stringifyPathToNode,
   valueOrVariable,
 } from '@src/lang/queryAst'
-import type { ArtifactGraph, PathToNode, Program } from '@src/lang/wasm'
+import type {
+  ArtifactGraph,
+  CallExpressionKw,
+  PathToNode,
+  Program,
+} from '@src/lang/wasm'
 import { modelingStdLibCommandName } from '@src/lib/commandBarConfigs/modelingCommandStdLib'
 import type { KclCommandValue } from '@src/lib/commandTypes'
 import { KCL_DEFAULT_CONSTANT_PREFIXES } from '@src/lib/constants'
@@ -73,6 +79,50 @@ function validateBooleanSelections(
       inputKeys.add(key)
     }
   }
+}
+
+function preserveSplitInputsOnEdit({
+  ast,
+  call,
+  nodeToEdit,
+  wasmInstance,
+}: {
+  ast: Node<Program>
+  call: Node<CallExpressionKw>
+  nodeToEdit?: PathToNode
+  wasmInstance: ModuleType
+}) {
+  if (!nodeToEdit) {
+    return
+  }
+
+  call.unlabeled = null
+  const existingCall = getNodeFromPath<CallExpressionKw>(
+    ast,
+    nodeToEdit,
+    wasmInstance,
+    'CallExpressionKw'
+  )
+  if (err(existingCall)) {
+    return
+  }
+
+  const existingToolsArg = existingCall.node.arguments.find(
+    (arg) => arg.label.name === 'tools'
+  )
+  if (!existingToolsArg) {
+    return
+  }
+
+  const replacementToolsIndex = call.arguments.findIndex(
+    (arg) => arg.label.name === 'tools'
+  )
+  if (replacementToolsIndex === -1) {
+    call.arguments.unshift(structuredClone(existingToolsArg))
+    return
+  }
+
+  call.arguments[replacementToolsIndex] = structuredClone(existingToolsArg)
 }
 
 export function addUnion({
@@ -432,6 +482,12 @@ export function addSplit({
     objectsExpr,
     labeledArgs
   )
+  preserveSplitInputsOnEdit({
+    ast: modifiedAst,
+    call,
+    nodeToEdit: mNodeToEdit,
+    wasmInstance,
+  })
 
   // 3. If edit, we assign the new function call declaration to the existing node,
   // otherwise just push to the end

--- a/src/lang/modifyAst/boolean.ts
+++ b/src/lang/modifyAst/boolean.ts
@@ -108,14 +108,14 @@ function preserveSplitInputsOnEdit({
   }
 
   const existingToolsArg = existingCall.node.arguments.find(
-    (arg) => arg.label.name === 'tools'
+    (arg) => arg.label?.name === 'tools'
   )
   if (!existingToolsArg) {
     return
   }
 
   const replacementToolsIndex = call.arguments.findIndex(
-    (arg) => arg.label.name === 'tools'
+    (arg) => arg.label?.name === 'tools'
   )
   if (replacementToolsIndex === -1) {
     call.arguments.unshift(structuredClone(existingToolsArg))

--- a/src/lang/modifyAst/booleanSplitEdit.spec.ts
+++ b/src/lang/modifyAst/booleanSplitEdit.spec.ts
@@ -18,7 +18,7 @@ import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { Selections } from '@src/machines/modelingSharedTypes'
 import { describe, expect, it } from 'vitest'
 
-describe('Boolean Split edit input preservation', () => {
+describe('Boolean split edit input preservation', () => {
   it('preserves target and tool inputs when editing an upstream split with a downstream composite child', () => {
     const wasmInstance = {} as ModuleType
     const targetPath: PathToNode = [

--- a/src/lang/modifyAst/booleanSplitEdit.test.ts
+++ b/src/lang/modifyAst/booleanSplitEdit.test.ts
@@ -1,0 +1,202 @@
+import type { Node } from '@rust/kcl-lib/bindings/Node'
+import {
+  createCallExpressionStdLibKw,
+  createLabeledArg,
+  createLiteral,
+  createLocalName,
+  createVariableDeclaration,
+} from '@src/lang/create'
+import { addSplit } from '@src/lang/modifyAst/boolean'
+import type {
+  Artifact,
+  ArtifactGraph,
+  PathToNode,
+  Program,
+} from '@src/lang/wasm'
+import { err } from '@src/lib/trap'
+import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
+import type { Selections } from '@src/machines/modelingSharedTypes'
+import { describe, expect, it } from 'vitest'
+
+describe('Boolean Split edit input preservation', () => {
+  it('preserves target and tool inputs when editing an upstream split with a downstream composite child', () => {
+    const wasmInstance = {} as ModuleType
+    const targetPath: PathToNode = [
+      ['body', ''],
+      [0, 'index'],
+    ]
+    const toolPath: PathToNode = [
+      ['body', ''],
+      [1, 'index'],
+    ]
+    const splitPath: PathToNode = [
+      ['body', ''],
+      [2, 'index'],
+      ['declaration', 'VariableDeclaration'],
+      ['init', 'VariableDeclarator'],
+    ]
+    const downstreamPath: PathToNode = [
+      ['body', ''],
+      [3, 'index'],
+    ]
+
+    const ast: Node<Program> = {
+      start: 0,
+      end: 0,
+      moduleId: 0,
+      outerAttrs: [],
+      preComments: [],
+      commentStart: 0,
+      body: [
+        createVariableDeclaration('extrude001', createLiteral(0, wasmInstance)),
+        createVariableDeclaration('extrude002', createLiteral(0, wasmInstance)),
+        createVariableDeclaration(
+          'split001',
+          createCallExpressionStdLibKw('split', createLocalName('extrude001'), [
+            createLabeledArg('tools', createLocalName('extrude002')),
+            createLabeledArg('merge', createLiteral(false, wasmInstance)),
+          ])
+        ),
+        createVariableDeclaration(
+          'union001',
+          createCallExpressionStdLibKw('union', createLocalName('split001'), [])
+        ),
+      ],
+      nonCodeMeta: {
+        nonCodeNodes: {},
+        startNodes: [],
+      },
+    }
+
+    const targetPathArtifact: Extract<Artifact, { type: 'path' }> = {
+      type: 'path',
+      id: 'target-path-id',
+      subType: 'sketch',
+      planeId: 'plane-id',
+      segIds: [],
+      consumed: true,
+      sweepId: 'target-sweep-id',
+      trajectorySweepId: null,
+      solid2dId: null,
+      compositeSolidId: 'split-id',
+      codeRef: {
+        range: [0, 10, 0],
+        pathToNode: targetPath,
+        nodePath: { steps: [] },
+      },
+    }
+    const targetSweep: Extract<Artifact, { type: 'sweep' }> = {
+      type: 'sweep',
+      id: 'target-sweep-id',
+      subType: 'extrusion',
+      pathId: targetPathArtifact.id,
+      surfaceIds: [],
+      edgeIds: [],
+      codeRef: {
+        range: [0, 10, 0],
+        pathToNode: targetPath,
+        nodePath: { steps: [] },
+      },
+      trajectoryId: null,
+      method: 'new',
+      consumed: true,
+    }
+    const toolPathArtifact: Extract<Artifact, { type: 'path' }> = {
+      ...targetPathArtifact,
+      id: 'tool-path-id',
+      sweepId: 'tool-sweep-id',
+      compositeSolidId: null,
+      codeRef: {
+        range: [11, 20, 0],
+        pathToNode: toolPath,
+        nodePath: { steps: [] },
+      },
+    }
+    const toolSweep: Extract<Artifact, { type: 'sweep' }> = {
+      ...targetSweep,
+      id: 'tool-sweep-id',
+      pathId: toolPathArtifact.id,
+      consumed: false,
+      codeRef: {
+        range: [11, 20, 0],
+        pathToNode: toolPath,
+        nodePath: { steps: [] },
+      },
+    }
+    const splitArtifact: Extract<Artifact, { type: 'compositeSolid' }> = {
+      type: 'compositeSolid',
+      id: 'split-id',
+      consumed: true,
+      subType: 'split',
+      outputIndex: null,
+      solidIds: [targetSweep.id],
+      toolIds: [toolSweep.id],
+      compositeSolidId: 'downstream-union-id',
+      codeRef: {
+        range: [21, 40, 0],
+        pathToNode: splitPath,
+        nodePath: { steps: [] },
+      },
+    }
+    const downstreamUnion: Extract<Artifact, { type: 'compositeSolid' }> = {
+      type: 'compositeSolid',
+      id: 'downstream-union-id',
+      consumed: false,
+      subType: 'union',
+      outputIndex: null,
+      solidIds: [splitArtifact.id],
+      toolIds: [],
+      codeRef: {
+        range: [41, 60, 0],
+        pathToNode: downstreamPath,
+        nodePath: { steps: [] },
+      },
+    }
+    const artifactGraph: ArtifactGraph = new Map<string, Artifact>([
+      [targetPathArtifact.id, targetPathArtifact],
+      [targetSweep.id, targetSweep],
+      [toolPathArtifact.id, toolPathArtifact],
+      [toolSweep.id, toolSweep],
+      [splitArtifact.id, splitArtifact],
+      [downstreamUnion.id, downstreamUnion],
+    ])
+    const targets: Selections = {
+      graphSelections: [
+        { artifact: targetPathArtifact, codeRef: targetPathArtifact.codeRef },
+      ],
+      otherSelections: [],
+    }
+    const tools: Selections = {
+      graphSelections: [
+        { artifact: toolPathArtifact, codeRef: toolPathArtifact.codeRef },
+      ],
+      otherSelections: [],
+    }
+
+    const result = addSplit({
+      ast,
+      artifactGraph,
+      targets,
+      tools,
+      merge: true,
+      nodeToEdit: splitPath,
+      wasmInstance,
+    })
+    if (err(result)) {
+      throw result
+    }
+
+    const editedDeclaration = result.modifiedAst.body[2]
+    expect(editedDeclaration.type).toBe('VariableDeclaration')
+    if (editedDeclaration.type !== 'VariableDeclaration') {
+      throw new Error('Expected edited split variable declaration')
+    }
+    const editedCall = editedDeclaration.declaration.init
+    expect(editedCall.type).toBe('CallExpressionKw')
+    if (editedCall.type !== 'CallExpressionKw') {
+      throw new Error('Expected edited split call')
+    }
+    expect(editedCall.unlabeled).toEqual(createLocalName('extrude001'))
+    expect(editedCall.unlabeled).not.toEqual(createLocalName('union001'))
+  })
+})

--- a/src/lang/modifyAst/booleanVariablelessPipes.spec.ts
+++ b/src/lang/modifyAst/booleanVariablelessPipes.spec.ts
@@ -1,0 +1,243 @@
+import {
+  addIntersect,
+  addSplit,
+  addSubtract,
+  addUnion,
+} from '@src/lang/modifyAst/boolean'
+import { assertParse, recast } from '@src/lang/wasm'
+import {
+  createSelectionFromArtifacts,
+  enginelessExecutor,
+} from '@src/lib/testHelpers'
+import { err } from '@src/lib/trap'
+import { buildTheWorldAndNoEngineConnection } from '@src/unitTestUtils'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@src/lib/commandBarConfigs/modelingCommandStdLibCommands', () => ({
+  STD_LIB_COMMANDS: {},
+}))
+
+describe('boolean operations on distinct variable-less pipes', () => {
+  it.each(['union', 'intersect', 'subtract', 'split'] as const)(
+    'keeps both selected bodies when creating %s',
+    async (operation) => {
+      const { instance, rustContext } =
+        await buildTheWorldAndNoEngineConnection()
+      const code = `@settings(experimentalFeatures = allow)
+
+startSketchOn(XY)
+  |> circle(center = [0, 0], radius = 2)
+  |> extrude(length = 2)
+startSketchOn(XZ)
+  |> circle(center = [0, 0], radius = 2)
+  |> extrude(length = 2)`
+      const ast = assertParse(code, instance)
+      const { artifactGraph } = await enginelessExecutor(ast, rustContext)
+      const sweeps = [...artifactGraph.values()].filter(
+        (artifact) => artifact.type === 'sweep'
+      )
+      expect(sweeps).toHaveLength(2)
+
+      const first = createSelectionFromArtifacts([sweeps[0]], artifactGraph)
+      const second = createSelectionFromArtifacts([sweeps[1]], artifactGraph)
+      const both = createSelectionFromArtifacts(sweeps, artifactGraph)
+      const result =
+        operation === 'union'
+          ? addUnion({
+              ast,
+              artifactGraph,
+              solids: both,
+              wasmInstance: instance,
+            })
+          : operation === 'intersect'
+            ? addIntersect({
+                ast,
+                artifactGraph,
+                solids: both,
+                wasmInstance: instance,
+              })
+            : operation === 'subtract'
+              ? addSubtract({
+                  ast,
+                  artifactGraph,
+                  solids: first,
+                  tools: second,
+                  wasmInstance: instance,
+                })
+              : addSplit({
+                  ast,
+                  artifactGraph,
+                  targets: first,
+                  tools: second,
+                  wasmInstance: instance,
+                })
+      if (err(result)) {
+        throw result
+      }
+
+      const output = recast(result.modifiedAst, instance)
+      expect(output).toContain('solid001 = startSketchOn(XY)')
+      expect(output).toContain('solid002 = startSketchOn(XZ)')
+      if (operation === 'union' || operation === 'intersect') {
+        expect(output).toContain(
+          `solid003 = ${operation}([solid001, solid002])`
+        )
+      } else if (operation === 'subtract') {
+        expect(output).toContain(
+          'solid003 = subtract(solid001, tools = solid002)'
+        )
+      } else {
+        expect(output).toContain('split001 = split(solid001, tools = solid002)')
+      }
+      const execution = await enginelessExecutor(
+        result.modifiedAst,
+        rustContext
+      )
+      expect(execution.issues).toEqual([])
+    }
+  )
+
+  it.each(['subtract', 'split'] as const)(
+    'materializes a variable-less %s tool for its labeled argument',
+    async (operation) => {
+      const { instance, rustContext } =
+        await buildTheWorldAndNoEngineConnection()
+      const code = `@settings(experimentalFeatures = allow)
+
+sketch001 = startSketchOn(XY)
+profile001 = circle(sketch001, center = [0, 0], radius = 2)
+extrude001 = extrude(profile001, length = 2)
+startSketchOn(XZ)
+  |> circle(center = [0, 0], radius = 2)
+  |> extrude(length = 2)`
+      const ast = assertParse(code, instance)
+      const { artifactGraph } = await enginelessExecutor(ast, rustContext)
+      const sweeps = [...artifactGraph.values()].filter(
+        (artifact) => artifact.type === 'sweep'
+      )
+      expect(sweeps).toHaveLength(2)
+      const targets = createSelectionFromArtifacts([sweeps[0]], artifactGraph)
+      const tools = createSelectionFromArtifacts([sweeps[1]], artifactGraph)
+
+      const result =
+        operation === 'subtract'
+          ? addSubtract({
+              ast,
+              artifactGraph,
+              solids: targets,
+              tools,
+              wasmInstance: instance,
+            })
+          : addSplit({
+              ast,
+              artifactGraph,
+              targets,
+              tools,
+              wasmInstance: instance,
+            })
+      if (err(result)) {
+        throw result
+      }
+
+      const output = recast(result.modifiedAst, instance)
+      expect(output).toContain('solid001 = startSketchOn(XZ)')
+      expect(output).toContain(
+        operation === 'subtract'
+          ? 'solid002 = subtract(extrude001, tools = solid001)'
+          : 'split001 = split(extrude001, tools = solid001)'
+      )
+      const execution = await enginelessExecutor(
+        result.modifiedAst,
+        rustContext
+      )
+      expect(execution.issues).toEqual([])
+    }
+  )
+
+  it('still rejects one variable-less body selected as both target and tool', async () => {
+    const { instance, rustContext } = await buildTheWorldAndNoEngineConnection()
+    const code = `@settings(experimentalFeatures = allow)
+
+startSketchOn(XY)
+  |> circle(center = [0, 0], radius = 2)
+  |> extrude(length = 2)`
+    const ast = assertParse(code, instance)
+    const { artifactGraph } = await enginelessExecutor(ast, rustContext)
+    const sweep = [...artifactGraph.values()].find(
+      (artifact) => artifact.type === 'sweep'
+    )
+    if (!sweep) {
+      throw new Error('Expected a sweep')
+    }
+    const selection = createSelectionFromArtifacts([sweep], artifactGraph)
+
+    const result = addSubtract({
+      ast,
+      artifactGraph,
+      solids: selection,
+      tools: selection,
+      wasmInstance: instance,
+    })
+
+    expect(result).toEqual(
+      new Error(
+        'The same body cannot be used more than once in a Boolean operation. Please check your selections.'
+      )
+    )
+  })
+
+  it.each(['subtract', 'split'] as const)(
+    'preserves the existing in-pipe %s path for a variable-less target',
+    async (operation) => {
+      const { instance, rustContext } =
+        await buildTheWorldAndNoEngineConnection()
+      const code = `@settings(experimentalFeatures = allow)
+
+sketch001 = startSketchOn(XY)
+profile001 = circle(sketch001, center = [0, 0], radius = 2)
+extrude001 = extrude(profile001, length = 2)
+startSketchOn(XZ)
+  |> circle(center = [0, 0], radius = 2)
+  |> extrude(length = 2)`
+      const ast = assertParse(code, instance)
+      const { artifactGraph } = await enginelessExecutor(ast, rustContext)
+      const sweeps = [...artifactGraph.values()].filter(
+        (artifact) => artifact.type === 'sweep'
+      )
+      expect(sweeps).toHaveLength(2)
+      const tools = createSelectionFromArtifacts([sweeps[0]], artifactGraph)
+      const targets = createSelectionFromArtifacts([sweeps[1]], artifactGraph)
+
+      const result =
+        operation === 'subtract'
+          ? addSubtract({
+              ast,
+              artifactGraph,
+              solids: targets,
+              tools,
+              wasmInstance: instance,
+            })
+          : addSplit({
+              ast,
+              artifactGraph,
+              targets,
+              tools,
+              wasmInstance: instance,
+            })
+      if (err(result)) {
+        throw result
+      }
+
+      const output = recast(result.modifiedAst, instance)
+      expect(output).toContain(
+        `  |> extrude(length = 2)\n  |> ${operation}(tools = extrude001)`
+      )
+      expect(output).not.toContain('solid001 = startSketchOn(XZ)')
+      const execution = await enginelessExecutor(
+        result.modifiedAst,
+        rustContext
+      )
+      expect(execution.issues).toEqual([])
+    }
+  )
+})


### PR DESCRIPTION
Preserve the original target and tool when editing an existing Boolean Split so changing an option cannot retarget the operation to a downstream child.

Fixes #13420. The focused integration regression and touched-file checks pass.