### PR TITLE
Skip supplementary browser coverage on external workflows

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -204,22 +204,29 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Primary platform and browser coverage
           - os: namespace-profile-ubuntu-8-cores;overrides.cache-tag=modeling-app-general-v2
             label: ubuntu
             test_script: test:e2e:web
             playwright_cache_path: ~/.cache/ms-playwright
+            primary: true
           - os: namespace-profile-macos-8-cores
             label: macos
             test_script: test:e2e:web
             playwright_cache_path: ~/Library/Caches/ms-playwright
+            primary: true
           - os: namespace-profile-windows-8-cores
             label: windows
             test_script: test:e2e:web
             playwright_cache_path: ~/AppData/Local/ms-playwright
+            primary: true
+          # Supplemental coverage, skipped for external workflow calls
           - os: namespace-profile-macos-8-cores
             label: macos, webkit
             test_script: test:e2e:web:webkit
             playwright_cache_path: ~/Library/Caches/ms-playwright
+            primary: false
+    if: ${{ matrix.primary || github.repository == 'kittycad/modeling-app' }}
     runs-on: ${{ matrix.os }}
     name: e2e:web (${{ matrix.label }})
     env:


### PR DESCRIPTION
The external workflow calls are used as a quality gate on production deployment for `engine` and `text-to-cad`. It is wasteful to run the full suite of browser compatibility tests at this point. Those will have already run on `modeling-app` PRs and scheduled on `main`.