### PR TITLE
Guard empty engine error responses

### DIFF
--- a/src/lib/engineConnection/websocketConnection.test.ts
+++ b/src/lib/engineConnection/websocketConnection.test.ts
@@ -86,4 +86,14 @@ describe('createOnWebSocketMessage', () => {
 
     expect(reportClientError).not.toHaveBeenCalled()
   })
+
+  it('does not throw when an unsuccessful response has no errors', () => {
+    const handler = createMessageHandler()
+    const event = new MessageEvent('message', {
+      data: JSON.stringify({ success: false, errors: [] }),
+    })
+
+    expect(() => handler(event)).not.toThrow()
+    expect(reportClientError).not.toHaveBeenCalled()
+  })
 })

--- a/src/lib/engineConnection/websocketConnection.ts
+++ b/src/lib/engineConnection/websocketConnection.ts
@@ -172,6 +172,9 @@ export const createOnWebSocketMessage = ({
       }
 
       const firstError = message.errors[0]
+      if (!firstError) {
+        return
+      }
       if (firstError.error_code === 'auth_token_invalid') {
         notifySessionExpired('engine-websocket')
         disconnectAll()


### PR DESCRIPTION
Closed during the September 6 CI dependency review because merged #13305 already added the equivalent optional guards for empty engine errors and a regression for `errors: []`. Current main protects both `auth_token_invalid` and `internal_api` checks. Keeping this PR would duplicate that implementation and conflict with its test. The branch is retained for reference.

---

## What this changes

Guard the first engine error before checking its error code, and add a unit regression for an unsuccessful WebSocket response with `errors: []`.

In plain English: an incomplete error response from the modeling service is logged but no longer crashes the client-side response handler.

Fixes #13470.

## Why

The Windows desktop suite captured `Cannot read properties of undefined (reading 'error_code')` from this handler. The legacy unit-testing WebSocket handler already performs the equivalent length check.

Representative job: https://github.com/KittyCAD/modeling-app/actions/runs/33277515478/job/99168411828

## Test goal / intent

Prove that a malformed or incomplete unsuccessful response cannot crash engine-message handling or fail an unrelated user action.

## Validation

- `npm run test:unit -- --run src/lib/engineConnection/websocketConnection.test.ts` — 4/4 passed.
- Formatting check passed for both changed files.
- The draft PR CI matrix will validate the full desktop and unit suites.
