### PR TITLE
Fix sketch point constraint colours

### DIFF
--- a/rust/kcl-lib/src/tooling/sketch_visualizer/extract.rs
+++ b/rust/kcl-lib/src/tooling/sketch_visualizer/extract.rs
@@ -132,7 +132,6 @@ impl<'a> Extraction<'a> {
             id.0,
             InternalPoint {
                 position: position_to_point(&point.position),
-                owner: point.owner.map(|owner| owner.0),
                 freedom: point.freedom(),
             },
         );

--- a/rust/kcl-lib/src/tooling/sketch_visualizer/model.rs
+++ b/rust/kcl-lib/src/tooling/sketch_visualizer/model.rs
@@ -6,7 +6,6 @@ use crate::front::Freedom;
 #[derive(Debug, Clone)]
 pub(super) struct InternalPoint {
     pub(super) position: SketchVisualizationPoint,
-    pub(super) owner: Option<usize>,
     pub(super) freedom: Freedom,
 }
 

--- a/rust/kcl-lib/src/tooling/sketch_visualizer/render.rs
+++ b/rust/kcl-lib/src/tooling/sketch_visualizer/render.rs
@@ -76,11 +76,7 @@ pub(super) fn render_png(
     }
 
     for (point_id, point) in points {
-        let owner_color = point
-            .owner
-            .and_then(|owner| segments.get(&owner))
-            .map(|segment| dof_color(segment.freedom));
-        let color = owner_color.unwrap_or_else(|| dof_color(Some(point.freedom)));
+        let color = dof_color(Some(point.freedom));
         let radius = if contact_point_ids.contains(point_id) {
             CONTACT_POINT_RADIUS
         } else {
@@ -225,5 +221,65 @@ fn interpolate_screen(a: ScreenPoint, b: ScreenPoint, t: f64) -> ScreenPoint {
     ScreenPoint {
         x: a.x + (b.x - a.x) * t,
         y: a.y + (b.y - a.y) * t,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tooling::sketch_visualizer::sampling::sample_circle;
+
+    #[test]
+    fn point_colors_are_independent_of_segment_colors() {
+        let center = SketchVisualizationPoint { x: 0.0, y: 0.0 };
+        let bounds = SketchVisualizationBounds {
+            min: SketchVisualizationPoint { x: -12.0, y: -12.0 },
+            max: SketchVisualizationPoint { x: 12.0, y: 12.0 },
+        };
+        for segment_freedom in [Freedom::Free, Freedom::Fixed, Freedom::Conflict] {
+            for point_freedom in [Freedom::Free, Freedom::Fixed, Freedom::Conflict] {
+                let segments = BTreeMap::from([(
+                    1,
+                    InternalSegment {
+                        construction: false,
+                        freedom: Some(segment_freedom),
+                        polyline: sample_circle(center, 10.0),
+                    },
+                )]);
+                let start = SketchVisualizationPoint { x: 10.0, y: 0.0 };
+                let points = BTreeMap::from([
+                    (
+                        2,
+                        InternalPoint {
+                            position: center,
+                            freedom: point_freedom,
+                        },
+                    ),
+                    (
+                        3,
+                        InternalPoint {
+                            position: start,
+                            freedom: point_freedom,
+                        },
+                    ),
+                ]);
+                let png = render_png(&segments, &points, &BTreeSet::new(), bounds).unwrap();
+                let image = image::load_from_memory(&png).unwrap().into_rgba8();
+                for position in [center, start] {
+                    let pixel = Transform::new(bounds).point(position);
+                    assert_eq!(
+                        *image.get_pixel(pixel.x as u32, pixel.y as u32),
+                        dof_color(Some(point_freedom)).to_rgba(),
+                        "point={point_freedom:?}, segment={segment_freedom:?}"
+                    );
+                }
+                let rim = Transform::new(bounds).point(SketchVisualizationPoint { x: -10.0, y: 0.0 });
+                assert_eq!(
+                    *image.get_pixel(rim.x as u32, rim.y as u32),
+                    dof_color(Some(segment_freedom)).to_rgba(),
+                    "the circle stroke must retain its segment constraint color"
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Render each sketch point using its own solver freedom rather than inheriting the colour of its owning segment.

For example, a constrained circle centre stays white even when the circle stroke is blue because another circle parameter remains free. This corrects the display; it does not change solver behaviour or constraint requirements.

Remove the now-unused point-owner field and cover free, fixed and conflicting point/segment colour combinations in renderer tests. The segment stroke retains its own constraint colour.

## Scope

This PR is now point colours only, following the code owner's request to separate duplicate-name handling from constraint/DOF display changes. Instance selection is in #13882; execution performance/cancellation is in #13883, stacked on #13882. No region or segment-selection overlays are included.

The previously tested combined commit `70b856e29374d84ca2f0ca5707e0b2b427b551c9` is preserved on `codex/sketch-visualization-tested-combined`. Existing MCP/TTC pins still reference that complete build during review; this narrowed PR alone is not the full native dependency required by MCP #248.
