### PR TITLE
Hide platform-hidden commands from command search

### DIFF
--- a/src/components/CommandBar/CommandBar.test.ts
+++ b/src/components/CommandBar/CommandBar.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import { isCommandVisibleInSearch } from '@src/components/CommandBar/commandSearchVisibility'
+import type { Command } from '@src/lib/commandTypes'
+
+function command(overrides: Partial<Command> = {}): Command {
+  return {
+    name: 'Test command',
+    groupId: 'test',
+    needsReview: false,
+    onSubmit: () => undefined,
+    ...overrides,
+  }
+}
+
+describe('isCommandVisibleInSearch', () => {
+  it('shows ordinary commands', () => {
+    expect(isCommandVisibleInSearch(command(), false)).toBe(true)
+  })
+
+  it('hides commands explicitly hidden from search', () => {
+    expect(
+      isCommandVisibleInSearch(command({ hideFromSearch: true }), false)
+    ).toBe(false)
+  })
+
+  it('allows commands with hideFromSearch explicitly false', () => {
+    expect(
+      isCommandVisibleInSearch(command({ hideFromSearch: false }), false)
+    ).toBe(true)
+  })
+
+  it('hides commands hidden on both platforms', () => {
+    expect(isCommandVisibleInSearch(command({ hide: 'both' }), false)).toBe(
+      false
+    )
+  })
+
+  it('hides web-hidden commands on web', () => {
+    expect(isCommandVisibleInSearch(command({ hide: 'web' }), false)).toBe(
+      false
+    )
+  })
+
+  it('shows web-hidden commands on desktop', () => {
+    expect(isCommandVisibleInSearch(command({ hide: 'web' }), true)).toBe(true)
+  })
+
+  it('hides desktop-hidden commands on desktop', () => {
+    expect(isCommandVisibleInSearch(command({ hide: 'desktop' }), true)).toBe(
+      false
+    )
+  })
+
+  it('shows desktop-hidden commands on web', () => {
+    expect(isCommandVisibleInSearch(command({ hide: 'desktop' }), false)).toBe(
+      true
+    )
+  })
+})

--- a/src/components/CommandBar/CommandBar.tsx
+++ b/src/components/CommandBar/CommandBar.tsx
@@ -13,6 +13,7 @@ import { useApp } from '@src/lib/boot'
 import type { Command, CommandArgument } from '@src/lib/commandTypes'
 import useHotkeyWrapper from '@src/lib/hotkeyWrapper'
 import { keymapService } from '@src/registry/contracts/keymap'
+import { isCommandVisibleInSearch } from '@src/components/CommandBar/commandSearchVisibility'
 
 export const COMMAND_PALETTE_HOTKEY = 'mod+k'
 
@@ -169,14 +170,9 @@ export const CommandBar = () => {
           >
             {commandBarState.matches('Selecting command') ? (
               <CommandComboBox
-                options={commands.filter((command: Command) => {
-                  return (
-                    // By default everything is undefined
-                    // If marked explicitly as false hide
-                    command.hideFromSearch === undefined ||
-                    command.hideFromSearch === false
-                  )
-                })}
+                options={commands.filter((command: Command) =>
+                  isCommandVisibleInSearch(command)
+                )}
               />
             ) : commandBarState.matches('Gathering arguments') ? (
               <CommandBarArgument stepBack={stepBack} />

--- a/src/components/CommandBar/commandSearchVisibility.ts
+++ b/src/components/CommandBar/commandSearchVisibility.ts
@@ -1,0 +1,13 @@
+import type { Command } from '@src/lib/commandTypes'
+import { isDesktop } from '@src/lib/isDesktop'
+
+export function isCommandVisibleInSearch(
+  command: Command,
+  desktop = isDesktop()
+) {
+  if (command.hideFromSearch === true) return false
+  if (command.hide === 'both') return false
+  if (command.hide === 'desktop' && desktop) return false
+  if (command.hide === 'web' && !desktop) return false
+  return true
+}


### PR DESCRIPTION
Fixes #13515.

Plain-English test intent:
On the web app, users should not see or start desktop-only commands through command search. This specifically guards the Insert command: the toolbar already disables Insert on web and the command config marks it hide: "web", so command search should respect the same platform-hidden state.

Summary:
- Add a small isCommandVisibleInSearch predicate for command-search filtering.
- Preserve existing hideFromSearch behavior.
- Apply hide: "both", hide: "web", and hide: "desktop" consistently for raw command objects shown in the command palette.
- Add focused unit coverage for default, hideFromSearch, web-hidden, desktop-hidden, and both-hidden cases.

Validation:
- npx biome check --write --formatter-enabled=true --linter-enabled=false --assist-enabled=false --files-ignore-unknown=true src/components/CommandBar/CommandBar.tsx src/components/CommandBar/CommandBar.test.ts src/components/CommandBar/commandSearchVisibility.ts
- node --require ./scripts/register-typescript-eslint-typescript.cjs ./node_modules/eslint/bin/eslint.js --max-warnings 0 src/components/CommandBar/CommandBar.tsx src/components/CommandBar/CommandBar.test.ts src/components/CommandBar/commandSearchVisibility.ts
- npm run test:unit -- src/components/CommandBar/CommandBar.test.ts --reporter=verbose

Fuzzer evidence:
- Production current-main failure reproduced 2/2 with e2e/playwright/gui-fuzz-insert-command-hidden-web.spec.ts.
- Toolbar Insert was disabled, but command search visibly offered "Insert from a file in the current project directory".
- Local artifact directory: /Users/jordan/.codex/worktrees/6489/modeling-app-current-main-fuzz/test-results/gui-fuzz-insert-command-hi-592e0-desktop-only-Insert-command-Google-Chrome.