### PR TITLE
Restore Engine concurrency limits for LSP tests

### DIFF
--- a/rust/.config/nextest.toml
+++ b/rust/.config/nextest.toml
@@ -30,6 +30,18 @@ threads-required = 2
 # that recovery local to engine-capable KCL tests instead of the workspace.
 retries = { backoff = "exponential", count = 2, delay = "1s", max-delay = "2s", jitter = true }
 
+# LSP execution tests moved out of kcl-lib in #13440. Keep their Engine
+# allocations inside the same budget; the two hover tests predate kcl_test_.
+[[profile.default.overrides]]
+filter = 'package(kcl-language-server) and (test(kcl_test_) or test(/^lsp::tests::test_kcl_lsp_on_hover(_untitled_file_scheme)?$/))'
+test-group = "uses-engine"
+threads-required = 2
+
+[[profile.ci.overrides]]
+filter = 'package(kcl-language-server) and (test(kcl_test_) or test(/^lsp::tests::test_kcl_lsp_on_hover(_untitled_file_scheme)?$/))'
+test-group = "uses-engine"
+threads-required = 2
+
 [[profile.default.overrides]]
 filter = "test(/export_bindings/)"
 test-group = "export-bindings"


### PR DESCRIPTION
Fixes #13744.

After the LSP moved out of kcl-lib, its live-Engine tests no longer matched the Engine concurrency overrides. Add both default and CI profile overrides for the LSP kcl_test_ family and the two execution-backed hover tests, using the existing uses-engine group and two-slot weight. This covers all 15 tests that open an Engine, plus five conservatively included local kcl_test_ tests, without changing test assertions, group capacity, or retry counts.

Validated the actual nextest group resolver against a dependency-free workspace containing the source test names: all 15 Engine-backed LSP tests are ungrouped before and share uses-engine afterward in both profiles; the non-executing shebang-hover control remains outside. This validates scheduling, not an end-to-end fix for all service disconnects. The change is intentionally separate from the video-codec PR.
