### PR TITLE
Fix web sample project creation

### DIFF
--- a/e2e/playwright/cloud-sync.spec.ts
+++ b/e2e/playwright/cloud-sync.spec.ts
@@ -1,5 +1,6 @@
 import {
   type CloudProject,
+  cloudProjectResponse,
   createRemoteListGate,
   opfsPathExists,
   PROJECT_DIR,
@@ -41,6 +42,66 @@ async function expectCloudSyncHomeReady(page: Page) {
     page.getByRole('heading', { name: /^(Project Libraries|Personal Cloud)$/ })
   ).toBeVisible({ timeout: CLOUD_SYNC_E2E_TIMEOUT })
 }
+
+test(
+  'creates a multi-file sample in Personal Cloud from Home',
+  { tag: ['@web'] },
+  async ({ context, page }, testInfo) => {
+    const createdProject: CloudProject = {
+      id: 'created-sample-project',
+      title: 'Artificial Heart',
+      revision: 'created-sample-rev-1',
+      files: {},
+    }
+    const remoteProjects: CloudProject[] = []
+    const { calls: apiCalls } = await routeCloudProjects(context, {
+      remoteProjects,
+      createProject: () => {
+        remoteProjects.push(createdProject)
+        return createdProject
+      },
+      updateProject: ({ projectId }) => {
+        if (projectId !== createdProject.id) {
+          return undefined
+        }
+
+        createdProject.revision = 'created-sample-rev-2'
+        return { status: 200, body: cloudProjectResponse(createdProject) }
+      },
+    })
+
+    await setup(context, page, testInfo, [OPFS_CLOUD_FEATURE_FLAG])
+    await expectCloudFeatureEnabled(page)
+    await expectCloudSyncHomeReady(page)
+
+    await page.getByTestId('home-create-from-sample').click()
+    await expect(page.getByTestId('cmd-bar-arg-name')).toHaveText('sample')
+    await page
+      .getByRole('option', { name: 'Artificial Heart', exact: true })
+      .click()
+
+    await expect(page).toHaveURL(/artificial-heart%2Fmain\.kcl$/, {
+      timeout: CLOUD_SYNC_E2E_TIMEOUT,
+    })
+    await expect
+      .poll(() => apiCalls.creates.length, {
+        timeout: CLOUD_SYNC_E2E_TIMEOUT,
+      })
+      .toBe(1)
+    await expect
+      .poll(() =>
+        opfsPathExists(page, `${PROJECT_DIR}/artificial-heart/housing.kcl`)
+      )
+      .toBe(true)
+    const files = await readOpfsTextFiles(page, {
+      main: `${PROJECT_DIR}/artificial-heart/main.kcl`,
+    })
+    expect(files.main).toContain('import "housing.kcl" as housing')
+    await expect(
+      page.getByText('Unable to determine the project directory.')
+    ).toHaveCount(0)
+  }
+)
 
 test(
   'streams remote-only projects into an empty local list and materializes opened clones',

--- a/src/lib/commandBarConfigs/applicationCommandConfig.ts
+++ b/src/lib/commandBarConfigs/applicationCommandConfig.ts
@@ -21,10 +21,11 @@ import {
   getEXTNoPeriod,
   getStringAfterLastSeparator,
   joinOSPaths,
-  webSafePathSplit,
+  PATHS,
+  safeEncodeForRouterPaths,
 } from '@src/lib/paths'
 import { getProjectDirectoryOptions } from '@src/lib/projectDisplayName'
-import { reportRejection } from '@src/lib/trap'
+import { reportRejection, trap } from '@src/lib/trap'
 import { isArray, returnSelfOrGetHostNameFromURL } from '@src/lib/utils'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { CommandBarActorType } from '@src/machines/commandBarMachine'
@@ -38,6 +39,7 @@ import {
   GLOBAL_COMMAND_SCOPES,
   HOME_COMMAND_SCOPE,
 } from '@src/registry/contracts/commands'
+import { routerService } from '@src/registry/contracts/router'
 import toast from 'react-hot-toast'
 import type { ActorRefFrom } from 'xstate'
 
@@ -117,6 +119,16 @@ export function createApplicationCommands({
   app: App
   wasmInstance: ModuleType
 }) {
+  const createProjectLibraryTargets = () => app.getCreateProjectLibraryTargets()
+  const createProjectLibraryOptions = () =>
+    createProjectLibraryTargets().map((target) => ({
+      name: target.library.title,
+      value: target.library.id,
+      isCurrent: false,
+    }))
+  const defaultCreateProjectLibraryId = () =>
+    createProjectLibraryOptions()[0]?.value ?? ''
+
   const addKCLFileToProject: Command = {
     scopes: GLOBAL_COMMAND_SCOPES,
     name: 'add-kcl-file-to-project',
@@ -341,14 +353,7 @@ export function createApplicationCommands({
     },
   }
 
-  /**
-   * Looks similar to Add file to project but more data is hard coded for the home page button
-   * to direct the user in a more seamless method.
-   *
-   * This will always create a new folder on disk does not import into existing projects.
-   * Desktop only command for now!
-   */
-  const createASampleDesktopOnly: Command = {
+  const createASample: Command = {
     scopes: [HOME_COMMAND_SCOPE],
     name: 'create-a-sample',
     displayName: 'Create a sample',
@@ -359,10 +364,6 @@ export function createApplicationCommands({
     hideFromSearch: true,
     onSubmit: (data) => {
       if (data) {
-        const folders = app.systemIOActor.getSnapshot().context.folders
-        if (!folders) {
-          return
-        }
         const kclSample = findKclSample(data.sample)
         if (!kclSample) {
           toast.error(
@@ -370,20 +371,46 @@ export function createApplicationCommands({
           )
           return
         }
-        const pathParts = webSafePathSplit(
-          kclSample.pathFromProjectDirectoryToFirstFile
-        )
-        const folderNameBecomesSampleName = pathParts[0]
-        const uniqueNameIfNeeded = getUniqueProjectName(
-          folderNameBecomesSampleName,
-          folders
-        )
-        onSubmitKCLSampleCreation({
-          sample: data.sample,
-          uniqueNameIfNeeded,
-          systemIOActor: app.systemIOActor,
-          isProjectNew: true,
+        const targets = createProjectLibraryTargets()
+        const target =
+          targets.find(({ library }) => library.id === data.libraryId) ??
+          targets[0]
+        if (!target) {
+          toast.error(
+            'Add a writable project library before creating a sample.'
+          )
+          return
+        }
+
+        return downloadKclSample(data.sample, {
+          assetUrlPrefix: isDesktop() ? '.' : '',
         })
+          .then(async ({ requestedProjectName, sample, initialProject }) => {
+            const project = await target.createProject.run({
+              library: target.library,
+              requestedProjectName,
+              requestedProjectTitle: sample.title,
+              initialProject,
+            })
+            if (!project?.default_file) {
+              return Promise.reject(
+                new Error('Unable to create the sample project.')
+              )
+            }
+
+            void app.registry
+              .get(routerService)
+              .navigate(
+                `${PATHS.FILE}/${safeEncodeForRouterPaths(project.default_file)}`
+              )
+          })
+          .catch((error: unknown) => {
+            trap(
+              error instanceof Error
+                ? error
+                : new Error('Unable to create the sample project.')
+            )
+          })
       }
     },
     args: {
@@ -412,6 +439,22 @@ export function createApplicationCommands({
             name: sample.title,
           }
         }),
+      },
+      libraryId: {
+        displayName: 'Library',
+        required: () => createProjectLibraryOptions().length > 1,
+        prepopulate: true,
+        hidden: () => createProjectLibraryOptions().length <= 1,
+        inputType: 'options',
+        options: createProjectLibraryOptions,
+        defaultValue: defaultCreateProjectLibraryId,
+        valueSummary(value) {
+          return (
+            createProjectLibraryOptions().find(
+              (option) => option.value === value
+            )?.name ?? 'Library'
+          )
+        },
       },
     },
   }
@@ -640,7 +683,7 @@ export function createApplicationCommands({
     ...(isDesktop() ? [checkForUpdatesCommand] : []),
     resetLayoutCommand,
     setLayoutCommand,
-    createASampleDesktopOnly,
+    createASample,
     switchEnvironmentsCommand,
     overrideEngineCommand,
     overrideZookeeperCommand,

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -49,6 +49,7 @@ import {
 } from '@src/machines/systemIO/hooks'
 import { SystemIOMachineStates } from '@src/machines/systemIO/utils'
 import type { WebContentSendPayload } from '@src/menu/channels'
+import { HOME_COMMAND_SCOPE } from '@src/registry/contracts/commands'
 import {
   type HomeProjectActionsService,
   type HomeProjectEntry,
@@ -56,7 +57,6 @@ import {
   homeProjectEntriesValueSpec,
 } from '@src/registry/contracts/homeProjects'
 import { homeSidebarItemsValueSpec } from '@src/registry/contracts/homeSidebar'
-import { HOME_COMMAND_SCOPE } from '@src/registry/contracts/commands'
 import {
   findKeymapItemForCommand,
   keymapKeystrokesDisplay,
@@ -685,6 +685,9 @@ const Home = () => {
                       name: 'create-a-sample',
                       argDefaultValues: {
                         source: 'kcl-samples',
+                        ...(selectedProjectLibrary
+                          ? { libraryId: selectedProjectLibrary.id }
+                          : {}),
                       },
                     },
                   })


### PR DESCRIPTION
Bug: 
- "Create from a sample" 
- select a project
-> "Unable to determine the project directory."

Codex:
The Home “Create from a sample” button still uses the legacy SystemIO workflow:
- [Home.tsx](/Users/andrewvarga/projects/zoo/modeling-app/src/routes/Home.tsx) invokes create-a-sample.
- [applicationCommandConfig.ts](/Users/andrewvarga/projects/zoo/modeling-app/src/lib/commandBarConfigs/applicationCommandConfig.ts) sends bulk files directly to SystemIO.
- On web, Personal Cloud replaces the default directory library. Consequently, [SystemIOMachineLogicListener.tsx](/Users/andrewvarga/projects/zoo/modeling-app/src/components/SystemIOMachineLogicListener.tsx) sets projectDirectoryPath to ''.
- Multi-file samples then hit [systemIOMachineImpl.ts](/Users/andrewvarga/projects/zoo/modeling-app/src/machines/systemIO/systemIOMachineImpl.ts), which produces the exact “Unable to determine the project directory.” error.
Desktop works because it retains a directory-backed library.
The correct pattern already exists for sample links in [useQueryParamEffects.ts](/Users/andrewvarga/projects/zoo/modeling-app/src/hooks/useQueryParamEffects.ts): download the sample, call the selected project library’s createProject operation with initialProject, then navigate to its returned default file.
Recommended fix: migrate the Home command to that library-aware flow and pass the currently selected library ID. Avoid adding a SystemIO fallback, since that could bypass cloud materialization and sync enrollment.