### PR TITLE
Combine release steps for kcl crates into one

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -17,11 +17,7 @@
 5. Check out main, to the commit from your merged PR.
 6. Publish the crates:
     ```bash
-    just publish-kcl-part1
-    ```
-    Follow the instructions for updating the old crate versions.
-    ```bash
-    just publish-kcl-part2 {version}
+    just publish-kcl {version}
     ```
     - This will publish the relevant crates and push a new tag with the prefix
     `kcl-`. DO NOT SET THE PREFIX TO `kcl-` when you run the command. The `just`

--- a/rust/justfile
+++ b/rust/justfile
@@ -102,14 +102,10 @@ bump-kcl-crate-versions bump='patch':
     ./target/debug/kcl-bumper --bump {{ bump }}
     cargo check -p kcl-bumper # this way Cargo.lock gets updated
 
-publish-kcl-part1:
+publish-kcl version:
+    git tag kcl-{{ version }} -m "Release kcl-{{ version }}"
     cargo publish -p kcl-error
     cargo publish -p kcl-api
-    @echo "You should now update the transitive kcl-api dependency and commit this."
-    @echo "    cargo update -p kcl-api@<old-version>"
-
-publish-kcl-part2 version:
-    git tag kcl-{{ version }} -m "Release kcl-{{ version }}"
     cargo publish -p kcl-derive-docs
     cargo publish -p kcl-directory-test-macro
     cargo publish -p kcl-engine-codec


### PR DESCRIPTION
Because of the cargo feature, we no longer need the extra step.