### PR TITLE
Prevent stale prepared Wasm reuse

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -47,8 +47,16 @@ jobs:
           # attributed to the caller's parent run. Using `e2e-tests.yml` works
           # as the canonical caller since this runs every hour on main.
           workflow: e2e-tests.yml
-          branch: main
+          # Reuse only Wasm built for this PR's exact base. Falling back to the
+          # newest artifact on main can pair new TypeScript with stale Rust.
+          commit: ${{ github.event.pull_request.base.sha || github.sha }}
           path: rust/kcl-wasm-lib/pkg
+
+      - name: Verify downloaded Wasm version
+        id: cached-wasm-version
+        if: ${{ steps.download-wasm.outcome == 'success' }}
+        continue-on-error: true
+        run: node scripts/verify-kcl-wasm-version.mjs
 
       - name: Determine Wasm rebuild
         id: wasm
@@ -56,10 +64,12 @@ jobs:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           DOWNLOAD_OUTCOME: ${{ steps.download-wasm.outcome }}
           RUST_CHANGES: ${{ steps.filter.outputs.rust || 'false' }}
+          WASM_VERSION_OUTCOME: ${{ steps.cached-wasm-version.outcome }}
         run: |
           # Build Wasm with Rust changes, cache misses, or for stacked PRs
           if [[ "${RUST_CHANGES}" == 'true' || \
                 "${DOWNLOAD_OUTCOME}" == 'failure' || \
+                "${WASM_VERSION_OUTCOME}" == 'failure' || \
                 ( -n "${BASE_REF}" && "${BASE_REF}" != 'main' ) ]]; then
             echo "should-build-wasm=true" >> $GITHUB_OUTPUT
           else
@@ -102,6 +112,9 @@ jobs:
         if: ${{ steps.wasm.outputs.should-build-wasm == 'true' }}
         shell: bash
         run: npm run build:wasm
+
+      - name: Verify prepared Wasm version
+        run: node scripts/verify-kcl-wasm-version.mjs
 
       - name: Use committed TypeScript bindings
         if: ${{ steps.wasm.outputs.should-build-wasm != 'true' }}

--- a/scripts/verify-kcl-wasm-version.mjs
+++ b/scripts/verify-kcl-wasm-version.mjs
@@ -1,0 +1,30 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const packageDirectory = path.resolve(
+  process.argv[2] ?? 'rust/kcl-wasm-lib/pkg'
+)
+const kclCargoToml = await readFile('rust/kcl-lib/Cargo.toml', 'utf8')
+const expectedVersion = kclCargoToml.match(/^version = "([^"]+)"/m)?.[1]
+
+if (!expectedVersion) {
+  throw new Error('Could not read the kcl-lib version from Cargo.toml.')
+}
+
+const wasmModule = await import(
+  pathToFileURL(path.join(packageDirectory, 'kcl_wasm_lib.js')).href
+)
+const wasmBytes = await readFile(
+  path.join(packageDirectory, 'kcl_wasm_lib_bg.wasm')
+)
+await wasmModule.default({ module_or_path: wasmBytes })
+
+const actualVersion = wasmModule.get_kcl_version()
+if (actualVersion !== expectedVersion) {
+  throw new Error(
+    `Prepared KCL Wasm version ${actualVersion} does not match source version ${expectedVersion}.`
+  )
+}
+
+console.log(`Prepared KCL Wasm matches source version ${expectedVersion}.`)


### PR DESCRIPTION
Addresses the stale KCL Wasm artifact that broke the STEP import E2E on #13598 after #13591 merged. The failing workflow paired KCL source version 0.2.182 with a cached Wasm artifact exporting version 0.2.181.

1. Restricts prepared-Wasm reuse to artifacts produced for the pull request's exact base commit.
2. Adds a low-level version guard comparing the Wasm export with the kcl-lib Cargo version.
3. Rebuilds Wasm when a downloaded artifact fails that guard, then verifies the artifact before upload.

## How to test

Inspect the Build Wasm job: a cache miss or mismatched cached artifact should select the rebuild path, and the final verification should report that prepared Wasm matches the source version. The version guard rejects the exact artifact from the failing #13598 run as 0.2.181 versus the expected 0.2.182.