### PR TITLE
Lock view controls during sketch solve mode

### DIFF
--- a/src/components/ViewControlMenu.tsx
+++ b/src/components/ViewControlMenu.tsx
@@ -21,6 +21,7 @@ import {
 import { resetCameraPosition } from '@src/lib/resetCameraPosition'
 import { selectSketchPlane } from '@src/lib/selections'
 import { reportRejection } from '@src/lib/trap'
+import { shouldLockViewControls } from '@src/components/viewControlMenuUtils'
 import toast from 'react-hot-toast'
 
 export function useViewControlMenuItems() {
@@ -33,9 +34,10 @@ export function useViewControlMenuItems() {
   )
 
   const settingsValues = settings.useSettings()
-  const shouldLockView =
-    modelingState.matches('Sketch') &&
-    !settingsValues.app.allowOrbitInSketchMode.current
+  const shouldLockView = shouldLockViewControls(
+    modelingState,
+    settingsValues.app.allowOrbitInSketchMode.current
+  )
 
   const sketching =
     modelingState.matches('Sketch') || modelingState.matches('sketchSolveMode')

--- a/src/components/viewControlMenuUtils.test.ts
+++ b/src/components/viewControlMenuUtils.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  isSketchSessionForViewControls,
+  shouldLockViewControls,
+} from '@src/components/viewControlMenuUtils'
+
+function modelingStateIn(activeState: string) {
+  return {
+    matches: (state: 'Sketch' | 'sketchSolveMode') => state === activeState,
+  }
+}
+
+describe('view control menu sketch session helpers', () => {
+  it.each(['Sketch', 'sketchSolveMode'])(
+    'locks standard view actions in %s when sketch orbit is disabled',
+    (activeState) => {
+      expect(shouldLockViewControls(modelingStateIn(activeState), false)).toBe(
+        true
+      )
+    }
+  )
+
+  it('does not lock standard view actions in sketch mode when sketch orbit is enabled', () => {
+    expect(
+      shouldLockViewControls(modelingStateIn('sketchSolveMode'), true)
+    ).toBe(false)
+  })
+
+  it('does not treat other modeling states as sketch sessions', () => {
+    expect(isSketchSessionForViewControls(modelingStateIn('idle'))).toBe(false)
+    expect(shouldLockViewControls(modelingStateIn('idle'), false)).toBe(false)
+  })
+})

--- a/src/components/viewControlMenuUtils.ts
+++ b/src/components/viewControlMenuUtils.ts
@@ -1,0 +1,20 @@
+type ModelingModeMatcher = {
+  matches: (state: 'Sketch' | 'sketchSolveMode') => boolean
+}
+
+export function isSketchSessionForViewControls(
+  modelingState: ModelingModeMatcher
+) {
+  return (
+    modelingState.matches('Sketch') || modelingState.matches('sketchSolveMode')
+  )
+}
+
+export function shouldLockViewControls(
+  modelingState: ModelingModeMatcher,
+  allowOrbitInSketchMode: boolean
+) {
+  return (
+    isSketchSessionForViewControls(modelingState) && !allowOrbitInSketchMode
+  )
+}


### PR DESCRIPTION
## Summary

Fixes #13519.

Standard view actions in the in-viewport **View settings** menu now respect the sketch orbit lock during current point-and-click Sketch Solve mode, not just the older `Sketch` state.

## Plain-English test goal / intent

When a user is sketching and the setting “allow orbit in sketch mode” is off, view controls should not rotate the camera out of the active sketch plane. That should be true for both legacy sketch mode and current point-and-click Sketch Solve mode.

This test protects the behavior where the menu should lock camera-changing actions such as **Right view**, **Reset view**, and **Center view on selection** while sketch orbiting is disabled. A passing result proves the view-menu lock condition covers `sketchSolveMode`, which is the state used by current point-and-click sketching.

## What changed

- Added a small view-control helper that treats both `Sketch` and `sketchSolveMode` as sketch sessions for camera-lock purposes.
- Updated `ViewControlMenu` to use that helper when deciding whether to disable standard view actions.
- Added a unit regression covering both sketch states, the enabled-orbit case, and non-sketch states.

## Validation

- `npm ci --ignore-scripts`
- `npm run test:unit -- src/components/viewControlMenuUtils.test.ts --reporter=dot`
- `npx biome check --write --formatter-enabled=true --linter-enabled=false --assist-enabled=false --files-ignore-unknown=true src/components/ViewControlMenu.tsx src/components/viewControlMenuUtils.ts src/components/viewControlMenuUtils.test.ts`
- `node --require ./scripts/register-typescript-eslint-typescript.cjs ./node_modules/eslint/bin/eslint.js --max-warnings 0 src/components/ViewControlMenu.tsx src/components/viewControlMenuUtils.ts src/components/viewControlMenuUtils.test.ts`
- `git diff --check`

## Fuzzer evidence

Found by Codex GUI fuzzing on current `main` while exploring non-codemod sketch/view-control behavior.

Observed behavior before the fix:

- The app was in `sketchSolveMode.active`.
- `allowOrbitInSketchMode` was false.
- The in-viewport **View settings** menu still enabled **Right view**.
- Clicking **Right view** moved the camera from `[0, 0, 22.99]` to `[22.99, 0, 0]`.
- Measured camera movement was about `32.5` units.

Reproduced 3/3 locally.

Local artifact directories:

- `/private/tmp/zds-gui-fuzz-sketch-solve-view-lock-20260831T1112Z-first`
- `/private/tmp/zds-gui-fuzz-sketch-solve-view-lock-20260831T1114Z-repeat`

Related but separate work:

- #12826 / #12915 cover Sketch Solve grid/snap behavior in this menu area.
- This PR is narrower: it only fixes camera-changing view actions ignoring the sketch orbit lock in `sketchSolveMode`.
