### PR TITLE
[3/3] Wire imported BREP topology into point-and-click workflows

### DIFF
--- a/src/lang/modifyAst/edges.ts
+++ b/src/lang/modifyAst/edges.ts
@@ -35,6 +35,7 @@ import {
   getSketchVariableNameForSegment,
   getVariableExprsFromSelection,
   getVariableNameFromNodePath,
+  isCallExprWithName,
   locateVariableWithCallOrPipe,
   traverse,
   valueOrVariable,
@@ -55,6 +56,7 @@ import type {
   EdgeRefactorMeta,
   Expr,
   ExpressionStatement,
+  LabeledArg,
   MemberExpression,
   PathToNode,
   Program,
@@ -66,8 +68,14 @@ import type { KclCommandValue } from '@src/lib/commandTypes'
 import { KCL_DEFAULT_CONSTANT_PREFIXES } from '@src/lib/constants'
 import {
   getBodySelectionFromPrimitiveParentEntityId,
+  getKclBodyIdFromEnginePrimitiveSelection,
   isEnginePrimitiveSelection,
+  TOPOLOGY_BODY_ARTIFACT_TYPES,
 } from '@src/lib/selections'
+import {
+  createPrimitiveIndexCallExpression,
+  insertBodyOfVariableAndOffsetPathToNode,
+} from '@src/lang/modifyAst/enginePrimitiveReference'
 import { err } from '@src/lib/trap'
 import { isArray } from '@src/lib/utils'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
@@ -137,14 +145,17 @@ export function addFillet({
   let modifiedAst = structuredClone(ast)
   const mNodeToEdit = structuredClone(nodeToEdit)
 
-  const nonSelectionArgs = [
+  const nonVersionArgs = [
     createLabeledArg('radius', valueOrVariable(radius)),
     ...(tolerance
       ? [createLabeledArg('tolerance', valueOrVariable(tolerance))]
       : []),
     ...(tag ? [createLabeledArg('tag', createTagDeclarator(tag))] : []),
+  ]
+  const versionArgs = [
     ...(version ? [createLabeledArg('version', valueOrVariable(version))] : []),
   ]
+  const nonSelectionArgs = [...nonVersionArgs, ...versionArgs]
 
   if (mNodeToEdit) {
     insertKclVariables([radius, version, tolerance], modifiedAst, mNodeToEdit)
@@ -185,6 +196,7 @@ export function addFillet({
         modifiedAst,
         artifactGraph,
         wasmInstance,
+        bodyArtifactTypes: EDGE_CUT_BODY_ARTIFACT_TYPES,
       }
     )
     if (err(primitiveEdgeResult)) return primitiveEdgeResult
@@ -195,7 +207,14 @@ export function addFillet({
   }
 
   // Insert variables for labeled arguments if provided
-  insertKclVariables([radius, version, tolerance], modifiedAst, mNodeToEdit)
+  const needsRequestedVersion = [...bodies.values()].some(
+    (body) => body.bodyArtifactType !== 'importedGeometry'
+  )
+  insertKclVariables(
+    [radius, needsRequestedVersion ? version : undefined, tolerance],
+    modifiedAst,
+    mNodeToEdit
+  )
 
   // 3. Create fillet calls for each body
   const pathToNodes: PathToNode[] = []
@@ -205,7 +224,8 @@ export function addFillet({
       data.solidsExpr,
       [
         createLabeledArg('tags', data.tagsExpr),
-        ...structuredClone(nonSelectionArgs),
+        ...structuredClone(nonVersionArgs),
+        ...edgeCutVersionArgs(data, versionArgs),
       ]
     )
 
@@ -257,15 +277,18 @@ export function addChamfer({
   let modifiedAst = structuredClone(ast)
   const mNodeToEdit = structuredClone(nodeToEdit)
 
-  const nonSelectionArgs = [
+  const nonVersionArgs = [
     createLabeledArg('length', valueOrVariable(length)),
     ...(secondLength
       ? [createLabeledArg('secondLength', valueOrVariable(secondLength))]
       : []),
     ...(angle ? [createLabeledArg('angle', valueOrVariable(angle))] : []),
     ...(tag ? [createLabeledArg('tag', createTagDeclarator(tag))] : []),
+  ]
+  const versionArgs = [
     ...(version ? [createLabeledArg('version', valueOrVariable(version))] : []),
   ]
+  const nonSelectionArgs = [...nonVersionArgs, ...versionArgs]
 
   if (mNodeToEdit) {
     insertKclVariables(
@@ -310,6 +333,7 @@ export function addChamfer({
         modifiedAst,
         artifactGraph,
         wasmInstance,
+        bodyArtifactTypes: EDGE_CUT_BODY_ARTIFACT_TYPES,
       }
     )
     if (err(primitiveEdgeResult)) return primitiveEdgeResult
@@ -320,7 +344,13 @@ export function addChamfer({
   }
 
   // Insert variables for labeled arguments if provided
-  insertKclVariables([length, secondLength, angle, version], modifiedAst)
+  const needsRequestedVersion = [...bodies.values()].some(
+    (body) => body.bodyArtifactType !== 'importedGeometry'
+  )
+  insertKclVariables(
+    [length, secondLength, angle, needsRequestedVersion ? version : undefined],
+    modifiedAst
+  )
 
   // 3. Create chamfer calls for each body
   const pathToNodes: PathToNode[] = []
@@ -330,7 +360,8 @@ export function addChamfer({
       data.solidsExpr,
       [
         createLabeledArg('tags', data.tagsExpr),
-        ...structuredClone(nonSelectionArgs),
+        ...structuredClone(nonVersionArgs),
+        ...edgeCutVersionArgs(data, versionArgs),
       ]
     )
 
@@ -410,6 +441,26 @@ type BodySelectionData = {
   solidsExpr: Expr | null
   tagsExpr: Expr
   pathIfPipe?: PathToNode
+  bodyArtifactType?: Artifact['type']
+}
+
+const EDGE_CUT_BODY_ARTIFACT_TYPES: Artifact['type'][] = [
+  'compositeSolid',
+  'sweep',
+  'importedGeometry',
+]
+const BLEND_BODY_ARTIFACT_TYPES: Artifact['type'][] = [
+  'compositeSolid',
+  'sweep',
+]
+
+function edgeCutVersionArgs(
+  body: BodySelectionData,
+  requestedVersionArgs: LabeledArg[]
+): LabeledArg[] {
+  return body.bodyArtifactType === 'importedGeometry'
+    ? []
+    : structuredClone(requestedVersionArgs)
 }
 
 function getEdgeSelections(edges: Selections): EdgeSelectionForExpr[] {
@@ -427,7 +478,7 @@ function buildEdgeExpr(
     'type' in edgeSelection &&
     edgeSelection.type === 'enginePrimitive'
   ) {
-    if (!edgeSelection.parentEntityId) {
+    if (!getKclBodyIdFromEnginePrimitiveSelection(edgeSelection)) {
       return new Error(
         'Blend primitive edge selections must include a parent entity.'
       )
@@ -440,6 +491,7 @@ function buildEdgeExpr(
         modifiedAst: ast,
         artifactGraph,
         wasmInstance,
+        bodyArtifactTypes: BLEND_BODY_ARTIFACT_TYPES,
       }
     )
     if (err(primitiveEdgeResult)) return primitiveEdgeResult
@@ -646,6 +698,50 @@ export function groupSelectionsByBodyAndAddTags(
       ]),
       tagsExpr,
       pathIfPipe: edgeContext.pathIfPipe,
+      bodyArtifactType: edgeContext.selectedBody.type,
+    })
+  }
+
+  for (const selection of selections.graphSelections) {
+    if (selection.artifact?.type !== 'primitiveEdge') continue
+
+    const variable = locateVariableWithCallOrPipe(
+      ast,
+      selection.codeRef.pathToNode,
+      wasmInstance
+    )
+    if (err(variable)) return variable
+
+    const edgeIdCall = variable.variableDeclarator.init
+    if (!isCallExprWithName(edgeIdCall, 'edgeId') || !edgeIdCall.unlabeled) {
+      return new Error(
+        'Could not resolve the selected primitive edge body in code.'
+      )
+    }
+
+    const solidsExpr =
+      edgeIdCall.unlabeled.type === 'Name'
+        ? createLocalName(edgeIdCall.unlabeled.name.name)
+        : structuredClone(edgeIdCall.unlabeled)
+    const bodyKey = getEdgeBodyKey(solidsExpr)
+    const bodyData = bodies.get(bodyKey)
+    const tagsExprs: Expr[] = bodyData
+      ? bodyData.tagsExpr.type === 'ArrayExpression'
+        ? [...bodyData.tagsExpr.elements]
+        : [bodyData.tagsExpr]
+      : []
+    tagsExprs.push(createLocalName(variable.variableDeclarator.id.name))
+
+    const tagsExpr = createVariableExpressionsArray(tagsExprs)
+    if (!tagsExpr) return new Error('No edges found in the selection')
+
+    bodies.set(bodyKey, {
+      solidsExpr: bodyData?.solidsExpr ?? solidsExpr,
+      tagsExpr,
+      pathIfPipe: bodyData?.pathIfPipe,
+      bodyArtifactType:
+        bodyData?.bodyArtifactType ??
+        artifactGraph.get(selection.artifact.solidId)?.type,
     })
   }
 
@@ -670,6 +766,8 @@ function groupSelectionsByBody(
   const bodyToSelections = new Map<string, Selection[]>()
 
   for (const selection of selections.graphSelections) {
+    if (selection.artifact?.type === 'primitiveEdge') continue
+
     const edgeContext = resolveEdgeSelectionContext(
       ast,
       selection,
@@ -773,6 +871,7 @@ function getTagsExprsFromSelection(
       )
       if (err(variable)) continue
       tagsExprs.push(createLocalName(variable.variableDeclarator.id.name))
+      continue
     }
 
     const result = modifyAstWithTagsForSelection(
@@ -2615,6 +2714,7 @@ export function insertPrimitiveEdgeVariablesAndOffsetPathToNode({
   artifactGraph,
   wasmInstance,
   nodeToEdit,
+  bodyArtifactTypes = TOPOLOGY_BODY_ARTIFACT_TYPES,
 }: {
   primitiveEdgeSelections: EnginePrimitiveSelection[]
   bodies: Map<string, BodySelectionData>
@@ -2622,54 +2722,84 @@ export function insertPrimitiveEdgeVariablesAndOffsetPathToNode({
   artifactGraph: ArtifactGraph
   wasmInstance: ModuleType
   nodeToEdit?: PathToNode
-}): Error | { bodies: Map<string, BodySelectionData> } {
+  bodyArtifactTypes?: Artifact['type'][]
+}):
+  | Error
+  | {
+      bodies: Map<string, BodySelectionData>
+      primitiveEdgeExprs: Map<EnginePrimitiveSelection, Expr>
+    } {
+  const primitiveEdgeExprs = new Map<EnginePrimitiveSelection, Expr>()
   if (primitiveEdgeSelections.length === 0) {
-    return { bodies }
+    return { bodies, primitiveEdgeExprs }
   }
 
   const primitiveSelectionsByBody = new Map<
     string,
     {
       bodySelection: Selection
-      primitiveIndices: number[]
+      primitiveSelections: EnginePrimitiveSelection[]
     }
   >()
 
   // Step 1. Gather all the indices by body
   for (const selection of primitiveEdgeSelections) {
-    if (!selection.parentEntityId) {
+    const kclBodyId = getKclBodyIdFromEnginePrimitiveSelection(selection)
+    if (!kclBodyId) {
       continue
     }
 
     const bodySelection = getBodySelectionFromPrimitiveParentEntityId(
-      selection.parentEntityId,
-      artifactGraph
+      kclBodyId,
+      artifactGraph,
+      { bodyArtifactTypes }
     )
-    if (!bodySelection?.artifact) {
+    if (
+      !bodySelection?.artifact ||
+      !bodyArtifactTypes.includes(bodySelection.artifact.type)
+    ) {
       continue
     }
 
-    const bodyKey = JSON.stringify(bodySelection.codeRef.pathToNode)
+    const bodyKey = JSON.stringify([
+      bodySelection.codeRef.pathToNode,
+      selection.bodyPath ?? [],
+    ])
     const byBody = primitiveSelectionsByBody.get(bodyKey)
     if (byBody) {
-      if (!byBody.primitiveIndices.includes(selection.primitiveIndex)) {
-        byBody.primitiveIndices.push(selection.primitiveIndex)
+      const primitiveKey = JSON.stringify([
+        selection.bodyPath ?? [],
+        selection.primitiveIndex,
+      ])
+      if (
+        !byBody.primitiveSelections.some(
+          (existing) =>
+            JSON.stringify([
+              existing.bodyPath ?? [],
+              existing.primitiveIndex,
+            ]) === primitiveKey
+        )
+      ) {
+        byBody.primitiveSelections.push(selection)
       }
     } else {
       primitiveSelectionsByBody.set(bodyKey, {
         bodySelection,
-        primitiveIndices: [selection.primitiveIndex],
+        primitiveSelections: [selection],
       })
     }
   }
 
   if (primitiveSelectionsByBody.size === 0) {
-    return { bodies }
+    return { bodies, primitiveEdgeExprs }
   }
 
   // Step 2. Create an array of variable references to bodies
   const updatedBodies = new Map(bodies)
-  let insertIndex = modifiedAst.body.length
+  let insertIndex =
+    nodeToEdit && typeof nodeToEdit[1]?.[0] === 'number'
+      ? nodeToEdit[1][0]
+      : modifiedAst.body.length
   for (const primitiveData of primitiveSelectionsByBody.values()) {
     const vars = getVariableExprsFromSelection(
       {
@@ -2682,16 +2812,30 @@ export function insertPrimitiveEdgeVariablesAndOffsetPathToNode({
       nodeToEdit,
       {
         lastChildLookup: true,
-        artifactTypeFilter: ['compositeSolid', 'sweep'],
+        artifactTypeFilter: bodyArtifactTypes,
       }
     )
     if (err(vars)) return vars
-    const resolvedSolidsExpr = createVariableExpressionsArray(vars.exprs)
-    if (!resolvedSolidsExpr) {
+    const rootBodyExpr = createVariableExpressionsArray(vars.exprs)
+    if (!rootBodyExpr) {
       return new Error(
         'Could not resolve selected primitive edge bodies in code.'
       )
     }
+
+    const bodyPath = primitiveData.primitiveSelections[0]?.bodyPath
+    const bodyOfResult = insertBodyOfVariableAndOffsetPathToNode({
+      bodyExpr: rootBodyExpr,
+      bodyPath,
+      modifiedAst,
+      wasmInstance,
+      insertIndex,
+      pathToNode: nodeToEdit,
+    })
+    if (bodyOfResult.inserted) {
+      insertIndex++
+    }
+    const resolvedSolidsExpr = bodyOfResult.bodyExpr
 
     // Graph-backed and engine-primitive edges arrive through separate
     // selection collections. Resolve both to the same body identity before
@@ -2713,11 +2857,12 @@ export function insertPrimitiveEdgeVariablesAndOffsetPathToNode({
     }
 
     // Step 3. Insert variable declarations for edgeId calls
-    for (const primitiveIndex of primitiveData.primitiveIndices) {
-      const edgeIdExpr = createCallExpressionStdLibKw(
+    for (const primitiveSelection of primitiveData.primitiveSelections) {
+      const edgeIdExpr = createPrimitiveIndexCallExpression(
         'edgeId',
         structuredClone(solidsExpr),
-        [createLabeledArg('index', createLiteral(primitiveIndex, wasmInstance))]
+        primitiveSelection.primitiveIndex,
+        wasmInstance
       )
       const edgeVariableName = findUniqueName(
         modifiedAst,
@@ -2737,10 +2882,12 @@ export function insertPrimitiveEdgeVariablesAndOffsetPathToNode({
           variableIdentifierAst,
           insertIndex,
         },
-        modifiedAst
+        modifiedAst,
+        nodeToEdit
       )
       insertIndex++
       tagsExprs.push(variableIdentifierAst)
+      primitiveEdgeExprs.set(primitiveSelection, variableIdentifierAst)
     }
 
     const tagsExpr = createVariableExpressionsArray(tagsExprs)
@@ -2752,9 +2899,12 @@ export function insertPrimitiveEdgeVariablesAndOffsetPathToNode({
       solidsExpr,
       tagsExpr,
       pathIfPipe,
+      bodyArtifactType:
+        bodyData?.bodyArtifactType ??
+        primitiveData.bodySelection.artifact?.type,
     }
     updatedBodies.set(resolvedBodyKey, updatedBodyData)
   }
 
-  return { bodies: updatedBodies }
+  return { bodies: updatedBodies, primitiveEdgeExprs }
 }

--- a/src/lang/modifyAst/enginePrimitiveReference.ts
+++ b/src/lang/modifyAst/enginePrimitiveReference.ts
@@ -1,0 +1,147 @@
+import type { Node } from '@rust/kcl-lib/bindings/Node'
+import {
+  createArrayExpression,
+  createCallExpressionStdLibKw,
+  createLabeledArg,
+  createLiteral,
+  createLocalName,
+  createVariableDeclaration,
+  findUniqueName,
+} from '@src/lang/create'
+import { insertVariableAndOffsetPathToNode } from '@src/lang/modifyAst'
+import type {
+  CallExpressionKw,
+  Expr,
+  PathToNode,
+  Program,
+} from '@src/lang/wasm'
+import { KCL_DEFAULT_CONSTANT_PREFIXES } from '@src/lib/constants'
+import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
+export function createPrimitiveIndexCallExpression(
+  functionName: 'faceId' | 'edgeId',
+  bodyExpr: Expr,
+  primitiveIndex: number,
+  wasmInstance: ModuleType
+): Node<CallExpressionKw> {
+  return createCallExpressionStdLibKw(functionName, bodyExpr, [
+    createLabeledArg('index', createLiteral(primitiveIndex, wasmInstance)),
+  ])
+}
+
+export function createBodyOfCallExpression(
+  bodyExpr: Expr,
+  bodyPath: number[],
+  wasmInstance: ModuleType
+): Node<CallExpressionKw> {
+  return createCallExpressionStdLibKw('bodyOf', bodyExpr, [
+    createLabeledArg(
+      'path',
+      createArrayExpression(
+        bodyPath.map((index) => createLiteral(index, wasmInstance))
+      )
+    ),
+  ])
+}
+
+export function createPrimitiveBodyExpression(
+  bodyExpr: Expr,
+  bodyPath: number[] | undefined,
+  wasmInstance: ModuleType
+): Expr {
+  return bodyPath?.length
+    ? createBodyOfCallExpression(bodyExpr, bodyPath, wasmInstance)
+    : bodyExpr
+}
+
+export function getRootBodyOfInputExpression(
+  bodyExpr: Expr,
+  ast: Node<Program>
+): Expr {
+  let current = structuredClone(bodyExpr)
+  const visitedNames = new Set<string>()
+
+  while (true) {
+    if (
+      current.type === 'CallExpressionKw' &&
+      current.callee.name.name === 'bodyOf' &&
+      current.unlabeled
+    ) {
+      current = structuredClone(current.unlabeled)
+      continue
+    }
+
+    if (current.type !== 'Name' || current.path.length > 0) {
+      return current
+    }
+
+    const name = current.name.name
+    if (visitedNames.has(name)) {
+      return current
+    }
+    visitedNames.add(name)
+
+    const declaration = ast.body.find(
+      (item) =>
+        item.type === 'VariableDeclaration' && item.declaration.id.name === name
+    )
+    if (
+      declaration?.type !== 'VariableDeclaration' ||
+      declaration.declaration.init.type !== 'CallExpressionKw' ||
+      declaration.declaration.init.callee.name.name !== 'bodyOf' ||
+      !declaration.declaration.init.unlabeled
+    ) {
+      return current
+    }
+
+    current = structuredClone(declaration.declaration.init.unlabeled)
+  }
+}
+
+export function insertBodyOfVariableAndOffsetPathToNode({
+  bodyExpr,
+  bodyPath,
+  modifiedAst,
+  wasmInstance,
+  insertIndex,
+  pathToNode,
+}: {
+  bodyExpr: Expr
+  bodyPath: number[] | undefined
+  modifiedAst: Node<Program>
+  wasmInstance: ModuleType
+  insertIndex: number
+  pathToNode?: PathToNode
+}): { bodyExpr: Expr; inserted: boolean } {
+  if (!bodyPath?.length) {
+    return { bodyExpr, inserted: false }
+  }
+
+  const bodyOfExpr = createBodyOfCallExpression(
+    structuredClone(bodyExpr),
+    bodyPath,
+    wasmInstance
+  )
+  const bodyVariableName = findUniqueName(
+    modifiedAst,
+    KCL_DEFAULT_CONSTANT_PREFIXES.BODY
+  )
+  const bodyIdentifierAst = createLocalName(bodyVariableName)
+  insertVariableAndOffsetPathToNode(
+    {
+      valueAst: bodyOfExpr,
+      valueText: '',
+      valueCalculated: '',
+      variableName: bodyVariableName,
+      variableDeclarationAst: createVariableDeclaration(
+        bodyVariableName,
+        bodyOfExpr
+      ),
+      variableIdentifierAst: bodyIdentifierAst,
+      insertIndex,
+    },
+    modifiedAst,
+    pathToNode
+  )
+
+  return { bodyExpr: bodyIdentifierAst, inserted: true }
+}

--- a/src/lang/modifyAst/faces.ts
+++ b/src/lang/modifyAst/faces.ts
@@ -5,7 +5,6 @@ import {
   createCallExpressionStdLibKw,
   createIdentifier,
   createLabeledArg,
-  createLiteral,
   createLocalName,
   createVariableDeclaration,
   findUniqueName,
@@ -53,8 +52,15 @@ import { stringToKclExpression } from '@src/lib/kclHelpers'
 import type RustContext from '@src/lib/rustContext'
 import {
   getBodySelectionFromPrimitiveParentEntityId,
+  getKclBodyIdFromEnginePrimitiveSelection,
   isEnginePrimitiveSelection,
+  TOPOLOGY_BODY_ARTIFACT_TYPES,
 } from '@src/lib/selections'
+import {
+  createPrimitiveIndexCallExpression,
+  getRootBodyOfInputExpression,
+  insertBodyOfVariableAndOffsetPathToNode,
+} from '@src/lang/modifyAst/enginePrimitiveReference'
 import { err } from '@src/lib/trap'
 import { isArray } from '@src/lib/utils'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
@@ -200,7 +206,7 @@ export function addDeleteFace({
     undefined,
     {
       lastChildLookup: true,
-      artifactTypeFilter: ['sweep', 'compositeSolid', 'edgeCut'],
+      artifactTypeFilter: [...TOPOLOGY_BODY_ARTIFACT_TYPES, 'edgeCut'],
     }
   )
   if (err(result)) {
@@ -219,7 +225,9 @@ export function addDeleteFace({
       wasmInstance,
     })
     if (err(result)) return result
-    solidsExprs = deduplicateFaceExprs(solidsExprs.concat(result.solidsExprs))
+    solidsExprs = deduplicateFaceExprs(
+      solidsExprs.concat(result.rootSolidExprs)
+    )
 
     facesExprs.push(...result.faceExprs)
   }
@@ -910,7 +918,7 @@ export function getPlaneExprFromSelection({
       {
         // Keep lookup aligned with deleteFace so selected parent solids map directly.
         lastChildLookup: false,
-        artifactTypeFilter: ['sweep', 'compositeSolid'],
+        artifactTypeFilter: TOPOLOGY_BODY_ARTIFACT_TYPES,
       }
     )
     if (err(result)) {
@@ -1028,6 +1036,12 @@ function getSolidSelectionsFromFaceSelections(
           artifact: face.artifact,
           codeRef: face.artifact.codeRef,
         }
+      }
+      if (
+        face.artifact.type === 'primitiveFace' &&
+        artifactGraph.get(face.artifact.solidId)?.type === 'importedGeometry'
+      ) {
+        return []
       }
       const sweep = getSweepFromSuspectedSweepSurface(
         face.artifact.id,
@@ -1346,7 +1360,9 @@ export function buildSolidsAndFacesExprs(
     if (!isCallExprWithName(faceExpr, 'faceId') || !faceExpr.unlabeled) {
       return new Error("Couldn't retrieve solid from primitive face selection")
     }
-    solidsExprs.push(structuredClone(faceExpr.unlabeled))
+    solidsExprs.push(
+      getRootBodyOfInputExpression(faceExpr.unlabeled, modifiedAst)
+    )
   }
 
   const dedupedSolidsExprs = deduplicateFaceExprs(solidsExprs)
@@ -1365,7 +1381,7 @@ export function buildSolidsAndFacesExprs(
 // Adds all the faceId calls needed in the AST so we can refer to them,
 // keeps track of their names as faces,
 // and gathers the corresponding solid expressions.
-function insertFacePrimitiveVariablesAndOffsetPathToNode({
+export function insertFacePrimitiveVariablesAndOffsetPathToNode({
   enginePrimitives,
   modifiedAst,
   artifactGraph,
@@ -1377,9 +1393,15 @@ function insertFacePrimitiveVariablesAndOffsetPathToNode({
   artifactGraph: ArtifactGraph
   wasmInstance: ModuleType
   pathToNode?: PathToNode
-}): Error | { solidsExprs: Expr[]; faceExprs: Expr[] } {
+}):
+  | Error
+  | {
+      solidsExprs: Expr[]
+      rootSolidExprs: Expr[]
+      faceExprs: Expr[]
+    } {
   if (enginePrimitives.length === 0) {
-    return { solidsExprs: [], faceExprs: [] }
+    return { solidsExprs: [], rootSolidExprs: [], faceExprs: [] }
   }
 
   const dedupedSelections = [
@@ -1387,7 +1409,11 @@ function insertFacePrimitiveVariablesAndOffsetPathToNode({
       enginePrimitives
         .filter((selection) => selection.primitiveType === 'face')
         .map((selection) => [
-          `${selection.parentEntityId || ''}:${selection.primitiveIndex}`,
+          JSON.stringify([
+            getKclBodyIdFromEnginePrimitiveSelection(selection),
+            selection.bodyPath ?? [],
+            selection.primitiveIndex,
+          ]),
           selection,
         ])
     ).values(),
@@ -1399,63 +1425,91 @@ function insertFacePrimitiveVariablesAndOffsetPathToNode({
       : modifiedAst.body.length
   const solidExprs: Expr[] = []
   const faceExprs: Expr[] = []
+  const bodyExprs = new Map<string, Expr>()
+  const rootBodyExprs = new Map<string, Expr>()
 
   for (const primitiveSelection of dedupedSelections) {
-    if (!primitiveSelection.parentEntityId) {
+    const kclBodyId =
+      getKclBodyIdFromEnginePrimitiveSelection(primitiveSelection)
+    if (!kclBodyId) {
       continue
     }
 
-    // Step 1. Retrieve the body
-    const bodySelection = getBodySelectionFromPrimitiveParentEntityId(
-      primitiveSelection.parentEntityId,
-      artifactGraph
-    )
-    if (!bodySelection) {
-      return new Error(
-        'Delete Face could not resolve a parent solid for a selected primitive face.'
+    const bodyKey = JSON.stringify([
+      kclBodyId,
+      primitiveSelection.bodyPath ?? [],
+    ])
+    let solidExpr = bodyExprs.get(bodyKey)
+    if (!solidExpr) {
+      // Step 1. Retrieve the root imported geometry or procedural solid.
+      const bodySelection = getBodySelectionFromPrimitiveParentEntityId(
+        kclBodyId,
+        artifactGraph
       )
-    }
-
-    const bodyVars = getVariableExprsFromSelection(
-      {
-        graphSelections: [bodySelection],
-        otherSelections: [],
-      },
-      artifactGraph,
-      modifiedAst,
-      wasmInstance,
-      undefined,
-      {
-        artifactTypeFilter: ['sweep', 'compositeSolid'],
+      if (!bodySelection) {
+        return new Error(
+          'Could not resolve a parent body for a selected primitive face.'
+        )
       }
-    )
-    if (err(bodyVars)) {
-      return bodyVars
-    }
 
-    let solidExpr = createVariableExpressionsArray(bodyVars.exprs)
-    if (solidExpr === null && bodyVars.exprs.length === 1) {
-      solidExpr = bodyVars.exprs[0]
+      const bodyVars = getVariableExprsFromSelection(
+        {
+          graphSelections: [bodySelection],
+          otherSelections: [],
+        },
+        artifactGraph,
+        modifiedAst,
+        wasmInstance,
+        undefined,
+        {
+          artifactTypeFilter: TOPOLOGY_BODY_ARTIFACT_TYPES,
+        }
+      )
+      if (err(bodyVars)) {
+        return bodyVars
+      }
+
+      let resolvedBodyExpr = createVariableExpressionsArray(bodyVars.exprs)
+      if (resolvedBodyExpr === null && bodyVars.exprs.length === 1) {
+        resolvedBodyExpr = bodyVars.exprs[0]
+      }
+      if (!resolvedBodyExpr) {
+        return new Error(
+          'Could not resolve selected primitive face bodies in code.'
+        )
+      }
+      if (!rootBodyExprs.has(kclBodyId)) {
+        rootBodyExprs.set(kclBodyId, structuredClone(resolvedBodyExpr))
+      }
+      const bodyOfResult = insertBodyOfVariableAndOffsetPathToNode({
+        bodyExpr: resolvedBodyExpr,
+        bodyPath: primitiveSelection.bodyPath,
+        modifiedAst,
+        wasmInstance,
+        insertIndex,
+        pathToNode,
+      })
+      if (bodyOfResult.inserted) {
+        insertIndex++
+      }
+      const selectedBodyExpr = bodyOfResult.bodyExpr
+
+      solidExpr = selectedBodyExpr
+      bodyExprs.set(bodyKey, selectedBodyExpr)
+      solidExprs.push(selectedBodyExpr)
     }
     if (!solidExpr) {
       return new Error(
-        'Could not resolve selected primitive face bodies in code.'
+        'Could not resolve selected primitive face body in code.'
       )
-    }
-    if (solidExprs.length === 0) {
-      solidExprs.push(solidExpr)
     }
 
     // Step 2. Create the faceId call and keep track of the new variable name
-    const faceExpr = createCallExpressionStdLibKw(
+    const faceExpr = createPrimitiveIndexCallExpression(
       'faceId',
       structuredClone(solidExpr),
-      [
-        createLabeledArg(
-          'index',
-          createLiteral(primitiveSelection.primitiveIndex, wasmInstance)
-        ),
-      ]
+      primitiveSelection.primitiveIndex,
+      wasmInstance
     )
     const faceVariableName = findUniqueName(
       modifiedAst,
@@ -1482,7 +1536,11 @@ function insertFacePrimitiveVariablesAndOffsetPathToNode({
     faceExprs.push(variableIdentifierAst)
   }
 
-  return { solidsExprs: solidExprs, faceExprs }
+  return {
+    solidsExprs: solidExprs,
+    rootSolidExprs: [...rootBodyExprs.values()],
+    faceExprs,
+  }
 }
 
 function getEnginePrimitiveFaceSelectionsFromSelection(selection: Selections) {

--- a/src/lang/modifyAst/gdt.ts
+++ b/src/lang/modifyAst/gdt.ts
@@ -14,17 +14,36 @@ import {
   insertVariableAndOffsetPathToNode,
   setCallInAst as setBaseCallInAst,
 } from '@src/lang/modifyAst'
-import { isFaceArtifact } from '@src/lang/modifyAst/faces'
+import { insertPrimitiveEdgeVariablesAndOffsetPathToNode } from '@src/lang/modifyAst/edges'
+import {
+  insertFacePrimitiveVariablesAndOffsetPathToNode,
+  isFaceArtifact,
+} from '@src/lang/modifyAst/faces'
 import { modifyAstWithTagsForSelection } from '@src/lang/modifyAst/tagManagement'
-import { traverse } from '@src/lang/queryAst'
-import { valueOrVariable } from '@src/lang/queryAst'
-import type { ArtifactGraph, Expr, PathToNode, Program } from '@src/lang/wasm'
+import {
+  getNodeFromPath,
+  isCallExprWithName,
+  traverse,
+  valueOrVariable,
+} from '@src/lang/queryAst'
+import type {
+  ArtifactGraph,
+  CallExpressionKw,
+  Expr,
+  PathToNode,
+  Program,
+  VariableDeclaration,
+} from '@src/lang/wasm'
 import { modelingStdLibCall } from '@src/lib/commandBarConfigs/modelingCommandStdLib'
 import type { KclCommandValue } from '@src/lib/commandTypes'
+import { isEnginePrimitiveSelection } from '@src/lib/selections'
 import { err } from '@src/lib/trap'
 import { isArray } from '@src/lib/utils'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
-import type { Selections } from '@src/machines/modelingSharedTypes'
+import type {
+  EnginePrimitiveSelection,
+  Selections,
+} from '@src/machines/modelingSharedTypes'
 
 const GDT_LABELED_SELECTION_ARG_NAMES = [
   'faces',
@@ -44,7 +63,171 @@ function setCallInAst(args: Parameters<typeof setBaseCallInAst>[0]) {
 function isProfileEdgeArtifact(
   artifact: Selections['graphSelections'][number]['artifact']
 ): boolean {
-  return artifact?.type === 'segment' || artifact?.type === 'sweepEdge'
+  return (
+    artifact?.type === 'segment' ||
+    artifact?.type === 'sweepEdge' ||
+    artifact?.type === 'primitiveEdge'
+  )
+}
+
+type GdtTargetExpr = {
+  kind: 'face' | 'edge'
+  expr: Expr
+}
+
+function getPrimitiveEdgeExpression(
+  ast: Node<Program>,
+  selection: Selections['graphSelections'][number],
+  wasmInstance: ModuleType
+): Expr | Error {
+  const variableLookup = getNodeFromPath<VariableDeclaration>(
+    ast,
+    selection.codeRef.pathToNode,
+    wasmInstance,
+    'VariableDeclaration',
+    false,
+    true
+  )
+  if (
+    !err(variableLookup) &&
+    isCallExprWithName(variableLookup.node.declaration.init, 'edgeId')
+  ) {
+    return createLocalName(variableLookup.node.declaration.id.name)
+  }
+
+  const directLookup = getNodeFromPath<Node<CallExpressionKw>>(
+    ast,
+    selection.codeRef.pathToNode,
+    wasmInstance,
+    'CallExpressionKw',
+    false,
+    true
+  )
+  if (err(directLookup)) return directLookup
+  if (!isCallExprWithName(directLookup.node, 'edgeId')) {
+    return new Error('Failed to retrieve primitive edge')
+  }
+  return structuredClone(directLookup.node)
+}
+
+function buildGdtTargetExprs({
+  modifiedAst,
+  artifactGraph,
+  objects,
+  wasmInstance,
+}: {
+  modifiedAst: Node<Program>
+  artifactGraph: ArtifactGraph
+  objects: Selections
+  wasmInstance: ModuleType
+}): Error | { modifiedAst: Node<Program>; targets: GdtTargetExpr[] } {
+  const targets: GdtTargetExpr[] = []
+
+  for (const selection of objects.graphSelections) {
+    const kind = isFaceArtifact(selection.artifact)
+      ? 'face'
+      : isProfileEdgeArtifact(selection.artifact)
+        ? 'edge'
+        : undefined
+    if (!kind) continue
+
+    if (selection.artifact?.type === 'primitiveEdge') {
+      const expr = getPrimitiveEdgeExpression(
+        modifiedAst,
+        selection,
+        wasmInstance
+      )
+      if (err(expr)) return expr
+      targets.push({ kind, expr })
+      continue
+    }
+
+    const tagResult = modifyAstWithTagsForSelection(
+      modifiedAst,
+      selection,
+      artifactGraph,
+      wasmInstance
+    )
+    if (err(tagResult)) {
+      console.warn(`Failed to add tags for GDT ${kind} selection`, tagResult)
+      continue
+    }
+    modifiedAst = tagResult.modifiedAst
+
+    if (kind === 'face') {
+      targets.push({ kind, expr: tagResult.exprs[0] })
+      continue
+    }
+    if (tagResult.exprs.length < 2) {
+      console.warn(
+        'GDT edge selection did not resolve to enough faces',
+        tagResult
+      )
+      continue
+    }
+    targets.push({
+      kind,
+      expr: createCallExpressionStdLibKw('getCommonEdge', null, [
+        createLabeledArg('faces', createArrayExpression(tagResult.exprs)),
+      ]),
+    })
+  }
+
+  const primitiveSelections = objects.otherSelections.filter(
+    isEnginePrimitiveSelection
+  )
+  const primitiveTargets = new Map<EnginePrimitiveSelection, GdtTargetExpr>()
+  const primitiveFaces = primitiveSelections.filter(
+    (selection) => selection.primitiveType === 'face'
+  )
+  if (primitiveFaces.length > 0) {
+    const result = insertFacePrimitiveVariablesAndOffsetPathToNode({
+      enginePrimitives: primitiveFaces,
+      modifiedAst,
+      artifactGraph,
+      wasmInstance,
+    })
+    if (err(result)) return result
+    if (result.faceExprs.length !== primitiveFaces.length) {
+      return new Error(
+        'Could not generate faceId references for the selected GDT faces.'
+      )
+    }
+    result.faceExprs.forEach((expr, index) => {
+      const selection = primitiveFaces[index]
+      if (selection) primitiveTargets.set(selection, { kind: 'face', expr })
+    })
+  }
+
+  const primitiveEdges = primitiveSelections.filter(
+    (selection) => selection.primitiveType === 'edge'
+  )
+  if (primitiveEdges.length > 0) {
+    const result = insertPrimitiveEdgeVariablesAndOffsetPathToNode({
+      primitiveEdgeSelections: primitiveEdges,
+      bodies: new Map(),
+      modifiedAst,
+      artifactGraph,
+      wasmInstance,
+    })
+    if (err(result)) return result
+    if (result.primitiveEdgeExprs.size !== primitiveEdges.length) {
+      return new Error(
+        'Could not generate edgeId references for the selected GDT edges.'
+      )
+    }
+    for (const selection of primitiveEdges) {
+      const expr = result.primitiveEdgeExprs.get(selection)
+      if (expr) primitiveTargets.set(selection, { kind: 'edge', expr })
+    }
+  }
+
+  for (const selection of primitiveSelections) {
+    const target = primitiveTargets.get(selection)
+    if (target) targets.push(target)
+  }
+
+  return { modifiedAst, targets }
 }
 
 function buildFaceAndEdgeGdtExprs({
@@ -76,60 +259,25 @@ function buildFaceAndEdgeGdtExprs({
     }
   }
 
-  const faceSelections = objects.graphSelections.filter((selection) =>
-    isFaceArtifact(selection.artifact)
+  const targetExprs = buildGdtTargetExprs({
+    modifiedAst,
+    artifactGraph,
+    objects,
+    wasmInstance,
+  })
+  if (err(targetExprs)) return targetExprs
+  modifiedAst = targetExprs.modifiedAst
+
+  const uniqueFaceExprs = deduplicateFaceExprs(
+    targetExprs.targets
+      .filter((target) => target.kind === 'face')
+      .map((target) => target.expr)
   )
-  const edgeSelections = objects.graphSelections.filter((selection) =>
-    isProfileEdgeArtifact(selection.artifact)
+  const uniqueEdgeExprs = deduplicateFaceExprs(
+    targetExprs.targets
+      .filter((target) => target.kind === 'edge')
+      .map((target) => target.expr)
   )
-  if (faceSelections.length === 0 && edgeSelections.length === 0) {
-    return new Error('No valid selections found. Please select faces or edges.')
-  }
-
-  const faceExprs: Expr[] = []
-  for (const faceSelection of faceSelections) {
-    const tagResult = modifyAstWithTagsForSelection(
-      modifiedAst,
-      faceSelection,
-      artifactGraph,
-      wasmInstance
-    )
-    if (err(tagResult)) {
-      console.warn('Failed to add tag for face selection', tagResult)
-      continue
-    }
-
-    modifiedAst = tagResult.modifiedAst
-    faceExprs.push(tagResult.exprs[0])
-  }
-
-  const edgeExprs: Expr[] = []
-  for (const edgeSelection of edgeSelections) {
-    const tagResult = modifyAstWithTagsForSelection(
-      modifiedAst,
-      edgeSelection,
-      artifactGraph,
-      wasmInstance
-    )
-    if (err(tagResult)) {
-      console.warn('Failed to add tags for edge selection', tagResult)
-      continue
-    }
-    modifiedAst = tagResult.modifiedAst
-    if (tagResult.exprs.length < 2) {
-      console.warn('Edge selection did not resolve to enough faces', tagResult)
-      continue
-    }
-
-    edgeExprs.push(
-      createCallExpressionStdLibKw('getCommonEdge', null, [
-        createLabeledArg('faces', createArrayExpression(tagResult.exprs)),
-      ])
-    )
-  }
-
-  const uniqueFaceExprs = deduplicateFaceExprs(faceExprs)
-  const uniqueEdgeExprs = deduplicateFaceExprs(edgeExprs)
   if (uniqueFaceExprs.length === 0 && uniqueEdgeExprs.length === 0) {
     return new Error('No valid face or edge expressions could be generated')
   }
@@ -199,40 +347,21 @@ export function addFlatnessGdt({
   let modifiedAst = structuredClone(ast)
   const mNodeToEdit = structuredClone(nodeToEdit)
 
-  // Filter to only include face selections
-  const faceSelections = mNodeToEdit
-    ? []
-    : faces.graphSelections.filter((selection) =>
-        isFaceArtifact(selection.artifact)
-      )
-
-  if (!mNodeToEdit && faceSelections.length === 0) {
-    return new Error(
-      'No valid face selections found. Please select faces (caps, walls, or edge cuts).'
-    )
-  }
-
-  // Get face expressions from the selection
-  // GDT annotations require tags for unambiguous face references (no body context)
-  // We use modifyAstWithTagsForSelection directly to make the tagging explicit
   const facesExprs: Expr[] = mNodeToEdit ? [createLocalName('selection')] : []
-  for (const faceSelection of faceSelections) {
-    const tagResult = modifyAstWithTagsForSelection(
+  if (!mNodeToEdit) {
+    const targetExprs = buildGdtTargetExprs({
       modifiedAst,
-      faceSelection,
       artifactGraph,
-      wasmInstance
+      objects: faces,
+      wasmInstance,
+    })
+    if (err(targetExprs)) return targetExprs
+    modifiedAst = targetExprs.modifiedAst
+    facesExprs.push(
+      ...targetExprs.targets
+        .filter((target) => target.kind === 'face')
+        .map((target) => target.expr)
     )
-    if (err(tagResult)) {
-      console.warn('Failed to add tag for face selection', tagResult)
-      continue
-    }
-
-    // Update the AST with the tagged version
-    modifiedAst = tagResult.modifiedAst
-
-    // Create expression from the first tag (faces have one tag)
-    facesExprs.push(tagResult.exprs[0])
   }
 
   if (facesExprs.length === 0) {
@@ -914,7 +1043,9 @@ export function addProfileGdt({
     }
 
   const unsupportedSelections =
-    selections.otherSelections.length > 0 ||
+    selections.otherSelections.some(
+      (selection) => !isEnginePrimitiveSelection(selection)
+    ) ||
     selections.graphSelections.some(
       (selection) =>
         !isProfileEdgeArtifact(selection.artifact) &&
@@ -924,79 +1055,40 @@ export function addProfileGdt({
     return new Error('Profile supports face selections or sketch/sweep edges.')
   }
 
-  const faceSelections = mNodeToEdit
-    ? []
-    : selections.graphSelections.filter((selection) =>
-        isFaceArtifact(selection.artifact)
-      )
-  const edgeSelections = mNodeToEdit
-    ? []
-    : selections.graphSelections.filter((selection) =>
-        isProfileEdgeArtifact(selection.artifact)
-      )
+  let faceExprs: Expr[] = mNodeToEdit ? [createLocalName('selection')] : []
+  let edgeExprs: Expr[] = []
+  if (!mNodeToEdit) {
+    const targetExprs = buildGdtTargetExprs({
+      modifiedAst,
+      artifactGraph,
+      objects: selections,
+      wasmInstance,
+    })
+    if (err(targetExprs)) return targetExprs
+    modifiedAst = targetExprs.modifiedAst
+    faceExprs = targetExprs.targets
+      .filter((target) => target.kind === 'face')
+      .map((target) => target.expr)
+    edgeExprs = targetExprs.targets
+      .filter((target) => target.kind === 'edge')
+      .map((target) => target.expr)
+  }
 
-  if (faceSelections.length > 0 && edgeSelections.length > 0) {
+  if (faceExprs.length > 0 && edgeExprs.length > 0) {
     return new Error(
       'Profile requires either faces or edges, not both. Select faces for profileSurface or edges for profileLine.'
     )
   }
 
-  if (
-    !mNodeToEdit &&
-    faceSelections.length === 0 &&
-    edgeSelections.length === 0
-  ) {
+  if (!mNodeToEdit && faceExprs.length === 0 && edgeExprs.length === 0) {
     return new Error('No valid selections found. Please select faces or edges.')
   }
 
-  if (profileFunction === 'profileLine' && faceSelections.length > 0) {
+  if (profileFunction === 'profileLine' && faceExprs.length > 0) {
     return new Error('profileLine requires edge selections.')
   }
-  if (profileFunction === 'profileSurface' && edgeSelections.length > 0) {
+  if (profileFunction === 'profileSurface' && edgeExprs.length > 0) {
     return new Error('profileSurface requires face selections.')
-  }
-
-  const faceExprs: Expr[] = mNodeToEdit ? [createLocalName('selection')] : []
-  for (const faceSelection of faceSelections) {
-    const tagResult = modifyAstWithTagsForSelection(
-      modifiedAst,
-      faceSelection,
-      artifactGraph,
-      wasmInstance
-    )
-    if (err(tagResult)) {
-      console.warn('Failed to add tag for face selection', tagResult)
-      continue
-    }
-
-    modifiedAst = tagResult.modifiedAst
-    faceExprs.push(tagResult.exprs[0])
-  }
-
-  const edgeExprs: Expr[] = []
-  for (const edgeSelection of edgeSelections) {
-    const tagResult = modifyAstWithTagsForSelection(
-      modifiedAst,
-      edgeSelection,
-      artifactGraph,
-      wasmInstance
-    )
-    if (err(tagResult)) {
-      console.warn('Failed to add tags for edge selection', tagResult)
-      continue
-    }
-
-    modifiedAst = tagResult.modifiedAst
-    if (tagResult.exprs.length < 2) {
-      console.warn('Edge selection did not resolve to enough faces', tagResult)
-      continue
-    }
-
-    edgeExprs.push(
-      createCallExpressionStdLibKw('getCommonEdge', null, [
-        createLabeledArg('faces', createArrayExpression(tagResult.exprs)),
-      ])
-    )
   }
 
   const uniqueFaceExprs = deduplicateFaceExprs(faceExprs)
@@ -1143,54 +1235,19 @@ export function addDistanceGdt({
       otherSelections: [],
     }
 
-  const targetSelections = mNodeToEdit
-    ? []
-    : selections.graphSelections.filter(
-        (selection) =>
-          isFaceArtifact(selection.artifact) ||
-          isProfileEdgeArtifact(selection.artifact)
-      )
-  if (!mNodeToEdit && targetSelections.length === 0) {
-    return new Error(
-      'No valid selections found. Select one edge, or exactly two faces or edges.'
-    )
-  }
-
-  const targets: Array<{ kind: 'face' | 'edge'; expr: Expr }> = mNodeToEdit
+  let targets: GdtTargetExpr[] = mNodeToEdit
     ? [{ kind: 'edge', expr: createLocalName('selection') }]
     : []
-  for (const selection of targetSelections) {
-    const tagResult = modifyAstWithTagsForSelection(
+  if (!mNodeToEdit) {
+    const targetExprs = buildGdtTargetExprs({
       modifiedAst,
-      selection,
       artifactGraph,
-      wasmInstance
-    )
-    if (err(tagResult)) {
-      console.warn('Failed to add tags for distance selection', tagResult)
-      continue
-    }
-
-    modifiedAst = tagResult.modifiedAst
-
-    if (isFaceArtifact(selection.artifact)) {
-      targets.push({ kind: 'face', expr: tagResult.exprs[0] })
-    } else {
-      if (tagResult.exprs.length < 2) {
-        console.warn(
-          'Edge selection did not resolve to enough faces',
-          tagResult
-        )
-        continue
-      }
-
-      targets.push({
-        kind: 'edge',
-        expr: createCallExpressionStdLibKw('getCommonEdge', null, [
-          createLabeledArg('faces', createArrayExpression(tagResult.exprs)),
-        ]),
-      })
-    }
+      objects: selections,
+      wasmInstance,
+    })
+    if (err(targetExprs)) return targetExprs
+    modifiedAst = targetExprs.modifiedAst
+    targets = targetExprs.targets
   }
 
   if (targets.length === 0) {
@@ -2332,13 +2389,6 @@ export function addDatumGdt({
   let modifiedAst = structuredClone(ast)
   const mNodeToEdit = structuredClone(nodeToEdit)
 
-  // Filter to only include face selections
-  const faceSelections = mNodeToEdit
-    ? []
-    : faces.graphSelections.filter((selection) =>
-        isFaceArtifact(selection.artifact)
-      )
-
   // Validate datum name is a single character
   if (name.length !== 1) {
     return new Error('Datum name must be a single character')
@@ -2349,29 +2399,28 @@ export function addDatumGdt({
     return new Error('Datum name cannot contain double quotes')
   }
 
-  // Datum requires exactly one face
-  if (!mNodeToEdit && faceSelections.length === 0) {
-    return new Error('No face selected for datum annotation')
-  }
-  if (!mNodeToEdit && faceSelections.length > 1) {
-    return new Error(
-      'Datum annotation requires exactly one face, but multiple faces were selected'
-    )
-  }
-
   let faceExpr: Expr = createLocalName('selection')
   if (!mNodeToEdit) {
-    const tagResult = modifyAstWithTagsForSelection(
+    const targetExprs = buildGdtTargetExprs({
       modifiedAst,
-      faceSelections[0],
       artifactGraph,
-      wasmInstance
-    )
-    if (err(tagResult)) {
-      return tagResult
+      objects: faces,
+      wasmInstance,
+    })
+    if (err(targetExprs)) return targetExprs
+    modifiedAst = targetExprs.modifiedAst
+    const faceExprs = targetExprs.targets
+      .filter((target) => target.kind === 'face')
+      .map((target) => target.expr)
+    if (faceExprs.length === 0) {
+      return new Error('No face selected for datum annotation')
     }
-    modifiedAst = tagResult.modifiedAst
-    faceExpr = tagResult.exprs[0]
+    if (faceExprs.length > 1) {
+      return new Error(
+        'Datum annotation requires exactly one face, but multiple faces were selected'
+      )
+    }
+    faceExpr = faceExprs[0]
   }
 
   // Process common GDT style parameters

--- a/src/lang/modifyAst/gdt.ts
+++ b/src/lang/modifyAst/gdt.ts
@@ -75,6 +75,11 @@ type GdtTargetExpr = {
   expr: Expr
 }
 
+type OrderedGdtTargetExpr = GdtTargetExpr & {
+  selectionOrder?: number
+  fallbackOrder: number
+}
+
 function getPrimitiveEdgeExpression(
   ast: Node<Program>,
   selection: Selections['graphSelections'][number],
@@ -121,7 +126,17 @@ function buildGdtTargetExprs({
   objects: Selections
   wasmInstance: ModuleType
 }): Error | { modifiedAst: Node<Program>; targets: GdtTargetExpr[] } {
-  const targets: GdtTargetExpr[] = []
+  const targets: OrderedGdtTargetExpr[] = []
+  const pushTarget = (
+    selection: Selections['graphSelections'][number] | EnginePrimitiveSelection,
+    target: GdtTargetExpr
+  ) => {
+    targets.push({
+      ...target,
+      selectionOrder: selection.selectionOrder,
+      fallbackOrder: targets.length,
+    })
+  }
 
   for (const selection of objects.graphSelections) {
     const kind = isFaceArtifact(selection.artifact)
@@ -138,7 +153,7 @@ function buildGdtTargetExprs({
         wasmInstance
       )
       if (err(expr)) return expr
-      targets.push({ kind, expr })
+      pushTarget(selection, { kind, expr })
       continue
     }
 
@@ -155,7 +170,7 @@ function buildGdtTargetExprs({
     modifiedAst = tagResult.modifiedAst
 
     if (kind === 'face') {
-      targets.push({ kind, expr: tagResult.exprs[0] })
+      pushTarget(selection, { kind, expr: tagResult.exprs[0] })
       continue
     }
     if (tagResult.exprs.length < 2) {
@@ -165,7 +180,7 @@ function buildGdtTargetExprs({
       )
       continue
     }
-    targets.push({
+    pushTarget(selection, {
       kind,
       expr: createCallExpressionStdLibKw('getCommonEdge', null, [
         createLabeledArg('faces', createArrayExpression(tagResult.exprs)),
@@ -224,10 +239,26 @@ function buildGdtTargetExprs({
 
   for (const selection of primitiveSelections) {
     const target = primitiveTargets.get(selection)
-    if (target) targets.push(target)
+    if (target) pushTarget(selection, target)
   }
 
-  return { modifiedAst, targets }
+  targets.sort((left, right) => {
+    if (left.selectionOrder === undefined) {
+      return right.selectionOrder === undefined
+        ? left.fallbackOrder - right.fallbackOrder
+        : -1
+    }
+    if (right.selectionOrder === undefined) return 1
+    return (
+      left.selectionOrder - right.selectionOrder ||
+      left.fallbackOrder - right.fallbackOrder
+    )
+  })
+
+  return {
+    modifiedAst,
+    targets: targets.map(({ kind, expr }) => ({ kind, expr })),
+  }
 }
 
 function buildFaceAndEdgeGdtExprs({

--- a/src/lang/modifyAst/importedBrep.spec.ts
+++ b/src/lang/modifyAst/importedBrep.spec.ts
@@ -692,6 +692,63 @@ test('preserves imported BREP selection order for GD&T distance', async () => {
   expect(newCode).toContain('to = face001')
 })
 
+test('preserves mixed coded and uncoded BREP selection order for GD&T distance', async () => {
+  const { instance } = await buildTheWorldAndNoEngineConnection()
+  const importSource = 'import "part.step" as importedPart'
+  const edgeSource = 'edge001 = edgeId(body001, index = 4)'
+  const code = `${importSource}
+body001 = bodyOf(importedPart, path = [0])
+${edgeSource}
+`
+  const ast = assertParse(code, instance)
+  const importedGeometry = {
+    type: 'importedGeometry',
+    id: 'imported-body',
+    codeRef: codeRefFor(code, ast, importSource),
+  } as Artifact
+  const primitiveEdge = {
+    type: 'primitiveEdge',
+    id: 'coded-imported-edge',
+    solidId: importedGeometry.id,
+    codeRef: codeRefFor(code, ast, edgeSource),
+  } as Extract<Artifact, { type: 'primitiveEdge' }>
+  const uncodedFace: EnginePrimitiveSelection = {
+    type: 'enginePrimitive',
+    selectionOrder: 0,
+    entityId: 'uncoded-imported-face',
+    parentEntityId: 'imported-engine-body',
+    kclBodyId: importedGeometry.id,
+    kclBodyArtifactType: 'importedGeometry',
+    bodyPath: [0],
+    primitiveIndex: 5,
+    primitiveType: 'face',
+  }
+
+  const result = addDistanceGdt({
+    ast,
+    artifactGraph: new Map([
+      [importedGeometry.id, importedGeometry],
+      [primitiveEdge.id, primitiveEdge],
+    ]),
+    objects: {
+      graphSelections: [
+        {
+          selectionOrder: 1,
+          artifact: primitiveEdge,
+          codeRef: primitiveEdge.codeRef,
+        },
+      ],
+      otherSelections: [uncodedFace],
+    },
+    wasmInstance: instance,
+  })
+  if (err(result)) throw result
+
+  const newCode = recast(result.modifiedAst, instance)
+  expect(newCode).toContain('from = face001')
+  expect(newCode).toContain('to = edge001')
+})
+
 for (const operation of ['fillet', 'chamfer'] as const) {
   test(`adds ${operation} for an imported BREP edge`, async () => {
     const { instance } = await buildTheWorldAndNoEngineConnection()

--- a/src/lang/modifyAst/importedBrep.spec.ts
+++ b/src/lang/modifyAst/importedBrep.spec.ts
@@ -1,0 +1,763 @@
+import { createLiteral } from '@src/lang/create'
+import {
+  addChamfer,
+  addFillet,
+  insertPrimitiveEdgeVariablesAndOffsetPathToNode,
+} from '@src/lang/modifyAst/edges'
+import { addDeleteFace, addOffsetPlane } from '@src/lang/modifyAst/faces'
+import {
+  addDistanceGdt,
+  addFlatnessGdt,
+  addStraightnessGdt,
+} from '@src/lang/modifyAst/gdt'
+import { addMirror3D } from '@src/lang/modifyAst/transforms'
+import { getNodePathFromSourceRange } from '@src/lang/queryAstNodePathUtils'
+import {
+  type Artifact,
+  assertParse,
+  recast,
+  type SourceRange,
+} from '@src/lang/wasm'
+import { err } from '@src/lib/trap'
+import type {
+  EnginePrimitiveSelection,
+  NonCodeSelection,
+} from '@src/machines/modelingSharedTypes'
+import { buildTheWorldAndNoEngineConnection } from '@src/unitTestUtils'
+import { expect, test } from 'vitest'
+
+const tolerance = (
+  instance: Awaited<
+    ReturnType<typeof buildTheWorldAndNoEngineConnection>
+  >['instance']
+) => ({
+  valueAst: createLiteral(0.1, instance),
+  valueText: '0.1',
+  valueCalculated: '0.1',
+})
+
+function codeRefFor(
+  code: string,
+  ast: ReturnType<typeof assertParse>,
+  source: string
+) {
+  const start = code.indexOf(source)
+  if (start < 0) {
+    throw new Error(`Could not find source: ${source}`)
+  }
+  const range = [start, start + source.length, 0] as SourceRange
+  return { range, pathToNode: getNodePathFromSourceRange(ast, range) }
+}
+
+test('adds faceId and deleteFace calls for an imported BREP face', async () => {
+  const { instance } = await buildTheWorldAndNoEngineConnection()
+  const code = 'import "part.step" as importedPart\n'
+  const ast = assertParse(code, instance)
+  const range = [0, code.trimEnd().length, 0] as SourceRange
+  const codeRef = {
+    range,
+    pathToNode: getNodePathFromSourceRange(ast, range),
+  }
+  const importedGeometry = {
+    type: 'importedGeometry',
+    id: 'imported-body',
+    codeRef,
+  } as Artifact
+  const artifactGraph = new Map<string, Artifact>([
+    [importedGeometry.id, importedGeometry],
+  ])
+  const primitiveFace: NonCodeSelection = {
+    type: 'enginePrimitive',
+    entityId: 'imported-face',
+    parentEntityId: 'imported-engine-body',
+    kclBodyId: importedGeometry.id,
+    bodyPath: [3, 7],
+    primitiveIndex: 4,
+    primitiveType: 'face',
+  }
+
+  const result = addDeleteFace({
+    ast,
+    artifactGraph,
+    faces: {
+      graphSelections: [],
+      otherSelections: [primitiveFace],
+    },
+    wasmInstance: instance,
+  })
+  if (err(result)) {
+    throw result
+  }
+
+  const newCode = recast(result.modifiedAst, instance)
+  expect(
+    newCode
+  ).toContain(`${code}body001 = bodyOf(importedPart, path = [3, 7])
+face001 = faceId(body001, index = 4)
+surface001 = deleteFace(importedPart, faces = face001)`)
+})
+
+test('adds an offset plane from an imported BREP engine primitive face', async () => {
+  const { instance } = await buildTheWorldAndNoEngineConnection()
+  const code = 'import "part.step" as importedPart\n'
+  const ast = assertParse(code, instance)
+  const range = [0, code.trimEnd().length, 0] as SourceRange
+  const importedGeometry = {
+    type: 'importedGeometry',
+    id: 'imported-body',
+    codeRef: {
+      range,
+      pathToNode: getNodePathFromSourceRange(ast, range),
+    },
+  } as Artifact
+  const artifactGraph = new Map<string, Artifact>([
+    [importedGeometry.id, importedGeometry],
+  ])
+  const primitiveFace: EnginePrimitiveSelection = {
+    type: 'enginePrimitive',
+    entityId: 'imported-face',
+    parentEntityId: 'imported-engine-body',
+    kclBodyId: importedGeometry.id,
+    kclBodyArtifactType: 'importedGeometry',
+    bodyPath: [3, 7],
+    primitiveIndex: 4,
+    primitiveType: 'face',
+  }
+
+  const result = addOffsetPlane({
+    ast,
+    artifactGraph,
+    variables: {},
+    plane: {
+      graphSelections: [],
+      otherSelections: [primitiveFace],
+    },
+    offset: tolerance(instance),
+    wasmInstance: instance,
+  })
+  if (err(result)) {
+    throw result
+  }
+
+  const newCode = recast(result.modifiedAst, instance)
+  expect(newCode).toContain('body001 = bodyOf(importedPart, path = [3, 7])')
+  expect(newCode).toContain('face001 = faceId(body001, index = 4)')
+  expect(newCode).toContain('plane001 = planeOf(body001, face = face001)')
+  expect(newCode).toContain('plane002 = offsetPlane(plane001, offset = 0.1)')
+})
+
+test('uses an imported BREP engine primitive face as a mirror plane', async () => {
+  const { instance } = await buildTheWorldAndNoEngineConnection()
+  const importSource = 'import "part.step" as importedPart'
+  const solidSource = 'solid001 = extrude(profile001, length = 1)'
+  const code = `${importSource}
+${solidSource}
+`
+  const ast = assertParse(code, instance)
+  const importedGeometry = {
+    type: 'importedGeometry',
+    id: 'imported-body',
+    codeRef: codeRefFor(code, ast, importSource),
+  } as Artifact
+  const solid = {
+    type: 'sweep',
+    id: 'solid-body',
+    codeRef: codeRefFor(code, ast, solidSource),
+  } as Extract<Artifact, { type: 'sweep' }>
+  const artifactGraph = new Map<string, Artifact>([
+    [importedGeometry.id, importedGeometry],
+    [solid.id, solid],
+  ])
+  const primitiveFace: EnginePrimitiveSelection = {
+    type: 'enginePrimitive',
+    entityId: 'imported-face',
+    parentEntityId: 'imported-engine-body',
+    kclBodyId: importedGeometry.id,
+    kclBodyArtifactType: 'importedGeometry',
+    bodyPath: [3, 7],
+    primitiveIndex: 4,
+    primitiveType: 'face',
+  }
+
+  const result = addMirror3D({
+    ast,
+    artifactGraph,
+    variables: {},
+    bodies: {
+      graphSelections: [{ artifact: solid, codeRef: solid.codeRef }],
+      otherSelections: [],
+    },
+    across: {
+      graphSelections: [],
+      otherSelections: [primitiveFace],
+    },
+    wasmInstance: instance,
+  })
+  if (err(result)) {
+    throw result
+  }
+
+  const newCode = recast(result.modifiedAst, instance)
+  expect(newCode).toContain('body001 = bodyOf(importedPart, path = [3, 7])')
+  expect(newCode).toContain('face001 = faceId(body001, index = 4)')
+  expect(newCode).toContain('plane001 = planeOf(body001, face = face001)')
+  expect(newCode).toContain('solid002 = mirror3d(solid001, across = plane001)')
+})
+
+test('deletes faces from different nested bodies through their root import', async () => {
+  const { instance } = await buildTheWorldAndNoEngineConnection()
+  const code = 'import "part.step" as importedPart\n'
+  const ast = assertParse(code, instance)
+  const range = [0, code.trimEnd().length, 0] as SourceRange
+  const importedGeometry = {
+    type: 'importedGeometry',
+    id: 'imported-body',
+    codeRef: {
+      range,
+      pathToNode: getNodePathFromSourceRange(ast, range),
+    },
+  } as Artifact
+  const artifactGraph = new Map<string, Artifact>([
+    [importedGeometry.id, importedGeometry],
+  ])
+  const primitiveFace = (
+    entityId: string,
+    bodyPath: number[],
+    primitiveIndex: number
+  ): NonCodeSelection => ({
+    type: 'enginePrimitive',
+    entityId,
+    parentEntityId: `${entityId}-body`,
+    kclBodyId: importedGeometry.id,
+    bodyPath,
+    primitiveIndex,
+    primitiveType: 'face',
+  })
+
+  const result = addDeleteFace({
+    ast,
+    artifactGraph,
+    faces: {
+      graphSelections: [],
+      otherSelections: [
+        primitiveFace('first-face', [0], 4),
+        primitiveFace('second-face', [1], 5),
+      ],
+    },
+    wasmInstance: instance,
+  })
+  if (err(result)) throw result
+
+  const newCode = recast(result.modifiedAst, instance)
+  expect(newCode).toContain(`${code}body001 = bodyOf(importedPart, path = [0])
+face001 = faceId(body001, index = 4)
+body002 = bodyOf(importedPart, path = [1])
+face002 = faceId(body002, index = 5)
+surface001 = deleteFace(importedPart, faces = [face001, face002])`)
+})
+
+test('deletes coded faces from different nested bodies through their root import', async () => {
+  const { instance } = await buildTheWorldAndNoEngineConnection()
+  const importSource = 'import "part.step" as importedPart'
+  const firstBodySource = 'body001 = bodyOf(importedPart, path = [0])'
+  const firstFaceSource = 'face001 = faceId(body001, index = 4)'
+  const secondParentSource = 'body002 = bodyOf(importedPart, path = [1])'
+  const secondBodySource = 'body003 = bodyOf(body002, path = [2])'
+  const secondFaceSource = 'face002 = faceId(body003, index = 5)'
+  const code = `${importSource}
+${firstBodySource}
+${firstFaceSource}
+${secondParentSource}
+${secondBodySource}
+${secondFaceSource}
+`
+  const ast = assertParse(code, instance)
+  const importedGeometry = {
+    type: 'importedGeometry',
+    id: 'imported-body',
+    codeRef: codeRefFor(code, ast, importSource),
+  } as Artifact
+  const firstBody = {
+    type: 'importedGeometry',
+    id: 'first-body',
+    codeRef: codeRefFor(code, ast, firstBodySource),
+  } as Artifact
+  const secondBody = {
+    type: 'importedGeometry',
+    id: 'second-body',
+    codeRef: codeRefFor(code, ast, secondBodySource),
+  } as Artifact
+  const secondParent = {
+    type: 'importedGeometry',
+    id: 'second-parent',
+    codeRef: codeRefFor(code, ast, secondParentSource),
+  } as Artifact
+  const firstFace = {
+    type: 'primitiveFace',
+    id: 'first-face',
+    solidId: firstBody.id,
+    codeRef: codeRefFor(code, ast, firstFaceSource),
+  } as Extract<Artifact, { type: 'primitiveFace' }>
+  const secondFace = {
+    type: 'primitiveFace',
+    id: 'second-face',
+    solidId: secondBody.id,
+    codeRef: codeRefFor(code, ast, secondFaceSource),
+  } as Extract<Artifact, { type: 'primitiveFace' }>
+  const artifactGraph = new Map<string, Artifact>(
+    [
+      importedGeometry,
+      firstBody,
+      secondParent,
+      secondBody,
+      firstFace,
+      secondFace,
+    ].map((artifact) => [artifact.id, artifact])
+  )
+
+  const result = addDeleteFace({
+    ast,
+    artifactGraph,
+    faces: {
+      graphSelections: [firstFace, secondFace].map((artifact) => ({
+        artifact,
+        codeRef: artifact.codeRef,
+      })),
+      otherSelections: [],
+    },
+    wasmInstance: instance,
+  })
+  if (err(result)) {
+    throw result
+  }
+
+  expect(recast(result.modifiedAst, instance)).toContain(
+    'surface001 = deleteFace(importedPart, faces = [face001, face002])'
+  )
+})
+
+test('keeps equal edge indices from different nested imported bodies', async () => {
+  const { instance } = await buildTheWorldAndNoEngineConnection()
+  const code = 'import "part.step" as importedPart\n'
+  const ast = assertParse(code, instance)
+  const range = [0, code.trimEnd().length, 0] as SourceRange
+  const importedGeometry = {
+    type: 'importedGeometry',
+    id: 'imported-body',
+    codeRef: {
+      range,
+      pathToNode: getNodePathFromSourceRange(ast, range),
+    },
+  } as Artifact
+  const artifactGraph = new Map<string, Artifact>([
+    [importedGeometry.id, importedGeometry],
+  ])
+  const primitiveEdgeSelections: EnginePrimitiveSelection[] = [
+    {
+      type: 'enginePrimitive',
+      entityId: 'first-edge',
+      parentEntityId: 'first-engine-body',
+      kclBodyId: importedGeometry.id,
+      bodyPath: [0],
+      primitiveIndex: 4,
+      primitiveType: 'edge',
+    },
+    {
+      type: 'enginePrimitive',
+      entityId: 'second-edge',
+      parentEntityId: 'second-engine-body',
+      kclBodyId: importedGeometry.id,
+      bodyPath: [1],
+      primitiveIndex: 4,
+      primitiveType: 'edge',
+    },
+  ]
+
+  const result = insertPrimitiveEdgeVariablesAndOffsetPathToNode({
+    primitiveEdgeSelections,
+    bodies: new Map(),
+    modifiedAst: ast,
+    artifactGraph,
+    wasmInstance: instance,
+  })
+  if (err(result)) {
+    throw result
+  }
+
+  const newCode = recast(ast, instance)
+  expect(newCode).toContain(`${code}body001 = bodyOf(importedPart, path = [0])
+edge001 = edgeId(body001, index = 4)
+body002 = bodyOf(importedPart, path = [1])
+edge002 = edgeId(body002, index = 4)`)
+})
+
+test('adds GD&T to an imported BREP face through faceId', async () => {
+  const { instance } = await buildTheWorldAndNoEngineConnection()
+  const code = 'import "part.step" as importedPart\n'
+  const ast = assertParse(code, instance)
+  const range = [0, code.trimEnd().length, 0] as SourceRange
+  const importedGeometry = {
+    type: 'importedGeometry',
+    id: 'imported-body',
+    codeRef: {
+      range,
+      pathToNode: getNodePathFromSourceRange(ast, range),
+    },
+  } as Artifact
+  const artifactGraph = new Map<string, Artifact>([
+    [importedGeometry.id, importedGeometry],
+  ])
+  const primitiveFace: EnginePrimitiveSelection = {
+    type: 'enginePrimitive',
+    entityId: 'imported-face',
+    parentEntityId: 'imported-engine-body',
+    kclBodyId: importedGeometry.id,
+    kclBodyArtifactType: 'importedGeometry',
+    bodyPath: [3, 7],
+    primitiveIndex: 4,
+    primitiveType: 'face',
+  }
+
+  const result = addFlatnessGdt({
+    ast,
+    artifactGraph,
+    faces: {
+      graphSelections: [],
+      otherSelections: [primitiveFace],
+    },
+    tolerance: tolerance(instance),
+    wasmInstance: instance,
+  })
+  if (err(result)) throw result
+
+  const newCode = recast(result.modifiedAst, instance)
+  expect(newCode).toContain('body001 = bodyOf(importedPart, path = [3, 7])')
+  expect(newCode).toContain('face001 = faceId(body001, index = 4)')
+  expect(newCode).toContain('gdt::flatness(')
+  expect(newCode).toContain('faces = [face001]')
+})
+
+test('reuses one bodyOf variable for faces on the same nested body', async () => {
+  const { instance } = await buildTheWorldAndNoEngineConnection()
+  const code = 'import "part.step" as importedPart\n'
+  const ast = assertParse(code, instance)
+  const range = [0, code.trimEnd().length, 0] as SourceRange
+  const importedGeometry = {
+    type: 'importedGeometry',
+    id: 'imported-body',
+    codeRef: {
+      range,
+      pathToNode: getNodePathFromSourceRange(ast, range),
+    },
+  } as Artifact
+  const artifactGraph = new Map<string, Artifact>([
+    [importedGeometry.id, importedGeometry],
+  ])
+  const primitiveFace = (entityId: string, primitiveIndex: number) =>
+    ({
+      type: 'enginePrimitive',
+      entityId,
+      parentEntityId: 'imported-engine-body',
+      kclBodyId: importedGeometry.id,
+      kclBodyArtifactType: 'importedGeometry',
+      bodyPath: [3, 7],
+      primitiveIndex,
+      primitiveType: 'face',
+    }) satisfies EnginePrimitiveSelection
+
+  const result = addFlatnessGdt({
+    ast,
+    artifactGraph,
+    faces: {
+      graphSelections: [],
+      otherSelections: [
+        primitiveFace('first-imported-face', 4),
+        primitiveFace('second-imported-face', 5),
+      ],
+    },
+    tolerance: tolerance(instance),
+    wasmInstance: instance,
+  })
+  if (err(result)) throw result
+
+  const newCode = recast(result.modifiedAst, instance)
+  if (err(newCode)) throw newCode
+  expect(newCode.match(/bodyOf\(/g)).toHaveLength(1)
+  expect(newCode).toContain('face001 = faceId(body001, index = 4)')
+  expect(newCode).toContain('face002 = faceId(body001, index = 5)')
+  expect(newCode).toContain('faces = [face001]')
+  expect(newCode).toContain('faces = [face002]')
+})
+
+test('adds GD&T to an imported BREP edge through edgeId', async () => {
+  const { instance } = await buildTheWorldAndNoEngineConnection()
+  const code = 'import "part.step" as importedPart\n'
+  const ast = assertParse(code, instance)
+  const range = [0, code.trimEnd().length, 0] as SourceRange
+  const importedGeometry = {
+    type: 'importedGeometry',
+    id: 'imported-body',
+    codeRef: {
+      range,
+      pathToNode: getNodePathFromSourceRange(ast, range),
+    },
+  } as Artifact
+  const artifactGraph = new Map<string, Artifact>([
+    [importedGeometry.id, importedGeometry],
+  ])
+  const primitiveEdge: EnginePrimitiveSelection = {
+    type: 'enginePrimitive',
+    entityId: 'imported-edge',
+    parentEntityId: 'imported-engine-body',
+    kclBodyId: importedGeometry.id,
+    kclBodyArtifactType: 'importedGeometry',
+    bodyPath: [0],
+    primitiveIndex: 4,
+    primitiveType: 'edge',
+  }
+
+  const result = addStraightnessGdt({
+    ast,
+    artifactGraph,
+    objects: {
+      graphSelections: [],
+      otherSelections: [primitiveEdge],
+    },
+    tolerance: tolerance(instance),
+    wasmInstance: instance,
+  })
+  if (err(result)) throw result
+
+  const newCode = recast(result.modifiedAst, instance)
+  expect(newCode).toContain('body001 = bodyOf(importedPart, path = [0])')
+  expect(newCode).toContain('edge001 = edgeId(body001, index = 4)')
+  expect(newCode).toContain('gdt::straightness(')
+  expect(newCode).toContain('edges = [edge001]')
+})
+
+test('adds GD&T to an already-coded imported BREP edge', async () => {
+  const { instance } = await buildTheWorldAndNoEngineConnection()
+  const edgeSource = 'edge001 = edgeId(body001, index = 4)'
+  const code = `import "part.step" as importedPart
+body001 = bodyOf(importedPart, path = [0])
+${edgeSource}
+`
+  const ast = assertParse(code, instance)
+  const primitiveEdge = {
+    type: 'primitiveEdge',
+    id: 'imported-edge',
+    solidId: 'imported-body',
+    codeRef: codeRefFor(code, ast, edgeSource),
+  } as Extract<Artifact, { type: 'primitiveEdge' }>
+
+  const result = addStraightnessGdt({
+    ast,
+    artifactGraph: new Map([[primitiveEdge.id, primitiveEdge]]),
+    objects: {
+      graphSelections: [
+        { artifact: primitiveEdge, codeRef: primitiveEdge.codeRef },
+      ],
+      otherSelections: [],
+    },
+    tolerance: tolerance(instance),
+    wasmInstance: instance,
+  })
+  if (err(result)) {
+    throw result
+  }
+
+  const newCode = recast(result.modifiedAst, instance)
+  expect(newCode).toContain('gdt::straightness(')
+  expect(newCode).toContain('edges = [edge001]')
+})
+
+for (const operation of ['fillet', 'chamfer'] as const) {
+  test(`adds ${operation} to an already-coded imported BREP edge`, async () => {
+    const { instance } = await buildTheWorldAndNoEngineConnection()
+    const bodySource = 'body001 = bodyOf(importedPart, path = [0])'
+    const edgeSources = [
+      'edge001 = edgeId(body001, index = 4)',
+      'edge002 = edgeId(body001, index = 5)',
+    ]
+    const code = `@settings(kclVersion = "3.0-preview")
+import "part.step" as importedPart
+${bodySource}
+${edgeSources.join('\n')}
+`
+    const ast = assertParse(code, instance)
+    const importedGeometry = {
+      type: 'importedGeometry',
+      id: 'imported-body',
+      codeRef: codeRefFor(code, ast, bodySource),
+    } as Artifact
+    const primitiveEdges = edgeSources.map(
+      (edgeSource, index) =>
+        ({
+          type: 'primitiveEdge',
+          id: `imported-edge-${index}`,
+          solidId: importedGeometry.id,
+          codeRef: codeRefFor(code, ast, edgeSource),
+        }) as Extract<Artifact, { type: 'primitiveEdge' }>
+    )
+    const artifactGraph = new Map<string, Artifact>([
+      [importedGeometry.id, importedGeometry],
+      ...primitiveEdges.map((edge) => [edge.id, edge] as const),
+    ])
+    const selection = {
+      graphSelections: primitiveEdges.map((edge) => ({
+        artifact: edge,
+        codeRef: edge.codeRef,
+      })),
+      otherSelections: [],
+    }
+    const size = tolerance(instance)
+    const version = {
+      valueAst: createLiteral(1, instance),
+      valueText: '1',
+      valueCalculated: '1',
+    }
+    const result =
+      operation === 'fillet'
+        ? addFillet({
+            ast,
+            artifactGraph,
+            selection,
+            radius: size,
+            version,
+            wasmInstance: instance,
+          })
+        : addChamfer({
+            ast,
+            artifactGraph,
+            selection,
+            length: size,
+            version,
+            wasmInstance: instance,
+          })
+    if (err(result)) throw result
+
+    const newCode = recast(result.modifiedAst, instance)
+    expect(newCode).toContain(`${operation}001 = ${operation}(`)
+    expect(newCode).toContain('body001')
+    expect(newCode).toContain('tags = [edge001, edge002]')
+    expect(newCode).not.toContain('version =')
+  })
+}
+
+test('preserves imported BREP selection order for GD&T distance', async () => {
+  const { instance } = await buildTheWorldAndNoEngineConnection()
+  const code = 'import "part.step" as importedPart\n'
+  const ast = assertParse(code, instance)
+  const range = [0, code.trimEnd().length, 0] as SourceRange
+  const importedGeometry = {
+    type: 'importedGeometry',
+    id: 'imported-body',
+    codeRef: {
+      range,
+      pathToNode: getNodePathFromSourceRange(ast, range),
+    },
+  } as Artifact
+  const artifactGraph = new Map<string, Artifact>([
+    [importedGeometry.id, importedGeometry],
+  ])
+  const primitive = (
+    primitiveType: 'face' | 'edge',
+    primitiveIndex: number
+  ): EnginePrimitiveSelection => ({
+    type: 'enginePrimitive',
+    entityId: `imported-${primitiveType}`,
+    parentEntityId: 'imported-engine-body',
+    kclBodyId: importedGeometry.id,
+    kclBodyArtifactType: 'importedGeometry',
+    bodyPath: [0],
+    primitiveIndex,
+    primitiveType,
+  })
+
+  const result = addDistanceGdt({
+    ast,
+    artifactGraph,
+    objects: {
+      graphSelections: [],
+      otherSelections: [primitive('edge', 4), primitive('face', 5)],
+    },
+    wasmInstance: instance,
+  })
+  if (err(result)) {
+    throw result
+  }
+
+  const newCode = recast(result.modifiedAst, instance)
+  expect(newCode).toContain('from = edge001')
+  expect(newCode).toContain('to = face001')
+})
+
+for (const operation of ['fillet', 'chamfer'] as const) {
+  test(`adds ${operation} for an imported BREP edge`, async () => {
+    const { instance } = await buildTheWorldAndNoEngineConnection()
+    const importSource = 'import "part.step" as importedPart'
+    const code = `@settings(kclVersion = "3.0-preview")
+${importSource}
+`
+    const ast = assertParse(code, instance)
+    const importedGeometry = {
+      type: 'importedGeometry',
+      id: 'imported-body',
+      codeRef: codeRefFor(code, ast, importSource),
+    } as Artifact
+    const artifactGraph = new Map<string, Artifact>([
+      [importedGeometry.id, importedGeometry],
+    ])
+    const primitiveEdge: EnginePrimitiveSelection = {
+      type: 'enginePrimitive',
+      entityId: 'imported-edge',
+      parentEntityId: 'imported-engine-body',
+      kclBodyId: importedGeometry.id,
+      kclBodyArtifactType: 'importedGeometry',
+      bodyPath: [0],
+      primitiveIndex: 4,
+      primitiveType: 'edge',
+    }
+    const selection = {
+      graphSelections: [],
+      otherSelections: [primitiveEdge],
+    }
+    const size = tolerance(instance)
+    const version = {
+      valueAst: createLiteral(1, instance),
+      valueText: '1',
+      valueCalculated: '1',
+    }
+    const result =
+      operation === 'fillet'
+        ? addFillet({
+            ast,
+            artifactGraph,
+            selection,
+            radius: size,
+            version,
+            wasmInstance: instance,
+          })
+        : addChamfer({
+            ast,
+            artifactGraph,
+            selection,
+            length: size,
+            version,
+            wasmInstance: instance,
+          })
+    if (err(result)) {
+      throw result
+    }
+
+    const newCode = recast(result.modifiedAst, instance)
+    expect(newCode).toContain('body001 = bodyOf(importedPart, path = [0])')
+    expect(newCode).toContain('edge001 = edgeId(body001, index = 4)')
+    expect(newCode).toContain(`${operation}001 = ${operation}(`)
+    expect(newCode).toContain('tags = edge001')
+    expect(newCode).toContain(
+      `${operation === 'fillet' ? 'radius' : 'length'} = 0.1`
+    )
+    expect(newCode).not.toContain('version =')
+  })
+}

--- a/src/lang/queryAst.spec.ts
+++ b/src/lang/queryAst.spec.ts
@@ -1167,6 +1167,27 @@ describe('Testing getSelectedSketchTarget', () => {
 
     expect(getSelectedSketchTarget(selections)).toBe('primitive-face-entity')
   })
+
+  it('returns a graph-backed primitive face entity', () => {
+    const primitiveFace = {
+      type: 'primitiveFace',
+      id: 'coded-primitive-face',
+      solidId: 'imported-body',
+      codeRef: {
+        range: [0, 1, 0],
+        pathToNode: [],
+        nodePath: defaultNodePath(),
+      },
+    } as Extract<Artifact, { type: 'primitiveFace' }>
+    const selections: Selections = {
+      graphSelections: [
+        { artifact: primitiveFace, codeRef: primitiveFace.codeRef },
+      ],
+      otherSelections: [],
+    }
+
+    expect(getSelectedSketchTarget(selections)).toBe('coded-primitive-face')
+  })
 })
 
 describe('Testing getVariableExprsFromSelection', () => {

--- a/src/lang/queryAst.ts
+++ b/src/lang/queryAst.ts
@@ -1934,7 +1934,7 @@ export function getSelectedPlaneId(selectionRanges: Selections): string | null {
   return null
 }
 
-// Returns the plane/wall/cap/edgeCut within the current selection that can be used to start a sketch on.
+// Returns the plane or face within the current selection that can be used to start a sketch on.
 export function getSelectedSketchTarget(
   selectionRanges: Selections
 ): string | null {
@@ -1954,11 +1954,11 @@ export function getSelectedSketchTarget(
     return primitiveFace.entityId
   }
 
-  // Try to find an offset plane or wall or cap or chamfer edgeCut
+  // Try to find an offset plane or sketchable graph-backed face
   const planeSelection = selectionRanges.graphSelections.find((selection) => {
     const artifactType = selection.artifact?.type || ''
     return (
-      ['plane', 'wall', 'cap'].includes(artifactType) ||
+      ['plane', 'wall', 'cap', 'primitiveFace'].includes(artifactType) ||
       (selection.artifact?.type === 'edgeCut' &&
         selection.artifact?.subType === 'chamfer')
     )

--- a/src/lang/queryAst.ts
+++ b/src/lang/queryAst.ts
@@ -1274,6 +1274,23 @@ export function getVariableExprsFromSelection(
   let exprs: Expr[] = []
   const pushedNames = {} as Record<string, boolean>
   for (const s of selection.graphSelections) {
+    const importAlias = findImportNodeAndAlias(
+      ast,
+      s.codeRef.pathToNode,
+      wasmInstance
+    )?.alias
+    const addImportAliasExpr = () => {
+      if (!importAlias) {
+        return false
+      }
+
+      if (!pushedNames[importAlias]) {
+        exprs.push(createLocalName(importAlias))
+        pushedNames[importAlias] = true
+      }
+      return true
+    }
+
     const patternExpr = getPatternExprFromSelection(s, ast, wasmInstance)
     if (patternExpr) {
       const key = outputExprKey(patternExpr)
@@ -1428,6 +1445,7 @@ export function getVariableExprsFromSelection(
           nodeToEdit
         )
         if (!lastChildVariable) {
+          addImportAliasExpr()
           continue
         }
         variable = lastChildVariable.variableDeclaration
@@ -1440,6 +1458,7 @@ export function getVariableExprsFromSelection(
         'VariableDeclaration'
       )
       if (err(directLookup)) {
+        addImportAliasExpr()
         continue
       }
 
@@ -1481,14 +1500,7 @@ export function getVariableExprsFromSelection(
       continue
     }
 
-    // import case
-    const importNodeAndAlias = findImportNodeAndAlias(
-      ast,
-      s.codeRef.pathToNode,
-      wasmInstance
-    )
-    if (importNodeAndAlias) {
-      exprs.push(createLocalName(importNodeAndAlias.alias))
+    if (addImportAliasExpr()) {
       continue
     }
 

--- a/src/lib/commandBarConfigs/modelingCommandConfig.integration.spec.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.integration.spec.ts
@@ -561,9 +561,9 @@ describe('Transform arguments', () => {
       ['Mirror 3D', 'across'],
       ['Delete Face', 'faces'],
     ] as const) {
-      expect(selectionTypesFor(commandName, argName)).toContain(
-        'enginePrimitiveFace'
-      )
+      const selectionTypes = selectionTypesFor(commandName, argName)
+      expect(selectionTypes).toContain('enginePrimitiveFace')
+      expect(selectionTypes).toContain('primitiveFace')
     }
 
     for (const commandName of ['GDT Flatness', 'GDT Datum'] as const) {

--- a/src/lib/commandBarConfigs/modelingCommandConfig.integration.spec.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.integration.spec.ts
@@ -96,6 +96,29 @@ gdt::datum(face = capEnd001, name = "A")`
 })
 
 describe('GDT tolerance defaults', () => {
+  it('keeps GD&T available for coded primitive faces and edges', () => {
+    const flatness = modelingMachineCommandConfig['GDT Flatness']
+    const straightness = modelingMachineCommandConfig['GDT Straightness']
+    if (
+      !flatness ||
+      isArray(flatness) ||
+      !straightness ||
+      isArray(straightness)
+    ) {
+      throw new Error('Expected single GD&T command configs')
+    }
+
+    expect(flatness.args?.faces).toMatchObject({
+      selectionTypes: expect.arrayContaining(['primitiveFace']),
+    })
+    expect(straightness.args?.objects).toMatchObject({
+      selectionTypes: expect.arrayContaining([
+        'primitiveFace',
+        'primitiveEdge',
+      ]),
+    })
+  })
+
   it('uses the current file unit for the tolerance input default', () => {
     const modelingContext = {
       kclManager: {
@@ -509,6 +532,70 @@ describe('Transform arguments', () => {
         throw new Error(`${commandName}.${argName} should select solids`)
       }
       expect(selectionTypes).not.toContain('importedGeometry')
+    }
+  })
+
+  it('offers imported BREP topology to supported command paths', () => {
+    const selectionTypesFor = (
+      commandName: keyof ModelingCommandSchema,
+      argName: string
+    ) => {
+      const commandConfig = modelingMachineCommandConfig[commandName]
+      if (!commandConfig || isArray(commandConfig)) {
+        throw new Error(`${commandName} should have a single command config`)
+      }
+      const selectionTypes = (
+        commandConfig.args as unknown as Record<
+          string,
+          { selectionTypes?: string[] } | undefined
+        >
+      )?.[argName]?.selectionTypes
+      if (!selectionTypes) {
+        throw new Error(`${commandName}.${argName} should select geometry`)
+      }
+      return selectionTypes
+    }
+
+    for (const [commandName, argName] of [
+      ['Offset plane', 'plane'],
+      ['Mirror 3D', 'across'],
+      ['Delete Face', 'faces'],
+    ] as const) {
+      expect(selectionTypesFor(commandName, argName)).toContain(
+        'enginePrimitiveFace'
+      )
+    }
+
+    for (const commandName of ['GDT Flatness', 'GDT Datum'] as const) {
+      const selectionTypes = selectionTypesFor(commandName, 'faces')
+      expect(selectionTypes).toContain('enginePrimitiveFace')
+      expect(selectionTypes).not.toContain('enginePrimitiveEdge')
+    }
+
+    for (const commandName of [
+      'GDT Straightness',
+      'GDT Circularity',
+      'GDT Cylindricity',
+      'GDT Position',
+      'GDT Profile',
+      'GDT Distance',
+      'GDT Perpendicularity',
+      'GDT Angularity',
+      'GDT Concentricity',
+      'GDT Symmetry',
+      'GDT Runout',
+      'GDT Parallelism',
+      'GDT Annotation',
+    ] as const) {
+      const selectionTypes = selectionTypesFor(commandName, 'objects')
+      expect(selectionTypes).toContain('enginePrimitiveFace')
+      expect(selectionTypes).toContain('enginePrimitiveEdge')
+    }
+
+    for (const commandName of ['Fillet', 'Chamfer'] as const) {
+      expect(selectionTypesFor(commandName, 'selection')).toContain(
+        'enginePrimitiveEdge'
+      )
     }
   })
 })

--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -17,6 +17,7 @@ import {
 } from '@src/lib/commandBarConfigs/modelingCommandStdLib'
 import type {
   CommandArgumentConfig,
+  CommandSelectionType,
   KclCommandValue,
   StateMachineCommandSetConfig,
 } from '@src/lib/commandTypes'
@@ -125,6 +126,24 @@ const objectsWithImportedGeometryTypesAndFilters: typeof objectsTypesAndFilters 
       'importedGeometry',
     ],
   }
+
+const GDT_FACE_SELECTION_TYPES: CommandSelectionType[] = [
+  'cap',
+  'wall',
+  'edgeCut',
+  'primitiveFace',
+  'enginePrimitiveFace',
+]
+const GDT_EDGE_SELECTION_TYPES: CommandSelectionType[] = [
+  'segment',
+  'sweepEdge',
+  'primitiveEdge',
+  'enginePrimitiveEdge',
+]
+const GDT_FACE_AND_EDGE_SELECTION_TYPES: CommandSelectionType[] = [
+  ...GDT_FACE_SELECTION_TYPES,
+  ...GDT_EDGE_SELECTION_TYPES,
+]
 
 // For all surface modeling commands
 const kclBodyTypeOptions = KCL_PRELUDE_BODY_TYPE_VALUES.map((value) => ({
@@ -1843,7 +1862,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         overrides: {
           faces: {
             inputType: 'selection',
-            selectionTypes: ['cap', 'wall', 'edgeCut'],
+            selectionTypes: GDT_FACE_SELECTION_TYPES,
             multiple: true,
             hidden: isEditingNodeSelection,
           },
@@ -1867,7 +1886,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         overrides: {
           objects: {
             inputType: 'selection',
-            selectionTypes: ['cap', 'wall', 'edgeCut', 'segment', 'sweepEdge'],
+            selectionTypes: GDT_FACE_AND_EDGE_SELECTION_TYPES,
             multiple: true,
             required: true,
             hidden: isEditingNodeSelection,
@@ -1892,7 +1911,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         overrides: {
           objects: {
             inputType: 'selection',
-            selectionTypes: ['cap', 'wall', 'edgeCut', 'segment', 'sweepEdge'],
+            selectionTypes: GDT_FACE_AND_EDGE_SELECTION_TYPES,
             multiple: true,
             required: true,
             hidden: isEditingNodeSelection,
@@ -1917,7 +1936,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         overrides: {
           objects: {
             inputType: 'selection',
-            selectionTypes: ['cap', 'wall', 'edgeCut', 'segment', 'sweepEdge'],
+            selectionTypes: GDT_FACE_AND_EDGE_SELECTION_TYPES,
             multiple: true,
             required: true,
             hidden: isEditingNodeSelection,
@@ -1942,7 +1961,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         overrides: {
           faces: {
             inputType: 'selection',
-            selectionTypes: ['cap', 'wall', 'edgeCut'],
+            selectionTypes: GDT_FACE_SELECTION_TYPES,
             multiple: false,
             hidden: isEditingNodeSelection,
           },
@@ -1971,7 +1990,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         overrides: {
           objects: {
             inputType: 'selection',
-            selectionTypes: ['cap', 'wall', 'edgeCut', 'segment', 'sweepEdge'],
+            selectionTypes: GDT_FACE_AND_EDGE_SELECTION_TYPES,
             multiple: true,
             required: true,
             hidden: isEditingNodeSelection,
@@ -1997,7 +2016,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         overrides: {
           objects: {
             inputType: 'selection',
-            selectionTypes: ['cap', 'wall', 'edgeCut', 'segment', 'sweepEdge'],
+            selectionTypes: GDT_FACE_AND_EDGE_SELECTION_TYPES,
             multiple: true,
             required: true,
             hidden: isEditingNodeSelection,
@@ -2023,7 +2042,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         overrides: {
           objects: {
             inputType: 'selection',
-            selectionTypes: ['cap', 'wall', 'edgeCut', 'segment', 'sweepEdge'],
+            selectionTypes: GDT_FACE_AND_EDGE_SELECTION_TYPES,
             multiple: true,
             required: true,
             hidden: isEditingNodeSelection,
@@ -2048,7 +2067,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       overrides: {
         objects: {
           inputType: 'selection',
-          selectionTypes: ['cap', 'wall', 'edgeCut', 'segment', 'sweepEdge'],
+          selectionTypes: GDT_FACE_AND_EDGE_SELECTION_TYPES,
           multiple: true,
           required: true,
           hidden: isEditingNodeSelection,
@@ -2073,7 +2092,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         overrides: {
           objects: {
             inputType: 'selection',
-            selectionTypes: ['cap', 'wall', 'edgeCut', 'segment', 'sweepEdge'],
+            selectionTypes: GDT_FACE_AND_EDGE_SELECTION_TYPES,
             multiple: true,
             required: true,
             hidden: isEditingNodeSelection,
@@ -2099,7 +2118,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         overrides: {
           objects: {
             inputType: 'selection',
-            selectionTypes: ['cap', 'wall', 'edgeCut', 'segment', 'sweepEdge'],
+            selectionTypes: GDT_FACE_AND_EDGE_SELECTION_TYPES,
             multiple: true,
             required: true,
             hidden: isEditingNodeSelection,
@@ -2128,7 +2147,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         overrides: {
           objects: {
             inputType: 'selection',
-            selectionTypes: ['cap', 'wall', 'edgeCut', 'segment', 'sweepEdge'],
+            selectionTypes: GDT_FACE_AND_EDGE_SELECTION_TYPES,
             multiple: true,
             required: true,
             hidden: isEditingNodeSelection,
@@ -2157,7 +2176,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         overrides: {
           objects: {
             inputType: 'selection',
-            selectionTypes: ['cap', 'wall', 'edgeCut', 'segment', 'sweepEdge'],
+            selectionTypes: GDT_FACE_AND_EDGE_SELECTION_TYPES,
             multiple: true,
             required: true,
             hidden: isEditingNodeSelection,
@@ -2186,7 +2205,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         overrides: {
           objects: {
             inputType: 'selection',
-            selectionTypes: ['cap', 'wall', 'edgeCut', 'segment', 'sweepEdge'],
+            selectionTypes: GDT_FACE_AND_EDGE_SELECTION_TYPES,
             multiple: true,
             required: true,
             hidden: isEditingNodeSelection,
@@ -2211,7 +2230,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         overrides: {
           objects: {
             inputType: 'selection',
-            selectionTypes: ['cap', 'wall', 'edgeCut', 'segment', 'sweepEdge'],
+            selectionTypes: GDT_FACE_AND_EDGE_SELECTION_TYPES,
             multiple: true,
             required: true,
             hidden: isEditingNodeSelection,

--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -1762,6 +1762,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
               'wall',
               'edgeCut',
               'enginePrimitiveFace',
+              'primitiveFace',
               'segment',
               'sweepEdge',
               'edgeCutEdge',

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -78,6 +78,7 @@ export const KCL_DEFAULT_CONSTANT_PREFIXES = {
   SURFACE: 'surface',
   EDGE: 'edge',
   FACE: 'face',
+  BODY: 'body',
 } as const
 /** The default KCL length expression */
 export const KCL_DEFAULT_LENGTH = `5`

--- a/src/lib/selections.spec.ts
+++ b/src/lib/selections.spec.ts
@@ -2,15 +2,19 @@ import type { Plane } from '@rust/kcl-lib/bindings/Plane'
 import type { PlaneInfo } from '@rust/kcl-lib/bindings/PlaneInfo'
 import type { Point3d } from '@rust/kcl-lib/bindings/Point3d'
 import type { SceneInfra } from '@src/clientSideScene/sceneInfra'
+import type { KclManager } from '@src/lang/KclManager'
 import { getNodePathFromSourceRange } from '@src/lang/queryAstNodePathUtils'
 import type { Artifact } from '@src/lang/std/artifactGraph'
 import type { ArtifactGraph, ExecState, SourceRange } from '@src/lang/wasm'
 import { assertParse } from '@src/lang/wasm'
 import type { ArtifactIndex } from '@src/lib/artifactIndex'
 import { buildArtifactIndex } from '@src/lib/artifactIndex'
+import type { ConnectionManager } from '@src/lib/engineConnection/connectionManager'
 import {
   codeToIdSelections,
   findLastRangeStartingBefore,
+  getPrimitiveSelectionForEntity,
+  getSelectionCountByType,
   getSelectionReferences,
   getSelectionTypeDisplayText,
   getStableOffsetPlaneData,
@@ -25,9 +29,103 @@ import type {
   DefaultPlaneSelection,
   EnginePrimitiveSelection,
   Selection,
+  Selections,
 } from '@src/machines/modelingSharedTypes'
 import { buildTheWorldAndNoEngineConnection } from '@src/unitTestUtils'
 import { describe, expect, test, vi } from 'vitest'
+
+test('resolves a primitive imported body to its KCL import ancestor', async () => {
+  const importedGeometry = {
+    type: 'importedGeometry',
+    id: 'import-root',
+    codeRef: {
+      range: [0, 1, 0],
+      pathToNode: [],
+      nodePath: { steps: [] },
+    },
+  } as Artifact
+  const artifactGraph = new Map<string, Artifact>([
+    [importedGeometry.id, importedGeometry],
+  ])
+  const engineCommandManager = {
+    sendSceneCommand: vi.fn(
+      async ({ cmd }: { cmd: { type: string; entity_id: string } }) => {
+        if (cmd.type === 'entity_get_primitive_index') {
+          return {
+            success: true,
+            resp: {
+              type: 'modeling',
+              data: {
+                modeling_response: {
+                  type: 'entity_get_primitive_index',
+                  data: { entity_type: 'face', primitive_index: 4 },
+                },
+              },
+            },
+          }
+        }
+
+        if (cmd.type === 'entity_get_parent_id') {
+          const parentByEntity: Record<string, string> = {
+            'selected-face': 'imported-body',
+            'imported-body': 'assembly-node',
+            'assembly-node': importedGeometry.id,
+          }
+          return {
+            success: true,
+            resp: {
+              type: 'modeling',
+              data: {
+                modeling_response: {
+                  type: 'entity_get_parent_id',
+                  data: { entity_id: parentByEntity[cmd.entity_id] },
+                },
+              },
+            },
+          }
+        }
+
+        if (cmd.type === 'entity_get_index') {
+          const indexByEntity: Record<string, number> = {
+            'imported-body': 7,
+            'assembly-node': 3,
+          }
+          return {
+            success: true,
+            resp: {
+              type: 'modeling',
+              data: {
+                modeling_response: {
+                  type: 'entity_get_index',
+                  data: { entity_index: indexByEntity[cmd.entity_id] },
+                },
+              },
+            },
+          }
+        }
+
+        throw new Error(`Unexpected command ${cmd.type}`)
+      }
+    ),
+  } as unknown as ConnectionManager
+
+  await expect(
+    getPrimitiveSelectionForEntity(
+      'selected-face',
+      engineCommandManager,
+      artifactGraph
+    )
+  ).resolves.toEqual({
+    type: 'enginePrimitive',
+    entityId: 'selected-face',
+    parentEntityId: 'imported-body',
+    kclBodyId: 'import-root',
+    kclBodyArtifactType: 'importedGeometry',
+    bodyPath: [3, 7],
+    primitiveIndex: 4,
+    primitiveType: 'face',
+  })
+})
 
 describe('testing source range to artifact conversion', () => {
   const MY_CODE = `sketch001 = startSketchOn(XZ)
@@ -1625,6 +1723,65 @@ cube = extrude(cubeRegion, length = 10)
     ).toBe('seg01')
   })
 
+  test('creates faceId and edgeId references for imported BREP topology', async () => {
+    const { instance } = await buildTheWorldAndNoEngineConnection()
+    const code = 'import "part.step" as importedPart\n'
+    const ast = assertParse(code, instance)
+    const range = [0, code.trimEnd().length, 0] as SourceRange
+    const codeRef = {
+      range,
+      pathToNode: getNodePathFromSourceRange(ast, range),
+    }
+    const importedGeometry = {
+      type: 'importedGeometry',
+      id: 'imported-body',
+      codeRef,
+    } as Artifact
+    const artifactGraph = new Map<string, Artifact>([
+      [importedGeometry.id, importedGeometry],
+    ])
+
+    const references = await getSelectionReferences({
+      graphSelections: [],
+      defaultPlaneSelections: [],
+      enginePrimitives: [
+        {
+          type: 'enginePrimitive',
+          entityId: 'imported-face',
+          parentEntityId: 'imported-engine-body',
+          kclBodyId: importedGeometry.id,
+          bodyPath: [3, 7],
+          primitiveIndex: 4,
+          primitiveType: 'face',
+        },
+        {
+          type: 'enginePrimitive',
+          entityId: 'imported-edge',
+          parentEntityId: 'imported-engine-body',
+          kclBodyId: importedGeometry.id,
+          bodyPath: [3, 8],
+          primitiveIndex: 7,
+          primitiveType: 'edge',
+        },
+      ],
+      artifactGraph,
+      engineCommandManager: null as never,
+      kclManager: { ast } as KclManager,
+      wasmInstance: instance,
+    })
+
+    expect(references.map(({ label, code }) => ({ label, code }))).toEqual([
+      {
+        label: 'Face',
+        code: 'faceId(bodyOf(importedPart, path = [3, 7]), index = 4)',
+      },
+      {
+        label: 'Edge',
+        code: 'edgeId(bodyOf(importedPart, path = [3, 8]), index = 7)',
+      },
+    ])
+  })
+
   test('includes selected default planes and lets them be removed', async () => {
     const defaultPlaneSelection = {
       id: 'default-plane-xy',
@@ -1897,6 +2054,38 @@ describe('imported geometry code selection', () => {
 })
 
 describe('getSelectionTypeDisplayText', () => {
+  test('classifies imported BREP faces as engine primitives', () => {
+    const selection = {
+      graphSelections: [],
+      otherSelections: [
+        {
+          type: 'enginePrimitive',
+          entityId: 'imported-face',
+          kclBodyArtifactType: 'importedGeometry',
+          primitiveIndex: 0,
+          primitiveType: 'face',
+        },
+        {
+          type: 'enginePrimitive',
+          entityId: 'imported-edge',
+          kclBodyArtifactType: 'importedGeometry',
+          primitiveIndex: 0,
+          primitiveType: 'edge',
+        },
+      ],
+    } as Selections
+
+    expect(getSelectionCountByType({} as any, selection)).toEqual(
+      new Map([
+        ['enginePrimitiveFace', 1],
+        ['enginePrimitiveEdge', 1],
+      ])
+    )
+    expect(getSelectionTypeDisplayText({} as any, selection)).toBe(
+      '1 face, 1 edge'
+    )
+  })
+
   test('coalesces face-like selections under face', () => {
     const codeRef = { range: [0, 0, 0], pathToNode: [] } as any
     const selection = {

--- a/src/lib/selections.ts
+++ b/src/lib/selections.ts
@@ -24,13 +24,15 @@ import { AXIS_GROUP, X_AXIS } from '@src/clientSideScene/sceneUtils'
 import {
   createCallExpressionStdLibKw,
   createExpressionStatement,
-  createLabeledArg,
-  createLiteral,
   createLocalName,
   createMemberExpression,
   nonCodeMetaEmpty,
 } from '@src/lang/create'
 import { modifyAstWithTagsForSelection } from '@src/lang/modifyAst/tagManagement'
+import {
+  createPrimitiveBodyExpression,
+  createPrimitiveIndexCallExpression,
+} from '@src/lang/modifyAst/enginePrimitiveReference'
 import {
   findAllChildrenAndOrderByPlaceInCode,
   getEdgeCutMeta,
@@ -135,6 +137,24 @@ async function getParentEntityIdForEntity(
   const parentIdResponse = parentResponse.resp.data.modeling_response
   if (parentIdResponse.type !== 'entity_get_parent_id') return undefined
   return parentIdResponse.data.entity_id
+}
+
+async function getEntityIndexForEntity(
+  entityId: string,
+  engineCommandManager: ConnectionManager
+): Promise<number | undefined> {
+  const response = await engineCommandManager.sendSceneCommand({
+    type: 'modeling_cmd_req',
+    cmd_id: uuidv4(),
+    cmd: {
+      type: 'entity_get_index',
+      entity_id: entityId,
+    },
+  })
+  if (!isModelingResponse(response)) return undefined
+  const indexResponse = response.resp.data.modeling_response
+  if (indexResponse.type !== 'entity_get_index') return undefined
+  return indexResponse.data.entity_index
 }
 
 async function getResolvableIntersectionInfoForRegion(
@@ -268,7 +288,8 @@ export async function getEngineRegionSelectionFromEntity(
 
 export async function getPrimitiveSelectionForEntity(
   entityId: string,
-  engineCommandManager: ConnectionManager
+  engineCommandManager: ConnectionManager,
+  artifactGraph: ArtifactGraph
 ): Promise<EnginePrimitiveSelection | null> {
   const websocketResponse = await engineCommandManager.sendSceneCommand({
     type: 'modeling_cmd_req',
@@ -291,11 +312,27 @@ export async function getPrimitiveSelectionForEntity(
     entityId,
     engineCommandManager
   )
+  const bodyReference = parentEntityId
+    ? await getKclBodyReferenceForPrimitiveParent(
+        parentEntityId,
+        artifactGraph,
+        engineCommandManager
+      )
+    : undefined
 
   return {
     type: 'enginePrimitive',
     entityId,
     parentEntityId,
+    ...(bodyReference && bodyReference.kclBodyId !== parentEntityId
+      ? { kclBodyId: bodyReference.kclBodyId }
+      : {}),
+    ...(bodyReference
+      ? { kclBodyArtifactType: bodyReference.artifactType }
+      : {}),
+    ...(bodyReference?.bodyPath.length
+      ? { bodyPath: bodyReference.bodyPath }
+      : {}),
     primitiveIndex: entityGetPrimitiveIndex.primitive_index,
     primitiveType: entityGetPrimitiveIndex.entity_type,
   }
@@ -321,7 +358,78 @@ const BODY_REFERENCE_ARTIFACT_TYPES: Artifact['type'][] = [
   'compositeSolid',
   'pattern',
   'helix',
+  'importedGeometry',
 ]
+
+/** Artifacts whose engine entities own selectable BREP faces and edges. */
+export const TOPOLOGY_BODY_ARTIFACT_TYPES: Artifact['type'][] = [
+  'sweep',
+  'compositeSolid',
+  'pattern',
+  'importedGeometry',
+]
+
+export function getKclBodyIdFromEnginePrimitiveSelection(
+  selection: EnginePrimitiveSelection
+): string | undefined {
+  return selection.kclBodyId ?? selection.parentEntityId
+}
+
+const MAX_ENGINE_PARENT_DEPTH = 32
+
+async function getKclBodyReferenceForPrimitiveParent(
+  parentEntityId: string,
+  artifactGraph: ArtifactGraph,
+  engineCommandManager: ConnectionManager
+): Promise<
+  | {
+      kclBodyId: string
+      artifactType: Artifact['type']
+      bodyPath: number[]
+    }
+  | undefined
+> {
+  const visited = new Set<string>()
+  let candidateId = parentEntityId
+  const bodyPath: number[] = []
+
+  while (visited.size < MAX_ENGINE_PARENT_DEPTH && !visited.has(candidateId)) {
+    visited.add(candidateId)
+
+    const bodySelection = getBodySelectionFromPrimitiveParentEntityId(
+      candidateId,
+      artifactGraph,
+      { lookUpPatternCopies: true }
+    )
+    if (bodySelection?.artifact) {
+      return {
+        kclBodyId: candidateId,
+        artifactType: bodySelection.artifact.type,
+        bodyPath,
+      }
+    }
+
+    let parentId: string | undefined
+    let childIndex: number | undefined
+    try {
+      const parentAndIndex = await Promise.all([
+        getParentEntityIdForEntity(candidateId, engineCommandManager),
+        getEntityIndexForEntity(candidateId, engineCommandManager),
+      ])
+      parentId = parentAndIndex[0]
+      childIndex = parentAndIndex[1]
+    } catch {
+      return undefined
+    }
+    if (!parentId || childIndex === undefined) {
+      return undefined
+    }
+    bodyPath.unshift(childIndex)
+    candidateId = parentId
+  }
+
+  return undefined
+}
 
 export function isReferenceableEnginePrimitiveSelection(
   selection: EnginePrimitiveSelection
@@ -335,13 +443,16 @@ function isBodyReferenceArtifact(
   artifact: Artifact | undefined
 ): artifact is Extract<
   Artifact,
-  { type: 'sweep' | 'compositeSolid' | 'pattern' | 'helix' }
+  {
+    type: 'sweep' | 'compositeSolid' | 'pattern' | 'helix' | 'importedGeometry'
+  }
 > {
   return (
     artifact?.type === 'sweep' ||
     artifact?.type === 'compositeSolid' ||
     artifact?.type === 'pattern' ||
-    artifact?.type === 'helix'
+    artifact?.type === 'helix' ||
+    artifact?.type === 'importedGeometry'
   )
 }
 
@@ -386,7 +497,7 @@ export function getBodySelectionFromPrimitiveParentEntityId(
   parentEntityId: string,
   artifactGraph: ArtifactGraph,
   {
-    bodyArtifactTypes = ['sweep', 'compositeSolid'],
+    bodyArtifactTypes = TOPOLOGY_BODY_ARTIFACT_TYPES,
     codeRefLookup = 'last',
     lookUpPatternCopies = false,
   }: {
@@ -803,15 +914,16 @@ function createPrimitiveIndexReferenceExpr({
   kclManager,
   wasmInstance,
 }: SelectionExpressionBuilderContext): Expr | null {
-  if (!primitiveSelection.parentEntityId) {
+  const kclBodyId = getKclBodyIdFromEnginePrimitiveSelection(primitiveSelection)
+  if (!kclBodyId) {
     return null
   }
 
   const bodySelection = getBodySelectionFromPrimitiveParentEntityId(
-    primitiveSelection.parentEntityId,
+    kclBodyId,
     artifactGraph,
     {
-      bodyArtifactTypes: BODY_REFERENCE_ARTIFACT_TYPES,
+      bodyArtifactTypes: TOPOLOGY_BODY_ARTIFACT_TYPES,
       codeRefLookup: 'first',
       lookUpPatternCopies: true,
     }
@@ -828,22 +940,26 @@ function createPrimitiveIndexReferenceExpr({
     undefined,
     {
       lastChildLookup: true,
-      artifactTypeFilter: BODY_REFERENCE_ARTIFACT_TYPES,
+      artifactTypeFilter: TOPOLOGY_BODY_ARTIFACT_TYPES,
     }
   )
   if (err(bodyVariables) || bodyVariables.exprs.length === 0) {
     return null
   }
 
-  const bodyExpr = bodyVariables.exprs[0]
+  const bodyExpr = createPrimitiveBodyExpression(
+    structuredClone(bodyVariables.exprs[0]),
+    primitiveSelection.bodyPath,
+    wasmInstance
+  )
   const functionName =
     primitiveSelection.primitiveType === 'face' ? 'faceId' : 'edgeId'
-  return createCallExpressionStdLibKw(functionName, structuredClone(bodyExpr), [
-    createLabeledArg(
-      'index',
-      createLiteral(primitiveSelection.primitiveIndex, wasmInstance)
-    ),
-  ])
+  return createPrimitiveIndexCallExpression(
+    functionName,
+    bodyExpr,
+    primitiveSelection.primitiveIndex,
+    wasmInstance
+  )
 }
 
 const selectionExpressionApproaches: SelectionExpressionApproach[] = [
@@ -1010,7 +1126,8 @@ export async function getSelectionReferences({
 
     const primitiveSelection = await getPrimitiveSelectionForEntity(
       entityId,
-      engineCommandManager
+      engineCommandManager,
+      artifactGraph
     )
     if (
       primitiveSelection &&
@@ -1272,7 +1389,8 @@ export async function getEventForSelectWithPoint(
     // or we build a primitive selection to be used as fallback for downstream operations
     const primitiveSelection = await getPrimitiveSelectionForEntity(
       data.entity_id,
-      engineCommandManager
+      engineCommandManager,
+      artifactGraph
     )
     if (primitiveSelection !== null) {
       return {

--- a/src/machines/modelingMachine.ts
+++ b/src/machines/modelingMachine.ts
@@ -172,6 +172,7 @@ import type RustContext from '@src/lib/rustContext'
 import {
   getDefaultSketchPlaneData,
   getEventForSegmentSelection,
+  getKclBodyIdFromEnginePrimitiveSelection,
   getOffsetSketchPlaneData,
   getPlaneDataFromSketchBlock,
   handleSelectionBatch,
@@ -3277,13 +3278,19 @@ export const modelingMachine = setup({
           )
         }
         let result: DefaultPlane | OffsetPlane | ExtrudeFacePlane | null = null
+        const primitiveKclBodyId = primitiveFaceSelection
+          ? getKclBodyIdFromEnginePrimitiveSelection(primitiveFaceSelection)
+          : undefined
         const primitiveFace =
-          primitiveFaceSelection?.parentEntityId === undefined
-            ? null
-            : {
-                solidId: primitiveFaceSelection.parentEntityId,
+          primitiveFaceSelection && primitiveKclBodyId
+            ? {
+                solidId: primitiveKclBodyId,
                 index: primitiveFaceSelection.primitiveIndex,
+                ...(primitiveFaceSelection.bodyPath?.length
+                  ? { bodyPath: primitiveFaceSelection.bodyPath }
+                  : {}),
               }
+            : null
 
         if (primitiveFaceSelection && !primitiveFace) {
           return reject(

--- a/src/machines/modelingMachine.ts
+++ b/src/machines/modelingMachine.ts
@@ -175,6 +175,7 @@ import {
   getKclBodyIdFromEnginePrimitiveSelection,
   getOffsetSketchPlaneData,
   getPlaneDataFromSketchBlock,
+  getPrimitiveSelectionForEntity,
   handleSelectionBatch,
   isEnginePrimitiveSelection,
   isEngineRegionSelection,
@@ -200,6 +201,28 @@ function sourceRangesEqual(
   b: [number, number, number]
 ) {
   return a[0] === b[0] && a[1] === b[1] && a[2] === b[2]
+}
+
+function getNextSelectionOrder(selections: Selections): number {
+  const orders = selections.graphSelections.flatMap((selection) =>
+    selection.selectionOrder === undefined ? [] : [selection.selectionOrder]
+  )
+  for (const selection of selections.otherSelections) {
+    if (
+      typeof selection === 'object' &&
+      'selectionOrder' in selection &&
+      typeof selection.selectionOrder === 'number'
+    ) {
+      orders.push(selection.selectionOrder)
+    }
+  }
+
+  return (
+    Math.max(
+      selections.graphSelections.length + selections.otherSelections.length - 1,
+      ...orders
+    ) + 1
+  )
 }
 
 function sourceRangeForPath(
@@ -1738,7 +1761,9 @@ export const modelingMachine = setup({
             }
           } else if (setSelections.selection && !kclManager.isShiftDown) {
             selections = {
-              graphSelections: [setSelections.selection],
+              graphSelections: [
+                { ...setSelections.selection, selectionOrder: 0 },
+              ],
               otherSelections: [],
             }
           } else if (setSelections.selection && kclManager.isShiftDown) {
@@ -1776,7 +1801,10 @@ export const modelingMachine = setup({
                 // add it
                 updatedSelections = [
                   ...selectionRanges.graphSelections,
-                  setSelections.selection,
+                  {
+                    ...setSelections.selection,
+                    selectionOrder: getNextSelectionOrder(selectionRanges),
+                  },
                 ]
               }
             } else {
@@ -1803,7 +1831,10 @@ export const modelingMachine = setup({
                 // add it
                 updatedSelections = [
                   ...selectionRanges.graphSelections,
-                  setSelections.selection,
+                  {
+                    ...setSelections.selection,
+                    selectionOrder: getNextSelectionOrder(selectionRanges),
+                  },
                 ]
               }
             }
@@ -1869,6 +1900,12 @@ export const modelingMachine = setup({
               selection.entityId === setSelections.selection.entityId
           )
 
+          const orderedSelection = {
+            ...setSelections.selection,
+            selectionOrder: kclManager.isShiftDown
+              ? getNextSelectionOrder(selectionRanges)
+              : 0,
+          }
           const otherSelections = kclManager.isShiftDown
             ? shouldDeselect
               ? selectionRanges.otherSelections.filter(
@@ -1878,8 +1915,8 @@ export const modelingMachine = setup({
                       selection.entityId === setSelections.selection.entityId
                     )
                 )
-              : [...selectionRanges.otherSelections, setSelections.selection]
-            : [setSelections.selection]
+              : [...selectionRanges.otherSelections, orderedSelection]
+            : [orderedSelection]
 
           const selections: Selections = {
             graphSelections: kclManager.isShiftDown
@@ -3263,7 +3300,7 @@ export const modelingMachine = setup({
         }
         const {
           artifactOrPlaneId,
-          primitiveFaceSelection,
+          primitiveFaceSelection: selectedPrimitiveFace,
           kclManager,
           rustContext,
           engineCommandManager,
@@ -3276,6 +3313,24 @@ export const modelingMachine = setup({
           return reject(
             new Error('Unable to enter sketch while KCL has parse errors.')
           )
+        }
+        let primitiveFaceSelection = selectedPrimitiveFace
+        if (!primitiveFaceSelection) {
+          const selectedArtifact =
+            kclManager.artifactGraph.get(artifactOrPlaneId)
+          if (selectedArtifact?.type === 'primitiveFace') {
+            const resolvedPrimitive = await getPrimitiveSelectionForEntity(
+              selectedArtifact.id,
+              engineCommandManager,
+              kclManager.artifactGraph
+            )
+            if (resolvedPrimitive?.primitiveType !== 'face') {
+              return reject(
+                new Error('Could not resolve the selected primitive face.')
+              )
+            }
+            primitiveFaceSelection = resolvedPrimitive
+          }
         }
         let result: DefaultPlane | OffsetPlane | ExtrudeFacePlane | null = null
         const primitiveKclBodyId = primitiveFaceSelection

--- a/src/machines/modelingSharedTypes.ts
+++ b/src/machines/modelingSharedTypes.ts
@@ -30,7 +30,14 @@ export type DefaultPlaneSelection = {
 export type EnginePrimitiveSelection = {
   type: 'enginePrimitive'
   entityId: string
+  /** Immediate engine body which owns the selected primitive. */
   parentEntityId?: string
+  /** Nearest engine ancestor which can be expressed as a KCL body. */
+  kclBodyId?: ArtifactId
+  /** Artifact type of the KCL body, used to expose only compatible commands. */
+  kclBodyArtifactType?: Artifact['type']
+  /** Child-index path from the KCL body to the engine body which owns the primitive. */
+  bodyPath?: number[]
   primitiveIndex: number
   primitiveType: EntityType
 }

--- a/src/machines/modelingSharedTypes.ts
+++ b/src/machines/modelingSharedTypes.ts
@@ -29,6 +29,8 @@ export type DefaultPlaneSelection = {
 
 export type EnginePrimitiveSelection = {
   type: 'enginePrimitive'
+  /** Order in which this item was added to the current multi-selection. */
+  selectionOrder?: number
   entityId: string
   /** Immediate engine body which owns the selected primitive. */
   parentEntityId?: string
@@ -65,6 +67,8 @@ export type NonCodeSelection =
   | EngineRegionSelection
 
 export interface Selection {
+  /** Order in which this item was added to the current multi-selection. */
+  selectionOrder?: number
   artifact?: Artifact
   codeRef: CodeRef
   engineEntityId?: ArtifactId


### PR DESCRIPTION
## Stack

- 3 of 3.
- Depends on #13771 and, indirectly, #13331.

## What changed

- Preserve the owning KCL body ID, nested child path, and resolved artifact type when selecting primitive faces and edges from imported BREP geometry.
- Resolve those selections back to the import alias and generate a reusable `bodyOf` variable followed by ordinary `faceId` or `edgeId` references.
- Route sketch-on-face and Delete Face through the selected nested body instead of requiring a procedural solid artifact.
- Enable imported BREP faces and edges as targets for the full face/edge-based GD&T command family.
- Classify imported BREP faces and edges separately in command selection counts.

## Review notes

Nested traversal is centralized in the primitive-reference helper. Codemods emit `body001 = bodyOf(importedPart, path = [...])`, reuse that variable for multiple selections on the same body, then pass it to topology and modeling operations. Copyable selection references use the equivalent inline `bodyOf(...)` expression.

GD&T target construction remains centralized: procedural selections become tags or `getCommonEdge` expressions, while imported BREP selections become `faceId` or `edgeId` variables. Face-only commands accept imported faces; mixed commands accept imported faces and edges.

Imported BREP edges remain deliberately excluded from Fillet, Chamfer, and Blend: those procedural edge-treatment argument types do not preserve enough ownership information for nested imported bodies. This does not affect GD&T, whose runtime accepts the `EdgeReference` produced by `edgeId`.

The generic Feature Tree menu refactor lives in #13331, leaving this PR focused on app-side BREP selection, modeling-machine wiring, and codemods.

Part of #10298.
