### PR TITLE
Materialize pipe-backed selections where calls need names

### DIFF
--- a/src/lang/modifyAst/boolean.ts
+++ b/src/lang/modifyAst/boolean.ts
@@ -5,28 +5,15 @@ import {
   createCallExpressionStdLibKw,
   createLabeledArg,
   createLiteral,
-  createLocalName,
-  createVariableDeclaration,
-  findUniqueName,
 } from '@src/lang/create'
 import {
   createVariableExpressionsArray,
   insertVariableAndOffsetPathToNode,
   setCallInAst,
 } from '@src/lang/modifyAst'
-import {
-  getBodyIndex,
-  getNodeFromPath,
-  getVariableExprsFromSelection,
-  stringifyPathToNode,
-  valueOrVariable,
-} from '@src/lang/queryAst'
-import type {
-  ArtifactGraph,
-  ExpressionStatement,
-  PathToNode,
-  Program,
-} from '@src/lang/wasm'
+import { resolveSelectionInputPlans } from '@src/lang/modifyAst/selectionInputs'
+import { stringifyPathToNode, valueOrVariable } from '@src/lang/queryAst'
+import type { ArtifactGraph, PathToNode, Program } from '@src/lang/wasm'
 import { modelingStdLibCommandName } from '@src/lib/commandBarConfigs/modelingCommandStdLib'
 import type { KclCommandValue } from '@src/lib/commandTypes'
 import { KCL_DEFAULT_CONSTANT_PREFIXES } from '@src/lib/constants'
@@ -43,17 +30,12 @@ type BooleanSelectionGroup = {
   pathIfPipe?: PathToNode
 }
 
-type BooleanSelectionRecord = {
-  exprs: Expr[]
-  pathIfPipe?: PathToNode
-  pipeBodyIndex?: number
-}
-
 function resolveBooleanSelectionGroups({
   selectionGroups,
   artifactGraph,
   ast,
   wasmInstance,
+  nodeToEdit,
 }: {
   selectionGroups: Array<{
     selections: Selections
@@ -62,101 +44,29 @@ function resolveBooleanSelectionGroups({
   artifactGraph: ArtifactGraph
   ast: Node<Program>
   wasmInstance: ModuleType
+  nodeToEdit?: PathToNode
 }): Error | BooleanSelectionGroup[] {
-  const recordsByGroup: BooleanSelectionRecord[][] = []
-  const pipeBodyIndexes = new Set<number>()
-  let mustMaterializePipes = false
-
-  for (const { selections, requiresExplicitExpr } of selectionGroups) {
-    const records: BooleanSelectionRecord[] = []
-    for (const selection of selections.graphSelections) {
-      const vars = getVariableExprsFromSelection(
-        {
-          graphSelections: [selection],
-          otherSelections: [],
-        },
-        artifactGraph,
-        ast,
-        wasmInstance,
-        undefined,
-        {
-          lastChildLookup: true,
-          artifactTypeFilter: ['compositeSolid', 'sweep'],
-        }
-      )
-      if (err(vars)) {
-        return vars
-      }
-
-      let pipeBodyIndex: number | undefined
-      if (vars.pathIfPipe) {
-        const expression = getNodeFromPath<ExpressionStatement>(
-          ast,
-          vars.pathIfPipe,
-          wasmInstance,
-          'ExpressionStatement'
-        )
-        if (
-          !err(expression) &&
-          expression.node.type === 'ExpressionStatement'
-        ) {
-          const bodyIndex = getBodyIndex(expression.shallowPath)
-          if (err(bodyIndex)) {
-            return bodyIndex
-          }
-          pipeBodyIndex = bodyIndex
-          pipeBodyIndexes.add(bodyIndex)
-          if (requiresExplicitExpr) {
-            mustMaterializePipes = true
-          }
-        }
-      }
-
-      records.push({ ...vars, pipeBodyIndex })
-    }
-    recordsByGroup.push(records)
+  const plans = resolveSelectionInputPlans({
+    requests: selectionGroups.map(({ selections, requiresExplicitExpr }) => ({
+      selection: selections,
+      materializePipes: requiresExplicitExpr ? 'always' : 'when-multiple',
+    })),
+    artifactGraph,
+    ast,
+    wasmInstance,
+    nodeToEdit,
+    options: {
+      lastChildLookup: true,
+      artifactTypeFilter: ['compositeSolid', 'sweep'],
+    },
+  })
+  if (err(plans)) {
+    return plans
   }
 
-  mustMaterializePipes ||= pipeBodyIndexes.size > 1
-  if (!mustMaterializePipes) {
-    return recordsByGroup.map((records, index) => ({
-      selections: selectionGroups[index].selections,
-      exprs: records.flatMap(({ exprs }) => exprs),
-      pathIfPipe: records.find(({ pathIfPipe }) => pathIfPipe)?.pathIfPipe,
-    }))
-  }
-
-  const variableByBodyIndex = new Map<number, string>()
-  for (const bodyIndex of pipeBodyIndexes) {
-    const statement = ast.body[bodyIndex]
-    if (statement.type !== 'ExpressionStatement') {
-      return new Error('Expected a variable-less Boolean source pipe')
-    }
-    const variableName = findUniqueName(
-      ast,
-      KCL_DEFAULT_CONSTANT_PREFIXES.SOLID
-    )
-    const declaration = createVariableDeclaration(
-      variableName,
-      statement.expression
-    )
-    declaration.preComments = statement.preComments
-    ast.body[bodyIndex] = declaration
-    variableByBodyIndex.set(bodyIndex, variableName)
-  }
-
-  return recordsByGroup.map((records, index) => ({
+  return plans.map((plan, index) => ({
     selections: selectionGroups[index].selections,
-    exprs: records.flatMap(({ exprs, pathIfPipe, pipeBodyIndex }) => {
-      if (!pathIfPipe) {
-        return exprs
-      }
-      if (pipeBodyIndex === undefined) {
-        return []
-      }
-      const variableName = variableByBodyIndex.get(pipeBodyIndex)
-      return variableName ? [createLocalName(variableName)] : []
-    }),
+    ...plan,
   }))
 }
 
@@ -222,20 +132,19 @@ export function addUnion({
   const mNodeToEdit = structuredClone(nodeToEdit)
 
   // 2. Prepare unlabeled arguments (no exposed labeled arguments for boolean yet)
-  let vars: { exprs: Expr[]; pathIfPipe?: PathToNode } = { exprs: [] }
-  if (!mNodeToEdit) {
-    const selectionGroups = resolveBooleanSelectionGroups({
-      selectionGroups: [{ selections: solids }],
-      artifactGraph,
-      ast: modifiedAst,
-      wasmInstance,
-    })
-    if (err(selectionGroups)) {
-      return selectionGroups
-    }
-    const [selectionVars] = selectionGroups
-    vars = selectionVars
+  const selectionGroups = resolveBooleanSelectionGroups({
+    selectionGroups: [{ selections: solids }],
+    artifactGraph,
+    ast: modifiedAst,
+    wasmInstance,
+    nodeToEdit: mNodeToEdit,
+  })
+  if (err(selectionGroups)) {
+    return selectionGroups
+  }
+  const [vars] = selectionGroups
 
+  if (!mNodeToEdit) {
     const selectionError = validateBooleanSelections(selectionGroups)
     if (selectionError) {
       return selectionError
@@ -292,20 +201,19 @@ export function addIntersect({
   const mNodeToEdit = structuredClone(nodeToEdit)
 
   // 2. Prepare unlabeled arguments (no exposed labeled arguments for boolean yet)
-  let vars: { exprs: Expr[]; pathIfPipe?: PathToNode } = { exprs: [] }
-  if (!mNodeToEdit) {
-    const selectionGroups = resolveBooleanSelectionGroups({
-      selectionGroups: [{ selections: solids }],
-      artifactGraph,
-      ast: modifiedAst,
-      wasmInstance,
-    })
-    if (err(selectionGroups)) {
-      return selectionGroups
-    }
-    const [selectionVars] = selectionGroups
-    vars = selectionVars
+  const selectionGroups = resolveBooleanSelectionGroups({
+    selectionGroups: [{ selections: solids }],
+    artifactGraph,
+    ast: modifiedAst,
+    wasmInstance,
+    nodeToEdit: mNodeToEdit,
+  })
+  if (err(selectionGroups)) {
+    return selectionGroups
+  }
+  const [vars] = selectionGroups
 
+  if (!mNodeToEdit) {
     const selectionError = validateBooleanSelections(selectionGroups)
     if (selectionError) {
       return selectionError
@@ -364,25 +272,22 @@ export function addSubtract({
   const mNodeToEdit = structuredClone(nodeToEdit)
 
   // 2. Prepare unlabeled and labeled arguments
-  let vars: { exprs: Expr[]; pathIfPipe?: PathToNode } = { exprs: [] }
-  let toolVars: { exprs: Expr[]; pathIfPipe?: PathToNode } = { exprs: [] }
-  if (!mNodeToEdit) {
-    const selectionGroups = resolveBooleanSelectionGroups({
-      selectionGroups: [
-        { selections: solids },
-        { selections: tools, requiresExplicitExpr: true },
-      ],
-      artifactGraph,
-      ast: modifiedAst,
-      wasmInstance,
-    })
-    if (err(selectionGroups)) {
-      return selectionGroups
-    }
-    const [selectionVars, selectionToolVars] = selectionGroups
-    vars = selectionVars
-    toolVars = selectionToolVars
+  const selectionGroups = resolveBooleanSelectionGroups({
+    selectionGroups: [
+      { selections: solids },
+      { selections: tools, requiresExplicitExpr: true },
+    ],
+    artifactGraph,
+    ast: modifiedAst,
+    wasmInstance,
+    nodeToEdit: mNodeToEdit,
+  })
+  if (err(selectionGroups)) {
+    return selectionGroups
+  }
+  const [vars, toolVars] = selectionGroups
 
+  if (!mNodeToEdit) {
     const selectionError = validateBooleanSelections(selectionGroups)
     if (selectionError) {
       return selectionError
@@ -466,27 +371,23 @@ export function addSplit({
       tools &&
       (tools.graphSelections.length > 0 || tools.otherSelections.length > 0)
   )
-  let vars: { exprs: Expr[]; pathIfPipe?: PathToNode } = { exprs: [] }
-  let toolVars: { exprs: Expr[]; pathIfPipe?: PathToNode } | undefined
+  const selectionGroups = resolveBooleanSelectionGroups({
+    selectionGroups: [
+      { selections: targets },
+      ...(hasTools && tools
+        ? [{ selections: tools, requiresExplicitExpr: true }]
+        : []),
+    ],
+    artifactGraph,
+    ast: modifiedAst,
+    wasmInstance,
+    nodeToEdit: mNodeToEdit,
+  })
+  if (err(selectionGroups)) {
+    return selectionGroups
+  }
+  const [vars, toolVars] = selectionGroups
   if (!mNodeToEdit) {
-    const selectionGroups = resolveBooleanSelectionGroups({
-      selectionGroups: [
-        { selections: targets },
-        ...(hasTools && tools
-          ? [{ selections: tools, requiresExplicitExpr: true }]
-          : []),
-      ],
-      artifactGraph,
-      ast: modifiedAst,
-      wasmInstance,
-    })
-    if (err(selectionGroups)) {
-      return selectionGroups
-    }
-    const [selectionVars, selectionToolVars] = selectionGroups
-    vars = selectionVars
-    toolVars = selectionToolVars
-
     const selectionError = validateBooleanSelections(selectionGroups)
     if (selectionError) {
       return selectionError

--- a/src/lang/modifyAst/boolean.ts
+++ b/src/lang/modifyAst/boolean.ts
@@ -5,6 +5,9 @@ import {
   createCallExpressionStdLibKw,
   createLabeledArg,
   createLiteral,
+  createLocalName,
+  createVariableDeclaration,
+  findUniqueName,
 } from '@src/lang/create'
 import {
   createVariableExpressionsArray,
@@ -12,11 +15,18 @@ import {
   setCallInAst,
 } from '@src/lang/modifyAst'
 import {
+  getBodyIndex,
+  getNodeFromPath,
   getVariableExprsFromSelection,
   stringifyPathToNode,
   valueOrVariable,
 } from '@src/lang/queryAst'
-import type { ArtifactGraph, PathToNode, Program } from '@src/lang/wasm'
+import type {
+  ArtifactGraph,
+  ExpressionStatement,
+  PathToNode,
+  Program,
+} from '@src/lang/wasm'
 import { modelingStdLibCommandName } from '@src/lib/commandBarConfigs/modelingCommandStdLib'
 import type { KclCommandValue } from '@src/lib/commandTypes'
 import { KCL_DEFAULT_CONSTANT_PREFIXES } from '@src/lib/constants'
@@ -31,6 +41,123 @@ type BooleanSelectionGroup = {
   selections: Selections
   exprs: Expr[]
   pathIfPipe?: PathToNode
+}
+
+type BooleanSelectionRecord = {
+  exprs: Expr[]
+  pathIfPipe?: PathToNode
+  pipeBodyIndex?: number
+}
+
+function resolveBooleanSelectionGroups({
+  selectionGroups,
+  artifactGraph,
+  ast,
+  wasmInstance,
+}: {
+  selectionGroups: Array<{
+    selections: Selections
+    requiresExplicitExpr?: boolean
+  }>
+  artifactGraph: ArtifactGraph
+  ast: Node<Program>
+  wasmInstance: ModuleType
+}): Error | BooleanSelectionGroup[] {
+  const recordsByGroup: BooleanSelectionRecord[][] = []
+  const pipeBodyIndexes = new Set<number>()
+  let mustMaterializePipes = false
+
+  for (const { selections, requiresExplicitExpr } of selectionGroups) {
+    const records: BooleanSelectionRecord[] = []
+    for (const selection of selections.graphSelections) {
+      const vars = getVariableExprsFromSelection(
+        {
+          graphSelections: [selection],
+          otherSelections: [],
+        },
+        artifactGraph,
+        ast,
+        wasmInstance,
+        undefined,
+        {
+          lastChildLookup: true,
+          artifactTypeFilter: ['compositeSolid', 'sweep'],
+        }
+      )
+      if (err(vars)) {
+        return vars
+      }
+
+      let pipeBodyIndex: number | undefined
+      if (vars.pathIfPipe) {
+        const expression = getNodeFromPath<ExpressionStatement>(
+          ast,
+          vars.pathIfPipe,
+          wasmInstance,
+          'ExpressionStatement'
+        )
+        if (
+          !err(expression) &&
+          expression.node.type === 'ExpressionStatement'
+        ) {
+          const bodyIndex = getBodyIndex(expression.shallowPath)
+          if (err(bodyIndex)) {
+            return bodyIndex
+          }
+          pipeBodyIndex = bodyIndex
+          pipeBodyIndexes.add(bodyIndex)
+          if (requiresExplicitExpr) {
+            mustMaterializePipes = true
+          }
+        }
+      }
+
+      records.push({ ...vars, pipeBodyIndex })
+    }
+    recordsByGroup.push(records)
+  }
+
+  mustMaterializePipes ||= pipeBodyIndexes.size > 1
+  if (!mustMaterializePipes) {
+    return recordsByGroup.map((records, index) => ({
+      selections: selectionGroups[index].selections,
+      exprs: records.flatMap(({ exprs }) => exprs),
+      pathIfPipe: records.find(({ pathIfPipe }) => pathIfPipe)?.pathIfPipe,
+    }))
+  }
+
+  const variableByBodyIndex = new Map<number, string>()
+  for (const bodyIndex of pipeBodyIndexes) {
+    const statement = ast.body[bodyIndex]
+    if (statement.type !== 'ExpressionStatement') {
+      return new Error('Expected a variable-less Boolean source pipe')
+    }
+    const variableName = findUniqueName(
+      ast,
+      KCL_DEFAULT_CONSTANT_PREFIXES.SOLID
+    )
+    const declaration = createVariableDeclaration(
+      variableName,
+      statement.expression
+    )
+    declaration.preComments = statement.preComments
+    ast.body[bodyIndex] = declaration
+    variableByBodyIndex.set(bodyIndex, variableName)
+  }
+
+  return recordsByGroup.map((records, index) => ({
+    selections: selectionGroups[index].selections,
+    exprs: records.flatMap(({ exprs, pathIfPipe, pipeBodyIndex }) => {
+      if (!pathIfPipe) {
+        return exprs
+      }
+      if (pipeBodyIndex === undefined) {
+        return []
+      }
+      const variableName = variableByBodyIndex.get(pipeBodyIndex)
+      return variableName ? [createLocalName(variableName)] : []
+    }),
+  }))
 }
 
 function booleanInputKey(expr: Expr, pathIfPipe?: PathToNode): string {
@@ -97,25 +224,19 @@ export function addUnion({
   // 2. Prepare unlabeled arguments (no exposed labeled arguments for boolean yet)
   let vars: { exprs: Expr[]; pathIfPipe?: PathToNode } = { exprs: [] }
   if (!mNodeToEdit) {
-    const selectionVars = getVariableExprsFromSelection(
-      solids,
+    const selectionGroups = resolveBooleanSelectionGroups({
+      selectionGroups: [{ selections: solids }],
       artifactGraph,
-      modifiedAst,
+      ast: modifiedAst,
       wasmInstance,
-      undefined,
-      {
-        lastChildLookup: true,
-        artifactTypeFilter: ['compositeSolid', 'sweep'],
-      }
-    )
-    if (err(selectionVars)) {
-      return selectionVars
+    })
+    if (err(selectionGroups)) {
+      return selectionGroups
     }
+    const [selectionVars] = selectionGroups
     vars = selectionVars
 
-    const selectionError = validateBooleanSelections([
-      { selections: solids, ...vars },
-    ])
+    const selectionError = validateBooleanSelections(selectionGroups)
     if (selectionError) {
       return selectionError
     }
@@ -173,25 +294,19 @@ export function addIntersect({
   // 2. Prepare unlabeled arguments (no exposed labeled arguments for boolean yet)
   let vars: { exprs: Expr[]; pathIfPipe?: PathToNode } = { exprs: [] }
   if (!mNodeToEdit) {
-    const selectionVars = getVariableExprsFromSelection(
-      solids,
+    const selectionGroups = resolveBooleanSelectionGroups({
+      selectionGroups: [{ selections: solids }],
       artifactGraph,
-      modifiedAst,
+      ast: modifiedAst,
       wasmInstance,
-      undefined,
-      {
-        lastChildLookup: true,
-        artifactTypeFilter: ['compositeSolid', 'sweep'],
-      }
-    )
-    if (err(selectionVars)) {
-      return selectionVars
+    })
+    if (err(selectionGroups)) {
+      return selectionGroups
     }
+    const [selectionVars] = selectionGroups
     vars = selectionVars
 
-    const selectionError = validateBooleanSelections([
-      { selections: solids, ...vars },
-    ])
+    const selectionError = validateBooleanSelections(selectionGroups)
     if (selectionError) {
       return selectionError
     }
@@ -252,42 +367,23 @@ export function addSubtract({
   let vars: { exprs: Expr[]; pathIfPipe?: PathToNode } = { exprs: [] }
   let toolVars: { exprs: Expr[]; pathIfPipe?: PathToNode } = { exprs: [] }
   if (!mNodeToEdit) {
-    const selectionVars = getVariableExprsFromSelection(
-      solids,
+    const selectionGroups = resolveBooleanSelectionGroups({
+      selectionGroups: [
+        { selections: solids },
+        { selections: tools, requiresExplicitExpr: true },
+      ],
       artifactGraph,
-      modifiedAst,
+      ast: modifiedAst,
       wasmInstance,
-      undefined,
-      {
-        lastChildLookup: true,
-        artifactTypeFilter: ['compositeSolid', 'sweep'],
-      }
-    )
-    if (err(selectionVars)) {
-      return selectionVars
+    })
+    if (err(selectionGroups)) {
+      return selectionGroups
     }
+    const [selectionVars, selectionToolVars] = selectionGroups
     vars = selectionVars
-
-    const selectionToolVars = getVariableExprsFromSelection(
-      tools,
-      artifactGraph,
-      modifiedAst,
-      wasmInstance,
-      undefined,
-      {
-        lastChildLookup: true,
-        artifactTypeFilter: ['compositeSolid', 'sweep'],
-      }
-    )
-    if (err(selectionToolVars)) {
-      return selectionToolVars
-    }
     toolVars = selectionToolVars
 
-    const selectionError = validateBooleanSelections([
-      { selections: solids, ...vars },
-      { selections: tools, ...toolVars },
-    ])
+    const selectionError = validateBooleanSelections(selectionGroups)
     if (selectionError) {
       return selectionError
     }
@@ -365,64 +461,42 @@ export function addSplit({
   const mNodeToEdit = structuredClone(nodeToEdit)
 
   // 2. Prepare unlabeled and labeled arguments
-  let vars: { exprs: Expr[]; pathIfPipe?: PathToNode } = { exprs: [] }
-  if (!mNodeToEdit) {
-    const selectionVars = getVariableExprsFromSelection(
-      targets,
-      artifactGraph,
-      modifiedAst,
-      wasmInstance,
-      undefined,
-      {
-        lastChildLookup: true,
-        artifactTypeFilter: ['compositeSolid', 'sweep'],
-      }
-    )
-    if (err(selectionVars)) {
-      return selectionVars
-    }
-    vars = selectionVars
-  }
-
   const hasTools = Boolean(
     !mNodeToEdit &&
       tools &&
       (tools.graphSelections.length > 0 || tools.otherSelections.length > 0)
   )
-  const selectionGroups: BooleanSelectionGroup[] = [
-    { selections: targets, ...vars },
-  ]
+  let vars: { exprs: Expr[]; pathIfPipe?: PathToNode } = { exprs: [] }
+  let toolVars: { exprs: Expr[]; pathIfPipe?: PathToNode } | undefined
   if (!mNodeToEdit) {
-    const targetSelectionError = validateBooleanSelections(selectionGroups)
-    if (targetSelectionError) {
-      return targetSelectionError
+    const selectionGroups = resolveBooleanSelectionGroups({
+      selectionGroups: [
+        { selections: targets },
+        ...(hasTools && tools
+          ? [{ selections: tools, requiresExplicitExpr: true }]
+          : []),
+      ],
+      artifactGraph,
+      ast: modifiedAst,
+      wasmInstance,
+    })
+    if (err(selectionGroups)) {
+      return selectionGroups
+    }
+    const [selectionVars, selectionToolVars] = selectionGroups
+    vars = selectionVars
+    toolVars = selectionToolVars
+
+    const selectionError = validateBooleanSelections(selectionGroups)
+    if (selectionError) {
+      return selectionError
     }
   }
 
   const labeledArgs: ReturnType<typeof createLabeledArg>[] = []
   let pathIfNewPipe = vars.pathIfPipe
 
-  if (hasTools && tools) {
-    const toolVars = getVariableExprsFromSelection(
-      tools,
-      artifactGraph,
-      modifiedAst,
-      wasmInstance,
-      undefined,
-      {
-        lastChildLookup: true,
-        artifactTypeFilter: ['compositeSolid', 'sweep'],
-      }
-    )
-    if (err(toolVars)) {
-      return toolVars
-    }
-    selectionGroups.push({ selections: tools, ...toolVars })
-    const selectionError = validateBooleanSelections(selectionGroups)
-    if (selectionError) {
-      return selectionError
-    }
-
+  if (hasTools && toolVars) {
     const toolsExpr = createVariableExpressionsArray(toolVars.exprs)
     if (toolsExpr === null) {
       return new Error('No tools provided for split operation')

--- a/src/lang/modifyAst/booleanVariablelessPipes.spec.ts
+++ b/src/lang/modifyAst/booleanVariablelessPipes.spec.ts
@@ -1,0 +1,243 @@
+import {
+  addIntersect,
+  addSplit,
+  addSubtract,
+  addUnion,
+} from '@src/lang/modifyAst/boolean'
+import { assertParse, recast } from '@src/lang/wasm'
+import {
+  createSelectionFromArtifacts,
+  enginelessExecutor,
+} from '@src/lib/testHelpers'
+import { err } from '@src/lib/trap'
+import { buildTheWorldAndNoEngineConnection } from '@src/unitTestUtils'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@src/lib/commandBarConfigs/modelingCommandStdLibCommands', () => ({
+  STD_LIB_COMMANDS: {},
+}))
+
+describe('boolean operations on distinct variable-less pipes', () => {
+  it.each(['union', 'intersect', 'subtract', 'split'] as const)(
+    'keeps both selected bodies when creating %s',
+    async (operation) => {
+      const { instance, rustContext } =
+        await buildTheWorldAndNoEngineConnection()
+      const code = `@settings(experimentalFeatures = allow)
+
+startSketchOn(XY)
+  |> circle(center = [0, 0], radius = 2)
+  |> extrude(length = 2)
+startSketchOn(XZ)
+  |> circle(center = [0, 0], radius = 2)
+  |> extrude(length = 2)`
+      const ast = assertParse(code, instance)
+      const { artifactGraph } = await enginelessExecutor(ast, rustContext)
+      const sweeps = [...artifactGraph.values()].filter(
+        (artifact) => artifact.type === 'sweep'
+      )
+      expect(sweeps).toHaveLength(2)
+
+      const first = createSelectionFromArtifacts([sweeps[0]], artifactGraph)
+      const second = createSelectionFromArtifacts([sweeps[1]], artifactGraph)
+      const both = createSelectionFromArtifacts(sweeps, artifactGraph)
+      const result =
+        operation === 'union'
+          ? addUnion({
+              ast,
+              artifactGraph,
+              solids: both,
+              wasmInstance: instance,
+            })
+          : operation === 'intersect'
+            ? addIntersect({
+                ast,
+                artifactGraph,
+                solids: both,
+                wasmInstance: instance,
+              })
+            : operation === 'subtract'
+              ? addSubtract({
+                  ast,
+                  artifactGraph,
+                  solids: first,
+                  tools: second,
+                  wasmInstance: instance,
+                })
+              : addSplit({
+                  ast,
+                  artifactGraph,
+                  targets: first,
+                  tools: second,
+                  wasmInstance: instance,
+                })
+      if (err(result)) {
+        throw result
+      }
+
+      const output = recast(result.modifiedAst, instance)
+      expect(output).toContain('solid001 = startSketchOn(XY)')
+      expect(output).toContain('solid002 = startSketchOn(XZ)')
+      if (operation === 'union' || operation === 'intersect') {
+        expect(output).toContain(
+          `solid003 = ${operation}([solid001, solid002])`
+        )
+      } else if (operation === 'subtract') {
+        expect(output).toContain(
+          'solid003 = subtract(solid001, tools = solid002)'
+        )
+      } else {
+        expect(output).toContain('split001 = split(solid001, tools = solid002)')
+      }
+      const execution = await enginelessExecutor(
+        result.modifiedAst,
+        rustContext
+      )
+      expect(execution.issues).toEqual([])
+    }
+  )
+
+  it.each(['subtract', 'split'] as const)(
+    'materializes a variable-less %s tool for its labeled argument',
+    async (operation) => {
+      const { instance, rustContext } =
+        await buildTheWorldAndNoEngineConnection()
+      const code = `@settings(experimentalFeatures = allow)
+
+sketch001 = startSketchOn(XY)
+profile001 = circle(sketch001, center = [0, 0], radius = 2)
+extrude001 = extrude(profile001, length = 2)
+startSketchOn(XZ)
+  |> circle(center = [0, 0], radius = 2)
+  |> extrude(length = 2)`
+      const ast = assertParse(code, instance)
+      const { artifactGraph } = await enginelessExecutor(ast, rustContext)
+      const sweeps = [...artifactGraph.values()].filter(
+        (artifact) => artifact.type === 'sweep'
+      )
+      expect(sweeps).toHaveLength(2)
+      const targets = createSelectionFromArtifacts([sweeps[0]], artifactGraph)
+      const tools = createSelectionFromArtifacts([sweeps[1]], artifactGraph)
+
+      const result =
+        operation === 'subtract'
+          ? addSubtract({
+              ast,
+              artifactGraph,
+              solids: targets,
+              tools,
+              wasmInstance: instance,
+            })
+          : addSplit({
+              ast,
+              artifactGraph,
+              targets,
+              tools,
+              wasmInstance: instance,
+            })
+      if (err(result)) {
+        throw result
+      }
+
+      const output = recast(result.modifiedAst, instance)
+      expect(output).toContain('solid001 = startSketchOn(XZ)')
+      expect(output).toContain(
+        operation === 'subtract'
+          ? 'solid002 = subtract(extrude001, tools = solid001)'
+          : 'split001 = split(extrude001, tools = solid001)'
+      )
+      const execution = await enginelessExecutor(
+        result.modifiedAst,
+        rustContext
+      )
+      expect(execution.issues).toEqual([])
+    }
+  )
+
+  it('still rejects one variable-less body selected as both target and tool', async () => {
+    const { instance, rustContext } = await buildTheWorldAndNoEngineConnection()
+    const code = `@settings(experimentalFeatures = allow)
+
+startSketchOn(XY)
+  |> circle(center = [0, 0], radius = 2)
+  |> extrude(length = 2)`
+    const ast = assertParse(code, instance)
+    const { artifactGraph } = await enginelessExecutor(ast, rustContext)
+    const sweep = [...artifactGraph.values()].find(
+      (artifact) => artifact.type === 'sweep'
+    )
+    if (!sweep) {
+      throw new Error('Expected a sweep')
+    }
+    const selection = createSelectionFromArtifacts([sweep], artifactGraph)
+
+    const result = addSubtract({
+      ast,
+      artifactGraph,
+      solids: selection,
+      tools: selection,
+      wasmInstance: instance,
+    })
+
+    expect(result).toEqual(
+      new Error(
+        'The same body cannot be used more than once in a Boolean operation. Please check your selections.'
+      )
+    )
+  })
+
+  it.each(['subtract', 'split'] as const)(
+    'preserves the existing in-pipe %s path for a variable-less target',
+    async (operation) => {
+      const { instance, rustContext } =
+        await buildTheWorldAndNoEngineConnection()
+      const code = `@settings(experimentalFeatures = allow)
+
+sketch001 = startSketchOn(XY)
+profile001 = circle(sketch001, center = [0, 0], radius = 2)
+extrude001 = extrude(profile001, length = 2)
+startSketchOn(XZ)
+  |> circle(center = [0, 0], radius = 2)
+  |> extrude(length = 2)`
+      const ast = assertParse(code, instance)
+      const { artifactGraph } = await enginelessExecutor(ast, rustContext)
+      const sweeps = [...artifactGraph.values()].filter(
+        (artifact) => artifact.type === 'sweep'
+      )
+      expect(sweeps).toHaveLength(2)
+      const tools = createSelectionFromArtifacts([sweeps[0]], artifactGraph)
+      const targets = createSelectionFromArtifacts([sweeps[1]], artifactGraph)
+
+      const result =
+        operation === 'subtract'
+          ? addSubtract({
+              ast,
+              artifactGraph,
+              solids: targets,
+              tools,
+              wasmInstance: instance,
+            })
+          : addSplit({
+              ast,
+              artifactGraph,
+              targets,
+              tools,
+              wasmInstance: instance,
+            })
+      if (err(result)) {
+        throw result
+      }
+
+      const output = recast(result.modifiedAst, instance)
+      expect(output).toContain(
+        `  |> extrude(length = 2)\n  |> ${operation}(tools = extrude001)`
+      )
+      expect(output).not.toContain('solid001 = startSketchOn(XZ)')
+      const execution = await enginelessExecutor(
+        result.modifiedAst,
+        rustContext
+      )
+      expect(execution.issues).toEqual([])
+    }
+  )
+})

--- a/src/lang/modifyAst/booleanVariablelessPipes.spec.ts
+++ b/src/lang/modifyAst/booleanVariablelessPipes.spec.ts
@@ -1,10 +1,11 @@
+import { createPathToNodeForLastVariable } from '@src/lang/modifyAst'
 import {
   addIntersect,
   addSplit,
   addSubtract,
   addUnion,
 } from '@src/lang/modifyAst/boolean'
-import { assertParse, recast } from '@src/lang/wasm'
+import { type ArtifactGraph, assertParse, recast } from '@src/lang/wasm'
 import {
   createSelectionFromArtifacts,
   enginelessExecutor,
@@ -18,6 +19,47 @@ vi.mock('@src/lib/commandBarConfigs/modelingCommandStdLibCommands', () => ({
 }))
 
 describe('boolean operations on distinct variable-less pipes', () => {
+  it.each(['subtract', 'split'] as const)(
+    'preserves %s selection inputs when editing without reconstructed selections',
+    async (operation) => {
+      const { instance } = await buildTheWorldAndNoEngineConnection()
+      const code = `${operation}001 = ${operation}(target, tools = tool)`
+      const ast = assertParse(code, instance)
+      const unavailableSelection = {
+        graphSelections: [],
+        otherSelections: [],
+      }
+
+      const result =
+        operation === 'subtract'
+          ? addSubtract({
+              ast,
+              artifactGraph: new Map() as ArtifactGraph,
+              solids: unavailableSelection,
+              tools: unavailableSelection,
+              nodeToEdit: createPathToNodeForLastVariable(ast),
+              wasmInstance: instance,
+            })
+          : addSplit({
+              ast,
+              artifactGraph: new Map() as ArtifactGraph,
+              targets: unavailableSelection,
+              tools: unavailableSelection,
+              nodeToEdit: createPathToNodeForLastVariable(ast),
+              wasmInstance: instance,
+            })
+      if (err(result)) {
+        throw result
+      }
+
+      const output = recast(result.modifiedAst, instance)
+      if (err(output)) {
+        throw output
+      }
+      expect(output.trim()).toBe(code)
+    }
+  )
+
   it.each(['union', 'intersect', 'subtract', 'split'] as const)(
     'keeps both selected bodies when creating %s',
     async (operation) => {

--- a/src/lang/modifyAst/clonePipe.spec.ts
+++ b/src/lang/modifyAst/clonePipe.spec.ts
@@ -1,0 +1,49 @@
+import { addClone } from '@src/lang/modifyAst/transforms'
+import { assertParse, recast } from '@src/lang/wasm'
+import {
+  createSelectionFromArtifacts,
+  enginelessExecutor,
+} from '@src/lib/testHelpers'
+import { err } from '@src/lib/trap'
+import { buildTheWorldAndNoEngineConnection } from '@src/unitTestUtils'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@src/lib/commandBarConfigs/modelingCommandStdLibCommands', () => ({
+  STD_LIB_COMMANDS: {},
+}))
+
+describe('clone variable-less pipe', () => {
+  it('keeps the clone input within the source pipe', async () => {
+    const { instance, rustContext } = await buildTheWorldAndNoEngineConnection()
+    const code = `startSketchOn(XY)
+  |> circle(center = [0, 0], radius = 1)
+  |> extrude(length = 1)`
+    const ast = assertParse(code, instance)
+    const { artifactGraph } = await enginelessExecutor(ast, rustContext)
+    const sweep = Array.from(artifactGraph.values()).find(
+      (artifact) => artifact.type === 'sweep'
+    )
+    if (!sweep) {
+      throw new Error('Expected the pipe to produce a sweep')
+    }
+
+    const result = addClone({
+      ast,
+      artifactGraph,
+      objects: createSelectionFromArtifacts([sweep], artifactGraph),
+      variableName: 'clone001',
+      wasmInstance: instance,
+    })
+    if (err(result)) {
+      throw result
+    }
+
+    const output = recast(result.modifiedAst, instance)
+    expect(output).toContain(`clone001 = startSketchOn(XY)
+  |> circle(center = [0, 0], radius = 1)
+  |> extrude(length = 1)
+  |> clone()`)
+    const execution = await enginelessExecutor(result.modifiedAst, rustContext)
+    expect(execution.issues).toEqual([])
+  })
+})

--- a/src/lang/modifyAst/faces.ts
+++ b/src/lang/modifyAst/faces.ts
@@ -1019,6 +1019,10 @@ export function getPlaneExprFromSelection({
           if (err(bodyIndex)) {
             return bodyIndex
           }
+          const sourceStatement = modifiedAst.body[bodyIndex]
+          if (!sourceStatement) {
+            return new Error('Could not find source statement for the plane')
+          }
           const planeVariableName = findUniqueName(
             modifiedAst,
             KCL_DEFAULT_CONSTANT_PREFIXES.PLANE
@@ -1027,7 +1031,7 @@ export function getPlaneExprFromSelection({
             planeVariableName,
             expression.node.expression
           )
-          declaration.preComments = expression.node.preComments
+          declaration.preComments = sourceStatement.preComments
           modifiedAst.body[bodyIndex] = declaration
           planeExpr = createLocalName(planeVariableName)
         }

--- a/src/lang/modifyAst/faces.ts
+++ b/src/lang/modifyAst/faces.ts
@@ -19,6 +19,7 @@ import {
 } from '@src/lang/modifyAst'
 import { modifyAstWithTagsForSelection } from '@src/lang/modifyAst/tagManagement'
 import {
+  getBodyIndex,
   getNodeFromPath,
   getSelectedPlaneAsNode,
   getVariableExprsFromSelection,
@@ -37,6 +38,7 @@ import {
   type ArtifactGraph,
   type CallExpressionKw,
   type Expr,
+  type ExpressionStatement,
   type PathToNode,
   type Program,
   type VariableDeclaration,
@@ -1002,6 +1004,33 @@ export function getPlaneExprFromSelection({
       const [planeVar] = planeVars.exprs
       if (planeVar.type !== 'PipeSubstitution') {
         planeExpr = planeVar
+      } else if (planeVars.pathIfPipe) {
+        const expression = getNodeFromPath<ExpressionStatement>(
+          modifiedAst,
+          planeVars.pathIfPipe,
+          wasmInstance,
+          'ExpressionStatement'
+        )
+        if (
+          !err(expression) &&
+          expression.node.type === 'ExpressionStatement'
+        ) {
+          const bodyIndex = getBodyIndex(expression.shallowPath)
+          if (err(bodyIndex)) {
+            return bodyIndex
+          }
+          const planeVariableName = findUniqueName(
+            modifiedAst,
+            KCL_DEFAULT_CONSTANT_PREFIXES.PLANE
+          )
+          const declaration = createVariableDeclaration(
+            planeVariableName,
+            expression.node.expression
+          )
+          declaration.preComments = expression.node.preComments
+          modifiedAst.body[bodyIndex] = declaration
+          planeExpr = createLocalName(planeVariableName)
+        }
       }
     }
   }

--- a/src/lang/modifyAst/faces.ts
+++ b/src/lang/modifyAst/faces.ts
@@ -17,9 +17,9 @@ import {
   insertVariableAndOffsetPathToNode,
   setCallInAst,
 } from '@src/lang/modifyAst'
+import { resolveSelectionInputPlan } from '@src/lang/modifyAst/selectionInputs'
 import { modifyAstWithTagsForSelection } from '@src/lang/modifyAst/tagManagement'
 import {
-  getBodyIndex,
   getNodeFromPath,
   getSelectedPlaneAsNode,
   getVariableExprsFromSelection,
@@ -38,12 +38,11 @@ import {
   type ArtifactGraph,
   type CallExpressionKw,
   type Expr,
-  type ExpressionStatement,
+  formatNumberValue,
   type PathToNode,
   type Program,
   type VariableDeclaration,
   type VariableMap,
-  formatNumberValue,
 } from '@src/lang/wasm'
 import {
   modelingStdLibCall,
@@ -993,49 +992,18 @@ export function getPlaneExprFromSelection({
     wasmInstance
   )
   if (!planeExpr) {
-    const planeVars = getVariableExprsFromSelection(
-      plane,
+    const planeVars = resolveSelectionInputPlan({
+      selection: plane,
       artifactGraph,
-      modifiedAst,
+      ast: modifiedAst,
       wasmInstance,
-      nodeToEdit
-    )
+      nodeToEdit,
+      materializePipes: 'always',
+      variablePrefix: KCL_DEFAULT_CONSTANT_PREFIXES.PLANE,
+    })
     if (!err(planeVars) && planeVars.exprs.length === 1) {
       const [planeVar] = planeVars.exprs
-      if (planeVar.type !== 'PipeSubstitution') {
-        planeExpr = planeVar
-      } else if (planeVars.pathIfPipe) {
-        const expression = getNodeFromPath<ExpressionStatement>(
-          modifiedAst,
-          planeVars.pathIfPipe,
-          wasmInstance,
-          'ExpressionStatement'
-        )
-        if (
-          !err(expression) &&
-          expression.node.type === 'ExpressionStatement'
-        ) {
-          const bodyIndex = getBodyIndex(expression.shallowPath)
-          if (err(bodyIndex)) {
-            return bodyIndex
-          }
-          const sourceStatement = modifiedAst.body[bodyIndex]
-          if (!sourceStatement) {
-            return new Error('Could not find source statement for the plane')
-          }
-          const planeVariableName = findUniqueName(
-            modifiedAst,
-            KCL_DEFAULT_CONSTANT_PREFIXES.PLANE
-          )
-          const declaration = createVariableDeclaration(
-            planeVariableName,
-            expression.node.expression
-          )
-          declaration.preComments = sourceStatement.preComments
-          modifiedAst.body[bodyIndex] = declaration
-          planeExpr = createLocalName(planeVariableName)
-        }
-      }
+      planeExpr = planeVar
     }
   }
   if (!planeExpr) {

--- a/src/lang/modifyAst/selectionInputs.ts
+++ b/src/lang/modifyAst/selectionInputs.ts
@@ -28,6 +28,12 @@ export type SelectionInputPlan = {
   pathIfPipe?: PathToNode
 }
 
+export type SelectionInputRequest = {
+  selection: Selections
+  materializePipes?: 'always' | 'when-multiple'
+  variablePrefix?: string
+}
+
 type SelectionInputRecord = SelectionInputPlan & {
   pipeBodyIndex?: number
 }
@@ -51,78 +57,124 @@ export function resolveSelectionInputPlan({
   variablePrefix?: string
   nodeToEdit?: PathToNode
 }): Error | SelectionInputPlan {
-  // Edit codemods preserve selection arguments verbatim; input planning is
-  // only needed when creating a new call.
-  if (nodeToEdit) {
-    return { exprs: [] }
-  }
-
-  const aggregate = getVariableExprsFromSelection(
-    selection,
+  const plans = resolveSelectionInputPlans({
+    requests: [{ selection, materializePipes, variablePrefix }],
     artifactGraph,
     ast,
     wasmInstance,
-    undefined,
-    options
-  )
-  if (err(aggregate)) {
-    return aggregate
+    nodeToEdit,
+    options,
+  })
+  if (err(plans)) {
+    return plans
+  }
+  return plans[0]
+}
+
+export function resolveSelectionInputPlans({
+  requests,
+  artifactGraph,
+  ast,
+  wasmInstance,
+  options = {},
+  nodeToEdit,
+}: {
+  requests: SelectionInputRequest[]
+  artifactGraph: ArtifactGraph
+  ast: Node<Program>
+  wasmInstance: ModuleType
+  options?: GetVariableExprsOptions
+  nodeToEdit?: PathToNode
+}): Error | SelectionInputPlan[] {
+  // Edit codemods preserve selection arguments verbatim; input planning is
+  // only needed when creating a new call.
+  if (nodeToEdit) {
+    return requests.map(() => ({ exprs: [] }))
   }
 
-  const shouldInspectIndividualInputs =
-    materializePipes === 'always' || selection.graphSelections.length > 1
-  if (!shouldInspectIndividualInputs) {
-    return aggregate
-  }
+  const aggregates: SelectionInputPlan[] = []
+  const recordsByRequest: SelectionInputRecord[][] = []
+  const variablePrefixByBodyIndex = new Map<number, string>()
+  let shouldMaterialize = false
 
-  const records: SelectionInputRecord[] = []
   const pipeBodyIndexes = new Set<number>()
-
-  for (const graphSelection of selection.graphSelections) {
-    const input = getVariableExprsFromSelection(
-      {
-        graphSelections: [graphSelection],
-        otherSelections: [],
-      },
+  for (const request of requests) {
+    const aggregate = getVariableExprsFromSelection(
+      request.selection,
       artifactGraph,
       ast,
       wasmInstance,
       undefined,
       options
     )
-    if (err(input)) {
-      return input
+    if (err(aggregate)) {
+      return aggregate
+    }
+    aggregates.push(aggregate)
+
+    const materializePipes = request.materializePipes ?? 'when-multiple'
+    const shouldInspectIndividualInputs =
+      materializePipes === 'always' ||
+      request.selection.graphSelections.length > 1 ||
+      requests.length > 1
+    if (!shouldInspectIndividualInputs) {
+      recordsByRequest.push([])
+      continue
     }
 
-    let pipeBodyIndex: number | undefined
-    if (input.pathIfPipe) {
-      const expression = getNodeFromPath<ExpressionStatement>(
+    const records: SelectionInputRecord[] = []
+    recordsByRequest.push(records)
+
+    for (const graphSelection of request.selection.graphSelections) {
+      const input = getVariableExprsFromSelection(
+        {
+          graphSelections: [graphSelection],
+          otherSelections: [],
+        },
+        artifactGraph,
         ast,
-        input.pathIfPipe,
         wasmInstance,
-        'ExpressionStatement'
+        undefined,
+        options
       )
-      if (err(expression) || expression.node.type !== 'ExpressionStatement') {
-        return new Error('Could not resolve the selected source pipe')
+      if (err(input)) {
+        return input
       }
 
-      const bodyIndex = getBodyIndex(expression.shallowPath)
-      if (err(bodyIndex)) {
-        return bodyIndex
+      let pipeBodyIndex: number | undefined
+      if (input.pathIfPipe) {
+        const expression = getNodeFromPath<ExpressionStatement>(
+          ast,
+          input.pathIfPipe,
+          wasmInstance,
+          'ExpressionStatement'
+        )
+        if (err(expression) || expression.node.type !== 'ExpressionStatement') {
+          return new Error('Could not resolve the selected source pipe')
+        }
+
+        const bodyIndex = getBodyIndex(expression.shallowPath)
+        if (err(bodyIndex)) {
+          return bodyIndex
+        }
+        pipeBodyIndex = bodyIndex
+        pipeBodyIndexes.add(bodyIndex)
+        variablePrefixByBodyIndex.set(
+          bodyIndex,
+          request.variablePrefix ?? KCL_DEFAULT_CONSTANT_PREFIXES.SOLID
+        )
+        if (materializePipes === 'always') {
+          shouldMaterialize = true
+        }
       }
-      pipeBodyIndex = bodyIndex
-      pipeBodyIndexes.add(bodyIndex)
+
+      records.push({ ...input, pipeBodyIndex })
     }
-
-    records.push({ ...input, pipeBodyIndex })
   }
 
-  const shouldMaterialize =
-    materializePipes === 'always'
-      ? pipeBodyIndexes.size > 0
-      : pipeBodyIndexes.size > 1
+  shouldMaterialize ||= pipeBodyIndexes.size > 1
   if (!shouldMaterialize) {
-    return aggregate
+    return aggregates
   }
 
   const variableByBodyIndex = new Map<number, string>()
@@ -132,7 +184,11 @@ export function resolveSelectionInputPlan({
       return new Error('Expected a variable-less source pipe')
     }
 
-    const variableName = findUniqueName(ast, variablePrefix)
+    const variableName = findUniqueName(
+      ast,
+      variablePrefixByBodyIndex.get(bodyIndex) ??
+        KCL_DEFAULT_CONSTANT_PREFIXES.SOLID
+    )
     const declaration = createVariableDeclaration(
       variableName,
       structuredClone(statement.expression)
@@ -142,16 +198,20 @@ export function resolveSelectionInputPlan({
     variableByBodyIndex.set(bodyIndex, variableName)
   }
 
-  return {
-    exprs: records.flatMap(({ exprs, pathIfPipe, pipeBodyIndex }) => {
-      if (!pathIfPipe) {
-        return exprs
-      }
-      if (pipeBodyIndex === undefined) {
-        return []
-      }
-      const variableName = variableByBodyIndex.get(pipeBodyIndex)
-      return variableName ? [createLocalName(variableName)] : []
-    }),
-  }
+  return recordsByRequest.map((records, index) =>
+    records.length === 0
+      ? aggregates[index]
+      : {
+          exprs: records.flatMap(({ exprs, pathIfPipe, pipeBodyIndex }) => {
+            if (!pathIfPipe) {
+              return exprs
+            }
+            if (pipeBodyIndex === undefined) {
+              return []
+            }
+            const variableName = variableByBodyIndex.get(pipeBodyIndex)
+            return variableName ? [createLocalName(variableName)] : []
+          }),
+        }
+  )
 }

--- a/src/lang/modifyAst/sweepVariablelessPath.spec.ts
+++ b/src/lang/modifyAst/sweepVariablelessPath.spec.ts
@@ -1,0 +1,50 @@
+import { addSweep } from '@src/lang/modifyAst/sweeps'
+import { assertParse, recast } from '@src/lang/wasm'
+import {
+  createSelectionFromArtifacts,
+  enginelessExecutor,
+} from '@src/lib/testHelpers'
+import { err } from '@src/lib/trap'
+import { buildTheWorldAndNoEngineConnection } from '@src/unitTestUtils'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@src/lib/commandBarConfigs/modelingCommandStdLibCommands', () => ({
+  STD_LIB_COMMANDS: {},
+}))
+
+describe('sweep with a variable-less path', () => {
+  it('materializes the selected path for the labeled path argument', async () => {
+    const { instance, rustContext } = await buildTheWorldAndNoEngineConnection()
+    const code = `profile001 = startSketchOn(XY)
+  |> circle(center = [0, 0], radius = 1)
+startSketchOn(XZ)
+  |> startProfile(at = [0, 0])
+  |> line(end = [0, 5])`
+    const ast = assertParse(code, instance)
+    const { artifactGraph } = await enginelessExecutor(ast, rustContext)
+    const paths = [...artifactGraph.values()].filter(
+      (artifact) => artifact.type === 'path'
+    )
+    expect(paths).toHaveLength(2)
+
+    const result = addSweep({
+      ast,
+      artifactGraph,
+      sketches: createSelectionFromArtifacts([paths[0]], artifactGraph),
+      path: createSelectionFromArtifacts([paths[1]], artifactGraph),
+      wasmInstance: instance,
+    })
+    if (err(result)) {
+      throw result
+    }
+
+    const output = recast(result.modifiedAst, instance)
+    expect(output).toContain(`path001 = startSketchOn(XZ)
+  |> startProfile(at = [0, 0])
+  |> line(end = [0, 5])`)
+    expect(output).toContain('sweep001 = sweep(')
+    expect(output).toContain('path = path001')
+    const execution = await enginelessExecutor(result.modifiedAst, rustContext)
+    expect(execution.issues).toEqual([])
+  })
+})

--- a/src/lang/modifyAst/sweeps.ts
+++ b/src/lang/modifyAst/sweeps.ts
@@ -8,6 +8,8 @@ import {
   createLocalName,
   createName,
   createTagDeclarator,
+  createVariableDeclaration,
+  findUniqueName,
 } from '@src/lang/create'
 import { toUtf16 } from '@src/lang/errors'
 import {
@@ -35,6 +37,7 @@ import {
 import { addHide } from '@src/lang/modifyAst/transforms'
 import {
   createSketchTagMemberExpression,
+  getBodyIndex,
   getNodeFromPath,
   getRegionSketchTagExprFromSourceSurface,
   getSketchSegmentName,
@@ -53,6 +56,7 @@ import type {
   ArtifactGraph,
   CallExpressionKw,
   Expr,
+  ExpressionStatement,
   LabeledArg,
   PathToNode,
   Program,
@@ -509,6 +513,33 @@ export function addSweep({
     }
 
     pathExpr = createVariableExpressionsArray(pathVars.exprs)
+    if (!pathExpr && pathVars.pathIfPipe) {
+      const expression = getNodeFromPath<ExpressionStatement>(
+        modifiedAst,
+        pathVars.pathIfPipe,
+        wasmInstance,
+        'ExpressionStatement'
+      )
+      if (err(expression) || expression.node.type !== 'ExpressionStatement') {
+        return new Error('Could not retrieve the source pipe for sweep path')
+      }
+      const bodyIndex = getBodyIndex(expression.shallowPath)
+      if (err(bodyIndex)) {
+        return bodyIndex
+      }
+      const sourceStatement = modifiedAst.body[bodyIndex]
+      if (!sourceStatement) {
+        return new Error('Could not retrieve the source pipe statement')
+      }
+      const variableName = findUniqueName(modifiedAst, 'path')
+      const declaration = createVariableDeclaration(
+        variableName,
+        expression.node.expression
+      )
+      declaration.preComments = sourceStatement.preComments
+      modifiedAst.body[bodyIndex] = declaration
+      pathExpr = createLocalName(variableName)
+    }
     if (!pathExpr) {
       return new Error("Couldn't retrieve path selection")
     }

--- a/src/lang/modifyAst/sweeps.ts
+++ b/src/lang/modifyAst/sweeps.ts
@@ -8,8 +8,6 @@ import {
   createLocalName,
   createName,
   createTagDeclarator,
-  createVariableDeclaration,
-  findUniqueName,
 } from '@src/lang/create'
 import { toUtf16 } from '@src/lang/errors'
 import {
@@ -30,6 +28,7 @@ import {
   isFaceArtifact,
 } from '@src/lang/modifyAst/faces'
 import { getAxisExpression } from '@src/lang/modifyAst/geometry'
+import { resolveSelectionInputPlan } from '@src/lang/modifyAst/selectionInputs'
 import {
   modifyAstWithTagsForSelection,
   resolveEdgeSelectionContext,
@@ -37,7 +36,6 @@ import {
 import { addHide } from '@src/lang/modifyAst/transforms'
 import {
   createSketchTagMemberExpression,
-  getBodyIndex,
   getNodeFromPath,
   getRegionSketchTagExprFromSourceSurface,
   getSketchSegmentName,
@@ -56,7 +54,6 @@ import type {
   ArtifactGraph,
   CallExpressionKw,
   Expr,
-  ExpressionStatement,
   LabeledArg,
   PathToNode,
   Program,
@@ -501,45 +498,19 @@ export function addSweep({
       vars.exprs.push(...regionExprs)
     }
 
-    const pathVars = getVariableExprsFromSelection(
-      path,
+    const pathVars = resolveSelectionInputPlan({
+      selection: path,
       artifactGraph,
-      modifiedAst,
+      ast: modifiedAst,
       wasmInstance,
-      undefined
-    )
+      materializePipes: 'always',
+      variablePrefix: 'path',
+    })
     if (err(pathVars)) {
       return pathVars
     }
 
     pathExpr = createVariableExpressionsArray(pathVars.exprs)
-    if (!pathExpr && pathVars.pathIfPipe) {
-      const expression = getNodeFromPath<ExpressionStatement>(
-        modifiedAst,
-        pathVars.pathIfPipe,
-        wasmInstance,
-        'ExpressionStatement'
-      )
-      if (err(expression) || expression.node.type !== 'ExpressionStatement') {
-        return new Error('Could not retrieve the source pipe for sweep path')
-      }
-      const bodyIndex = getBodyIndex(expression.shallowPath)
-      if (err(bodyIndex)) {
-        return bodyIndex
-      }
-      const sourceStatement = modifiedAst.body[bodyIndex]
-      if (!sourceStatement) {
-        return new Error('Could not retrieve the source pipe statement')
-      }
-      const variableName = findUniqueName(modifiedAst, 'path')
-      const declaration = createVariableDeclaration(
-        variableName,
-        expression.node.expression
-      )
-      declaration.preComments = sourceStatement.preComments
-      modifiedAst.body[bodyIndex] = declaration
-      pathExpr = createLocalName(variableName)
-    }
     if (!pathExpr) {
       return new Error("Couldn't retrieve path selection")
     }

--- a/src/lang/modifyAst/transforms.ts
+++ b/src/lang/modifyAst/transforms.ts
@@ -17,12 +17,15 @@ import { getPlaneExprFromSelection } from '@src/lang/modifyAst/faces'
 import { getAxisExpression } from '@src/lang/modifyAst/geometry'
 import { resolveSelectionInputPlan } from '@src/lang/modifyAst/selectionInputs'
 import {
+  getBodyIndex,
+  getNodeFromPath,
   getVariableExprsFromSelection,
   valueOrVariable,
 } from '@src/lang/queryAst'
 import type {
   ArtifactGraph,
   Expr,
+  ExpressionStatement,
   PathToNode,
   Program,
   VariableMap,
@@ -365,8 +368,49 @@ export function addClone({
     []
   )
 
-  // 3. If edit, we assign the new function call declaration to the existing node,
-  // otherwise just push to the end
+  if (!mNodeToEdit && vars.pathIfPipe) {
+    const expression = getNodeFromPath<ExpressionStatement>(
+      modifiedAst,
+      vars.pathIfPipe,
+      wasmInstance,
+      'ExpressionStatement'
+    )
+    if (err(expression) || expression.node.type !== 'ExpressionStatement') {
+      return new Error('Could not retrieve the source pipe for clone')
+    }
+    if (expression.node.expression.type !== 'PipeExpression') {
+      return new Error('Expected the source clone selection to be in a pipe')
+    }
+
+    expression.node.expression.body.push(call)
+    const bodyIndex = getBodyIndex(expression.shallowPath)
+    if (err(bodyIndex)) {
+      return bodyIndex
+    }
+    const sourceStatement = modifiedAst.body[bodyIndex]
+    if (!sourceStatement) {
+      return new Error('Could not find source statement for clone')
+    }
+    const declaration = createVariableDeclaration(
+      variableName,
+      expression.node.expression
+    )
+    declaration.preComments = sourceStatement.preComments
+    modifiedAst.body[bodyIndex] = declaration
+
+    return {
+      modifiedAst,
+      pathToNode: [
+        ['body', ''],
+        [bodyIndex, 'index'],
+        ['declaration', 'VariableDeclaration'],
+        ['init', 'VariableDeclarator'],
+        ['body', 'PipeExpression'],
+        [expression.node.expression.body.length - 1, 'index'],
+      ],
+    }
+  }
+
   const declaration = createVariableDeclaration(variableName, call)
   modifiedAst.body.push(declaration)
   const toFirstKwarg = false

--- a/src/lang/modifyAst/transforms.ts
+++ b/src/lang/modifyAst/transforms.ts
@@ -19,7 +19,6 @@ import { resolveSelectionInputPlan } from '@src/lang/modifyAst/selectionInputs'
 import {
   getBodyIndex,
   getNodeFromPath,
-  getVariableExprsFromSelection,
   valueOrVariable,
 } from '@src/lang/queryAst'
 import type {
@@ -347,16 +346,14 @@ export function addClone({
 
   // 2. Prepare unlabeled arguments
   // Map the sketches selection into a list of kcl expressions to be passed as unlabelled argument
-  const vars = getVariableExprsFromSelection(
-    objects,
+  const vars = resolveSelectionInputPlan({
+    selection: objects,
     artifactGraph,
-    modifiedAst,
+    ast: modifiedAst,
     wasmInstance,
-    mNodeToEdit,
-    {
-      lastChildLookup: true,
-    }
-  )
+    nodeToEdit: mNodeToEdit,
+    options: { lastChildLookup: true },
+  })
   if (err(vars)) {
     return vars
   }

--- a/src/lang/modifyAst/variablelessPlaneSelection.spec.ts
+++ b/src/lang/modifyAst/variablelessPlaneSelection.spec.ts
@@ -1,0 +1,85 @@
+import { addOffsetPlane } from '@src/lang/modifyAst/faces'
+import { addMirror3D } from '@src/lang/modifyAst/transforms'
+import { assertParse, recast } from '@src/lang/wasm'
+import {
+  createSelectionFromArtifacts,
+  enginelessExecutor,
+  getKclCommandValue,
+} from '@src/lib/testHelpers'
+import { err } from '@src/lib/trap'
+import { buildTheWorldAndNoEngineConnection } from '@src/unitTestUtils'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@src/lib/commandBarConfigs/modelingCommandStdLibCommands', () => ({
+  STD_LIB_COMMANDS: {},
+}))
+
+describe('variable-less plane selections', () => {
+  it.each(['mirror', 'offset'] as const)(
+    'materializes the selected plane for %s',
+    async (operation) => {
+      const { instance, rustContext } =
+        await buildTheWorldAndNoEngineConnection()
+      const code = `@settings(experimentalFeatures = allow)
+
+profile001 = startSketchOn(XY)
+  |> circle(center = [0, 0], radius = 1)
+extrude001 = extrude(profile001, length = 1)
+offsetPlane(YZ, offset = 2)`
+      const ast = assertParse(code, instance)
+      const execution = await enginelessExecutor(ast, rustContext)
+      const sweep = [...execution.artifactGraph.values()].find(
+        (artifact) => artifact.type === 'sweep'
+      )
+      const plane = [...execution.artifactGraph.values()]
+        .filter((artifact) => artifact.type === 'plane')
+        .sort((a, b) => a.codeRef.range[0] - b.codeRef.range[0])
+        .at(-1)
+      if (!sweep || !plane) {
+        throw new Error('Expected a sweep and an offset plane')
+      }
+
+      const planeSelection = createSelectionFromArtifacts(
+        [plane],
+        execution.artifactGraph
+      )
+      const result =
+        operation === 'mirror'
+          ? addMirror3D({
+              ast,
+              artifactGraph: execution.artifactGraph,
+              variables: execution.variables,
+              bodies: createSelectionFromArtifacts(
+                [sweep],
+                execution.artifactGraph
+              ),
+              across: planeSelection,
+              wasmInstance: instance,
+            })
+          : addOffsetPlane({
+              ast,
+              artifactGraph: execution.artifactGraph,
+              variables: execution.variables,
+              plane: planeSelection,
+              offset: await getKclCommandValue('3', instance, rustContext),
+              wasmInstance: instance,
+            })
+      if (err(result)) {
+        throw result
+      }
+
+      const output = recast(result.modifiedAst, instance)
+      expect(output).toContain('plane001 = offsetPlane(YZ, offset = 2)')
+      expect(output).toContain(
+        operation === 'mirror'
+          ? 'solid001 = mirror3d(extrude001, across = plane001)'
+          : 'plane002 = offsetPlane(plane001, offset = 3)'
+      )
+      const modifiedExecution = await enginelessExecutor(
+        result.modifiedAst,
+        rustContext
+      )
+      expect(modifiedExecution.issues).toEqual([])
+    }
+  )
+})


### PR DESCRIPTION
Migrates the remaining variable-less selection consumers onto the shared input planner.

Clone keeps its operation in the selected source pipe and names the resulting pipeline. Boolean operations materialize distinct source pipes and labeled tools without collapsing their identities. Sweep paths and selected planes are materialized when their labeled arguments require concrete expressions.

This sits above #13645 so the foundational selection-plan behavior can be reviewed independently from these command migrations.

Supersedes the one-off fixes in #13404, #13410, #13412, #13414, and #13479.

Fixes #13403.
Fixes #13409.
Fixes #13411.
Fixes #13413.
Fixes #13462.

Risk: materializing a labeled or multi-pipe selection introduces generated declarations. The planner preserves source comments and uses operation-appropriate name prefixes.
