### PR TITLE
Always set 3D edges to dark, even in dark mode

### DIFF
--- a/src/lib/engineConnection/connectionManager.ts
+++ b/src/lib/engineConnection/connectionManager.ts
@@ -56,6 +56,7 @@ import type { SettingsViaQueryString } from '@src/lib/settings/settingsTypes'
 import { getSettingsFromActorContext } from '@src/lib/settings/settingsUtils'
 import {
   darkModeMatcher,
+  edgeColor,
   getOppositeTheme,
   getThemeColorForEngine,
   type Themes,
@@ -448,6 +449,7 @@ export class ConnectionManager extends EventTarget {
       color: defaultSystemColor,
       highlight_color: SYSTEM_HIGHLIGHT_COLOR,
       selection_color: SYSTEM_SELECTION_COLOR,
+      edge_3d_color: edgeColor(),
     } as const
     EngineDebugger.addLog({
       label: 'connectionManager',

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -75,6 +75,12 @@ export function getThemeColorForEngine(theme: Themes) {
     : { r: light, g: light, b: light, a: 1 }
 }
 
+/** Same edge color regardless of theme */
+export function edgeColor() {
+  const light = 28 / 255
+  return { r: light, g: light, b: light, a: 1 }
+}
+
 /**
  * ThreeJS uses hex values for colors
  * @param theme


### PR DESCRIPTION
<img width="3680" height="2392" alt="Screenshot 2026-09-03 at 5 28 58 PM" src="https://github.com/user-attachments/assets/86253b67-4633-49e8-badf-2815f8f550b1" />

As shown, edges on bodies are now black. Segments still show up in white, so they're still easily visible against the black background.

Uses the new API endpoint added in https://github.com/KittyCAD/modeling-api/pull/1364