### PR TITLE
Clarify profileStart return value

### DIFF
--- a/docs/kcl-std/functions/std-sketch-profileStart.md
+++ b/docs/kcl-std/functions/std-sketch-profileStart.md
@@ -1,11 +1,11 @@
 ---
 title: "profileStart"
 subtitle: "Function in std::sketch"
-excerpt: "Extract the provided 2-dimensional sketch's profile's origin value."
+excerpt: "Extract the provided 2-dimensional sketch's profile origin as an array containing its X and Y values."
 layout: manual
 ---
 
-Extract the provided 2-dimensional sketch's profile's origin value.
+Extract the provided 2-dimensional sketch's profile origin as an array containing its X and Y values.
 
 ```kcl
 profileStart(@profile: Sketch): Point2d

--- a/rust/kcl-lib/std/sketch.kcl
+++ b/rust/kcl-lib/std/sketch.kcl
@@ -2483,7 +2483,7 @@ export fn tangentToEnd(
   @tag: TaggedEdge,
 ): number(Angle) {}
 
-/// Extract the provided 2-dimensional sketch's profile's origin value.
+/// Extract the provided 2-dimensional sketch's profile origin as an array containing its X and Y values.
 ///
 /// ```kcl,legacySketch
 /// sketch001 = startSketchOn(XY)


### PR DESCRIPTION
Closes #7224.

Clarifies that profileStart returns the profile origin as an array containing its X and Y values, matching the Point2d return type. Regenerates the corresponding stdlib documentation page from the canonical KCL comment.

Testing:
- EXPECTORATE=overwrite cargo nextest run --retries 3 --no-fail-fast -p kcl-lib --features artifact-graph docs::gen_std_tests::test_generate_stdlib
- git diff --check