### PR TITLE
Migrate Azure signing config for electron-builder 27

### DIFF
--- a/scripts/set-windows-codesign-config.sh
+++ b/scripts/set-windows-codesign-config.sh
@@ -16,11 +16,12 @@ for var in "${required_vars[@]}"; do
 done
 
 CONFIG_FILE="electron-builder.yml"
-yq -i 'del(.win.signtoolOptions)' $CONFIG_FILE
-yq -i '.win.azureSignOptions.endpoint = env(AZURE_TRUSTED_SIGNING_ENDPOINT)' $CONFIG_FILE
-yq -i '.win.azureSignOptions.codeSigningAccountName = env(AZURE_TRUSTED_SIGNING_ACCOUNT_NAME)' $CONFIG_FILE
-yq -i '.win.azureSignOptions.certificateProfileName = env(AZURE_TRUSTED_SIGNING_CERT_PROFILE_NAME)' $CONFIG_FILE
-yq -i '.win.azureSignOptions.publisherName = env(AZURE_TRUSTED_SIGNING_PUBLISHER_NAME)' $CONFIG_FILE
-yq -i '.win.azureSignOptions.fileDigest = "SHA256"' $CONFIG_FILE
-yq -i '.win.azureSignOptions.timestampDigest = "SHA256"' $CONFIG_FILE
-yq -i '.win.azureSignOptions.timestampRfc3161 = "http://timestamp.acs.microsoft.com"' $CONFIG_FILE
+yq -i 'del(.win.signtoolOptions, .win.azureSignOptions)' "$CONFIG_FILE"
+yq -i '.win.sign.type = "azure"' "$CONFIG_FILE"
+yq -i '.win.sign.endpoint = env(AZURE_TRUSTED_SIGNING_ENDPOINT)' "$CONFIG_FILE"
+yq -i '.win.sign.codeSigningAccountName = env(AZURE_TRUSTED_SIGNING_ACCOUNT_NAME)' "$CONFIG_FILE"
+yq -i '.win.sign.certificateProfileName = env(AZURE_TRUSTED_SIGNING_CERT_PROFILE_NAME)' "$CONFIG_FILE"
+yq -i '.win.sign.publisherName = env(AZURE_TRUSTED_SIGNING_PUBLISHER_NAME)' "$CONFIG_FILE"
+yq -i '.win.sign.fileDigest = "SHA256"' "$CONFIG_FILE"
+yq -i '.win.sign.timestampDigest = "SHA256"' "$CONFIG_FILE"
+yq -i '.win.sign.timestampRfc3161 = "http://timestamp.acs.microsoft.com"' "$CONFIG_FILE"


### PR DESCRIPTION
## Summary

- migrate the generated Azure Trusted Signing configuration from Electron Builder v26's `win.azureSignOptions` key to v27's unified `win.sign` schema
- select the Azure backend explicitly with `win.sign.type: azure`
- preserve the existing endpoint, account, certificate profile, publisher, digest, and RFC3161 timestamp settings
- remove both legacy Windows signing keys before writing the v27 configuration

## Root cause

[PR #13541](https://github.com/KittyCAD/modeling-app/pull/13541) upgrades to Electron Builder 27.0.0-alpha.7, which removes `win.azureSignOptions` and `win.signtoolOptions`. `scripts/set-windows-codesign-config.sh` still generates `win.azureSignOptions`, so Electron Builder rejects the entire configuration before any platform-specific packaging begins.

The first forced-staging run failed on [Linux](https://github.com/KittyCAD/modeling-app/actions/runs/33441301163/job/99650381825), [macOS](https://github.com/KittyCAD/modeling-app/actions/runs/33441301163/job/99650381912), and [Windows](https://github.com/KittyCAD/modeling-app/actions/runs/33441301163/job/99650381809) with:

```text
configuration.win has an unknown property 'azureSignOptions'
```

This is a v27 schema migration failure, not recurrence of the AppImage-parentheses bug. The failed jobs never reached AppImage creation.

## Implementation

Update `scripts/set-windows-codesign-config.sh` along these lines:

```diff
-yq -i 'del(.win.signtoolOptions)' $CONFIG_FILE
-yq -i '.win.azureSignOptions.endpoint = env(AZURE_TRUSTED_SIGNING_ENDPOINT)' $CONFIG_FILE
-yq -i '.win.azureSignOptions.codeSigningAccountName = env(AZURE_TRUSTED_SIGNING_ACCOUNT_NAME)' $CONFIG_FILE
-yq -i '.win.azureSignOptions.certificateProfileName = env(AZURE_TRUSTED_SIGNING_CERT_PROFILE_NAME)' $CONFIG_FILE
-yq -i '.win.azureSignOptions.publisherName = env(AZURE_TRUSTED_SIGNING_PUBLISHER_NAME)' $CONFIG_FILE
-yq -i '.win.azureSignOptions.fileDigest = "SHA256"' $CONFIG_FILE
-yq -i '.win.azureSignOptions.timestampDigest = "SHA256"' $CONFIG_FILE
-yq -i '.win.azureSignOptions.timestampRfc3161 = "http://timestamp.acs.microsoft.com"' $CONFIG_FILE
+yq -i 'del(.win.signtoolOptions, .win.azureSignOptions)' "$CONFIG_FILE"
+yq -i '.win.sign.type = "azure"' "$CONFIG_FILE"
+yq -i '.win.sign.endpoint = env(AZURE_TRUSTED_SIGNING_ENDPOINT)' "$CONFIG_FILE"
+yq -i '.win.sign.codeSigningAccountName = env(AZURE_TRUSTED_SIGNING_ACCOUNT_NAME)' "$CONFIG_FILE"
+yq -i '.win.sign.certificateProfileName = env(AZURE_TRUSTED_SIGNING_CERT_PROFILE_NAME)' "$CONFIG_FILE"
+yq -i '.win.sign.publisherName = env(AZURE_TRUSTED_SIGNING_PUBLISHER_NAME)' "$CONFIG_FILE"
+yq -i '.win.sign.fileDigest = "SHA256"' "$CONFIG_FILE"
+yq -i '.win.sign.timestampDigest = "SHA256"' "$CONFIG_FILE"
+yq -i '.win.sign.timestampRfc3161 = "http://timestamp.acs.microsoft.com"' "$CONFIG_FILE"
```

Electron Builder's v27 migration guide and `WindowsAzureSigningConfig` type confirm that all seven existing values remain supported under `win.sign`, with `type: azure` as the discriminator.

## Validation

- run `scripts/set-windows-codesign-config.sh` with non-secret fixture values and verify:

  ```bash
  yq -e '.win.sign.type == "azure"' electron-builder.yml
  yq -e '.win | has("azureSignOptions") | not' electron-builder.yml
  yq -e '.win | has("signtoolOptions") | not' electron-builder.yml
  ```

- run the forced-staging `build-apps` workflow from #13541 on the first attempt:
  - Linux x64 and arm64 AppImages succeed with `Zoo Design Studio (Staging)` filenames
  - universal macOS packaging succeeds
  - universal Windows packaging and Azure Trusted Signing succeed
- confirm no `productFilename` error, configuration-schema error, retry, or rerun
- confirm #13541 desktop E2E remains green on all eight Ubuntu shards, macOS, and Windows
- remove the temporary `TO REVERT: Force staging builds for PR` workflow override before marking #13541 ready or merging
- after merge, verify the first non-superseded `main` build completes `upload-apps-release`

## Relationship to existing work

This PR is stacked on draft PR #13541 because the `win.sign` schema is specific to Electron Builder 27 and is not valid on the current Electron Builder 26 configuration on `main`.

Fixes #13542.
