### PR TITLE
Fix Feature Tree delete for KCL named views

### DIFF
--- a/src/lang/modifyAst.spec.ts
+++ b/src/lang/modifyAst.spec.ts
@@ -856,6 +856,51 @@ extrude001 = extrude(sketch001.line1, length = 5, bodyType = SURFACE)`
     expect(newCode).not.toContain('extrude001 = extrude')
   })
 
+  it('deletes a KCL named view selected from the feature tree operation range', async () => {
+    const codeBefore = `@settings(kclVersion = 2.0, experimentalFeatures = allow)
+
+sketch001 = sketch(on = XY) {
+  line1 = line(start = [var 0mm, var 0mm], end = [var 4mm, var 0mm])
+}
+region001 = region(segments = [sketch001.line1])
+extrude001 = extrude(region001, length = 5mm)
+generatedTopView = view::named(
+  "Generated top",
+  camera = view::oriented(view::Orientation::Top, distance = 200mm),
+  baseline = view::Visibility::Show,
+)`
+    const ast = assertParse(codeBefore, instanceInThisFile)
+    const execState = await enginelessExecutor(ast, rustContextInThisFile)
+    const namedViewOperation = getAllOperations(execState.operations).find(
+      (op) => op.type === 'StdLibCall' && op.name === 'view::named'
+    )
+    if (!namedViewOperation || namedViewOperation.type !== 'StdLibCall') {
+      throw new Error('Could not find named view operation')
+    }
+    const artifact =
+      getArtifactFromRange(
+        namedViewOperation.sourceRange,
+        execState.artifactGraph
+      ) ?? undefined
+    expect(artifact?.type).toBe('namedView')
+
+    const result = await deleteFromSelection(
+      ast,
+      {
+        codeRef: codeRefFromRange(namedViewOperation.sourceRange, ast),
+        artifact,
+      },
+      execState.variables,
+      execState.artifactGraph,
+      instanceInThisFile
+    )
+    if (err(result)) throw result
+    const newCode = recast(result, instanceInThisFile)
+    expect(newCode).toContain('extrude001 = extrude')
+    expect(newCode).not.toContain('generatedTopView = view::named')
+    expect(newCode).not.toContain('"Generated top"')
+  })
+
   it.each([
     ['transform', `translate(bracket, x = 1, y = 2)`],
     [

--- a/src/lang/modifyAst/deleteFromSelection.ts
+++ b/src/lang/modifyAst/deleteFromSelection.ts
@@ -211,6 +211,7 @@ export async function deleteFromSelection(
     selection.artifact?.type === 'pattern' ||
     selection.artifact?.type === 'helix' ||
     selection.artifact?.type === 'planeOfFace' ||
+    selection.artifact?.type === 'namedView' ||
     !selection.artifact // aka expected to be a shell at this point
   ) {
     let extrudeNameToDelete = ''
@@ -223,7 +224,8 @@ export async function deleteFromSelection(
       selection.artifact.type !== 'pattern' &&
       selection.artifact.type !== 'helix' &&
       selection.artifact.type !== 'path' &&
-      selection.artifact.type !== 'planeOfFace'
+      selection.artifact.type !== 'planeOfFace' &&
+      selection.artifact.type !== 'namedView'
     ) {
       if (!varDecNode) return new Error('Could not find sketch variable')
       const varDecName = varDecNode.id.name


### PR DESCRIPTION
## Summary

Fixes #13517.

This allows KCL-declared named views to use the same Feature Tree **Remove operation** path as other deletable top-level operations.

## Plain-English test goal / intent

A user can create a named camera view in KCL and see it in the Feature Tree and Views pane. If they right-click that named view in the Feature Tree and choose **Remove operation**, the named view declaration should be removed from KCL. Existing modeling geometry, such as sketches and extrudes created earlier in the file, should remain intact.

This regression test guards against the Feature Tree selection being recognized as a named-view artifact but then falling through to the unsupported-selection path that shows “Unable to delete selection. Please edit manually in code pane.”

## What changed

- Treat `namedView` artifacts as valid direct-delete targets in `deleteFromSelection`.
- Keep named views out of the sketch/solid dependent-surface cleanup branch, matching other top-level operation artifacts such as patterns, helices, and plane-of-face artifacts.
- Add an integration regression covering a KCL `view::named(...)` selected through its operation source range.

## Validation

- `npm run test:integration -- src/lang/modifyAst.spec.ts -t 'deletes a KCL named view selected from the feature tree operation range' --reporter=dot`
- `npm run test:integration -- src/lang/modifyAst.spec.ts -t 'Testing deleteFromSelection' --reporter=dot`
- `npx biome check --write --formatter-enabled=true --linter-enabled=false --assist-enabled=false --files-ignore-unknown=true src/lang/modifyAst/deleteFromSelection.ts src/lang/modifyAst.spec.ts`
- `node --require ./scripts/register-typescript-eslint-typescript.cjs ./node_modules/eslint/bin/eslint.js --max-warnings 0 src/lang/modifyAst/deleteFromSelection.ts src/lang/modifyAst.spec.ts`
- `git diff --check`

## Fuzzer evidence

Found by Codex GUI fuzzing on current `main` while exploring KCL-declared named camera views after generated point-and-click geometry.

Observed behavior before the fix:

- The named view was visible in the Feature Tree and Views pane.
- Choosing **Remove operation** from the Feature Tree produced the toast: “Unable to delete selection. Please edit manually in code pane.”
- The `view::named(...)` declaration remained in KCL.
- Existing geometry remained visible, so the failure was scoped to the delete/codemod path.

Local artifacts from the exploratory run:

- `test-results/gui-fuzz-kcl-named-view-af-7865e-creating-generated-geometry-Google-Chrome/07-named-view-row-before-remove.png`
- `test-results/gui-fuzz-kcl-named-view-af-7865e-creating-generated-geometry-Google-Chrome/test-failed-1.png`
