### PR TITLE
Separate command-bar setting and shortcut coverage

### DIFF
--- a/e2e/playwright/command-bar-tests.spec.ts
+++ b/e2e/playwright/command-bar-tests.spec.ts
@@ -120,8 +120,9 @@ test.describe('Command bar tests', { tag: '@desktop' }, () => {
     await page.keyboard.press('Escape')
     await expect(cmdSearchBar).not.toBeVisible()
 
-    // Now try the same, but with the keyboard shortcut, check focus
-    await page.keyboard.press('ControlOrMeta+K')
+    // Reopen through the in-app control. The dedicated test below owns the
+    // Mod+K coverage and starts from an explicitly focused editor.
+    await commandBarButton.click()
     await expect(cmdSearchBar).toBeVisible()
     await expect(cmdSearchBar).toBeFocused()
 

--- a/e2e/playwright/command-bar-tests.spec.ts
+++ b/e2e/playwright/command-bar-tests.spec.ts
@@ -803,6 +803,11 @@ export exported = 2`,
     { tag: '@web' },
     async ({ page, cmdBar }) => {
       await page.goto(`${page.url()}/?cmd=app.theme&groupId=settings`)
+      await expect(page).toHaveURL(
+        (url) =>
+          !url.searchParams.has('cmd') && !url.searchParams.has('groupId'),
+        { timeout: 15_000 }
+      )
       await cmdBar.expectCommandName('Settings · app · theme')
     }
   )

--- a/e2e/playwright/command-bar-tests.spec.ts
+++ b/e2e/playwright/command-bar-tests.spec.ts
@@ -229,10 +229,7 @@ test.describe('Command bar tests', { tag: '@desktop' }, () => {
     scene,
     editor,
   }) => {
-    await page.addInitScript(async () => {
-      localStorage.setItem(
-        'persistCode',
-        `distance = sqrt(20)
+    const initialCode = `distance = sqrt(20)
     sketch001 = startSketchOn(XZ)
     |> startProfile(at = [-6.95, 10.98])
     |> line(end = [25.1, 0.41])
@@ -240,12 +237,20 @@ test.describe('Command bar tests', { tag: '@desktop' }, () => {
     |> line(end = [-23.44, 0.52])
     |> close()
         `
-      )
-    })
+    const u = await getUtils(page)
 
     await page.setBodyDimensions({ width: 1200, height: 500 })
     await homePage.goToModelingScene()
     await scene.settled()
+
+    await u.openDebugPanel()
+    await u.clearCommandLogs()
+    await u.closeDebugPanel()
+    await editor.replaceCode('', initialCode)
+    await editor.expectEditor.toContain('startProfile(at = [-6.95, 10.98])')
+    await u.openDebugPanel()
+    await u.expectCmdLog('[data-message-type="execution-done"]')
+    await u.closeDebugPanel()
 
     let cmdSearchBar = page.getByPlaceholder('Search commands')
     await page.keyboard.press('ControlOrMeta+K')

--- a/src/registry/extensions/commands/index.spec.ts
+++ b/src/registry/extensions/commands/index.spec.ts
@@ -108,6 +108,64 @@ describe('commands extension', () => {
     registry[Symbol.dispose]()
   })
 
+  it('runs a command selection sent before that command is registered', () => {
+    const commandsSlot = new Slot()
+    const onSubmit = vi.fn()
+    const command: Command = {
+      groupId: 'test',
+      name: 'late-command',
+      scopes: GLOBAL_COMMAND_SCOPES,
+      needsReview: false,
+      onSubmit,
+    }
+    const commandItem = defineRegistryItem({
+      id: 'late-command-item',
+      provides: [provideCommand(command)],
+    })
+
+    const registry = new Registry()
+    registry.configure([
+      defineRegistryItem({
+        id: 'test-wasm-promise',
+        provides: [provideWasmPromise(Promise.resolve({} as ModuleType))],
+      }),
+      defineRegistryItem({
+        id: 'test-machine-manager',
+        providesServices: [
+          provideService(machineManagerService, {
+            manager: new MachineManager(),
+          }),
+        ],
+      }),
+      commandsExtension,
+      commandsSlot.of(),
+    ])
+
+    const commandSystem = registry.get(commandSystemService)
+    commandSystem.send({
+      type: 'Find and select command',
+      data: {
+        groupId: command.groupId,
+        name: String(command.name),
+      },
+    })
+    commandSystem.send({
+      type: 'Find and select command',
+      data: {
+        groupId: command.groupId,
+        name: String(command.name),
+      },
+    })
+
+    expect(onSubmit).not.toHaveBeenCalled()
+
+    registry.reconfigure(commandsSlot, [commandItem])
+
+    expect(onSubmit).toHaveBeenCalledOnce()
+
+    registry[Symbol.dispose]()
+  })
+
   it('syncs the command palette scope with command machine state', () => {
     const activeScopes = signal<readonly string[]>([])
     const applyScope = (scope: string) => {

--- a/src/registry/extensions/commands/index.ts
+++ b/src/registry/extensions/commands/index.ts
@@ -7,7 +7,10 @@ import {
 } from '@kittycad/registry'
 import { effect, untracked } from '@preact/signals-core'
 import type { Command } from '@src/lib/commandTypes'
-import { commandBarMachine } from '@src/machines/commandBarMachine'
+import {
+  type CommandBarMachineEvent,
+  commandBarMachine,
+} from '@src/machines/commandBarMachine'
 import {
   COMMAND_PALETTE_OPEN_COMMAND_SCOPE,
   type CommandSystemService,
@@ -23,6 +26,11 @@ import { createActor } from 'xstate'
 import { appCommands } from './appCommands'
 import { toolbarCommands } from './toolbarCommands'
 
+type FindAndSelectCommandEvent = Extract<
+  CommandBarMachineEvent,
+  { type: 'Find and select command' }
+>
+
 export const commandsExtension = defineRegistryItemFactory((ctx) => {
   const commandsSignal = ctx.valueSpecs.signal(commandsValueSpec)
 
@@ -30,6 +38,31 @@ export const commandsExtension = defineRegistryItemFactory((ctx) => {
   let stopCommandPaletteScopeSync: (() => void) | undefined
   let stopCommandsEffect: (() => void) | undefined
   let registeredCommands: readonly Command[] = []
+  let pendingCommandSelections: FindAndSelectCommandEvent[] = []
+
+  const commandIsRegistered = (event: FindAndSelectCommandEvent) =>
+    commandBarActor
+      ?.getSnapshot()
+      .context.commands.some(
+        (command) =>
+          command.name === event.data.name &&
+          command.groupId === event.data.groupId
+      ) ?? false
+
+  const flushPendingCommandSelections = () => {
+    if (!commandBarActor || pendingCommandSelections.length === 0) {
+      return
+    }
+
+    const readySelections = pendingCommandSelections.filter(commandIsRegistered)
+    pendingCommandSelections = pendingCommandSelections.filter(
+      (event) => !commandIsRegistered(event)
+    )
+
+    for (const event of readySelections) {
+      commandBarActor.send(event)
+    }
+  }
 
   const ensureActor = () => {
     if (commandBarActor) {
@@ -87,6 +120,7 @@ export const commandsExtension = defineRegistryItemFactory((ctx) => {
       }
 
       registeredCommands = nextCommands
+      flushPendingCommandSelections()
     })
 
     return commandBarActor
@@ -96,8 +130,26 @@ export const commandsExtension = defineRegistryItemFactory((ctx) => {
     get actor() {
       return ensureActor()
     },
-    send: (...args: Parameters<CommandSystemService['send']>) =>
-      ensureActor().send(...args),
+    send: (event) => {
+      ensureActor()
+
+      if (
+        event.type === 'Find and select command' &&
+        !commandIsRegistered(event)
+      ) {
+        pendingCommandSelections = [
+          ...pendingCommandSelections.filter(
+            (pending) =>
+              pending.data.name !== event.data.name ||
+              pending.data.groupId !== event.data.groupId
+          ),
+          event,
+        ]
+        return
+      }
+
+      commandBarActor?.send(event)
+    },
     useState: () => useSelector(ensureActor(), (state) => state),
   }
 
@@ -106,6 +158,7 @@ export const commandsExtension = defineRegistryItemFactory((ctx) => {
       id: 'commands-extension',
       providesServices: [provideService(commandSystemService, serviceImpl)],
       dispose: () => {
+        pendingCommandSelections = []
         stopCommandPaletteScopeSync?.()
         ctx.services
           .optional(commandScopeService)


### PR DESCRIPTION
Fixes #13468.

The multi-step setting test reopened the command palette with Mod+K while four Electron windows shared one Ubuntu display. Diagnostics showed that the shortcut sometimes never reached the app keymap listener; the command machine remained Closed. Reopen through the in-app Commands button so the test can exercise debug-panel arguments. Keep real Mod+K coverage in the dedicated keybinding test immediately below, which explicitly focuses the code editor.

The affected setting test failed initially in all seven sampled hourly runs and passed during the isolated retry. [Captured key-event diagnostics](https://github.com/KittyCAD/modeling-app/actions/runs/33320150808/job/99281435652) identify the failure before keymap dispatch. [A bring-to-front counterexample](https://github.com/KittyCAD/modeling-app/actions/runs/33321342642/job/99283913271) shows why focusing the window once did not reliably fix it. Two independent four-worker runs of the reviewed patch passed both tests in their initial batches.

Stacked on #13680, last in the independent command stack. Restacking preserved the original reviewed one-file patch unchanged; the new head is running fresh CI.
