### PR TITLE
Fix to not have infinite loop in rename lint-fix

### DIFF
--- a/rust/kcl-language-server/src/lsp/kcl/mod.rs
+++ b/rust/kcl-language-server/src/lsp/kcl/mod.rs
@@ -1008,7 +1008,12 @@ impl Backend {
         // Let's convert the position to a character index.
         let pos = position_to_char_index(params.position, current_code);
         // Now let's perform the rename on the ast.
-        ast.rename_symbol(new_name, pos);
+        if !ast.rename_symbol(new_name, pos) {
+            // Nothing was renamed, e.g. the position is on a symbol we can't
+            // rename yet, like a local in a function body or an if-expression
+            // arm. Refuse instead of producing an edit that only reformats.
+            return Ok(None);
+        }
         // Now recast it.
         let recast = ast.recast_top(&Default::default(), 0);
 

--- a/rust/kcl-language-server/src/lsp/tests.rs
+++ b/rust/kcl-language-server/src/lsp/tests.rs
@@ -2416,6 +2416,64 @@ a1 = startSketchOn(offsetPlane(XY, offset = 10))
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_kcl_lsp_rename_local_in_if_arm_is_refused() {
+    // Renaming a declaration inside an if-expression arm isn't supported. The rename must
+    // return no edit, and prepare_rename must refuse, instead of producing a whole-document
+    // edit that only reformats the code.
+    let server = kcl_lsp_server(false).await.unwrap();
+
+    // Send open file.
+    server
+        .did_open(tower_lsp::lsp_types::DidOpenTextDocumentParams {
+            text_document: tower_lsp::lsp_types::TextDocumentItem {
+                uri: "file:///test.kcl".try_into().unwrap(),
+                language_id: "kcl".to_string(),
+                version: 1,
+                text: r#"x = if true {
+  local_value = 1
+  local_value
+} else {
+  0
+}
+"#
+                .to_string(),
+            },
+        })
+        .await;
+
+    // The position is on `local_value`'s declaration inside the `if` arm.
+    let position = tower_lsp::lsp_types::Position { line: 1, character: 3 };
+
+    // Send rename request.
+    let rename = server
+        .rename(tower_lsp::lsp_types::RenameParams {
+            text_document_position: tower_lsp::lsp_types::TextDocumentPositionParams {
+                text_document: tower_lsp::lsp_types::TextDocumentIdentifier {
+                    uri: "file:///test.kcl".try_into().unwrap(),
+                },
+                position,
+            },
+            new_name: "localValue".to_string(),
+            work_done_progress_params: Default::default(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(rename, None);
+
+    // Send prepare rename request.
+    let prepared = server
+        .prepare_rename(tower_lsp::lsp_types::TextDocumentPositionParams {
+            text_document: tower_lsp::lsp_types::TextDocumentIdentifier {
+                uri: "file:///test.kcl".try_into().unwrap(),
+            },
+            position,
+        })
+        .await
+        .unwrap();
+    assert_eq!(prepared, None);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_kcl_lsp_diagnostic_no_errors() {
     let server = kcl_lsp_server(false).await.unwrap();
 

--- a/rust/kcl-lib/src/lint/checks/camel_case.rs
+++ b/rust/kcl-lib/src/lint/checks/camel_case.rs
@@ -38,18 +38,24 @@ fn lint_lower_camel_case_var(decl: &VariableDeclarator, prog: &AstNode<Program>)
 
     if new_name != *name {
         let mut prog = prog.clone();
-        prog.rename_symbol(&new_name, ident.start);
-        let recast = prog.recast_top(&Default::default(), 0);
-
-        let suggestion = Suggestion {
-            title: format!("rename '{name}' to '{new_name}'"),
-            insert: recast,
-            source_range: prog.as_source_range(),
+        // We can't rename nested declarations yet (e.g. a local in a function
+        // body or an if-expression arm). A suggestion whose insert is the
+        // unchanged source would make auto-fix apply it forever, so only
+        // suggest a fix when the rename actually changed something.
+        let suggestion = if prog.rename_symbol(&new_name, ident.start) {
+            let recast = prog.recast_top(&Default::default(), 0);
+            Some(Suggestion {
+                title: format!("rename '{name}' to '{new_name}'"),
+                insert: recast,
+                source_range: prog.as_source_range(),
+            })
+        } else {
+            None
         };
         findings.push(Z0001.at(
             format!("found '{name}'"),
             SourceRange::new(ident.start, ident.end, ident.module_id),
-            Some(suggestion),
+            suggestion,
         ));
         return Ok(findings);
     }
@@ -215,6 +221,41 @@ part001 = startSketchOn(XY)
 circ = {angle_start = 0, angle_end = 360, radius = 5}
 ",
         "found 'angle_start'",
+        None
+    );
+
+    // A declaration in an if-expression arm is reported, but rename_symbol
+    // can't rename nested declarations, so there must be no suggestion: a
+    // suggestion with the unchanged source would make auto-fix loop forever.
+    test_finding!(
+        z0001_local_in_if_arm_has_no_suggestion,
+        lint_variables,
+        Z0001,
+        "\
+x = if true {
+  local_value = 1
+  local_value
+} else {
+  0
+}
+",
+        "found 'local_value'",
+        None
+    );
+
+    // Same for a declaration in a function body.
+    test_finding!(
+        z0001_local_in_fn_body_has_no_suggestion,
+        lint_variables,
+        Z0001,
+        "\
+fn foo() {
+  local_value = 1
+  return local_value
+}
+y = foo()
+",
+        "found 'local_value'",
         None
     );
 

--- a/rust/kcl-lib/src/lint/rule.rs
+++ b/rust/kcl-lib/src/lint/rule.rs
@@ -66,6 +66,14 @@ impl Discovered {
     }
 }
 
+/// The maximum number of iterations of the fix loops in [`lint_and_fix_all`]
+/// and [`lint_and_fix_families`]. Each iteration applies one suggestion, so
+/// this bounds how many auto-fixes can be applied to a single file. It's a
+/// backstop against a buggy suggestion that never converges, e.g. one whose
+/// insert is identical to the existing source, which would otherwise loop
+/// forever.
+const MAX_FIX_ITERATIONS: usize = 10_000;
+
 /// Lint, and try to apply all suggestions.
 /// Returns the new source code, and any lints without suggestions.
 /// # Implementation
@@ -75,7 +83,7 @@ impl Discovered {
 /// If/when we discover that this autofix loop is too slow, we'll change our lint system so that
 /// lints can be applied to a small part of the program.
 pub fn lint_and_fix_all(mut source: String) -> anyhow::Result<(String, Vec<Discovered>)> {
-    loop {
+    for _ in 0..MAX_FIX_ITERATIONS {
         let (program, errors) = crate::Program::parse(&source)?;
         if !errors.is_empty() {
             anyhow::bail!("Found errors while parsing, please run the parser and fix them before linting.");
@@ -90,6 +98,9 @@ pub fn lint_and_fix_all(mut source: String) -> anyhow::Result<(String, Vec<Disco
             return Ok((source, lints));
         }
     }
+    anyhow::bail!(
+        "Lint auto-fix did not finish after {MAX_FIX_ITERATIONS} iterations; a lint suggestion is not making progress"
+    )
 }
 
 /// Lint, and try to apply all suggestions.
@@ -104,7 +115,7 @@ pub fn lint_and_fix_families(
     mut source: String,
     families_to_fix: &[FindingFamily],
 ) -> anyhow::Result<(String, Vec<Discovered>)> {
-    loop {
+    for _ in 0..MAX_FIX_ITERATIONS {
         let (program, errors) = crate::Program::parse(&source)?;
         if !errors.is_empty() {
             anyhow::bail!("Found errors while parsing, please run the parser and fix them before linting.");
@@ -125,6 +136,9 @@ pub fn lint_and_fix_families(
             return Ok((source, lints));
         }
     }
+    anyhow::bail!(
+        "Lint auto-fix did not finish after {MAX_FIX_ITERATIONS} iterations; a lint suggestion is not making progress"
+    )
 }
 
 #[cfg(feature = "pyo3")]
@@ -360,6 +374,27 @@ mod test {
 
         // After the fix, no more snake_case identifiers.
         assert!(!new_code.contains('_'));
+    }
+
+    #[test]
+    fn test_lint_and_fix_all_terminates_on_unfixable_rename() {
+        // A snake_case declaration in an if-expression arm gets a Z0001
+        // finding, but it can't be auto-renamed, so it must come back unfixed
+        // with the source unchanged. This used to produce a suggestion whose
+        // insert was identical to the source, making this loop forever.
+        let source = "\
+x = if true {
+  local_value = 1
+  local_value
+} else {
+  0
+}
+";
+        let (new_code, unfixed) = lint_and_fix_all(source.to_string()).unwrap();
+        assert_eq!(new_code, source);
+        assert_eq!(unfixed.len(), 1, "unfixed: {unfixed:?}");
+        assert_eq!(unfixed[0].description, "found 'local_value'");
+        assert!(unfixed[0].suggestion.is_none());
     }
 
     #[test]

--- a/rust/kcl-lib/src/parsing/ast/types/mod.rs
+++ b/rust/kcl-lib/src/parsing/ast/types/mod.rs
@@ -1004,7 +1004,14 @@ impl Program {
     }
 
     /// Rename the variable declaration at the given position.
-    pub fn rename_symbol(&mut self, new_name: &str, pos: usize) {
+    ///
+    /// Returns whether anything was actually renamed. Only top-level
+    /// declarations, import aliases, and parameters of top-level functions are
+    /// supported; a position inside a nested declaration (e.g. a local in a
+    /// function body or an if-expression arm) renames nothing and returns
+    /// false.
+    #[must_use = "if this returns false, nothing was renamed"]
+    pub fn rename_symbol(&mut self, new_name: &str, pos: usize) -> bool {
         // The position must be within the variable declaration.
         let mut old_name = None;
         for item in &mut self.body {
@@ -1028,12 +1035,13 @@ impl Program {
         if let Some(old_name) = old_name {
             // Now rename all the identifiers in the rest of the program.
             self.rename_identifiers(&old_name, new_name, &[]);
+            true
         } else {
             // Okay so this was not a top level variable declaration.
             // But it might be a variable declaration inside a function or function params.
             // So we need to check that.
             let Some(ref mut item) = self.get_mut_body_item_for_position(pos) else {
-                return;
+                return false;
             };
 
             // Recurse over the item.
@@ -1058,10 +1066,12 @@ impl Program {
                         param.identifier.rename(&old_name, new_name);
                         // Now rename all the identifiers in the rest of the program.
                         function_expression.body.rename_identifiers(&old_name, new_name, &[]);
-                        return;
+                        return true;
                     }
                 }
             }
+
+            false
         }
     }
 
@@ -5592,7 +5602,7 @@ byField = obj.key + key
         let mut program = parse(code);
         let pos = code.find("key").unwrap() + 1;
 
-        program.rename_symbol("idx", pos);
+        assert!(program.rename_symbol("idx", pos));
 
         let formatted = program.recast_top(&Default::default(), 0);
         assert_eq!(
@@ -5624,7 +5634,7 @@ angle = atan(rise / run)"#;
         assert_eq!(lit.raw, "8");
 
         // Rename it.
-        program.rename_symbol("yoyo", var_decl.as_source_range().start() + 1);
+        assert!(program.rename_symbol("yoyo", var_decl.as_source_range().start() + 1));
 
         // Recast the program to a string.
         let formatted = program.recast_top(&Default::default(), 0);
@@ -5660,7 +5670,7 @@ foo()
         };
         let pos = first_decl.declaration.id.start + 1;
 
-        program.rename_symbol("BETTER", pos);
+        assert!(program.rename_symbol("BETTER", pos));
 
         let formatted = program.recast_top(&Default::default(), 0);
         assert_eq!(
@@ -5698,7 +5708,7 @@ fn demo(a) {
         };
         let pos = first_decl.declaration.id.start + 1;
 
-        program.rename_symbol("foo_initial", pos);
+        assert!(program.rename_symbol("foo_initial", pos));
 
         let formatted = program.recast_top(&Default::default(), 0);
         assert_eq!(
@@ -5729,7 +5739,7 @@ result = line1
         let mut program = parse(code);
         let pos = code.find("line1 = 99").unwrap() + 1;
 
-        program.rename_symbol("width", pos);
+        assert!(program.rename_symbol("width", pos));
 
         let formatted = program.recast_top(&Default::default(), 0);
         assert_eq!(
@@ -5761,7 +5771,7 @@ s = sketch(on = XY) {
         };
         let pos = first_decl.declaration.id.start + 1;
 
-        program.rename_symbol("foo_initial", pos);
+        assert!(program.rename_symbol("foo_initial", pos));
 
         let formatted = program.recast_top(&Default::default(), 0);
         assert_eq!(
@@ -5796,7 +5806,7 @@ result = line1
         let mut program = parse(code);
         let pos = code.find("line1 = line").unwrap() + 1;
 
-        program.rename_symbol("renamed", pos);
+        assert!(!program.rename_symbol("renamed", pos));
 
         let formatted = program.recast_top(&Default::default(), 0);
         assert_eq!(formatted, code);
@@ -5817,7 +5827,46 @@ result = line1
         let mut program = parse(code);
         let pos = code.find("line1.end").unwrap() + 1;
 
-        program.rename_symbol("renamed", pos);
+        assert!(!program.rename_symbol("renamed", pos));
+
+        let formatted = program.recast_top(&Default::default(), 0);
+        assert_eq!(formatted, code);
+    }
+
+    #[test]
+    fn test_rename_of_declaration_inside_if_arm_is_a_no_op() {
+        // Renaming a variable declared inside an if-expression arm is not supported yet; the
+        // rename must report that nothing changed instead of silently doing nothing.
+        let code = r#"x = if true {
+  localValue = 1
+  localValue
+} else {
+  0
+}
+"#;
+        let mut program = parse(code);
+        let pos = code.find("localValue").unwrap() + 1;
+
+        assert!(!program.rename_symbol("renamed", pos));
+
+        let formatted = program.recast_top(&Default::default(), 0);
+        assert_eq!(formatted, code);
+    }
+
+    #[test]
+    fn test_rename_of_declaration_inside_fn_body_is_a_no_op() {
+        // Renaming a variable declared inside a function body is not supported yet; the rename
+        // must report that nothing changed instead of silently doing nothing.
+        let code = r#"fn foo() {
+  localValue = 1
+  return localValue
+}
+y = foo()
+"#;
+        let mut program = parse(code);
+        let pos = code.find("localValue").unwrap() + 1;
+
+        assert!(!program.rename_symbol("renamed", pos));
 
         let formatted = program.recast_top(&Default::default(), 0);
         assert_eq!(formatted, code);
@@ -5838,7 +5887,7 @@ b = helper()
         let mut program = parse(code);
         let pos = code.find("helper").unwrap() + 1;
 
-        program.rename_symbol("assist", pos);
+        assert!(program.rename_symbol("assist", pos));
 
         let BodyItem::VariableDeclaration(decl) = program.body.first().unwrap() else {
             panic!("expected variable declaration")
@@ -5873,7 +5922,7 @@ result = myFunc()
         let mut program = parse(code);
         let pos = code.find("myFunc").unwrap() + 1;
 
-        program.rename_symbol("yourFunc", pos);
+        assert!(program.rename_symbol("yourFunc", pos));
 
         let formatted = program.recast_top(&Default::default(), 0);
         assert_eq!(
@@ -5899,7 +5948,7 @@ total = accum(3)
         };
         let pos = first_decl.declaration.id.start + 1;
 
-        program.rename_symbol("addUp", pos);
+        assert!(program.rename_symbol("addUp", pos));
 
         let formatted = program.recast_top(&Default::default(), 0);
         assert_eq!(
@@ -5929,7 +5978,7 @@ fn helper() {
         };
         let pos = first_decl.declaration.id.start + 1;
 
-        program.rename_symbol("bar", pos);
+        assert!(program.rename_symbol("bar", pos));
 
         let formatted = program.recast_top(&Default::default(), 0);
         assert_eq!(
@@ -5963,7 +6012,7 @@ fn helper() {
         };
         let pos = first_decl.declaration.id.start + 1;
 
-        program.rename_symbol("bar", pos);
+        assert!(program.rename_symbol("bar", pos));
 
         let formatted = program.recast_top(&Default::default(), 0);
         assert_eq!(
@@ -5994,7 +6043,7 @@ if true {
         let mut program = parse(code);
         let pos = code.find("param1").unwrap() + 1;
 
-        program.rename_symbol("height", pos);
+        assert!(program.rename_symbol("height", pos));
 
         let formatted = program.recast_top(&Default::default(), 0);
         assert_eq!(

--- a/rust/kcl-lib/src/unparser.rs
+++ b/rust/kcl-lib/src/unparser.rs
@@ -3102,7 +3102,7 @@ fn ghi(part001) {
 }
 "#;
         let mut program = crate::parsing::top_level_parse(some_program_string).unwrap();
-        program.rename_symbol("mySuperCoolPart", 6);
+        assert!(program.rename_symbol("mySuperCoolPart", 6));
 
         let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(
@@ -3130,7 +3130,7 @@ fn ghi(part001) {
   return x
 }"#;
         let mut program = crate::parsing::top_level_parse(some_program_string).unwrap();
-        program.rename_symbol("newName", 7);
+        assert!(program.rename_symbol("newName", 7));
 
         let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(

--- a/rust/kcl-lib/tests/tangent_circle_circle/lints.snap
+++ b/rust/kcl-lib/tests/tangent_circle_circle/lints.snap
@@ -18,15 +18,7 @@ description: Lints tangent_circle_circle.kcl
       0
     ],
     "overridden": false,
-    "suggestion": {
-      "title": "rename 'a_top' to 'aTop'",
-      "insert": "@settings(experimentalFeatures = allow)\n\ns = sketch(on = XY) {\n  // Circle A modeled as two arcs.\n  a_top = arc(start = [var -5mm, var 0mm], end = [var 5mm, var 0mm], center = [var 0mm, var 0mm])\n  a_bot = arc(start = [var 5mm, var 0mm], end = [var -5mm, var 0mm], center = [var 0mm, var 0mm])\n  coincident([a_top.center, a_bot.center])\n  coincident([a_top.start, a_bot.end])\n  coincident([a_top.end, a_bot.start])\n\n  // Circle B modeled as two arcs.\n  b_top = arc(start = [var 7mm, var 0mm], end = [var 13mm, var 0mm], center = [var 10mm, var 0mm])\n  b_bot = arc(start = [var 13mm, var 0mm], end = [var 7mm, var 0mm], center = [var 10mm, var 0mm])\n  coincident([b_top.center, b_bot.center])\n  coincident([b_top.start, b_bot.end])\n  coincident([b_top.end, b_bot.start])\n\n  // Keep radii fixed so tangency cannot be satisfied by radius drift.\n  radius(a_top) == 5mm\n  radius(a_bot) == 5mm\n  radius(b_top) == 3mm\n  radius(b_bot) == 3mm\n\n  // Fix frame to remove rigid-body ambiguity.\n  fixed([a_top.center, [0mm, 0mm]])\n  b_top.center.at[1] == 0mm\n\n  tangent([a_top, b_top])\n}\n\nassert(s.b_top.center.at[0], isEqualTo = 8mm, tolerance = 0.001)\nassert(s.b_top.center.at[1], isEqualTo = 0mm, tolerance = 0.001)\n",
-      "source_range": [
-        0,
-        1206,
-        0
-      ]
-    }
+    "suggestion": null
   },
   {
     "finding": {
@@ -43,15 +35,7 @@ description: Lints tangent_circle_circle.kcl
       0
     ],
     "overridden": false,
-    "suggestion": {
-      "title": "rename 'a_bot' to 'aBot'",
-      "insert": "@settings(experimentalFeatures = allow)\n\ns = sketch(on = XY) {\n  // Circle A modeled as two arcs.\n  a_top = arc(start = [var -5mm, var 0mm], end = [var 5mm, var 0mm], center = [var 0mm, var 0mm])\n  a_bot = arc(start = [var 5mm, var 0mm], end = [var -5mm, var 0mm], center = [var 0mm, var 0mm])\n  coincident([a_top.center, a_bot.center])\n  coincident([a_top.start, a_bot.end])\n  coincident([a_top.end, a_bot.start])\n\n  // Circle B modeled as two arcs.\n  b_top = arc(start = [var 7mm, var 0mm], end = [var 13mm, var 0mm], center = [var 10mm, var 0mm])\n  b_bot = arc(start = [var 13mm, var 0mm], end = [var 7mm, var 0mm], center = [var 10mm, var 0mm])\n  coincident([b_top.center, b_bot.center])\n  coincident([b_top.start, b_bot.end])\n  coincident([b_top.end, b_bot.start])\n\n  // Keep radii fixed so tangency cannot be satisfied by radius drift.\n  radius(a_top) == 5mm\n  radius(a_bot) == 5mm\n  radius(b_top) == 3mm\n  radius(b_bot) == 3mm\n\n  // Fix frame to remove rigid-body ambiguity.\n  fixed([a_top.center, [0mm, 0mm]])\n  b_top.center.at[1] == 0mm\n\n  tangent([a_top, b_top])\n}\n\nassert(s.b_top.center.at[0], isEqualTo = 8mm, tolerance = 0.001)\nassert(s.b_top.center.at[1], isEqualTo = 0mm, tolerance = 0.001)\n",
-      "source_range": [
-        0,
-        1206,
-        0
-      ]
-    }
+    "suggestion": null
   },
   {
     "finding": {
@@ -68,15 +52,7 @@ description: Lints tangent_circle_circle.kcl
       0
     ],
     "overridden": false,
-    "suggestion": {
-      "title": "rename 'b_top' to 'bTop'",
-      "insert": "@settings(experimentalFeatures = allow)\n\ns = sketch(on = XY) {\n  // Circle A modeled as two arcs.\n  a_top = arc(start = [var -5mm, var 0mm], end = [var 5mm, var 0mm], center = [var 0mm, var 0mm])\n  a_bot = arc(start = [var 5mm, var 0mm], end = [var -5mm, var 0mm], center = [var 0mm, var 0mm])\n  coincident([a_top.center, a_bot.center])\n  coincident([a_top.start, a_bot.end])\n  coincident([a_top.end, a_bot.start])\n\n  // Circle B modeled as two arcs.\n  b_top = arc(start = [var 7mm, var 0mm], end = [var 13mm, var 0mm], center = [var 10mm, var 0mm])\n  b_bot = arc(start = [var 13mm, var 0mm], end = [var 7mm, var 0mm], center = [var 10mm, var 0mm])\n  coincident([b_top.center, b_bot.center])\n  coincident([b_top.start, b_bot.end])\n  coincident([b_top.end, b_bot.start])\n\n  // Keep radii fixed so tangency cannot be satisfied by radius drift.\n  radius(a_top) == 5mm\n  radius(a_bot) == 5mm\n  radius(b_top) == 3mm\n  radius(b_bot) == 3mm\n\n  // Fix frame to remove rigid-body ambiguity.\n  fixed([a_top.center, [0mm, 0mm]])\n  b_top.center.at[1] == 0mm\n\n  tangent([a_top, b_top])\n}\n\nassert(s.b_top.center.at[0], isEqualTo = 8mm, tolerance = 0.001)\nassert(s.b_top.center.at[1], isEqualTo = 0mm, tolerance = 0.001)\n",
-      "source_range": [
-        0,
-        1206,
-        0
-      ]
-    }
+    "suggestion": null
   },
   {
     "finding": {
@@ -93,14 +69,6 @@ description: Lints tangent_circle_circle.kcl
       0
     ],
     "overridden": false,
-    "suggestion": {
-      "title": "rename 'b_bot' to 'bBot'",
-      "insert": "@settings(experimentalFeatures = allow)\n\ns = sketch(on = XY) {\n  // Circle A modeled as two arcs.\n  a_top = arc(start = [var -5mm, var 0mm], end = [var 5mm, var 0mm], center = [var 0mm, var 0mm])\n  a_bot = arc(start = [var 5mm, var 0mm], end = [var -5mm, var 0mm], center = [var 0mm, var 0mm])\n  coincident([a_top.center, a_bot.center])\n  coincident([a_top.start, a_bot.end])\n  coincident([a_top.end, a_bot.start])\n\n  // Circle B modeled as two arcs.\n  b_top = arc(start = [var 7mm, var 0mm], end = [var 13mm, var 0mm], center = [var 10mm, var 0mm])\n  b_bot = arc(start = [var 13mm, var 0mm], end = [var 7mm, var 0mm], center = [var 10mm, var 0mm])\n  coincident([b_top.center, b_bot.center])\n  coincident([b_top.start, b_bot.end])\n  coincident([b_top.end, b_bot.start])\n\n  // Keep radii fixed so tangency cannot be satisfied by radius drift.\n  radius(a_top) == 5mm\n  radius(a_bot) == 5mm\n  radius(b_top) == 3mm\n  radius(b_bot) == 3mm\n\n  // Fix frame to remove rigid-body ambiguity.\n  fixed([a_top.center, [0mm, 0mm]])\n  b_top.center.at[1] == 0mm\n\n  tangent([a_top, b_top])\n}\n\nassert(s.b_top.center.at[0], isEqualTo = 8mm, tolerance = 0.001)\nassert(s.b_top.center.at[1], isEqualTo = 0mm, tolerance = 0.001)\n",
-      "source_range": [
-        0,
-        1206,
-        0
-      ]
-    }
+    "suggestion": null
   }
 ]


### PR DESCRIPTION
There are lots of situations where we're not smart enough to rename. The "lint and fix all" would blindly loop forever applying suggestions that never changed anything.

Changes in this PR:

1. Stop suggesting renames that we can't apply.
2. Limit the number of lints we apply. This also protects against lints that ping pong between outputs and never settle, not just suggestions that make no changes.