### PR TITLE
Keep native menu tests from launching the system browser

### DIFF
--- a/e2e/playwright/native-file-menu.spec.ts
+++ b/e2e/playwright/native-file-menu.spec.ts
@@ -213,18 +213,52 @@ test.describe(
         const actual = cmdBar.cmdBarElement.getByTestId('cmd-bar-search')
         await expect(actual).toBeVisible()
       })
-      await test.step('Home.Help.KCL code samples', async () => {
-        await page.reload()
-        await homePage.projectsLoaded()
-        await homePage.isNativeFileMenuCreated()
-        await nativeMenu.click('Help.KCL code samples')
-      })
-      await test.step('Home.Help.Report a bug', async () => {
-        await page.reload()
-        await homePage.projectsLoaded()
-        await homePage.isNativeFileMenuCreated()
-        await nativeMenu.click('Help.Report a bug')
-        await homePage.projectsLoaded()
+      await test.step('Home.Help external links', async () => {
+        // Verify the OS handoff without launching an unmanaged system browser.
+        const externalLinks = await tronApp.electron.evaluateHandle(
+          ({ shell }) => {
+            // Preserve the exact method for restoration, without rebinding it.
+            // eslint-disable-next-line @typescript-eslint/unbound-method
+            const originalOpenExternal = shell.openExternal
+            const urls: string[] = []
+            shell.openExternal = async (url) => {
+              urls.push(url)
+            }
+            return {
+              urls,
+              restore: () => {
+                shell.openExternal = originalOpenExternal
+              },
+            }
+          }
+        )
+        try {
+          await test.step('Home.Help.KCL code samples', async () => {
+            await page.reload()
+            await homePage.projectsLoaded()
+            await homePage.isNativeFileMenuCreated()
+            await nativeMenu.click('Help.KCL code samples')
+            await expect
+              .poll(() => externalLinks.evaluate(({ urls }) => urls))
+              .toEqual([expect.stringMatching(/\/docs\/kcl-samples$/)])
+          })
+          await test.step('Home.Help.Report a bug', async () => {
+            await page.reload()
+            await homePage.projectsLoaded()
+            await homePage.isNativeFileMenuCreated()
+            await nativeMenu.click('Help.Report a bug')
+            await expect
+              .poll(() => externalLinks.evaluate(({ urls }) => urls))
+              .toEqual([
+                expect.stringMatching(/\/docs\/kcl-samples$/),
+                'https://github.com/KittyCAD/modeling-app/issues/new?template=bug_report.yml',
+              ])
+            await homePage.projectsLoaded()
+          })
+        } finally {
+          await externalLinks.evaluate(({ restore }) => restore())
+          await externalLinks.dispose()
+        }
       })
       await test.step('Home.Help.Replay onboarding tutorial', async () => {
         await page.reload()


### PR DESCRIPTION
The native Home-menu test opens the system browser for KCL samples and bug reporting, leaving those processes outside Playwright ownership. A Linux retry passed the test but then [timed out during worker shutdown](https://github.com/KittyCAD/modeling-app/actions/runs/34027090482/job/101471068694).

Intercept `shell.openExternal` only around those two steps, assert both requested URLs, and restore the exact native method in `finally`. This preserves the menu dispatch coverage and removes the unmanaged browser launches. It does not establish that every observed teardown timeout had the same cause.

An isolated Electron 40.8.5 check exercised the real native menu callbacks, captured both URLs, verified restoration, and closed in 43 ms. The full local Home-menu test stopped at the sign-in screen before the changed steps, so its complete platform run remains CI validation. Related historical discussion: #3373.
