### PR TITLE
Prevent Feature Tree sketch edits during execution

### DIFF
--- a/e2e/playwright/feature-tree-execution.spec.ts
+++ b/e2e/playwright/feature-tree-execution.spec.ts
@@ -1,0 +1,82 @@
+import { closeOnboardingModalIfPresent } from '@e2e/playwright/test-utils'
+import { expect, test } from '@e2e/playwright/zoo-test'
+import { LEGACY_SKETCH_MODE_FEATURE_FLAG } from '@src/lib/constants'
+
+test.use({ userFeatures: [LEGACY_SKETCH_MODE_FEATURE_FLAG] })
+
+const WASHER_CODE = `@settings(defaultLengthUnit = in)
+
+innerDiameter = 0.203
+outerDiameter = 0.438
+thicknessMax = 0.038
+thicknessMin = 0.024
+washerSketch = startSketchOn(XY)
+  |> circle(center = [0, 0], radius = outerDiameter / 2)
+
+washer = extrude(washerSketch, length = thicknessMax)
+faceSketch = startSketchOn(washer, face = END)
+faceProfile001 = circle(faceSketch, center = [0, 0], radius = 0.01)`
+
+test(
+  'Feature Tree waits for execution before editing a face sketch',
+  { tag: ['@desktop', '@web'] },
+  async ({ page, homePage, editor, toolbar, scene }, testInfo) => {
+    await homePage.goToModelingScene()
+    await closeOnboardingModalIfPresent(page)
+    await scene.settled()
+
+    let executionHeld = false
+    let releaseExecution = () => {}
+    const executionGate = new Promise<void>((resolve) => {
+      releaseExecution = resolve
+    })
+    await page.exposeFunction('holdFeatureTreeExecution', async () => {
+      executionHeld = true
+      await executionGate
+    })
+    await page.evaluate(() => {
+      const rustContext = window.app.singletons.kclManager.rustContext
+      const execute = rustContext.execute.bind(rustContext)
+      // Finish real Engine execution and live operation callbacks, but hold the
+      // result before KclManager publishes the artifact graph for those rows.
+      rustContext.execute = async (...args: Parameters<typeof execute>) => {
+        rustContext.execute = execute
+        const result = await execute(...args)
+        const testWindow = window as typeof window & {
+          holdFeatureTreeExecution: () => Promise<void>
+        }
+        await testWindow.holdFeatureTreeExecution()
+        return result
+      }
+    })
+
+    try {
+      await editor.replaceCode('', WASHER_CODE)
+      await expect.poll(() => executionHeld).toBe(true)
+      await toolbar.openFeatureTreePane()
+      const faceSketch = await toolbar.getFeatureTreeOperation('Sketch', 1)
+      await expect(faceSketch).toBeVisible()
+      await expect(faceSketch).toBeDisabled()
+      await expect(toolbar.exitSketchBtn).not.toBeVisible()
+      await page.screenshot({
+        path: testInfo.outputPath('feature-tree-executing.png'),
+      })
+    } finally {
+      releaseExecution()
+    }
+
+    await toolbar.editSketch(1)
+    await toolbar.expectToolbarMode.toBe('sketching')
+    await expect(
+      page.getByText(
+        'Editing sketches on faces or offset planes through the feature tree is not yet supported. Please double-click the path in the scene for now.',
+        { exact: true }
+      )
+    ).not.toBeVisible()
+    await page.screenshot({
+      path: testInfo.outputPath('face-sketch-after-execution.png'),
+    })
+    await toolbar.exitSketch()
+    await toolbar.expectToolbarMode.toBe('modeling')
+  }
+)

--- a/e2e/playwright/regression-tests.spec.ts
+++ b/e2e/playwright/regression-tests.spec.ts
@@ -744,7 +744,7 @@ faceProfile001 = circle(faceSketch, center = [0, 0], radius = 0.01)`
     const [circleCenterClick] = scene.makeMouseHelpers(650, 300)
     const [circleRadiusClick] = scene.makeMouseHelpers(800, 320)
 
-    await page.waitForTimeout(100)
+    await scene.settled()
     await test.step('Enter the seeded washer-face sketch', async () => {
       // Helper to verify that use of legacy sketch mode is logged
       const legacySketchClientError = page.waitForRequest(
@@ -759,9 +759,14 @@ faceProfile001 = circle(faceSketch, center = [0, 0], radius = 0.01)`
         },
         { timeout: 15_000 }
       )
-      await toolbar.editSketch(1)
-      await toolbar.expectToolbarMode.toBe('sketching')
-      await legacySketchClientError
+      // Attach both rejection handlers before editing can fail or close the page.
+      await Promise.all([
+        legacySketchClientError,
+        (async () => {
+          await toolbar.editSketch(1)
+          await toolbar.expectToolbarMode.toBe('sketching')
+        })(),
+      ])
     })
 
     await test.step('Draw a circle and verify code', async () => {

--- a/src/components/layout/areas/FeatureTreePane.tsx
+++ b/src/components/layout/areas/FeatureTreePane.tsx
@@ -281,8 +281,11 @@ export const FeatureTreePaneContents = memo(() => {
     : disableModelingForUnrenderedChanges
       ? kclManager.lastSuccessfulCode || kclManager.codeSignal.value
       : kclManager.codeSignal.value
+  // Live operation rows arrive before the completed artifact graph.
   const isReadOnlyFeatureTree =
-    hasParseErrors || disableModelingForUnrenderedChanges
+    kclManager.isExecuting ||
+    hasParseErrors ||
+    disableModelingForUnrenderedChanges
 
   // We filter out operations that are not useful to show in the feature tree
   const operationList = buildOperationTree(


### PR DESCRIPTION
Fixes #13751. Stacked on #13750 (`achalmers/fix-repeated-test-failures`); merge the parent first, then retarget this PR to `main`.

Live Feature Tree rows can become clickable before execution publishes their artifact graph. Double-clicking a face sketch during that interval shows the unsupported-face-edit error and never enters sketch mode; the same edit succeeds after execution completes. Make operation rows read-only while `kclManager.isExecuting`, using the existing disabled-row behavior.

The affected scale regression now waits for `scene.settled()` instead of a 100 ms sleep. It also awaits sketch entry and the legacy telemetry request together, so an entry failure cannot leave an unhandled request-wait rejection at page teardown. Telemetry and geometry assertions remain in place.

The new regression holds the result of a real Engine execution after live operation callbacks but before artifact publication. It checks that the Sketch row is disabled during that interval, then releases execution and verifies sketch entry and exit. On the unchanged parent, it fails with `Expected: disabled; Received: enabled`; it passes with this change.

Focused verification used one worker and zero retries: macOS Electron passed the new regression and the original scale test (2/2); Chrome passed the new regression and a browser-adapted scale flow (2/2). The scale checks observed legacy telemetry, circle coordinate/radius magnitude, exit, and the `yd` setting. A forced entry rejection remained one expected test-local failure with zero global errors. The parent's six retry-validator tests also passed.

The behavior change is that operation-row interactions wait until execution completes; other entry paths are outside this patch. The barrier regression covers that boundary and recovery. Before merge, smoke-test opening a slow model and editing its face sketch from the Feature Tree after it settles. Linux CI and the full suite have not been replayed locally. The original CI trace lacks browser-context events, so its exact historical click state remains unproven; the controlled reproduction confirms this race independently. Raw traces/screenshots remain private.
