### PR TITLE
Plan variable-less selection inputs without collapsing pipes

### DIFF
--- a/src/lang/modifyAst/multiVariablelessSelectionTransforms.spec.ts
+++ b/src/lang/modifyAst/multiVariablelessSelectionTransforms.spec.ts
@@ -1,5 +1,6 @@
 import {
   addAppearance,
+  addMirror3D,
   addRotate,
   addScale,
   addTranslate,
@@ -53,14 +54,26 @@ startSketchOn(XY)
   |> extrude(length = 2)
 startSketchOn(XZ)
   |> circle(center = [0, 0], radius = 2)
-  |> extrude(length = 2)`
+  |> extrude(length = 2)
+plane001 = offsetPlane(YZ, offset = 1)`
     const ast = assertParse(code, instance)
-    const { artifactGraph } = await enginelessExecutor(ast, rustContext)
+    const { artifactGraph, variables } = await enginelessExecutor(
+      ast,
+      rustContext
+    )
     const sweeps = [...artifactGraph.values()].filter(
       (artifact) => artifact.type === 'sweep'
     )
     expect(sweeps).toHaveLength(2)
     const objects = createSelectionFromArtifacts(sweeps, artifactGraph)
+    const planes = [...artifactGraph.values()].filter(
+      (artifact) => artifact.type === 'plane'
+    )
+    const plane = planes.at(-1)
+    if (!plane) {
+      throw new Error('Expected an offset plane for mirror3d')
+    }
+    const across = createSelectionFromArtifacts([plane], artifactGraph)
 
     await expectValidTransformOutput(
       addTranslate({
@@ -110,6 +123,20 @@ startSketchOn(XZ)
         wasmInstance: instance,
       }),
       'appearance([solid001, solid002], color = "#ff0000")',
+      instance,
+      rustContext
+    )
+
+    await expectValidTransformOutput(
+      addMirror3D({
+        ast,
+        artifactGraph,
+        variables,
+        bodies: objects,
+        across,
+        wasmInstance: instance,
+      }),
+      'solid003 = mirror3d([solid001, solid002], across = plane001)',
       instance,
       rustContext
     )

--- a/src/lang/modifyAst/multiVariablelessSelectionTransforms.spec.ts
+++ b/src/lang/modifyAst/multiVariablelessSelectionTransforms.spec.ts
@@ -1,3 +1,4 @@
+import type { Node } from '@rust/kcl-lib/bindings/Node'
 import {
   addAppearance,
   addMirror3D,
@@ -5,7 +6,7 @@ import {
   addScale,
   addTranslate,
 } from '@src/lang/modifyAst/transforms'
-import type { Node, Program } from '@src/lang/wasm'
+import type { Program } from '@src/lang/wasm'
 import { assertParse, recast } from '@src/lang/wasm'
 import {
   createSelectionFromArtifacts,

--- a/src/lang/modifyAst/multiVariablelessSelectionTransforms.spec.ts
+++ b/src/lang/modifyAst/multiVariablelessSelectionTransforms.spec.ts
@@ -1,0 +1,117 @@
+import {
+  addAppearance,
+  addRotate,
+  addScale,
+  addTranslate,
+} from '@src/lang/modifyAst/transforms'
+import type { Node, Program } from '@src/lang/wasm'
+import { assertParse, recast } from '@src/lang/wasm'
+import {
+  createSelectionFromArtifacts,
+  enginelessExecutor,
+  getKclCommandValue,
+} from '@src/lib/testHelpers'
+import { err } from '@src/lib/trap'
+import { buildTheWorldAndNoEngineConnection } from '@src/unitTestUtils'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@src/lib/commandBarConfigs/modelingCommandStdLibCommands', () => ({
+  STD_LIB_COMMANDS: {},
+}))
+
+describe('transforms on multiple variable-less pipes', () => {
+  async function expectValidTransformOutput(
+    result: Error | { modifiedAst: Node<Program> },
+    expectedCall: string,
+    instance: Awaited<
+      ReturnType<typeof buildTheWorldAndNoEngineConnection>
+    >['instance'],
+    rustContext: Awaited<
+      ReturnType<typeof buildTheWorldAndNoEngineConnection>
+    >['rustContext']
+  ) {
+    if (err(result)) {
+      throw result
+    }
+
+    const output = recast(result.modifiedAst, instance)
+    expect(output).toContain('solid001 = startSketchOn(XY)')
+    expect(output).toContain('solid002 = startSketchOn(XZ)')
+    expect(output).toContain(expectedCall)
+    expect(output).not.toContain('[%, %]')
+
+    const execution = await enginelessExecutor(result.modifiedAst, rustContext)
+    expect(execution.issues).toEqual([])
+  }
+
+  it('keeps every selected source body for multi-object transforms', async () => {
+    const { instance, rustContext } = await buildTheWorldAndNoEngineConnection()
+    const code = `@settings(experimentalFeatures = allow)
+
+startSketchOn(XY)
+  |> circle(center = [0, 0], radius = 2)
+  |> extrude(length = 2)
+startSketchOn(XZ)
+  |> circle(center = [0, 0], radius = 2)
+  |> extrude(length = 2)`
+    const ast = assertParse(code, instance)
+    const { artifactGraph } = await enginelessExecutor(ast, rustContext)
+    const sweeps = [...artifactGraph.values()].filter(
+      (artifact) => artifact.type === 'sweep'
+    )
+    expect(sweeps).toHaveLength(2)
+    const objects = createSelectionFromArtifacts(sweeps, artifactGraph)
+
+    await expectValidTransformOutput(
+      addTranslate({
+        ast,
+        artifactGraph,
+        objects,
+        x: await getKclCommandValue('1', instance, rustContext),
+        wasmInstance: instance,
+      }),
+      'translate([solid001, solid002], x = 1)',
+      instance,
+      rustContext
+    )
+
+    await expectValidTransformOutput(
+      addRotate({
+        ast,
+        artifactGraph,
+        objects,
+        roll: await getKclCommandValue('10', instance, rustContext),
+        wasmInstance: instance,
+      }),
+      'rotate([solid001, solid002], roll = 10)',
+      instance,
+      rustContext
+    )
+
+    await expectValidTransformOutput(
+      addScale({
+        ast,
+        artifactGraph,
+        objects,
+        factor: await getKclCommandValue('2', instance, rustContext),
+        wasmInstance: instance,
+      }),
+      'scale([solid001, solid002], factor = 2)',
+      instance,
+      rustContext
+    )
+
+    await expectValidTransformOutput(
+      addAppearance({
+        ast,
+        artifactGraph,
+        objects,
+        color: '#ff0000',
+        wasmInstance: instance,
+      }),
+      'appearance([solid001, solid002], color = "#ff0000")',
+      instance,
+      rustContext
+    )
+  })
+})

--- a/src/lang/modifyAst/selectionInputs.ts
+++ b/src/lang/modifyAst/selectionInputs.ts
@@ -1,0 +1,150 @@
+import type { Node } from '@rust/kcl-lib/bindings/Node'
+
+import {
+  createLocalName,
+  createVariableDeclaration,
+  findUniqueName,
+} from '@src/lang/create'
+import {
+  getBodyIndex,
+  getNodeFromPath,
+  getVariableExprsFromSelection,
+} from '@src/lang/queryAst'
+import type {
+  ArtifactGraph,
+  Expr,
+  ExpressionStatement,
+  PathToNode,
+  Program,
+} from '@src/lang/wasm'
+import { KCL_DEFAULT_CONSTANT_PREFIXES } from '@src/lib/constants'
+import { err } from '@src/lib/trap'
+import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
+import type { Selections } from '@src/machines/modelingSharedTypes'
+
+type VariableExprsOptions = NonNullable<
+  Parameters<typeof getVariableExprsFromSelection>[4]
+>
+
+export type SelectionInputPlan = {
+  exprs: Expr[]
+  pathIfPipe?: PathToNode
+}
+
+type SelectionInputRecord = SelectionInputPlan & {
+  pipeBodyIndex?: number
+}
+
+export function resolveSelectionInputPlan({
+  selection,
+  artifactGraph,
+  ast,
+  wasmInstance,
+  options = {},
+  materializePipes = 'when-multiple',
+  variablePrefix = KCL_DEFAULT_CONSTANT_PREFIXES.SOLID,
+}: {
+  selection: Selections
+  artifactGraph: ArtifactGraph
+  ast: Node<Program>
+  wasmInstance: ModuleType
+  options?: VariableExprsOptions
+  materializePipes?: 'always' | 'when-multiple'
+  variablePrefix?: string
+}): Error | SelectionInputPlan {
+  const aggregate = getVariableExprsFromSelection(
+    selection,
+    artifactGraph,
+    ast,
+    wasmInstance,
+    options
+  )
+  if (err(aggregate)) {
+    return aggregate
+  }
+
+  const shouldInspectIndividualInputs =
+    materializePipes === 'always' || selection.graphSelections.length > 1
+  if (!shouldInspectIndividualInputs) {
+    return aggregate
+  }
+
+  const records: SelectionInputRecord[] = []
+  const pipeBodyIndexes = new Set<number>()
+
+  for (const graphSelection of selection.graphSelections) {
+    const input = getVariableExprsFromSelection(
+      {
+        graphSelections: [graphSelection],
+        otherSelections: [],
+      },
+      artifactGraph,
+      ast,
+      wasmInstance,
+      options
+    )
+    if (err(input)) {
+      return input
+    }
+
+    let pipeBodyIndex: number | undefined
+    if (input.pathIfPipe) {
+      const expression = getNodeFromPath<ExpressionStatement>(
+        ast,
+        input.pathIfPipe,
+        wasmInstance,
+        'ExpressionStatement'
+      )
+      if (err(expression) || expression.node.type !== 'ExpressionStatement') {
+        return new Error('Could not resolve the selected source pipe')
+      }
+
+      const bodyIndex = getBodyIndex(expression.shallowPath)
+      if (err(bodyIndex)) {
+        return bodyIndex
+      }
+      pipeBodyIndex = bodyIndex
+      pipeBodyIndexes.add(bodyIndex)
+    }
+
+    records.push({ ...input, pipeBodyIndex })
+  }
+
+  const shouldMaterialize =
+    materializePipes === 'always'
+      ? pipeBodyIndexes.size > 0
+      : pipeBodyIndexes.size > 1
+  if (!shouldMaterialize) {
+    return aggregate
+  }
+
+  const variableByBodyIndex = new Map<number, string>()
+  for (const bodyIndex of pipeBodyIndexes) {
+    const statement = ast.body[bodyIndex]
+    if (!statement || statement.type !== 'ExpressionStatement') {
+      return new Error('Expected a variable-less source pipe')
+    }
+
+    const variableName = findUniqueName(ast, variablePrefix)
+    const declaration = createVariableDeclaration(
+      variableName,
+      structuredClone(statement.expression)
+    )
+    declaration.preComments = statement.preComments
+    ast.body[bodyIndex] = declaration
+    variableByBodyIndex.set(bodyIndex, variableName)
+  }
+
+  return {
+    exprs: records.flatMap(({ exprs, pathIfPipe, pipeBodyIndex }) => {
+      if (!pathIfPipe) {
+        return exprs
+      }
+      if (pipeBodyIndex === undefined) {
+        return []
+      }
+      const variableName = variableByBodyIndex.get(pipeBodyIndex)
+      return variableName ? [createLocalName(variableName)] : []
+    }),
+  }
+}

--- a/src/lang/modifyAst/selectionInputs.ts
+++ b/src/lang/modifyAst/selectionInputs.ts
@@ -5,6 +5,7 @@ import {
   createVariableDeclaration,
   findUniqueName,
 } from '@src/lang/create'
+import type { GetVariableExprsOptions } from '@src/lang/queryAst'
 import {
   getBodyIndex,
   getNodeFromPath,
@@ -21,10 +22,6 @@ import { KCL_DEFAULT_CONSTANT_PREFIXES } from '@src/lib/constants'
 import { err } from '@src/lib/trap'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { Selections } from '@src/machines/modelingSharedTypes'
-
-type VariableExprsOptions = NonNullable<
-  Parameters<typeof getVariableExprsFromSelection>[4]
->
 
 export type SelectionInputPlan = {
   exprs: Expr[]
@@ -43,20 +40,29 @@ export function resolveSelectionInputPlan({
   options = {},
   materializePipes = 'when-multiple',
   variablePrefix = KCL_DEFAULT_CONSTANT_PREFIXES.SOLID,
+  nodeToEdit,
 }: {
   selection: Selections
   artifactGraph: ArtifactGraph
   ast: Node<Program>
   wasmInstance: ModuleType
-  options?: VariableExprsOptions
+  options?: GetVariableExprsOptions
   materializePipes?: 'always' | 'when-multiple'
   variablePrefix?: string
+  nodeToEdit?: PathToNode
 }): Error | SelectionInputPlan {
+  // Edit codemods preserve selection arguments verbatim; input planning is
+  // only needed when creating a new call.
+  if (nodeToEdit) {
+    return { exprs: [] }
+  }
+
   const aggregate = getVariableExprsFromSelection(
     selection,
     artifactGraph,
     ast,
     wasmInstance,
+    undefined,
     options
   )
   if (err(aggregate)) {
@@ -81,6 +87,7 @@ export function resolveSelectionInputPlan({
       artifactGraph,
       ast,
       wasmInstance,
+      undefined,
       options
     )
     if (err(input)) {

--- a/src/lang/modifyAst/transforms.ts
+++ b/src/lang/modifyAst/transforms.ts
@@ -6,6 +6,7 @@ import {
   createLiteral,
   createLocalName,
   createVariableDeclaration,
+  findUniqueName,
 } from '@src/lang/create'
 import {
   createPathToNodeForLastVariable,
@@ -17,12 +18,15 @@ import {
 import { getPlaneExprFromSelection } from '@src/lang/modifyAst/faces'
 import { getAxisExpression } from '@src/lang/modifyAst/geometry'
 import {
+  getBodyIndex,
+  getNodeFromPath,
   getVariableExprsFromSelection,
   valueOrVariable,
 } from '@src/lang/queryAst'
 import type {
   ArtifactGraph,
   Expr,
+  ExpressionStatement,
   PathToNode,
   Program,
   VariableMap,
@@ -469,6 +473,117 @@ export function addAppearance({
 
 type ObjectTransformName = 'hide' | 'delete'
 
+type VariableExprsOptions = NonNullable<
+  Parameters<typeof getVariableExprsFromSelection>[5]
+>
+
+type ObjectTransformSelectionRecord = {
+  exprs: Expr[]
+  pathIfPipe?: PathToNode
+  pipeBodyIndex?: number
+}
+
+function getObjectTransformVariableExprsFromSelection(
+  selection: Selections,
+  artifactGraph: ArtifactGraph,
+  ast: Node<Program>,
+  wasmInstance: ModuleType,
+  options: VariableExprsOptions = {}
+): Error | { exprs: Expr[]; pathIfPipe?: PathToNode } {
+  const vars = getVariableExprsFromSelection(
+    selection,
+    artifactGraph,
+    ast,
+    wasmInstance,
+    undefined,
+    options
+  )
+  if (err(vars)) {
+    return vars
+  }
+
+  if (selection.graphSelections.length < 2) {
+    return vars
+  }
+
+  const records: ObjectTransformSelectionRecord[] = []
+  const pipeBodyIndexes = new Set<number>()
+
+  for (const graphSelection of selection.graphSelections) {
+    const singleSelectionVars = getVariableExprsFromSelection(
+      {
+        graphSelections: [graphSelection],
+        otherSelections: [],
+      },
+      artifactGraph,
+      ast,
+      wasmInstance,
+      undefined,
+      options
+    )
+    if (err(singleSelectionVars)) {
+      return singleSelectionVars
+    }
+
+    let pipeBodyIndex: number | undefined
+    if (singleSelectionVars.pathIfPipe) {
+      const expression = getNodeFromPath<ExpressionStatement>(
+        ast,
+        singleSelectionVars.pathIfPipe,
+        wasmInstance,
+        'ExpressionStatement'
+      )
+      if (!err(expression) && expression.node.type === 'ExpressionStatement') {
+        const bodyIndex = getBodyIndex(expression.shallowPath)
+        if (err(bodyIndex)) {
+          return bodyIndex
+        }
+        pipeBodyIndex = bodyIndex
+        pipeBodyIndexes.add(bodyIndex)
+      }
+    }
+
+    records.push({ ...singleSelectionVars, pipeBodyIndex })
+  }
+
+  if (pipeBodyIndexes.size <= 1) {
+    return vars
+  }
+
+  const variableByBodyIndex = new Map<number, string>()
+  for (const bodyIndex of pipeBodyIndexes) {
+    const statement = ast.body[bodyIndex]
+    if (!statement || statement.type !== 'ExpressionStatement') {
+      return new Error('Expected a variable-less object transform source pipe')
+    }
+
+    const variableName = findUniqueName(
+      ast,
+      KCL_DEFAULT_CONSTANT_PREFIXES.SOLID
+    )
+    const declaration = createVariableDeclaration(
+      variableName,
+      statement.expression
+    )
+    declaration.preComments = statement.preComments
+    ast.body[bodyIndex] = declaration
+    variableByBodyIndex.set(bodyIndex, variableName)
+  }
+
+  return {
+    exprs: records.flatMap(({ exprs, pathIfPipe, pipeBodyIndex }) => {
+      if (!pathIfPipe) {
+        return exprs
+      }
+      if (pipeBodyIndex === undefined) {
+        return []
+      }
+      const variableName = variableByBodyIndex.get(pipeBodyIndex)
+      return variableName ? [createLocalName(variableName)] : []
+    }),
+  }
+}
+
 function addObjectTransform({
   ast,
   artifactGraph,
@@ -492,7 +607,7 @@ function addObjectTransform({
   const artifact = objects.graphSelections[0].artifact
   const lastChildLookup =
     artifact?.type !== 'helix' && artifact?.type !== 'sketchBlock'
-  const vars = getVariableExprsFromSelection(
+  const vars = getObjectTransformVariableExprsFromSelection(
     objects,
     artifactGraph,
     modifiedAst,

--- a/src/lang/modifyAst/transforms.ts
+++ b/src/lang/modifyAst/transforms.ts
@@ -6,7 +6,6 @@ import {
   createLiteral,
   createLocalName,
   createVariableDeclaration,
-  findUniqueName,
 } from '@src/lang/create'
 import {
   createPathToNodeForLastVariable,
@@ -17,16 +16,14 @@ import {
 } from '@src/lang/modifyAst'
 import { getPlaneExprFromSelection } from '@src/lang/modifyAst/faces'
 import { getAxisExpression } from '@src/lang/modifyAst/geometry'
+import { resolveSelectionInputPlan } from '@src/lang/modifyAst/selectionInputs'
 import {
-  getBodyIndex,
-  getNodeFromPath,
   getVariableExprsFromSelection,
   valueOrVariable,
 } from '@src/lang/queryAst'
 import type {
   ArtifactGraph,
   Expr,
-  ExpressionStatement,
   PathToNode,
   Program,
   VariableMap,
@@ -37,117 +34,6 @@ import { KCL_DEFAULT_CONSTANT_PREFIXES } from '@src/lib/constants'
 import { err } from '@src/lib/trap'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { Selections } from '@src/machines/modelingSharedTypes'
-
-type VariableExprsOptions = NonNullable<
-  Parameters<typeof getVariableExprsFromSelection>[5]
->
-
-type TransformSelectionRecord = {
-  exprs: Expr[]
-  pathIfPipe?: PathToNode
-  pipeBodyIndex?: number
-}
-
-function getTransformVariableExprsFromSelection(
-  selection: Selections,
-  artifactGraph: ArtifactGraph,
-  ast: Node<Program>,
-  wasmInstance: ModuleType,
-  options: VariableExprsOptions = {}
-): Error | { exprs: Expr[]; pathIfPipe?: PathToNode } {
-  const vars = getVariableExprsFromSelection(
-    selection,
-    artifactGraph,
-    ast,
-    wasmInstance,
-    undefined,
-    options
-  )
-  if (err(vars)) {
-    return vars
-  }
-
-  if (selection.graphSelections.length < 2) {
-    return vars
-  }
-
-  const records: TransformSelectionRecord[] = []
-  const pipeBodyIndexes = new Set<number>()
-
-  for (const graphSelection of selection.graphSelections) {
-    const singleSelectionVars = getVariableExprsFromSelection(
-      {
-        graphSelections: [graphSelection],
-        otherSelections: [],
-      },
-      artifactGraph,
-      ast,
-      wasmInstance,
-      undefined,
-      options
-    )
-    if (err(singleSelectionVars)) {
-      return singleSelectionVars
-    }
-
-    let pipeBodyIndex: number | undefined
-    if (singleSelectionVars.pathIfPipe) {
-      const expression = getNodeFromPath<ExpressionStatement>(
-        ast,
-        singleSelectionVars.pathIfPipe,
-        wasmInstance,
-        'ExpressionStatement'
-      )
-      if (!err(expression) && expression.node.type === 'ExpressionStatement') {
-        const bodyIndex = getBodyIndex(expression.shallowPath)
-        if (err(bodyIndex)) {
-          return bodyIndex
-        }
-        pipeBodyIndex = bodyIndex
-        pipeBodyIndexes.add(bodyIndex)
-      }
-    }
-
-    records.push({ ...singleSelectionVars, pipeBodyIndex })
-  }
-
-  if (pipeBodyIndexes.size <= 1) {
-    return vars
-  }
-
-  const variableByBodyIndex = new Map<number, string>()
-  for (const bodyIndex of pipeBodyIndexes) {
-    const statement = ast.body[bodyIndex]
-    if (!statement || statement.type !== 'ExpressionStatement') {
-      return new Error('Expected a variable-less transform source pipe')
-    }
-
-    const variableName = findUniqueName(
-      ast,
-      KCL_DEFAULT_CONSTANT_PREFIXES.SOLID
-    )
-    const declaration = createVariableDeclaration(
-      variableName,
-      statement.expression
-    )
-    declaration.preComments = statement.preComments
-    ast.body[bodyIndex] = declaration
-    variableByBodyIndex.set(bodyIndex, variableName)
-  }
-
-  return {
-    exprs: records.flatMap(({ exprs, pathIfPipe, pipeBodyIndex }) => {
-      if (!pathIfPipe) {
-        return exprs
-      }
-      if (pipeBodyIndex === undefined) {
-        return []
-      }
-      const variableName = variableByBodyIndex.get(pipeBodyIndex)
-      return variableName ? [createLocalName(variableName)] : []
-    }),
-  }
-}
 
 export function addTranslate({
   ast,
@@ -186,15 +72,15 @@ export function addTranslate({
         wasmInstance,
         nodeToEdit: mNodeToEdit,
       })
-    : getTransformVariableExprsFromSelection(
-        objects,
+    : resolveSelectionInputPlan({
+        selection: objects,
         artifactGraph,
-        modifiedAst,
+        ast: modifiedAst,
         wasmInstance,
-        {
+        options: {
           lastChildLookup: true,
-        }
-      )
+        },
+      })
   if (err(vars)) {
     return vars
   }
@@ -288,15 +174,15 @@ export function addRotate({
         wasmInstance,
         nodeToEdit: mNodeToEdit,
       })
-    : getTransformVariableExprsFromSelection(
-        objects,
+    : resolveSelectionInputPlan({
+        selection: objects,
         artifactGraph,
-        modifiedAst,
+        ast: modifiedAst,
         wasmInstance,
-        {
+        options: {
           lastChildLookup: true,
-        }
-      )
+        },
+      })
   if (err(vars)) {
     return vars
   }
@@ -400,15 +286,15 @@ export function addScale({
         wasmInstance,
         nodeToEdit: mNodeToEdit,
       })
-    : getTransformVariableExprsFromSelection(
-        objects,
+    : resolveSelectionInputPlan({
+        selection: objects,
         artifactGraph,
-        modifiedAst,
+        ast: modifiedAst,
         wasmInstance,
-        {
+        options: {
           lastChildLookup: true,
-        }
-      )
+        },
+      })
   if (err(vars)) {
     return vars
   }
@@ -486,16 +372,25 @@ export function addClone({
 
   // 2. Prepare unlabeled arguments
   // Map the sketches selection into a list of kcl expressions to be passed as unlabelled argument
-  const vars = getVariableExprsFromSelection(
-    objects,
-    artifactGraph,
-    modifiedAst,
-    wasmInstance,
-    mNodeToEdit,
-    {
-      lastChildLookup: true,
-    }
-  )
+  const vars = mNodeToEdit
+    ? getVariableExprsFromSelection(
+        objects,
+        artifactGraph,
+        modifiedAst,
+        wasmInstance,
+        mNodeToEdit,
+        { lastChildLookup: true }
+      )
+    : getVariableExprsFromSelection(
+        objects,
+        artifactGraph,
+        modifiedAst,
+        wasmInstance,
+        undefined,
+        {
+          lastChildLookup: true,
+        }
+      )
   if (err(vars)) {
     return vars
   }
@@ -507,12 +402,20 @@ export function addClone({
     []
   )
 
-  // 3. If edit, we assign the new function call declaration to the existing node,
-  // otherwise just push to the end
-  const declaration = createVariableDeclaration(variableName, call)
-  modifiedAst.body.push(declaration)
-  const toFirstKwarg = false
-  const pathToNode = createPathToNodeForLastVariable(modifiedAst, toFirstKwarg)
+  let pathToNode: PathToNode | Error
+  if (mNodeToEdit) {
+    pathToNode = setCallInAst({
+      ast: modifiedAst,
+      call,
+      pathToEdit: mNodeToEdit,
+      wasmInstance,
+    })
+  } else {
+    const declaration = createVariableDeclaration(variableName, call)
+    modifiedAst.body.push(declaration)
+    const toFirstKwarg = false
+    pathToNode = createPathToNodeForLastVariable(modifiedAst, toFirstKwarg)
+  }
   if (err(pathToNode)) {
     return pathToNode
   }
@@ -558,15 +461,15 @@ export function addAppearance({
         wasmInstance,
         nodeToEdit: mNodeToEdit,
       })
-    : getTransformVariableExprsFromSelection(
-        objects,
+    : resolveSelectionInputPlan({
+        selection: objects,
         artifactGraph,
-        modifiedAst,
+        ast: modifiedAst,
         wasmInstance,
-        {
+        options: {
           lastChildLookup: true,
-        }
-      )
+        },
+      })
   if (err(vars)) {
     return vars
   }
@@ -624,117 +527,6 @@ export function addAppearance({
 
 type ObjectTransformName = 'hide' | 'delete'
 
-type VariableExprsOptions = NonNullable<
-  Parameters<typeof getVariableExprsFromSelection>[5]
->
-
-type ObjectTransformSelectionRecord = {
-  exprs: Expr[]
-  pathIfPipe?: PathToNode
-  pipeBodyIndex?: number
-}
-
-function getObjectTransformVariableExprsFromSelection(
-  selection: Selections,
-  artifactGraph: ArtifactGraph,
-  ast: Node<Program>,
-  wasmInstance: ModuleType,
-  options: VariableExprsOptions = {}
-): Error | { exprs: Expr[]; pathIfPipe?: PathToNode } {
-  const vars = getVariableExprsFromSelection(
-    selection,
-    artifactGraph,
-    ast,
-    wasmInstance,
-    undefined,
-    options
-  )
-  if (err(vars)) {
-    return vars
-  }
-
-  if (selection.graphSelections.length < 2) {
-    return vars
-  }
-
-  const records: ObjectTransformSelectionRecord[] = []
-  const pipeBodyIndexes = new Set<number>()
-
-  for (const graphSelection of selection.graphSelections) {
-    const singleSelectionVars = getVariableExprsFromSelection(
-      {
-        graphSelections: [graphSelection],
-        otherSelections: [],
-      },
-      artifactGraph,
-      ast,
-      wasmInstance,
-      undefined,
-      options
-    )
-    if (err(singleSelectionVars)) {
-      return singleSelectionVars
-    }
-
-    let pipeBodyIndex: number | undefined
-    if (singleSelectionVars.pathIfPipe) {
-      const expression = getNodeFromPath<ExpressionStatement>(
-        ast,
-        singleSelectionVars.pathIfPipe,
-        wasmInstance,
-        'ExpressionStatement'
-      )
-      if (!err(expression) && expression.node.type === 'ExpressionStatement') {
-        const bodyIndex = getBodyIndex(expression.shallowPath)
-        if (err(bodyIndex)) {
-          return bodyIndex
-        }
-        pipeBodyIndex = bodyIndex
-        pipeBodyIndexes.add(bodyIndex)
-      }
-    }
-
-    records.push({ ...singleSelectionVars, pipeBodyIndex })
-  }
-
-  if (pipeBodyIndexes.size <= 1) {
-    return vars
-  }
-
-  const variableByBodyIndex = new Map<number, string>()
-  for (const bodyIndex of pipeBodyIndexes) {
-    const statement = ast.body[bodyIndex]
-    if (!statement || statement.type !== 'ExpressionStatement') {
-      return new Error('Expected a variable-less object transform source pipe')
-    }
-
-    const variableName = findUniqueName(
-      ast,
-      KCL_DEFAULT_CONSTANT_PREFIXES.SOLID
-    )
-    const declaration = createVariableDeclaration(
-      variableName,
-      statement.expression
-    )
-    declaration.preComments = statement.preComments
-    ast.body[bodyIndex] = declaration
-    variableByBodyIndex.set(bodyIndex, variableName)
-  }
-
-  return {
-    exprs: records.flatMap(({ exprs, pathIfPipe, pipeBodyIndex }) => {
-      if (!pathIfPipe) {
-        return exprs
-      }
-      if (pipeBodyIndex === undefined) {
-        return []
-      }
-      const variableName = variableByBodyIndex.get(pipeBodyIndex)
-      return variableName ? [createLocalName(variableName)] : []
-    }),
-  }
-}
-
 function addObjectTransform({
   ast,
   artifactGraph,
@@ -758,16 +550,15 @@ function addObjectTransform({
   const artifact = objects.graphSelections[0].artifact
   const lastChildLookup =
     artifact?.type !== 'helix' && artifact?.type !== 'sketchBlock'
-  const vars = getObjectTransformVariableExprsFromSelection(
-    objects,
+  const vars = resolveSelectionInputPlan({
+    selection: objects,
     artifactGraph,
-    modifiedAst,
+    ast: modifiedAst,
     wasmInstance,
-    undefined,
-    {
+    options: {
       lastChildLookup,
-    }
-  )
+    },
+  })
 
   if (err(vars)) {
     return vars
@@ -860,16 +651,16 @@ export function addMirror3D({
   let vars: { exprs: Expr[]; pathIfPipe?: PathToNode } = { exprs: [] }
   let acrossArg: Expr | undefined
   if (!mNodeToEdit) {
-    const selectionVars = getTransformVariableExprsFromSelection(
-      bodies,
+    const selectionVars = resolveSelectionInputPlan({
+      selection: bodies,
       artifactGraph,
-      modifiedAst,
+      ast: modifiedAst,
       wasmInstance,
-      {
+      options: {
         lastChildLookup: true,
         artifactTypeFilter: ['compositeSolid', 'sweep'],
-      }
-    )
+      },
+    })
     if (err(selectionVars)) {
       return selectionVars
     }

--- a/src/lang/modifyAst/transforms.ts
+++ b/src/lang/modifyAst/transforms.ts
@@ -514,6 +514,7 @@ function addObjectTransform({
   const pathToNode = setCallInAst({
     ast: modifiedAst,
     call,
+    pathIfNewPipe: vars.pathIfPipe,
     variableIfNewDecl,
     wasmInstance,
   })

--- a/src/lang/modifyAst/transforms.ts
+++ b/src/lang/modifyAst/transforms.ts
@@ -38,6 +38,117 @@ import { err } from '@src/lib/trap'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { Selections } from '@src/machines/modelingSharedTypes'
 
+type VariableExprsOptions = NonNullable<
+  Parameters<typeof getVariableExprsFromSelection>[5]
+>
+
+type TransformSelectionRecord = {
+  exprs: Expr[]
+  pathIfPipe?: PathToNode
+  pipeBodyIndex?: number
+}
+
+function getTransformVariableExprsFromSelection(
+  selection: Selections,
+  artifactGraph: ArtifactGraph,
+  ast: Node<Program>,
+  wasmInstance: ModuleType,
+  options: VariableExprsOptions = {}
+): Error | { exprs: Expr[]; pathIfPipe?: PathToNode } {
+  const vars = getVariableExprsFromSelection(
+    selection,
+    artifactGraph,
+    ast,
+    wasmInstance,
+    undefined,
+    options
+  )
+  if (err(vars)) {
+    return vars
+  }
+
+  if (selection.graphSelections.length < 2) {
+    return vars
+  }
+
+  const records: TransformSelectionRecord[] = []
+  const pipeBodyIndexes = new Set<number>()
+
+  for (const graphSelection of selection.graphSelections) {
+    const singleSelectionVars = getVariableExprsFromSelection(
+      {
+        graphSelections: [graphSelection],
+        otherSelections: [],
+      },
+      artifactGraph,
+      ast,
+      wasmInstance,
+      undefined,
+      options
+    )
+    if (err(singleSelectionVars)) {
+      return singleSelectionVars
+    }
+
+    let pipeBodyIndex: number | undefined
+    if (singleSelectionVars.pathIfPipe) {
+      const expression = getNodeFromPath<ExpressionStatement>(
+        ast,
+        singleSelectionVars.pathIfPipe,
+        wasmInstance,
+        'ExpressionStatement'
+      )
+      if (!err(expression) && expression.node.type === 'ExpressionStatement') {
+        const bodyIndex = getBodyIndex(expression.shallowPath)
+        if (err(bodyIndex)) {
+          return bodyIndex
+        }
+        pipeBodyIndex = bodyIndex
+        pipeBodyIndexes.add(bodyIndex)
+      }
+    }
+
+    records.push({ ...singleSelectionVars, pipeBodyIndex })
+  }
+
+  if (pipeBodyIndexes.size <= 1) {
+    return vars
+  }
+
+  const variableByBodyIndex = new Map<number, string>()
+  for (const bodyIndex of pipeBodyIndexes) {
+    const statement = ast.body[bodyIndex]
+    if (!statement || statement.type !== 'ExpressionStatement') {
+      return new Error('Expected a variable-less transform source pipe')
+    }
+
+    const variableName = findUniqueName(
+      ast,
+      KCL_DEFAULT_CONSTANT_PREFIXES.SOLID
+    )
+    const declaration = createVariableDeclaration(
+      variableName,
+      statement.expression
+    )
+    declaration.preComments = statement.preComments
+    ast.body[bodyIndex] = declaration
+    variableByBodyIndex.set(bodyIndex, variableName)
+  }
+
+  return {
+    exprs: records.flatMap(({ exprs, pathIfPipe, pipeBodyIndex }) => {
+      if (!pathIfPipe) {
+        return exprs
+      }
+      if (pipeBodyIndex === undefined) {
+        return []
+      }
+      const variableName = variableByBodyIndex.get(pipeBodyIndex)
+      return variableName ? [createLocalName(variableName)] : []
+    }),
+  }
+}
+
 export function addTranslate({
   ast,
   artifactGraph,
@@ -67,13 +178,23 @@ export function addTranslate({
 
   // 2. Prepare unlabeled and labeled arguments
   // Map the sketches selection into a list of kcl expressions to be passed as unlabelled argument
-  const vars = getSelectionVarsForCall({
-    selection: objects,
-    artifactGraph,
-    modifiedAst,
-    wasmInstance,
-    nodeToEdit: mNodeToEdit,
-  })
+  const vars = mNodeToEdit
+    ? getSelectionVarsForCall({
+        selection: objects,
+        artifactGraph,
+        modifiedAst,
+        wasmInstance,
+        nodeToEdit: mNodeToEdit,
+      })
+    : getTransformVariableExprsFromSelection(
+        objects,
+        artifactGraph,
+        modifiedAst,
+        wasmInstance,
+        {
+          lastChildLookup: true,
+        }
+      )
   if (err(vars)) {
     return vars
   }
@@ -159,13 +280,23 @@ export function addRotate({
 
   // 2. Prepare unlabeled and labeled arguments
   // Map the sketches selection into a list of kcl expressions to be passed as unlabelled argument
-  const vars = getSelectionVarsForCall({
-    selection: objects,
-    artifactGraph,
-    modifiedAst,
-    wasmInstance,
-    nodeToEdit: mNodeToEdit,
-  })
+  const vars = mNodeToEdit
+    ? getSelectionVarsForCall({
+        selection: objects,
+        artifactGraph,
+        modifiedAst,
+        wasmInstance,
+        nodeToEdit: mNodeToEdit,
+      })
+    : getTransformVariableExprsFromSelection(
+        objects,
+        artifactGraph,
+        modifiedAst,
+        wasmInstance,
+        {
+          lastChildLookup: true,
+        }
+      )
   if (err(vars)) {
     return vars
   }
@@ -261,13 +392,23 @@ export function addScale({
 
   // 2. Prepare unlabeled and labeled arguments
   // Map the sketches selection into a list of kcl expressions to be passed as unlabelled argument
-  const vars = getSelectionVarsForCall({
-    selection: objects,
-    artifactGraph,
-    modifiedAst,
-    wasmInstance,
-    nodeToEdit: mNodeToEdit,
-  })
+  const vars = mNodeToEdit
+    ? getSelectionVarsForCall({
+        selection: objects,
+        artifactGraph,
+        modifiedAst,
+        wasmInstance,
+        nodeToEdit: mNodeToEdit,
+      })
+    : getTransformVariableExprsFromSelection(
+        objects,
+        artifactGraph,
+        modifiedAst,
+        wasmInstance,
+        {
+          lastChildLookup: true,
+        }
+      )
   if (err(vars)) {
     return vars
   }
@@ -409,13 +550,23 @@ export function addAppearance({
 
   // 2. Prepare unlabeled and labeled arguments
   // Map the sketches selection into a list of kcl expressions to be passed as unlabelled argument
-  const vars = getSelectionVarsForCall({
-    selection: objects,
-    artifactGraph,
-    modifiedAst,
-    wasmInstance,
-    nodeToEdit: mNodeToEdit,
-  })
+  const vars = mNodeToEdit
+    ? getSelectionVarsForCall({
+        selection: objects,
+        artifactGraph,
+        modifiedAst,
+        wasmInstance,
+        nodeToEdit: mNodeToEdit,
+      })
+    : getTransformVariableExprsFromSelection(
+        objects,
+        artifactGraph,
+        modifiedAst,
+        wasmInstance,
+        {
+          lastChildLookup: true,
+        }
+      )
   if (err(vars)) {
     return vars
   }
@@ -709,12 +860,11 @@ export function addMirror3D({
   let vars: { exprs: Expr[]; pathIfPipe?: PathToNode } = { exprs: [] }
   let acrossArg: Expr | undefined
   if (!mNodeToEdit) {
-    const selectionVars = getVariableExprsFromSelection(
+    const selectionVars = getTransformVariableExprsFromSelection(
       bodies,
       artifactGraph,
       modifiedAst,
       wasmInstance,
-      undefined,
       {
         lastChildLookup: true,
         artifactTypeFilter: ['compositeSolid', 'sweep'],

--- a/src/lang/modifyAst/transforms.ts
+++ b/src/lang/modifyAst/transforms.ts
@@ -10,7 +10,6 @@ import {
 import {
   createPathToNodeForLastVariable,
   createVariableExpressionsArray,
-  getSelectionVarsForCall,
   insertVariableAndOffsetPathToNode,
   setCallInAst,
 } from '@src/lang/modifyAst'
@@ -64,23 +63,14 @@ export function addTranslate({
 
   // 2. Prepare unlabeled and labeled arguments
   // Map the sketches selection into a list of kcl expressions to be passed as unlabelled argument
-  const vars = mNodeToEdit
-    ? getSelectionVarsForCall({
-        selection: objects,
-        artifactGraph,
-        modifiedAst,
-        wasmInstance,
-        nodeToEdit: mNodeToEdit,
-      })
-    : resolveSelectionInputPlan({
-        selection: objects,
-        artifactGraph,
-        ast: modifiedAst,
-        wasmInstance,
-        options: {
-          lastChildLookup: true,
-        },
-      })
+  const vars = resolveSelectionInputPlan({
+    selection: objects,
+    artifactGraph,
+    ast: modifiedAst,
+    wasmInstance,
+    nodeToEdit: mNodeToEdit,
+    options: { lastChildLookup: true },
+  })
   if (err(vars)) {
     return vars
   }
@@ -166,23 +156,14 @@ export function addRotate({
 
   // 2. Prepare unlabeled and labeled arguments
   // Map the sketches selection into a list of kcl expressions to be passed as unlabelled argument
-  const vars = mNodeToEdit
-    ? getSelectionVarsForCall({
-        selection: objects,
-        artifactGraph,
-        modifiedAst,
-        wasmInstance,
-        nodeToEdit: mNodeToEdit,
-      })
-    : resolveSelectionInputPlan({
-        selection: objects,
-        artifactGraph,
-        ast: modifiedAst,
-        wasmInstance,
-        options: {
-          lastChildLookup: true,
-        },
-      })
+  const vars = resolveSelectionInputPlan({
+    selection: objects,
+    artifactGraph,
+    ast: modifiedAst,
+    wasmInstance,
+    nodeToEdit: mNodeToEdit,
+    options: { lastChildLookup: true },
+  })
   if (err(vars)) {
     return vars
   }
@@ -278,23 +259,14 @@ export function addScale({
 
   // 2. Prepare unlabeled and labeled arguments
   // Map the sketches selection into a list of kcl expressions to be passed as unlabelled argument
-  const vars = mNodeToEdit
-    ? getSelectionVarsForCall({
-        selection: objects,
-        artifactGraph,
-        modifiedAst,
-        wasmInstance,
-        nodeToEdit: mNodeToEdit,
-      })
-    : resolveSelectionInputPlan({
-        selection: objects,
-        artifactGraph,
-        ast: modifiedAst,
-        wasmInstance,
-        options: {
-          lastChildLookup: true,
-        },
-      })
+  const vars = resolveSelectionInputPlan({
+    selection: objects,
+    artifactGraph,
+    ast: modifiedAst,
+    wasmInstance,
+    nodeToEdit: mNodeToEdit,
+    options: { lastChildLookup: true },
+  })
   if (err(vars)) {
     return vars
   }
@@ -372,25 +344,16 @@ export function addClone({
 
   // 2. Prepare unlabeled arguments
   // Map the sketches selection into a list of kcl expressions to be passed as unlabelled argument
-  const vars = mNodeToEdit
-    ? getVariableExprsFromSelection(
-        objects,
-        artifactGraph,
-        modifiedAst,
-        wasmInstance,
-        mNodeToEdit,
-        { lastChildLookup: true }
-      )
-    : getVariableExprsFromSelection(
-        objects,
-        artifactGraph,
-        modifiedAst,
-        wasmInstance,
-        undefined,
-        {
-          lastChildLookup: true,
-        }
-      )
+  const vars = getVariableExprsFromSelection(
+    objects,
+    artifactGraph,
+    modifiedAst,
+    wasmInstance,
+    mNodeToEdit,
+    {
+      lastChildLookup: true,
+    }
+  )
   if (err(vars)) {
     return vars
   }
@@ -402,20 +365,12 @@ export function addClone({
     []
   )
 
-  let pathToNode: PathToNode | Error
-  if (mNodeToEdit) {
-    pathToNode = setCallInAst({
-      ast: modifiedAst,
-      call,
-      pathToEdit: mNodeToEdit,
-      wasmInstance,
-    })
-  } else {
-    const declaration = createVariableDeclaration(variableName, call)
-    modifiedAst.body.push(declaration)
-    const toFirstKwarg = false
-    pathToNode = createPathToNodeForLastVariable(modifiedAst, toFirstKwarg)
-  }
+  // 3. If edit, we assign the new function call declaration to the existing node,
+  // otherwise just push to the end
+  const declaration = createVariableDeclaration(variableName, call)
+  modifiedAst.body.push(declaration)
+  const toFirstKwarg = false
+  const pathToNode = createPathToNodeForLastVariable(modifiedAst, toFirstKwarg)
   if (err(pathToNode)) {
     return pathToNode
   }
@@ -453,23 +408,14 @@ export function addAppearance({
 
   // 2. Prepare unlabeled and labeled arguments
   // Map the sketches selection into a list of kcl expressions to be passed as unlabelled argument
-  const vars = mNodeToEdit
-    ? getSelectionVarsForCall({
-        selection: objects,
-        artifactGraph,
-        modifiedAst,
-        wasmInstance,
-        nodeToEdit: mNodeToEdit,
-      })
-    : resolveSelectionInputPlan({
-        selection: objects,
-        artifactGraph,
-        ast: modifiedAst,
-        wasmInstance,
-        options: {
-          lastChildLookup: true,
-        },
-      })
+  const vars = resolveSelectionInputPlan({
+    selection: objects,
+    artifactGraph,
+    ast: modifiedAst,
+    wasmInstance,
+    nodeToEdit: mNodeToEdit,
+    options: { lastChildLookup: true },
+  })
   if (err(vars)) {
     return vars
   }
@@ -648,24 +594,23 @@ export function addMirror3D({
   const mNodeToEdit = structuredClone(nodeToEdit)
 
   // 2. Prepare unlabeled and labeled arguments
-  let vars: { exprs: Expr[]; pathIfPipe?: PathToNode } = { exprs: [] }
+  const vars = resolveSelectionInputPlan({
+    selection: bodies,
+    artifactGraph,
+    ast: modifiedAst,
+    wasmInstance,
+    nodeToEdit: mNodeToEdit,
+    options: {
+      lastChildLookup: true,
+      artifactTypeFilter: ['compositeSolid', 'sweep'],
+    },
+  })
+  if (err(vars)) {
+    return vars
+  }
+
   let acrossArg: Expr | undefined
   if (!mNodeToEdit) {
-    const selectionVars = resolveSelectionInputPlan({
-      selection: bodies,
-      artifactGraph,
-      ast: modifiedAst,
-      wasmInstance,
-      options: {
-        lastChildLookup: true,
-        artifactTypeFilter: ['compositeSolid', 'sweep'],
-      },
-    })
-    if (err(selectionVars)) {
-      return selectionVars
-    }
-    vars = selectionVars
-
     const isEdgeSelection = across.graphSelections.some(
       (selection) =>
         selection.artifact?.type === 'segment' ||

--- a/src/lang/modifyAst/transformsVariablelessPipe.spec.ts
+++ b/src/lang/modifyAst/transformsVariablelessPipe.spec.ts
@@ -54,4 +54,50 @@ startSketchOn(XY)
       expect(execution.issues).toEqual([])
     }
   )
+
+  it.each([
+    ['hide', addHide, 'hidden001 = hide([solid001, solid002])'],
+    ['delete', addDelete, 'delete([solid001, solid002])'],
+  ] as const)(
+    'keeps every selected source pipe represented for multi-selected %s',
+    async (_, add, expectedCall) => {
+      const { instance, rustContext } =
+        await buildTheWorldAndNoEngineConnection()
+      const code = `@settings(experimentalFeatures = allow)
+
+startSketchOn(XY)
+  |> circle(center = [0, 0], radius = 1)
+  |> extrude(length = 1)
+startSketchOn(XZ)
+  |> circle(center = [0, 0], radius = 1)
+  |> extrude(length = 1)`
+      const ast = assertParse(code, instance)
+      const { artifactGraph } = await enginelessExecutor(ast, rustContext)
+      const sweeps = Array.from(artifactGraph.values()).filter(
+        (artifact) => artifact.type === 'sweep'
+      )
+      expect(sweeps).toHaveLength(2)
+
+      const result = add({
+        ast,
+        artifactGraph,
+        objects: createSelectionFromArtifacts(sweeps, artifactGraph),
+        wasmInstance: instance,
+      })
+      if (err(result)) {
+        throw result
+      }
+
+      const output = recast(result.modifiedAst, instance)
+      expect(output).toContain('solid001 = startSketchOn(XY)')
+      expect(output).toContain('solid002 = startSketchOn(XZ)')
+      expect(output).toContain(expectedCall)
+
+      const execution = await enginelessExecutor(
+        result.modifiedAst,
+        rustContext
+      )
+      expect(execution.issues).toEqual([])
+    }
+  )
 })

--- a/src/lang/modifyAst/transformsVariablelessPipe.spec.ts
+++ b/src/lang/modifyAst/transformsVariablelessPipe.spec.ts
@@ -28,9 +28,9 @@ startSketchOn(XY)
   |> extrude(length = 1)`
       const ast = assertParse(code, instance)
       const { artifactGraph } = await enginelessExecutor(ast, rustContext)
-      const sweep = artifactGraph
-        .values()
-        .find((artifact) => artifact.type === 'sweep')
+      const sweep = Array.from(artifactGraph.values()).find(
+        (artifact) => artifact.type === 'sweep'
+      )
       if (!sweep) {
         throw new Error('Expected the pipe to produce a sweep')
       }

--- a/src/lang/modifyAst/transformsVariablelessPipe.spec.ts
+++ b/src/lang/modifyAst/transformsVariablelessPipe.spec.ts
@@ -1,0 +1,57 @@
+import { addDelete, addHide } from '@src/lang/modifyAst/transforms'
+import { assertParse, recast } from '@src/lang/wasm'
+import {
+  createSelectionFromArtifacts,
+  enginelessExecutor,
+} from '@src/lib/testHelpers'
+import { err } from '@src/lib/trap'
+import { buildTheWorldAndNoEngineConnection } from '@src/unitTestUtils'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@src/lib/commandBarConfigs/modelingCommandStdLibCommands', () => ({
+  STD_LIB_COMMANDS: {},
+}))
+
+describe('object transforms on a variable-less pipe', () => {
+  it.each([
+    ['hide', addHide],
+    ['delete', addDelete],
+  ] as const)(
+    'keeps %s attached to the selected source pipe',
+    async (name, add) => {
+      const { instance, rustContext } =
+        await buildTheWorldAndNoEngineConnection()
+      const code = `@settings(experimentalFeatures = allow)
+
+startSketchOn(XY)
+  |> circle(center = [0, 0], radius = 1)
+  |> extrude(length = 1)`
+      const ast = assertParse(code, instance)
+      const { artifactGraph } = await enginelessExecutor(ast, rustContext)
+      const sweep = artifactGraph
+        .values()
+        .find((artifact) => artifact.type === 'sweep')
+      if (!sweep) {
+        throw new Error('Expected the pipe to produce a sweep')
+      }
+
+      const result = add({
+        ast,
+        artifactGraph,
+        objects: createSelectionFromArtifacts([sweep], artifactGraph),
+        wasmInstance: instance,
+      })
+      if (err(result)) {
+        throw result
+      }
+
+      const output = recast(result.modifiedAst, instance)
+      expect(output).toContain(`  |> extrude(length = 1)\n  |> ${name}()`)
+      const execution = await enginelessExecutor(
+        result.modifiedAst,
+        rustContext
+      )
+      expect(execution.issues).toEqual([])
+    }
+  )
+})

--- a/src/lang/queryAst.ts
+++ b/src/lang/queryAst.ts
@@ -1253,7 +1253,7 @@ export function getVariableNameFromNodePath(
   return undefined
 }
 
-type GetVariableExprsOptions = {
+export type GetVariableExprsOptions = {
   lastChildLookup?: boolean
   artifactTypeFilter?: Array<Artifact['type']>
 }


### PR DESCRIPTION
Stacked on #13662.

Introduces a shared selection-input plan that keeps each selected source pipe distinct until the codemod decides whether it can stay inline or must be materialized.

Migrates Translate, Rotate, Scale, Appearance, Mirror 3D, Hide, and Delete to the shared planner. A single variable-less input still stays in its source pipe; multiple source pipes are assigned stable names so every selected body remains represented.

Edit calls still reconstruct selections for dialogs and future true selection edits, but the planner returns before materializing or rerouting those inputs. This layer changes creation behavior only.

This is intentionally the narrow foundation for the stack. Clone, Boolean, Sweep, and plane selection migrations are left to the next PR so reviewers can evaluate the representation and materialization rules before the broader adoption.

Supersedes the overlapping one-off fixes in #13408 and #13417.

Fixes #13407.
Fixes #13416.
Fixes #13418.

Risk: converting multiple bare source expressions into declarations changes formatting and introduces generated names. Comments are carried onto the replacement declarations.