### PR TITLE
Limit usage of the Vercel Playwright token to testing

### DIFF
--- a/src/machines/authMachine.ts
+++ b/src/machines/authMachine.ts
@@ -384,6 +384,10 @@ export function getCookie(): string | null {
 function getTokenFromEnvOrCookie(): string {
   if (typeof window === 'undefined') return ''
 
+  // Try to retrieve the token from the cookie
+  const cookieToken = getCookie()
+  if (cookieToken) return cookieToken
+
   // Store the token passed to the Vercel environment
   const queryParams = new URLSearchParams(window.location?.search ?? '')
   const queryToken = queryParams.get(VERCEL_PLAYWRIGHT_TOKEN_QUERY_PARAM)
@@ -396,10 +400,6 @@ function getTokenFromEnvOrCookie(): string {
   // Try to retrieve the token from the environment variable
   const envToken = env().VITE_ZOO_API_TOKEN
   if (envToken) return envToken
-
-  // Try to retrieve the token from the cookie
-  const cookieToken = getCookie()
-  if (cookieToken) return cookieToken
 
   // Try to retrieve the token from storage for Playwright
   if (window.localStorage?.getItem(IS_PLAYWRIGHT_KEY) === 'true') {

--- a/src/machines/authMachine.ts
+++ b/src/machines/authMachine.ts
@@ -38,6 +38,7 @@ import { mark, markOnce } from '@src/lib/performance'
 import { withAPIBaseURL } from '@src/lib/withBaseURL'
 import { xstateEventError } from '@src/machines/utils'
 import { assign, fromPromise, setup } from 'xstate'
+import { IS_STAGING_OR_DEBUG } from '@src/routes/utils'
 
 const NO_TOKEN_FOUND_MESSAGE = 'No token found'
 
@@ -391,7 +392,7 @@ function getTokenFromEnvOrCookie(): string {
   // Store the token passed to the Vercel environment
   const queryParams = new URLSearchParams(window.location?.search ?? '')
   const queryToken = queryParams.get(VERCEL_PLAYWRIGHT_TOKEN_QUERY_PARAM)
-  if (queryToken) {
+  if (queryToken && IS_STAGING_OR_DEBUG) {
     window.localStorage?.setItem(TOKEN_PERSIST_KEY, queryToken)
     window.localStorage?.setItem(IS_PLAYWRIGHT_KEY, 'true')
     return queryToken


### PR DESCRIPTION
With this change it will prefer existing auth and limit the query parameter to non-production environments.

See: https://github.com/KittyCAD/modeling-app/security/advisories/GHSA-jfr5-hqx5-63xh