### PR TITLE
Remove "Please report this" from CSG error message.

### DIFF
--- a/rust/kcl-lib/tests/consumed_solid_original_issue/execution_error.snap
+++ b/rust/kcl-lib/tests/consumed_solid_original_issue/execution_error.snap
@@ -4,8 +4,7 @@ description: Error from executing consumed_solid_original_issue.kcl
 ---
 KCL Engine error
 
-  × engine: The Zoo engine cannot handle this 3D intersection yet.  Please
-  │ report this as an issue
+  × engine: The Zoo engine cannot handle this 3D intersection yet.
     ╭─[66:17]
  65 │ 
  66 │ ballEndHandle = intersect([ballEnd, rawHandle])
@@ -15,7 +14,6 @@ KCL Engine error
   ╰─▶ KCL Engine error
       
         × engine: The Zoo engine cannot handle this 3D intersection yet.
-        │ Please report this as an issue
           ╭─[66:17]
        65 │
        66 │ ballEndHandle = intersect([ballEnd, rawHandle])

--- a/rust/kcl-lib/tests/error_large_fillet_radius/execution_error.snap
+++ b/rust/kcl-lib/tests/error_large_fillet_radius/execution_error.snap
@@ -4,8 +4,7 @@ description: Error from executing error_large_fillet_radius.kcl
 ---
 KCL Engine error
 
-  × engine: The Zoo engine cannot handle this 3D subtraction yet.  Please
-  │ report this as an issue
+  × engine: The Zoo engine cannot handle this 3D subtraction yet.
   │ Edge cut failed
     ╭─[21:13]
  20 │ extrude001 = extrude(region001, length = 5, tagEnd = $capEnd001)


### PR DESCRIPTION
We don't need users to report these anymore, we get enough error cases from Zookeeper and internal use.

Closes https://github.com/KittyCAD/modeling-app/issues/13593

CI will fail until the updated engine, with the updated error message, has deployed.