### PR TITLE
Synchronize projects before Aquarium publication

### DIFF
--- a/e2e/playwright/cloud-sync.spec.ts
+++ b/e2e/playwright/cloud-sync.spec.ts
@@ -5,6 +5,7 @@ import {
   PROJECT_DIR,
   projectTitles,
   projectToml,
+  readCloudSyncProjectMetadata,
   readOpfsTextFiles,
   routeCloudProjects,
   seedCloudSyncState,
@@ -132,7 +133,7 @@ test(
         updatedAt: '2026-06-02T20:00:00.000Z',
         files: {
           'main.kcl': 'remoteEmptyOne = 1\n',
-          'project.toml': projectToml('Remote empty one'),
+          'project.toml': projectToml('Remote empty one', 'remote-empty-one'),
         },
       },
       {
@@ -142,7 +143,10 @@ test(
         updatedAt: '2026-06-02T19:00:00.000Z',
         files: {
           'main.kcl': 'broken = 1\n',
-          'project.toml': projectToml('Remote empty broken'),
+          'project.toml': projectToml(
+            'Remote empty broken',
+            'remote-empty-broken'
+          ),
         },
       },
       {
@@ -152,7 +156,7 @@ test(
         updatedAt: '2026-06-02T18:00:00.000Z',
         files: {
           'main.kcl': 'remoteEmptyTwo = 1\n',
-          'project.toml': projectToml('Remote empty two'),
+          'project.toml': projectToml('Remote empty two', 'remote-empty-two'),
         },
       },
       {
@@ -162,7 +166,10 @@ test(
         updatedAt: '2026-06-02T17:00:00.000Z',
         files: {
           'main.kcl': 'remoteEmptyThree = 1\n',
-          'project.toml': projectToml('Remote empty three'),
+          'project.toml': projectToml(
+            'Remote empty three',
+            'remote-empty-three'
+          ),
         },
       },
     ]
@@ -249,6 +256,7 @@ test(
     const publicProjectTitle = '!!!'
     const publicProjectDirectoryName = 'shared-project'
     const publicProjectSettingsId = '29501ba6-dfa1-486f-b51d-aa9331ee441e'
+    const personalCloudSettingsId = '29501ba6-dfa1-486f-b51d-aa9331ee442f'
     const publicProjectFiles = {
       'main.kcl': 'aquariumShared = 1\n',
       'project.toml': [
@@ -261,7 +269,16 @@ test(
       id: 'personal-cloud-copy',
       title: publicProjectTitle,
       revision: 'personal-cloud-copy-rev-1',
-      files: publicProjectFiles,
+      files: {
+        'main.kcl': publicProjectFiles['main.kcl'],
+        'project.toml': [
+          'project_id = "personal-cloud-copy"',
+          '',
+          '[settings.meta]',
+          `id = "${personalCloudSettingsId}"`,
+          '',
+        ].join('\n'),
+      },
     }
     const publicProjectArchive = await zipProject(publicProjectFiles)
     let publicProjectDownloads = 0
@@ -325,10 +342,15 @@ test(
       .toBe(true)
     await expect
       .poll(async () => {
-        const files = await readOpfsTextFiles(page, {
-          projectToml: `${PROJECT_DIR}/${publicProjectDirectoryName}/project.toml`,
-        })
-        return files.projectToml
+        try {
+          const files = await readOpfsTextFiles(page, {
+            projectToml: `${PROJECT_DIR}/${publicProjectDirectoryName}/project.toml`,
+          })
+          return files.projectToml
+        } catch {
+          // Replacing a project archive briefly removes the old directory.
+          return ''
+        }
       })
       .toContain('project_id = "personal-cloud-copy"')
 
@@ -359,7 +381,10 @@ test(
       revision: 'remote-only-rev-1',
       files: {
         'main.kcl': 'remoteOnly = 1\n',
-        'project.toml': projectToml('Remote only project'),
+        'project.toml': projectToml(
+          'Remote only project',
+          'remote-only-project'
+        ),
       },
     }
     const cleanSyncedProject: CloudProject = {
@@ -386,25 +411,49 @@ test(
         ),
       },
     }
+    const localOnlyFiles = {
+      'main.kcl': 'localOnly = 1\n',
+      'project.toml': projectToml('Local only project'),
+    }
+    const createdLocalOnlyProject: CloudProject = {
+      id: 'created-local-only-project',
+      title: 'Local only project',
+      revision: 'created-local-only-rev-1',
+      files: {
+        ...localOnlyFiles,
+        'project.toml': projectToml(
+          'Local only project',
+          'created-local-only-project'
+        ),
+      },
+    }
+    const remoteProjects = [
+      remoteOnlyProject,
+      cleanSyncedProject,
+      staleDirtyProject,
+    ]
+    const remoteArchives = new Map<string, Buffer>(
+      await Promise.all(
+        remoteProjects.map(
+          async (project) =>
+            [project.id, await zipProject(project.files)] as const
+        )
+      )
+    )
     const remoteListGate = createRemoteListGate()
     const { calls: apiCalls } = await routeCloudProjects(context, {
-      remoteProjects: [
-        remoteOnlyProject,
-        cleanSyncedProject,
-        staleDirtyProject,
-      ],
-      listedProjects: [
-        remoteOnlyProject,
-        cleanSyncedProject,
-        staleDirtyProject,
-      ],
+      remoteProjects,
+      listedProjects: remoteProjects,
+      remoteArchives,
       remoteListGate,
-      createProject: () => ({
-        id: 'created-local-only-project',
-        title: 'Local only project',
-        revision: 'created-local-only-rev-1',
-        files: {},
-      }),
+      createProject: async () => {
+        remoteProjects.push(createdLocalOnlyProject)
+        remoteArchives.set(
+          createdLocalOnlyProject.id,
+          await zipProject(createdLocalOnlyProject.files)
+        )
+        return createdLocalOnlyProject
+      },
       updateProject: ({ projectId }) =>
         projectId === staleDirtyProject.id
           ? {
@@ -425,10 +474,6 @@ test(
     await expectCloudFeatureEnabled(page)
     await expectCloudSyncHomeReady(page)
 
-    const localOnlyFiles = {
-      'main.kcl': 'localOnly = 1\n',
-      'project.toml': projectToml('Local only project'),
-    }
     const cleanSyncedFiles = {
       'main.kcl': 'cleanLocal = 1\n',
       'project.toml': projectToml(
@@ -547,6 +592,16 @@ test(
       )
     await expect.poll(() => apiCalls.creates.length).toBeGreaterThanOrEqual(1)
     await expect.poll(() => staleUpdateCalls().length).toBeGreaterThanOrEqual(1)
+    await expect
+      .poll(
+        () =>
+          readCloudSyncProjectMetadata(
+            page,
+            `${PROJECT_DIR}/local-only-project`
+          ),
+        { timeout: CLOUD_SYNC_E2E_TIMEOUT }
+      )
+      .toMatchObject({ remoteProjectId: 'created-local-only-project' })
 
     // The mutation observer recorded every project-title DOM change after the
     // local list appeared. Once all local-first projects are present, every
@@ -589,7 +644,6 @@ test(
       cleanSynced: `${PROJECT_DIR}/clean-synced-project/main.kcl`,
       cleanSyncedToml: `${PROJECT_DIR}/clean-synced-project/project.toml`,
       localOnly: `${PROJECT_DIR}/local-only-project/main.kcl`,
-      localOnlyToml: `${PROJECT_DIR}/local-only-project/project.toml`,
       staleDirty: `${PROJECT_DIR}/stale-dirty-project/main.kcl`,
     })
 
@@ -598,9 +652,6 @@ test(
       'project_id = "clean-synced-project"'
     )
     expect(localFiles.localOnly).toContain('localOnly = 1')
-    expect(localFiles.localOnlyToml).toContain(
-      'project_id = "created-local-only-project"'
-    )
     expect(localFiles.staleDirty).toContain('staleLocalDirty = 2')
     expect(staleUpdateCalls()[0]?.url).toContain('expected_revision')
 

--- a/e2e/playwright/lib/cloudSyncTestUtils.ts
+++ b/e2e/playwright/lib/cloudSyncTestUtils.ts
@@ -19,8 +19,14 @@ export type CloudProject = {
   categoryIds?: string[]
   revision: string
   updatedAt?: string
+  publicationStatus?: string
+  submittedAt?: string
+  publishedAt?: string
+  feedback?: string
   files: ProjectFiles
 }
+
+type MaybePromise<T> = T | Promise<T>
 
 type RemoteListGate = ReturnType<typeof createRemoteListGate>
 
@@ -96,7 +102,13 @@ export function cloudProjectResponse(project: CloudProject) {
     description: project.description ?? '',
     category_ids: project.categoryIds ?? [],
     revision: project.revision,
-    ...(project.updatedAt ? { updated_at: project.updatedAt } : {}),
+    updated_at: project.updatedAt ?? '2026-09-01T12:00:00.000Z',
+    publication_status: project.publicationStatus ?? 'private',
+    publication: {
+      submitted_at: project.submittedAt,
+      last_published_at: project.publishedAt,
+      feedback: project.feedback,
+    },
   }
 }
 
@@ -108,8 +120,13 @@ export async function routeCloudProjects(
     remoteArchives?: Map<string, Buffer>
     remoteListGate?: RemoteListGate
     brokenArchiveProjectIds?: Iterable<string>
-    createProject?: (postData: string) => CloudProject
-    updateProject?: (request: ProjectRequest) => JsonRouteResponse | undefined
+    createProject?: (postData: string) => MaybePromise<CloudProject>
+    updateProject?: (
+      request: ProjectRequest
+    ) => MaybePromise<JsonRouteResponse | undefined>
+    publishProject?: (
+      projectId: string
+    ) => MaybePromise<JsonRouteResponse | undefined>
   }
 ) {
   // Mock the subset of the Projects API that cloud sync uses: remote listing,
@@ -132,6 +149,7 @@ export async function routeCloudProjects(
   const calls = {
     creates: [] as string[],
     downloads: [] as string[],
+    publishes: [] as string[],
     remoteListResponses: 0,
     updates: [] as ProjectRequest[],
   }
@@ -160,14 +178,35 @@ export async function routeCloudProjects(
     if (pathname === '/user/projects' && request.method() === 'POST') {
       const postData = request.postData() || ''
       calls.creates.push(postData)
+      const createdProject = await options.createProject?.(postData)
       await fulfillJson(
         route,
-        options.createProject?.(postData) ?? {
-          id: 'created-project',
-          title: 'Created project',
-          revision: 'created-rev-1',
-          files: {},
-        }
+        cloudProjectResponse(
+          createdProject ?? {
+            id: 'created-project',
+            title: 'Created project',
+            revision: 'created-rev-1',
+            files: {},
+          }
+        )
+      )
+      return
+    }
+
+    if (
+      projectId &&
+      pathname.endsWith('/publish') &&
+      request.method() === 'POST'
+    ) {
+      calls.publishes.push(projectId)
+      const response = await options.publishProject?.(projectId)
+      await fulfillJson(
+        route,
+        response?.body ?? {
+          id: projectId,
+          publication_status: 'pending_review',
+        },
+        response?.status ?? 200
       )
       return
     }
@@ -179,7 +218,7 @@ export async function routeCloudProjects(
         postData: request.postData() || '',
       }
       calls.updates.push(updateRequest)
-      const response = options.updateProject?.(updateRequest)
+      const response = await options.updateProject?.(updateRequest)
       if (response) {
         await fulfillJson(route, response.body, response.status)
         return
@@ -438,6 +477,37 @@ export async function opfsPathExists(page: Page, path: string) {
       return false
     }
   }, path)
+}
+
+export async function readCloudSyncProjectMetadata(
+  page: Page,
+  projectPath: string
+) {
+  return page.evaluate(async (localProjectPath) => {
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open('zds-opfs-cloud-sync', 1)
+      request.onerror = () => reject(request.error)
+      request.onsuccess = () => resolve(request.result)
+    })
+    const project = await new Promise<
+      | {
+          localProjectPath: string
+          remoteProjectId?: string
+          remoteRevision?: string
+          conflict?: unknown
+        }
+      | undefined
+    >((resolve, reject) => {
+      const request = db
+        .transaction('projects', 'readonly')
+        .objectStore('projects')
+        .get(localProjectPath)
+      request.onerror = () => reject(request.error)
+      request.onsuccess = () => resolve(request.result)
+    })
+    db.close()
+    return project
+  }, projectPath)
 }
 
 async function fulfillJson(route: Route, body: unknown, status = 200) {

--- a/e2e/playwright/publish-directory-project.spec.ts
+++ b/e2e/playwright/publish-directory-project.spec.ts
@@ -1,0 +1,419 @@
+import * as fsp from 'node:fs/promises'
+import path from 'node:path'
+import {
+  type CloudProject,
+  cloudProjectResponse,
+  routeCloudProjects,
+} from '@e2e/playwright/lib/cloudSyncTestUtils'
+import { playwrightPluginSettings } from '@e2e/playwright/storageStates'
+import { mockClientErrorReports } from '@e2e/playwright/test-utils'
+import { expect, test } from '@e2e/playwright/zoo-test'
+import type { Page } from '@playwright/test'
+import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
+import { DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_LOCAL_PATH } from '@src/lib/projectLibraries'
+import JSZip from 'jszip'
+
+const FLOW_TIMEOUT = 30_000
+
+declare global {
+  interface Window {
+    __publishFlowMessages: string[]
+  }
+}
+
+test.use({ userFeatures: [OPFS_CLOUD_FEATURE_FLAG] })
+
+test.describe('Aquarium publication', { tag: ['@desktop'] }, () => {
+  let originalDesktopPaths:
+    | {
+        appData: string
+        home: string
+      }
+    | undefined
+
+  test.afterEach(async ({ tronApp }) => {
+    if (!tronApp || !originalDesktopPaths) {
+      return
+    }
+    await tronApp.electron.evaluate(({ app }, originalPaths) => {
+      app.setPath('appData', originalPaths.appData)
+      app.setPath('home', originalPaths.home)
+    }, originalDesktopPaths)
+  })
+
+  test('publishes an open directory-library project and moves the same project into Personal Cloud', async ({
+    context,
+    homePage,
+    page,
+    tronApp,
+  }, testInfo) => {
+    if (!tronApp) {
+      throw new Error('tronApp is required for this desktop test.')
+    }
+
+    const directoryLibraryPath = testInfo.outputPath(
+      'electron-test-projects-dir'
+    )
+    const cloudTestRoot = testInfo.outputPath('electron-test-cloud-root')
+    const testAppDataPath = path.join(cloudTestRoot, 'AppData')
+    const testHomePath = path.join(cloudTestRoot, 'Home')
+    const desktopPaths = await tronApp.electron.evaluate(({ app }) => ({
+      appData: app.getPath('appData'),
+      home: app.getPath('home'),
+      isMac: process.platform === 'darwin',
+    }))
+    originalDesktopPaths = desktopPaths
+    const cloudLibraryPath = desktopPaths.isMac
+      ? path.join(cloudTestRoot, 'CloudStorage', 'Zoo', 'personal')
+      : path.join(testHomePath, 'Zoo', 'personal')
+    const sourceDirectoryName = 'directory-publish-source'
+    const sourceProjectPath = path.join(
+      directoryLibraryPath,
+      sourceDirectoryName
+    )
+    const sourceMainFile = path.join(sourceProjectPath, 'main.kcl')
+    const sourceProjectToml = path.join(sourceProjectPath, 'project.toml')
+    const publicationTitle = 'Published directory project'
+    const movedProjectPath = path.join(
+      cloudLibraryPath,
+      'published-directory-project'
+    )
+    const movedMainFile = path.join(movedProjectPath, 'main.kcl')
+    const movedProjectToml = path.join(movedProjectPath, 'project.toml')
+    const remoteProjectId = '12945000-0000-4000-8000-000000000101'
+    const categoryId = '12945000-0000-4000-8000-000000000201'
+    const remoteProjects: CloudProject[] = []
+    const remoteArchives = new Map<string, Buffer>()
+    const createdProject: CloudProject = {
+      id: remoteProjectId,
+      title: publicationTitle,
+      revision: 'directory-publish-rev-1',
+      files: {
+        'main.kcl': 'publishedPart = 42\n',
+        'project.toml': [
+          `title = "${publicationTitle}"`,
+          'default_file = "main.kcl"',
+          '',
+          '[custom]',
+          'keep = "yes"',
+          '',
+          '[cloud."dev.zoo.dev"]',
+          `project_id = "${remoteProjectId}"`,
+          '',
+        ].join('\n'),
+      },
+    }
+    await tronApp.electron.evaluate(
+      ({ app }, testPaths) => {
+        app.setPath('appData', testPaths.appData)
+        app.setPath('home', testPaths.home)
+      },
+      { appData: testAppDataPath, home: testHomePath }
+    )
+    await clearCloudSyncState(page)
+    await tronApp.cleanProjectDir({
+      plugins: playwrightPluginSettings({ cloudSyncEnabled: true }),
+      app: {
+        libraries: [
+          {
+            title: 'Local Projects',
+            path: directoryLibraryPath,
+            type: 'directory',
+          },
+          {
+            title: 'Personal Cloud',
+            path: DEFAULT_PERSONAL_CLOUD_PROJECT_LIBRARY_LOCAL_PATH,
+            type: 'cloud',
+          },
+        ],
+      },
+    })
+    await fsp.mkdir(sourceProjectPath, { recursive: true })
+    await fsp.mkdir(cloudLibraryPath, { recursive: true })
+    await fsp.writeFile(sourceMainFile, 'publishedPart = 42\n')
+    await fsp.writeFile(
+      sourceProjectToml,
+      [
+        'title = "Directory publish source"',
+        'default_file = "main.kcl"',
+        '',
+        '[custom]',
+        'keep = "yes"',
+        '',
+      ].join('\n')
+    )
+
+    await mockClientErrorReports(context)
+    await context.route('**/user', async (route) => {
+      if (
+        new URL(route.request().url()).pathname !== '/user' ||
+        route.request().method() !== 'GET'
+      ) {
+        await route.continue()
+        return
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: '12945000-0000-4000-8000-000000000001',
+          name: 'Playwright User',
+          username: 'playwright',
+          email: 'playwright@example.com',
+          image: '',
+          created_at: '2026-09-01T12:00:00.000Z',
+          updated_at: '2026-09-01T12:00:00.000Z',
+        }),
+      })
+    })
+    await context.route('**/projects/categories', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: categoryId,
+            slug: 'fixtures',
+            display_name: 'Fixtures',
+            description: 'Projects used by end-to-end tests.',
+            sort_order: 1,
+            is_active: true,
+          },
+        ]),
+      })
+    })
+
+    const { calls: apiCalls } = await routeCloudProjects(context, {
+      remoteProjects,
+      remoteArchives,
+      createProject: async () => {
+        if (!remoteProjects.includes(createdProject)) {
+          remoteProjects.push(createdProject)
+        }
+        remoteArchives.set(
+          remoteProjectId,
+          await zipLocalProject(movedProjectPath, {
+            'project.toml': createdProject.files['project.toml'],
+          })
+        )
+        return createdProject
+      },
+      updateProject: ({ projectId }) => {
+        const project = remoteProjects.find(({ id }) => id === projectId)
+        if (!project) {
+          return undefined
+        }
+
+        project.description = 'A project published from a directory library.'
+        project.categoryIds = [categoryId]
+        project.revision = 'directory-publish-rev-2'
+        return { status: 200, body: cloudProjectResponse(project) }
+      },
+      publishProject: (projectId) => {
+        const project = remoteProjects.find(({ id }) => id === projectId)
+        if (!project) {
+          return undefined
+        }
+
+        project.publicationStatus = 'pending_review'
+        project.submittedAt = '2026-09-01T12:05:00.000Z'
+        return { status: 200, body: cloudProjectResponse(project) }
+      },
+    })
+
+    await page.addInitScript(() => {
+      window.__publishFlowMessages = []
+      const observer = new MutationObserver((mutations) => {
+        const addedText = mutations
+          .flatMap((mutation) => Array.from(mutation.addedNodes))
+          .map((node) => node.textContent ?? '')
+          .join('\n')
+        for (const message of [
+          'Reloading file from disk.',
+          'The project could not be synced before publication.',
+          'Project submitted for review.',
+        ]) {
+          if (addedText.includes(message)) {
+            window.__publishFlowMessages.push(message)
+          }
+        }
+      })
+      const observeDocument = () =>
+        observer.observe(document.documentElement, {
+          childList: true,
+          subtree: true,
+        })
+      if (document.documentElement) {
+        observeDocument()
+      } else {
+        document.addEventListener('DOMContentLoaded', observeDocument, {
+          once: true,
+        })
+      }
+    })
+
+    await page.reload()
+    await homePage.openProject('Directory publish source')
+    await expect(page).toHaveURL(/\/file\/.*main\.kcl/, {
+      timeout: FLOW_TIMEOUT,
+    })
+    await expect(page.getByTestId('publish-button')).toBeEnabled()
+
+    await page.getByTestId('publish-button').click()
+    await expect(
+      page.getByRole('heading', { name: 'Publish project' })
+    ).toBeVisible()
+    await page.getByLabel('Title*').fill(publicationTitle)
+    await page
+      .getByTestId('publish-project-description-editor')
+      .fill('A project published from a directory library.')
+    await page.getByRole('checkbox', { name: /Fixtures/ }).check()
+    await page.getByRole('button', { name: 'Submit for review' }).click()
+
+    await expect
+      .poll(
+        () =>
+          page.evaluate(
+            () => window.app.project?.projectIORefSignal.value.path
+          ),
+        { timeout: FLOW_TIMEOUT }
+      )
+      .toBe(movedProjectPath)
+    await expect(page.getByTestId('app-header-project-name')).toHaveText(
+      publicationTitle
+    )
+    await expect
+      .poll(() => page.url())
+      .toContain(encodeURIComponent(movedMainFile))
+
+    await expect.poll(() => apiCalls.creates.length).toBe(1)
+    await expect.poll(() => apiCalls.updates.length).toBeGreaterThanOrEqual(1)
+    expect(
+      apiCalls.updates.some(({ postData }) =>
+        postData.includes('A project published from a directory library.')
+      )
+    ).toBe(true)
+    expect(apiCalls.publishes).toEqual([remoteProjectId])
+    expect(await pathExists(sourceProjectPath)).toBe(false)
+    expect(await pathExists(movedMainFile)).toBe(true)
+
+    const [movedMainContents, movedTomlContents] = await Promise.all([
+      fsp.readFile(movedMainFile, 'utf8'),
+      fsp.readFile(movedProjectToml, 'utf8'),
+    ])
+    expect(movedMainContents).toBe('publishedPart = 42\n')
+    expect(movedTomlContents).toContain(`title = "${publicationTitle}"`)
+    expect(movedTomlContents).toContain('default_file = "main.kcl"')
+    expect(movedTomlContents).toContain('[custom]')
+    expect(movedTomlContents).toContain('keep = "yes"')
+    expect(movedTomlContents).toContain(`project_id = "${remoteProjectId}"`)
+
+    await expect
+      .poll(() => readCloudSyncState(page), { timeout: FLOW_TIMEOUT })
+      .toMatchObject({
+        outboxCount: 0,
+        projects: [
+          {
+            localProjectPath: movedProjectPath,
+            remoteProjectId,
+            remoteRevision: expect.stringMatching(
+              /^directory-publish-rev-[12]$/
+            ),
+            conflict: undefined,
+          },
+        ],
+      })
+    expect(await page.evaluate(() => window.__publishFlowMessages)).toEqual([
+      'Project submitted for review.',
+    ])
+    await expect(page.getByTestId('cloud-conflict-badge')).toHaveCount(0)
+    await expect(
+      page.getByTestId('project-sidebar-cloud-conflict-badge')
+    ).toHaveCount(0)
+  })
+})
+
+async function pathExists(targetPath: string) {
+  try {
+    await fsp.stat(targetPath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function readCloudSyncState(page: Page) {
+  return page.evaluate(async () => {
+    type StoredProject = {
+      localProjectPath: string
+      remoteProjectId?: string
+      remoteRevision?: string
+      conflict?: unknown
+    }
+
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open('zds-opfs-cloud-sync', 1)
+      request.onerror = () => reject(request.error)
+      request.onsuccess = () => resolve(request.result)
+    })
+    const getAll = (storeName: string) =>
+      new Promise<StoredProject[]>((resolve, reject) => {
+        const request = db
+          .transaction(storeName, 'readonly')
+          .objectStore(storeName)
+          .getAll()
+        request.onerror = () => reject(request.error)
+        request.onsuccess = () => resolve(request.result)
+      })
+
+    const [projects, outbox] = await Promise.all([
+      getAll('projects'),
+      getAll('outbox'),
+    ])
+    db.close()
+    return {
+      outboxCount: outbox.length,
+      projects: projects.map((project) => ({
+        localProjectPath: project.localProjectPath,
+        remoteProjectId: project.remoteProjectId,
+        remoteRevision: project.remoteRevision,
+        conflict: project.conflict,
+      })),
+    }
+  })
+}
+
+async function clearCloudSyncState(page: Page) {
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        const request = indexedDB.deleteDatabase('zds-opfs-cloud-sync')
+        request.onerror = () => reject(request.error)
+        request.onsuccess = () => resolve()
+      })
+  )
+}
+
+async function zipLocalProject(
+  projectPath: string,
+  overrides: Record<string, string>
+) {
+  const zip = new JSZip()
+  const entries = await fsp.readdir(projectPath, {
+    recursive: true,
+    withFileTypes: true,
+  })
+  for (const entry of entries) {
+    if (!entry.isFile()) {
+      continue
+    }
+    const absolutePath = path.join(entry.parentPath, entry.name)
+    const relativePath = path.relative(projectPath, absolutePath)
+    zip.file(
+      relativePath,
+      overrides[relativePath] ?? (await fsp.readFile(absolutePath))
+    )
+  }
+  return Buffer.from(await zip.generateAsync({ type: 'uint8array' }))
+}

--- a/src/components/PublishButton.spec.tsx
+++ b/src/components/PublishButton.spec.tsx
@@ -1,9 +1,11 @@
-import type { ProjectPublishSubmission } from '@src/lib/share'
+import type { ProjectPublishSubmission, PublishedProject } from '@src/lib/share'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 type PublishDialogTestProps = {
-  onSubmit: (submission: ProjectPublishSubmission) => Promise<boolean>
+  onSubmit: (
+    submission: ProjectPublishSubmission
+  ) => Promise<boolean | PublishedProject>
   willMoveProjectToCloud: boolean
 }
 
@@ -11,6 +13,7 @@ const mockState = vi.hoisted(() => ({
   useProjectStatus: vi.fn(),
   publishCurrentProject: vi.fn(),
   getCurrentProjectPublicationDetails: vi.fn(),
+  writeProjectTitleToProjectToml: vi.fn(),
   publishDialogProps: null as PublishDialogTestProps | null,
 }))
 
@@ -24,6 +27,10 @@ vi.mock('@src/lib/share', () => ({
     mockState.getCurrentProjectPublicationDetails,
 }))
 
+vi.mock('@src/lib/desktop', () => ({
+  writeProjectTitleToProjectToml: mockState.writeProjectTitleToProjectToml,
+}))
+
 vi.mock('@src/components/PublishDialog', () => ({
   PublishDialog: (props: PublishDialogTestProps) => {
     mockState.publishDialogProps = props
@@ -33,6 +40,7 @@ vi.mock('@src/components/PublishDialog', () => ({
 
 import { PublishButton } from '@src/components/PublishButton'
 import type { App } from '@src/lib/app'
+import { cloudSyncService } from '@src/lib/cloudSync/registry/contract'
 import type { Project } from '@src/lib/project'
 import {
   CLOUD_PROJECT_LIBRARY_TYPE,
@@ -62,6 +70,8 @@ const localProject = {
 
 const homeProject = {
   localProjectPath: localProject.path,
+  name: 'example',
+  title: 'Old Example',
 } as HomeProjectEntry
 
 const cloudLibraryTarget = {
@@ -81,6 +91,8 @@ function createApp({
   project = defaultProject,
   hasCloudSyncFeature = false,
   homeProjectActions,
+  startProjectSync = vi.fn().mockResolvedValue(undefined),
+  syncNow = vi.fn().mockResolvedValue({ remoteProjectId: 'remote-synced' }),
   writeToFile = vi.fn().mockResolvedValue(undefined),
   closeProject = vi.fn(),
   settingsSend = vi.fn(),
@@ -88,6 +100,8 @@ function createApp({
   project?: Project
   hasCloudSyncFeature?: boolean
   homeProjectActions?: HomeProjectActionsService
+  startProjectSync?: ReturnType<typeof vi.fn>
+  syncNow?: ReturnType<typeof vi.fn>
   writeToFile?: ReturnType<typeof vi.fn>
   closeProject?: ReturnType<typeof vi.fn>
   settingsSend?: ReturnType<typeof vi.fn>
@@ -126,8 +140,15 @@ function createApp({
       },
     },
     registry: {
-      optional: (service: unknown) =>
-        service === homeProjectActionsService ? homeProjectActions : undefined,
+      optional: (service: unknown) => {
+        if (service === homeProjectActionsService) {
+          return homeProjectActions
+        }
+        if (service === cloudSyncService) {
+          return { startProjectSync, syncNow }
+        }
+        return undefined
+      },
       get: (valueSpec: unknown) =>
         valueSpec === homeProjectEntriesValueSpec ? [homeProject] : [],
     },
@@ -157,7 +178,9 @@ describe('PublishButton', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockState.useProjectStatus.mockReturnValue(null)
-    mockState.publishCurrentProject.mockResolvedValue(true)
+    mockState.publishCurrentProject.mockResolvedValue({
+      remoteProjectId: 'remote-published',
+    })
     mockState.getCurrentProjectPublicationDetails.mockResolvedValue(null)
     mockState.publishDialogProps = null
   })
@@ -227,11 +250,19 @@ describe('PublishButton', () => {
     async (_label, hasCloudSyncFeature, shouldMove) => {
       const moveToLibrary = vi.fn().mockResolvedValue({
         defaultFile: '/cloud/example/main.kcl',
+        localProjectPath: '/cloud/example',
       })
+      const rename = vi.fn().mockResolvedValue(undefined)
+      const startProjectSync = vi.fn().mockResolvedValue(undefined)
+      const syncNow = vi
+        .fn()
+        .mockResolvedValue({ remoteProjectId: 'remote-synced' })
       const writeToFile = vi.fn().mockResolvedValue(undefined)
       const closeProject = vi.fn()
       const settingsSend = vi.fn()
       const homeProjectActions = {
+        canRename: vi.fn().mockReturnValue(true),
+        rename,
         getMoveToLibraryTargets: vi.fn().mockReturnValue([cloudLibraryTarget]),
         moveToLibrary,
       } as unknown as HomeProjectActionsService
@@ -239,6 +270,8 @@ describe('PublishButton', () => {
         project: localProject,
         hasCloudSyncFeature,
         homeProjectActions,
+        startProjectSync,
+        syncNow,
         writeToFile,
         closeProject,
         settingsSend,
@@ -255,21 +288,70 @@ describe('PublishButton', () => {
       expect(writeToFile).toHaveBeenCalledBefore(
         mockState.publishCurrentProject
       )
+      expect(rename).toHaveBeenCalledTimes(shouldMove ? 0 : 1)
+      expect(startProjectSync).not.toHaveBeenCalled()
+      expect(syncNow).toHaveBeenCalledTimes(shouldMove ? 1 : 0)
       expect(moveToLibrary).toHaveBeenCalledTimes(shouldMove ? 1 : 0)
       if (shouldMove) {
+        expect(mockState.writeProjectTitleToProjectToml).toHaveBeenCalledWith(
+          localProject.path,
+          'Example'
+        )
+        expect(syncNow).toHaveBeenCalledWith('/cloud/example')
+        expect(syncNow).toHaveBeenCalledBefore(mockState.publishCurrentProject)
+        expect(mockState.publishCurrentProject).toHaveBeenCalledWith(
+          expect.objectContaining({ remoteProjectId: 'remote-synced' })
+        )
         expect(moveToLibrary).toHaveBeenCalledWith(
           homeProject,
           'personal-cloud'
         )
-        expect(
-          mockState.publishCurrentProject.mock.invocationCallOrder[0]
-        ).toBeLessThan(moveToLibrary.mock.invocationCallOrder[0])
+        expect(moveToLibrary).toHaveBeenCalledBefore(syncNow)
         expect(closeProject).toHaveBeenCalledOnce()
         expect(settingsSend).toHaveBeenCalledWith({
           type: 'clear.project',
         })
         expect(closeProject).toHaveBeenCalledBefore(moveToLibrary)
+      } else {
+        expect(rename).toHaveBeenCalledWith(homeProject, 'Example', {
+          notify: false,
+        })
+        expect(rename).toHaveBeenCalledBefore(mockState.publishCurrentProject)
+        expect(mockState.publishCurrentProject).toHaveBeenCalledWith(
+          expect.objectContaining({ remoteProjectId: undefined })
+        )
       }
     }
   )
+
+  test('does not publish when cloud sync fails after moving the project', async () => {
+    const homeProjectActions = {
+      canRename: vi.fn().mockReturnValue(true),
+      rename: vi.fn().mockResolvedValue(undefined),
+      getMoveToLibraryTargets: vi.fn().mockReturnValue([cloudLibraryTarget]),
+      moveToLibrary: vi.fn().mockResolvedValue({
+        defaultFile: '/cloud/example/main.kcl',
+        localProjectPath: '/cloud/example',
+      }),
+    } as unknown as HomeProjectActionsService
+    const syncNow = vi.fn().mockRejectedValue(new Error('sync failed'))
+    const app = createApp({
+      project: localProject,
+      hasCloudSyncFeature: true,
+      homeProjectActions,
+      syncNow,
+    })
+    const dialogProps = await openPublishDialog(app)
+
+    await act(async () => {
+      await expect(dialogProps.onSubmit(publishSubmission)).resolves.toBe(false)
+    })
+
+    expect(syncNow).toHaveBeenCalledWith('/cloud/example')
+    expect(mockState.publishCurrentProject).not.toHaveBeenCalled()
+    expect(homeProjectActions.moveToLibrary).toHaveBeenCalledWith(
+      homeProject,
+      'personal-cloud'
+    )
+  })
 })

--- a/src/components/PublishButton.tsx
+++ b/src/components/PublishButton.tsx
@@ -8,10 +8,15 @@ import {
   useProjectStatus,
 } from '@src/hooks/useProjectStatus'
 import type { App } from '@src/lib/app'
+import { cloudSyncService } from '@src/lib/cloudSync/registry/contract'
 import { OPFS_CLOUD_FEATURE_FLAG } from '@src/lib/constants'
+import fsZds from '@src/lib/fs-zds'
 import type { Project } from '@src/lib/project'
 import { CLOUD_PROJECT_LIBRARY_TYPE } from '@src/lib/projectLibraries'
-import { moveOpenedProjectToCloudLibrary } from '@src/lib/projectLibraries/moveOpenedProjectToCloudLibrary'
+import {
+  moveOpenedProjectToCloudLibrary,
+  updateProjectTitleForPublication,
+} from '@src/lib/projectLibraries/moveOpenedProjectToCloudLibrary'
 import {
   type CurrentProjectPublicationDetails,
   getCurrentProjectPublicationDetails,
@@ -119,25 +124,29 @@ function PublishPopoverContent({
     [keymap, markdownEditor]
   )
 
-  const fetchPublicationDetails = useCallback(async () => {
-    if (!token || !project) {
-      return null
-    }
+  const fetchPublicationDetails = useCallback(
+    async (remoteProjectId?: string) => {
+      if (!token || !project) {
+        return null
+      }
 
-    const wasmInstance = await kclManager.wasmInstancePromise
-    const details = await getCurrentProjectPublicationDetails({
-      token,
-      project,
-      wasmInstance,
-    })
+      const wasmInstance = await kclManager.wasmInstancePromise
+      const details = await getCurrentProjectPublicationDetails({
+        token,
+        project,
+        wasmInstance,
+        remoteProjectId,
+      })
 
-    if (err(details)) {
-      console.error('Failed to load project publication details', details)
-      return null
-    }
+      if (err(details)) {
+        console.error('Failed to load project publication details', details)
+        return null
+      }
 
-    return details
-  }, [kclManager, project, token])
+      return details
+    },
+    [kclManager, project, token]
+  )
 
   useEffect(() => {
     let isCancelled = false
@@ -174,24 +183,102 @@ function PublishPopoverContent({
       if (err(saved)) {
         return false
       }
+      if (!project) {
+        return false
+      }
+
+      const publicationTitle = submission.title.trim()
+      let publicationProject = project
+      let publicationFilePath = kclManager.path
+
+      if (willMoveProjectToCloud) {
+        const relativeFilePath = fsZds.relative(
+          project.path,
+          publicationFilePath
+        )
+        const moved = await moveOpenedProjectToCloudLibrary({
+          app,
+          project,
+          navigate,
+          title: publicationTitle,
+        })
+        if (err(moved)) {
+          console.error('Project could not be moved to Personal Cloud', moved)
+          toast.error('The project could not be moved to Personal Cloud.', {
+            duration: 5000,
+          })
+          return false
+        }
+
+        publicationFilePath = fsZds.join(moved.projectPath, relativeFilePath)
+        publicationProject = {
+          ...project,
+          title: publicationTitle,
+          name: fsZds.basename(moved.projectPath),
+          path: moved.projectPath,
+          default_file: moved.defaultFile,
+          libraryPath: fsZds.dirname(moved.projectPath),
+          libraryType: CLOUD_PROJECT_LIBRARY_TYPE,
+        }
+      } else {
+        const updatedTitle = await updateProjectTitleForPublication({
+          app,
+          project,
+          title: publicationTitle,
+        })
+        if (err(updatedTitle)) {
+          console.error('Failed to update the project title', updatedTitle)
+          toast.error('The project title could not be updated.', {
+            duration: 5000,
+          })
+          return false
+        }
+        publicationProject = {
+          ...project,
+          title: publicationTitle,
+        }
+      }
+
+      let remoteProjectId: string | undefined
+      if (willMoveProjectToCloud) {
+        const cloudSync = app.registry.optional(cloudSyncService)
+        if (!cloudSync) {
+          toast.error('Cloud sync is unavailable for this project.', {
+            duration: 5000,
+          })
+          return false
+        }
+        try {
+          remoteProjectId = (await cloudSync.syncNow(publicationProject.path))
+            .remoteProjectId
+        } catch (error) {
+          console.error('Failed to sync the project before publication', error)
+          toast.error('The project could not be synced before publication.', {
+            duration: 5000,
+          })
+          return false
+        }
+      }
+
       const published = await publishCurrentProject({
         token,
-        project,
-        currentFilePath: kclManager.path,
+        project: publicationProject,
+        currentFilePath: publicationFilePath,
         currentFileContents: kclManager.code,
         wasmInstance,
         submission,
+        remoteProjectId,
       })
 
       if (!published) {
         return false
       }
 
-      const details = await fetchPublicationDetails()
+      const details = await fetchPublicationDetails(published.remoteProjectId)
       setPublicationDetails(details)
       if (details) {
         setSubmittedProjectStatus({
-          projectId: project?.cloudProjectId,
+          projectId: published.remoteProjectId,
           status: {
             publicationStatus: details.publicationStatus,
             feedback:
@@ -201,25 +288,6 @@ function PublishPopoverContent({
                 : undefined,
           },
         })
-      }
-
-      if (willMoveProjectToCloud && project) {
-        const moved = await moveOpenedProjectToCloudLibrary({
-          app,
-          project,
-          navigate,
-        })
-        if (err(moved)) {
-          console.error(
-            'Project was submitted to Aquarium but could not be moved to Personal Cloud',
-            moved
-          )
-          toast.error(
-            'Project submitted to Aquarium, but it could not be moved to Personal Cloud.',
-            { duration: 5000 }
-          )
-          return false
-        }
       }
 
       return true

--- a/src/lib/cloudSync/README.md
+++ b/src/lib/cloudSync/README.md
@@ -46,7 +46,7 @@ Canonical selection prefers a clean cloud-library realization, then the newest c
 
 ### Moving projects between libraries
 
-- Directory -> Cloud: move the local project directory into the Personal Cloud storage directory. If cloud sync is enabled, explicitly enroll the moved project with `startProjectSync`. If the project already has a valid cloud project ID, the engine may bind to that remote project; otherwise the next sync creates one.
+- Directory -> Cloud: move the local project directory into the Personal Cloud storage directory. If cloud sync is enabled, explicitly enroll the moved project with `startProjectSync`. Workflows that need a cloud identity before continuing should enroll the project and then await `syncNow`. Otherwise, an existing cloud ID may be bound from project settings or the next sync creates the remote project.
 - Cloud -> Directory: treat this as "make local-only." Before the filesystem move, run the user-initiated disconnect flow: remove the local `project.toml` cloud project ID, clear pending cloud sync work, mark the local project `syncExcluded` with `reason: "user-disconnected"`, delete the remote cloud project, and update the remote project index. If remote deletion fails, the disconnect restores the local cloud link and the move should fail rather than leaving a half-detached project.
 - Cloud -> Cloud: if we add multiple cloud-type libraries, moving between them should preserve the cloud binding. Do not disconnect unless the target library type is not cloud.
 - Directory -> Directory: leave existing project metadata alone, but do not auto-enroll local-only projects. Directory-type libraries may discover projects that already carry cloud metadata, but they do not own cloud sync enrollment.

--- a/src/lib/cloudSync/cloudApi.spec.ts
+++ b/src/lib/cloudSync/cloudApi.spec.ts
@@ -24,6 +24,16 @@ function projectFile(relativePath: string, contents = ''): ProjectArchiveFile {
   }
 }
 
+function projectFiles() {
+  return [
+    projectFile('main.kcl'),
+    projectFile(
+      'project.toml',
+      'title = "bracket"\ndefault_file = "main.kcl"\n'
+    ),
+  ]
+}
+
 async function uploadBodyFromRequest(init?: RequestInit) {
   expect(init?.body).toBeInstanceOf(FormData)
   const bodyPart = (init?.body as FormData).get('body')
@@ -61,7 +71,7 @@ describe('remote project uploads', () => {
         baseUrl: 'https://api.dev.zoo.dev',
       },
       '/projects/bracket',
-      [projectFile('main.kcl')]
+      projectFiles()
     )
 
     expect(uploadedBody).toEqual({
@@ -92,7 +102,7 @@ describe('remote project uploads', () => {
         description: 'Existing Aquarium description.',
         category_ids: ['category-a', 'category-b'],
       },
-      files: [projectFile('main.kcl')],
+      files: projectFiles(),
       expectedRevision: 'rev-1',
     })
 
@@ -131,7 +141,7 @@ describe('remote project uploads', () => {
         description: '',
         category_ids: [],
       },
-      files: [projectFile('main.kcl')],
+      files: projectFiles(),
       expectedRevision: 'rev-1',
       deletedPaths: [],
     })
@@ -157,7 +167,7 @@ describe('remote project uploads', () => {
         description: '',
         category_ids: [],
       },
-      files: [projectFile('main.kcl')],
+      files: projectFiles(),
       expectedRevision: 'rev-1',
       deletedPaths: ['old/part.kcl', 'obsolete.kcl', 'obsolete.kcl'],
     })

--- a/src/lib/cloudSync/engine.ts
+++ b/src/lib/cloudSync/engine.ts
@@ -32,7 +32,7 @@ import {
   projectManifestFromFiles,
   projectManifestsEqual,
   toArrayBuffer,
-  withRemoteProjectMetadataInArchiveFiles,
+  withProjectTitleInArchiveFiles,
   withUpdatedProjectTomlInArchiveFiles,
 } from '@src/lib/cloudSync/projectArchive'
 import {
@@ -51,6 +51,7 @@ import type {
   CloudSyncLocalProject,
   CloudSyncOpenedProject,
   CloudSyncProjectMetadataIndexEntry,
+  CloudSyncProjectNowResult,
   CloudSyncStatus,
   OutboxEntry,
   ProjectArchiveFile,
@@ -138,6 +139,9 @@ const SYNC_RETRY_MAX_MS = 5 * 60 * 1000
 const PROJECT_API_THROTTLE_MS = 250
 const PROJECT_API_THROTTLE_JITTER_MS = 250
 const REMOTE_INDEX_INTERVAL_MS = 5 * 60 * 1000
+// A new project needs one upload pass and one API-archive reconciliation pass.
+// Leave room for an outbox mutation arriving between those operations.
+const SYNC_NOW_MAX_PASSES = 4
 const REMOTE_UPLOAD_FORBIDDEN_MESSAGE =
   'Cloud sync cannot upload local changes because this account does not have edit access to the linked cloud project. Local changes are safe on this device.'
 
@@ -148,6 +152,7 @@ let config: CloudSyncConfig = {
 }
 let syncTimer: ReturnType<typeof setTimeout> | undefined
 let syncInProgress = false
+const syncIdleWaiters = new Set<() => void>()
 let syncRetryAttempt = 0
 let lastRemoteIndexSyncAt = 0
 let initialLocalScanComplete = false
@@ -166,6 +171,21 @@ type CloudSyncProjectApiRequestThrottle = () => Promise<void>
 
 const unthrottledCloudSyncProjectApiRequest: CloudSyncProjectApiRequestThrottle =
   async () => undefined
+
+async function acquireCloudSyncOperation() {
+  while (syncInProgress) {
+    await new Promise<void>((resolve) => syncIdleWaiters.add(resolve))
+  }
+  syncInProgress = true
+}
+
+function releaseCloudSyncOperation() {
+  syncInProgress = false
+  for (const resolve of syncIdleWaiters) {
+    resolve()
+  }
+  syncIdleWaiters.clear()
+}
 
 export const cloudSyncStatus = signal<CloudSyncStatus>({
   enabled: false,
@@ -846,13 +866,7 @@ async function downloadRemoteProjectSnapshot({
   const parsedArchive = await parseProjectArchive(
     await downloadRemoteProjectArchive(config, projectId)
   )
-  const filesWithMetadata = withRemoteProjectMetadataInArchiveFiles(
-    parsedArchive,
-    project.title,
-    projectId,
-    getEnvironmentName()
-  )
-  const files = filterCloudSyncProjectFilesForSync(filesWithMetadata)
+  const files = filterCloudSyncProjectFilesForSync(parsedArchive)
 
   if (!verifyStableRevision) {
     return {
@@ -936,18 +950,6 @@ export function getCloudSyncMissingRemoteProjectAction({
 async function writeLocalProjectTitle(projectPath: string, title: string) {
   return updateLocalProjectToml(projectPath, (projectToml) =>
     getProjectTitleFromProjectTomlContents(projectToml) === title
-      ? projectToml
-      : setProjectTitleInProjectTomlContents(projectToml, title)
-  )
-}
-
-async function ensureLocalProjectTitle(projectPath: string, title?: string) {
-  if (!title?.trim()) {
-    return false
-  }
-
-  return updateLocalProjectToml(projectPath, (projectToml) =>
-    getProjectTitleFromProjectTomlContents(projectToml)
       ? projectToml
       : setProjectTitleInProjectTomlContents(projectToml, title)
   )
@@ -1330,13 +1332,28 @@ async function replaceLocalProjectWithFiles(
   projectPath: string,
   files: ProjectArchiveFile[]
 ) {
-  if (await exists(projectPath)) {
-    await localFs.rm(projectPath, { recursive: true })
+  const existingFiles = (await exists(projectPath))
+    ? await collectLocalProjectFiles(projectPath)
+    : []
+  const existingFilesByPath = projectArchiveFileMap(existingFiles)
+  const remotePaths = new Set(files.map((file) => file.relativePath))
+
+  // Keep the project root continuously available while applying a remote
+  // snapshot. File routes and editor watchers treat a missing root as a
+  // deleted project and otherwise race a safe cloud hydration back to Home.
+  for (const existingFile of existingFiles) {
+    if (!remotePaths.has(existingFile.relativePath)) {
+      await localFs.rm(localFs.join(projectPath, existingFile.relativePath))
+    }
   }
 
   await localFs.mkdir(projectPath, { recursive: true })
   for (const file of files) {
     if (!file.relativePath) {
+      continue
+    }
+    const existingFile = existingFilesByPath.get(file.relativePath)
+    if (existingFile && archiveFileContentsEqual(existingFile, file)) {
       continue
     }
     const targetPath = localFs.join(projectPath, file.relativePath)
@@ -1346,6 +1363,16 @@ async function replaceLocalProjectWithFiles(
       new Uint8Array(toArrayBuffer(file.data))
     )
   }
+}
+
+function archiveFileContentsEqual(
+  left: ProjectArchiveFile,
+  right: ProjectArchiveFile
+) {
+  if (left.data.byteLength !== right.data.byteLength) {
+    return false
+  }
+  return left.data.every((byte, index) => byte === right.data[index])
 }
 
 async function uniqueProjectPath(
@@ -1715,12 +1742,7 @@ async function cloneRemoteProjectToLocal(
       : await uniqueProjectPath(projectDirectory, projectName)
   const archive = await downloadRemoteProjectArchive(config, remoteProject.id)
   const files = filterCloudSyncProjectFilesForSync(
-    withRemoteProjectMetadataInArchiveFiles(
-      await parseProjectArchive(archive),
-      remoteProject.title,
-      remoteProject.id,
-      getEnvironmentName()
-    )
+    await parseProjectArchive(archive)
   )
   const nextMetadata = {
     ...metadataForProject(projectPath),
@@ -1830,10 +1852,6 @@ export async function ensureCloudProjectLocallySynced(
       remoteProjectId: projectId,
       tombstone: false,
     }
-    await ensureLocalProjectTitle(
-      existingProjectPath,
-      getRemoteProjectTitleForProjectToml(remoteProject.title)
-    )
     await putProjectMetadata(nextMetadata)
     nextMetadata = await syncCloudProjectDirectoryNameFromTitle({
       metadata: nextMetadata,
@@ -1880,15 +1898,13 @@ export async function renameRemoteCloudProject(
   }
 
   const remoteProject = await getRemoteProject(config, projectId)
-  const files = withRemoteProjectMetadataInArchiveFiles(
+  const files = withProjectTitleInArchiveFiles(
     filterCloudSyncProjectFilesForSync(
       await parseProjectArchive(
         await downloadRemoteProjectArchive(config, projectId)
       )
     ),
-    title,
-    projectId,
-    getEnvironmentName()
+    title
   )
   const updated = await updateRemoteProject({
     config,
@@ -2616,7 +2632,7 @@ export function getCloudSyncProjectSyncPreflightAction({
   if (!hasRemoteProjectId) {
     return 'create-remote'
   }
-  if (!localChanged && !remoteChanged) {
+  if (!localChanged && !remoteChanged && hasRemoteRevision) {
     return 'mark-synced'
   }
   if (localChanged && !remoteChanged && hasRemoteRevision) {
@@ -2860,13 +2876,6 @@ async function syncProject(
       return
     }
 
-    if (metadata.remoteProjectId) {
-      await writeLocalProjectCloudProjectId(
-        metadata.localProjectPath,
-        metadata.remoteProjectId
-      )
-    }
-
     let remoteProject: RemoteProject | undefined
     let remoteRevision: Revision | undefined
     let remoteChanged = false
@@ -2892,12 +2901,6 @@ async function syncProject(
       remoteRevision = getRevision(remoteProject)
     }
 
-    await ensureLocalProjectTitle(
-      metadata.localProjectPath,
-      remoteProject
-        ? getRemoteProjectTitleForProjectToml(remoteProject.title)
-        : metadata.projectName
-    )
     if (entries.length === 0) {
       metadata = await syncCloudProjectDirectoryNameFromTitle({
         metadata,
@@ -2946,22 +2949,25 @@ async function syncProject(
         throttleProjectApiRequest,
         () => createRemoteProject(config, metadata.localProjectPath, localFiles)
       )
-      await writeLocalProjectCloudProjectId(
-        metadata.localProjectPath,
-        created.id
-      )
-      const nextLocalFiles = await collectLocalProjectFiles(
-        metadata.localProjectPath
-      )
       await clearOutboxEntriesForProject(metadata.localProjectPath)
-      await markProjectSynced(
-        {
-          ...metadata,
-          remoteProjectId: created.id,
-        },
-        await projectManifestFromFiles(nextLocalFiles),
-        remoteSyncMetadata(created, { useNowAsUpdatedAtFallback: true })
-      )
+      const uploadedMetadata: ProjectMetadata = {
+        ...metadata,
+        remoteProjectId: created.id,
+        remoteRevision: undefined,
+        remoteUpdatedAt: undefined,
+        baseManifest: localManifest,
+        conflict: undefined,
+        lastFailure: undefined,
+      }
+      await putProjectMetadata(uploadedMetadata)
+      publishScopedProjectCloudProjectId(uploadedMetadata)
+      await appendOutboxEntry({
+        projectPath: metadata.localProjectPath,
+        kind: 'upsert',
+        targetPath: metadata.localProjectPath,
+        createdAt: nowIso(),
+      })
+      scheduleSync(0)
       return
     }
 
@@ -3017,12 +3023,7 @@ async function syncProject(
       () => downloadRemoteProjectArchive(config, remoteProjectId)
     )
     const remoteFiles = filterCloudSyncProjectFilesForSync(
-      withRemoteProjectMetadataInArchiveFiles(
-        await parseProjectArchive(remoteArchive),
-        remoteProject.title,
-        remoteProjectId,
-        getEnvironmentName()
-      )
+      await parseProjectArchive(remoteArchive)
     )
     const remoteManifest = await projectManifestFromFiles(remoteFiles)
 
@@ -3368,10 +3369,6 @@ async function syncRemoteIndex(
           remoteProjectId: remoteProject.id,
           remoteUpdatedAt: getRemoteUpdatedAt(remoteProject),
         }
-        await ensureLocalProjectTitle(
-          existingProjectPath,
-          getRemoteProjectTitleForProjectToml(remoteProject.title)
-        )
         await putProjectMetadata(nextMetadata)
         nextMetadata = await syncCloudProjectDirectoryNameFromTitle({
           metadata: nextMetadata,
@@ -3596,7 +3593,6 @@ async function runCloudSync() {
     scheduleSyncFailureRetry(error)
     failureRetryScheduled = true
   } finally {
-    syncInProgress = false
     pendingStatusSyncedAt = undefined
     if (
       shouldScheduleCloudSyncPendingWork({
@@ -3607,6 +3603,7 @@ async function runCloudSync() {
     ) {
       scheduleSync(SYNC_DEBOUNCE_MS)
     }
+    releaseCloudSyncOperation()
   }
 }
 
@@ -3720,6 +3717,92 @@ export async function startCloudSyncProject(projectPath: string) {
     lastFailureAt: undefined,
   })
   scheduleSync(0)
+}
+
+/** Synchronize one explicitly enrolled project before returning. */
+export async function syncCloudSyncProjectNow(
+  projectPath: string
+): Promise<CloudSyncProjectNowResult> {
+  if (!isConfiguredForCloud()) {
+    // eslint-disable-next-line suggest-no-throw/suggest-no-throw
+    throw new Error('Cloud sync is not enabled.')
+  }
+
+  const normalizedProjectPath = normalizePathForSync(projectPath)
+  const stat = await localFs.stat(normalizedProjectPath)
+  if (!statIsDirectory(stat)) {
+    // eslint-disable-next-line suggest-no-throw/suggest-no-throw
+    throw new Error('Cloud sync can only run for a project directory.')
+  }
+
+  if (syncTimer) {
+    clearTimeout(syncTimer)
+    syncTimer = undefined
+  }
+  await acquireCloudSyncOperation()
+  pendingStatusSyncedAt = undefined
+  updateStatus({
+    enabled: true,
+    state: 'syncing',
+    activeProjectPath: normalizedProjectPath,
+    lastFailure: undefined,
+    lastFailureAt: undefined,
+  })
+
+  try {
+    for (let pass = 0; pass < SYNC_NOW_MAX_PASSES; pass += 1) {
+      if (syncTimer) {
+        clearTimeout(syncTimer)
+        syncTimer = undefined
+      }
+      const entries = outboxEntriesForProject(
+        await getAllOutboxEntries(),
+        normalizedProjectPath
+      )
+      await syncProject(normalizedProjectPath, entries)
+
+      const metadata = await getProjectMetadata(normalizedProjectPath)
+      const remainingEntries = outboxEntriesForProject(
+        await getAllOutboxEntries(),
+        normalizedProjectPath
+      )
+      if (metadata?.conflict) {
+        // eslint-disable-next-line suggest-no-throw/suggest-no-throw
+        throw new Error(
+          'Cloud sync found conflicting local and remote changes.'
+        )
+      }
+      if (metadata?.lastFailure) {
+        // eslint-disable-next-line suggest-no-throw/suggest-no-throw
+        throw new Error(metadata.lastFailure.message)
+      }
+      if (
+        metadata?.remoteProjectId &&
+        metadata.baseManifest &&
+        remainingEntries.length === 0
+      ) {
+        await refreshPendingCount()
+        updateStatus({
+          state: 'idle',
+          activeProjectPath: undefined,
+          lastFailure: undefined,
+          lastFailureAt: undefined,
+          lastSyncedAt: metadata.lastSyncedAt,
+        })
+        return { remoteProjectId: metadata.remoteProjectId }
+      }
+    }
+
+    // eslint-disable-next-line suggest-no-throw/suggest-no-throw
+    throw new Error('Cloud sync did not converge for this project.')
+  } finally {
+    if (syncTimer) {
+      clearTimeout(syncTimer)
+      syncTimer = undefined
+    }
+    pendingStatusSyncedAt = undefined
+    releaseCloudSyncOperation()
+  }
 }
 
 /**

--- a/src/lib/cloudSync/index.test.ts
+++ b/src/lib/cloudSync/index.test.ts
@@ -27,10 +27,8 @@ import {
   isCloudSyncExcludedPath,
 } from '@src/lib/cloudSync/paths'
 import {
-  getProjectArchiveEntrypointPath,
   normalizeProjectArchiveFilesForCloudSync,
   projectManifestFromFiles,
-  withRemoteProjectMetadataInArchiveFiles,
 } from '@src/lib/cloudSync/projectArchive'
 import {
   PROJECT_FOLDER,
@@ -263,27 +261,15 @@ describe('cloudSync sync helpers', () => {
     ])
   })
 
-  it('adds a project.toml upload file without default_file when local project settings are missing', () => {
-    const payload = prepareProjectFilesForCloudUpload('/projects/bracket', [
-      projectFile('main.kcl'),
-    ])
-    const projectToml = new TextDecoder().decode(
-      payload.files.find(
-        (file) => file.relativePath === PROJECT_SETTINGS_FILE_NAME
-      )?.data
-    )
-
-    expect(payload.body.entrypoint_path).toBe('main.kcl')
-    expect(payload.body.project_toml_path).toBe(PROJECT_SETTINGS_FILE_NAME)
-    expect(payload.files.map((file) => file.relativePath)).toEqual([
-      'main.kcl',
-      PROJECT_SETTINGS_FILE_NAME,
-    ])
-    expect(projectToml).toContain('title = "bracket"')
-    expect(projectToml).not.toContain('default_file')
+  it('rejects uploads without project.toml instead of synthesizing one', () => {
+    expect(() =>
+      prepareProjectFilesForCloudUpload('/projects/bracket', [
+        projectFile('main.kcl'),
+      ])
+    ).toThrow('Cloud project uploads require an existing project.toml.')
   })
 
-  it('adds the upload title to project.toml when local project settings have no title', () => {
+  it('does not add an upload title when project.toml has no title', () => {
     const payload = prepareProjectFilesForCloudUpload('/projects/bracket', [
       projectFile('main.kcl'),
       projectFile(PROJECT_SETTINGS_FILE_NAME, 'default_file = "main.kcl"\n'),
@@ -295,8 +281,7 @@ describe('cloudSync sync helpers', () => {
     )
 
     expect(payload.body.title).toBe('bracket')
-    expect(projectToml).toContain('default_file = "main.kcl"')
-    expect(projectToml).toContain('title = "bracket"')
+    expect(projectToml).toBe('default_file = "main.kcl"\n')
   })
 
   it('uses API entrypoint metadata for uploads without writing default_file into project.toml', () => {
@@ -350,47 +335,6 @@ describe('cloudSync sync helpers', () => {
         await projectManifestFromFiles(cloudOrderFiles)
       )
     ).toBe(false)
-  })
-
-  it('adds an Untitled project.toml title when remote project metadata has no title', () => {
-    const files = withRemoteProjectMetadataInArchiveFiles(
-      [projectFile('main.kcl')],
-      undefined,
-      'remote-project-123',
-      'dev.zoo.dev'
-    )
-    const projectToml = new TextDecoder().decode(
-      files.find((file) => file.relativePath === PROJECT_SETTINGS_FILE_NAME)
-        ?.data
-    )
-
-    expect(projectToml).toContain('title = "Untitled"')
-    expect(projectToml).not.toContain('default_file')
-    expect(projectToml).toContain('project_id = "remote-project-123"')
-  })
-
-  it('does not write project.toml default_file from remote entrypoint metadata', () => {
-    const files = withRemoteProjectMetadataInArchiveFiles(
-      [
-        projectFile('main.kcl'),
-        projectFile('nested/part.kcl'),
-        projectFile(PROJECT_SETTINGS_FILE_NAME, 'title = "Bracket"\n'),
-      ],
-      'Bracket',
-      'remote-project-123',
-      'dev.zoo.dev'
-    )
-    const projectToml = new TextDecoder().decode(
-      files.find((file) => file.relativePath === PROJECT_SETTINGS_FILE_NAME)
-        ?.data
-    )
-
-    expect(getProjectArchiveEntrypointPath(files, 'nested/part.kcl')).toBe(
-      'nested/part.kcl'
-    )
-    expect(projectToml).toContain('title = "Bracket"')
-    expect(projectToml).not.toContain('default_file')
-    expect(projectToml).toContain('project_id = "remote-project-123"')
   })
 
   it('excludes files ignored by project .gitignore from cloud sync manifests and uploads', () => {
@@ -449,7 +393,10 @@ describe('cloudSync sync helpers', () => {
   it('includes expected revisions in guarded project update uploads', () => {
     const payload = prepareProjectFilesForCloudUpload(
       '/projects/bracket',
-      [projectFile('main.kcl')],
+      [
+        projectFile('main.kcl'),
+        projectFile(PROJECT_SETTINGS_FILE_NAME, 'title = "Bracket"\n'),
+      ],
       'revision-123'
     )
 
@@ -640,6 +587,20 @@ describe('cloudSync sync helpers', () => {
         localChanged: true,
         remoteChanged: true,
         hasRemoteRevision: true,
+      })
+    ).toBe('compare-remote-archive')
+  })
+
+  it('compares the remote archive when adopting an upload without a known revision', () => {
+    expect(
+      getCloudSyncProjectSyncPreflightAction({
+        latestKind: 'upsert',
+        localProjectExists: true,
+        tombstone: false,
+        hasRemoteProjectId: true,
+        localChanged: false,
+        remoteChanged: false,
+        hasRemoteRevision: false,
       })
     ).toBe('compare-remote-archive')
   })

--- a/src/lib/cloudSync/liveConflicts.test.ts
+++ b/src/lib/cloudSync/liveConflicts.test.ts
@@ -8,6 +8,8 @@ import {
   loadCloudSyncProjectConflictInspection,
   type ProjectArchiveFile,
   resolveCloudSyncProjectConflict,
+  startCloudSyncProject,
+  syncCloudSyncProjectNow,
 } from '@src/lib/cloudSync'
 import {
   normalizeProjectArchiveFilesForCloudSync,
@@ -116,6 +118,10 @@ function installFetchMock({
       return jsonResponse([remoteProjectPayload(remoteRevision)])
     }
 
+    if (url === `${baseUrl}/user/projects` && method === 'POST') {
+      return jsonResponse(remoteProjectPayload('rev-1'))
+    }
+
     if (url === remoteProjectUrl && method === 'GET') {
       return jsonResponse(remoteProjectPayload(remoteRevision))
     }
@@ -163,6 +169,76 @@ describe('cloud sync live conflicts', () => {
     configureCloudSyncEngine({ enabled: false })
     vi.unstubAllGlobals()
     await deleteCloudSyncTestDatabase()
+  })
+
+  it('awaits initial project creation and exact API archive reconciliation', async () => {
+    const localProjectToml =
+      'title = "Demo"\ndefault_file = "main.kcl"\n\n[settings.app]\nunits = "mm"\n'
+    const remoteProjectToml = `${localProjectToml}\n[cloud."dev.zoo.dev"]\nproject_id = "${remoteProjectId}"\n`
+    const files = new Map([
+      [`${projectPath}/main.kcl`, 'base = 1\n'],
+      [`${projectPath}/${PROJECT_SETTINGS_FILE_NAME}`, localProjectToml],
+    ])
+    const cloudSyncFs = createCloudSyncTestFs(files, { projectDirectory })
+    const rm = vi.spyOn(cloudSyncFs, 'rm')
+    const writeFile = vi.spyOn(cloudSyncFs, 'writeFile')
+    configureCloudSyncLocalFileSystem(cloudSyncFs)
+    installFetchMock({
+      remoteFiles: [
+        { relativePath: 'main.kcl', contents: 'base = 1\n' },
+        {
+          relativePath: PROJECT_SETTINGS_FILE_NAME,
+          contents: remoteProjectToml,
+        },
+      ],
+    })
+    configureCloudSyncEngine({
+      enabled: true,
+      baseUrl,
+      environmentName: 'dev.zoo.dev',
+      cloudProjectDirectoryPaths: [projectDirectory],
+      autoEnrollCloudLibraryProjects: false,
+    })
+
+    await startCloudSyncProject(projectPath)
+    await expect(syncCloudSyncProjectNow(projectPath)).resolves.toEqual({
+      remoteProjectId,
+    })
+
+    await expect(
+      getCloudSyncProjectMetadata(projectPath)
+    ).resolves.toMatchObject({
+      remoteProjectId,
+      remoteRevision: 'rev-2',
+      conflict: undefined,
+      lastFailure: undefined,
+    })
+    expect(files.get(`${projectPath}/main.kcl`)).toBe('base = 1\n')
+    expect(files.get(`${projectPath}/${PROJECT_SETTINGS_FILE_NAME}`)).toBe(
+      remoteProjectToml
+    )
+    expect(rm).not.toHaveBeenCalledWith(
+      projectPath,
+      expect.objectContaining({ recursive: true })
+    )
+    expect(writeFile).not.toHaveBeenCalledWith(
+      `${projectPath}/main.kcl`,
+      expect.anything()
+    )
+    expect(
+      fetchMock.mock.calls.filter(
+        ([input, init]) =>
+          getFetchUrl(input) === `${baseUrl}/user/projects` &&
+          getFetchMethod(input, init) === 'POST'
+      )
+    ).toHaveLength(1)
+    expect(clientErrorsMock.reportClientError).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: expect.stringMatching(
+          /^cloud_sync_(?:conflict|untracked_local_changes)$/
+        ),
+      })
+    )
   })
 
   it('marks conflicts without creating persisted conflict-copy projects', async () => {

--- a/src/lib/cloudSync/localProjectNames.spec.ts
+++ b/src/lib/cloudSync/localProjectNames.spec.ts
@@ -75,7 +75,13 @@ function installFetchMock() {
     }
     if (url === remoteProjectDownloadUrl && method === 'GET') {
       return jsonResponse({
-        files: [{ relativePath: 'main.kcl', contents: 'x = 1' }],
+        files: [
+          { relativePath: 'main.kcl', contents: 'x = 1' },
+          {
+            relativePath: PROJECT_SETTINGS_FILE_NAME,
+            contents: cloudProjectToml(),
+          },
+        ],
       })
     }
 

--- a/src/lib/cloudSync/projectArchive.ts
+++ b/src/lib/cloudSync/projectArchive.ts
@@ -15,7 +15,6 @@ import { webSafePathSplit } from '@src/lib/pathUtils'
 import {
   getProjectDefaultFileFromProjectTomlContents,
   getProjectTitleFromProjectTomlContents,
-  setCloudProjectIdInProjectTomlContents,
   setProjectTitleInProjectTomlContents,
 } from '@src/lib/projectTomlMetadata'
 import { isArray } from '@src/lib/utils'
@@ -71,11 +70,10 @@ export function prepareProjectFilesForCloudUpload(
     normalizedFiles,
     preferredEntrypointPath
   )
-  const projectTomlPath = ensureProjectTomlUploadFile(normalizedFiles)
+  const projectTomlPath = getUploadProjectTomlPath(normalizedFiles)
   const projectTitle =
     getProjectTomlTitle(normalizedFiles) ||
     localFs.basename(projectPath.replaceAll('\\', '/').replace(/\/+$/g, ''))
-  ensureProjectTomlUploadTitle(normalizedFiles, projectTitle || 'project')
   const publicationMetadata =
     typeof optionsOrExpectedRevision === 'string'
       ? undefined
@@ -118,7 +116,7 @@ export function normalizeProjectArchiveFilesForCloudSync(
   })
 }
 
-function ensureProjectTomlUploadFile(files: ProjectArchiveFile[]) {
+function getUploadProjectTomlPath(files: ProjectArchiveFile[]) {
   const projectTomlFile = files.find(
     (file) => file.relativePath === PROJECT_SETTINGS_FILE_NAME
   )
@@ -126,32 +124,8 @@ function ensureProjectTomlUploadFile(files: ProjectArchiveFile[]) {
     return projectTomlFile.relativePath
   }
 
-  files.push({
-    relativePath: PROJECT_SETTINGS_FILE_NAME,
-    data: new Uint8Array(),
-  })
-  return PROJECT_SETTINGS_FILE_NAME
-}
-
-function ensureProjectTomlUploadTitle(
-  files: ProjectArchiveFile[],
-  title: string
-) {
-  const projectTomlFile = files.find(
-    (file) => file.relativePath === PROJECT_SETTINGS_FILE_NAME
-  )
-  if (!projectTomlFile) {
-    return
-  }
-
-  const existingProjectToml = new TextDecoder().decode(projectTomlFile.data)
-  if (getProjectTitleFromProjectTomlContents(existingProjectToml)) {
-    return
-  }
-
-  projectTomlFile.data = new TextEncoder().encode(
-    setProjectTitleInProjectTomlContents(existingProjectToml, title)
-  )
+  // eslint-disable-next-line suggest-no-throw/suggest-no-throw
+  throw new Error('Cloud project uploads require an existing project.toml.')
 }
 
 function getProjectTomlTitle(files: ProjectArchiveFile[]) {
@@ -262,20 +236,6 @@ export function withProjectTitleInArchiveFiles(
   )
 }
 
-export function withProjectCloudProjectIdInArchiveFiles(
-  files: ProjectArchiveFile[],
-  projectId: string,
-  environmentName?: string
-) {
-  if (!environmentName) {
-    return files
-  }
-
-  return withUpdatedProjectTomlInArchiveFiles(files, (contents) =>
-    setCloudProjectIdInProjectTomlContents(contents, environmentName, projectId)
-  )
-}
-
 export function withUpdatedProjectTomlInArchiveFiles(
   files: ProjectArchiveFile[],
   update: (contents: string) => string
@@ -312,22 +272,6 @@ export function withUpdatedProjectTomlInArchiveFiles(
   }
 
   return nextFiles
-}
-
-export function withRemoteProjectMetadataInArchiveFiles(
-  files: ProjectArchiveFile[],
-  title: string | undefined,
-  projectId: string,
-  environmentName?: string
-) {
-  return withProjectCloudProjectIdInArchiveFiles(
-    withProjectTitleInArchiveFiles(
-      files,
-      getRemoteProjectTitleForProjectToml(title)
-    ),
-    projectId,
-    environmentName
-  )
 }
 
 export function projectManifestsEqual(

--- a/src/lib/cloudSync/registry/contract.ts
+++ b/src/lib/cloudSync/registry/contract.ts
@@ -9,6 +9,7 @@ import type {
   CloudSyncStatus,
   RemoteProjectSummary,
 } from '@src/lib/cloudSync'
+import type { CloudSyncProjectNowResult } from '@src/lib/cloudSync/types'
 import type { IZooDesignStudioFS } from '@src/lib/fs-zds/interface'
 import type { ProjectLibraryRealization } from '@src/registry/contracts/projectLibraries'
 
@@ -93,6 +94,11 @@ export type CloudSyncRegistryService = {
    * policy is not auto-enrolling existing local projects.
    */
   startProjectSync: (projectPath: string) => Promise<void>
+  /**
+   * Synchronize one explicitly enrolled project before returning. This is for
+   * workflows that need its remote identity and exact API archive immediately.
+   */
+  syncNow: (projectPath: string) => Promise<CloudSyncProjectNowResult>
   /**
    * Delete the remote cloud project and keep the local project as local-only.
    * The local project is marked excluded so later edits do not recreate it.

--- a/src/lib/cloudSync/registry/extension.test.ts
+++ b/src/lib/cloudSync/registry/extension.test.ts
@@ -42,6 +42,7 @@ vi.mock('@src/lib/cloudSync', () => ({
   deleteRemoteCloudProject: vi.fn(),
   ensureCloudProjectLocallySynced: vi.fn(),
   startCloudSyncProject: vi.fn(),
+  syncCloudSyncProjectNow: vi.fn(),
   disconnectCloudSyncProject: vi.fn(),
   getCloudSyncProjectMetadata: vi.fn(),
   getCloudSyncProjectMetadataIndex: vi.fn(),

--- a/src/lib/cloudSync/registry/extension.ts
+++ b/src/lib/cloudSync/registry/extension.ts
@@ -22,6 +22,7 @@ import {
   retryCloudSync,
   setCloudSyncOpenedProject,
   startCloudSyncProject,
+  syncCloudSyncProjectNow,
 } from '@src/lib/cloudSync'
 import { getCloudProjectLibraryMaterializationDirectoryPath } from '@src/lib/cloudSync/paths'
 import { CLOUD_SYNC_PLUGIN_ID } from '@src/lib/cloudSync/registry/constants'
@@ -283,6 +284,7 @@ export const cloudSyncExtension = defineRegistryItemFactory((ctx) => {
     retry: retryCloudSync,
     setOpenedProject: setCloudSyncOpenedProject,
     startProjectSync: startCloudSyncProject,
+    syncNow: syncCloudSyncProjectNow,
     disconnectProjectSync: disconnectCloudSyncProject,
     deleteRemoteProject: deleteRemoteCloudProject,
     deleteLocalProjectRealizations: deleteCloudSyncLocalProjectRealizations,

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -244,6 +244,7 @@ function createCloudSyncService(): CloudSyncRegistryService {
     retry: vi.fn(),
     setOpenedProject: vi.fn(),
     startProjectSync: vi.fn().mockResolvedValue(undefined),
+    syncNow: vi.fn().mockResolvedValue({ remoteProjectId: 'remote-123' }),
     disconnectProjectSync: vi.fn().mockResolvedValue(undefined),
     deleteRemoteProject: vi.fn().mockResolvedValue(undefined),
     deleteLocalProjectRealizations: vi.fn().mockResolvedValue(undefined),

--- a/src/lib/cloudSync/types.ts
+++ b/src/lib/cloudSync/types.ts
@@ -20,6 +20,11 @@ export type ProjectArchiveFile = {
   data: Uint8Array
 }
 
+/** Result of synchronizing one explicitly enrolled project to convergence. */
+export type CloudSyncProjectNowResult = {
+  remoteProjectId: string
+}
+
 /** Durable per-project sync metadata stored locally in the cloud sync DB. */
 export type ProjectMetadata = {
   schemaVersion: 1

--- a/src/lib/projectLibraries/moveOpenedProjectToCloudLibrary.test.ts
+++ b/src/lib/projectLibraries/moveOpenedProjectToCloudLibrary.test.ts
@@ -1,0 +1,86 @@
+import type { App } from '@src/lib/app'
+import type { Project } from '@src/lib/project'
+import {
+  CLOUD_PROJECT_LIBRARY_TYPE,
+  DIRECTORY_PROJECT_LIBRARY_TYPE,
+} from '@src/lib/projectLibraries'
+import { moveOpenedProjectToCloudLibrary } from '@src/lib/projectLibraries/moveOpenedProjectToCloudLibrary'
+import type {
+  HomeProjectActionsService,
+  HomeProjectEntry,
+  HomeProjectMoveToLibraryTarget,
+} from '@src/registry/contracts/homeProjects'
+import {
+  homeProjectActionsService,
+  homeProjectEntriesValueSpec,
+} from '@src/registry/contracts/homeProjects'
+import { expect, test, vi } from 'vitest'
+
+const { writeProjectTitleToProjectToml } = vi.hoisted(() => ({
+  writeProjectTitleToProjectToml: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@src/lib/desktop', () => ({
+  writeProjectTitleToProjectToml,
+}))
+
+test('moves an open directory project before navigating directly to its new file', async () => {
+  const project = {
+    path: '/projects/example',
+    libraryType: DIRECTORY_PROJECT_LIBRARY_TYPE,
+  } as Project
+  const homeProject = {
+    localProjectPath: project.path,
+    name: 'example',
+  } as HomeProjectEntry
+  const cloudLibraryTarget = {
+    library: {
+      id: 'personal-cloud',
+      type: CLOUD_PROJECT_LIBRARY_TYPE,
+    },
+  } as HomeProjectMoveToLibraryTarget
+  const moveToLibrary = vi.fn().mockResolvedValue({
+    defaultFile: '/cloud/example/main.kcl',
+    localProjectPath: '/cloud/example',
+  })
+  const actions = {
+    getMoveToLibraryTargets: vi.fn().mockReturnValue([cloudLibraryTarget]),
+    moveToLibrary,
+  } as unknown as HomeProjectActionsService
+  const closeProject = vi.fn()
+  const clearProjectSettings = vi.fn()
+  const app = {
+    closeProject,
+    settings: { actor: { send: clearProjectSettings } },
+    registry: {
+      optional: (service: unknown) =>
+        service === homeProjectActionsService ? actions : undefined,
+      get: (valueSpec: unknown) =>
+        valueSpec === homeProjectEntriesValueSpec ? [homeProject] : [],
+    },
+  } as unknown as App
+  const navigate = vi.fn().mockResolvedValue(undefined)
+
+  await expect(
+    moveOpenedProjectToCloudLibrary({
+      app,
+      project,
+      navigate,
+      title: 'Published example',
+    })
+  ).resolves.toEqual({
+    defaultFile: '/cloud/example/main.kcl',
+    projectPath: '/cloud/example',
+  })
+
+  expect(closeProject).toHaveBeenCalledOnce()
+  expect(clearProjectSettings).toHaveBeenCalledWith({ type: 'clear.project' })
+  expect(writeProjectTitleToProjectToml).toHaveBeenCalledWith(
+    '/projects/example',
+    'Published example'
+  )
+  expect(moveToLibrary).toHaveBeenCalledWith(homeProject, 'personal-cloud')
+  expect(navigate).toHaveBeenCalledOnce()
+  expect(navigate).toHaveBeenCalledWith('/file/%2Fcloud%2Fexample%2Fmain.kcl')
+  expect(moveToLibrary).toHaveBeenCalledBefore(navigate)
+})

--- a/src/lib/projectLibraries/moveOpenedProjectToCloudLibrary.ts
+++ b/src/lib/projectLibraries/moveOpenedProjectToCloudLibrary.ts
@@ -1,8 +1,10 @@
 import type { App } from '@src/lib/app'
+import { writeProjectTitleToProjectToml } from '@src/lib/desktop'
+import fsZds from '@src/lib/fs-zds'
+import { getHomeProjectDisplayName } from '@src/lib/homeProjects'
 import { PATHS } from '@src/lib/paths'
 import type { Project } from '@src/lib/project'
 import { CLOUD_PROJECT_LIBRARY_TYPE } from '@src/lib/projectLibraries'
-import { err } from '@src/lib/trap'
 import {
   homeProjectActionsService,
   homeProjectEntriesValueSpec,
@@ -10,68 +12,104 @@ import {
 import type { NavigateFunction } from 'react-router-dom'
 
 /**
- * Relocates the open project through the same closed-session lifecycle used by
- * Home so no editor or settings watcher retains ownership of its old path.
+ * Releases the open project, relocates it, then routes directly to the moved
+ * file so no intermediate Home navigation is visible to the user.
  *
- * TODO: Replace this manual close/navigate/move/reopen sequence with the
- * projectSession and router relocation workflow once that migration lands.
+ * The move must finish before navigation because the destination library may
+ * choose a different directory name to avoid a collision.
  */
 export async function moveOpenedProjectToCloudLibrary({
   app,
   project,
   navigate,
+  title,
 }: {
   app: App
   project: Project
   navigate: NavigateFunction
-}): Promise<true | Error> {
-  app.closeProject()
-  app.settings.actor.send({ type: 'clear.project' })
-  await navigate(PATHS.HOME)
+  title: string
+}): Promise<{ defaultFile: string; projectPath: string } | Error> {
+  const actions = app.registry.optional(homeProjectActionsService)
+  const homeProject = app.registry
+    .get(homeProjectEntriesValueSpec)
+    .find((entry) => entry.localProjectPath === project.path)
+  const cloudLibraryTarget = homeProject
+    ? actions
+        ?.getMoveToLibraryTargets(homeProject)
+        .find((target) => target.library.type === CLOUD_PROJECT_LIBRARY_TYPE)
+    : undefined
 
-  const movedDefaultFile = await moveProjectToCloudLibrary(app, project)
-  if (err(movedDefaultFile)) {
-    return movedDefaultFile
+  if (!actions || !homeProject || !cloudLibraryTarget) {
+    return new Error('No cloud library is available for the open project.')
   }
 
-  await navigate(`${PATHS.FILE}/${encodeURIComponent(movedDefaultFile)}`)
-  return true
-}
+  app.closeProject()
+  app.settings.actor.send({ type: 'clear.project' })
 
-/**
- * Moves a published local realization into its configured cloud library.
- * Publishing runs first so project.toml contains the remote cloud identity.
- */
-async function moveProjectToCloudLibrary(app: App, project: Project) {
   try {
-    const actions = app.registry.optional(homeProjectActionsService)
-    const homeProject = app.registry
-      .get(homeProjectEntriesValueSpec)
-      .find((entry) => entry.localProjectPath === project.path)
-    const cloudLibraryTarget = homeProject
-      ? actions
-          ?.getMoveToLibraryTargets(homeProject)
-          .find((target) => target.library.type === CLOUD_PROJECT_LIBRARY_TYPE)
-      : undefined
-
-    if (!actions || !homeProject || !cloudLibraryTarget) {
-      return new Error('No cloud library is available for the open project.')
-    }
-
-    const result = await actions.moveToLibrary(
+    // Persist through the project metadata API after closing the editor. The
+    // destination library uses this title for the final directory name, while
+    // the closed project cannot mistake the relocation for an external reload.
+    await writeProjectTitleToProjectToml(project.path, title)
+    const moved = await actions.moveToLibrary(
       homeProject,
       cloudLibraryTarget.library.id
     )
-    if (!result?.defaultFile) {
+    if (!moved?.defaultFile) {
+      await navigate(PATHS.HOME)
       return new Error(
         'Moving the open project did not return its new file path.'
       )
     }
 
-    return result.defaultFile
+    const projectPath =
+      moved.localProjectPath ?? fsZds.dirname(moved.defaultFile)
+    await navigate(`${PATHS.FILE}/${encodeURIComponent(moved.defaultFile)}`)
+    return {
+      defaultFile: moved.defaultFile,
+      projectPath,
+    }
   } catch (error) {
+    // The old route no longer has an active project session. Fall back to Home
+    // only when relocation fails; successful publication never renders it.
+    await navigate(PATHS.HOME)
     return error instanceof Error
       ? error
       : new Error('Moving the open project to Personal Cloud failed.')
+  }
+}
+
+/**
+ * Persists the publication title through the owning project library's rename
+ * operation. This keeps project settings serialization in the domain API that
+ * already owns it and completes before publication snapshots any files.
+ */
+export async function updateProjectTitleForPublication({
+  app,
+  project,
+  title,
+}: {
+  app: App
+  project: Project
+  title: string
+}): Promise<true | Error> {
+  try {
+    const actions = app.registry.optional(homeProjectActionsService)
+    const homeProject = app.registry
+      .get(homeProjectEntriesValueSpec)
+      .find((entry) => entry.localProjectPath === project.path)
+    if (!actions || !homeProject || !actions.canRename(homeProject)) {
+      return new Error('The open project title could not be updated.')
+    }
+    if (getHomeProjectDisplayName(homeProject) === title) {
+      return true
+    }
+
+    await actions.rename(homeProject, title, { notify: false })
+    return true
+  } catch (error) {
+    return error instanceof Error
+      ? error
+      : new Error('Updating the project title failed.')
   }
 }

--- a/src/lib/share.test.ts
+++ b/src/lib/share.test.ts
@@ -78,7 +78,9 @@ const mockState = vi.hoisted(() => ({
     },
     {
       relativePath: 'project.toml',
-      data: new TextEncoder().encode('title = "bracket"\n'),
+      data: new TextEncoder().encode(
+        'title = "Bracket"\ndefault_file = "main.kcl"\n'
+      ),
     },
   ]),
 }))
@@ -195,7 +197,9 @@ describe('publishCurrentProject', () => {
       },
     })
 
-    expect(published).toBe(true)
+    expect(published).toEqual({
+      remoteProjectId: 'project-created',
+    })
     expect(mockState.createProject).toHaveBeenCalledWith({
       client: {
         mocked: true,
@@ -221,6 +225,8 @@ describe('publishCurrentProject', () => {
         title: 'Bracket',
         description: 'A mounting bracket.',
         category_ids: ['category-a', 'category-b'],
+        entrypoint_path: 'main.kcl',
+        project_toml_path: 'project.toml',
       })
     )
     expect(createProjectFiles.map((file) => file.name)).toContain('.gitignore')
@@ -228,14 +234,7 @@ describe('publishCurrentProject', () => {
     await expect(mainFile?.data.text()).resolves.toBe(
       'part001 = startSketchOn(XY)'
     )
-    expect(mockState.fsWriteFile).toHaveBeenCalledOnce()
-    const persistedProjectToml = mockState.fsWriteFile.mock.calls[0]?.[1]
-    expect(new TextDecoder().decode(persistedProjectToml)).toContain(
-      'title = "bracket"'
-    )
-    expect(new TextDecoder().decode(persistedProjectToml)).toContain(
-      'project_id = "project-created"'
-    )
+    expect(mockState.fsWriteFile).not.toHaveBeenCalled()
     expect(mockState.publishProject).toHaveBeenCalledWith({
       client: {
         mocked: true,
@@ -276,6 +275,32 @@ describe('publishCurrentProject', () => {
       { duration: 5000 }
     )
     expect(mockState.publishProject).not.toHaveBeenCalled()
+  })
+
+  it('publishes the project identity returned by an awaited cloud sync', async () => {
+    const published = await publishCurrentProject({
+      token: 'token-123',
+      project: makeProject(),
+      currentFilePath: '/projects/bracket/main.kcl',
+      currentFileContents: 'part001 = startSketchOn(XY)',
+      wasmInstance: {} as never,
+      submission: {
+        title: 'Bracket',
+        description: 'A mounting bracket.',
+        categoryIds: ['category-a'],
+      },
+      remoteProjectId: 'project-synced',
+    })
+
+    expect(published).toEqual({ remoteProjectId: 'project-synced' })
+    expect(mockState.updateProject).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'project-synced' })
+    )
+    expect(mockState.createProject).not.toHaveBeenCalled()
+    expect(mockState.readProjectSettingsFile).not.toHaveBeenCalled()
+    expect(mockState.publishProject).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'project-synced' })
+    )
   })
 })
 
@@ -333,5 +358,23 @@ describe('getCurrentProjectPublicationDetails', () => {
 
     expect(details).toBeNull()
     expect(mockState.getProject).not.toHaveBeenCalled()
+  })
+
+  it('loads a just-published project before its cloud id is synced locally', async () => {
+    const details = await getCurrentProjectPublicationDetails({
+      token: 'token-123',
+      project: makeProject(),
+      wasmInstance: {} as never,
+      remoteProjectId: 'project-created',
+    })
+
+    expect(details).toEqual(
+      expect.objectContaining({ projectId: 'project-created' })
+    )
+    expect(mockState.readProjectSettingsFile).not.toHaveBeenCalled()
+    expect(mockState.getProject).toHaveBeenCalledWith({
+      client: expect.any(Object),
+      id: 'project-created',
+    })
   })
 })

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -3,9 +3,12 @@ import env, { getEnvironmentNameFromEnv } from '@src/env'
 import { collectLocalProjectFilesForCloudSync } from '@src/lib/cloudSync/localManifest'
 import {
   getMimeType,
-  withRemoteProjectMetadataInArchiveFiles,
+  prepareProjectFilesForCloudUpload,
 } from '@src/lib/cloudSync/projectArchive'
-import type { ProjectArchiveFile } from '@src/lib/cloudSync/types'
+import type {
+  ProjectArchiveFile,
+  ProjectUploadPublicationMetadata,
+} from '@src/lib/cloudSync/types'
 import { PROJECT_SETTINGS_FILE_NAME } from '@src/lib/constants'
 import { readProjectSettingsFile } from '@src/lib/desktop'
 import fsZds from '@src/lib/fs-zds'
@@ -25,6 +28,7 @@ export type PublishCurrentProjectArgs = {
   currentFileContents: string
   wasmInstance: ModuleType
   submission: ProjectPublishSubmission
+  remoteProjectId?: string
 }
 
 export type ProjectPublishSubmission = {
@@ -44,19 +48,18 @@ export type CurrentProjectPublicationDetails = {
   updatedAt: string
 }
 
+/** Remote identity of the project submitted to Aquarium. */
+export type PublishedProject = {
+  remoteProjectId: string
+}
+
 type CurrentProjectUploadArgs = Omit<PublishCurrentProjectArgs, 'project'> & {
   project: Project
 }
 
-type ProjectUpsertBody = {
-  title: string
-  description: string
-  category_ids: string[]
-}
-
 export async function publishCurrentProject(
   args: PublishCurrentProjectArgs
-): Promise<boolean> {
+): Promise<PublishedProject | false> {
   if (!args.token) {
     toast.error('You need to be signed in to publish a project.', {
       duration: 5000,
@@ -104,7 +107,9 @@ export async function publishCurrentProject(
     }
   )
 
-  return true
+  return {
+    remoteProjectId: uploadedProject.projectId,
+  }
 }
 
 function getPublishErrorMessage(error: Error) {
@@ -122,27 +127,32 @@ export async function getCurrentProjectPublicationDetails({
   token,
   project,
   wasmInstance,
+  remoteProjectId,
 }: {
   token: string
   project: Project | undefined
   wasmInstance: ModuleType
+  remoteProjectId?: string
 }): Promise<CurrentProjectPublicationDetails | null | Error> {
   if (!token || !project) {
     return null
   }
 
-  const environmentName = getCurrentEnvironmentName()
-  if (err(environmentName)) {
-    return environmentName
-  }
-
-  const projectId = await getCloudProjectIdForEnvironment(
-    project.path,
-    wasmInstance,
-    environmentName
-  )
-  if (err(projectId)) {
-    return projectId
+  let projectId = remoteProjectId
+  if (!projectId) {
+    const environmentName = getCurrentEnvironmentName()
+    if (err(environmentName)) {
+      return environmentName
+    }
+    const localProjectId = await getCloudProjectIdForEnvironment(
+      project.path,
+      wasmInstance,
+      environmentName
+    )
+    if (err(localProjectId)) {
+      return localProjectId
+    }
+    projectId = localProjectId
   }
 
   if (!projectId) {
@@ -196,37 +206,31 @@ async function ensureCurrentProjectUploaded(
   }
 
   const client = createKCClient(args.token)
-  const existingProjectId = await getCloudProjectIdForEnvironment(
-    project.path,
-    args.wasmInstance,
-    environmentName
-  )
+  const existingProjectId =
+    args.remoteProjectId ??
+    (await getCloudProjectIdForEnvironment(
+      project.path,
+      args.wasmInstance,
+      environmentName
+    ))
   if (err(existingProjectId)) {
     return existingProjectId
   }
 
   if (existingProjectId) {
-    const projectBody = getProjectUpsertBody(project, args.submission)
-
     const projectResp = await kcCall(() =>
       projects.update_project({
         client,
         id: existingProjectId,
-        files: toKittyCadFiles(uploadFiles, projectBody),
+        files: toKittyCadFiles(
+          project.path,
+          uploadFiles,
+          getProjectUploadPublicationMetadata(args.submission)
+        ),
       })
     )
     if (err(projectResp)) {
       return projectResp
-    }
-
-    const persisted = await persistUploadedProjectMetadata({
-      projectPath: project.path,
-      environmentName,
-      remoteProject: projectResp,
-      uploadFiles,
-    })
-    if (err(persisted)) {
-      return persisted
     }
 
     return {
@@ -235,40 +239,30 @@ async function ensureCurrentProjectUploaded(
     }
   }
 
-  const projectBody = getProjectUpsertBody(project, args.submission)
   const projectResp = await kcCall(() =>
     projects.create_project({
       client,
-      files: toKittyCadFiles(uploadFiles, projectBody),
+      files: toKittyCadFiles(
+        project.path,
+        uploadFiles,
+        getProjectUploadPublicationMetadata(args.submission)
+      ),
     })
   )
   if (err(projectResp)) {
     return projectResp
   }
 
-  const projectId = projectResp.id
-  const persisted = await persistUploadedProjectMetadata({
-    projectPath: project.path,
-    environmentName,
-    remoteProject: projectResp,
-    uploadFiles,
-  })
-  if (err(persisted)) {
-    return persisted
-  }
-
   return {
     client,
-    projectId,
+    projectId: projectResp.id,
   }
 }
 
-function getProjectUpsertBody(
-  project: Project,
+function getProjectUploadPublicationMetadata(
   submission: ProjectPublishSubmission
-): ProjectUpsertBody {
+): ProjectUploadPublicationMetadata {
   return {
-    title: submission.title.trim() || getDefaultProjectTitle(project),
     description: submission.description.trim(),
     category_ids: submission.categoryIds,
   }
@@ -371,58 +365,22 @@ async function getCloudProjectIdForEnvironment(
   }
 }
 
-async function persistUploadedProjectMetadata({
-  projectPath,
-  environmentName,
-  remoteProject,
-  uploadFiles,
-}: {
-  projectPath: string
-  environmentName: string
-  remoteProject: { id: string; title: string }
-  uploadFiles: ProjectArchiveFile[]
-}) {
-  try {
-    // The API currently shares one title between the stored project and its
-    // Aquarium listing. Mirror the server-normalized metadata byte-for-byte so
-    // cloud sync can adopt this upload without an artificial first conflict.
-    // Once Publication owns a separate title, this should retain the local
-    // project title while persisting only the cloud project ID.
-    const filesWithRemoteMetadata = withRemoteProjectMetadataInArchiveFiles(
-      uploadFiles,
-      remoteProject.title,
-      remoteProject.id,
-      environmentName
-    )
-    const projectToml = filesWithRemoteMetadata.find(
-      (file) => file.relativePath === PROJECT_SETTINGS_FILE_NAME
-    )
-    if (!projectToml) {
-      return new Error('Published project metadata was not generated.')
-    }
-
-    await fsZds.writeFile(
-      fsZds.join(projectPath, PROJECT_SETTINGS_FILE_NAME),
-      Uint8Array.from(projectToml.data)
-    )
-    return true
-  } catch (error) {
-    return new Error(
-      `Failed to save published project metadata: ${error instanceof Error ? error.message : String(error)}`
-    )
-  }
-}
-
 function toKittyCadFiles(
+  projectPath: string,
   files: ProjectArchiveFile[],
-  body: ProjectUpsertBody
+  publicationMetadata: ProjectUploadPublicationMetadata
 ): Parameters<typeof projects.create_project>[0]['files'] {
+  const upload = prepareProjectFilesForCloudUpload(projectPath, files, {
+    publicationMetadata,
+  })
   return [
     {
       name: 'body',
-      data: new Blob([JSON.stringify(body)], { type: 'application/json' }),
+      data: new Blob([JSON.stringify(upload.body)], {
+        type: 'application/json',
+      }),
     },
-    ...files.map((file) => ({
+    ...upload.files.map((file) => ({
       name: file.relativePath,
       data: new Blob([Uint8Array.from(file.data)], {
         type: getMimeType(file.relativePath),

--- a/src/registry/contracts/homeProjects.ts
+++ b/src/registry/contracts/homeProjects.ts
@@ -94,6 +94,11 @@ export type HomeProjectEntryContributionGroup =
 
 export type HomeProjectOpenResult = {
   defaultFile: string
+  localProjectPath?: string
+}
+
+export type HomeProjectRenameOptions = {
+  notify?: boolean
 }
 
 export interface HomeProjectMoveToLibraryTarget {
@@ -112,7 +117,11 @@ export interface HomeProjectActionsService {
     project: HomeProjectEntry
   ) => Promise<HomeProjectOpenResult | undefined>
   duplicate: (project: HomeProjectEntry) => Promise<void>
-  rename: (project: HomeProjectEntry, requestedName: string) => Promise<void>
+  rename: (
+    project: HomeProjectEntry,
+    requestedName: string,
+    options?: HomeProjectRenameOptions
+  ) => Promise<void>
   delete: (project: HomeProjectEntry) => Promise<void>
   getMoveToLibraryTargets: (
     project: HomeProjectEntry

--- a/src/registry/extensions/homeProjects/index.test.ts
+++ b/src/registry/extensions/homeProjects/index.test.ts
@@ -214,6 +214,7 @@ function createCloudSyncService(
     retry: vi.fn(),
     setOpenedProject: vi.fn(),
     startProjectSync: vi.fn().mockResolvedValue(undefined),
+    syncNow: vi.fn().mockResolvedValue({ remoteProjectId: 'remote-123' }),
     disconnectProjectSync: vi.fn().mockResolvedValue(undefined),
     deleteRemoteProject: vi.fn().mockResolvedValue(undefined),
     deleteLocalProjectRealizations: vi.fn().mockResolvedValue(undefined),

--- a/src/registry/extensions/homeProjects/index.ts
+++ b/src/registry/extensions/homeProjects/index.ts
@@ -485,7 +485,7 @@ const homeProjectActions = defineRegistryItemFactory((ctx) => {
         toast.success(result.message)
       }
     },
-    rename: async (project, requestedName) => {
+    rename: async (project, requestedName, options) => {
       const renameProject = getProjectOperation(project, 'renameProject')
       if (!serviceImpl.canRename(project) || !renameProject) {
         return
@@ -499,7 +499,9 @@ const homeProjectActions = defineRegistryItemFactory((ctx) => {
         })
       ) {
         const message = `Project with title "${requestedName}" already exists`
-        toast.error(message)
+        if (options?.notify !== false) {
+          toast.error(message)
+        }
         return Promise.reject(new Error(message))
       }
 
@@ -508,9 +510,11 @@ const homeProjectActions = defineRegistryItemFactory((ctx) => {
         project,
         requestedName,
       })
-      toast.success(
-        `Successfully renamed "${getHomeProjectDisplayName(project)}" to "${requestedName}"`
-      )
+      if (options?.notify !== false) {
+        toast.success(
+          `Successfully renamed "${getHomeProjectDisplayName(project)}" to "${requestedName}"`
+        )
+      }
     },
     delete: async (project) => {
       const deleteProject = getProjectOperation(project, 'deleteProject')
@@ -570,6 +574,7 @@ const homeProjectActions = defineRegistryItemFactory((ctx) => {
       return result?.defaultFile
         ? {
             defaultFile: result.defaultFile,
+            localProjectPath: result.localProjectPath,
           }
         : undefined
     },


### PR DESCRIPTION
Addresses the immediate cloud conflicts and broken navigation seen after publishing a directory-library project. KittyCAD/api#4523 makes the uploaded archive authoritative; this keeps one project path and remote identity through cloud sync and Aquarium submission.

1. **One archive contract:** cloud sync and publication use the same upload builder. The client no longer synthesizes or normalizes `project.toml`; it accepts the exact API archive as the sync base.
2. **Awaitable sync:** `syncNow` shares the background worker's operation lock, waits through initial creation and API-archive reconciliation, and returns the remote project ID.
3. **One project lifecycle:** save the title through the existing project metadata API, close the old session, move and navigate directly to Personal Cloud, sync the final path, then submit that same remote project.
4. **Stable hydration:** apply remote changes in place and skip unchanged files so routing and file watchers never observe the project root disappearing.

## How to test

Publish a directory-library project with a new title while Personal Cloud is enabled. It should navigate directly to the renamed Personal Cloud project, retain `default_file` and unrelated settings, submit successfully, and show no reload, sync-failure, or conflict state.

The desktop Playwright regression mocks the Project and publication endpoints and checks that complete flow.
