### PR TITLE
Fix to bump kcl-language-server dev-dependencies

### DIFF
--- a/rust/kcl-bumper/src/main.rs
+++ b/rust/kcl-bumper/src/main.rs
@@ -10,6 +10,7 @@ use toml_edit::value;
 /// Deps that need to be updated in lock-step.
 const KCL_API_DEPS: [&str; 1] = ["kcl-error"];
 const KCL_LANGUAGE_SERVER_DEPS: [&str; 1] = ["kcl-lib"];
+const KCL_LANGUAGE_SERVER_DEV_DEPS: [&str; 1] = ["kcl-lib"];
 const KCL_LIB_DEPS: [&str; 5] = [
     "kcl-api",
     "kcl-derive-docs",
@@ -55,16 +56,22 @@ fn run_on_manifest(manifest_path: std::path::PathBuf, args: &Args) -> Result<()>
     if let Some(next_version) = next_version.as_ref() {
         match crate_name.as_ref() {
             "kcl-api" => {
-                update_dependency_versions(&crate_name, &KCL_API_DEPS, &mut doc, next_version);
+                update_dependency_versions(&crate_name, &KCL_API_DEPS, &[], &mut doc, next_version);
             }
             "kcl-lib" => {
-                update_dependency_versions(&crate_name, &KCL_LIB_DEPS, &mut doc, next_version);
+                update_dependency_versions(&crate_name, &KCL_LIB_DEPS, &[], &mut doc, next_version);
             }
             "kcl-language-server" => {
-                update_dependency_versions(&crate_name, &KCL_LANGUAGE_SERVER_DEPS, &mut doc, next_version);
+                update_dependency_versions(
+                    &crate_name,
+                    &KCL_LANGUAGE_SERVER_DEPS,
+                    &KCL_LANGUAGE_SERVER_DEV_DEPS,
+                    &mut doc,
+                    next_version,
+                );
             }
             "kcl-test-server" => {
-                update_dependency_versions(&crate_name, &KCL_TEST_SERVER_DEPS, &mut doc, next_version);
+                update_dependency_versions(&crate_name, &KCL_TEST_SERVER_DEPS, &[], &mut doc, next_version);
             }
             _ => {}
         }
@@ -111,20 +118,32 @@ fn update_semver(bump: Option<SemverBump>, cargo_dot_toml: &mut DocumentMut) -> 
 fn update_dependency_versions(
     crate_name: &str,
     dependencies: &[&str],
+    dev_dependencies: &[&str],
     cargo_dot_toml: &mut DocumentMut,
     next_version: &semver::Version,
 ) {
     // Make crate depend on the new versions so that crates that depend on
     // crate also update these.
     for dependency in dependencies {
-        if !update_dependency_version(cargo_dot_toml, dependency, next_version) {
+        if !update_dependency_version(cargo_dot_toml, false, dependency, next_version) {
+            eprintln!("Warning: could not find dependency `{dependency}` in {crate_name} [dependencies]");
+        }
+    }
+    for dependency in dev_dependencies {
+        if !update_dependency_version(cargo_dot_toml, true, dependency, next_version) {
             eprintln!("Warning: could not find dependency `{dependency}` in {crate_name} [dependencies]");
         }
     }
 }
 
-fn update_dependency_version(cargo_dot_toml: &mut DocumentMut, dependency: &str, version: &semver::Version) -> bool {
-    let Some(dependencies) = cargo_dot_toml["dependencies"].as_table_like_mut() else {
+fn update_dependency_version(
+    cargo_dot_toml: &mut DocumentMut,
+    dev: bool,
+    dependency: &str,
+    version: &semver::Version,
+) -> bool {
+    let key = if dev { "dev-dependencies" } else { "dependencies" };
+    let Some(dependencies) = cargo_dot_toml[key].as_table_like_mut() else {
         return false;
     };
     let Some(dependency_item) = dependencies.get_mut(dependency) else {
@@ -288,7 +307,7 @@ kcl-error = { version = "0.1", path = "../kcl-error" }
         let next_version = update_semver(Some(SemverBump::Patch), &mut cargo_dot_toml)
             .unwrap()
             .unwrap();
-        update_dependency_versions("kcl-lib", &KCL_LIB_DEPS, &mut cargo_dot_toml, &next_version);
+        update_dependency_versions("kcl-lib", &KCL_LIB_DEPS, &[], &mut cargo_dot_toml, &next_version);
 
         assert_eq!(
             cargo_dot_toml["dependencies"]["kcl-derive-docs"]["version"]
@@ -319,6 +338,9 @@ version = "0.2.128"
 
 [dependencies]
 kcl-lib = { version = "=0.2.128", path = "../kcl-lib" }
+
+[dev-dependencies]
+kcl-lib = { version = "=0.2.128", path = "../kcl-lib", features = ["lsp-test-util"] }
         "#;
 
         let mut cargo_dot_toml = LANGUAGE_SERVER_EXAMPLE.parse::<DocumentMut>().unwrap();
@@ -328,12 +350,19 @@ kcl-lib = { version = "=0.2.128", path = "../kcl-lib" }
         update_dependency_versions(
             "kcl-language-server",
             &KCL_LANGUAGE_SERVER_DEPS,
+            &KCL_LANGUAGE_SERVER_DEV_DEPS,
             &mut cargo_dot_toml,
             &next_version,
         );
 
         assert_eq!(
             cargo_dot_toml["dependencies"]["kcl-lib"]["version"]
+                .as_value()
+                .and_then(Value::as_str),
+            Some("=0.2.129")
+        );
+        assert_eq!(
+            cargo_dot_toml["dev-dependencies"]["kcl-lib"]["version"]
                 .as_value()
                 .and_then(Value::as_str),
             Some("=0.2.129")
@@ -355,7 +384,7 @@ kcl-derive-docs = { version = "0.1", path = "../kcl-derive-docs" }
         let next_version = update_semver(Some(SemverBump::Patch), &mut cargo_dot_toml)
             .unwrap()
             .unwrap();
-        update_dependency_versions("kcl-lib", &KCL_LIB_DEPS, &mut cargo_dot_toml, &next_version);
+        update_dependency_versions("kcl-lib", &KCL_LIB_DEPS, &[], &mut cargo_dot_toml, &next_version);
 
         assert_eq!(
             cargo_dot_toml["dependencies"]["kcl-derive-docs"]["version"]
@@ -385,7 +414,7 @@ kcl-error = "0.1"
         let next_version = update_semver(Some(SemverBump::Patch), &mut cargo_dot_toml)
             .unwrap()
             .unwrap();
-        update_dependency_versions("kcl-lib", &KCL_LIB_DEPS, &mut cargo_dot_toml, &next_version);
+        update_dependency_versions("kcl-lib", &KCL_LIB_DEPS, &[], &mut cargo_dot_toml, &next_version);
 
         assert_eq!(
             cargo_dot_toml["dependencies"]["kcl-derive-docs"]
@@ -419,6 +448,7 @@ kcl-lib = { version = "0.1", path = "../kcl-lib" }
         update_dependency_versions(
             "kcl-test-server",
             &KCL_TEST_SERVER_DEPS,
+            &[],
             &mut cargo_dot_toml,
             &next_version,
         );


### PR DESCRIPTION
`kcl-language-server` has `kcl-lib` both as a dep and a dev-dep.