### PR TITLE
Follow-up cleanup after #13662

### DIFF
--- a/src/lang/modifyAst/faces.ts
+++ b/src/lang/modifyAst/faces.ts
@@ -197,7 +197,7 @@ export function addDeleteFace({
     artifactGraph,
     modifiedAst,
     wasmInstance,
-    mNodeToEdit,
+    undefined,
     {
       lastChildLookup: true,
       artifactTypeFilter: ['sweep', 'compositeSolid', 'edgeCut'],

--- a/src/lib/operations.ts
+++ b/src/lib/operations.ts
@@ -2044,12 +2044,7 @@ const prepareToEditGdtFlatness: PrepareToEditCallback = async ({
   }
 
   const facesArg = operation.labeledArgs?.['faces']
-  const faces: Selections = {
-    graphSelections: facesArg?.sourceRange
-      ? extractFaceSelections(artifactGraph, facesArg)
-      : [],
-    otherSelections: [],
-  }
+  const faces = retrieveFaceAndEdgeSelectionsForEdit(artifactGraph, facesArg)
 
   const tolerance = await extractKclArgument(
     code,
@@ -2285,12 +2280,7 @@ const prepareToEditGdtDatum: PrepareToEditCallback = async ({
   }
 
   const faceArg = operation.labeledArgs?.['face']
-  const faces: Selections = {
-    graphSelections: faceArg?.sourceRange
-      ? extractFaceSelections(artifactGraph, faceArg)
-      : [],
-    otherSelections: [],
-  }
+  const faces = retrieveFaceAndEdgeSelectionsForEdit(artifactGraph, faceArg)
 
   // Extract name argument as a plain string (strip quotes if present)
   const nameRaw = extractStringArgument(code, operation, 'name')


### PR DESCRIPTION
Follow-up to #13662 addressing its post-merge review feedback.

- Make the Delete Face creation path pass its known `undefined` edit node explicitly.
- Reuse `retrieveFaceAndEdgeSelectionsForEdit` for GDT Flatness and GDT Datum.

No behavior change intended; this removes duplicated selection reconstruction and makes the create-only invariant explicit.