### PR TITLE
Add physical property snapshots to simulation tests

### DIFF
--- a/rust/kcl-lib/src/simulation_tests.rs
+++ b/rust/kcl-lib/src/simulation_tests.rs
@@ -5,6 +5,14 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use indexmap::IndexMap;
+use kittycad_modeling_cmds::ModelingCmd;
+use kittycad_modeling_cmds::each_cmd as mcmd;
+use kittycad_modeling_cmds::ok_response::OkModelingCmdResponse;
+use kittycad_modeling_cmds::units::UnitArea;
+use kittycad_modeling_cmds::units::UnitDensity;
+use kittycad_modeling_cmds::units::UnitLength;
+use kittycad_modeling_cmds::units::UnitMass;
+use kittycad_modeling_cmds::websocket::OkWebSocketResponseData;
 use kittycad_modeling_cmds::websocket::WebSocketResponse;
 use uuid::Uuid;
 
@@ -44,12 +52,15 @@ struct Test {
     /// True to skip asserting the artifact graph and only write it. The default
     /// is false and to assert it.
     skip_assert_artifact_graph: bool,
+    /// Whether a successful execution should snapshot physical properties.
+    snapshot_physical_properties: bool,
     /// If set, assert that execution emits exactly this many deprecation warnings.
     expected_deprecation_warnings: Option<usize>,
 }
 
 const REPO_ROOT: &str = "../..";
 const KCL_SAMPLE_DEPRECATION_VERSION: &str = "2.0";
+const MATERIAL_DENSITY_KG_PER_CUBIC_METER: f64 = 1000.0;
 
 fn is_writing() -> bool {
     matches!(std::env::var("ZOO_SIM_UPDATE").as_deref(), Ok("always"))
@@ -63,8 +74,14 @@ impl Test {
             input_dir: Path::new("tests").join(name),
             output_dir: Path::new("tests").join(name),
             skip_assert_artifact_graph: false,
+            snapshot_physical_properties: true,
             expected_deprecation_warnings: None,
         }
+    }
+
+    fn without_physical_properties(mut self) -> Self {
+        self.snapshot_physical_properties = false;
+        self
     }
 
     /// Read in the entry point file and return its contents as a string.
@@ -283,6 +300,105 @@ async fn execute(test_name: &str, render_to_png: bool) {
     execute_test(&Test::new(test_name), render_to_png, false).await
 }
 
+async fn physical_properties(ctx: &ExecutorContext) -> Option<serde_json::Value> {
+    // Ask for mass first because it returns "Nothing to export" without
+    // closing the engine connection when a successful KCL program produces no
+    // physical body. Bounding box requests close empty-scene connections.
+    let mass_response = match ctx
+        .engine
+        .send_modeling_cmd(
+            &ctx.engine_batch,
+            Uuid::new_v4(),
+            crate::SourceRange::default(),
+            &ModelingCmd::from(
+                mcmd::Mass::builder()
+                    .material_density(MATERIAL_DENSITY_KG_PER_CUBIC_METER)
+                    .material_density_unit(UnitDensity::KilogramsPerCubicMeter)
+                    .output_unit(UnitMass::Grams)
+                    .build(),
+            ),
+        )
+        .await
+    {
+        Ok(response) => response,
+        Err(err)
+            if err.message() == "Nothing to export"
+                // Surface bodies have area and bounds, but no volume from
+                // which the engine can calculate mass.
+                || err.message() == "internal error: unknown" =>
+        {
+            return None;
+        }
+        Err(err) => panic!("simulation test should measure the model mass: {err}"),
+    };
+    let OkWebSocketResponseData::Modeling {
+        modeling_response: OkModelingCmdResponse::Mass(mass),
+    } = mass_response
+    else {
+        panic!("Expected a mass response, got {mass_response:?}");
+    };
+
+    let bounding_box_response = ctx
+        .engine
+        .send_modeling_cmd(
+            &ctx.engine_batch,
+            Uuid::new_v4(),
+            crate::SourceRange::default(),
+            &ModelingCmd::from(
+                mcmd::BoundingBox::builder()
+                    .output_unit(UnitLength::Millimeters)
+                    .build(),
+            ),
+        )
+        .await
+        .expect("simulation test should measure the model bounding box");
+    let OkWebSocketResponseData::Modeling {
+        modeling_response: OkModelingCmdResponse::BoundingBox(bounding_box),
+    } = bounding_box_response
+    else {
+        panic!("Expected a bounding box response, got {bounding_box_response:?}");
+    };
+
+    let surface_area_response = ctx
+        .engine
+        .send_modeling_cmd(
+            &ctx.engine_batch,
+            Uuid::new_v4(),
+            crate::SourceRange::default(),
+            &ModelingCmd::from(
+                mcmd::SurfaceArea::builder()
+                    .output_unit(UnitArea::SquareMillimeters)
+                    .build(),
+            ),
+        )
+        .await
+        .expect("simulation test should measure the model surface area");
+    let OkWebSocketResponseData::Modeling {
+        modeling_response: OkModelingCmdResponse::SurfaceArea(surface_area),
+    } = surface_area_response
+    else {
+        panic!("Expected a surface area response, got {surface_area_response:?}");
+    };
+
+    Some(serde_json::json!({
+        "bounding_box": {
+            "center": bounding_box.center,
+            "dimensions": bounding_box.dimensions,
+            "unit": UnitLength::Millimeters,
+        },
+        "weight": {
+            "value": mass.mass,
+            "unit": mass.output_unit,
+            "material_density": MATERIAL_DENSITY_KG_PER_CUBIC_METER,
+            "material_density_unit": UnitDensity::KilogramsPerCubicMeter,
+        },
+        "surface_area": {
+            "value": surface_area.surface_area,
+            "unit": surface_area.output_unit,
+        },
+    }))
+}
+
 async fn execute_test(test: &Test, render_to_png: bool, export_step: bool) {
     let input = test.read();
     let ast = crate::Program::parse_no_errs(&input).unwrap();
@@ -290,7 +406,7 @@ async fn execute_test(test: &Test, render_to_png: bool, export_step: bool) {
 
     // Run the program.
     let exec_res = execute_with_retries(&RetryConfig::default(), || {
-        crate::test_server::execute_and_snapshot_ast(
+        crate::test_server::execute_and_snapshot_ast_no_close(
             ast.clone(),
             Some(test.entry_point.clone()),
             export_step,
@@ -384,8 +500,31 @@ async fn execute_test(test: &Test, render_to_png: bool, export_step: bool) {
 
             let (outcome, module_state, responses) =
                 exec_state.into_test_exec_outcome(env_ref, &ctx, &test.input_dir).await;
+            let physical_properties = if test.snapshot_physical_properties {
+                physical_properties(&ctx).await
+            } else {
+                None
+            };
+            ctx.close().await;
 
-            let snapshot_results = common_snapshots(test, outcome.variables, responses);
+            let mut snapshot_results = common_snapshots(test, outcome.variables, responses);
+            if let Some(physical_properties) = physical_properties {
+                snapshot_results.push(catch_unwind(AssertUnwindSafe(|| {
+                    assert_snapshot(test, "Physical properties", || {
+                        insta::assert_json_snapshot!("physical_properties", physical_properties)
+                    })
+                })));
+            } else {
+                let physical_properties_snap_path = test.output_dir.join("physical_properties.snap");
+                if is_writing() {
+                    let _ = std::fs::remove_file(&physical_properties_snap_path);
+                } else if physical_properties_snap_path.exists() {
+                    panic!(
+                        "This test case produced no physical model, but it previously did. If this is intended, delete kcl-lib/{}.",
+                        physical_properties_snap_path.to_string_lossy()
+                    );
+                }
+            }
 
             assert_artifact_snapshots(test, module_state, outcome.artifact_graph);
 
@@ -2141,7 +2280,7 @@ mod mike_stress_test {
     /// Test that KCL is executed correctly.
     #[tokio::test(flavor = "multi_thread")]
     async fn kcl_test_execute() {
-        super::execute(TEST_NAME, true).await
+        super::execute_test(&super::Test::new(TEST_NAME).without_physical_properties(), true, false).await
     }
 }
 mod pentagon_fillet_sugar {

--- a/rust/kcl-lib/src/simulation_tests/kcl_samples.rs
+++ b/rust/kcl-lib/src/simulation_tests/kcl_samples.rs
@@ -197,6 +197,7 @@ fn test(test_name: &str, entry_point: std::path::PathBuf) -> Test {
         output_dir: relative_output_dir,
         // Skip is temporary while we have non-deterministic output.
         skip_assert_artifact_graph: true,
+        snapshot_physical_properties: true,
         expected_deprecation_warnings: Some(0),
     }
 }

--- a/rust/kcl-lib/src/test_server.rs
+++ b/rust/kcl-lib/src/test_server.rs
@@ -110,7 +110,8 @@ pub async fn execute_and_snapshot_ast(
 }
 
 /// Executes a KCL program and takes a snapshot without closing the engine
-/// connection. The caller must close the returned context.
+/// connection. If OK, the caller must close the returned context.
+/// If Err, the context will already be closed within this function.
 #[cfg(test)]
 pub async fn execute_and_snapshot_ast_no_close(
     ast: Program,

--- a/rust/kcl-lib/src/test_server.rs
+++ b/rust/kcl-lib/src/test_server.rs
@@ -95,7 +95,66 @@ pub async fn execute_and_snapshot_ast(
     ),
     ExecErrorWithState,
 > {
-    let ctx = new_context(true, current_file).await?;
+    let result = execute_and_snapshot_ast_with_heartbeats(
+        ast,
+        current_file,
+        with_export_step,
+        deprecation_version_override,
+        None,
+    )
+    .await;
+    if let Ok((_, ctx, _, _, _)) = &result {
+        ctx.close().await;
+    }
+    result
+}
+
+/// Executes a KCL program and takes a snapshot without closing the engine
+/// connection. The caller must close the returned context.
+#[cfg(test)]
+pub async fn execute_and_snapshot_ast_no_close(
+    ast: Program,
+    current_file: Option<PathBuf>,
+    with_export_step: bool,
+    deprecation_version_override: Option<&str>,
+) -> Result<
+    (
+        ExecState,
+        ExecutorContext,
+        EnvironmentRef,
+        image::DynamicImage,
+        Option<Vec<u8>>,
+    ),
+    ExecErrorWithState,
+> {
+    execute_and_snapshot_ast_with_heartbeats(
+        ast,
+        current_file,
+        with_export_step,
+        deprecation_version_override,
+        Some(5),
+    )
+    .await
+}
+
+#[cfg(test)]
+async fn execute_and_snapshot_ast_with_heartbeats(
+    ast: Program,
+    current_file: Option<PathBuf>,
+    with_export_step: bool,
+    deprecation_version_override: Option<&str>,
+    heartbeats: Option<u64>,
+) -> Result<
+    (
+        ExecState,
+        ExecutorContext,
+        EnvironmentRef,
+        image::DynamicImage,
+        Option<Vec<u8>>,
+    ),
+    ExecErrorWithState,
+> {
+    let ctx = new_context_with_heartbeats(true, current_file, heartbeats).await?;
     let (exec_state, env, img) = match do_execute_and_snapshot(&ctx, ast, deprecation_version_override).await {
         Ok((exec_state, env_ref, img)) => (exec_state, env_ref, img),
         Err(err) => {
@@ -122,7 +181,6 @@ pub async fn execute_and_snapshot_ast(
 
         step = files.into_iter().next().map(|f| f.contents);
     }
-    ctx.close().await;
     Ok((exec_state, ctx, env, img, step))
 }
 
@@ -197,6 +255,14 @@ async fn do_execute_and_snapshot(
 }
 
 pub async fn new_context(with_auth: bool, current_file: Option<PathBuf>) -> Result<ExecutorContext, ConnectionError> {
+    new_context_with_heartbeats(with_auth, current_file, None).await
+}
+
+async fn new_context_with_heartbeats(
+    with_auth: bool,
+    current_file: Option<PathBuf>,
+    heartbeats: Option<u64>,
+) -> Result<ExecutorContext, ConnectionError> {
     let mut client = new_zoo_client(if with_auth { None } else { Some("bad_token".to_string()) }, None)
         .map_err(ConnectionError::CouldNotMakeClient)?;
     if !with_auth {
@@ -215,7 +281,7 @@ pub async fn new_context(with_auth: bool, current_file: Option<PathBuf>) -> Resu
         current_file: None,
         fixed_size_grid: true,
         skip_artifact_graph: false,
-        heartbeats: None,
+        heartbeats,
         default_backface_color: Some("#00D5FF".to_owned()),
     };
     if let Some(current_file) = current_file {

--- a/rust/kcl-lib/tests/angled_line/physical_properties.snap
+++ b/rust/kcl-lib/tests/angled_line/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties angled_line.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 10.865906786014012,
+      "y": 2.183434335797447,
+      "z": 2.0
+    },
+    "dimensions": {
+      "x": 29.31382371356637,
+      "y": 30.85575759408613,
+      "z": 4.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 909.011418116279
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 1.1402588325400604
+  }
+}

--- a/rust/kcl-lib/tests/artifact_graph_example_code1/physical_properties.snap
+++ b/rust/kcl-lib/tests/artifact_graph_example_code1/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties artifact_graph_example_code1.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 2.7750000000000004,
+      "y": 0.0,
+      "z": -5.0
+    },
+    "dimensions": {
+      "x": 15.55,
+      "y": 10.0,
+      "z": 10.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 644.6608172512302
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 1.0283155663154062
+  }
+}

--- a/rust/kcl-lib/tests/artifact_graph_sketch_on_face_etc/physical_properties.snap
+++ b/rust/kcl-lib/tests/artifact_graph_sketch_on_face_etc/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties artifact_graph_sketch_on_face_etc.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 6.488050371381701,
+      "y": -3.0,
+      "z": 5.131064892933411
+    },
+    "dimensions": {
+      "x": 14.776100742763402,
+      "y": 6.0,
+      "z": 11.862129785866824
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 347.0930811602102
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.2742500005287196
+  }
+}

--- a/rust/kcl-lib/tests/assembly_mixed_units_cubes/physical_properties.snap
+++ b/rust/kcl-lib/tests/assembly_mixed_units_cubes/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties assembly_mixed_units_cubes.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -119.5,
+      "y": -185.5,
+      "z": 63.5
+    },
+    "dimensions": {
+      "x": 269.0,
+      "y": 391.0,
+      "z": 127.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 96924.00067069684
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 2048.508389269917
+  }
+}

--- a/rust/kcl-lib/tests/basic_fillet_cube_close_opposite/physical_properties.snap
+++ b/rust/kcl-lib/tests/basic_fillet_cube_close_opposite/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties basic_fillet_cube_close_opposite.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 5.0,
+      "y": 5.0,
+      "z": 5.0
+    },
+    "dimensions": {
+      "x": 10.0,
+      "y": 10.0,
+      "z": 10.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 579.3527749724525
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.9827309584246418
+  }
+}

--- a/rust/kcl-lib/tests/basic_fillet_cube_end/physical_properties.snap
+++ b/rust/kcl-lib/tests/basic_fillet_cube_end/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties basic_fillet_cube_end.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 5.0,
+      "y": 5.0,
+      "z": 5.0
+    },
+    "dimensions": {
+      "x": 10.0,
+      "y": 10.0,
+      "z": 10.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 579.3527749866633
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.9827309879126278
+  }
+}

--- a/rust/kcl-lib/tests/basic_fillet_cube_next_adjacent/physical_properties.snap
+++ b/rust/kcl-lib/tests/basic_fillet_cube_next_adjacent/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties basic_fillet_cube_next_adjacent.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 5.0,
+      "y": 5.0,
+      "z": 5.0
+    },
+    "dimensions": {
+      "x": 10.0,
+      "y": 10.0,
+      "z": 10.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 589.6763687891494
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.9913654781997424
+  }
+}

--- a/rust/kcl-lib/tests/basic_fillet_cube_previous_adjacent/physical_properties.snap
+++ b/rust/kcl-lib/tests/basic_fillet_cube_previous_adjacent/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties basic_fillet_cube_previous_adjacent.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 5.0,
+      "y": 5.0,
+      "z": 5.0
+    },
+    "dimensions": {
+      "x": 10.0,
+      "y": 10.0,
+      "z": 10.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 589.6763900326007
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.991365481761708
+  }
+}

--- a/rust/kcl-lib/tests/basic_fillet_cube_start/physical_properties.snap
+++ b/rust/kcl-lib/tests/basic_fillet_cube_start/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties basic_fillet_cube_start.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 5.0,
+      "y": 5.0,
+      "z": 5.0
+    },
+    "dimensions": {
+      "x": 10.0,
+      "y": 10.0,
+      "z": 10.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 579.3527759885286
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.9827309539027956
+  }
+}

--- a/rust/kcl-lib/tests/basic_revolve_circle/physical_properties.snap
+++ b/rust/kcl-lib/tests/basic_revolve_circle/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties basic_revolve_circle.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 40.0,
+      "y": 10.0,
+      "z": 40.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 2959.6069766384403
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 7.383068101067883
+  }
+}

--- a/rust/kcl-lib/tests/beam_sweeps/physical_properties.snap
+++ b/rust/kcl-lib/tests/beam_sweeps/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties beam_sweeps.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 2540.0,
+      "y": 1066.8,
+      "z": 1270.0000000000002
+    },
+    "dimensions": {
+      "x": 5892.799999999999,
+      "y": 2946.4,
+      "z": 3352.8000000000006
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 105443067.6830234
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 666735.5014942586
+  }
+}

--- a/rust/kcl-lib/tests/blend_with_edge_specifier_objects/physical_properties.snap
+++ b/rust/kcl-lib/tests/blend_with_edge_specifier_objects/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties blend_with_edge_specifier_objects.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.92,
+      "y": -0.46499999999999986,
+      "z": 2.78
+    },
+    "dimensions": {
+      "x": 8.16,
+      "y": 9.07,
+      "z": 2.04
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 79.0725151889049
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.020732126702604586
+  }
+}

--- a/rust/kcl-lib/tests/chamfer_multiple_auto_hole_region_face_api/physical_properties.snap
+++ b/rust/kcl-lib/tests/chamfer_multiple_auto_hole_region_face_api/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties chamfer_multiple_auto_hole_region_face_api.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 2.5
+    },
+    "dimensions": {
+      "x": 60.0,
+      "y": 40.0,
+      "z": 5.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 5766.212762722489
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 11.182405916206523
+  }
+}

--- a/rust/kcl-lib/tests/christmas_tree_mirror3d_union/physical_properties.snap
+++ b/rust/kcl-lib/tests/christmas_tree_mirror3d_union/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties christmas_tree_mirror3d_union.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.25,
+      "y": -2.5,
+      "z": 5.000000000000001
+    },
+    "dimensions": {
+      "x": 10.5,
+      "y": 5.0,
+      "z": 12.000000000000002
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 334.68852890528035
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.2940924753539835
+  }
+}

--- a/rust/kcl-lib/tests/circle_three_point/physical_properties.snap
+++ b/rust/kcl-lib/tests/circle_three_point/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties circle_three_point.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 24.75,
+      "y": 19.75,
+      "z": 5.0
+    },
+    "dimensions": {
+      "x": 12.614277624977184,
+      "y": 12.614277624977184,
+      "z": 10.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 503.5570579324799
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.8669957664390419
+  }
+}

--- a/rust/kcl-lib/tests/circular_pattern3d_a_pattern/physical_properties.snap
+++ b/rust/kcl-lib/tests/circular_pattern3d_a_pattern/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties circular_pattern3d_a_pattern.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -19.95848981175034,
+      "y": -19.95241669679996,
+      "z": 1.0
+    },
+    "dimensions": {
+      "x": 124.9246680550302,
+      "y": 122.31859716918107,
+      "z": 4.8
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 8703.147124151656
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 2.5830011480838104
+  }
+}

--- a/rust/kcl-lib/tests/clone_a_blend/physical_properties.snap
+++ b/rust/kcl-lib/tests/clone_a_blend/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties clone_a_blend.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.07499999997500062,
+      "y": 2.283259505292792,
+      "z": 3.325000000375
+    },
+    "dimensions": {
+      "x": 10.85000000005,
+      "y": 8.566519010585584,
+      "z": 6.9500000006499985
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 59.45247697836109
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.02546100057870815
+  }
+}

--- a/rust/kcl-lib/tests/clone_a_mirror3d/physical_properties.snap
+++ b/rust/kcl-lib/tests/clone_a_mirror3d/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties clone_a_mirror3d.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 50.0,
+      "y": 0.0,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 100.0,
+      "y": 100.0,
+      "z": 100.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 240.3326545990514
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.12316677421078208
+  }
+}

--- a/rust/kcl-lib/tests/clone_a_pattern/physical_properties.snap
+++ b/rust/kcl-lib/tests/clone_a_pattern/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties clone_a_pattern.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -1.2787647962758033,
+      "y": -1.7799999999999998,
+      "z": 0.25
+    },
+    "dimensions": {
+      "x": 5.822470407448394,
+      "y": 1.42,
+      "z": 0.5
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 25.71017049586219
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.0032311133482510203
+  }
+}

--- a/rust/kcl-lib/tests/clone_an_import/physical_properties.snap
+++ b/rust/kcl-lib/tests/clone_an_import/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties clone_an_import.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 12.499999999999773,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 200.0,
+      "y": 3625.0,
+      "z": 216.00000000000009
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 2363769.7074646554
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 40098.83322644233
+  }
+}

--- a/rust/kcl-lib/tests/clone_dodecahedron/physical_properties.snap
+++ b/rust/kcl-lib/tests/clone_dodecahedron/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties clone_dodecahedron.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 1.1103823831654154,
+      "y": -1.0369446806798803,
+      "z": 2.192155805812945
+    },
+    "dimensions": {
+      "x": 43134.37232586624,
+      "y": 42938.08584581372,
+      "z": 41679.8654791392
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 956017100.8110046
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 526924338.69838715
+  }
+}

--- a/rust/kcl-lib/tests/clone_w_face_tags/physical_properties.snap
+++ b/rust/kcl-lib/tests/clone_w_face_tags/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties clone_w_face_tags.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 1.76,
+      "y": 2.635,
+      "z": 1.0
+    },
+    "dimensions": {
+      "x": 2.68,
+      "y": 3.45,
+      "z": 2.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 84.4434889018808
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.03640803564070963
+  }
+}

--- a/rust/kcl-lib/tests/clone_w_shell/physical_properties.snap
+++ b/rust/kcl-lib/tests/clone_w_shell/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties clone_w_shell.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 3.125
+    },
+    "dimensions": {
+      "x": 28.2,
+      "y": 28.2,
+      "z": 6.25
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 4537.0000534603605
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.561126218083056
+  }
+}

--- a/rust/kcl-lib/tests/consumed_solid_subtract_use_result_success/physical_properties.snap
+++ b/rust/kcl-lib/tests/consumed_solid_subtract_use_result_success/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties consumed_solid_subtract_use_result_success.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 10.0
+    },
+    "dimensions": {
+      "x": 22.0,
+      "y": 22.0,
+      "z": 20.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 2399.9998993531335
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 7.927999834104563
+  }
+}

--- a/rust/kcl-lib/tests/crab_mirror_region/physical_properties.snap
+++ b/rust/kcl-lib/tests/crab_mirror_region/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties crab_mirror_region.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 1.041399999999996,
+      "z": 25.4
+    },
+    "dimensions": {
+      "x": 307.84799999999996,
+      "y": 182.3212,
+      "z": 50.8
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 126240.40363220956
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 1078.9543590590256
+  }
+}

--- a/rust/kcl-lib/tests/crazy_multi_profile/physical_properties.snap
+++ b/rust/kcl-lib/tests/crazy_multi_profile/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties crazy_multi_profile.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.08000000000000185,
+      "y": -0.3717357951397773,
+      "z": 4.223555838091645
+    },
+    "dimensions": {
+      "x": 38.58,
+      "y": 39.256528409720445,
+      "z": 29.567111676183288
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 1434.2204335378028
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 1.0768354851512878
+  }
+}

--- a/rust/kcl-lib/tests/csg_subtract_multi_target_result_reuse/physical_properties.snap
+++ b/rust/kcl-lib/tests/csg_subtract_multi_target_result_reuse/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties csg_subtract_multi_target_result_reuse.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 1.7000000000000002
+    },
+    "dimensions": {
+      "x": 100.0,
+      "y": 100.0,
+      "z": 5.4
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 200.0000074531272
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.11200000675041603
+  }
+}

--- a/rust/kcl-lib/tests/cube/physical_properties.snap
+++ b/rust/kcl-lib/tests/cube/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties cube.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 20.0
+    },
+    "dimensions": {
+      "x": 40.0,
+      "y": 40.0,
+      "z": 40.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 9599.999757483602
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 63.99999983841553
+  }
+}

--- a/rust/kcl-lib/tests/delete_face_by_id/physical_properties.snap
+++ b/rust/kcl-lib/tests/delete_face_by_id/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties delete_face_by_id.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.09999999999998188,
+      "y": 0.0,
+      "z": 2.75
+    },
+    "dimensions": {
+      "x": 8.798000000000037,
+      "y": 9.816,
+      "z": 5.5
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 236.1797382085529
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.1547076829792419
+  }
+}

--- a/rust/kcl-lib/tests/delete_face_by_index/physical_properties.snap
+++ b/rust/kcl-lib/tests/delete_face_by_index/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties delete_face_by_index.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.09999999999998188,
+      "y": 0.0,
+      "z": 2.75
+    },
+    "dimensions": {
+      "x": 8.798000000000037,
+      "y": 9.816,
+      "z": 5.5
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 236.1797382085529
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.1547076829792419
+  }
+}

--- a/rust/kcl-lib/tests/early_return_geometry/physical_properties.snap
+++ b/rust/kcl-lib/tests/early_return_geometry/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties early_return_geometry.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 5.0,
+      "y": 5.0,
+      "z": 5.0
+    },
+    "dimensions": {
+      "x": 10.0,
+      "y": 10.0,
+      "z": 10.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 599.9999848427251
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.9999999974752428
+  }
+}

--- a/rust/kcl-lib/tests/endless_impeller/physical_properties.snap
+++ b/rust/kcl-lib/tests/endless_impeller/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties endless_impeller.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.5,
+      "y": 0.5,
+      "z": 0.5
+    },
+    "dimensions": {
+      "x": 2.0,
+      "y": 2.0,
+      "z": 2.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 42.00000194032327
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.007000000579182597
+  }
+}

--- a/rust/kcl-lib/tests/extrude_closes/physical_properties.snap
+++ b/rust/kcl-lib/tests/extrude_closes/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties extrude_closes.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.09999999999999964,
+      "y": -0.8250000000000002,
+      "z": 2.5
+    },
+    "dimensions": {
+      "x": 7.488,
+      "y": 7.068,
+      "z": 5.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 163.91552253480768
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.1418432482580556
+  }
+}

--- a/rust/kcl-lib/tests/extrude_face/physical_properties.snap
+++ b/rust/kcl-lib/tests/extrude_face/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties extrude_face.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.5,
+      "y": 0.5,
+      "z": 0.5
+    },
+    "dimensions": {
+      "x": 1.2000000000000002,
+      "y": 1.2000000000000002,
+      "z": 1.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 26.55636978943221
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.006156860484403855
+  }
+}

--- a/rust/kcl-lib/tests/extrude_split/physical_properties.snap
+++ b/rust/kcl-lib/tests/extrude_split/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties extrude_split.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": -42.0,
+      "z": -91.5
+    },
+    "dimensions": {
+      "x": 150.00000000000003,
+      "y": 284.0,
+      "z": 185.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 110617.59211931132
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 1738.034284615016
+  }
+}

--- a/rust/kcl-lib/tests/extrude_to_edge_specifier/physical_properties.snap
+++ b/rust/kcl-lib/tests/extrude_to_edge_specifier/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties extrude_to_edge_specifier.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 3.0,
+      "y": 0.0,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 2.0,
+      "y": 100.0,
+      "z": 100.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 7.953293033706888
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.001193806272659197
+  }
+}

--- a/rust/kcl-lib/tests/face_api_fillet_edge_refs_variant_1/physical_properties.snap
+++ b/rust/kcl-lib/tests/face_api_fillet_edge_refs_variant_1/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties face_api_fillet_edge_refs_variant_1.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 4.5,
+      "y": 6.0,
+      "z": 2.5
+    },
+    "dimensions": {
+      "x": 6.0,
+      "y": 14.4,
+      "z": 5.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 157.99009515119965
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.0743340312933747
+  }
+}

--- a/rust/kcl-lib/tests/face_api_fillet_edge_refs_variant_2/physical_properties.snap
+++ b/rust/kcl-lib/tests/face_api_fillet_edge_refs_variant_2/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties face_api_fillet_edge_refs_variant_2.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 4.5,
+      "y": 6.0,
+      "z": 2.5
+    },
+    "dimensions": {
+      "x": 6.0,
+      "y": 14.4,
+      "z": 5.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 159.9519445658346
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.07442993911397783
+  }
+}

--- a/rust/kcl-lib/tests/face_api_fillet_edge_refs_variant_3/physical_properties.snap
+++ b/rust/kcl-lib/tests/face_api_fillet_edge_refs_variant_3/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties face_api_fillet_edge_refs_variant_3.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 4.5,
+      "y": 6.0,
+      "z": 2.5
+    },
+    "dimensions": {
+      "x": 6.0,
+      "y": 14.4,
+      "z": 5.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 159.91548838807222
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.07442778315692432
+  }
+}

--- a/rust/kcl-lib/tests/face_api_fillet_edge_refs_variant_4/physical_properties.snap
+++ b/rust/kcl-lib/tests/face_api_fillet_edge_refs_variant_4/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties face_api_fillet_edge_refs_variant_4.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 4.5,
+      "y": 6.0,
+      "z": 2.5
+    },
+    "dimensions": {
+      "x": 6.0,
+      "y": 14.4,
+      "z": 5.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 159.9519445658346
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.07442993911397783
+  }
+}

--- a/rust/kcl-lib/tests/face_api_fillet_edge_refs_variant_5/physical_properties.snap
+++ b/rust/kcl-lib/tests/face_api_fillet_edge_refs_variant_5/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties face_api_fillet_edge_refs_variant_5.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 4.5,
+      "y": 6.0,
+      "z": 2.5
+    },
+    "dimensions": {
+      "x": 6.0,
+      "y": 14.4,
+      "z": 5.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 159.91548838807222
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.07442778315692432
+  }
+}

--- a/rust/kcl-lib/tests/face_api_fillet_edge_refs_variant_6/physical_properties.snap
+++ b/rust/kcl-lib/tests/face_api_fillet_edge_refs_variant_6/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties face_api_fillet_edge_refs_variant_6.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 4.5,
+      "y": 6.0,
+      "z": 2.5
+    },
+    "dimensions": {
+      "x": 6.0,
+      "y": 14.4,
+      "z": 5.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 159.9519445658346
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.07442993911397783
+  }
+}

--- a/rust/kcl-lib/tests/face_api_fillet_edge_refs_variant_7/physical_properties.snap
+++ b/rust/kcl-lib/tests/face_api_fillet_edge_refs_variant_7/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties face_api_fillet_edge_refs_variant_7.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 4.5,
+      "y": 6.0,
+      "z": 2.5
+    },
+    "dimensions": {
+      "x": 6.0,
+      "y": 14.4,
+      "z": 5.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 159.91548838807222
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.07442778315692432
+  }
+}

--- a/rust/kcl-lib/tests/fillet-and-shell/physical_properties.snap
+++ b/rust/kcl-lib/tests/fillet-and-shell/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties fillet-and-shell.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 19.0,
+      "y": 36.5,
+      "z": 4.0
+    },
+    "dimensions": {
+      "x": 38.0,
+      "y": 73.0,
+      "z": 8.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 9301.034241962823
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 4.5285488152885245
+  }
+}

--- a/rust/kcl-lib/tests/fillet_ambiguous_region_edge_specifier/physical_properties.snap
+++ b/rust/kcl-lib/tests/fillet_ambiguous_region_edge_specifier/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties fillet_ambiguous_region_edge_specifier.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.529237019207331,
+      "y": 0.010917630454832404,
+      "z": 2.0
+    },
+    "dimensions": {
+      "x": 12.951161905493308,
+      "y": 15.68068641316409,
+      "z": 4.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 287.29292290341493
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.3033588114052842
+  }
+}

--- a/rust/kcl-lib/tests/fillet_ambiguous_region_edge_specifier_broad/physical_properties.snap
+++ b/rust/kcl-lib/tests/fillet_ambiguous_region_edge_specifier_broad/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties fillet_ambiguous_region_edge_specifier_broad.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.529237019207331,
+      "y": 0.010917630454832404,
+      "z": 2.0
+    },
+    "dimensions": {
+      "x": 12.951161905493308,
+      "y": 15.68068641316409,
+      "z": 4.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 286.8894034295244
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.3033487341525945
+  }
+}

--- a/rust/kcl-lib/tests/flush_batch_on_end/physical_properties.snap
+++ b/rust/kcl-lib/tests/flush_batch_on_end/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties flush_batch_on_end.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 19.049999999999997
+    },
+    "dimensions": {
+      "x": 16.66875,
+      "y": 16.66875,
+      "z": 38.099999999999994
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 2937.1428723550252
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 3.2141558031402915
+  }
+}

--- a/rust/kcl-lib/tests/function_sketch/physical_properties.snap
+++ b/rust/kcl-lib/tests/function_sketch/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties function_sketch.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 5.0,
+      "y": 3.0,
+      "z": 1.5
+    },
+    "dimensions": {
+      "x": 10.0,
+      "y": 6.0,
+      "z": 3.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 215.99999672616832
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.18000000068241206
+  }
+}

--- a/rust/kcl-lib/tests/function_sketch_with_position/physical_properties.snap
+++ b/rust/kcl-lib/tests/function_sketch_with_position/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties function_sketch_with_position.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 5.0,
+      "y": 3.0,
+      "z": 1.5
+    },
+    "dimensions": {
+      "x": 10.0,
+      "y": 6.0,
+      "z": 3.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 215.99999672616832
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.18000000068241206
+  }
+}

--- a/rust/kcl-lib/tests/gdt_face_api_edge_specifier/physical_properties.snap
+++ b/rust/kcl-lib/tests/gdt_face_api_edge_specifier/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties gdt_face_api_edge_specifier.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 5.0,
+      "y": 5.0,
+      "z": 5.0
+    },
+    "dimensions": {
+      "x": 10.0,
+      "y": 10.0,
+      "z": 10.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 599.9999848427251
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.9999999974752428
+  }
+}

--- a/rust/kcl-lib/tests/helix_axis_edge_ref/physical_properties.snap
+++ b/rust/kcl-lib/tests/helix_axis_edge_ref/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties helix_axis_edge_ref.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.15000000000000036,
+      "y": -17.82,
+      "z": 1.5
+    },
+    "dimensions": {
+      "x": 20.320000000000004,
+      "y": 50.0,
+      "z": 7.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 940.1672868989408
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 1.486668130231313
+  }
+}

--- a/rust/kcl-lib/tests/helix_ccw/physical_properties.snap
+++ b/rust/kcl-lib/tests/helix_ccw/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties helix_ccw.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 4.999999999999998,
+      "y": 4.999999999999998,
+      "z": 5.0
+    },
+    "dimensions": {
+      "x": 24.000000000000004,
+      "y": 24.000000000000004,
+      "z": 10.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 1256.321652126413
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 3.1403310065125645
+  }
+}

--- a/rust/kcl-lib/tests/hide_offset_plane/physical_properties.snap
+++ b/rust/kcl-lib/tests/hide_offset_plane/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties hide_offset_plane.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 50.0
+    },
+    "dimensions": {
+      "x": 100.0,
+      "y": 100.0,
+      "z": 100.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 119999.99359250069
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 1999.9995517234008
+  }
+}

--- a/rust/kcl-lib/tests/holes_cube/physical_properties.snap
+++ b/rust/kcl-lib/tests/holes_cube/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties holes_cube.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 5.0000000000963105,
+      "y": 10.049870986601306,
+      "z": -0.0000000000006217248937900878
+    },
+    "dimensions": {
+      "x": 23.297056274643843,
+      "y": 23.396798248091063,
+      "z": 23.297056275249993
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 2902.8240501098867
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 6.134260243173127
+  }
+}

--- a/rust/kcl-lib/tests/i_shape/physical_properties.snap
+++ b/rust/kcl-lib/tests/i_shape/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties i_shape.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 36.70000000000001,
+      "y": 65.0,
+      "z": 1.5
+    },
+    "dimensions": {
+      "x": 88.08,
+      "y": 156.0,
+      "z": 3.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 12322.37842072692
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 15.738794269838651
+  }
+}

--- a/rust/kcl-lib/tests/import_async/physical_properties.snap
+++ b/rust/kcl-lib/tests/import_async/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties import_async.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 6.750001907348633,
+      "z": 0.18249988555908203
+    },
+    "dimensions": {
+      "x": 100.0,
+      "y": 113.50000381469728,
+      "z": 13.635000228881836
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 5431.1267741500715
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 8.840586078577067
+  }
+}

--- a/rust/kcl-lib/tests/import_function_not_sketch/physical_properties.snap
+++ b/rust/kcl-lib/tests/import_function_not_sketch/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties import_function_not_sketch.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": -2.0,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 20.0,
+      "y": 28.0,
+      "z": 20.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 2334.562250155159
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 3.921226754854956
+  }
+}

--- a/rust/kcl-lib/tests/import_whole_simple/physical_properties.snap
+++ b/rust/kcl-lib/tests/import_whole_simple/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties import_whole_simple.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 127.0,
+      "y": 127.0,
+      "z": 127.0
+    },
+    "dimensions": {
+      "x": 609.6,
+      "y": 609.6,
+      "z": 254.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 810528.5104234099
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 51460.81226958425
+  }
+}

--- a/rust/kcl-lib/tests/import_whole_transitive_import/physical_properties.snap
+++ b/rust/kcl-lib/tests/import_whole_transitive_import/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties import_whole_transitive_import.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 127.0,
+      "y": 127.0,
+      "z": 127.0
+    },
+    "dimensions": {
+      "x": 609.6,
+      "y": 609.6,
+      "z": 254.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 810528.5104234099
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 51460.81226958425
+  }
+}

--- a/rust/kcl-lib/tests/intersect_cubes/physical_properties.snap
+++ b/rust/kcl-lib/tests/intersect_cubes/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties intersect_cubes.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 6.400000000000001,
+      "y": 3.0,
+      "z": 6.0
+    },
+    "dimensions": {
+      "x": 8.800000000000002,
+      "y": 12.0,
+      "z": 12.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 519.9999868636951
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.7999999252679876
+  }
+}

--- a/rust/kcl-lib/tests/involute_circular_units/physical_properties.snap
+++ b/rust/kcl-lib/tests/involute_circular_units/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties involute_circular_units.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.05987528817645682,
+      "y": 0.08386532513296174,
+      "z": 1.5
+    },
+    "dimensions": {
+      "x": 137.9016244733531,
+      "y": 137.88632562681562,
+      "z": 3.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 19695.62892524973
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 26.598668324272023
+  }
+}

--- a/rust/kcl-lib/tests/join_surfaces_single_input_does_not_consume/physical_properties.snap
+++ b/rust/kcl-lib/tests/join_surfaces_single_input_does_not_consume/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties join_surfaces_single_input_does_not_consume.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 5.0
+    },
+    "dimensions": {
+      "x": 20.0,
+      "y": 20.0,
+      "z": 10.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 1727.999921058654
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 3.8399999198190926
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/angle-gauge/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/angle-gauge/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties angle-gauge.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 19.05,
+      "y": 15.87499999999998,
+      "z": 0.635
+    },
+    "dimensions": {
+      "x": 45.720000000000006,
+      "y": 38.10000000000004,
+      "z": 1.27
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 2098.8876412957325
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 1.1824607829188
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/artificial-heart/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/artificial-heart/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties artificial-heart.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -28.966941282025417,
+      "y": 1.0942220478680085,
+      "z": -21.48581115589407
+    },
+    "dimensions": {
+      "x": 157.93388256405083,
+      "y": 73.48414599393286,
+      "z": 144.22634297790384
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 138485.21358110776
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 121.59687846351144
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/axial-fan/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/axial-fan/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties axial-fan.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.27487875471160805,
+      "y": -1.9201458561965268,
+      "z": 12.500000000000002
+    },
+    "dimensions": {
+      "x": 171.48694119926074,
+      "y": 174.7774754022314,
+      "z": 25.000000000000004
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 79488.84092079825
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 82.58606560656324
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/ball-bearing/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/ball-bearing/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties ball-bearing.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 100.0,
+      "y": 100.0,
+      "z": 12.389208878470034
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 7059.38434893083
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 5.275631165689778
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/bench-for-kids/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/bench-for-kids/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties bench-for-kids.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 100.0,
+      "z": 230.7592344560256
+    },
+    "dimensions": {
+      "x": 480.0,
+      "y": 1000.0,
+      "z": 561.5184689120512
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 1364942.3384985474
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 57925.24860833859
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/bench/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/bench/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties bench.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.02499999999999858,
+      "y": 0.0,
+      "z": 3.560846446480312
+    },
+    "dimensions": {
+      "x": 60.05000000000001,
+      "y": 100.0,
+      "z": 107.12169289296062
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 21421.262466050888
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 19.396430867861874
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/bike-hub-washer/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/bike-hub-washer/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties bike-hub-washer.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.0000000000000017763568394002505,
+      "y": -0.0000000000000017763568394002505,
+      "z": 2.75
+    },
+    "dimensions": {
+      "x": 29.000000000000004,
+      "y": 29.000000000000004,
+      "z": 9.5
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 2011.6153253120217
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 2.3758538786518755
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/blend-tutorial/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/blend-tutorial/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties blend-tutorial.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 250.0,
+      "y": -100.0,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 700.0,
+      "y": 400.0,
+      "z": 100.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 163125.726960061
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 2917.8419093417083
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/bone-plate/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/bone-plate/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties bone-plate.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -2.052546915451593,
+      "y": 49.01302610038835,
+      "z": 70.84877587300453
+    },
+    "dimensions": {
+      "x": 75.44355645642527,
+      "y": 59.400516666687295,
+      "z": 141.69755174600922
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 16695.5027382666
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 46.92365499194516
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/bottle/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/bottle/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties bottle.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.000000000003808509063674137,
+      "y": 0.05272312249223887,
+      "z": 110.0
+    },
+    "dimensions": {
+      "x": 150.0,
+      "y": 131.1866751582267,
+      "z": 220.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 174662.89732715266
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 347.5081454856384
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/box/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/box/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties box.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": -0.0000000000000017763568394002505,
+      "z": 5.0
+    },
+    "dimensions": {
+      "x": 10.0,
+      "y": 10.0,
+      "z": 10.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 599.9999848427251
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.9999999974752428
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/bracket-with-slot/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/bracket-with-slot/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties bracket-with-slot.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 84.80000001210722,
+      "y": -0.0000000019334223111400206,
+      "z": 34.800000009902774
+    },
+    "dimensions": {
+      "x": 170.4000000242144,
+      "y": 40.00000003988923,
+      "z": 70.40000001980556
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 19018.63923853853
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 32.478247100916256
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/bracket/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/bracket/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties bracket.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 63.01123264079055,
+      "y": 0.0,
+      "z": -28.086232640790556
+    },
+    "dimensions": {
+      "x": 127.9775347184189,
+      "y": 127.0,
+      "z": 58.1275347184189
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 48458.42244702681
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 201.5553166316112
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/c-shape-solid/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/c-shape-solid/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties c-shape-solid.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.025062814503304057,
+      "y": 0.00000000007704059612478886,
+      "z": 1.0
+    },
+    "dimensions": {
+      "x": 23.939849245843547,
+      "y": 25.11269457546165,
+      "z": 2.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 651.7843263509349
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.4511515325026731
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/camshaft/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/camshaft/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties camshaft.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 236.2454
+    },
+    "dimensions": {
+      "x": 100.0,
+      "y": 100.0,
+      "z": 472.4908
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 108554.66750128106
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 456.4102501755836
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/car-wheel-assembly/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/car-wheel-assembly/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties car-wheel-assembly.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": -15.07999998976868,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 610.1619588470033,
+      "y": 259.7354122936622,
+      "z": 610.1619588470033
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 2746390.878500077
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 18140.135792800287
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/cassette/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/cassette/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties cassette.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": -0.000000000000007105427357601002,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 100.0,
+      "y": 76.43873379874411,
+      "z": 100.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 29787.412085660493
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 15.894615541069705
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/ceiling-fan/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/ceiling-fan/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties ceiling-fan.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.00000000019032597720070044,
+      "y": 28.293345943452664,
+      "z": 0.00000000038667380408696767
+    },
+    "dimensions": {
+      "x": 238.02205076004628,
+      "y": 206.13314261939897,
+      "z": 16.591523959010715
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 17015.094396845452
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 26.13535354809016
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/clock/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/clock/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties clock.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 29.999999999999993
+    },
+    "dimensions": {
+      "x": 600.0,
+      "y": 600.0,
+      "z": 60.000000000000014
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 635800.313455519
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 10290.117018247003
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/coilover-assembly/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/coilover-assembly/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties coilover-assembly.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 62.74981250011064
+    },
+    "dimensions": {
+      "x": 100.0,
+      "y": 84.0,
+      "z": 404.69637485840406
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 85199.78819441842
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 334.959835389161
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/cold-plate/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/cold-plate/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties cold-plate.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 6.858000001747712,
+      "y": -0.000000000055990767577895895,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 397.3870567926017,
+      "y": 287.3202848991133,
+      "z": 100.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 428772.49386481254
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 1895.032607496516
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/color-cube/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/color-cube/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties color-cube.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 0.5
+    },
+    "dimensions": {
+      "x": 100.0,
+      "y": 100.00000000000004,
+      "z": 101.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 122400.01183818094
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 60.00017871580591
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/cone/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/cone/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties cone.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 2.5,
+      "z": 5.0
+    },
+    "dimensions": {
+      "x": 10.0,
+      "y": 15.0,
+      "z": 10.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 253.84303213282777
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.2610567521506753
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/counterdrilled-weldment/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/counterdrilled-weldment/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties counterdrilled-weldment.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 31.623000000000005
+    },
+    "dimensions": {
+      "x": 165.10000000000036,
+      "y": 114.30000000000064,
+      "z": 63.754000000000005
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 66384.79176012347
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 250.97198460055648
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/countersunk-plate/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/countersunk-plate/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties countersunk-plate.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.000000000044209969018993434,
+      "y": -0.000000000018047785488306545,
+      "z": 4.445000000000002
+    },
+    "dimensions": {
+      "x": 198.12000000278832,
+      "y": 135.49855902823953,
+      "z": 10.160000000000014
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 18955.78302026024
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 59.26681734713668
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/cpu-cooler/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/cpu-cooler/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties cpu-cooler.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 85.23500000000001
+    },
+    "dimensions": {
+      "x": 170.2384081608256,
+      "y": 141.60000000000002,
+      "z": 171.13
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 672872.7215840691
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 522.5486175726365
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/crash-box/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/crash-box/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties crash-box.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": -0.0000000003195737008354626,
+      "z": -575.0000000000001
+    },
+    "dimensions": {
+      "x": 420.0,
+      "y": 403.99999999986915,
+      "z": 1250.0000000000002
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 3232614.9765685843
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 31454.95327711009
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/curtain-wall-anchor-plate/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/curtain-wall-anchor-plate/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties curtain-wall-anchor-plate.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 125.0,
+      "y": 0.0,
+      "z": 15.0
+    },
+    "dimensions": {
+      "x": 350.0,
+      "y": 200.0,
+      "z": 130.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 163086.57684403373
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 592.729667132493
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/cycloidal-gear/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/cycloidal-gear/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties cycloidal-gear.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.27898777894521487,
+      "y": -0.7484718774538806,
+      "z": 19.049999999999997
+    },
+    "dimensions": {
+      "x": 46.72859908568111,
+      "y": 43.92264398405216,
+      "z": 38.099999999999994
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 6714.575912003084
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 26.331933907983164
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/cylinder/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/cylinder/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties cylinder.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 5.0
+    },
+    "dimensions": {
+      "x": 12.0,
+      "y": 12.0,
+      "z": 10.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 471.00240055919505
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.7846099465506443
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/desk-edge-stopper/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/desk-edge-stopper/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties desk-edge-stopper.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 100.0,
+      "y": 17.499999999444942,
+      "z": 20.250000000121982
+    },
+    "dimensions": {
+      "x": 200.0,
+      "y": 34.99999999941564,
+      "z": 50.4999999994958
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 47418.27821237621
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 110.31272769497964
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/dining-table/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/dining-table/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties dining-table.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 375.0,
+      "y": 1025.0,
+      "z": 375.0
+    },
+    "dimensions": {
+      "x": 850.0,
+      "y": 2150.0,
+      "z": 750.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 5375199.896283448
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 50271.912021950506
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/dodecahedron/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/dodecahedron/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties dodecahedron.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -1.6836165385448112,
+      "y": -1.1611772705509793,
+      "z": -0.33020058987858647
+    },
+    "dimensions": {
+      "x": 20638.26243010455,
+      "y": 19869.563947551826,
+      "z": 14841.259542864904
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 726433343.8873291
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 1599387494.4051106
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/double-hook/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/double-hook/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties double-hook.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -12.99999999113737,
+      "y": 17.00000004637261,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 31.001338603898244,
+      "y": 55.001338697872875,
+      "z": 5.000000000000007
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 1386.6405493786206
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 1.6801962189191124
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/enclosure/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/enclosure/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties enclosure.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 137.50000000000006,
+      "y": 87.5,
+      "z": 36.5
+    },
+    "dimensions": {
+      "x": 275.0000000000001,
+      "y": 181.2,
+      "z": 73.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 227163.8013306685
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 330.47592629820156
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/end-effector-gripper-fingers/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/end-effector-gripper-fingers/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties end-effector-gripper-fingers.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -9.201885317730728,
+      "y": -17.22834996325288,
+      "z": 115.07883155176437
+    },
+    "dimensions": {
+      "x": 259.1291730063341,
+      "y": 254.046429285034,
+      "z": 330.1576631035287
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 379034.66695646994
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 1865.5233504914631
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/engine-valve/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/engine-valve/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties engine-valve.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 32.499999997865714,
+      "z": 40.0
+    },
+    "dimensions": {
+      "x": 30.000000008537157,
+      "y": 95.00000000426856,
+      "z": 80.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 2976.623793012223
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 4.617689043436475
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/exhaust-manifold/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/exhaust-manifold/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties exhaust-manifold.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 76.56391684900001,
+      "y": 132.85735749829672,
+      "z": 195.8168201542004
+    },
+    "dimensions": {
+      "x": 259.50779868719997,
+      "y": 343.01461132270276,
+      "z": 391.6336403084008
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 595467.7689093301
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 318.1051921027726
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/field-monitor-stand/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/field-monitor-stand/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties field-monitor-stand.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 33.0,
+      "y": -30.0,
+      "z": 56.85140355754746
+    },
+    "dimensions": {
+      "x": 66.0,
+      "y": 72.0,
+      "z": 136.4433685381139
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 25581.90349556355
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 35.39208707241639
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/flange/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/flange/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties flange.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.000000004444984824658604,
+      "y": 0.0,
+      "z": 8.800599999999996
+    },
+    "dimensions": {
+      "x": 140.97000002667,
+      "y": 140.97000002667,
+      "z": 20.651200000000003
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 30493.849178128585
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 156.75951111996747
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/flat-bladed-impeller/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/flat-bladed-impeller/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties flat-bladed-impeller.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 8.750499999999999
+    },
+    "dimensions": {
+      "x": 237.5,
+      "y": 237.5,
+      "z": 57.501
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 58982.21591633046
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 108.94240718073434
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/focusrite-scarlett-mounting-bracket/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/focusrite-scarlett-mounting-bracket/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties focusrite-scarlett-mounting-bracket.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 22.5
+    },
+    "dimensions": {
+      "x": 178.4,
+      "y": 100.0,
+      "z": 53.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 52675.56096368686
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 94.97382887957428
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/food-service-spatula/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/food-service-spatula/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties food-service-spatula.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 57.22932954487879,
+      "y": 26.46064449999999,
+      "z": 27.43541033614048
+    },
+    "dimensions": {
+      "x": 289.864444329997,
+      "y": 129.72128899999998,
+      "z": 154.87082067228096
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 25590.105778146462
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 54.29881538298227
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/fun-stacker-toy/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/fun-stacker-toy/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties fun-stacker-toy.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 76.20000001828356,
+      "z": 139.69999999999993
+    },
+    "dimensions": {
+      "x": 304.79999999999995,
+      "y": 457.2000000365671,
+      "z": 330.1999999999998
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 790389.1122993798
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 11433.16219861982
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/gallows-bracket/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/gallows-bracket/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties gallows-bracket.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 176.0,
+      "y": 1125.0,
+      "z": 637.5
+    },
+    "dimensions": {
+      "x": 552.0,
+      "y": 2404.0,
+      "z": 1375.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 4878147.739896349
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 16574.398191129418
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/gas-impeller/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/gas-impeller/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties gas-impeller.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 3.051813831676114,
+      "y": -0.8034746997554123,
+      "z": 32.5
+    },
+    "dimensions": {
+      "x": 211.17766992120457,
+      "y": 213.98030644582428,
+      "z": 65.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 125592.16387864684
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 266.45495286736764
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/gdt-tutorial/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/gdt-tutorial/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties gdt-tutorial.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.6400000000000006,
+      "y": -0.39000000000000057,
+      "z": 50.0
+    },
+    "dimensions": {
+      "x": 200.0,
+      "y": 100.0,
+      "z": 100.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 99999.99962747096
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 2000.0000561897955
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/gear-rack/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/gear-rack/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties gear-rack.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.03999999999999915,
+      "y": 0.0,
+      "z": 2.5
+    },
+    "dimensions": {
+      "x": 100.38,
+      "y": 100.0,
+      "z": 5.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 4785.066629071772
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 5.730286553801608
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/gingerbread-man-cookie-cutter/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/gingerbread-man-cookie-cutter/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties gingerbread-man-cookie-cutter.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 239.33391954388208,
+      "z": 50.00000000000001
+    },
+    "dimensions": {
+      "x": 728.5114023374399,
+      "y": 1006.71712044763,
+      "z": 100.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 735037.2304263146
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 3340.4760996518235
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/gingerbread-man/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/gingerbread-man/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties gingerbread-man.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.00000000006770051186322235,
+      "y": 199.44518862131588,
+      "z": 30.00000000000002
+    },
+    "dimensions": {
+      "x": 505.91069606753126,
+      "y": 699.1096227581268,
+      "z": 60.00000000000004
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 493902.7613080285
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 7814.147032373005
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/golf-tee/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/golf-tee/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties golf-tee.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0000000000000008881784197001252,
+      "y": -0.0000000000000008881784197001252,
+      "z": 35.0
+    },
+    "dimensions": {
+      "x": 14.6,
+      "y": 14.6,
+      "z": 70.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 1355.8647821585446
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 1.7406923525335134
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/gridfinity-baseplate-magnets/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/gridfinity-baseplate-magnets/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties gridfinity-baseplate-magnets.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 17.1425,
+      "y": 38.1425,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 134.285,
+      "y": 176.285,
+      "z": 100.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 41430.50258758496
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 29.51844961649682
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/gridfinity-baseplate/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/gridfinity-baseplate/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties gridfinity-baseplate.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 42.0,
+      "y": 38.1425,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 84.57,
+      "y": 176.285,
+      "z": 100.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 13132.680770084447
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 7.365330838523595
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/gridfinity-bins-stacking-lip/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/gridfinity-bins-stacking-lip/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties gridfinity-bins-stacking-lip.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 21.200000000000003,
+      "y": 44.3,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 142.4,
+      "y": 188.6,
+      "z": 100.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 65922.62407143872
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 59.80008107033466
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/gridfinity-bins/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/gridfinity-bins/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties gridfinity-bins.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 21.200000000000003,
+      "y": 44.3,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 142.4,
+      "y": 188.6,
+      "z": 100.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 65099.49804463755
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 58.25663549108382
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/hammer/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/hammer/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties hammer.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 15.661859926766924,
+      "y": 0.0,
+      "z": 167.68833334115158
+    },
+    "dimensions": {
+      "x": 131.65371985344976,
+      "y": 100.0,
+      "z": 335.40567113206964
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 45429.890502199254
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 257.9901420573804
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/hand-trolley/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/hand-trolley/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties hand-trolley.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 24.645733327151845,
+      "z": 651.8889858986249
+    },
+    "dimensions": {
+      "x": 703.5799999999999,
+      "y": 515.6172333456961,
+      "z": 1312.4266717972496
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 2721802.9303733455
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 16899.95394042961
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/helium-tank/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/helium-tank/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties helium-tank.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 1.3101052611927455,
+      "y": 1.968500000000006,
+      "z": 368.69999999999993
+    },
+    "dimensions": {
+      "x": 288.75789474941917,
+      "y": 288.75789474941917,
+      "z": 837.3999999999999
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 799394.0078724644
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 1458.594943377971
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/herringbone-gear/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/herringbone-gear/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties herringbone-gear.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.017074028219152382,
+      "y": -0.003304864524972473,
+      "z": 4.0
+    },
+    "dimensions": {
+      "x": 26.954717241442022,
+      "y": 26.99078473104263,
+      "z": 8.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 2256.8866662333457
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 3.58387961488209
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/hex-nut-with-chamfer/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/hex-nut-with-chamfer/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties hex-nut-with-chamfer.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.00000000009874590034542051,
+      "y": -0.000000000029817925906172604,
+      "z": 5.0
+    },
+    "dimensions": {
+      "x": 25.177132043733184,
+      "y": 25.177132043733188,
+      "z": 10.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 1152.8855416003123
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 1.966513939734756
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/hex-nut/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/hex-nut/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties hex-nut.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.0000000000027995383788947947,
+      "y": -0.00000000005203926178865004,
+      "z": -0.00000000005203837361023034
+    },
+    "dimensions": {
+      "x": 19.050000000006747,
+      "y": 13.748153285299528,
+      "z": 16.497783942359433
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 718.7226708254002
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.7719561595139387
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/i-beam/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/i-beam/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties i-beam.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.000000000000007105427357601002,
+      "y": 0.0,
+      "z": -0.000000000000007105427357601002
+    },
+    "dimensions": {
+      "x": 81.16824000000007,
+      "y": 1828.8,
+      "z": 121.92000000000002
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 814299.7917148023
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 2849.8868384000766
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/inner-thread/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/inner-thread/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties inner-thread.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 5.499999999725001
+    },
+    "dimensions": {
+      "x": 12.0,
+      "y": 12.0,
+      "z": 11.499999999650004
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 742.4797806442201
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.2534081786389056
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/lattice-cubic/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/lattice-cubic/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties lattice-cubic.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 20.0,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 100.0,
+      "y": 50.0,
+      "z": 100.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 11890.714269751745
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 14.929497640315104
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/lego/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/lego/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties lego.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 62.23049999999999
+    },
+    "dimensions": {
+      "x": 401.32,
+      "y": 604.52,
+      "z": 129.539
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 1049224.1673853614
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 16570.290332506233
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/linear-shelf-system/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/linear-shelf-system/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties linear-shelf-system.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 800.0,
+      "y": -175.0,
+      "z": 1000.0
+    },
+    "dimensions": {
+      "x": 2000.0,
+      "y": 450.0,
+      "z": 2000.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 28209000.63868612
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 279700.3071949196
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/liquid-impeller/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/liquid-impeller/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties liquid-impeller.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -2.741410845589421,
+      "y": -0.2014832491017984,
+      "z": 4.737099999999998
+    },
+    "dimensions": {
+      "x": 113.18056937582524,
+      "y": 115.68825210536954,
+      "z": 10.845800000000004
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 26630.269673659113
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 32.46392839151522
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/m4-hex-socket-countersunk-head-screw/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/m4-hex-socket-countersunk-head-screw/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties m4-hex-socket-countersunk-head-screw.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": -9.372131582250518,
+      "z": -0.0000000000000004440892098500626
+    },
+    "dimensions": {
+      "x": 7.900000000040002,
+      "y": 21.255736835498965,
+      "z": 7.900000000040001
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 352.30559600563095
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.2673426148236402
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/m4-insert/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/m4-insert/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties m4-insert.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": -4.0500000000000105,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 6.300000000000001,
+      "y": 8.100000000000003,
+      "z": 6.300000000000001
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 304.2139690343504
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.1520419672940143
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/manhole-cover/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/manhole-cover/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties manhole-cover.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 693.4200000000001,
+      "y": 693.4200000000001,
+      "z": 100.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 844658.0315703613
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 9572.735379758038
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/modular-shelf-grid/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/modular-shelf-grid/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties modular-shelf-grid.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 800.0,
+      "y": -200.0,
+      "z": 750.0
+    },
+    "dimensions": {
+      "x": 2000.0,
+      "y": 400.0,
+      "z": 1500.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 22631999.612785876
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 206400.11360713592
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/mounting-plate/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/mounting-plate/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties mounting-plate.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 6.35
+    },
+    "dimensions": {
+      "x": 152.39999999999998,
+      "y": 254.0,
+      "z": 12.7
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 76047.70345960787
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 380.5277875604437
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/multi-axis-robot/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/multi-axis-robot/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties multi-axis-robot.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 65.23753132580913,
+      "y": 434.213,
+      "z": 546.0364999999998
+    },
+    "dimensions": {
+      "x": 807.0749130952256,
+      "y": 1147.826,
+      "z": 1098.1689999999996
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 952431.9811741062
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 15073.250077776038
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/parametric-shelf-unit/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/parametric-shelf-unit/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties parametric-shelf-unit.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": -175.0,
+      "z": 1000.0
+    },
+    "dimensions": {
+      "x": 1000.0,
+      "y": 450.0,
+      "z": 2000.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 9169800.316914916
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 95840.00865773608
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/pillow-block-bearing/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/pillow-block-bearing/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties pillow-block-bearing.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 7.9375
+    },
+    "dimensions": {
+      "x": 155.575,
+      "y": 104.77500000000002,
+      "z": 15.875
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 59770.59825433123
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 169.5398950863898
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/pipe-elbow-90deg/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/pipe-elbow-90deg/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties pipe-elbow-90deg.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 28.507583637608583,
+      "y": 44.06295386375135,
+      "z": 79.00000000009257
+    },
+    "dimensions": {
+      "x": 229.2669827255051,
+      "y": 244.1259077253291,
+      "z": 158.00000000018514
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 150482.07265317615
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 674.9061638672653
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/pipe-flange-assembly/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/pipe-flange-assembly/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties pipe-flange-assembly.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": -30.47999999999999,
+      "z": 56.78799999999998
+    },
+    "dimensions": {
+      "x": 182.88,
+      "y": 243.83999999999995,
+      "z": 213.57599999999996
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 258727.68915597
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 876.638933160283
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/pipe-straight/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/pipe-straight/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties pipe-straight.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 10.0,
+      "y": 0.0,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 170.0,
+      "y": 156.0,
+      "z": 156.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 160126.25160374228
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 681.7612452228635
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/pipe-with-bend/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/pipe-with-bend/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties pipe-with-bend.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 508.0,
+      "y": 381.0,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 1016.0,
+      "y": 1270.0,
+      "z": 508.00000000000006
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 3169036.1191685954
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 181866.20379242412
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/pipe/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/pipe/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties pipe.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.00000000603250782660325,
+      "y": 0.0,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 72.38999995656602,
+      "y": 152.39999999999998,
+      "z": 72.38999995656602
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 54858.466573932674
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 127.01375253717136
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/planetary-gearset/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/planetary-gearset/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties planetary-gearset.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 2.5
+    },
+    "dimensions": {
+      "x": 100.0,
+      "y": 100.0,
+      "z": 5.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 9446.718693775065
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 10.405921527050818
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/propeller/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/propeller/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties propeller.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 436.8799999879214,
+      "y": 0.0,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 1310.6400000241597,
+      "y": 2299.3684210526317,
+      "z": 256.4766229013642
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 1073766.0459656883
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 13900.71078960912
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/rack-blanking-panel/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/rack-blanking-panel/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties rack-blanking-panel.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 17.568333333333335,
+      "z": 22.225
+    },
+    "dimensions": {
+      "x": 482.6,
+      "y": 53.763333333333335,
+      "z": 53.34
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 56373.23019975326
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 45.18293699481054
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/radial-flow-centrifugal-impeller/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/radial-flow-centrifugal-impeller/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties radial-flow-centrifugal-impeller.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.000000018750000663203537,
+      "y": 0.0,
+      "z": 16.30000000000002
+    },
+    "dimensions": {
+      "x": 180.00000000000006,
+      "y": 180.00000000000006,
+      "z": 56.60000000000004
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 85102.6179868768
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 174.1077135524923
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/rectangle-table/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/rectangle-table/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties rectangle-table.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 275.0,
+      "y": 725.0,
+      "z": 375.0
+    },
+    "dimensions": {
+      "x": 650.0,
+      "y": 1550.0,
+      "z": 750.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 2435200.0954095274
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 40544.030140154064
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/round-table/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/round-table/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties round-table.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 375.0
+    },
+    "dimensions": {
+      "x": 840.0,
+      "y": 840.0,
+      "z": 750.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 1168840.883598307
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 13326.462823563645
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/router-template-cross-bar/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/router-template-cross-bar/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties router-template-cross-bar.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.0003983530770881316,
+      "y": 15.939999999999776,
+      "z": 15.939999999999776
+    },
+    "dimensions": {
+      "x": 205.26098900814873,
+      "y": 51.88000000000045,
+      "z": 51.88000000000045
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 14988.837398050237
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 26.966359282454277
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/router-template-slate/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/router-template-slate/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties router-template-slate.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.0003125000003123546,
+      "y": -47.18499999999999,
+      "z": -47.18499999999999
+    },
+    "dimensions": {
+      "x": 61.500625000000625,
+      "y": 150.61,
+      "z": 150.61
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 23474.541908353076
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 49.74584564898521
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/saturn-v/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/saturn-v/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties saturn-v.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 46020.0,
+      "z": 50000.0
+    },
+    "dimensions": {
+      "x": 15920.0,
+      "y": 107960.0,
+      "z": 100000.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 4471399578.164273
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 4849434365.71358
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/scrub-daddy-holder/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/scrub-daddy-holder/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties scrub-daddy-holder.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 20.75
+    },
+    "dimensions": {
+      "x": 100.0,
+      "y": 100.0,
+      "z": 41.5
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 7073.019283082793
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 16.697573550267155
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/shaft-grommet/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/shaft-grommet/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties shaft-grommet.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.25354511957023096,
+      "y": 0.06251543488288558,
+      "z": 2.032
+    },
+    "dimensions": {
+      "x": 7.810541406561585,
+      "y": 8.002969130234227,
+      "z": 4.064
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 150.74022414651722
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.046437595411965425
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/sheet-metal-bracket/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/sheet-metal-bracket/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties sheet-metal-bracket.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.05397379451741813,
+      "y": 0.0,
+      "z": 32.84432320054621
+    },
+    "dimensions": {
+      "x": 256.031998531744,
+      "y": 139.7,
+      "z": 79.00653557566464
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 82531.3360818285
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 119.20488703335656
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/single-impeller-blade/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/single-impeller-blade/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties single-impeller-blade.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 30.0
+    },
+    "dimensions": {
+      "x": 100.0,
+      "y": 100.0,
+      "z": 60.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 5799.999722512439
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 11.999999514955562
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/snowman/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/snowman/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties snowman.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 102.0
+    },
+    "dimensions": {
+      "x": 172.32,
+      "y": 172.32,
+      "z": 212.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 79315.81069739092
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 495.1942148862578
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/socket-head-cap-screw/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/socket-head-cap-screw/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties socket-head-cap-screw.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": -10.287,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 9.7536,
+      "y": 30.226,
+      "z": 9.7536
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 677.4186983662389
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.710009977436532
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/sphere/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/sphere/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties sphere.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 10.0,
+      "y": 10.0,
+      "z": 10.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 313.69119559432335
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.5220315172534129
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/spinning-highrise-tower/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/spinning-highrise-tower/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties spinning-highrise-tower.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 40500.0
+    },
+    "dimensions": {
+      "x": 50000.0,
+      "y": 50000.0,
+      "z": 91400.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 74421039588.80902
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 71881049851.09966
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/split-washer-flat-version/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/split-washer-flat-version/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties split-washer-flat-version.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 0.30000000000000004
+    },
+    "dimensions": {
+      "x": 100.0,
+      "y": 100.0,
+      "z": 1.6
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 111.11658908191656
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.03568635011108601
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/split-washer-spring-version/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/split-washer-spring-version/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties split-washer-spring-version.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.0007415964537109687,
+      "y": -0.0003628310029499815,
+      "z": 1.0
+    },
+    "dimensions": {
+      "x": 8.001483192907422,
+      "y": 8.004026311512696,
+      "z": 2.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 111.60138267740648
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.0358235085811873
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/sprocket/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/sprocket/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties sprocket.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.00000000000008526512829121202,
+      "y": 0.000000000000035527136788005016,
+      "z": 1.4287500000000002
+    },
+    "dimensions": {
+      "x": 72.04360834604955,
+      "y": 72.0436083460495,
+      "z": 2.8575000000000004
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 5577.738524522147
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 6.200057351107846
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/stylized-car/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/stylized-car/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties stylized-car.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0000023000006876827683,
+      "y": 14.749998059999823,
+      "z": 989.9999999737332
+    },
+    "dimensions": {
+      "x": 4439.9999959199995,
+      "y": 2110.4999961199997,
+      "z": 2120.000000052534
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 61370069.6666009
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 7938106.735624994
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/stylized-cybertruck/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/stylized-cybertruck/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties stylized-cybertruck.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0000023000006876827683,
+      "y": 34.99999921499989,
+      "z": 939.9999998880004
+    },
+    "dimensions": {
+      "x": 4439.9999959199995,
+      "y": 2229.9999906099997,
+      "z": 2020.0000002240004
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 58086708.465480566
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 7275827.452317269
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/stylized-dump-truck/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/stylized-dump-truck/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties stylized-dump-truck.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.00000160000081450562,
+      "y": 14.749998059999823,
+      "z": 1204.9999998879998
+    },
+    "dimensions": {
+      "x": 5279.999994240001,
+      "y": 2110.4999961199997,
+      "z": 2550.0000002240004
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 86672493.12716728
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 14015305.378037738
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/stylized-firetruck/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/stylized-firetruck/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties stylized-firetruck.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.00000160000081450562,
+      "y": 14.749998059999823,
+      "z": 1389.9999998879998
+    },
+    "dimensions": {
+      "x": 5279.999994240001,
+      "y": 2110.4999961199997,
+      "z": 2920.0000002240004
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 102316491.91024904
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 14914106.124885924
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/stylized-mini-bus/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/stylized-mini-bus/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties stylized-mini-bus.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.000002100000983773498,
+      "y": 14.749998059999823,
+      "z": 1089.9999998879998
+    },
+    "dimensions": {
+      "x": 4679.99999544,
+      "y": 2110.4999961199997,
+      "z": 2320.0000002240004
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 78665749.92611265
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 11840105.934946526
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/stylized-pickup-truck/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/stylized-pickup-truck/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties stylized-pickup-truck.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0000018000009731622413,
+      "y": 14.749998059999823,
+      "z": 1144.9999998879998
+    },
+    "dimensions": {
+      "x": 5039.999994719999,
+      "y": 2110.4999961199997,
+      "z": 2430.0000002240004
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 63634261.42968171
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 7209474.975917449
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/surgical-drill-guide/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/surgical-drill-guide/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties surgical-drill-guide.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 44.23213446488944,
+      "z": 11.305364821725531
+    },
+    "dimensions": {
+      "x": 100.0,
+      "y": 250.45464998654543,
+      "z": 122.61072964345108
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 27956.215690217337
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 74.10358453519007
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/t-slot-frame/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/t-slot-frame/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties t-slot-frame.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 419.1,
+      "y": 266.7000000000002,
+      "z": 1219.1999999999996
+    },
+    "dimensions": {
+      "x": 922.0200000000002,
+      "y": 617.2200000000008,
+      "z": 2446.019999999999
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 5143756.184839937
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 9362.063958865408
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/t-slot-rail/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/t-slot-rail/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties t-slot-rail.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -8.25500000000001,
+      "y": 304.8,
+      "z": 19.05
+    },
+    "dimensions": {
+      "x": 67.31000000000003,
+      "y": 609.6,
+      "z": 45.720000000000034
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 206708.0137946391
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 374.6941635469625
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/t-slot-rectangle/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/t-slot-rectangle/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties t-slot-rectangle.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -228.5999999999999,
+      "y": 279.4,
+      "z": 12.699999999999996
+    },
+    "dimensions": {
+      "x": 462.2799999999999,
+      "y": 614.6800000000001,
+      "z": 30.480000000000004
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 471512.0546550295
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 516.2824798938814
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/t-slot-shelf/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/t-slot-shelf/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties t-slot-shelf.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 419.1,
+      "y": 266.7000000000002,
+      "z": 1219.1999999999996
+    },
+    "dimensions": {
+      "x": 922.0200000000002,
+      "y": 617.2200000000008,
+      "z": 2446.019999999999
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 6073327.6577569
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 11048.02090942203
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/teapot/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/teapot/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties teapot.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.628084327916298,
+      "y": 25.48190798839397,
+      "z": 40.24665797230057
+    },
+    "dimensions": {
+      "x": 249.7475152964956,
+      "y": 210.02281591241427,
+      "z": 180.4933159446011
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 141080.3563548697
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 404.8425492110015
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/thermal-block-insert/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/thermal-block-insert/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties thermal-block-insert.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": -0.00000000000006394884621840903,
+      "z": 100.0
+    },
+    "dimensions": {
+      "x": 480.0,
+      "y": 106.7647058823527,
+      "z": 200.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 560520.8365013823
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 5882.352893725813
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/torus/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/torus/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties torus.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 40.0,
+      "y": 10.0,
+      "z": 40.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 2959.6069766384403
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 7.383068101067883
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/truss-structure/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/truss-structure/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties truss-structure.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -1371.6000000000004,
+      "y": 0.0,
+      "z": -38.40776005091311
+    },
+    "dimensions": {
+      "x": 5791.200000000001,
+      "y": 3657.6,
+      "z": 2361.584479898176
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 12279590.764590466
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 189929.82382716643
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/tube-manifold/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/tube-manifold/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties tube-manifold.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -214.63000000000005,
+      "y": 0.0,
+      "z": 36.83000000000027
+    },
+    "dimensions": {
+      "x": 734.0600000000001,
+      "y": 157.48000000000002,
+      "z": 231.14000000000055
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 791357.3030907912
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 2003.5864794113088
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/usb-c/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/usb-c/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties usb-c.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -34.30318547243999,
+      "y": 0.9899999999999948,
+      "z": 1.5349104242748055
+    },
+    "dimensions": {
+      "x": 82.20637094487998,
+      "y": 101.98,
+      "z": 103.0698208485496
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 1991.7228061419048
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 1.9619375227289868
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/utility-sink/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/utility-sink/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties utility-sink.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 596.3249999938,
+      "y": 366.0,
+      "z": 485.0
+    },
+    "dimensions": {
+      "x": 1292.6499999876,
+      "y": 832.0,
+      "z": 1070.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 7738136.351269883
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 34383.194221199985
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/v-block/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/v-block/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties v-block.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 5.225999999999999,
+      "z": 8.248599999999996
+    },
+    "dimensions": {
+      "x": 76.19999999999999,
+      "y": 110.452,
+      "z": 116.4972
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 20443.179689891625
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 118.85807260488453
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/washer/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/washer/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties washer.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.000000000025400126446584178,
+      "y": 0.0,
+      "z": 0.4064
+    },
+    "dimensions": {
+      "x": 13.35024000006096,
+      "y": 13.35024000006096,
+      "z": 0.8128
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 194.0664596560282
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.06197704148502847
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/wedge/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/wedge/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties wedge.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 5.0,
+      "y": 5.0,
+      "z": 5.0
+    },
+    "dimensions": {
+      "x": 12.0,
+      "y": 12.0,
+      "z": 10.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 441.4213399286382
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.49999999873762135
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/wheel-hub/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/wheel-hub/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties wheel-hub.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": -48.006428571427485,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 182.88,
+      "y": 109.72714285714515,
+      "z": 182.88
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 114954.2991042818
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 472.6683538118411
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/wind-turbine-blade-root-inserts/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/wind-turbine-blade-root-inserts/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties wind-turbine-blade-root-inserts.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 25486.9753480228,
+      "y": 452.33237504404497,
+      "z": 1092.832579209236
+    },
+    "dimensions": {
+      "x": 53026.0493039544,
+      "y": 4987.785765826251,
+      "z": 5154.9850886389095
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 30199487.028964937
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 2166515.544830773
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/wing-spar/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/wing-spar/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties wing-spar.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -17.881268963927766,
+      "y": -326.4657652473819,
+      "z": 2.527649229693772
+    },
+    "dimensions": {
+      "x": 745.7625379278554,
+      "y": 747.0684695052362,
+      "z": 105.05529845938754
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 318307.09556334116
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 628.3962805025411
+  }
+}

--- a/rust/kcl-lib/tests/kcl_samples/zoo-logo/physical_properties.snap
+++ b/rust/kcl-lib/tests/kcl_samples/zoo-logo/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties zoo-logo.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 40.745494551477776,
+      "y": 12.700000000000092,
+      "z": 1.27
+    },
+    "dimensions": {
+      "x": 84.71678910295554,
+      "y": 39.21340219736892,
+      "z": 2.54
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 3008.284159250252
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 2.478913481873679
+  }
+}

--- a/rust/kcl-lib/tests/kittycad_svg/physical_properties.snap
+++ b/rust/kcl-lib/tests/kittycad_svg/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties kittycad_svg.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 10.5,
+      "y": -14.279999999999998,
+      "z": 0.5
+    },
+    "dimensions": {
+      "x": 25.200000000000003,
+      "y": 34.272,
+      "z": 1.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 1322.426360739251
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.3543474097408127
+  }
+}

--- a/rust/kcl-lib/tests/linear_pattern3d_a_pattern/physical_properties.snap
+++ b/rust/kcl-lib/tests/linear_pattern3d_a_pattern/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties linear_pattern3d_a_pattern.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 19.5,
+      "y": -0.5,
+      "z": 4.0
+    },
+    "dimensions": {
+      "x": 39.599999999999994,
+      "y": 1.0,
+      "z": 10.8
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 1485.9034181426978
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.441000000887352
+  }
+}

--- a/rust/kcl-lib/tests/loft_arc_subtract/physical_properties.snap
+++ b/rust/kcl-lib/tests/loft_arc_subtract/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties loft_arc_subtract.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": -4.5,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 100.0,
+      "y": 11.0,
+      "z": 100.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 265.73313993338843
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.10202833852548016
+  }
+}

--- a/rust/kcl-lib/tests/loop_tag/physical_properties.snap
+++ b/rust/kcl-lib/tests/loop_tag/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties loop_tag.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 5.0,
+      "y": 79.47272421932655,
+      "z": 25.0
+    },
+    "dimensions": {
+      "x": 191.11165331890385,
+      "y": 190.7345381263837,
+      "z": 50.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 64736.36256669124
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 993.409072217825
+  }
+}

--- a/rust/kcl-lib/tests/mirror3d_and_boolean/physical_properties.snap
+++ b/rust/kcl-lib/tests/mirror3d_and_boolean/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties mirror3d_and_boolean.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 32.85
+    },
+    "dimensions": {
+      "x": 132.0,
+      "y": 132.0,
+      "z": 69.30000000000005
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 33291.792219387164
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 141.58572118150303
+  }
+}

--- a/rust/kcl-lib/tests/mirror3d_edge_specifier/physical_properties.snap
+++ b/rust/kcl-lib/tests/mirror3d_edge_specifier/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties mirror3d_edge_specifier.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 5.0,
+      "y": 5.0,
+      "z": 2.5
+    },
+    "dimensions": {
+      "x": 10.0,
+      "y": 10.0,
+      "z": 5.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 799.9999797903001
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.9999999974752428
+  }
+}

--- a/rust/kcl-lib/tests/mirror3d_edge_specifier_after_subtract/physical_properties.snap
+++ b/rust/kcl-lib/tests/mirror3d_edge_specifier_after_subtract/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties mirror3d_edge_specifier_after_subtract.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 2.005,
+      "y": 6.0,
+      "z": 2.5
+    },
+    "dimensions": {
+      "x": 10.99,
+      "y": 14.4,
+      "z": 5.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 323.893772701922
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.14910570273844273
+  }
+}

--- a/rust/kcl-lib/tests/module_return_using_var/physical_properties.snap
+++ b/rust/kcl-lib/tests/module_return_using_var/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties module_return_using_var.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.5,
+      "y": 0.5,
+      "z": 0.5
+    },
+    "dimensions": {
+      "x": 1.0,
+      "y": 1.0,
+      "z": 1.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 6.0000011217198335
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.0010000002307701077
+  }
+}

--- a/rust/kcl-lib/tests/multi_body_multi_tool_subtract/physical_properties.snap
+++ b/rust/kcl-lib/tests/multi_body_multi_tool_subtract/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties multi_body_multi_tool_subtract.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -79.4004,
+      "y": 0.0,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 158.8008,
+      "y": 63.5,
+      "z": 63.5
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 74083.34751863776
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 365.9834686186395
+  }
+}

--- a/rust/kcl-lib/tests/multi_target_csg/physical_properties.snap
+++ b/rust/kcl-lib/tests/multi_target_csg/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties multi_target_csg.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": -1.7859514699999997,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 11.429999999999998,
+      "y": 8.65190294,
+      "z": 100.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 425.0095025933112
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.23463975400589732
+  }
+}

--- a/rust/kcl-lib/tests/multi_transform/physical_properties.snap
+++ b/rust/kcl-lib/tests/multi_transform/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties multi_transform.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 14.121320343559644,
+      "y": 30.0,
+      "z": 2.0
+    },
+    "dimensions": {
+      "x": 62.18376618407356,
+      "y": 93.94112549695429,
+      "z": 4.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 3360.0011811358854
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 4.800001950873896
+  }
+}

--- a/rust/kcl-lib/tests/multiple-foreign-imports-all-render/physical_properties.snap
+++ b/rust/kcl-lib/tests/multiple-foreign-imports-all-render/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties multiple-foreign-imports-all-render.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.5,
+      "y": 0.5,
+      "z": 500.5
+    },
+    "dimensions": {
+      "x": 1001.0,
+      "y": 1001.0,
+      "z": 1001.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 18000000.0
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 3000000.0
+  }
+}

--- a/rust/kcl-lib/tests/named_views_baseline_hide/physical_properties.snap
+++ b/rust/kcl-lib/tests/named_views_baseline_hide/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties named_views_baseline_hide.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 30.0,
+      "y": 10.0,
+      "z": 4.0
+    },
+    "dimensions": {
+      "x": 60.0,
+      "y": 20.0,
+      "z": 8.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 2719.9998876312748
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 4.799999790823979
+  }
+}

--- a/rust/kcl-lib/tests/named_views_baseline_show/physical_properties.snap
+++ b/rust/kcl-lib/tests/named_views_baseline_show/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties named_views_baseline_show.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 30.0,
+      "y": 10.0,
+      "z": 4.0
+    },
+    "dimensions": {
+      "x": 60.0,
+      "y": 20.0,
+      "z": 8.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 2719.9998876312748
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 4.799999790823979
+  }
+}

--- a/rust/kcl-lib/tests/named_views_except_a_sketch_block/physical_properties.snap
+++ b/rust/kcl-lib/tests/named_views_except_a_sketch_block/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties named_views_except_a_sketch_block.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 20.0,
+      "y": 10.0,
+      "z": 2.5
+    },
+    "dimensions": {
+      "x": 40.0,
+      "y": 20.0,
+      "z": 5.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 2199.999944423326
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 3.999999989900971
+  }
+}

--- a/rust/kcl-lib/tests/named_views_hide_extrude/physical_properties.snap
+++ b/rust/kcl-lib/tests/named_views_hide_extrude/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties named_views_hide_extrude.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 15.0,
+      "y": 5.0,
+      "z": 5.0
+    },
+    "dimensions": {
+      "x": 30.0,
+      "y": 10.0,
+      "z": 10.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 599.9999848427251
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.999999883788405
+  }
+}

--- a/rust/kcl-lib/tests/named_views_hide_extrude_v1/physical_properties.snap
+++ b/rust/kcl-lib/tests/named_views_hide_extrude_v1/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties named_views_hide_extrude_v1.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 15.0,
+      "y": 5.0,
+      "z": 5.0
+    },
+    "dimensions": {
+      "x": 32.0,
+      "y": 12.0,
+      "z": 10.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 441.4213399286382
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.4999999418942025
+  }
+}

--- a/rust/kcl-lib/tests/named_views_hide_gdt/physical_properties.snap
+++ b/rust/kcl-lib/tests/named_views_hide_gdt/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties named_views_hide_gdt.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 2.5,
+      "y": 2.5,
+      "z": 2.5
+    },
+    "dimensions": {
+      "x": 5.0,
+      "y": 5.0,
+      "z": 5.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 149.99999621068127
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.12499999968440534
+  }
+}

--- a/rust/kcl-lib/tests/named_views_hide_helix/physical_properties.snap
+++ b/rust/kcl-lib/tests/named_views_hide_helix/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties named_views_hide_helix.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 10.0,
+      "y": 0.0,
+      "z": 10.0
+    },
+    "dimensions": {
+      "x": 50.0,
+      "y": 30.0,
+      "z": 20.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 599.9999848427251
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.9999998458927924
+  }
+}

--- a/rust/kcl-lib/tests/named_views_hide_imported/physical_properties.snap
+++ b/rust/kcl-lib/tests/named_views_hide_imported/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties named_views_hide_imported.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 749.5,
+      "y": 500.5,
+      "z": -0.5
+    },
+    "dimensions": {
+      "x": 2501.0,
+      "y": 1001.0,
+      "z": 1001.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 1500000.0
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 125000.0
+  }
+}

--- a/rust/kcl-lib/tests/named_views_hide_loft/physical_properties.snap
+++ b/rust/kcl-lib/tests/named_views_hide_loft/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties named_views_hide_loft.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 6.0
+    },
+    "dimensions": {
+      "x": 100.0,
+      "y": 100.0,
+      "z": 12.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 599.9999848427251
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.999999883788405
+  }
+}

--- a/rust/kcl-lib/tests/named_views_hide_pattern/physical_properties.snap
+++ b/rust/kcl-lib/tests/named_views_hide_pattern/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties named_views_hide_pattern.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 17.5,
+      "y": 20.0,
+      "z": 5.0
+    },
+    "dimensions": {
+      "x": 35.0,
+      "y": 40.0,
+      "z": 10.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 599.9999848427251
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 1.0000000732664678
+  }
+}

--- a/rust/kcl-lib/tests/named_views_hide_plane/physical_properties.snap
+++ b/rust/kcl-lib/tests/named_views_hide_plane/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties named_views_hide_plane.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 20.0
+    },
+    "dimensions": {
+      "x": 100.0,
+      "y": 100.0,
+      "z": 40.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 599.9999848427251
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.999999883788405
+  }
+}

--- a/rust/kcl-lib/tests/named_views_hide_revolve/physical_properties.snap
+++ b/rust/kcl-lib/tests/named_views_hide_revolve/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties named_views_hide_revolve.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 1.5
+    },
+    "dimensions": {
+      "x": 46.0,
+      "y": 46.0,
+      "z": 3.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 1620.6549308890317
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 1.2153079775127178
+  }
+}

--- a/rust/kcl-lib/tests/named_views_hide_sweep/physical_properties.snap
+++ b/rust/kcl-lib/tests/named_views_hide_sweep/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties named_views_hide_sweep.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 13.5,
+      "y": 6.0,
+      "z": 7.5
+    },
+    "dimensions": {
+      "x": 33.0,
+      "y": 18.0,
+      "z": 15.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 599.9999848427251
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.999999883788405
+  }
+}

--- a/rust/kcl-lib/tests/named_views_hide_sweep_v1/physical_properties.snap
+++ b/rust/kcl-lib/tests/named_views_hide_sweep_v1/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties named_views_hide_sweep_v1.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 14.0,
+      "y": 3.999999999999999,
+      "z": 7.5
+    },
+    "dimensions": {
+      "x": 34.0,
+      "y": 14.000000000000002,
+      "z": 15.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 441.4213399286382
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.4999999418942025
+  }
+}

--- a/rust/kcl-lib/tests/neg_xz_plane/physical_properties.snap
+++ b/rust/kcl-lib/tests/neg_xz_plane/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties neg_xz_plane.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -50.0,
+      "y": 6.0,
+      "z": 50.0
+    },
+    "dimensions": {
+      "x": 120.0,
+      "y": 12.0,
+      "z": 120.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 14097.05716650933
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 60.00000212225132
+  }
+}

--- a/rust/kcl-lib/tests/nested_assembly/physical_properties.snap
+++ b/rust/kcl-lib/tests/nested_assembly/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties nested_assembly.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 40.0,
+      "y": 10.0,
+      "z": 40.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 2959.6069766384403
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 7.383068101067883
+  }
+}

--- a/rust/kcl-lib/tests/nested_main_kcl/physical_properties.snap
+++ b/rust/kcl-lib/tests/nested_main_kcl/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties nested_main_kcl.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 40.0,
+      "y": 10.0,
+      "z": 40.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 2959.6069766384403
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 7.383068101067883
+  }
+}

--- a/rust/kcl-lib/tests/nested_windows_main_kcl/physical_properties.snap
+++ b/rust/kcl-lib/tests/nested_windows_main_kcl/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties nested_windows_main_kcl.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 40.0,
+      "y": 10.0,
+      "z": 40.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 2959.6069766384403
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 7.383068101067883
+  }
+}

--- a/rust/kcl-lib/tests/out_of_band_sketches/physical_properties.snap
+++ b/rust/kcl-lib/tests/out_of_band_sketches/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties out_of_band_sketches.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 248.57000000000005,
+      "y": -129.6885,
+      "z": 44.66
+    },
+    "dimensions": {
+      "x": 546.4559999999999,
+      "y": 259.377,
+      "z": 467.232
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 462665.01338686794
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 2213.54285167763
+  }
+}

--- a/rust/kcl-lib/tests/parametric/physical_properties.snap
+++ b/rust/kcl-lib/tests/parametric/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties parametric.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 4.0,
+      "y": 2.5,
+      "z": 4.5
+    },
+    "dimensions": {
+      "x": 8.0,
+      "y": 5.0,
+      "z": 9.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 238.745590067424
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.02135515423754934
+  }
+}

--- a/rust/kcl-lib/tests/parametric_with_tan_arc/physical_properties.snap
+++ b/rust/kcl-lib/tests/parametric_with_tan_arc/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties parametric_with_tan_arc.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -4.861813613493316,
+      "y": 4.361813613493316,
+      "z": 5.5
+    },
+    "dimensions": {
+      "x": 11.66835267238396,
+      "y": 10.468352672383958,
+      "z": 11.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 413.6185392979996
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.07105244107426707
+  }
+}

--- a/rust/kcl-lib/tests/pattern_circular_in_module/physical_properties.snap
+++ b/rust/kcl-lib/tests/pattern_circular_in_module/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties pattern_circular_in_module.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": -0.5,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 60.0,
+      "y": 1.0,
+      "z": 60.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 175.99998318473808
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.03999999620418748
+  }
+}

--- a/rust/kcl-lib/tests/pattern_into_union/physical_properties.snap
+++ b/rust/kcl-lib/tests/pattern_into_union/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties pattern_into_union.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 5.7625,
+      "y": 1.6437007874015666,
+      "z": 0.675
+    },
+    "dimensions": {
+      "x": 11.525,
+      "y": 3.2874015748032184,
+      "z": 1.35
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 211.2944939863734
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.018006771176057534
+  }
+}

--- a/rust/kcl-lib/tests/pattern_linear_in_module/physical_properties.snap
+++ b/rust/kcl-lib/tests/pattern_linear_in_module/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties pattern_linear_in_module.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 12.0,
+      "y": -0.5,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 26.4,
+      "y": 1.0,
+      "z": 2.4
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 175.55443610800526
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.04383244315049837
+  }
+}

--- a/rust/kcl-lib/tests/pentagon_fillet_sugar/physical_properties.snap
+++ b/rust/kcl-lib/tests/pentagon_fillet_sugar/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties pentagon_fillet_sugar.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.00000000000011368683772161605,
+      "y": 216.5063509461097,
+      "z": 100.0
+    },
+    "dimensions": {
+      "x": 600.0,
+      "y": 519.6152422706632,
+      "z": 200.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 612681.5935998593
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 25665.854456293386
+  }
+}

--- a/rust/kcl-lib/tests/plane_of/physical_properties.snap
+++ b/rust/kcl-lib/tests/plane_of/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties plane_of.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 1828.8
+    },
+    "dimensions": {
+      "x": 7315.2,
+      "y": 7315.2,
+      "z": 3657.6
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 45618773.46038818
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 17877345.72092692
+  }
+}

--- a/rust/kcl-lib/tests/plane_of_chamfer/physical_properties.snap
+++ b/rust/kcl-lib/tests/plane_of_chamfer/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties plane_of_chamfer.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.665,
+      "y": 0.5700000000000001,
+      "z": 1.0499999999999998
+    },
+    "dimensions": {
+      "x": 1.596,
+      "y": 1.368,
+      "z": 2.0999999999999996
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 7.670607087284509
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.0010456430906321164
+  }
+}

--- a/rust/kcl-lib/tests/poop_chute/physical_properties.snap
+++ b/rust/kcl-lib/tests/poop_chute/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties poop_chute.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 2.00000005,
+      "y": -1.0,
+      "z": 2.75
+    },
+    "dimensions": {
+      "x": 7.0000001,
+      "y": 2.4000000000000004,
+      "z": 6.6
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 147.3834900458382
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.008012521814716133
+  }
+}

--- a/rust/kcl-lib/tests/radius_circle_native/physical_properties.snap
+++ b/rust/kcl-lib/tests/radius_circle_native/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties radius_circle_native.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 1.0
+    },
+    "dimensions": {
+      "x": 7.2,
+      "y": 7.2,
+      "z": 2.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 94.18156811424882
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.056491917841544614
+  }
+}

--- a/rust/kcl-lib/tests/regression_test_hide_flatten_consumed/physical_properties.snap
+++ b/rust/kcl-lib/tests/regression_test_hide_flatten_consumed/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties regression_test_hide_flatten_consumed.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 2.152614782083611,
+      "y": 2.7521973774374686,
+      "z": 0.5500000000000005
+    },
+    "dimensions": {
+      "x": 3.2452295641672215,
+      "y": 2.9043947548749376,
+      "z": 1.100000000000001
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 22.024155674316148
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.005323669139601442
+  }
+}

--- a/rust/kcl-lib/tests/revolve-colinear/physical_properties.snap
+++ b/rust/kcl-lib/tests/revolve-colinear/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties revolve-colinear.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 1.0
+    },
+    "dimensions": {
+      "x": 2.0,
+      "y": 2.0,
+      "z": 2.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 18.817428488672466
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.006261776411044713
+  }
+}

--- a/rust/kcl-lib/tests/revolve_about_edge/physical_properties.snap
+++ b/rust/kcl-lib/tests/revolve_about_edge/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties revolve_about_edge.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -42.5,
+      "y": 0.0,
+      "z": -17.5
+    },
+    "dimensions": {
+      "x": 35.0,
+      "y": 50.0,
+      "z": 35.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 3094.7582063562963
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 12.324201548804169
+  }
+}

--- a/rust/kcl-lib/tests/revolve_axis_edge_ref/physical_properties.snap
+++ b/rust/kcl-lib/tests/revolve_axis_edge_ref/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties revolve_axis_edge_ref.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -42.0,
+      "y": 0.0,
+      "z": -15.0
+    },
+    "dimensions": {
+      "x": 36.0,
+      "y": 50.0,
+      "z": 40.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 3704.7582509730505
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 12.574201851337875
+  }
+}

--- a/rust/kcl-lib/tests/revolve_on_edge_get_edge/physical_properties.snap
+++ b/rust/kcl-lib/tests/revolve_on_edge_get_edge/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties revolve_on_edge_get_edge.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 10.0,
+      "y": 5.0,
+      "z": 5.0
+    },
+    "dimensions": {
+      "x": 20.0,
+      "y": 10.0,
+      "z": 10.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 828.4789934691617
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 1.1570638331903638
+  }
+}

--- a/rust/kcl-lib/tests/revolve_on_face/physical_properties.snap
+++ b/rust/kcl-lib/tests/revolve_on_face/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties revolve_on_face.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 6.225005
+    },
+    "dimensions": {
+      "x": 10.7,
+      "y": 10.70002,
+      "z": 12.45001
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 150.72904673735232
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.13926827223629626
+  }
+}

--- a/rust/kcl-lib/tests/riddle_small/physical_properties.snap
+++ b/rust/kcl-lib/tests/riddle_small/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties riddle_small.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -25.5,
+      "y": -0.5,
+      "z": 33.5
+    },
+    "dimensions": {
+      "x": 1.0,
+      "y": 1.0,
+      "z": 1.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 6.0000088524247985
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.0010000307248958509
+  }
+}

--- a/rust/kcl-lib/tests/rolling_ball_chamfer_interacting_edges/physical_properties.snap
+++ b/rust/kcl-lib/tests/rolling_ball_chamfer_interacting_edges/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties rolling_ball_chamfer_interacting_edges.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": -0.0004999999999881766
+    },
+    "dimensions": {
+      "x": 22.860000000000007,
+      "y": 22.860000000000007,
+      "z": 304.80099999999993
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 23059.685991711376
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 82.78122748113977
+  }
+}

--- a/rust/kcl-lib/tests/rotate_after_fillet/physical_properties.snap
+++ b/rust/kcl-lib/tests/rotate_after_fillet/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties rotate_after_fillet.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": -0.9375,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 1.1256,
+      "y": 3.125,
+      "z": 1.1256
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 8.037265310567587
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.0007470739011167422
+  }
+}

--- a/rust/kcl-lib/tests/runtime_exit_in_pattern_transform/physical_properties.snap
+++ b/rust/kcl-lib/tests/runtime_exit_in_pattern_transform/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties runtime_exit_in_pattern_transform.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 2.0
+    },
+    "dimensions": {
+      "x": 33.94112549695428,
+      "y": 33.94112549695428,
+      "z": 4.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 1120.000553783029
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 1.6000010418792954
+  }
+}

--- a/rust/kcl-lib/tests/scale_after_fillet/physical_properties.snap
+++ b/rust/kcl-lib/tests/scale_after_fillet/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties scale_after_fillet.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": -0.9375,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 1.1256,
+      "y": 3.125,
+      "z": 1.1256
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 87.2587427435123
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.03366732910821893
+  }
+}

--- a/rust/kcl-lib/tests/sketch-on-chamfer-two-times-different-order/physical_properties.snap
+++ b/rust/kcl-lib/tests/sketch-on-chamfer-two-times-different-order/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties sketch-on-chamfer-two-times-different-order.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 224.8705963856297,
+      "y": -59.93179207768074,
+      "z": 208.57000000000016
+    },
+    "dimensions": {
+      "x": 298.1411927713791,
+      "y": 119.86358415538464,
+      "z": 217.2600000000029
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 211317.9990112428
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 5539.964282813041
+  }
+}

--- a/rust/kcl-lib/tests/sketch-on-chamfer-two-times/physical_properties.snap
+++ b/rust/kcl-lib/tests/sketch-on-chamfer-two-times/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties sketch-on-chamfer-two-times.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 224.8705963856297,
+      "y": -59.93179207768074,
+      "z": 208.57000000000016
+    },
+    "dimensions": {
+      "x": 298.1411927713791,
+      "y": 119.86358415538464,
+      "z": 217.2600000000029
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 211317.9990112428
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 5539.964282813041
+  }
+}

--- a/rust/kcl-lib/tests/sketch_block_arc_direction_cw/physical_properties.snap
+++ b/rust/kcl-lib/tests/sketch_block_arc_direction_cw/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties sketch_block_arc_direction_cw.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.0000000000032223113066720543,
+      "y": 6.03553390578853,
+      "z": 1.0
+    },
+    "dimensions": {
+      "x": 20.0181436545993,
+      "y": 14.485281373836813,
+      "z": 2.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 371.8577801734568
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.28524129669360576
+  }
+}

--- a/rust/kcl-lib/tests/sketch_block_circle_constants/physical_properties.snap
+++ b/rust/kcl-lib/tests/sketch_block_circle_constants/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties sketch_block_circle_constants.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 3.999999998800001,
+      "y": 0.0,
+      "z": 1.0
+    },
+    "dimensions": {
+      "x": 15.1999999908,
+      "y": 7.1999999952,
+      "z": 2.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 188.36313606779288
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.11298382812460991
+  }
+}

--- a/rust/kcl-lib/tests/sketch_block_get_common_edge_fillet/physical_properties.snap
+++ b/rust/kcl-lib/tests/sketch_block_get_common_edge_fillet/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties sketch_block_get_common_edge_fillet.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 50.0,
+      "y": 50.0,
+      "z": 50.0
+    },
+    "dimensions": {
+      "x": 100.0,
+      "y": 100.0,
+      "z": 100.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 58967.64453221693
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 991.365459564501
+  }
+}

--- a/rust/kcl-lib/tests/sketch_block_on_face/physical_properties.snap
+++ b/rust/kcl-lib/tests/sketch_block_on_face/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties sketch_block_on_face.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 1.0,
+      "y": 1.0,
+      "z": 1.0
+    },
+    "dimensions": {
+      "x": 2.0,
+      "y": 2.0,
+      "z": 2.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 24.00000266788993
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.008000001550101388
+  }
+}

--- a/rust/kcl-lib/tests/sketch_block_on_plane_of/physical_properties.snap
+++ b/rust/kcl-lib/tests/sketch_block_on_plane_of/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties sketch_block_on_plane_of.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 1.0,
+      "y": 1.0,
+      "z": 1.0
+    },
+    "dimensions": {
+      "x": 2.0,
+      "y": 2.0,
+      "z": 2.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 24.00000266788993
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.008000001550101388
+  }
+}

--- a/rust/kcl-lib/tests/sketch_in_object/physical_properties.snap
+++ b/rust/kcl-lib/tests/sketch_in_object/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties sketch_in_object.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.5,
+      "y": 0.5,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 1.0,
+      "y": 1.0,
+      "z": 20.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 84.00000569963595
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.02000000165480742
+  }
+}

--- a/rust/kcl-lib/tests/sketch_on_face/physical_properties.snap
+++ b/rust/kcl-lib/tests/sketch_on_face/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties sketch_on_face.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 21.18,
+      "y": 12.519882338946037,
+      "z": 5.0
+    },
+    "dimensions": {
+      "x": 44.831999999999994,
+      "y": 47.671764677892064,
+      "z": 10.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 2521.2187774741324
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 4.374961586487795
+  }
+}

--- a/rust/kcl-lib/tests/sketch_on_face_after_fillets_referencing_face/physical_properties.snap
+++ b/rust/kcl-lib/tests/sketch_on_face_after_fillets_referencing_face/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties sketch_on_face_after_fillets_referencing_face.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -4.0,
+      "y": 8.0,
+      "z": 3.0
+    },
+    "dimensions": {
+      "x": 8.0,
+      "y": 16.0,
+      "z": 6.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 252.75688288939335
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.06393164904069937
+  }
+}

--- a/rust/kcl-lib/tests/sketch_on_face_circle_tagged/physical_properties.snap
+++ b/rust/kcl-lib/tests/sketch_on_face_circle_tagged/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties sketch_on_face_circle_tagged.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 7.0,
+      "y": 7.0,
+      "z": 12.5
+    },
+    "dimensions": {
+      "x": 26.0,
+      "y": 26.0,
+      "z": 25.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 2713.843946959393
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 8.392068705740755
+  }
+}

--- a/rust/kcl-lib/tests/sketch_on_face_end/physical_properties.snap
+++ b/rust/kcl-lib/tests/sketch_on_face_end/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties sketch_on_face_end.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 10.0,
+      "y": 10.0,
+      "z": 12.5
+    },
+    "dimensions": {
+      "x": 20.0,
+      "y": 20.0,
+      "z": 25.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 2799.999958369881
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 8.50000014906982
+  }
+}

--- a/rust/kcl-lib/tests/sketch_on_face_end_negative_extrude/physical_properties.snap
+++ b/rust/kcl-lib/tests/sketch_on_face_end_negative_extrude/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties sketch_on_face_end_negative_extrude.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 10.0,
+      "y": 10.0,
+      "z": 10.0
+    },
+    "dimensions": {
+      "x": 20.0,
+      "y": 20.0,
+      "z": 20.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 2800.039903377183
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 8.500099947165532
+  }
+}

--- a/rust/kcl-lib/tests/sketch_on_face_index/physical_properties.snap
+++ b/rust/kcl-lib/tests/sketch_on_face_index/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties sketch_on_face_index.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 0.7
+    },
+    "dimensions": {
+      "x": 2.4,
+      "y": 2.4,
+      "z": 1.4
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 14.912335707576926
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.002527973646035538
+  }
+}

--- a/rust/kcl-lib/tests/sketch_on_face_loft_subtract/physical_properties.snap
+++ b/rust/kcl-lib/tests/sketch_on_face_loft_subtract/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties sketch_on_face_loft_subtract.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 1.075
+    },
+    "dimensions": {
+      "x": 100.0,
+      "y": 100.0,
+      "z": 2.15
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 351.4051779234251
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.09916555450869188
+  }
+}

--- a/rust/kcl-lib/tests/sketch_on_face_normal/physical_properties.snap
+++ b/rust/kcl-lib/tests/sketch_on_face_normal/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties sketch_on_face_normal.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": -0.25,
+      "z": 4.75
+    },
+    "dimensions": {
+      "x": 10.0,
+      "y": 10.5,
+      "z": 10.5
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 599.9999848427251
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.9999999974752428
+  }
+}

--- a/rust/kcl-lib/tests/sketch_on_face_normal_inches/physical_properties.snap
+++ b/rust/kcl-lib/tests/sketch_on_face_normal_inches/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties sketch_on_face_normal_inches.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": -6.349999999999994,
+      "z": 120.65
+    },
+    "dimensions": {
+      "x": 254.0,
+      "y": 266.7,
+      "z": 266.7
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 387096.00269794464
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 16387.06400990486
+  }
+}

--- a/rust/kcl-lib/tests/sketch_on_face_of_region_extrude_one_to_many/physical_properties.snap
+++ b/rust/kcl-lib/tests/sketch_on_face_of_region_extrude_one_to_many/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties sketch_on_face_of_region_extrude_one_to_many.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 15.159242590597383,
+      "y": 9.300843305321054,
+      "z": 1.0
+    },
+    "dimensions": {
+      "x": 41.34117116840347,
+      "y": 22.60168661064211,
+      "z": 2.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 980.058555882124
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.8086154511255383
+  }
+}

--- a/rust/kcl-lib/tests/sketch_on_face_of_region_extrude_one_to_one/physical_properties.snap
+++ b/rust/kcl-lib/tests/sketch_on_face_of_region_extrude_one_to_one/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties sketch_on_face_of_region_extrude_one_to_one.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 1.5866666937915466,
+      "y": 1.2900460130395055,
+      "z": 1.0
+    },
+    "dimensions": {
+      "x": 4.338513915285771,
+      "y": 7.933310307474775,
+      "z": 2.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 45.787231861993405
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.01640208954420408
+  }
+}

--- a/rust/kcl-lib/tests/sketch_on_face_start/physical_properties.snap
+++ b/rust/kcl-lib/tests/sketch_on_face_start/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties sketch_on_face_start.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 5.0,
+      "y": 10.0,
+      "z": 7.5
+    },
+    "dimensions": {
+      "x": 30.0,
+      "y": 20.0,
+      "z": 25.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 2799.9999292660505
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 8.499999978539563
+  }
+}

--- a/rust/kcl-lib/tests/sketch_on_face_union/physical_properties.snap
+++ b/rust/kcl-lib/tests/sketch_on_face_union/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties sketch_on_face_union.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 25.4,
+      "y": 0.0,
+      "z": -51.1009209344802
+    },
+    "dimensions": {
+      "x": 50.8,
+      "y": 3657.6,
+      "z": 2336.1981581310392
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 2831540.5481189373
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 46232.46998630748
+  }
+}

--- a/rust/kcl-lib/tests/solid_edge_cut_using_edge_ref_csg/physical_properties.snap
+++ b/rust/kcl-lib/tests/solid_edge_cut_using_edge_ref_csg/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties solid_edge_cut_using_edge_ref_csg.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 7.15,
+      "y": 5.000000000000025,
+      "z": 4.00000001434574
+    },
+    "dimensions": {
+      "x": 25.7,
+      "y": 12.00000000000004,
+      "z": 8.00000002869148
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 933.7780225967816
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 1.6434166763267903
+  }
+}

--- a/rust/kcl-lib/tests/spheres/physical_properties.snap
+++ b/rust/kcl-lib/tests/spheres/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties spheres.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 2.5,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 10.0,
+      "y": 15.0,
+      "z": 10.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 627.3823926905563
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 1.0440629504006371
+  }
+}

--- a/rust/kcl-lib/tests/ssi_pattern/physical_properties.snap
+++ b/rust/kcl-lib/tests/ssi_pattern/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties ssi_pattern.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 8.024999999999997,
+      "y": -25.0,
+      "z": 1.1750000000000007
+    },
+    "dimensions": {
+      "x": 29.699999999999992,
+      "y": 50.0,
+      "z": 32.24400000000001
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 8696.771696117266
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 14.997458586044528
+  }
+}

--- a/rust/kcl-lib/tests/subtract_cylinder_from_cube/physical_properties.snap
+++ b/rust/kcl-lib/tests/subtract_cylinder_from_cube/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties subtract_cylinder_from_cube.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 2.0,
+      "y": 1.59999999999998,
+      "z": 5.193000000000001
+    },
+    "dimensions": {
+      "x": 20.0,
+      "y": 20.80000000000004,
+      "z": 10.386000000000005
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 1676.6956723340832
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 3.900691117793749
+  }
+}

--- a/rust/kcl-lib/tests/subtract_doesnt_need_brackets/physical_properties.snap
+++ b/rust/kcl-lib/tests/subtract_doesnt_need_brackets/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties subtract_doesnt_need_brackets.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.4000000000000022,
+      "y": 0.0,
+      "z": 5.45
+    },
+    "dimensions": {
+      "x": 20.800000000000004,
+      "y": 20.0,
+      "z": 10.9
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 1743.9999380712834
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 3.279999908419503
+  }
+}

--- a/rust/kcl-lib/tests/subtract_regression00/physical_properties.snap
+++ b/rust/kcl-lib/tests/subtract_regression00/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties subtract_regression00.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 25.0
+    },
+    "dimensions": {
+      "x": 100.0,
+      "y": 100.0,
+      "z": 60.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 17945.24379329232
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 100.49572121791546
+  }
+}

--- a/rust/kcl-lib/tests/subtract_regression01/physical_properties.snap
+++ b/rust/kcl-lib/tests/subtract_regression01/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties subtract_regression01.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 1.7410128797943545,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 100.0,
+      "y": 39.961958208478435,
+      "z": 100.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 3019.895088954172
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 2.7494269280101125
+  }
+}

--- a/rust/kcl-lib/tests/subtract_regression02/physical_properties.snap
+++ b/rust/kcl-lib/tests/subtract_regression02/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties subtract_regression02.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 45.71999999999999,
+      "y": 45.71999999999999,
+      "z": 33.274
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 5769.972619209085
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 13.938330620207514
+  }
+}

--- a/rust/kcl-lib/tests/subtract_regression03/physical_properties.snap
+++ b/rust/kcl-lib/tests/subtract_regression03/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties subtract_regression03.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.000025148909742256365,
+      "y": 0.018408231751578796,
+      "z": -0.0000000000421835899544476
+    },
+    "dimensions": {
+      "x": 37.88281442784543,
+      "y": 17.588222138383543,
+      "z": 3.0175200001047173
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 471.59107575589496
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.27994557978867907
+  }
+}

--- a/rust/kcl-lib/tests/subtract_regression04/physical_properties.snap
+++ b/rust/kcl-lib/tests/subtract_regression04/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties subtract_regression04.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 0.000000000000003552713678800501
+    },
+    "dimensions": {
+      "x": 25.4,
+      "y": 76.19999999999999,
+      "z": 26.194038661278697
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 10997.994027137636
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 16.55971151292198
+  }
+}

--- a/rust/kcl-lib/tests/subtract_regression05/physical_properties.snap
+++ b/rust/kcl-lib/tests/subtract_regression05/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties subtract_regression05.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 56.40545883830833,
+      "y": 26.10794955960509,
+      "z": 0.0000000000012576606422953773
+    },
+    "dimensions": {
+      "x": 112.81091767661664,
+      "y": 112.88410088078984,
+      "z": 64.2726012576482
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 50112.63668207988
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 148.27745175356617
+  }
+}

--- a/rust/kcl-lib/tests/subtract_regression06/physical_properties.snap
+++ b/rust/kcl-lib/tests/subtract_regression06/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties subtract_regression06.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.04254417868401106,
+      "y": 22.979327246400416,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 86.26637227632915,
+      "y": 135.349614608639,
+      "z": 25.4
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 17685.914986032003
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 24.342701060516465
+  }
+}

--- a/rust/kcl-lib/tests/subtract_regression07/physical_properties.snap
+++ b/rust/kcl-lib/tests/subtract_regression07/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties subtract_regression07.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 0.7937500000000002
+    },
+    "dimensions": {
+      "x": 100.0,
+      "y": 100.0,
+      "z": 11.1125
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 373.51755698911137
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.20728792374427885
+  }
+}

--- a/rust/kcl-lib/tests/subtract_regression08/physical_properties.snap
+++ b/rust/kcl-lib/tests/subtract_regression08/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties subtract_regression08.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 59.37250000000001,
+      "y": 23.1775,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 118.74500000000002,
+      "y": 118.74500000000002,
+      "z": 72.39000000000001
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 49587.30882336226
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 150.6507442261551
+  }
+}

--- a/rust/kcl-lib/tests/subtract_regression09/physical_properties.snap
+++ b/rust/kcl-lib/tests/subtract_regression09/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties subtract_regression09.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.000000000000003552713678800501,
+      "y": 0.07710037257340474,
+      "z": -0.000000000000003552713678800501
+    },
+    "dimensions": {
+      "x": 59.94400000000001,
+      "y": 60.098200745146826,
+      "z": 7.200000000000024
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 6761.586445467316
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 16.2330765823467
+  }
+}

--- a/rust/kcl-lib/tests/subtract_regression10/physical_properties.snap
+++ b/rust/kcl-lib/tests/subtract_regression10/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties subtract_regression10.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 23.893200313112004,
+      "y": 88.49100730426946,
+      "z": 120.522209422153
+    },
+    "dimensions": {
+      "x": 159.06703400971315,
+      "y": 287.62175430457233,
+      "z": 329.85799090049073
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 107932.72337542837
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 466.22353556391784
+  }
+}

--- a/rust/kcl-lib/tests/subtract_regression11/physical_properties.snap
+++ b/rust/kcl-lib/tests/subtract_regression11/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties subtract_regression11.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.000000000004994227253973804,
+      "y": 0.0,
+      "z": 0.05000000000000071
+    },
+    "dimensions": {
+      "x": 7.200020412785775,
+      "y": 6.0,
+      "z": 40.1
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 805.0826628032137
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 1.1095951484851874
+  }
+}

--- a/rust/kcl-lib/tests/subtract_regression12/physical_properties.snap
+++ b/rust/kcl-lib/tests/subtract_regression12/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties subtract_regression12.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.49999999999997513,
+      "y": -1.0159999999999982,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 12.176000000000052,
+      "y": 27.43200000000001,
+      "z": 11.176000000000002
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 877.890708339768
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.7435905742629126
+  }
+}

--- a/rust/kcl-lib/tests/subtract_with_pattern/physical_properties.snap
+++ b/rust/kcl-lib/tests/subtract_with_pattern/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties subtract_with_pattern.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 14.039999999999996,
+      "y": 0.8599999999999994,
+      "z": 250.0
+    },
+    "dimensions": {
+      "x": 29.04,
+      "y": 27.216,
+      "z": 500.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 51995.95107291089
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 237.69181381568436
+  }
+}

--- a/rust/kcl-lib/tests/subtract_with_pattern_cut_thru/physical_properties.snap
+++ b/rust/kcl-lib/tests/subtract_with_pattern_cut_thru/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties subtract_with_pattern_cut_thru.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 14.05707214165922,
+      "y": 0.8599999999999959,
+      "z": 250.0
+    },
+    "dimensions": {
+      "x": 29.07414428331844,
+      "y": 27.21600000000006,
+      "z": 500.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 26856.169857637724
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 112.83961248883163
+  }
+}

--- a/rust/kcl-lib/tests/surface_extrude_edge_bidirectional/physical_properties.snap
+++ b/rust/kcl-lib/tests/surface_extrude_edge_bidirectional/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties surface_extrude_edge_bidirectional.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.5129318397204008,
+      "y": -0.0509982826661286,
+      "z": 2.5
+    },
+    "dimensions": {
+      "x": 5.164495600268674,
+      "y": 5.880952178243334,
+      "z": 5.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 115.16653489707096
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.02474866904004595
+  }
+}

--- a/rust/kcl-lib/tests/surface_extrude_edge_direction/physical_properties.snap
+++ b/rust/kcl-lib/tests/surface_extrude_edge_direction/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties surface_extrude_edge_direction.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.5129318397204008,
+      "y": -0.0509982826661286,
+      "z": 2.5
+    },
+    "dimensions": {
+      "x": 5.164495600268674,
+      "y": 5.880952178243334,
+      "z": 5.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 98.40990810516814
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.08882880579245504
+  }
+}

--- a/rust/kcl-lib/tests/surface_extrude_edge_from_solid/physical_properties.snap
+++ b/rust/kcl-lib/tests/surface_extrude_edge_from_solid/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties surface_extrude_edge_from_solid.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.5129318397204008,
+      "y": -0.0509982826661286,
+      "z": 2.5
+    },
+    "dimensions": {
+      "x": 6.197394720322409,
+      "y": 7.057142613892,
+      "z": 5.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 133.729672953109
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.05885994051417024
+  }
+}

--- a/rust/kcl-lib/tests/surface_extrude_edge_from_surface/physical_properties.snap
+++ b/rust/kcl-lib/tests/surface_extrude_edge_from_surface/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties surface_extrude_edge_from_surface.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.5129318397204008,
+      "y": -0.0509982826661286,
+      "z": 2.5
+    },
+    "dimensions": {
+      "x": 5.164495600268674,
+      "y": 5.880952178243334,
+      "z": 5.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 102.5054473302589
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.00491308460581763
+  }
+}

--- a/rust/kcl-lib/tests/surface_extrude_edge_specifier_direction/physical_properties.snap
+++ b/rust/kcl-lib/tests/surface_extrude_edge_specifier_direction/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties surface_extrude_edge_specifier_direction.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.5129318397204008,
+      "y": -0.0509982826661286,
+      "z": 2.5
+    },
+    "dimensions": {
+      "x": 6.197394720322409,
+      "y": 7.057142613892,
+      "z": 5.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 172.45337166116315
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.07806036043482105
+  }
+}

--- a/rust/kcl-lib/tests/surface_extrude_edge_specifier_input/physical_properties.snap
+++ b/rust/kcl-lib/tests/surface_extrude_edge_specifier_input/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties surface_extrude_edge_specifier_input.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.5129318397204008,
+      "y": -0.0509982826661286,
+      "z": 2.5
+    },
+    "dimensions": {
+      "x": 6.197394720322409,
+      "y": 7.057142613892,
+      "z": 5.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 133.729672953109
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.05885994051417024
+  }
+}

--- a/rust/kcl-lib/tests/surface_extrude_edge_symmetric/physical_properties.snap
+++ b/rust/kcl-lib/tests/surface_extrude_edge_symmetric/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties surface_extrude_edge_symmetric.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.5129318397204008,
+      "y": -0.0509982826661286,
+      "z": 2.5
+    },
+    "dimensions": {
+      "x": 5.164495600268674,
+      "y": 5.880952178243334,
+      "z": 5.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 102.5054473302589
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.03648829223953006
+  }
+}

--- a/rust/kcl-lib/tests/sweep_mirror/physical_properties.snap
+++ b/rust/kcl-lib/tests/sweep_mirror/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties sweep_mirror.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -0.0616197696612063,
+      "y": 2.2344176542023524,
+      "z": 2.745615228095534
+    },
+    "dimensions": {
+      "x": 1.4434465090579829,
+      "y": 6.263897515979254,
+      "z": 5.491230456191068
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 12.513526632673688
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.0007606977050581923
+  }
+}

--- a/rust/kcl-lib/tests/tag_inner_face/physical_properties.snap
+++ b/rust/kcl-lib/tests/tag_inner_face/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties tag_inner_face.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 29.464,
+      "y": -25.4,
+      "z": 13.462000000000003
+    },
+    "dimensions": {
+      "x": 131.67360000000002,
+      "y": 50.8,
+      "z": 103.02239999999998
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 32752.052531577647
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 148.85353281594385
+  }
+}

--- a/rust/kcl-lib/tests/tangential_arc/physical_properties.snap
+++ b/rust/kcl-lib/tests/tangential_arc/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties tangential_arc.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": -2.5,
+      "y": 7.5,
+      "z": 5.0
+    },
+    "dimensions": {
+      "x": 6.0,
+      "y": 18.0,
+      "z": 10.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 400.89995022185576
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.3212707135509992
+  }
+}

--- a/rust/kcl-lib/tests/translate_after_fillet/physical_properties.snap
+++ b/rust/kcl-lib/tests/translate_after_fillet/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties translate_after_fillet.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": -0.9375,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 1.1256,
+      "y": 3.125,
+      "z": 1.1256
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 8.727044207412076
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.0010476170424500904
+  }
+}

--- a/rust/kcl-lib/tests/truss_bridge/physical_properties.snap
+++ b/rust/kcl-lib/tests/truss_bridge/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties truss_bridge.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 2698.1016675108567,
+      "y": 826.36995,
+      "z": 843.28
+    },
+    "dimensions": {
+      "x": 5481.395068562997,
+      "y": 1720.3801,
+      "z": 1788.16
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 9068405.9541677
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 31725.626460937932
+  }
+}

--- a/rust/kcl-lib/tests/union_cubes/physical_properties.snap
+++ b/rust/kcl-lib/tests/union_cubes/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties union_cubes.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 1.0,
+      "y": 0.0,
+      "z": 10.0
+    },
+    "dimensions": {
+      "x": 22.0,
+      "y": 20.0,
+      "z": 20.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 2479.9999519018456
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 8.199999914045483
+  }
+}

--- a/rust/kcl-lib/tests/union_self/physical_properties.snap
+++ b/rust/kcl-lib/tests/union_self/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties union_self.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 0.0
+    },
+    "dimensions": {
+      "x": 20001.0,
+      "y": 20001.0,
+      "z": 1.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 2399.9996919883415
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 7.99999922188969
+  }
+}

--- a/rust/kcl-lib/tests/user_reported_union_2_bug/physical_properties.snap
+++ b/rust/kcl-lib/tests/user_reported_union_2_bug/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties user_reported_union_2_bug.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 0.0,
+      "y": 10.95477464690093,
+      "z": 4.066652524174749
+    },
+    "dimensions": {
+      "x": 84.0,
+      "y": 109.90954929380186,
+      "z": 8.761336523264823
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 6122.311558856452
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 11.596860534942207
+  }
+}

--- a/rust/kcl-lib/tests/xz_plane/physical_properties.snap
+++ b/rust/kcl-lib/tests/xz_plane/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties xz_plane.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 50.0,
+      "y": -6.0,
+      "z": 50.0
+    },
+    "dimensions": {
+      "x": 120.0,
+      "y": 12.0,
+      "z": 120.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 14097.05716650933
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 60.00000212225132
+  }
+}

--- a/rust/kcl-lib/tests/zds_extrude_fillet_top_edge/physical_properties.snap
+++ b/rust/kcl-lib/tests/zds_extrude_fillet_top_edge/physical_properties.snap
@@ -1,0 +1,29 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Physical properties zds_extrude_fillet_top_edge.kcl
+---
+{
+  "bounding_box": {
+    "center": {
+      "x": 2.03,
+      "y": 2.725,
+      "z": 0.5
+    },
+    "dimensions": {
+      "x": 3.0,
+      "y": 2.8500000000000005,
+      "z": 1.0
+    },
+    "unit": "mm"
+  },
+  "surface_area": {
+    "unit": "mm2",
+    "value": 28.04731658083426
+  },
+  "weight": {
+    "material_density": 1000.0,
+    "material_density_unit": "kg:m3",
+    "unit": "g",
+    "value": 0.008388102601975903
+  }
+}


### PR DESCRIPTION
## Summary

- snapshot model bounding boxes in millimeters, surface areas in square millimeters, and weights in grams after successful simulation tests
- use a deterministic material density of 1000 kg/m3
- allow non-physical or prohibitively expensive tests to opt out
- exclude Mike Stress Test and the cassette, T-slot frame, and T-slot shelf assemblies from physical measurements
- add 292 physical_properties.snap baselines