### PR TITLE
Stabilize involute snapshots with per-test UUID redaction

### DIFF
--- a/rust/kcl-lib/tests/involute_circular_units/artifact_commands.snap
+++ b/rust/kcl-lib/tests/involute_circular_units/artifact_commands.snap
@@ -5,7 +5,7 @@ description: Artifact commands involute_circular_units.kcl
 {
   "rust/kcl-lib/tests/involute_circular_units/input.kcl": [
     {
-      "cmdId": "3c085bb9-a401-55d5-8042-5a9095193d55",
+      "cmdId": "[uuid]",
       "range": [],
       "command": {
         "type": "make_plane",
@@ -30,11 +30,11 @@ description: Artifact commands involute_circular_units.kcl
       }
     },
     {
-      "cmdId": "91226189-7e64-5690-9203-67ee33a6eb03",
+      "cmdId": "[uuid]",
       "range": [],
       "command": {
         "type": "enable_sketch_mode",
-        "entity_id": "3c085bb9-a401-55d5-8042-5a9095193d55",
+        "entity_id": "[uuid]",
         "ortho": false,
         "animated": false,
         "adjust_camera": false,
@@ -46,18 +46,18 @@ description: Artifact commands involute_circular_units.kcl
       }
     },
     {
-      "cmdId": "8868de97-0e2a-52f7-8e1a-8f0671a194e3",
+      "cmdId": "[uuid]",
       "range": [],
       "command": {
         "type": "start_path"
       }
     },
     {
-      "cmdId": "bbcd405a-3da3-5b6f-a7b5-95071e3f2d53",
+      "cmdId": "[uuid]",
       "range": [],
       "command": {
         "type": "move_path_pen",
-        "path": "8868de97-0e2a-52f7-8e1a-8f0671a194e3",
+        "path": "[uuid]",
         "to": {
           "x": 49.333862591260186,
           "y": 0.0,
@@ -66,18 +66,18 @@ description: Artifact commands involute_circular_units.kcl
       }
     },
     {
-      "cmdId": "efd1e3b2-5268-50fd-858e-26540f8146e5",
+      "cmdId": "[uuid]",
       "range": [],
       "command": {
         "type": "sketch_mode_disable"
       }
     },
     {
-      "cmdId": "8a662fcd-9569-5482-8c42-aafff7b3f8d4",
+      "cmdId": "[uuid]",
       "range": [],
       "command": {
         "type": "extend_path",
-        "path": "8868de97-0e2a-52f7-8e1a-8f0671a194e3",
+        "path": "[uuid]",
         "segment": {
           "type": "circular_involute",
           "start_radius": 49.333862591260186,
@@ -91,11 +91,11 @@ description: Artifact commands involute_circular_units.kcl
       }
     },
     {
-      "cmdId": "89316223-2ea1-5731-9c72-0492bc30fbe2",
+      "cmdId": "[uuid]",
       "range": [],
       "command": {
         "type": "extend_path",
-        "path": "8868de97-0e2a-52f7-8e1a-8f0671a194e3",
+        "path": "[uuid]",
         "segment": {
           "type": "line",
           "end": {
@@ -108,11 +108,11 @@ description: Artifact commands involute_circular_units.kcl
       }
     },
     {
-      "cmdId": "daa2fbb0-8c3a-525f-bc28-3b5a77c8094b",
+      "cmdId": "[uuid]",
       "range": [],
       "command": {
         "type": "extend_path",
-        "path": "8868de97-0e2a-52f7-8e1a-8f0671a194e3",
+        "path": "[uuid]",
         "segment": {
           "type": "arc",
           "center": {
@@ -133,11 +133,11 @@ description: Artifact commands involute_circular_units.kcl
       }
     },
     {
-      "cmdId": "523b9fc1-d681-5ef3-b407-128525533bfe",
+      "cmdId": "[uuid]",
       "range": [],
       "command": {
         "type": "extend_path",
-        "path": "8868de97-0e2a-52f7-8e1a-8f0671a194e3",
+        "path": "[uuid]",
         "segment": {
           "type": "circular_involute",
           "start_radius": 49.333862591260186,
@@ -151,11 +151,11 @@ description: Artifact commands involute_circular_units.kcl
       }
     },
     {
-      "cmdId": "41c630c9-9d44-581b-98af-caee575bea48",
+      "cmdId": "[uuid]",
       "range": [],
       "command": {
         "type": "extend_path",
-        "path": "8868de97-0e2a-52f7-8e1a-8f0671a194e3",
+        "path": "[uuid]",
         "segment": {
           "type": "line",
           "end": {
@@ -168,11 +168,11 @@ description: Artifact commands involute_circular_units.kcl
       }
     },
     {
-      "cmdId": "ef8bf6bd-dce6-5443-b5a0-3d60dbd57f79",
+      "cmdId": "[uuid]",
       "range": [],
       "command": {
         "type": "extend_path",
-        "path": "8868de97-0e2a-52f7-8e1a-8f0671a194e3",
+        "path": "[uuid]",
         "segment": {
           "type": "line",
           "end": {
@@ -185,11 +185,11 @@ description: Artifact commands involute_circular_units.kcl
       }
     },
     {
-      "cmdId": "fc1035ae-3877-5cf6-9e94-7e1f3b755966",
+      "cmdId": "[uuid]",
       "range": [],
       "command": {
         "type": "entity_circular_pattern",
-        "entity_id": "8868de97-0e2a-52f7-8e1a-8f0671a194e3",
+        "entity_id": "[uuid]",
         "axis": {
           "x": 0.0,
           "y": 0.0,
@@ -206,19 +206,19 @@ description: Artifact commands involute_circular_units.kcl
       }
     },
     {
-      "cmdId": "f5cca6d8-813c-5e62-81d9-e4e8e17ede93",
+      "cmdId": "[uuid]",
       "range": [],
       "command": {
         "type": "close_path",
-        "path_id": "8868de97-0e2a-52f7-8e1a-8f0671a194e3"
+        "path_id": "[uuid]"
       }
     },
     {
-      "cmdId": "38f0111a-8034-5e85-9ec1-07dbc9646b06",
+      "cmdId": "[uuid]",
       "range": [],
       "command": {
         "type": "enable_sketch_mode",
-        "entity_id": "3c085bb9-a401-55d5-8042-5a9095193d55",
+        "entity_id": "[uuid]",
         "ortho": false,
         "animated": false,
         "adjust_camera": false,
@@ -230,18 +230,18 @@ description: Artifact commands involute_circular_units.kcl
       }
     },
     {
-      "cmdId": "2fb0a795-692e-5806-9d7e-a6d1b5ee79b7",
+      "cmdId": "[uuid]",
       "range": [],
       "command": {
         "type": "start_path"
       }
     },
     {
-      "cmdId": "fe76cc2a-18a1-5937-82e8-b2572a7c2149",
+      "cmdId": "[uuid]",
       "range": [],
       "command": {
         "type": "move_path_pen",
-        "path": "2fb0a795-692e-5806-9d7e-a6d1b5ee79b7",
+        "path": "[uuid]",
         "to": {
           "x": 10.0,
           "y": 0.0,
@@ -250,18 +250,18 @@ description: Artifact commands involute_circular_units.kcl
       }
     },
     {
-      "cmdId": "dbfb7312-0d20-502d-9d41-6a13c5e4a8c9",
+      "cmdId": "[uuid]",
       "range": [],
       "command": {
         "type": "sketch_mode_disable"
       }
     },
     {
-      "cmdId": "7b681387-29ea-57f1-8713-d63280827139",
+      "cmdId": "[uuid]",
       "range": [],
       "command": {
         "type": "extend_path",
-        "path": "2fb0a795-692e-5806-9d7e-a6d1b5ee79b7",
+        "path": "[uuid]",
         "segment": {
           "type": "arc",
           "center": {
@@ -282,37 +282,37 @@ description: Artifact commands involute_circular_units.kcl
       }
     },
     {
-      "cmdId": "7b681387-29ea-57f1-8713-d63280827139",
+      "cmdId": "[uuid]",
       "range": [],
       "command": {
         "type": "close_path",
-        "path_id": "2fb0a795-692e-5806-9d7e-a6d1b5ee79b7"
+        "path_id": "[uuid]"
       }
     },
     {
-      "cmdId": "19fe8534-2bed-5e2a-afe9-63f57b621004",
+      "cmdId": "[uuid]",
       "range": [],
       "command": {
         "type": "solid2d_add_hole",
-        "object_id": "8868de97-0e2a-52f7-8e1a-8f0671a194e3",
-        "hole_id": "2fb0a795-692e-5806-9d7e-a6d1b5ee79b7"
+        "object_id": "[uuid]",
+        "hole_id": "[uuid]"
       }
     },
     {
-      "cmdId": "e00e9caf-6e9e-5221-8545-b199546c367f",
+      "cmdId": "[uuid]",
       "range": [],
       "command": {
         "type": "object_visible",
-        "object_id": "2fb0a795-692e-5806-9d7e-a6d1b5ee79b7",
+        "object_id": "[uuid]",
         "hidden": true
       }
     },
     {
-      "cmdId": "f084ad07-5777-5607-a544-c69f455c2aab",
+      "cmdId": "[uuid]",
       "range": [],
       "command": {
         "type": "enable_sketch_mode",
-        "entity_id": "3c085bb9-a401-55d5-8042-5a9095193d55",
+        "entity_id": "[uuid]",
         "ortho": false,
         "animated": false,
         "adjust_camera": false,
@@ -324,11 +324,11 @@ description: Artifact commands involute_circular_units.kcl
       }
     },
     {
-      "cmdId": "2ca0f7fa-0a31-5abe-bba1-1db6bf5cc493",
+      "cmdId": "[uuid]",
       "range": [],
       "command": {
         "type": "extrude",
-        "target": "8868de97-0e2a-52f7-8e1a-8f0671a194e3",
+        "target": "[uuid]",
         "distance": 3.0,
         "faces": null,
         "opposite": "None",
@@ -337,36 +337,36 @@ description: Artifact commands involute_circular_units.kcl
       }
     },
     {
-      "cmdId": "186e6756-e0a9-5df7-a3d1-f5f025d153e3",
+      "cmdId": "[uuid]",
       "range": [],
       "command": {
         "type": "sketch_mode_disable"
       }
     },
     {
-      "cmdId": "9370af21-6a1d-5f9a-b1d3-83351b2043e6",
+      "cmdId": "[uuid]",
       "range": [],
       "command": {
         "type": "object_bring_to_front",
-        "object_id": "8868de97-0e2a-52f7-8e1a-8f0671a194e3"
+        "object_id": "[uuid]"
       }
     },
     {
-      "cmdId": "c6c38d17-92b3-5556-b0a7-5be52ccdd1ec",
+      "cmdId": "[uuid]",
       "range": [],
       "command": {
         "type": "solid3d_get_extrusion_face_info",
-        "object_id": "8868de97-0e2a-52f7-8e1a-8f0671a194e3",
-        "edge_id": "8a662fcd-9569-5482-8c42-aafff7b3f8d4"
+        "object_id": "[uuid]",
+        "edge_id": "[uuid]"
       }
     },
     {
-      "cmdId": "837bc8b4-ea00-5674-8e14-4dd0cf97b3b3",
+      "cmdId": "[uuid]",
       "range": [],
       "command": {
         "type": "solid3d_get_adjacency_info",
-        "object_id": "8868de97-0e2a-52f7-8e1a-8f0671a194e3",
-        "edge_id": "8a662fcd-9569-5482-8c42-aafff7b3f8d4"
+        "object_id": "[uuid]",
+        "edge_id": "[uuid]"
       }
     }
   ]

--- a/rust/kcl-lib/tests/involute_circular_units/config.toml
+++ b/rust/kcl-lib/tests/involute_circular_units/config.toml
@@ -1,0 +1,2 @@
+# Engine-generated face and cap IDs vary between otherwise identical runs.
+redact_uuids = true

--- a/rust/kcl-lib/tests/involute_circular_units/ops.snap
+++ b/rust/kcl-lib/tests/involute_circular_units/ops.snap
@@ -300,7 +300,7 @@ description: Operations executed involute_circular_units.kcl
       "unlabeledArg": {
         "value": {
           "type": "Plane",
-          "artifact_id": "400a2ed4-52ae-5786-967d-7fdba1bd0850"
+          "artifact_id": "[uuid]"
         },
         "sourceRange": []
       },
@@ -332,7 +332,7 @@ description: Operations executed involute_circular_units.kcl
         "value": {
           "type": "Sketch",
           "value": {
-            "artifactId": "8868de97-0e2a-52f7-8e1a-8f0671a194e3"
+            "artifactId": "[uuid]"
           }
         },
         "sourceRange": []
@@ -342,7 +342,7 @@ description: Operations executed involute_circular_units.kcl
           "value": {
             "type": "Sketch",
             "value": {
-              "artifactId": "2fb0a795-692e-5806-9d7e-a6d1b5ee79b7"
+              "artifactId": "[uuid]"
             }
           },
           "sourceRange": []
@@ -375,7 +375,7 @@ description: Operations executed involute_circular_units.kcl
         "value": {
           "type": "Sketch",
           "value": {
-            "artifactId": "8868de97-0e2a-52f7-8e1a-8f0671a194e3"
+            "artifactId": "[uuid]"
           }
         },
         "sourceRange": []

--- a/rust/kcl-lib/tests/involute_circular_units/program_memory.snap
+++ b/rust/kcl-lib/tests/involute_circular_units/program_memory.snap
@@ -98,14 +98,14 @@ description: Variables in memory after executing involute_circular_units.kcl
     "type": "Solid",
     "value": {
       "type": "Solid",
-      "id": "8868de97-0e2a-52f7-8e1a-8f0671a194e3",
-      "originalId": "8868de97-0e2a-52f7-8e1a-8f0671a194e3",
-      "topologyId": "8868de97-0e2a-52f7-8e1a-8f0671a194e3",
-      "artifactId": "2ca0f7fa-0a31-5abe-bba1-1db6bf5cc493",
+      "id": "[uuid]",
+      "originalId": "[uuid]",
+      "topologyId": "[uuid]",
+      "artifactId": "[uuid]",
       "value": [
         {
-          "faceId": "bf58f0a8-1c05-5add-869c-e440afd1676b",
-          "id": "8a662fcd-9569-5482-8c42-aafff7b3f8d4",
+          "faceId": "[uuid]",
+          "id": "[uuid]",
           "sourceRange": [],
           "tag": {
             "commentStart": 508,
@@ -118,15 +118,15 @@ description: Variables in memory after executing involute_circular_units.kcl
           "type": "extrudePlane"
         },
         {
-          "faceId": "7f2df6ef-6b67-53e2-8ea3-015c4e457f10",
-          "id": "89316223-2ea1-5731-9c72-0492bc30fbe2",
+          "faceId": "[uuid]",
+          "id": "[uuid]",
           "sourceRange": [],
           "tag": null,
           "type": "extrudePlane"
         },
         {
-          "faceId": "957d5fa4-1fc8-5e24-b523-9322436d5c46",
-          "id": "daa2fbb0-8c3a-525f-bc28-3b5a77c8094b",
+          "faceId": "[uuid]",
+          "id": "[uuid]",
           "sourceRange": [],
           "tag": {
             "commentStart": 714,
@@ -139,29 +139,29 @@ description: Variables in memory after executing involute_circular_units.kcl
           "type": "extrudeArc"
         },
         {
-          "faceId": "aba0ac5b-efa2-5360-82f1-1735e86807cf",
-          "id": "523b9fc1-d681-5ef3-b407-128525533bfe",
+          "faceId": "[uuid]",
+          "id": "[uuid]",
           "sourceRange": [],
           "tag": null,
           "type": "extrudePlane"
         },
         {
-          "faceId": "6242ceb5-5a7a-56f8-93ea-d05aa2cc65dc",
-          "id": "41c630c9-9d44-581b-98af-caee575bea48",
+          "faceId": "[uuid]",
+          "id": "[uuid]",
           "sourceRange": [],
           "tag": null,
           "type": "extrudePlane"
         },
         {
-          "faceId": "acd8ec64-3cf7-58de-bade-6c448314c59b",
-          "id": "ef8bf6bd-dce6-5443-b5a0-3d60dbd57f79",
+          "faceId": "[uuid]",
+          "id": "[uuid]",
           "sourceRange": [],
           "tag": null,
           "type": "extrudePlane"
         },
         {
-          "faceId": "ca97be7e-230e-571c-a75a-7a583a1a0dc9",
-          "id": "7b681387-29ea-57f1-8713-d63280827139",
+          "faceId": "[uuid]",
+          "id": "[uuid]",
           "sourceRange": [],
           "tag": null,
           "type": "extrudeArc"
@@ -170,11 +170,11 @@ description: Variables in memory after executing involute_circular_units.kcl
       "sketch": {
         "creatorType": "sketch",
         "type": "Sketch",
-        "id": "8868de97-0e2a-52f7-8e1a-8f0671a194e3",
+        "id": "[uuid]",
         "paths": [
           {
             "__geoMeta": {
-              "id": "8a662fcd-9569-5482-8c42-aafff7b3f8d4",
+              "id": "[uuid]",
               "sourceRange": []
             },
             "from": [
@@ -198,7 +198,7 @@ description: Variables in memory after executing involute_circular_units.kcl
           },
           {
             "__geoMeta": {
-              "id": "89316223-2ea1-5731-9c72-0492bc30fbe2",
+              "id": "[uuid]",
               "sourceRange": []
             },
             "from": [
@@ -215,7 +215,7 @@ description: Variables in memory after executing involute_circular_units.kcl
           },
           {
             "__geoMeta": {
-              "id": "daa2fbb0-8c3a-525f-bc28-3b5a77c8094b",
+              "id": "[uuid]",
               "sourceRange": []
             },
             "ccw": true,
@@ -245,7 +245,7 @@ description: Variables in memory after executing involute_circular_units.kcl
           },
           {
             "__geoMeta": {
-              "id": "523b9fc1-d681-5ef3-b407-128525533bfe",
+              "id": "[uuid]",
               "sourceRange": []
             },
             "from": [
@@ -262,7 +262,7 @@ description: Variables in memory after executing involute_circular_units.kcl
           },
           {
             "__geoMeta": {
-              "id": "41c630c9-9d44-581b-98af-caee575bea48",
+              "id": "[uuid]",
               "sourceRange": []
             },
             "from": [
@@ -279,7 +279,7 @@ description: Variables in memory after executing involute_circular_units.kcl
           },
           {
             "__geoMeta": {
-              "id": "ef8bf6bd-dce6-5443-b5a0-3d60dbd57f79",
+              "id": "[uuid]",
               "sourceRange": []
             },
             "from": [
@@ -296,7 +296,7 @@ description: Variables in memory after executing involute_circular_units.kcl
           },
           {
             "__geoMeta": {
-              "id": "f5cca6d8-813c-5e62-81d9-e4e8e17ede93",
+              "id": "[uuid]",
               "sourceRange": []
             },
             "from": [
@@ -315,7 +315,7 @@ description: Variables in memory after executing involute_circular_units.kcl
         "innerPaths": [
           {
             "__geoMeta": {
-              "id": "7b681387-29ea-57f1-8713-d63280827139",
+              "id": "[uuid]",
               "sourceRange": []
             },
             "ccw": true,
@@ -339,8 +339,8 @@ description: Variables in memory after executing involute_circular_units.kcl
         ],
         "on": {
           "type": "plane",
-          "artifactId": "3c085bb9-a401-55d5-8042-5a9095193d55",
-          "id": "3c085bb9-a401-55d5-8042-5a9095193d55",
+          "artifactId": "[uuid]",
+          "id": "[uuid]",
           "objectId": 0,
           "kind": "XY",
           "origin": {
@@ -380,7 +380,7 @@ description: Variables in memory after executing involute_circular_units.kcl
           "units": "cm",
           "tag": null,
           "__geoMeta": {
-            "id": "bbcd405a-3da3-5b6f-a7b5-95071e3f2d53",
+            "id": "[uuid]",
             "sourceRange": []
           }
         },
@@ -394,13 +394,13 @@ description: Variables in memory after executing involute_circular_units.kcl
             "value": "seg02"
           }
         },
-        "artifactId": "8868de97-0e2a-52f7-8e1a-8f0671a194e3",
-        "originalId": "8868de97-0e2a-52f7-8e1a-8f0671a194e3",
+        "artifactId": "[uuid]",
+        "originalId": "[uuid]",
         "units": "cm",
         "isClosed": "explicitly"
       },
-      "startCapId": "78ffa58f-431c-53f9-a090-062ebc437543",
-      "endCapId": "feb6b608-d0bd-5a4a-a45b-acc8d7c73298",
+      "startCapId": "[uuid]",
+      "endCapId": "[uuid]",
       "units": "cm",
       "sectional": false
     }


### PR DESCRIPTION
The [scheduled main run](https://github.com/KittyCAD/modeling-app/actions/runs/34305465492/job/102321820543) failed `involute_circular_units` on all three attempts after seven face IDs and two cap IDs differed from the new literal-UUID snapshot. Enable the per-test UUID-redaction option introduced in #13582 for this case. The three affected text snapshots exactly match their versions before #13582; the KCL input, rendered image, physical properties and artifact graph stay unchanged.

Replaying all three captured snapshot diffs through the existing filter matches the redacted reference, while a changed-units control still fails. This preserves the existing stopgap for Engine ID nondeterminism; it does not fix the ID generator. Local Engine replay was unavailable without a configured token, so this draft awaits runtime CI validation.
