### PR TITLE
Quiet stale AST path lookups after Feature Tree deletes

### DIFF
--- a/src/lang/queryAst.spec.ts
+++ b/src/lang/queryAst.spec.ts
@@ -1,9 +1,8 @@
+import type { Artifact, Plane } from '@rust/kcl-lib/bindings/Artifact'
 import type { Name } from '@rust/kcl-lib/bindings/Name'
 import type { Node } from '@rust/kcl-lib/bindings/Node'
 import type { Operation } from '@rust/kcl-lib/bindings/Operation'
 import type { Program } from '@rust/kcl-lib/bindings/Program'
-
-import type { Artifact, Plane } from '@rust/kcl-lib/bindings/Artifact'
 import { ARG_END_ABSOLUTE } from '@src/lang/constants'
 import {
   createArrayExpression,
@@ -11,6 +10,7 @@ import {
   createLabeledArg,
   createPipeSubstitution,
 } from '@src/lang/create'
+import type { KclManager } from '@src/lang/KclManager'
 import {
   doesSceneHaveExtrudedSketch,
   doesSceneHaveSweepableSketch,
@@ -23,6 +23,7 @@ import {
   getSelectedPlaneId,
   getSelectedSketchTarget,
   getVariableExprsFromSelection,
+  getVariableNameFromNodePath,
   hasSketchPipeBeenExtruded,
   isCursorInFunctionDefinition,
   isNodeSafeToReplace,
@@ -41,19 +42,17 @@ import {
   getAllOperations,
   recast,
 } from '@src/lang/wasm'
+import type { ConnectionManager } from '@src/lib/engineConnection/connectionManager'
+import type RustContext from '@src/lib/rustContext'
 import {
   enginelessExecutor,
   getAstAndArtifactGraph,
 } from '@src/lib/testHelpers'
 import { err } from '@src/lib/trap'
-import type { Selection, Selections } from '@src/machines/modelingSharedTypes'
-
-import type { KclManager } from '@src/lang/KclManager'
-import type RustContext from '@src/lib/rustContext'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
-import type { ConnectionManager } from '@src/lib/engineConnection/connectionManager'
+import type { Selection, Selections } from '@src/machines/modelingSharedTypes'
 import { buildTheWorldAndConnectToEngine } from '@src/unitTestUtils'
-import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 let instanceInThisFile: ModuleType = null!
 let kclManagerInThisFile: KclManager = null!
@@ -837,6 +836,61 @@ describe('Testing specific sketch getNodeFromPath workflow', () => {
       instanceInThisFile
     )
     expect(result).toEqual(false)
+  })
+  it('does not log when a cursor function-definition check gets a stale node path', () => {
+    const ast = assertParse('x = 1', instanceInThisFile)
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const stalePathToPrimitive = [
+      ['body', ''],
+      [0, 'index'],
+      ['declaration', 'VariableDeclaration'],
+      ['id', ''],
+      ['name', ''],
+      ['stale', ''],
+    ] as PathToNode
+
+    try {
+      const result = isCursorInFunctionDefinition(
+        ast,
+        {
+          codeRef: {
+            range: [0, 0, 0],
+            pathToNode: stalePathToPrimitive,
+          },
+        },
+        instanceInThisFile
+      )
+
+      expect(result).toEqual(false)
+      expect(consoleError).not.toHaveBeenCalled()
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+  it('does not log when operation variable lookup gets a stale node path', () => {
+    const ast = assertParse('x = 1', instanceInThisFile)
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const stalePathToPrimitive = [
+      ['body', ''],
+      [0, 'index'],
+      ['declaration', 'VariableDeclaration'],
+      ['id', ''],
+      ['name', ''],
+      ['stale', ''],
+    ] as PathToNode
+
+    try {
+      const result = getVariableNameFromNodePath(
+        stalePathToPrimitive,
+        ast,
+        instanceInThisFile
+      )
+
+      expect(result).toBeUndefined()
+      expect(consoleError).not.toHaveBeenCalled()
+    } finally {
+      consoleError.mockRestore()
+    }
   })
 })
 

--- a/src/lang/queryAst.ts
+++ b/src/lang/queryAst.ts
@@ -1,9 +1,13 @@
+import type { Artifact, Plane } from '@rust/kcl-lib/bindings/Artifact'
 import type { Block } from '@rust/kcl-lib/bindings/Block'
 import type { ElseIf } from '@rust/kcl-lib/bindings/ElseIf'
 import type { FunctionExpression } from '@rust/kcl-lib/bindings/FunctionExpression'
 import type { ImportStatement } from '@rust/kcl-lib/bindings/ImportStatement'
 import type { Node } from '@rust/kcl-lib/bindings/Node'
 import type { NumericLiteral } from '@rust/kcl-lib/bindings/NumericLiteral'
+import type { NumericType } from '@rust/kcl-lib/bindings/NumericType'
+import type { OpArg, Operation } from '@rust/kcl-lib/bindings/Operation'
+import type { SketchBlock } from '@rust/kcl-lib/bindings/SketchBlock'
 import type { TypeDeclaration } from '@rust/kcl-lib/bindings/TypeDeclaration'
 import {
   createLiteral,
@@ -12,6 +16,7 @@ import {
   createPipeSubstitution,
 } from '@src/lang/create'
 import { splitPathAtLastIndex } from '@src/lang/modifyAst'
+import { ARG_INDEX_FIELD, LABELED_ARG_FIELD } from '@src/lang/queryAstConstants'
 import { getNodePathFromSourceRange } from '@src/lang/queryAstNodePathUtils'
 import { sourceRangeContains } from '@src/lang/sourceRange'
 import {
@@ -52,21 +57,15 @@ import type {
   VariableMap,
 } from '@src/lang/wasm'
 import { kclSettings, recast, sketchFromKclValue } from '@src/lang/wasm'
+import type { KclCommandValue } from '@src/lib/commandTypes'
 import type { KclSettingsAnnotation } from '@src/lib/settings/settingsTypes'
-import { err } from '@src/lib/trap'
+import { err, isErr } from '@src/lib/trap'
 import { isArray } from '@src/lib/utils'
 import {
   isParallel as areVectorsParallel,
   deg2Rad,
   subVec,
 } from '@src/lib/utils2d'
-
-import type { Artifact, Plane } from '@rust/kcl-lib/bindings/Artifact'
-import type { NumericType } from '@rust/kcl-lib/bindings/NumericType'
-import type { OpArg, Operation } from '@rust/kcl-lib/bindings/Operation'
-import type { SketchBlock } from '@rust/kcl-lib/bindings/SketchBlock'
-import { ARG_INDEX_FIELD, LABELED_ARG_FIELD } from '@src/lang/queryAstConstants'
-import type { KclCommandValue } from '@src/lib/commandTypes'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type {
   EdgeCutInfo,
@@ -1059,9 +1058,11 @@ export function isCursorInFunctionDefinition(
     ast,
     selectionRanges.codeRef.pathToNode,
     wasmInstance,
-    'FunctionExpression'
+    'FunctionExpression',
+    false,
+    true
   )
-  if (err(node)) return false
+  if (isErr(node)) return false
   if (node.node.type === 'FunctionExpression') return true
   return false
 }
@@ -1211,10 +1212,12 @@ export function getVariableNameFromNodePath(
     program,
     pathToNode,
     wasmInstance,
-    ['CallExpressionKw', 'SketchBlock']
+    ['CallExpressionKw', 'SketchBlock'],
+    false,
+    true
   )
   if (
-    err(call) ||
+    isErr(call) ||
     !(call.node.type === 'CallExpressionKw' || call.node.type === 'SketchBlock')
   ) {
     return undefined
@@ -1224,9 +1227,11 @@ export function getVariableNameFromNodePath(
     program,
     pathToNode,
     wasmInstance,
-    'VariableDeclaration'
+    'VariableDeclaration',
+    false,
+    true
   )
-  if (err(varDec)) {
+  if (isErr(varDec)) {
     return undefined
   }
   if (varDec.node.type !== 'VariableDeclaration') {
@@ -1244,9 +1249,11 @@ export function getVariableNameFromNodePath(
     program,
     pathToNode,
     wasmInstance,
-    'PipeExpression'
+    'PipeExpression',
+    false,
+    true
   )
-  if (err(pipe)) {
+  if (isErr(pipe)) {
     return undefined
   }
   if (


### PR DESCRIPTION
## Summary

Fixes #13453.

This PR quiets optional stale AST path lookups that can occur immediately after deleting a Feature Tree operation. The underlying delete can leave valid KCL and correct geometry state, while stale operation/selection paths are still briefly queried by UI helpers. Those expected misses should return `undefined` or `false`, not report browser console errors.

## Plain-English test intent

The fuzz-discovered user path is: create a point-and-click rectangle extrusion, delete the extrusion from the Feature Tree, and continue with a valid sketch/region-only model. A passing result proves the UI can tolerate stale operation and cursor-selection paths during that delete transition without surfacing scary internal AST traversal errors.

This does not change modeling behavior. It keeps the existing semantics: if the helper cannot resolve a variable name, it returns `undefined`; if the cursor is not inside a function definition, it returns `false`.

## Changes

- Use non-reporting `isErr(...)` instead of reporting `err(...)` in optional lookup helpers:
  - `isCursorInFunctionDefinition(...)`
  - `getVariableNameFromNodePath(...)`
- Pass `suppressNoise = true` to the underlying `getNodeFromPath(...)` calls used by those helpers.
- Add regression tests that create stale paths into primitive AST fields and assert:
  - `isCursorInFunctionDefinition(...)` returns `false` without `console.error`;
  - `getVariableNameFromNodePath(...)` returns `undefined` without `console.error`.

## Validation

- `npm run test -- src/lang/queryAst.spec.ts --run`
  - 61 passed
- `node --require ./scripts/register-typescript-eslint-typescript.cjs ./node_modules/eslint/bin/eslint.js --max-warnings 0 src/lang/queryAst.ts src/lang/queryAst.spec.ts`
  - passed
- `npx biome check --formatter-enabled=true --linter-enabled=false --assist-enabled=false --files-ignore-unknown=true src/lang/queryAst.ts src/lang/queryAst.spec.ts`
  - passed
- `git diff --check -- src/lang/queryAst.ts src/lang/queryAst.spec.ts`
  - passed

## Fuzzer provenance

Codex GUI-fuzz reproduced the minimized delete path 3/3 on production before this patch. Local artifact directory:

```text
test-results/gui-fuzz/20260830T034900Z-remove-extrude-only-prod-repeat
```

The visible end state was valid: `extrude001` removed, body removed, sketch/region KCL preserved, and no editor lint marker. The product issue was the deterministic runtime error noise from stale optional AST path lookups.
