### PR TITLE
Preserve selection arguments during point-and-click edits

### DIFF
--- a/src/lang/modifyAst.test.ts
+++ b/src/lang/modifyAst.test.ts
@@ -8,7 +8,7 @@ import type { PathToNode } from '@src/lang/wasm'
 import { describe, expect, it } from 'vitest'
 
 describe('editing calls in place', () => {
-  it('preserves an existing unlabeled argument when reconstruction fails', () => {
+  it('preserves an existing unlabeled argument when the edit omits it', () => {
     const inlineInput = createCallExpressionStdLibKw(
       'extrude',
       createLocalName('profile'),
@@ -30,7 +30,7 @@ describe('editing calls in place', () => {
     expect(replacementCall.unlabeled).toBeNull()
   })
 
-  it('uses a reconstructed unlabeled argument when available', () => {
+  it('ignores a replacement unlabeled argument', () => {
     const existingCall = createCallExpressionStdLibKw(
       'translate',
       createLocalName('oldBody'),
@@ -45,7 +45,77 @@ describe('editing calls in place', () => {
 
     replaceCallInPlace(existingCall, replacementCall)
 
-    expect(existingCall.unlabeled).toEqual(replacementInput)
+    expect(existingCall.unlabeled).toEqual(createLocalName('oldBody'))
+  })
+
+  it('preserves labeled selection arguments and applies other edits', () => {
+    const existingCall = createCallExpressionStdLibKw(
+      'split',
+      createLocalName('target'),
+      [
+        createLabeledArg('tools', createLocalName('oldTool')),
+        createLabeledArg('merge', createLocalName('oldMerge')),
+      ]
+    )
+    const replacementMerge = createLabeledArg(
+      'merge',
+      createLocalName('newMerge')
+    )
+    const replacementCall = createCallExpressionStdLibKw(
+      'split',
+      createLocalName('differentTarget'),
+      [replacementMerge]
+    )
+
+    replaceCallInPlace(existingCall, replacementCall, ['tools'])
+
+    expect(existingCall.unlabeled).toEqual(createLocalName('target'))
+    expect(existingCall.arguments).toEqual([
+      createLabeledArg('tools', createLocalName('oldTool')),
+      replacementMerge,
+    ])
+  })
+
+  it('ignores a replacement labeled selection argument', () => {
+    const existingTool = createLabeledArg('tools', createLocalName('oldTool'))
+    const existingCall = createCallExpressionStdLibKw(
+      'subtract',
+      createLocalName('target'),
+      [existingTool]
+    )
+    const replacementCall = createCallExpressionStdLibKw(
+      'subtract',
+      createLocalName('differentTarget'),
+      [createLabeledArg('tools', createLocalName('differentTool'))]
+    )
+
+    replaceCallInPlace(existingCall, replacementCall, ['tools'])
+
+    expect(existingCall.arguments).toEqual([existingTool])
+  })
+
+  it('ignores a reconstructed labeled selection that did not exist', () => {
+    const existingCall = createCallExpressionStdLibKw(
+      'extrude',
+      createLocalName('profile'),
+      [createLabeledArg('length', createLocalName('oldLength'))]
+    )
+    const replacementLength = createLabeledArg(
+      'length',
+      createLocalName('newLength')
+    )
+    const replacementCall = createCallExpressionStdLibKw(
+      'extrude',
+      createLocalName('differentProfile'),
+      [
+        replacementLength,
+        createLabeledArg('direction', createLocalName('rebuiltDirection')),
+      ]
+    )
+
+    replaceCallInPlace(existingCall, replacementCall, ['direction'])
+
+    expect(existingCall.arguments).toEqual([replacementLength])
   })
 
   it('recognizes different calls in the same pipe', () => {

--- a/src/lang/modifyAst.ts
+++ b/src/lang/modifyAst.ts
@@ -40,6 +40,7 @@ import type {
   CallExpressionKw,
   Expr,
   ExpressionStatement,
+  LabeledArg,
   NumericSuffix,
   PathToNode,
   PipeExpression,
@@ -1310,13 +1311,28 @@ export function pathsReferToSamePipe(
 
 export function replaceCallInPlace(
   existingCall: CallExpressionKw,
-  replacementCall: CallExpressionKw
+  replacementCall: CallExpressionKw,
+  labeledSelectionArgNames: readonly string[] = []
 ) {
-  const unlabeled =
-    replacementCall.unlabeled === null
-      ? structuredClone(existingCall.unlabeled)
-      : replacementCall.unlabeled
-  Object.assign(existingCall, replacementCall, { unlabeled })
+  // Until selection edits can roll back, reconstructed selections are
+  // display-only. Drop them, then restore the originals at their old positions.
+  const isLabeledSelectionArgument = (argument: LabeledArg) =>
+    argument.label !== null &&
+    labeledSelectionArgNames.includes(argument.label.name)
+  const mergedArguments = replacementCall.arguments.filter(
+    (argument) => !isLabeledSelectionArgument(argument)
+  )
+
+  for (const [index, argument] of existingCall.arguments.entries()) {
+    if (isLabeledSelectionArgument(argument)) {
+      mergedArguments.splice(index, 0, structuredClone(argument))
+    }
+  }
+
+  Object.assign(existingCall, replacementCall, {
+    unlabeled: structuredClone(existingCall.unlabeled),
+    arguments: mergedArguments,
+  })
 }
 
 export function setCallInAst({
@@ -1325,6 +1341,7 @@ export function setCallInAst({
   pathToEdit,
   pathIfNewPipe,
   variableIfNewDecl,
+  labeledSelectionArgNames,
   wasmInstance,
 }: {
   ast: Node<Program>
@@ -1332,6 +1349,7 @@ export function setCallInAst({
   pathToEdit?: PathToNode
   pathIfNewPipe?: PathToNode
   variableIfNewDecl?: string
+  labeledSelectionArgNames?: readonly string[]
   wasmInstance: ModuleType
 }): Error | PathToNode {
   let pathToNode: PathToNode | undefined
@@ -1353,7 +1371,7 @@ export function setCallInAst({
       return result
     }
 
-    replaceCallInPlace(result.node, call)
+    replaceCallInPlace(result.node, call, labeledSelectionArgNames)
     pathToNode = pathToEdit
   } else if (pathIfNewPipe) {
     const pipe = getNodeFromPath<PipeExpression>(

--- a/src/lang/modifyAst.ts
+++ b/src/lang/modifyAst.ts
@@ -24,6 +24,7 @@ import {
   getNodeFromPath,
   getSettingsAnnotation,
   getSketchSegmentName,
+  getVariableExprsFromSelection,
   getVariableNameFromNodePath,
   isCallExprWithName,
   isNodeSafeToReplace,
@@ -86,6 +87,7 @@ import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type {
   EngineRegionSelection,
   ExtrudeFacePlane,
+  Selections,
 } from '@src/machines/modelingSharedTypes'
 
 export function startSketchOnDefault(
@@ -1270,6 +1272,35 @@ export function createVariableExpressionsArray(exprs: Expr[]): Expr | null {
     expr = createArrayExpression(exprs)
   }
   return expr
+}
+
+export function getSelectionVarsForCall({
+  selection,
+  artifactGraph,
+  modifiedAst,
+  wasmInstance,
+  nodeToEdit,
+}: {
+  selection: Selections
+  artifactGraph: ArtifactGraph
+  modifiedAst: Node<Program>
+  wasmInstance: ModuleType
+  nodeToEdit?: PathToNode
+}) {
+  // Edit codemods preserve the existing selection argument, so only rebuild
+  // selection expressions when creating a new call.
+  if (nodeToEdit) {
+    return { exprs: [] }
+  }
+
+  return getVariableExprsFromSelection(
+    selection,
+    artifactGraph,
+    modifiedAst,
+    wasmInstance,
+    undefined,
+    { lastChildLookup: true }
+  )
 }
 
 // Create a path to node to the last variable declaroator of an ast

--- a/src/lang/modifyAst/boolean.spec.ts
+++ b/src/lang/modifyAst/boolean.spec.ts
@@ -1,11 +1,12 @@
 import type { KclManager } from '@src/lang/KclManager'
+import { createPathToNodeForLastVariable } from '@src/lang/modifyAst'
 import {
   addIntersect,
   addSplit,
   addSubtract,
   addUnion,
 } from '@src/lang/modifyAst/boolean'
-import { recast } from '@src/lang/wasm'
+import { type ArtifactGraph, assertParse, recast } from '@src/lang/wasm'
 import type { ConnectionManager } from '@src/lib/engineConnection/connectionManager'
 import type RustContext from '@src/lib/rustContext'
 import {
@@ -495,6 +496,39 @@ extrude001 = extrude(profile001, length = -5, method = NEW)`
   // The detailed addIntersect and addUnion behavior remains covered by the existing e2e tests.
 
   describe('Testing addSplit', () => {
+    it('preserves unavailable tools while editing keepTools', () => {
+      const code =
+        'split001 = split(target, tools = tool, merge = false, keepTools = true)'
+      const ast = assertParse(code, instanceInThisFile)
+      const unavailableSelection = {
+        graphSelections: [],
+        otherSelections: [],
+      }
+
+      const result = addSplit({
+        ast,
+        artifactGraph: new Map() as ArtifactGraph,
+        targets: unavailableSelection,
+        tools: unavailableSelection,
+        merge: true,
+        keepTools: false,
+        nodeToEdit: createPathToNodeForLastVariable(ast),
+        wasmInstance: instanceInThisFile,
+      })
+      if (err(result)) throw result
+
+      const newCode = recast(result.modifiedAst, instanceInThisFile)
+      if (err(newCode)) throw newCode
+      expect(newCode.trim()).toBe(
+        `split001 = split(
+  target,
+  tools = tool,
+  merge = true,
+  keepTools = false,
+)`
+      )
+    })
+
     async function runAddSplitTest({
       code,
       targetIds,

--- a/src/lang/modifyAst/boolean.ts
+++ b/src/lang/modifyAst/boolean.ts
@@ -95,26 +95,30 @@ export function addUnion({
   const mNodeToEdit = structuredClone(nodeToEdit)
 
   // 2. Prepare unlabeled arguments (no exposed labeled arguments for boolean yet)
-  const vars = getVariableExprsFromSelection(
-    solids,
-    artifactGraph,
-    modifiedAst,
-    wasmInstance,
-    mNodeToEdit,
-    {
-      lastChildLookup: true,
-      artifactTypeFilter: ['compositeSolid', 'sweep'],
+  let vars: { exprs: Expr[]; pathIfPipe?: PathToNode } = { exprs: [] }
+  if (!mNodeToEdit) {
+    const selectionVars = getVariableExprsFromSelection(
+      solids,
+      artifactGraph,
+      modifiedAst,
+      wasmInstance,
+      undefined,
+      {
+        lastChildLookup: true,
+        artifactTypeFilter: ['compositeSolid', 'sweep'],
+      }
+    )
+    if (err(selectionVars)) {
+      return selectionVars
     }
-  )
-  if (err(vars)) {
-    return vars
-  }
+    vars = selectionVars
 
-  const selectionError = validateBooleanSelections([
-    { selections: solids, ...vars },
-  ])
-  if (selectionError) {
-    return selectionError
+    const selectionError = validateBooleanSelections([
+      { selections: solids, ...vars },
+    ])
+    if (selectionError) {
+      return selectionError
+    }
   }
 
   const objectsExpr = createVariableExpressionsArray(vars.exprs)
@@ -167,26 +171,30 @@ export function addIntersect({
   const mNodeToEdit = structuredClone(nodeToEdit)
 
   // 2. Prepare unlabeled arguments (no exposed labeled arguments for boolean yet)
-  const vars = getVariableExprsFromSelection(
-    solids,
-    artifactGraph,
-    modifiedAst,
-    wasmInstance,
-    mNodeToEdit,
-    {
-      lastChildLookup: true,
-      artifactTypeFilter: ['compositeSolid', 'sweep'],
+  let vars: { exprs: Expr[]; pathIfPipe?: PathToNode } = { exprs: [] }
+  if (!mNodeToEdit) {
+    const selectionVars = getVariableExprsFromSelection(
+      solids,
+      artifactGraph,
+      modifiedAst,
+      wasmInstance,
+      undefined,
+      {
+        lastChildLookup: true,
+        artifactTypeFilter: ['compositeSolid', 'sweep'],
+      }
+    )
+    if (err(selectionVars)) {
+      return selectionVars
     }
-  )
-  if (err(vars)) {
-    return vars
-  }
+    vars = selectionVars
 
-  const selectionError = validateBooleanSelections([
-    { selections: solids, ...vars },
-  ])
-  if (selectionError) {
-    return selectionError
+    const selectionError = validateBooleanSelections([
+      { selections: solids, ...vars },
+    ])
+    if (selectionError) {
+      return selectionError
+    }
   }
 
   const objectsExpr = createVariableExpressionsArray(vars.exprs)
@@ -241,47 +249,53 @@ export function addSubtract({
   const mNodeToEdit = structuredClone(nodeToEdit)
 
   // 2. Prepare unlabeled and labeled arguments
-  const vars = getVariableExprsFromSelection(
-    solids,
-    artifactGraph,
-    modifiedAst,
-    wasmInstance,
-    mNodeToEdit,
-    {
-      lastChildLookup: true,
-      artifactTypeFilter: ['compositeSolid', 'sweep'],
+  let vars: { exprs: Expr[]; pathIfPipe?: PathToNode } = { exprs: [] }
+  let toolVars: { exprs: Expr[]; pathIfPipe?: PathToNode } = { exprs: [] }
+  if (!mNodeToEdit) {
+    const selectionVars = getVariableExprsFromSelection(
+      solids,
+      artifactGraph,
+      modifiedAst,
+      wasmInstance,
+      undefined,
+      {
+        lastChildLookup: true,
+        artifactTypeFilter: ['compositeSolid', 'sweep'],
+      }
+    )
+    if (err(selectionVars)) {
+      return selectionVars
     }
-  )
-  if (err(vars)) {
-    return vars
-  }
+    vars = selectionVars
 
-  const toolVars = getVariableExprsFromSelection(
-    tools,
-    artifactGraph,
-    modifiedAst,
-    wasmInstance,
-    mNodeToEdit,
-    {
-      lastChildLookup: true,
-      artifactTypeFilter: ['compositeSolid', 'sweep'],
+    const selectionToolVars = getVariableExprsFromSelection(
+      tools,
+      artifactGraph,
+      modifiedAst,
+      wasmInstance,
+      undefined,
+      {
+        lastChildLookup: true,
+        artifactTypeFilter: ['compositeSolid', 'sweep'],
+      }
+    )
+    if (err(selectionToolVars)) {
+      return selectionToolVars
     }
-  )
-  if (err(toolVars)) {
-    return toolVars
-  }
+    toolVars = selectionToolVars
 
-  const selectionError = validateBooleanSelections([
-    { selections: solids, ...vars },
-    { selections: tools, ...toolVars },
-  ])
-  if (selectionError) {
-    return selectionError
+    const selectionError = validateBooleanSelections([
+      { selections: solids, ...vars },
+      { selections: tools, ...toolVars },
+    ])
+    if (selectionError) {
+      return selectionError
+    }
   }
 
   const objectsExpr = createVariableExpressionsArray(vars.exprs)
   const toolsExpr = createVariableExpressionsArray(toolVars.exprs)
-  if (toolsExpr === null) {
+  if (!mNodeToEdit && toolsExpr === null) {
     return new Error('No tools provided for subtraction operation')
   }
 
@@ -289,7 +303,7 @@ export function addSubtract({
     modelingStdLibCommandName('Boolean Subtract'),
     objectsExpr,
     [
-      createLabeledArg('tools', toolsExpr),
+      ...(toolsExpr ? [createLabeledArg('tools', toolsExpr)] : []),
       ...(tolerance
         ? [createLabeledArg('tolerance', valueOrVariable(tolerance))]
         : []),
@@ -351,31 +365,38 @@ export function addSplit({
   const mNodeToEdit = structuredClone(nodeToEdit)
 
   // 2. Prepare unlabeled and labeled arguments
-  const vars = getVariableExprsFromSelection(
-    targets,
-    artifactGraph,
-    modifiedAst,
-    wasmInstance,
-    mNodeToEdit,
-    {
-      lastChildLookup: true,
-      artifactTypeFilter: ['compositeSolid', 'sweep'],
+  let vars: { exprs: Expr[]; pathIfPipe?: PathToNode } = { exprs: [] }
+  if (!mNodeToEdit) {
+    const selectionVars = getVariableExprsFromSelection(
+      targets,
+      artifactGraph,
+      modifiedAst,
+      wasmInstance,
+      undefined,
+      {
+        lastChildLookup: true,
+        artifactTypeFilter: ['compositeSolid', 'sweep'],
+      }
+    )
+    if (err(selectionVars)) {
+      return selectionVars
     }
-  )
-  if (err(vars)) {
-    return vars
+    vars = selectionVars
   }
 
   const hasTools = Boolean(
-    tools &&
+    !mNodeToEdit &&
+      tools &&
       (tools.graphSelections.length > 0 || tools.otherSelections.length > 0)
   )
   const selectionGroups: BooleanSelectionGroup[] = [
     { selections: targets, ...vars },
   ]
-  const targetSelectionError = validateBooleanSelections(selectionGroups)
-  if (targetSelectionError) {
-    return targetSelectionError
+  if (!mNodeToEdit) {
+    const targetSelectionError = validateBooleanSelections(selectionGroups)
+    if (targetSelectionError) {
+      return targetSelectionError
+    }
   }
 
   const labeledArgs: ReturnType<typeof createLabeledArg>[] = []
@@ -387,7 +408,7 @@ export function addSplit({
       artifactGraph,
       modifiedAst,
       wasmInstance,
-      mNodeToEdit,
+      undefined,
       {
         lastChildLookup: true,
         artifactTypeFilter: ['compositeSolid', 'sweep'],
@@ -421,7 +442,7 @@ export function addSplit({
       createLabeledArg('merge', createLiteral(merge, wasmInstance))
     )
   }
-  if (hasTools && keepTools !== undefined) {
+  if ((hasTools || mNodeToEdit) && keepTools !== undefined) {
     labeledArgs.push(
       createLabeledArg('keepTools', createLiteral(keepTools, wasmInstance))
     )

--- a/src/lang/modifyAst/boolean.ts
+++ b/src/lang/modifyAst/boolean.ts
@@ -314,6 +314,7 @@ export function addSubtract({
     pathIfNewPipe,
     pathToEdit: mNodeToEdit,
     variableIfNewDecl: KCL_DEFAULT_CONSTANT_PREFIXES.SOLID,
+    labeledSelectionArgNames: ['tools'],
     wasmInstance,
   })
   if (err(pathToNode)) {
@@ -441,6 +442,7 @@ export function addSplit({
     pathIfNewPipe,
     pathToEdit: mNodeToEdit,
     variableIfNewDecl: KCL_DEFAULT_CONSTANT_PREFIXES.SPLIT,
+    labeledSelectionArgNames: ['tools'],
     wasmInstance,
   })
   if (err(pathToNode)) {

--- a/src/lang/modifyAst/edges.spec.ts
+++ b/src/lang/modifyAst/edges.spec.ts
@@ -888,18 +888,7 @@ extrude001 = extrude(profile001, length = 20, tagEnd = $capEnd001)
       }
 
       const newCode = recast(result.modifiedAst, instanceInThisFile)
-      expect(newCode).toContain(
-        code.replace(
-          '  |> fillet(tags = getCommonEdge(faces = [rectangleSegmentA001, capEnd001]), radius = 2.5)',
-          `  |> fillet(
-       tags = getCommonEdge(faces = [
-         rectangleSegmentA001,
-         %.faces.capEnd001
-       ]),
-       radius = 2,
-     )`
-        )
-      )
+      expect(newCode).toContain(code.replace('radius = 2.5', 'radius = 2'))
       await enginelessExecutor(result.modifiedAst, rustContextInThisFile)
     })
 

--- a/src/lang/modifyAst/edges.spec.ts
+++ b/src/lang/modifyAst/edges.spec.ts
@@ -15,6 +15,7 @@ import {
 import { topLevelRange } from '@src/lang/util'
 import {
   type Artifact,
+  type ArtifactGraph,
   type PathToNode,
   assertParse,
   recast,
@@ -166,6 +167,36 @@ extrude002 = extrude([sketch002.line1, sketch002.line2], length = 5, bodyType = 
 `
 
   describe('Testing addFillet', () => {
+    it.each([
+      'tags = [edgeTag]',
+      'edges = [{ sideFaces = [sideTag, capTag] }]',
+      'edgeRefs = [edgeRef]',
+    ])(
+      'edits scalar arguments with an unavailable %s selection',
+      async (selectionArgument) => {
+        const code = `fillet001 = fillet(body, ${selectionArgument}, radius = 1)`
+        const ast = assertParse(code, instanceInThisFile)
+        const radius = (await stringToKclExpression(
+          '2',
+          rustContextInThisFile
+        )) as KclCommandValue
+
+        const result = addFillet({
+          ast,
+          artifactGraph: new Map() as ArtifactGraph,
+          selection: { graphSelections: [], otherSelections: [] },
+          radius,
+          nodeToEdit: createPathToNodeForLastVariable(ast, false),
+          wasmInstance: instanceInThisFile,
+        })
+        if (err(result)) throw result
+
+        const newCode = recast(result.modifiedAst, instanceInThisFile)
+        if (err(newCode)) throw newCode
+        expect(newCode.trim()).toBe(code.replace('radius = 1', 'radius = 2'))
+      }
+    )
+
     it('should add a basic fillet call on sweepEdge', async () => {
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         extrudedTriangle,

--- a/src/lang/modifyAst/edges.ts
+++ b/src/lang/modifyAst/edges.ts
@@ -199,6 +199,7 @@ export function addFillet({
       pathToEdit: mNodeToEdit,
       pathIfNewPipe: data.pathIfPipe,
       variableIfNewDecl: KCL_DEFAULT_CONSTANT_PREFIXES.FILLET,
+      labeledSelectionArgNames: ['tags'],
       wasmInstance,
     })
     if (err(pathToNode)) return pathToNode
@@ -326,6 +327,7 @@ export function addChamfer({
       pathToEdit: mNodeToEdit,
       pathIfNewPipe: data.pathIfPipe,
       variableIfNewDecl: KCL_DEFAULT_CONSTANT_PREFIXES.CHAMFER,
+      labeledSelectionArgNames: ['tags'],
       wasmInstance,
     })
     if (err(pathToNode)) return pathToNode

--- a/src/lang/modifyAst/edges.ts
+++ b/src/lang/modifyAst/edges.ts
@@ -125,6 +125,41 @@ export function addFillet({
   let modifiedAst = structuredClone(ast)
   const mNodeToEdit = structuredClone(nodeToEdit)
 
+  if (mNodeToEdit) {
+    const call = createCallExpressionStdLibKw(
+      modelingStdLibCommandName('Fillet'),
+      null,
+      [
+        createLabeledArg('radius', valueOrVariable(radius)),
+        ...(tolerance
+          ? [createLabeledArg('tolerance', valueOrVariable(tolerance))]
+          : []),
+        ...(tag ? [createLabeledArg('tag', createTagDeclarator(tag))] : []),
+        ...(version
+          ? [createLabeledArg('version', valueOrVariable(version))]
+          : []),
+      ]
+    )
+    if ('variableName' in radius && radius.variableName) {
+      insertVariableAndOffsetPathToNode(radius, modifiedAst, mNodeToEdit)
+    }
+    if (tolerance && 'variableName' in tolerance && tolerance.variableName) {
+      insertVariableAndOffsetPathToNode(tolerance, modifiedAst, mNodeToEdit)
+    }
+    if (version && 'variableName' in version && version.variableName) {
+      insertVariableAndOffsetPathToNode(version, modifiedAst, mNodeToEdit)
+    }
+    const pathToNode = setCallInAst({
+      ast: modifiedAst,
+      call,
+      pathToEdit: mNodeToEdit,
+      labeledSelectionArgNames: ['tags', 'edges', 'edgeRefs'],
+      wasmInstance,
+    })
+    if (err(pathToNode)) return pathToNode
+    return { modifiedAst, pathToNode: [pathToNode] }
+  }
+
   // 2. Prepare unlabeled and labeled arguments
   // Group selections by body and add all tags first (before variable insertion)
   // This must happen before insertVariableAndOffsetPathToNode because that invalidates artifactGraph paths
@@ -199,7 +234,7 @@ export function addFillet({
       pathToEdit: mNodeToEdit,
       pathIfNewPipe: data.pathIfPipe,
       variableIfNewDecl: KCL_DEFAULT_CONSTANT_PREFIXES.FILLET,
-      labeledSelectionArgNames: ['tags'],
+      labeledSelectionArgNames: ['tags', 'edges', 'edgeRefs'],
       wasmInstance,
     })
     if (err(pathToNode)) return pathToNode
@@ -240,6 +275,49 @@ export function addChamfer({
   // 1. Clone the ast and nodeToEdit so we can freely edit them
   let modifiedAst = structuredClone(ast)
   const mNodeToEdit = structuredClone(nodeToEdit)
+
+  if (mNodeToEdit) {
+    const call = createCallExpressionStdLibKw(
+      modelingStdLibCommandName('Chamfer'),
+      null,
+      [
+        createLabeledArg('length', valueOrVariable(length)),
+        ...(secondLength
+          ? [createLabeledArg('secondLength', valueOrVariable(secondLength))]
+          : []),
+        ...(angle ? [createLabeledArg('angle', valueOrVariable(angle))] : []),
+        ...(tag ? [createLabeledArg('tag', createTagDeclarator(tag))] : []),
+        ...(version
+          ? [createLabeledArg('version', valueOrVariable(version))]
+          : []),
+      ]
+    )
+    if ('variableName' in length && length.variableName) {
+      insertVariableAndOffsetPathToNode(length, modifiedAst, mNodeToEdit)
+    }
+    if (
+      secondLength &&
+      'variableName' in secondLength &&
+      secondLength.variableName
+    ) {
+      insertVariableAndOffsetPathToNode(secondLength, modifiedAst, mNodeToEdit)
+    }
+    if (angle && 'variableName' in angle && angle.variableName) {
+      insertVariableAndOffsetPathToNode(angle, modifiedAst, mNodeToEdit)
+    }
+    if (version && 'variableName' in version && version.variableName) {
+      insertVariableAndOffsetPathToNode(version, modifiedAst, mNodeToEdit)
+    }
+    const pathToNode = setCallInAst({
+      ast: modifiedAst,
+      call,
+      pathToEdit: mNodeToEdit,
+      labeledSelectionArgNames: ['tags', 'edges', 'edgeRefs'],
+      wasmInstance,
+    })
+    if (err(pathToNode)) return pathToNode
+    return { modifiedAst, pathToNode: [pathToNode] }
+  }
 
   // 2. Prepare unlabeled and labeled arguments
   // Group selections by body and add all tags first (before variable insertion)
@@ -327,7 +405,7 @@ export function addChamfer({
       pathToEdit: mNodeToEdit,
       pathIfNewPipe: data.pathIfPipe,
       variableIfNewDecl: KCL_DEFAULT_CONSTANT_PREFIXES.CHAMFER,
-      labeledSelectionArgNames: ['tags'],
+      labeledSelectionArgNames: ['tags', 'edges', 'edgeRefs'],
       wasmInstance,
     })
     if (err(pathToNode)) return pathToNode

--- a/src/lang/modifyAst/edges.ts
+++ b/src/lang/modifyAst/edges.ts
@@ -95,6 +95,18 @@ function createMemberExpr(
   }
 }
 
+function insertKclVariables(
+  variables: Array<KclCommandValue | undefined>,
+  modifiedAst: Node<Program>,
+  nodeToEdit?: PathToNode
+) {
+  for (const variable of variables) {
+    if (variable) {
+      insertVariableAndOffsetPathToNode(variable, modifiedAst, nodeToEdit)
+    }
+  }
+}
+
 export function addFillet({
   ast,
   artifactGraph,
@@ -125,33 +137,24 @@ export function addFillet({
   let modifiedAst = structuredClone(ast)
   const mNodeToEdit = structuredClone(nodeToEdit)
 
+  const nonSelectionArgs = [
+    createLabeledArg('radius', valueOrVariable(radius)),
+    ...(tolerance
+      ? [createLabeledArg('tolerance', valueOrVariable(tolerance))]
+      : []),
+    ...(tag ? [createLabeledArg('tag', createTagDeclarator(tag))] : []),
+    ...(version ? [createLabeledArg('version', valueOrVariable(version))] : []),
+  ]
+
   if (mNodeToEdit) {
-    const call = createCallExpressionStdLibKw(
-      modelingStdLibCommandName('Fillet'),
-      null,
-      [
-        createLabeledArg('radius', valueOrVariable(radius)),
-        ...(tolerance
-          ? [createLabeledArg('tolerance', valueOrVariable(tolerance))]
-          : []),
-        ...(tag ? [createLabeledArg('tag', createTagDeclarator(tag))] : []),
-        ...(version
-          ? [createLabeledArg('version', valueOrVariable(version))]
-          : []),
-      ]
-    )
-    if ('variableName' in radius && radius.variableName) {
-      insertVariableAndOffsetPathToNode(radius, modifiedAst, mNodeToEdit)
-    }
-    if (tolerance && 'variableName' in tolerance && tolerance.variableName) {
-      insertVariableAndOffsetPathToNode(tolerance, modifiedAst, mNodeToEdit)
-    }
-    if (version && 'variableName' in version && version.variableName) {
-      insertVariableAndOffsetPathToNode(version, modifiedAst, mNodeToEdit)
-    }
+    insertKclVariables([radius, tolerance, version], modifiedAst, mNodeToEdit)
     const pathToNode = setCallInAst({
       ast: modifiedAst,
-      call,
+      call: createCallExpressionStdLibKw(
+        modelingStdLibCommandName('Fillet'),
+        null,
+        nonSelectionArgs
+      ),
       pathToEdit: mNodeToEdit,
       labeledSelectionArgNames: ['tags', 'edges', 'edgeRefs'],
       wasmInstance,
@@ -194,37 +197,17 @@ export function addFillet({
   }
 
   // Insert variables for labeled arguments if provided
-  if ('variableName' in radius && radius.variableName) {
-    insertVariableAndOffsetPathToNode(radius, modifiedAst, mNodeToEdit)
-  }
-  if (version && 'variableName' in version && version.variableName) {
-    insertVariableAndOffsetPathToNode(version, modifiedAst, mNodeToEdit)
-  }
-  if (tolerance && 'variableName' in tolerance && tolerance.variableName) {
-    insertVariableAndOffsetPathToNode(tolerance, modifiedAst, mNodeToEdit)
-  }
+  insertKclVariables([radius, version, tolerance], modifiedAst, mNodeToEdit)
 
   // 3. Create fillet calls for each body
   const pathToNodes: PathToNode[] = []
   for (const data of bodies.values()) {
-    const tagArgs = tag
-      ? [createLabeledArg('tag', createTagDeclarator(tag))]
-      : []
-    const toleranceArgs = tolerance
-      ? [createLabeledArg('tolerance', valueOrVariable(tolerance))]
-      : []
-    const versionArgs = version
-      ? [createLabeledArg('version', valueOrVariable(version))]
-      : []
     const call = createCallExpressionStdLibKw(
       modelingStdLibCommandName('Fillet'),
       data.solidsExpr,
       [
         createLabeledArg('tags', data.tagsExpr),
-        createLabeledArg('radius', valueOrVariable(radius)),
-        ...toleranceArgs,
-        ...tagArgs,
-        ...versionArgs,
+        ...structuredClone(nonSelectionArgs),
       ]
     )
 
@@ -276,41 +259,29 @@ export function addChamfer({
   let modifiedAst = structuredClone(ast)
   const mNodeToEdit = structuredClone(nodeToEdit)
 
+  const nonSelectionArgs = [
+    createLabeledArg('length', valueOrVariable(length)),
+    ...(secondLength
+      ? [createLabeledArg('secondLength', valueOrVariable(secondLength))]
+      : []),
+    ...(angle ? [createLabeledArg('angle', valueOrVariable(angle))] : []),
+    ...(tag ? [createLabeledArg('tag', createTagDeclarator(tag))] : []),
+    ...(version ? [createLabeledArg('version', valueOrVariable(version))] : []),
+  ]
+
   if (mNodeToEdit) {
-    const call = createCallExpressionStdLibKw(
-      modelingStdLibCommandName('Chamfer'),
-      null,
-      [
-        createLabeledArg('length', valueOrVariable(length)),
-        ...(secondLength
-          ? [createLabeledArg('secondLength', valueOrVariable(secondLength))]
-          : []),
-        ...(angle ? [createLabeledArg('angle', valueOrVariable(angle))] : []),
-        ...(tag ? [createLabeledArg('tag', createTagDeclarator(tag))] : []),
-        ...(version
-          ? [createLabeledArg('version', valueOrVariable(version))]
-          : []),
-      ]
+    insertKclVariables(
+      [length, secondLength, angle, version],
+      modifiedAst,
+      mNodeToEdit
     )
-    if ('variableName' in length && length.variableName) {
-      insertVariableAndOffsetPathToNode(length, modifiedAst, mNodeToEdit)
-    }
-    if (
-      secondLength &&
-      'variableName' in secondLength &&
-      secondLength.variableName
-    ) {
-      insertVariableAndOffsetPathToNode(secondLength, modifiedAst, mNodeToEdit)
-    }
-    if (angle && 'variableName' in angle && angle.variableName) {
-      insertVariableAndOffsetPathToNode(angle, modifiedAst, mNodeToEdit)
-    }
-    if (version && 'variableName' in version && version.variableName) {
-      insertVariableAndOffsetPathToNode(version, modifiedAst, mNodeToEdit)
-    }
     const pathToNode = setCallInAst({
       ast: modifiedAst,
-      call,
+      call: createCallExpressionStdLibKw(
+        modelingStdLibCommandName('Chamfer'),
+        null,
+        nonSelectionArgs
+      ),
       pathToEdit: mNodeToEdit,
       labeledSelectionArgNames: ['tags', 'edges', 'edgeRefs'],
       wasmInstance,
@@ -353,49 +324,21 @@ export function addChamfer({
   }
 
   // Insert variables for labeled arguments if provided
-  if ('variableName' in length && length.variableName) {
-    insertVariableAndOffsetPathToNode(length, modifiedAst, mNodeToEdit)
-  }
-  if (
-    secondLength &&
-    'variableName' in secondLength &&
-    secondLength.variableName
-  ) {
-    insertVariableAndOffsetPathToNode(secondLength, modifiedAst, mNodeToEdit)
-  }
-  if (angle && 'variableName' in angle && angle.variableName) {
-    insertVariableAndOffsetPathToNode(angle, modifiedAst, mNodeToEdit)
-  }
-  if (version && 'variableName' in version && version.variableName) {
-    insertVariableAndOffsetPathToNode(version, modifiedAst, mNodeToEdit)
-  }
+  insertKclVariables(
+    [length, secondLength, angle, version],
+    modifiedAst,
+    mNodeToEdit
+  )
 
   // 3. Create chamfer calls for each body
   const pathToNodes: PathToNode[] = []
   for (const data of bodies.values()) {
-    const secondLengthArgs = secondLength
-      ? [createLabeledArg('secondLength', valueOrVariable(secondLength))]
-      : []
-    const angleArgs = angle
-      ? [createLabeledArg('angle', valueOrVariable(angle))]
-      : []
-    const tagArgs = tag
-      ? [createLabeledArg('tag', createTagDeclarator(tag))]
-      : []
-    const versionArgs = version
-      ? [createLabeledArg('version', valueOrVariable(version))]
-      : []
-
     const call = createCallExpressionStdLibKw(
       modelingStdLibCommandName('Chamfer'),
       data.solidsExpr,
       [
         createLabeledArg('tags', data.tagsExpr),
-        createLabeledArg('length', valueOrVariable(length)),
-        ...secondLengthArgs,
-        ...angleArgs,
-        ...tagArgs,
-        ...versionArgs,
+        ...structuredClone(nonSelectionArgs),
       ]
     )
 

--- a/src/lang/modifyAst/edges.ts
+++ b/src/lang/modifyAst/edges.ts
@@ -147,7 +147,7 @@ export function addFillet({
   ]
 
   if (mNodeToEdit) {
-    insertKclVariables([radius, tolerance, version], modifiedAst, mNodeToEdit)
+    insertKclVariables([radius, version, tolerance], modifiedAst, mNodeToEdit)
     const pathToNode = setCallInAst({
       ast: modifiedAst,
       call: createCallExpressionStdLibKw(
@@ -170,8 +170,7 @@ export function addFillet({
     selection,
     artifactGraph,
     modifiedAst,
-    wasmInstance,
-    mNodeToEdit
+    wasmInstance
   )
   if (err(bodyData)) return bodyData
   let bodies = bodyData.bodies
@@ -186,7 +185,6 @@ export function addFillet({
         modifiedAst,
         artifactGraph,
         wasmInstance,
-        nodeToEdit: mNodeToEdit,
       }
     )
     if (err(primitiveEdgeResult)) return primitiveEdgeResult
@@ -297,8 +295,7 @@ export function addChamfer({
     selection,
     artifactGraph,
     modifiedAst,
-    wasmInstance,
-    mNodeToEdit
+    wasmInstance
   )
   if (err(bodyData)) return bodyData
   let bodies = bodyData.bodies
@@ -313,7 +310,6 @@ export function addChamfer({
         modifiedAst,
         artifactGraph,
         wasmInstance,
-        nodeToEdit: mNodeToEdit,
       }
     )
     if (err(primitiveEdgeResult)) return primitiveEdgeResult
@@ -324,11 +320,7 @@ export function addChamfer({
   }
 
   // Insert variables for labeled arguments if provided
-  insertKclVariables(
-    [length, secondLength, angle, version],
-    modifiedAst,
-    mNodeToEdit
-  )
+  insertKclVariables([length, secondLength, angle, version], modifiedAst)
 
   // 3. Create chamfer calls for each body
   const pathToNodes: PathToNode[] = []
@@ -345,7 +337,6 @@ export function addChamfer({
     const pathToNode = setCallInAst({
       ast: modifiedAst,
       call,
-      pathToEdit: mNodeToEdit,
       pathIfNewPipe: data.pathIfPipe,
       variableIfNewDecl: KCL_DEFAULT_CONSTANT_PREFIXES.CHAMFER,
       labeledSelectionArgNames: ['tags', 'edges', 'edgeRefs'],

--- a/src/lang/modifyAst/faces.spec.ts
+++ b/src/lang/modifyAst/faces.spec.ts
@@ -267,7 +267,7 @@ shell001 = shell(extrude001, faces = END, thickness = 1)
         instanceInThisFile,
         kclManagerInThisFile
       )
-      const faces = getCapFromCylinder(artifactGraph)
+      const faces = { graphSelections: [], otherSelections: [] }
       const thickness = (await stringToKclExpression(
         '2',
         rustContextInThisFile
@@ -286,7 +286,7 @@ shell001 = shell(extrude001, faces = END, thickness = 1)
       }
 
       const newCode = recast(result.modifiedAst, instanceInThisFile)
-      expect(newCode).toContain(cylinderWithEndTag)
+      expect(newCode).toContain(cylinder)
       expect(newCode).toContain(
         `shell001 = shell(extrude001, faces = END, thickness = 2)`
       )

--- a/src/lang/modifyAst/faces.spec.ts
+++ b/src/lang/modifyAst/faces.spec.ts
@@ -288,7 +288,7 @@ shell001 = shell(extrude001, faces = END, thickness = 1)
       const newCode = recast(result.modifiedAst, instanceInThisFile)
       expect(newCode).toContain(cylinderWithEndTag)
       expect(newCode).toContain(
-        `shell001 = shell(extrude001, faces = capEnd001, thickness = 2)`
+        `shell001 = shell(extrude001, faces = END, thickness = 2)`
       )
       await enginelessExecutor(result.modifiedAst, rustContextInThisFile)
     })

--- a/src/lang/modifyAst/faces.ts
+++ b/src/lang/modifyAst/faces.ts
@@ -89,32 +89,39 @@ export function addShell({
   const mNodeToEdit = structuredClone(nodeToEdit)
 
   // 2. Prepare unlabeled and labeled arguments
-  const result = buildSolidsAndFacesExprs(
-    faces,
-    artifactGraph,
-    modifiedAst,
-    wasmInstance,
-    mNodeToEdit,
-    {
-      lastChildLookup: true,
-      artifactTypeFilter: ['sweep', 'compositeSolid'],
+  let solidsExpr: Expr | null = null
+  let facesExpr: Expr | null = null
+  let pathIfPipe: PathToNode | undefined
+  if (!mNodeToEdit) {
+    const result = buildSolidsAndFacesExprs(
+      faces,
+      artifactGraph,
+      modifiedAst,
+      wasmInstance,
+      undefined,
+      {
+        lastChildLookup: true,
+        artifactTypeFilter: ['sweep', 'compositeSolid'],
+      }
+    )
+    if (err(result)) {
+      return result
     }
-  )
-  if (err(result)) {
-    return result
-  }
 
-  const { solidsExpr, facesExpr, pathIfPipe } = result
-  modifiedAst = result.modifiedAst
-  if (!facesExpr) {
-    return new Error("Couldn't retrieve face from selection")
+    solidsExpr = result.solidsExpr
+    facesExpr = result.facesExpr
+    pathIfPipe = result.pathIfPipe
+    modifiedAst = result.modifiedAst
+    if (!facesExpr) {
+      return new Error("Couldn't retrieve face from selection")
+    }
   }
 
   const call = createCallExpressionStdLibKw(
     modelingStdLibCommandName('Shell'),
     solidsExpr,
     [
-      createLabeledArg('faces', facesExpr),
+      ...(facesExpr ? [createLabeledArg('faces', facesExpr)] : []),
       createLabeledArg('thickness', valueOrVariable(thickness)),
     ]
   )
@@ -166,6 +173,23 @@ export function addDeleteFace({
   // 1. Clone the ast and nodeToEdit so we can freely edit them
   let modifiedAst = structuredClone(ast)
   const mNodeToEdit = structuredClone(nodeToEdit)
+
+  if (mNodeToEdit) {
+    const call = createCallExpressionStdLibKw(
+      modelingStdLibCommandName('Delete Face'),
+      null,
+      []
+    )
+    const pathToNode = setCallInAst({
+      ast: modifiedAst,
+      call,
+      pathToEdit: mNodeToEdit,
+      labeledSelectionArgNames: ['faces'],
+      wasmInstance,
+    })
+    if (err(pathToNode)) return pathToNode
+    return { modifiedAst, pathToNode }
+  }
 
   // 2. Prepare unlabeled and labeled arguments
   const result = buildSolidsAndFacesExprs(
@@ -285,25 +309,32 @@ export function addHole({
   const mNodeToEdit = structuredClone(nodeToEdit)
 
   // 2. Prepare unlabeled and labeled arguments
-  const result = buildSolidsAndFacesExprs(
-    face,
-    artifactGraph,
-    modifiedAst,
-    wasmInstance,
-    mNodeToEdit,
-    {
-      lastChildLookup: true,
-      artifactTypeFilter: ['compositeSolid', 'sweep'],
+  let solidsExpr: Expr | null = null
+  let facesExpr: Expr | null = null
+  let pathIfPipe: PathToNode | undefined
+  if (!mNodeToEdit) {
+    const result = buildSolidsAndFacesExprs(
+      face,
+      artifactGraph,
+      modifiedAst,
+      wasmInstance,
+      undefined,
+      {
+        lastChildLookup: true,
+        artifactTypeFilter: ['compositeSolid', 'sweep'],
+      }
+    )
+    if (err(result)) {
+      return result
     }
-  )
-  if (err(result)) {
-    return result
-  }
 
-  const { solidsExpr, facesExpr, pathIfPipe } = result
-  modifiedAst = result.modifiedAst
-  if (!facesExpr) {
-    return new Error("Couldn't retrieve face from selection")
+    solidsExpr = result.solidsExpr
+    facesExpr = result.facesExpr
+    pathIfPipe = result.pathIfPipe
+    modifiedAst = result.modifiedAst
+    if (!facesExpr) {
+      return new Error("Couldn't retrieve face from selection")
+    }
   }
 
   // Extra args for createCallExpressionStdLibKw as we're calling functions from a module
@@ -408,7 +439,7 @@ export function addHole({
     holeCall.name,
     solidsExpr,
     [
-      createLabeledArg('face', facesExpr),
+      ...(facesExpr ? [createLabeledArg('face', facesExpr)] : []),
       createLabeledArg('cutAt', cutAtExpr),
       createLabeledArg('holeBottom', holeBottomNode),
       createLabeledArg('holeBody', holeBodyNode),
@@ -417,12 +448,6 @@ export function addHole({
     nonCodeMeta,
     modulePath
   )
-
-  if (mNodeToEdit) {
-    // The selected face can resolve to a downstream hole through last-child
-    // lookup. The solid input is not editable, so preserve the existing one.
-    call.unlabeled = null
-  }
 
   // Insert variables for labeled arguments if provided
   // Only insert cutAt variable if we used valueOrVariable (not for arrays)
@@ -804,22 +829,25 @@ export function addOffsetPlane({
   const mNodeToEdit = structuredClone(nodeToEdit)
 
   // 2. Prepare unlabeled and labeled arguments
-  const planeResult = getPlaneExprFromSelection({
-    ast: modifiedAst,
-    artifactGraph,
-    variables,
-    plane,
-    wasmInstance,
-    nodeToEdit: mNodeToEdit,
-  })
-  if (err(planeResult)) {
-    return planeResult
+  let planeExpr: Expr | null = null
+  if (!mNodeToEdit) {
+    const planeResult = getPlaneExprFromSelection({
+      ast: modifiedAst,
+      artifactGraph,
+      variables,
+      plane,
+      wasmInstance,
+    })
+    if (err(planeResult)) {
+      return planeResult
+    }
+    modifiedAst = planeResult.modifiedAst
+    planeExpr = planeResult.expr
   }
-  modifiedAst = planeResult.modifiedAst
 
   const call = createCallExpressionStdLibKw(
     modelingStdLibCommandName('Offset plane'),
-    planeResult.expr,
+    planeExpr,
     [createLabeledArg('offset', valueOrVariable(offset))]
   )
 

--- a/src/lang/modifyAst/faces.ts
+++ b/src/lang/modifyAst/faces.ts
@@ -132,6 +132,7 @@ export function addShell({
     pathToEdit: mNodeToEdit,
     pathIfNewPipe: pathIfPipe,
     variableIfNewDecl: KCL_DEFAULT_CONSTANT_PREFIXES.SHELL,
+    labeledSelectionArgNames: ['faces'],
     wasmInstance,
   })
   if (err(pathToNode)) {
@@ -219,6 +220,7 @@ export function addDeleteFace({
     pathToEdit: mNodeToEdit,
     pathIfNewPipe: result.pathIfPipe,
     variableIfNewDecl: KCL_DEFAULT_CONSTANT_PREFIXES.SURFACE,
+    labeledSelectionArgNames: ['faces'],
     wasmInstance,
   })
   if (err(pathToNode)) {
@@ -512,6 +514,7 @@ export function addHole({
     pathToEdit: mNodeToEdit,
     pathIfNewPipe: pathIfPipe,
     variableIfNewDecl: KCL_DEFAULT_CONSTANT_PREFIXES.HOLE,
+    labeledSelectionArgNames: ['face'],
     wasmInstance,
   })
   if (err(pathToNode)) {

--- a/src/lang/modifyAst/gdt.spec.ts
+++ b/src/lang/modifyAst/gdt.spec.ts
@@ -1,4 +1,5 @@
 import type { KclManager } from '@src/lang/KclManager'
+import { createPathToNodeForLastVariable } from '@src/lang/modifyAst'
 import {
   addAngularityGdt,
   addAnnotationGdt,
@@ -110,6 +111,33 @@ async function getKclCommandValue(
 }
 
 describe('gdt.spec.ts', () => {
+  it('edits scalar arguments when target reconstruction is unavailable', async () => {
+    const code =
+      'annotation001 = gdt::straightness(edges = [edgeRef], tolerance = 0.1)'
+    const ast = assertParse(code, instanceInThisFile)
+    const tolerance = await getKclCommandValue(
+      '0.2',
+      instanceInThisFile,
+      rustContextInThisFile
+    )
+
+    const result = addStraightnessGdt({
+      ast,
+      artifactGraph: new Map(),
+      objects: { graphSelections: [], otherSelections: [] },
+      tolerance,
+      nodeToEdit: createPathToNodeForLastVariable(ast),
+      wasmInstance: instanceInThisFile,
+    })
+    if (err(result)) throw result
+
+    const newCode = recast(result.modifiedAst, instanceInThisFile)
+    if (err(newCode)) throw newCode
+    expect(newCode.trim()).toBe(
+      code.replace('tolerance = 0.1', 'tolerance = 0.2')
+    )
+  })
+
   const boxWithOneTagAndChamfer = `sketch001 = startSketchOn(XY)
 profile001 = startProfile(sketch001, at = [0, 0])
   |> xLine(length = 10, tag = $seg01)

--- a/src/lang/modifyAst/gdt.ts
+++ b/src/lang/modifyAst/gdt.ts
@@ -47,6 +47,100 @@ function isProfileEdgeArtifact(
   return artifact?.type === 'segment' || artifact?.type === 'sweepEdge'
 }
 
+function buildFaceAndEdgeGdtExprs({
+  modifiedAst,
+  artifactGraph,
+  objects,
+  wasmInstance,
+  nodeToEdit,
+}: {
+  modifiedAst: Node<Program>
+  artifactGraph: ArtifactGraph
+  objects: Selections
+  wasmInstance: ModuleType
+  nodeToEdit?: PathToNode
+}):
+  | Error
+  | {
+      modifiedAst: Node<Program>
+      faceExprs: Expr[]
+      edgeExprs: Expr[]
+    } {
+  if (nodeToEdit) {
+    // The placeholder selects which single edit call to build. setCallInAst
+    // removes it and restores the existing selection argument verbatim.
+    return {
+      modifiedAst,
+      faceExprs: [createLocalName('selection')],
+      edgeExprs: [],
+    }
+  }
+
+  const faceSelections = objects.graphSelections.filter((selection) =>
+    isFaceArtifact(selection.artifact)
+  )
+  const edgeSelections = objects.graphSelections.filter((selection) =>
+    isProfileEdgeArtifact(selection.artifact)
+  )
+  if (faceSelections.length === 0 && edgeSelections.length === 0) {
+    return new Error('No valid selections found. Please select faces or edges.')
+  }
+
+  const faceExprs: Expr[] = []
+  for (const faceSelection of faceSelections) {
+    const tagResult = modifyAstWithTagsForSelection(
+      modifiedAst,
+      faceSelection,
+      artifactGraph,
+      wasmInstance
+    )
+    if (err(tagResult)) {
+      console.warn('Failed to add tag for face selection', tagResult)
+      continue
+    }
+
+    modifiedAst = tagResult.modifiedAst
+    faceExprs.push(tagResult.exprs[0])
+  }
+
+  const edgeExprs: Expr[] = []
+  for (const edgeSelection of edgeSelections) {
+    const tagResult = modifyAstWithTagsForSelection(
+      modifiedAst,
+      edgeSelection,
+      artifactGraph,
+      wasmInstance
+    )
+    if (err(tagResult)) {
+      console.warn('Failed to add tags for edge selection', tagResult)
+      continue
+    }
+    modifiedAst = tagResult.modifiedAst
+    if (tagResult.exprs.length < 2) {
+      console.warn('Edge selection did not resolve to enough faces', tagResult)
+      continue
+    }
+
+    edgeExprs.push(
+      createCallExpressionStdLibKw('getCommonEdge', null, [
+        createLabeledArg('faces', createArrayExpression(tagResult.exprs)),
+      ])
+    )
+  }
+
+  const uniqueFaceExprs = deduplicateFaceExprs(faceExprs)
+  const uniqueEdgeExprs = deduplicateFaceExprs(edgeExprs)
+  if (uniqueFaceExprs.length === 0 && uniqueEdgeExprs.length === 0) {
+    return new Error('No valid face or edge expressions could be generated')
+  }
+
+  return {
+    modifiedAst,
+    faceExprs: uniqueFaceExprs,
+    edgeExprs: uniqueEdgeExprs,
+  }
+}
+
 function modelingStdLibCallWithModulePath(
   commandName: Parameters<typeof modelingStdLibCall>[0]
 ) {
@@ -106,11 +200,13 @@ export function addFlatnessGdt({
   const mNodeToEdit = structuredClone(nodeToEdit)
 
   // Filter to only include face selections
-  const faceSelections = faces.graphSelections.filter((selection) =>
-    isFaceArtifact(selection.artifact)
-  )
+  const faceSelections = mNodeToEdit
+    ? []
+    : faces.graphSelections.filter((selection) =>
+        isFaceArtifact(selection.artifact)
+      )
 
-  if (faceSelections.length === 0) {
+  if (!mNodeToEdit && faceSelections.length === 0) {
     return new Error(
       'No valid face selections found. Please select faces (caps, walls, or edge cuts).'
     )
@@ -119,7 +215,7 @@ export function addFlatnessGdt({
   // Get face expressions from the selection
   // GDT annotations require tags for unambiguous face references (no body context)
   // We use modifyAstWithTagsForSelection directly to make the tagging explicit
-  const facesExprs: Expr[] = []
+  const facesExprs: Expr[] = mNodeToEdit ? [createLocalName('selection')] : []
   for (const faceSelection of faceSelections) {
     const tagResult = modifyAstWithTagsForSelection(
       modifiedAst,
@@ -269,65 +365,17 @@ export function addStraightnessGdt({
   let modifiedAst = structuredClone(ast)
   const mNodeToEdit = structuredClone(nodeToEdit)
 
-  const faceSelections = objects.graphSelections.filter((selection) =>
-    isFaceArtifact(selection.artifact)
-  )
-  const edgeSelections = objects.graphSelections.filter((selection) =>
-    isProfileEdgeArtifact(selection.artifact)
-  )
-
-  if (faceSelections.length === 0 && edgeSelections.length === 0) {
-    return new Error('No valid selections found. Please select faces or edges.')
-  }
-
-  const faceExprs: Expr[] = []
-  for (const faceSelection of faceSelections) {
-    const tagResult = modifyAstWithTagsForSelection(
-      modifiedAst,
-      faceSelection,
-      artifactGraph,
-      wasmInstance
-    )
-    if (err(tagResult)) {
-      console.warn('Failed to add tag for face selection', tagResult)
-      continue
-    }
-
-    modifiedAst = tagResult.modifiedAst
-    faceExprs.push(tagResult.exprs[0])
-  }
-
-  const edgeExprs: Expr[] = []
-  for (const edgeSelection of edgeSelections) {
-    const tagResult = modifyAstWithTagsForSelection(
-      modifiedAst,
-      edgeSelection,
-      artifactGraph,
-      wasmInstance
-    )
-    if (err(tagResult)) {
-      console.warn('Failed to add tags for edge selection', tagResult)
-      continue
-    }
-
-    modifiedAst = tagResult.modifiedAst
-    if (tagResult.exprs.length < 2) {
-      console.warn('Edge selection did not resolve to enough faces', tagResult)
-      continue
-    }
-
-    edgeExprs.push(
-      createCallExpressionStdLibKw('getCommonEdge', null, [
-        createLabeledArg('faces', createArrayExpression(tagResult.exprs)),
-      ])
-    )
-  }
-
-  const uniqueFaceExprs = deduplicateFaceExprs(faceExprs)
-  const uniqueEdgeExprs = deduplicateFaceExprs(edgeExprs)
-  if (uniqueFaceExprs.length === 0 && uniqueEdgeExprs.length === 0) {
-    return new Error('No valid face or edge expressions could be generated')
-  }
+  const targetExprs = buildFaceAndEdgeGdtExprs({
+    modifiedAst,
+    artifactGraph,
+    objects,
+    wasmInstance,
+    nodeToEdit: mNodeToEdit,
+  })
+  if (err(targetExprs)) return targetExprs
+  modifiedAst = targetExprs.modifiedAst
+  const uniqueFaceExprs = targetExprs.faceExprs
+  const uniqueEdgeExprs = targetExprs.edgeExprs
 
   if ('variableName' in tolerance && tolerance.variableName) {
     insertVariableAndOffsetPathToNode(tolerance, modifiedAst, mNodeToEdit)
@@ -451,65 +499,17 @@ export function addCircularityGdt({
   let modifiedAst = structuredClone(ast)
   const mNodeToEdit = structuredClone(nodeToEdit)
 
-  const faceSelections = objects.graphSelections.filter((selection) =>
-    isFaceArtifact(selection.artifact)
-  )
-  const edgeSelections = objects.graphSelections.filter((selection) =>
-    isProfileEdgeArtifact(selection.artifact)
-  )
-
-  if (faceSelections.length === 0 && edgeSelections.length === 0) {
-    return new Error('No valid selections found. Please select faces or edges.')
-  }
-
-  const faceExprs: Expr[] = []
-  for (const faceSelection of faceSelections) {
-    const tagResult = modifyAstWithTagsForSelection(
-      modifiedAst,
-      faceSelection,
-      artifactGraph,
-      wasmInstance
-    )
-    if (err(tagResult)) {
-      console.warn('Failed to add tag for face selection', tagResult)
-      continue
-    }
-
-    modifiedAst = tagResult.modifiedAst
-    faceExprs.push(tagResult.exprs[0])
-  }
-
-  const edgeExprs: Expr[] = []
-  for (const edgeSelection of edgeSelections) {
-    const tagResult = modifyAstWithTagsForSelection(
-      modifiedAst,
-      edgeSelection,
-      artifactGraph,
-      wasmInstance
-    )
-    if (err(tagResult)) {
-      console.warn('Failed to add tags for edge selection', tagResult)
-      continue
-    }
-
-    modifiedAst = tagResult.modifiedAst
-    if (tagResult.exprs.length < 2) {
-      console.warn('Edge selection did not resolve to enough faces', tagResult)
-      continue
-    }
-
-    edgeExprs.push(
-      createCallExpressionStdLibKw('getCommonEdge', null, [
-        createLabeledArg('faces', createArrayExpression(tagResult.exprs)),
-      ])
-    )
-  }
-
-  const uniqueFaceExprs = deduplicateFaceExprs(faceExprs)
-  const uniqueEdgeExprs = deduplicateFaceExprs(edgeExprs)
-  if (uniqueFaceExprs.length === 0 && uniqueEdgeExprs.length === 0) {
-    return new Error('No valid face or edge expressions could be generated')
-  }
+  const targetExprs = buildFaceAndEdgeGdtExprs({
+    modifiedAst,
+    artifactGraph,
+    objects,
+    wasmInstance,
+    nodeToEdit: mNodeToEdit,
+  })
+  if (err(targetExprs)) return targetExprs
+  modifiedAst = targetExprs.modifiedAst
+  const uniqueFaceExprs = targetExprs.faceExprs
+  const uniqueEdgeExprs = targetExprs.edgeExprs
 
   if ('variableName' in tolerance && tolerance.variableName) {
     insertVariableAndOffsetPathToNode(tolerance, modifiedAst, mNodeToEdit)
@@ -633,65 +633,17 @@ export function addCylindricityGdt({
   let modifiedAst = structuredClone(ast)
   const mNodeToEdit = structuredClone(nodeToEdit)
 
-  const faceSelections = objects.graphSelections.filter((selection) =>
-    isFaceArtifact(selection.artifact)
-  )
-  const edgeSelections = objects.graphSelections.filter((selection) =>
-    isProfileEdgeArtifact(selection.artifact)
-  )
-
-  if (faceSelections.length === 0 && edgeSelections.length === 0) {
-    return new Error('No valid selections found. Please select faces or edges.')
-  }
-
-  const faceExprs: Expr[] = []
-  for (const faceSelection of faceSelections) {
-    const tagResult = modifyAstWithTagsForSelection(
-      modifiedAst,
-      faceSelection,
-      artifactGraph,
-      wasmInstance
-    )
-    if (err(tagResult)) {
-      console.warn('Failed to add tag for face selection', tagResult)
-      continue
-    }
-
-    modifiedAst = tagResult.modifiedAst
-    faceExprs.push(tagResult.exprs[0])
-  }
-
-  const edgeExprs: Expr[] = []
-  for (const edgeSelection of edgeSelections) {
-    const tagResult = modifyAstWithTagsForSelection(
-      modifiedAst,
-      edgeSelection,
-      artifactGraph,
-      wasmInstance
-    )
-    if (err(tagResult)) {
-      console.warn('Failed to add tags for edge selection', tagResult)
-      continue
-    }
-
-    modifiedAst = tagResult.modifiedAst
-    if (tagResult.exprs.length < 2) {
-      console.warn('Edge selection did not resolve to enough faces', tagResult)
-      continue
-    }
-
-    edgeExprs.push(
-      createCallExpressionStdLibKw('getCommonEdge', null, [
-        createLabeledArg('faces', createArrayExpression(tagResult.exprs)),
-      ])
-    )
-  }
-
-  const uniqueFaceExprs = deduplicateFaceExprs(faceExprs)
-  const uniqueEdgeExprs = deduplicateFaceExprs(edgeExprs)
-  if (uniqueFaceExprs.length === 0 && uniqueEdgeExprs.length === 0) {
-    return new Error('No valid face or edge expressions could be generated')
-  }
+  const targetExprs = buildFaceAndEdgeGdtExprs({
+    modifiedAst,
+    artifactGraph,
+    objects,
+    wasmInstance,
+    nodeToEdit: mNodeToEdit,
+  })
+  if (err(targetExprs)) return targetExprs
+  modifiedAst = targetExprs.modifiedAst
+  const uniqueFaceExprs = targetExprs.faceExprs
+  const uniqueEdgeExprs = targetExprs.edgeExprs
 
   if ('variableName' in tolerance && tolerance.variableName) {
     insertVariableAndOffsetPathToNode(tolerance, modifiedAst, mNodeToEdit)
@@ -812,65 +764,17 @@ export function addPositionGdt({
   let modifiedAst = structuredClone(ast)
   const mNodeToEdit = structuredClone(nodeToEdit)
 
-  const faceSelections = objects.graphSelections.filter((selection) =>
-    isFaceArtifact(selection.artifact)
-  )
-  const edgeSelections = objects.graphSelections.filter((selection) =>
-    isProfileEdgeArtifact(selection.artifact)
-  )
-
-  if (faceSelections.length === 0 && edgeSelections.length === 0) {
-    return new Error('No valid selections found. Please select faces or edges.')
-  }
-
-  const faceExprs: Expr[] = []
-  for (const faceSelection of faceSelections) {
-    const tagResult = modifyAstWithTagsForSelection(
-      modifiedAst,
-      faceSelection,
-      artifactGraph,
-      wasmInstance
-    )
-    if (err(tagResult)) {
-      console.warn('Failed to add tag for face selection', tagResult)
-      continue
-    }
-
-    modifiedAst = tagResult.modifiedAst
-    faceExprs.push(tagResult.exprs[0])
-  }
-
-  const edgeExprs: Expr[] = []
-  for (const edgeSelection of edgeSelections) {
-    const tagResult = modifyAstWithTagsForSelection(
-      modifiedAst,
-      edgeSelection,
-      artifactGraph,
-      wasmInstance
-    )
-    if (err(tagResult)) {
-      console.warn('Failed to add tags for edge selection', tagResult)
-      continue
-    }
-
-    modifiedAst = tagResult.modifiedAst
-    if (tagResult.exprs.length < 2) {
-      console.warn('Edge selection did not resolve to enough faces', tagResult)
-      continue
-    }
-
-    edgeExprs.push(
-      createCallExpressionStdLibKw('getCommonEdge', null, [
-        createLabeledArg('faces', createArrayExpression(tagResult.exprs)),
-      ])
-    )
-  }
-
-  const uniqueFaceExprs = deduplicateFaceExprs(faceExprs)
-  const uniqueEdgeExprs = deduplicateFaceExprs(edgeExprs)
-  if (uniqueFaceExprs.length === 0 && uniqueEdgeExprs.length === 0) {
-    return new Error('No valid face or edge expressions could be generated')
-  }
+  const targetExprs = buildFaceAndEdgeGdtExprs({
+    modifiedAst,
+    artifactGraph,
+    objects,
+    wasmInstance,
+    nodeToEdit: mNodeToEdit,
+  })
+  if (err(targetExprs)) return targetExprs
+  modifiedAst = targetExprs.modifiedAst
+  const uniqueFaceExprs = targetExprs.faceExprs
+  const uniqueEdgeExprs = targetExprs.edgeExprs
 
   if ('variableName' in tolerance && tolerance.variableName) {
     insertVariableAndOffsetPathToNode(tolerance, modifiedAst, mNodeToEdit)
@@ -1002,13 +906,12 @@ export function addProfileGdt({
 }): Error | { modifiedAst: Node<Program>; pathToNode: PathToNode } {
   let modifiedAst = structuredClone(ast)
   const mNodeToEdit = structuredClone(nodeToEdit)
-  const selections = objects ?? edges ?? faces
-
-  if (!selections) {
-    return new Error(
-      'No selections found. Please select faces or edges for profile.'
-    )
-  }
+  const selections = objects ??
+    edges ??
+    faces ?? {
+      graphSelections: [],
+      otherSelections: [],
+    }
 
   const unsupportedSelections =
     selections.otherSelections.length > 0 ||
@@ -1017,16 +920,20 @@ export function addProfileGdt({
         !isProfileEdgeArtifact(selection.artifact) &&
         !isFaceArtifact(selection.artifact)
     )
-  if (unsupportedSelections) {
+  if (!mNodeToEdit && unsupportedSelections) {
     return new Error('Profile supports face selections or sketch/sweep edges.')
   }
 
-  const faceSelections = selections.graphSelections.filter((selection) =>
-    isFaceArtifact(selection.artifact)
-  )
-  const edgeSelections = selections.graphSelections.filter((selection) =>
-    isProfileEdgeArtifact(selection.artifact)
-  )
+  const faceSelections = mNodeToEdit
+    ? []
+    : selections.graphSelections.filter((selection) =>
+        isFaceArtifact(selection.artifact)
+      )
+  const edgeSelections = mNodeToEdit
+    ? []
+    : selections.graphSelections.filter((selection) =>
+        isProfileEdgeArtifact(selection.artifact)
+      )
 
   if (faceSelections.length > 0 && edgeSelections.length > 0) {
     return new Error(
@@ -1034,7 +941,11 @@ export function addProfileGdt({
     )
   }
 
-  if (faceSelections.length === 0 && edgeSelections.length === 0) {
+  if (
+    !mNodeToEdit &&
+    faceSelections.length === 0 &&
+    edgeSelections.length === 0
+  ) {
     return new Error('No valid selections found. Please select faces or edges.')
   }
 
@@ -1045,7 +956,7 @@ export function addProfileGdt({
     return new Error('profileSurface requires face selections.')
   }
 
-  const faceExprs: Expr[] = []
+  const faceExprs: Expr[] = mNodeToEdit ? [createLocalName('selection')] : []
   for (const faceSelection of faceSelections) {
     const tagResult = modifyAstWithTagsForSelection(
       modifiedAst,
@@ -1226,26 +1137,28 @@ export function addDistanceGdt({
 }): Error | { modifiedAst: Node<Program>; pathToNode: PathToNode } {
   let modifiedAst = structuredClone(ast)
   const mNodeToEdit = structuredClone(nodeToEdit)
-  const selections = objects ?? edges
+  const selections = objects ??
+    edges ?? {
+      graphSelections: [],
+      otherSelections: [],
+    }
 
-  if (!selections) {
-    return new Error(
-      'No selections found. Select one edge for an edge length, or exactly two faces or edges for a distance.'
-    )
-  }
-
-  const targetSelections = selections.graphSelections.filter(
-    (selection) =>
-      isFaceArtifact(selection.artifact) ||
-      isProfileEdgeArtifact(selection.artifact)
-  )
-  if (targetSelections.length === 0) {
+  const targetSelections = mNodeToEdit
+    ? []
+    : selections.graphSelections.filter(
+        (selection) =>
+          isFaceArtifact(selection.artifact) ||
+          isProfileEdgeArtifact(selection.artifact)
+      )
+  if (!mNodeToEdit && targetSelections.length === 0) {
     return new Error(
       'No valid selections found. Select one edge, or exactly two faces or edges.'
     )
   }
 
-  const targets: Array<{ kind: 'face' | 'edge'; expr: Expr }> = []
+  const targets: Array<{ kind: 'face' | 'edge'; expr: Expr }> = mNodeToEdit
+    ? [{ kind: 'edge', expr: createLocalName('selection') }]
+    : []
   for (const selection of targetSelections) {
     const tagResult = modifyAstWithTagsForSelection(
       modifiedAst,
@@ -1405,65 +1318,17 @@ export function addPerpendicularityGdt({
   let modifiedAst = structuredClone(ast)
   const mNodeToEdit = structuredClone(nodeToEdit)
 
-  const faceSelections = objects.graphSelections.filter((selection) =>
-    isFaceArtifact(selection.artifact)
-  )
-  const edgeSelections = objects.graphSelections.filter((selection) =>
-    isProfileEdgeArtifact(selection.artifact)
-  )
-
-  if (faceSelections.length === 0 && edgeSelections.length === 0) {
-    return new Error('No valid selections found. Please select faces or edges.')
-  }
-
-  const faceExprs: Expr[] = []
-  for (const faceSelection of faceSelections) {
-    const tagResult = modifyAstWithTagsForSelection(
-      modifiedAst,
-      faceSelection,
-      artifactGraph,
-      wasmInstance
-    )
-    if (err(tagResult)) {
-      console.warn('Failed to add tag for face selection', tagResult)
-      continue
-    }
-
-    modifiedAst = tagResult.modifiedAst
-    faceExprs.push(tagResult.exprs[0])
-  }
-
-  const edgeExprs: Expr[] = []
-  for (const edgeSelection of edgeSelections) {
-    const tagResult = modifyAstWithTagsForSelection(
-      modifiedAst,
-      edgeSelection,
-      artifactGraph,
-      wasmInstance
-    )
-    if (err(tagResult)) {
-      console.warn('Failed to add tags for edge selection', tagResult)
-      continue
-    }
-
-    modifiedAst = tagResult.modifiedAst
-    if (tagResult.exprs.length < 2) {
-      console.warn('Edge selection did not resolve to enough faces', tagResult)
-      continue
-    }
-
-    edgeExprs.push(
-      createCallExpressionStdLibKw('getCommonEdge', null, [
-        createLabeledArg('faces', createArrayExpression(tagResult.exprs)),
-      ])
-    )
-  }
-
-  const uniqueFaceExprs = deduplicateFaceExprs(faceExprs)
-  const uniqueEdgeExprs = deduplicateFaceExprs(edgeExprs)
-  if (uniqueFaceExprs.length === 0 && uniqueEdgeExprs.length === 0) {
-    return new Error('No valid face or edge expressions could be generated')
-  }
+  const targetExprs = buildFaceAndEdgeGdtExprs({
+    modifiedAst,
+    artifactGraph,
+    objects,
+    wasmInstance,
+    nodeToEdit: mNodeToEdit,
+  })
+  if (err(targetExprs)) return targetExprs
+  modifiedAst = targetExprs.modifiedAst
+  const uniqueFaceExprs = targetExprs.faceExprs
+  const uniqueEdgeExprs = targetExprs.edgeExprs
 
   if ('variableName' in tolerance && tolerance.variableName) {
     insertVariableAndOffsetPathToNode(tolerance, modifiedAst, mNodeToEdit)
@@ -1591,65 +1456,17 @@ export function addAngularityGdt({
   let modifiedAst = structuredClone(ast)
   const mNodeToEdit = structuredClone(nodeToEdit)
 
-  const faceSelections = objects.graphSelections.filter((selection) =>
-    isFaceArtifact(selection.artifact)
-  )
-  const edgeSelections = objects.graphSelections.filter((selection) =>
-    isProfileEdgeArtifact(selection.artifact)
-  )
-
-  if (faceSelections.length === 0 && edgeSelections.length === 0) {
-    return new Error('No valid selections found. Please select faces or edges.')
-  }
-
-  const faceExprs: Expr[] = []
-  for (const faceSelection of faceSelections) {
-    const tagResult = modifyAstWithTagsForSelection(
-      modifiedAst,
-      faceSelection,
-      artifactGraph,
-      wasmInstance
-    )
-    if (err(tagResult)) {
-      console.warn('Failed to add tag for face selection', tagResult)
-      continue
-    }
-
-    modifiedAst = tagResult.modifiedAst
-    faceExprs.push(tagResult.exprs[0])
-  }
-
-  const edgeExprs: Expr[] = []
-  for (const edgeSelection of edgeSelections) {
-    const tagResult = modifyAstWithTagsForSelection(
-      modifiedAst,
-      edgeSelection,
-      artifactGraph,
-      wasmInstance
-    )
-    if (err(tagResult)) {
-      console.warn('Failed to add tags for edge selection', tagResult)
-      continue
-    }
-
-    modifiedAst = tagResult.modifiedAst
-    if (tagResult.exprs.length < 2) {
-      console.warn('Edge selection did not resolve to enough faces', tagResult)
-      continue
-    }
-
-    edgeExprs.push(
-      createCallExpressionStdLibKw('getCommonEdge', null, [
-        createLabeledArg('faces', createArrayExpression(tagResult.exprs)),
-      ])
-    )
-  }
-
-  const uniqueFaceExprs = deduplicateFaceExprs(faceExprs)
-  const uniqueEdgeExprs = deduplicateFaceExprs(edgeExprs)
-  if (uniqueFaceExprs.length === 0 && uniqueEdgeExprs.length === 0) {
-    return new Error('No valid face or edge expressions could be generated')
-  }
+  const targetExprs = buildFaceAndEdgeGdtExprs({
+    modifiedAst,
+    artifactGraph,
+    objects,
+    wasmInstance,
+    nodeToEdit: mNodeToEdit,
+  })
+  if (err(targetExprs)) return targetExprs
+  modifiedAst = targetExprs.modifiedAst
+  const uniqueFaceExprs = targetExprs.faceExprs
+  const uniqueEdgeExprs = targetExprs.edgeExprs
 
   if ('variableName' in tolerance && tolerance.variableName) {
     insertVariableAndOffsetPathToNode(tolerance, modifiedAst, mNodeToEdit)
@@ -1777,65 +1594,17 @@ export function addConcentricityGdt({
   let modifiedAst = structuredClone(ast)
   const mNodeToEdit = structuredClone(nodeToEdit)
 
-  const faceSelections = objects.graphSelections.filter((selection) =>
-    isFaceArtifact(selection.artifact)
-  )
-  const edgeSelections = objects.graphSelections.filter((selection) =>
-    isProfileEdgeArtifact(selection.artifact)
-  )
-
-  if (faceSelections.length === 0 && edgeSelections.length === 0) {
-    return new Error('No valid selections found. Please select faces or edges.')
-  }
-
-  const faceExprs: Expr[] = []
-  for (const faceSelection of faceSelections) {
-    const tagResult = modifyAstWithTagsForSelection(
-      modifiedAst,
-      faceSelection,
-      artifactGraph,
-      wasmInstance
-    )
-    if (err(tagResult)) {
-      console.warn('Failed to add tag for face selection', tagResult)
-      continue
-    }
-
-    modifiedAst = tagResult.modifiedAst
-    faceExprs.push(tagResult.exprs[0])
-  }
-
-  const edgeExprs: Expr[] = []
-  for (const edgeSelection of edgeSelections) {
-    const tagResult = modifyAstWithTagsForSelection(
-      modifiedAst,
-      edgeSelection,
-      artifactGraph,
-      wasmInstance
-    )
-    if (err(tagResult)) {
-      console.warn('Failed to add tags for edge selection', tagResult)
-      continue
-    }
-
-    modifiedAst = tagResult.modifiedAst
-    if (tagResult.exprs.length < 2) {
-      console.warn('Edge selection did not resolve to enough faces', tagResult)
-      continue
-    }
-
-    edgeExprs.push(
-      createCallExpressionStdLibKw('getCommonEdge', null, [
-        createLabeledArg('faces', createArrayExpression(tagResult.exprs)),
-      ])
-    )
-  }
-
-  const uniqueFaceExprs = deduplicateFaceExprs(faceExprs)
-  const uniqueEdgeExprs = deduplicateFaceExprs(edgeExprs)
-  if (uniqueFaceExprs.length === 0 && uniqueEdgeExprs.length === 0) {
-    return new Error('No valid face or edge expressions could be generated')
-  }
+  const targetExprs = buildFaceAndEdgeGdtExprs({
+    modifiedAst,
+    artifactGraph,
+    objects,
+    wasmInstance,
+    nodeToEdit: mNodeToEdit,
+  })
+  if (err(targetExprs)) return targetExprs
+  modifiedAst = targetExprs.modifiedAst
+  const uniqueFaceExprs = targetExprs.faceExprs
+  const uniqueEdgeExprs = targetExprs.edgeExprs
 
   if ('variableName' in tolerance && tolerance.variableName) {
     insertVariableAndOffsetPathToNode(tolerance, modifiedAst, mNodeToEdit)
@@ -1959,65 +1728,17 @@ export function addSymmetryGdt({
   let modifiedAst = structuredClone(ast)
   const mNodeToEdit = structuredClone(nodeToEdit)
 
-  const faceSelections = objects.graphSelections.filter((selection) =>
-    isFaceArtifact(selection.artifact)
-  )
-  const edgeSelections = objects.graphSelections.filter((selection) =>
-    isProfileEdgeArtifact(selection.artifact)
-  )
-
-  if (faceSelections.length === 0 && edgeSelections.length === 0) {
-    return new Error('No valid selections found. Please select faces or edges.')
-  }
-
-  const faceExprs: Expr[] = []
-  for (const faceSelection of faceSelections) {
-    const tagResult = modifyAstWithTagsForSelection(
-      modifiedAst,
-      faceSelection,
-      artifactGraph,
-      wasmInstance
-    )
-    if (err(tagResult)) {
-      console.warn('Failed to add tag for face selection', tagResult)
-      continue
-    }
-
-    modifiedAst = tagResult.modifiedAst
-    faceExprs.push(tagResult.exprs[0])
-  }
-
-  const edgeExprs: Expr[] = []
-  for (const edgeSelection of edgeSelections) {
-    const tagResult = modifyAstWithTagsForSelection(
-      modifiedAst,
-      edgeSelection,
-      artifactGraph,
-      wasmInstance
-    )
-    if (err(tagResult)) {
-      console.warn('Failed to add tags for edge selection', tagResult)
-      continue
-    }
-
-    modifiedAst = tagResult.modifiedAst
-    if (tagResult.exprs.length < 2) {
-      console.warn('Edge selection did not resolve to enough faces', tagResult)
-      continue
-    }
-
-    edgeExprs.push(
-      createCallExpressionStdLibKw('getCommonEdge', null, [
-        createLabeledArg('faces', createArrayExpression(tagResult.exprs)),
-      ])
-    )
-  }
-
-  const uniqueFaceExprs = deduplicateFaceExprs(faceExprs)
-  const uniqueEdgeExprs = deduplicateFaceExprs(edgeExprs)
-  if (uniqueFaceExprs.length === 0 && uniqueEdgeExprs.length === 0) {
-    return new Error('No valid face or edge expressions could be generated')
-  }
+  const targetExprs = buildFaceAndEdgeGdtExprs({
+    modifiedAst,
+    artifactGraph,
+    objects,
+    wasmInstance,
+    nodeToEdit: mNodeToEdit,
+  })
+  if (err(targetExprs)) return targetExprs
+  modifiedAst = targetExprs.modifiedAst
+  const uniqueFaceExprs = targetExprs.faceExprs
+  const uniqueEdgeExprs = targetExprs.edgeExprs
 
   if ('variableName' in tolerance && tolerance.variableName) {
     insertVariableAndOffsetPathToNode(tolerance, modifiedAst, mNodeToEdit)
@@ -2141,65 +1862,17 @@ export function addRunoutGdt({
   let modifiedAst = structuredClone(ast)
   const mNodeToEdit = structuredClone(nodeToEdit)
 
-  const faceSelections = objects.graphSelections.filter((selection) =>
-    isFaceArtifact(selection.artifact)
-  )
-  const edgeSelections = objects.graphSelections.filter((selection) =>
-    isProfileEdgeArtifact(selection.artifact)
-  )
-
-  if (faceSelections.length === 0 && edgeSelections.length === 0) {
-    return new Error('No valid selections found. Please select faces or edges.')
-  }
-
-  const faceExprs: Expr[] = []
-  for (const faceSelection of faceSelections) {
-    const tagResult = modifyAstWithTagsForSelection(
-      modifiedAst,
-      faceSelection,
-      artifactGraph,
-      wasmInstance
-    )
-    if (err(tagResult)) {
-      console.warn('Failed to add tag for face selection', tagResult)
-      continue
-    }
-
-    modifiedAst = tagResult.modifiedAst
-    faceExprs.push(tagResult.exprs[0])
-  }
-
-  const edgeExprs: Expr[] = []
-  for (const edgeSelection of edgeSelections) {
-    const tagResult = modifyAstWithTagsForSelection(
-      modifiedAst,
-      edgeSelection,
-      artifactGraph,
-      wasmInstance
-    )
-    if (err(tagResult)) {
-      console.warn('Failed to add tags for edge selection', tagResult)
-      continue
-    }
-
-    modifiedAst = tagResult.modifiedAst
-    if (tagResult.exprs.length < 2) {
-      console.warn('Edge selection did not resolve to enough faces', tagResult)
-      continue
-    }
-
-    edgeExprs.push(
-      createCallExpressionStdLibKw('getCommonEdge', null, [
-        createLabeledArg('faces', createArrayExpression(tagResult.exprs)),
-      ])
-    )
-  }
-
-  const uniqueFaceExprs = deduplicateFaceExprs(faceExprs)
-  const uniqueEdgeExprs = deduplicateFaceExprs(edgeExprs)
-  if (uniqueFaceExprs.length === 0 && uniqueEdgeExprs.length === 0) {
-    return new Error('No valid face or edge expressions could be generated')
-  }
+  const targetExprs = buildFaceAndEdgeGdtExprs({
+    modifiedAst,
+    artifactGraph,
+    objects,
+    wasmInstance,
+    nodeToEdit: mNodeToEdit,
+  })
+  if (err(targetExprs)) return targetExprs
+  modifiedAst = targetExprs.modifiedAst
+  const uniqueFaceExprs = targetExprs.faceExprs
+  const uniqueEdgeExprs = targetExprs.edgeExprs
 
   if ('variableName' in tolerance && tolerance.variableName) {
     insertVariableAndOffsetPathToNode(tolerance, modifiedAst, mNodeToEdit)
@@ -2323,65 +1996,17 @@ export function addParallelismGdt({
   let modifiedAst = structuredClone(ast)
   const mNodeToEdit = structuredClone(nodeToEdit)
 
-  const faceSelections = objects.graphSelections.filter((selection) =>
-    isFaceArtifact(selection.artifact)
-  )
-  const edgeSelections = objects.graphSelections.filter((selection) =>
-    isProfileEdgeArtifact(selection.artifact)
-  )
-
-  if (faceSelections.length === 0 && edgeSelections.length === 0) {
-    return new Error('No valid selections found. Please select faces or edges.')
-  }
-
-  const faceExprs: Expr[] = []
-  for (const faceSelection of faceSelections) {
-    const tagResult = modifyAstWithTagsForSelection(
-      modifiedAst,
-      faceSelection,
-      artifactGraph,
-      wasmInstance
-    )
-    if (err(tagResult)) {
-      console.warn('Failed to add tag for face selection', tagResult)
-      continue
-    }
-
-    modifiedAst = tagResult.modifiedAst
-    faceExprs.push(tagResult.exprs[0])
-  }
-
-  const edgeExprs: Expr[] = []
-  for (const edgeSelection of edgeSelections) {
-    const tagResult = modifyAstWithTagsForSelection(
-      modifiedAst,
-      edgeSelection,
-      artifactGraph,
-      wasmInstance
-    )
-    if (err(tagResult)) {
-      console.warn('Failed to add tags for edge selection', tagResult)
-      continue
-    }
-
-    modifiedAst = tagResult.modifiedAst
-    if (tagResult.exprs.length < 2) {
-      console.warn('Edge selection did not resolve to enough faces', tagResult)
-      continue
-    }
-
-    edgeExprs.push(
-      createCallExpressionStdLibKw('getCommonEdge', null, [
-        createLabeledArg('faces', createArrayExpression(tagResult.exprs)),
-      ])
-    )
-  }
-
-  const uniqueFaceExprs = deduplicateFaceExprs(faceExprs)
-  const uniqueEdgeExprs = deduplicateFaceExprs(edgeExprs)
-  if (uniqueFaceExprs.length === 0 && uniqueEdgeExprs.length === 0) {
-    return new Error('No valid face or edge expressions could be generated')
-  }
+  const targetExprs = buildFaceAndEdgeGdtExprs({
+    modifiedAst,
+    artifactGraph,
+    objects,
+    wasmInstance,
+    nodeToEdit: mNodeToEdit,
+  })
+  if (err(targetExprs)) return targetExprs
+  modifiedAst = targetExprs.modifiedAst
+  const uniqueFaceExprs = targetExprs.faceExprs
+  const uniqueEdgeExprs = targetExprs.edgeExprs
 
   if ('variableName' in tolerance && tolerance.variableName) {
     insertVariableAndOffsetPathToNode(tolerance, modifiedAst, mNodeToEdit)
@@ -2505,65 +2130,17 @@ export function addAnnotationGdt({
   let modifiedAst = structuredClone(ast)
   const mNodeToEdit = structuredClone(nodeToEdit)
 
-  const faceSelections = objects.graphSelections.filter((selection) =>
-    isFaceArtifact(selection.artifact)
-  )
-  const edgeSelections = objects.graphSelections.filter((selection) =>
-    isProfileEdgeArtifact(selection.artifact)
-  )
-
-  if (faceSelections.length === 0 && edgeSelections.length === 0) {
-    return new Error('No valid selections found. Please select faces or edges.')
-  }
-
-  const faceExprs: Expr[] = []
-  for (const faceSelection of faceSelections) {
-    const tagResult = modifyAstWithTagsForSelection(
-      modifiedAst,
-      faceSelection,
-      artifactGraph,
-      wasmInstance
-    )
-    if (err(tagResult)) {
-      console.warn('Failed to add tag for face selection', tagResult)
-      continue
-    }
-
-    modifiedAst = tagResult.modifiedAst
-    faceExprs.push(tagResult.exprs[0])
-  }
-
-  const edgeExprs: Expr[] = []
-  for (const edgeSelection of edgeSelections) {
-    const tagResult = modifyAstWithTagsForSelection(
-      modifiedAst,
-      edgeSelection,
-      artifactGraph,
-      wasmInstance
-    )
-    if (err(tagResult)) {
-      console.warn('Failed to add tags for edge selection', tagResult)
-      continue
-    }
-
-    modifiedAst = tagResult.modifiedAst
-    if (tagResult.exprs.length < 2) {
-      console.warn('Edge selection did not resolve to enough faces', tagResult)
-      continue
-    }
-
-    edgeExprs.push(
-      createCallExpressionStdLibKw('getCommonEdge', null, [
-        createLabeledArg('faces', createArrayExpression(tagResult.exprs)),
-      ])
-    )
-  }
-
-  const uniqueFaceExprs = deduplicateFaceExprs(faceExprs)
-  const uniqueEdgeExprs = deduplicateFaceExprs(edgeExprs)
-  if (uniqueFaceExprs.length === 0 && uniqueEdgeExprs.length === 0) {
-    return new Error('No valid face or edge expressions could be generated')
-  }
+  const targetExprs = buildFaceAndEdgeGdtExprs({
+    modifiedAst,
+    artifactGraph,
+    objects,
+    wasmInstance,
+    nodeToEdit: mNodeToEdit,
+  })
+  if (err(targetExprs)) return targetExprs
+  modifiedAst = targetExprs.modifiedAst
+  const uniqueFaceExprs = targetExprs.faceExprs
+  const uniqueEdgeExprs = targetExprs.edgeExprs
 
   const styleResult = processGdtStyleParameters({
     modifiedAst,
@@ -2756,9 +2333,11 @@ export function addDatumGdt({
   const mNodeToEdit = structuredClone(nodeToEdit)
 
   // Filter to only include face selections
-  const faceSelections = faces.graphSelections.filter((selection) =>
-    isFaceArtifact(selection.artifact)
-  )
+  const faceSelections = mNodeToEdit
+    ? []
+    : faces.graphSelections.filter((selection) =>
+        isFaceArtifact(selection.artifact)
+      )
 
   // Validate datum name is a single character
   if (name.length !== 1) {
@@ -2771,33 +2350,29 @@ export function addDatumGdt({
   }
 
   // Datum requires exactly one face
-  if (faceSelections.length === 0) {
+  if (!mNodeToEdit && faceSelections.length === 0) {
     return new Error('No face selected for datum annotation')
   }
-  if (faceSelections.length > 1) {
+  if (!mNodeToEdit && faceSelections.length > 1) {
     return new Error(
       'Datum annotation requires exactly one face, but multiple faces were selected'
     )
   }
 
-  const faceSelection = faceSelections[0]
-
-  // Get face expression with tag
-  const tagResult = modifyAstWithTagsForSelection(
-    modifiedAst,
-    faceSelection,
-    artifactGraph,
-    wasmInstance
-  )
-  if (err(tagResult)) {
-    return tagResult
+  let faceExpr: Expr = createLocalName('selection')
+  if (!mNodeToEdit) {
+    const tagResult = modifyAstWithTagsForSelection(
+      modifiedAst,
+      faceSelections[0],
+      artifactGraph,
+      wasmInstance
+    )
+    if (err(tagResult)) {
+      return tagResult
+    }
+    modifiedAst = tagResult.modifiedAst
+    faceExpr = tagResult.exprs[0]
   }
-
-  // Update the AST with the tagged version
-  modifiedAst = tagResult.modifiedAst
-
-  // Create expression from the first tag
-  const faceExpr = tagResult.exprs[0]
 
   // Process common GDT style parameters
   const styleResult = processGdtStyleParameters({

--- a/src/lang/modifyAst/gdt.ts
+++ b/src/lang/modifyAst/gdt.ts
@@ -12,7 +12,7 @@ import {
   createPoint2dExpression,
   deduplicateFaceExprs,
   insertVariableAndOffsetPathToNode,
-  setCallInAst,
+  setCallInAst as setBaseCallInAst,
 } from '@src/lang/modifyAst'
 import { isFaceArtifact } from '@src/lang/modifyAst/faces'
 import { modifyAstWithTagsForSelection } from '@src/lang/modifyAst/tagManagement'
@@ -25,6 +25,21 @@ import { err } from '@src/lib/trap'
 import { isArray } from '@src/lib/utils'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { Selections } from '@src/machines/modelingSharedTypes'
+
+const GDT_LABELED_SELECTION_ARG_NAMES = [
+  'faces',
+  'edges',
+  'from',
+  'to',
+  'face',
+] as const
+
+function setCallInAst(args: Parameters<typeof setBaseCallInAst>[0]) {
+  return setBaseCallInAst({
+    ...args,
+    labeledSelectionArgNames: GDT_LABELED_SELECTION_ARG_NAMES,
+  })
+}
 
 function isProfileEdgeArtifact(
   artifact: Selections['graphSelections'][number]['artifact']

--- a/src/lang/modifyAst/geometry.ts
+++ b/src/lang/modifyAst/geometry.ts
@@ -161,6 +161,9 @@ export function addHelix({
     pathToEdit: mNodeToEdit,
     pathIfNewPipe,
     variableIfNewDecl: KCL_DEFAULT_CONSTANT_PREFIXES.HELIX,
+    // During edits, `axis` is set only for explicit X/Y/Z values. If it is
+    // undefined, keep whichever selection-backed input exists: `axis` or `cylinder`.
+    labeledSelectionArgNames: mNodeToEdit && !axis ? ['axis', 'cylinder'] : [],
     wasmInstance,
   })
   if (err(pathToNode)) {

--- a/src/lang/modifyAst/geometry.ts
+++ b/src/lang/modifyAst/geometry.ts
@@ -76,13 +76,15 @@ export function addHelix({
   let pathIfNewPipe: PathToNode | undefined
   const axisExpr: LabeledArg[] = []
   const cylinderExpr: LabeledArg[] = []
-  if (cylinder) {
+  // Only explicit X/Y/Z axes are editable. Selection-backed axis and cylinder
+  // arguments are omitted here, then restored verbatim by setCallInAst.
+  if (cylinder && !mNodeToEdit) {
     const vars = getVariableExprsFromSelection(
       cylinder,
       artifactGraph,
       modifiedAst,
       wasmInstance,
-      mNodeToEdit,
+      undefined,
       {
         lastChildLookup: true,
       }
@@ -92,7 +94,7 @@ export function addHelix({
     }
     cylinderExpr.push(createLabeledArg('cylinder', vars.exprs[0]))
     pathIfNewPipe = vars.pathIfPipe
-  } else if (axis || edge) {
+  } else if (axis || (edge && !mNodeToEdit)) {
     const result = getAxisExpression(
       axis,
       edge,
@@ -105,7 +107,7 @@ export function addHelix({
     }
     axisExpr.push(createLabeledArg('axis', result.generatedAxis))
     modifiedAst = result.modifiedAst
-  } else {
+  } else if (!mNodeToEdit) {
     return new Error('Helix must have either an axis or a cylinder')
   }
 

--- a/src/lang/modifyAst/pattern3D.ts
+++ b/src/lang/modifyAst/pattern3D.ts
@@ -25,6 +25,33 @@ import { isArray } from '@src/lib/utils'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { Selections } from '@src/machines/modelingSharedTypes'
 
+function getPatternSelectionVars({
+  solids,
+  artifactGraph,
+  modifiedAst,
+  wasmInstance,
+  nodeToEdit,
+}: {
+  solids: Selections
+  artifactGraph: ArtifactGraph
+  modifiedAst: Node<Program>
+  wasmInstance: ModuleType
+  nodeToEdit?: PathToNode
+}) {
+  if (nodeToEdit) {
+    return { exprs: [] }
+  }
+
+  return getVariableExprsFromSelection(
+    solids,
+    artifactGraph,
+    modifiedAst,
+    wasmInstance,
+    undefined,
+    { lastChildLookup: true }
+  )
+}
+
 export function addPatternCircular3D({
   ast,
   artifactGraph,
@@ -55,16 +82,13 @@ export function addPatternCircular3D({
   const mNodeToEdit = structuredClone(nodeToEdit)
 
   // Prepare function arguments from selected solids
-  const vars = getVariableExprsFromSelection(
+  const vars = getPatternSelectionVars({
     solids,
     artifactGraph,
     modifiedAst,
     wasmInstance,
-    mNodeToEdit,
-    {
-      lastChildLookup: true,
-    }
-  )
+    nodeToEdit: mNodeToEdit,
+  })
   if (err(vars)) {
     return vars
   }
@@ -226,16 +250,13 @@ export function addPatternLinear3D({
   const mNodeToEdit = structuredClone(nodeToEdit)
 
   // Prepare function arguments from selected solids
-  const vars = getVariableExprsFromSelection(
+  const vars = getPatternSelectionVars({
     solids,
     artifactGraph,
     modifiedAst,
     wasmInstance,
-    mNodeToEdit,
-    {
-      lastChildLookup: true,
-    }
-  )
+    nodeToEdit: mNodeToEdit,
+  })
   if (err(vars)) {
     return vars
   }

--- a/src/lang/modifyAst/pattern3D.ts
+++ b/src/lang/modifyAst/pattern3D.ts
@@ -9,13 +9,11 @@ import {
 } from '@src/lang/create'
 import {
   createVariableExpressionsArray,
+  getSelectionVarsForCall,
   insertVariableAndOffsetPathToNode,
   setCallInAst,
 } from '@src/lang/modifyAst'
-import {
-  getVariableExprsFromSelection,
-  valueOrVariable,
-} from '@src/lang/queryAst'
+import { valueOrVariable } from '@src/lang/queryAst'
 import type { ArtifactGraph, PathToNode, Program } from '@src/lang/wasm'
 import { modelingStdLibCommandName } from '@src/lib/commandBarConfigs/modelingCommandStdLib'
 import type { KclCommandValue } from '@src/lib/commandTypes'
@@ -24,33 +22,6 @@ import { err } from '@src/lib/trap'
 import { isArray } from '@src/lib/utils'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { Selections } from '@src/machines/modelingSharedTypes'
-
-function getPatternSelectionVars({
-  solids,
-  artifactGraph,
-  modifiedAst,
-  wasmInstance,
-  nodeToEdit,
-}: {
-  solids: Selections
-  artifactGraph: ArtifactGraph
-  modifiedAst: Node<Program>
-  wasmInstance: ModuleType
-  nodeToEdit?: PathToNode
-}) {
-  if (nodeToEdit) {
-    return { exprs: [] }
-  }
-
-  return getVariableExprsFromSelection(
-    solids,
-    artifactGraph,
-    modifiedAst,
-    wasmInstance,
-    undefined,
-    { lastChildLookup: true }
-  )
-}
 
 export function addPatternCircular3D({
   ast,
@@ -82,8 +53,8 @@ export function addPatternCircular3D({
   const mNodeToEdit = structuredClone(nodeToEdit)
 
   // Prepare function arguments from selected solids
-  const vars = getPatternSelectionVars({
-    solids,
+  const vars = getSelectionVarsForCall({
+    selection: solids,
     artifactGraph,
     modifiedAst,
     wasmInstance,
@@ -250,8 +221,8 @@ export function addPatternLinear3D({
   const mNodeToEdit = structuredClone(nodeToEdit)
 
   // Prepare function arguments from selected solids
-  const vars = getPatternSelectionVars({
-    solids,
+  const vars = getSelectionVarsForCall({
+    selection: solids,
     artifactGraph,
     modifiedAst,
     wasmInstance,

--- a/src/lang/modifyAst/surfaces.ts
+++ b/src/lang/modifyAst/surfaces.ts
@@ -12,7 +12,7 @@ import {
   getVariableExprsFromSelection,
   valueOrVariable,
 } from '@src/lang/queryAst'
-import type { ArtifactGraph, PathToNode, Program } from '@src/lang/wasm'
+import type { ArtifactGraph, Expr, PathToNode, Program } from '@src/lang/wasm'
 import { modelingStdLibCommandName } from '@src/lib/commandBarConfigs/modelingCommandStdLib'
 import type { KclCommandValue } from '@src/lib/commandTypes'
 import { KCL_DEFAULT_CONSTANT_PREFIXES } from '@src/lib/constants'
@@ -47,22 +47,24 @@ export function addFlipSurface({
   const mNodeToEdit = structuredClone(nodeToEdit)
 
   // 2. Prepare unlabeled arguments
-  if (surface.graphSelections.length < 1) {
+  if (!mNodeToEdit && surface.graphSelections.length < 1) {
     return new Error('flipSurface surfaces must have at least one selection.')
   }
 
-  const vars = getVariableExprsFromSelection(
-    surface,
-    artifactGraph,
-    modifiedAst,
-    wasmInstance,
-    mNodeToEdit,
-    {
-      lastChildLookup: true,
+  let vars: { exprs: Expr[]; pathIfPipe?: PathToNode } = { exprs: [] }
+  if (!mNodeToEdit) {
+    const selectionVars = getVariableExprsFromSelection(
+      surface,
+      artifactGraph,
+      modifiedAst,
+      wasmInstance,
+      undefined,
+      { lastChildLookup: true }
+    )
+    if (err(selectionVars)) {
+      return selectionVars
     }
-  )
-  if (err(vars)) {
-    return vars
+    vars = selectionVars
   }
 
   const objectsExpr = createVariableExpressionsArray(vars.exprs)
@@ -121,23 +123,27 @@ export function addJoinSurfaces({
   const mNodeToEdit = structuredClone(nodeToEdit)
 
   // 2. Prepare unlabeled arguments
-  if (selection.graphSelections.length < 1) {
+  if (!mNodeToEdit && selection.graphSelections.length < 1) {
     return new Error('join selection must have at least one selection.')
   }
 
-  const vars = getVariableExprsFromSelection(
-    selection,
-    artifactGraph,
-    modifiedAst,
-    wasmInstance,
-    mNodeToEdit,
-    {
-      lastChildLookup: true,
-      artifactTypeFilter: ['compositeSolid', 'sweep'],
+  let vars: { exprs: Expr[]; pathIfPipe?: PathToNode } = { exprs: [] }
+  if (!mNodeToEdit) {
+    const selectionVars = getVariableExprsFromSelection(
+      selection,
+      artifactGraph,
+      modifiedAst,
+      wasmInstance,
+      undefined,
+      {
+        lastChildLookup: true,
+        artifactTypeFilter: ['compositeSolid', 'sweep'],
+      }
+    )
+    if (err(selectionVars)) {
+      return selectionVars
     }
-  )
-  if (err(vars)) {
-    return vars
+    vars = selectionVars
   }
 
   const objectsExpr = createVariableExpressionsArray(vars.exprs)

--- a/src/lang/modifyAst/sweeps.spec.ts
+++ b/src/lang/modifyAst/sweeps.spec.ts
@@ -205,6 +205,44 @@ profile002 = rectangle(
 }`
 
   describe('Testing addExtrude', () => {
+    it('edits scalar arguments when selection reconstruction is unavailable', async () => {
+      const code =
+        'extrude001 = extrude(profile001, to = cap, direction = axis)'
+      const ast = assertParse(code, instanceInThisFile)
+      const length = await getKclCommandValue(
+        '2',
+        instanceInThisFile,
+        rustContextInThisFile
+      )
+      const unavailableSelection = {
+        graphSelections: [],
+        otherSelections: [],
+      }
+
+      const result = addExtrude({
+        ast,
+        artifactGraph: new Map() as ArtifactGraph,
+        sketches: unavailableSelection,
+        to: unavailableSelection,
+        direction: unavailableSelection,
+        length,
+        nodeToEdit: createPathToNodeForLastVariable(ast),
+        wasmInstance: instanceInThisFile,
+      })
+      if (err(result)) throw result
+
+      const newCode = recast(result.modifiedAst, instanceInThisFile)
+      if (err(newCode)) throw newCode
+      expect(newCode.trim()).toBe(
+        `extrude001 = extrude(
+  profile001,
+  to = cap,
+  direction = axis,
+  length = 2,
+)`
+      )
+    })
+
     it('should add a basic extrude call', async () => {
       const { ast, sketches, artifactGraph } = await getAstAndSketchSelections(
         circleProfileCode,

--- a/src/lang/modifyAst/sweeps.ts
+++ b/src/lang/modifyAst/sweeps.ts
@@ -135,75 +135,77 @@ export function addExtrude({
     exprs: Expr[]
     pathIfPipe?: PathToNode
   } = { exprs: [] }
-  const res = getFacesExprsFromSelection(
-    modifiedAst,
-    sketches,
-    artifactGraph,
-    wasmInstance
-  )
-  if (err(res)) return res
-  modifiedAst = res.modifiedAst
-  vars.exprs.push(...res.exprs)
-
-  const nonFaceSelections: Selections = {
-    graphSelections: sketches.graphSelections.filter(
-      (selection) =>
-        !isFaceArtifact(selection.artifact) &&
-        selection.artifact?.type !== 'sweepEdge'
-    ),
-    otherSelections: sketches.otherSelections.filter(
-      (selection) =>
-        !(
-          isEnginePrimitiveSelection(selection) &&
-          selection.primitiveType === 'edge'
-        )
-    ),
-  }
-  if (nonFaceSelections.graphSelections.length > 0) {
-    const res = getVariableExprsFromSelection(
-      nonFaceSelections,
-      artifactGraph,
+  if (!mNodeToEdit) {
+    const res = getFacesExprsFromSelection(
       modifiedAst,
-      wasmInstance,
-      mNodeToEdit
+      sketches,
+      artifactGraph,
+      wasmInstance
     )
-    if (err(res)) {
-      return res
-    }
-    vars.pathIfPipe = res.pathIfPipe
+    if (err(res)) return res
+    modifiedAst = res.modifiedAst
     vars.exprs.push(...res.exprs)
-  }
 
-  const edgeProfileExprs = getEdgeProfileExprsFromSelection({
-    selections: sketches,
-    modifiedAst,
-    artifactGraph,
-    wasmInstance,
-    nodeToEdit: mNodeToEdit,
-  })
-  if (err(edgeProfileExprs)) return edgeProfileExprs
-  modifiedAst = edgeProfileExprs.modifiedAst
-  vars.exprs.push(...edgeProfileExprs.exprs)
+    const nonFaceSelections: Selections = {
+      graphSelections: sketches.graphSelections.filter(
+        (selection) =>
+          !isFaceArtifact(selection.artifact) &&
+          selection.artifact?.type !== 'sweepEdge'
+      ),
+      otherSelections: sketches.otherSelections.filter(
+        (selection) =>
+          !(
+            isEnginePrimitiveSelection(selection) &&
+            selection.primitiveType === 'edge'
+          )
+      ),
+    }
+    if (nonFaceSelections.graphSelections.length > 0) {
+      const res = getVariableExprsFromSelection(
+        nonFaceSelections,
+        artifactGraph,
+        modifiedAst,
+        wasmInstance
+      )
+      if (err(res)) {
+        return res
+      }
+      vars.pathIfPipe = res.pathIfPipe
+      vars.exprs.push(...res.exprs)
+    }
 
-  const engineRegions = sketches.otherSelections.filter(isEngineRegionSelection)
-  if (engineRegions.length > 0) {
-    const hideResult = addHideCallsForRegionSketches({
-      engineRegions,
+    const edgeProfileExprs = getEdgeProfileExprsFromSelection({
+      selections: sketches,
       modifiedAst,
       artifactGraph,
       wasmInstance,
     })
-    if (err(hideResult)) return hideResult
-    modifiedAst = hideResult
+    if (err(edgeProfileExprs)) return edgeProfileExprs
+    modifiedAst = edgeProfileExprs.modifiedAst
+    vars.exprs.push(...edgeProfileExprs.exprs)
 
-    const regionExprs = insertRegionVariablesAndOffsetPathToNode({
-      engineRegions,
-      modifiedAst,
-      artifactGraph,
-      wasmInstance,
-    })
-    if (err(regionExprs)) return regionExprs
-    vars.exprs.push(...regionExprs)
+    const engineRegions = sketches.otherSelections.filter(
+      isEngineRegionSelection
+    )
+    if (engineRegions.length > 0) {
+      const hideResult = addHideCallsForRegionSketches({
+        engineRegions,
+        modifiedAst,
+        artifactGraph,
+        wasmInstance,
+      })
+      if (err(hideResult)) return hideResult
+      modifiedAst = hideResult
+
+      const regionExprs = insertRegionVariablesAndOffsetPathToNode({
+        engineRegions,
+        modifiedAst,
+        artifactGraph,
+        wasmInstance,
+      })
+      if (err(regionExprs)) return regionExprs
+      vars.exprs.push(...regionExprs)
+    }
   }
 
   // Extra labeled args expressions
@@ -212,7 +214,7 @@ export function addExtrude({
     : []
   // Special handling for 'to' arg
   let toExpr: LabeledArg[] = []
-  if (to) {
+  if (to && !mNodeToEdit) {
     if (to.graphSelections.length !== 1) {
       return new Error('Extrude "to" argument must have exactly one selection.')
     }
@@ -231,7 +233,7 @@ export function addExtrude({
       ? [createLabeledArg('symmetric', createLiteral(symmetric, wasmInstance))]
       : []
   let directionExpr: LabeledArg[] = []
-  if (direction) {
+  if (direction && !mNodeToEdit) {
     const edgeDirectionResult = getEdgeProfileExprsFromSelection({
       selections: direction,
       modifiedAst,
@@ -440,73 +442,76 @@ export function addSweep({
     exprs: Expr[]
     pathIfPipe?: PathToNode
   } = { exprs: [] }
-  const res = getFacesExprsFromSelection(
-    modifiedAst,
-    sketches,
-    artifactGraph,
-    wasmInstance
-  )
-  if (err(res)) return res
-  modifiedAst = res.modifiedAst
-  vars.exprs.push(...res.exprs)
-
-  const nonFaceSelections: Selections = {
-    graphSelections: sketches.graphSelections.filter(
-      (selection) => !isFaceArtifact(selection.artifact)
-    ),
-    otherSelections: sketches.otherSelections,
-  }
-  if (nonFaceSelections.graphSelections.length > 0) {
-    const res = getVariableExprsFromSelection(
-      nonFaceSelections,
-      artifactGraph,
+  let pathExpr: Expr | null = null
+  if (!mNodeToEdit) {
+    const res = getFacesExprsFromSelection(
       modifiedAst,
-      wasmInstance,
-      mNodeToEdit
+      sketches,
+      artifactGraph,
+      wasmInstance
     )
-    if (err(res)) {
-      return res
-    }
-    vars.pathIfPipe = res.pathIfPipe
+    if (err(res)) return res
+    modifiedAst = res.modifiedAst
     vars.exprs.push(...res.exprs)
-  }
 
-  const engineRegions = sketches.otherSelections.filter(isEngineRegionSelection)
-  if (engineRegions.length > 0) {
-    const hideResult = addHideCallsForRegionSketches({
-      engineRegions,
-      modifiedAst,
+    const nonFaceSelections: Selections = {
+      graphSelections: sketches.graphSelections.filter(
+        (selection) => !isFaceArtifact(selection.artifact)
+      ),
+      otherSelections: sketches.otherSelections,
+    }
+    if (nonFaceSelections.graphSelections.length > 0) {
+      const res = getVariableExprsFromSelection(
+        nonFaceSelections,
+        artifactGraph,
+        modifiedAst,
+        wasmInstance
+      )
+      if (err(res)) {
+        return res
+      }
+      vars.pathIfPipe = res.pathIfPipe
+      vars.exprs.push(...res.exprs)
+    }
+
+    const engineRegions = sketches.otherSelections.filter(
+      isEngineRegionSelection
+    )
+    if (engineRegions.length > 0) {
+      const hideResult = addHideCallsForRegionSketches({
+        engineRegions,
+        modifiedAst,
+        artifactGraph,
+        wasmInstance,
+      })
+      if (err(hideResult)) return hideResult
+      modifiedAst = hideResult
+
+      const regionExprs = insertRegionVariablesAndOffsetPathToNode({
+        engineRegions,
+        modifiedAst,
+        artifactGraph,
+        wasmInstance,
+      })
+      if (err(regionExprs)) return regionExprs
+      vars.exprs.push(...regionExprs)
+    }
+
+    const pathVars = getVariableExprsFromSelection(
+      path,
       artifactGraph,
-      wasmInstance,
-    })
-    if (err(hideResult)) return hideResult
-    modifiedAst = hideResult
-
-    const regionExprs = insertRegionVariablesAndOffsetPathToNode({
-      engineRegions,
       modifiedAst,
-      artifactGraph,
       wasmInstance,
-    })
-    if (err(regionExprs)) return regionExprs
-    vars.exprs.push(...regionExprs)
-  }
+      undefined
+    )
+    if (err(pathVars)) {
+      return pathVars
+    }
 
-  // Find the path declaration for the labeled argument
-  const pathVars = getVariableExprsFromSelection(
-    path,
-    artifactGraph,
-    modifiedAst,
-    wasmInstance,
-    mNodeToEdit
-  )
-  if (err(pathVars)) {
-    return pathVars
-  }
-
-  const pathExpr = createVariableExpressionsArray(pathVars.exprs)
-  if (!pathExpr) {
-    return new Error("Couldn't retrieve path selection")
+    pathExpr = createVariableExpressionsArray(pathVars.exprs)
+    if (!pathExpr) {
+      return new Error("Couldn't retrieve path selection")
+    }
   }
 
   // Extra labeled args expressions
@@ -578,7 +583,7 @@ export function addSweep({
     modelingStdLibCommandName('Sweep'),
     sketchesExpr,
     [
-      createLabeledArg('path', pathExpr),
+      ...(pathExpr ? [createLabeledArg('path', pathExpr)] : []),
       ...sectionalExpr,
       ...toleranceExpr,
       ...relativeToExpr,
@@ -657,36 +662,42 @@ export function addLoft({
 
   // 2. Prepare unlabeled and labeled arguments
   // Map the sketches selection into a list of kcl expressions to be passed as unlabelled argument
-  const vars = getVariableExprsFromSelection(
-    sketches,
-    artifactGraph,
-    modifiedAst,
-    wasmInstance,
-    mNodeToEdit
-  )
-  if (err(vars)) {
-    return vars
-  }
-
-  const engineRegions = sketches.otherSelections.filter(isEngineRegionSelection)
-  if (engineRegions.length > 0) {
-    const hideResult = addHideCallsForRegionSketches({
-      engineRegions,
-      modifiedAst,
+  const vars: { exprs: Expr[]; pathIfPipe?: PathToNode } = { exprs: [] }
+  if (!mNodeToEdit) {
+    const selectionVars = getVariableExprsFromSelection(
+      sketches,
       artifactGraph,
-      wasmInstance,
-    })
-    if (err(hideResult)) return hideResult
-    modifiedAst = hideResult
-
-    const regionExprs = insertRegionVariablesAndOffsetPathToNode({
-      engineRegions,
       modifiedAst,
-      artifactGraph,
-      wasmInstance,
-    })
-    if (err(regionExprs)) return regionExprs
-    vars.exprs.push(...regionExprs)
+      wasmInstance
+    )
+    if (err(selectionVars)) {
+      return selectionVars
+    }
+    vars.exprs = selectionVars.exprs
+    vars.pathIfPipe = selectionVars.pathIfPipe
+
+    const engineRegions = sketches.otherSelections.filter(
+      isEngineRegionSelection
+    )
+    if (engineRegions.length > 0) {
+      const hideResult = addHideCallsForRegionSketches({
+        engineRegions,
+        modifiedAst,
+        artifactGraph,
+        wasmInstance,
+      })
+      if (err(hideResult)) return hideResult
+      modifiedAst = hideResult
+
+      const regionExprs = insertRegionVariablesAndOffsetPathToNode({
+        engineRegions,
+        modifiedAst,
+        artifactGraph,
+        wasmInstance,
+      })
+      if (err(regionExprs)) return regionExprs
+      vars.exprs.push(...regionExprs)
+    }
   }
 
   // Extra labeled args expressions
@@ -810,49 +821,60 @@ export function addRevolve({
 
   // 2. Prepare unlabeled and labeled arguments
   // Map the sketches selection into a list of kcl expressions to be passed as unlabelled argument
-  const vars = getVariableExprsFromSelection(
-    sketches,
-    artifactGraph,
-    modifiedAst,
-    wasmInstance,
-    mNodeToEdit
-  )
-  if (err(vars)) {
-    return vars
-  }
-  const engineRegions = sketches.otherSelections.filter(isEngineRegionSelection)
-  if (engineRegions.length > 0) {
-    const hideResult = addHideCallsForRegionSketches({
-      engineRegions,
-      modifiedAst,
+  const vars: { exprs: Expr[]; pathIfPipe?: PathToNode } = { exprs: [] }
+  if (!mNodeToEdit) {
+    const selectionVars = getVariableExprsFromSelection(
+      sketches,
       artifactGraph,
-      wasmInstance,
-    })
-    if (err(hideResult)) return hideResult
-    modifiedAst = hideResult
+      modifiedAst,
+      wasmInstance
+    )
+    if (err(selectionVars)) {
+      return selectionVars
+    }
+    vars.exprs = selectionVars.exprs
+    vars.pathIfPipe = selectionVars.pathIfPipe
 
-    const regionExprs = insertRegionVariablesAndOffsetPathToNode({
-      engineRegions,
-      modifiedAst,
-      artifactGraph,
-      wasmInstance,
-    })
-    if (err(regionExprs)) return regionExprs
-    vars.exprs.push(...regionExprs)
+    const engineRegions = sketches.otherSelections.filter(
+      isEngineRegionSelection
+    )
+    if (engineRegions.length > 0) {
+      const hideResult = addHideCallsForRegionSketches({
+        engineRegions,
+        modifiedAst,
+        artifactGraph,
+        wasmInstance,
+      })
+      if (err(hideResult)) return hideResult
+      modifiedAst = hideResult
+
+      const regionExprs = insertRegionVariablesAndOffsetPathToNode({
+        engineRegions,
+        modifiedAst,
+        artifactGraph,
+        wasmInstance,
+      })
+      if (err(regionExprs)) return regionExprs
+      vars.exprs.push(...regionExprs)
+    }
   }
 
   // Retrieve axis expression depending on mode
-  const getAxisResult = getAxisExpression(
-    axis,
-    edge,
-    modifiedAst,
-    wasmInstance,
-    artifactGraph
-  )
-  if (err(getAxisResult)) {
-    return new Error('Generated axis selection is missing.')
+  const axisExpr: LabeledArg[] = []
+  if (axis || !mNodeToEdit) {
+    const getAxisResult = getAxisExpression(
+      axis,
+      edge,
+      modifiedAst,
+      wasmInstance,
+      artifactGraph
+    )
+    if (err(getAxisResult)) {
+      return new Error('Generated axis selection is missing.')
+    }
+    modifiedAst = getAxisResult.modifiedAst
+    axisExpr.push(createLabeledArg('axis', getAxisResult.generatedAxis))
   }
-  modifiedAst = getAxisResult.modifiedAst
 
   // Extra labeled args expressions
   const symmetricExpr =
@@ -886,7 +908,7 @@ export function addRevolve({
     sketchesExpr,
     [
       createLabeledArg('angle', valueOrVariable(angle)),
-      createLabeledArg('axis', getAxisResult.generatedAxis),
+      ...axisExpr,
       ...toleranceExpr,
       ...symmetricExpr,
       ...bidirectionalAngleExpr,

--- a/src/lang/modifyAst/sweeps.ts
+++ b/src/lang/modifyAst/sweeps.ts
@@ -370,6 +370,7 @@ export function addExtrude({
     pathToEdit: mNodeToEdit,
     pathIfNewPipe: vars.pathIfPipe,
     variableIfNewDecl: KCL_DEFAULT_CONSTANT_PREFIXES.EXTRUDE,
+    labeledSelectionArgNames: ['to', 'direction'],
     wasmInstance,
   })
   if (err(pathToNode)) {
@@ -605,6 +606,7 @@ export function addSweep({
     pathToEdit: mNodeToEdit,
     pathIfNewPipe: vars.pathIfPipe,
     variableIfNewDecl: KCL_DEFAULT_CONSTANT_PREFIXES.SWEEP,
+    labeledSelectionArgNames: ['path'],
     wasmInstance,
   })
   if (err(pathToNode)) {
@@ -922,6 +924,9 @@ export function addRevolve({
     pathToEdit: mNodeToEdit,
     pathIfNewPipe: vars.pathIfPipe,
     variableIfNewDecl: KCL_DEFAULT_CONSTANT_PREFIXES.REVOLVE,
+    // During edits, `axis` is set only for explicit X/Y/Z values. If it is
+    // undefined, keep the existing selection-backed `axis` argument.
+    labeledSelectionArgNames: mNodeToEdit && !axis ? ['axis'] : [],
     wasmInstance,
   })
   if (err(pathToNode)) {

--- a/src/lang/modifyAst/transforms.ts
+++ b/src/lang/modifyAst/transforms.ts
@@ -33,6 +33,33 @@ import { err } from '@src/lib/trap'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { Selections } from '@src/machines/modelingSharedTypes'
 
+function getTransformSelectionVars({
+  objects,
+  artifactGraph,
+  modifiedAst,
+  wasmInstance,
+  nodeToEdit,
+}: {
+  objects: Selections
+  artifactGraph: ArtifactGraph
+  modifiedAst: Node<Program>
+  wasmInstance: ModuleType
+  nodeToEdit?: PathToNode
+}) {
+  if (nodeToEdit) {
+    return { exprs: [] }
+  }
+
+  return getVariableExprsFromSelection(
+    objects,
+    artifactGraph,
+    modifiedAst,
+    wasmInstance,
+    undefined,
+    { lastChildLookup: true }
+  )
+}
+
 export function addTranslate({
   ast,
   artifactGraph,
@@ -62,16 +89,13 @@ export function addTranslate({
 
   // 2. Prepare unlabeled and labeled arguments
   // Map the sketches selection into a list of kcl expressions to be passed as unlabelled argument
-  const vars = getVariableExprsFromSelection(
+  const vars = getTransformSelectionVars({
     objects,
     artifactGraph,
     modifiedAst,
     wasmInstance,
-    mNodeToEdit,
-    {
-      lastChildLookup: true,
-    }
-  )
+    nodeToEdit: mNodeToEdit,
+  })
   if (err(vars)) {
     return vars
   }
@@ -157,16 +181,13 @@ export function addRotate({
 
   // 2. Prepare unlabeled and labeled arguments
   // Map the sketches selection into a list of kcl expressions to be passed as unlabelled argument
-  const vars = getVariableExprsFromSelection(
+  const vars = getTransformSelectionVars({
     objects,
     artifactGraph,
     modifiedAst,
     wasmInstance,
-    mNodeToEdit,
-    {
-      lastChildLookup: true,
-    }
-  )
+    nodeToEdit: mNodeToEdit,
+  })
   if (err(vars)) {
     return vars
   }
@@ -262,16 +283,13 @@ export function addScale({
 
   // 2. Prepare unlabeled and labeled arguments
   // Map the sketches selection into a list of kcl expressions to be passed as unlabelled argument
-  const vars = getVariableExprsFromSelection(
+  const vars = getTransformSelectionVars({
     objects,
     artifactGraph,
     modifiedAst,
     wasmInstance,
-    mNodeToEdit,
-    {
-      lastChildLookup: true,
-    }
-  )
+    nodeToEdit: mNodeToEdit,
+  })
   if (err(vars)) {
     return vars
   }
@@ -413,16 +431,13 @@ export function addAppearance({
 
   // 2. Prepare unlabeled and labeled arguments
   // Map the sketches selection into a list of kcl expressions to be passed as unlabelled argument
-  const vars = getVariableExprsFromSelection(
+  const vars = getTransformSelectionVars({
     objects,
     artifactGraph,
     modifiedAst,
     wasmInstance,
-    mNodeToEdit,
-    {
-      lastChildLookup: true,
-    }
-  )
+    nodeToEdit: mNodeToEdit,
+  })
   if (err(vars)) {
     return vars
   }
@@ -601,63 +616,65 @@ export function addMirror3D({
   const mNodeToEdit = structuredClone(nodeToEdit)
 
   // 2. Prepare unlabeled and labeled arguments
-  const vars = getVariableExprsFromSelection(
-    bodies,
-    artifactGraph,
-    modifiedAst,
-    wasmInstance,
-    mNodeToEdit,
-    {
-      lastChildLookup: true,
-      artifactTypeFilter: ['compositeSolid', 'sweep'],
-    }
-  )
-  if (err(vars)) {
-    return vars
-  }
-
-  const isEdgeSelection = across.graphSelections.some(
-    (selection) =>
-      selection.artifact?.type === 'segment' ||
-      selection.artifact?.type === 'sweepEdge' ||
-      selection.artifact?.type === 'edgeCutEdge'
-  )
-  let acrossArg: Expr
-  if (isEdgeSelection) {
-    const result = getAxisExpression(
-      undefined,
-      across,
+  let vars: { exprs: Expr[]; pathIfPipe?: PathToNode } = { exprs: [] }
+  let acrossArg: Expr | undefined
+  if (!mNodeToEdit) {
+    const selectionVars = getVariableExprsFromSelection(
+      bodies,
+      artifactGraph,
       modifiedAst,
       wasmInstance,
-      artifactGraph,
-      mNodeToEdit
+      undefined,
+      {
+        lastChildLookup: true,
+        artifactTypeFilter: ['compositeSolid', 'sweep'],
+      }
     )
-    if (err(result)) {
-      return result
+    if (err(selectionVars)) {
+      return selectionVars
     }
-    modifiedAst = result.modifiedAst
-    acrossArg = result.generatedAxis
-  } else {
-    const result = getPlaneExprFromSelection({
-      ast: modifiedAst,
-      artifactGraph,
-      variables,
-      plane: across,
-      wasmInstance,
-      nodeToEdit: mNodeToEdit,
-    })
-    if (err(result)) {
-      return result
+    vars = selectionVars
+
+    const isEdgeSelection = across.graphSelections.some(
+      (selection) =>
+        selection.artifact?.type === 'segment' ||
+        selection.artifact?.type === 'sweepEdge' ||
+        selection.artifact?.type === 'edgeCutEdge'
+    )
+    if (isEdgeSelection) {
+      const result = getAxisExpression(
+        undefined,
+        across,
+        modifiedAst,
+        wasmInstance,
+        artifactGraph
+      )
+      if (err(result)) {
+        return result
+      }
+      modifiedAst = result.modifiedAst
+      acrossArg = result.generatedAxis
+    } else {
+      const result = getPlaneExprFromSelection({
+        ast: modifiedAst,
+        artifactGraph,
+        variables,
+        plane: across,
+        wasmInstance,
+      })
+      if (err(result)) {
+        return result
+      }
+      modifiedAst = result.modifiedAst
+      acrossArg = result.expr
     }
-    modifiedAst = result.modifiedAst
-    acrossArg = result.expr
   }
 
   const objectsExpr = createVariableExpressionsArray(vars.exprs)
   const call = createCallExpressionStdLibKw(
     modelingStdLibCommandName('Mirror 3D'),
     objectsExpr,
-    [createLabeledArg('across', acrossArg)]
+    acrossArg ? [createLabeledArg('across', acrossArg)] : []
   )
 
   // 3. If edit, we assign the new function call declaration to the existing node,

--- a/src/lang/modifyAst/transforms.ts
+++ b/src/lang/modifyAst/transforms.ts
@@ -668,6 +668,7 @@ export function addMirror3D({
     pathToEdit: mNodeToEdit,
     pathIfNewPipe: vars.pathIfPipe,
     variableIfNewDecl: KCL_DEFAULT_CONSTANT_PREFIXES.SOLID,
+    labeledSelectionArgNames: ['across'],
     wasmInstance,
   })
   if (err(pathToNode)) {

--- a/src/lang/modifyAst/transforms.ts
+++ b/src/lang/modifyAst/transforms.ts
@@ -10,6 +10,7 @@ import {
 import {
   createPathToNodeForLastVariable,
   createVariableExpressionsArray,
+  getSelectionVarsForCall,
   insertVariableAndOffsetPathToNode,
   setCallInAst,
 } from '@src/lang/modifyAst'
@@ -32,33 +33,6 @@ import { KCL_DEFAULT_CONSTANT_PREFIXES } from '@src/lib/constants'
 import { err } from '@src/lib/trap'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { Selections } from '@src/machines/modelingSharedTypes'
-
-function getTransformSelectionVars({
-  objects,
-  artifactGraph,
-  modifiedAst,
-  wasmInstance,
-  nodeToEdit,
-}: {
-  objects: Selections
-  artifactGraph: ArtifactGraph
-  modifiedAst: Node<Program>
-  wasmInstance: ModuleType
-  nodeToEdit?: PathToNode
-}) {
-  if (nodeToEdit) {
-    return { exprs: [] }
-  }
-
-  return getVariableExprsFromSelection(
-    objects,
-    artifactGraph,
-    modifiedAst,
-    wasmInstance,
-    undefined,
-    { lastChildLookup: true }
-  )
-}
 
 export function addTranslate({
   ast,
@@ -89,8 +63,8 @@ export function addTranslate({
 
   // 2. Prepare unlabeled and labeled arguments
   // Map the sketches selection into a list of kcl expressions to be passed as unlabelled argument
-  const vars = getTransformSelectionVars({
-    objects,
+  const vars = getSelectionVarsForCall({
+    selection: objects,
     artifactGraph,
     modifiedAst,
     wasmInstance,
@@ -181,8 +155,8 @@ export function addRotate({
 
   // 2. Prepare unlabeled and labeled arguments
   // Map the sketches selection into a list of kcl expressions to be passed as unlabelled argument
-  const vars = getTransformSelectionVars({
-    objects,
+  const vars = getSelectionVarsForCall({
+    selection: objects,
     artifactGraph,
     modifiedAst,
     wasmInstance,
@@ -283,8 +257,8 @@ export function addScale({
 
   // 2. Prepare unlabeled and labeled arguments
   // Map the sketches selection into a list of kcl expressions to be passed as unlabelled argument
-  const vars = getTransformSelectionVars({
-    objects,
+  const vars = getSelectionVarsForCall({
+    selection: objects,
     artifactGraph,
     modifiedAst,
     wasmInstance,
@@ -431,8 +405,8 @@ export function addAppearance({
 
   // 2. Prepare unlabeled and labeled arguments
   // Map the sketches selection into a list of kcl expressions to be passed as unlabelled argument
-  const vars = getTransformSelectionVars({
-    objects,
+  const vars = getSelectionVarsForCall({
+    selection: objects,
     artifactGraph,
     modifiedAst,
     wasmInstance,

--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -659,6 +659,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
             clearSelectionFirst: true,
             multiple: false,
             description: 'Only parallel faces are supported for now.',
+            hidden: isEditingNodeSelection,
           },
           tagStart: {
             // TODO: add validation like for Clone command
@@ -676,6 +677,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
             ],
             multiple: false,
             clearSelectionFirst: true,
+            hidden: isEditingNodeSelection,
           },
           method: {
             inputType: 'options',

--- a/src/lib/operations.spec.ts
+++ b/src/lib/operations.spec.ts
@@ -179,6 +179,11 @@ function toArtifactGraph(artifacts: Artifact[]): ArtifactGraph {
   return new Map(artifacts.map((artifact) => [artifact.id, artifact]))
 }
 
+const EMPTY_SELECTIONS = {
+  graphSelections: [],
+  otherSelections: [],
+}
+
 /** Stands in for the global app instance that holds the user's feature flags. */
 function stubUserFeatures(features: string[]) {
   const previousApp = window.app
@@ -576,10 +581,10 @@ describe('operations.test.ts', () => {
   }
 
   describe('Extrude edit flow', () => {
-    it('continues when the unlabeled selection cannot be retrieved', async () => {
+    it('continues when selections cannot be retrieved', async () => {
       const { rustContext } = await buildTheWorldAndNoEngineConnection()
       const code =
-        'extrude001 = extrude(region(point = [1, 1], sketch = s), length = 10)'
+        'extrude001 = extrude(region(point = [1, 1], sketch = s), length = 10, to = missingFace, direction = missingEdge)'
       const operation = stdlib('extrude')
       if (operation.type !== 'StdLibCall') {
         throw new Error('Expected operation to be a StdLibCall')
@@ -592,6 +597,18 @@ describe('operations.test.ts', () => {
         length: {
           value: { type: 'Number', value: 10, ty: { type: 'Any' } },
           sourceRange: rangeOfText(code, '10'),
+        },
+        to: {
+          value: {
+            type: 'TagIdentifier',
+            value: 'missingFace',
+            artifact_id: 'missing-face-id',
+          },
+          sourceRange: rangeOfText(code, 'missingFace'),
+        },
+        direction: {
+          value: { type: 'Object', value: {} },
+          sourceRange: rangeOfText(code, 'missingEdge'),
         },
       }
 
@@ -610,12 +627,13 @@ describe('operations.test.ts', () => {
 
       const argDefaultValues = result.data.argDefaultValues as {
         sketches?: { graphSelections: unknown[]; otherSelections: unknown[] }
+        to?: typeof EMPTY_SELECTIONS
+        direction?: typeof EMPTY_SELECTIONS
         length?: { valueText: string }
       }
-      expect(argDefaultValues.sketches).toEqual({
-        graphSelections: [],
-        otherSelections: [],
-      })
+      expect(argDefaultValues.sketches).toEqual(EMPTY_SELECTIONS)
+      expect(argDefaultValues.to).toEqual(EMPTY_SELECTIONS)
+      expect(argDefaultValues.direction).toEqual(EMPTY_SELECTIONS)
       expect(argDefaultValues.length?.valueText).toBe('10')
     })
 
@@ -796,6 +814,49 @@ describe('operations.test.ts', () => {
   })
 
   describe('Sweep edit flow', () => {
+    it('continues when the path selection cannot be retrieved', async () => {
+      const { rustContext } = await buildTheWorldAndNoEngineConnection()
+      const code = 'sweep001 = sweep(profile001, path = missingPath)'
+      const operation = stdlib('sweep')
+      if (operation.type !== 'StdLibCall') {
+        throw new Error('Expected operation to be a StdLibCall')
+      }
+      operation.unlabeledArg = {
+        value: {
+          type: 'Sketch',
+          value: { artifactId: 'profile-path-id' },
+        },
+        sourceRange: rangeOfText(code, 'profile001'),
+      }
+      operation.labeledArgs = {
+        path: {
+          value: {
+            type: 'Sketch',
+            value: { artifactId: 'missing-path-id' },
+          },
+          sourceRange: rangeOfText(code, 'missingPath'),
+        },
+      }
+
+      const result = await enterEditFlow({
+        operation,
+        code,
+        artifactGraph: toArtifactGraph([pathArtifact('profile-path-id')]),
+        rustContext,
+      })
+      if (isErr(result)) {
+        throw result
+      }
+      if (result.type !== 'Find and select command') {
+        throw new Error(`Expected edit flow event, got ${result.type}`)
+      }
+
+      const argDefaultValues = result.data.argDefaultValues as {
+        path?: typeof EMPTY_SELECTIONS
+      }
+      expect(argDefaultValues.path).toEqual(EMPTY_SELECTIONS)
+    })
+
     it('retrieves tagged cap profiles in the command defaults', async () => {
       const { rustContext } = await buildTheWorldAndNoEngineConnection()
       const code =
@@ -991,6 +1052,52 @@ describe('operations.test.ts', () => {
   })
 
   describe('GDT edit flow', () => {
+    it('continues when geometry selections cannot be retrieved', async () => {
+      const { rustContext } = await buildTheWorldAndNoEngineConnection()
+      const code = 'gdt::straightness(faces = [missingFace], tolerance = 0.1mm)'
+      const operation = stdlib('gdt::straightness')
+      if (operation.type !== 'StdLibCall') {
+        throw new Error('Expected operation to be a StdLibCall')
+      }
+      operation.labeledArgs = {
+        faces: {
+          value: {
+            type: 'Array',
+            value: [
+              {
+                type: 'TagIdentifier',
+                value: 'missingFace',
+                artifact_id: 'missing-face-id',
+              },
+            ],
+          },
+          sourceRange: rangeOfText(code, '[missingFace]'),
+        },
+        tolerance: {
+          value: { type: 'Number', value: 0.1, ty: { type: 'Any' } },
+          sourceRange: rangeOfText(code, '0.1mm'),
+        },
+      }
+
+      const result = await enterEditFlow({
+        operation,
+        code,
+        artifactGraph: new Map(),
+        rustContext,
+      })
+      if (isErr(result)) {
+        throw result
+      }
+      if (result.type !== 'Find and select command') {
+        throw new Error(`Expected edit flow event, got ${result.type}`)
+      }
+
+      const argDefaultValues = result.data.argDefaultValues as {
+        objects?: typeof EMPTY_SELECTIONS
+      }
+      expect(argDefaultValues.objects).toEqual(EMPTY_SELECTIONS)
+    })
+
     it.each([
       {
         operationName: 'gdt::profile',

--- a/src/lib/operations.ts
+++ b/src/lib/operations.ts
@@ -118,16 +118,28 @@ function retrieveUnlabeledSelectionsForEdit(
   artifactGraph: ArtifactGraph
 ): Selections {
   if (!operation.unlabeledArg) {
-    return { graphSelections: [], otherSelections: [] }
+    return emptySelections()
   }
 
-  const selections = retrieveSelectionsFromOpArg(
-    operation.unlabeledArg,
-    artifactGraph
+  return selectionResultOrEmpty(
+    retrieveSelectionsFromOpArg(operation.unlabeledArg, artifactGraph)
   )
-  return isErr(selections)
-    ? { graphSelections: [], otherSelections: [] }
-    : selections
+}
+
+function emptySelections(): Selections {
+  return { graphSelections: [], otherSelections: [] }
+}
+
+// Selection reconstruction is best-effort in edit flows. The edit codemods
+// preserve existing selection arguments when this fallback is used.
+function selectionResultOrEmpty(result: Selections | Error): Selections {
+  return isErr(result) ? emptySelections() : result
+}
+
+// Axis arguments can hold either an option value or a selection. Only the
+// direction-vector form is an option value whose retrieval errors should fail.
+function isExplicitAxisArgument(argument: OpArg): boolean {
+  return argument.value.type === 'Object' && 'direction' in argument.value.value
 }
 
 function getProfileFunctionFromOperationName(
@@ -183,7 +195,7 @@ async function extractKclArgument(
 function extractFaceSelections(
   artifactGraph: ArtifactGraph,
   facesArg: OpArg
-): Selection[] | { error: string } {
+): Selection[] {
   const faceValues: OpKclValue[] =
     facesArg.value.type === 'Array' ? facesArg.value.value : [facesArg.value]
 
@@ -223,7 +235,7 @@ function extractFaceSelections(
             { key: artifact.id, types: ['segment'] },
             artifactGraph
           )
-          if (!err(segArtifact)) {
+          if (!isErr(segArtifact)) {
             targetCodeRefs = [segArtifact.codeRef]
           }
         }
@@ -240,17 +252,13 @@ function extractFaceSelections(
     }
   }
 
-  if (graphSelections.length === 0) {
-    return { error: 'No valid face selections found in TagIdentifier objects' }
-  }
-
   return graphSelections
 }
 
 function extractDistanceTargetSelections(
   artifactGraph: ArtifactGraph,
   targetArg: OpArg
-): Selection[] | { error: string } {
+): Selection[] {
   const value = targetArg.value
 
   if (value.type === 'Uuid') {
@@ -268,7 +276,7 @@ function extractDistanceTargetSelections(
   }
 
   const faceSelections = extractFaceSelections(artifactGraph, targetArg)
-  if (!('error' in faceSelections)) {
+  if (faceSelections.length > 0) {
     return faceSelections
   }
 
@@ -280,7 +288,43 @@ function extractDistanceTargetSelections(
     return edgeSelections
   }
 
-  return { error: 'Missing or invalid distance target argument' }
+  return []
+}
+
+function retrieveFaceAndEdgeSelectionsForEdit(
+  artifactGraph: ArtifactGraph,
+  facesArg?: OpArg,
+  edgesArg?: OpArg
+): Selections {
+  const graphSelections = facesArg?.sourceRange
+    ? extractFaceSelections(artifactGraph, facesArg)
+    : []
+
+  if (edgesArg?.sourceRange) {
+    graphSelections.push(
+      ...retrieveEdgeSelectionsFromOpArgs(edgesArg, artifactGraph)
+        .graphSelections
+    )
+  }
+
+  return { graphSelections, otherSelections: [] }
+}
+
+function retrieveFaceSelectionsForEdit(
+  solidArg: OpArg | null | undefined,
+  faceArg: OpArg | undefined,
+  artifactGraph: ArtifactGraph
+): Selections {
+  if (!solidArg || !faceArg) {
+    return emptySelections()
+  }
+
+  const result = retrieveFaceSelectionsFromOpArgs(
+    solidArg,
+    faceArg,
+    artifactGraph
+  )
+  return isErr(result) ? emptySelections() : result.faces
 }
 
 function extractStringArgument(
@@ -432,12 +476,13 @@ const prepareToEditExtrude: PrepareToEditCallback = async ({
 
   let to: Selections | undefined
   if ('to' in operation.labeledArgs && operation.labeledArgs.to) {
-    const graphSelections = extractFaceSelections(
-      artifactGraph,
-      operation.labeledArgs.to
-    )
-    if ('error' in graphSelections) return { reason: graphSelections.error }
-    to = { graphSelections, otherSelections: [] }
+    to = {
+      graphSelections: extractFaceSelections(
+        artifactGraph,
+        operation.labeledArgs.to
+      ),
+      otherSelections: [],
+    }
   }
 
   // symmetric argument from a string to boolean
@@ -455,10 +500,10 @@ const prepareToEditExtrude: PrepareToEditCallback = async ({
       operation.labeledArgs.direction,
       artifactGraph
     )
-    if (err(axisEdgeSelection) || !axisEdgeSelection.edge) {
-      return { reason: 'Missing or invalid direction edge selection' }
-    }
-    direction = axisEdgeSelection.edge
+    direction =
+      isErr(axisEdgeSelection) || !axisEdgeSelection.edge
+        ? emptySelections()
+        : axisEdgeSelection.edge
   }
 
   // bidirectionalLength argument from a string to a KCL expression
@@ -766,21 +811,18 @@ const prepareToEditFillet: PrepareToEditCallback = async ({
   }
 
   // 1. Map the selected edges from either legacy tags or the new edges kwarg.
-  if (!operation.unlabeledArg) {
-    return { reason: `Couldn't retrieve operation arguments` }
-  }
-
   const edgeArg =
     operation.labeledArgs?.edges ?? operation.labeledArgs?.edgeRefs
   const selection = edgeArg
-    ? retrieveEdgeSelectionsFromEdgeRefs(edgeArg, artifactGraph)
+    ? selectionResultOrEmpty(
+        retrieveEdgeSelectionsFromEdgeRefs(edgeArg, artifactGraph)
+      )
     : operation.labeledArgs?.tags
       ? retrieveEdgeSelectionsFromOpArgs(
           operation.labeledArgs.tags,
           artifactGraph
         )
-      : new Error(`Couldn't retrieve operation arguments`)
-  if (err(selection)) return { reason: selection.message }
+      : emptySelections()
 
   // 2. Convert the radius argument from a string to a KCL expression
   const radius = await extractKclArgument(
@@ -846,21 +888,18 @@ const prepareToEditChamfer: PrepareToEditCallback = async ({
   }
 
   // 1. Map the selected edges from either legacy tags or the new edges kwarg.
-  if (!operation.unlabeledArg) {
-    return { reason: `Couldn't retrieve operation arguments` }
-  }
-
   const edgeArg =
     operation.labeledArgs?.edges ?? operation.labeledArgs?.edgeRefs
   const selection = edgeArg
-    ? retrieveEdgeSelectionsFromEdgeRefs(edgeArg, artifactGraph)
+    ? selectionResultOrEmpty(
+        retrieveEdgeSelectionsFromEdgeRefs(edgeArg, artifactGraph)
+      )
     : operation.labeledArgs?.tags
       ? retrieveEdgeSelectionsFromOpArgs(
           operation.labeledArgs.tags,
           artifactGraph
         )
-      : new Error(`Couldn't retrieve operation arguments`)
-  if (err(selection)) return { reason: selection.message }
+      : emptySelections()
 
   // 2. Convert the length argument from a string to a KCL expression
   const length = await extractKclArgument(
@@ -923,20 +962,11 @@ const prepareToEditShell: PrepareToEditCallback = async ({
   const boundToUtf16 = (n: number) => toUtf16(n, code)
 
   // 1. Map the unlabeled and faces arguments to solid2d selections
-  if (!operation.unlabeledArg || !operation.labeledArgs?.faces) {
-    return { reason: `Couldn't retrieve operation arguments` }
-  }
-
-  const result = retrieveFaceSelectionsFromOpArgs(
+  const faces = retrieveFaceSelectionsForEdit(
     operation.unlabeledArg,
     operation.labeledArgs.faces,
     artifactGraph
   )
-  if (err(result)) {
-    return { reason: "Couldn't retrieve faces argument" }
-  }
-
-  const { faces } = result
 
   // 2. Convert the thickness argument from a string to a KCL expression
   if (
@@ -988,17 +1018,11 @@ const prepareToEditHole: PrepareToEditCallback = async ({
   }
 
   // 1. Map the unlabeled face arguments to solid2d selections
-  if (!operation.unlabeledArg || !operation.labeledArgs?.face) {
-    return { reason: `Couldn't retrieve operation arguments` }
-  }
-
-  const result = retrieveFaceSelectionsFromOpArgs(
+  const face = retrieveFaceSelectionsForEdit(
     operation.unlabeledArg,
     operation.labeledArgs.face,
     artifactGraph
   )
-  if (err(result)) return { reason: result.message }
-  const { faces: face } = result
 
   // 2.1 Convert the required arg from string to KclExpression
   const isArray = true
@@ -1312,34 +1336,28 @@ const prepareToEditOffsetPlane: PrepareToEditCallback = async ({
   const boundToUtf16 = (n: number) => toUtf16(n, code)
 
   // 1. Map the plane and faces arguments to plane or face selections
-  if (!operation.unlabeledArg) {
-    return { reason: `Couldn't retrieve operation arguments` }
-  }
-
-  let plane: Selections | undefined
-  const maybeDefaultPlaneName = getStringValue(
-    code,
-    operation.unlabeledArg.sourceRange
-  )
-  if (isDefaultPlaneStr(maybeDefaultPlaneName)) {
-    const id = rustContext.getDefaultPlaneId(maybeDefaultPlaneName)
-    if (err(id)) {
-      return { reason: "Couldn't retrieve default plane ID" }
-    }
-
-    plane = {
-      graphSelections: [],
-      otherSelections: [{ id, name: maybeDefaultPlaneName }],
-    }
-  } else {
-    const result = retrieveNonDefaultPlaneSelectionFromOpArg(
-      operation.unlabeledArg,
-      artifactGraph
+  let plane = emptySelections()
+  if (operation.unlabeledArg) {
+    const maybeDefaultPlaneName = getStringValue(
+      code,
+      operation.unlabeledArg.sourceRange
     )
-    if (err(result)) {
-      return { reason: result.message }
+    if (isDefaultPlaneStr(maybeDefaultPlaneName)) {
+      const id = rustContext.getDefaultPlaneId(maybeDefaultPlaneName)
+      if (!isErr(id)) {
+        plane = {
+          graphSelections: [],
+          otherSelections: [{ id, name: maybeDefaultPlaneName }],
+        }
+      }
+    } else {
+      plane = selectionResultOrEmpty(
+        retrieveNonDefaultPlaneSelectionFromOpArg(
+          operation.unlabeledArg,
+          artifactGraph
+        )
+      )
     }
-    plane = result
   }
 
   // 2. Convert the offset argument from a string to a KCL expression
@@ -1393,17 +1411,11 @@ const prepareToEditSweep: PrepareToEditCallback = async ({
   const sketches = retrieveUnlabeledSelectionsForEdit(operation, artifactGraph)
 
   // 2. Prepare labeled arguments
-  if (!operation.labeledArgs.path) {
-    return { reason: "Couldn't retrieve path argument" }
-  }
-
-  const path = retrieveSelectionsFromOpArg(
-    operation.labeledArgs.path,
-    artifactGraph
-  )
-  if (err(path)) {
-    return { reason: "Couldn't retrieve path argument" }
-  }
+  const path = operation.labeledArgs.path
+    ? selectionResultOrEmpty(
+        retrieveSelectionsFromOpArg(operation.labeledArgs.path, artifactGraph)
+      )
+    : emptySelections()
 
   // optional arguments
   let sectional: boolean | undefined
@@ -1544,42 +1556,38 @@ const prepareToEditHelix: PrepareToEditCallback = async ({
   const boundToUtf16 = (n: number) => toUtf16(n, code)
 
   // Flow arg
-  let mode: HelixModes | undefined
+  let mode: HelixModes = 'Axis'
   // Three different arguments depending on mode
   let axis: string | undefined
   let edge: Selections | undefined
   let cylinder: Selections | undefined
   if ('axis' in operation.labeledArgs && operation.labeledArgs.axis) {
     // axis options string or selection arg
+    const axisArg = operation.labeledArgs.axis
     const axisEdgeSelection = retrieveAxisOrEdgeSelectionsFromOpArg(
-      operation.labeledArgs.axis,
+      axisArg,
       artifactGraph
     )
-    if (err(axisEdgeSelection)) {
-      return { reason: "Couldn't retrieve axis or edge selection" }
+    if (isErr(axisEdgeSelection)) {
+      if (isExplicitAxisArgument(axisArg)) {
+        return { reason: 'Invalid direction-vector axis argument' }
+      }
+      mode = 'Edge'
+      edge = emptySelections()
+    } else {
+      mode = axisEdgeSelection.axisOrEdge
+      axis = axisEdgeSelection.axis
+      edge = axisEdgeSelection.edge
     }
-    mode = axisEdgeSelection.axisOrEdge
-    axis = axisEdgeSelection.axis
-    edge = axisEdgeSelection.edge
   } else if (
     'cylinder' in operation.labeledArgs &&
     operation.labeledArgs.cylinder
   ) {
     // axis cylinder selection arg
-    const result = retrieveSelectionsFromOpArg(
-      operation.labeledArgs.cylinder,
-      artifactGraph
+    cylinder = selectionResultOrEmpty(
+      retrieveSelectionsFromOpArg(operation.labeledArgs.cylinder, artifactGraph)
     )
-    if (err(result)) {
-      return { reason: "Couldn't retrieve cylinder selection" }
-    }
-
     mode = 'Cylinder'
-    cylinder = result
-  } else {
-    return {
-      reason: "The axis or cylinder arguments couldn't be retrieved.",
-    }
   }
 
   // revolutions kcl arg (required for all)
@@ -1689,18 +1697,27 @@ const prepareToEditRevolve: PrepareToEditCallback = async ({
 
   // 2. Prepare labeled arguments
   // axis options string arg
-  if (!('axis' in operation.labeledArgs) || !operation.labeledArgs.axis) {
-    return { reason: "Couldn't find axis argument" }
+  const axisArg = operation.labeledArgs.axis
+  let axisOrEdge: 'Axis' | 'Edge' = 'Axis'
+  let axis: string | undefined
+  let edge: Selections | undefined
+  if (axisArg) {
+    const axisEdgeSelection = retrieveAxisOrEdgeSelectionsFromOpArg(
+      axisArg,
+      artifactGraph
+    )
+    if (isErr(axisEdgeSelection)) {
+      if (isExplicitAxisArgument(axisArg)) {
+        return { reason: 'Invalid direction-vector axis argument' }
+      }
+      axisOrEdge = 'Edge'
+      edge = emptySelections()
+    } else {
+      axisOrEdge = axisEdgeSelection.axisOrEdge
+      axis = axisEdgeSelection.axis
+      edge = axisEdgeSelection.edge
+    }
   }
-
-  const axisEdgeSelection = retrieveAxisOrEdgeSelectionsFromOpArg(
-    operation.labeledArgs.axis,
-    artifactGraph
-  )
-  if (err(axisEdgeSelection)) {
-    return { reason: "Couldn't retrieve axis or edge selections" }
-  }
-  const { axisOrEdge, axis, edge } = axisEdgeSelection
 
   // angle kcl arg
   // Default to '360' if not present
@@ -2027,17 +2044,12 @@ const prepareToEditGdtFlatness: PrepareToEditCallback = async ({
   }
 
   const facesArg = operation.labeledArgs?.['faces']
-  if (!facesArg || !facesArg.sourceRange) {
-    return { reason: 'Missing or invalid faces argument' }
+  const faces: Selections = {
+    graphSelections: facesArg?.sourceRange
+      ? extractFaceSelections(artifactGraph, facesArg)
+      : [],
+    otherSelections: [],
   }
-
-  // Extract face selections
-  const graphSelections = extractFaceSelections(artifactGraph, facesArg)
-  if ('error' in graphSelections) {
-    return { reason: graphSelections.error }
-  }
-
-  const faces = { graphSelections, otherSelections: [] }
 
   const tolerance = await extractKclArgument(
     code,
@@ -2092,27 +2104,11 @@ const prepareToEditGdtStraightness: PrepareToEditCallback = async ({
     return { reason: 'Wrong operation type' }
   }
 
-  const graphSelections: Selections['graphSelections'] = []
-  const facesArg = operation.labeledArgs?.['faces']
-  if (facesArg?.sourceRange) {
-    const faces = extractFaceSelections(artifactGraph, facesArg)
-    if ('error' in faces) {
-      return { reason: faces.error }
-    }
-    graphSelections.push(...faces)
-  }
-
-  const edgesArg = operation.labeledArgs?.['edges']
-  if (edgesArg?.sourceRange) {
-    graphSelections.push(
-      ...retrieveEdgeSelectionsFromOpArgs(edgesArg, artifactGraph)
-        .graphSelections
-    )
-  }
-
-  if (graphSelections.length === 0) {
-    return { reason: 'Missing or invalid faces or edges argument' }
-  }
+  const objects = retrieveFaceAndEdgeSelectionsForEdit(
+    artifactGraph,
+    operation.labeledArgs?.faces,
+    operation.labeledArgs?.edges
+  )
 
   const tolerance = await extractKclArgument(
     code,
@@ -2138,7 +2134,7 @@ const prepareToEditGdtStraightness: PrepareToEditCallback = async ({
   const framePlane = extractStringArgument(code, operation, 'framePlane')
 
   const argDefaultValues: ModelingCommandSchema['GDT Straightness'] = {
-    objects: { graphSelections, otherSelections: [] },
+    objects,
     tolerance,
     precision,
     framePosition,
@@ -2168,27 +2164,11 @@ const prepareToEditGdtCircularity: PrepareToEditCallback = async ({
     return { reason: 'Wrong operation type' }
   }
 
-  const graphSelections: Selections['graphSelections'] = []
-  const facesArg = operation.labeledArgs?.['faces']
-  if (facesArg?.sourceRange) {
-    const faces = extractFaceSelections(artifactGraph, facesArg)
-    if ('error' in faces) {
-      return { reason: faces.error }
-    }
-    graphSelections.push(...faces)
-  }
-
-  const edgesArg = operation.labeledArgs?.['edges']
-  if (edgesArg?.sourceRange) {
-    graphSelections.push(
-      ...retrieveEdgeSelectionsFromOpArgs(edgesArg, artifactGraph)
-        .graphSelections
-    )
-  }
-
-  if (graphSelections.length === 0) {
-    return { reason: 'Missing or invalid faces or edges argument' }
-  }
+  const objects = retrieveFaceAndEdgeSelectionsForEdit(
+    artifactGraph,
+    operation.labeledArgs?.faces,
+    operation.labeledArgs?.edges
+  )
 
   const tolerance = await extractKclArgument(
     code,
@@ -2214,7 +2194,7 @@ const prepareToEditGdtCircularity: PrepareToEditCallback = async ({
   const framePlane = extractStringArgument(code, operation, 'framePlane')
 
   const argDefaultValues: ModelingCommandSchema['GDT Circularity'] = {
-    objects: { graphSelections, otherSelections: [] },
+    objects,
     tolerance,
     precision,
     framePosition,
@@ -2244,27 +2224,11 @@ const prepareToEditGdtCylindricity: PrepareToEditCallback = async ({
     return { reason: 'Wrong operation type' }
   }
 
-  const graphSelections: Selections['graphSelections'] = []
-  const facesArg = operation.labeledArgs?.['faces']
-  if (facesArg?.sourceRange) {
-    const faces = extractFaceSelections(artifactGraph, facesArg)
-    if ('error' in faces) {
-      return { reason: faces.error }
-    }
-    graphSelections.push(...faces)
-  }
-
-  const edgesArg = operation.labeledArgs?.['edges']
-  if (edgesArg?.sourceRange) {
-    graphSelections.push(
-      ...retrieveEdgeSelectionsFromOpArgs(edgesArg, artifactGraph)
-        .graphSelections
-    )
-  }
-
-  if (graphSelections.length === 0) {
-    return { reason: 'Missing or invalid faces or edges argument' }
-  }
+  const objects = retrieveFaceAndEdgeSelectionsForEdit(
+    artifactGraph,
+    operation.labeledArgs?.faces,
+    operation.labeledArgs?.edges
+  )
 
   const tolerance = await extractKclArgument(
     code,
@@ -2290,7 +2254,7 @@ const prepareToEditGdtCylindricity: PrepareToEditCallback = async ({
   const framePlane = extractStringArgument(code, operation, 'framePlane')
 
   const argDefaultValues: ModelingCommandSchema['GDT Cylindricity'] = {
-    objects: { graphSelections, otherSelections: [] },
+    objects,
     tolerance,
     precision,
     framePosition,
@@ -2321,17 +2285,12 @@ const prepareToEditGdtDatum: PrepareToEditCallback = async ({
   }
 
   const faceArg = operation.labeledArgs?.['face']
-  if (!faceArg || !faceArg.sourceRange) {
-    return { reason: 'Missing or invalid face argument' }
+  const faces: Selections = {
+    graphSelections: faceArg?.sourceRange
+      ? extractFaceSelections(artifactGraph, faceArg)
+      : [],
+    otherSelections: [],
   }
-
-  // Extract face selections (datum uses single face)
-  const graphSelections = extractFaceSelections(artifactGraph, faceArg)
-  if ('error' in graphSelections) {
-    return { reason: graphSelections.error }
-  }
-
-  const faces = { graphSelections, otherSelections: [] }
 
   // Extract name argument as a plain string (strip quotes if present)
   const nameRaw = extractStringArgument(code, operation, 'name')
@@ -2380,27 +2339,11 @@ const prepareToEditGdtPosition: PrepareToEditCallback = async ({
     return { reason: 'Wrong operation type' }
   }
 
-  const graphSelections: Selections['graphSelections'] = []
-  const facesArg = operation.labeledArgs?.['faces']
-  if (facesArg?.sourceRange) {
-    const faces = extractFaceSelections(artifactGraph, facesArg)
-    if ('error' in faces) {
-      return { reason: faces.error }
-    }
-    graphSelections.push(...faces)
-  }
-
-  const edgesArg = operation.labeledArgs?.['edges']
-  if (edgesArg?.sourceRange) {
-    graphSelections.push(
-      ...retrieveEdgeSelectionsFromOpArgs(edgesArg, artifactGraph)
-        .graphSelections
-    )
-  }
-
-  if (graphSelections.length === 0) {
-    return { reason: 'Missing or invalid faces or edges argument' }
-  }
+  const objects = retrieveFaceAndEdgeSelectionsForEdit(
+    artifactGraph,
+    operation.labeledArgs?.faces,
+    operation.labeledArgs?.edges
+  )
 
   const tolerance = await extractKclArgument(
     code,
@@ -2435,7 +2378,7 @@ const prepareToEditGdtPosition: PrepareToEditCallback = async ({
   }
 
   const argDefaultValues: ModelingCommandSchema['GDT Position'] = {
-    objects: { graphSelections, otherSelections: [] },
+    objects,
     datums,
     tolerance,
     precision,
@@ -2468,29 +2411,11 @@ const prepareToEditGdtProfile: PrepareToEditCallback = async ({
 
   const edgesArg = operation.labeledArgs?.['edges']
   const facesArg = operation.labeledArgs?.['faces']
-  if (edgesArg && facesArg) {
-    return { reason: 'Profile operation has both edges and faces arguments' }
-  }
-  if (!edgesArg && !facesArg) {
-    return { reason: 'Missing or invalid profile target argument' }
-  }
-
-  let objects: Selections
-  if (edgesArg) {
-    if (!edgesArg.sourceRange) {
-      return { reason: 'Missing or invalid edges argument' }
-    }
-    objects = retrieveEdgeSelectionsFromOpArgs(edgesArg, artifactGraph)
-  } else {
-    if (!facesArg?.sourceRange) {
-      return { reason: 'Missing or invalid faces argument' }
-    }
-    const graphSelections = extractFaceSelections(artifactGraph, facesArg)
-    if ('error' in graphSelections) {
-      return { reason: graphSelections.error }
-    }
-    objects = { graphSelections, otherSelections: [] }
-  }
+  const objects = retrieveFaceAndEdgeSelectionsForEdit(
+    artifactGraph,
+    facesArg,
+    edgesArg
+  )
 
   const tolerance = await extractKclArgument(
     code,
@@ -2560,25 +2485,15 @@ const prepareToEditGdtDistance: PrepareToEditCallback = async ({
   const graphSelections: Selections['graphSelections'] = []
   const fromArg = operation.labeledArgs?.['from']
   const toArg = operation.labeledArgs?.['to']
-  if (fromArg?.sourceRange || toArg?.sourceRange) {
-    if (!fromArg?.sourceRange || !toArg?.sourceRange) {
-      return { reason: 'Distance requires both from and to arguments' }
-    }
-
-    const fromSelections = extractDistanceTargetSelections(
-      artifactGraph,
-      fromArg
+  if (fromArg?.sourceRange) {
+    graphSelections.push(
+      ...extractDistanceTargetSelections(artifactGraph, fromArg)
     )
-    if ('error' in fromSelections) {
-      return { reason: fromSelections.error }
-    }
-
-    const toSelections = extractDistanceTargetSelections(artifactGraph, toArg)
-    if ('error' in toSelections) {
-      return { reason: toSelections.error }
-    }
-
-    graphSelections.push(...fromSelections, ...toSelections)
+  }
+  if (toArg?.sourceRange) {
+    graphSelections.push(
+      ...extractDistanceTargetSelections(artifactGraph, toArg)
+    )
   }
 
   const edgesArg = operation.labeledArgs?.['edges']
@@ -2589,9 +2504,7 @@ const prepareToEditGdtDistance: PrepareToEditCallback = async ({
     )
   }
 
-  if (graphSelections.length === 0) {
-    return { reason: 'Missing or invalid distance target argument' }
-  }
+  const objects = { graphSelections, otherSelections: [] }
 
   const tolerance = await extractKclArgument(
     code,
@@ -2617,7 +2530,7 @@ const prepareToEditGdtDistance: PrepareToEditCallback = async ({
   const framePlane = extractStringArgument(code, operation, 'framePlane')
 
   const argDefaultValues: ModelingCommandSchema['GDT Distance'] = {
-    objects: { graphSelections, otherSelections: [] },
+    objects,
     tolerance,
     precision,
     framePosition,
@@ -2647,27 +2560,11 @@ const prepareToEditGdtPerpendicularity: PrepareToEditCallback = async ({
     return { reason: 'Wrong operation type' }
   }
 
-  const graphSelections: Selections['graphSelections'] = []
-  const facesArg = operation.labeledArgs?.['faces']
-  if (facesArg?.sourceRange) {
-    const faces = extractFaceSelections(artifactGraph, facesArg)
-    if ('error' in faces) {
-      return { reason: faces.error }
-    }
-    graphSelections.push(...faces)
-  }
-
-  const edgesArg = operation.labeledArgs?.['edges']
-  if (edgesArg?.sourceRange) {
-    graphSelections.push(
-      ...retrieveEdgeSelectionsFromOpArgs(edgesArg, artifactGraph)
-        .graphSelections
-    )
-  }
-
-  if (graphSelections.length === 0) {
-    return { reason: 'Missing or invalid faces or edges argument' }
-  }
+  const objects = retrieveFaceAndEdgeSelectionsForEdit(
+    artifactGraph,
+    operation.labeledArgs?.faces,
+    operation.labeledArgs?.edges
+  )
 
   const tolerance = await extractKclArgument(
     code,
@@ -2702,7 +2599,7 @@ const prepareToEditGdtPerpendicularity: PrepareToEditCallback = async ({
   }
 
   const argDefaultValues: ModelingCommandSchema['GDT Perpendicularity'] = {
-    objects: { graphSelections, otherSelections: [] },
+    objects,
     datums,
     tolerance,
     precision,
@@ -2733,27 +2630,11 @@ const prepareToEditGdtAngularity: PrepareToEditCallback = async ({
     return { reason: 'Wrong operation type' }
   }
 
-  const graphSelections: Selections['graphSelections'] = []
-  const facesArg = operation.labeledArgs?.['faces']
-  if (facesArg?.sourceRange) {
-    const faces = extractFaceSelections(artifactGraph, facesArg)
-    if ('error' in faces) {
-      return { reason: faces.error }
-    }
-    graphSelections.push(...faces)
-  }
-
-  const edgesArg = operation.labeledArgs?.['edges']
-  if (edgesArg?.sourceRange) {
-    graphSelections.push(
-      ...retrieveEdgeSelectionsFromOpArgs(edgesArg, artifactGraph)
-        .graphSelections
-    )
-  }
-
-  if (graphSelections.length === 0) {
-    return { reason: 'Missing or invalid faces or edges argument' }
-  }
+  const objects = retrieveFaceAndEdgeSelectionsForEdit(
+    artifactGraph,
+    operation.labeledArgs?.faces,
+    operation.labeledArgs?.edges
+  )
 
   const tolerance = await extractKclArgument(
     code,
@@ -2788,7 +2669,7 @@ const prepareToEditGdtAngularity: PrepareToEditCallback = async ({
   }
 
   const argDefaultValues: ModelingCommandSchema['GDT Angularity'] = {
-    objects: { graphSelections, otherSelections: [] },
+    objects,
     datums,
     tolerance,
     precision,
@@ -2819,27 +2700,11 @@ const prepareToEditGdtConcentricity: PrepareToEditCallback = async ({
     return { reason: 'Wrong operation type' }
   }
 
-  const graphSelections: Selections['graphSelections'] = []
-  const facesArg = operation.labeledArgs?.['faces']
-  if (facesArg?.sourceRange) {
-    const faces = extractFaceSelections(artifactGraph, facesArg)
-    if ('error' in faces) {
-      return { reason: faces.error }
-    }
-    graphSelections.push(...faces)
-  }
-
-  const edgesArg = operation.labeledArgs?.['edges']
-  if (edgesArg?.sourceRange) {
-    graphSelections.push(
-      ...retrieveEdgeSelectionsFromOpArgs(edgesArg, artifactGraph)
-        .graphSelections
-    )
-  }
-
-  if (graphSelections.length === 0) {
-    return { reason: 'Missing or invalid faces or edges argument' }
-  }
+  const objects = retrieveFaceAndEdgeSelectionsForEdit(
+    artifactGraph,
+    operation.labeledArgs?.faces,
+    operation.labeledArgs?.edges
+  )
 
   const datums = await extractKclArgument(
     code,
@@ -2877,7 +2742,7 @@ const prepareToEditGdtConcentricity: PrepareToEditCallback = async ({
   const framePlane = extractStringArgument(code, operation, 'framePlane')
 
   const argDefaultValues: ModelingCommandSchema['GDT Concentricity'] = {
-    objects: { graphSelections, otherSelections: [] },
+    objects,
     datums,
     tolerance,
     precision,
@@ -2908,27 +2773,11 @@ const prepareToEditGdtSymmetry: PrepareToEditCallback = async ({
     return { reason: 'Wrong operation type' }
   }
 
-  const graphSelections: Selections['graphSelections'] = []
-  const facesArg = operation.labeledArgs?.['faces']
-  if (facesArg?.sourceRange) {
-    const faces = extractFaceSelections(artifactGraph, facesArg)
-    if ('error' in faces) {
-      return { reason: faces.error }
-    }
-    graphSelections.push(...faces)
-  }
-
-  const edgesArg = operation.labeledArgs?.['edges']
-  if (edgesArg?.sourceRange) {
-    graphSelections.push(
-      ...retrieveEdgeSelectionsFromOpArgs(edgesArg, artifactGraph)
-        .graphSelections
-    )
-  }
-
-  if (graphSelections.length === 0) {
-    return { reason: 'Missing or invalid faces or edges argument' }
-  }
+  const objects = retrieveFaceAndEdgeSelectionsForEdit(
+    artifactGraph,
+    operation.labeledArgs?.faces,
+    operation.labeledArgs?.edges
+  )
 
   const datums = await extractKclArgument(
     code,
@@ -2966,7 +2815,7 @@ const prepareToEditGdtSymmetry: PrepareToEditCallback = async ({
   const framePlane = extractStringArgument(code, operation, 'framePlane')
 
   const argDefaultValues: ModelingCommandSchema['GDT Symmetry'] = {
-    objects: { graphSelections, otherSelections: [] },
+    objects,
     datums,
     tolerance,
     precision,
@@ -2997,27 +2846,11 @@ const prepareToEditGdtRunout: PrepareToEditCallback = async ({
     return { reason: 'Wrong operation type' }
   }
 
-  const graphSelections: Selections['graphSelections'] = []
-  const facesArg = operation.labeledArgs?.['faces']
-  if (facesArg?.sourceRange) {
-    const faces = extractFaceSelections(artifactGraph, facesArg)
-    if ('error' in faces) {
-      return { reason: faces.error }
-    }
-    graphSelections.push(...faces)
-  }
-
-  const edgesArg = operation.labeledArgs?.['edges']
-  if (edgesArg?.sourceRange) {
-    graphSelections.push(
-      ...retrieveEdgeSelectionsFromOpArgs(edgesArg, artifactGraph)
-        .graphSelections
-    )
-  }
-
-  if (graphSelections.length === 0) {
-    return { reason: 'Missing or invalid faces or edges argument' }
-  }
+  const objects = retrieveFaceAndEdgeSelectionsForEdit(
+    artifactGraph,
+    operation.labeledArgs?.faces,
+    operation.labeledArgs?.edges
+  )
 
   const datums = await extractKclArgument(
     code,
@@ -3055,7 +2888,7 @@ const prepareToEditGdtRunout: PrepareToEditCallback = async ({
   const framePlane = extractStringArgument(code, operation, 'framePlane')
 
   const argDefaultValues: ModelingCommandSchema['GDT Runout'] = {
-    objects: { graphSelections, otherSelections: [] },
+    objects,
     datums,
     tolerance,
     precision,
@@ -3086,27 +2919,11 @@ const prepareToEditGdtParallelism: PrepareToEditCallback = async ({
     return { reason: 'Wrong operation type' }
   }
 
-  const graphSelections: Selections['graphSelections'] = []
-  const facesArg = operation.labeledArgs?.['faces']
-  if (facesArg?.sourceRange) {
-    const faces = extractFaceSelections(artifactGraph, facesArg)
-    if ('error' in faces) {
-      return { reason: faces.error }
-    }
-    graphSelections.push(...faces)
-  }
-
-  const edgesArg = operation.labeledArgs?.['edges']
-  if (edgesArg?.sourceRange) {
-    graphSelections.push(
-      ...retrieveEdgeSelectionsFromOpArgs(edgesArg, artifactGraph)
-        .graphSelections
-    )
-  }
-
-  if (graphSelections.length === 0) {
-    return { reason: 'Missing or invalid faces or edges argument' }
-  }
+  const objects = retrieveFaceAndEdgeSelectionsForEdit(
+    artifactGraph,
+    operation.labeledArgs?.faces,
+    operation.labeledArgs?.edges
+  )
 
   const tolerance = await extractKclArgument(
     code,
@@ -3141,7 +2958,7 @@ const prepareToEditGdtParallelism: PrepareToEditCallback = async ({
   }
 
   const argDefaultValues: ModelingCommandSchema['GDT Parallelism'] = {
-    objects: { graphSelections, otherSelections: [] },
+    objects,
     datums,
     tolerance,
     precision,
@@ -3172,27 +2989,11 @@ const prepareToEditGdtAnnotation: PrepareToEditCallback = async ({
     return { reason: 'Wrong operation type' }
   }
 
-  const graphSelections: Selections['graphSelections'] = []
-  const facesArg = operation.labeledArgs?.['faces']
-  if (facesArg?.sourceRange) {
-    const faces = extractFaceSelections(artifactGraph, facesArg)
-    if ('error' in faces) {
-      return { reason: faces.error }
-    }
-    graphSelections.push(...faces)
-  }
-
-  const edgesArg = operation.labeledArgs?.['edges']
-  if (edgesArg?.sourceRange) {
-    graphSelections.push(
-      ...retrieveEdgeSelectionsFromOpArgs(edgesArg, artifactGraph)
-        .graphSelections
-    )
-  }
-
-  if (graphSelections.length === 0) {
-    return { reason: 'Missing or invalid faces or edges argument' }
-  }
+  const objects = retrieveFaceAndEdgeSelectionsForEdit(
+    artifactGraph,
+    operation.labeledArgs?.faces,
+    operation.labeledArgs?.edges
+  )
 
   const annotationRaw = extractStringArgument(code, operation, 'annotation')
   if (!annotationRaw) {
@@ -3213,7 +3014,7 @@ const prepareToEditGdtAnnotation: PrepareToEditCallback = async ({
   const framePlane = extractStringArgument(code, operation, 'framePlane')
 
   const argDefaultValues: ModelingCommandSchema['GDT Annotation'] = {
-    objects: { graphSelections, otherSelections: [] },
+    objects,
     annotation,
     framePosition,
     framePlane,
@@ -3289,11 +3090,9 @@ const prepareToEditSplit: PrepareToEditCallback = async ({
   let tools: Selections | undefined
   const toolsArg = operation.labeledArgs?.tools
   if (toolsArg) {
-    const toolsResult = retrieveSelectionsFromOpArg(toolsArg, artifactGraph)
-    if (err(toolsResult)) {
-      return { reason: "Couldn't retrieve tools" }
-    }
-    tools = toolsResult
+    tools = selectionResultOrEmpty(
+      retrieveSelectionsFromOpArg(toolsArg, artifactGraph)
+    )
   }
 
   let merge: boolean | undefined


### PR DESCRIPTION
Middle ground solution: Edit flows still reconstruct geometry selections into command defaults, keeping them available for modeling dialogs #10747 and for future true selection editing. When an edit is submitted, the AST codemod preserves every existing selection argument verbatim and applies only non-selection changes.

This covers unlabeled inputs and opted-in labeled selections such as edge tags, faces, boolean tools, sweep paths, extrude targets and directions, mirror planes, and GDT targets. Explicit X/Y/Z axis choices remain editable.

Selection reconstruction still runs while preparing command defaults but doesn't error on failure. Selection-to-AST reconstruction and its tagging side effects are skipped when the edit is submitted.

Fixes #13644.
Fixes #13391.
Fixes #13394.
Fixes #13397.
Fixes #13401.
Fixes #13420.
Fixes #13422.

This PR replaces #13652 as the base of the stack, supersedes #13605, and replaces the edge-axis one-off in #13402. It builds on the null fallback from #12541.