### PR TITLE
"Executing" indicator becomes checkmark when done

### DIFF
--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -1105,7 +1105,7 @@ export class KclManager extends File {
   private _cancelTokens: Map<number, boolean> = new Map()
   private _executeIsStale: ExecuteArgs | null = null
   private _isExecuting = signal(false)
-  private _executionElapsedMs = signal(0)
+  private _executionElapsedMs = signal<number | null>(null)
   private executionStartedAtMs: number | null = null
   private executionTimerIntervalId: ReturnType<typeof setInterval> | undefined =
     undefined

--- a/src/registry/contracts/executingEditor.ts
+++ b/src/registry/contracts/executingEditor.ts
@@ -13,7 +13,8 @@ export interface ExecutingEditorService {
   readonly code: ReadonlySignal<string>
   readonly hasEditsSinceLastExecution: ReadonlySignal<boolean>
   readonly isExecuting: ReadonlySignal<boolean>
-  readonly executionElapsedMs: ReadonlySignal<number>
+  /** Null before the first execution; retains the final duration afterward. */
+  readonly executionElapsedMs: ReadonlySignal<number | null>
   readonly selectionStatusLabel: ReadonlySignal<string>
   readonly showExperimentalFeaturesStatusBarItem: ReadonlySignal<boolean>
   getPendingCommandCount(): number

--- a/src/registry/extensions/engineScene/executionIndicator/EngineExecutionStatusTooltip.test.tsx
+++ b/src/registry/extensions/engineScene/executionIndicator/EngineExecutionStatusTooltip.test.tsx
@@ -1,0 +1,78 @@
+import { signal } from '@preact/signals-core'
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { EngineExecutionStatusTooltip } from './EngineExecutionStatusTooltip'
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+describe('EngineExecutionStatusTooltip', () => {
+  it('shows the retained duration without polling pending commands when opened after execution', () => {
+    const getPendingCommandCount = vi.fn(() => 0)
+    render(
+      <EngineExecutionStatusTooltip
+        isExecuting={false}
+        executionElapsedMs={signal(65_000)}
+        getPendingCommandCount={getPendingCommandCount}
+      />
+    )
+
+    expect(
+      screen.getByText('Engine execution took 1m 05s.')
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/Pending commands/)).not.toBeInTheDocument()
+    expect(getPendingCommandCount).not.toHaveBeenCalled()
+  })
+
+  it('updates an open tooltip when execution finishes and resumes live timing on the next run', () => {
+    vi.useFakeTimers()
+    const executionElapsedMs = signal(1200)
+    const getPendingCommandCount = vi.fn(() => 2)
+    const { rerender } = render(
+      <EngineExecutionStatusTooltip
+        isExecuting
+        executionElapsedMs={executionElapsedMs}
+        getPendingCommandCount={getPendingCommandCount}
+      />
+    )
+
+    expect(screen.getByText('Engine executing for 1.2s.')).toBeInTheDocument()
+    expect(screen.getByText('Pending commands: 2')).toBeInTheDocument()
+
+    act(() => {
+      executionElapsedMs.value = 1500
+    })
+    rerender(
+      <EngineExecutionStatusTooltip
+        isExecuting={false}
+        executionElapsedMs={executionElapsedMs}
+        getPendingCommandCount={getPendingCommandCount}
+      />
+    )
+
+    expect(screen.getByText('Engine execution took 1.5s.')).toBeInTheDocument()
+    expect(screen.queryByText(/Pending commands/)).not.toBeInTheDocument()
+    getPendingCommandCount.mockClear()
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(getPendingCommandCount).not.toHaveBeenCalled()
+
+    act(() => {
+      executionElapsedMs.value = 0
+    })
+    getPendingCommandCount.mockReturnValue(3)
+    rerender(
+      <EngineExecutionStatusTooltip
+        isExecuting
+        executionElapsedMs={executionElapsedMs}
+        getPendingCommandCount={getPendingCommandCount}
+      />
+    )
+
+    expect(screen.getByText('Engine executing for 0.0s.')).toBeInTheDocument()
+    expect(screen.getByText('Pending commands: 3')).toBeInTheDocument()
+  })
+})

--- a/src/registry/extensions/engineScene/executionIndicator/EngineExecutionStatusTooltip.tsx
+++ b/src/registry/extensions/engineScene/executionIndicator/EngineExecutionStatusTooltip.tsx
@@ -15,18 +15,22 @@ function formatExecutionDuration(elapsedMs: number) {
 }
 
 export function EngineExecutionStatusTooltip({
+  isExecuting,
   executionElapsedMs,
   getPendingCommandCount,
 }: {
-  executionElapsedMs: ReadonlySignal<number>
+  isExecuting: boolean
+  executionElapsedMs: ReadonlySignal<number | null>
   getPendingCommandCount: () => number
 }) {
   useSignals()
-  const [pendingCommandCount, setPendingCommandCount] = useState(
-    getPendingCommandCount
+  const [pendingCommandCount, setPendingCommandCount] = useState(() =>
+    isExecuting ? getPendingCommandCount() : 0
   )
 
   useEffect(() => {
+    if (!isExecuting) return
+
     const updatePendingCommandCount = () => {
       setPendingCommandCount(getPendingCommandCount())
     }
@@ -35,15 +39,19 @@ export function EngineExecutionStatusTooltip({
     const intervalId = window.setInterval(updatePendingCommandCount, 100)
 
     return () => window.clearInterval(intervalId)
-  }, [getPendingCommandCount])
+  }, [isExecuting, getPendingCommandCount])
 
   return (
     <>
       <p className="text-sm">
-        Engine executing for {formatExecutionDuration(executionElapsedMs.value)}
-        .
+        {isExecuting ? 'Engine executing for' : 'Engine execution took'}{' '}
+        {formatExecutionDuration(executionElapsedMs.value ?? 0)}.
       </p>
-      <p className="text-sm text-2">Pending commands: {pendingCommandCount}</p>
+      {isExecuting && (
+        <p className="text-sm text-2">
+          Pending commands: {pendingCommandCount}
+        </p>
+      )}
     </>
   )
 }

--- a/src/registry/extensions/engineScene/executionIndicator/index.test.ts
+++ b/src/registry/extensions/engineScene/executionIndicator/index.test.ts
@@ -12,13 +12,14 @@ import executionIndicator from '.'
 import { EXECUTION_INDICATOR_STATUS_BAR_ITEM_ID } from './constants'
 
 function createExecutingEditorService(
-  isExecuting = signal(false)
+  isExecuting = signal(false),
+  executionElapsedMs = signal<number | null>(null)
 ): ExecutingEditorService {
   return {
     code: signal(''),
     hasEditsSinceLastExecution: signal(false),
     isExecuting,
-    executionElapsedMs: signal(0),
+    executionElapsedMs,
     selectionStatusLabel: signal('No selection'),
     showExperimentalFeaturesStatusBarItem: signal(true),
     getPendingCommandCount: vi.fn(() => 0),
@@ -53,8 +54,9 @@ describe('executionIndicator', () => {
     ).toEqual([EXECUTION_INDICATOR_STATUS_BAR_ITEM_ID])
   })
 
-  it('removes the execution status item when execution finishes', () => {
+  it('keeps a checkmark after execution finishes and restores the spinner on the next run', () => {
     const isExecuting = signal(true)
+    const executionElapsedMs = signal<number | null>(0)
     const registry = new Registry()
     registry.configure([
       defineRegistryItem({
@@ -62,7 +64,7 @@ describe('executionIndicator', () => {
         providesServices: [
           provideService(
             executingEditorService,
-            createExecutingEditorService(isExecuting)
+            createExecutingEditorService(isExecuting, executionElapsedMs)
           ),
         ],
       }),
@@ -73,8 +75,42 @@ describe('executionIndicator', () => {
       registry.get(statusBarLocalItemsValueSpec).map((item) => item.id)
     ).toEqual([EXECUTION_INDICATOR_STATUS_BAR_ITEM_ID])
 
+    executionElapsedMs.value = 1234
     isExecuting.value = false
 
-    expect(registry.get(statusBarLocalItemsValueSpec)).toEqual([])
+    expect(registry.get(statusBarLocalItemsValueSpec)).toMatchObject([
+      {
+        id: EXECUTION_INDICATOR_STATUS_BAR_ITEM_ID,
+        icon: 'checkmark',
+        label: 'Engine execution finished',
+      },
+    ])
+
+    isExecuting.value = true
+    executionElapsedMs.value = 0
+
+    expect(registry.get(statusBarLocalItemsValueSpec)).toMatchObject([
+      { icon: 'loading', label: 'Engine executing' },
+    ])
+  })
+
+  it('shows a completed execution even when it took zero milliseconds', () => {
+    const registry = new Registry()
+    registry.configure([
+      defineRegistryItem({
+        id: 'test-executing-editor-service',
+        providesServices: [
+          provideService(
+            executingEditorService,
+            createExecutingEditorService(signal(false), signal(0))
+          ),
+        ],
+      }),
+      executionIndicator,
+    ])
+
+    expect(registry.get(statusBarLocalItemsValueSpec)).toMatchObject([
+      { icon: 'checkmark' },
+    ])
   })
 })

--- a/src/registry/extensions/engineScene/executionIndicator/index.ts
+++ b/src/registry/extensions/engineScene/executionIndicator/index.ts
@@ -19,19 +19,24 @@ const executionIndicator = defineRegistryItemFactory((ctx) => {
     nullableStatusBarItem(
       (() => {
         const service = executionService.value
+        if (!service) return null
 
-        return service?.isExecuting.value
+        const isExecuting = service.isExecuting.value
+        return isExecuting || service.executionElapsedMs.value !== null
           ? {
               id: EXECUTION_INDICATOR_STATUS_BAR_ITEM_ID,
               'data-testid': 'engine-executing-status',
               element: 'text' as const,
-              icon: 'loading' as const,
-              label: 'Engine executing',
+              icon: isExecuting ? ('loading' as const) : ('checkmark' as const),
+              label: isExecuting
+                ? 'Engine executing'
+                : 'Engine execution finished',
               hideLabel: true,
               order: 0,
               scopes: ['file'],
               toolTip: {
                 children: createElement(EngineExecutionStatusTooltip, {
+                  isExecuting,
                   executionElapsedMs: service.executionElapsedMs,
                   getPendingCommandCount: () =>
                     executionService.value?.getPendingCommandCount() ?? 0,

--- a/src/registry/extensions/engineScene/index.spec.ts
+++ b/src/registry/extensions/engineScene/index.spec.ts
@@ -55,7 +55,7 @@ function createExecutingEditorService(
     code: signal(''),
     hasEditsSinceLastExecution: signal(false),
     isExecuting,
-    executionElapsedMs: signal(0),
+    executionElapsedMs: signal<number | null>(null),
     selectionStatusLabel: signal('No selection'),
     showExperimentalFeaturesStatusBarItem,
     getPendingCommandCount: vi.fn(() => 0),


### PR DESCRIPTION
I'd like to know how long it takes to execute my project. While it's executing, the "executing" indicator spinner shows how long my file's been executing, but once it's done it disappears, and I lose that info. That's really annoying if I alt-tab away while running a large file.

Instead, this PR will leave the indicator around after execution is done (changing it to a checkmark). You can still hover over it to see how long the execution took.

<img width="584" height="115" alt="Screenshot 2026-09-03 at 7 39 39 PM" src="https://github.com/user-attachments/assets/7acd4c53-6845-49db-9075-0d4383bc5d94" />
