### PR TITLE
Add Zookeeper API consumer contract test

### DIFF
--- a/e2e/playwright/zookeeper-api-contract.spec.ts
+++ b/e2e/playwright/zookeeper-api-contract.spec.ts
@@ -53,9 +53,7 @@ test.describe(
               }
             }
 
-            override send(
-              data: string | ArrayBufferLike | Blob | ArrayBufferView
-            ) {
+            override send(data: string | Blob | BufferSource) {
               let outgoing = data
               if (this.isZookeeperContractSocket && typeof data === 'string') {
                 try {
@@ -70,7 +68,7 @@ test.describe(
                   // Non-JSON messages should pass through unchanged.
                 }
               }
-              super.send(outgoing)
+              NativeWebSocket.prototype.send.call(this, outgoing)
             }
           }
 

--- a/e2e/playwright/zookeeper-api-contract.spec.ts
+++ b/e2e/playwright/zookeeper-api-contract.spec.ts
@@ -70,7 +70,7 @@ test.describe(
                   // Non-JSON messages should pass through unchanged.
                 }
               }
-              super.send(outgoing as string | Blob | BufferSource)
+              super.send(outgoing)
             }
           }
 

--- a/e2e/playwright/zookeeper-api-contract.spec.ts
+++ b/e2e/playwright/zookeeper-api-contract.spec.ts
@@ -87,7 +87,6 @@ test.describe(
       await expect(toolbar.locator).toBeVisible({ timeout: 30_000 })
       await toolbar.closePane(DefaultLayoutPaneID.Code)
       await toolbar.openPane(DefaultLayoutPaneID.Zookeeper)
-      await copilot.setMode('fast')
 
       const prompt = 'Complete my final credited Zookeeper prompt.'
       await copilot.conversationInput.fill(prompt)

--- a/e2e/playwright/zookeeper-api-contract.spec.ts
+++ b/e2e/playwright/zookeeper-api-contract.spec.ts
@@ -1,6 +1,9 @@
 import { existsSync } from 'node:fs'
 
-import { expect, test } from '@e2e/playwright/zoo-test'
+import { CopilotFixture } from '@e2e/playwright/fixtures/copilotFixture'
+import { ToolbarFixture } from '@e2e/playwright/fixtures/toolbarFixture'
+import { setup } from '@e2e/playwright/test-utils'
+import { expect, test } from '@playwright/test'
 import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
 
 type ContractSocket = WebSocket & { isZookeeperContractSocket?: boolean }
@@ -25,17 +28,15 @@ test.describe(
 
     test('shows billing recovery without retrying a non-retryable denial', async ({
       page,
-      homePage,
-      scene,
-      toolbar,
-      copilot,
-    }) => {
+      context,
+    }, testInfo) => {
       if (!contractWebSocketUrl || !contractApiToken || !exhaustedFile) {
         throw new Error('Missing Zookeeper API contract configuration')
       }
-      await page.setBodyDimensions({ width: 1500, height: 1000 })
+      await page.setViewportSize({ width: 1500, height: 1000 })
+      await setup(context, page, testInfo)
 
-      await page.evaluate(
+      await page.addInitScript(
         ({ websocketUrl, apiToken }) => {
           const contractWindow = window as ContractWindow
           const NativeWebSocket = window.WebSocket
@@ -80,8 +81,10 @@ test.describe(
         }
       )
 
-      await homePage.goToModelingScene()
-      await scene.settled()
+      await page.goto('/')
+      const toolbar = new ToolbarFixture(page)
+      const copilot = new CopilotFixture(page)
+      await expect(toolbar.locator).toBeVisible({ timeout: 30_000 })
       await toolbar.closePane(DefaultLayoutPaneID.Code)
       await toolbar.openPane(DefaultLayoutPaneID.Zookeeper)
       await copilot.setMode('fast')

--- a/e2e/playwright/zookeeper-api-contract.spec.ts
+++ b/e2e/playwright/zookeeper-api-contract.spec.ts
@@ -115,7 +115,9 @@ test.describe(
         activeSocket.close()
       })
 
-      const outOfCreditsBanner = page.getByRole('alert')
+      const outOfCreditsBanner = page.getByRole('alert').filter({
+        hasText: "You're out of Zookeeper credits.",
+      })
       await expect(outOfCreditsBanner).toHaveClass(/border-ml-green/, {
         timeout: 30_000,
       })

--- a/e2e/playwright/zookeeper-api-contract.spec.ts
+++ b/e2e/playwright/zookeeper-api-contract.spec.ts
@@ -88,6 +88,12 @@ test.describe(
       await toolbar.closePane(DefaultLayoutPaneID.Code)
       await toolbar.openPane(DefaultLayoutPaneID.Zookeeper)
 
+      const onboardingInvite = page.getByTestId('onboarding-toast')
+      if (await onboardingInvite.isVisible()) {
+        await page.getByTestId('onboarding-not-right-now').click()
+        await expect(onboardingInvite).not.toBeVisible()
+      }
+
       const prompt = 'Complete my final credited Zookeeper prompt.'
       await copilot.conversationInput.fill(prompt)
       await copilot.submitButton.click()

--- a/e2e/playwright/zookeeper-api-contract.spec.ts
+++ b/e2e/playwright/zookeeper-api-contract.spec.ts
@@ -1,0 +1,153 @@
+import { existsSync } from 'node:fs'
+
+import { expect, test } from '@e2e/playwright/zoo-test'
+import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
+
+type ContractSocket = WebSocket & { isZookeeperContractSocket?: boolean }
+
+type ContractWindow = Window &
+  typeof globalThis & {
+    zookeeperContractSockets?: ContractSocket[]
+  }
+
+const contractWebSocketUrl = process.env.ZOOKEEPER_CONTRACT_WEBSOCKET_URL
+const contractApiToken = process.env.ZOOKEEPER_CONTRACT_API_TOKEN
+const exhaustedFile = process.env.ZOOKEEPER_CONTRACT_EXHAUSTED_FILE
+
+test.describe(
+  'Zookeeper API consumer contract',
+  { tag: '@api-contract' },
+  () => {
+    test.skip(
+      !contractWebSocketUrl || !contractApiToken || !exhaustedFile,
+      'The API contract harness supplies the candidate URL, token, and billing signal.'
+    )
+
+    test('shows billing recovery without retrying a non-retryable denial', async ({
+      page,
+      homePage,
+      scene,
+      toolbar,
+      copilot,
+    }) => {
+      if (!contractWebSocketUrl || !contractApiToken || !exhaustedFile) {
+        throw new Error('Missing Zookeeper API contract configuration')
+      }
+      await page.setBodyDimensions({ width: 1500, height: 1000 })
+
+      await page.evaluate(
+        ({ websocketUrl, apiToken }) => {
+          const contractWindow = window as ContractWindow
+          const NativeWebSocket = window.WebSocket
+          contractWindow.zookeeperContractSockets = []
+
+          class ZookeeperContractWebSocket extends NativeWebSocket {
+            isZookeeperContractSocket = false
+
+            constructor(url: string | URL, protocols?: string | string[]) {
+              super(url, protocols)
+              this.isZookeeperContractSocket =
+                String(url).split('?')[0] === websocketUrl.split('?')[0]
+              if (this.isZookeeperContractSocket) {
+                contractWindow.zookeeperContractSockets?.push(this)
+              }
+            }
+
+            override send(
+              data: string | ArrayBufferLike | Blob | ArrayBufferView
+            ) {
+              let outgoing = data
+              if (this.isZookeeperContractSocket && typeof data === 'string') {
+                try {
+                  const message = JSON.parse(data) as {
+                    headers?: Record<string, string>
+                  }
+                  if (message.headers?.Authorization) {
+                    message.headers.Authorization = `Bearer ${apiToken}`
+                    outgoing = JSON.stringify(message)
+                  }
+                } catch {
+                  // Non-JSON messages should pass through unchanged.
+                }
+              }
+              super.send(outgoing as string | Blob | BufferSource)
+            }
+          }
+
+          window.WebSocket = ZookeeperContractWebSocket
+        },
+        {
+          websocketUrl: contractWebSocketUrl,
+          apiToken: contractApiToken,
+        }
+      )
+
+      await homePage.goToModelingScene()
+      await scene.settled()
+      await toolbar.closePane(DefaultLayoutPaneID.Code)
+      await toolbar.openPane(DefaultLayoutPaneID.Zookeeper)
+      await copilot.setMode('fast')
+
+      const prompt = 'Complete my final credited Zookeeper prompt.'
+      await copilot.conversationInput.fill(prompt)
+      await copilot.submitButton.click()
+      await expect(page.getByTestId('ml-request-chat-bubble')).toContainText(
+        prompt
+      )
+      await expect(copilot.placeHolderResponse).not.toBeVisible({
+        timeout: 30_000,
+      })
+
+      await expect
+        .poll(() => existsSync(exhaustedFile), { timeout: 30_000 })
+        .toBe(true)
+
+      await page.evaluate(() => {
+        const sockets =
+          (window as ContractWindow).zookeeperContractSockets ?? []
+        const activeSocket = sockets.find(
+          (socket) => socket.readyState === WebSocket.OPEN
+        )
+        if (!activeSocket) {
+          throw new Error('No open Zookeeper contract socket')
+        }
+        activeSocket.close()
+      })
+
+      const outOfCreditsBanner = page.getByRole('alert')
+      await expect(outOfCreditsBanner).toHaveClass(/border-ml-green/, {
+        timeout: 30_000,
+      })
+      await expect(outOfCreditsBanner).toContainText(
+        "You're out of Zookeeper credits."
+      )
+      await expect(outOfCreditsBanner).toContainText('Enable pay as you go')
+      await expect(
+        outOfCreditsBanner.getByRole('link', { name: 'Manage billing' })
+      ).toBeVisible()
+      await expect(
+        outOfCreditsBanner.getByRole('button', { name: 'Check again' })
+      ).toBeVisible()
+      await expect(
+        page.getByText('Zookeeper disconnected unexpectedly.')
+      ).not.toBeVisible()
+
+      await expect
+        .poll(
+          () =>
+            page.evaluate(
+              () =>
+                (window as ContractWindow).zookeeperContractSockets?.length ?? 0
+            ),
+          { timeout: 5_000 }
+        )
+        .toBe(2)
+      await page.waitForTimeout(3_500)
+      expect(
+        await page.evaluate(
+          () => (window as ContractWindow).zookeeperContractSockets?.length ?? 0
+        )
+      ).toBe(2)
+    })
+  }
+)

--- a/e2e/playwright/zookeeper.spec.ts
+++ b/e2e/playwright/zookeeper.spec.ts
@@ -4,6 +4,8 @@ import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
 // See zookeeper/text_to_cad/zookeeper_magic_bypass.py
 const ZK_MOCK_REPLY_MARKER =
   'ZOO_MAGIC_STRING_TRIGGER_MOCK_REPLY_D39D279C6F84FA63AD49364FDEFB4A27D0E15BA7FB0975D4D6E003A8A594E460'
+const ZK_MOCK_REPLY_THEN_OUT_OF_CREDITS_MARKER =
+  'ZOO_MAGIC_STRING_TRIGGER_MOCK_REPLY_THEN_OUT_OF_CREDITS_172B4640DFAB8E3153C024DB7A18C6BD07B53E421910C837C941B0C9D9EFF7A9'
 
 test.describe('Zookeeper tests', { tag: ['@desktop', '@web'] }, () => {
   test('Happy path: new project, easy prompt, good result', async ({
@@ -46,6 +48,54 @@ test.describe('Zookeeper tests', { tag: ['@desktop', '@web'] }, () => {
       const extrude = await toolbar.getFeatureTreeOperation('cube', 0)
       await expect(extrude).toBeVisible()
     })
+  })
+  test('Shows out-of-credits banner when the last prompt completes', async ({
+    page,
+    editor,
+    homePage,
+    scene,
+    toolbar,
+    copilot,
+  }) => {
+    await page.setBodyDimensions({ width: 1500, height: 1000 })
+    await homePage.goToModelingScene()
+    await scene.settled()
+
+    const prompt = `make a cube [${ZK_MOCK_REPLY_THEN_OUT_OF_CREDITS_MARKER}]`
+
+    await toolbar.closePane(DefaultLayoutPaneID.Code)
+    await toolbar.openPane(DefaultLayoutPaneID.Zookeeper)
+    await copilot.setMode('fast')
+    await copilot.conversationInput.fill(prompt)
+    await copilot.submitButton.click()
+
+    await expect(page.getByTestId('ml-request-chat-bubble')).toContainText(
+      prompt
+    )
+    await expect(copilot.placeHolderResponse).not.toBeVisible({
+      timeout: 30_000,
+    })
+
+    await toolbar.openPane(DefaultLayoutPaneID.Code)
+    await expect(editor.codeContent).toContainText('sketch', {
+      timeout: 30_000,
+    })
+
+    const outOfCreditsBanner = page.getByRole('alert')
+    await expect(outOfCreditsBanner).toHaveClass(/border-ml-green/)
+    await expect(outOfCreditsBanner).toContainText(
+      "You're out of Zookeeper credits."
+    )
+    await expect(outOfCreditsBanner).toContainText('Enable pay as you go')
+    await expect(
+      outOfCreditsBanner.getByRole('link', { name: 'Manage billing' })
+    ).toBeVisible()
+    await expect(
+      outOfCreditsBanner.getByRole('button', { name: 'Check again' })
+    ).toBeVisible()
+    await expect(
+      page.getByText('Zookeeper disconnected unexpectedly.')
+    ).not.toBeVisible()
   })
   test(
     'Chat history can be cleared',

--- a/e2e/playwright/zookeeper.spec.ts
+++ b/e2e/playwright/zookeeper.spec.ts
@@ -4,8 +4,6 @@ import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
 // See zookeeper/text_to_cad/zookeeper_magic_bypass.py
 const ZK_MOCK_REPLY_MARKER =
   'ZOO_MAGIC_STRING_TRIGGER_MOCK_REPLY_D39D279C6F84FA63AD49364FDEFB4A27D0E15BA7FB0975D4D6E003A8A594E460'
-const ZK_MOCK_REPLY_THEN_OUT_OF_CREDITS_MARKER =
-  'ZOO_MAGIC_STRING_TRIGGER_MOCK_REPLY_THEN_OUT_OF_CREDITS_172B4640DFAB8E3153C024DB7A18C6BD07B53E421910C837C941B0C9D9EFF7A9'
 
 test.describe('Zookeeper tests', { tag: ['@desktop', '@web'] }, () => {
   test('Happy path: new project, easy prompt, good result', async ({
@@ -48,54 +46,6 @@ test.describe('Zookeeper tests', { tag: ['@desktop', '@web'] }, () => {
       const extrude = await toolbar.getFeatureTreeOperation('cube', 0)
       await expect(extrude).toBeVisible()
     })
-  })
-  test('Shows out-of-credits banner when the last prompt completes', async ({
-    page,
-    editor,
-    homePage,
-    scene,
-    toolbar,
-    copilot,
-  }) => {
-    await page.setBodyDimensions({ width: 1500, height: 1000 })
-    await homePage.goToModelingScene()
-    await scene.settled()
-
-    const prompt = `make a cube [${ZK_MOCK_REPLY_THEN_OUT_OF_CREDITS_MARKER}]`
-
-    await toolbar.closePane(DefaultLayoutPaneID.Code)
-    await toolbar.openPane(DefaultLayoutPaneID.Zookeeper)
-    await copilot.setMode('fast')
-    await copilot.conversationInput.fill(prompt)
-    await copilot.submitButton.click()
-
-    await expect(page.getByTestId('ml-request-chat-bubble')).toContainText(
-      prompt
-    )
-    await expect(copilot.placeHolderResponse).not.toBeVisible({
-      timeout: 30_000,
-    })
-
-    await toolbar.openPane(DefaultLayoutPaneID.Code)
-    await expect(editor.codeContent).toContainText('sketch', {
-      timeout: 30_000,
-    })
-
-    const outOfCreditsBanner = page.getByRole('alert')
-    await expect(outOfCreditsBanner).toHaveClass(/border-ml-green/)
-    await expect(outOfCreditsBanner).toContainText(
-      "You're out of Zookeeper credits."
-    )
-    await expect(outOfCreditsBanner).toContainText('Enable pay as you go')
-    await expect(
-      outOfCreditsBanner.getByRole('link', { name: 'Manage billing' })
-    ).toBeVisible()
-    await expect(
-      outOfCreditsBanner.getByRole('button', { name: 'Check again' })
-    ).toBeVisible()
-    await expect(
-      page.getByText('Zookeeper disconnected unexpectedly.')
-    ).not.toBeVisible()
   })
   test(
     'Chat history can be cleared',


### PR DESCRIPTION
## What changed

Adds an API-contract Playwright spec that exercises the real cross-service boundary. The test submits the final credited prompt, waits for the API billing harness to confirm the temporary account reached zero, forces the transport to reconnect, and then verifies:

- the green out-of-credits billing recovery banner is shown
- Manage billing and Check again are available
- the generic reconnect-failed banner is absent
- exactly one post-exhaustion connection is attempted

KittyCAD/api#4552 owns the provider-side harness and runs this contract against both the latest released modeling app and main.

## Risk and rollout

Test-only. It is tagged api-contract, so the normal modeling-app E2E suite does not run it without the API harness environment.