### PR TITLE
Issue 3972: lazy-loading support for attachments fetching during replay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@csstools/postcss-oklab-function": "^4.0.12",
         "@headlessui/react": "^1.7.19",
         "@headlessui/tailwindcss": "^0.2.2",
-        "@kittycad/lib": "^4.4.2",
+        "@kittycad/lib": "^4.4.7",
         "@lezer/highlight": "^1.2.1",
         "@lezer/lr": "^1.4.10",
         "@microlink/react-json-view": "^1.31.28",
@@ -9301,18 +9301,18 @@
       "link": true
     },
     "node_modules/@kittycad/kcl-wasm-lib": {
-      "version": "0.1.179",
-      "resolved": "https://registry.npmjs.org/@kittycad/kcl-wasm-lib/-/kcl-wasm-lib-0.1.179.tgz",
-      "integrity": "sha512-ddp4j6rs7H+xWmWDS3L4KP3NoZRquyzf+FpAEjDxh+HIIR8CwQZ77b34YbZa/FSIzZMx4ZaRg6ilJ6ldlKVmSQ==",
+      "version": "0.1.181",
+      "resolved": "https://registry.npmjs.org/@kittycad/kcl-wasm-lib/-/kcl-wasm-lib-0.1.181.tgz",
+      "integrity": "sha512-9AtdDbjVHW1uryaJlEKI9/jnQNYHk9NoTEPLGuErkmHxzR+bRTxhsrliQA8ITwkNSYkCtqCzq0LfcCY8a0JrkA==",
       "license": "MIT"
     },
     "node_modules/@kittycad/lib": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@kittycad/lib/-/lib-4.4.2.tgz",
-      "integrity": "sha512-lsLvmHY1BaOSBllx1jbskUk7o7ws3TMJUJLBSO2i7E9fehXuGsK3qgW8qHQvXVDr381HOftUGYcUdpHM95N8ew==",
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/@kittycad/lib/-/lib-4.4.7.tgz",
+      "integrity": "sha512-geAhfMJpwY0ToyzBHtyUVQ0Bh6c9GLgYCogGylEvZ8Ejecp2iW3Dt63ob7TZssF5KAMjlcd75wpoK3yicNFarA==",
       "license": "MIT",
       "dependencies": {
-        "@kittycad/kcl-wasm-lib": "0.1.179",
+        "@kittycad/kcl-wasm-lib": "0.1.181",
         "@kittycad/oauth2-auth-code-pkce": "^4.0.0",
         "@msgpack/msgpack": "^3.1.3",
         "bson": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@csstools/postcss-oklab-function": "^4.0.12",
     "@headlessui/react": "^1.7.19",
     "@headlessui/tailwindcss": "^0.2.2",
-    "@kittycad/lib": "^4.4.2",
+    "@kittycad/lib": "^4.4.7",
     "@lezer/highlight": "^1.2.1",
     "@lezer/lr": "^1.4.10",
     "@microlink/react-json-view": "^1.31.28",

--- a/src/components/ExchangeCard.test.tsx
+++ b/src/components/ExchangeCard.test.tsx
@@ -1,0 +1,114 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { ExchangeCard } from '@src/components/ExchangeCard'
+import { describe, expect, test, vi } from 'vitest'
+
+describe('ExchangeCard replay attachments', () => {
+  const attachmentRef = {
+    prompt_id: '00000000-0000-4000-8000-000000000001',
+    seq: 3,
+    index: 1,
+  }
+  const attachmentKey = `${attachmentRef.prompt_id}:${attachmentRef.seq}:${attachmentRef.index}`
+
+  const exchangeProps = {
+    request: {
+      type: 'user' as const,
+      content: 'Use this reference',
+      additional_files: [
+        {
+          name: 'reference.png',
+          mimetype: 'image/png',
+          data: [],
+          attachment_ref: attachmentRef,
+        },
+      ],
+    },
+    responses: [],
+    deltasAggregated: '',
+    isLastResponse: true,
+    onClickClearChat: vi.fn(),
+  }
+
+  test('requests replay attachment bytes and shows its loading state', () => {
+    const onFetchAttachment = vi.fn()
+    const { rerender } = render(
+      <ExchangeCard {...exchangeProps} onFetchAttachment={onFetchAttachment} />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /reference\.png/ }))
+    expect(onFetchAttachment).toHaveBeenCalledOnce()
+    expect(onFetchAttachment).toHaveBeenCalledWith(attachmentRef)
+
+    rerender(
+      <ExchangeCard
+        {...exchangeProps}
+        onFetchAttachment={onFetchAttachment}
+        attachmentFetches={{
+          [attachmentKey]: { status: 'loading' },
+        }}
+      />
+    )
+
+    expect(
+      screen.getByRole('button', { name: /reference\.png Loading…/ })
+    ).toBeDisabled()
+
+    rerender(
+      <ExchangeCard
+        {...exchangeProps}
+        onFetchAttachment={onFetchAttachment}
+        attachmentFetches={{
+          [attachmentKey]: {
+            status: 'loaded',
+            file: {
+              ...exchangeProps.request.additional_files[0],
+              data: [1, 2, 3],
+            },
+          },
+        }}
+      />
+    )
+
+    expect(screen.queryByRole('button', { name: /reference\.png/ })).toBeNull()
+    expect(screen.getByText('Loaded')).toBeInTheDocument()
+  })
+
+  test('renders a metadata-only server file without a reasoning message', () => {
+    const onFetchAttachment = vi.fn()
+
+    render(
+      <ExchangeCard
+        {...exchangeProps}
+        request={{
+          type: 'user',
+          content: 'Create a reference image',
+          additional_files: [],
+        }}
+        responses={[
+          {
+            files: {
+              files: [
+                {
+                  name: 'generated.png',
+                  mimetype: 'image/png',
+                  data: [],
+                  attachment_ref: attachmentRef,
+                },
+              ],
+            },
+          },
+        ]}
+        onFetchAttachment={onFetchAttachment}
+      />
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'generated.png: Load attachment',
+      })
+    )
+
+    expect(onFetchAttachment).toHaveBeenCalledOnce()
+    expect(onFetchAttachment).toHaveBeenCalledWith(attachmentRef)
+  })
+})

--- a/src/components/ExchangeCard.tsx
+++ b/src/components/ExchangeCard.tsx
@@ -1,4 +1,4 @@
-import type { MlCopilotServerMessage } from '@kittycad/lib'
+import type { AttachmentRef, MlCopilotServerMessage } from '@kittycad/lib'
 import { CustomIcon } from '@src/components/CustomIcon'
 import { MarkdownText } from '@src/components/MarkdownText'
 import { PlaceholderLine } from '@src/components/PlaceholderLine'
@@ -10,7 +10,9 @@ import {
 import Tooltip from '@src/components/Tooltip'
 import {
   type Exchange,
+  getZookeeperAttachmentKey,
   isMlCopilotUserRequest,
+  type ZookeeperAttachmentFetchState,
 } from '@src/lib/zookeeper/zookeeperManagerMachine'
 import ms from 'ms'
 import {
@@ -26,6 +28,8 @@ export type ExchangeCardProps = Exchange & {
   userAvatar?: string
   onClickClearChat: () => void
   isLastResponse: boolean
+  attachmentFetches?: Record<string, ZookeeperAttachmentFetchState>
+  onFetchAttachment?: (attachmentRef: AttachmentRef) => void
 }
 
 type MlCopilotServerMessageError = Extract<
@@ -146,6 +150,8 @@ export const ResponseCardToolBar = (props: {
 
 export const ExchangeCardStatus = (props: {
   responses?: MlCopilotServerMessage[]
+  attachmentFetches?: Record<string, ZookeeperAttachmentFetchState>
+  onFetchAttachment?: (attachmentRef: AttachmentRef) => void
   onlyShowImmediateThought: boolean
   startedAt: Date
   updatedAt?: Date
@@ -156,6 +162,8 @@ export const ExchangeCardStatus = (props: {
     <Thinking
       thoughts={props.responses}
       isDone={props.responses?.some((m) => 'delta' in m) || false}
+      attachmentFetches={props.attachmentFetches}
+      onFetchAttachment={props.onFetchAttachment}
       onlyShowImmediateThought={props.onlyShowImmediateThought}
     />
   )
@@ -234,6 +242,8 @@ export const AvatarUser = (props: { src?: string }) => {
 
 type RequestCardProps = Exchange['request'] & {
   userAvatar?: ReactNode
+  attachmentFetches?: Record<string, ZookeeperAttachmentFetchState>
+  onFetchAttachment?: (attachmentRef: AttachmentRef) => void
 }
 
 const MAX_VISIBLE_ATTACHMENTS = 2
@@ -309,15 +319,54 @@ export const RequestCard = (props: RequestCardProps) => {
             <div className="w-full text-right text-xs font-medium text-chalkboard-70 dark:text-chalkboard-40">
               Attachments
             </div>
-            {visibleAttachments.map((file, index) => (
-              <div
-                key={`${file.name}-${index}`}
-                className="flex items-center gap-1 rounded-sm border border-chalkboard-30 dark:border-chalkboard-70 px-2 py-1 text-xs"
-              >
-                <CustomIcon name="paperclip" className="w-3 h-3 shrink-0" />
-                <span className="min-w-0 truncate">{file.name}</span>
-              </div>
-            ))}
+            {visibleAttachments.map((file, index) => {
+              const attachmentRef = file.attachment_ref
+              const fetchState = attachmentRef
+                ? props.attachmentFetches?.[
+                    getZookeeperAttachmentKey(attachmentRef)
+                  ]
+                : undefined
+              const canFetch =
+                file.data.length === 0 &&
+                attachmentRef !== undefined &&
+                props.onFetchAttachment !== undefined &&
+                fetchState?.status !== 'loaded'
+
+              const contents = (
+                <>
+                  <CustomIcon name="paperclip" className="w-3 h-3 shrink-0" />
+                  <span className="min-w-0 truncate">{file.name}</span>
+                  {fetchState?.status === 'loading' && (
+                    <span className="text-chalkboard-70 dark:text-chalkboard-40">
+                      Loading…
+                    </span>
+                  )}
+                  {fetchState?.status === 'loaded' && (
+                    <span className="text-chalkboard-70 dark:text-chalkboard-40">
+                      Loaded
+                    </span>
+                  )}
+                </>
+              )
+              const className =
+                'flex items-center gap-1 rounded-sm border border-chalkboard-30 dark:border-chalkboard-70 px-2 py-1 text-xs'
+
+              return canFetch ? (
+                <button
+                  type="button"
+                  key={`${file.name}-${index}`}
+                  className={className}
+                  disabled={fetchState?.status === 'loading'}
+                  onClick={() => props.onFetchAttachment?.(attachmentRef)}
+                >
+                  {contents}
+                </button>
+              ) : (
+                <div key={`${file.name}-${index}`} className={className}>
+                  {contents}
+                </div>
+              )
+            })}
             {hasHiddenAttachments && (
               <button
                 type="button"
@@ -348,6 +397,8 @@ type ResponsesCardProp = {
   deltasAggregated: Exchange['deltasAggregated']
   isLastResponse: boolean
   onClickClearChat: () => void
+  attachmentFetches?: Record<string, ZookeeperAttachmentFetchState>
+  onFetchAttachment?: (attachmentRef: AttachmentRef) => void
 }
 
 const MaybeError = (props: { maybeError?: MlCopilotServerMessageError }) =>
@@ -408,7 +459,12 @@ export const ResponsesCard = (props: ResponsesCardProp) => {
     maybeError ? <MaybeError key="error" maybeError={maybeError} /> : null,
     deltasAggregatedMarkdown,
     exportDownloadFiles.length > 0 ? (
-      <ExportDownloadFiles key="downloads" files={exportDownloadFiles} />
+      <ExportDownloadFiles
+        key="downloads"
+        files={exportDownloadFiles}
+        attachmentFetches={props.attachmentFetches}
+        onFetchAttachment={props.onFetchAttachment}
+      />
     ) : null,
   ].filter((x: ReactNode) => x !== null)
 
@@ -506,7 +562,12 @@ export const ExchangeCard = (props: ExchangeCardProps) => {
 
   const maybeError = props.responses.filter((r) => 'error' in r)[0]
 
-  const reasoningThoughts = props.responses.filter((r) => 'reasoning' in r)
+  const hasReasoningContent = props.responses.some(
+    (response) =>
+      'reasoning' in response ||
+      ('files' in response &&
+        response.files.files.some((file) => !isExportDownloadFile(file)))
+  )
 
   return (
     <div className={cssCard}>
@@ -517,19 +578,23 @@ export const ExchangeCard = (props: ExchangeCardProps) => {
         <RequestCard
           {...props.request}
           userAvatar={<AvatarUser src={props.userAvatar} />}
+          attachmentFetches={props.attachmentFetches}
+          onFetchAttachment={props.onFetchAttachment}
         />
       )}
-      {showFullReasoning && reasoningThoughts.length > 0 && (
+      {showFullReasoning && hasReasoningContent && (
         <div>
           <ExchangeCardStatus
             responses={props.responses}
+            attachmentFetches={props.attachmentFetches}
+            onFetchAttachment={props.onFetchAttachment}
             onlyShowImmediateThought={false}
             startedAt={startedAt}
             updatedAt={updatedAt}
           />
         </div>
       )}
-      {reasoningThoughts.length > 0 && (
+      {hasReasoningContent && (
         <div
           tabIndex={0}
           role="button"
@@ -551,6 +616,8 @@ export const ExchangeCard = (props: ExchangeCardProps) => {
             <ExchangeCardStatus
               maybeError={maybeError}
               responses={props.responses}
+              attachmentFetches={props.attachmentFetches}
+              onFetchAttachment={props.onFetchAttachment}
               onlyShowImmediateThought={true}
               startedAt={startedAt}
               updatedAt={updatedAt}
@@ -563,6 +630,8 @@ export const ExchangeCard = (props: ExchangeCardProps) => {
         deltasAggregated={props.deltasAggregated}
         isLastResponse={props.isLastResponse}
         onClickClearChat={props.onClickClearChat}
+        attachmentFetches={props.attachmentFetches}
+        onFetchAttachment={props.onFetchAttachment}
       />
     </div>
   )

--- a/src/components/Thinking.spec.tsx
+++ b/src/components/Thinking.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
 import type { MlCopilotFile, MlCopilotServerMessage } from '@kittycad/lib'
@@ -71,6 +71,69 @@ describe('FilesSnapshot', () => {
     ).not.toBeInTheDocument()
 
     expect(createObjectURLMock).not.toHaveBeenCalled()
+  })
+
+  test('fetches a metadata-only attachment before rendering its contents', () => {
+    const attachmentRef = {
+      prompt_id: '00000000-0000-4000-8000-000000000001',
+      seq: 3,
+      index: 1,
+      content_hash:
+        'sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+    }
+    const attachmentKey = `${attachmentRef.prompt_id}:${attachmentRef.seq}:${attachmentRef.index}`
+    const files: MlCopilotFile[] = [
+      {
+        name: 'reference.png',
+        mimetype: 'image/png',
+        data: [],
+        attachment_ref: attachmentRef,
+      },
+    ]
+    const onFetchAttachment = vi.fn()
+    const { rerender } = render(
+      <FilesSnapshot files={files} onFetchAttachment={onFetchAttachment} />
+    )
+
+    expect(createObjectURLMock).not.toHaveBeenCalled()
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'reference.png: Load attachment',
+      })
+    )
+    expect(onFetchAttachment).toHaveBeenCalledOnce()
+    expect(onFetchAttachment).toHaveBeenCalledWith(attachmentRef)
+
+    rerender(
+      <FilesSnapshot
+        files={files}
+        attachmentFetches={{
+          [attachmentKey]: { status: 'loading' },
+        }}
+        onFetchAttachment={onFetchAttachment}
+      />
+    )
+    expect(
+      screen.getByRole('button', {
+        name: 'reference.png: Loading attachment',
+      })
+    ).toBeDisabled()
+
+    rerender(
+      <FilesSnapshot
+        files={files}
+        attachmentFetches={{
+          [attachmentKey]: {
+            status: 'loaded',
+            file: { ...files[0], data: MOCK_PNG_DATA },
+          },
+        }}
+        onFetchAttachment={onFetchAttachment}
+      />
+    )
+
+    expect(screen.getByAltText('reference.png')).toBeInTheDocument()
+    expect(createObjectURLMock).toHaveBeenCalledOnce()
   })
 
   test('renders a single image file with correct filename', () => {

--- a/src/components/Thinking.tsx
+++ b/src/components/Thinking.tsx
@@ -1,11 +1,26 @@
 import ms from 'ms'
 
-import type { MlCopilotFile, MlCopilotServerMessage } from '@kittycad/lib'
+import type {
+  AttachmentRef,
+  MlCopilotFile,
+  MlCopilotServerMessage,
+} from '@kittycad/lib'
 import type { PlanStep } from '@kittycad/lib'
 import { CustomIcon } from '@src/components/CustomIcon'
 import { MarkdownText } from '@src/components/MarkdownText'
 import { PlaceholderLine } from '@src/components/PlaceholderLine'
-import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react'
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import {
+  getZookeeperAttachmentKey,
+  type ZookeeperAttachmentFetchState,
+} from '@src/lib/zookeeper/zookeeperManagerMachine'
 
 interface IRowCollapse {
   fn: () => void
@@ -417,6 +432,42 @@ const UnavailableFileItem = (props: { file: MlCopilotFile }) => {
   )
 }
 
+type AttachmentFetchProps = {
+  attachmentFetches?: Record<string, ZookeeperAttachmentFetchState>
+  onFetchAttachment?: (attachmentRef: AttachmentRef) => void
+}
+
+const AttachmentFetchItem = (props: {
+  file: MlCopilotFile
+  attachmentRef: AttachmentRef
+  fetchState?: ZookeeperAttachmentFetchState
+  onFetchAttachment?: (attachmentRef: AttachmentRef) => void
+}) => {
+  const isLoading = props.fetchState?.status === 'loading'
+  const isError = props.fetchState?.status === 'error'
+  const action = isLoading
+    ? 'Loading attachment'
+    : isError
+      ? 'Retry attachment'
+      : 'Load attachment'
+
+  return (
+    <button
+      type="button"
+      className="flex w-full flex-row items-center gap-2 rounded p-2 text-left transition-colors hover:bg-chalkboard-20 disabled:cursor-default disabled:hover:bg-transparent dark:hover:bg-chalkboard-90"
+      aria-label={`${props.file.name}: ${action}`}
+      disabled={isLoading || props.onFetchAttachment === undefined}
+      onClick={() => props.onFetchAttachment?.(props.attachmentRef)}
+    >
+      <CustomIcon name="file" className="h-5 w-5 flex-shrink-0" />
+      <span className="min-w-0 flex-1 truncate text-sm">{props.file.name}</span>
+      <span className="flex-shrink-0 text-xs text-chalkboard-70 dark:text-chalkboard-40">
+        {isLoading ? 'Loading…' : isError ? 'Retry' : 'Load'}
+      </span>
+    </button>
+  )
+}
+
 /**
  * Component for displaying an image file with error handling
  */
@@ -465,13 +516,26 @@ const ImageFileItem = (props: {
   )
 }
 
-const FileList = (props: { files: MlCopilotFile[] }) => {
+const FileList = (props: { files: MlCopilotFile[] } & AttachmentFetchProps) => {
   const [objectUrls, setObjectUrls] = useState<Array<string | undefined>>([])
+
+  const resolvedFiles = useMemo(
+    () =>
+      props.files.map((file) => {
+        const attachmentRef = file.attachment_ref
+        if (!attachmentRef) return file
+
+        const fetchState =
+          props.attachmentFetches?.[getZookeeperAttachmentKey(attachmentRef)]
+        return fetchState?.status === 'loaded' ? fetchState.file : file
+      }),
+    [props.attachmentFetches, props.files]
+  )
 
   useEffect(() => {
     // Create object URLs for all files
-    const urls = props.files.map((file) =>
-      isReplayAttachmentUnavailable(file)
+    const urls = resolvedFiles.map((file) =>
+      isReplayAttachmentUnavailable(file) || file.data.length === 0
         ? undefined
         : bytesToDataUrl(file.data, file.mimetype)
     )
@@ -485,7 +549,7 @@ const FileList = (props: { files: MlCopilotFile[] }) => {
         }
       })
     }
-  }, [props.files])
+  }, [resolvedFiles])
 
   const handleDownload = (url: string, filename: string) => {
     const link = document.createElement('a')
@@ -496,23 +560,46 @@ const FileList = (props: { files: MlCopilotFile[] }) => {
     document.body.removeChild(link)
   }
 
-  const imageFiles = props.files.filter((file) =>
+  const fileItems = resolvedFiles.map((file, index) => ({ file, index }))
+  const imageFiles = fileItems.filter(({ file }) =>
     isImageMimetype(file.mimetype)
   )
-  const otherFiles = props.files.filter(
-    (file) => !isImageMimetype(file.mimetype)
+  const otherFiles = fileItems.filter(
+    ({ file }) => !isImageMimetype(file.mimetype)
   )
+
+  const attachmentFetchItem = (index: number) => {
+    const originalFile = props.files[index]
+    const attachmentRef = originalFile.attachment_ref
+    if (!attachmentRef || originalFile.data.length > 0) return null
+
+    const fetchState =
+      props.attachmentFetches?.[getZookeeperAttachmentKey(attachmentRef)]
+    if (fetchState?.status === 'loaded') return null
+
+    return (
+      <AttachmentFetchItem
+        key={`${originalFile.name}-${index}`}
+        file={originalFile}
+        attachmentRef={attachmentRef}
+        fetchState={fetchState}
+        onFetchAttachment={props.onFetchAttachment}
+      />
+    )
+  }
 
   return (
     <div className="flex max-w-full min-w-0 flex-col gap-3">
-      {imageFiles.map((file, index) => {
+      {imageFiles.map(({ file, index }) => {
         if (isReplayAttachmentUnavailable(file)) {
           return (
             <UnavailableFileItem key={`${file.name}-${index}`} file={file} />
           )
         }
-        const fileIndex = props.files.indexOf(file)
-        const url = objectUrls[fileIndex]
+        const fetchItem = attachmentFetchItem(index)
+        if (fetchItem) return fetchItem
+
+        const url = objectUrls[index]
         return (
           <ImageFileItem
             key={`${file.name}-${index}`}
@@ -522,14 +609,16 @@ const FileList = (props: { files: MlCopilotFile[] }) => {
           />
         )
       })}
-      {otherFiles.map((file, index) => {
+      {otherFiles.map(({ file, index }) => {
         if (isReplayAttachmentUnavailable(file)) {
           return (
             <UnavailableFileItem key={`${file.name}-${index}`} file={file} />
           )
         }
-        const fileIndex = props.files.indexOf(file)
-        const url = objectUrls[fileIndex]
+        const fetchItem = attachmentFetchItem(index)
+        if (fetchItem) return fetchItem
+
+        const url = objectUrls[index]
         return (
           <button
             key={`${file.name}-${index}`}
@@ -550,7 +639,9 @@ const FileList = (props: { files: MlCopilotFile[] }) => {
   )
 }
 
-export const FilesSnapshot = (props: { files: MlCopilotFile[] }) => {
+export const FilesSnapshot = (
+  props: { files: MlCopilotFile[] } & AttachmentFetchProps
+) => {
   return (
     <ThoughtContainer
       heading={
@@ -563,19 +654,29 @@ export const FilesSnapshot = (props: { files: MlCopilotFile[] }) => {
     >
       {/* Using a custom content wrapper without height restriction for images */}
       <div className="min-w-0 max-w-full pt-4 pb-4 border-l pl-5 ml-3 b-3">
-        <FileList files={props.files} />
+        <FileList
+          files={props.files}
+          attachmentFetches={props.attachmentFetches}
+          onFetchAttachment={props.onFetchAttachment}
+        />
       </div>
     </ThoughtContainer>
   )
 }
 
-export const ExportDownloadFiles = (props: { files: MlCopilotFile[] }) => {
+export const ExportDownloadFiles = (
+  props: { files: MlCopilotFile[] } & AttachmentFetchProps
+) => {
   return (
     <div
       className="mt-3 min-w-0 max-w-full rounded-sm border b-4"
       data-testid="ml-response-download-files"
     >
-      <FileList files={props.files} />
+      <FileList
+        files={props.files}
+        attachmentFetches={props.attachmentFetches}
+        onFetchAttachment={props.onFetchAttachment}
+      />
     </div>
   )
 }
@@ -591,7 +692,7 @@ const fromDataToComponent = (
     key?: string | number
     setAnyRowCollapse: React.Dispatch<React.SetStateAction<IRowCollapse[]>>
     keyIndex: number
-  }
+  } & AttachmentFetchProps
 ) => {
   if ('reasoning' in thought) {
     const type = thought.reasoning.type
@@ -771,18 +872,25 @@ const fromDataToComponent = (
       (file) => !isExportDownloadFile(file)
     )
     return reasoningFiles.length > 0 ? (
-      <FilesSnapshot key={options.key} files={reasoningFiles} />
+      <FilesSnapshot
+        key={options.key}
+        files={reasoningFiles}
+        attachmentFetches={options.attachmentFetches}
+        onFetchAttachment={options.onFetchAttachment}
+      />
     ) : null
   }
 
   return null
 }
 
-export const Thinking = (props: {
-  thoughts?: MlCopilotServerMessage[]
-  isDone: boolean
-  onlyShowImmediateThought: boolean
-}) => {
+export const Thinking = (
+  props: {
+    thoughts?: MlCopilotServerMessage[]
+    isDone: boolean
+    onlyShowImmediateThought: boolean
+  } & AttachmentFetchProps
+) => {
   const refViewFull = useRef<HTMLDivElement>(null)
   const isProgrammaticScrollRef = useRef(false)
   const userHasInteractedWithPaneRef = useRef(false)
@@ -870,6 +978,8 @@ export const Thinking = (props: {
       key: index,
       setAnyRowCollapse,
       keyIndex: index,
+      attachmentFetches: props.attachmentFetches,
+      onFetchAttachment: props.onFetchAttachment,
     })
   })
 

--- a/src/lib/zookeeper/components/ZookeeperConversation.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversation.tsx
@@ -1,5 +1,5 @@
 import { Popover } from '@headlessui/react'
-import type { MlCopilotAccessDeniedCode } from '@kittycad/lib'
+import type { AttachmentRef, MlCopilotAccessDeniedCode } from '@kittycad/lib'
 import { ActionButton } from '@src/components/ActionButton'
 import { ConnectionRecovery } from '@src/components/ConnectionRecovery'
 import { CustomIcon } from '@src/components/CustomIcon'
@@ -20,6 +20,7 @@ import {
   isResponseComplete,
   type MlCopilotModeId,
   type MlCopilotModeOption,
+  type ZookeeperAttachmentFetchState,
 } from '@src/lib/zookeeper/zookeeperManagerMachine'
 import type { Selections } from '@src/machines/modelingSharedTypes'
 import {
@@ -82,6 +83,8 @@ export interface ZookeeperConversationProps {
   onSteer: (id: string) => void
   modeOptions?: MlCopilotModeOption[]
   modeScopeKey?: string
+  attachmentFetches?: Record<string, ZookeeperAttachmentFetchState>
+  onFetchAttachment?: (attachmentRef: AttachmentRef) => void
 }
 
 const getModeOption = (
@@ -676,6 +679,8 @@ export const ZookeeperConversation = (props: ZookeeperConversationProps) => {
           userAvatar={props.userAvatarSrc}
           isLastResponse={isLastResponse}
           onClickClearChat={isLastResponse ? props.onClickClearChat : noop}
+          attachmentFetches={props.attachmentFetches}
+          onFetchAttachment={props.onFetchAttachment}
         />
       )
     }

--- a/src/lib/zookeeper/components/ZookeeperConversationPane.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPane.tsx
@@ -133,6 +133,10 @@ export const ZookeeperConversationPane = (props: {
     props.zookeeperManagerActor,
     (actor) => actor.context.attachmentsLoadedForCurrentPrompt
   )
+  const attachmentFetches = useSelector(
+    props.zookeeperManagerActor,
+    (actor) => actor.context.attachmentFetches
+  )
   const defaultMode = useSelector(props.zookeeperManagerActor, (actor) => {
     return actor.context.defaultMode
   })
@@ -737,6 +741,13 @@ export const ZookeeperConversationPane = (props: {
         { type: 'selections', data: props.contextModeling.selectionRanges },
       ]}
       conversation={conversation}
+      attachmentFetches={attachmentFetches}
+      onFetchAttachment={(attachmentRef) => {
+        props.zookeeperManagerActor.send({
+          type: ZookeeperManagerTransitions.AttachmentFetch,
+          attachmentRef,
+        })
+      }}
       welcomeMessage={
         // Replace this local component with a remote-authored content source
         // later. `ZookeeperConversation` already handles placement and ordering.

--- a/src/lib/zookeeper/zookeeperManagerMachine.test.ts
+++ b/src/lib/zookeeper/zookeeperManagerMachine.test.ts
@@ -1,9 +1,14 @@
-import type { ClientErrorReport } from '@kittycad/lib'
+import type {
+  AttachmentRef,
+  ClientErrorReport,
+  MlCopilotFile,
+} from '@kittycad/lib'
 import { resetReportedClientErrorsForTests } from '@src/lib/clientErrors'
 import type { FileMeta } from '@src/lib/types'
 import {
   type Conversation,
   createZookeeperCorrelation,
+  getZookeeperAttachmentKey,
   hasBeenInterruptedOnLast,
   type MlCopilotModeOption,
   NUMBER_OF_ZOOKEEPER_SETUP_ATTEMPTS,
@@ -1395,6 +1400,129 @@ describe('zookeeperManagerMachine', () => {
       expect(setupContext?.cachedSetup?.activeExchangeStartedAt).toBe(
         completedConversationStartedAt
       )
+
+      actor.stop()
+    })
+  })
+
+  describe('attachment fetching', () => {
+    const attachmentRef: AttachmentRef = {
+      prompt_id: '00000000-0000-4000-8000-000000000001',
+      seq: 3,
+      index: 1,
+      content_hash:
+        'sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+    }
+
+    const loadedFile: MlCopilotFile = {
+      name: 'reference.png',
+      mimetype: 'image/png',
+      data: [1, 2, 3],
+      attachment_ref: attachmentRef,
+    }
+
+    const createReadyActor = async () => {
+      const ws: TestWebSocket = new TestSocket() as TestWebSocket
+      ws.readyState = WebSocket.OPEN
+      const machine = zookeeperManagerMachine.provide({
+        actors: {
+          [ZookeeperManagerStates.Setup]: fromPromise<
+            Partial<ZookeeperManagerContext>,
+            SetupActorInput
+          >(async () => ({
+            ws,
+            conversation: completedConversation,
+            conversationId: 'conversation-id',
+          })),
+        },
+      })
+      const actor = createActor(machine, {
+        input: { apiToken: 'token' },
+      }).start()
+
+      actor.send({
+        type: ZookeeperManagerTransitions.CacheSetupAndConnect,
+        refParentSend: vi.fn(),
+      })
+      await waitFor(actor, (state) =>
+        state.matches(ZookeeperManagerStates.WaitForContinueCheck)
+      )
+
+      actor.send({
+        type: ZookeeperManagerStates.ContinueCheck,
+        projectName: 'zoo-project',
+        projectFiles: [],
+      })
+      await waitFor(actor, (state) =>
+        state.matches(ZookeeperManagerStates.Ready)
+      )
+
+      return { actor, ws }
+    }
+
+    it('requests an attachment once and records its loading state', async () => {
+      const { actor, ws } = await createReadyActor()
+
+      actor.send({
+        type: ZookeeperManagerTransitions.AttachmentFetch,
+        attachmentRef,
+      })
+      actor.send({
+        type: ZookeeperManagerTransitions.AttachmentFetch,
+        attachmentRef,
+      })
+
+      expect(ws.sentPayloads).toHaveLength(1)
+      expect(JSON.parse(ws.sentPayloads[0])).toEqual({
+        type: 'fetch_attachments',
+        prompt_id: attachmentRef.prompt_id,
+        seq: attachmentRef.seq,
+        indices: [attachmentRef.index],
+      })
+      expect(
+        actor.getSnapshot().context.attachmentFetches[
+          getZookeeperAttachmentKey(attachmentRef)
+        ]
+      ).toEqual({ status: 'loading' })
+
+      actor.stop()
+    })
+
+    it('stores fetched bytes without changing conversation state', async () => {
+      const { actor } = await createReadyActor()
+      const before = actor.getSnapshot().context
+
+      actor.send({
+        type: ZookeeperManagerTransitions.AttachmentFetch,
+        attachmentRef,
+      })
+      actor.send({
+        type: ZookeeperManagerTransitions.ResponseReceive,
+        response: {
+          attachments: {
+            prompt_id: attachmentRef.prompt_id,
+            seq: attachmentRef.seq,
+            role: 'client',
+            files: [loadedFile],
+          },
+        },
+      })
+
+      await waitFor(
+        actor,
+        (state) =>
+          state.context.attachmentFetches[
+            getZookeeperAttachmentKey(attachmentRef)
+          ]?.status === 'loaded'
+      )
+
+      const after = actor.getSnapshot().context
+      expect(
+        after.attachmentFetches[getZookeeperAttachmentKey(attachmentRef)]
+      ).toEqual({ status: 'loaded', file: loadedFile })
+      expect(after.conversation).toBe(before.conversation)
+      expect(after.lastMessageId).toBe(before.lastMessageId)
+      expect(after.awaitingResponse).toBe(before.awaitingResponse)
 
       actor.stop()
     })

--- a/src/lib/zookeeper/zookeeperManagerMachine.ts
+++ b/src/lib/zookeeper/zookeeperManagerMachine.ts
@@ -1,4 +1,5 @@
 import type {
+  AttachmentRef,
   MlCopilotAccessDeniedCode,
   MlCopilotClientMessage,
   MlCopilotFile,
@@ -238,6 +239,7 @@ export enum ZookeeperManagerTransitions {
   CacheSetupAndConnect = 'cache-setup-and-connect',
   BackendShutdown = 'backend-shutdown',
   SetupProgress = 'setup-progress',
+  AttachmentFetch = 'attachment-fetch',
 }
 
 export const NUMBER_OF_ZOOKEEPER_SETUP_ATTEMPTS = 3
@@ -407,6 +409,10 @@ export type ZookeeperManagerEvents =
   | {
       type: ZookeeperManagerTransitions.SetupProgress
     }
+  | {
+      type: ZookeeperManagerTransitions.AttachmentFetch
+      attachmentRef: AttachmentRef
+    }
 
 export interface Exchange {
   // Technically the WebSocket could send us a response at any time, without
@@ -432,6 +438,16 @@ export type Conversation = {
   exchanges: Exchange[]
 }
 
+export type ZookeeperAttachmentFetchState =
+  | { status: 'loading' }
+  | { status: 'loaded'; file: MlCopilotFile }
+  | { status: 'error'; message: string }
+
+export const getZookeeperAttachmentKey = (
+  attachmentRef: AttachmentRef
+): string =>
+  `${attachmentRef.prompt_id}:${attachmentRef.seq}:${attachmentRef.index}`
+
 export interface ZookeeperManagerContext {
   apiToken: string
   ws?: WebSocket
@@ -449,6 +465,7 @@ export interface ZookeeperManagerContext {
   projectNameCurrentlyOpened?: string
   awaitingResponse: boolean
   attachmentsLoadedForCurrentPrompt: boolean
+  attachmentFetches: Record<string, ZookeeperAttachmentFetchState>
   pendingBackendShutdown: boolean
   defaultMode?: MlCopilotModeId
   modeOptions?: MlCopilotModeOption[]
@@ -480,6 +497,7 @@ export const zookeeperDefaultContext = (args: {
   projectNameCurrentlyOpened: undefined,
   awaitingResponse: false,
   attachmentsLoadedForCurrentPrompt: true,
+  attachmentFetches: {},
   pendingBackendShutdown: false,
   defaultMode: undefined,
   modeOptions: undefined,
@@ -805,6 +823,19 @@ export const zookeeperManagerMachine = setup({
       assertEvent(event, ZookeeperManagerTransitions.ResumeSuperseded)
       return context.ws === event.webSocket
     },
+    canFetchAttachment: ({ context, event }) => {
+      assertEvent(event, ZookeeperManagerTransitions.AttachmentFetch)
+
+      const key = getZookeeperAttachmentKey(event.attachmentRef)
+      const found = context.attachmentFetches[key]
+
+      // prevent duplicate requests
+      return (
+        context.ws?.readyState === WebSocket.OPEN &&
+        found?.status !== 'loading' &&
+        found?.status !== 'loaded'
+      )
+    },
   },
   actions: {
     assignApiToken: assign(({ event }) => {
@@ -1001,6 +1032,7 @@ export const zookeeperManagerMachine = setup({
         modeOptions: undefined,
         awaitingResponse: false,
         attachmentsLoadedForCurrentPrompt: true,
+        attachmentFetches: {},
         pendingBackendShutdown: false,
         cachedSetup: {
           refParentSend: event.refParentSend,
@@ -1012,6 +1044,40 @@ export const zookeeperManagerMachine = setup({
         },
       }
     }),
+    markAttachmentLoading: assign(({ context, event }) => {
+      assertEvent(event, ZookeeperManagerTransitions.AttachmentFetch)
+
+      const key = getZookeeperAttachmentKey(event.attachmentRef)
+
+      return {
+        attachmentFetches: {
+          ...context.attachmentFetches,
+          [key]: { status: 'loading' as const },
+        },
+      }
+    }),
+
+    sendAttachmentFetch: ({ context, event }) => {
+      assertEvent(event, ZookeeperManagerTransitions.AttachmentFetch)
+
+      if (context.ws?.readyState !== WebSocket.OPEN) {
+        return
+      }
+
+      const { prompt_id, seq, index } = event.attachmentRef
+
+      const request: Extract<
+        MlCopilotClientMessage,
+        { type: 'fetch_attachments' }
+      > = {
+        type: 'fetch_attachments',
+        prompt_id,
+        seq,
+        indices: [index],
+      }
+
+      context.ws.send(JSON.stringify(request))
+    },
     clearCacheSetup: assign({
       cachedSetup: undefined,
     }),
@@ -1038,6 +1104,7 @@ export const zookeeperManagerMachine = setup({
       if (maybeConversationId) {
         queryParams.set('conversation_id', maybeConversationId)
         queryParams.set('replay', 'true')
+        queryParams.set('replay_attachment_mode', 'metadata_only')
       }
       const querystring = queryParams.toString()
         ? `?${queryParams.toString()}`
@@ -1837,6 +1904,10 @@ export const zookeeperManagerMachine = setup({
         [ZookeeperManagerTransitions.BackendShutdown]: {
           actions: ['handleBackendShutdown', 'disconnectIfIdle'],
         },
+        [ZookeeperManagerTransitions.AttachmentFetch]: {
+          guard: 'canFetchAttachment',
+          actions: ['markAttachmentLoading', 'sendAttachmentFetch'],
+        },
       },
       states: {
         [ZookeeperManagerStates.Response]: {
@@ -1870,6 +1941,35 @@ export const zookeeperManagerMachine = setup({
                     assertEvent(event, [
                       ZookeeperManagerTransitions.ResponseReceive,
                     ])
+
+                    if ('attachments' in event.response) {
+                      const attachmentFetches: Record<
+                        string,
+                        ZookeeperAttachmentFetchState
+                      > = {
+                        ...context.attachmentFetches,
+                      }
+
+                      for (const file of event.response.attachments.files) {
+                        if (file.attachment_ref === undefined) {
+                          continue
+                        }
+
+                        const key = getZookeeperAttachmentKey(
+                          file.attachment_ref
+                        )
+
+                        attachmentFetches[key] = {
+                          status: 'loaded',
+                          file,
+                        }
+                      }
+                      // This early return is needed because attachment response
+                      // is just a bookkeeping, not a message.
+                      // It should not create a conversation exchange, increment lastMessageId,
+                      // change awaitingResponse, or affect active Zookeeper generation.
+                      return { attachmentFetches }
+                    }
 
                     const lastMessageId = (context.lastMessageId ?? -1) + 1
                     const responseComplete = isResponseComplete(event.response)
@@ -2092,6 +2192,7 @@ export const zookeeperManagerMachine = setup({
               lastMessageType: undefined,
               awaitingResponse: false,
               attachmentsLoadedForCurrentPrompt: true,
+              attachmentFetches: {},
               pendingBackendShutdown: false,
               closeReason: undefined,
               ws: undefined,


### PR DESCRIPTION
As part of [Issue-3972](https://github.com/KittyCAD/api/issues/3972), this PR adds modeling-app support for lazy-loading of attachments from conversations' replay. This is a followup frontend change for the deployed backend change: https://github.com/KittyCAD/api/pull/3772

1. Requests conversation replay using 'replay_attachment=metadata_only'.
2. Adds attachment fetch state and ownership to Zookeeper manager machine.
3. Sends 'fetch_attachments' messages using each attachment's 'prompt_id', 'seq', and 'index'.
4. Prevents duplicate requests in case an attachment is loading or finished loading.
5. Handles incoming 'attachments' responses without adding them to the visible conversation.
6. Adds "click to load" functionality for historical attachments.
7. Passes attachment state and fetch actions throughout the conversation UI.
8. Adds lazy-loading, and utilizes existing preview and download functionality for server-generated files and exports.
9. Avoids creating object URLs for metadata-only placeholders.
10. Clears cached attachment state when conversation is reset.

Known limitation: backend's "attachment not found" response does not currently include attachment coordinates. That means that if multiple fetches are happening at the same time, the modeling-app will not be able to identify which attachment failed, the the failed request may remain in the "loading" state until the conversation is reopened. Follow-up api + modeling PRs may be needed to address this.