### PR TITLE
[DO NOT MERGE] Add region overlays to sketch PNGs

### DIFF
--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -593,6 +593,25 @@ impl ExecOutcome {
         &self,
         sketch_name: &str,
     ) -> std::result::Result<Vec<u8>, crate::tooling::sketch_visualizer::SketchVisualizationError> {
+        self.render_sketch_png_with_overlays(sketch_name, &[], None)
+    }
+
+    /// Render one sketch from this execution result as a PNG, with optional
+    /// overlays for named sketch segments and an engine-resolved region.
+    ///
+    /// Highlighted segment names are local variables from the named sketch
+    /// block. The resolved region must be a top-level `region()` result from
+    /// that sketch. Highlighted segments are magenta and the resolved region
+    /// boundary is green.
+    pub fn render_sketch_png_with_overlays(
+        &self,
+        sketch_name: &str,
+        highlighted_segment_names: &[String],
+        resolved_region_name: Option<&str>,
+    ) -> std::result::Result<Vec<u8>, crate::tooling::sketch_visualizer::SketchVisualizationError> {
+        use std::collections::BTreeSet;
+
+        use crate::execution::SegmentRepr;
         use crate::front::ObjectKind;
         use crate::tooling::sketch_visualizer::SketchVisualizationError;
 
@@ -619,7 +638,118 @@ impl ExecOutcome {
             }
         };
 
-        crate::tooling::sketch_visualizer::render_sketch_png(&self.scene_objects, sketch)
+        let needs_sketch_value = !highlighted_segment_names.is_empty() || resolved_region_name.is_some();
+        let sketch_fields = if needs_sketch_value {
+            let Some(KclValueView::Object { value, .. }) = self.variables.get(sketch_name) else {
+                return Err(SketchVisualizationError::SketchNotFound {
+                    name: sketch_name.to_owned(),
+                });
+            };
+            Some(value)
+        } else {
+            None
+        };
+
+        let mut highlighted_segment_ids = BTreeSet::new();
+        for segment_name in highlighted_segment_names {
+            let segment_value = sketch_fields.and_then(|fields| fields.get(segment_name));
+            let Some(KclValueView::Segment { value }) = segment_value else {
+                return Err(SketchVisualizationError::SegmentNotFound {
+                    sketch_name: sketch_name.to_owned(),
+                    segment_name: segment_name.clone(),
+                });
+            };
+            let SegmentRepr::Solved { segment } = &value.repr else {
+                return Err(SketchVisualizationError::SegmentNotSolved {
+                    sketch_name: sketch_name.to_owned(),
+                    segment_name: segment_name.clone(),
+                });
+            };
+            highlighted_segment_ids.insert(segment.object_id.0);
+        }
+
+        let mut region_boundary_segment_ids = BTreeSet::new();
+        if let Some(region_name) = resolved_region_name {
+            let region = match self.variables.get(region_name) {
+                Some(KclValueView::Sketch { value }) => value,
+                Some(_) => {
+                    return Err(SketchVisualizationError::NotARegion {
+                        name: region_name.to_owned(),
+                    });
+                }
+                None => {
+                    return Err(SketchVisualizationError::RegionNotFound {
+                        name: region_name.to_owned(),
+                    });
+                }
+            };
+            let Some(origin_sketch_id) = region.origin_sketch_id else {
+                return Err(SketchVisualizationError::NotARegion {
+                    name: region_name.to_owned(),
+                });
+            };
+
+            let Some(fields) = sketch_fields else {
+                return Err(SketchVisualizationError::SketchNotFound {
+                    name: sketch_name.to_owned(),
+                });
+            };
+            let selected_sketch = fields
+                .get(SKETCH_OBJECT_META)
+                .and_then(|value| match value {
+                    KclValueView::Object { value, .. } => value.get(SKETCH_OBJECT_META_SKETCH),
+                    _ => None,
+                })
+                .and_then(|value| match value {
+                    KclValueView::Sketch { value } => Some(value),
+                    _ => None,
+                });
+            if selected_sketch.is_none_or(|selected_sketch| selected_sketch.id != origin_sketch_id) {
+                return Err(SketchVisualizationError::RegionSketchMismatch {
+                    sketch_name: sketch_name.to_owned(),
+                    region_name: region_name.to_owned(),
+                });
+            }
+
+            let solved_segments = fields.values().filter_map(|value| {
+                let KclValueView::Segment { value } = value else {
+                    return None;
+                };
+                let SegmentRepr::Solved { segment } = &value.repr else {
+                    return None;
+                };
+                Some(segment.as_ref())
+            });
+            let segments_by_artifact_id = solved_segments
+                .filter(|segment| segment.sketch_id == origin_sketch_id)
+                .map(|segment| (ArtifactId::new(segment.id), segment.object_id.0))
+                .collect::<BTreeMap<_, _>>();
+
+            for path in &region.paths {
+                let artifact_id = ArtifactId::new(path.get_id());
+                let Some(Artifact::Segment(region_segment)) = self.artifact_graph.get(&artifact_id) else {
+                    continue;
+                };
+                let Some(original_segment_id) = region_segment.original_seg_id else {
+                    continue;
+                };
+                if let Some(object_id) = segments_by_artifact_id.get(&original_segment_id) {
+                    region_boundary_segment_ids.insert(*object_id);
+                }
+            }
+            if region_boundary_segment_ids.is_empty() {
+                return Err(SketchVisualizationError::RegionBoundaryNotFound {
+                    region_name: region_name.to_owned(),
+                });
+            }
+        }
+
+        crate::tooling::sketch_visualizer::render_sketch_png(
+            &self.scene_objects,
+            sketch,
+            &highlighted_segment_ids,
+            &region_boundary_segment_ids,
+        )
     }
 }
 

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -601,13 +601,14 @@ impl ExecOutcome {
     ///
     /// Highlighted segment names are local variables from the named sketch
     /// block. The resolved region must be a top-level `region()` result from
-    /// that sketch. Highlighted segments are magenta and the resolved region
-    /// boundary is green.
+    /// that sketch, captured with `resolve_sketch_region` before closing the
+    /// engine session. Magenta seed halos and a soft green region fill sit
+    /// underneath the normal constraint-colored lines.
     pub fn render_sketch_png_with_overlays(
         &self,
         sketch_name: &str,
         highlighted_segment_names: &[String],
-        resolved_region_name: Option<&str>,
+        resolved_region: Option<&crate::tooling::sketch_visualizer::ResolvedSketchRegion>,
     ) -> std::result::Result<Vec<u8>, crate::tooling::sketch_visualizer::SketchVisualizationError> {
         use std::collections::BTreeSet;
 
@@ -638,7 +639,7 @@ impl ExecOutcome {
             }
         };
 
-        let needs_sketch_value = !highlighted_segment_names.is_empty() || resolved_region_name.is_some();
+        let needs_sketch_value = !highlighted_segment_names.is_empty() || resolved_region.is_some();
         let sketch_fields = if needs_sketch_value {
             let Some(KclValueView::Object { value, .. }) = self.variables.get(sketch_name) else {
                 return Err(SketchVisualizationError::SketchNotFound {
@@ -668,26 +669,15 @@ impl ExecOutcome {
             highlighted_segment_ids.insert(segment.object_id.0);
         }
 
-        let mut region_boundary_segment_ids = BTreeSet::new();
-        if let Some(region_name) = resolved_region_name {
-            let region = match self.variables.get(region_name) {
-                Some(KclValueView::Sketch { value }) => value,
-                Some(_) => {
-                    return Err(SketchVisualizationError::NotARegion {
-                        name: region_name.to_owned(),
-                    });
-                }
-                None => {
-                    return Err(SketchVisualizationError::RegionNotFound {
-                        name: region_name.to_owned(),
-                    });
-                }
-            };
-            let Some(origin_sketch_id) = region.origin_sketch_id else {
-                return Err(SketchVisualizationError::NotARegion {
+        if let Some(region) = resolved_region {
+            let region_name = region.name();
+            // Require the captured geometry's region identity to match.
+            if !matches!(self.variables.get(region_name), Some(KclValueView::Sketch { value }) if value.id == region.id)
+            {
+                return Err(SketchVisualizationError::RegionNotFound {
                     name: region_name.to_owned(),
                 });
-            };
+            }
 
             let Some(fields) = sketch_fields else {
                 return Err(SketchVisualizationError::SketchNotFound {
@@ -704,41 +694,9 @@ impl ExecOutcome {
                     KclValueView::Sketch { value } => Some(value),
                     _ => None,
                 });
-            if selected_sketch.is_none_or(|selected_sketch| selected_sketch.id != origin_sketch_id) {
+            if selected_sketch.is_none_or(|selected_sketch| selected_sketch.id != region.origin_sketch_id) {
                 return Err(SketchVisualizationError::RegionSketchMismatch {
                     sketch_name: sketch_name.to_owned(),
-                    region_name: region_name.to_owned(),
-                });
-            }
-
-            let solved_segments = fields.values().filter_map(|value| {
-                let KclValueView::Segment { value } = value else {
-                    return None;
-                };
-                let SegmentRepr::Solved { segment } = &value.repr else {
-                    return None;
-                };
-                Some(segment.as_ref())
-            });
-            let segments_by_artifact_id = solved_segments
-                .filter(|segment| segment.sketch_id == origin_sketch_id)
-                .map(|segment| (ArtifactId::new(segment.id), segment.object_id.0))
-                .collect::<BTreeMap<_, _>>();
-
-            for path in &region.paths {
-                let artifact_id = ArtifactId::new(path.get_id());
-                let Some(Artifact::Segment(region_segment)) = self.artifact_graph.get(&artifact_id) else {
-                    continue;
-                };
-                let Some(original_segment_id) = region_segment.original_seg_id else {
-                    continue;
-                };
-                if let Some(object_id) = segments_by_artifact_id.get(&original_segment_id) {
-                    region_boundary_segment_ids.insert(*object_id);
-                }
-            }
-            if region_boundary_segment_ids.is_empty() {
-                return Err(SketchVisualizationError::RegionBoundaryNotFound {
                     region_name: region_name.to_owned(),
                 });
             }
@@ -748,7 +706,7 @@ impl ExecOutcome {
             &self.scene_objects,
             sketch,
             &highlighted_segment_ids,
-            &region_boundary_segment_ids,
+            resolved_region,
         )
     }
 }

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -602,7 +602,7 @@ impl ExecOutcome {
     /// Highlighted segment names are local variables from the named sketch
     /// block. The resolved region must be a top-level `region()` result from
     /// that sketch, captured with `resolve_sketch_region` before closing the
-    /// engine session. Magenta seed halos and a soft green region fill sit
+    /// engine session. Gold seed halos with dark separators and a soft green fill sit
     /// underneath the normal constraint-colored lines.
     pub fn render_sketch_png_with_overlays(
         &self,

--- a/rust/kcl-lib/src/tooling/sketch_visualizer/api.rs
+++ b/rust/kcl-lib/src/tooling/sketch_visualizer/api.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use super::extract::Extraction;
 use super::types::SketchVisualizationError;
 use crate::front::Object;
@@ -6,8 +8,10 @@ use crate::front::Sketch;
 pub(crate) fn render_sketch_png(
     scene_objects: &[Object],
     sketch: &Sketch,
+    highlighted_segment_ids: &BTreeSet<usize>,
+    region_boundary_segment_ids: &BTreeSet<usize>,
 ) -> Result<Vec<u8>, SketchVisualizationError> {
-    let mut extraction = Extraction::new(scene_objects);
+    let mut extraction = Extraction::new(scene_objects, highlighted_segment_ids, region_boundary_segment_ids);
     extraction.collect_points_and_segments(sketch)?;
     extraction.finish()
 }

--- a/rust/kcl-lib/src/tooling/sketch_visualizer/api.rs
+++ b/rust/kcl-lib/src/tooling/sketch_visualizer/api.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeSet;
 
 use super::extract::Extraction;
+use super::region::ResolvedSketchRegion;
 use super::types::SketchVisualizationError;
 use crate::front::Object;
 use crate::front::Sketch;
@@ -9,9 +10,9 @@ pub(crate) fn render_sketch_png(
     scene_objects: &[Object],
     sketch: &Sketch,
     highlighted_segment_ids: &BTreeSet<usize>,
-    region_boundary_segment_ids: &BTreeSet<usize>,
+    resolved_region: Option<&ResolvedSketchRegion>,
 ) -> Result<Vec<u8>, SketchVisualizationError> {
-    let mut extraction = Extraction::new(scene_objects, highlighted_segment_ids, region_boundary_segment_ids);
+    let mut extraction = Extraction::new(scene_objects, highlighted_segment_ids);
     extraction.collect_points_and_segments(sketch)?;
-    extraction.finish()
+    extraction.finish(resolved_region)
 }

--- a/rust/kcl-lib/src/tooling/sketch_visualizer/extract.rs
+++ b/rust/kcl-lib/src/tooling/sketch_visualizer/extract.rs
@@ -27,14 +27,22 @@ use crate::front::Segment;
 #[derive(Debug)]
 pub(super) struct Extraction<'a> {
     scene_objects: &'a [Object],
+    highlighted_segment_ids: &'a BTreeSet<usize>,
+    region_boundary_segment_ids: &'a BTreeSet<usize>,
     points: BTreeMap<usize, InternalPoint>,
     segments: BTreeMap<usize, InternalSegment>,
 }
 
 impl<'a> Extraction<'a> {
-    pub(super) fn new(scene_objects: &'a [Object]) -> Self {
+    pub(super) fn new(
+        scene_objects: &'a [Object],
+        highlighted_segment_ids: &'a BTreeSet<usize>,
+        region_boundary_segment_ids: &'a BTreeSet<usize>,
+    ) -> Self {
         Self {
             scene_objects,
+            highlighted_segment_ids,
+            region_boundary_segment_ids,
             points: BTreeMap::new(),
             segments: BTreeMap::new(),
         }
@@ -67,6 +75,8 @@ impl<'a> Extraction<'a> {
                         InternalSegment {
                             construction: line.construction,
                             freedom: segment.freedom(|id| self.point_freedom(id)),
+                            highlighted: self.highlighted_segment_ids.contains(&object.id.0),
+                            region_boundary: self.region_boundary_segment_ids.contains(&object.id.0),
                             polyline,
                         },
                     );
@@ -80,6 +90,8 @@ impl<'a> Extraction<'a> {
                         InternalSegment {
                             construction: arc.construction,
                             freedom: segment.freedom(|id| self.point_freedom(id)),
+                            highlighted: self.highlighted_segment_ids.contains(&object.id.0),
+                            region_boundary: self.region_boundary_segment_ids.contains(&object.id.0),
                             polyline,
                         },
                     );
@@ -93,6 +105,8 @@ impl<'a> Extraction<'a> {
                         InternalSegment {
                             construction: circle.construction,
                             freedom: segment.freedom(|id| self.point_freedom(id)),
+                            highlighted: self.highlighted_segment_ids.contains(&object.id.0),
+                            region_boundary: self.region_boundary_segment_ids.contains(&object.id.0),
                             polyline,
                         },
                     );
@@ -111,6 +125,8 @@ impl<'a> Extraction<'a> {
                         InternalSegment {
                             construction: spline.construction,
                             freedom: segment.freedom(|id| self.point_freedom(id)),
+                            highlighted: self.highlighted_segment_ids.contains(&object.id.0),
+                            region_boundary: self.region_boundary_segment_ids.contains(&object.id.0),
                             polyline: sample_control_point_spline(&control_points, spline.degree as usize),
                         },
                     );

--- a/rust/kcl-lib/src/tooling/sketch_visualizer/extract.rs
+++ b/rust/kcl-lib/src/tooling/sketch_visualizer/extract.rs
@@ -5,6 +5,7 @@ use std::collections::BTreeSet;
 
 use super::model::InternalPoint;
 use super::model::InternalSegment;
+use super::region::ResolvedSketchRegion;
 use super::render::render_png;
 use super::sampling::BoundsBuilder;
 use super::sampling::distance;
@@ -28,21 +29,15 @@ use crate::front::Segment;
 pub(super) struct Extraction<'a> {
     scene_objects: &'a [Object],
     highlighted_segment_ids: &'a BTreeSet<usize>,
-    region_boundary_segment_ids: &'a BTreeSet<usize>,
     points: BTreeMap<usize, InternalPoint>,
     segments: BTreeMap<usize, InternalSegment>,
 }
 
 impl<'a> Extraction<'a> {
-    pub(super) fn new(
-        scene_objects: &'a [Object],
-        highlighted_segment_ids: &'a BTreeSet<usize>,
-        region_boundary_segment_ids: &'a BTreeSet<usize>,
-    ) -> Self {
+    pub(super) fn new(scene_objects: &'a [Object], highlighted_segment_ids: &'a BTreeSet<usize>) -> Self {
         Self {
             scene_objects,
             highlighted_segment_ids,
-            region_boundary_segment_ids,
             points: BTreeMap::new(),
             segments: BTreeMap::new(),
         }
@@ -76,7 +71,6 @@ impl<'a> Extraction<'a> {
                             construction: line.construction,
                             freedom: segment.freedom(|id| self.point_freedom(id)),
                             highlighted: self.highlighted_segment_ids.contains(&object.id.0),
-                            region_boundary: self.region_boundary_segment_ids.contains(&object.id.0),
                             polyline,
                         },
                     );
@@ -91,7 +85,6 @@ impl<'a> Extraction<'a> {
                             construction: arc.construction,
                             freedom: segment.freedom(|id| self.point_freedom(id)),
                             highlighted: self.highlighted_segment_ids.contains(&object.id.0),
-                            region_boundary: self.region_boundary_segment_ids.contains(&object.id.0),
                             polyline,
                         },
                     );
@@ -106,7 +99,6 @@ impl<'a> Extraction<'a> {
                             construction: circle.construction,
                             freedom: segment.freedom(|id| self.point_freedom(id)),
                             highlighted: self.highlighted_segment_ids.contains(&object.id.0),
-                            region_boundary: self.region_boundary_segment_ids.contains(&object.id.0),
                             polyline,
                         },
                     );
@@ -126,7 +118,6 @@ impl<'a> Extraction<'a> {
                             construction: spline.construction,
                             freedom: segment.freedom(|id| self.point_freedom(id)),
                             highlighted: self.highlighted_segment_ids.contains(&object.id.0),
-                            region_boundary: self.region_boundary_segment_ids.contains(&object.id.0),
                             polyline: sample_control_point_spline(&control_points, spline.degree as usize),
                         },
                     );
@@ -137,10 +128,19 @@ impl<'a> Extraction<'a> {
         Ok(())
     }
 
-    pub(super) fn finish(self) -> Result<Vec<u8>, SketchVisualizationError> {
+    pub(super) fn finish(
+        self,
+        resolved_region: Option<&ResolvedSketchRegion>,
+    ) -> Result<Vec<u8>, SketchVisualizationError> {
         let bounds = self.bounds();
         let contact_point_ids = self.contact_point_ids();
-        render_png(&self.segments, &self.points, &contact_point_ids, bounds)
+        render_png(
+            &self.segments,
+            &self.points,
+            &contact_point_ids,
+            bounds,
+            resolved_region,
+        )
     }
 
     fn insert_point(&mut self, id: ObjectId, point: &crate::front::Point) {

--- a/rust/kcl-lib/src/tooling/sketch_visualizer/extract.rs
+++ b/rust/kcl-lib/src/tooling/sketch_visualizer/extract.rs
@@ -148,7 +148,6 @@ impl<'a> Extraction<'a> {
             id.0,
             InternalPoint {
                 position: position_to_point(&point.position),
-                owner: point.owner.map(|owner| owner.0),
                 freedom: point.freedom(),
             },
         );

--- a/rust/kcl-lib/src/tooling/sketch_visualizer/mod.rs
+++ b/rust/kcl-lib/src/tooling/sketch_visualizer/mod.rs
@@ -3,6 +3,7 @@
 mod api;
 mod extract;
 mod model;
+mod region;
 mod render;
 mod sampling;
 mod scene;
@@ -12,4 +13,5 @@ mod types;
 mod tests;
 
 pub(crate) use api::render_sketch_png;
+pub use region::ResolvedSketchRegion;
 pub use types::SketchVisualizationError;

--- a/rust/kcl-lib/src/tooling/sketch_visualizer/model.rs
+++ b/rust/kcl-lib/src/tooling/sketch_visualizer/model.rs
@@ -14,5 +14,7 @@ pub(super) struct InternalPoint {
 pub(super) struct InternalSegment {
     pub(super) construction: bool,
     pub(super) freedom: Option<Freedom>,
+    pub(super) highlighted: bool,
+    pub(super) region_boundary: bool,
     pub(super) polyline: Vec<SketchVisualizationPoint>,
 }

--- a/rust/kcl-lib/src/tooling/sketch_visualizer/model.rs
+++ b/rust/kcl-lib/src/tooling/sketch_visualizer/model.rs
@@ -15,6 +15,5 @@ pub(super) struct InternalSegment {
     pub(super) construction: bool,
     pub(super) freedom: Option<Freedom>,
     pub(super) highlighted: bool,
-    pub(super) region_boundary: bool,
     pub(super) polyline: Vec<SketchVisualizationPoint>,
 }

--- a/rust/kcl-lib/src/tooling/sketch_visualizer/model.rs
+++ b/rust/kcl-lib/src/tooling/sketch_visualizer/model.rs
@@ -6,7 +6,6 @@ use crate::front::Freedom;
 #[derive(Debug, Clone)]
 pub(super) struct InternalPoint {
     pub(super) position: SketchVisualizationPoint,
-    pub(super) owner: Option<usize>,
     pub(super) freedom: Freedom,
 }
 

--- a/rust/kcl-lib/src/tooling/sketch_visualizer/region.rs
+++ b/rust/kcl-lib/src/tooling/sketch_visualizer/region.rs
@@ -1,0 +1,451 @@
+//! Capture the engine's trimmed region curves while its connection is live.
+
+use std::collections::BTreeSet;
+
+use kittycad_modeling_cmds as cmds;
+use kittycad_modeling_cmds::ModelingCmd;
+use kittycad_modeling_cmds::SketchGetInfo;
+use kittycad_modeling_cmds::ok_response::OkModelingCmdResponse;
+use kittycad_modeling_cmds::shared::CurveDebug;
+use kittycad_modeling_cmds::shared::CurveTypeDebug;
+use kittycad_modeling_cmds::websocket::OkWebSocketResponseData;
+
+use super::sampling::distance;
+use super::sampling::sample_arc;
+use super::sampling::sample_circle;
+use super::types::CONTACT_TOLERANCE;
+use super::types::SketchVisualizationError;
+use super::types::SketchVisualizationPoint;
+use crate::ExecOutcome;
+use crate::ExecutorContext;
+use crate::execution::KclValueView;
+
+/// Engine-resolved, sampled closed contours. Capturing these is opt-in; ordinary
+/// execution and constraint checks do not need an additional engine request.
+#[derive(Debug, Clone)]
+pub struct ResolvedSketchRegion {
+    pub(crate) name: String,
+    pub(crate) id: uuid::Uuid,
+    pub(crate) origin_sketch_id: uuid::Uuid,
+    pub(super) contours: Vec<Vec<SketchVisualizationPoint>>,
+}
+
+impl ResolvedSketchRegion {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl ExecOutcome {
+    /// Capture a region before closing its engine session. KCL's local region
+    /// paths copy the original curves and are not authoritative trimmed edges.
+    pub async fn resolve_sketch_region(
+        &self,
+        ctx: &ExecutorContext,
+        name: &str,
+    ) -> Result<ResolvedSketchRegion, SketchVisualizationError> {
+        let region = match self.variables.get(name) {
+            Some(KclValueView::Sketch { value }) => value,
+            Some(_) => return Err(SketchVisualizationError::NotARegion { name: name.to_owned() }),
+            None => return Err(SketchVisualizationError::RegionNotFound { name: name.to_owned() }),
+        };
+        let origin_sketch_id = region
+            .origin_sketch_id
+            .ok_or_else(|| SketchVisualizationError::NotARegion { name: name.to_owned() })?;
+        let OkModelingCmdResponse::GetEntityType(entity) = query(
+            ctx,
+            cmds::GetEntityType::builder().entity_id(region.id).build().into(),
+            name,
+        )
+        .await?
+        else {
+            return Err(invalid_boundary(name));
+        };
+        let polylines = if matches!(
+            entity.entity_type,
+            cmds::shared::EntityType::Object | cmds::shared::EntityType::Region | cmds::shared::EntityType::Solid2D
+        ) {
+            // Current regions own real child curves, not a Path. KCL's local
+            // region mappings can include obsolete IDs, so query the engine.
+            region_object_curves(ctx, region, name).await?
+        } else {
+            let response = ctx
+                .engine
+                .send_modeling_cmd(
+                    &ctx.engine_batch,
+                    uuid::Uuid::new_v4(),
+                    Default::default(),
+                    &ModelingCmd::from(SketchGetInfo::builder().path_id(region.id.into()).build()),
+                )
+                .await?;
+            let OkWebSocketResponseData::Modeling {
+                modeling_response: OkModelingCmdResponse::SketchGetInfo(info),
+            } = response
+            else {
+                return Err(invalid_boundary(name));
+            };
+            let expected_ids = region
+                .paths
+                .iter()
+                .chain(&region.inner_paths)
+                .map(|path| path.get_id())
+                .collect::<BTreeSet<_>>();
+            let actual_ids = info
+                .curves
+                .iter()
+                .map(|curve| uuid::Uuid::from(curve.id))
+                .collect::<BTreeSet<_>>();
+            // The debug API must not silently omit unsupported curves, or a partial
+            // contour could incorrectly shade an area that the engine did not select.
+            if expected_ids.is_empty() || expected_ids != actual_ids || actual_ids.len() != info.curves.len() {
+                return Err(invalid_boundary(name));
+            }
+            info.curves
+                .iter()
+                .map(|curve| sample_region_curve(curve).ok_or_else(|| invalid_boundary(name)))
+                .collect::<Result<Vec<_>, _>>()?
+        };
+        let mut contours = closed_contours(polylines).ok_or_else(|| invalid_boundary(name))?;
+        // Engine curves use millimeters; frontend points use the sketch's
+        // module length unit. Keep the fill in the same space as its strokes.
+        let scale = crate::execution::types::adjust_length(kcl_api::UnitLength::Millimeters, 1.0, region.units).0;
+        for point in contours.iter_mut().flatten() {
+            point.x *= scale;
+            point.y *= scale;
+        }
+        Ok(ResolvedSketchRegion {
+            name: name.to_owned(),
+            id: region.id,
+            origin_sketch_id,
+            contours,
+        })
+    }
+}
+
+async fn query(
+    ctx: &ExecutorContext,
+    command: ModelingCmd,
+    name: &str,
+) -> Result<OkModelingCmdResponse, SketchVisualizationError> {
+    match ctx
+        .engine
+        .send_modeling_cmd(&ctx.engine_batch, uuid::Uuid::new_v4(), Default::default(), &command)
+        .await?
+    {
+        OkWebSocketResponseData::Modeling { modeling_response } => Ok(modeling_response),
+        _ => Err(invalid_boundary(name)),
+    }
+}
+
+async fn region_object_curves(
+    ctx: &ExecutorContext,
+    region: &crate::execution::Sketch,
+    name: &str,
+) -> Result<Vec<Vec<SketchVisualizationPoint>>, SketchVisualizationError> {
+    let OkModelingCmdResponse::EntityGetAllChildUuids(children) = query(
+        ctx,
+        cmds::EntityGetAllChildUuids::builder()
+            .entity_id(region.id)
+            .build()
+            .into(),
+        name,
+    )
+    .await?
+    else {
+        return Err(invalid_boundary(name));
+    };
+    let mut curves = Vec::new();
+    let mut controls = Vec::new();
+    let ids = children
+        .entity_ids
+        .into_iter()
+        .chain(region.inner_paths.iter().map(|path| path.get_id()))
+        .collect::<BTreeSet<_>>();
+    for id in ids {
+        let OkModelingCmdResponse::GetEntityType(entity) =
+            query(ctx, cmds::GetEntityType::builder().entity_id(id).build().into(), name).await?
+        else {
+            return Err(invalid_boundary(name));
+        };
+        match entity.entity_type {
+            cmds::shared::EntityType::Vertex | cmds::shared::EntityType::Face => continue,
+            cmds::shared::EntityType::Curve => {}
+            _ => return Err(invalid_boundary(name)),
+        }
+        let OkModelingCmdResponse::CurveGetType(kind) =
+            query(ctx, cmds::CurveGetType::builder().curve_id(id).build().into(), name).await?
+        else {
+            return Err(invalid_boundary(name));
+        };
+        if !matches!(
+            kind.curve_type,
+            cmds::shared::CurveType::Line | cmds::shared::CurveType::Arc
+        ) {
+            return Err(invalid_boundary(name));
+        }
+        let OkModelingCmdResponse::CurveGetControlPoints(points) = query(
+            ctx,
+            cmds::CurveGetControlPoints::builder().curve_id(id).build().into(),
+            name,
+        )
+        .await?
+        else {
+            return Err(invalid_boundary(name));
+        };
+        curves.push((kind.curve_type, points.control_points.len()));
+        controls.extend(points.control_points);
+    }
+    if controls.is_empty() {
+        return Err(invalid_boundary(name));
+    }
+    // These path control points are already sketch-local, even when the
+    // sketch is on XZ/a rotated plane. Projecting them again would flatten it.
+    if controls
+        .iter()
+        .any(|p| !p.z.is_finite() || p.z.abs() > CONTACT_TOLERANCE)
+    {
+        return Err(invalid_boundary(name));
+    }
+    let points = controls
+        .iter()
+        .map(|p| SketchVisualizationPoint { x: p.x, y: p.y })
+        .collect::<Vec<_>>();
+    let mut offset = 0;
+    curves
+        .into_iter()
+        .map(|(kind, count)| {
+            let result =
+                sample_controlled_curve(kind, &points[offset..offset + count]).ok_or_else(|| invalid_boundary(name));
+            offset += count;
+            result
+        })
+        .collect()
+}
+
+/// Engine circular curves use rational quadratic spans: endpoints at even
+/// indices, tangent intersections at odd indices. Never treat the control
+/// polygon itself as a boundary or assume a generic NURBS curve is circular.
+fn sample_controlled_curve(
+    kind: cmds::shared::CurveType,
+    controls: &[SketchVisualizationPoint],
+) -> Option<Vec<SketchVisualizationPoint>> {
+    if controls.iter().any(|p| !p.x.is_finite() || !p.y.is_finite()) {
+        return None;
+    }
+    if kind == cmds::shared::CurveType::Line {
+        return (controls.len() == 2).then(|| controls.to_vec());
+    }
+    if kind != cmds::shared::CurveType::Arc || controls.len() < 3 || controls.len() % 2 != 1 {
+        return None;
+    }
+    let start = controls[0];
+    let end = *controls.last()?;
+    let tangent = point_sub(controls[1], start);
+    let normal = SketchVisualizationPoint {
+        x: -tangent.y,
+        y: tangent.x,
+    };
+    let chord = point_sub(controls[2], start);
+    let denominator = 2.0 * (normal.x * chord.x + normal.y * chord.y);
+    if denominator.abs() <= f64::EPSILON {
+        return None;
+    }
+    let t = (chord.x * chord.x + chord.y * chord.y) / denominator;
+    let center = SketchVisualizationPoint {
+        x: start.x + t * normal.x,
+        y: start.y + t * normal.y,
+    };
+    let radius = distance(start, center);
+    if !radius.is_finite() || radius <= CONTACT_TOLERANCE {
+        return None;
+    }
+    for span in controls.windows(3).step_by(2) {
+        for p in [span[0], span[2]] {
+            if (distance(p, center) - radius).abs() > 1e-6 * libm::fmax(radius, 1.0) {
+                return None;
+            }
+            let radial = point_sub(p, center);
+            let tangent = point_sub(span[1], p);
+            if (radial.x * tangent.x + radial.y * tangent.y).abs()
+                > 1e-6 * radius * libm::fmax(distance(span[1], p), 1.0)
+            {
+                return None;
+            }
+        }
+    }
+    let radial = point_sub(start, center);
+    let mut points = sample_arc(center, start, end, radial.x * tangent.y - radial.y * tangent.x > 0.0);
+    *points.first_mut()? = start;
+    *points.last_mut()? = end;
+    Some(points)
+}
+
+fn point_sub(a: SketchVisualizationPoint, b: SketchVisualizationPoint) -> SketchVisualizationPoint {
+    SketchVisualizationPoint {
+        x: a.x - b.x,
+        y: a.y - b.y,
+    }
+}
+
+fn invalid_boundary(name: &str) -> SketchVisualizationError {
+    SketchVisualizationError::RegionBoundaryNotFound {
+        region_name: name.to_owned(),
+    }
+}
+
+fn sample_region_curve(curve: &CurveDebug) -> Option<Vec<SketchVisualizationPoint>> {
+    let point = |p: kittycad_modeling_cmds::shared::Point2d<f64>| SketchVisualizationPoint { x: p.x, y: p.y };
+    let start = point(curve.start?);
+    let mut points = match curve.segment_type {
+        CurveTypeDebug::Line => vec![start, point(curve.end?)],
+        CurveTypeDebug::Circle => {
+            let center = point(curve.center?);
+            sample_circle(center, distance(start, center))
+        }
+        CurveTypeDebug::ThreePointArc => {
+            let end = point(curve.end?);
+            let mid = point(curve.mid?);
+            // SketchGetInfo can omit the center for trimmed three-point arcs.
+            let center = curve
+                .center
+                .map(point)
+                .or_else(|| center_through_points(start, mid, end))?;
+            // Use the engine's on-arc midpoint, not the original segment's
+            // direction: trimming can reverse traversal or choose the other arc.
+            let cross = (mid.x - start.x) * (end.y - mid.y) - (mid.y - start.y) * (end.x - mid.x);
+            if cross.abs() <= f64::EPSILON {
+                return None;
+            }
+            let mut points = sample_arc(center, start, end, cross > 0.0);
+            *points.first_mut()? = start;
+            *points.last_mut()? = end;
+            points
+        }
+    };
+    if points.iter().any(|point| !point.x.is_finite() || !point.y.is_finite()) {
+        return None;
+    }
+    if matches!(curve.segment_type, CurveTypeDebug::Circle) {
+        *points.last_mut()? = *points.first()?;
+    }
+    Some(points)
+}
+
+fn center_through_points(
+    start: SketchVisualizationPoint,
+    mid: SketchVisualizationPoint,
+    end: SketchVisualizationPoint,
+) -> Option<SketchVisualizationPoint> {
+    let a = point_sub(mid, start);
+    let b = point_sub(end, start);
+    let d = 2.0 * (a.x * b.y - a.y * b.x);
+    if d.abs() <= f64::EPSILON {
+        return None;
+    }
+    let aa = a.x * a.x + a.y * a.y;
+    let bb = b.x * b.x + b.y * b.y;
+    Some(SketchVisualizationPoint {
+        x: start.x + (b.y * aa - a.y * bb) / d,
+        y: start.y + (a.x * bb - b.x * aa) / d,
+    })
+}
+
+/// Assemble all loops without inventing closing chords. Even-odd filling later
+/// preserves holes without relying on the engine's contour ordering or winding.
+fn closed_contours(mut polylines: Vec<Vec<SketchVisualizationPoint>>) -> Option<Vec<Vec<SketchVisualizationPoint>>> {
+    let mut contours = Vec::new();
+    while let Some(mut contour) = polylines.pop() {
+        let start = *contour.first()?;
+        while distance(*contour.last()?, start) > CONTACT_TOLERANCE {
+            let end = *contour.last()?;
+            let matches = polylines
+                .iter()
+                .enumerate()
+                .filter_map(|(index, line)| {
+                    if distance(end, *line.first()?) <= CONTACT_TOLERANCE {
+                        Some((index, false))
+                    } else if distance(end, *line.last()?) <= CONTACT_TOLERANCE {
+                        Some((index, true))
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>();
+            let [(index, reverse)] = matches.as_slice() else {
+                return None;
+            };
+            let mut next = polylines.remove(*index);
+            if *reverse {
+                next.reverse();
+            }
+            contour.extend(next.into_iter().skip(1));
+        }
+        if contour.len() < 4 {
+            return None;
+        }
+        *contour.last_mut()? = start;
+        contours.push(contour);
+    }
+    (!contours.is_empty()).then_some(contours)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn point(x: f64, y: f64) -> SketchVisualizationPoint {
+        SketchVisualizationPoint { x, y }
+    }
+
+    #[test]
+    fn samples_circular_controls_but_rejects_unsupported_shapes() {
+        let controls = [point(1.0, 0.0), point(1.0, 1.0), point(0.0, 1.0)];
+        let arc = sample_controlled_curve(cmds::shared::CurveType::Arc, &controls).unwrap();
+        assert_eq!(arc.first(), controls.first());
+        assert_eq!(arc.last(), controls.last());
+        assert!(arc.iter().all(|p| (libm::hypot(p.x, p.y) - 1.0).abs() < 1e-9));
+        assert!(sample_controlled_curve(cmds::shared::CurveType::Nurbs, &controls).is_none());
+        let noncircular = [point(1.0, 0.0), point(1.0, 1.0), point(0.0, 2.0)];
+        assert!(sample_controlled_curve(cmds::shared::CurveType::Arc, &noncircular).is_none());
+        assert!(sample_controlled_curve(cmds::shared::CurveType::Line, &controls).is_none());
+    }
+
+    #[test]
+    fn assembles_reversed_edges_without_closing_gaps_or_branches() {
+        let edges = vec![
+            vec![point(0.0, 0.0), point(2.0, 0.0)],
+            vec![point(0.0, 2.0), point(2.0, 0.0)],
+            vec![point(0.0, 2.0), point(0.0, 0.0)],
+        ];
+        assert_eq!(closed_contours(edges.clone()).unwrap()[0].len(), 4);
+        assert!(closed_contours(edges[..2].to_vec()).is_none());
+        let mut branched = edges;
+        branched.push(vec![point(0.0, 0.0), point(-1.0, -1.0)]);
+        assert!(closed_contours(branched).is_none());
+    }
+
+    #[test]
+    fn arc_midpoint_selects_minor_or_major_sweep() {
+        let mut curve = CurveDebug {
+            id: uuid::Uuid::nil().into(),
+            segment_type: CurveTypeDebug::ThreePointArc,
+            start: Some([1.0, 0.0].into()),
+            end: Some([0.0, 1.0].into()),
+            center: Some([0.0, 0.0].into()),
+            mid: Some([0.5f64.sqrt(), 0.5f64.sqrt()].into()),
+        };
+        let minor = sample_region_curve(&curve).unwrap();
+        assert!(minor.iter().all(|p| p.x >= -1e-9 && p.y >= -1e-9));
+        curve.center = None;
+        let without_center = sample_region_curve(&curve).unwrap();
+        assert!(without_center.iter().zip(&minor).all(|(a, b)| distance(*a, *b) < 1e-9));
+        curve.mid = Some([-0.5f64.sqrt(), -0.5f64.sqrt()].into());
+        let major = sample_region_curve(&curve).unwrap();
+        assert!(major.iter().any(|p| p.x < -0.9));
+        assert!(major.iter().any(|p| p.y < -0.9));
+        curve.mid = None;
+        assert!(sample_region_curve(&curve).is_none());
+        curve.start = Some([f64::NAN, 0.0].into());
+        assert!(sample_region_curve(&curve).is_none());
+    }
+}

--- a/rust/kcl-lib/src/tooling/sketch_visualizer/render.rs
+++ b/rust/kcl-lib/src/tooling/sketch_visualizer/render.rs
@@ -24,12 +24,16 @@ const CANVAS_WIDTH: u32 = 1024;
 const CANVAS_HEIGHT: u32 = 1024;
 const CANVAS_PADDING: u32 = 48;
 const PRIMARY_LINE_WIDTH: f64 = 3.0;
+const REGION_BOUNDARY_LINE_WIDTH: f64 = 8.0;
+const HIGHLIGHT_LINE_WIDTH: f64 = 5.0;
 const POINT_RADIUS: f64 = 4.0;
 const CONTACT_POINT_RADIUS: f64 = 5.0;
 
 const FREE_COLOR: Color = Color::rgb(0x3c, 0x73, 0xff);
 const CONFLICT_COLOR: Color = Color::rgb(0xff, 0x5e, 0x5b);
 const FIXED_COLOR: Color = Color::rgb(0xff, 0xff, 0xff);
+const HIGHLIGHT_COLOR: Color = Color::rgb(0xff, 0x4f, 0xd8);
+const REGION_BOUNDARY_COLOR: Color = Color::rgb(0x75, 0xff, 0x5a);
 const DARK_BACKGROUND: Color = Color::rgb(0x18, 0x1a, 0x1f);
 const POINT_OUTLINE_DARK: Color = Color::rgb(0x18, 0x1a, 0x1f);
 
@@ -72,7 +76,38 @@ pub(super) fn render_png(
     // transform below is the only world-to-screen conversion in the raster path.
     for segment in segments.values() {
         let color = dof_color(segment.freedom);
-        draw_polyline(&mut image, &segment.polyline, color, segment.construction, &transform);
+        draw_polyline(
+            &mut image,
+            &segment.polyline,
+            color,
+            PRIMARY_LINE_WIDTH,
+            segment.construction,
+            &transform,
+        );
+    }
+
+    // Draw the engine-resolved region first, then the caller-selected seed
+    // segments. When a seed is also on the resolved boundary, the green halo
+    // remains visible around the narrower magenta stroke.
+    for segment in segments.values().filter(|segment| segment.region_boundary) {
+        draw_polyline(
+            &mut image,
+            &segment.polyline,
+            REGION_BOUNDARY_COLOR,
+            REGION_BOUNDARY_LINE_WIDTH,
+            false,
+            &transform,
+        );
+    }
+    for segment in segments.values().filter(|segment| segment.highlighted) {
+        draw_polyline(
+            &mut image,
+            &segment.polyline,
+            HIGHLIGHT_COLOR,
+            HIGHLIGHT_LINE_WIDTH,
+            false,
+            &transform,
+        );
     }
 
     for (point_id, point) in points {
@@ -141,6 +176,7 @@ fn draw_polyline(
     image: &mut RgbaImage,
     points: &[SketchVisualizationPoint],
     color: Color,
+    line_width: f64,
     dashed: bool,
     transform: &Transform,
 ) {
@@ -148,14 +184,14 @@ fn draw_polyline(
         let start = transform.point(segment[0]);
         let end = transform.point(segment[1]);
         if dashed {
-            draw_dashed_line(image, start, end, color);
+            draw_dashed_line(image, start, end, color, line_width);
         } else {
-            draw_line(image, start, end, color);
+            draw_line(image, start, end, color, line_width);
         }
     }
 }
 
-fn draw_dashed_line(image: &mut RgbaImage, start: ScreenPoint, end: ScreenPoint, color: Color) {
+fn draw_dashed_line(image: &mut RgbaImage, start: ScreenPoint, end: ScreenPoint, color: Color, line_width: f64) {
     let length = screen_distance(start, end);
     if length <= f64::EPSILON {
         return;
@@ -169,15 +205,15 @@ fn draw_dashed_line(image: &mut RgbaImage, start: ScreenPoint, end: ScreenPoint,
         let dash_end = libm::fmin(cursor + dash, length);
         let from = interpolate_screen(start, end, cursor / length);
         let to = interpolate_screen(start, end, dash_end / length);
-        draw_line(image, from, to, color);
+        draw_line(image, from, to, color, line_width);
         cursor += step;
     }
 }
 
-fn draw_line(image: &mut RgbaImage, start: ScreenPoint, end: ScreenPoint, color: Color) {
+fn draw_line(image: &mut RgbaImage, start: ScreenPoint, end: ScreenPoint, color: Color, line_width: f64) {
     let length = screen_distance(start, end);
     if length <= f64::EPSILON {
-        draw_filled_circle(image, start, PRIMARY_LINE_WIDTH * 0.5, color);
+        draw_filled_circle(image, start, line_width * 0.5, color);
         return;
     }
 
@@ -187,12 +223,7 @@ fn draw_line(image: &mut RgbaImage, start: ScreenPoint, end: ScreenPoint, color:
     let samples = length.ceil() as usize;
     for index in 0..=samples {
         let t = index as f64 / samples as f64;
-        draw_filled_circle(
-            image,
-            interpolate_screen(start, end, t),
-            PRIMARY_LINE_WIDTH * 0.5,
-            color,
-        );
+        draw_filled_circle(image, interpolate_screen(start, end, t), line_width * 0.5, color);
     }
 }
 

--- a/rust/kcl-lib/src/tooling/sketch_visualizer/render.rs
+++ b/rust/kcl-lib/src/tooling/sketch_visualizer/render.rs
@@ -15,6 +15,7 @@ use image::RgbaImage;
 
 use super::model::InternalPoint;
 use super::model::InternalSegment;
+use super::region::ResolvedSketchRegion;
 use super::types::SketchVisualizationBounds;
 use super::types::SketchVisualizationError;
 use super::types::SketchVisualizationPoint;
@@ -24,7 +25,6 @@ const CANVAS_WIDTH: u32 = 1024;
 const CANVAS_HEIGHT: u32 = 1024;
 const CANVAS_PADDING: u32 = 48;
 const PRIMARY_LINE_WIDTH: f64 = 3.0;
-const REGION_BOUNDARY_LINE_WIDTH: f64 = 8.0;
 const HIGHLIGHT_LINE_WIDTH: f64 = 5.0;
 const POINT_RADIUS: f64 = 4.0;
 const CONTACT_POINT_RADIUS: f64 = 5.0;
@@ -33,7 +33,9 @@ const FREE_COLOR: Color = Color::rgb(0x3c, 0x73, 0xff);
 const CONFLICT_COLOR: Color = Color::rgb(0xff, 0x5e, 0x5b);
 const FIXED_COLOR: Color = Color::rgb(0xff, 0xff, 0xff);
 const HIGHLIGHT_COLOR: Color = Color::rgb(0xff, 0x4f, 0xd8);
-const REGION_BOUNDARY_COLOR: Color = Color::rgb(0x75, 0xff, 0x5a);
+// #75ff5a at 20% opacity over the dark background. The fill is drawn once,
+// before strokes and points, so their original constraint colors stay intact.
+const REGION_FILL_COLOR: Color = Color::rgb(43, 72, 43);
 const DARK_BACKGROUND: Color = Color::rgb(0x18, 0x1a, 0x1f);
 const POINT_OUTLINE_DARK: Color = Color::rgb(0x18, 0x1a, 0x1f);
 
@@ -68,44 +70,33 @@ pub(super) fn render_png(
     points: &BTreeMap<usize, InternalPoint>,
     contact_point_ids: &BTreeSet<usize>,
     bounds: SketchVisualizationBounds,
+    resolved_region: Option<&ResolvedSketchRegion>,
 ) -> Result<Vec<u8>, SketchVisualizationError> {
     let mut image = RgbaImage::from_pixel(CANVAS_WIDTH, CANVAS_HEIGHT, DARK_BACKGROUND.to_rgba());
     let transform = Transform::new(bounds);
 
-    // Segment polylines were sampled in world coordinates by extraction. The
-    // transform below is the only world-to-screen conversion in the raster path.
-    for segment in segments.values() {
-        let color = dof_color(segment.freedom);
-        draw_polyline(
-            &mut image,
-            &segment.polyline,
-            color,
-            PRIMARY_LINE_WIDTH,
-            segment.construction,
-            &transform,
-        );
+    if let Some(region) = resolved_region {
+        fill_region(&mut image, &region.contours, &transform);
     }
 
-    // Draw the engine-resolved region first, then the caller-selected seed
-    // segments. When a seed is also on the resolved boundary, the green halo
-    // remains visible around the narrower magenta stroke.
-    for segment in segments.values().filter(|segment| segment.region_boundary) {
-        draw_polyline(
-            &mut image,
-            &segment.polyline,
-            REGION_BOUNDARY_COLOR,
-            REGION_BOUNDARY_LINE_WIDTH,
-            false,
-            &transform,
-        );
-    }
+    // Seed halos sit below the normal stroke, not in place of constraint colors.
     for segment in segments.values().filter(|segment| segment.highlighted) {
         draw_polyline(
             &mut image,
             &segment.polyline,
             HIGHLIGHT_COLOR,
             HIGHLIGHT_LINE_WIDTH,
-            false,
+            segment.construction,
+            &transform,
+        );
+    }
+    for segment in segments.values() {
+        draw_polyline(
+            &mut image,
+            &segment.polyline,
+            dof_color(segment.freedom),
+            PRIMARY_LINE_WIDTH,
+            segment.construction,
             &transform,
         );
     }
@@ -130,6 +121,38 @@ pub(super) fn render_png(
     let mut cursor = Cursor::new(Vec::new());
     dynamic.write_to(&mut cursor, ImageFormat::Png)?;
     Ok(cursor.into_inner())
+}
+
+/// Even-odd scanline filling preserves nested holes regardless of winding.
+/// Contours have already been checked for closure; never infer closing edges.
+fn fill_region(image: &mut RgbaImage, contours: &[Vec<SketchVisualizationPoint>], transform: &Transform) {
+    let edges = contours
+        .iter()
+        .flat_map(|contour| {
+            contour
+                .windows(2)
+                .map(|edge| (transform.point(edge[0]), transform.point(edge[1])))
+        })
+        .collect::<Vec<_>>();
+    let mut crossings = Vec::new();
+    for row in 0..image.height() {
+        let y = row as f64 + 0.5;
+        crossings.clear();
+        for &(a, b) in &edges {
+            // Half-open intervals count a shared vertex only once.
+            if (a.y <= y && y < b.y) || (b.y <= y && y < a.y) {
+                crossings.push(a.x + (y - a.y) * (b.x - a.x) / (b.y - a.y));
+            }
+        }
+        crossings.sort_by(f64::total_cmp);
+        for pair in crossings.as_chunks::<2>().0 {
+            let start = (pair[0] - 0.5).ceil().clamp(0.0, image.width() as f64) as u32;
+            let end = (pair[1] - 0.5).ceil().clamp(0.0, image.width() as f64) as u32;
+            for column in start..end {
+                image.put_pixel(column, row, REGION_FILL_COLOR.to_rgba());
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/rust/kcl-lib/src/tooling/sketch_visualizer/render.rs
+++ b/rust/kcl-lib/src/tooling/sketch_visualizer/render.rs
@@ -25,14 +25,15 @@ const CANVAS_WIDTH: u32 = 1024;
 const CANVAS_HEIGHT: u32 = 1024;
 const CANVAS_PADDING: u32 = 48;
 const PRIMARY_LINE_WIDTH: f64 = 3.0;
-const HIGHLIGHT_LINE_WIDTH: f64 = 5.0;
+const HIGHLIGHT_LINE_WIDTH: f64 = 7.0;
+const HIGHLIGHT_SEPARATOR_WIDTH: f64 = 5.0;
 const POINT_RADIUS: f64 = 4.0;
 const CONTACT_POINT_RADIUS: f64 = 5.0;
 
 const FREE_COLOR: Color = Color::rgb(0x3c, 0x73, 0xff);
 const CONFLICT_COLOR: Color = Color::rgb(0xff, 0x5e, 0x5b);
 const FIXED_COLOR: Color = Color::rgb(0xff, 0xff, 0xff);
-const HIGHLIGHT_COLOR: Color = Color::rgb(0xff, 0x4f, 0xd8);
+const HIGHLIGHT_COLOR: Color = Color::rgb(0xff, 0xc0, 0x00);
 // #75ff5a at 20% opacity over the dark background. The fill is drawn once,
 // before strokes and points, so their original constraint colors stay intact.
 const REGION_FILL_COLOR: Color = Color::rgb(43, 72, 43);
@@ -79,13 +80,21 @@ pub(super) fn render_png(
         fill_region(&mut image, &region.contours, &transform);
     }
 
-    // Seed halos sit below the normal stroke, not in place of constraint colors.
+    // Gold halos and a dark separator sit below all constraint-colored strokes.
     for segment in segments.values().filter(|segment| segment.highlighted) {
         draw_polyline(
             &mut image,
             &segment.polyline,
             HIGHLIGHT_COLOR,
             HIGHLIGHT_LINE_WIDTH,
+            segment.construction,
+            &transform,
+        );
+        draw_polyline(
+            &mut image,
+            &segment.polyline,
+            DARK_BACKGROUND,
+            HIGHLIGHT_SEPARATOR_WIDTH,
             segment.construction,
             &transform,
         );
@@ -282,6 +291,63 @@ fn interpolate_screen(a: ScreenPoint, b: ScreenPoint, t: f64) -> ScreenPoint {
 mod tests {
     use super::*;
     use crate::tooling::sketch_visualizer::sampling::sample_circle;
+
+    #[test]
+    fn selected_strokes_keep_constraint_colors_separate_from_gold_and_region_fill() {
+        let point = |x, y| SketchVisualizationPoint { x, y };
+        let bounds = SketchVisualizationBounds {
+            min: point(-12.0, -12.0),
+            max: point(12.0, 12.0),
+        };
+        let region = ResolvedSketchRegion {
+            name: "region".to_owned(),
+            id: uuid::Uuid::nil(),
+            origin_sketch_id: uuid::Uuid::nil(),
+            contours: vec![vec![
+                point(-5.0, -5.0),
+                point(5.0, -5.0),
+                point(5.0, 5.0),
+                point(-5.0, 5.0),
+                point(-5.0, -5.0),
+            ]],
+        };
+        for freedom in [Freedom::Free, Freedom::Fixed, Freedom::Conflict] {
+            for resolved_region in [None, Some(&region)] {
+                let segments = BTreeMap::from([(
+                    1,
+                    InternalSegment {
+                        construction: false,
+                        freedom: Some(freedom),
+                        highlighted: true,
+                        polyline: vec![point(-10.0, 0.0), point(10.0, 0.0)],
+                    },
+                )]);
+                let png = render_png(&segments, &BTreeMap::new(), &BTreeSet::new(), bounds, resolved_region).unwrap();
+                let image = image::load_from_memory(&png).unwrap().into_rgba8();
+                // Probe both sides of the stroke, inside and outside the region.
+                for world_x in [-8.0, 0.0, 8.0] {
+                    let x = Transform::new(bounds).point(point(world_x, 0.0)).x as u32;
+                    for y in [511, 512] {
+                        assert_eq!(*image.get_pixel(x, y), dof_color(Some(freedom)).to_rgba());
+                    }
+                    for y in [510, 513] {
+                        assert_eq!(*image.get_pixel(x, y), DARK_BACKGROUND.to_rgba());
+                    }
+                    for y in [509, 514] {
+                        assert_eq!(*image.get_pixel(x, y), HIGHLIGHT_COLOR.to_rgba());
+                    }
+                    let background = if resolved_region.is_some() && world_x == 0.0 {
+                        REGION_FILL_COLOR
+                    } else {
+                        DARK_BACKGROUND
+                    };
+                    for y in [508, 515] {
+                        assert_eq!(*image.get_pixel(x, y), background.to_rgba());
+                    }
+                }
+            }
+        }
+    }
 
     #[test]
     fn point_colors_are_independent_of_segment_colors() {

--- a/rust/kcl-lib/src/tooling/sketch_visualizer/render.rs
+++ b/rust/kcl-lib/src/tooling/sketch_visualizer/render.rs
@@ -102,11 +102,7 @@ pub(super) fn render_png(
     }
 
     for (point_id, point) in points {
-        let owner_color = point
-            .owner
-            .and_then(|owner| segments.get(&owner))
-            .map(|segment| dof_color(segment.freedom));
-        let color = owner_color.unwrap_or_else(|| dof_color(Some(point.freedom)));
+        let color = dof_color(Some(point.freedom));
         let radius = if contact_point_ids.contains(point_id) {
             CONTACT_POINT_RADIUS
         } else {
@@ -279,5 +275,68 @@ fn interpolate_screen(a: ScreenPoint, b: ScreenPoint, t: f64) -> ScreenPoint {
     ScreenPoint {
         x: a.x + (b.x - a.x) * t,
         y: a.y + (b.y - a.y) * t,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tooling::sketch_visualizer::sampling::sample_circle;
+
+    #[test]
+    fn point_colors_are_independent_of_segment_colors() {
+        let center = SketchVisualizationPoint { x: 0.0, y: 0.0 };
+        let bounds = SketchVisualizationBounds {
+            min: SketchVisualizationPoint { x: -12.0, y: -12.0 },
+            max: SketchVisualizationPoint { x: 12.0, y: 12.0 },
+        };
+        for segment_freedom in [Freedom::Free, Freedom::Fixed, Freedom::Conflict] {
+            for point_freedom in [Freedom::Free, Freedom::Fixed, Freedom::Conflict] {
+                for highlighted in [false, true] {
+                    let segments = BTreeMap::from([(
+                        1,
+                        InternalSegment {
+                            construction: false,
+                            freedom: Some(segment_freedom),
+                            highlighted,
+                            polyline: sample_circle(center, 10.0),
+                        },
+                    )]);
+                    let start = SketchVisualizationPoint { x: 10.0, y: 0.0 };
+                    let points = BTreeMap::from([
+                        (
+                            2,
+                            InternalPoint {
+                                position: center,
+                                freedom: point_freedom,
+                            },
+                        ),
+                        (
+                            3,
+                            InternalPoint {
+                                position: start,
+                                freedom: point_freedom,
+                            },
+                        ),
+                    ]);
+                    let png = render_png(&segments, &points, &BTreeSet::new(), bounds, None).unwrap();
+                    let image = image::load_from_memory(&png).unwrap().into_rgba8();
+                    for position in [center, start] {
+                        let pixel = Transform::new(bounds).point(position);
+                        assert_eq!(
+                            *image.get_pixel(pixel.x as u32, pixel.y as u32),
+                            dof_color(Some(point_freedom)).to_rgba(),
+                            "point={point_freedom:?}, segment={segment_freedom:?}, highlighted={highlighted}"
+                        );
+                    }
+                    let rim = Transform::new(bounds).point(SketchVisualizationPoint { x: -10.0, y: 0.0 });
+                    assert_eq!(
+                        *image.get_pixel(rim.x as u32, rim.y as u32),
+                        dof_color(Some(segment_freedom)).to_rgba(),
+                        "the circle stroke must retain its segment constraint color"
+                    );
+                }
+            }
+        }
     }
 }

--- a/rust/kcl-lib/src/tooling/sketch_visualizer/tests.rs
+++ b/rust/kcl-lib/src/tooling/sketch_visualizer/tests.rs
@@ -30,6 +30,54 @@ async fn exec_outcome_renders_sketch_png_separately_from_constraint_report() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn exec_outcome_highlights_named_segments() {
+    let outcome = execute_visualizer_kcl(&sketch_visualizer_test_root().join("connected_profile/input.kcl")).await;
+    let png = outcome
+        .render_sketch_png_with_overlays("profile", &["bottom".to_owned(), "right".to_owned()], None)
+        .expect("the named segments should be highlighted");
+
+    assert!(png_contains_color(&png, [0xff, 0x4f, 0xd8, 0xff]));
+    assert!(!png_contains_color(&png, [0x75, 0xff, 0x5a, 0xff]));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn exec_outcome_rejects_unknown_overlay_names() {
+    let outcome = execute_visualizer_kcl(&sketch_visualizer_test_root().join("connected_profile/input.kcl")).await;
+
+    let segment_error = outcome
+        .render_sketch_png_with_overlays("profile", &["missing".to_owned()], None)
+        .expect_err("an unknown segment should fail");
+    assert!(matches!(
+        segment_error,
+        crate::tooling::sketch_visualizer::SketchVisualizationError::SegmentNotFound { .. }
+    ));
+
+    let region_error = outcome
+        .render_sketch_png_with_overlays("profile", &[], Some("missing"))
+        .expect_err("an unknown region should fail");
+    assert!(matches!(
+        region_error,
+        crate::tooling::sketch_visualizer::SketchVisualizationError::RegionNotFound { .. }
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn exec_outcome_renders_engine_resolved_region_boundary() {
+    let outcome =
+        execute_visualizer_kcl_with_engine(&sketch_visualizer_test_root().join("region_overlay/input.kcl")).await;
+    let png = outcome
+        .render_sketch_png_with_overlays(
+            "profile",
+            &["bottom".to_owned(), "right".to_owned()],
+            Some("selectedRegion"),
+        )
+        .expect("the named segments and resolved region should be highlighted");
+
+    assert!(png_contains_color(&png, [0xff, 0x4f, 0xd8, 0xff]));
+    assert!(png_contains_color(&png, [0x75, 0xff, 0x5a, 0xff]));
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn snapshots_kcl_visualizer_pngs() {
     let manifest = sketch_visualizer_snapshot_manifest();
 
@@ -49,6 +97,14 @@ fn assert_png_snapshot(case_name: &str, png: &[u8]) {
     twenty_twenty::assert_image(output_dir.join("dof.png"), &image, 1.0);
 }
 
+fn png_contains_color(png: &[u8], expected: [u8; 4]) -> bool {
+    image::load_from_memory(png)
+        .expect("the renderer should return a valid PNG")
+        .into_rgba8()
+        .pixels()
+        .any(|pixel| pixel.0 == expected)
+}
+
 async fn execute_visualizer_kcl(input_path: &Path) -> ExecOutcome {
     let source = std::fs::read_to_string(input_path)
         .unwrap_or_else(|err| panic!("failed to read `{}`: {err}", input_path.display()));
@@ -66,6 +122,25 @@ async fn execute_visualizer_kcl(input_path: &Path) -> ExecOutcome {
                 ..Default::default()
             },
         )
+        .await
+        .unwrap_or_else(|err| panic!("failed to execute `{}`: {err:?}", input_path.display()));
+    ctx.close().await;
+    outcome
+}
+
+async fn execute_visualizer_kcl_with_engine(input_path: &Path) -> ExecOutcome {
+    let source = std::fs::read_to_string(input_path)
+        .unwrap_or_else(|err| panic!("failed to read `{}`: {err}", input_path.display()));
+    let program = Program::parse_no_errs(&source)
+        .unwrap_or_else(|err| panic!("failed to parse `{}`: {err:?}", input_path.display()));
+    let mut settings = ExecutorSettings::default();
+    settings.with_current_file(TypedPath(input_path.to_path_buf()));
+    settings.project_directory = input_path.parent().map(|path| TypedPath(path.to_path_buf()));
+    let ctx = ExecutorContext::new_with_client(settings, None, None)
+        .await
+        .expect("the engine context should connect");
+    let outcome = ctx
+        .run_with_caching(program)
         .await
         .unwrap_or_else(|err| panic!("failed to execute `{}`: {err:?}", input_path.display()));
     ctx.close().await;

--- a/rust/kcl-lib/src/tooling/sketch_visualizer/tests.rs
+++ b/rust/kcl-lib/src/tooling/sketch_visualizer/tests.rs
@@ -37,7 +37,7 @@ async fn exec_outcome_highlights_named_segments() {
         .expect("the named segments should be highlighted");
 
     assert!(png_contains_color(&png, [0xff, 0x4f, 0xd8, 0xff]));
-    assert!(!png_contains_color(&png, [0x75, 0xff, 0x5a, 0xff]));
+    assert!(!png_contains_color(&png, [43, 72, 43, 255]));
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -52,8 +52,10 @@ async fn exec_outcome_rejects_unknown_overlay_names() {
         crate::tooling::sketch_visualizer::SketchVisualizationError::SegmentNotFound { .. }
     ));
 
+    let ctx = ExecutorContext::new_mock(None).await;
     let region_error = outcome
-        .render_sketch_png_with_overlays("profile", &[], Some("missing"))
+        .resolve_sketch_region(&ctx, "missing")
+        .await
         .expect_err("an unknown region should fail");
     assert!(matches!(
         region_error,
@@ -62,19 +64,30 @@ async fn exec_outcome_rejects_unknown_overlay_names() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn exec_outcome_renders_engine_resolved_region_boundary() {
-    let outcome =
+async fn exec_outcome_renders_engine_resolved_region_fill() {
+    let (outcome, region) =
         execute_visualizer_kcl_with_engine(&sketch_visualizer_test_root().join("region_overlay/input.kcl")).await;
     let png = outcome
-        .render_sketch_png_with_overlays(
-            "profile",
-            &["bottom".to_owned(), "right".to_owned()],
-            Some("selectedRegion"),
-        )
+        .render_sketch_png_with_overlays("profile", &["bottom".to_owned(), "right".to_owned()], Some(&region))
         .expect("the named segments and resolved region should be highlighted");
 
     assert!(png_contains_color(&png, [0xff, 0x4f, 0xd8, 0xff]));
-    assert!(png_contains_color(&png, [0x75, 0xff, 0x5a, 0xff]));
+    assert!(png_contains_color(&png, [43, 72, 43, 255]));
+    // Every original line/point pixel must retain its constraint color.
+    let plain = image::load_from_memory(&outcome.render_sketch_png("profile").unwrap())
+        .unwrap()
+        .into_rgba8();
+    let filled = image::load_from_memory(&png).unwrap().into_rgba8();
+    for (before, after) in plain.pixels().zip(filled.pixels()) {
+        if matches!(
+            before.0,
+            [60, 115, 255, 255] | [255, 255, 255, 255] | [255, 94, 91, 255]
+        ) {
+            assert_eq!(before, after);
+        }
+    }
+    assert_eq!(filled.get_pixel(512, 512).0, [43, 72, 43, 255]);
+    assert_eq!(filled.get_pixel(20, 20).0, [24, 26, 31, 255]);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -88,6 +101,83 @@ async fn snapshots_kcl_visualizer_pngs() {
             .render_sketch_png(&case.sketch)
             .unwrap_or_else(|err| panic!("failed to visualize sketch for case `{}`: {err:?}", case.name));
         assert_png_snapshot(&case.name, &png);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn engine_region_fill_uses_trimmed_curves_and_sketch_units() {
+    // Public primitive regression fixtures, not trace/eval checkpoint data.
+    for (plane, unit, direction) in [("XY", "mm", "CW"), ("XZ", "in", "CCW")] {
+        let source = format!(
+            r#"
+@settings(defaultLengthUnit = {unit}, kclVersion = "3.0-preview")
+profile = sketch(on = {plane}) {{
+  rim = circle(start = [10{unit}, 0{unit}], center = [0{unit}, 0{unit}])
+  chord = line(start = [-8{unit}, 6{unit}], end = [8{unit}, 6{unit}])
+}}
+selectedRegion = region(segments = [profile.chord, profile.rim], direction = {direction})
+"#
+        );
+        let ctx = ExecutorContext::new_with_client(ExecutorSettings::default(), None, None)
+            .await
+            .unwrap();
+        let outcome = ctx
+            .run_with_caching(Program::parse_no_errs(&source).unwrap())
+            .await
+            .unwrap_or_else(|e| panic!("{}", e.error));
+        let region = outcome.resolve_sketch_region(&ctx, "selectedRegion").await.unwrap();
+        ctx.close().await;
+        assert_eq!(region.contours.len(), 1);
+        let contour = &region.contours[0];
+        assert!(contour.len() > 4, "the circular portion must be sampled");
+        assert!(
+            contour.iter().all(|p| libm::hypot(p.x, p.y) <= 10.00001),
+            "must not include untrimmed chord endpoints"
+        );
+        assert!(
+            contour
+                .iter()
+                .any(|p| (p.y - 6.0).abs() < 1e-6 && (p.x.abs() - 8.0).abs() < 1e-6)
+        );
+        let png = outcome
+            .render_sketch_png_with_overlays("profile", &["chord".to_owned()], Some(&region))
+            .unwrap();
+        assert!(png_contains_color(&png, [43, 72, 43, 255]));
+        assert!(png_contains_color(&png, [255, 255, 255, 255]));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn engine_region_fill_preserves_holes() {
+    let source = r#"
+@settings(kclVersion = "3.0-preview")
+profile = sketch(on = XY) {
+  rim = circle(start = [10mm, 0mm], center = [0mm, 0mm])
+  hole = circle(start = [3mm, 0mm], center = [0mm, 0mm])
+}
+selectedRegion = subtract2d(region(segments = [profile.rim]), tool = region(segments = [profile.hole]))
+"#;
+    let inch_source = source
+        .replace("mm", "in")
+        .replace("on = XY", "on = XZ")
+        .replace("@settings(", "@settings(defaultLengthUnit = in, ");
+    for source in [source, inch_source.as_str()] {
+        let ctx = ExecutorContext::new_with_client(ExecutorSettings::default(), None, None)
+            .await
+            .unwrap();
+        let outcome = ctx
+            .run_with_caching(Program::parse_no_errs(source).unwrap())
+            .await
+            .unwrap_or_else(|e| panic!("{}", e.error));
+        let region = outcome.resolve_sketch_region(&ctx, "selectedRegion").await.unwrap();
+        ctx.close().await;
+        assert_eq!(region.contours.len(), 2);
+        let png = outcome
+            .render_sketch_png_with_overlays("profile", &[], Some(&region))
+            .unwrap();
+        let image = image::load_from_memory(&png).unwrap().into_rgba8();
+        assert_eq!(image.get_pixel(540, 540).0, [24, 26, 31, 255]);
+        assert_eq!(image.get_pixel(800, 512).0, [43, 72, 43, 255]);
     }
 }
 
@@ -128,7 +218,7 @@ async fn execute_visualizer_kcl(input_path: &Path) -> ExecOutcome {
     outcome
 }
 
-async fn execute_visualizer_kcl_with_engine(input_path: &Path) -> ExecOutcome {
+async fn execute_visualizer_kcl_with_engine(input_path: &Path) -> (ExecOutcome, super::ResolvedSketchRegion) {
     let source = std::fs::read_to_string(input_path)
         .unwrap_or_else(|err| panic!("failed to read `{}`: {err}", input_path.display()));
     let program = Program::parse_no_errs(&source)
@@ -143,8 +233,9 @@ async fn execute_visualizer_kcl_with_engine(input_path: &Path) -> ExecOutcome {
         .run_with_caching(program)
         .await
         .unwrap_or_else(|err| panic!("failed to execute `{}`: {err:?}", input_path.display()));
+    let region = outcome.resolve_sketch_region(&ctx, "selectedRegion").await.unwrap();
     ctx.close().await;
-    outcome
+    (outcome, region)
 }
 
 fn sketch_visualizer_snapshot_manifest() -> SketchVisualizerSnapshotManifest {

--- a/rust/kcl-lib/src/tooling/sketch_visualizer/tests.rs
+++ b/rust/kcl-lib/src/tooling/sketch_visualizer/tests.rs
@@ -187,6 +187,109 @@ fn assert_png_snapshot(case_name: &str, png: &[u8]) {
     twenty_twenty::assert_image(output_dir.join("dof.png"), &image, 1.0);
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn engine_trace_checkpoint_overlays() {
+    for (name, sketch, seeds, region_name) in [
+        (
+            "case_cover_0009",
+            "flangeSketch",
+            vec!["topRightBlend", "topLeftBlend", "bottomRightBlend", "bottomLeftBlend"],
+            Some("topEarRegion"),
+        ),
+        (
+            "case_cover_0034",
+            "flangeSketch",
+            vec!["topChord", "topRightBlend", "topLug", "topLeftBlend"],
+            Some("topEarRegion"),
+        ),
+        (
+            "case_cover_0055",
+            "flangeSketch",
+            vec!["topChord", "topRightBlend", "topLug", "topLeftBlend"],
+            Some("topEarRegion"),
+        ),
+        (
+            "case_cover_0126",
+            "topEarSketch",
+            vec!["rightBlend", "lugOuter", "leftBlend", "chord"],
+            Some("topEarRegion"),
+        ),
+        (
+            "ceiling_tile_hanger_0054",
+            "hookOuterSketch",
+            vec!["topEdge", "rightEdge", "rightRound", "leftRound", "leftEdge"],
+            None,
+        ),
+    ] {
+        let source = std::fs::read_to_string(
+            sketch_visualizer_test_root()
+                .join("trace_overlays")
+                .join(format!("{name}.kcl")),
+        )
+        .unwrap();
+        let ctx = ExecutorContext::new_with_client(ExecutorSettings::default(), None, None)
+            .await
+            .unwrap();
+        let outcome = ctx
+            .run_with_caching(Program::parse_no_errs(&source).unwrap())
+            .await
+            .unwrap_or_else(|e| panic!("{name}: {}", e.error));
+        let region = match region_name {
+            Some(region_name) => Some(outcome.resolve_sketch_region(&ctx, region_name).await.unwrap()),
+            None => None,
+        };
+        ctx.close().await;
+        let seeds = seeds.into_iter().map(str::to_owned).collect::<Vec<_>>();
+        let plain = image::load_from_memory(&outcome.render_sketch_png(sketch).unwrap())
+            .unwrap()
+            .into_rgba8();
+        let png = outcome
+            .render_sketch_png_with_overlays(sketch, &seeds, region.as_ref())
+            .unwrap();
+        let overlay = image::load_from_memory(&png).unwrap().into_rgba8();
+        assert_eq!(plain.dimensions(), overlay.dimensions());
+        for (before, after) in plain.pixels().zip(overlay.pixels()) {
+            if matches!(
+                before.0,
+                [60, 115, 255, 255] | [255, 255, 255, 255] | [255, 94, 91, 255]
+            ) {
+                assert_eq!(before, after, "{name}: overlay replaced a constraint color");
+            }
+        }
+        assert!(png_contains_color(&png, [0xff, 0x4f, 0xd8, 0xff]));
+        let filled_pixels = overlay.pixels().filter(|p| p.0 == [43, 72, 43, 255]).count();
+        if let Some(region) = region {
+            assert_eq!(region.contours.len(), 1, "{name}: unexpected extra boundary");
+            let contour = &region.contours[0];
+            assert!(super::sampling::distance(contour[0], *contour.last().unwrap()) < 1e-6);
+            let area = contour
+                .windows(2)
+                .map(|p| p[0].x * p[1].y - p[1].x * p[0].y)
+                .sum::<f64>()
+                .abs()
+                / 2.0;
+            if name == "case_cover_0009" {
+                assert!((area - 34.1219393).abs() < 1e-4);
+                assert!(filled_pixels > 350_000);
+                assert_eq!(overlay.get_pixel(550, 550).0, [43, 72, 43, 255]);
+            } else {
+                // These real checkpoints select a tiny cap of the right blend,
+                // not the intended ear. Do not inflate it or fill the whole loop.
+                assert!((area - 0.0709887).abs() < 1e-5, "{name}: area={area}");
+                assert!(
+                    contour
+                        .iter()
+                        .all(|p| (1.07..1.91).contains(&p.x) && (2.86..2.99).contains(&p.y))
+                );
+                assert!((300..700).contains(&filled_pixels), "{name}: pixels={filled_pixels}");
+                assert_eq!(overlay.get_pixel(550, 550).0, [24, 26, 31, 255]);
+            }
+        } else {
+            assert_eq!(filled_pixels, 0);
+        }
+    }
+}
+
 fn png_contains_color(png: &[u8], expected: [u8; 4]) -> bool {
     image::load_from_memory(png)
         .expect("the renderer should return a valid PNG")

--- a/rust/kcl-lib/src/tooling/sketch_visualizer/tests.rs
+++ b/rust/kcl-lib/src/tooling/sketch_visualizer/tests.rs
@@ -36,7 +36,7 @@ async fn exec_outcome_highlights_named_segments() {
         .render_sketch_png_with_overlays("profile", &["bottom".to_owned(), "right".to_owned()], None)
         .expect("the named segments should be highlighted");
 
-    assert!(png_contains_color(&png, [0xff, 0x4f, 0xd8, 0xff]));
+    assert!(png_contains_color(&png, [0xff, 0xc0, 0x00, 0xff]));
     assert!(!png_contains_color(&png, [43, 72, 43, 255]));
 }
 
@@ -71,7 +71,7 @@ async fn exec_outcome_renders_engine_resolved_region_fill() {
         .render_sketch_png_with_overlays("profile", &["bottom".to_owned(), "right".to_owned()], Some(&region))
         .expect("the named segments and resolved region should be highlighted");
 
-    assert!(png_contains_color(&png, [0xff, 0x4f, 0xd8, 0xff]));
+    assert!(png_contains_color(&png, [0xff, 0xc0, 0x00, 0xff]));
     assert!(png_contains_color(&png, [43, 72, 43, 255]));
     // Every original line/point pixel must retain its constraint color.
     let plain = image::load_from_memory(&outcome.render_sketch_png("profile").unwrap())
@@ -256,7 +256,7 @@ async fn engine_trace_checkpoint_overlays() {
                 assert_eq!(before, after, "{name}: overlay replaced a constraint color");
             }
         }
-        assert!(png_contains_color(&png, [0xff, 0x4f, 0xd8, 0xff]));
+        assert!(png_contains_color(&png, [0xff, 0xc0, 0x00, 0xff]));
         let filled_pixels = overlay.pixels().filter(|p| p.0 == [43, 72, 43, 255]).count();
         if let Some(region) = region {
             assert_eq!(region.contours.len(), 1, "{name}: unexpected extra boundary");
@@ -281,7 +281,20 @@ async fn engine_trace_checkpoint_overlays() {
                         .iter()
                         .all(|p| (1.07..1.91).contains(&p.x) && (2.86..2.99).contains(&p.y))
                 );
-                assert!((300..700).contains(&filled_pixels), "{name}: pixels={filled_pixels}");
+                let region_only = outcome
+                    .render_sketch_png_with_overlays(sketch, &[], Some(&region))
+                    .unwrap();
+                let region_pixels = image::load_from_memory(&region_only)
+                    .unwrap()
+                    .into_rgba8()
+                    .pixels()
+                    .filter(|p| p.0 == [43, 72, 43, 255])
+                    .count();
+                // Halos can cover part of this tiny cap, but must not erase or enlarge it.
+                assert!(
+                    filled_pixels > 0 && filled_pixels <= region_pixels,
+                    "{name}: pixels={filled_pixels}"
+                );
                 assert_eq!(overlay.get_pixel(550, 550).0, [24, 26, 31, 255]);
             }
         } else {

--- a/rust/kcl-lib/src/tooling/sketch_visualizer/types.rs
+++ b/rust/kcl-lib/src/tooling/sketch_visualizer/types.rs
@@ -24,6 +24,18 @@ pub enum SketchVisualizationError {
     SketchNotFound { name: String },
     #[error("found {count} sketches named `{name}` in the execution outcome")]
     AmbiguousSketchName { name: String, count: usize },
+    #[error("sketch `{sketch_name}` has no segment named `{segment_name}`")]
+    SegmentNotFound { sketch_name: String, segment_name: String },
+    #[error("segment `{segment_name}` in sketch `{sketch_name}` was not solved")]
+    SegmentNotSolved { sketch_name: String, segment_name: String },
+    #[error("no region named `{name}` was found in the execution outcome")]
+    RegionNotFound { name: String },
+    #[error("`{name}` is not a resolved region")]
+    NotARegion { name: String },
+    #[error("region `{region_name}` was resolved from a different sketch than `{sketch_name}`")]
+    RegionSketchMismatch { sketch_name: String, region_name: String },
+    #[error("region `{region_name}` has no resolved boundary segments in the artifact graph")]
+    RegionBoundaryNotFound { region_name: String },
     #[error("object id {id} was missing from the execution scene objects")]
     MissingObject { id: usize },
     #[error("failed to encode sketch visualization PNG: {0}")]

--- a/rust/kcl-lib/src/tooling/sketch_visualizer/types.rs
+++ b/rust/kcl-lib/src/tooling/sketch_visualizer/types.rs
@@ -34,8 +34,10 @@ pub enum SketchVisualizationError {
     NotARegion { name: String },
     #[error("region `{region_name}` was resolved from a different sketch than `{sketch_name}`")]
     RegionSketchMismatch { sketch_name: String, region_name: String },
-    #[error("region `{region_name}` has no resolved boundary segments in the artifact graph")]
+    #[error("region `{region_name}` has no complete supported closed boundary available for filling")]
     RegionBoundaryNotFound { region_name: String },
+    #[error("failed to query the resolved region: {0}")]
+    Engine(#[from] crate::KclError),
     #[error("object id {id} was missing from the execution scene objects")]
     MissingObject { id: usize },
     #[error("failed to encode sketch visualization PNG: {0}")]

--- a/rust/kcl-lib/tests/sketch_visualizer/region_overlay/input.kcl
+++ b/rust/kcl-lib/tests/sketch_visualizer/region_overlay/input.kcl
@@ -1,0 +1,13 @@
+profile = sketch(on = XY) {
+  bottom = line(start = [var 0mm, var 0mm], end = [var 40mm, var 0mm])
+  right = line(start = [var 40mm, var 0mm], end = [var 40mm, var 24mm])
+  top = line(start = [var 40mm, var 24mm], end = [var 0mm, var 24mm])
+  left = line(start = [var 0mm, var 24mm], end = [var 0mm, var 0mm])
+
+  coincident([bottom.end, right.start])
+  coincident([right.end, top.start])
+  coincident([top.end, left.start])
+  coincident([left.end, bottom.start])
+}
+
+selectedRegion = region(segments = [profile.bottom, profile.right])

--- a/rust/kcl-lib/tests/sketch_visualizer/trace_overlays/README.md
+++ b/rust/kcl-lib/tests/sketch_visualizer/trace_overlays/README.md
@@ -1,0 +1,45 @@
+# Trace-backed overlay regression fixtures
+
+These are real Zookeeper checkpoints, not generated examples or new eval items.
+Each file is the unchanged source prefix through the requested top-level sketch
+or region declaration, extracted using MCP's `_source_through_sketch`. Later
+declarations were omitted to isolate rendering from downstream modeling errors.
+No coordinates, constraints, region arguments, or seed names were rewritten.
+The table includes both the full recorded source revision and fixture hash.
+
+- Case Cover: [trace 01a073ce-f333-772e-8893-981425ccec0d](https://www.comet.com/opik/zookeeper/projects/019c72bb-b1bb-7633-849d-007f7e84b9b2/logs?trace=01a073ce-f333-772e-8893-981425ccec0d),
+  [workflow 33996386838](https://github.com/KittyCAD/text-to-cad-eval/actions/runs/33996386838),
+  artifact `controlled-sketch-repair-candidate-2`.
+- Ceiling Tile Hanger: [trace 01a073bb-0e4d-7c5e-b9b4-3ac9c5b1d696](https://www.comet.com/opik/zookeeper/projects/019c72bb-b1bb-7633-849d-007f7e84b9b2/logs?trace=01a073bb-0e4d-7c5e-b9b4-3ac9c5b1d696),
+  [workflow 33996388007](https://github.com/KittyCAD/text-to-cad-eval/actions/runs/33996388007),
+  artifact `controlled-sketch-repair-candidate-1`.
+
+Frame numbers are zero-based indexes in the saved `response.json` stream;
+images are named `zk-stream-NNNN-00-sketch-visualization.png`.
+
+| Fixture | Stream frame | Tool call ID | Full source SHA-256 | Fixture SHA-256 |
+| --- | --- | --- | --- | --- |
+| case_cover_0009.kcl | 9 | `call_MwmiLhqkAwcWRSYV9SW4vJHr` | `e5086cecb6623f4b8f85619073e471cb9cc5ce1042ef2299b3271a892d1fac33` | `bb9106d503d389819a8ffd7f1469b532bbd0c23cd79f91336632a157bd965421` |
+| case_cover_0034.kcl | 34 | `call_xvfTPoQC80wkFItm7lr4yHYc` | `dd1abad185a5e7ed0364bc7e881faf85fe59597d3aca975685f5b8d765180d28` | `8dfdc878a4b89dbbf606a0db9eb250b7c682e53fd06262c83758f28948282f48` |
+| case_cover_0055.kcl | 55 | `call_naPVaLCXGveUZG3F6EqvFO33` | `e592dda89c3cdb69414859ac753bc9849b7365cb9ef9cb29df7bb772055c9a23` | `07f889ad9bfccee04038a6476c9320f947910f74e3b81c2bf3a20c2e916f41d3` |
+| case_cover_0126.kcl | 126 | `call_c8DJdKZIfgihrQ7D6Vjo27GQ` | `70f96958fcaf4a989ce8716981947c6cf6a9afc6828ba2df8d75b0ba3965cf86` | `48aad6ad4bbe61fb4bbca603786dd743351929272b64ca97d0956334b8a21c9d` |
+| ceiling_tile_hanger_0054.kcl | 54 | `call_vMklmNlP7vMPD6R2zBD040Jm` | `00dfd61d54715651b45a5dda438570498a61f9fc46c1d8bf9bacf60fe4fa61ea` | `1b101be0fb1598e608c8fc2886db8594573328616c4e858ca91e0d89cceb0a0f` |
+
+## What is verified
+
+`engine_trace_checkpoint_overlays` executes these prefixes with the real engine,
+captures trimmed region contours, and renders with the recorded seed selection.
+
+- Frame 9 selects the large central region (about 34.12194 square inches).
+- Frames 34, 55, and 126 select a small circular cap of the right blend
+  (about 0.0709887 square inches), not the whole intended ear.
+  The original PNGs contain respectively 390, 390, and 506 green pixels.
+  These fills are small, not absent or zero-area. The regression checks both
+  contour coordinates/area and bounded visible fill size, not just PNG success.
+- Hanger frame 54 requests highlights without a resolved region and must not fill.
+- Every existing blue/white/red line or point pixel must retain its constraint
+  color when overlays are added.
+
+Run from `rust/` with engine credentials:
+`cargo test -p kcl-lib engine_trace_checkpoint_overlays --lib`.
+These tests do not invoke Zookeeper, change dataset items, or calculate eval scores.

--- a/rust/kcl-lib/tests/sketch_visualizer/trace_overlays/case_cover_0009.kcl
+++ b/rust/kcl-lib/tests/sketch_visualizer/trace_overlays/case_cover_0009.kcl
@@ -1,0 +1,134 @@
+// Case Cover
+// Dimensioned ABS cover reproduced from drawing 25-02-09.
+@settings(defaultLengthUnit = in, kclVersion = 2.0)
+
+mainDiameter = 6.875in
+mainRadius = mainDiameter / 2
+overallLength = 9.000in
+lugOuterRadius = 1.125in
+lugCenterOffset = overallLength / 2 - lugOuterRadius
+lugBlendRadius = 0.750in
+lugThroughDiameter = 0.875in
+lugCounterboreDiameter = 1.375in
+lugCounterboreDepth = 0.250in
+flangeThickness = 0.625in
+shellBaseInset = 0.375in
+shellOuterBaseRadius = mainRadius - shellBaseInset
+overallHeight = 2.250in
+centralHoleDiameter = 2.500in
+centralHoleRadius = centralHoleDiameter / 2
+wallThickness = 0.375in
+outerCrownRadius = 1.375in
+innerCrownRadius = 1.000in
+draftAngle = 16deg
+crownCenterHeight = overallHeight - outerCrownRadius
+outerTangentHeight = crownCenterHeight + outerCrownRadius * sin(draftAngle)
+outerTangentRadius = shellOuterBaseRadius - (outerTangentHeight - flangeThickness) * tan(draftAngle)
+crownCenterRadius = outerTangentRadius - outerCrownRadius * cos(draftAngle)
+innerTangentHeight = crownCenterHeight + innerCrownRadius * sin(draftAngle)
+innerTangentRadius = crownCenterRadius + innerCrownRadius * cos(draftAngle)
+cavityOpeningRadius = innerTangentRadius + (innerTangentHeight - flangeThickness) * tan(draftAngle)
+
+flangeSketch = sketch(on = XY) {
+  mainRight = arc(
+    start = [var 1.9057in, var 2.8609in],
+    end = [var 1.9057in, var -2.8609in],
+    center = [var 0in, var 0in],
+    direction = CW,
+  )
+  mainLeft = arc(
+    start = [var -1.9057in, var 2.8609in],
+    end = [var -1.9057in, var -2.8609in],
+    center = [var 0in, var 0in],
+  )
+  topLug = arc(
+    start = [var 0.8940in, var 2.6920in],
+    end = [var -0.8940in, var 2.6920in],
+    center = [var 0in, var 3.375in],
+  )
+  bottomLug = arc(
+    start = [var 0.8940in, var -2.6920in],
+    end = [var -0.8940in, var -2.6920in],
+    center = [var 0in, var -3.375in],
+    direction = CW,
+  )
+  topRightBlend = arc(
+    start = [var 1.9057in, var 2.8609in],
+    end = [var 0.8940in, var 2.6920in],
+    center = [var 1.4899in, var 2.2367in],
+  )
+  topLeftBlend = arc(
+    start = [var -1.9057in, var 2.8609in],
+    end = [var -0.8940in, var 2.6920in],
+    center = [var -1.4899in, var 2.2367in],
+    direction = CW,
+  )
+  bottomRightBlend = arc(
+    start = [var 1.9057in, var -2.8609in],
+    end = [var 0.8940in, var -2.6920in],
+    center = [var 1.4899in, var -2.2367in],
+    direction = CW,
+  )
+  bottomLeftBlend = arc(
+    start = [var -1.9057in, var -2.8609in],
+    end = [var -0.8940in, var -2.6920in],
+    center = [var -1.4899in, var -2.2367in],
+  )
+  topChord = line(
+    start = [var -1.9057in, var 2.8609in],
+    end = [var 1.9057in, var 2.8609in],
+  )
+  bottomChord = line(
+    start = [var 1.9057in, var -2.8609in],
+    end = [var -1.9057in, var -2.8609in],
+  )
+
+  coincident([mainRight.center, ORIGIN])
+  coincident([mainLeft.center, mainRight.center])
+  radius(mainRight) == mainRadius
+  equalRadius([mainRight, mainLeft])
+
+  horizontalDistance([ORIGIN, topLug.center]) == 0in
+  verticalDistance([ORIGIN, topLug.center]) == lugCenterOffset
+  horizontalDistance([ORIGIN, bottomLug.center]) == 0in
+  verticalDistance([ORIGIN, bottomLug.center]) == -lugCenterOffset
+  radius(topLug) == lugOuterRadius
+  equalRadius([topLug, bottomLug])
+
+  radius(topRightBlend) == lugBlendRadius
+  equalRadius([
+    topRightBlend,
+    topLeftBlend,
+    bottomRightBlend,
+    bottomLeftBlend
+  ])
+
+  coincident([mainRight.start, topRightBlend.start])
+  coincident([topRightBlend.end, topLug.start])
+  coincident([topLug.end, topLeftBlend.end])
+  coincident([topLeftBlend.start, mainLeft.start])
+  coincident([mainLeft.end, bottomLeftBlend.start])
+  coincident([bottomLeftBlend.end, bottomLug.end])
+  coincident([bottomLug.start, bottomRightBlend.end])
+  coincident([bottomRightBlend.start, mainRight.end])
+  coincident([topChord.start, mainLeft.start])
+  coincident([topChord.end, mainRight.start])
+  coincident([bottomChord.start, mainRight.end])
+  coincident([bottomChord.end, mainLeft.end])
+  horizontal(topChord)
+  horizontal(bottomChord)
+
+  tangent([mainRight, topRightBlend])
+  tangent([topRightBlend, topLug])
+  tangent([topLug, topLeftBlend])
+  tangent([topLeftBlend, mainLeft])
+  tangent([mainLeft, bottomLeftBlend])
+  tangent([bottomLeftBlend, bottomLug])
+  tangent([bottomLug, bottomRightBlend])
+  tangent([bottomRightBlend, mainRight])
+}
+topEarRegion = region(
+  segments = [flangeSketch.topRightBlend, flangeSketch.topLug],
+  intersectionIndex = -1,
+  direction = CCW,
+)

--- a/rust/kcl-lib/tests/sketch_visualizer/trace_overlays/case_cover_0034.kcl
+++ b/rust/kcl-lib/tests/sketch_visualizer/trace_overlays/case_cover_0034.kcl
@@ -1,0 +1,134 @@
+// Case Cover
+// Dimensioned ABS cover reproduced from drawing 25-02-09.
+@settings(defaultLengthUnit = in, kclVersion = 2.0)
+
+mainDiameter = 6.875in
+mainRadius = mainDiameter / 2
+overallLength = 9.000in
+lugOuterRadius = 1.125in
+lugCenterOffset = overallLength / 2 - lugOuterRadius
+lugBlendRadius = 0.750in
+lugThroughDiameter = 0.875in
+lugCounterboreDiameter = 1.375in
+lugCounterboreDepth = 0.250in
+flangeThickness = 0.625in
+shellBaseInset = 0.375in
+shellOuterBaseRadius = mainRadius - shellBaseInset
+overallHeight = 2.250in
+centralHoleDiameter = 2.500in
+centralHoleRadius = centralHoleDiameter / 2
+wallThickness = 0.375in
+outerCrownRadius = 1.375in
+innerCrownRadius = 1.000in
+draftAngle = 16deg
+crownCenterHeight = overallHeight - outerCrownRadius
+outerTangentHeight = crownCenterHeight + outerCrownRadius * sin(draftAngle)
+outerTangentRadius = shellOuterBaseRadius - (outerTangentHeight - flangeThickness) * tan(draftAngle)
+crownCenterRadius = outerTangentRadius - outerCrownRadius * cos(draftAngle)
+innerTangentHeight = crownCenterHeight + innerCrownRadius * sin(draftAngle)
+innerTangentRadius = crownCenterRadius + innerCrownRadius * cos(draftAngle)
+cavityOpeningRadius = innerTangentRadius + (innerTangentHeight - flangeThickness) * tan(draftAngle)
+
+flangeSketch = sketch(on = XY) {
+  mainRight = arc(
+    start = [var 1.9057in, var 2.8609in],
+    end = [var 1.9057in, var -2.8609in],
+    center = [var 0in, var 0in],
+    direction = CW,
+  )
+  mainLeft = arc(
+    start = [var -1.9057in, var 2.8609in],
+    end = [var -1.9057in, var -2.8609in],
+    center = [var 0in, var 0in],
+  )
+  topLug = arc(
+    start = [var 0.8940in, var 2.6920in],
+    end = [var -0.8940in, var 2.6920in],
+    center = [var 0in, var 3.375in],
+  )
+  bottomLug = arc(
+    start = [var 0.8940in, var -2.6920in],
+    end = [var -0.8940in, var -2.6920in],
+    center = [var 0in, var -3.375in],
+    direction = CW,
+  )
+  topRightBlend = arc(
+    start = [var 1.9057in, var 2.8609in],
+    end = [var 0.8940in, var 2.6920in],
+    center = [var 1.4899in, var 2.2367in],
+  )
+  topLeftBlend = arc(
+    start = [var -1.9057in, var 2.8609in],
+    end = [var -0.8940in, var 2.6920in],
+    center = [var -1.4899in, var 2.2367in],
+    direction = CW,
+  )
+  bottomRightBlend = arc(
+    start = [var 1.9057in, var -2.8609in],
+    end = [var 0.8940in, var -2.6920in],
+    center = [var 1.4899in, var -2.2367in],
+    direction = CW,
+  )
+  bottomLeftBlend = arc(
+    start = [var -1.9057in, var -2.8609in],
+    end = [var -0.8940in, var -2.6920in],
+    center = [var -1.4899in, var -2.2367in],
+  )
+  topChord = line(
+    start = [var -1.9057in, var 2.8609in],
+    end = [var 1.9057in, var 2.8609in],
+  )
+  bottomChord = line(
+    start = [var 1.9057in, var -2.8609in],
+    end = [var -1.9057in, var -2.8609in],
+  )
+
+  coincident([mainRight.center, ORIGIN])
+  coincident([mainLeft.center, mainRight.center])
+  radius(mainRight) == mainRadius
+  equalRadius([mainRight, mainLeft])
+
+  horizontalDistance([ORIGIN, topLug.center]) == 0in
+  verticalDistance([ORIGIN, topLug.center]) == lugCenterOffset
+  horizontalDistance([ORIGIN, bottomLug.center]) == 0in
+  verticalDistance([ORIGIN, bottomLug.center]) == -lugCenterOffset
+  radius(topLug) == lugOuterRadius
+  equalRadius([topLug, bottomLug])
+
+  radius(topRightBlend) == lugBlendRadius
+  equalRadius([
+    topRightBlend,
+    topLeftBlend,
+    bottomRightBlend,
+    bottomLeftBlend
+  ])
+
+  coincident([mainRight.start, topRightBlend.start])
+  coincident([topRightBlend.end, topLug.start])
+  coincident([topLug.end, topLeftBlend.end])
+  coincident([topLeftBlend.start, mainLeft.start])
+  coincident([mainLeft.end, bottomLeftBlend.start])
+  coincident([bottomLeftBlend.end, bottomLug.end])
+  coincident([bottomLug.start, bottomRightBlend.end])
+  coincident([bottomRightBlend.start, mainRight.end])
+  coincident([topChord.start, mainLeft.start])
+  coincident([topChord.end, mainRight.start])
+  coincident([bottomChord.start, mainRight.end])
+  coincident([bottomChord.end, mainLeft.end])
+  horizontal(topChord)
+  horizontal(bottomChord)
+
+  tangent([mainRight, topRightBlend])
+  tangent([topRightBlend, topLug])
+  tangent([topLug, topLeftBlend])
+  tangent([topLeftBlend, mainLeft])
+  tangent([mainLeft, bottomLeftBlend])
+  tangent([bottomLeftBlend, bottomLug])
+  tangent([bottomLug, bottomRightBlend])
+  tangent([bottomRightBlend, mainRight])
+}
+topEarRegion = region(
+  segments = [flangeSketch.topChord, flangeSketch.topRightBlend],
+  intersectionIndex = -1,
+  direction = CCW,
+)

--- a/rust/kcl-lib/tests/sketch_visualizer/trace_overlays/case_cover_0055.kcl
+++ b/rust/kcl-lib/tests/sketch_visualizer/trace_overlays/case_cover_0055.kcl
@@ -1,0 +1,134 @@
+// Case Cover
+// Dimensioned ABS cover reproduced from drawing 25-02-09.
+@settings(defaultLengthUnit = in, kclVersion = 2.0)
+
+mainDiameter = 6.875in
+mainRadius = mainDiameter / 2
+overallLength = 9.000in
+lugOuterRadius = 1.125in
+lugCenterOffset = overallLength / 2 - lugOuterRadius
+lugBlendRadius = 0.750in
+lugThroughDiameter = 0.875in
+lugCounterboreDiameter = 1.375in
+lugCounterboreDepth = 0.250in
+flangeThickness = 0.625in
+shellBaseInset = 0.375in
+shellOuterBaseRadius = mainRadius - shellBaseInset
+overallHeight = 2.250in
+centralHoleDiameter = 2.500in
+centralHoleRadius = centralHoleDiameter / 2
+wallThickness = 0.375in
+outerCrownRadius = 1.375in
+innerCrownRadius = 1.000in
+draftAngle = 16deg
+crownCenterHeight = overallHeight - outerCrownRadius
+outerTangentHeight = crownCenterHeight + outerCrownRadius * sin(draftAngle)
+outerTangentRadius = shellOuterBaseRadius - (outerTangentHeight - flangeThickness) * tan(draftAngle)
+crownCenterRadius = outerTangentRadius - outerCrownRadius * cos(draftAngle)
+innerTangentHeight = crownCenterHeight + innerCrownRadius * sin(draftAngle)
+innerTangentRadius = crownCenterRadius + innerCrownRadius * cos(draftAngle)
+cavityOpeningRadius = innerTangentRadius + (innerTangentHeight - flangeThickness) * tan(draftAngle)
+
+flangeSketch = sketch(on = XY) {
+  mainRight = arc(
+    start = [var 1.9057in, var 2.8609in],
+    end = [var 1.9057in, var -2.8609in],
+    center = [var 0in, var 0in],
+    direction = CW,
+  )
+  mainLeft = arc(
+    start = [var -1.9057in, var 2.8609in],
+    end = [var -1.9057in, var -2.8609in],
+    center = [var 0in, var 0in],
+  )
+  topLug = arc(
+    start = [var 0.8940in, var 2.6920in],
+    end = [var -0.8940in, var 2.6920in],
+    center = [var 0in, var 3.375in],
+  )
+  bottomLug = arc(
+    start = [var 0.8940in, var -2.6920in],
+    end = [var -0.8940in, var -2.6920in],
+    center = [var 0in, var -3.375in],
+    direction = CW,
+  )
+  topRightBlend = arc(
+    start = [var 1.9057in, var 2.8609in],
+    end = [var 0.8940in, var 2.6920in],
+    center = [var 1.4899in, var 2.2367in],
+  )
+  topLeftBlend = arc(
+    start = [var -1.9057in, var 2.8609in],
+    end = [var -0.8940in, var 2.6920in],
+    center = [var -1.4899in, var 2.2367in],
+    direction = CW,
+  )
+  bottomRightBlend = arc(
+    start = [var 1.9057in, var -2.8609in],
+    end = [var 0.8940in, var -2.6920in],
+    center = [var 1.4899in, var -2.2367in],
+    direction = CW,
+  )
+  bottomLeftBlend = arc(
+    start = [var -1.9057in, var -2.8609in],
+    end = [var -0.8940in, var -2.6920in],
+    center = [var -1.4899in, var -2.2367in],
+  )
+  topChord = line(
+    start = [var -1.9057in, var 2.8609in],
+    end = [var 1.9057in, var 2.8609in],
+  )
+  bottomChord = line(
+    start = [var 1.9057in, var -2.8609in],
+    end = [var -1.9057in, var -2.8609in],
+  )
+
+  coincident([mainRight.center, ORIGIN])
+  coincident([mainLeft.center, mainRight.center])
+  radius(mainRight) == mainRadius
+  equalRadius([mainRight, mainLeft])
+
+  horizontalDistance([ORIGIN, topLug.center]) == 0in
+  verticalDistance([ORIGIN, topLug.center]) == lugCenterOffset
+  horizontalDistance([ORIGIN, bottomLug.center]) == 0in
+  verticalDistance([ORIGIN, bottomLug.center]) == -lugCenterOffset
+  radius(topLug) == lugOuterRadius
+  equalRadius([topLug, bottomLug])
+
+  radius(topRightBlend) == lugBlendRadius
+  equalRadius([
+    topRightBlend,
+    topLeftBlend,
+    bottomRightBlend,
+    bottomLeftBlend
+  ])
+
+  coincident([mainRight.start, topRightBlend.start])
+  coincident([topRightBlend.end, topLug.start])
+  coincident([topLug.end, topLeftBlend.end])
+  coincident([topLeftBlend.start, mainLeft.start])
+  coincident([mainLeft.end, bottomLeftBlend.start])
+  coincident([bottomLeftBlend.end, bottomLug.end])
+  coincident([bottomLug.start, bottomRightBlend.end])
+  coincident([bottomRightBlend.start, mainRight.end])
+  coincident([topChord.start, mainLeft.start])
+  coincident([topChord.end, mainRight.start])
+  coincident([bottomChord.start, mainRight.end])
+  coincident([bottomChord.end, mainLeft.end])
+  horizontal(topChord)
+  horizontal(bottomChord)
+
+  tangent([mainRight, topRightBlend])
+  tangent([topRightBlend, topLug])
+  tangent([topLug, topLeftBlend])
+  tangent([topLeftBlend, mainLeft])
+  tangent([mainLeft, bottomLeftBlend])
+  tangent([bottomLeftBlend, bottomLug])
+  tangent([bottomLug, bottomRightBlend])
+  tangent([bottomRightBlend, mainRight])
+}
+topEarRegion = region(
+  segments = [flangeSketch.topRightBlend, flangeSketch.topChord],
+  intersectionIndex = -1,
+  direction = CCW,
+)

--- a/rust/kcl-lib/tests/sketch_visualizer/trace_overlays/case_cover_0126.kcl
+++ b/rust/kcl-lib/tests/sketch_visualizer/trace_overlays/case_cover_0126.kcl
@@ -1,0 +1,157 @@
+// Case Cover
+// Dimensioned ABS cover reproduced from drawing 25-02-09.
+@settings(defaultLengthUnit = in, kclVersion = 2.0)
+
+mainDiameter = 6.875in
+mainRadius = mainDiameter / 2
+overallLength = 9.0in
+lugOuterRadius = 1.125in
+lugCenterOffset = overallLength / 2 - lugOuterRadius
+lugBlendRadius = 0.750in
+lugThroughDiameter = 0.875in
+lugCounterboreDiameter = 1.375in
+lugCounterboreDepth = 0.250in
+flangeThickness = 0.625in
+shellBaseInset = 0.375in
+shellOuterBaseRadius = mainRadius - shellBaseInset
+overallHeight = 2.250in
+centralHoleDiameter = 2.500in
+centralHoleRadius = centralHoleDiameter / 2
+wallThickness = 0.375in
+outerCrownRadius = 1.375in
+innerCrownRadius = 1.0in
+draftAngle = 16deg
+crownCenterHeight = overallHeight - outerCrownRadius
+outerTangentHeight = crownCenterHeight + outerCrownRadius * sin(draftAngle)
+outerTangentRadius = shellOuterBaseRadius - ((outerTangentHeight - flangeThickness) * tan(draftAngle))
+crownCenterRadius = outerTangentRadius - (outerCrownRadius * cos(draftAngle))
+innerTangentHeight = crownCenterHeight + innerCrownRadius * sin(draftAngle)
+innerTangentRadius = crownCenterRadius + innerCrownRadius * cos(draftAngle)
+cavityOpeningRadius = innerTangentRadius + (innerTangentHeight - flangeThickness) * tan(draftAngle)
+
+shellProfile = sketch(on = XZ) {
+  draftGuide = line(start = [var 0in, var 0in], end = [var 0in, var 3in], construction = true)
+  flangeBottom = line(start = [var 2.672in, var 0in], end = [var 3.4375in, var 0in])
+  outerFlangeEdge = line(start = [var 3.4375in, var 0in], end = [var 3.4375in, var 0.625in])
+  flangeTop = line(start = [var 3.4375in, var 0.625in], end = [var 3.0625in, var 0.625in])
+  outerWall = line(start = [var 3.0625in, var 0.625in], end = [var 2.882in, var 1.254in])
+  outerCrown = arc(start = [var 2.882in, var 1.254in], end = [var 1.563in, var 2.250in], center = [var 1.563in, var 0.875in])
+  topLand = line(start = [var 1.563in, var 2.250in], end = [var 1.250in, var 2.250in])
+  holeWall = line(start = [var 1.250in, var 2.250in], end = [var 1.250in, var 1.875in])
+  innerLand = line(start = [var 1.250in, var 1.875in], end = [var 1.563in, var 1.875in])
+  innerCrown = arc(
+    start = [var 1.563in, var 1.875in],
+    end = [var 2.522in, var 1.151in],
+    center = [var 1.563in, var 0.875in],
+    direction = CW,
+  )
+  innerWall = line(start = [var 2.522in, var 1.151in], end = [var 2.672in, var 0.625in])
+  innerFlangeEdge = line(start = [var 2.672in, var 0.625in], end = [var 2.672in, var 0in])
+
+  coincident([draftGuide.start, ORIGIN])
+  vertical(draftGuide)
+  distance([draftGuide.start, draftGuide.end]) == 3in
+
+  coincident([
+    flangeBottom.end,
+    outerFlangeEdge.start
+  ])
+  coincident([outerFlangeEdge.end, flangeTop.start])
+  coincident([flangeTop.end, outerWall.start])
+  coincident([outerWall.end, outerCrown.start])
+  coincident([outerCrown.end, topLand.start])
+  coincident([topLand.end, holeWall.start])
+  coincident([holeWall.end, innerLand.start])
+  coincident([innerLand.end, innerCrown.start])
+  coincident([innerCrown.end, innerWall.start])
+  coincident([innerWall.end, innerFlangeEdge.start])
+  coincident([
+    innerFlangeEdge.end,
+    flangeBottom.start
+  ])
+
+  horizontal(flangeBottom)
+  vertical(outerFlangeEdge)
+  horizontal(flangeTop)
+  horizontal(topLand)
+  vertical(holeWall)
+  horizontal(innerLand)
+  vertical(innerFlangeEdge)
+
+  horizontalDistance([ORIGIN, outerFlangeEdge.end]) == mainRadius
+  verticalDistance([ORIGIN, outerFlangeEdge.end]) == flangeThickness
+  distance([
+  outerFlangeEdge.start,
+  outerFlangeEdge.end
+]) == flangeThickness
+  distance([flangeTop.start, flangeTop.end]) == shellBaseInset
+  angleDimension(lines = [draftGuide, outerWall], sector = 1) == draftAngle
+
+  tangent([outerWall, outerCrown])
+  tangent([outerCrown, topLand])
+  radius(outerCrown) == outerCrownRadius
+  verticalDistance([ORIGIN, topLand.end]) == overallHeight
+  horizontalDistance([ORIGIN, topLand.end]) == centralHoleRadius
+  distance([holeWall.start, holeWall.end]) == wallThickness
+
+  coincident([innerCrown.center, outerCrown.center])
+  radius(innerCrown) == innerCrownRadius
+  tangent([innerLand, innerCrown])
+  tangent([innerCrown, innerWall])
+  parallel([outerWall, innerWall])
+  horizontalDistance([ORIGIN, innerFlangeEdge.start]) == cavityOpeningRadius
+  verticalDistance([ORIGIN, innerFlangeEdge.start]) == flangeThickness
+}
+shellRegion = region(
+  segments = [
+    shellProfile.flangeBottom,
+    shellProfile.outerFlangeEdge
+  ],
+  intersectionIndex = -1,
+  direction = CCW,
+)
+mainCover = revolve(shellRegion, axis = Y)[0]
+hide(shellProfile)
+
+topEarSketch = sketch(on = XY) {
+  mainGuide = circle(start = [var 3.4375in, var 0in], center = [var 0in, var 0in], construction = true)
+  rightBlend = arc(start = [var 1.9057in, var 2.8609in], end = [var 0.8940in, var 2.6920in], center = [var 1.4899in, var 2.2367in])
+  lugOuter = arc(start = [var 0.8940in, var 2.6920in], end = [var -0.8940in, var 2.6920in], center = [var 0in, var 3.375in])
+  leftBlend = arc(
+    start = [var -1.9057in, var 2.8609in],
+    end = [var -0.8940in, var 2.6920in],
+    center = [var -1.4899in, var 2.2367in],
+    direction = CW,
+  )
+  chord = line(start = [var -1.9057in, var 2.8609in], end = [var 1.9057in, var 2.8609in])
+
+  coincident([mainGuide.center, ORIGIN])
+  radius(mainGuide) == mainRadius
+  horizontal([mainGuide.center, mainGuide.start])
+  horizontalDistance([ORIGIN, lugOuter.center]) == 0in
+  verticalDistance([ORIGIN, lugOuter.center]) == lugCenterOffset
+  radius(lugOuter) == lugOuterRadius
+  radius(rightBlend) == lugBlendRadius
+  equalRadius([rightBlend, leftBlend])
+
+  coincident([rightBlend.start, mainGuide])
+  coincident([leftBlend.start, mainGuide])
+  coincident([rightBlend.end, lugOuter.start])
+  coincident([leftBlend.end, lugOuter.end])
+  coincident([chord.start, leftBlend.start])
+  coincident([chord.end, rightBlend.start])
+  horizontal(chord)
+
+  tangent([mainGuide, rightBlend])
+  tangent([rightBlend, lugOuter])
+  tangent([lugOuter, leftBlend])
+  tangent([leftBlend, mainGuide])
+}
+topEarRegion = region(
+  segments = [
+    topEarSketch.chord,
+    topEarSketch.rightBlend
+  ],
+  intersectionIndex = -1,
+  direction = CCW,
+)

--- a/rust/kcl-lib/tests/sketch_visualizer/trace_overlays/ceiling_tile_hanger_0054.kcl
+++ b/rust/kcl-lib/tests/sketch_visualizer/trace_overlays/ceiling_tile_hanger_0054.kcl
@@ -1,0 +1,36 @@
+// Ceiling Tile Hanger
+// Parametric reproduction of McMaster-Carr part 12295A44 from the attached reference drawing.
+
+@settings(defaultLengthUnit = in, kclVersion = 2.0)
+
+clipWidth = 1in
+hookWidth = 0.25in
+mainDepth = 1in
+overallHeight = 1.41in
+slotWidth = 0.24in
+
+// Narrow hook plate, viewed from the side.
+hookOuterSketch = sketch(on = XZ) {
+  topEdge = line(start = [var -0.50in, var 0.51in], end = [var 0.50in, var 0.51in])
+  rightEdge = line(start = [var 0.50in, var 0.51in], end = [var 0.50in, var -0.40in])
+  rightRound = arc(start = [var 0.50in, var -0.40in], end = [var 0in, var -0.90in], center = [var 0in, var -0.40in])
+  leftRound = arc(start = [var 0in, var -0.90in], end = [var -0.50in, var -0.40in], center = [var 0in, var -0.40in])
+  leftEdge = line(start = [var -0.50in, var -0.40in], end = [var -0.50in, var 0.51in])
+
+  coincident([topEdge.end, rightEdge.start])
+  coincident([rightEdge.end, rightRound.start])
+  coincident([rightRound.end, leftRound.start])
+  coincident([rightRound.center, leftRound.center])
+  coincident([leftRound.end, leftEdge.start])
+  coincident([leftEdge.end, topEdge.start])
+  fixed([topEdge.start, [-0.50in, 0.51in]])
+  fixed([rightRound.center, [0in, -0.40in]])
+  horizontal(topEdge)
+  vertical(rightEdge)
+  vertical(leftEdge)
+  vertical([rightRound.end, rightRound.center])
+  horizontalDistance([topEdge.start, topEdge.end]) == mainDepth
+  distance([rightEdge.start, rightEdge.end]) == 0.91in
+  radius(rightRound) == 0.50in
+  radius(leftRound) == 0.50in
+}

--- a/rust/kcl-python-bindings/kcl.pyi
+++ b/rust/kcl-python-bindings/kcl.pyi
@@ -199,10 +199,16 @@ class ExecOutcome:
         Analyze all sketches from this execution and group them by constraint
         status.
         """
-    def render_sketch_png(self, sketch_name: builtins.str) -> builtins.list[builtins.int]:
+    def render_sketch_png(
+        self,
+        sketch_name: builtins.str,
+        *,
+        highlighted_segments: builtins.list[builtins.str] | None = None,
+        resolved_region: builtins.str | None = None,
+    ) -> builtins.list[builtins.int]:
         r"""
         Render one sketch from this execution as a PNG, colored by solver
-        freedom.
+        freedom, with optional highlighted segments and a resolved region.
         """
     def report_all(self) -> builtins.list[builtins.str]: ...
 

--- a/rust/kcl-python-bindings/kcl.pyi
+++ b/rust/kcl-python-bindings/kcl.pyi
@@ -199,13 +199,7 @@ class ExecOutcome:
         Analyze all sketches from this execution and group them by constraint
         status.
         """
-    def render_sketch_png(
-        self,
-        sketch_name: builtins.str,
-        *,
-        highlighted_segments: builtins.list[builtins.str] | None = None,
-        resolved_region: builtins.str | None = None,
-    ) -> builtins.list[builtins.int]:
+    def render_sketch_png(self, sketch_name: builtins.str, *, highlighted_segments: typing.Optional[typing.Sequence[builtins.str]] = None, resolved_region: typing.Optional[builtins.str] = None) -> builtins.list[builtins.int]:
         r"""
         Render one sketch from this execution as a PNG, colored by solver
         freedom, with optional highlighted segments and a resolved region.

--- a/rust/kcl-python-bindings/kcl.pyi
+++ b/rust/kcl-python-bindings/kcl.pyi
@@ -591,8 +591,9 @@ class Point3d:
 @typing.final
 class RawFile:
     r"""
-    A raw file with unencoded contents to be passed over binary websockets.
-    When raw files come back for exports it is sent as binary/bson, not text/json.
+    A raw file with unencoded contents.
+    
+    See the command that emits this type for its response encoding.
     """
     @property
     def contents(self) -> builtins.list[builtins.int]: ...
@@ -1080,7 +1081,7 @@ class UnitArea(enum.Enum):
     """
     SquareYards = ...
     r"""
-    Square yards <https://en.wikipedia.org/wiki/Square_mile>
+    Square yards <https://en.wikipedia.org/wiki/Square_yard>
     """
 
 @typing.final

--- a/rust/kcl-python-bindings/kcl.pyi
+++ b/rust/kcl-python-bindings/kcl.pyi
@@ -202,7 +202,9 @@ class ExecOutcome:
     def render_sketch_png(self, sketch_name: builtins.str, *, highlighted_segments: typing.Optional[typing.Sequence[builtins.str]] = None, resolved_region: typing.Optional[builtins.str] = None) -> builtins.list[builtins.int]:
         r"""
         Render one sketch from this execution as a PNG, colored by solver
-        freedom, with optional highlighted segments and a resolved region.
+        freedom, with optional seed halos and a soft region fill. To fill a
+        region, pass its name to execute/execute_code's resolved_region option
+        first so its trimmed boundary is captured before the engine disconnects.
         """
     def report_all(self) -> builtins.list[builtins.str]: ...
 
@@ -1305,9 +1307,10 @@ async def default_units(path: builtins.str) -> zooDefaultUnits:
     Get the default length and angle units from a kcl file.
     """
 
-async def execute(path: builtins.str) -> zooExecOutcome:
+async def execute(path: builtins.str, *, resolved_region: typing.Optional[builtins.str] = None) -> zooExecOutcome:
     r"""
     Execute the kcl code from a file path.
+    Optionally capture a region's trimmed boundary for render_sketch_png.
     """
 
 async def execute_and_bounding_box(path: builtins.str, entity_ids: typing.Optional[typing.Sequence[builtins.str]] = None, output_unit: typing.Optional[UnitLength] = None) -> zooBoundingBoxResponse:
@@ -1332,9 +1335,10 @@ async def execute_and_snapshot(path: builtins.str, image_format: zooImageFormat,
 
 async def execute_and_snapshot_views(path: builtins.str, image_format: zooImageFormat, snapshot_options: typing.Sequence[SnapshotOptions], *, zoom: typing.Optional[builtins.bool] = None, highlight_edges: typing.Optional[builtins.bool] = None) -> builtins.list[builtins.list[builtins.int]]: ...
 
-async def execute_code(code: builtins.str) -> zooExecOutcome:
+async def execute_code(code: builtins.str, *, resolved_region: typing.Optional[builtins.str] = None) -> zooExecOutcome:
     r"""
     Execute the kcl code.
+    Optionally capture a region's trimmed boundary for render_sketch_png.
     """
 
 async def execute_code_and_bounding_box(code: builtins.str, entity_ids: typing.Optional[typing.Sequence[builtins.str]] = None, output_unit: typing.Optional[UnitLength] = None) -> zooBoundingBoxResponse:

--- a/rust/kcl-python-bindings/src/lib.rs
+++ b/rust/kcl-python-bindings/src/lib.rs
@@ -305,9 +305,21 @@ impl ExecOutcome {
     }
 
     /// Render one sketch from this execution as a PNG, colored by solver
-    /// freedom.
-    fn render_sketch_png(&self, sketch_name: &str) -> PyResult<Vec<u8>> {
-        self.inner.render_sketch_png(sketch_name).map_err(to_py_exception)
+    /// freedom, with optional highlighted segments and a resolved region.
+    #[pyo3(signature = (sketch_name, *, highlighted_segments = None, resolved_region = None))]
+    fn render_sketch_png(
+        &self,
+        sketch_name: &str,
+        highlighted_segments: Option<Vec<String>>,
+        resolved_region: Option<&str>,
+    ) -> PyResult<Vec<u8>> {
+        self.inner
+            .render_sketch_png_with_overlays(
+                sketch_name,
+                highlighted_segments.as_deref().unwrap_or_default(),
+                resolved_region,
+            )
+            .map_err(to_py_exception)
     }
 
     fn report_all(&self) -> Vec<String> {

--- a/rust/kcl-python-bindings/src/lib.rs
+++ b/rust/kcl-python-bindings/src/lib.rs
@@ -271,6 +271,7 @@ async fn new_context_state(
 #[derive(Debug, Clone)]
 struct ExecOutcome {
     inner: kcl_lib::ExecOutcome,
+    resolved_region: Option<kcl_lib::tooling::sketch_visualizer::ResolvedSketchRegion>,
     code: String,
     filename: String,
 }
@@ -305,7 +306,9 @@ impl ExecOutcome {
     }
 
     /// Render one sketch from this execution as a PNG, colored by solver
-    /// freedom, with optional highlighted segments and a resolved region.
+    /// freedom, with optional seed halos and a soft region fill. To fill a
+    /// region, pass its name to execute/execute_code's resolved_region option
+    /// first so its trimmed boundary is captured before the engine disconnects.
     #[pyo3(signature = (sketch_name, *, highlighted_segments = None, resolved_region = None))]
     fn render_sketch_png(
         &self,
@@ -313,12 +316,15 @@ impl ExecOutcome {
         highlighted_segments: Option<Vec<String>>,
         resolved_region: Option<&str>,
     ) -> PyResult<Vec<u8>> {
+        let region = resolved_region
+            .map(|name| {
+                self.resolved_region.as_ref().filter(|region| region.name() == name).ok_or_else(|| {
+                    to_py_exception(format!("region `{name}` was not captured; call execute or execute_code with resolved_region=\"{name}\""))
+                })
+            })
+            .transpose()?;
         self.inner
-            .render_sketch_png_with_overlays(
-                sketch_name,
-                highlighted_segments.as_deref().unwrap_or_default(),
-                resolved_region,
-            )
+            .render_sketch_png_with_overlays(sketch_name, highlighted_segments.as_deref().unwrap_or_default(), region)
             .map_err(to_py_exception)
     }
 
@@ -370,7 +376,7 @@ async fn run_kcl(input: KclInput, mock: bool, highlight_edges: Option<bool>) -> 
     })
 }
 
-async fn execute_impl(input: KclInput, mock: bool) -> PyResult<ExecOutcome> {
+async fn execute_impl(input: KclInput, mock: bool, resolved_region_name: Option<String>) -> PyResult<ExecOutcome> {
     let ExecutedKcl {
         ctx,
         state,
@@ -386,9 +392,25 @@ async fn execute_impl(input: KclInput, mock: bool) -> PyResult<ExecOutcome> {
             return Err(to_py_exception(err));
         }
     };
+    let resolved_region = match resolved_region_name {
+        Some(name) => match outcome.resolve_sketch_region(&ctx, &name).await {
+            Ok(region) => Some(region),
+            Err(err) => {
+                ctx.close().await;
+                return Err(match err {
+                    kcl_lib::tooling::sketch_visualizer::SketchVisualizationError::Engine(err) => {
+                        into_kcl_exception(err)
+                    }
+                    err => to_py_exception(err),
+                });
+            }
+        },
+        None => None,
+    };
     ctx.close().await;
     Ok(ExecOutcome {
         inner: outcome,
+        resolved_region,
         code,
         filename,
     })
@@ -588,31 +610,33 @@ fn parse_code(code: String) -> PyResult<bool> {
 }
 
 /// Execute the kcl code from a file path.
+/// Optionally capture a region's trimmed boundary for render_sketch_png.
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
-#[pyfunction]
-async fn execute(path: String) -> PyResult<ExecOutcome> {
-    spawn_py(async move { execute_impl(KclInput::Path(path), false).await }).await
+#[pyfunction(signature = (path, *, resolved_region = None))]
+async fn execute(path: String, resolved_region: Option<String>) -> PyResult<ExecOutcome> {
+    spawn_py(async move { execute_impl(KclInput::Path(path), false, resolved_region).await }).await
 }
 
 /// Execute the kcl code.
+/// Optionally capture a region's trimmed boundary for render_sketch_png.
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
-#[pyfunction]
-async fn execute_code(code: String) -> PyResult<ExecOutcome> {
-    spawn_py(async move { execute_impl(KclInput::Code(code), false).await }).await
+#[pyfunction(signature = (code, *, resolved_region = None))]
+async fn execute_code(code: String, resolved_region: Option<String>) -> PyResult<ExecOutcome> {
+    spawn_py(async move { execute_impl(KclInput::Code(code), false, resolved_region).await }).await
 }
 
 /// Mock execute the kcl code.
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
 #[pyfunction]
 async fn mock_execute_code(code: String) -> PyResult<ExecOutcome> {
-    spawn_py(async move { execute_impl(KclInput::Code(code), true).await }).await
+    spawn_py(async move { execute_impl(KclInput::Code(code), true, None).await }).await
 }
 
 /// Mock execute the kcl code from a file path.
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
 #[pyfunction]
 async fn mock_execute(path: String) -> PyResult<ExecOutcome> {
-    spawn_py(async move { execute_impl(KclInput::Path(path), true).await }).await
+    spawn_py(async move { execute_impl(KclInput::Path(path), true, None).await }).await
 }
 
 /// Execute a kcl file and return a report of sketch constraint status.
@@ -1383,7 +1407,7 @@ result = subtract(cube, tools = [cylinder])
 
     #[tokio::test(flavor = "multi_thread")]
     async fn exec_outcome_report_renders_csg_no_overlap_warning() {
-        let outcome = execute_impl(KclInput::Code(NO_OVERLAP_SUBTRACT_KCL.to_string()), false)
+        let outcome = execute_impl(KclInput::Code(NO_OVERLAP_SUBTRACT_KCL.to_string()), false, None)
             .await
             .expect("execute_impl should succeed for valid non-overlapping subtract");
 
@@ -1424,7 +1448,7 @@ result = subtract(cube, tools = [cylinder])
     #[tokio::test(flavor = "multi_thread")]
     async fn mock_exec_outcome_report_renders_imported_module_warning_against_imported_source() {
         let project_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/files/imported_warning");
-        let outcome = execute_impl(KclInput::Path(project_dir.to_owned()), true)
+        let outcome = execute_impl(KclInput::Path(project_dir.to_owned()), true, None)
             .await
             .expect("mock execute_impl should succeed for a project that only warns");
 

--- a/rust/kcl-python-bindings/tests/tests.py
+++ b/rust/kcl-python-bindings/tests/tests.py
@@ -654,6 +654,22 @@ s2 = sketch(on = XZ) {
 }
 """
 
+region_overlay_code = """
+profile = sketch(on = XY) {
+  bottom = line(start = [var 0mm, var 0mm], end = [var 40mm, var 0mm])
+  right = line(start = [var 40mm, var 0mm], end = [var 40mm, var 24mm])
+  top = line(start = [var 40mm, var 24mm], end = [var 0mm, var 24mm])
+  left = line(start = [var 0mm, var 24mm], end = [var 0mm, var 0mm])
+
+  coincident([bottom.end, right.start])
+  coincident([right.end, top.start])
+  coincident([top.end, left.start])
+  coincident([left.end, bottom.start])
+}
+
+selectedRegion = region(segments = [profile.bottom, profile.right])
+"""
+
 named_sketches_all_statuses_code = """
 @settings(experimentalFeatures = allow)
 
@@ -776,6 +792,21 @@ async def test_sketch_constraint_status_mixed():
     assert report.under_constrained[0].name == "s2"
     assert bytes(outcome.render_sketch_png("s1")).startswith(b"\x89PNG\r\n\x1a\n")
     assert bytes(outcome.render_sketch_png("s2")).startswith(b"\x89PNG\r\n\x1a\n")
+    assert bytes(
+        outcome.render_sketch_png("s1", highlighted_segments=["line1"])
+    ).startswith(b"\x89PNG\r\n\x1a\n")
+
+
+@requires_engine
+@pytest.mark.asyncio
+async def test_sketch_png_region_overlays():
+    outcome = await execute_with_retries(kcl.execute_code, region_overlay_code)
+    png = outcome.render_sketch_png(
+        "profile",
+        highlighted_segments=["bottom", "right"],
+        resolved_region="selectedRegion",
+    )
+    assert bytes(png).startswith(b"\x89PNG\r\n\x1a\n")
 
 
 @requires_engine

--- a/rust/kcl-python-bindings/tests/tests.py
+++ b/rust/kcl-python-bindings/tests/tests.py
@@ -800,13 +800,22 @@ async def test_sketch_constraint_status_mixed():
 @requires_engine
 @pytest.mark.asyncio
 async def test_sketch_png_region_overlays():
-    outcome = await execute_with_retries(kcl.execute_code, region_overlay_code)
+    outcome = await execute_with_retries(
+        kcl.execute_code, region_overlay_code, resolved_region="selectedRegion"
+    )
     png = outcome.render_sketch_png(
         "profile",
         highlighted_segments=["bottom", "right"],
         resolved_region="selectedRegion",
     )
     assert bytes(png).startswith(b"\x89PNG\r\n\x1a\n")
+
+
+@pytest.mark.asyncio
+async def test_sketch_png_requires_explicit_region_capture() -> None:
+    outcome = await kcl.mock_execute_code(under_constrained_sketch_code)
+    with pytest.raises(Exception, match="was not captured"):
+        outcome.render_sketch_png("s1", resolved_region="selectedRegion")
 
 
 @requires_engine


### PR DESCRIPTION
## Summary

Add optional named-segment highlighting and resolved-region visualization to the existing sketch PNG renderer. Option A now uses a soft green interior fill beneath the normal blue/white/red constraint lines. Magenta seed halos also sit underneath those lines, and holes remain unfilled.

The fill uses actual engine-resolved, trimmed curves, not the original-segment membership mapping. That distinction matters when a region contains only part of a circle or arc. Legacy path regions use `SketchGetInfo`; current region objects expose their real child curves. Region capture is opt-in while the execution's engine connection is still live. Ordinary execution, constraint reports, and plain sketch rendering do not make these extra queries.

For the draft Python API, request capture before rendering:

```python
outcome = await kcl.execute_code(source, resolved_region="selectedRegion")
png = outcome.render_sketch_png(
    "profile",
    highlighted_segments=["bottom", "right"],
    resolved_region="selectedRegion",
)
```

KittyCAD/mcp#260 handles capture and downstream-error isolation without changing Zookeeper's tool arguments. KittyCAD/text-to-cad#4150 supplies the corresponding legend. If region creation fails, callers can omit `resolved_region` and inspect the seed segments alone.

## Boundaries and tradeoffs

- Filling supports lines, circular arcs, and circles. Unsupported curves, incomplete boundaries, and ambiguous joins fail explicitly rather than inventing an area.
- Current object regions require per-curve queries, only when their fill is requested. A batched boundary API could reduce those round trips later.
- Engine-backed primitive regressions cover trimmed arcs in both directions, holes, mm/inch units, and XY/XZ planes. Pixel comparisons check that existing constraint-colored strokes and markers are preserved; plain PNG snapshots are unchanged.
- This update was validated with public primitive fixtures, not a new Zookeeper evaluation or a rerun of private trace checkpoints.
- Standalone Python-binding lint/type checks still report pre-existing test-code violations and generated `zoo*` type aliases. Scoped Rust checks and the downstream MCP/TTC checks pass; this change does not repair the existing stub generator.

Closes #13602
