### PR TITLE
Open shared cloud project directly in WebKit test

### DIFF
--- a/e2e/playwright/cloud-sync.spec.ts
+++ b/e2e/playwright/cloud-sync.spec.ts
@@ -308,7 +308,8 @@ test(
     await setup(context, page, testInfo, [OPFS_CLOUD_FEATURE_FLAG], {
       cloudSyncEnabled: true,
     })
-    await expectCloudFeatureEnabled(page)
+    // Open the shared link directly. Visiting Home first interrupts its pending
+    // cloud requests and lazy imports when WebKit navigates to the shared link.
     await page.goto(`/?project-id=${publicProjectId}&ask-open-desktop=true`)
     await page.getByTestId('continue-to-web-app-button').click()
 


### PR DESCRIPTION
The shared-project cloud-sync test visits Home before navigating to the shared link. On WebKit, the second navigation can interrupt Home's pending requests and lazy imports, causing the console-error assertion to fail before the shared-project assertions run.

Open the shared link directly after configuring cloud sync. This matches the case being tested: opening a shared project without an existing project. Keep the assertions for one public download, one cloud creation, the local file contents, persisted cloud project ID, distinct settings identity, and final file route.

Observed in [Engine deployment job 102344258013](https://github.com/KittyCAD/engine/actions/runs/34285282483/job/102344258013), using Modeling App `a85c18787f15a98f6913f6087fcc4bc51b6ff9ba`. The first attempt reported a projects-fetch access-control error; its trace shows that the request was mocked and fulfilled with HTTP 200. The retry reported a module import error. Both errors occurred immediately after the shared-link navigation began. This supports interrupted navigation as the cause; the original case passed three local WebKit runs, so the CI failure was not reproduced locally.

Validation on macOS, Playwright 1.60.0, using the CI-prepared Wasm and bindings from the same base revision:

- Unmodified control: WebKit 3/3 and Google Chrome 1/1 passed, with zero retries.
- Changed case: WebKit 5/5 and Google Chrome 1/1 passed, with zero retries.
- Targeted Biome and ESLint checks, plus `git diff --check`, passed.

The change is limited to this test's initial navigation. CI validation of the PR is still pending.
