### PR TITLE
Fix live Zookeeper thinking status

### DIFF
--- a/src/components/Thinking.spec.tsx
+++ b/src/components/Thinking.spec.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
-import type { MlCopilotFile } from '@kittycad/lib'
-import { FilesSnapshot } from '@src/components/Thinking'
+import type { MlCopilotFile, MlCopilotServerMessage } from '@kittycad/lib'
+import { FilesSnapshot, Thinking } from '@src/components/Thinking'
 
 // Mock a small valid PNG image (1x1 transparent pixel)
 const MOCK_PNG_DATA = [
@@ -215,5 +215,45 @@ describe('FilesSnapshot', () => {
     const fileButton = screen.getByTitle('Click to download clickable-doc.pdf')
     expect(fileButton).toBeInTheDocument()
     expect(fileButton.tagName).toBe('BUTTON')
+  })
+})
+
+describe('Thinking', () => {
+  test('shows thinking after a tool status when markdown reasoning arrives', () => {
+    const thoughts: MlCopilotServerMessage[] = [
+      {
+        reasoning: {
+          type: 'text',
+          content: 'Checking Constraints',
+        },
+      },
+    ]
+    const view = () => (
+      <Thinking
+        thoughts={thoughts}
+        isDone={false}
+        onlyShowImmediateThought={true}
+      />
+    )
+    const { rerender } = render(view())
+
+    expect(screen.getByTestId('thinking-immediate')).toHaveTextContent(
+      'Checking Constraints'
+    )
+    expect(screen.queryByLabelText('brain')).not.toBeInTheDocument()
+
+    thoughts.push({
+      reasoning: {
+        type: 'markdown',
+        content: 'Inspecting the constraint relationships.',
+      },
+    })
+    rerender(view())
+
+    expect(screen.getByTestId('thinking-immediate')).toHaveTextContent(
+      'Thinking'
+    )
+    expect(screen.getByLabelText('brain')).toBeInTheDocument()
+    expect(screen.queryByText('Checking Constraints')).not.toBeInTheDocument()
   })
 })

--- a/src/components/Thinking.tsx
+++ b/src/components/Thinking.tsx
@@ -877,20 +877,30 @@ export const Thinking = (props: {
     componentThoughts.push(<End key={reasoningThoughts.length} />)
   }
 
-  const lastTextualThought = reasoningThoughts.findLast(
-    (thought) => 'reasoning' in thought && thought.reasoning.type === 'text'
+  const lastImmediateThought = reasoningThoughts.findLast(
+    (thought) =>
+      'reasoning' in thought &&
+      (thought.reasoning.type === 'text' ||
+        thought.reasoning.type === 'markdown')
   )
 
-  const componentLastGenericThought = (
-    <Generic
-      content={
-        lastTextualThought !== undefined &&
-        'reasoning' in lastTextualThought &&
-        lastTextualThought.reasoning.type === 'text'
-          ? lastTextualThought.reasoning.content
-          : ''
-      }
-    />
+  const isImmediateThinking =
+    lastImmediateThought !== undefined &&
+    'reasoning' in lastImmediateThought &&
+    lastImmediateThought.reasoning.type === 'markdown'
+  const immediateThoughtContent =
+    lastImmediateThought !== undefined &&
+    'reasoning' in lastImmediateThought &&
+    lastImmediateThought.reasoning.type === 'text'
+      ? lastImmediateThought.reasoning.content
+      : ''
+  const componentLastGenericThought = isImmediateThinking ? (
+    <div className="flex flex-row items-center gap-2">
+      <CustomIcon name="brain" className="w-6 h-6" />
+      <Generic content="Thinking" />
+    </div>
+  ) : (
+    <Generic content={immediateThoughtContent} />
   )
 
   const ViewFull = (


### PR DESCRIPTION
## Summary

- Track the latest text or markdown reasoning event in the compact Zookeeper status.
- Replace a stale tool-call label with a brain-icon Thinking state while markdown reasoning is active.
- Keep the compact Thinking typography consistent with tool-call statuses and cover the streaming transition with a regression test.
