### PR TITLE
Restore editor focus after command-bar formatting

### DIFF
--- a/src/registry/extensions/commands/appCommands.ts
+++ b/src/registry/extensions/commands/appCommands.ts
@@ -221,7 +221,13 @@ export const appCommands: readonly Command[] = [
     id: APP_COMMAND_IDS.editor.format,
     displayName: 'Format code',
     scopes: FILE_AND_CODE_EDITOR_COMMAND_SCOPES,
-    onSubmit: (input) => getKclManager(input)?.format().catch(reportRejection),
+    onSubmit: (input) => {
+      const kclManager = getKclManager(input)
+      return kclManager
+        ?.format()
+        .then(() => kclManager.editorView.focus())
+        .catch(reportRejection)
+    },
   }),
   createAppCommand({
     id: APP_COMMAND_IDS.editor.convertToVariable,

--- a/src/registry/extensions/commands/index.spec.ts
+++ b/src/registry/extensions/commands/index.spec.ts
@@ -586,4 +586,23 @@ describe('commands extension', () => {
       },
     ])
   })
+
+  it('refocuses the editor after formatting from the command palette', async () => {
+    const format = vi.fn().mockResolvedValue(undefined)
+    const focus = vi.fn()
+    const kclManager = {
+      format,
+      editorView: { focus },
+    } as unknown as KclManager
+    const command = appCommands.find(
+      (candidate) => candidate.id === APP_COMMAND_IDS.editor.format
+    )
+
+    await command?.onSubmit({
+      context: { kclManager } as CommandBarContext,
+    })
+
+    expect(format).toHaveBeenCalledOnce()
+    expect(focus).toHaveBeenCalledOnce()
+  })
 })


### PR DESCRIPTION
After command-bar formatting completes, return focus to the KCL editor while preserving existing rejection reporting.

Fixes #3142.

Validation: Wasm build, all 27 command-extension integration tests, formatting, and patch hygiene.