### PR TITLE
Render backticked diagnostic text as inline code

### DIFF
--- a/e2e/playwright/code-pane-and-errors.spec.ts
+++ b/e2e/playwright/code-pane-and-errors.spec.ts
@@ -186,15 +186,17 @@ middle()`)
       await page.keyboard.press('ControlOrMeta+Shift+M')
     })
 
-    // The original error message is preserved, and import frames are
-    // labeled as imports (no call parens), innermost first.
-    await expect(
-      page.getByLabel('Diagnostics').getByText(`\`missingName\` is not defined
+    // The variable renders as inline code; import frames retain their labels
+    // (no call parens) and their innermost-first order.
+    const diagnostic = page
+      .getByLabel('Diagnostics')
+      .getByText(`missingName is not defined
 
 Backtrace:
 import broken.kcl
 import assembly.kcl`)
-    ).toBeVisible()
+    await expect(diagnostic).toBeVisible()
+    await expect(diagnostic.locator('code')).toHaveText('missingName')
     // The import frames are in other files and the top-level frame is the
     // error's own range, so there are no backtrace hint diagnostics.
     await expect(page.getByText('Part of the error backtrace')).toHaveCount(0)

--- a/e2e/playwright/editor-tests.spec.ts
+++ b/e2e/playwright/editor-tests.spec.ts
@@ -876,9 +876,9 @@ a1 = startSketchOn(offsetPlane(XY, offset = 10))
 
     await page.locator('.cm-lint-marker.cm-lint-marker-error').hover()
     await expect(page.locator('.cm-diagnosticText').first()).toBeVisible()
-    await expect(
-      page.getByText('Cannot redefine `topAng`').first()
-    ).toBeVisible()
+    const diagnostic = page.getByText('Cannot redefine topAng').first()
+    await expect(diagnostic).toBeVisible()
+    await expect(diagnostic.locator('code')).toHaveText('topAng')
 
     const secondTopAng = page.getByText('topAng').first()
     await secondTopAng?.dblclick()

--- a/e2e/playwright/projects.spec.ts
+++ b/e2e/playwright/projects.spec.ts
@@ -197,7 +197,7 @@ test(
           // error text on hover
           await page.hover('.cm-lint-marker-error')
           const crypticErrorText =
-            'tag requires a value with type `TagDecl`, but found a value with type `string`.'
+            'tag requires a value with type TagDecl, but found a value with type string.'
           await expect(page.getByText(crypticErrorText).first()).toBeVisible()
         })
       },
@@ -365,7 +365,7 @@ test(
           // error text on hover
           await page.hover('.cm-lint-marker-error')
           const crypticErrorText =
-            'tag requires a value with type `TagDecl`, but found a value with type `string`.'
+            'tag requires a value with type TagDecl, but found a value with type string.'
           await expect(page.getByText(crypticErrorText).first()).toBeVisible()
         })
       },
@@ -414,7 +414,7 @@ test(
     // error text on hover
     await page.locator('.cm-lint-marker-error').hover()
     const crypticErrorText =
-      'tag requires a value with type `TagDecl`, but found a value with type `string`.'
+      'tag requires a value with type TagDecl, but found a value with type string.'
     await expect(
       page.locator('.cm-tooltip-lint').getByText(crypticErrorText)
     ).toBeVisible({ timeout: 15_000 })

--- a/src/editor/plugins/diagnosticTooltipCloseButton.ts
+++ b/src/editor/plugins/diagnosticTooltipCloseButton.ts
@@ -76,6 +76,13 @@ export function diagnosticTooltipCloseButton(): Extension {
         position: 'relative',
         paddingRight: '1.75rem',
       },
+      '.cm-tooltip-lint .cm-diagnosticText code': {
+        borderRadius: '0.25rem',
+        backgroundColor: 'rgba(127, 127, 127, 0.18)',
+        fontFamily:
+          'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+        padding: '0.1rem 0.25rem',
+      },
       '.cm-tooltip-lint .cm-diagnosticAction.cm-diagnosticClose': {
         position: 'absolute',
         top: '0.25rem',

--- a/src/lang/errors.test.ts
+++ b/src/lang/errors.test.ts
@@ -1,6 +1,11 @@
 import type { BacktraceItem } from '@rust/kcl-lib/bindings/BacktraceItem'
 import type { KCLError } from '@src/lang/errors'
-import { kclErrorsToDiagnostics, toUtf8, toUtf16 } from '@src/lang/errors'
+import {
+  kclErrorsToDiagnostics,
+  renderDiagnosticMessage,
+  toUtf8,
+  toUtf16,
+} from '@src/lang/errors'
 import { defaultArtifactGraph } from '@src/lang/std/artifactGraph'
 import { topLevelRange } from '@src/lang/util'
 import { emptyOperationsByModule } from '@src/lang/wasm'
@@ -30,6 +35,37 @@ describe('test UTF conversions', () => {
     const utf16Range: [number, number, number] = [actualStart, actualEnd, 0]
     const actualUtf8Range = toUtf8(utf16Range, sourceCode)
     expect(actualUtf8Range).toStrictEqual(utf8SourceRange)
+  })
+})
+
+describe('diagnostic message rendering', () => {
+  function render(message: string) {
+    const container = document.createElement('div')
+    container.append(renderDiagnosticMessage(message))
+    return container
+  }
+
+  it('renders paired backticks as inline code', () => {
+    const view = render('Use `startSketchOn` here')
+
+    expect(view.textContent).toBe('Use startSketchOn here')
+    expect(view.querySelector('code')?.textContent).toBe('startSketchOn')
+  })
+
+  it('keeps markup-like code content inert', () => {
+    const view = render('Unexpected `<img src=x onerror=alert(1)>`')
+
+    expect(view.querySelector('img')).toBeNull()
+    expect(view.querySelector('code')?.textContent).toBe(
+      '<img src=x onerror=alert(1)>'
+    )
+  })
+
+  it('leaves unmatched backticks as plain text', () => {
+    const view = render('Unexpected `value')
+
+    expect(view.textContent).toBe('Unexpected `value')
+    expect(view.querySelector('code')).toBeNull()
   })
 })
 
@@ -122,6 +158,7 @@ describe('test kclErrToDiagnostic', () => {
         to: 41,
         message:
           '`missingName` is not defined\n\nBacktrace:\nimport broken.kcl\nimport assembly.kcl',
+        renderMessage: expect.any(Function),
         severity: 'error',
       },
     ])
@@ -160,6 +197,7 @@ describe('test kclErrToDiagnostic', () => {
         from: 0,
         to: 32,
         message: '`missingName` is not defined\n\nBacktrace:\nimport part.kcl',
+        renderMessage: expect.any(Function),
         severity: 'error',
       },
     ])
@@ -241,6 +279,7 @@ describe('test kclErrToDiagnostic', () => {
         to: 41,
         message:
           '`missingName` is not defined\n\nBacktrace:\ninner()\nouter()\nimport assembly.kcl',
+        renderMessage: expect.any(Function),
         severity: 'error',
       },
     ])

--- a/src/lang/errors.ts
+++ b/src/lang/errors.ts
@@ -102,6 +102,31 @@ export function sourceRangeToUtf16(
 // When a backtrace has more than twice this many lines, elide the middle,
 // keeping this many innermost and outermost frames.
 const BACKTRACE_EDGE_LINES = 15
+const INLINE_CODE_PATTERN = /`([^`\n]+)`/g
+
+export function renderDiagnosticMessage(message: string): Node {
+  const fragment = document.createDocumentFragment()
+  let lastIndex = 0
+
+  for (const match of message.matchAll(INLINE_CODE_PATTERN)) {
+    const index = match.index
+    fragment.append(document.createTextNode(message.slice(lastIndex, index)))
+
+    const code = document.createElement('code')
+    code.textContent = match[1]
+    fragment.append(code)
+    lastIndex = index + match[0].length
+  }
+
+  fragment.append(document.createTextNode(message.slice(lastIndex)))
+  return fragment
+}
+
+function diagnosticMessageRenderer(message: string): (() => Node) | undefined {
+  return /`[^`\n]+`/.test(message)
+    ? () => renderDiagnosticMessage(message)
+    : undefined
+}
 
 /**
  * Maps the KCL errors to an array of CodeMirror diagnostics.
@@ -190,10 +215,12 @@ export function kclErrorsToDiagnostics(
           compilationIssuesToDiagnostics(err.nonFatal, sourceCode)
         )
       }
+      const renderMessage = diagnosticMessageRenderer(message)
       diagnostics.push({
         from: toUtf16(err.sourceRange[0], sourceCode),
         to: toUtf16(err.sourceRange[1], sourceCode),
         message,
+        ...(renderMessage && { renderMessage }),
         severity: 'error',
       })
       return diagnostics
@@ -231,10 +258,12 @@ export function compilationIssuesToDiagnostics(
           },
         ]
       }
+      const renderMessage = diagnosticMessageRenderer(issue.message)
       return {
         from: toUtf16(issue.sourceRange[0], sourceCode),
         to: toUtf16(issue.sourceRange[1], sourceCode),
         message: issue.message,
+        ...(renderMessage && { renderMessage }),
         severity,
         actions,
       }


### PR DESCRIPTION
Closes #5207.

Render paired backticks in KCL diagnostic messages as inline code in CodeMirror tooltips and the diagnostics panel. Build nodes with textContent so markup-like text stays inert, and preserve unmatched backticks as plain text. Messages without paired backticks retain CodeMirror's default rendering.

Update the affected E2E assertions to check the visible text and inline-code nodes, while preserving import-backtrace order. The 12 focused unit tests cover rendering, escaping, unmatched backticks, and diagnostic conversion.

Targets main directly after #13714 landed physical-property tolerance. The individual patch is unchanged, including the latest source-thread fixes; fresh CI is required on this independent head.
