### PR TITLE
[2/2] Show Zookeeper activity in the pane toggle

### DIFF
--- a/e2e/playwright/zookeeper.spec.ts
+++ b/e2e/playwright/zookeeper.spec.ts
@@ -57,10 +57,19 @@ test.describe('Zookeeper tests', { tag: ZOOKEEPER_TEST_TAGS }, () => {
       )
       await expect(copilot.placeHolderResponse).toBeVisible()
 
+      const zookeeperPaneButton = page.getByTestId(
+        `${DefaultLayoutPaneID.Zookeeper}-pane-button`
+      )
       await toolbar.closePane(DefaultLayoutPaneID.Zookeeper)
+      await expect(
+        zookeeperPaneButton.locator('svg[aria-label="loading"]')
+      ).toBeVisible()
       expect(zookeeperConnectionCount).toBe(1)
       holdResponses = false
       releaseResponses()
+      await expect(
+        zookeeperPaneButton.locator('svg[aria-label="sparkles"]')
+      ).toBeVisible({ timeout: 30_000 })
       expect(zookeeperConnectionCount).toBe(1)
 
       await toolbar.openPane(DefaultLayoutPaneID.Code)

--- a/src/lib/layout/components.tsx
+++ b/src/lib/layout/components.tsx
@@ -503,6 +503,7 @@ function PaneButton({
   const isActiveIndex = parentActiveIndices.indexOf(childIndex) >= 0
   const resolvedAreaType =
     pane.type === LayoutType.Simple ? areaLibrary[pane.areaType] : undefined
+  const icon = resolvedAreaType?.icon ?? pane.icon
   useHotkeys(
     resolvedAreaType?.shortcut || '',
     () => {
@@ -530,7 +531,11 @@ function PaneButton({
         style={{ [buttonBorderWidthProp]: '2px' }}
         data-testid={`${pane.id}-pane-button`}
       >
-        <CustomIcon name={pane.icon} className="w-5 h-5" aria-hidden />
+        <CustomIcon
+          name={icon}
+          className={`w-5 h-5 ${icon === 'loading' ? 'animate-spin' : ''}`}
+          aria-hidden
+        />
         <span className="sr-only">{pane.label}</span>
       </Switch>
       <Tooltip

--- a/src/lib/layout/types.ts
+++ b/src/lib/layout/types.ts
@@ -30,6 +30,7 @@ export type AreaTypeComponentProps = {
 export type AreaTypeDefinition = {
   hide: () => boolean
   shortcut?: string
+  icon?: CustomIconName
   /** I decided this is where impure stuff like the Zookeeper button's custom styling should live */
   cssClassOverrides?: PaneChildCssOverrides
   useNotifications?: () => ReturnType<

--- a/src/lib/zookeeper/registry/index.spec.ts
+++ b/src/lib/zookeeper/registry/index.spec.ts
@@ -15,6 +15,7 @@ import {
   type LayoutService,
   LayoutType,
 } from '@src/lib/layout/types'
+import { zookeeperPromptRunningSignal } from '@src/lib/zookeeper/zookeeperPromptState'
 import {
   layoutAreaLibraryValueSpec,
   layoutService,
@@ -72,7 +73,7 @@ function createTestLayoutServiceRegistryItem(layoutSignal: Signal<Layout>) {
 }
 
 describe('zookeeper plugin', () => {
-  it('contributes the conversation pane and credits', async () => {
+  it('contributes the conversation pane, running indicator, and credits', async () => {
     const { default: zookeeper } = await import('.')
     const layoutSignal = signal(zookeeperPaneLayout())
     const registry = new Registry()
@@ -93,6 +94,10 @@ describe('zookeeper plugin', () => {
     expect(zookeeperArea).toMatchObject({
       shortcut: 'Ctrl + T',
     })
+    zookeeperPromptRunningSignal.value = true
+    expect(
+      registry.get(layoutAreaLibraryValueSpec)[AreaType.Zookeeper]?.icon
+    ).toBeUndefined()
     expect(
       registry.get(statusBarLocalItemsValueSpec).map((item) => item.id)
     ).toContain('zookeeper-credits')
@@ -100,8 +105,22 @@ describe('zookeeper plugin', () => {
     layoutSignal.value = zookeeperPaneLayout([])
 
     expect(
+      registry.get(layoutAreaLibraryValueSpec)[AreaType.Zookeeper]?.icon
+    ).toBe('loading')
+    expect(
       registry.get(statusBarLocalItemsValueSpec).map((item) => item.id)
     ).not.toContain('zookeeper-credits')
+
+    layoutSignal.value = zookeeperPaneLayout()
+    expect(
+      registry.get(layoutAreaLibraryValueSpec)[AreaType.Zookeeper]?.icon
+    ).toBeUndefined()
+
+    layoutSignal.value = zookeeperPaneLayout([])
+    zookeeperPromptRunningSignal.value = false
+    expect(
+      registry.get(layoutAreaLibraryValueSpec)[AreaType.Zookeeper]?.icon
+    ).toBeUndefined()
   })
 
   it('removes and restores zookeeper contributions when toggled', async () => {

--- a/src/lib/zookeeper/registry/runtime.tsx
+++ b/src/lib/zookeeper/registry/runtime.tsx
@@ -14,17 +14,23 @@ import { LayoutPanel, LayoutPanelHeader } from '@src/components/layout/Panel'
 import { Spinner } from '@src/components/Spinner'
 import type { KclManager, ZDSProject } from '@src/lang/KclManager'
 import type { BillingRegistryService } from '@src/lib/billing'
+import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
 import { AreaType, type AreaTypeComponentProps } from '@src/lib/layout/types'
+import { getOpenPanes } from '@src/lib/layout/utils'
 import type {
   ZookeeperSessionController,
   ZookeeperSessionControllerDependencies,
 } from '@src/lib/zookeeper/registry/controller'
+import { zookeeperPromptRunningSignal } from '@src/lib/zookeeper/zookeeperPromptState'
 import {
   type AuthRegistryService,
   authService,
 } from '@src/registry/contracts/auth'
 import { billingService } from '@src/registry/contracts/billing'
-import { layoutAreaLibraryValueSpec } from '@src/registry/contracts/layout'
+import {
+  layoutAreaLibraryValueSpec,
+  layoutService,
+} from '@src/registry/contracts/layout'
 import {
   type ProjectSessionService,
   projectSession,
@@ -394,6 +400,7 @@ export function ZookeeperPaneOutlet({
 }
 
 export const zookeeperRuntimeRegistryItem = defineRegistryItemFactory((ctx) => {
+  const layout = ctx.services.signal(layoutService)
   const runtime = createZookeeperRuntime({
     auth: ctx.services.signal(authService),
     billing: ctx.services.signal(billingService),
@@ -405,23 +412,35 @@ export const zookeeperRuntimeRegistryItem = defineRegistryItemFactory((ctx) => {
   const PaneOutlet = (props: AreaTypeComponentProps) => (
     <ZookeeperPaneOutlet {...props} runtime={runtime} />
   )
+  const areaLibrary = computed(() => {
+    const layoutSystem = layout.value
+    const isOpen =
+      layoutSystem !== undefined &&
+      getOpenPanes({ rootLayout: layoutSystem.signal.value }).includes(
+        DefaultLayoutPaneID.Zookeeper
+      )
+
+    return {
+      [AreaType.Zookeeper]: {
+        hide: () => false,
+        shortcut: 'Ctrl + T',
+        cssClassOverrides: {
+          button:
+            'bg-ml-green pressed:bg-transparent dark:!text-chalkboard-100 hover:dark:!text-inherit dark:pressed:!text-inherit',
+        },
+        icon:
+          !isOpen && zookeeperPromptRunningSignal.value
+            ? ('loading' as const)
+            : undefined,
+        Component: PaneOutlet,
+      },
+    }
+  })
 
   return {
     item: defineRuntimeRegistryItem({
       id: 'zookeeper.runtime',
-      provides: [
-        provide(layoutAreaLibraryValueSpec, {
-          [AreaType.Zookeeper]: {
-            hide: () => false,
-            shortcut: 'Ctrl + T',
-            cssClassOverrides: {
-              button:
-                'bg-ml-green pressed:bg-transparent dark:!text-chalkboard-100 hover:dark:!text-inherit dark:pressed:!text-inherit',
-            },
-            Component: PaneOutlet,
-          },
-        }),
-      ],
+      provides: [provide(layoutAreaLibraryValueSpec, areaLibrary)],
       dispose: () => runtime.dispose(),
     }),
   }


### PR DESCRIPTION
Stacked on #13741.

Adds an optional icon override to registered pane definitions. The Zookeeper plugin derives that override through a computed registry contribution that watches the layout and prompt state. While a prompt is running with the pane closed, the pane toggle shows the existing loading spinner; opening the pane or completing the prompt restores the sparkles icon.

The browser regression holds a response while the pane is closed, verifies the spinner-to-sparkles transition, and confirms the persistent Zookeeper runtime keeps a single WebSocket.
