### PR TITLE
Fix Zookeeper deep-link query cleanup race

### DIFF
--- a/src/lib/zookeeper/components/ZookeeperConversationPane.spec.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPane.spec.tsx
@@ -1,6 +1,7 @@
 import { signal } from '@preact/signals-core'
-import { act, render, screen, waitFor } from '@testing-library/react'
-import { MemoryRouter, useLocation } from 'react-router-dom'
+import { CMD_GROUP_QUERY_PARAM, CMD_NAME_QUERY_PARAM } from '@src/lib/constants'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, useLocation, useSearchParams } from 'react-router-dom'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 const conversationRender = vi.hoisted(() => vi.fn())
@@ -211,6 +212,24 @@ const latestConversationProps = () => {
 const LocationProbe = () => {
   const location = useLocation()
   return <output data-testid="location-search">{location.search}</output>
+}
+
+const GenericCommandQueryConsumer = () => {
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        const nextSearchParams = new URLSearchParams(searchParams)
+        nextSearchParams.delete(CMD_NAME_QUERY_PARAM)
+        nextSearchParams.delete(CMD_GROUP_QUERY_PARAM)
+        setSearchParams(nextSearchParams)
+      }}
+    >
+      Consume generic command
+    </button>
+  )
 }
 
 beforeEach(() => {
@@ -475,5 +494,36 @@ describe('ZookeeperConversationPane', () => {
       )
     })
     expect(latestConversationProps().initialMlCopilotMode).toBe('user-mode')
+  })
+
+  test('waits for generic command params before consuming the URL prompt', async () => {
+    const fake = createFakeController({
+      actorContext: { conversation: completedConversation },
+    })
+    render(
+      <MemoryRouter
+        initialEntries={[
+          '/projects/cube?cmd=set-layout&groupId=application&zookeeper-prompt=make+a+gear',
+        ]}
+      >
+        <GenericCommandQueryConsumer />
+        <ZookeeperConversationPane {...createPaneProps(fake.controller)} />
+        <LocationProbe />
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(latestConversationProps().defaultPrompt).toBe('make a gear')
+      expect(screen.getByTestId('location-search')).toHaveTextContent(
+        'cmd=set-layout&groupId=application&zookeeper-prompt=make+a+gear'
+      )
+    })
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Consume generic command' })
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId('location-search')).toHaveTextContent(/^$/)
+    })
   })
 })

--- a/src/lib/zookeeper/components/ZookeeperConversationPane.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPane.tsx
@@ -1,5 +1,7 @@
 import { useSignals } from '@preact/signals-react/runtime'
 import {
+  CMD_GROUP_QUERY_PARAM,
+  CMD_NAME_QUERY_PARAM,
   LEGACY_SEARCH_PARAM_ZOOKEEPER_PROMPT_KEY,
   SEARCH_PARAM_ZOOKEEPER_PROMPT_KEY,
 } from '@src/lib/constants'
@@ -127,6 +129,16 @@ export const ZookeeperConversationPane = (props: {
     }
 
     setDefaultPrompt(promptParam)
+    // A generic command may still be consuming its own query parameters from
+    // an earlier snapshot. Let it finish before replacing the URL so this
+    // effect cannot restore cmd/groupId while removing the prompt.
+    if (
+      searchParams.has(CMD_NAME_QUERY_PARAM) &&
+      searchParams.has(CMD_GROUP_QUERY_PARAM)
+    ) {
+      return
+    }
+
     const nextSearchParams = new URLSearchParams(searchParams)
     nextSearchParams.delete(SEARCH_PARAM_ZOOKEEPER_PROMPT_KEY)
     nextSearchParams.delete(LEGACY_SEARCH_PARAM_ZOOKEEPER_PROMPT_KEY)


### PR DESCRIPTION
Serialize deep-link query cleanup so the command consumer removes `cmd` and `groupId` before Zookeeper removes `ttc-prompt`; neither effect can restore parameters already consumed by the other.

Fixes #13447. The focused integration suite passes, and the deployed preview scenario passed 5/5 with retries disabled.