### PR TITLE
Refocus editor after LSP symbol rename

### DIFF
--- a/packages/codemirror-lsp-client/src/plugin/lsp.ts
+++ b/packages/codemirror-lsp-client/src/plugin/lsp.ts
@@ -616,6 +616,7 @@ export class LanguageServerPlugin implements PluginValue {
           )
         } finally {
           popup.remove()
+          view.focus()
         }
       }
 


### PR DESCRIPTION
## Summary

- restore CodeMirror focus after a rename request completes
- preserve the existing rename success, error, and popup cleanup behavior

Fixes #7245.

## Testing

- `npm run build -w @kittycad/codemirror-lsp-client`
- Biome format check on the changed file