### PR TITLE
Stabilize onboarding conclusion navigation E2E

### DIFF
--- a/e2e/playwright/onboarding-web.spec.ts
+++ b/e2e/playwright/onboarding-web.spec.ts
@@ -112,7 +112,7 @@ test(
       page.getByRole('heading', { name: 'Time to start building' })
     ).toBeVisible({ timeout: 15_000 })
     await Promise.all([
-      page.waitForURL(/\/home$/, { timeout: 5_000 }),
+      page.waitForURL(/\/home$/, { timeout: 15_000 }),
       page.getByRole('button', { name: /Finish$/ }).click(),
     ])
     await expectBackDoesNotReopenOnboarding(page)

--- a/e2e/playwright/onboarding-web.spec.ts
+++ b/e2e/playwright/onboarding-web.spec.ts
@@ -110,10 +110,10 @@ test(
     await expect(page).toHaveURL(/\/onboarding\/desktop\/conclusion$/)
     await expect(
       page.getByRole('heading', { name: 'Time to start building' })
-    ).toBeVisible()
+    ).toBeVisible({ timeout: 15_000 })
     await Promise.all([
       page.waitForURL(/\/home$/, { timeout: 5_000 }),
-      page.getByRole('button', { name: 'Finish', exact: true }).click(),
+      page.getByRole('button', { name: /Finish$/ }).click(),
     ])
     await expectBackDoesNotReopenOnboarding(page)
     await expect(

--- a/e2e/playwright/onboarding-web.spec.ts
+++ b/e2e/playwright/onboarding-web.spec.ts
@@ -108,8 +108,13 @@ test(
     )}/onboarding/desktop/conclusion`
     await page.evaluate((url) => window.location.replace(url), conclusionUrl)
     await expect(page).toHaveURL(/\/onboarding\/desktop\/conclusion$/)
-    await page.getByTestId('onboarding-next').click()
-    await expect(page).toHaveURL(/\/home$/)
+    await expect(
+      page.getByRole('heading', { name: 'Time to start building' })
+    ).toBeVisible()
+    await Promise.all([
+      page.waitForURL(/\/home$/, { timeout: 5_000 }),
+      page.getByRole('button', { name: 'Finish', exact: true }).click(),
+    ])
     await expectBackDoesNotReopenOnboarding(page)
     await expect(
       page.getByRole('heading', {


### PR DESCRIPTION
Closed during the September 6 CI dependency review: #13611 removed the replay/conclusion scenario that this PR synchronized. There is no surviving conclusion-test change to stack. The branch is retained for reference. The separate blank-file navigation product fix and focused Scene regression continue in #13475. This closure does not claim the deleted replay flow is validated.

---

## Plain-English test goal

This test is checking that finishing onboarding actually completes the tutorial, saves that completion, and returns the user home.

The test used to assume that seeing `/onboarding/desktop/conclusion` in the address bar meant the conclusion screen was ready. The URL can update before React replaces the previous onboarding step, so an extremely fast Playwright click could hit the previous **Next** button instead of the conclusion's **Finish** button.

A passing test now proves that the real conclusion screen is visible, the real **Finish** action was clicked, and the application navigated home after persisting the onboarding setting.

## Change

- Wait up to 15 seconds for the user-visible `Time to start building` conclusion heading after the full-page replacement. This is a condition wait, not a sleep.
- Target the rendered **Finish** button by its accessible-name suffix instead of the shared `onboarding-next` test ID. The icon contributes `checkmark` to the full accessible name, so an exact `Finish` match does not find the button.
- Arm a 15-second `/home` navigation wait before clicking so a fast navigation cannot be missed while still allowing the asynchronous settings write to finish.
- Keep the existing single end-to-end scenario.

Closes #13461.

## Evidence

Before the fix, scheduled run [33291559648, Ubuntu web job 99204562339](https://github.com/KittyCAD/modeling-app/actions/runs/33291559648/job/99204562339) timed out waiting for `/home`. Its retained failure snapshot showed the conclusion heading and **Finish** button, confirming that the earlier click had occurred before that UI mounted. The test passed on retry.

Local checks:

- `npx biome check e2e/playwright/onboarding-web.spec.ts` — passed.
- `git diff --check` — passed.
- A retries-disabled local run reached the conclusion five times and exposed a defect in the first draft: Playwright's retained snapshot named the button `checkmark Finish`, so `{ name: 'Finish', exact: true }` never clicked it. The final locator uses `/Finish$/`.
- A subsequent five-run full-scenario attempt was blocked before the conclusion by the separately tracked Replay-before-Wasm race; a later focused attempt was blocked by a shared Vite server returning HTML for the Wasm asset. Those are recorded as upstream test/setup failures, not pass evidence for this conclusion change.

CI on the first draft also exposed the exact-locator problem rather than validating it: Ubuntu exhausted all six onboarding attempts, with later attempts timing out on the unclicked Finish action. After correcting the locator, macOS passed the full flow once Replay succeeded. Ubuntu passed the conclusion on two attempts and the entire scenario on the second retry; its initial conclusion attempt still exceeded the old five-second settings/navigation bound, which is why the final condition wait is 15 seconds.

Final commit `77d7c4d8b9` validation: [Ubuntu web job 99215310732](https://github.com/KittyCAD/modeling-app/actions/runs/33295838899/job/99215310732) failed its first two attempts before the changed code at the known Replay navigation race on line 35. Retry 2 then completed the entire scenario in 1.1 minutes. The final run recorded no conclusion-heading, Finish-locator, or Finish-navigation failure.

The branch's unrelated `Build test artifacts` red check is the already tracked Rust/Namespace cache-permission failure; it does not execute this TypeScript test.

The PR's isolated CI and preview deployment are the authoritative full-flow validation for this branch.
