### PR TITLE
Second flag to test updater on PR

### DIFF
--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -70,7 +70,7 @@ jobs:
           export VERSION=255.255.0
           npm run files:set-version
 
-      - name: Set dummy updater url (forced release build that doesn't downgrade to the last release)
+      - name: Set dummy updater URL
         if: ${{ env.FORCE_RELEASE_BUILD == 'true' && env.FORCE_RELEASE_BUILD_ALLOW_DOWNGRADE == 'false' }}
         run: |
           yq -i '.publish[0].url = "https://dl.zoo.dev/releases/design-studio/no-update"' electron-builder.yml

--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -12,6 +12,7 @@ env:
   IS_RELEASE: ${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}
   IS_STAGING: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
   FORCE_RELEASE_BUILD: false # Set to true to enable codesign in a PR
+  FORCE_RELEASE_BUILD_ALLOW_DOWNGRADE: false # Set to true to allow the updater to downgrade to the last release
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -63,11 +64,15 @@ jobs:
           export VERSION=${GITHUB_REF_NAME#v}
           npm run files:set-version
 
-      - name: Set dummy release version (forced release build) and disable updater
+      - name: Set dummy release version (forced release build)
         if: ${{ env.FORCE_RELEASE_BUILD == 'true' }}
         run: |
           export VERSION=255.255.0
           npm run files:set-version
+
+      - name: Set dummy updater url (forced release build that doesn't downgrade to the last release)
+        if: ${{ env.FORCE_RELEASE_BUILD == 'true' && env.FORCE_RELEASE_BUILD_ALLOW_DOWNGRADE == 'false' }}
+        run: |
           yq -i '.publish[0].url = "https://dl.zoo.dev/releases/design-studio/no-update"' electron-builder.yml
 
       - name: Set windows codesign config


### PR DESCRIPTION
It prevents the override of the updater URL to a dummy one, which means the forced release build will prompt to "upgrade" to the last production release. Same codesign so it will work.

FORCE_RELEASE_BUILD: true is good to share test builds from PRs, won't ask to upgrade.

But if the PR author wants to quickly test the updater, setting FORCE_RELEASE_BUILD_ALLOW_DOWNGRADE to true will work for that case!

This came up during the manual testing of https://github.com/KittyCAD/modeling-app/pull/13129