### PR TITLE
Stabilize module Feature Tree context menu test

### DIFF
--- a/e2e/playwright/point-click-assemblies.spec.ts
+++ b/e2e/playwright/point-click-assemblies.spec.ts
@@ -626,6 +626,16 @@ test.describe(
         page
       )
 
+      await toolbar.openPane(DefaultLayoutPaneID.Code)
+      await editor.expectEditor.toContain(
+        `
+          import "bracket.kcl" as bracket
+        `,
+        { shouldNormalise: true }
+      )
+      await scene.settled()
+      await toolbar.closePane(DefaultLayoutPaneID.Code)
+
       await toolbar.openPane(DefaultLayoutPaneID.FeatureTree)
       const op = await toolbar.getFeatureTreeOperation('bracket', 0)
       await op.click({ button: 'right' })


### PR DESCRIPTION
Fixes #13685.

The module source-only context-menu test interacted with the Feature Tree immediately after submitting the Insert command. At that point the imported-module branch can still be rendering live operations; its execution-state key then remounts the branch and clears the menu opened by the test.

This change follows the readiness sequence already used by the surrounding assembly tests: confirm the import reached the editor, wait for the scene to settle, close the code pane, and only then acquire and right-click the module row. It preserves the existing source-only assertions and adds no sleep or retry.

The targeted file passes formatting and lint checks, and Playwright discovers exactly the intended Electron test. A local Electron execution could not reach the test body because the `tronApp` fixture timed out during setup, so hosted E2E remains the runtime validation for this draft.
