### PR TITLE
Test onboarding cloud edits through the application observer

### DIFF
--- a/e2e/playwright/lib/cloudSyncTestUtils.ts
+++ b/e2e/playwright/lib/cloudSyncTestUtils.ts
@@ -440,6 +440,74 @@ export async function opfsPathExists(page: Page, path: string) {
   }, path)
 }
 
+export async function readCloudSyncProjectState(
+  page: Page,
+  projectPath: string
+) {
+  return page.evaluate(async (projectPathToRead) => {
+    type StoredProjectMetadata = {
+      remoteProjectId?: unknown
+      remoteRevision?: unknown
+      baseManifest?: unknown
+    }
+    type StoredOutboxEntry = {
+      projectPath?: unknown
+    }
+
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open('zds-opfs-cloud-sync', 1)
+      request.onerror = () => reject(request.error)
+      request.onsuccess = () => resolve(request.result)
+    })
+    const requestResult = <T>(request: IDBRequest<T>) =>
+      new Promise<T>((resolve, reject) => {
+        request.onerror = () => reject(request.error)
+        request.onsuccess = () => resolve(request.result)
+      })
+
+    try {
+      if (
+        !db.objectStoreNames.contains('projects') ||
+        !db.objectStoreNames.contains('outbox')
+      ) {
+        return undefined
+      }
+
+      const transaction = db.transaction(['projects', 'outbox'], 'readonly')
+      const [metadata, outboxEntries] = await Promise.all([
+        requestResult(
+          transaction.objectStore('projects').get(projectPathToRead)
+        ) as Promise<StoredProjectMetadata | undefined>,
+        requestResult(transaction.objectStore('outbox').getAll()) as Promise<
+          StoredOutboxEntry[]
+        >,
+      ])
+      if (!metadata) {
+        return undefined
+      }
+
+      return {
+        remoteProjectId:
+          typeof metadata.remoteProjectId === 'string'
+            ? metadata.remoteProjectId
+            : undefined,
+        remoteRevision:
+          typeof metadata.remoteRevision === 'string'
+            ? metadata.remoteRevision
+            : undefined,
+        hasBaseManifest:
+          typeof metadata.baseManifest === 'object' &&
+          metadata.baseManifest !== null,
+        pendingOutboxCount: outboxEntries.filter(
+          (entry) => entry.projectPath === projectPathToRead
+        ).length,
+      }
+    } finally {
+      db.close()
+    }
+  }, projectPath)
+}
+
 async function fulfillJson(route: Route, body: unknown, status = 200) {
   await route.fulfill({
     status,

--- a/e2e/playwright/onboarding-web.spec.ts
+++ b/e2e/playwright/onboarding-web.spec.ts
@@ -1,3 +1,4 @@
+import { EditorFixture } from '@e2e/playwright/fixtures/editorFixture'
 import {
   type CloudProject,
   createRemoteListGate,
@@ -49,6 +50,22 @@ test(
   'Replay onboarding creates a uniquely named Personal Cloud tutorial',
   { tag: '@web' },
   async ({ context, page }, testInfo) => {
+    const clientErrors: Array<{ code?: string; stack?: string }> = []
+    await context.route('**/user/client-errors', async (route) => {
+      const report = route.request().postDataJSON() as {
+        code?: unknown
+        stack?: unknown
+      }
+      clientErrors.push({
+        code: typeof report.code === 'string' ? report.code : undefined,
+        stack: typeof report.stack === 'string' ? report.stack : undefined,
+      })
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({}),
+      })
+    })
     const remoteProjects: CloudProject[] = []
     const remoteRevisions = new Map<string, number>()
     const remoteListGate = createRemoteListGate()
@@ -132,6 +149,9 @@ test(
     await expect
       .poll(() => apiCalls.remoteListResponses)
       .toBeGreaterThanOrEqual(1)
+    await expect(page.getByTestId('cloud-library-sync-status')).toContainText(
+      'Cloud synced'
+    )
     await expect(tutorialProjectLink).toHaveCount(1)
     await expect(
       tutorialProjectLink.getByTestId('project-file-count')
@@ -139,13 +159,29 @@ test(
     await tutorialProjectLink.click()
     await expect(page).toHaveURL(/tutorial-project%2Fmain\.kcl$/)
 
-    await page.evaluate(async (mainPath) => {
-      await window.fsZds.writeFile(
-        mainPath,
-        new TextEncoder().encode('changed = true')
+    const editor = new EditorFixture(page)
+    await editor.openPane()
+    await expect(editor.codeContent).toContainText('plateLength = 10')
+    const firstProjectUpdatesBeforeEdit = apiCalls.updates.filter(
+      ({ projectId }) => projectId === TUTORIAL_PROJECT_IDS[0]
+    ).length
+    await editor.replaceCode('', 'changed = true')
+    await expect
+      .poll(async () => {
+        const files = await readOpfsTextFiles(page, {
+          main: `${PROJECT_DIR}/tutorial-project/main.kcl`,
+        })
+        return files.main
+      })
+      .toBe('changed = true')
+    await expect
+      .poll(
+        () =>
+          apiCalls.updates.filter(
+            ({ projectId }) => projectId === TUTORIAL_PROJECT_IDS[0]
+          ).length
       )
-    }, `${PROJECT_DIR}/tutorial-project/main.kcl`)
-    await expect.poll(() => apiCalls.updates.length).toBeGreaterThanOrEqual(1)
+      .toBeGreaterThan(firstProjectUpdatesBeforeEdit)
 
     await replayOnboardingFromSettings(page, 'tutorial-project-1')
     await expect.poll(() => apiCalls.creates.length).toBe(2)
@@ -213,6 +249,13 @@ test(
       `project_id = "${TUTORIAL_PROJECT_IDS[1]}"`
     )
     expect(apiCalls.creates).toHaveLength(2)
+    expect(
+      clientErrors.some(
+        ({ code, stack }) =>
+          code === 'cloud_sync_untracked_local_changes' &&
+          stack?.includes(TUTORIAL_PROJECT_IDS[0])
+      )
+    ).toBe(false)
 
     await page.keyboard.press('Escape')
     await expect(page).toHaveURL(/\/home$/)

--- a/e2e/playwright/onboarding-web.spec.ts
+++ b/e2e/playwright/onboarding-web.spec.ts
@@ -4,6 +4,7 @@ import {
   createRemoteListGate,
   opfsPathExists,
   PROJECT_DIR,
+  readCloudSyncProjectState,
   readOpfsTextFiles,
   routeCloudProjects,
 } from '@e2e/playwright/lib/cloudSyncTestUtils'
@@ -143,15 +144,24 @@ test(
     await expect(
       tutorialProjectLink.getByTestId('project-file-count')
     ).toHaveText('1')
+    const cloudSyncStatus = page.getByTestId('cloud-library-sync-status')
+    await expect(cloudSyncStatus).toContainText('Cloud syncing')
     remoteListGate.release()
     await expect.poll(() => apiCalls.creates.length).toBe(1)
     expect(apiCalls.creates[0]).toContain('tutorial-project')
     await expect
       .poll(() => apiCalls.remoteListResponses)
       .toBeGreaterThanOrEqual(1)
-    await expect(page.getByTestId('cloud-library-sync-status')).toContainText(
-      'Cloud synced'
-    )
+    const firstProjectPath = `${PROJECT_DIR}/tutorial-project`
+    await expect
+      .poll(() => readCloudSyncProjectState(page, firstProjectPath))
+      .toMatchObject({
+        remoteProjectId: TUTORIAL_PROJECT_IDS[0],
+        remoteRevision: `${TUTORIAL_PROJECT_IDS[0]}-rev-1`,
+        hasBaseManifest: true,
+        pendingOutboxCount: 0,
+      })
+    await expect(cloudSyncStatus).toContainText('Cloud synced')
     await expect(tutorialProjectLink).toHaveCount(1)
     await expect(
       tutorialProjectLink.getByTestId('project-file-count')
@@ -165,6 +175,18 @@ test(
     const firstProjectUpdatesBeforeEdit = apiCalls.updates.filter(
       ({ projectId }) => projectId === TUTORIAL_PROJECT_IDS[0]
     ).length
+    const firstProjectStateBeforeEdit = await readCloudSyncProjectState(
+      page,
+      firstProjectPath
+    )
+    expect(firstProjectStateBeforeEdit?.remoteRevision).toBeDefined()
+    const firstProjectUpdateResponse = page.waitForResponse((response) => {
+      const url = new URL(response.url())
+      return (
+        response.request().method() === 'PUT' &&
+        url.pathname.endsWith(`/user/projects/${TUTORIAL_PROJECT_IDS[0]}`)
+      )
+    })
     await editor.replaceCode('', 'changed = true')
     await expect
       .poll(async () => {
@@ -174,14 +196,28 @@ test(
         return files.main
       })
       .toBe('changed = true')
+    expect((await firstProjectUpdateResponse).ok()).toBe(true)
+    expect(
+      apiCalls.updates.filter(
+        ({ projectId }) => projectId === TUTORIAL_PROJECT_IDS[0]
+      ).length
+    ).toBeGreaterThan(firstProjectUpdatesBeforeEdit)
     await expect
-      .poll(
-        () =>
-          apiCalls.updates.filter(
-            ({ projectId }) => projectId === TUTORIAL_PROJECT_IDS[0]
-          ).length
-      )
-      .toBeGreaterThan(firstProjectUpdatesBeforeEdit)
+      .poll(async () => {
+        const state = await readCloudSyncProjectState(page, firstProjectPath)
+        return {
+          ...state,
+          remoteRevisionChanged:
+            state?.remoteRevision !==
+            firstProjectStateBeforeEdit?.remoteRevision,
+        }
+      })
+      .toMatchObject({
+        remoteProjectId: TUTORIAL_PROJECT_IDS[0],
+        remoteRevisionChanged: true,
+        hasBaseManifest: true,
+        pendingOutboxCount: 0,
+      })
 
     await replayOnboardingFromSettings(page, 'tutorial-project-1')
     await expect.poll(() => apiCalls.creates.length).toBe(2)


### PR DESCRIPTION
Closed during the September 6 CI dependency review: #13611 removed the replay/cloud-edit scenario that this PR corrected. Its new cloud-state helper was used only by that removed scenario. The branch is retained for reference. The separate blank-file navigation product fix and focused Scene regression continue in #13475. This closure does not claim the deleted replay flow is validated.

---

## Plain-English intent

This test should prove that a user edit to the first cloud tutorial is saved locally and fully synced to that same cloud project before onboarding is replayed.

Previously the test changed OPFS through a Playwright-only filesystem handle. That skipped the observer used by the real application, then treated any cloud update request as success. Even after switching to the editor, merely observing a PUT was still too early: the mock records the request before the response is fulfilled, while the application clears its durable outbox and advances the stored project revision only after the response succeeds.

## What changed

- Edit the tutorial through the real CodeMirror UI with `EditorFixture`.
- Verify OPFS contains exactly `changed = true`.
- Wait for the exact project PUT response and require an HTTP success.
- Read the exact project cloud-sync state from IndexedDB.
- Before editing, require enrollment to have a remote project ID, initial remote revision, base manifest, and zero pending outbox entries.
- After editing, require the remote revision to advance, the base manifest to remain present, and the project outbox to return to zero.
- Keep the client-error assertion scoped to the first tutorial project.

Closes #13480.

## Validation

- Diagnostic control, retries disabled: restoring the old direct `window.fsZds` write reproduced `cloud_sync_untracked_local_changes` for the first tutorial project while the surrounding UI flow still completed (1/1).
- Corrected editor/save/upload checkpoint before the durable-state review change, retries disabled: 5/5 passed.
- Full onboarding scenario before this review change, retries disabled: 3 consecutive passes; the local Playwright worker then stalled between repetitions with 2 repetitions not started.
- Current review change: `git diff --check`, Biome for both changed files, and Playwright discovery/TypeScript loading all pass.
- Two current retries-disabled local attempts did not reach the changed checkpoint: one hung on the initial Settings navigation, and one reached the conclusion URL before its component mounted. A third attempt, with local-only waits for those known onboarding lifecycle defects, still failed because Replay remained on Settings. These are pre-checkpoint failures in the independently tracked onboarding initialization path, not failures of the new sync barrier. The local-only workarounds were removed and are not in this PR.
- CI and the new Vercel preview run are in progress for commit `a17b3c6d48`.

The durable barrier matches the application ordering in `src/lib/cloudSync/engine.ts`: the PUT completes, the project outbox is cleared, and then the project metadata is marked synced with the new revision and base manifest.

## Classification

Test-harness correctness fix. The product diagnostic behaved correctly when the test mutated storage behind the observer. This PR does not claim that ordinary editor writes bypass cloud sync.

Derived from Codex investigation of onboarding CI flakiness.