### PR TITLE
KCL: new optional GD&T param, 'annotationName'

### DIFF
--- a/docs/kcl-std/functions/std-gdt-angularity.md
+++ b/docs/kcl-std/functions/std-gdt-angularity.md
@@ -18,6 +18,7 @@ gdt::angularity(
   framePlane?: Plane,
   leaderScale?: number(_),
   fontSize?: number(Length),
+  annotationName?: string,
 ): [GdtAnnotation; 1+]
 ```
 
@@ -42,6 +43,7 @@ omitting both is an error.
 | `framePlane` | [`Plane`](/docs/kcl-std/types/std-types-Plane) | The plane in which to display the feature control frame. The default is `XY`. Other standard planes like `XZ` and `YZ` can also be used. The frame may be displayed in a plane parallel to the given plane. | No |
 | `leaderScale` | [`number(_)`](/docs/kcl-std/types/std-types-number) | Visual scale of the leader dot. The default is `1.0`, which maps to the calibrated normal dot size. The value is normalized against `fontSize` so the dot stays consistent as text size changes. Must be greater than `0`. | No |
 | `fontSize` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit. This changes the scene size, not the internal raster texture quality. | No |
+| `annotationName` | [`string`](/docs/kcl-std/types/std-types-string) | Human-friendly name for this annotation in exports and model metadata. This is not displayed visually. | No |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-gdt-annotation.md
+++ b/docs/kcl-std/functions/std-gdt-annotation.md
@@ -16,6 +16,7 @@ gdt::annotation(
   framePlane?: Plane,
   leaderScale?: number(_),
   fontSize?: number(Length),
+  annotationName?: string,
 ): [GdtAnnotation; 1+]
 ```
 
@@ -32,6 +33,7 @@ This is part of model-based definition (MBD).
 | `framePlane` | [`Plane`](/docs/kcl-std/types/std-types-Plane) | The plane in which to display the annotation. The default is `XY`. Other standard planes like `XZ` and `YZ` can also be used. The annotation may be displayed in a plane parallel to the given plane. | No |
 | `leaderScale` | [`number(_)`](/docs/kcl-std/types/std-types-number) | Visual scale of the leader dot. The default is `1.0`, which maps to the calibrated normal dot size. The value is normalized against `fontSize` so the dot stays consistent as text size changes. Must be greater than `0`. | No |
 | `fontSize` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit. This changes the scene size, not the internal raster texture quality. | No |
+| `annotationName` | [`string`](/docs/kcl-std/types/std-types-string) | Human-friendly name for this annotation in exports and model metadata. This is not displayed visually. | No |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-gdt-circularity.md
+++ b/docs/kcl-std/functions/std-gdt-circularity.md
@@ -17,6 +17,7 @@ gdt::circularity(
   framePlane?: Plane,
   leaderScale?: number(_),
   fontSize?: number(Length),
+  annotationName?: string,
 ): [GdtAnnotation; 1+]
 ```
 
@@ -43,6 +44,7 @@ Circularity is a form tolerance, so it does not reference datums.
 | `framePlane` | [`Plane`](/docs/kcl-std/types/std-types-Plane) | The plane in which to display the feature control frame. The default is `XY`. Other standard planes like `XZ` and `YZ` can also be used. The frame may be displayed in a plane parallel to the given plane. | No |
 | `leaderScale` | [`number(_)`](/docs/kcl-std/types/std-types-number) | Visual scale of the leader dot. The default is `1.0`, which maps to the calibrated normal dot size. The value is normalized against `fontSize` so the dot stays consistent as text size changes. Must be greater than `0`. | No |
 | `fontSize` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit. This changes the scene size, not the internal raster texture quality. | No |
+| `annotationName` | [`string`](/docs/kcl-std/types/std-types-string) | Human-friendly name for this annotation in exports and model metadata. This is not displayed visually. | No |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-gdt-concentricity.md
+++ b/docs/kcl-std/functions/std-gdt-concentricity.md
@@ -18,6 +18,7 @@ gdt::concentricity(
   framePlane?: Plane,
   leaderScale?: number(_),
   fontSize?: number(Length),
+  annotationName?: string,
 ): [GdtAnnotation; 1+]
 ```
 
@@ -47,6 +48,7 @@ where appropriate. ISO standards use the name coaxiality for this concept.
 | `framePlane` | [`Plane`](/docs/kcl-std/types/std-types-Plane) | The plane in which to display the feature control frame. The default is `XY`. Other standard planes like `XZ` and `YZ` can also be used. The frame may be displayed in a plane parallel to the given plane. | No |
 | `leaderScale` | [`number(_)`](/docs/kcl-std/types/std-types-number) | Visual scale of the leader dot. The default is `1.0`, which maps to the calibrated normal dot size. The value is normalized against `fontSize` so the dot stays consistent as text size changes. Must be greater than `0`. | No |
 | `fontSize` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit. This changes the scene size, not the internal raster texture quality. | No |
+| `annotationName` | [`string`](/docs/kcl-std/types/std-types-string) | Human-friendly name for this annotation in exports and model metadata. This is not displayed visually. | No |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-gdt-cylindricity.md
+++ b/docs/kcl-std/functions/std-gdt-cylindricity.md
@@ -17,6 +17,7 @@ gdt::cylindricity(
   framePlane?: Plane,
   leaderScale?: number(_),
   fontSize?: number(Length),
+  annotationName?: string,
 ): [GdtAnnotation; 1+]
 ```
 
@@ -44,6 +45,7 @@ Cylindricity is a form tolerance, so it does not reference datums.
 | `framePlane` | [`Plane`](/docs/kcl-std/types/std-types-Plane) | The plane in which to display the feature control frame. The default is `XY`. Other standard planes like `XZ` and `YZ` can also be used. The frame may be displayed in a plane parallel to the given plane. | No |
 | `leaderScale` | [`number(_)`](/docs/kcl-std/types/std-types-number) | Visual scale of the leader dot. The default is `1.0`, which maps to the calibrated normal dot size. The value is normalized against `fontSize` so the dot stays consistent as text size changes. Must be greater than `0`. | No |
 | `fontSize` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit. This changes the scene size, not the internal raster texture quality. | No |
+| `annotationName` | [`string`](/docs/kcl-std/types/std-types-string) | Human-friendly name for this annotation in exports and model metadata. This is not displayed visually. | No |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-gdt-datum.md
+++ b/docs/kcl-std/functions/std-gdt-datum.md
@@ -15,6 +15,7 @@ gdt::datum(
   framePlane?: Plane,
   leaderScale?: number(_),
   fontSize?: number(Length),
+  annotationName?: string,
 ): GdtAnnotation
 ```
 
@@ -30,6 +31,7 @@ This is part of model-based definition (MBD).
 | `framePlane` | [`Plane`](/docs/kcl-std/types/std-types-Plane) | The plane in which to display the feature control frame. The default is `XY`. Other standard planes like `XZ` and `YZ` can also be used. The frame may be displayed in a plane parallel to the given plane. | No |
 | `leaderScale` | [`number(_)`](/docs/kcl-std/types/std-types-number) | Visual scale of the leader dot. The default is `1.0`, which maps to the calibrated normal dot size. The value is normalized against `fontSize` so the dot stays consistent as text size changes. Must be greater than `0`. | No |
 | `fontSize` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit. This changes the scene size, not the internal raster texture quality. | No |
+| `annotationName` | [`string`](/docs/kcl-std/types/std-types-string) | Human-friendly name for this annotation in exports and model metadata. This is not displayed visually. | No |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-gdt-distance.md
+++ b/docs/kcl-std/functions/std-gdt-distance.md
@@ -18,6 +18,7 @@ gdt::distance(
   framePlane?: Plane,
   leaderScale?: number(_),
   fontSize?: number(Length),
+  annotationName?: string,
 ): [GdtAnnotation; 1+]
 ```
 
@@ -36,6 +37,7 @@ This is part of model-based definition (MBD).
 | `framePlane` | [`Plane`](/docs/kcl-std/types/std-types-Plane) | The plane in which to display the distance. The default is `XY`. Other standard planes like `XZ` and `YZ` can also be used. The distance may be displayed in a plane parallel to the given plane. | No |
 | `leaderScale` | [`number(_)`](/docs/kcl-std/types/std-types-number) | Scale of the distance arrows. The default is `1.0`. Must be greater than `0`. | No |
 | `fontSize` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit. This changes the scene size, not the internal raster texture quality. | No |
+| `annotationName` | [`string`](/docs/kcl-std/types/std-types-string) | Human-friendly name for this annotation in exports and model metadata. This is not displayed visually. | No |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-gdt-flatness.md
+++ b/docs/kcl-std/functions/std-gdt-flatness.md
@@ -16,6 +16,7 @@ gdt::flatness(
   framePlane?: Plane,
   leaderScale?: number(_),
   fontSize?: number(Length),
+  annotationName?: string,
 ): [GdtAnnotation; 1+]
 ```
 
@@ -32,6 +33,7 @@ This is part of model-based definition (MBD).
 | `framePlane` | [`Plane`](/docs/kcl-std/types/std-types-Plane) | The plane in which to display the feature control frame. The default is `XY`. Other standard planes like `XZ` and `YZ` can also be used. The frame may be displayed in a plane parallel to the given plane. | No |
 | `leaderScale` | [`number(_)`](/docs/kcl-std/types/std-types-number) | Visual scale of the leader dot. The default is `1.0`, which maps to the calibrated normal dot size. The value is normalized against `fontSize` so the dot stays consistent as text size changes. Must be greater than `0`. | No |
 | `fontSize` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit. This changes the scene size, not the internal raster texture quality. | No |
+| `annotationName` | [`string`](/docs/kcl-std/types/std-types-string) | Human-friendly name for this annotation in exports and model metadata. This is not displayed visually. | No |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-gdt-note.md
+++ b/docs/kcl-std/functions/std-gdt-note.md
@@ -13,6 +13,7 @@ gdt::note(
   framePlane?: Plane,
   framePosition?: Point2d,
   fontSize?: number(Length),
+  annotationName?: string,
 ): GdtAnnotation
 ```
 
@@ -28,6 +29,7 @@ and is placed directly on a plane. By default it lives on the world `XY` plane, 
 | `framePlane` | [`Plane`](/docs/kcl-std/types/std-types-Plane) | The plane the note lies in. The default is `XY`. Other standard planes like `XZ` and `YZ`, or a user-defined plane, can also be used. | No |
 | `framePosition` | [`Point2d`](/docs/kcl-std/types/std-types-Point2d) | The 2D position of the note within the plane, in the plane's local coordinates. The default is `[100mm, 100mm]`. | No |
 | `fontSize` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | The model-space height to use for the note text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit. This changes the scene size, not the internal raster texture quality. | No |
+| `annotationName` | [`string`](/docs/kcl-std/types/std-types-string) | Human-friendly name for this annotation in exports and model metadata. This is not displayed visually. | No |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-gdt-parallelism.md
+++ b/docs/kcl-std/functions/std-gdt-parallelism.md
@@ -18,6 +18,7 @@ gdt::parallelism(
   framePlane?: Plane,
   leaderScale?: number(_),
   fontSize?: number(Length),
+  annotationName?: string,
 ): [GdtAnnotation; 1+]
 ```
 
@@ -36,6 +37,7 @@ This is part of model-based definition (MBD).
 | `framePlane` | [`Plane`](/docs/kcl-std/types/std-types-Plane) | The plane in which to display the feature control frame. The default is `XY`. Other standard planes like `XZ` and `YZ` can also be used. The frame may be displayed in a plane parallel to the given plane. | No |
 | `leaderScale` | [`number(_)`](/docs/kcl-std/types/std-types-number) | Visual scale of the leader dot. The default is `1.0`, which maps to the calibrated normal dot size. The value is normalized against `fontSize` so the dot stays consistent as text size changes. Must be greater than `0`. | No |
 | `fontSize` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit. This changes the scene size, not the internal raster texture quality. | No |
+| `annotationName` | [`string`](/docs/kcl-std/types/std-types-string) | Human-friendly name for this annotation in exports and model metadata. This is not displayed visually. | No |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-gdt-perpendicularity.md
+++ b/docs/kcl-std/functions/std-gdt-perpendicularity.md
@@ -18,6 +18,7 @@ gdt::perpendicularity(
   framePlane?: Plane,
   leaderScale?: number(_),
   fontSize?: number(Length),
+  annotationName?: string,
 ): [GdtAnnotation; 1+]
 ```
 
@@ -36,6 +37,7 @@ This is part of model-based definition (MBD).
 | `framePlane` | [`Plane`](/docs/kcl-std/types/std-types-Plane) | The plane in which to display the feature control frame. The default is `XY`. Other standard planes like `XZ` and `YZ` can also be used. The frame may be displayed in a plane parallel to the given plane. | No |
 | `leaderScale` | [`number(_)`](/docs/kcl-std/types/std-types-number) | Visual scale of the leader dot. The default is `1.0`, which maps to the calibrated normal dot size. The value is normalized against `fontSize` so the dot stays consistent as text size changes. Must be greater than `0`. | No |
 | `fontSize` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit. This changes the scene size, not the internal raster texture quality. | No |
+| `annotationName` | [`string`](/docs/kcl-std/types/std-types-string) | Human-friendly name for this annotation in exports and model metadata. This is not displayed visually. | No |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-gdt-position.md
+++ b/docs/kcl-std/functions/std-gdt-position.md
@@ -18,6 +18,7 @@ gdt::position(
   framePlane?: Plane,
   leaderScale?: number(_),
   fontSize?: number(Length),
+  annotationName?: string,
 ): [GdtAnnotation; 1+]
 ```
 
@@ -36,6 +37,7 @@ This is part of model-based definition (MBD).
 | `framePlane` | [`Plane`](/docs/kcl-std/types/std-types-Plane) | The plane in which to display the feature control frame. The default is `XY`. Other standard planes like `XZ` and `YZ` can also be used. The frame may be displayed in a plane parallel to the given plane. | No |
 | `leaderScale` | [`number(_)`](/docs/kcl-std/types/std-types-number) | Visual scale of the leader dot. The default is `1.0`, which maps to the calibrated normal dot size. The value is normalized against `fontSize` so the dot stays consistent as text size changes. Must be greater than `0`. | No |
 | `fontSize` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit. This changes the scene size, not the internal raster texture quality. | No |
+| `annotationName` | [`string`](/docs/kcl-std/types/std-types-string) | Human-friendly name for this annotation in exports and model metadata. This is not displayed visually. | No |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-gdt-profile.md
+++ b/docs/kcl-std/functions/std-gdt-profile.md
@@ -18,6 +18,7 @@ gdt::profile(
   framePlane?: Plane,
   leaderScale?: number(_),
   fontSize?: number(Length),
+  annotationName?: string,
 ): [GdtAnnotation; 1+]
 ```
 
@@ -44,6 +45,7 @@ or neither, is a KCL error.
 | `framePlane` | [`Plane`](/docs/kcl-std/types/std-types-Plane) | The plane in which to display the feature control frame. The default is `XY`. Other standard planes like `XZ` and `YZ` can also be used. The frame may be displayed in a plane parallel to the given plane. | No |
 | `leaderScale` | [`number(_)`](/docs/kcl-std/types/std-types-number) | Visual scale of the leader dot. The default is `1.0`, which maps to the calibrated normal dot size. The value is normalized against `fontSize` so the dot stays consistent as text size changes. Must be greater than `0`. | No |
 | `fontSize` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit. This changes the scene size, not the internal raster texture quality. | No |
+| `annotationName` | [`string`](/docs/kcl-std/types/std-types-string) | Human-friendly name for this annotation in exports and model metadata. This is not displayed visually. | No |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-gdt-profileLine.md
+++ b/docs/kcl-std/functions/std-gdt-profileLine.md
@@ -17,6 +17,7 @@ gdt::profileLine(
   framePlane?: Plane,
   leaderScale?: number(_),
   fontSize?: number(Length),
+  annotationName?: string,
 ): [GdtAnnotation; 1+]
 ```
 
@@ -36,6 +37,7 @@ Profile of a line is a two-dimensional tolerance zone for a cross-section or edg
 | `framePlane` | [`Plane`](/docs/kcl-std/types/std-types-Plane) | The plane in which to display the feature control frame. The default is `XY`. Other standard planes like `XZ` and `YZ` can also be used. The frame may be displayed in a plane parallel to the given plane. | No |
 | `leaderScale` | [`number(_)`](/docs/kcl-std/types/std-types-number) | Visual scale of the leader dot. The default is `1.0`, which maps to the calibrated normal dot size. The value is normalized against `fontSize` so the dot stays consistent as text size changes. Must be greater than `0`. | No |
 | `fontSize` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit. This changes the scene size, not the internal raster texture quality. | No |
+| `annotationName` | [`string`](/docs/kcl-std/types/std-types-string) | Human-friendly name for this annotation in exports and model metadata. This is not displayed visually. | No |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-gdt-profileSurface.md
+++ b/docs/kcl-std/functions/std-gdt-profileSurface.md
@@ -17,6 +17,7 @@ gdt::profileSurface(
   framePlane?: Plane,
   leaderScale?: number(_),
   fontSize?: number(Length),
+  annotationName?: string,
 ): [GdtAnnotation; 1+]
 ```
 
@@ -36,6 +37,7 @@ Profile of a surface is a three-dimensional tolerance zone that applies across t
 | `framePlane` | [`Plane`](/docs/kcl-std/types/std-types-Plane) | The plane in which to display the feature control frame. The default is `XY`. Other standard planes like `XZ` and `YZ` can also be used. The frame may be displayed in a plane parallel to the given plane. | No |
 | `leaderScale` | [`number(_)`](/docs/kcl-std/types/std-types-number) | Visual scale of the leader dot. The default is `1.0`, which maps to the calibrated normal dot size. The value is normalized against `fontSize` so the dot stays consistent as text size changes. Must be greater than `0`. | No |
 | `fontSize` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit. This changes the scene size, not the internal raster texture quality. | No |
+| `annotationName` | [`string`](/docs/kcl-std/types/std-types-string) | Human-friendly name for this annotation in exports and model metadata. This is not displayed visually. | No |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-gdt-runout.md
+++ b/docs/kcl-std/functions/std-gdt-runout.md
@@ -18,6 +18,7 @@ gdt::runout(
   framePlane?: Plane,
   leaderScale?: number(_),
   fontSize?: number(Length),
+  annotationName?: string,
 ): [GdtAnnotation; 1+]
 ```
 
@@ -42,6 +43,7 @@ Runout is applied regardless of feature size and does not use MMC or LMC.
 | `framePlane` | [`Plane`](/docs/kcl-std/types/std-types-Plane) | The plane in which to display the feature control frame. The default is `XY`. Other standard planes like `XZ` and `YZ` can also be used. The frame may be displayed in a plane parallel to the given plane. | No |
 | `leaderScale` | [`number(_)`](/docs/kcl-std/types/std-types-number) | Visual scale of the leader dot. The default is `1.0`, which maps to the calibrated normal dot size. The value is normalized against `fontSize` so the dot stays consistent as text size changes. Must be greater than `0`. | No |
 | `fontSize` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit. This changes the scene size, not the internal raster texture quality. | No |
+| `annotationName` | [`string`](/docs/kcl-std/types/std-types-string) | Human-friendly name for this annotation in exports and model metadata. This is not displayed visually. | No |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-gdt-straightness.md
+++ b/docs/kcl-std/functions/std-gdt-straightness.md
@@ -17,6 +17,7 @@ gdt::straightness(
   framePlane?: Plane,
   leaderScale?: number(_),
   fontSize?: number(Length),
+  annotationName?: string,
 ): [GdtAnnotation; 1+]
 ```
 
@@ -42,6 +43,7 @@ a face normal may appear like an edge.
 | `framePlane` | [`Plane`](/docs/kcl-std/types/std-types-Plane) | The plane in which to display the feature control frame. The default is `XY`. Other standard planes like `XZ` and `YZ` can also be used. The frame may be displayed in a plane parallel to the given plane. | No |
 | `leaderScale` | [`number(_)`](/docs/kcl-std/types/std-types-number) | Visual scale of the leader dot. The default is `1.0`, which maps to the calibrated normal dot size. The value is normalized against `fontSize` so the dot stays consistent as text size changes. Must be greater than `0`. | No |
 | `fontSize` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit. This changes the scene size, not the internal raster texture quality. | No |
+| `annotationName` | [`string`](/docs/kcl-std/types/std-types-string) | Human-friendly name for this annotation in exports and model metadata. This is not displayed visually. | No |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-gdt-symmetry.md
+++ b/docs/kcl-std/functions/std-gdt-symmetry.md
@@ -18,6 +18,7 @@ gdt::symmetry(
   framePlane?: Plane,
   leaderScale?: number(_),
   fontSize?: number(Length),
+  annotationName?: string,
 ): [GdtAnnotation; 1+]
 ```
 
@@ -51,6 +52,7 @@ condition (MMC) or least material condition (LMC) modifiers.
 | `framePlane` | [`Plane`](/docs/kcl-std/types/std-types-Plane) | The plane in which to display the feature control frame. The default is `XY`. Other standard planes like `XZ` and `YZ` can also be used. The frame may be displayed in a plane parallel to the given plane. | No |
 | `leaderScale` | [`number(_)`](/docs/kcl-std/types/std-types-number) | Visual scale of the leader dot. The default is `1.0`, which maps to the calibrated normal dot size. The value is normalized against `fontSize` so the dot stays consistent as text size changes. Must be greater than `0`. | No |
 | `fontSize` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit. This changes the scene size, not the internal raster texture quality. | No |
+| `annotationName` | [`string`](/docs/kcl-std/types/std-types-string) | Human-friendly name for this annotation in exports and model metadata. This is not displayed visually. | No |
 
 ### Returns
 

--- a/rust/AGENTS.md
+++ b/rust/AGENTS.md
@@ -32,6 +32,7 @@ This file applies to Rust development under `rust/`. It supplements the repo roo
   - `export ZOO_API_TOKEN=your-token-here`
   - `TWENTY_TWENTY=update cargo nextest run --workspace --no-fail-fast`
 - Generate stdlib markdown docs (from `rust/`): `just redo-kcl-stdlib-docs-no-imgs`
+- Run `npm run bindings:update` before pushing.
 
 ## Simulation tests
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2617,9 +2617,9 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.224"
+version = "0.2.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eaa800375ae686cca00b3d916d3712108411de18665bff360e0ec7947b21b6"
+checksum = "0ffff04fdb1e477bb9f81a0d2c1ae3e50f64a03ae95d9929a5b20e7833f2c9f3"
 dependencies = [
  "anyhow",
  "bon",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -30,7 +30,7 @@ kittycad = { version = "0.5.0", default-features = false, features = [
   "js",
   "requests",
 ] }
-kittycad-modeling-cmds = { version = "0.2.223", features = [
+kittycad-modeling-cmds = { version = "0.2.226", features = [
   "ts-rs",
   "websocket",
 ] }

--- a/rust/kcl-lib/expected-bindings/ts-rs/ModelingCmd.ts
+++ b/rust/kcl-lib/expected-bindings/ts-rs/ModelingCmd.ts
@@ -327,7 +327,14 @@ feature_control: AnnotationFeatureControl | null,
 /**
  * Set as a feature tag annotation
  */
-feature_tag: AnnotationFeatureTag | null, };
+feature_tag: AnnotationFeatureTag | null, 
+/**
+ * Human-friendly identifier for this annotation.
+ * Included in some exports and metadata of the model.
+ * This is _not_ displayed visually in, the annotation,
+ * it's only metadata.
+ */
+name?: string | null, };
 
 /**
  * Horizontal Text alignment
@@ -466,9 +473,26 @@ use_legacy?: boolean,
 tolerance: LengthUnit, };
 
 /**
- * Create a new solid from subtracting several other solids.
- * The 'target' is what will be cut from.
- * The 'tool' is what will be cut out from 'target'.
+ * Given a target solid, subtract a set of "tool solids" to create a new solid.
+ *
+ * Most successful subtracts come from solids who's faces do not overlap
+ * aka non-coplanar.
+ *
+ * Prefer one `tool` over multiple when calling this feature.
+ * 
+ * Failure cases:
+ * * A common failure is unsupported coplanar faces try to be unioned.
+ *
+ * Warning cases:
+ *
+ * Notable behaviors:
+ * If two tools occupy the same vertical range and overlap, like two cubes of the same height,
+ * the subtract of the first will cause the second tool to fail because the first leaves behind
+ * coplanar faces, causing an aforementioned failure case.
+ *
+ * Unlike `boolean_union`, if one tool in the set overlaps, any OTHER tool in the set
+ * that doesn't WILL NOT signal a non-overlap warning.
+ *
  */
 export type BooleanSubtract = { 
 /**
@@ -493,8 +517,22 @@ use_legacy?: boolean,
 tolerance: LengthUnit, };
 
 /**
- * Create a new solid from combining other smaller solids.
- * In other words, every part of the input solids will be included in the output solid.
+ * Given a set of overlapping solids, create a new single solid.
+ *
+ * Most successful unions come from solids who's faces do not overlap
+ * aka non-coplanar.
+ * 
+ * Failure cases:
+ * * A common failure is unsupported coincident faces try to be unioned.
+ *
+ * Warning cases:
+ * * When an element of the set doesn't overlap.
+ *
+ * Notable behaviors:
+ * * What appear to be coincident points will succeed and not give a "no overlap" warning, even if they're not.
+ * * Elements' top or bottom faces may not combine into one new face, which can seem like the union failed. You can tell they succeeded from side faces not extending into the original solids.
+ * * When exporting to STEP, if the above behavior is observed, will merged the faces.
+ *
  */
 export type BooleanUnion = { 
 /**
@@ -990,7 +1028,7 @@ view: CameraViewState, };
 export type DefaultCameraZoom = { 
 /**
  * Move the camera forward along the vector it's looking at,
- * by this magnitudedefaultCameraZoom.
+ * by this magnitude.
  * Basically, how much should the camera move forward by.
  */
 magnitude: number, };
@@ -1609,6 +1647,8 @@ export type EntityType = "entity" | "object" | "path" | "segment" | "curve" | "s
 
 /**
  * Export the scene to a file.
+ *
+ * The response is a MsgPack-encoded message in a WebSocket binary frame.
  */
 export type Export = { 
 /**
@@ -1635,6 +1675,8 @@ format: OutputFormat2d, };
 
 /**
  * Export the scene to a file.
+ *
+ * The response is a MsgPack-encoded message in a WebSocket binary frame.
  */
 export type Export3d = { 
 /**
@@ -1680,6 +1722,8 @@ target?: ModelingCmdId | null,
 target_reference?: EdgeSpecifier | null, 
 /**
  * How far off the plane to extrude
+ * This distance is relative to the target's plane, not an absolute coordinate.
+ * Symmetric extrusions will extrude outwards from both sides of the sketch to the length specified.
  */
 distance: LengthUnit, 
 /**
@@ -2019,9 +2063,7 @@ sequence: number | null, };
 export type ImageFormat = "png" | "jpeg";
 
 /**
- * File to import into the current model.
- * If you are sending binary data for a file, be sure to send the WebSocketRequest as
- * binary/bson, not text/json.
+ * File to import into the current scene.
  */
 export type ImportFile = { 
 /**
@@ -2034,7 +2076,13 @@ path: string,
 data: Array<number>, };
 
 /**
- * Import files to the current model.
+ * Import CAD files to the current scene.
+ *
+ * Send a request containing binary file data as a MsgPack-encoded message in a WebSocket binary frame.
+ *
+ * Note: These imports are non-editable. In the future we may expose a proprietary-to-KCL function
+ * to resolve this. The main intention today is to use imports as design references.
+ *
  */
 export type ImportFiles = { 
 /**
@@ -3667,7 +3715,7 @@ export type Solid3dGetNextAdjacentEdge = {
  */
 object_id: string, 
 /**
- * Which edge you want the opposite of.
+ * Which edge you want the next edge of.
  */
 edge_id: string, 
 /**
@@ -3701,7 +3749,7 @@ export type Solid3dGetPrevAdjacentEdge = {
  */
 object_id: string, 
 /**
- * Which edge you want the opposite of.
+ * Which edge you want the previous edge of.
  */
 edge_id: string, 
 /**

--- a/rust/kcl-lib/expected-bindings/ts-rs/StdLibCommands.ts
+++ b/rust/kcl-lib/expected-bindings/ts-rs/StdLibCommands.ts
@@ -2058,6 +2058,16 @@ export default {
         "experimental": false,
         "deprecated": false,
         "deprecatedSince": null
+      },
+      {
+        "name": "annotationName",
+        "ty": "string",
+        "docs": "Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.",
+        "required": false,
+        "special": false,
+        "experimental": false,
+        "deprecated": false,
+        "deprecatedSince": null
       }
     ]
   },
@@ -2136,6 +2146,16 @@ export default {
         "name": "fontSize",
         "ty": "number(Length)",
         "docs": "The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit. This changes the scene size, not the internal raster texture quality.",
+        "required": false,
+        "special": false,
+        "experimental": false,
+        "deprecated": false,
+        "deprecatedSince": null
+      },
+      {
+        "name": "annotationName",
+        "ty": "string",
+        "docs": "Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.",
         "required": false,
         "special": false,
         "experimental": false,
@@ -2229,6 +2249,16 @@ export default {
         "name": "fontSize",
         "ty": "number(Length)",
         "docs": "The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit. This changes the scene size, not the internal raster texture quality.",
+        "required": false,
+        "special": false,
+        "experimental": false,
+        "deprecated": false,
+        "deprecatedSince": null
+      },
+      {
+        "name": "annotationName",
+        "ty": "string",
+        "docs": "Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.",
         "required": false,
         "special": false,
         "experimental": false,
@@ -2337,6 +2367,16 @@ export default {
         "experimental": false,
         "deprecated": false,
         "deprecatedSince": null
+      },
+      {
+        "name": "annotationName",
+        "ty": "string",
+        "docs": "Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.",
+        "required": false,
+        "special": false,
+        "experimental": false,
+        "deprecated": false,
+        "deprecatedSince": null
       }
     ]
   },
@@ -2430,6 +2470,16 @@ export default {
         "experimental": false,
         "deprecated": false,
         "deprecatedSince": null
+      },
+      {
+        "name": "annotationName",
+        "ty": "string",
+        "docs": "Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.",
+        "required": false,
+        "special": false,
+        "experimental": false,
+        "deprecated": false,
+        "deprecatedSince": null
       }
     ]
   },
@@ -2498,6 +2548,16 @@ export default {
         "name": "fontSize",
         "ty": "number(Length)",
         "docs": "The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit. This changes the scene size, not the internal raster texture quality.",
+        "required": false,
+        "special": false,
+        "experimental": false,
+        "deprecated": false,
+        "deprecatedSince": null
+      },
+      {
+        "name": "annotationName",
+        "ty": "string",
+        "docs": "Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.",
         "required": false,
         "special": false,
         "experimental": false,
@@ -2606,6 +2666,16 @@ export default {
         "experimental": false,
         "deprecated": false,
         "deprecatedSince": null
+      },
+      {
+        "name": "annotationName",
+        "ty": "string",
+        "docs": "Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.",
+        "required": false,
+        "special": false,
+        "experimental": false,
+        "deprecated": false,
+        "deprecatedSince": null
       }
     ]
   },
@@ -2689,6 +2759,16 @@ export default {
         "experimental": false,
         "deprecated": false,
         "deprecatedSince": null
+      },
+      {
+        "name": "annotationName",
+        "ty": "string",
+        "docs": "Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.",
+        "required": false,
+        "special": false,
+        "experimental": false,
+        "deprecated": false,
+        "deprecatedSince": null
       }
     ]
   },
@@ -2737,6 +2817,16 @@ export default {
         "name": "fontSize",
         "ty": "number(Length)",
         "docs": "The model-space height to use for the note text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit. This changes the scene size, not the internal raster texture quality.",
+        "required": false,
+        "special": false,
+        "experimental": false,
+        "deprecated": false,
+        "deprecatedSince": null
+      },
+      {
+        "name": "annotationName",
+        "ty": "string",
+        "docs": "Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.",
         "required": false,
         "special": false,
         "experimental": false,
@@ -2845,6 +2935,16 @@ export default {
         "experimental": false,
         "deprecated": false,
         "deprecatedSince": null
+      },
+      {
+        "name": "annotationName",
+        "ty": "string",
+        "docs": "Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.",
+        "required": false,
+        "special": false,
+        "experimental": false,
+        "deprecated": false,
+        "deprecatedSince": null
       }
     ]
   },
@@ -2943,6 +3043,16 @@ export default {
         "name": "fontSize",
         "ty": "number(Length)",
         "docs": "The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit. This changes the scene size, not the internal raster texture quality.",
+        "required": false,
+        "special": false,
+        "experimental": false,
+        "deprecated": false,
+        "deprecatedSince": null
+      },
+      {
+        "name": "annotationName",
+        "ty": "string",
+        "docs": "Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.",
         "required": false,
         "special": false,
         "experimental": false,
@@ -3051,6 +3161,16 @@ export default {
         "experimental": false,
         "deprecated": false,
         "deprecatedSince": null
+      },
+      {
+        "name": "annotationName",
+        "ty": "string",
+        "docs": "Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.",
+        "required": false,
+        "special": false,
+        "experimental": false,
+        "deprecated": false,
+        "deprecatedSince": null
       }
     ]
   },
@@ -3154,6 +3274,16 @@ export default {
         "experimental": false,
         "deprecated": false,
         "deprecatedSince": null
+      },
+      {
+        "name": "annotationName",
+        "ty": "string",
+        "docs": "Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.",
+        "required": false,
+        "special": false,
+        "experimental": false,
+        "deprecated": false,
+        "deprecatedSince": null
       }
     ]
   },
@@ -3247,6 +3377,16 @@ export default {
         "experimental": false,
         "deprecated": false,
         "deprecatedSince": null
+      },
+      {
+        "name": "annotationName",
+        "ty": "string",
+        "docs": "Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.",
+        "required": false,
+        "special": false,
+        "experimental": false,
+        "deprecated": false,
+        "deprecatedSince": null
       }
     ]
   },
@@ -3335,6 +3475,16 @@ export default {
         "name": "fontSize",
         "ty": "number(Length)",
         "docs": "The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit. This changes the scene size, not the internal raster texture quality.",
+        "required": false,
+        "special": false,
+        "experimental": false,
+        "deprecated": false,
+        "deprecatedSince": null
+      },
+      {
+        "name": "annotationName",
+        "ty": "string",
+        "docs": "Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.",
         "required": false,
         "special": false,
         "experimental": false,
@@ -3443,6 +3593,16 @@ export default {
         "experimental": false,
         "deprecated": false,
         "deprecatedSince": null
+      },
+      {
+        "name": "annotationName",
+        "ty": "string",
+        "docs": "Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.",
+        "required": false,
+        "special": false,
+        "experimental": false,
+        "deprecated": false,
+        "deprecatedSince": null
       }
     ]
   },
@@ -3531,6 +3691,16 @@ export default {
         "name": "fontSize",
         "ty": "number(Length)",
         "docs": "The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit. This changes the scene size, not the internal raster texture quality.",
+        "required": false,
+        "special": false,
+        "experimental": false,
+        "deprecated": false,
+        "deprecatedSince": null
+      },
+      {
+        "name": "annotationName",
+        "ty": "string",
+        "docs": "Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.",
         "required": false,
         "special": false,
         "experimental": false,
@@ -3634,6 +3804,16 @@ export default {
         "name": "fontSize",
         "ty": "number(Length)",
         "docs": "The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit. This changes the scene size, not the internal raster texture quality.",
+        "required": false,
+        "special": false,
+        "experimental": false,
+        "deprecated": false,
+        "deprecatedSince": null
+      },
+      {
+        "name": "annotationName",
+        "ty": "string",
+        "docs": "Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.",
         "required": false,
         "special": false,
         "experimental": false,

--- a/rust/kcl-lib/src/std/gdt.rs
+++ b/rust/kcl-lib/src/std/gdt.rs
@@ -97,6 +97,10 @@ fn gdt_dimension_leader_scale(leader_scale: Option<&TyF64>, args: &Args) -> Resu
     gdt_user_leader_scale(leader_scale, DEFAULT_GDT_DIMENSION_LEADER_SCALE, args)
 }
 
+fn gdt_annotation_name(exec_state: &mut ExecState, args: &Args) -> Result<Option<String>, KclError> {
+    args.get_kw_arg_opt("annotationName", &RuntimeType::string(), exec_state)
+}
+
 #[derive(Debug, Clone)]
 enum DistanceEntity {
     Face(Box<Face>),
@@ -398,12 +402,17 @@ async fn inner_datum(
         .font_point_size(GDT_FONT_TEXTURE_POINT_SIZE)
         .leader_scale(gdt_dot_leader_scale(leader_scale.as_ref(), font_size.as_ref(), args)?)
         .build();
+    let annotation_name = gdt_annotation_name(exec_state, args)?;
+    let options = AnnotationOptions::builder()
+        .feature_control(feature_control)
+        .maybe_name(annotation_name)
+        .build();
     exec_state
         .batch_modeling_cmd(
             ModelingCmdMeta::from_args_id(exec_state, args, annotation_id),
             ModelingCmd::from(
                 mcmd::NewAnnotation::builder()
-                    .options(AnnotationOptions::builder().feature_control(feature_control).build())
+                    .options(options)
                     .clobber(false)
                     .annotation_type(AnnotationType::T3D)
                     .build(),
@@ -476,12 +485,17 @@ async fn inner_note(
         .font_point_size(GDT_FONT_TEXTURE_POINT_SIZE)
         .leader_scale(1.0)
         .build();
+    let annotation_name = gdt_annotation_name(exec_state, args)?;
+    let options = AnnotationOptions::builder()
+        .feature_tag(feature_tag)
+        .maybe_name(annotation_name)
+        .build();
     exec_state
         .batch_modeling_cmd(
             ModelingCmdMeta::from_args_id(exec_state, args, annotation_id),
             ModelingCmd::from(
                 mcmd::NewAnnotation::builder()
-                    .options(AnnotationOptions::builder().feature_tag(feature_tag).build())
+                    .options(options)
                     .clobber(false)
                     .annotation_type(AnnotationType::T3D)
                     .build(),
@@ -1109,9 +1123,11 @@ async fn create_basic_distance_annotation(
         .font_point_size(GDT_FONT_TEXTURE_POINT_SIZE)
         .arrow_scale(gdt_dimension_leader_scale(leader_scale, args)?)
         .build();
+    let annotation_name = gdt_annotation_name(exec_state, args)?;
     let options = AnnotationOptions::builder()
         .dimension(dimension)
         .units(display_units.to_kcmc())
+        .maybe_name(annotation_name)
         .build();
     let annotation_cmd = ModelingCmd::from(
         mcmd::NewAnnotation::builder()
@@ -1560,7 +1576,11 @@ async fn create_feature_control_annotation(
         .font_point_size(GDT_FONT_TEXTURE_POINT_SIZE)
         .leader_scale(gdt_dot_leader_scale(leader_scale, font_size, args)?)
         .build();
-    let options = AnnotationOptions::builder().feature_control(feature_control).build();
+    let annotation_name = gdt_annotation_name(exec_state, args)?;
+    let options = AnnotationOptions::builder()
+        .feature_control(feature_control)
+        .maybe_name(annotation_name)
+        .build();
     exec_state
         .batch_modeling_cmd(
             ModelingCmdMeta::from_args_id(exec_state, args, annotation_id),
@@ -1653,7 +1673,11 @@ async fn create_annotation(
         .font_point_size(GDT_FONT_TEXTURE_POINT_SIZE)
         .leader_scale(gdt_dot_leader_scale(leader_scale, font_size, args)?)
         .build();
-    let options = AnnotationOptions::builder().feature_control(feature_control).build();
+    let annotation_name = gdt_annotation_name(exec_state, args)?;
+    let options = AnnotationOptions::builder()
+        .feature_control(feature_control)
+        .maybe_name(annotation_name)
+        .build();
     exec_state
         .batch_modeling_cmd(
             ModelingCmdMeta::from_args_id(exec_state, args, annotation_id),
@@ -1898,6 +1922,33 @@ gdt::flatness(
                     vec![SourceRange::default()],
                 ))
             })
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn gdt_annotation_name_comes_from_explicit_argument() -> Result<(), KclError> {
+        let unbound_code = gdt_flatness_kcl("mm", "0.01mm", "[10, -10]");
+        let unbound_commands = gdt_commands(&unbound_code).await;
+        let unbound_index = new_annotation_command_index(&unbound_commands)?;
+        assert_eq!(annotation_options(&unbound_commands[unbound_index])?.name, None);
+
+        let assigned_code = unbound_code.replacen("gdt::flatness(", "topFlatness = gdt::flatness(", 1);
+        let assigned_commands = gdt_commands(&assigned_code).await;
+        let assigned_index = new_annotation_command_index(&assigned_commands)?;
+        assert_eq!(annotation_options(&assigned_commands[assigned_index])?.name, None);
+
+        let named_code = unbound_code.replacen(
+            "gdt::flatness(\n",
+            "gdt::flatness(\n  annotationName = \"topFlatness\",\n",
+            1,
+        );
+        let named_commands = gdt_commands(&named_code).await;
+        let named_index = new_annotation_command_index(&named_commands)?;
+        assert_eq!(
+            annotation_options(&named_commands[named_index])?.name.as_deref(),
+            Some("topFlatness")
+        );
+
+        Ok(())
     }
 
     #[test]

--- a/rust/kcl-lib/std/gdt.kcl
+++ b/rust/kcl-lib/std/gdt.kcl
@@ -75,6 +75,8 @@ export fn datum(
   /// The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit.
   /// This changes the scene size, not the internal raster texture quality.
   fontSize?: number(Length),
+  /// Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.
+  annotationName?: string,
 ): GdtAnnotation {}
 
 /// GD&T annotation specifying how flat faces should be.
@@ -162,6 +164,8 @@ export fn flatness(
   /// The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit.
   /// This changes the scene size, not the internal raster texture quality.
   fontSize?: number(Length),
+  /// Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.
+  annotationName?: string,
 ): [GdtAnnotation; 1+] {}
 
 /// GD&T annotation specifying how straight a feature must be.
@@ -269,6 +273,8 @@ export fn straightness(
   /// The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit.
   /// This changes the scene size, not the internal raster texture quality.
   fontSize?: number(Length),
+  /// Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.
+  annotationName?: string,
 ): [GdtAnnotation; 1+] {}
 
 /// GD&T annotation specifying how circular (round) a feature must be.
@@ -344,6 +350,8 @@ export fn circularity(
   /// The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit.
   /// This changes the scene size, not the internal raster texture quality.
   fontSize?: number(Length),
+  /// Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.
+  annotationName?: string,
 ): [GdtAnnotation; 1+] {}
 
 /// GD&T annotation specifying how closely a feature must conform to a perfect cylinder.
@@ -420,6 +428,8 @@ export fn cylindricity(
   /// The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit.
   /// This changes the scene size, not the internal raster texture quality.
   fontSize?: number(Length),
+  /// Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.
+  annotationName?: string,
 ): [GdtAnnotation; 1+] {}
 
 /// GD&T concentricity annotation specifying how closely a feature's median axis must align with datum references.
@@ -509,6 +519,8 @@ export fn concentricity(
   /// The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit.
   /// This changes the scene size, not the internal raster texture quality.
   fontSize?: number(Length),
+  /// Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.
+  annotationName?: string,
 ): [GdtAnnotation; 1+] {}
 
 /// GD&T symmetry annotation specifying how closely a feature's median plane must align with datum references.
@@ -632,6 +644,8 @@ export fn symmetry(
   /// The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit.
   /// This changes the scene size, not the internal raster texture quality.
   fontSize?: number(Length),
+  /// Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.
+  annotationName?: string,
 ): [GdtAnnotation; 1+] {}
 
 /// GD&T annotation specifying circular runout relative to a datum axis.
@@ -726,6 +740,8 @@ export fn runout(
   /// The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit.
   /// This changes the scene size, not the internal raster texture quality.
   fontSize?: number(Length),
+  /// Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.
+  annotationName?: string,
 ): [GdtAnnotation; 1+] {}
 
 /// GD&T angularity annotation specifying how much faces or edges may deviate from an orientation at a basic angle relative to datum references.
@@ -867,6 +883,8 @@ export fn angularity(
   /// The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit.
   /// This changes the scene size, not the internal raster texture quality.
   fontSize?: number(Length),
+  /// Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.
+  annotationName?: string,
 ): [GdtAnnotation; 1+] {}
 
 /// GD&T perpendicularity annotation specifying how much faces or edges may deviate from perpendicular orientation relative to datum references.
@@ -937,6 +955,8 @@ export fn perpendicularity(
   /// The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit.
   /// This changes the scene size, not the internal raster texture quality.
   fontSize?: number(Length),
+  /// Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.
+  annotationName?: string,
 ): [GdtAnnotation; 1+] {}
 
 /// GD&T parallelism annotation specifying how much faces or edges may deviate from parallel orientation relative to datum references.
@@ -1007,6 +1027,8 @@ export fn parallelism(
   /// The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit.
   /// This changes the scene size, not the internal raster texture quality.
   fontSize?: number(Length),
+  /// Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.
+  annotationName?: string,
 ): [GdtAnnotation; 1+] {}
 
 /// GD&T position annotation specifying how much faces or edges may deviate from their ideal location.
@@ -1077,6 +1099,8 @@ export fn position(
   /// The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit.
   /// This changes the scene size, not the internal raster texture quality.
   fontSize?: number(Length),
+  /// Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.
+  annotationName?: string,
 ): [GdtAnnotation; 1+] {}
 
 /// GD&T annotation for attaching manufacturing text to faces or edges.
@@ -1140,6 +1164,8 @@ export fn annotation(
   /// The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit.
   /// This changes the scene size, not the internal raster texture quality.
   fontSize?: number(Length),
+  /// Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.
+  annotationName?: string,
 ): [GdtAnnotation; 1+] {}
 
 /// GD&T note for adding free-floating manufacturing text that is not attached to a face or edge.
@@ -1208,6 +1234,8 @@ export fn note(
   /// The model-space height to use for the note text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit.
   /// This changes the scene size, not the internal raster texture quality.
   fontSize?: number(Length),
+  /// Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.
+  annotationName?: string,
 ): GdtAnnotation {}
 
 /// GD&T distance annotation for displaying measured edge lengths or distances between two entities.
@@ -1312,6 +1340,8 @@ export fn distance(
   /// The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit.
   /// This changes the scene size, not the internal raster texture quality.
   fontSize?: number(Length),
+  /// Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.
+  annotationName?: string,
 ): [GdtAnnotation; 1+] {}
 
 /// GD&T profile annotation specifying how much edges or faces may deviate from their ideal shape.
@@ -1384,6 +1414,8 @@ export fn profile(
   /// The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit.
   /// This changes the scene size, not the internal raster texture quality.
   fontSize?: number(Length),
+  /// Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.
+  annotationName?: string,
 ): [GdtAnnotation; 1+] {}
 
 /// GD&T profile-of-a-line annotation specifying how much edges may deviate from their ideal shape.
@@ -1460,6 +1492,8 @@ export fn profileLine(
   /// The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit.
   /// This changes the scene size, not the internal raster texture quality.
   fontSize?: number(Length),
+  /// Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.
+  annotationName?: string,
 ): [GdtAnnotation; 1+] {}
 
 /// GD&T profile-of-a-surface annotation specifying how much faces may deviate from their ideal shape.
@@ -1502,4 +1536,6 @@ export fn profileSurface(
   /// The model-space height to use for annotation text. The default is `10mm`. Explicit units are supported; bare numbers use the file's default length unit.
   /// This changes the scene size, not the internal raster texture quality.
   fontSize?: number(Length),
+  /// Human-friendly name for this annotation in exports and model metadata. This is not displayed visually.
+  annotationName?: string,
 ): [GdtAnnotation; 1+] {}

--- a/rust/kcl-lib/tests/gdt_face_api_edge_specifier/artifact_commands.snap
+++ b/rust/kcl-lib/tests/gdt_face_api_edge_specifier/artifact_commands.snap
@@ -296,7 +296,8 @@ description: Artifact commands gdt_face_api_edge_specifier.kcl
             "font_point_size": 36,
             "leader_scale": 5.0
           },
-          "feature_tag": null
+          "feature_tag": null,
+          "name": "sample GD&T annotation"
         },
         "clobber": false,
         "annotation_type": "t3d"

--- a/rust/kcl-lib/tests/gdt_face_api_edge_specifier/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/gdt_face_api_edge_specifier/artifact_graph_flowchart.snap.md
@@ -48,7 +48,7 @@ flowchart LR
   24["SweepEdge Adjacent"]
   25["SweepEdge Opposite"]
   26["SweepEdge Adjacent"]
-  27["Plane<br>[740, 914, 0]"]
+  27["Plane<br>[740, 959, 0]"]
     %% [ProgramBodyItem { index: 3 }, ExpressionStatementExpr]
   28["SketchBlock<br>[41, 606, 0]"]
     %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit]
@@ -68,7 +68,7 @@ flowchart LR
     %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 10 }, ExpressionStatementExpr]
   36["SketchBlockConstraint Horizontal<br>[587, 604, 0]"]
     %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, SketchBlockBody, SketchBlockBodyItem { index: 11 }, ExpressionStatementExpr]
-  37["GdtAnnotation<br>[740, 914, 0]"]
+  37["GdtAnnotation<br>[740, 959, 0]"]
     %% [ProgramBodyItem { index: 3 }, ExpressionStatementExpr]
   1 --- 2
   1 <--x 7

--- a/rust/kcl-lib/tests/gdt_face_api_edge_specifier/ast.snap
+++ b/rust/kcl-lib/tests/gdt_face_api_edge_specifier/ast.snap
@@ -1967,6 +1967,27 @@ description: Result of parsing gdt_face_api_edge_specifier.kcl
                 "commentStart": 0,
                 "end": 0,
                 "moduleId": 0,
+                "name": "annotationName",
+                "start": 0,
+                "type": "Identifier"
+              },
+              "arg": {
+                "commentStart": 0,
+                "end": 0,
+                "moduleId": 0,
+                "raw": "\"sample GD&T annotation\"",
+                "start": 0,
+                "type": "Literal",
+                "type": "Literal",
+                "value": "sample GD&T annotation"
+              }
+            },
+            {
+              "type": "LabeledArg",
+              "label": {
+                "commentStart": 0,
+                "end": 0,
+                "moduleId": 0,
                 "name": "tolerance",
                 "start": 0,
                 "type": "Identifier"

--- a/rust/kcl-lib/tests/gdt_face_api_edge_specifier/input.kcl
+++ b/rust/kcl-lib/tests/gdt_face_api_edge_specifier/input.kcl
@@ -24,6 +24,7 @@ gdt::straightness(
       sideFaces = [region001.tags.line1, capStart001]
     }
   ],
+  annotationName = "sample GD&T annotation",
   tolerance = 0.1mm,
   framePosition = [12mm, 8mm],
   framePlane = XZ,

--- a/rust/kcl-lib/tests/gdt_face_api_edge_specifier/ops.snap
+++ b/rust/kcl-lib/tests/gdt_face_api_edge_specifier/ops.snap
@@ -858,6 +858,13 @@ description: Operations executed gdt_face_api_edge_specifier.kcl
       "name": "gdt::straightness",
       "unlabeledArg": null,
       "labeledArgs": {
+        "annotationName": {
+          "value": {
+            "type": "String",
+            "value": "sample GD&T annotation"
+          },
+          "sourceRange": []
+        },
         "edges": {
           "value": {
             "type": "Array",

--- a/rust/kcl-lib/tests/gdt_face_api_edge_specifier/unparsed.snap
+++ b/rust/kcl-lib/tests/gdt_face_api_edge_specifier/unparsed.snap
@@ -28,6 +28,7 @@ gdt::straightness(
       sideFaces = [region001.tags.line1, capStart001]
     }
   ],
+  annotationName = "sample GD&T annotation",
   tolerance = 0.1mm,
   framePosition = [12mm, 8mm],
   framePlane = XZ,


### PR DESCRIPTION
Integrates https://github.com/KittyCAD/modeling-api/pull/1356 into KCL, so that the human-friendly names for a GD&T annotation can be sent to the engine and included in exported STEP files.