### PR TITLE
Fix Namespace Rust cache ownership isolation

### DIFF
--- a/.github/ci-cd-scripts/verify-rust-cache-writable.sh
+++ b/.github/ci-cd-scripts/verify-rust-cache-writable.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+target_dir="${CARGO_TARGET_DIR:-rust/target}"
+mkdir -p "${target_dir}"
+
+probe="${target_dir}/.write-probe-${GITHUB_RUN_ID:-local}-${GITHUB_JOB:-local}-$$"
+trap 'rm -f "${probe}"' EXIT
+: > "${probe}"
+rm "${probe}"
+trap - EXIT
+
+shopt -s nullglob
+for cache_path in "${target_dir}" "${target_dir}"/*; do
+  if [[ -d "${cache_path}" && ! -w "${cache_path}" ]]; then
+    ls -ldn "${cache_path}"
+    echo "::error file=${cache_path}::Rust cache directory is not writable by uid $(id -u)"
+    exit 1
+  fi
+done
+
+for lock_file in "${target_dir}"/*/.cargo-lock "${target_dir}"/*/.cargo-*-lock; do
+  if [[ -f "${lock_file}" && ! -w "${lock_file}" ]]; then
+    ls -ldn "${lock_file}"
+    echo "::error file=${lock_file}::Rust cache lock is not writable by uid $(id -u)"
+    exit 1
+  fi
+done
+
+ls -ldn "${target_dir}"
+echo "Rust cache is writable by uid $(id -u), gid $(id -g): ${target_dir}"

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -11,7 +11,8 @@ permissions:
 
 jobs:
   build-wasm:
-    runs-on: namespace-profile-ubuntu-8-cores
+    # Keep host-user Cargo outputs separate from the root-run MUSL build.
+    runs-on: namespace-profile-ubuntu-8-cores;overrides.cache-tag=modeling-app-rust-host-v2
     steps:
       - uses: actions/checkout@v7.0.1
         with:
@@ -105,6 +106,10 @@ jobs:
             rust/target
             ~/.cargo/registry
             ~/.cargo/git
+
+      - name: Verify Rust cache is writable
+        if: ${{ steps.wasm.outputs.should-build-wasm == 'true' }}
+        run: .github/ci-cd-scripts/verify-rust-cache-writable.sh
 
       - name: Build Wasm
         if: ${{ steps.wasm.outputs.should-build-wasm == 'true' }}

--- a/.github/workflows/cargo-check.yml
+++ b/.github/workflows/cargo-check.yml
@@ -8,6 +8,7 @@ on:
       - '**/rust-toolchain.toml'
       - '**.rs'
       - .github/workflows/cargo-check.yml
+      - .github/ci-cd-scripts/verify-rust-cache-writable.sh
   pull_request:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -18,7 +19,8 @@ permissions:
 jobs:
   cargocheck:
     name: cargo check
-    runs-on: namespace-profile-ubuntu-8-cores
+    # Keep host-user Cargo outputs separate from the root-run MUSL build.
+    runs-on: namespace-profile-ubuntu-8-cores;overrides.cache-tag=modeling-app-rust-host-v2
     steps:
       - uses: actions/checkout@v7.0.1
       - name: Use correct Rust toolchain
@@ -50,6 +52,9 @@ jobs:
             rust/target
             ~/.cargo/registry
             ~/.cargo/git
+
+      - name: Verify Rust cache is writable
+        run: .github/ci-cd-scripts/verify-rust-cache-writable.sh
 
       - name: Run check
         run: |

--- a/.github/workflows/cargo-clippy.yml
+++ b/.github/workflows/cargo-clippy.yml
@@ -8,6 +8,7 @@ on:
       - '**/rust-toolchain.toml'
       - '**.rs'
       - .github/workflows/cargo-clippy.yml
+      - .github/ci-cd-scripts/verify-rust-cache-writable.sh
   pull_request:
     paths:
       - '**/Cargo.toml'
@@ -15,6 +16,7 @@ on:
       - '**/rust-toolchain.toml'
       - '**.rs'
       - .github/workflows/cargo-clippy.yml
+      - .github/ci-cd-scripts/verify-rust-cache-writable.sh
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -24,7 +26,8 @@ permissions:
 jobs:
   cargoclippy:
     name: cargo clippy
-    runs-on: namespace-profile-ubuntu-8-cores
+    # Keep host-user Cargo outputs separate from the root-run MUSL build.
+    runs-on: namespace-profile-ubuntu-8-cores;overrides.cache-tag=modeling-app-rust-host-v2
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: taiki-e/install-action@just
@@ -48,6 +51,9 @@ jobs:
             rust/target
             ~/.cargo/registry
             ~/.cargo/git
+
+      - name: Verify Rust cache is writable
+        run: .github/ci-cd-scripts/verify-rust-cache-writable.sh
 
       - name: Run clippy
         run: |

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -20,7 +20,8 @@ concurrency:
 jobs:
   build-test-artifacts:
     name: Build test artifacts
-    runs-on: namespace-profile-ubuntu-8-cores
+    # Keep host-user Cargo outputs separate from the root-run MUSL build.
+    runs-on: namespace-profile-ubuntu-8-cores;overrides.cache-tag=modeling-app-rust-host-v2
     steps:
       - uses: runs-on/action@v2.3.0
       - uses: actions/create-github-app-token@v3.2.0
@@ -65,6 +66,8 @@ jobs:
             rust/target
             ~/.cargo/registry
             ~/.cargo/git
+      - name: Verify Rust cache is writable
+        run: .github/ci-cd-scripts/verify-rust-cache-writable.sh
       - name: Fetch the base branch
         if: ${{ github.event_name == 'pull_request' }}
         env:

--- a/.github/workflows/kcl-language-server.yml
+++ b/.github/workflows/kcl-language-server.yml
@@ -10,6 +10,7 @@ on:
       - "rust/kcl-language-server/**"
       - "**.rs"
       - .github/workflows/kcl-language-server.yml
+      - .github/ci-cd-scripts/verify-rust-cache-writable.sh
     tags:
       - "kcl-*"
   pull_request:
@@ -20,6 +21,7 @@ on:
       - "rust/kcl-language-server/**"
       - "**.rs"
       - .github/workflows/kcl-language-server.yml
+      - .github/ci-cd-scripts/verify-rust-cache-writable.sh
   workflow_dispatch:
 permissions:
   contents: read
@@ -83,16 +85,16 @@ jobs:
             #- os: namespace-profile-windows-8-cores
             #target: aarch64-pc-windows-msvc
             #code-target: win32-arm64
-          - os: namespace-profile-ubuntu-8-cores
+          - os: namespace-profile-ubuntu-8-cores;overrides.cache-tag=modeling-app-rust-host-v2
             target: x86_64-unknown-linux-gnu
             code-target: linux-x64
             #- os: namespace-profile-ubuntu-8-cores
             #target: aarch64-unknown-linux-musl
             #code-target: linux-arm64
-          - os: namespace-profile-ubuntu-8-cores
+          - os: namespace-profile-ubuntu-8-cores;overrides.cache-tag=modeling-app-rust-host-v2
             target: aarch64-unknown-linux-gnu
             code-target: linux-arm64
-          - os: namespace-profile-ubuntu-8-cores
+          - os: namespace-profile-ubuntu-8-cores;overrides.cache-tag=modeling-app-rust-host-v2
             target: arm-unknown-linux-gnueabihf
             code-target: linux-armhf
           - os: namespace-profile-macos-6-cores
@@ -126,6 +128,9 @@ jobs:
             rust/target
             ~/.cargo/registry
             ~/.cargo/git
+      - name: Verify Rust cache is writable
+        if: runner.os == 'Linux'
+        run: .github/ci-cd-scripts/verify-rust-cache-writable.sh
       - name: Install Node.js
         uses: actions/setup-node@v7.0.0
         with:
@@ -203,7 +208,8 @@ jobs:
           path: ./rust/build
   build-release-x86_64-unknown-linux-musl:
     name: kcl-language-server build-release (x86_64-unknown-linux-musl)
-    runs-on: namespace-profile-ubuntu-8-cores
+    # Alpine runs as root, so it must not share Cargo outputs with host jobs.
+    runs-on: namespace-profile-ubuntu-8-cores;overrides.cache-tag=modeling-app-rust-musl-v2
     env:
       RA_TARGET: x86_64-unknown-linux-musl
       # For some reason `-crt-static` is not working for clang without lld
@@ -256,6 +262,8 @@ jobs:
             rust/target
             /github/home/.cargo/registry
             /github/home/.cargo/git
+      - name: Verify Rust cache is writable
+        run: .github/ci-cd-scripts/verify-rust-cache-writable.sh
       - name: build
         env:
           GITHUB_RUN_NUMBER: ${{ github.run_number }}


### PR DESCRIPTION
## Plain-English intent

Rust CI jobs should be able to reuse compiled output without occasionally inheriting files they cannot write. Normal Namespace runners execute as the `runner` user, while the Alpine language-server build executes as `root`. Those two ownership domains must not write to the same cached `rust/target` snapshot.

## What changed

- Give every Linux host job that caches `rust/target` the fresh cache identity `modeling-app-rust-host-v2`.
- Give the root-run Alpine/MUSL job the separate cache identity `modeling-app-rust-musl-v2`.
- Keep `rust/target`, Cargo registry, and Cargo git caching enabled.
- Check the mounted target directory and Cargo lock files before starting a build. On failure, report the numeric owner and the current UID instead of waiting for Cargo to fail later with an opaque `os error 13`.

Fresh identities also prevent existing wrong-owner snapshots from entering either repaired cache.

## Local validation

- Parsed all five modified workflow files as YAML.
- `bash -n .github/ci-cd-scripts/verify-rust-cache-writable.sh`
- Coverage audit: 6 `rust/target` mounts, 6 write checks, 7 Linux host runner entries on the host identity, and 1 Alpine runner entry on the MUSL identity.
- Positive control: the check accepts a writable empty target directory.
- Negative control: the check rejects a read-only `debug/.cargo-artifact-lock` and reports its numeric ownership.
- `git diff --check`

## Live validation

Fresh-cache PR runs:

- [`cargo test` run 33277150564](https://github.com/KittyCAD/modeling-app/actions/runs/33277150564): `Build test artifacts` passed, including the cache write check and `cargo nextest archive`.
- [`kcl-language-server` run 33277150528](https://github.com/KittyCAD/modeling-app/actions/runs/33277150528): all GNU, ARM, macOS, Windows, and Alpine/MUSL builds passed. Every executed Linux cache write check passed.
- [`cargo check` run 33277150686](https://github.com/KittyCAD/modeling-app/actions/runs/33277150686), [`cargo clippy` run 33277150527](https://github.com/KittyCAD/modeling-app/actions/runs/33277150527), and four invoked Wasm builds passed.

Populated-cache controls:

- Cargo Check and Clippy both passed again on run attempt 2; their write checks passed before compilation.
- [`cargo test` dispatch 33277444354](https://github.com/KittyCAD/modeling-app/actions/runs/33277444354): the second `Build test artifacts` job passed its write check and `cargo nextest archive`. The workflow was then canceled to avoid running unrelated downstream shards; the successful build job had already exited cleanly.
- [`kcl-language-server` dispatch 33277517205](https://github.com/KittyCAD/modeling-app/actions/runs/33277517205): the entire second workflow passed. Host GNU/ARM and root Alpine/MUSL write checks and builds all succeeded.

At the end of validation, GitHub reported no failed or pending checks on this PR.

Fixes #13274.
