### PR TITLE
Issue-3972: render an unavailable attachment without offering a download

### DIFF
--- a/src/components/Thinking.spec.tsx
+++ b/src/components/Thinking.spec.tsx
@@ -44,6 +44,35 @@ describe('FilesSnapshot', () => {
     vi.restoreAllMocks()
   })
 
+  test('renders an unavailable replay attachment without offering a download', () => {
+    const files: MlCopilotFile[] = [
+      {
+        name: 'missing.png',
+        mimetype: 'image/png',
+        data: [],
+        metadata: {
+          zoo_replay_error: 'attachment_unavailable',
+        },
+      },
+    ]
+
+    render(<FilesSnapshot files={files} />)
+
+    expect(screen.getByText('Zookeeper File')).toBeInTheDocument()
+    expect(screen.getByText('missing.png')).toBeInTheDocument()
+    expect(screen.getByText('Attachment unavailable')).toBeInTheDocument()
+
+    expect(
+      screen.getByLabelText('missing.png: Attachment unavailable')
+    ).toBeInTheDocument()
+
+    expect(
+      screen.queryByTitle('Click to download missing.png')
+    ).not.toBeInTheDocument()
+
+    expect(createObjectURLMock).not.toHaveBeenCalled()
+  })
+
   test('renders a single image file with correct filename', () => {
     const files: MlCopilotFile[] = [
       {

--- a/src/components/Thinking.tsx
+++ b/src/components/Thinking.tsx
@@ -12,6 +12,9 @@ interface IRowCollapse {
   keyIndex: number
 }
 
+const REPLAY_ATTACHMENT_ERROR_KEY = 'zoo_replay_error'
+const REPLAY_ATTACHMENT_UNAVAILABLE = 'attachment_unavailable'
+
 export const Generic = (props: { content: string }) => {
   return <div>{props.content}</div>
 }
@@ -383,6 +386,38 @@ export const isExportDownloadFile = (file: MlCopilotFile): boolean => {
 }
 
 /**
+ * If attachment is unavailable, backend api sends an empty file placeholder
+ * with an error label in the metadata as "zoo_replay_error: attachment_unavailable"
+ */
+const isReplayAttachmentUnavailable = (file: MlCopilotFile): boolean => {
+  return (
+    file.metadata?.[REPLAY_ATTACHMENT_ERROR_KEY] ===
+    REPLAY_ATTACHMENT_UNAVAILABLE
+  )
+}
+
+/**
+ * Component for displaying an empty attachment, which is what backend returns
+ * when an attachment is unavailable
+ */
+const UnavailableFileItem = (props: { file: MlCopilotFile }) => {
+  return (
+    <div
+      role="status"
+      className="flex w-full flex-row items-center gap-2 rounded p-2 text-left text-chalkboard-70 dark:text-chalkboard-40"
+      aria-label={`${props.file.name}: Attachment unavailable`}
+    >
+      <CustomIcon
+        name="triangleExclamation"
+        className="h-5 w-5 flex-shrink-0"
+      />
+      <span className="min-w-0 flex-1 truncate text-sm">{props.file.name}</span>
+      <span className="flex-shrink-0 text-xs">Attachment unavailable</span>
+    </div>
+  )
+}
+
+/**
  * Component for displaying an image file with error handling
  */
 const ImageFileItem = (props: {
@@ -431,18 +466,24 @@ const ImageFileItem = (props: {
 }
 
 const FileList = (props: { files: MlCopilotFile[] }) => {
-  const [objectUrls, setObjectUrls] = useState<string[]>([])
+  const [objectUrls, setObjectUrls] = useState<Array<string | undefined>>([])
 
   useEffect(() => {
     // Create object URLs for all files
     const urls = props.files.map((file) =>
-      bytesToDataUrl(file.data, file.mimetype)
+      isReplayAttachmentUnavailable(file)
+        ? undefined
+        : bytesToDataUrl(file.data, file.mimetype)
     )
     setObjectUrls(urls)
 
     // Cleanup object URLs when component unmounts
     return () => {
-      urls.forEach((url) => URL.revokeObjectURL(url))
+      urls.forEach((url) => {
+        if (url) {
+          URL.revokeObjectURL(url)
+        }
+      })
     }
   }, [props.files])
 
@@ -465,6 +506,11 @@ const FileList = (props: { files: MlCopilotFile[] }) => {
   return (
     <div className="flex max-w-full min-w-0 flex-col gap-3">
       {imageFiles.map((file, index) => {
+        if (isReplayAttachmentUnavailable(file)) {
+          return (
+            <UnavailableFileItem key={`${file.name}-${index}`} file={file} />
+          )
+        }
         const fileIndex = props.files.indexOf(file)
         const url = objectUrls[fileIndex]
         return (
@@ -477,6 +523,11 @@ const FileList = (props: { files: MlCopilotFile[] }) => {
         )
       })}
       {otherFiles.map((file, index) => {
+        if (isReplayAttachmentUnavailable(file)) {
+          return (
+            <UnavailableFileItem key={`${file.name}-${index}`} file={file} />
+          )
+        }
         const fileIndex = props.files.indexOf(file)
         const url = objectUrls[fileIndex]
         return (


### PR DESCRIPTION
As part of [Issue-3972](https://github.com/KittyCAD/api/issues/3972) improvements, instead of cancelling the whole conversation replay because of a single unreadable object, the backend api will instead insert an empty zero byte placeholder with an error label in the metadata: "zoo_replay_error": "attachment_unavailable". While this change should be compatible with the modeling app, there will likely be a discrepancy from the user perspective - an unavailable attachment would look like a generic downloadable file and clicking it would download an empty file. 

This PR adds changes to how the frontend responds to conversation replay with possible unavailable attachments. The app should display "Attachment unavailable" label to the user, and prevent the user from downloading an empty file.