### PR TITLE
Limit CI retries and bound engine-test concurrency

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -104,7 +104,7 @@ jobs:
           set -euo pipefail
           cd rust
           cargo nextest run \
-            --workspace --features=artifact-graph --retries=10 --no-fail-fast --profile=ci \
+            --workspace --features=artifact-graph --no-fail-fast --profile=ci \
             simulation_tests::kcl_samples \
             2>&1 | tee /tmp/github-actions.log
         env:
@@ -239,7 +239,7 @@ jobs:
             executor_filter=(-E "package(kcl-lib) and not (test(/^parsing::/) or test(/^unparser::/) or test(/^walk::/) or test(/^settings::/) or test(/^fs::/) or test(/^fmt::/) or test(/^tooling::/) or test(/^errors::/) or test(/export_bindings/))")
           fi
           cargo nextest run \
-            --retries=10 --no-fail-fast --profile=ci --archive-file nextest-archive.tar.zst \
+            --no-fail-fast --profile=ci --archive-file nextest-archive.tar.zst \
             --partition count:${{ matrix.partitionIndex}}/${{ matrix.partitionTotal }} \
             "${executor_filter[@]}" \
             2>&1 | tee /tmp/github-actions.log || true  # let TAB determine failure

--- a/rust/.config/nextest.toml
+++ b/rust/.config/nextest.toml
@@ -4,6 +4,9 @@
 uses-engine = { max-threads = 32 }
 # If a test must run after the engine tests, we want to make sure the engine tests are done first.
 after-engine = { max-threads = 32 }
+# ts-rs export tests merge declarations into shared output files. Running more
+# than one at a time can corrupt an in-progress file and fail nondeterministically.
+export-bindings = { max-threads = 1 }
 
 [profile.default]
 slow-timeout = { period = "280s", terminate-after = 1 }
@@ -12,16 +15,28 @@ slow-timeout = { period = "280s", terminate-after = 1 }
 slow-timeout = { period = "280s", terminate-after = 5 }
 
 [[profile.default.overrides]]
-# If a test starts with kcl_test_, then it uses the engine. So, limit its parallelism.
-filter = "test(kcl_test_)"
+# Engine-backed tests are not consistently named kcl_test_. Match the same
+# executor-sensitive KCL surface as CI while excluding known local-only groups.
+filter = "package(kcl-lib) and not (test(/^parsing::/) or test(/^unparser::/) or test(/^walk::/) or test(/^settings::/) or test(/^fs::/) or test(/^fmt::/) or test(/^tooling::/) or test(/^errors::/) or test(/export_bindings/) or test(docs::gen_std_tests) or test(test_after_engine_))"
 test-group = "uses-engine"
 threads-required = 2
 
 [[profile.ci.overrides]]
-# If a test starts with kcl_test_, then it uses the engine. So, limit its parallelism.
-filter = "test(kcl_test_)"
+# See the default-profile override above.
+filter = "package(kcl-lib) and not (test(/^parsing::/) or test(/^unparser::/) or test(/^walk::/) or test(/^settings::/) or test(/^fs::/) or test(/^fmt::/) or test(/^tooling::/) or test(/^errors::/) or test(/export_bindings/) or test(docs::gen_std_tests) or test(test_after_engine_))"
 test-group = "uses-engine"
 threads-required = 2
+# Engine allocations can occasionally disconnect before a test starts. Keep
+# that recovery local to engine-capable KCL tests instead of the workspace.
+retries = { backoff = "exponential", count = 2, delay = "1s", max-delay = "2s", jitter = true }
+
+[[profile.default.overrides]]
+filter = "test(/export_bindings/)"
+test-group = "export-bindings"
+
+[[profile.ci.overrides]]
+filter = "test(/export_bindings/)"
+test-group = "export-bindings"
 
 [[profile.default.overrides]]
 filter = "test(parser::parser_impl::snapshot_tests)"
@@ -49,6 +64,21 @@ test-group = "after-engine"
 # Generate the docs tests after the engine tests.
 filter = "test(docs::gen_std_tests)"
 test-group = "after-engine"
+# These generators execute embedded KCL examples and can therefore see the
+# same transient engine disconnects as the main engine-backed test group.
+retries = { backoff = "exponential", count = 2, delay = "1s", max-delay = "2s", jitter = true }
+
+[[profile.default.overrides]]
+# This report test executes a real non-overlapping subtract through the engine.
+filter = "package(kcl-python-bindings) and test(exec_outcome_report_renders_csg_no_overlap_warning)"
+test-group = "uses-engine"
+threads-required = 2
+
+[[profile.ci.overrides]]
+filter = "package(kcl-python-bindings) and test(exec_outcome_report_renders_csg_no_overlap_warning)"
+test-group = "uses-engine"
+threads-required = 2
+retries = { backoff = "exponential", count = 2, delay = "1s", max-delay = "2s", jitter = true }
 
 [[profile.default.overrides]]
 filter = 'test(kcl_samples)'

--- a/rust/kcl-lib/src/docs/gen_std_tests.rs
+++ b/rust/kcl-lib/src/docs/gen_std_tests.rs
@@ -5,7 +5,6 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use serde_json::json;
-use tokio::task::JoinSet;
 
 use super::kcl_doc::ConstData;
 use super::kcl_doc::DocCategory;
@@ -800,7 +799,7 @@ fn test_generate_stdlib_markdown_docs() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_code_in_topics() {
-    let mut join_set = JoinSet::new();
+    let mut failures = Vec::new();
     for entry in fs::read_dir("../../docs/kcl-lang").unwrap() {
         let entry = entry.unwrap();
         if entry.file_type().unwrap().is_dir() {
@@ -814,17 +813,15 @@ async fn test_code_in_topics() {
                 continue;
             }
 
-            let f = path.display().to_string();
-            join_set.spawn(async move { (format!("{f}, example {i}"), run_example_with_retries(&eg).await) });
+            // This is one scheduled test, so keep at most one engine connection
+            // active instead of opening a connection for every example at once.
+            // run_example closes each connection before the next example starts.
+            if let Err(error) = run_example_with_retries(&eg).await {
+                failures.push(format!("{}, example {i}: {error}", path.display()));
+            }
         }
     }
-    let results: Vec<_> = join_set
-        .join_all()
-        .await
-        .into_iter()
-        .filter_map(|a| a.1.err().map(|e| format!("{}: {}", a.0, e)))
-        .collect();
-    assert!(results.is_empty(), "Failures: {}", results.join(", "))
+    assert!(failures.is_empty(), "Failures: {}", failures.join(", "))
 }
 
 fn find_examples(text: &str, filename: &Path) -> Vec<(String, String)> {

--- a/rust/kcl-python-bindings/kcl.pyi
+++ b/rust/kcl-python-bindings/kcl.pyi
@@ -591,8 +591,9 @@ class Point3d:
 @typing.final
 class RawFile:
     r"""
-    A raw file with unencoded contents to be passed over binary websockets.
-    When raw files come back for exports it is sent as binary/bson, not text/json.
+    A raw file with unencoded contents.
+    
+    See the command that emits this type for its response encoding.
     """
     @property
     def contents(self) -> builtins.list[builtins.int]: ...
@@ -1080,7 +1081,7 @@ class UnitArea(enum.Enum):
     """
     SquareYards = ...
     r"""
-    Square yards <https://en.wikipedia.org/wiki/Square_mile>
+    Square yards <https://en.wikipedia.org/wiki/Square_yard>
     """
 
 @typing.final

--- a/rust/kcl-python-bindings/pyproject.toml
+++ b/rust/kcl-python-bindings/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-test = ["pytest", "pytest-asyncio", "flaky"]
+test = ["pytest", "pytest-asyncio"]
 
 [tool.maturin]
 features = ["pyo3/extension-module"]

--- a/rust/kcl-python-bindings/tests/tests.py
+++ b/rust/kcl-python-bindings/tests/tests.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
+import asyncio
 import os
 import sys
 
 import pytest
-from flaky import flaky
 
 import kcl
 from kcl import Point3d
@@ -50,18 +50,28 @@ requires_engine = pytest.mark.skipif(
 )
 
 MAX_EXECUTION_ATTEMPTS = 3
+EXECUTION_RETRY_BASE_DELAY_SECONDS = 1
 
 
 async def execute_with_retries(async_fn, *args, **kwargs):
     retries_remaining = MAX_EXECUTION_ATTEMPTS - 1
+    attempt = 1
     while True:
         try:
             return await async_fn(*args, **kwargs)
         except Exception as error:
             is_retryable = getattr(error, "is_retryable", None)
             if retries_remaining > 0 and callable(is_retryable) and is_retryable():
-                print(f"Execute got {error}; retrying...", file=sys.stderr)
+                delay_seconds = EXECUTION_RETRY_BASE_DELAY_SECONDS * 2 ** (attempt - 1)
+                print(
+                    f"Execute attempt {attempt}/{MAX_EXECUTION_ATTEMPTS} got "
+                    f"retryable {type(error).__name__}: {error}; retrying in "
+                    f"{delay_seconds}s...",
+                    file=sys.stderr,
+                )
+                await asyncio.sleep(delay_seconds)
                 retries_remaining -= 1
+                attempt += 1
                 continue
             raise
 
@@ -108,6 +118,54 @@ async def test_kcl_parse():
 def test_kcl_error_is_retryable():
     assert kcl.KclError("retry me", True).is_retryable() is True
     assert kcl.KclError("do not retry").is_retryable() is False
+
+
+@pytest.mark.asyncio
+async def test_execute_with_retries_uses_backoff_for_retryable_errors(
+    monkeypatch, capsys
+):
+    attempts = 0
+    observed_delays = []
+
+    class RetryableTestError(Exception):
+        def is_retryable(self):
+            return True
+
+    async def fail_twice_then_succeed():
+        nonlocal attempts
+        attempts += 1
+        if attempts < MAX_EXECUTION_ATTEMPTS:
+            raise RetryableTestError("temporary engine failure")
+        return "success"
+
+    async def record_sleep(delay_seconds):
+        observed_delays.append(delay_seconds)
+
+    monkeypatch.setattr(asyncio, "sleep", record_sleep)
+
+    assert await execute_with_retries(fail_twice_then_succeed) == "success"
+    assert attempts == MAX_EXECUTION_ATTEMPTS
+    assert observed_delays == [1, 2]
+    assert "attempt 1/3" in capsys.readouterr().err
+
+
+@pytest.mark.asyncio
+async def test_execute_with_retries_does_not_retry_other_errors(monkeypatch):
+    attempts = 0
+
+    async def fail():
+        nonlocal attempts
+        attempts += 1
+        raise ValueError("deterministic failure")
+
+    async def unexpected_sleep(_delay_seconds):
+        pytest.fail("a non-retryable failure must not back off")
+
+    monkeypatch.setattr(asyncio, "sleep", unexpected_sleep)
+
+    with pytest.raises(ValueError, match="deterministic failure"):
+        await execute_with_retries(fail)
+    assert attempts == 1
 
 
 @pytest.mark.asyncio
@@ -263,7 +321,6 @@ async def test_kcl_execute_code_and_export():
 
 
 @requires_engine
-@flaky
 @pytest.mark.asyncio
 async def test_kcl_execute_dir_assembly():
     # Read from a file.
@@ -368,7 +425,6 @@ async def test_import_and_snapshots_single():
 
 
 @requires_engine
-@flaky
 @pytest.mark.asyncio
 async def test_kcl_execute_and_snapshot_dir():
     # Read from a file.


### PR DESCRIPTION
Rust CI previously retried every test up to ten times, masking shared binding-file races and retrying deterministic failures. Scope recovery to engine-capable tests, serialize binding exporters, and run the documentation-topic examples one engine connection at a time. Python keeps its existing retryable-error gate with backoff and drops redundant broad retry decorators.

Closes #13465.

- Rust engine-capable tests receive at most two retries with 1s/2s exponential backoff and jitter. Local-only families and binding exporters do not receive this retry policy.
- Binding exporters share a serial nextest group because they merge declarations into the same files.
- The topic-documentation test retains all 32 runnable examples and both executor legs, but awaits each example and its connection close before starting the next. It still aggregates every example failure. Previously, one scheduled test opened 32 connections concurrently and exhausted the engine's 100-per-user limit across all three attempts in [machine shard 1](https://github.com/KittyCAD/modeling-app/actions/runs/34021813553/job/101456433832).
- Python removes the two broad flaky decorators and adds delay/attempt telemetry to its existing retryable-engine-error helper. Its regressions distinguish transient errors from deterministic failures.

Targets main directly. The binding-name collision and default-file preservation prerequisites are already in main. This PR preserves its reviewed six-file patch and can land independently of #13693 / #13678; the unrelated Electron fixture cleanup in #13705 is deferred.

The documentation test bounds its own connections; separate CI runs still share account capacity.
