### PR TITLE
Use an explicit Namespace cache tag for general CI jobs

### DIFF
--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -23,7 +23,7 @@ jobs:
 
   prepare-files:
     needs: [build-wasm]
-    runs-on: namespace-profile-ubuntu-8-cores
+    runs-on: namespace-profile-ubuntu-8-cores;overrides.cache-tag=modeling-app-general-v2
     outputs:
       version: ${{ steps.export_version.outputs.version }}
       notes: ${{ steps.export_notes.outputs.notes }}

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -173,7 +173,7 @@ jobs:
           path: rust/nextest-archive.tar.zst
   run-test-artifacts:
     name: cargo test (${{ matrix.executor }}, shard ${{ matrix.partitionIndex}})
-    runs-on: namespace-profile-ubuntu-8-cores
+    runs-on: namespace-profile-ubuntu-8-cores;overrides.cache-tag=modeling-app-general-v2
     needs: build-test-artifacts
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -442,7 +442,7 @@ jobs:
 
   vercel:
     name: e2e:web (vercel)
-    runs-on: namespace-profile-ubuntu-8-cores
+    runs-on: namespace-profile-ubuntu-8-cores;overrides.cache-tag=modeling-app-general-v2
     if: github.repository == 'kittycad/modeling-app' && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'main'))
 
     steps:

--- a/.github/workflows/kcl-python-bindings.yml
+++ b/.github/workflows/kcl-python-bindings.yml
@@ -74,7 +74,7 @@ jobs:
           fi
   linux-x86_64:
     name: kcl-python-bindings (linux-x86_64)
-    runs-on: namespace-profile-ubuntu-8-cores
+    runs-on: namespace-profile-ubuntu-8-cores;overrides.cache-tag=modeling-app-general-v2
     # The hourly schedule exists to observe flaky tests. It runs the test job
     # and nothing else.
     if: github.event_name != 'schedule'
@@ -249,7 +249,7 @@ jobs:
           path: rust/kcl-python-bindings/dist
   test:
     name: kcl-python-bindings (test)
-    runs-on: namespace-profile-ubuntu-8-cores
+    runs-on: namespace-profile-ubuntu-8-cores;overrides.cache-tag=modeling-app-general-v2
     steps:
       - uses: actions/checkout@v7.0.1
       - name: Track setup
@@ -292,7 +292,7 @@ jobs:
           CI_SUITE: integration:kcl
   sdist:
     name: kcl-python-bindings (sdist)
-    runs-on: namespace-profile-ubuntu-8-cores
+    runs-on: namespace-profile-ubuntu-8-cores;overrides.cache-tag=modeling-app-general-v2
     if: github.event_name != 'schedule'
     steps:
       - uses: actions/checkout@v7.0.1
@@ -317,7 +317,7 @@ jobs:
           path: rust/kcl-python-bindings/dist
   release:
     name: Release
-    runs-on: namespace-profile-ubuntu-8-cores
+    runs-on: namespace-profile-ubuntu-8-cores;overrides.cache-tag=modeling-app-general-v2
     permissions:
       contents: write
     if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -26,7 +26,7 @@ jobs:
           nix flake check --all-systems
 
   nix-build-linux:
-    runs-on: namespace-profile-ubuntu-8-cores
+    runs-on: namespace-profile-ubuntu-8-cores;overrides.cache-tag=modeling-app-general-v2
     steps:
       - uses: actions/checkout@v7.0.1
         with:
@@ -52,4 +52,3 @@ jobs:
 
       - name: nix build . for x86_64-darwin
         run: nix build .
-

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -65,7 +65,7 @@ jobs:
   npm-lint:
     # 8 cores for the extra memory: the type-aware lint needs more heap
     # (--max-old-space-size=4096) than the 2-core profile's RAM can hold.
-    runs-on: namespace-profile-ubuntu-8-cores
+    runs-on: namespace-profile-ubuntu-8-cores;overrides.cache-tag=modeling-app-general-v2
     needs: build-wasm
 
     steps:

--- a/.github/workflows/update-python-stubs.yml
+++ b/.github/workflows/update-python-stubs.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   build-and-stub:
-    runs-on: namespace-profile-ubuntu-8-cores
+    runs-on: namespace-profile-ubuntu-8-cores;overrides.cache-tag=modeling-app-general-v2
     defaults:
       run:
         shell: bash -eux {0}


### PR DESCRIPTION
## Plain-English intent

Stop modeling-app CI jobs from silently attaching the old repository/profile-default Namespace cache. Every 8-core cached job now says which modeling-app cache it intends to use, so the legacy volume can be released without the next run recreating it.

## What changed

- Added `overrides.cache-tag=modeling-app-general-v2` to the 10 remaining bare `namespace-profile-ubuntu-8-cores` job definitions.
- Preserved the existing `modeling-app-rust-host-v2` and `modeling-app-rust-musl-v2` isolation from #13441.
- Did not change runner resources, job commands, matrices, tests, or artifacts.

The 10 definitions are spread across seven workflow files. The cargo-test definition expands to six runtime shards, so this removes as many as 15 modeling-app runner attachments per full workflow set from the legacy implicit identity.

## Validation

- Parsed all seven modified workflow files successfully as YAML.
- Confirmed exactly 10 `modeling-app-general-v2` declarations.
- Confirmed zero bare `namespace-profile-ubuntu-8-cores` declarations remain under `.github/workflows`.
- Confirmed the existing Rust cache declarations remain: four static host declarations plus one MUSL declaration. The language-server host declaration is matrix-driven and covers multiple runtime jobs.
- `git diff --check` passed.

## Live validation

The initial PR run created `modeling-app-general-v2` in Namespace and attached multiple fresh generations to it. Instance `2mp7gp9ilng3u` was assigned to `Auto-update PyO3 stubs—build-and-stub` on this branch at commit `9822c5a275`, confirming that an affected job selected the new explicit identity rather than the legacy implicit volume.

## Deployment validation plan

1. Let the PR-triggered workflows finish against the fresh `modeling-app-general-v2` cache.
2. After this PR merges and active legacy generations finish, release the legacy implicit volume.
3. Verify a later modeling-app run does not recreate the legacy identity.

## Risk

Low. The first affected jobs will use a cold cache and may be slower. Subsequent runs should recover normal cache behavior. The shared Namespace profile and other repositories are unchanged.

Closes #13493.
