### PR TITLE
Gate legacy sketch editing on a feature flag

### DIFF
--- a/e2e/playwright/benchmark/hot-path.spec.ts
+++ b/e2e/playwright/benchmark/hot-path.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@e2e/playwright/zoo-test'
+import { LEGACY_SKETCH_MODE_FEATURE_FLAG } from '@src/lib/constants'
 import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
 
 /**
@@ -8,6 +9,9 @@ import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
  */
 
 test.describe('Hot path', { tag: '@desktop' }, () => {
+  // These sketches are KCL 1.0, so editing them needs the legacy sketch flag.
+  test.use({ userFeatures: [LEGACY_SKETCH_MODE_FEATURE_FLAG] })
+
   test(`Draw a circle and extrude it`, async ({
     page,
     homePage,

--- a/e2e/playwright/command-bar-tests.spec.ts
+++ b/e2e/playwright/command-bar-tests.spec.ts
@@ -1,5 +1,8 @@
 import path, { join } from 'path'
-import { KCL_DEFAULT_LENGTH } from '@src/lib/constants'
+import {
+  KCL_DEFAULT_LENGTH,
+  LEGACY_SKETCH_MODE_FEATURE_FLAG,
+} from '@src/lib/constants'
 import * as fsp from 'fs/promises'
 
 import { executorInputPath, getUtils } from '@e2e/playwright/test-utils'
@@ -7,6 +10,9 @@ import { expect, test } from '@e2e/playwright/zoo-test'
 import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
 
 test.describe('Command bar tests', { tag: '@desktop' }, () => {
+  // Some of these sketches are KCL 1.0, so editing them needs the legacy sketch flag.
+  test.use({ userFeatures: [LEGACY_SKETCH_MODE_FEATURE_FLAG] })
+
   test('Extrude from command bar selects extrude line after', async ({
     page,
     homePage,

--- a/e2e/playwright/editor-tests.spec.ts
+++ b/e2e/playwright/editor-tests.spec.ts
@@ -10,7 +10,11 @@ import {
 } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
 import type { Page } from '@playwright/test'
+import { LEGACY_SKETCH_MODE_FEATURE_FLAG } from '@src/lib/constants'
 import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
+
+// Some of these sketches are KCL 1.0, so editing them needs the legacy sketch flag.
+test.use({ userFeatures: [LEGACY_SKETCH_MODE_FEATURE_FLAG] })
 
 type MainAxisTestFixtures = Pick<Fixtures, 'homePage' | 'toolbar' | 'scene'> & {
   page: Page

--- a/e2e/playwright/feature-tree-pane.spec.ts
+++ b/e2e/playwright/feature-tree-pane.spec.ts
@@ -2,7 +2,11 @@ import { join } from 'path'
 import * as fsp from 'fs/promises'
 
 import { expect, test } from '@e2e/playwright/zoo-test'
+import { LEGACY_SKETCH_MODE_FEATURE_FLAG } from '@src/lib/constants'
 import { DefaultLayoutPaneID } from '@src/lib/layout'
+
+// These sketches are KCL 1.0, so editing them needs the legacy sketch flag.
+test.use({ userFeatures: [LEGACY_SKETCH_MODE_FEATURE_FLAG] })
 
 const FEATURE_TREE_EXAMPLE_CODE = `export fn timesFive(@x) {
   return 5 * x

--- a/e2e/playwright/file-tree.spec.ts
+++ b/e2e/playwright/file-tree.spec.ts
@@ -4,10 +4,17 @@ import {
   getUtils,
 } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
-import { FILE_EXT, PROJECT_SETTINGS_FILE_NAME } from '@src/lib/constants'
+import {
+  FILE_EXT,
+  LEGACY_SKETCH_MODE_FEATURE_FLAG,
+  PROJECT_SETTINGS_FILE_NAME,
+} from '@src/lib/constants'
 import type { PromisifiedZooDesignStudioFS } from '@src/lib/fs-zds/interface'
 import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
 import * as nodeFsP from 'fs/promises'
+
+// Some of these sketches are KCL 1.0, so editing them needs the legacy sketch flag.
+test.use({ userFeatures: [LEGACY_SKETCH_MODE_FEATURE_FLAG] })
 
 const exists = async (
   fs: PromisifiedZooDesignStudioFS,

--- a/e2e/playwright/point-click-sketch-v1.spec.ts
+++ b/e2e/playwright/point-click-sketch-v1.spec.ts
@@ -9,13 +9,20 @@ import {
   EXPERIMENTAL_POINT_AND_CLICK_FLAG,
   KCL_DEFAULT_INSTANCES,
   KCL_DEFAULT_LENGTH,
+  LEGACY_SKETCH_MODE_FEATURE_FLAG,
 } from '@src/lib/constants'
 import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
 
 // test file is for testing point an click code gen functionality that's not sketch mode related
 
 test.describe('Point-and-click tests - sketch v1', { tag: '@desktop' }, () => {
-  test.use({ userFeatures: [EXPERIMENTAL_POINT_AND_CLICK_FLAG] })
+  // These sketches are KCL 1.0, so editing them needs the legacy sketch flag.
+  test.use({
+    userFeatures: [
+      EXPERIMENTAL_POINT_AND_CLICK_FLAG,
+      LEGACY_SKETCH_MODE_FEATURE_FLAG,
+    ],
+  })
 
   test('Create an Extrude operation with a tag and edit it via Feature Tree', async ({
     context,

--- a/e2e/playwright/projects.spec.ts
+++ b/e2e/playwright/projects.spec.ts
@@ -1,6 +1,10 @@
 import nodeFsSync from 'fs'
 import path from 'path'
-import { DEFAULT_PROJECT_KCL_FILE, REGEXP_UUIDV4 } from '@src/lib/constants'
+import {
+  DEFAULT_PROJECT_KCL_FILE,
+  LEGACY_SKETCH_MODE_FEATURE_FLAG,
+  REGEXP_UUIDV4,
+} from '@src/lib/constants'
 import nodeFs from 'fs/promises'
 import type { Page } from '@playwright/test'
 import { NIL as uuidNIL } from 'uuid'
@@ -16,6 +20,9 @@ import {
 } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
 import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
+
+// Some of these sketches are KCL 1.0, so editing them needs the legacy sketch flag.
+test.use({ userFeatures: [LEGACY_SKETCH_MODE_FEATURE_FLAG] })
 
 type ProjectCardContextMenuAction = 'rename' | 'delete'
 

--- a/e2e/playwright/regression-tests.spec.ts
+++ b/e2e/playwright/regression-tests.spec.ts
@@ -13,7 +13,11 @@ import {
   getUtils,
 } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
+import { LEGACY_SKETCH_MODE_FEATURE_FLAG } from '@src/lib/constants'
 import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
+
+// Some of these sketches are KCL 1.0, so editing them needs the legacy sketch flag.
+test.use({ userFeatures: [LEGACY_SKETCH_MODE_FEATURE_FLAG] })
 
 const bracket = fs.readFileSync(
   path.resolve('public', 'kcl-samples', 'bracket', 'main.kcl'),

--- a/e2e/playwright/snap-to-grid.spec.ts
+++ b/e2e/playwright/snap-to-grid.spec.ts
@@ -1,6 +1,10 @@
 import { expect, test } from '@e2e/playwright/zoo-test'
+import { LEGACY_SKETCH_MODE_FEATURE_FLAG } from '@src/lib/constants'
 
 test.describe('Snap to Grid', { tag: '@desktop' }, () => {
+  // These sketches are KCL 1.0, so editing them needs the legacy sketch flag.
+  test.use({ userFeatures: [LEGACY_SKETCH_MODE_FEATURE_FLAG] })
+
   test('draws a line with snap to grid turned on', async ({
     page,
     homePage,

--- a/e2e/playwright/test-network-and-connection-issues.spec.ts
+++ b/e2e/playwright/test-network-and-connection-issues.spec.ts
@@ -1,5 +1,9 @@
 import { TEST_COLORS, circleMove, getUtils } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
+import { LEGACY_SKETCH_MODE_FEATURE_FLAG } from '@src/lib/constants'
+
+// Some of these sketches are KCL 1.0, so editing them needs the legacy sketch flag.
+test.use({ userFeatures: [LEGACY_SKETCH_MODE_FEATURE_FLAG] })
 
 test.describe('Test network related behaviors', { tag: '@desktop' }, () => {
   test(

--- a/e2e/playwright/testing-constraints.spec.ts
+++ b/e2e/playwright/testing-constraints.spec.ts
@@ -8,9 +8,13 @@ import {
   pollEditorLinesSelectedLength,
 } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
+import { LEGACY_SKETCH_MODE_FEATURE_FLAG } from '@src/lib/constants'
 import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
 
 test.describe('Testing constraints', { tag: '@desktop' }, () => {
+  // These sketches are KCL 1.0, so editing them needs the legacy sketch flag.
+  test.use({ userFeatures: [LEGACY_SKETCH_MODE_FEATURE_FLAG] })
+
   test('Can constrain line length', async ({ page, homePage, cmdBar }) => {
     await page.addInitScript(async () => {
       localStorage.setItem(

--- a/e2e/playwright/testing-segment-overlays.spec.ts
+++ b/e2e/playwright/testing-segment-overlays.spec.ts
@@ -6,8 +6,12 @@ import type { CmdBarFixture } from '@e2e/playwright/fixtures/cmdBarFixture'
 import type { EditorFixture } from '@e2e/playwright/fixtures/editorFixture'
 import { deg, getUtils, wiggleMove } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
+import { LEGACY_SKETCH_MODE_FEATURE_FLAG } from '@src/lib/constants'
 
 test.describe('Testing segment overlays', { tag: '@desktop' }, () => {
+  // These sketches are KCL 1.0, so editing them needs the legacy sketch flag.
+  test.use({ userFeatures: [LEGACY_SKETCH_MODE_FEATURE_FLAG] })
+
   test.describe('Hover over a segment should show its overlay, hovering over the input overlays should show its popover, clicking the input overlay should constrain/unconstrain it', () => {
     /**
      * Clicks on an constrained element

--- a/e2e/playwright/testing-selections.spec.ts
+++ b/e2e/playwright/testing-selections.spec.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import { getUtils } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
+import { LEGACY_SKETCH_MODE_FEATURE_FLAG } from '@src/lib/constants'
 
 const bracket = fs.readFileSync(
   path.resolve('public', 'kcl-samples', 'bracket', 'main.kcl'),
@@ -9,6 +10,9 @@ const bracket = fs.readFileSync(
 )
 
 test.describe('Testing selections', { tag: '@desktop' }, () => {
+  // Some of these sketches are KCL 1.0, so editing them needs the legacy sketch flag.
+  test.use({ userFeatures: [LEGACY_SKETCH_MODE_FEATURE_FLAG] })
+
   test("Extrude button should be disabled if there's no extrudable geometry when nothing is selected", async ({
     page,
     editor,

--- a/e2e/playwright/testing-settings.spec.ts
+++ b/e2e/playwright/testing-settings.spec.ts
@@ -14,12 +14,18 @@ import {
 import { expect, test } from '@e2e/playwright/zoo-test'
 import type { UnitLength } from '@kittycad/lib/dist/types/src'
 import type { Page } from '@playwright/test'
-import { PROJECT_SETTINGS_FILE_NAME } from '@src/lib/constants'
+import {
+  LEGACY_SKETCH_MODE_FEATURE_FLAG,
+  PROJECT_SETTINGS_FILE_NAME,
+} from '@src/lib/constants'
 import type { SettingsLevel } from '@src/lib/settings/settingsTypes'
 import { Themes } from '@src/lib/theme'
 import { isArray, uuidv4 } from '@src/lib/utils'
 import * as fsp from 'fs/promises'
 import path, { join } from 'path'
+
+// Some of these sketches are KCL 1.0, so editing them needs the legacy sketch flag.
+test.use({ userFeatures: [LEGACY_SKETCH_MODE_FEATURE_FLAG] })
 
 const settingsSwitchTab = (page: Page) => async (tab: 'user' | 'proj') => {
   const projectSettingsTab = page.getByRole('radio', { name: 'Project' })

--- a/e2e/playwright/various.spec.ts
+++ b/e2e/playwright/various.spec.ts
@@ -4,6 +4,10 @@ import {
   getUtils,
 } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
+import { LEGACY_SKETCH_MODE_FEATURE_FLAG } from '@src/lib/constants'
+
+// Some of these sketches are KCL 1.0, so editing them needs the legacy sketch flag.
+test.use({ userFeatures: [LEGACY_SKETCH_MODE_FEATURE_FLAG] })
 
 test('Units menu', { tag: '@desktop' }, async ({ page, homePage }) => {
   await page.setBodyDimensions({ width: 1200, height: 500 })

--- a/e2e/playwright/view-controls.spec.ts
+++ b/e2e/playwright/view-controls.spec.ts
@@ -3,6 +3,10 @@ import { uuidv4 } from '@src/lib/utils'
 import { TEST_CODE_GIZMO } from '@e2e/playwright/storageStates'
 import { getUtils } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
+import { LEGACY_SKETCH_MODE_FEATURE_FLAG } from '@src/lib/constants'
+
+// Some of these sketches are KCL 1.0, so editing them needs the legacy sketch flag.
+test.use({ userFeatures: [LEGACY_SKETCH_MODE_FEATURE_FLAG] })
 
 test.describe('Testing Gizmo', { tag: '@desktop' }, () => {
   const cases = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@csstools/postcss-oklab-function": "^4.0.12",
         "@headlessui/react": "^1.7.19",
         "@headlessui/tailwindcss": "^0.2.2",
-        "@kittycad/lib": "^4.3.32",
+        "@kittycad/lib": "^4.4.2",
         "@lezer/highlight": "^1.2.1",
         "@lezer/lr": "^1.4.10",
         "@microlink/react-json-view": "^1.31.28",
@@ -9301,18 +9301,18 @@
       "link": true
     },
     "node_modules/@kittycad/kcl-wasm-lib": {
-      "version": "0.1.174",
-      "resolved": "https://registry.npmjs.org/@kittycad/kcl-wasm-lib/-/kcl-wasm-lib-0.1.174.tgz",
-      "integrity": "sha512-d8qcvrz1cgaA6w7P9A4fSuMCmXjs4q6GcNLAH/PgUIzy9y2ywpWX2wzU4ff1dZw/+jGBn8kUDLo2ij0gmpgSjQ==",
+      "version": "0.1.179",
+      "resolved": "https://registry.npmjs.org/@kittycad/kcl-wasm-lib/-/kcl-wasm-lib-0.1.179.tgz",
+      "integrity": "sha512-ddp4j6rs7H+xWmWDS3L4KP3NoZRquyzf+FpAEjDxh+HIIR8CwQZ77b34YbZa/FSIzZMx4ZaRg6ilJ6ldlKVmSQ==",
       "license": "MIT"
     },
     "node_modules/@kittycad/lib": {
-      "version": "4.3.32",
-      "resolved": "https://registry.npmjs.org/@kittycad/lib/-/lib-4.3.32.tgz",
-      "integrity": "sha512-SIpJj4Cl0ne480ETvV8Nw1N4rZF6xiGjCcwu6UOjkksQRSf7rgLHQN231fYxDQsljvCt81SOYs1qjie/7RDf1Q==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@kittycad/lib/-/lib-4.4.2.tgz",
+      "integrity": "sha512-lsLvmHY1BaOSBllx1jbskUk7o7ws3TMJUJLBSO2i7E9fehXuGsK3qgW8qHQvXVDr381HOftUGYcUdpHM95N8ew==",
       "license": "MIT",
       "dependencies": {
-        "@kittycad/kcl-wasm-lib": "0.1.174",
+        "@kittycad/kcl-wasm-lib": "0.1.179",
         "@kittycad/oauth2-auth-code-pkce": "^4.0.0",
         "@msgpack/msgpack": "^3.1.3",
         "bson": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@csstools/postcss-oklab-function": "^4.0.12",
     "@headlessui/react": "^1.7.19",
     "@headlessui/tailwindcss": "^0.2.2",
-    "@kittycad/lib": "^4.3.32",
+    "@kittycad/lib": "^4.4.2",
     "@lezer/highlight": "^1.2.1",
     "@lezer/lr": "^1.4.10",
     "@microlink/react-json-view": "^1.31.28",

--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -1,5 +1,3 @@
-import { memo, use, useCallback, useMemo, useRef, useState } from 'react'
-
 import { useSignals } from '@preact/signals-react/runtime'
 import { useAppState } from '@src/AppState'
 import { ActionButton } from '@src/components/ActionButton'
@@ -22,6 +20,7 @@ import {
   shouldDisableModelingForUnrenderedChanges,
 } from '@src/lib/automaticRendering'
 import { useApp, useSingletons } from '@src/lib/boot'
+import { EngineConnectionStateType } from '@src/lib/engineConnection/utils'
 import { type HotkeySequence, hotkeyDisplay } from '@src/lib/hotkeys'
 import { isDesktop } from '@src/lib/isDesktop'
 import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
@@ -46,11 +45,10 @@ import {
 } from '@src/lib/toolbar'
 import { toolbarToastsSignal } from '@src/lib/toolbarToast'
 import { reportRejection } from '@src/lib/trap'
-import { type Platform, isArray } from '@src/lib/utils'
+import { isArray, type Platform } from '@src/lib/utils'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { getSymmetricToolSelectionStep } from '@src/machines/sketchSolve/constraints/constraintUtils'
 import type { sketchSolveMachine } from '@src/machines/sketchSolve/sketchSolveDiagram'
-import { EngineConnectionStateType } from '@src/lib/engineConnection/utils'
 import { executingEditorService } from '@src/registry/contracts/executingEditor'
 import {
   findKeymapItemForCommand,
@@ -60,6 +58,7 @@ import {
 } from '@src/registry/contracts/keymap'
 import { APP_COMMAND_IDS } from '@src/registry/extensions/commands/appCommands'
 import { useSelector } from '@xstate/react'
+import { memo, use, useCallback, useMemo, useRef, useState } from 'react'
 import type { SnapshotFrom } from 'xstate'
 
 type ToolbarProps = {
@@ -261,11 +260,6 @@ const Toolbar_ = memo(
         const isConfiguredAvailable = ['available', 'experimental'].includes(
           maybeIconConfig.status
         )
-        const isDisabled =
-          disableAllButtons ||
-          disableSketchToolbar ||
-          !isConfiguredAvailable ||
-          maybeIconConfig.disabled?.(props.state, wasmInstance) === true
 
         // Calculate the isActive state for this specific item
         const itemIsActive = maybeIconConfig.isActive?.(props.state) || false
@@ -275,6 +269,15 @@ const Toolbar_ = memo(
           ...configCallbackProps,
           isActive: itemIsActive,
         }
+        const isDisabled =
+          disableAllButtons ||
+          disableSketchToolbar ||
+          !isConfiguredAvailable ||
+          maybeIconConfig.disabled?.(
+            props.state,
+            wasmInstance,
+            itemCallbackProps
+          ) === true
 
         const title =
           typeof maybeIconConfig.title === 'string'
@@ -305,7 +308,7 @@ const Toolbar_ = memo(
             props.disableModelingForUnrenderedChanges && isDisabled
               ? getUnrenderedChangesDisabledReason()
               : typeof maybeIconConfig.disabledReason === 'function'
-                ? maybeIconConfig.disabledReason(props.state)
+                ? maybeIconConfig.disabledReason(props.state, itemCallbackProps)
                 : maybeIconConfig.disabledReason,
           status: maybeIconConfig.status,
           // Store the item-specific callback props for use in onClick handlers
@@ -939,7 +942,9 @@ const ToolbarItemTooltipRichContent = memo(
           {itemConfig.icon && (
             <CustomIcon
               className="w-5 h-5"
-              style={{ color: itemConfig.iconColor }}
+              style={{
+                color: itemConfig.disabled ? undefined : itemConfig.iconColor,
+              }}
               name={itemConfig.icon}
             />
           )}
@@ -985,16 +990,12 @@ const ToolbarItemTooltipRichContent = memo(
             {itemConfig.extraInfo}
           </p>
         )}
-        {/* Add disabled reason if item is disabled */}
         {itemConfig.disabled && itemConfig.disabledReason && (
-          <>
-            <hr className="border-chalkboard-20 dark:border-chalkboard-80" />
-            <p className="px-2 my-2 text-ch font-sans text-chalkboard-70 dark:text-chalkboard-40">
-              {typeof itemConfig.disabledReason === 'function'
-                ? itemConfig.disabledReason(state)
-                : itemConfig.disabledReason}
-            </p>
-          </>
+          <p className="px-2 my-2 text-ch font-sans text-destroy-80 dark:text-destroy-20">
+            {typeof itemConfig.disabledReason === 'function'
+              ? itemConfig.disabledReason(state)
+              : itemConfig.disabledReason}
+          </p>
         )}
         {itemConfig.links.length > 0 && (
           <>

--- a/src/components/Announcements.tsx
+++ b/src/components/Announcements.tsx
@@ -4,7 +4,7 @@ import { MarkdownText } from '@src/components/MarkdownText'
 import { createKCClient } from '@src/lib/kcClient'
 import { useEffect, useState } from 'react'
 
-export const LEGACY_SKETCH_MODE_BANNER =
+export const LEGACY_SKETCH_MODE_DEPRECATION_MESSAGE =
   'This older sketch opens in legacy mode. New projects use the redesigned sketch mode with a fully-integrated constraint solver.'
 
 export function Announcements({ token }: { token?: string }) {
@@ -69,7 +69,7 @@ export function LegacySketchModeBanner() {
       className="mt-2 w-[min(34rem,calc(100vw-2rem))] py-1 px-2 bg-chalkboard-10 dark:bg-chalkboard-90 border border-chalkboard-20 dark:border-chalkboard-80 rounded shadow-lg whitespace-normal"
     >
       <p className="text-xs text-center whitespace-normal break-words">
-        {LEGACY_SKETCH_MODE_BANNER}
+        {LEGACY_SKETCH_MODE_DEPRECATION_MESSAGE}
       </p>
     </div>
   )

--- a/src/components/ConnectionStream.tsx
+++ b/src/components/ConnectionStream.tsx
@@ -27,6 +27,10 @@ import { getAllOperations } from '@src/lang/wasm'
 import { useApp, useSingletons } from '@src/lib/boot'
 import { btnName } from '@src/lib/cameraControls'
 import { ClientErrorCode, reportClientError } from '@src/lib/clientErrors'
+import {
+  LEGACY_SKETCH_MODE_FEATURE_FLAG,
+  LEGACY_SKETCH_MODE_REMOVED_MESSAGE,
+} from '@src/lib/constants'
 import { EngineDebugger } from '@src/lib/debugger'
 import { EngineConnectionManagerEvents } from '@src/lib/engineConnection/utils'
 import { prepareEditCommand } from '@src/lib/featureTree'
@@ -43,6 +47,7 @@ import type {
 } from '@src/registry/contracts/engineScene'
 import type { MouseEventHandler } from 'react'
 import { use, useCallback, useMemo, useRef, useState } from 'react'
+import toast from 'react-hot-toast'
 
 const TIME_TO_CONNECT = 30_000
 
@@ -63,7 +68,11 @@ interface ConnectionStreamProps {
 }
 
 export const ConnectionStream = (props: ConnectionStreamProps) => {
-  const { settings, project, wasmPromise, commands } = useApp()
+  const { settings, project, wasmPromise, commands, userFeatures } = useApp()
+  const hasLegacySketchMode = userFeatures.useHas(
+    LEGACY_SKETCH_MODE_FEATURE_FLAG,
+    false
+  )
   const wasmInstance = use(wasmPromise)
   const { kclManager } = useSingletons()
   const engineCommandManager = kclManager.engineCommandManager
@@ -254,6 +263,12 @@ export const ConnectionStream = (props: ConnectionStreamProps) => {
             if (err(path)) {
               return path
             }
+            // Anything left here belongs to a KCL 1.0 sketch, since sketch
+            // blocks and undeclared regions were handled above.
+            if (!hasLegacySketchMode) {
+              toast.error(LEGACY_SKETCH_MODE_REMOVED_MESSAGE)
+              return
+            }
             sceneInfra.modelingSend({ type: 'Enter sketch' })
           })
           .catch(reportRejection)
@@ -262,6 +277,7 @@ export const ConnectionStream = (props: ConnectionStreamProps) => {
       [
         commands.actor,
         engineCommandManager,
+        hasLegacySketchMode,
         isNetworkOkay,
         kclManager.artifactGraph,
         kclManager.ast,

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -39,6 +39,10 @@ export const KCL_CEK_EXECUTOR_FEATURE_FLAG: Feature = 'kcl_cek_executor'
 export const KCL_NEW_LEXER_PARSER_FEATURE_FLAG: Feature = 'kcl_new_lexer_parser'
 /** Gates named view changes to ZDS UI */
 export const NAMED_VIEWS_UI_FEATURE_FLAG: Feature = 'named_views_ui'
+/** Allows legacy sketches to be edited using point-and-click */
+export const LEGACY_SKETCH_MODE_FEATURE_FLAG: Feature = 'legacy_sketch_mode'
+export const LEGACY_SKETCH_MODE_REMOVED_MESSAGE =
+  '⚠ Editing of KCL 1.0 sketches is no longer supported.'
 /** Default file to open when a project is opened */
 export const PROJECT_ENTRYPOINT = `main${FILE_EXT}` as const
 /** Thumbnail file name */

--- a/src/lib/operations.spec.ts
+++ b/src/lib/operations.spec.ts
@@ -16,6 +16,10 @@ import {
 } from '@src/lang/wasm'
 import type { Artifact, ArtifactGraph } from '@src/lang/wasm'
 import {
+  LEGACY_SKETCH_MODE_FEATURE_FLAG,
+  LEGACY_SKETCH_MODE_REMOVED_MESSAGE,
+} from '@src/lib/constants'
+import {
   enterEditFlow,
   filterOperations,
   getHideOpByArtifactId,
@@ -173,6 +177,18 @@ function capArtifact(id: string, sweepId: string): Artifact {
 
 function toArtifactGraph(artifacts: Artifact[]): ArtifactGraph {
   return new Map(artifacts.map((artifact) => [artifact.id, artifact]))
+}
+
+/** Stands in for the global app instance that holds the user's feature flags. */
+function stubUserFeatures(features: string[]) {
+  const previousApp = window.app
+  window.app = {
+    userFeatures: { has: (feature: string) => features.includes(feature) },
+  } as unknown as typeof window.app
+
+  return () => {
+    window.app = previousApp
+  }
 }
 
 function sketchBlockBegin(index = 0): Operation {
@@ -931,6 +947,46 @@ describe('operations.test.ts', () => {
       expect(argDefaultValues.roll?.valueText).toBe('10deg')
       expect(argDefaultValues.pitch?.valueText).toBe('20deg')
       expect(argDefaultValues.yaw?.valueText).toBe('30deg')
+    })
+  })
+
+  describe('Legacy sketch edit flow', () => {
+    const code = 'sketch001 = startSketchOn(XZ)'
+
+    async function editStartSketchOn() {
+      const { rustContext } = await buildTheWorldAndNoEngineConnection()
+      return enterEditFlow({
+        operation: stdlib('startSketchOn'),
+        code,
+        artifact: pathArtifact('path-id'),
+        artifactGraph: toArtifactGraph([pathArtifact('path-id')]),
+        rustContext,
+      })
+    }
+
+    it('refuses to edit without the legacy sketch mode feature', async () => {
+      const result = await editStartSketchOn()
+
+      expect(isErr(result)).toBe(true)
+      expect((result as Error).message).toBe(LEGACY_SKETCH_MODE_REMOVED_MESSAGE)
+    })
+
+    it('enters sketch mode with the legacy sketch mode feature', async () => {
+      const restoreApp = stubUserFeatures([LEGACY_SKETCH_MODE_FEATURE_FLAG])
+
+      try {
+        const result = await editStartSketchOn()
+        if (isErr(result)) {
+          throw result
+        }
+        if (result.type !== 'Find and select command') {
+          throw new Error(`Expected edit flow event, got ${result.type}`)
+        }
+
+        expect(result.data.name).toBe('Enter sketch')
+      } finally {
+        restoreApp()
+      }
     })
   })
 

--- a/src/lib/operations.ts
+++ b/src/lib/operations.ts
@@ -60,6 +60,8 @@ import {
   KCL_PRELUDE_EXTRUDE_METHOD_NEW,
   type KclPreludeBodyType,
   type KclPreludeExtrudeMethod,
+  LEGACY_SKETCH_MODE_FEATURE_FLAG,
+  LEGACY_SKETCH_MODE_REMOVED_MESSAGE,
 } from '@src/lib/constants'
 import { getStringValue, stringToKclExpression } from '@src/lib/kclHelpers'
 import { isDefaultPlaneStr } from '@src/lib/planes'
@@ -102,6 +104,13 @@ interface StdLibCallInfo {
   supportsTranslate?: boolean
   supportsRotate?: boolean
   supportsScale?: boolean
+}
+
+function hasLegacySketchMode(): boolean {
+  return (
+    window.app?.userFeatures.has(LEGACY_SKETCH_MODE_FEATURE_FLAG, false) ??
+    false
+  )
 }
 
 function retrieveUnlabeledSelectionsForEdit(
@@ -3737,6 +3746,9 @@ export const stdLibMap: Record<string, StdLibCallInfo> = {
     // TODO: fix matching sketches-on-faces and offset planes back to their
     // original plane artifacts in order to edit them.
     async prepareToEdit({ artifact }) {
+      if (!hasLegacySketchMode()) {
+        return { reason: LEGACY_SKETCH_MODE_REMOVED_MESSAGE }
+      }
       if (artifact) {
         return {
           name: 'Enter sketch',

--- a/src/lib/toolbar.spec.ts
+++ b/src/lib/toolbar.spec.ts
@@ -6,18 +6,19 @@ vi.mock('@src/lib/boot', () => ({
 }))
 
 import {
-  type ToolbarDropdown,
-  type ToolbarItem,
   buildToolbarConfig,
   getConstraintToolbarToggleEvent,
   getDefaultRecentToolbarItemIds,
   getSketchSolveToolIconMap,
+  isLegacySketchEditRequest,
   isSketchSolveConstraintToolActive,
   isSketchToolbarTransitioning,
   modelingMachineStateToToolbarModeName,
   promoteRecentToolbarItemId,
   recordRecentToolbarItemId,
   resolveRecentToolbarItems,
+  type ToolbarDropdown,
+  type ToolbarItem,
 } from '@src/lib/toolbar'
 import type { modelingMachine } from '@src/machines/modelingMachine'
 import { defaultKeymap } from '@src/registry/extensions/keymap/defaultKeymap'
@@ -52,10 +53,16 @@ function findModelingToolbarDropdown(id: string): ToolbarDropdown | undefined {
   )
 }
 
-function findModelingToolbarItem(id: string): ToolbarItem {
-  const item = buildToolbarConfig({
-    send: () => {},
-  }).modeling.items.find(
+function findModelingToolbarItem(
+  id: string,
+  options?: Parameters<typeof buildToolbarConfig>[1]
+): ToolbarItem {
+  const item = buildToolbarConfig(
+    {
+      send: () => {},
+    },
+    options
+  ).modeling.items.find(
     (item): item is ToolbarItem =>
       item !== 'break' && !('array' in item) && item.id === id
   )
@@ -361,6 +368,92 @@ describe('toolbar state helpers', () => {
       type: 'Select sketch solve plane',
       data: 'default-plane-xy',
     })
+  })
+
+  test('does not enter legacy sketch edit without the feature flag', () => {
+    const modelingSend = vi.fn()
+    const sketchItem = findModelingToolbarItem('sketch')
+    const modelingState = {
+      context: {
+        selectionRanges: {
+          graphSelections: [],
+          otherSelections: [],
+        },
+      },
+    } as unknown as StateFrom<typeof modelingMachine>
+    const props = {
+      modelingSend,
+      modelingState,
+      sketchPathId: 'path-001',
+      editorHasFocus: true,
+      isActive: false,
+      keepSelection: false,
+    }
+
+    expect(isLegacySketchEditRequest(props)).toBe(true)
+    expect(sketchItem.disabled?.(modelingState, {} as never, props)).toBe(true)
+    sketchItem.onClick(props)
+    expect(modelingSend).not.toHaveBeenCalled()
+  })
+
+  test('enters legacy sketch edit when the feature flag is present', () => {
+    const modelingSend = vi.fn()
+    const sketchItem = findModelingToolbarItem('sketch', {
+      hasLegacySketchMode: true,
+    })
+    const modelingState = {
+      context: {
+        selectionRanges: {
+          graphSelections: [],
+          otherSelections: [],
+        },
+      },
+    } as unknown as StateFrom<typeof modelingMachine>
+    const props = {
+      modelingSend,
+      modelingState,
+      sketchPathId: 'path-001',
+      editorHasFocus: true,
+      isActive: false,
+      keepSelection: false,
+    }
+
+    expect(sketchItem.disabled?.(modelingState, {} as never, props)).toBe(false)
+    sketchItem.onClick(props)
+    expect(modelingSend).toHaveBeenCalledWith({ type: 'Enter sketch' })
+  })
+
+  test('still edits sketch blocks without the legacy sketch mode flag', () => {
+    const modelingSend = vi.fn()
+    const sketchItem = findModelingToolbarItem('sketch')
+    const modelingState = {
+      context: {
+        selectionRanges: {
+          graphSelections: [
+            {
+              artifact: {
+                type: 'sketchBlock',
+                sketchId: 1,
+              },
+            },
+          ],
+          otherSelections: [],
+        },
+      },
+    } as unknown as StateFrom<typeof modelingMachine>
+    const props = {
+      modelingSend,
+      modelingState,
+      sketchPathId: false as const,
+      editorHasFocus: false,
+      isActive: false,
+      keepSelection: false,
+    }
+
+    expect(isLegacySketchEditRequest(props)).toBe(false)
+    expect(sketchItem.disabled?.(modelingState, {} as never, props)).toBe(false)
+    sketchItem.onClick(props)
+    expect(modelingSend).toHaveBeenCalledWith({ type: 'Enter sketch' })
   })
 
   test('keeps the sketch-solve constraints dropdown on its default visible items before use', () => {

--- a/src/lib/toolbar.ts
+++ b/src/lib/toolbar.ts
@@ -1,6 +1,3 @@
-import { useMemo } from 'react'
-import type { EventFrom, StateFrom } from 'xstate'
-
 import type { CustomIconName } from '@src/components/CustomIcon'
 import { createLiteral } from '@src/lang/create'
 import {
@@ -10,6 +7,8 @@ import {
 import { useApp } from '@src/lib/boot'
 import {
   EXPERIMENTAL_POINT_AND_CLICK_FLAG,
+  LEGACY_SKETCH_MODE_FEATURE_FLAG,
+  LEGACY_SKETCH_MODE_REMOVED_MESSAGE,
   SKETCH_DEFAULT_PLANE_XY,
   SKETCH_DEFAULT_PLANE_XZ,
   SKETCH_DEFAULT_PLANE_YZ,
@@ -31,11 +30,13 @@ import { isSketchBlockSelected } from '@src/machines/sketchSolve/sketchSolveImpl
 import type { ConstraintToolName } from '@src/machines/sketchSolve/tools/constraintToolModel'
 import {
   MODE_MODELING_KEYMAP_SCOPE,
-  MODE_SKETCHING_KEYMAP_SCOPE,
   MODE_SKETCH_NO_FACE_KEYMAP_SCOPE,
   MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
+  MODE_SKETCHING_KEYMAP_SCOPE,
 } from '@src/registry/contracts/keymap'
 import { TOOLBAR_COMMAND_IDS } from '@src/registry/extensions/commands/toolbarCommands'
+import { useMemo } from 'react'
+import type { EventFrom, StateFrom } from 'xstate'
 
 export type ToolbarModeName =
   | 'modeling'
@@ -112,7 +113,8 @@ export type ToolbarItem = {
   status: 'available' | 'unavailable' | 'kcl-only' | 'experimental'
   disabled?: (
     state: StateFrom<typeof modelingMachine>,
-    wasmInstance: ModuleType
+    wasmInstance: ModuleType,
+    props?: ToolbarItemCallbackProps
   ) => boolean
   title: string | ((props: ToolbarItemCallbackProps) => string)
   tooltipTitle?: string | ((props: ToolbarItemCallbackProps) => string)
@@ -123,7 +125,10 @@ export type ToolbarItem = {
   isActive?: (state: StateFrom<typeof modelingMachine>) => boolean
   disabledReason?:
     | string
-    | ((state: StateFrom<typeof modelingMachine>) => string | undefined)
+    | ((
+        state: StateFrom<typeof modelingMachine>,
+        props?: ToolbarItemCallbackProps
+      ) => string | undefined)
 }
 
 type ToolbarConfig = Record<ToolbarModeName, ToolbarMode>
@@ -496,12 +501,28 @@ const sketchSolveConstraintItems: ToolbarItem[] = [
 
 type ToolbarCommands = Pick<ReturnType<typeof useApp>['commands'], 'send'>
 
+export function isLegacySketchEditRequest({
+  editorHasFocus,
+  sketchPathId,
+  modelingState,
+}: Pick<
+  ToolbarItemCallbackProps,
+  'editorHasFocus' | 'sketchPathId' | 'modelingState'
+>): boolean {
+  return (
+    Boolean(editorHasFocus && sketchPathId) &&
+    !isSketchBlockSelected(modelingState.context.selectionRanges)
+  )
+}
+
 export function buildToolbarConfig(
   commands: ToolbarCommands,
   {
     showExperimentalFeatures = false,
+    hasLegacySketchMode = false,
   }: {
     showExperimentalFeatures?: boolean
+    hasLegacySketchMode?: boolean
   } = {}
 ): ToolbarConfig {
   const splineToolbarItem: ToolbarItem = {
@@ -559,18 +580,23 @@ export function buildToolbarConfig(
         {
           id: 'sketch',
           command: TOOLBAR_COMMAND_IDS.modeling.sketch,
-          onClick: ({
-            modelingSend,
-            modelingState,
-            sketchPathId,
-            editorHasFocus,
-          }) => {
+          onClick: (props) => {
+            const {
+              modelingSend,
+              modelingState,
+              sketchPathId,
+              editorHasFocus,
+            } = props
             const isSketchBlock = isSketchBlockSelected(
               modelingState.context.selectionRanges
             )
             const selectedSketchTarget =
               getSelectedSketchTarget(modelingState.context.selectionRanges)
                 ?.id ?? null
+
+            if (isLegacySketchEditRequest(props) && !hasLegacySketchMode) {
+              return
+            }
 
             // Don't force new sketch if we're in a sketch block or have a sketchBlock selected
             if ((editorHasFocus && sketchPathId) || isSketchBlock) {
@@ -600,6 +626,14 @@ export function buildToolbarConfig(
           iconColor: ({ modelingState }) =>
             getSelectedSketchIconColor(modelingState.context.selectionRanges),
           status: 'available',
+          disabled: (_state, _wasmInstance, props) =>
+            Boolean(
+              props && isLegacySketchEditRequest(props) && !hasLegacySketchMode
+            ),
+          disabledReason: (_state, props) =>
+            props && isLegacySketchEditRequest(props) && !hasLegacySketchMode
+              ? LEGACY_SKETCH_MODE_REMOVED_MESSAGE
+              : undefined,
           title: ({ editorHasFocus, sketchPathId, modelingState }) => {
             const isSketchBlock = isSketchBlockSelected(
               modelingState.context.selectionRanges
@@ -2575,10 +2609,18 @@ export const useToolbarConfig = () => {
     EXPERIMENTAL_POINT_AND_CLICK_FLAG,
     false
   )
+  const hasLegacySketchMode = userFeatures.useHas(
+    LEGACY_SKETCH_MODE_FEATURE_FLAG,
+    false
+  )
 
   return useMemo<Record<ToolbarModeName, ToolbarMode>>(
-    () => buildToolbarConfig(commands, { showExperimentalFeatures }),
-    [commands, showExperimentalFeatures]
+    () =>
+      buildToolbarConfig(commands, {
+        showExperimentalFeatures,
+        hasLegacySketchMode,
+      }),
+    [commands, showExperimentalFeatures, hasLegacySketchMode]
   )
 }
 

--- a/src/registry/extensions/commands/toolbarCommands.ts
+++ b/src/registry/extensions/commands/toolbarCommands.ts
@@ -5,7 +5,10 @@ import {
 } from '@src/lang/queryAst'
 import { isCursorInSketchCommandRange } from '@src/lang/util'
 import type { Command } from '@src/lib/commandTypes'
-import { EXPERIMENTAL_POINT_AND_CLICK_FLAG } from '@src/lib/constants'
+import {
+  EXPERIMENTAL_POINT_AND_CLICK_FLAG,
+  LEGACY_SKETCH_MODE_FEATURE_FLAG,
+} from '@src/lib/constants'
 import { selectSketchPlane } from '@src/lib/selections'
 import type { CommandBarContext } from '@src/machines/commandBarMachine'
 import type {
@@ -165,6 +168,12 @@ function hasSketchExperimentalFeatures(input: unknown): boolean {
   )
 }
 
+function hasLegacySketchMode(input: unknown): boolean {
+  return (
+    getUserFeatures(input)?.has(LEGACY_SKETCH_MODE_FEATURE_FLAG, false) ?? false
+  )
+}
+
 function getModelingState(input: unknown): ModelingState | undefined {
   return getKclManager(input)?.modelingState ?? undefined
 }
@@ -304,6 +313,14 @@ async function enterSketch(input: unknown) {
   )
 
   if ((kclManager.editorView.hasFocus && sketchPathId) || isSketchBlock) {
+    if (
+      kclManager.editorView.hasFocus &&
+      sketchPathId &&
+      !isSketchBlock &&
+      !hasLegacySketchMode(input)
+    ) {
+      return
+    }
     return sendModelingEvent(input, { type: 'Enter sketch' })
   }
 


### PR DESCRIPTION
In the Admin Dashboard, `legacy_sketch_mode` is still enabled for users created before 8/15.  The plan is to do a phased "blackout" of this feature once the logs indicate minimal usage.

To test this, create a project with a KCL 1.0 sketch:

```
@settings(kclVersion = 1.0)

sketch001 = startSketchOn(XY)
profile001 = circle(sketch001, center = [0, 0], radius = 5)
```

With the staging feature flag on and off for your user:

- Highlight `startSketchOn` and attempt to edit using point-and-click
- Double-click on the legacy sketch in the feature tree

<img width="1358" height="1020" alt="Screenshot 2026-08-28 at 7 20 25 PM" src="https://github.com/user-attachments/assets/018b57e0-33ad-457e-a07a-594cc2ac2fdf" />


---

Contributes to https://github.com/KittyCAD/modeling-app/issues/12998