### PR TITLE
Execute Zookeeper commands in the active client

### DIFF
--- a/src/lib/browserSaveFile.test.ts
+++ b/src/lib/browserSaveFile.test.ts
@@ -21,7 +21,7 @@ vi.mock('react-hot-toast', () => ({
 }))
 
 import {
-  browserSaveFile,
+  browserSaveFileWithResult,
   getShowSaveFilePickerOptions,
 } from '@src/lib/browserSaveFile'
 import { EXPORT_TOAST_MESSAGES } from '@src/lib/constants'
@@ -74,8 +74,13 @@ describe('browserSaveFile', () => {
   it('uses the download fallback when showSaveFilePicker is unavailable', async () => {
     const blob = new Blob(['contents'])
 
-    await browserSaveFile(blob, 'main.step', 'toast-id')
+    const result = await browserSaveFileWithResult(
+      blob,
+      'main.step',
+      'toast-id'
+    )
 
+    expect(result).toEqual({ status: 'saved' })
     expect(createObjectURL).toHaveBeenCalledWith(blob)
     expect(clickSpy).toHaveBeenCalledTimes(1)
     expect(document.querySelector('a')?.download).toBe('main.step')
@@ -98,8 +103,13 @@ describe('browserSaveFile', () => {
       )
     setShowSaveFilePicker(showSaveFilePicker)
 
-    await browserSaveFile(blob, 'main.step', 'toast-id')
+    const result = await browserSaveFileWithResult(
+      blob,
+      'main.step',
+      'toast-id'
+    )
 
+    expect(result).toEqual({ status: 'saved' })
     expect(showSaveFilePicker).toHaveBeenCalledWith(
       getShowSaveFilePickerOptions('main.step')
     )
@@ -118,8 +128,13 @@ describe('browserSaveFile', () => {
       .mockRejectedValue(new DOMException('User canceled', 'AbortError'))
     setShowSaveFilePicker(showSaveFilePicker)
 
-    await browserSaveFile(new Blob(['contents']), 'main.step', 'toast-id')
+    const result = await browserSaveFileWithResult(
+      new Blob(['contents']),
+      'main.step',
+      'toast-id'
+    )
 
+    expect(result).toEqual({ status: 'cancelled' })
     expect(createObjectURL).not.toHaveBeenCalled()
     expect(clickSpy).not.toHaveBeenCalled()
     expect(mockToast.dismiss).toHaveBeenCalledWith('toast-id')

--- a/src/lib/browserSaveFile.ts
+++ b/src/lib/browserSaveFile.ts
@@ -1,8 +1,15 @@
 // Saves a file through the File System Access API when possible, then falls
 // back to a normal browser download link.
+
 import toast from 'react-hot-toast'
 
 import { EXPORT_TOAST_MESSAGES } from '@src/lib/constants'
+
+/** The observable outcome of a browser or desktop-style file save flow. */
+export type FileSaveResult =
+  | { status: 'saved' }
+  | { status: 'cancelled' }
+  | { status: 'failed'; error: Error }
 
 const getSuggestedExtension = (suggestedName: string): `.${string}` | null => {
   const finalDotIndex = suggestedName.lastIndexOf('.')
@@ -53,7 +60,7 @@ const saveWithDownloadLink = (
   blob: Blob,
   suggestedName: string,
   toastId: string
-) => {
+): FileSaveResult => {
   const blobURL = URL.createObjectURL(blob)
   const a = document.createElement('a')
 
@@ -68,14 +75,15 @@ const saveWithDownloadLink = (
     a.remove()
   }, 1000)
   toast.success(EXPORT_TOAST_MESSAGES.SUCCESS, { id: toastId })
+  return { status: 'saved' }
 }
 
 // user will get a file save dialog where they can choose where the file should be saved.
-export const browserSaveFile = async (
+export const browserSaveFileWithResult = async (
   blob: Blob,
   suggestedName: string,
   toastId: string
-) => {
+): Promise<FileSaveResult> => {
   // Feature detection. The API needs to be supported
   // and the app not run in an iframe.
   const supportsFileSystemAccess =
@@ -103,22 +111,35 @@ export const browserSaveFile = async (
       await writable.write(blob)
       await writable.close()
       toast.success(EXPORT_TOAST_MESSAGES.SUCCESS, { id: toastId })
-      return
+      return { status: 'saved' }
     } catch (err: unknown) {
       const name = errorName(err)
 
       // Fail silently if the user has simply canceled the dialog.
       if (name === 'AbortError') {
         toast.dismiss(toastId)
+        return { status: 'cancelled' }
       } else if (name === 'NotAllowedError') {
-        saveWithDownloadLink(blob, suggestedName, toastId)
+        return saveWithDownloadLink(blob, suggestedName, toastId)
       } else {
         console.error(name, err)
         toast.error(EXPORT_TOAST_MESSAGES.FAILED, { id: toastId })
+        return {
+          status: 'failed',
+          error: err instanceof Error ? err : new Error(String(err)),
+        }
       }
-      return
     }
   }
   // Fallback if the File System Access API is not supported…
-  saveWithDownloadLink(blob, suggestedName, toastId)
+  return saveWithDownloadLink(blob, suggestedName, toastId)
+}
+
+/** Save a browser file while preserving the legacy fire-and-forget contract. */
+export const browserSaveFile = async (
+  blob: Blob,
+  suggestedName: string,
+  toastId: string
+): Promise<void> => {
+  await browserSaveFileWithResult(blob, suggestedName, toastId)
 }

--- a/src/lib/exportSave.ts
+++ b/src/lib/exportSave.ts
@@ -1,12 +1,18 @@
 import JSZip from 'jszip'
 import toast from 'react-hot-toast'
 
-import { browserSaveFile } from '@src/lib/browserSaveFile'
+import {
+  browserSaveFileWithResult,
+  type FileSaveResult,
+} from '@src/lib/browserSaveFile'
 import { EXPORT_TOAST_MESSAGES } from '@src/lib/constants'
 import fsZds from '@src/lib/fs-zds'
 import type ModelingAppFile from '@src/lib/modelingAppFile'
 
-const save_ = async (file: ModelingAppFile, toastId: string) => {
+const save_ = async (
+  file: ModelingAppFile,
+  toastId: string
+): Promise<FileSaveResult> => {
   try {
     if (window.electron) {
       const extension = file.name.split('.').pop() || null
@@ -33,7 +39,7 @@ const save_ = async (file: ModelingAppFile, toastId: string) => {
           id: toastId,
           duration: 10_000,
         })
-        return
+        return { status: 'saved' }
       }
 
       // Open a dialog to save the file.
@@ -51,7 +57,7 @@ const save_ = async (file: ModelingAppFile, toastId: string) => {
       // Return early.
       if (filePathMeta.canceled) {
         toast.dismiss(toastId)
-        return
+        return { status: 'cancelled' }
       }
 
       // Write the file.
@@ -60,6 +66,7 @@ const save_ = async (file: ModelingAppFile, toastId: string) => {
         new Uint8Array(file.contents)
       )
       toast.success(EXPORT_TOAST_MESSAGES.SUCCESS, { id: toastId })
+      return { status: 'saved' }
     } else {
       // Download the file to the user's computer.
       // Now we need to download the files to the user's downloads folder.
@@ -68,12 +75,16 @@ const save_ = async (file: ModelingAppFile, toastId: string) => {
       // Create a new blob.
       const blob = new Blob([new Uint8Array(file.contents)])
       // Save the file.
-      await browserSaveFile(blob, file.name, toastId)
+      return await browserSaveFileWithResult(blob, file.name, toastId)
     }
   } catch (e) {
     // TODO: do something real with the error.
     console.error('export error', e)
     toast.error(EXPORT_TOAST_MESSAGES.FAILED, { id: toastId })
+    return {
+      status: 'failed',
+      error: e instanceof Error ? e : new Error(String(e)),
+    }
   }
 }
 
@@ -87,7 +98,7 @@ export async function exportSave({
   files: ModelingAppFile[]
   fileName: string
   toastId: string
-}) {
+}): Promise<FileSaveResult> {
   if (files.length > 1) {
     let zip = new JSZip()
     for (const file of files) {

--- a/src/lib/zookeeper/clientCommands.test.ts
+++ b/src/lib/zookeeper/clientCommands.test.ts
@@ -1,15 +1,22 @@
 import { exportSave } from '@src/lib/exportSave'
+import type { Command } from '@src/lib/commandTypes'
 import {
   CLIENT_COMMAND_SCHEMA_REVISION,
-  CLIENT_COMMAND_SCHEMA_UPDATE,
+  createClientCommandSchemaUpdate,
   type ExecuteClientCommandDependencies,
   executeClientCommand,
+  isClientCommandAvailable,
   parseClientCommandRequest,
 } from '@src/lib/zookeeper/clientCommands'
+import {
+  DEFAULT_COMMAND_SCOPES,
+  MODE_MODELING_COMMAND_SCOPE,
+  MODE_SKETCHING_COMMAND_SCOPE,
+} from '@src/registry/contracts/commands'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@src/lib/exportSave', () => ({
-  exportSave: vi.fn().mockResolvedValue(undefined),
+  exportSave: vi.fn().mockResolvedValue({ status: 'saved' }),
 }))
 
 vi.mock('react-hot-toast', () => ({
@@ -20,18 +27,36 @@ vi.mock('react-hot-toast', () => ({
 }))
 
 describe('Zookeeper client commands', () => {
+  const exportCommand = {
+    groupId: 'modeling',
+    name: 'Export',
+    displayName: 'Export current part',
+    description: 'Export the active part.',
+    needsReview: true,
+    onSubmit: vi.fn(),
+  } as unknown as Command
+
+  const exportRequest = {
+    request_id: 'request-1',
+    catalog_revision: CLIENT_COMMAND_SCHEMA_REVISION,
+    command_id: 'modeling.export',
+    arguments: { format: 'step' },
+  }
+
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
   it('advertises only the explicit STEP export capability', () => {
-    expect(CLIENT_COMMAND_SCHEMA_UPDATE).toEqual({
+    expect(createClientCommandSchemaUpdate([exportCommand])).toEqual({
       type: 'update_client_command_schema',
       protocol_version: 1,
       revision: CLIENT_COMMAND_SCHEMA_REVISION,
       commands: [
         expect.objectContaining({
           id: 'modeling.export',
+          title: 'Export current part',
+          description: 'Export the active part.',
           input_schema: expect.objectContaining({
             required: ['format'],
             additionalProperties: false,
@@ -39,6 +64,38 @@ describe('Zookeeper client commands', () => {
         }),
       ],
     })
+    expect(createClientCommandSchemaUpdate([]).commands).toEqual([])
+    expect(
+      createClientCommandSchemaUpdate([{ ...exportCommand, disabled: true }])
+        .commands
+    ).toEqual([])
+  })
+
+  it('uses scopes as runtime readiness without removing the capability', () => {
+    const scopedExport = {
+      ...exportCommand,
+      scopes: [MODE_MODELING_COMMAND_SCOPE],
+    } as Command
+
+    expect(
+      createClientCommandSchemaUpdate([scopedExport]).commands
+    ).toHaveLength(1)
+    expect(
+      isClientCommandAvailable(
+        exportRequest,
+        [scopedExport],
+        [MODE_SKETCHING_COMMAND_SCOPE],
+        DEFAULT_COMMAND_SCOPES
+      )
+    ).toBe(false)
+    expect(
+      isClientCommandAvailable(
+        exportRequest,
+        [scopedExport],
+        [MODE_MODELING_COMMAND_SCOPE],
+        DEFAULT_COMMAND_SCOPES
+      )
+    ).toBe(true)
   })
 
   it('parses the externally tagged server request', () => {
@@ -77,15 +134,11 @@ describe('Zookeeper client commands', () => {
       rustContext: { export: exportFromEngine },
     } as unknown as ExecuteClientCommandDependencies['kclManager']
 
-    const result = await executeClientCommand(
-      {
-        request_id: 'request-1',
-        catalog_revision: CLIENT_COMMAND_SCHEMA_REVISION,
-        command_id: 'modeling.export',
-        arguments: { format: 'step' },
-      },
-      { kclManager, defaultUnit: 'mm', waitForProjectIdle }
-    )
+    const result = await executeClientCommand(exportRequest, {
+      kclManager,
+      defaultUnit: 'mm',
+      waitForProjectIdle,
+    })
 
     expect(waitForProjectIdle).toHaveBeenCalledOnce()
     expect(exportFromEngine).toHaveBeenCalledWith(
@@ -99,5 +152,36 @@ describe('Zookeeper client commands', () => {
     expect(result).toEqual(
       expect.objectContaining({ status: 'succeeded', request_id: 'request-1' })
     )
+  })
+
+  it.each([
+    [{ status: 'cancelled' }, 'cancelled'],
+    [{ status: 'failed', error: new Error('disk full') }, 'failed'],
+  ] as const)('reports a %s save as %s', async (saveResult, status) => {
+    vi.mocked(exportSave).mockResolvedValueOnce(saveResult)
+    const kclManager = {
+      ast: { body: [{}] },
+      currentFileName: 'main.kcl',
+      hasErrors: () => false,
+      rustContext: {
+        export: vi.fn().mockResolvedValue([
+          {
+            name: 'engine-output.step',
+            contents: new Uint8Array([1, 2, 3]),
+          },
+        ]),
+      },
+    } as unknown as ExecuteClientCommandDependencies['kclManager']
+
+    const result = await executeClientCommand(exportRequest, {
+      kclManager,
+      defaultUnit: 'mm',
+      waitForProjectIdle: vi.fn().mockResolvedValue(undefined),
+    })
+
+    expect(result.status).toBe(status)
+    if (status === 'failed') {
+      expect(result.error).toBe('disk full')
+    }
   })
 })

--- a/src/lib/zookeeper/clientCommands.test.ts
+++ b/src/lib/zookeeper/clientCommands.test.ts
@@ -1,0 +1,103 @@
+import { exportSave } from '@src/lib/exportSave'
+import {
+  CLIENT_COMMAND_SCHEMA_REVISION,
+  CLIENT_COMMAND_SCHEMA_UPDATE,
+  type ExecuteClientCommandDependencies,
+  executeClientCommand,
+  parseClientCommandRequest,
+} from '@src/lib/zookeeper/clientCommands'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@src/lib/exportSave', () => ({
+  exportSave: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('react-hot-toast', () => ({
+  default: {
+    error: vi.fn(),
+    loading: vi.fn(() => 'toast-id'),
+  },
+}))
+
+describe('Zookeeper client commands', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('advertises only the explicit STEP export capability', () => {
+    expect(CLIENT_COMMAND_SCHEMA_UPDATE).toEqual({
+      type: 'update_client_command_schema',
+      protocol_version: 1,
+      revision: CLIENT_COMMAND_SCHEMA_REVISION,
+      commands: [
+        expect.objectContaining({
+          id: 'modeling.export',
+          input_schema: expect.objectContaining({
+            required: ['format'],
+            additionalProperties: false,
+          }),
+        }),
+      ],
+    })
+  })
+
+  it('parses the externally tagged server request', () => {
+    expect(
+      parseClientCommandRequest({
+        client_command_request: {
+          request_id: 'request-1',
+          catalog_revision: 1,
+          command_id: 'modeling.export',
+          arguments: { format: 'step' },
+        },
+      })
+    ).toEqual({
+      request_id: 'request-1',
+      catalog_revision: 1,
+      command_id: 'modeling.export',
+      arguments: { format: 'step' },
+    })
+    expect(parseClientCommandRequest({ delta: { delta: 'hello' } })).toBe(
+      undefined
+    )
+  })
+
+  it('exports through the active client Engine and waits for the save flow', async () => {
+    const waitForProjectIdle = vi.fn().mockResolvedValue(undefined)
+    const exportFromEngine = vi.fn().mockResolvedValue([
+      {
+        name: 'engine-output.step',
+        contents: new Uint8Array([1, 2, 3]),
+      },
+    ])
+    const kclManager = {
+      ast: { body: [{}] },
+      currentFileName: 'main.kcl',
+      hasErrors: () => false,
+      rustContext: { export: exportFromEngine },
+    } as unknown as ExecuteClientCommandDependencies['kclManager']
+
+    const result = await executeClientCommand(
+      {
+        request_id: 'request-1',
+        catalog_revision: CLIENT_COMMAND_SCHEMA_REVISION,
+        command_id: 'modeling.export',
+        arguments: { format: 'step' },
+      },
+      { kclManager, defaultUnit: 'mm', waitForProjectIdle }
+    )
+
+    expect(waitForProjectIdle).toHaveBeenCalledOnce()
+    expect(exportFromEngine).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'step', units: 'mm' }),
+      { settings: { modeling: { base_unit: 'mm' } } },
+      'toast-id'
+    )
+    expect(exportSave).toHaveBeenCalledWith(
+      expect.objectContaining({ fileName: 'main.step' })
+    )
+    expect(result).toEqual(
+      expect.objectContaining({ status: 'succeeded', request_id: 'request-1' })
+    )
+  })
+})

--- a/src/lib/zookeeper/clientCommands.test.ts
+++ b/src/lib/zookeeper/clientCommands.test.ts
@@ -1,12 +1,15 @@
-import { exportSave } from '@src/lib/exportSave'
 import type { Command } from '@src/lib/commandTypes'
+import { exportSave } from '@src/lib/exportSave'
 import {
   CLIENT_COMMAND_SCHEMA_REVISION,
+  type ClientCommandResponse,
   createClientCommandSchemaUpdate,
   type ExecuteClientCommandDependencies,
   executeClientCommand,
+  getRememberedClientCommandResponse,
   isClientCommandAvailable,
   parseClientCommandRequest,
+  rememberClientCommandResponse,
 } from '@src/lib/zookeeper/clientCommands'
 import {
   DEFAULT_COMMAND_SCOPES,
@@ -117,6 +120,30 @@ describe('Zookeeper client commands', () => {
     expect(parseClientCommandRequest({ delta: { delta: 'hello' } })).toBe(
       undefined
     )
+  })
+
+  it('replays a bounded terminal response for a stable request id', () => {
+    const responses = new Map<string, ClientCommandResponse>()
+    rememberClientCommandResponse(responses, {
+      type: 'client_command_response',
+      request_id: exportRequest.request_id,
+      catalog_revision: exportRequest.catalog_revision,
+      status: 'succeeded',
+      result: { file_name: 'main.step' },
+    })
+
+    expect(
+      getRememberedClientCommandResponse(responses, {
+        ...exportRequest,
+        catalog_revision: 2,
+      })
+    ).toEqual({
+      type: 'client_command_response',
+      request_id: exportRequest.request_id,
+      catalog_revision: 2,
+      status: 'succeeded',
+      result: { file_name: 'main.step' },
+    })
   })
 
   it('exports through the active client Engine and waits for the save flow', async () => {

--- a/src/lib/zookeeper/clientCommands.ts
+++ b/src/lib/zookeeper/clientCommands.ts
@@ -1,0 +1,191 @@
+import type { Feature } from '@kittycad/lib'
+import type { UnitLength } from '@rust/kcl-lib/bindings/ModelingCmd'
+import type { KclManager } from '@src/lang/KclManager'
+import { EXPORT_TOAST_MESSAGES } from '@src/lib/constants'
+import { exportSave } from '@src/lib/exportSave'
+import { isRecord } from '@src/lib/utils'
+import toast from 'react-hot-toast'
+
+export const ZOOKEEPER_CLIENT_COMMANDS_FEATURE =
+  'zookeeper_client_commands' as Feature
+export const CLIENT_COMMAND_PROTOCOL_VERSION = 1
+export const CLIENT_COMMAND_SCHEMA_REVISION = 1
+
+type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | { [key: string]: JsonValue }
+
+/** A transient command request received from Zookeeper for this connection. */
+export interface ClientCommandRequest {
+  request_id: string
+  catalog_revision: number
+  command_id: string
+  arguments: { [key: string]: JsonValue }
+}
+
+export type ClientCommandResponseStatus =
+  | 'accepted'
+  | 'succeeded'
+  | 'rejected'
+  | 'failed'
+  | 'cancelled'
+
+export interface ClientCommandResponse {
+  type: 'client_command_response'
+  request_id: string
+  catalog_revision: number
+  status: ClientCommandResponseStatus
+  result?: JsonValue
+  error?: string
+}
+
+/** Explicit allowlist advertised to Zookeeper; command-bar config is never serialized. */
+export const CLIENT_COMMAND_SCHEMA_UPDATE = {
+  type: 'update_client_command_schema',
+  protocol_version: CLIENT_COMMAND_PROTOCOL_VERSION,
+  revision: CLIENT_COMMAND_SCHEMA_REVISION,
+  commands: [
+    {
+      id: 'modeling.export',
+      title: 'Export model',
+      description:
+        'Export the active Zoo Design Studio Engine scene as a STEP file and save it locally.',
+      input_schema: {
+        type: 'object',
+        properties: {
+          format: {
+            type: 'string',
+            enum: ['step'],
+            description:
+              'File format to export. The experimental command supports STEP.',
+          },
+        },
+        required: ['format'],
+        additionalProperties: false,
+      },
+    },
+  ],
+} as const
+
+export function parseClientCommandRequest(
+  message: unknown
+): ClientCommandRequest | undefined {
+  if (!isRecord(message) || !isRecord(message.client_command_request)) {
+    return undefined
+  }
+
+  const request = message.client_command_request
+  if (
+    typeof request.request_id !== 'string' ||
+    typeof request.catalog_revision !== 'number' ||
+    typeof request.command_id !== 'string' ||
+    !isRecord(request.arguments)
+  ) {
+    return undefined
+  }
+
+  return {
+    request_id: request.request_id,
+    catalog_revision: request.catalog_revision,
+    command_id: request.command_id,
+    arguments: request.arguments as ClientCommandRequest['arguments'],
+  }
+}
+
+function response(
+  request: ClientCommandRequest,
+  status: ClientCommandResponseStatus,
+  details?: Pick<ClientCommandResponse, 'result' | 'error'>
+): ClientCommandResponse {
+  return {
+    type: 'client_command_response',
+    request_id: request.request_id,
+    catalog_revision: request.catalog_revision,
+    status,
+    ...details,
+  }
+}
+
+export interface ExecuteClientCommandDependencies {
+  kclManager: KclManager
+  defaultUnit?: UnitLength
+  waitForProjectIdle: () => Promise<void>
+}
+
+/** Execute one allowlisted command and resolve only after its user-facing flow settles. */
+export async function executeClientCommand(
+  request: ClientCommandRequest,
+  dependencies: ExecuteClientCommandDependencies
+): Promise<ClientCommandResponse> {
+  if (request.catalog_revision !== CLIENT_COMMAND_SCHEMA_REVISION) {
+    return response(request, 'rejected', {
+      error: `The request used stale command schema revision ${request.catalog_revision}.`,
+    })
+  }
+  if (request.command_id !== 'modeling.export') {
+    return response(request, 'rejected', {
+      error: `Client command ${request.command_id} is not available.`,
+    })
+  }
+  if (request.arguments.format !== 'step') {
+    return response(request, 'rejected', {
+      error: 'modeling.export currently requires {"format":"step"}.',
+    })
+  }
+
+  await dependencies.waitForProjectIdle()
+  const { kclManager } = dependencies
+  if (kclManager.hasErrors() || kclManager.ast.body.length === 0) {
+    return response(request, 'failed', {
+      error: kclManager.hasErrors()
+        ? 'The active model has KCL errors and cannot be exported.'
+        : 'The active model is empty and cannot be exported.',
+    })
+  }
+
+  const units = dependencies.defaultUnit ?? 'mm'
+  let fileName = (kclManager.currentFileName ?? 'output.kcl').replace(
+    /\.kcl$/i,
+    '.step'
+  )
+  if (!fileName.includes('.')) {
+    fileName += '.step'
+  }
+
+  const toastId = toast.loading(EXPORT_TOAST_MESSAGES.START)
+  try {
+    const files = await kclManager.rustContext.export(
+      {
+        type: 'step',
+        units,
+        coords: {
+          forward: { axis: 'y', direction: 'negative' },
+          up: { axis: 'z', direction: 'positive' },
+        },
+      },
+      { settings: { modeling: { base_unit: units } } },
+      toastId
+    )
+    if (files === undefined) {
+      return response(request, 'failed', {
+        error: 'The client Engine did not produce an export file.',
+      })
+    }
+
+    await exportSave({ files, toastId, fileName })
+    return response(request, 'succeeded', {
+      result: {
+        format: 'step',
+        file_names: files.map((file) => file.name),
+      },
+    })
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+    toast.error(EXPORT_TOAST_MESSAGES.FAILED, { id: toastId })
+    return response(request, 'failed', { error: detail })
+  }
+}

--- a/src/lib/zookeeper/clientCommands.ts
+++ b/src/lib/zookeeper/clientCommands.ts
@@ -1,9 +1,16 @@
 import type { Feature } from '@kittycad/lib'
 import type { UnitLength } from '@rust/kcl-lib/bindings/ModelingCmd'
 import type { KclManager } from '@src/lang/KclManager'
+import type { Command } from '@src/lib/commandTypes'
 import { EXPORT_TOAST_MESSAGES } from '@src/lib/constants'
 import { exportSave } from '@src/lib/exportSave'
 import { isRecord } from '@src/lib/utils'
+import {
+  type CommandScope,
+  commandKey,
+  getEffectiveCommandScopeSet,
+  isCommandAvailable,
+} from '@src/registry/contracts/commands'
 import toast from 'react-hot-toast'
 
 export const ZOOKEEPER_CLIENT_COMMANDS_FEATURE =
@@ -43,33 +50,128 @@ export interface ClientCommandResponse {
   error?: string
 }
 
-/** Explicit allowlist advertised to Zookeeper; command-bar config is never serialized. */
-export const CLIENT_COMMAND_SCHEMA_UPDATE = {
-  type: 'update_client_command_schema',
-  protocol_version: CLIENT_COMMAND_PROTOCOL_VERSION,
-  revision: CLIENT_COMMAND_SCHEMA_REVISION,
-  commands: [
-    {
-      id: 'modeling.export',
-      title: 'Export model',
-      description:
-        'Export the active Zoo Design Studio Engine scene as a STEP file and save it locally.',
-      input_schema: {
-        type: 'object',
-        properties: {
-          format: {
-            type: 'string',
-            enum: ['step'],
-            description:
-              'File format to export. The experimental command supports STEP.',
-          },
+interface ClientCommandDefinition {
+  id: string
+  commandKey: string
+  fallbackDescription: string
+  inputSchema: {
+    type: 'object'
+    properties: Record<string, JsonValue>
+    required: string[]
+    additionalProperties: false
+  }
+}
+
+/**
+ * Explicit protocol adapters for registered commands that are safe to invoke
+ * without entering the command bar's interactive review state.
+ */
+const CLIENT_COMMAND_DEFINITIONS: readonly ClientCommandDefinition[] = [
+  {
+    id: 'modeling.export',
+    commandKey: 'modeling:Export',
+    fallbackDescription:
+      'Export the active Zoo Design Studio Engine scene as a STEP file and save it locally.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        format: {
+          type: 'string',
+          enum: ['step'],
+          description:
+            'File format to export. The experimental command supports STEP.',
         },
-        required: ['format'],
-        additionalProperties: false,
       },
+      required: ['format'],
+      additionalProperties: false,
     },
-  ],
-} as const
+  },
+]
+
+export interface ClientCommandSchemaUpdate {
+  type: 'update_client_command_schema'
+  protocol_version: number
+  revision: number
+  commands: Array<{
+    id: string
+    title: string
+    description: string
+    input_schema: ClientCommandDefinition['inputSchema']
+  }>
+}
+
+function findClientCommandDefinition(commandId: string) {
+  return CLIENT_COMMAND_DEFINITIONS.find(
+    (definition) => definition.id === commandId
+  )
+}
+
+function findRegisteredClientCommand(
+  commandId: string,
+  commands: readonly Command[]
+) {
+  const definition = findClientCommandDefinition(commandId)
+  if (!definition) return
+
+  const command = commands.find(
+    (candidate) => commandKey(candidate) === definition.commandKey
+  )
+  if (!command) return
+
+  return { command, definition }
+}
+
+/** Build the connection-local capability catalog from registered commands. */
+export function createClientCommandSchemaUpdate(
+  commands: readonly Command[],
+  revision = CLIENT_COMMAND_SCHEMA_REVISION
+): ClientCommandSchemaUpdate {
+  return {
+    type: 'update_client_command_schema',
+    protocol_version: CLIENT_COMMAND_PROTOCOL_VERSION,
+    revision,
+    commands: CLIENT_COMMAND_DEFINITIONS.flatMap((definition) => {
+      const command = commands.find(
+        (candidate) => commandKey(candidate) === definition.commandKey
+      )
+      if (!command || command.disabled) return []
+
+      return [
+        {
+          id: definition.id,
+          title: command.displayName ?? String(command.name),
+          description: command.description ?? definition.fallbackDescription,
+          input_schema: definition.inputSchema,
+        },
+      ]
+    }),
+  }
+}
+
+export function isClientCommandAvailable(
+  request: ClientCommandRequest,
+  commands: readonly Command[],
+  activeScopes: readonly string[],
+  commandScopes: readonly CommandScope[]
+) {
+  const registered = findRegisteredClientCommand(request.command_id, commands)
+  if (!registered || registered.command.disabled) return false
+
+  return isCommandAvailable(
+    registered.command,
+    getEffectiveCommandScopeSet(activeScopes, commandScopes)
+  )
+}
+
+export function getClientCommandTitle(
+  commandId: string,
+  commands: readonly Command[]
+) {
+  const registered = findRegisteredClientCommand(commandId, commands)
+  return registered
+    ? (registered.command.displayName ?? String(registered.command.name))
+    : commandId
+}
 
 export function parseClientCommandRequest(
   message: unknown
@@ -121,11 +223,6 @@ export async function executeClientCommand(
   request: ClientCommandRequest,
   dependencies: ExecuteClientCommandDependencies
 ): Promise<ClientCommandResponse> {
-  if (request.catalog_revision !== CLIENT_COMMAND_SCHEMA_REVISION) {
-    return response(request, 'rejected', {
-      error: `The request used stale command schema revision ${request.catalog_revision}.`,
-    })
-  }
   if (request.command_id !== 'modeling.export') {
     return response(request, 'rejected', {
       error: `Client command ${request.command_id} is not available.`,
@@ -176,7 +273,16 @@ export async function executeClientCommand(
       })
     }
 
-    await exportSave({ files, toastId, fileName })
+    const saveResult = await exportSave({ files, toastId, fileName })
+    if (saveResult.status === 'cancelled') {
+      return response(request, 'cancelled')
+    }
+    if (saveResult.status === 'failed') {
+      return response(request, 'failed', {
+        error: saveResult.error.message,
+      })
+    }
+
     return response(request, 'succeeded', {
       result: {
         format: 'step',

--- a/src/lib/zookeeper/clientCommands.ts
+++ b/src/lib/zookeeper/clientCommands.ts
@@ -17,6 +17,7 @@ export const ZOOKEEPER_CLIENT_COMMANDS_FEATURE =
   'zookeeper_client_commands' as Feature
 export const CLIENT_COMMAND_PROTOCOL_VERSION = 1
 export const CLIENT_COMMAND_SCHEMA_REVISION = 1
+export const MAX_COMPLETED_CLIENT_COMMAND_RESPONSES = 128
 
 type JsonValue =
   | null
@@ -48,6 +49,33 @@ export interface ClientCommandResponse {
   status: ClientCommandResponseStatus
   result?: JsonValue
   error?: string
+}
+
+/** Retain a bounded result so a stable request ID cannot execute twice after reconnect. */
+export function rememberClientCommandResponse(
+  responses: Map<string, ClientCommandResponse>,
+  response: ClientCommandResponse
+) {
+  responses.delete(response.request_id)
+  responses.set(response.request_id, response)
+  while (responses.size > MAX_COMPLETED_CLIENT_COMMAND_RESPONSES) {
+    const oldestRequestId = responses.keys().next().value
+    if (oldestRequestId === undefined) {
+      return
+    }
+    responses.delete(oldestRequestId)
+  }
+}
+
+/** Rebind a cached terminal response to the catalog revision of a retry. */
+export function getRememberedClientCommandResponse(
+  responses: ReadonlyMap<string, ClientCommandResponse>,
+  request: ClientCommandRequest
+) {
+  const response = responses.get(request.request_id)
+  return response === undefined
+    ? undefined
+    : { ...response, catalog_revision: request.catalog_revision }
 }
 
 interface ClientCommandDefinition {

--- a/src/lib/zookeeper/components/ZookeeperConversation.spec.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversation.spec.tsx
@@ -379,6 +379,70 @@ describe('ZookeeperConversation', () => {
     ).toHaveClass('text-chalkboard-100', 'dark:text-chalkboard-10')
   })
 
+  test('shows FIFO client-command state and allows cancelling non-active items', () => {
+    const onCancelClientCommand = vi.fn()
+    render(
+      <ZookeeperConversation
+        isLoading={false}
+        conversation={{ exchanges: [] }}
+        onProcess={() => {}}
+        onClickClearChat={() => {}}
+        onReconnect={() => {}}
+        onCancel={() => {}}
+        needsReconnect={false}
+        contexts={[]}
+        hasPromptCompleted={true}
+        isProcessing={false}
+        queue={[]}
+        clientCommandQueue={[
+          {
+            requestId: 'request-1',
+            commandId: 'modeling.export',
+            title: 'Export',
+            status: 'waiting',
+          },
+          {
+            requestId: 'request-2',
+            commandId: 'modeling.export',
+            title: 'Export',
+            status: 'queued',
+          },
+          {
+            requestId: 'request-3',
+            commandId: 'modeling.export',
+            title: 'Export',
+            status: 'executing',
+          },
+        ]}
+        onCancelClientCommand={onCancelClientCommand}
+        onRemoveFromQueue={() => {}}
+        onSteer={() => {}}
+      />
+    )
+
+    expect(
+      screen.getByText(/Waiting for command.*to become available/)
+    ).toHaveTextContent(
+      'Waiting for command modeling.export to become available...'
+    )
+    expect(screen.getByText(/Queued command/)).toHaveTextContent(
+      'Queued command modeling.export.'
+    )
+    expect(screen.getByText(/Running command/)).toHaveTextContent(
+      'Running command modeling.export...'
+    )
+    expect(
+      screen.getAllByRole('button', { name: 'Cancel queued command Export' })
+    ).toHaveLength(2)
+
+    fireEvent.click(
+      screen.getAllByRole('button', {
+        name: 'Cancel queued command Export',
+      })[1]
+    )
+    expect(onCancelClientCommand).toHaveBeenCalledWith('request-2')
+  })
+
   function rendersRequestBubbleThenDisplayResponse(
     mode: MlCopilotModeId = 'deep'
   ) {

--- a/src/lib/zookeeper/components/ZookeeperConversation.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversation.tsx
@@ -41,6 +41,14 @@ export interface QueuedMessage {
   attachments: File[]
 }
 
+/** A transient client command shown while Zookeeper waits for ZDS to run it. */
+export interface ClientCommandQueueItem {
+  requestId: string
+  commandId: string
+  title: string
+  status: 'queued' | 'waiting' | 'executing'
+}
+
 export interface ZookeeperConversationProps {
   isLoading: boolean
   conversation?: Conversation
@@ -79,6 +87,8 @@ export interface ZookeeperConversationProps {
   isProcessing: boolean
   isLoadingAttachments?: boolean
   queue: QueuedMessage[]
+  clientCommandQueue?: readonly ClientCommandQueueItem[]
+  onCancelClientCommand?: (requestId: string) => void
   onRemoveFromQueue: (id: string) => void
   onSteer: (id: string) => void
   modeOptions?: MlCopilotModeOption[]
@@ -827,6 +837,51 @@ export const ZookeeperConversation = (props: ZookeeperConversationProps) => {
                   >
                     <CustomIcon name="close" className="w-4 h-4" />
                   </button>
+                </div>
+              ))}
+            </div>
+          )}
+          {(props.clientCommandQueue?.length ?? 0) > 0 && (
+            <div
+              className="border-t b-4 px-4 py-2 flex flex-col gap-1"
+              aria-label="Zookeeper client command queue"
+            >
+              <span className="text-xs text-3">Zookeeper commands</span>
+              {props.clientCommandQueue?.map((command, index) => (
+                <div
+                  key={command.requestId}
+                  className="flex items-center gap-2 rounded bg-chalkboard-10 dark:bg-chalkboard-90 border border-chalkboard-20 dark:border-chalkboard-80 px-2 py-1 text-xs"
+                  role="status"
+                >
+                  <span className="text-3 shrink-0">{index + 1}.</span>
+                  <span className="min-w-0 flex-1">
+                    {command.status === 'executing' ? (
+                      <>Running command </>
+                    ) : command.status === 'waiting' ? (
+                      <>Waiting for command </>
+                    ) : (
+                      <>Queued command </>
+                    )}
+                    <code>{command.commandId}</code>
+                    {command.status === 'waiting'
+                      ? ' to become available...'
+                      : command.status === 'executing'
+                        ? '...'
+                        : '.'}
+                  </span>
+                  {command.status !== 'executing' &&
+                  props.onCancelClientCommand ? (
+                    <button
+                      type="button"
+                      onClick={() =>
+                        props.onCancelClientCommand?.(command.requestId)
+                      }
+                      className="shrink-0 text-3 hover:text-chalkboard-100 dark:hover:text-chalkboard-20 px-1 py-0.5 m-0 border-none bg-transparent"
+                      aria-label={`Cancel queued command ${command.title}`}
+                    >
+                      Cancel
+                    </button>
+                  ) : null}
                 </div>
               ))}
             </div>

--- a/src/lib/zookeeper/components/ZookeeperConversationPane.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPane.tsx
@@ -1,6 +1,7 @@
 import {
-  ZookeeperConversation,
+  type ClientCommandQueueItem,
   type QueuedMessage,
+  ZookeeperConversation,
 } from '@src/lib/zookeeper/components/ZookeeperConversation'
 import { ZookeeperConversationWelcome } from '@src/lib/zookeeper/components/ZookeeperConversationWelcome'
 import { useOnWindowOnlineOffline } from '@src/hooks/network/useOnWindowOnlineOffline'
@@ -54,6 +55,8 @@ export const ZookeeperConversationPane = (props: {
   loaderFile: FileEntry | undefined
   settings: SettingsType
   user?: ZookeeperConversationPaneUser
+  clientCommandQueue?: readonly ClientCommandQueueItem[]
+  onCancelClientCommand?: (requestId: string) => void
   showMakeathonAnnouncement?: boolean
   onMlCopilotModeChange?: (mode: MlCopilotModeId | undefined) => void
 }) => {
@@ -797,6 +800,8 @@ export const ZookeeperConversationPane = (props: {
       hasPromptCompleted={!isPromptRunning && !interruptedTurnAwaitingResume}
       isProcessing={isPromptRunning}
       queue={queue}
+      clientCommandQueue={props.clientCommandQueue}
+      onCancelClientCommand={props.onCancelClientCommand}
       onRemoveFromQueue={onRemoveFromQueue}
       onSteer={onSteer}
       userAvatarSrc={props.user?.image}

--- a/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.spec.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.spec.tsx
@@ -8,6 +8,13 @@ const mocks = vi.hoisted(() => {
   const systemIOSend = vi.fn()
   const useWatchForNewFileRequestsFromZookeeper = vi.fn()
   const zookeeperSubscribe = vi.fn(() => ({ unsubscribe: vi.fn() }))
+  const zookeeperSnapshot = {
+    context: {
+      clientCommandsEnabled: false,
+      clientCommandQueue: [],
+      activeClientCommandRequestId: undefined,
+    },
+  }
   const kclManager = {
     captureEditorHistoryState: vi.fn(() => ({
       doc: { toString: () => 'initial code' },
@@ -23,6 +30,7 @@ const mocks = vi.hoisted(() => {
 
   return {
     kclManager,
+    zookeeperSnapshot,
     zookeeperSubscribe,
     systemIOSend,
     useWatchForNewFileRequestsFromZookeeper,
@@ -80,6 +88,10 @@ vi.mock('@src/lib/boot', () => ({
       executingPath: '/workspace/demo/main.kcl',
       executingFileEntry: { value: { name: 'main.kcl' } },
     },
+    registry: {
+      signal: () => ({ value: [] }),
+      optional: () => undefined,
+    },
     settings: {
       actor: { send: vi.fn() },
       useSettings: () => ({ meta: { id: { current: 'project-id' } } }),
@@ -113,13 +125,13 @@ vi.mock('@src/lib/zookeeper/zookeeperManagerMachine', () => ({
   ZookeeperConversationToMarkdown: vi.fn(() => ''),
   ZookeeperManagerTransitions: {
     AuthTokenChanged: 'auth-token-changed',
+    ClientCommandFinished: 'client-command-finished',
+    ClientCommandStarted: 'client-command-started',
   },
   ZookeeperManagerReactContext: {
     Provider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
     useActorRef: () => ({
-      getSnapshot: () => ({
-        context: {},
-      }),
+      getSnapshot: () => mocks.zookeeperSnapshot,
       send: vi.fn(),
       subscribe: mocks.zookeeperSubscribe,
     }),

--- a/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.spec.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.spec.tsx
@@ -1,5 +1,5 @@
-import { ZookeeperConversationPaneWrapper } from '@src/lib/zookeeper/components/ZookeeperConversationPaneWrapper'
 import { AreaType, LayoutType } from '@src/lib/layout/types'
+import { ZookeeperConversationPaneWrapper } from '@src/lib/zookeeper/components/ZookeeperConversationPaneWrapper'
 import type * as SystemIOUtils from '@src/machines/systemIO/utils'
 import { render, waitFor } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
@@ -56,7 +56,11 @@ vi.mock('@src/lib/zookeeper/components/ZookeeperConversationPane', () => ({
 
 vi.mock('@src/hooks/useModelingContext', () => ({
   useModelingContext: () => ({
-    context: {},
+    context: {
+      store: {
+        defaultUnit: { current: 'mm' },
+      },
+    },
     send: vi.fn(),
     theProject: { current: undefined },
   }),
@@ -82,6 +86,9 @@ vi.mock('@src/lib/boot', () => ({
     },
     systemIOActor: {
       send: mocks.systemIOSend,
+    },
+    userFeatures: {
+      useHas: () => false,
     },
   }),
   useSingletons: () => ({

--- a/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.tsx
@@ -9,13 +9,17 @@ import { BillingTransition } from '@src/lib/billing'
 import { useApp, useSingletons } from '@src/lib/boot'
 import { browserSaveFile } from '@src/lib/browserSaveFile'
 import { isCodeTheSame } from '@src/lib/codeEditor'
+import type { Command } from '@src/lib/commandTypes'
 import { isPathNotFoundError } from '@src/lib/desktop'
 import fsZds from '@src/lib/fs-zds'
 import type { AreaTypeComponentProps } from '@src/lib/layout'
 import {
   type ClientCommandResponse,
+  createClientCommandSchemaUpdate,
   type ExecuteClientCommandDependencies,
   executeClientCommand,
+  getClientCommandTitle,
+  isClientCommandAvailable,
   ZOOKEEPER_CLIENT_COMMANDS_FEATURE,
 } from '@src/lib/zookeeper/clientCommands'
 import { ZookeeperConversationPane } from '@src/lib/zookeeper/components/ZookeeperConversationPane'
@@ -48,7 +52,14 @@ import {
   SystemIOMachineEvents,
   waitForIdleState,
 } from '@src/machines/systemIO/utils'
+import {
+  type CommandScope,
+  commandScopeService,
+  commandScopesValueSpec,
+  commandsValueSpec,
+} from '@src/registry/contracts/commands'
 import { IS_STAGING_OR_DEBUG } from '@src/routes/utils'
+import { useSelector } from '@xstate/react'
 import { applyPatch, parsePatch, reversePatch } from 'diff'
 import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 
@@ -99,11 +110,15 @@ function getZookeeperChangedFilePreviousCode(
 export function ZookeeperConversationPaneWrapper(
   props: AreaTypeComponentProps
 ) {
-  const { auth, userFeatures } = useApp()
+  useSignals()
+  const { auth, registry, userFeatures } = useApp()
   const token = auth.useToken()
   const clientCommandsEnabled = userFeatures.useHas(
     ZOOKEEPER_CLIENT_COMMANDS_FEATURE,
     false
+  )
+  const clientCommandSchemaUpdate = createClientCommandSchemaUpdate(
+    registry.signal(commandsValueSpec).value
   )
 
   return (
@@ -113,6 +128,7 @@ export function ZookeeperConversationPaneWrapper(
         input: {
           apiToken: token,
           clientCommandsEnabled,
+          clientCommandSchemaUpdate,
         },
       }}
     >
@@ -127,31 +143,38 @@ function useHandleZookeeperClientCommandRequests({
   kclManager,
   defaultUnit,
   systemIOActor,
+  commands,
+  activeScopes,
+  commandScopes,
 }: {
   enabled: boolean
   zookeeperManagerActor: ZookeeperManagerActor
   kclManager: KclManager
   defaultUnit: ExecuteClientCommandDependencies['defaultUnit']
   systemIOActor: SystemIOActor
+  commands: readonly Command[]
+  activeScopes: readonly string[]
+  commandScopes: readonly CommandScope[]
 }) {
-  const handledRequestIds = useRef(new Set<string>())
+  const acknowledgedRequestIds = useRef(new Set<string>())
+  const processingRequestId = useRef<string | undefined>(undefined)
+  const pumpQueue = useRef<() => void>(() => undefined)
+  const runtimeState = useRef({ commands, activeScopes, commandScopes })
+  runtimeState.current = { commands, activeScopes, commandScopes }
 
   useEffect(() => {
     let disposed = false
+    let currentWebSocket: WebSocket | undefined
 
     const handleSnapshot = (
       snapshot: ReturnType<typeof zookeeperManagerActor.getSnapshot>
     ) => {
-      const request = snapshot.context.pendingClientCommandRequest
-      if (
-        request === undefined ||
-        handledRequestIds.current.has(request.request_id)
-      ) {
-        return
-      }
-      handledRequestIds.current.add(request.request_id)
-
       const ws = snapshot.context.ws
+      if (ws !== currentWebSocket) {
+        currentWebSocket = ws
+        acknowledgedRequestIds.current.clear()
+      }
+
       const sendResponse = (response: ClientCommandResponse) => {
         if (
           disposed ||
@@ -164,26 +187,67 @@ function useHandleZookeeperClientCommandRequests({
         ws.send(JSON.stringify(response))
       }
 
-      if (!enabled) {
+      if (ws === undefined || ws.readyState !== WebSocket.OPEN) {
+        return
+      }
+
+      const schema = snapshot.context.clientCommandSchemaUpdate
+      for (const request of snapshot.context.clientCommandQueue) {
+        if (acknowledgedRequestIds.current.has(request.request_id)) continue
+
+        acknowledgedRequestIds.current.add(request.request_id)
+        const rejection = !enabled
+          ? 'Experimental Zookeeper client commands are disabled.'
+          : request.catalog_revision !== schema?.revision
+            ? `The request used stale command schema revision ${request.catalog_revision}.`
+            : !schema.commands.some(
+                  (command) => command.id === request.command_id
+                )
+              ? `Client command ${request.command_id} is not available.`
+              : undefined
+
+        if (rejection) {
+          sendResponse({
+            type: 'client_command_response',
+            request_id: request.request_id,
+            catalog_revision: request.catalog_revision,
+            status: 'rejected',
+            error: rejection,
+          })
+          zookeeperManagerActor.send({
+            type: ZookeeperManagerTransitions.ClientCommandFinished,
+            requestId: request.request_id,
+          })
+          return
+        }
+
         sendResponse({
           type: 'client_command_response',
           request_id: request.request_id,
           catalog_revision: request.catalog_revision,
-          status: 'rejected',
-          error: 'Experimental Zookeeper client commands are disabled.',
+          status: 'accepted',
         })
-        zookeeperManagerActor.send({
-          type: ZookeeperManagerTransitions.ClientCommandFinished,
-          requestId: request.request_id,
-        })
+      }
+
+      const request = snapshot.context.clientCommandQueue[0]
+      if (
+        request === undefined ||
+        processingRequestId.current !== undefined ||
+        snapshot.context.activeClientCommandRequestId !== undefined ||
+        !isClientCommandAvailable(
+          request,
+          runtimeState.current.commands,
+          runtimeState.current.activeScopes,
+          runtimeState.current.commandScopes
+        )
+      ) {
         return
       }
 
-      sendResponse({
-        type: 'client_command_response',
-        request_id: request.request_id,
-        catalog_revision: request.catalog_revision,
-        status: 'accepted',
+      processingRequestId.current = request.request_id
+      zookeeperManagerActor.send({
+        type: ZookeeperManagerTransitions.ClientCommandStarted,
+        requestId: request.request_id,
       })
 
       void executeClientCommand(request, {
@@ -204,6 +268,7 @@ function useHandleZookeeperClientCommandRequests({
           })
         })
         .finally(() => {
+          processingRequestId.current = undefined
           zookeeperManagerActor.send({
             type: ZookeeperManagerTransitions.ClientCommandFinished,
             requestId: request.request_id,
@@ -211,13 +276,51 @@ function useHandleZookeeperClientCommandRequests({
         })
     }
 
+    pumpQueue.current = () =>
+      handleSnapshot(zookeeperManagerActor.getSnapshot())
     handleSnapshot(zookeeperManagerActor.getSnapshot())
     const subscription = zookeeperManagerActor.subscribe(handleSnapshot)
     return () => {
       disposed = true
+      pumpQueue.current = () => undefined
       subscription.unsubscribe()
     }
   }, [defaultUnit, enabled, kclManager, systemIOActor, zookeeperManagerActor])
+
+  useEffect(() => {
+    pumpQueue.current()
+  }, [activeScopes, commands, commandScopes])
+
+  const cancelQueuedRequest = useCallback(
+    (requestId: string) => {
+      const snapshot = zookeeperManagerActor.getSnapshot()
+      if (snapshot.context.activeClientCommandRequestId === requestId) return
+
+      const request = snapshot.context.clientCommandQueue.find(
+        (candidate) => candidate.request_id === requestId
+      )
+      const ws = snapshot.context.ws
+      if (!request || ws === undefined || ws.readyState !== WebSocket.OPEN) {
+        return
+      }
+
+      ws.send(
+        JSON.stringify({
+          type: 'client_command_response',
+          request_id: request.request_id,
+          catalog_revision: request.catalog_revision,
+          status: 'cancelled',
+        } satisfies ClientCommandResponse)
+      )
+      zookeeperManagerActor.send({
+        type: ZookeeperManagerTransitions.ClientCommandFinished,
+        requestId,
+      })
+    },
+    [zookeeperManagerActor]
+  )
+
+  return { cancelQueuedRequest }
 }
 
 function ZookeeperConversationPaneInner(props: AreaTypeComponentProps) {
@@ -235,14 +338,46 @@ function ZookeeperConversationPaneInner(props: AreaTypeComponentProps) {
   } = useModelingContext()
   const loaderFile = project?.executingFileEntry.value
   const zookeeperManagerActor = ZookeeperManagerReactContext.useActorRef()
+  const commands = app.registry.signal(commandsValueSpec).value
+  const commandScopes = app.registry.signal(commandScopesValueSpec).value
+  const activeScopes =
+    app.registry.optional(commandScopeService)?.activeScopes.value ?? []
+  const clientCommandQueue = useSelector(
+    zookeeperManagerActor,
+    (snapshot) => snapshot.context.clientCommandQueue
+  )
+  const activeClientCommandRequestId = useSelector(
+    zookeeperManagerActor,
+    (snapshot) => snapshot.context.activeClientCommandRequestId
+  )
 
-  useHandleZookeeperClientCommandRequests({
+  const { cancelQueuedRequest } = useHandleZookeeperClientCommandRequests({
     enabled: zookeeperManagerActor.getSnapshot().context.clientCommandsEnabled,
     zookeeperManagerActor,
     kclManager,
     defaultUnit: contextModeling.store.defaultUnit?.current,
     systemIOActor,
+    commands,
+    activeScopes,
+    commandScopes,
   })
+  const clientCommandQueueItems = clientCommandQueue.map((request, index) => ({
+    requestId: request.request_id,
+    commandId: request.command_id,
+    title: getClientCommandTitle(request.command_id, commands),
+    status:
+      activeClientCommandRequestId === request.request_id
+        ? ('executing' as const)
+        : index === 0 &&
+            !isClientCommandAvailable(
+              request,
+              commands,
+              activeScopes,
+              commandScopes
+            )
+          ? ('waiting' as const)
+          : ('queued' as const),
+  }))
 
   useEffect(() => {
     zookeeperManagerActor.send({
@@ -560,6 +695,8 @@ function ZookeeperConversationPaneInner(props: AreaTypeComponentProps) {
           loaderFile,
           settings: settingsValues,
           user,
+          clientCommandQueue: clientCommandQueueItems,
+          onCancelClientCommand: cancelQueuedRequest,
           showMakeathonAnnouncement,
           onMlCopilotModeChange: (mode) => {
             settings.actor.send({

--- a/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.tsx
@@ -12,6 +12,12 @@ import { isCodeTheSame } from '@src/lib/codeEditor'
 import { isPathNotFoundError } from '@src/lib/desktop'
 import fsZds from '@src/lib/fs-zds'
 import type { AreaTypeComponentProps } from '@src/lib/layout'
+import {
+  type ClientCommandResponse,
+  type ExecuteClientCommandDependencies,
+  executeClientCommand,
+  ZOOKEEPER_CLIENT_COMMANDS_FEATURE,
+} from '@src/lib/zookeeper/clientCommands'
 import { ZookeeperConversationPane } from '@src/lib/zookeeper/components/ZookeeperConversationPane'
 import {
   useProjectIdToConversationId,
@@ -38,6 +44,7 @@ import { zookeeperPromptRunningSignal } from '@src/lib/zookeeper/zookeeperPrompt
 import {
   normalizeKCLFileDeletePath,
   prepareZookeeperNewFileRequest,
+  type SystemIOActor,
   SystemIOMachineEvents,
   waitForIdleState,
 } from '@src/machines/systemIO/utils'
@@ -92,20 +99,125 @@ function getZookeeperChangedFilePreviousCode(
 export function ZookeeperConversationPaneWrapper(
   props: AreaTypeComponentProps
 ) {
-  const { auth } = useApp()
+  const { auth, userFeatures } = useApp()
   const token = auth.useToken()
+  const clientCommandsEnabled = userFeatures.useHas(
+    ZOOKEEPER_CLIENT_COMMANDS_FEATURE,
+    false
+  )
 
   return (
     <ZookeeperManagerReactContext.Provider
+      key={clientCommandsEnabled ? 'client-commands' : 'standard'}
       options={{
         input: {
           apiToken: token,
+          clientCommandsEnabled,
         },
       }}
     >
       <ZookeeperConversationPaneInner {...props} />
     </ZookeeperManagerReactContext.Provider>
   )
+}
+
+function useHandleZookeeperClientCommandRequests({
+  enabled,
+  zookeeperManagerActor,
+  kclManager,
+  defaultUnit,
+  systemIOActor,
+}: {
+  enabled: boolean
+  zookeeperManagerActor: ZookeeperManagerActor
+  kclManager: KclManager
+  defaultUnit: ExecuteClientCommandDependencies['defaultUnit']
+  systemIOActor: SystemIOActor
+}) {
+  const handledRequestIds = useRef(new Set<string>())
+
+  useEffect(() => {
+    let disposed = false
+
+    const handleSnapshot = (
+      snapshot: ReturnType<typeof zookeeperManagerActor.getSnapshot>
+    ) => {
+      const request = snapshot.context.pendingClientCommandRequest
+      if (
+        request === undefined ||
+        handledRequestIds.current.has(request.request_id)
+      ) {
+        return
+      }
+      handledRequestIds.current.add(request.request_id)
+
+      const ws = snapshot.context.ws
+      const sendResponse = (response: ClientCommandResponse) => {
+        if (
+          disposed ||
+          ws === undefined ||
+          ws.readyState !== WebSocket.OPEN ||
+          zookeeperManagerActor.getSnapshot().context.ws !== ws
+        ) {
+          return
+        }
+        ws.send(JSON.stringify(response))
+      }
+
+      if (!enabled) {
+        sendResponse({
+          type: 'client_command_response',
+          request_id: request.request_id,
+          catalog_revision: request.catalog_revision,
+          status: 'rejected',
+          error: 'Experimental Zookeeper client commands are disabled.',
+        })
+        zookeeperManagerActor.send({
+          type: ZookeeperManagerTransitions.ClientCommandFinished,
+          requestId: request.request_id,
+        })
+        return
+      }
+
+      sendResponse({
+        type: 'client_command_response',
+        request_id: request.request_id,
+        catalog_revision: request.catalog_revision,
+        status: 'accepted',
+      })
+
+      void executeClientCommand(request, {
+        kclManager,
+        defaultUnit,
+        waitForProjectIdle: async () => {
+          await waitForIdleState({ systemIOActor })
+        },
+      })
+        .then(sendResponse)
+        .catch((error: unknown) => {
+          sendResponse({
+            type: 'client_command_response',
+            request_id: request.request_id,
+            catalog_revision: request.catalog_revision,
+            status: 'failed',
+            error: error instanceof Error ? error.message : String(error),
+          })
+        })
+        .finally(() => {
+          zookeeperManagerActor.send({
+            type: ZookeeperManagerTransitions.ClientCommandFinished,
+            requestId: request.request_id,
+          })
+        })
+    }
+
+    handleSnapshot(zookeeperManagerActor.getSnapshot())
+    const subscription = zookeeperManagerActor.subscribe(handleSnapshot)
+    return () => {
+      disposed = true
+      subscription.unsubscribe()
+    }
+  }, [defaultUnit, enabled, kclManager, systemIOActor, zookeeperManagerActor])
 }
 
 function ZookeeperConversationPaneInner(props: AreaTypeComponentProps) {
@@ -123,6 +235,14 @@ function ZookeeperConversationPaneInner(props: AreaTypeComponentProps) {
   } = useModelingContext()
   const loaderFile = project?.executingFileEntry.value
   const zookeeperManagerActor = ZookeeperManagerReactContext.useActorRef()
+
+  useHandleZookeeperClientCommandRequests({
+    enabled: zookeeperManagerActor.getSnapshot().context.clientCommandsEnabled,
+    zookeeperManagerActor,
+    kclManager,
+    defaultUnit: contextModeling.store.defaultUnit?.current,
+    systemIOActor,
+  })
 
   useEffect(() => {
     zookeeperManagerActor.send({

--- a/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.tsx
@@ -19,7 +19,9 @@ import {
   type ExecuteClientCommandDependencies,
   executeClientCommand,
   getClientCommandTitle,
+  getRememberedClientCommandResponse,
   isClientCommandAvailable,
+  rememberClientCommandResponse,
   ZOOKEEPER_CLIENT_COMMANDS_FEATURE,
 } from '@src/lib/zookeeper/clientCommands'
 import { ZookeeperConversationPane } from '@src/lib/zookeeper/components/ZookeeperConversationPane'
@@ -157,6 +159,7 @@ function useHandleZookeeperClientCommandRequests({
   commandScopes: readonly CommandScope[]
 }) {
   const acknowledgedRequestIds = useRef(new Set<string>())
+  const completedResponses = useRef(new Map<string, ClientCommandResponse>())
   const processingRequestId = useRef<string | undefined>(undefined)
   const pumpQueue = useRef<() => void>(() => undefined)
   const runtimeState = useRef({ commands, activeScopes, commandScopes })
@@ -193,6 +196,18 @@ function useHandleZookeeperClientCommandRequests({
 
       const schema = snapshot.context.clientCommandSchemaUpdate
       for (const request of snapshot.context.clientCommandQueue) {
+        const rememberedResponse = getRememberedClientCommandResponse(
+          completedResponses.current,
+          request
+        )
+        if (rememberedResponse !== undefined) {
+          sendResponse(rememberedResponse)
+          zookeeperManagerActor.send({
+            type: ZookeeperManagerTransitions.ClientCommandFinished,
+            requestId: request.request_id,
+          })
+          return
+        }
         if (acknowledgedRequestIds.current.has(request.request_id)) continue
 
         acknowledgedRequestIds.current.add(request.request_id)
@@ -207,13 +222,15 @@ function useHandleZookeeperClientCommandRequests({
               : undefined
 
         if (rejection) {
-          sendResponse({
+          const response = {
             type: 'client_command_response',
             request_id: request.request_id,
             catalog_revision: request.catalog_revision,
             status: 'rejected',
             error: rejection,
-          })
+          } satisfies ClientCommandResponse
+          rememberClientCommandResponse(completedResponses.current, response)
+          sendResponse(response)
           zookeeperManagerActor.send({
             type: ZookeeperManagerTransitions.ClientCommandFinished,
             requestId: request.request_id,
@@ -257,22 +274,36 @@ function useHandleZookeeperClientCommandRequests({
           await waitForIdleState({ systemIOActor })
         },
       })
-        .then(sendResponse)
+        .then((response) => {
+          rememberClientCommandResponse(completedResponses.current, response)
+          sendResponse(response)
+        })
         .catch((error: unknown) => {
-          sendResponse({
+          const response = {
             type: 'client_command_response',
             request_id: request.request_id,
             catalog_revision: request.catalog_revision,
             status: 'failed',
             error: error instanceof Error ? error.message : String(error),
-          })
+          } satisfies ClientCommandResponse
+          rememberClientCommandResponse(completedResponses.current, response)
+          sendResponse(response)
         })
         .finally(() => {
           processingRequestId.current = undefined
-          zookeeperManagerActor.send({
-            type: ZookeeperManagerTransitions.ClientCommandFinished,
-            requestId: request.request_id,
-          })
+          if (
+            zookeeperManagerActor.getSnapshot().context
+              .activeClientCommandRequestId === request.request_id
+          ) {
+            zookeeperManagerActor.send({
+              type: ZookeeperManagerTransitions.ClientCommandFinished,
+              requestId: request.request_id,
+            })
+          } else {
+            // A reconnect may have queued the same stable request ID while the
+            // original execution was settling. Pump it through the cache.
+            pumpQueue.current()
+          }
         })
     }
 
@@ -304,14 +335,14 @@ function useHandleZookeeperClientCommandRequests({
         return
       }
 
-      ws.send(
-        JSON.stringify({
-          type: 'client_command_response',
-          request_id: request.request_id,
-          catalog_revision: request.catalog_revision,
-          status: 'cancelled',
-        } satisfies ClientCommandResponse)
-      )
+      const response = {
+        type: 'client_command_response',
+        request_id: request.request_id,
+        catalog_revision: request.catalog_revision,
+        status: 'cancelled',
+      } satisfies ClientCommandResponse
+      rememberClientCommandResponse(completedResponses.current, response)
+      ws.send(JSON.stringify(response))
       zookeeperManagerActor.send({
         type: ZookeeperManagerTransitions.ClientCommandFinished,
         requestId,

--- a/src/lib/zookeeper/zookeeperManagerMachine.test.ts
+++ b/src/lib/zookeeper/zookeeperManagerMachine.test.ts
@@ -5,6 +5,7 @@ import type {
 } from '@kittycad/lib'
 import { resetReportedClientErrorsForTests } from '@src/lib/clientErrors'
 import type { FileMeta } from '@src/lib/types'
+import { CLIENT_COMMAND_SCHEMA_UPDATE } from '@src/lib/zookeeper/clientCommands'
 import {
   type Conversation,
   createZookeeperCorrelation,
@@ -16,6 +17,7 @@ import {
   toMlCopilotFile,
   ZOOKEEPER_HEARTBEAT_INTERVAL_MS,
   ZOOKEEPER_HEARTBEAT_TIMEOUT_MS,
+  ZOOKEEPER_RESUME_SUPERSEDED_CLOSE_CODE,
   ZOOKEEPER_SETUP_ATTEMPT_TIMEOUT_MS,
   ZOOKEEPER_SETUP_INACTIVITY_TIMEOUT_MS,
   ZookeeperConversationToMarkdown,
@@ -25,7 +27,6 @@ import {
   ZookeeperManagerTransitions,
   ZookeeperSetupErrors,
   zookeeperManagerMachine,
-  ZOOKEEPER_RESUME_SUPERSEDED_CLOSE_CODE,
 } from '@src/lib/zookeeper/zookeeperManagerMachine'
 import { S } from '@src/machines/utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -400,6 +401,51 @@ describe('zookeeperManagerMachine', () => {
             type: 'headers',
             headers: { Authorization: 'Bearer hydrated-token' },
           })
+        )
+      })
+
+      actor.stop()
+    })
+
+    it('advertises and routes ephemeral client commands when enabled', async () => {
+      vi.stubGlobal('WebSocket', ControllableSetupWebSocket)
+      const actor = createActor(zookeeperManagerMachine, {
+        input: {
+          apiToken: 'token',
+          clientCommandsEnabled: true,
+        },
+      }).start()
+
+      actor.send({
+        type: ZookeeperManagerTransitions.CacheSetupAndConnect,
+        refParentSend: vi.fn(),
+      })
+
+      const socket = ControllableSetupWebSocket.instances[0]
+      socket.open()
+      await vi.waitFor(() => {
+        expect(socket.sentPayloads).toContain(
+          JSON.stringify(CLIENT_COMMAND_SCHEMA_UPDATE)
+        )
+      })
+
+      socket.receive({
+        client_command_request: {
+          request_id: 'request-1',
+          catalog_revision: 1,
+          command_id: 'modeling.export',
+          arguments: { format: 'step' },
+        },
+      })
+
+      await vi.waitFor(() => {
+        expect(actor.getSnapshot().context.pendingClientCommandRequest).toEqual(
+          {
+            request_id: 'request-1',
+            catalog_revision: 1,
+            command_id: 'modeling.export',
+            arguments: { format: 'step' },
+          }
         )
       })
 

--- a/src/lib/zookeeper/zookeeperManagerMachine.test.ts
+++ b/src/lib/zookeeper/zookeeperManagerMachine.test.ts
@@ -5,7 +5,7 @@ import type {
 } from '@kittycad/lib'
 import { resetReportedClientErrorsForTests } from '@src/lib/clientErrors'
 import type { FileMeta } from '@src/lib/types'
-import { CLIENT_COMMAND_SCHEMA_UPDATE } from '@src/lib/zookeeper/clientCommands'
+import type { ClientCommandSchemaUpdate } from '@src/lib/zookeeper/clientCommands'
 import {
   type Conversation,
   createZookeeperCorrelation,
@@ -31,6 +31,25 @@ import {
 import { S } from '@src/machines/utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createActor, fromPromise, waitFor } from 'xstate'
+
+const CLIENT_COMMAND_SCHEMA_UPDATE: ClientCommandSchemaUpdate = {
+  type: 'update_client_command_schema',
+  protocol_version: 1,
+  revision: 1,
+  commands: [
+    {
+      id: 'modeling.export',
+      title: 'Export',
+      description: 'Export the active part.',
+      input_schema: {
+        type: 'object',
+        properties: {},
+        required: ['format'],
+        additionalProperties: false,
+      },
+    },
+  ],
+}
 
 function stubClientErrorFetch() {
   resetReportedClientErrorsForTests()
@@ -413,6 +432,7 @@ describe('zookeeperManagerMachine', () => {
         input: {
           apiToken: 'token',
           clientCommandsEnabled: true,
+          clientCommandSchemaUpdate: CLIENT_COMMAND_SCHEMA_UPDATE,
         },
       }).start()
 
@@ -439,15 +459,82 @@ describe('zookeeperManagerMachine', () => {
       })
 
       await vi.waitFor(() => {
-        expect(actor.getSnapshot().context.pendingClientCommandRequest).toEqual(
+        expect(actor.getSnapshot().context.clientCommandQueue).toEqual([
           {
             request_id: 'request-1',
             catalog_revision: 1,
             command_id: 'modeling.export',
             arguments: { format: 'step' },
-          }
-        )
+          },
+        ])
       })
+
+      actor.stop()
+    })
+
+    it('keeps client commands in FIFO order and only starts the head', () => {
+      const actor = createActor(zookeeperManagerMachine, {
+        input: { apiToken: 'token' },
+      }).start()
+      const request = (requestId: string) => ({
+        request_id: requestId,
+        catalog_revision: 1,
+        command_id: 'modeling.export',
+        arguments: { format: 'step' },
+      })
+
+      for (const requestId of ['request-1', 'request-2', 'request-3']) {
+        actor.send({
+          type: ZookeeperManagerTransitions.ClientCommandRequested,
+          request: request(requestId),
+        })
+      }
+      actor.send({
+        type: ZookeeperManagerTransitions.ClientCommandStarted,
+        requestId: 'request-2',
+      })
+
+      expect(
+        actor
+          .getSnapshot()
+          .context.clientCommandQueue.map((item) => item.request_id)
+      ).toEqual(['request-1', 'request-2', 'request-3'])
+      expect(
+        actor.getSnapshot().context.activeClientCommandRequestId
+      ).toBeUndefined()
+
+      actor.send({
+        type: ZookeeperManagerTransitions.ClientCommandStarted,
+        requestId: 'request-1',
+      })
+      actor.send({
+        type: ZookeeperManagerTransitions.ClientCommandFinished,
+        requestId: 'request-1',
+      })
+      actor.send({
+        type: ZookeeperManagerTransitions.ClientCommandStarted,
+        requestId: 'request-2',
+      })
+
+      expect(actor.getSnapshot().context.activeClientCommandRequestId).toBe(
+        'request-2'
+      )
+      expect(
+        actor
+          .getSnapshot()
+          .context.clientCommandQueue.map((item) => item.request_id)
+      ).toEqual(['request-2', 'request-3'])
+
+      // A completed ID remains deduplicated until the connection is reset.
+      actor.send({
+        type: ZookeeperManagerTransitions.ClientCommandRequested,
+        request: request('request-1'),
+      })
+      expect(
+        actor
+          .getSnapshot()
+          .context.clientCommandQueue.map((item) => item.request_id)
+      ).toEqual(['request-2', 'request-3'])
 
       actor.stop()
     })

--- a/src/lib/zookeeper/zookeeperManagerMachine.ts
+++ b/src/lib/zookeeper/zookeeperManagerMachine.ts
@@ -32,6 +32,11 @@ import type { FileEntry, Project } from '@src/lib/project'
 import type { FileMeta } from '@src/lib/types'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import {
+  CLIENT_COMMAND_SCHEMA_UPDATE,
+  type ClientCommandRequest,
+  parseClientCommandRequest,
+} from '@src/lib/zookeeper/clientCommands'
+import {
   constructZookeeperUserPromptRequest,
   type KittyCadLibFile,
 } from '@src/lib/zookeeper/zookeeperPromptRequest'
@@ -240,6 +245,8 @@ export enum ZookeeperManagerTransitions {
   BackendShutdown = 'backend-shutdown',
   SetupProgress = 'setup-progress',
   AttachmentFetch = 'attachment-fetch',
+  ClientCommandRequested = 'client-command-requested',
+  ClientCommandFinished = 'client-command-finished',
 }
 
 export const NUMBER_OF_ZOOKEEPER_SETUP_ATTEMPTS = 3
@@ -413,6 +420,14 @@ export type ZookeeperManagerEvents =
       type: ZookeeperManagerTransitions.AttachmentFetch
       attachmentRef: AttachmentRef
     }
+  | {
+      type: ZookeeperManagerTransitions.ClientCommandRequested
+      request: ClientCommandRequest
+    }
+  | {
+      type: ZookeeperManagerTransitions.ClientCommandFinished
+      requestId: string
+    }
 
 export interface Exchange {
   // Technically the WebSocket could send us a response at any time, without
@@ -450,6 +465,7 @@ export const getZookeeperAttachmentKey = (
 
 export interface ZookeeperManagerContext {
   apiToken: string
+  clientCommandsEnabled: boolean
   ws?: WebSocket
   abruptlyClosed: boolean
   setupFailed: boolean
@@ -469,6 +485,7 @@ export interface ZookeeperManagerContext {
   pendingBackendShutdown: boolean
   defaultMode?: MlCopilotModeId
   modeOptions?: MlCopilotModeOption[]
+  pendingClientCommandRequest?: ClientCommandRequest
   cachedSetup?: {
     refParentSend?: (event: ZookeeperManagerEvents) => void
     conversationId?: string
@@ -479,9 +496,11 @@ export interface ZookeeperManagerContext {
 export const zookeeperDefaultContext = (args: {
   input?: {
     apiToken?: string
+    clientCommandsEnabled?: boolean
   } | null
 }): ZookeeperManagerContext => ({
   apiToken: args.input?.apiToken ?? '',
+  clientCommandsEnabled: args.input?.clientCommandsEnabled ?? false,
   ws: undefined,
   abruptlyClosed: false,
   setupFailed: false,
@@ -501,6 +520,7 @@ export const zookeeperDefaultContext = (args: {
   pendingBackendShutdown: false,
   defaultMode: undefined,
   modeOptions: undefined,
+  pendingClientCommandRequest: undefined,
 })
 
 const ZOOKEEPER_DISCONNECT_LOG_PREFIX = '[zookeeper-disconnect]'
@@ -797,7 +817,10 @@ type XSInput<T> = {
 export const zookeeperManagerMachine = setup({
   types: {
     context: {} as ZookeeperManagerContext,
-    input: {} as Pick<ZookeeperManagerContext, 'apiToken'>,
+    input: {} as {
+      apiToken: string
+      clientCommandsEnabled?: boolean
+    },
     events: {} as ZookeeperManagerEvents,
   },
   guards: {
@@ -914,6 +937,7 @@ export const zookeeperManagerMachine = setup({
         setupFailureReason: undefined,
         accessDeniedCode,
         closeReason,
+        pendingClientCommandRequest: undefined,
       }
     }),
     handleNetworkOffline: assign(({ context }) => {
@@ -926,6 +950,7 @@ export const zookeeperManagerMachine = setup({
         setupFailureReason: undefined,
         accessDeniedCode: undefined,
         closeReason: 'No internet connection.',
+        pendingClientCommandRequest: undefined,
       }
     }),
     prepareSetupRetry: assign(({ event, context }) => {
@@ -981,6 +1006,17 @@ export const zookeeperManagerMachine = setup({
         modeOptions: event.modeOptions,
       }
     }),
+    assignClientCommandRequest: assign(({ event }) => {
+      assertEvent(event, ZookeeperManagerTransitions.ClientCommandRequested)
+      return { pendingClientCommandRequest: event.request }
+    }),
+    clearFinishedClientCommandRequest: assign(({ context, event }) => {
+      assertEvent(event, ZookeeperManagerTransitions.ClientCommandFinished)
+      if (context.pendingClientCommandRequest?.request_id !== event.requestId) {
+        return {}
+      }
+      return { pendingClientCommandRequest: undefined }
+    }),
     disconnectIfIdle: ({ context }) => {
       if (!context.awaitingResponse) {
         logZookeeperDisconnect(
@@ -1034,6 +1070,7 @@ export const zookeeperManagerMachine = setup({
         attachmentsLoadedForCurrentPrompt: true,
         attachmentFetches: {},
         pendingBackendShutdown: false,
+        pendingClientCommandRequest: undefined,
         cachedSetup: {
           refParentSend: event.refParentSend,
           conversationId: event.conversationId,
@@ -1312,6 +1349,15 @@ export const zookeeperManagerMachine = setup({
               return
             }
 
+            const clientCommandRequest = parseClientCommandRequest(response)
+            if (clientCommandRequest !== undefined) {
+              theRefParentSend({
+                type: ZookeeperManagerTransitions.ClientCommandRequested,
+                request: clientCommandRequest,
+              })
+              return
+            }
+
             if (!isMlCopilotServerMessage(response)) return
 
             // Ignore the authorization bug
@@ -1449,6 +1495,9 @@ export const zookeeperManagerMachine = setup({
             type: 'list_modes',
           }
           ws.send(JSON.stringify(listModesRequest))
+          if (args.input.context.clientCommandsEnabled) {
+            ws.send(JSON.stringify(CLIENT_COMMAND_SCHEMA_UPDATE))
+          }
 
           ws.addEventListener('close', function (event: CloseEvent) {
             clearInterval(pingIntervalId)
@@ -1703,6 +1752,12 @@ export const zookeeperManagerMachine = setup({
     [ZookeeperManagerTransitions.ModesReceive]: {
       actions: ['assignModeOptions'],
     },
+    [ZookeeperManagerTransitions.ClientCommandRequested]: {
+      actions: ['assignClientCommandRequest'],
+    },
+    [ZookeeperManagerTransitions.ClientCommandFinished]: {
+      actions: ['clearFinishedClientCommandRequest'],
+    },
     [ZookeeperManagerTransitions.AbruptClose]: {
       target: '#zookeeper-abrupt-close',
       actions: ['handleAbruptClose'],
@@ -1799,6 +1854,7 @@ export const zookeeperManagerMachine = setup({
               awaitingResponse: false,
               attachmentsLoadedForCurrentPrompt: true,
               pendingBackendShutdown: false,
+              pendingClientCommandRequest: undefined,
             })),
             'clearCacheSetup',
           ],
@@ -2194,6 +2250,7 @@ export const zookeeperManagerMachine = setup({
               attachmentsLoadedForCurrentPrompt: true,
               attachmentFetches: {},
               pendingBackendShutdown: false,
+              pendingClientCommandRequest: undefined,
               closeReason: undefined,
               ws: undefined,
             }

--- a/src/lib/zookeeper/zookeeperManagerMachine.ts
+++ b/src/lib/zookeeper/zookeeperManagerMachine.ts
@@ -32,8 +32,8 @@ import type { FileEntry, Project } from '@src/lib/project'
 import type { FileMeta } from '@src/lib/types'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import {
-  CLIENT_COMMAND_SCHEMA_UPDATE,
   type ClientCommandRequest,
+  type ClientCommandSchemaUpdate,
   parseClientCommandRequest,
 } from '@src/lib/zookeeper/clientCommands'
 import {
@@ -246,6 +246,7 @@ export enum ZookeeperManagerTransitions {
   SetupProgress = 'setup-progress',
   AttachmentFetch = 'attachment-fetch',
   ClientCommandRequested = 'client-command-requested',
+  ClientCommandStarted = 'client-command-started',
   ClientCommandFinished = 'client-command-finished',
 }
 
@@ -425,6 +426,10 @@ export type ZookeeperManagerEvents =
       request: ClientCommandRequest
     }
   | {
+      type: ZookeeperManagerTransitions.ClientCommandStarted
+      requestId: string
+    }
+  | {
       type: ZookeeperManagerTransitions.ClientCommandFinished
       requestId: string
     }
@@ -485,7 +490,12 @@ export interface ZookeeperManagerContext {
   pendingBackendShutdown: boolean
   defaultMode?: MlCopilotModeId
   modeOptions?: MlCopilotModeOption[]
-  pendingClientCommandRequest?: ClientCommandRequest
+  /** Connection-local FIFO; only the head may become eligible to execute. */
+  clientCommandQueue: ClientCommandRequest[]
+  /** Request IDs already observed on this connection, including completed ones. */
+  receivedClientCommandRequestIds: string[]
+  activeClientCommandRequestId?: string
+  clientCommandSchemaUpdate?: ClientCommandSchemaUpdate
   cachedSetup?: {
     refParentSend?: (event: ZookeeperManagerEvents) => void
     conversationId?: string
@@ -497,6 +507,7 @@ export const zookeeperDefaultContext = (args: {
   input?: {
     apiToken?: string
     clientCommandsEnabled?: boolean
+    clientCommandSchemaUpdate?: ClientCommandSchemaUpdate
   } | null
 }): ZookeeperManagerContext => ({
   apiToken: args.input?.apiToken ?? '',
@@ -520,7 +531,10 @@ export const zookeeperDefaultContext = (args: {
   pendingBackendShutdown: false,
   defaultMode: undefined,
   modeOptions: undefined,
-  pendingClientCommandRequest: undefined,
+  clientCommandQueue: [],
+  receivedClientCommandRequestIds: [],
+  activeClientCommandRequestId: undefined,
+  clientCommandSchemaUpdate: args.input?.clientCommandSchemaUpdate,
 })
 
 const ZOOKEEPER_DISCONNECT_LOG_PREFIX = '[zookeeper-disconnect]'
@@ -820,6 +834,7 @@ export const zookeeperManagerMachine = setup({
     input: {} as {
       apiToken: string
       clientCommandsEnabled?: boolean
+      clientCommandSchemaUpdate?: ClientCommandSchemaUpdate
     },
     events: {} as ZookeeperManagerEvents,
   },
@@ -937,7 +952,9 @@ export const zookeeperManagerMachine = setup({
         setupFailureReason: undefined,
         accessDeniedCode,
         closeReason,
-        pendingClientCommandRequest: undefined,
+        clientCommandQueue: [],
+        receivedClientCommandRequestIds: [],
+        activeClientCommandRequestId: undefined,
       }
     }),
     handleNetworkOffline: assign(({ context }) => {
@@ -950,7 +967,9 @@ export const zookeeperManagerMachine = setup({
         setupFailureReason: undefined,
         accessDeniedCode: undefined,
         closeReason: 'No internet connection.',
-        pendingClientCommandRequest: undefined,
+        clientCommandQueue: [],
+        receivedClientCommandRequestIds: [],
+        activeClientCommandRequestId: undefined,
       }
     }),
     prepareSetupRetry: assign(({ event, context }) => {
@@ -1006,16 +1025,44 @@ export const zookeeperManagerMachine = setup({
         modeOptions: event.modeOptions,
       }
     }),
-    assignClientCommandRequest: assign(({ event }) => {
+    enqueueClientCommandRequest: assign(({ context, event }) => {
       assertEvent(event, ZookeeperManagerTransitions.ClientCommandRequested)
-      return { pendingClientCommandRequest: event.request }
+      if (
+        context.receivedClientCommandRequestIds.includes(
+          event.request.request_id
+        )
+      ) {
+        return {}
+      }
+      return {
+        clientCommandQueue: [...context.clientCommandQueue, event.request],
+        receivedClientCommandRequestIds: [
+          ...context.receivedClientCommandRequestIds,
+          event.request.request_id,
+        ],
+      }
+    }),
+    startClientCommandRequest: assign(({ context, event }) => {
+      assertEvent(event, ZookeeperManagerTransitions.ClientCommandStarted)
+      if (
+        context.activeClientCommandRequestId !== undefined ||
+        context.clientCommandQueue[0]?.request_id !== event.requestId
+      ) {
+        return {}
+      }
+      return { activeClientCommandRequestId: event.requestId }
     }),
     clearFinishedClientCommandRequest: assign(({ context, event }) => {
       assertEvent(event, ZookeeperManagerTransitions.ClientCommandFinished)
-      if (context.pendingClientCommandRequest?.request_id !== event.requestId) {
-        return {}
+      return {
+        clientCommandQueue: context.clientCommandQueue.filter(
+          (request) => request.request_id !== event.requestId
+        ),
+        activeClientCommandRequestId:
+          context.activeClientCommandRequestId === event.requestId
+            ? undefined
+            : context.activeClientCommandRequestId,
       }
-      return { pendingClientCommandRequest: undefined }
     }),
     disconnectIfIdle: ({ context }) => {
       if (!context.awaitingResponse) {
@@ -1070,7 +1117,9 @@ export const zookeeperManagerMachine = setup({
         attachmentsLoadedForCurrentPrompt: true,
         attachmentFetches: {},
         pendingBackendShutdown: false,
-        pendingClientCommandRequest: undefined,
+        clientCommandQueue: [],
+        receivedClientCommandRequestIds: [],
+        activeClientCommandRequestId: undefined,
         cachedSetup: {
           refParentSend: event.refParentSend,
           conversationId: event.conversationId,
@@ -1495,8 +1544,13 @@ export const zookeeperManagerMachine = setup({
             type: 'list_modes',
           }
           ws.send(JSON.stringify(listModesRequest))
-          if (args.input.context.clientCommandsEnabled) {
-            ws.send(JSON.stringify(CLIENT_COMMAND_SCHEMA_UPDATE))
+          if (
+            args.input.context.clientCommandsEnabled &&
+            args.input.context.clientCommandSchemaUpdate
+          ) {
+            ws.send(
+              JSON.stringify(args.input.context.clientCommandSchemaUpdate)
+            )
           }
 
           ws.addEventListener('close', function (event: CloseEvent) {
@@ -1753,7 +1807,10 @@ export const zookeeperManagerMachine = setup({
       actions: ['assignModeOptions'],
     },
     [ZookeeperManagerTransitions.ClientCommandRequested]: {
-      actions: ['assignClientCommandRequest'],
+      actions: ['enqueueClientCommandRequest'],
+    },
+    [ZookeeperManagerTransitions.ClientCommandStarted]: {
+      actions: ['startClientCommandRequest'],
     },
     [ZookeeperManagerTransitions.ClientCommandFinished]: {
       actions: ['clearFinishedClientCommandRequest'],
@@ -1854,7 +1911,9 @@ export const zookeeperManagerMachine = setup({
               awaitingResponse: false,
               attachmentsLoadedForCurrentPrompt: true,
               pendingBackendShutdown: false,
-              pendingClientCommandRequest: undefined,
+              clientCommandQueue: [],
+              receivedClientCommandRequestIds: [],
+              activeClientCommandRequestId: undefined,
             })),
             'clearCacheSetup',
           ],
@@ -2250,7 +2309,9 @@ export const zookeeperManagerMachine = setup({
               attachmentsLoadedForCurrentPrompt: true,
               attachmentFetches: {},
               pendingBackendShutdown: false,
-              pendingClientCommandRequest: undefined,
+              clientCommandQueue: [],
+              receivedClientCommandRequestIds: [],
+              activeClientCommandRequestId: undefined,
               closeReason: undefined,
               ws: undefined,
             }


### PR DESCRIPTION
Closes #13574.

Adds the Zoo Design Studio side of experimental Zookeeper client commands. ZDS derives its connection-scoped capability catalog from registered commands, re-advertises it after each authenticated WebSocket connection, and implements the first explicit protocol adapter, modeling.export, against the active client Engine scene.

1. Derives advertised command membership, titles, and descriptions from commandsValueSpec while keeping protocol IDs and JSON input schemas in an explicit adapter allowlist.
2. Accepts valid requests into an ephemeral per-connection FIFO, with only the head eligible to execute; later requests cannot leapfrog it.
3. Treats command scopes as runtime readiness. An unavailable head remains suspended in the conversation UI until its registered command becomes available, while later requests remain queued.
4. Shows waiting, executing, and queued command state in the conversation and lets the user cancel any non-active request.
5. Preserves the explicit direct executor for allowlisted commands instead of entering command-bar review UI.
6. Reports STEP save completion accurately as succeeded, cancelled, or failed, including desktop save-dialog cancellation and write failures.

## How to test

Deploy KittyCAD/api#4542, enable zookeeper_client_commands for the test account, and set Application → Override Zookeeper to:

wss://api.dev.zoo.dev/ws/ml/copilot?pr=4213

Open a valid model and ask Zookeeper to export it as STEP. Verify the save flow and the terminal result; cancel the save dialog and confirm it reports cancellation. Dispatch several commands and confirm they remain FIFO and that a non-active item can be cancelled from the conversation.

After #13306 is present, dispatch Export while a sketch scope is active. It should appear as waiting for modeling.export, then execute when the app returns to a modeling scope without requiring a new capability advertisement.

The queue and catalog are intentionally connection-local and are discarded on disconnect. The local protocol types remain transitional for preview testing; the shared source-of-truth types are introduced by the API PR and can replace them after the next generated SDK release.