### PR TITLE
Experimental STEP-to-KCL import workflow

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -6,7 +6,7 @@ NODE_ENV=development
 VITE_ZOO_BASE_DOMAIN=dev.zoo.dev
 #VITE_ZOO_API_TOKEN="required for testing, optional to skip auth in the app"
 #VITE_KITTYCAD_WEBSOCKET_URL="optional override for engine WebSocket URL"
-#VITE_MLEPHANT_WEBSOCKET_URL="optional override for copilot WebSocket URL"
+VITE_MLEPHANT_WEBSOCKET_URL="wss://api.dev.zoo.dev/ws/ml/copilot?pr=4196"
 #VITE_WASM_BASE_URL="optional override of Wasm URL if not on default port 3000"
 FAIL_ON_CONSOLE_ERRORS=true
 

--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   IS_RELEASE: ${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}
-  IS_STAGING: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.head_ref == 'step-to-kcl-import-demo') }}
+  IS_STAGING: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
   FORCE_RELEASE_BUILD: false # Set to true to enable codesign in a PR
 
 concurrency:

--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   IS_RELEASE: ${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}
-  IS_STAGING: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+  IS_STAGING: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.head_ref == 'step-to-kcl-import-demo') }}
   FORCE_RELEASE_BUILD: false # Set to true to enable codesign in a PR
 
 concurrency:

--- a/e2e/playwright/native-file-menu.spec.ts
+++ b/e2e/playwright/native-file-menu.spec.ts
@@ -1,4 +1,5 @@
 import { throwTronAppMissing } from '@e2e/playwright/lib/electron-helpers'
+import path from 'node:path'
 import {
   clickElectronNativeMenuById,
   findElectronNativeMenuById,
@@ -150,6 +151,66 @@ test.describe(
         // const signIn = page.getByTestId('sign-in-button')
         // await expect(signIn).toBeVisible()
       })
+    })
+    test('STEP import is available from native and project File menus', async ({
+      tronApp,
+      cmdBar,
+      page,
+      homePage,
+      scene,
+    }) => {
+      if (!tronApp) {
+        throwTronAppMissing()
+        return
+      }
+
+      await homePage.goToModelingScene()
+      await scene.settled(cmdBar)
+      await scene.connectionEstablished()
+      await scene.isNativeFileMenuCreated()
+
+      const nativeMenuItem = await tronApp.electron.evaluate(
+        async ({ app }) => {
+          const item = app.applicationMenu?.getMenuItemById(
+            'File.Import STEP as editable KCL'
+          )
+          return item
+            ? {
+                label: item.label,
+                enabled: item.enabled,
+                visible: item.visible,
+              }
+            : null
+        }
+      )
+      expect(nativeMenuItem).toEqual({
+        label: 'Import STEP as Editable KCL… (Experimental)',
+        enabled: true,
+        visible: true,
+      })
+
+      const projectMenuToggle = page.getByTestId('project-sidebar-toggle')
+      await projectMenuToggle.click()
+      await expect(page.getByTestId('step-to-kcl-import-button')).toBeVisible()
+      await projectMenuToggle.click()
+
+      const fileChooserPromise = page.waitForEvent('filechooser')
+      await clickElectronNativeMenuById(
+        tronApp,
+        'File.Import STEP as editable KCL'
+      )
+      const fileChooser = await fileChooserPromise
+      const stepFileName = '1614A11_swinging-bar-latch.stp'
+      await fileChooser.setFiles(
+        path.resolve('public/kcl-samples/dog-house-great-dane', stepFileName)
+      )
+
+      await expect(
+        page.getByTestId('ml-ephant-conversation-input')
+      ).toHaveValue(
+        new RegExp(`Reconstruct the attached STEP model.*${stepFileName}`, 's')
+      )
+      await expect(page.getByText(stepFileName, { exact: true })).toBeVisible()
     })
     test('Modeling page', async ({
       tronApp,

--- a/src/components/MlEphantConversation.spec.tsx
+++ b/src/components/MlEphantConversation.spec.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen, within } from '@testing-library/react'
-import { expect, vi, describe, test, beforeEach, afterEach } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
 // Mock modules that access localStorage at import time
 vi.mock('@src/routes/utils', () => ({
@@ -23,11 +23,11 @@ vi.mock('@src/lib/boot', () => ({
   }),
 }))
 
-import { MlEphantConversation } from '@src/components/MlEphantConversation'
-import type { Conversation } from '@src/machines/mlEphantManagerMachine'
 import type { MlCopilotMode } from '@kittycad/lib'
+import { MlEphantConversation } from '@src/components/MlEphantConversation'
 import { DEFAULT_ML_COPILOT_MODE } from '@src/lib/constants'
 import { withSiteBaseURL } from '@src/lib/withBaseURL'
+import type { Conversation } from '@src/machines/mlEphantManagerMachine'
 
 describe('MlEphantConversation', () => {
   function rendersRequestBubbleThenDisplayResponse(
@@ -247,7 +247,11 @@ describe('MlEphantConversation', () => {
       return new File([content], name, { type })
     }
 
-    const renderConversation = (handleProcess = vi.fn(), disabled = false) => {
+    const renderConversation = (
+      handleProcess = vi.fn(),
+      disabled = false,
+      defaultAttachments?: File[]
+    ) => {
       return render(
         <MlEphantConversation
           isLoading={false}
@@ -264,6 +268,7 @@ describe('MlEphantConversation', () => {
           queue={[]}
           onRemoveFromQueue={() => {}}
           onSteer={() => {}}
+          defaultAttachments={defaultAttachments}
         />
       )
     }
@@ -280,6 +285,18 @@ describe('MlEphantConversation', () => {
       renderConversation()
       expect(
         screen.getByTestId('ml-ephant-attachments-button')
+      ).toBeInTheDocument()
+    })
+
+    test('stages attachments supplied by another app workflow', async () => {
+      const stepFile = createMockFile(
+        'mounting-bracket.step',
+        'application/step'
+      )
+      renderConversation(vi.fn(), false, [stepFile])
+
+      expect(
+        await screen.findByText('mounting-bracket.step')
       ).toBeInTheDocument()
     })
 

--- a/src/components/MlEphantConversation.tsx
+++ b/src/components/MlEphantConversation.tsx
@@ -1,21 +1,21 @@
-import { getSelectionTypeDisplayText } from '@src/lib/selections'
-import Loading from '@src/components/Loading'
-import { type Selections } from '@src/machines/modelingSharedTypes'
-import type { MlCopilotMode } from '@kittycad/lib'
 import { Popover } from '@headlessui/react'
+import type { MlCopilotMode } from '@kittycad/lib'
 import { CustomIcon } from '@src/components/CustomIcon'
 import { ExchangeCard } from '@src/components/ExchangeCard'
+import { isExternalFileDrag } from '@src/components/Explorer/utils'
+import Loading from '@src/components/Loading'
+import Tooltip from '@src/components/Tooltip'
+import { useSingletons } from '@src/lib/boot'
+import { DEFAULT_ML_COPILOT_MODE } from '@src/lib/constants'
+import { takeViewportScreenshot } from '@src/lib/screenshot'
+import { getSelectionTypeDisplayText } from '@src/lib/selections'
 import type {
   Conversation,
   Exchange,
 } from '@src/machines/mlEphantManagerMachine'
+import { type Selections } from '@src/machines/modelingSharedTypes'
 import type { ChangeEvent, ReactNode } from 'react'
 import { useEffect, useRef, useState } from 'react'
-import { DEFAULT_ML_COPILOT_MODE } from '@src/lib/constants'
-import { useSingletons } from '@src/lib/boot'
-import Tooltip from '@src/components/Tooltip'
-import { isExternalFileDrag } from '@src/components/Explorer/utils'
-import { takeViewportScreenshot } from '@src/lib/screenshot'
 
 const noop = () => {}
 
@@ -40,6 +40,7 @@ export interface MlEphantConversationProps {
   userAvatarSrc?: string
   blockedReason?: string
   defaultPrompt?: string
+  defaultAttachments?: File[]
   initialMlCopilotMode?: MlCopilotMode // resolved from project settings
   onMlCopilotModeChange?: (mode: MlCopilotMode) => void
   isProcessing: boolean
@@ -220,6 +221,7 @@ interface MlEphantConversationInputProps {
   disabled?: boolean
   needsReconnect: boolean
   defaultPrompt?: string
+  defaultAttachments?: File[]
   hasAlreadySentPrompts: boolean
   initialMlCopilotMode?: MlCopilotMode
   onMlCopilotModeChange?: (mode: MlCopilotMode) => void
@@ -242,6 +244,11 @@ export const MlEphantConversationInput = (
 
   // Without this the cursor ends up at the start of the text
   useEffect(() => setValue(props.defaultPrompt || ''), [props.defaultPrompt])
+
+  useEffect(
+    () => setAttachments(props.defaultAttachments || []),
+    [props.defaultAttachments]
+  )
 
   useEffect(() => {
     const next = props.initialMlCopilotMode ?? DEFAULT_ML_COPILOT_MODE
@@ -667,6 +674,7 @@ export const MlEphantConversation = (props: MlEphantConversationProps) => {
               onReconnect={props.onReconnect}
               onCancel={props.onCancel}
               defaultPrompt={props.defaultPrompt}
+              defaultAttachments={props.defaultAttachments}
               hasAlreadySentPrompts={
                 exchangeCards !== undefined && exchangeCards.length > 0
               }

--- a/src/components/ProjectSidebarMenu.tsx
+++ b/src/components/ProjectSidebarMenu.tsx
@@ -1,6 +1,6 @@
 import { Popover, Transition } from '@headlessui/react'
 import { useSelector } from '@xstate/react'
-import { Fragment, useMemo } from 'react'
+import { Fragment, useMemo, useRef } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import type { SnapshotFrom } from 'xstate'
 
@@ -12,16 +12,20 @@ import { useLspContext } from '@src/components/LspProvider'
 import Tooltip from '@src/components/Tooltip'
 import { useAbsoluteFilePath } from '@src/hooks/useAbsoluteFilePath'
 import usePlatform from '@src/hooks/usePlatform'
+import { useApp, useSingletons } from '@src/lib/boot'
+import { sendAddFileToProjectCommandForCurrentProject } from '@src/lib/commandBarConfigs/applicationCommandConfig'
 import { APP_NAME } from '@src/lib/constants'
+import { hotkeyDisplay } from '@src/lib/hotkeys'
 import { isDesktop } from '@src/lib/isDesktop'
 import { PATHS } from '@src/lib/paths'
-import { useApp, useSingletons } from '@src/lib/boot'
-import type { IndexLoaderData } from '@src/lib/types'
-import { sendAddFileToProjectCommandForCurrentProject } from '@src/lib/commandBarConfigs/applicationCommandConfig'
-import { hotkeyDisplay } from '@src/lib/hotkeys'
 import type { FileEntry, Project } from '@src/lib/project'
+import type { IndexLoaderData } from '@src/lib/types'
 
 import fsZds from '@src/lib/fs-zds'
+import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
+import { togglePaneLayoutNode } from '@src/lib/layout/utils'
+import { isStepFileName, stepToKclDraftBroker } from '@src/lib/stepToKcl'
+import toast from 'react-hot-toast'
 
 interface ProjectSidebarMenuProps extends React.PropsWithChildren {
   enableMenu?: boolean
@@ -108,7 +112,7 @@ function ProjectMenuPopover({
   project?: IndexLoaderData['project']
   file?: IndexLoaderData['file']
 }) {
-  const { machineManager, commands, settings } = useApp()
+  const { machineManager, commands, settings, layout } = useApp()
   const { kclManager } = useSingletons()
   const machineApiEnabled = settings.useSettings().app.machineApi.current
   const platform = usePlatform()
@@ -117,6 +121,28 @@ function ProjectMenuPopover({
   const commandsSelector = (state: SnapshotFrom<typeof commands.actor>) =>
     state.context.commands
   const commandList = useSelector(commands.actor, commandsSelector)
+  const stepFileInputRef = useRef<HTMLInputElement>(null)
+
+  const stageStepToKclDraft = (file: File) => {
+    if (!isStepFileName(file.name)) {
+      toast.error('Choose a STEP file with a .step or .stp extension.')
+      return
+    }
+
+    settings.actor.send({
+      type: 'set.app.zookeeperMode',
+      data: { level: 'project', value: 'thoughtful' },
+    })
+    layout.set(
+      togglePaneLayoutNode({
+        rootLayout: structuredClone(layout.signal.value),
+        targetNodeId: DefaultLayoutPaneID.TTC,
+        shouldExpand: true,
+      })
+    )
+    stepToKclDraftBroker.request(file)
+    toast.success('STEP reconstruction is ready to review in Zookeeper.')
+  }
 
   const { onProjectClose } = useLspContext()
   const exportCommandInfo = { name: 'Export', groupId: 'modeling' }
@@ -169,6 +195,19 @@ function ProjectMenuPopover({
               settings.actor,
               commands.actor
             ),
+        },
+        {
+          id: 'convertStepToKcl',
+          Element: 'button',
+          children: (
+            <>
+              <span className="flex-1">Convert STEP to editable KCL...</span>
+              <span className="text-[10px] text-chalkboard-70 dark:text-chalkboard-40">
+                Experimental
+              </span>
+            </>
+          ),
+          onClick: () => stepFileInputRef.current?.click(),
         },
         {
           id: 'export',
@@ -242,6 +281,8 @@ function ProjectMenuPopover({
       platform,
       findCommand,
       machineApiEnabled,
+      layout,
+      settings.actor,
       // eslint-disable-next-line @typescript-eslint/unbound-method
       commands.send,
       kclManager.engineCommandManager,
@@ -262,6 +303,18 @@ function ProjectMenuPopover({
 
   return (
     <Popover className="relative">
+      <input
+        ref={stepFileInputRef}
+        type="file"
+        accept=".step,.stp"
+        className="hidden"
+        data-testid="step-to-kcl-file-input"
+        onChange={(event) => {
+          const file = event.currentTarget.files?.[0]
+          event.currentTarget.value = ''
+          if (file) stageStepToKclDraft(file)
+        }}
+      />
       <Popover.Button
         className="gap-1 rounded-sm mr-auto max-h-min min-w-max border-0 py-1 px-2 flex items-center  focus-visible:outline-appForeground dark:hover:bg-chalkboard-90"
         data-testid="project-sidebar-toggle"

--- a/src/components/ProjectSidebarMenu.tsx
+++ b/src/components/ProjectSidebarMenu.tsx
@@ -11,6 +11,7 @@ import { Logo } from '@src/components/Logo'
 import { useLspContext } from '@src/components/LspProvider'
 import Tooltip from '@src/components/Tooltip'
 import { useAbsoluteFilePath } from '@src/hooks/useAbsoluteFilePath'
+import { useMenuListener } from '@src/hooks/useMenu'
 import usePlatform from '@src/hooks/usePlatform'
 import { useApp, useSingletons } from '@src/lib/boot'
 import { sendAddFileToProjectCommandForCurrentProject } from '@src/lib/commandBarConfigs/applicationCommandConfig'
@@ -123,6 +124,12 @@ function ProjectMenuPopover({
   const commandList = useSelector(commands.actor, commandsSelector)
   const stepFileInputRef = useRef<HTMLInputElement>(null)
 
+  useMenuListener((data) => {
+    if (data.menuLabel === 'File.Import STEP as editable KCL') {
+      stepFileInputRef.current?.click()
+    }
+  })
+
   const stageStepToKclDraft = (file: File) => {
     if (!isStepFileName(file.name)) {
       toast.error('Choose a STEP file with a .step or .stp extension.')
@@ -199,9 +206,10 @@ function ProjectMenuPopover({
         {
           id: 'convertStepToKcl',
           Element: 'button',
+          'data-testid': 'step-to-kcl-import-button',
           children: (
             <>
-              <span className="flex-1">Convert STEP to editable KCL...</span>
+              <span className="flex-1">Import STEP as editable KCL…</span>
               <span className="text-[10px] text-chalkboard-70 dark:text-chalkboard-40">
                 Experimental
               </span>

--- a/src/components/layout/areas/MlEphantConversationPane.tsx
+++ b/src/components/layout/areas/MlEphantConversationPane.tsx
@@ -1,30 +1,31 @@
-import { reportRejection } from '@src/lib/trap'
-import { NIL as uuidNIL } from 'uuid'
-import type { SettingsType } from '@src/lib/settings/initialSettings'
-import type { KclManager } from '@src/lang/KclManager'
-import { useEffect, useState, useRef, useCallback } from 'react'
-import {
-  type SystemIOActor,
-  SystemIOMachineEvents,
-} from '@src/machines/systemIO/utils'
+import type { MlCopilotMode } from '@kittycad/lib'
 import {
   MlEphantConversation,
   type QueuedMessage,
 } from '@src/components/MlEphantConversation'
+import { type useModelingContext } from '@src/hooks/useModelingContext'
+import type { KclManager } from '@src/lang/KclManager'
+import { SEARCH_PARAM_ML_PROMPT_KEY } from '@src/lib/constants'
+import type { FileEntry, Project } from '@src/lib/project'
+import type { SettingsType } from '@src/lib/settings/initialSettings'
+import { stepToKclDraftBroker } from '@src/lib/stepToKcl'
+import { reportRejection } from '@src/lib/trap'
 import type { MlEphantManagerActor } from '@src/machines/mlEphantManagerMachine'
 import {
   MlEphantManagerStates,
   MlEphantManagerTransitions,
 } from '@src/machines/mlEphantManagerMachine'
+import type { ModelingMachineContext } from '@src/machines/modelingSharedTypes'
+import {
+  type SystemIOActor,
+  SystemIOMachineEvents,
+} from '@src/machines/systemIO/utils'
 import { collectProjectFiles } from '@src/machines/systemIO/utils'
 import { S } from '@src/machines/utils'
-import type { ModelingMachineContext } from '@src/machines/modelingSharedTypes'
-import type { FileEntry, Project } from '@src/lib/project'
 import { useSelector } from '@xstate/react'
-import type { MlCopilotMode } from '@kittycad/lib'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
-import { SEARCH_PARAM_ML_PROMPT_KEY } from '@src/lib/constants'
-import { type useModelingContext } from '@src/hooks/useModelingContext'
+import { NIL as uuidNIL } from 'uuid'
 import type { SnapshotFrom } from 'xstate'
 
 type MlEphantConversationPaneUser = {
@@ -51,6 +52,7 @@ export const MlEphantConversationPane = (props: {
   onMlCopilotModeChange?: (mode: MlCopilotMode) => void
 }) => {
   const [defaultPrompt, setDefaultPrompt] = useState('')
+  const [defaultAttachments, setDefaultAttachments] = useState<File[]>([])
   const [searchParams, setSearchParams] = useSearchParams()
   const timeoutReconnect = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined
@@ -58,6 +60,15 @@ export const MlEphantConversationPane = (props: {
   const [queue, setQueue] = useState<QueuedMessage[]>([])
   const isSubmittingFromQueue = useRef(false)
   const steeredId = useRef<string | null>(null)
+
+  useEffect(
+    () =>
+      stepToKclDraftBroker.subscribe((draft) => {
+        setDefaultPrompt(draft.prompt)
+        setDefaultAttachments([draft.attachment])
+      }),
+    []
+  )
 
   let conversation = useSelector(props.mlEphantManagerActor, (actor) => {
     return actor.context.conversation
@@ -411,6 +422,7 @@ export const MlEphantConversationPane = (props: {
       userAvatarSrc={props.user?.image}
       blockedReason={userBlockedOnPaymentReason}
       defaultPrompt={defaultPrompt}
+      defaultAttachments={defaultAttachments}
       initialMlCopilotMode={props.settings.app.zookeeperMode.current}
       onMlCopilotModeChange={props.onMlCopilotModeChange}
     />

--- a/src/lib/stepToKcl.test.ts
+++ b/src/lib/stepToKcl.test.ts
@@ -1,0 +1,43 @@
+import {
+  StepToKclDraftBroker,
+  buildStepToKclPrompt,
+  generatedKclFileName,
+  isStepFileName,
+} from '@src/lib/stepToKcl'
+import { describe, expect, test, vi } from 'vitest'
+
+describe('STEP-to-KCL draft', () => {
+  test('recognizes both STEP extensions without case sensitivity', () => {
+    expect(isStepFileName('part.step')).toBe(true)
+    expect(isStepFileName('PART.STP')).toBe(true)
+    expect(isStepFileName('part.stl')).toBe(false)
+  })
+
+  test('builds a non-destructive editable reconstruction prompt', () => {
+    expect(generatedKclFileName('mounting-bracket.step')).toBe(
+      'mounting-bracket.generated.kcl'
+    )
+
+    const prompt = buildStepToKclPrompt('mounting-bracket.step')
+    expect(prompt).toContain('standalone, editable KCL')
+    expect(prompt).toContain('mounting-bracket.generated.kcl')
+    expect(prompt).toContain('Do not modify or delete existing project files')
+    expect(prompt).toContain('do not import or reference the STEP file')
+  })
+
+  test('holds a draft until the Zookeeper pane subscribes', () => {
+    const broker = new StepToKclDraftBroker()
+    const listener = vi.fn()
+    const attachment = new File(['ISO-10303-21;'], 'part.step')
+
+    broker.request(attachment)
+    const unsubscribe = broker.subscribe(listener)
+
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({ attachment, prompt: expect.any(String) })
+    )
+
+    unsubscribe()
+  })
+})

--- a/src/lib/stepToKcl.test.ts
+++ b/src/lib/stepToKcl.test.ts
@@ -21,6 +21,9 @@ describe('STEP-to-KCL draft', () => {
     const prompt = buildStepToKclPrompt('mounting-bracket.step')
     expect(prompt).toContain('standalone, editable KCL')
     expect(prompt).toContain('mounting-bracket.generated.kcl')
+    expect(prompt).toContain(
+      'Activate the step-to-kcl skill before inspecting the source.'
+    )
     expect(prompt).toContain('Do not modify or delete existing project files')
     expect(prompt).toContain('do not import or reference the STEP file')
   })

--- a/src/lib/stepToKcl.ts
+++ b/src/lib/stepToKcl.ts
@@ -20,7 +20,7 @@ export function buildStepToKclPrompt(stepFileName: string): string {
 
   return `Reconstruct the attached STEP model \`${sourceName}\` as standalone, editable KCL.
 
-Use the step-to-kcl skill if it is available. Treat the complete ISO-10303-21 data as dimensional and topological evidence: recover its units, coordinate system, solid bodies, overall dimensions, holes, pockets, repeated features, fillets, and chamfers as accurately as KCL supports.
+Activate the step-to-kcl skill before inspecting the source. Follow its evidence-ledger, source-frame, topology, workflow-budget, and final-verification rules. Treat the complete ISO-10303-21 data as dimensional and topological evidence: recover its units, coordinate system, solid bodies, overall dimensions, holes, pockets, repeated features, fillets, and chamfers as accurately as KCL supports.
 
 Create a new file named \`${outputName}\`. Do not modify or delete existing project files, and do not import or reference the STEP file from the generated KCL. Prefer concise, idiomatic, parameterized KCL built from native sketches, sweeps, booleans, patterns, and edge treatments. Execute and render the result, fix any KCL errors, and clearly describe any approximations or unsupported source features when you finish.`
 }

--- a/src/lib/stepToKcl.ts
+++ b/src/lib/stepToKcl.ts
@@ -1,0 +1,67 @@
+export interface StepToKclDraft {
+  attachment: File
+  prompt: string
+}
+
+type StepToKclDraftListener = (draft: StepToKclDraft) => void
+
+export function isStepFileName(fileName: string): boolean {
+  return /\.(step|stp)$/i.test(fileName)
+}
+
+export function generatedKclFileName(stepFileName: string): string {
+  const baseName = stepFileName.replace(/\.(step|stp)$/i, '') || 'model'
+  return `${baseName}.generated.kcl`
+}
+
+export function buildStepToKclPrompt(stepFileName: string): string {
+  const sourceName = stepFileName.replaceAll('`', "'")
+  const outputName = generatedKclFileName(sourceName)
+
+  return `Reconstruct the attached STEP model \`${sourceName}\` as standalone, editable KCL.
+
+Use the step-to-kcl skill if it is available. Treat the complete ISO-10303-21 data as dimensional and topological evidence: recover its units, coordinate system, solid bodies, overall dimensions, holes, pockets, repeated features, fillets, and chamfers as accurately as KCL supports.
+
+Create a new file named \`${outputName}\`. Do not modify or delete existing project files, and do not import or reference the STEP file from the generated KCL. Prefer concise, idiomatic, parameterized KCL built from native sketches, sweeps, booleans, patterns, and edge treatments. Execute and render the result, fix any KCL errors, and clearly describe any approximations or unsupported source features when you finish.`
+}
+
+/**
+ * A tiny handoff between the project menu and the lazily-mounted Zookeeper
+ * pane. Keeping one pending draft means the file picker still works when the
+ * pane is closed and mounts only after the menu action expands it.
+ */
+export class StepToKclDraftBroker {
+  private pendingDraft: StepToKclDraft | undefined
+  private listeners = new Set<StepToKclDraftListener>()
+
+  request(attachment: File) {
+    const draft = {
+      attachment,
+      prompt: buildStepToKclPrompt(attachment.name),
+    }
+
+    if (this.listeners.size === 0) {
+      this.pendingDraft = draft
+      return
+    }
+
+    this.pendingDraft = undefined
+    this.listeners.forEach((listener) => listener(draft))
+  }
+
+  subscribe(listener: StepToKclDraftListener): () => void {
+    this.listeners.add(listener)
+
+    if (this.pendingDraft) {
+      const draft = this.pendingDraft
+      this.pendingDraft = undefined
+      listener(draft)
+    }
+
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+}
+
+export const stepToKclDraftBroker = new StepToKclDraftBroker()

--- a/src/menu/channels.ts
+++ b/src/menu/channels.ts
@@ -25,6 +25,7 @@ export type MenuLabels =
   | 'File.Create new file'
   | 'File.Create new folder'
   | 'File.Add file to project'
+  | 'File.Import STEP as editable KCL'
   | 'File.Export current part'
   | 'File.Preferences.Project settings'
   | 'Design.Start sketch'

--- a/src/menu/fileRole.ts
+++ b/src/menu/fileRole.ts
@@ -156,6 +156,15 @@ export const modelingFileRole = (
         },
       },
       {
+        label: 'Import STEP as Editable KCL… (Experimental)',
+        id: 'File.Import STEP as editable KCL',
+        click: () => {
+          typeSafeWebContentsSend(mainWindow, 'menu-action-clicked', {
+            menuLabel: 'File.Import STEP as editable KCL',
+          })
+        },
+      },
+      {
         label: 'Export Current Part',
         id: 'File.Export current part',
         click: () => {

--- a/src/menu/roles.ts
+++ b/src/menu/roles.ts
@@ -26,6 +26,7 @@ type FileRoleLabel =
   | 'Share Part via Zoo Link'
   | 'Project Settings'
   | 'Add File to Project'
+  | 'Import STEP as Editable KCL… (Experimental)'
   | 'User Default Units'
 
 type EditRoleLabel =


### PR DESCRIPTION
## Summary
- add an experimental “Convert STEP to editable KCL...” action to the project menu
- stage the selected STEP file and a reconstruction prompt in Zookeeper
- switch to Thoughtful mode and keep submission reviewable instead of auto-sending
- preserve the source file and ask Zookeeper to create a separate generated KCL file

## Validation
- npm run tsc -- --pretty false
- npm run test:unit -- --no-file-parallelism src/lib/stepToKcl.test.ts
- npm run test:integration -- --no-file-parallelism src/components/MlEphantConversation.spec.tsx
- targeted ESLint and Biome checks
- local browser smoke test with rust/kcl-lib/tests/inputs/cube.step

This is intentionally a narrow UI experiment for a shareable preview build.