### PR TITLE
Restore empty cloud deletion intent compatibility

### DIFF
--- a/src/lib/cloudSync/cloudApi.spec.ts
+++ b/src/lib/cloudSync/cloudApi.spec.ts
@@ -110,8 +110,33 @@ describe('remote project uploads', () => {
       entrypoint_path: 'main.kcl',
       project_toml_path: 'project.toml',
       expected_revision: 'rev-1',
-      deleted_paths: [],
     })
+  })
+
+  test('omits deletion intent when no deleted paths are provided', async () => {
+    let uploadedBody: Record<string, unknown> | undefined
+    vi.stubGlobal(
+      'fetch',
+      vi.fn<typeof fetch>(async (_input, init) => {
+        uploadedBody = await uploadBodyFromRequest(init)
+        return projectResponse('project-existing', 'rev-2')
+      })
+    )
+
+    await updateRemoteProject({
+      config: { enabled: true, baseUrl: 'https://api.dev.zoo.dev' },
+      projectPath: '/projects/bracket',
+      project: {
+        id: 'project-existing',
+        description: '',
+        category_ids: [],
+      },
+      files: [projectFile('main.kcl')],
+      expectedRevision: 'rev-1',
+      deletedPaths: [],
+    })
+
+    expect(uploadedBody).not.toHaveProperty('deleted_paths')
   })
 
   test('declares explicit deletion intent when replacing a cloud project', async () => {

--- a/src/lib/cloudSync/cloudApi.ts
+++ b/src/lib/cloudSync/cloudApi.ts
@@ -389,7 +389,7 @@ export async function updateRemoteProject({
   files,
   expectedRevision,
   entrypointPath,
-  deletedPaths = [],
+  deletedPaths,
 }: {
   config: CloudSyncConfig
   projectPath: string

--- a/src/lib/cloudSync/projectArchive.ts
+++ b/src/lib/cloudSync/projectArchive.ts
@@ -92,7 +92,7 @@ export function prepareProjectFilesForCloudUpload(
   }
   if (
     typeof optionsOrExpectedRevision !== 'string' &&
-    optionsOrExpectedRevision?.deletedPaths
+    optionsOrExpectedRevision?.deletedPaths?.length
   ) {
     body.deleted_paths = Array.from(
       new Set(optionsOrExpectedRevision.deletedPaths.map(normalizeRelativePath))


### PR DESCRIPTION
## Summary

- omit `deleted_paths` when cloud sync has no non-empty deletion declaration
- preserve strict deletion-intent validation for observed deletions
- cover both omitted and explicitly empty inputs with regression tests

## Why

The projects API uses field presence to distinguish its legacy compatibility path from strict deletion validation. Defaulting the client argument to `[]` caused every update to send `deleted_paths: []`, producing persistent 409 conflicts whenever an older or otherwise untracked local/remote file divergence existed.

Production logs showed 1,704 occurrences across 15 projects in a bounded six-hour window. The rejected requests were non-mutating, but affected projects could not synchronize.

## Testing

- `npm run test:integration -- src/lib/cloudSync/cloudApi.spec.ts`
- `npx biome check src/lib/cloudSync/cloudApi.ts src/lib/cloudSync/projectArchive.ts src/lib/cloudSync/cloudApi.spec.ts`
- `git diff --check`

Targeted ESLint was attempted but the local Node 23.9.0 runtime is unsupported by the installed TypeScript ESLint dependency (`Cannot read properties of undefined (reading 'Cjs')`).

## Risk

This restores the API compatibility behavior for empty deletion sets. Non-empty observed deletions are still declared and checked exactly. The longer-term migration away from the omitted-field compatibility path remains separate work.
