### PR TITLE
Clarify defaultAngleUnit deprecation warning

### DIFF
--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -942,7 +942,7 @@ impl ExecutorContext {
                         exec_state.warn(
                             CompilationIssue::err(
                                 annotation.as_source_range(),
-                                "Prefer to use explicit units for angles",
+                                "The `defaultAngleUnit` setting is deprecated; use explicit units for angles",
                             ),
                             annotations::WARN_ANGLE_UNITS,
                         );


### PR DESCRIPTION
## Summary

- explicitly identify defaultAngleUnit as deprecated in the runtime warning
- direct users toward explicit angle units

Fixes #11696

## Testing

- cargo +nightly fmt --all -- --check
- cargo +nightly check -p kcl-lib