### PR TITLE
GLTF/GLB Export fixes

### DIFF
--- a/e2e/playwright/desktop-export.spec.ts
+++ b/e2e/playwright/desktop-export.spec.ts
@@ -50,7 +50,7 @@ test(
 
       // Select the first format option
       const gltfOption = cmdBar.selectOption({ name: 'glTF' })
-      const exportFileName = `bracket.gltf` // project is named `bracket`
+      const exportFileName = `bracket.glb` // project is named `bracket`
       await expect(gltfOption).toBeVisible()
       await page.keyboard.press('Enter')
 
@@ -72,21 +72,25 @@ test(
         getPlaywrightDownloadDir(tronApp.projectDirName),
         exportFileName
       )
-      await test.step('Check the export size', async () => {
+      await test.step('Check the binary glTF export', async () => {
         await expect
           .poll(
             async () => {
               try {
-                const outputGltf = await fsp.readFile(firstFileFullPath)
-                return outputGltf.byteLength
+                const outputGlb = await fsp.readFile(firstFileFullPath)
+                return outputGlb.subarray(0, 4).toString('utf8')
               } catch (error: unknown) {
                 void error
-                return 0
+                return ''
               }
             },
             { timeout: 15_000 }
           )
-          .toBeGreaterThan(30_000)
+          .toBe('glTF')
+        const outputGlb = await fsp.readFile(firstFileFullPath)
+        expect(outputGlb.byteLength).toBeGreaterThan(30_000)
+        expect(outputGlb.readUInt32LE(4)).toBe(2)
+        expect(outputGlb.readUInt32LE(8)).toBe(outputGlb.byteLength)
       })
     })
 
@@ -112,7 +116,7 @@ test(
 
       // Select the first format option
       const gltfOption = cmdBar.selectOption({ name: 'glTF' })
-      const exportFileName = `other.gltf` // source file is named `other.kcl`
+      const exportFileName = `other.glb` // source file is named `other.kcl`
       await expect(gltfOption).toBeVisible()
       await page.keyboard.press('Enter')
 
@@ -142,21 +146,25 @@ test(
         getPlaywrightDownloadDir(tronApp.projectDirName),
         exportFileName
       )
-      await test.step('Check the export size', async () => {
+      await test.step('Check the binary glTF export', async () => {
         await expect
           .poll(
             async () => {
               try {
-                const outputGltf = await fsp.readFile(secondFileFullPath)
-                return outputGltf.byteLength
+                const outputGlb = await fsp.readFile(secondFileFullPath)
+                return outputGlb.subarray(0, 4).toString('utf8')
               } catch (error: unknown) {
                 void error
-                return 0
+                return ''
               }
             },
             { timeout: 15_000 }
           )
-          .toBeGreaterThan(50_000)
+          .toBe('glTF')
+        const outputGlb = await fsp.readFile(secondFileFullPath)
+        expect(outputGlb.byteLength).toBeGreaterThan(40_000)
+        expect(outputGlb.readUInt32LE(4)).toBe(2)
+        expect(outputGlb.readUInt32LE(8)).toBe(outputGlb.byteLength)
       })
     })
   }

--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -443,7 +443,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         defaultValue: (c) => {
           switch (c.argumentsToSubmit.type) {
             case 'gltf':
-              return 'embedded'
+              return 'binary'
             case 'stl':
               return 'ascii'
             case 'ply':
@@ -469,8 +469,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
           switch (type) {
             case 'gltf':
               return [
-                { name: 'embedded', isCurrent: true, value: 'embedded' },
-                { name: 'binary', isCurrent: false, value: 'binary' },
+                { name: 'binary', isCurrent: true, value: 'binary' },
+                { name: 'embedded', isCurrent: false, value: 'embedded' },
                 { name: 'standard', isCurrent: false, value: 'standard' },
               ]
             case 'stl':

--- a/src/machines/modelingMachine.ts
+++ b/src/machines/modelingMachine.ts
@@ -7468,7 +7468,11 @@ export const modelingMachine = setup({
           }
           fileName = fileName.replace(/\.kcl$/i, '') // remove trailing .kcl
           fileName = sanitizeProjectName(fileName, 'output') // remove slash, backslash
-          fileName += `.${event.data.type}` // add file extension
+          const extension =
+            event.data.type === 'gltf' && event.data.storage === 'binary'
+              ? 'glb'
+              : event.data.type
+          fileName += `.${extension}` // add file extension
 
           return {
             data: event.data,


### PR DESCRIPTION
Two small fixes when exporting GLTF:
- when exporting to binary the file extension is now .glb (it was .gltf which is not correct according to the GLTF [spec](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#file-extensions-and-media-types): "glTF files stored in GLB container SHOULD use .glb extension and model/gltf-binary Media Type."

- default is binary now (it was embedded which is not an ideal variant of GLTF, it embeds buffers and textures as base64 string into the json)