### PR TITLE
Add mock sketch constraint reports

### DIFF
--- a/rust/kcl-python-bindings/files/sketch_constraint_import_main.kcl
+++ b/rust/kcl-python-bindings/files/sketch_constraint_import_main.kcl
@@ -1,0 +1,3 @@
+import importedSketch from "sketch_constraint_imported.kcl"
+
+sketchFromImport = importedSketch()

--- a/rust/kcl-python-bindings/files/sketch_constraint_imported.kcl
+++ b/rust/kcl-python-bindings/files/sketch_constraint_imported.kcl
@@ -1,0 +1,8 @@
+@settings(experimentalFeatures = allow)
+
+export fn importedSketch() {
+  result = sketch(on = XY) {
+    line1 = line(start = [var 1mm, var 2mm], end = [var 3mm, var 4mm])
+  }
+  return result
+}

--- a/rust/kcl-python-bindings/kcl.pyi
+++ b/rust/kcl-python-bindings/kcl.pyi
@@ -1374,14 +1374,16 @@ async def format_dir(dir: builtins.str) -> None:
     Format a whole directory of kcl code.
     """
 
-async def get_sketch_constraint_status(path: builtins.str) -> zooSketchConstraintReport:
+async def get_sketch_constraint_status(path: builtins.str, *, mock: builtins.bool = ...) -> zooSketchConstraintReport:
     r"""
-    Execute a kcl file and return a report of sketch constraint status.
+    Execute a kcl file and return a report of sketch constraint status. Set `mock` to true to solve sketches without
+    sending modeling commands to the engine.
     """
 
-async def get_sketch_constraint_status_code(code: builtins.str) -> zooSketchConstraintReport:
+async def get_sketch_constraint_status_code(code: builtins.str, *, mock: builtins.bool = ...) -> zooSketchConstraintReport:
     r"""
-    Execute kcl code and return a report of sketch constraint status.
+    Execute kcl code and return a report of sketch constraint status. Set `mock` to true to solve sketches without
+    sending modeling commands to the engine.
     """
 
 async def import_and_snapshot(filepaths: typing.Sequence[builtins.str], format: zooInputFormat3d, image_format: zooImageFormat, *, zoom: typing.Optional[builtins.bool] = None, highlight_edges: typing.Optional[builtins.bool] = None) -> builtins.list[builtins.int]: ...

--- a/rust/kcl-python-bindings/src/lib.rs
+++ b/rust/kcl-python-bindings/src/lib.rs
@@ -382,7 +382,7 @@ async fn execute_impl(input: KclInput, mock: bool) -> PyResult<ExecOutcome> {
     })
 }
 
-async fn sketch_constraint_report_impl(input: KclInput) -> PyResult<SketchConstraintReport> {
+async fn sketch_constraint_report_impl(input: KclInput, mock: bool) -> PyResult<SketchConstraintReport> {
     let (code, path, filename) = match input {
         KclInput::Path(input_path) => {
             let (code, path) = get_code_and_file_path(&input_path).await.map_err(to_py_exception)?;
@@ -400,7 +400,7 @@ async fn sketch_constraint_report_impl(input: KclInput) -> PyResult<SketchConstr
         }
     };
 
-    let (ctx, mut state) = new_context_state(path, false, None).await.map_err(to_py_exception)?;
+    let (ctx, mut state) = new_context_state(path, mock, None).await.map_err(to_py_exception)?;
     let result = match ctx.run(&program, &mut state).await {
         Ok((env_ref, _)) => {
             let outcome = state.into_exec_outcome(env_ref, &ctx).await.map_err(to_py_exception)?;
@@ -603,18 +603,20 @@ async fn mock_execute(path: String) -> PyResult<ExecOutcome> {
     spawn_py(async move { execute_impl(KclInput::Path(path), true).await }).await
 }
 
-/// Execute a kcl file and return a report of sketch constraint status.
+/// Execute a kcl file and return a report of sketch constraint status. Set `mock` to true to solve sketches without
+/// sending modeling commands to the engine.
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
-#[pyfunction]
-async fn get_sketch_constraint_status(path: String) -> PyResult<SketchConstraintReport> {
-    spawn_py(async move { sketch_constraint_report_impl(KclInput::Path(path)).await }).await
+#[pyfunction(signature = (path, *, mock=false))]
+async fn get_sketch_constraint_status(path: String, mock: bool) -> PyResult<SketchConstraintReport> {
+    spawn_py(async move { sketch_constraint_report_impl(KclInput::Path(path), mock).await }).await
 }
 
-/// Execute kcl code and return a report of sketch constraint status.
+/// Execute kcl code and return a report of sketch constraint status. Set `mock` to true to solve sketches without
+/// sending modeling commands to the engine.
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
-#[pyfunction]
-async fn get_sketch_constraint_status_code(code: String) -> PyResult<SketchConstraintReport> {
-    spawn_py(async move { sketch_constraint_report_impl(KclInput::Code(code)).await }).await
+#[pyfunction(signature = (code, *, mock=false))]
+async fn get_sketch_constraint_status_code(code: String, mock: bool) -> PyResult<SketchConstraintReport> {
+    spawn_py(async move { sketch_constraint_report_impl(KclInput::Code(code), mock).await }).await
 }
 
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]

--- a/rust/kcl-python-bindings/tests/tests.py
+++ b/rust/kcl-python-bindings/tests/tests.py
@@ -749,6 +749,39 @@ s1 = sketch(on = YZ) {
 extrude(missing_sketch, length = 5mm)
 """
 
+mock_csg_file = os.path.join(
+    kcl_dir, "e2e", "executor", "inputs", "repro_mock_subtract.kcl"
+)
+mock_import_file = os.path.join(files_dir, "sketch_constraint_import_main.kcl")
+mock_generated_faces_file = os.path.join(
+    kcl_dir,
+    "e2e",
+    "executor",
+    "inputs",
+    "boolean-setup-with-sketch-solve-on-faces.kcl",
+)
+mock_solved_point_reference_file = os.path.join(
+    tests_dir, "use_point_from_other_sketch", "input.kcl"
+)
+
+function_loop_condition_sketches_code = """
+@settings(experimentalFeatures = allow)
+
+fn makeSketch(@ignored) {
+  result = sketch(on = XY) {
+    line1 = line(start = [var 1mm, var 2mm], end = [var 3mm, var 4mm])
+  }
+  return result
+}
+
+fromLoop = map([0, 1], f = makeSketch)
+fromCondition = if true {
+  makeSketch(2)
+} else {
+  makeSketch(3)
+}
+"""
+
 parse_error_sketch_code = """
 @settings(experimentalFeatures = allow)
 
@@ -909,6 +942,91 @@ async def test_sketch_constraint_status_parse_error_returns_report():
     assert report.kcl_error.phase == "parse"
     assert "KCL Syntax error" in report.kcl_error.text
     assert "Unexpected token" in report.kcl_error.text
+
+
+@pytest.mark.asyncio
+async def test_sketch_constraint_status_mock_solves_without_engine():
+    report = await kcl.get_sketch_constraint_status_code(
+        fully_constrained_sketch_code, mock=True
+    )
+    assert report.total_sketches() == 1
+    assert len(report.fully_constrained) == 1
+    assert len(report.errors) == 0
+    assert report.is_complete is True
+    assert report.kcl_error is None
+
+
+@pytest.mark.asyncio
+async def test_sketch_constraint_status_mock_preserves_status_categories():
+    report = await kcl.get_sketch_constraint_status_code(
+        named_sketches_all_statuses_code, mock=True
+    )
+    assert report.total_sketches() == 3
+    assert report.fully_constrained[0].name == "fixedSketch"
+    assert report.under_constrained[0].name == "looseSketch"
+    assert report.over_constrained[0].name == "conflictSketch"
+    assert report.is_complete is True
+    assert report.kcl_error is None
+
+
+@pytest.mark.asyncio
+async def test_sketch_constraint_status_mock_completes_after_csg():
+    report = await kcl.get_sketch_constraint_status(mock_csg_file, mock=True)
+    assert report.total_sketches() == 3
+    assert len(report.errors) == 0
+    assert report.is_complete is True
+    assert report.kcl_error is None
+
+
+@pytest.mark.asyncio
+async def test_sketch_constraint_status_mock_returns_partial_status_after_error():
+    report = await kcl.get_sketch_constraint_status_code(
+        execution_error_after_sketch_code, mock=True
+    )
+    assert report.total_sketches() == 1
+    assert report.fully_constrained[0].name == "s1"
+    assert report.is_complete is False
+    assert report.kcl_error is not None
+    assert report.kcl_error.phase == "execution"
+    assert "missing_sketch" in report.kcl_error.text
+
+
+@pytest.mark.asyncio
+async def test_sketch_constraint_status_mock_handles_imported_function():
+    report = await kcl.get_sketch_constraint_status(mock_import_file, mock=True)
+    assert report.total_sketches() == 1
+    assert report.under_constrained[0].name == "result"
+    assert report.is_complete is True
+    assert report.kcl_error is None
+
+
+@pytest.mark.asyncio
+async def test_sketch_constraint_status_mock_handles_functions_loops_and_conditions():
+    report = await kcl.get_sketch_constraint_status_code(
+        function_loop_condition_sketches_code, mock=True
+    )
+    assert report.total_sketches() == 3
+    assert len(report.under_constrained) == 3
+    assert all(status.name == "result" for status in report.under_constrained)
+    assert report.is_complete is True
+    assert report.kcl_error is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("path", "expected_sketches"),
+    [
+        (mock_generated_faces_file, 6),
+        (mock_solved_point_reference_file, 2),
+    ],
+)
+async def test_sketch_constraint_status_mock_handles_geometry_dependencies(
+    path: str, expected_sketches: int
+):
+    report = await kcl.get_sketch_constraint_status(path, mock=True)
+    assert report.total_sketches() == expected_sketches
+    assert report.is_complete is True
+    assert report.kcl_error is None
 
 
 @requires_engine


### PR DESCRIPTION
Add an explicit keyword-only `mock` mode to both Python sketch-constraint report APIs while keeping real Engine execution as the default.

Closes #13390. Downstream adoption: KittyCAD/text-to-cad#4192.