### PR TITLE
Use a signal for onboarding startup pending state

### DIFF
--- a/src/routes/Onboarding/utils.spec.ts
+++ b/src/routes/Onboarding/utils.spec.ts
@@ -177,16 +177,31 @@ describe('Onboarding utility functions', () => {
       })
       const navigate = vi.fn()
       const deps = createOnboardingDeps([cloud.target], navigate)
+      const { result } = renderHook(() => useOnboardingStartPending())
 
-      const firstStart = acceptOnboarding(deps)
+      expect(result.current).toBe(false)
+
+      let firstStart: Promise<void> | undefined
+      act(() => {
+        firstStart = acceptOnboarding(deps)
+      })
       const secondStart = acceptOnboarding(deps)
+      const { result: lateSubscriber } = renderHook(() =>
+        useOnboardingStartPending()
+      )
 
       expect(secondStart).toBe(firstStart)
       expect(cloud.run).toHaveBeenCalledOnce()
+      expect(result.current).toBe(true)
+      expect(lateSubscriber.current).toBe(true)
 
-      resolveProject?.(createProject('/cloud/tutorial-project/main.kcl'))
-      await Promise.all([firstStart, secondStart])
+      await act(async () => {
+        resolveProject?.(createProject('/cloud/tutorial-project/main.kcl'))
+        await Promise.all([firstStart, secondStart])
+      })
       expect(navigate).toHaveBeenCalledOnce()
+      expect(result.current).toBe(false)
+      expect(lateSubscriber.current).toBe(false)
     })
 
     it('exposes pending state and restores interaction after a failed replay', async () => {

--- a/src/routes/Onboarding/utils.tsx
+++ b/src/routes/Onboarding/utils.tsx
@@ -1,4 +1,6 @@
-import { useCallback, useEffect, useState, useSyncExternalStore } from 'react'
+import { signal } from '@preact/signals-core'
+import { useSignals } from '@preact/signals-react/runtime'
+import { useCallback, useEffect, useState } from 'react'
 import {
   type NavigateFunction,
   type useLocation,
@@ -322,30 +324,11 @@ export interface OnboardingUtilDeps {
   navigate: NavigateFunction
 }
 
-let pendingOnboardingStart: Promise<void> | undefined
-const onboardingStartListeners = new Set<() => void>()
-
-function emitOnboardingStartPendingChange() {
-  for (const listener of onboardingStartListeners) {
-    listener()
-  }
-}
-
-function subscribeToOnboardingStartPending(listener: () => void) {
-  onboardingStartListeners.add(listener)
-  return () => onboardingStartListeners.delete(listener)
-}
-
-function getOnboardingStartPendingSnapshot() {
-  return pendingOnboardingStart !== undefined
-}
+const pendingOnboardingStart = signal<Promise<void> | undefined>(undefined)
 
 export function useOnboardingStartPending() {
-  return useSyncExternalStore(
-    subscribeToOnboardingStartPending,
-    getOnboardingStartPendingSnapshot,
-    () => false
-  )
+  useSignals()
+  return pendingOnboardingStart.value !== undefined
 }
 
 async function createOnboardingProject(
@@ -419,19 +402,18 @@ export function acceptOnboarding(deps: OnboardingUtilDeps): Promise<void> {
     ? onboardingStartPath
     : deps.onboardingStatus
 
-  if (pendingOnboardingStart) {
-    return pendingOnboardingStart
+  const pendingStart = pendingOnboardingStart.peek()
+  if (pendingStart) {
+    return pendingStart
   }
 
   const start = createOnboardingProject(deps, onboardingStatus)
   const trackedStart = start.finally(() => {
-    if (pendingOnboardingStart === trackedStart) {
-      pendingOnboardingStart = undefined
-      emitOnboardingStartPendingChange()
+    if (pendingOnboardingStart.peek() === trackedStart) {
+      pendingOnboardingStart.value = undefined
     }
   })
-  pendingOnboardingStart = trackedStart
-  emitOnboardingStartPendingChange()
+  pendingOnboardingStart.value = trackedStart
   return trackedStart
 }
 


### PR DESCRIPTION
Replace the manual onboarding-start listener set and `useSyncExternalStore` adapter with the app's existing Preact signals pattern, following [the review comment on #13467](https://github.com/KittyCAD/modeling-app/pull/13467#discussion_r3950312773).

The shared promise is the signal's value, and the existing hook derives whether startup is pending. Concurrent replay calls still share that promise, and the identity-guarded `finally` clears it on success or failure so both controls can recover.

Extend the existing regression to cover subscribers mounted before and during startup returning to idle together. The desktop Replay scenario passed locally with retries disabled, exercising the pending states in Settings and Help, tutorial navigation, and one project per replay.
