### PR TITLE
Stabilize Zookeeper happy-path E2E assertion

### DIFF
--- a/e2e/playwright/zookeeper.spec.ts
+++ b/e2e/playwright/zookeeper.spec.ts
@@ -20,14 +20,16 @@ test.describe('Zookeeper tests', { tag: ['@desktop', '@web'] }, () => {
     await scene.settled()
 
     await test.step('Submit basic prompt', async () => {
+      const prompt = `make a 10x10x10cm cube centered on the origin, name the last variable "cube" [${ZK_MOCK_REPLY_MARKER}]`
+
       await toolbar.closePane(DefaultLayoutPaneID.Code)
       await toolbar.openPane(DefaultLayoutPaneID.Zookeeper)
       await copilot.setMode('fast')
-      await copilot.conversationInput.fill(
-        `make a 10x10x10cm cube centered on the origin, name the last variable "cube" [${ZK_MOCK_REPLY_MARKER}]`
-      )
+      await copilot.conversationInput.fill(prompt)
       await copilot.submitButton.click()
-      await expect(copilot.placeHolderResponse).toBeVisible()
+      await expect(page.getByTestId('ml-request-chat-bubble')).toContainText(
+        prompt
+      )
       await expect(copilot.placeHolderResponse).not.toBeVisible({
         timeout: 30_000,
       })


### PR DESCRIPTION
Fixes #13449

## Intent in plain English

This test is meant to prove that Zookeeper accepts a prompt and produces the expected CAD result. The temporary “thinking” bubble is not the result: a fast mocked response may finish before Playwright ever sees that frame. The test now proves submission using the durable user message and then verifies the same final KCL and Feature Tree output as before.

## What changed

- Reused the submitted prompt as a named value.
- Asserted that the durable request chat bubble contains that prompt.
- Removed only the requirement that the transient thinking bubble must first be visible.
- Kept the wait for thinking to finish and both stable result assertions.

## Validation

- Biome completed for the changed spec (only the file's two pre-existing unused-fixture warnings were reported).
- ESLint completed with zero warnings.
- `git diff --check` passed.
- Branch-head web E2E on Ubuntu passed the changed Zookeeper happy path on its first attempt in 28.4 seconds: https://github.com/KittyCAD/modeling-app/actions/runs/33290129640/job/99200304198

The independent local production attempt did not reach the test body because that browser was redirected to sign-in, so it is classified as local authentication setup rather than evidence for or against this change.
