### PR TITLE
Make missing tronApp failures actionable

### DIFF
--- a/e2e/playwright/auth.spec.ts
+++ b/e2e/playwright/auth.spec.ts
@@ -1,3 +1,4 @@
+import { throwTronAppMissing } from '@e2e/playwright/lib/electron-helpers'
 import { expect, test } from '@e2e/playwright/zoo-test'
 
 test.describe('Authentication tests', { tag: '@desktop' }, () => {
@@ -8,7 +9,7 @@ test.describe('Authentication tests', { tag: '@desktop' }, () => {
     toolbar,
     tronApp,
   }) => {
-    if (!tronApp) throw new Error('tronApp is missing.')
+    if (!tronApp) throwTronAppMissing()
 
     await page.setBodyDimensions({ width: 1000, height: 500 })
     await homePage.projectSection.waitFor()

--- a/e2e/playwright/desktop-export.spec.ts
+++ b/e2e/playwright/desktop-export.spec.ts
@@ -1,6 +1,7 @@
 import path from 'path'
 import fsp from 'fs/promises'
 
+import { throwTronAppMissing } from '@e2e/playwright/lib/electron-helpers'
 import {
   executorInputPath,
   getPlaywrightDownloadDir,
@@ -15,7 +16,7 @@ test(
     { page, scene, tronApp, cmdBar, toolbar, folderSetupFn },
     testInfo
   ) => {
-    if (!tronApp) throw new Error('tronApp is missing.')
+    if (!tronApp) throwTronAppMissing()
 
     await folderSetupFn(async (dir) => {
       const bracketDir = path.join(dir, 'bracket')
@@ -177,7 +178,7 @@ test(
     { page, scene, tronApp, cmdBar, toolbar, folderSetupFn },
     testInfo
   ) => {
-    if (!tronApp) throw new Error('tronApp is missing.')
+    if (!tronApp) throwTronAppMissing()
 
     await folderSetupFn(async (dir) => {
       const sketchDir = path.join(dir, 'sketch-project')
@@ -272,7 +273,7 @@ test(
     { page, scene, tronApp, cmdBar, toolbar, folderSetupFn },
     testInfo
   ) => {
-    if (!tronApp) throw new Error('tronApp is missing.')
+    if (!tronApp) throwTronAppMissing()
 
     await folderSetupFn(async (dir) => {
       const sketchDir = path.join(dir, 'second-sketch-project')

--- a/e2e/playwright/fixtures/nativeMenuFixture.ts
+++ b/e2e/playwright/fixtures/nativeMenuFixture.ts
@@ -1,4 +1,5 @@
 import type { ElectronZoo } from '@e2e/playwright/fixtures/fixtureSetup'
+import { throwTronAppMissing } from '@e2e/playwright/lib/electron-helpers'
 import type { Page } from '@playwright/test'
 import { expect } from '@playwright/test'
 
@@ -10,10 +11,6 @@ type NativeMenuItemSnapshot = {
 }
 
 type NativeMenuActionResult = boolean | NativeMenuItemSnapshot | null
-
-function throwTronAppMissing(): never {
-  throw new Error('tronApp is missing.')
-}
 
 export class NativeMenuFixture {
   constructor(private readonly tronApp: ElectronZoo | undefined) {}

--- a/e2e/playwright/lib/electron-helpers.ts
+++ b/e2e/playwright/lib/electron-helpers.ts
@@ -2,6 +2,8 @@ export const throwError = (message: string): never => {
   throw new Error(message)
 }
 
-export const throwTronAppMissing = () => {
-  throwError('tronApp is missing')
+export function throwTronAppMissing(): never {
+  return throwError(
+    'tronApp is required for this desktop test. Run it without TARGET=web.'
+  )
 }

--- a/e2e/playwright/native-file-menu.spec.ts
+++ b/e2e/playwright/native-file-menu.spec.ts
@@ -104,7 +104,7 @@ test.describe(
       nativeMenu,
     }) => {
       if (!tronApp) {
-        throw new Error('tronApp is missing.')
+        throwTronAppMissing()
       }
 
       await test.step('Home.File.New window', async () => {

--- a/e2e/playwright/point-click-assemblies.spec.ts
+++ b/e2e/playwright/point-click-assemblies.spec.ts
@@ -6,6 +6,7 @@ import type { EditorFixture } from '@e2e/playwright/fixtures/editorFixture'
 import type { HomePageFixture } from '@e2e/playwright/fixtures/homePageFixture'
 import type { SceneFixture } from '@e2e/playwright/fixtures/sceneFixture'
 import type { ToolbarFixture } from '@e2e/playwright/fixtures/toolbarFixture'
+import { throwTronAppMissing } from '@e2e/playwright/lib/electron-helpers'
 import {
   doAndWaitForImageDiff,
   executorInputPath,
@@ -103,7 +104,7 @@ test.describe(
       cmdBar,
       tronApp,
     }) => {
-      if (!tronApp) throw new Error('tronApp is missing.')
+      if (!tronApp) throwTronAppMissing()
 
       await test.step('Setup parts and expect empty assembly scene', async () => {
         const projectName = 'assembly'
@@ -598,7 +599,7 @@ test.describe(
       tronApp,
       folderSetupFn,
     }) => {
-      if (!tronApp) throw new Error('tronApp is missing.')
+      if (!tronApp) throwTronAppMissing()
       test.slow()
 
       const projectName = 'assembly'
@@ -663,7 +664,7 @@ test.describe(
       tronApp,
       folderSetupFn,
     }) => {
-      if (!tronApp) throw new Error('tronApp is missing.')
+      if (!tronApp) throwTronAppMissing()
       test.slow()
       await testBracketInsertionThenTransformsThenDeletion(
         context,
@@ -688,7 +689,7 @@ test.describe(
       cmdBar,
       tronApp,
     }) => {
-      if (!tronApp) throw new Error('tronApp is missing.')
+      if (!tronApp) throwTronAppMissing()
 
       const complexPlmFileName = 'cube_Complex-PLM_Name_-001.sldprt'
       const camelCasedSolidworksFileName = 'cubeComplexPLMName001'
@@ -788,7 +789,7 @@ test.describe(
       cmdBar,
       tronApp,
     }) => {
-      if (!tronApp) throw new Error('tronApp is missing.')
+      if (!tronApp) throwTronAppMissing()
 
       const projectName = 'assembly'
 
@@ -870,7 +871,7 @@ foreign
       cmdBar,
       tronApp,
     }) => {
-      if (!tronApp) throw new Error('tronApp is missing.')
+      if (!tronApp) throwTronAppMissing()
 
       const projectName = 'assembly'
       const cloneLine = `clone001 = clone(washer)`

--- a/e2e/playwright/projects.spec.ts
+++ b/e2e/playwright/projects.spec.ts
@@ -18,6 +18,7 @@ import {
   isOutOfViewInScrollContainer,
   runningOnWindows,
 } from '@e2e/playwright/test-utils'
+import { throwTronAppMissing } from '@e2e/playwright/lib/electron-helpers'
 import { expect, test } from '@e2e/playwright/zoo-test'
 import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
 
@@ -1341,7 +1342,7 @@ test(
     tag: '@desktop',
   },
   async ({ page, tronApp, homePage, folderSetupFn }, testInfo) => {
-    if (!tronApp) throw new Error('tronApp is missing.')
+    if (!tronApp) throwTronAppMissing()
 
     await folderSetupFn(async (dir) => {
       await Promise.all([

--- a/e2e/playwright/publish-directory-project.spec.ts
+++ b/e2e/playwright/publish-directory-project.spec.ts
@@ -5,6 +5,7 @@ import {
   cloudProjectResponse,
   routeCloudProjects,
 } from '@e2e/playwright/lib/cloudSyncTestUtils'
+import { throwTronAppMissing } from '@e2e/playwright/lib/electron-helpers'
 import { playwrightPluginSettings } from '@e2e/playwright/storageStates'
 import { mockClientErrorReports } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
@@ -48,7 +49,7 @@ test.describe('Aquarium publication', { tag: ['@desktop'] }, () => {
     tronApp,
   }, testInfo) => {
     if (!tronApp) {
-      throw new Error('tronApp is required for this desktop test.')
+      throwTronAppMissing()
     }
 
     const directoryLibraryPath = testInfo.outputPath(

--- a/e2e/playwright/test-network-and-connection-issues.spec.ts
+++ b/e2e/playwright/test-network-and-connection-issues.spec.ts
@@ -1,3 +1,4 @@
+import { throwTronAppMissing } from '@e2e/playwright/lib/electron-helpers'
 import { TEST_COLORS, circleMove, getUtils } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
 import { LEGACY_SKETCH_MODE_FEATURE_FLAG } from '@src/lib/constants'
@@ -236,7 +237,7 @@ test.describe('Test network related behaviors', { tag: '@desktop' }, () => {
       )
       const networkToggleWeakText = page.getByText('Network health (Ok)')
 
-      if (!tronApp) throw new Error('tronApp is missing.')
+      if (!tronApp) throwTronAppMissing()
 
       await tronApp.cleanProjectDir({
         app: {

--- a/e2e/playwright/testing-settings.spec.ts
+++ b/e2e/playwright/testing-settings.spec.ts
@@ -4,6 +4,7 @@ import {
   TEST_SETTINGS_DEFAULT_THEME,
   TEST_SETTINGS_KEY,
 } from '@e2e/playwright/storageStates'
+import { throwTronAppMissing } from '@e2e/playwright/lib/electron-helpers'
 import {
   createProject,
   executorInputPath,
@@ -56,7 +57,7 @@ test.describe(
       'Stored settings are validated and fall back to defaults',
       { tag: ['@macos', '@windows'] },
       async ({ page, homePage, tronApp }) => {
-        if (!tronApp) throw new Error('tronApp is missing.')
+        if (!tronApp) throwTronAppMissing()
 
         // Override beforeEach test setup
         // with corrupted settings
@@ -315,7 +316,7 @@ test.describe(
       `Load desktop app with a settings file, but no project directory setting`,
       { tag: ['@macos', '@windows'] },
       async ({ page, tronApp }) => {
-        if (!tronApp) throw new Error('tronApp is missing.')
+        if (!tronApp) throwTronAppMissing()
 
         await tronApp.cleanProjectDir({
           modeling: {
@@ -692,7 +693,7 @@ test.describe(
       `Changing system theme preferences (via media query) should update UI and stream`,
       { tag: ['@macos', '@windows'] },
       async ({ page, homePage, tronApp }) => {
-        if (!tronApp) throw new Error('tronApp is missing.')
+        if (!tronApp) throwTronAppMissing()
 
         await tronApp.cleanProjectDir({
           // Override the settings so that the theme is set to `system`
@@ -750,7 +751,7 @@ test.describe(
       `Changing system theme preferences should not override fixed light theme`,
       { tag: ['@macos', '@windows'] },
       async ({ page, homePage, tronApp }) => {
-        if (!tronApp) throw new Error('tronApp is missing.')
+        if (!tronApp) throwTronAppMissing()
 
         await tronApp.cleanProjectDir({
           ...TEST_SETTINGS,

--- a/e2e/playwright/various.spec.ts
+++ b/e2e/playwright/various.spec.ts
@@ -1,3 +1,4 @@
+import { throwTronAppMissing } from '@e2e/playwright/lib/electron-helpers'
 import {
   doExport,
   expectKeybindingsSettingsVisible,
@@ -87,7 +88,7 @@ part001 = startSketchOn(-XZ)
     await page.waitForTimeout(1000)
     await u.clearAndCloseDebugPanel()
 
-    if (!tronApp) throw new Error('tronApp is missing.')
+    if (!tronApp) throwTronAppMissing()
 
     await doExport(
       {


### PR DESCRIPTION
Closes #5789.

Give desktop-only tests one actionable error when the Electron fixture is unavailable: run without TARGET=web. All existing desktop-only guards use the shared helper. A declared never-returning function preserves TypeScript narrowing at the call sites; the original inferred function type left tronApp possibly undefined and failed compilation.

Targets main directly after #13714 landed physical-property tolerance. The individual patch is unchanged, including the latest source-thread fixes; fresh CI is required on this independent head.
