### PR TITLE
KCL: targetRepresentation should no longer require experimental features

### DIFF
--- a/e2e/playwright/point-click-assemblies.spec.ts
+++ b/e2e/playwright/point-click-assemblies.spec.ts
@@ -709,7 +709,6 @@ test.describe(
         await toolbar.openPane(DefaultLayoutPaneID.Code)
         await editor.expectEditor.toContain(
           `
-          @settings(experimentalFeatures = allow)
           @(targetRepresentation = mesh)
           import "cube.step" as cube
         `,

--- a/rust/kcl-lib/src/execution/import.rs
+++ b/rust/kcl-lib/src/execution/import.rs
@@ -450,12 +450,7 @@ mod test {
     fn annotations() {
         let (_, issues) = crate::Program::parse("@(targetRepresentation = mesh)\nimport '../foo.step' as foo")
             .expect("program should parse");
-        assert_eq!(issues.len(), 1);
-        assert_eq!(issues[0].severity, crate::errors::Severity::Error);
-        assert_eq!(
-            issues[0].message,
-            "Use of the `targetRepresentation` import attribute is experimental and may change or be removed."
-        );
+        assert_eq!(issues.len(), 0);
 
         // no annotations
         assert!(
@@ -533,8 +528,7 @@ mod test {
         assert_eq!(fmt, get_import_format_from_extension("step").unwrap());
 
         // STEP target representation.
-        let text =
-            "@settings(experimentalFeatures = allow)\n@(targetRepresentation = mesh)\nimport '../foo.step' as foo";
+        let text = "@(targetRepresentation = mesh)\nimport '../foo.step' as foo";
         let parsed = crate::Program::parse_no_errs(text).unwrap().ast;
         let attrs = parsed.body[0].get_attrs();
         let fmt = format_from_annotations(attrs, &TypedPath::from("../foo.step"), SourceRange::default())
@@ -548,8 +542,7 @@ mod test {
             kcmc::format::step::TargetRepresentation::Mesh
         );
 
-        let text =
-            "@settings(experimentalFeatures = allow)\n@(targetRepresentation = brep)\nimport '../foo.step' as foo";
+        let text = "@(targetRepresentation = brep)\nimport '../foo.step' as foo";
         let parsed = crate::Program::parse_no_errs(text).unwrap().ast;
         let attrs = parsed.body[0].get_attrs();
         let fmt = format_from_annotations(attrs, &TypedPath::from("../foo.step"), SourceRange::default())
@@ -587,12 +580,12 @@ mod test {
             "`lengthUnit` option cannot be applied",
         );
         assert_annotation_error(
-            "@settings(experimentalFeatures = allow)\n@(targetRepresentation = brep)\nimport '../foo.obj' as foo",
+            "@(targetRepresentation = brep)\nimport '../foo.obj' as foo",
             "../foo.obj",
             "`targetRepresentation` option cannot be applied",
         );
         assert_annotation_error(
-            "@settings(experimentalFeatures = allow)\n@(targetRepresentation = voxels)\nimport '../foo.step' as foo",
+            "@(targetRepresentation = voxels)\nimport '../foo.step' as foo",
             "../foo.step",
             "Unknown target representation",
         );

--- a/rust/kcl-lib/src/parsing/parser.rs
+++ b/rust/kcl-lib/src/parsing/parser.rs
@@ -598,17 +598,6 @@ fn annotation(i: &mut TokenSlice) -> ModalResult<Node<Annotation>> {
         at.module_id,
     );
 
-    if let Some(property) = value.properties.as_deref().and_then(|properties| {
-        properties
-            .iter()
-            .find(|property| property.key.name == annotations::IMPORT_TARGET_REPRESENTATION)
-    }) {
-        ParseContext::experimental(
-            "the `targetRepresentation` import attribute",
-            property.as_source_range(),
-        );
-    }
-
     ParseContext::handle_attribute(&value);
 
     Ok(value)

--- a/src/lang/modifyAst.spec.ts
+++ b/src/lang/modifyAst.spec.ts
@@ -304,8 +304,7 @@ describe('Testing addSketchTo', () => {
 })
 
 describe('Testing addModuleImport', () => {
-  const emptyProgram = () =>
-    assertParse('@settings(experimentalFeatures = allow)\n', instanceInThisFile)
+  const emptyProgram = () => assertParse('', instanceInThisFile)
 
   it.each(['mesh', 'brep'] as const)(
     'adds the %s STEP representation annotation',
@@ -318,7 +317,7 @@ describe('Testing addModuleImport', () => {
       })
 
       expect(recast(result.modifiedAst, instanceInThisFile)).toBe(
-        `@settings(experimentalFeatures = allow)\n\n@(targetRepresentation = ${representation})\nimport "cube.step" as cube\n`
+        `@(targetRepresentation = ${representation})\nimport "cube.step" as cube\n`
       )
     }
   )

--- a/src/lib/kclCommands.ts
+++ b/src/lib/kclCommands.ts
@@ -268,7 +268,6 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
           displayName: 'Representation',
           description:
             'Choose how this STEP file should be represented in your model.',
-          status: 'experimental',
           inputType: 'options',
           required: (context) => isStepFile(context.argumentsToSubmit.path),
           hidden: (context) => !isStepFile(context.argumentsToSubmit.path),
@@ -295,33 +294,13 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
           return new Error(NO_INPUT_PROVIDED_MESSAGE)
         }
 
-        let ast = commandProps.kclManager.ast
         const { path, localName } = data
         const representation = isStepFile(path)
           ? (data.representation ?? DEFAULT_IMPORT_REPRESENTATION)
           : undefined
 
-        if (
-          representation &&
-          commandProps.kclManager.fileSettings.experimentalFeatures?.type !==
-            'Allow'
-        ) {
-          const astWithExperimentalFeatures = setExperimentalFeatures(
-            commandProps.kclManager.code,
-            { type: 'Allow' },
-            commandProps.wasmInstance
-          )
-          if (err(astWithExperimentalFeatures)) {
-            toast.error(
-              `Failed to enable experimental features for STEP import: ${astWithExperimentalFeatures.message}`
-            )
-            return astWithExperimentalFeatures
-          }
-          ast = astWithExperimentalFeatures
-        }
-
         const { modifiedAst, pathToNode } = addModuleImport({
-          ast,
+          ast: commandProps.kclManager.ast,
           path,
           localName,
           representation,


### PR DESCRIPTION
There's engine and format support for this now.