### PR TITLE
Restore editor focus after LSP rename

### DIFF
--- a/packages/codemirror-lsp-client/src/plugin/lsp.ts
+++ b/packages/codemirror-lsp-client/src/plugin/lsp.ts
@@ -616,6 +616,7 @@ export class LanguageServerPlugin implements PluginValue {
           )
         } finally {
           popup.remove()
+          view.focus()
         }
       }
 


### PR DESCRIPTION
## Summary

- refocus the CodeMirror editor after the LSP rename popup closes
- apply the focus restoration on success, cancellation, and failure via the existing finally block

## Testing

- `npx biome check --formatter-enabled=true --linter-enabled=false --assist-enabled=false packages/codemirror-lsp-client/src/plugin/lsp.ts`
- `git diff --check`

Fixes #7245