### PR TITLE
Fail desktop CI when Playwright reports global errors

### DIFF
--- a/.github/ci-cd-scripts/playwright-electron.sh
+++ b/.github/ci-cd-scripts/playwright-electron.sh
@@ -3,6 +3,11 @@
 # bash strict mode
 set -euo pipefail
 
+if [[ -f "test-results/.last-run.json" ]]; then
+    # An outer retry must not accept a saved passed status with global errors.
+    node scripts/check-playwright-run.mjs
+fi
+
 if [[ ! -f "test-results/.last-run.json" ]]; then
     # If no last run artifact, than run Playwright normally
     echo "run playwright normally"
@@ -18,6 +23,7 @@ if [[ ! -f "test-results/.last-run.json" ]]; then
     fi
     # Log failures for Axiom to pick up
     node playwrightProcess.mjs > /tmp/github-actions.log
+    node scripts/check-playwright-run.mjs
 fi
 
 retry=1
@@ -42,6 +48,7 @@ while [[ $retry -le $max_retries ]]; do
             fi
             # Log failures for Axiom to pick up
             node playwrightProcess.mjs > /tmp/github-actions.log
+            node scripts/check-playwright-run.mjs
             retry=$((retry + 1))
         else
             echo "retried=false" >>$GITHUB_OUTPUT

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -16,6 +16,15 @@ permissions:
   actions: read
 
 jobs:
+  playwright-run-checks:
+    runs-on: namespace-profile-ubuntu-2-cores
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-node@v7.0.0
+        with:
+          node-version-file: .nvmrc
+      - run: node --test scripts/check-playwright-run.test.mjs
+
   npm-fmt-check:
     runs-on: namespace-profile-ubuntu-2-cores
     steps:

--- a/e2e/playwright/native-file-menu.spec.ts
+++ b/e2e/playwright/native-file-menu.spec.ts
@@ -213,18 +213,52 @@ test.describe(
         const actual = cmdBar.cmdBarElement.getByTestId('cmd-bar-search')
         await expect(actual).toBeVisible()
       })
-      await test.step('Home.Help.KCL code samples', async () => {
-        await page.reload()
-        await homePage.projectsLoaded()
-        await homePage.isNativeFileMenuCreated()
-        await nativeMenu.click('Help.KCL code samples')
-      })
-      await test.step('Home.Help.Report a bug', async () => {
-        await page.reload()
-        await homePage.projectsLoaded()
-        await homePage.isNativeFileMenuCreated()
-        await nativeMenu.click('Help.Report a bug')
-        await homePage.projectsLoaded()
+      await test.step('Home.Help external links', async () => {
+        // Verify the OS handoff without launching an unmanaged system browser.
+        const externalLinks = await tronApp.electron.evaluateHandle(
+          ({ shell }) => {
+            // Preserve the exact method for restoration, without rebinding it.
+            // eslint-disable-next-line @typescript-eslint/unbound-method
+            const originalOpenExternal = shell.openExternal
+            const urls: string[] = []
+            shell.openExternal = async (url) => {
+              urls.push(url)
+            }
+            return {
+              urls,
+              restore: () => {
+                shell.openExternal = originalOpenExternal
+              },
+            }
+          }
+        )
+        try {
+          await test.step('Home.Help.KCL code samples', async () => {
+            await page.reload()
+            await homePage.projectsLoaded()
+            await homePage.isNativeFileMenuCreated()
+            await nativeMenu.click('Help.KCL code samples')
+            await expect
+              .poll(() => externalLinks.evaluate(({ urls }) => urls))
+              .toEqual([expect.stringMatching(/\/docs\/kcl-samples$/)])
+          })
+          await test.step('Home.Help.Report a bug', async () => {
+            await page.reload()
+            await homePage.projectsLoaded()
+            await homePage.isNativeFileMenuCreated()
+            await nativeMenu.click('Help.Report a bug')
+            await expect
+              .poll(() => externalLinks.evaluate(({ urls }) => urls))
+              .toEqual([
+                expect.stringMatching(/\/docs\/kcl-samples$/),
+                'https://github.com/KittyCAD/modeling-app/issues/new?template=bug_report.yml',
+              ])
+            await homePage.projectsLoaded()
+          })
+        } finally {
+          await externalLinks.evaluate(({ restore }) => restore())
+          await externalLinks.dispose()
+        }
       })
       await test.step('Home.Help.Replay onboarding tutorial', async () => {
         await page.reload()

--- a/scripts/check-playwright-run.mjs
+++ b/scripts/check-playwright-run.mjs
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs'
+
+// .last-run.json tracks test failures, but can say passed when worker teardown
+// failed. Those errors cannot be recovered by selecting only --last-failed.
+const report = JSON.parse(readFileSync('test-results/report.json', 'utf8'))
+const lastRun = JSON.parse(readFileSync('test-results/.last-run.json', 'utf8'))
+
+if (!Array.isArray(report.errors)) {
+  throw new Error('Playwright report is missing its global errors array')
+}
+if (!['passed', 'failed'].includes(lastRun.status)) {
+  throw new Error(`Playwright run did not finish: ${lastRun.status}`)
+}
+if (report.errors.length > 0) {
+  console.error('Playwright reported errors outside individual tests:')
+  for (const error of report.errors) {
+    console.error(error.message ?? error.stack ?? JSON.stringify(error))
+  }
+  process.exitCode = 1
+}

--- a/scripts/check-playwright-run.test.mjs
+++ b/scripts/check-playwright-run.test.mjs
@@ -1,0 +1,134 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repo = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+
+function fixture(t, attempts, saved) {
+  const dir = mkdtempSync(path.join(tmpdir(), 'playwright-run-check-'))
+  t.after(() => rmSync(dir, { recursive: true, force: true }))
+  for (const name of ['scripts', 'test-results', 'bin'])
+    mkdirSync(path.join(dir, name))
+  copyFileSync(
+    path.join(repo, 'scripts/check-playwright-run.mjs'),
+    path.join(dir, 'scripts/check-playwright-run.mjs')
+  )
+  copyFileSync(
+    path.join(repo, 'playwrightProcess.mjs'),
+    path.join(dir, 'playwrightProcess.mjs')
+  )
+  writeFileSync(path.join(dir, 'attempts.json'), JSON.stringify(attempts))
+  writeFileSync(
+    path.join(dir, 'bin/npm'),
+    `#!${process.execPath}
+const fs = require('node:fs');
+const attempts = JSON.parse(fs.readFileSync('attempts.json', 'utf8'));
+const count = fs.existsSync('calls') ? Number(fs.readFileSync('calls', 'utf8')) : 0;
+const attempt = attempts[count];
+fs.writeFileSync('calls', String(count + 1));
+if (!attempt) process.exit(99);
+fs.writeFileSync('test-results/.last-run.json', JSON.stringify({ status: attempt.status, failedTests: attempt.status === 'failed' ? ['test-id'] : [] }));
+fs.writeFileSync('test-results/report.json', JSON.stringify({ suites: [], errors: attempt.errors }));
+process.exit(attempt.exitCode ?? (attempt.status === 'failed' ? 1 : 0));
+`,
+    { mode: 0o755 }
+  )
+  if (saved) {
+    writeFileSync(
+      path.join(dir, 'test-results/.last-run.json'),
+      JSON.stringify({ status: saved.status, failedTests: [] })
+    )
+    writeFileSync(
+      path.join(dir, 'test-results/report.json'),
+      JSON.stringify({ suites: [], errors: saved.errors })
+    )
+  }
+  const run = () =>
+    spawnSync(
+      'bash',
+      [
+        path.join(repo, '.github/ci-cd-scripts/playwright-electron.sh'),
+        '1',
+        '6',
+        'windows',
+      ],
+      {
+        cwd: dir,
+        env: {
+          ...process.env,
+          PATH: `${path.join(dir, 'bin')}${path.delimiter}${process.env.PATH}`,
+          GITHUB_OUTPUT: path.join(dir, 'github-output'),
+        },
+        encoding: 'utf8',
+        timeout: 10_000,
+      }
+    )
+  return {
+    dir,
+    run,
+    calls: () => Number(readFileSync(path.join(dir, 'calls'), 'utf8')),
+  }
+}
+
+const passed = { status: 'passed', errors: [] }
+const testFailure = { status: 'failed', errors: [] }
+const teardownFailure = {
+  status: 'passed',
+  errors: [{ message: 'Worker teardown timeout of 120000ms exceeded.' }],
+  exitCode: 1,
+}
+
+test('passes a successful run', (t) => {
+  const f = fixture(t, [passed])
+  assert.equal(f.run().status, 0)
+  assert.equal(f.calls(), 1)
+})
+
+test('retains the one retry for individual test failures', (t) => {
+  const f = fixture(t, [testFailure, passed])
+  assert.equal(f.run().status, 0)
+  assert.equal(f.calls(), 2)
+})
+
+test('fails a global error even when the saved test status is passed', (t) => {
+  const f = fixture(t, [teardownFailure])
+  const result = f.run()
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /Worker teardown timeout/)
+  assert.equal(f.calls(), 1)
+  // Reproduce the outer action retry: it must not turn the same saved run green.
+  assert.equal(f.run().status, 1)
+  assert.equal(f.calls(), 1)
+})
+
+test('fails a global error after the last-failed retry', (t) => {
+  const f = fixture(t, [testFailure, teardownFailure])
+  assert.equal(f.run().status, 1)
+  assert.equal(f.calls(), 2)
+  assert.equal(f.run().status, 1)
+  assert.equal(f.calls(), 2)
+})
+
+test('does not replay test selection when the run also had a global error', (t) => {
+  const f = fixture(t, [{ ...teardownFailure, status: 'failed' }])
+  assert.equal(f.run().status, 1)
+  assert.equal(f.calls(), 1)
+})
+
+test('fails closed for an incomplete or missing saved report', (t) => {
+  const f = fixture(t, [], { ...passed, status: 'interrupted' })
+  assert.equal(f.run().status, 1)
+  rmSync(path.join(f.dir, 'test-results/report.json'))
+  assert.equal(f.run().status, 1)
+})


### PR DESCRIPTION
Desktop CI can report success after Playwright reports a worker teardown error. In [this completed Linux job](https://github.com/KittyCAD/modeling-app/actions/runs/34027090482/job/101471068694), the final retry had two passing tests and a 120-second worker teardown timeout; `report.json.errors` contained that error, while `.last-run.json` said `passed`. The shell script accepted the latter, including on a later outer-wrapper invocation.

Check the full report and saved run status before reusing results and after every Playwright invocation. Global errors, incomplete run statuses, and missing or malformed reports fail the job; individual test failures keep the existing single `--last-failed` retry. Global errors cannot be recovered by selecting only failed test IDs. The retry budgets are unchanged.

Six regression cases execute the actual shell script, including a later outer invocation. All pass with the guard; four reproduce failures against the original script. Static Analysis runs these checks without building the application. The guard also rejects the exact archived report above.

This is a separate CI reporting correction related to #13477; it does not retire the outer retry wrapper. Stacked after the native-menu external-link isolation fix.
