### PR TITLE
Preserve camera when opening empty KCL files

### DIFF
--- a/src/lang/KclManager.spec.ts
+++ b/src/lang/KclManager.spec.ts
@@ -38,7 +38,7 @@ import {
   getLatestDispatchedDiagnostics,
 } from '@src/lang/testHelpers/kclManagerTestHarness'
 import type { Artifact, ArtifactGraph } from '@src/lang/wasm'
-import { defaultNodePath, emptyExecState } from '@src/lang/wasm'
+import { assertParse, defaultNodePath, emptyExecState } from '@src/lang/wasm'
 
 function createDeferred<T>() {
   let resolve!: (value: T) => void
@@ -510,6 +510,44 @@ describe('KclManager diagnostics', () => {
     expect(executeCodeSpy).toHaveBeenCalledTimes(1)
     expect(executeCodeSpy).toHaveBeenCalledWith('abc')
   })
+
+  it.each([
+    { code: '@settings(kclVersion = 2.0)\n// New part\n', fitsModel: false },
+    { code: 'part = 1\n', fitsModel: true },
+  ])(
+    'fits deferred file loads only when they have statements: $fitsModel',
+    async ({ code, fitsModel }) => {
+      vi.useFakeTimers()
+      const { app, kclManager } = createKclManagerTestHarness('previous = 1')
+      const wasm = await kclManager.wasmInstancePromise
+      kclManager.engineCommandManager.connection = { connected: true } as any
+      vi.spyOn(kclManager, 'executeCode').mockImplementation(async (source) => {
+        kclManager.ast = assertParse(source ?? kclManager.code, wasm)
+      })
+      const sendCommand = vi
+        .spyOn(kclManager.engineCommandManager, 'sendSceneCommand')
+        .mockResolvedValue({} as never)
+
+      try {
+        kclManager.updateCodeEditor(code, {
+          shouldExecute: true,
+          shouldResetCamera: true,
+          shouldSyncRust: false,
+          shouldWriteToDisk: false,
+        })
+        await kclManager.flushPendingEditorExecution()
+        const cameraCommands = sendCommand.mock.calls.filter(
+          ([request]) =>
+            request.type === 'modeling_cmd_req' &&
+            (request.cmd.type === 'view_isometric' ||
+              request.cmd.type === 'zoom_to_fit')
+        )
+        expect(cameraCommands).toHaveLength(fitsModel ? 1 : 0)
+      } finally {
+        app.dispose()
+      }
+    }
+  )
 
   it('flushes a pending direct editor execution before starting a sketch', async () => {
     vi.useFakeTimers()

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -534,11 +534,15 @@ export class ZDSProject {
     ) {
       await newEditor.executeCode(newEditor.code)
       assertCurrent()
-      await resetCameraPosition({
-        sceneInfra: newEditor.sceneInfra,
-        engineCommandManager: newEditor.engineCommandManager,
-        settingsActor: this.app.settings.actor,
-      })
+      // Fitting an empty scene can collapse the camera to sub-millimeter scale,
+      // where normal sketch clicks fall below the rectangle tool's minimum size.
+      if (newEditor.ast.body.length > 0) {
+        await resetCameraPosition({
+          sceneInfra: newEditor.sceneInfra,
+          engineCommandManager: newEditor.engineCommandManager,
+          settingsActor: this.app.settings.actor,
+        })
+      }
     }
     return newEditor
   }
@@ -1830,7 +1834,7 @@ export class KclManager extends File {
           }
         } else {
           await this.executeCode(newCode)
-          if (shouldResetCamera) {
+          if (shouldResetCamera && this.ast.body.length > 0) {
             await resetCameraPosition({
               sceneInfra: this.sceneInfra,
               engineCommandManager: this.engineCommandManager,

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -2,6 +2,7 @@ import type { Feature } from '@kittycad/lib'
 import { pluginsValueSpec } from '@kittycad/registry'
 import { signal } from '@preact/signals-core'
 import { File, type KclManager } from '@src/lang/KclManager'
+import { assertParse } from '@src/lang/wasm'
 import { App } from '@src/lib/app'
 import {
   KCL_CEK_EXECUTOR_FEATURE_FLAG,
@@ -945,6 +946,71 @@ describe('project system', () => {
     }
   })
 
+  it.each([
+    { name: 'empty', code: '', fitsModel: false },
+    {
+      name: 'settings and comments only',
+      code: '@settings(kclVersion = 2.0)\n// A new part\n',
+      fitsModel: false,
+    },
+    { name: 'model statements', code: 'part = 1\n', fitsModel: true },
+  ])(
+    'fits file loads only when they have statements: $name',
+    async ({ code, fitsModel }) => {
+      const projectPath = `/tmp/app-file-switch-camera-${crypto.randomUUID()}`
+      const mainPath = fsZds.join(projectPath, 'main.kcl')
+      const alternatePath = fsZds.join(projectPath, 'alternate.kcl')
+      const app = createAppForTest()
+
+      try {
+        await writeText(mainPath, 'main = true\n')
+        await writeText(alternatePath, code)
+        const project = await app.openProject({
+          ...mockProject,
+          name: fsZds.basename(projectPath),
+          path: projectPath,
+          default_file: mainPath,
+          kcl_file_count: 2,
+          children: [
+            { name: 'main.kcl', path: mainPath, children: null },
+            { name: 'alternate.kcl', path: alternatePath, children: null },
+          ],
+        })
+        const editor = await project.openEditor(mainPath)
+        const wasm = await editor.wasmInstancePromise
+        const execute = vi
+          .spyOn(editor, 'executeCode')
+          .mockImplementation(async (code) => {
+            editor.ast = assertParse(code ?? editor.code, wasm)
+          })
+        vi.spyOn(editor.rustContext, 'sendOpenProject').mockResolvedValue()
+        const sendCommand = vi
+          .spyOn(editor.engineCommandManager, 'sendSceneCommand')
+          .mockResolvedValue({} as never)
+        editor.engineCommandManager.connection = {
+          connected: true,
+        } as typeof editor.engineCommandManager.connection
+
+        await project.openEditor(alternatePath, editor)
+
+        expect(execute).toHaveBeenCalledWith(code)
+        expect(editor.path).toBe(alternatePath)
+        expect(editor.code).toBe(code)
+        const cameraCommands = sendCommand.mock.calls.filter(
+          ([request]) =>
+            request.type === 'modeling_cmd_req' &&
+            (request.cmd.type === 'view_isometric' ||
+              request.cmd.type === 'zoom_to_fit')
+        )
+        expect(cameraCommands).toHaveLength(fitsModel ? 1 : 0)
+        expect(await fsZds.readFile(mainPath, 'utf8')).toBe('main = true\n')
+      } finally {
+        app.dispose()
+        await fsZds.rm(projectPath, { recursive: true, force: true })
+      }
+    }
+  )
+
   it('does not let a superseded route load replace the active editor', async () => {
     const projectPath = `/tmp/app-stale-route-load-${crypto.randomUUID()}`
     const mainPath = fsZds.join(projectPath, 'main.kcl')
@@ -1125,6 +1191,7 @@ describe('project system', () => {
 
   it('can open, close project', async () => {
     // Stub out File read and write implementations
+    const originalFileIO = { ...File.ioImplementations }
     File.ioImplementations.read = () => Promise.resolve('')
     File.ioImplementations.write = () => Promise.resolve()
 
@@ -1151,6 +1218,7 @@ describe('project system', () => {
 
       expect(app.project).toBeUndefined()
     } finally {
+      File.ioImplementations = originalFileIO
       app.dispose()
     }
   })


### PR DESCRIPTION
Opening an empty or settings-only KCL file now preserves the current camera. Files containing model statements keep the existing fit behavior in both direct-open and deferred editor execution paths.

Closes #13715.