### PR TITLE
ci: Remove running the recursive executor in CI

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -172,7 +172,7 @@ jobs:
           name: nextest-archive
           path: rust/nextest-archive.tar.zst
   run-test-artifacts:
-    name: cargo test (${{ matrix.executor }}, shard ${{ matrix.partitionIndex}})
+    name: cargo test (shard ${{ matrix.partitionIndex}})
     runs-on: namespace-profile-ubuntu-8-cores;overrides.cache-tag=modeling-app-general-v2
     needs: build-test-artifacts
     strategy:
@@ -180,10 +180,6 @@ jobs:
       matrix:
         partitionIndex: [1, 2, 3]
         partitionTotal: [3]
-        # Differential testing: the whole suite runs under both the recursive
-        # executor and the CEK machine executor, and must produce identical
-        # snapshots. See rust/kcl-lib/src/execution/machine.rs.
-        executor: [recursive, machine]
     steps:
       - uses: runs-on/action@v2.3.0
       - uses: actions/create-github-app-token@v3.2.0
@@ -228,20 +224,9 @@ jobs:
         run: |-
           cp nextest-archive.tar.zst rust/nextest-archive.tar.zst
           pushd rust
-          # The recursive leg runs the full suite. The machine leg reruns
-          # only executor-sensitive tests: packages and modules that never
-          # construct an ExecutorContext (parsers, printers, ts-rs bindings
-          # codegen, ...) behave identically under both executors, so they
-          # run once. Exclusion-based so that a new execution test is
-          # machine-covered by default.
-          executor_filter=()
-          if [ "${{ matrix.executor }}" = "machine" ]; then
-            executor_filter=(-E "package(kcl-lib) and not (test(/^parsing::/) or test(/^unparser::/) or test(/^walk::/) or test(/^settings::/) or test(/^fs::/) or test(/^fmt::/) or test(/^tooling::/) or test(/^errors::/) or test(/export_bindings/))")
-          fi
           cargo nextest run \
             --no-fail-fast --profile=ci --archive-file nextest-archive.tar.zst \
             --partition count:${{ matrix.partitionIndex}}/${{ matrix.partitionTotal }} \
-            "${executor_filter[@]}" \
             2>&1 | tee /tmp/github-actions.log || true  # let TAB determine failure
           popd
           .github/ci-cd-scripts/upload-results.sh
@@ -249,7 +234,6 @@ jobs:
           ZOO_API_TOKEN: ${{secrets.ZOO_API_TOKEN}}
           ZOO_HOST: https://api.dev.zoo.dev
           RUST_MIN_STACK: 10485760000
-          KCL_EXECUTOR: ${{ matrix.executor }}
           TAB_API_URL: ${{ vars.TAB_API_URL }}
           TAB_API_KEY: ${{ secrets.TAB_API_KEY }}
           CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
We're going all in on the new executor implementation. Start with removing the old one from CI.