### PR TITLE
Stabilize Replay onboarding Wasm readiness

### DIFF
--- a/e2e/playwright/onboarding-web.spec.ts
+++ b/e2e/playwright/onboarding-web.spec.ts
@@ -15,6 +15,13 @@ const TUTORIAL_PROJECT_IDS = [
   '12902000-0000-4000-8000-000000000002',
 ] as const
 
+async function waitForKclWasm(page: Page) {
+  await page.waitForFunction(() => Boolean(window.app?.singletons?.kclManager))
+  await page.evaluate(async () => {
+    await window.app.singletons.kclManager.wasmInstancePromise
+  })
+}
+
 async function replayOnboardingFromSettings(
   page: Page,
   expectedProjectName: string
@@ -30,6 +37,7 @@ async function replayOnboardingFromSettings(
   await expect(
     page.getByRole('heading', { name: 'Settings', exact: true })
   ).toBeVisible()
+  await waitForKclWasm(page)
   await page.getByRole('button', { name: 'Replay onboarding' }).click()
 
   await expect(page).toHaveURL(


### PR DESCRIPTION
Closed during the September 6 CI dependency review: #13611 removed `e2e/playwright/onboarding-web.spec.ts`, the only file this PR changed. The Wasm-readiness helper has no remaining caller. The branch is retained for reference. The separate blank-file navigation product fix and focused Scene regression continue in #13475. This closure does not claim the deleted replay flow is validated.

---

## Test intent in plain English

The onboarding test should click **Replay onboarding** only after the KCL Wasm runtime used to create and parse the tutorial project is actually ready. A visible Settings page proves the UI route rendered; it does not prove that the asynchronous modeling runtime finished loading.

A passing test after this change proves the Replay action was exercised from a valid initialized state, rather than relying on Playwright timing or broad retries to get lucky.

## What changed

- Add a focused `waitForKclWasm(page)` helper to the existing web onboarding scenario.
- Wait for the application KCL manager to exist.
- Await its application-owned `wasmInstancePromise` before clicking Replay.
- Preserve the existing single end-to-end onboarding scenario and add no fixed sleep.

This PR changes only test sequencing. It does not change the Replay button's product UX; disabling or showing loading state while initialization is pending is separate work.

Fixes #13457.

## Validation

- `npx biome check e2e/playwright/onboarding-web.spec.ts` — passed.
- Repository ESLint invocation for `e2e/playwright/onboarding-web.spec.ts` — passed.
- `git diff --check` — passed.
- Full `npm run tsc -- --noEmit` reached existing generated API/binding drift outside this file; no changed-file TypeScript or lint diagnostic was produced.

Current CI evidence for the underlying flaky scenario: [scheduled E2E run 33293759444](https://github.com/KittyCAD/modeling-app/actions/runs/33293759444), Ubuntu web job [99210476998](https://github.com/KittyCAD/modeling-app/actions/runs/33293759444/job/99210476998). The onboarding scenario failed its initial run and two retries before passing retry 3. Other onboarding lifecycle races are being handled separately, so this PR claims only the missing Wasm-readiness invariant.

Branch CI evidence: [E2E run 33294520837](https://github.com/KittyCAD/modeling-app/actions/runs/33294520837). The macOS, Ubuntu, and Windows web jobs all passed. Across their 7 total executions of this scenario, every attempt crossed the new KCL Wasm readiness boundary and completed Replay/tutorial creation; there was no failure at the Replay action or Wasm initialization.

The scenario still needed retries because it hit separate, later lifecycle races: conclusion navigation did not reach `/home`, the conclusion action was not mounted yet, or the home heading had not rendered. Those failures are outside this focused PR and confirm that green aggregate CI must not be presented as a retries-disabled pass.

Retries-disabled local browser repetition was attempted from an isolated worktree but did not reach the authenticated application. That attempt is classified as test setup and is not counted as validation. This PR remains a draft until the separate lifecycle work allows honest retries-disabled repetition of the complete scenario.
