### PR TITLE
Wait for completed exports

### DIFF
--- a/e2e/playwright/desktop-export.spec.ts
+++ b/e2e/playwright/desktop-export.spec.ts
@@ -126,7 +126,8 @@ test(
       // Look out for the toast message
       const exportingToastMessage = page.getByText(`Exporting...`)
       const alreadyExportingToastMessage = page.getByText(`Already exporting`)
-      await expect(exportingToastMessage).toBeVisible()
+      // A fast export can finish before the progress toast is observed.
+      // The completed file below is the authoritative success condition.
       await expect(alreadyExportingToastMessage).not.toBeVisible()
 
       // Expect it to succeed
@@ -135,13 +136,7 @@ test(
       await expect(errorToastMessage).not.toBeVisible()
       await expect(engineErrorToastMessage).not.toBeVisible()
 
-      const successToastMessage = page.getByText(`Exported successfully`)
-      await page.waitForTimeout(1_000)
-      const count = await successToastMessage.count()
-      expect(count).toBeGreaterThanOrEqual(1)
-      await expect(exportingToastMessage).not.toBeVisible()
-
-      // Check for the exported file=
+      // Check for the exported file.
       const secondFileFullPath = path.resolve(
         getPlaywrightDownloadDir(tronApp.projectDirName),
         exportFileName
@@ -166,6 +161,10 @@ test(
         expect(outputGlb.readUInt32LE(4)).toBe(2)
         expect(outputGlb.readUInt32LE(8)).toBe(outputGlb.byteLength)
       })
+      await expect(exportingToastMessage).not.toBeVisible()
+      await expect(alreadyExportingToastMessage).not.toBeVisible()
+      await expect(errorToastMessage).not.toBeVisible()
+      await expect(engineErrorToastMessage).not.toBeVisible()
     })
   }
 )

--- a/e2e/playwright/regression-tests.spec.ts
+++ b/e2e/playwright/regression-tests.spec.ts
@@ -404,18 +404,11 @@ extrude002 = extrude(profile002, length = 150)`
       // Click the checkbox
       await cmdBar.submit()
 
-      // Find the toast.
-      // Look out for the toast message
-      await expect(exportingToastMessage).toBeVisible()
-
-      // Expect it to succeed.
+      // A fast export can complete before its progress toast is observed.
+      const successToastMessage = page.getByText(`Exported successfully`)
+      await expect(successToastMessage.first()).toBeVisible({ timeout: 15_000 })
       await expect(exportingToastMessage).not.toBeVisible()
       await expect(engineErrorToastMessage).not.toBeVisible()
-
-      const successToastMessage = page.getByText(`Exported successfully`)
-      await page.waitForTimeout(1_000)
-      const count = await successToastMessage.count()
-      expect(count).toBeGreaterThanOrEqual(1)
     }
   )
   // We updated this test such that you can have multiple exports going at once.
@@ -465,10 +458,11 @@ extrude002 = extrude(profile002, length = 150)`
 
       await test.step('The first export still succeeds', async () => {
         await Promise.all([
-          expect(exportingToastMessage).not.toBeVisible({ timeout: 15_000 }),
+          expect(exportingToastMessage).toHaveCount(0, { timeout: 15_000 }),
           expect(errorToastMessage).not.toBeVisible(),
           expect(engineErrorToastMessage).not.toBeVisible(),
-          expect(successToastMessage).toBeVisible({ timeout: 15_000 }),
+          // Overlapping exports can each retain a success notification.
+          expect(successToastMessage.first()).toBeVisible({ timeout: 15_000 }),
           expect(alreadyExportingToastMessage).not.toBeVisible({
             timeout: 15_000,
           }),
@@ -484,7 +478,7 @@ extrude002 = extrude(profile002, length = 150)`
 
       // Expect it to succeed.
       await Promise.all([
-        expect(exportingToastMessage).not.toBeVisible({ timeout: 15_000 }),
+        expect(exportingToastMessage).toHaveCount(0, { timeout: 15_000 }),
         expect(errorToastMessage).not.toBeVisible(),
         expect(engineErrorToastMessage).not.toBeVisible(),
         expect(alreadyExportingToastMessage).not.toBeVisible(),


### PR DESCRIPTION
Fast exports can replace the progress toast before the test observes it, and overlapping exports can leave multiple success notifications. Wait for validated desktop output or a completion notification, accept multiple success notifications, and require progress to clear.

Fixes https://github.com/KittyCAD/modeling-app/issues/13829.

The controlled Playwright replay rejects the old fast-completion assertion and passes the corrected one while still rejecting missing output, corrupt GLB headers, and lingering progress; it does not exercise Windows or the live Engine.
