### PR TITLE
Fix remaining E2E Namespace cache tag overrides

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -204,7 +204,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: namespace-profile-ubuntu-8-cores
+          - os: namespace-profile-ubuntu-8-cores;overrides.cache-tag=modeling-app-general-v2
           - os: namespace-profile-macos-8-cores
           - os: namespace-profile-windows-8-cores
     runs-on: ${{ matrix.os }}
@@ -310,7 +310,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [namespace-profile-ubuntu-8-cores]
+        os:
+          - namespace-profile-ubuntu-8-cores;overrides.cache-tag=modeling-app-general-v2
         shardIndex: [1, 2, 3, 4, 5, 6, 7, 8]
         shardTotal: [8]
         include:


### PR DESCRIPTION
## Plain-English intent

Keep the Ubuntu web and desktop E2E jobs from attaching to the legacy implicit Namespace cache. PR #13494 updated direct `runs-on` labels, but these two runner labels live inside job matrices and were missed. Without this follow-up, every E2E run can recreate the legacy cache after it is released.

## Changes

- Route the Ubuntu web E2E matrix entry to `modeling-app-general-v2`.
- Route all eight Ubuntu desktop E2E shards to `modeling-app-general-v2`.
- Leave macOS, Windows, Rust host, and Rust MUSL cache routing unchanged.

## Runtime evidence

- [Post-merge main E2E run 33332502883](https://github.com/KittyCAD/modeling-app/actions/runs/33332502883) still attached Ubuntu web and desktop jobs to the legacy cache.
- [PR #13496 E2E run 33332887425](https://github.com/KittyCAD/modeling-app/actions/runs/33332887425) reproduced the same behavior for Ubuntu web plus all eight desktop shards.
- The Namespace dashboard showed 20 retained legacy generations; all source instances were stopped at the 2026-08-30 13:36 PDT inspection, but the two remaining matrix labels meant future E2E runs would recreate the volume.
- Recent jobs using `modeling-app-general-v2`, `modeling-app-rust-host-v2`, and `modeling-app-rust-musl-v2` completed successfully.

## Validation

- `git diff --check`
- Prettier check for `.github/workflows/e2e-tests.yml`
- Ruby YAML parse confirming both matrix values resolve exactly to the intended override label
- Repository-wide workflow audit confirming no executable bare `namespace-profile-ubuntu-8-cores` label remains

Follow-up to #13494.