### PR TITLE
Adjust the message and styling of legacy sketch warnings

### DIFF
--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -991,7 +991,7 @@ const ToolbarItemTooltipRichContent = memo(
           </p>
         )}
         {itemConfig.disabled && itemConfig.disabledReason && (
-          <p className="px-2 my-2 text-ch font-sans text-destroy-80 dark:text-destroy-20">
+          <p className="mx-2 my-2 rounded border px-2 py-1.5 text-ch font-sans border-destroy-40 bg-destroy-10/50 text-destroy-80 dark:border-destroy-80 dark:bg-destroy-80/20 dark:text-destroy-20">
             {typeof itemConfig.disabledReason === 'function'
               ? itemConfig.disabledReason(state)
               : itemConfig.disabledReason}

--- a/src/components/Announcements.tsx
+++ b/src/components/Announcements.tsx
@@ -4,8 +4,9 @@ import { MarkdownText } from '@src/components/MarkdownText'
 import { createKCClient } from '@src/lib/kcClient'
 import { useEffect, useState } from 'react'
 
-export const LEGACY_SKETCH_MODE_DEPRECATION_MESSAGE =
-  'This older sketch opens in legacy mode. New projects use the redesigned sketch mode with a fully-integrated constraint solver.'
+import { LEGACY_SKETCH_MODE_REMOVED_MESSAGE } from '@src/lib/constants'
+
+const LEGACY_SKETCH_MODE_DEPRECATION_MESSAGE = `${LEGACY_SKETCH_MODE_REMOVED_MESSAGE}. This legacy sketch mode will soon be removed.`
 
 export function Announcements({ token }: { token?: string }) {
   const [announcements, setAnnouncements] = useState<Announcement[]>([])

--- a/src/components/ConnectionStream.tsx
+++ b/src/components/ConnectionStream.tsx
@@ -266,7 +266,9 @@ export const ConnectionStream = (props: ConnectionStreamProps) => {
             // Anything left here belongs to a KCL 1.0 sketch, since sketch
             // blocks and undeclared regions were handled above.
             if (!hasLegacySketchMode) {
-              toast.error(LEGACY_SKETCH_MODE_REMOVED_MESSAGE)
+              toast.error(LEGACY_SKETCH_MODE_REMOVED_MESSAGE, {
+                duration: 5_000,
+              })
               return
             }
             sceneInfra.modelingSend({ type: 'Enter sketch' })

--- a/src/components/layout/areas/FeatureTreePane.tsx
+++ b/src/components/layout/areas/FeatureTreePane.tsx
@@ -22,6 +22,7 @@ import {
   getAllOperations,
 } from '@src/lang/wasm'
 import { useApp, useSingletons } from '@src/lib/boot'
+import { LEGACY_SKETCH_MODE_REMOVED_MESSAGE } from '@src/lib/constants'
 import {
   type OperationTreeNode,
   buildOperationTree,
@@ -1139,7 +1140,11 @@ const OperationItem = ({
         selectOperation,
         systemDeps,
       }).catch((e) => {
-        toast.error(err(e) ? e.message : JSON.stringify(e))
+        const message = err(e) ? e.message : JSON.stringify(e)
+        toast.error(message, {
+          duration:
+            message === LEGACY_SKETCH_MODE_REMOVED_MESSAGE ? 5_000 : undefined,
+        })
       })
     }
   }, [

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -42,7 +42,7 @@ export const NAMED_VIEWS_UI_FEATURE_FLAG: Feature = 'named_views_ui'
 /** Allows legacy sketches to be edited using point-and-click */
 export const LEGACY_SKETCH_MODE_FEATURE_FLAG: Feature = 'legacy_sketch_mode'
 export const LEGACY_SKETCH_MODE_REMOVED_MESSAGE =
-  '⚠ Editing of KCL 1.0 sketches is no longer supported.'
+  'Editing of KCL 1.0 sketches is no longer supported.'
 /** Default file to open when a project is opened */
 export const PROJECT_ENTRYPOINT = `main${FILE_EXT}` as const
 /** Thumbnail file name */


### PR DESCRIPTION
This makes the message a bit more prominent and fixes the double icon in toasts.

<img width="329" height="242" alt="Screenshot 2026-09-01 at 2 52 25 PM" src="https://github.com/user-attachments/assets/7ec84664-29cf-4b4f-a8c4-0d8768a81358" />

<img width="564" height="140" alt="Screenshot 2026-09-01 at 2 52 36 PM" src="https://github.com/user-attachments/assets/6fe7c56c-0d28-409b-92c3-995ecf754835" />

