### PR TITLE
Derive unlimited credits from subscription entitlements

### DIFF
--- a/packages/ui-components/src/lib/billing.ts
+++ b/packages/ui-components/src/lib/billing.ts
@@ -197,6 +197,7 @@ export async function getBillingInfo(
 
   switch (tier) {
     case 'enterprise':
+    case 'enterprise-free':
     case 'team':
       balance = Number.POSITIVE_INFINITY
       hasSubscription = true

--- a/packages/ui-components/src/lib/billing.ts
+++ b/packages/ui-components/src/lib/billing.ts
@@ -5,9 +5,7 @@
 import {
   type Client,
   type CustomerBalance,
-  type UserOrgInfo,
   type ZooProductSubscriptions,
-  orgs,
   payments,
 } from '@kittycad/lib'
 
@@ -162,51 +160,35 @@ export async function getBillingInfo(
     { client: Client }
   >(payments.get_user_subscription, { client })
 
-  const org = await fetchBilling<UserOrgInfo, { client: Client }>(
-    orgs.get_user_org,
-    { client }
-  )
-  const hasOrgError = BillingError.from(org)
-  const payAsYouGoApiCreditPrice = BillingError.from(subscriptions)
-    ? undefined
-    : subscriptions.modeling_app.pay_as_you_go_api_credit_price
-
-  if (!hasOrgError) {
-    return {
-      balance: Number.POSITIVE_INFINITY,
-      userPaymentBalance: billing,
-      payAsYouGoApiCreditPrice,
-      isOrg: true,
-      hasSubscription: true,
-    }
-  }
-
   if (BillingError.from(subscriptions)) {
     return subscriptions
   }
 
-  const tier = subscriptions.modeling_app.name
+  const isOrg = subscriptions.modeling_app.type.type === 'organization'
   const ratioSec = subscriptions.modeling_app.pay_as_you_go_api_credit_price
+
+  if (isOrg) {
+    return {
+      balance: Number.POSITIVE_INFINITY,
+      userPaymentBalance: billing,
+      payAsYouGoApiCreditPrice: ratioSec,
+      isOrg,
+      hasSubscription: true,
+    }
+  }
+
+  const tier = subscriptions.modeling_app.name
   const toMinutes = (value: number, ratioSec: number) => value / ratioSec / 60
   const computedAllowance =
     subscriptions.modeling_app.monthly_pay_as_you_go_api_credits_monetary_value
   let balance = 0
   let allowance: number | undefined
   let hasSubscription = false
-  let isOrg = false
 
   switch (tier) {
-    case 'enterprise':
-    case 'enterprise-free':
-    case 'team':
-      balance = Number.POSITIVE_INFINITY
-      hasSubscription = true
-      isOrg = true
-      break
     case 'pro':
       balance = Number.POSITIVE_INFINITY
       hasSubscription = true
-      isOrg = false
       break
     case 'plus':
       if (ratioSec === undefined || computedAllowance === undefined) {
@@ -220,7 +202,6 @@ export async function getBillingInfo(
           billing.stable_api_credits_remaining_monetary_value,
         ratioSec
       )
-      isOrg = false
       hasSubscription = true
       break
     case 'free':
@@ -235,7 +216,6 @@ export async function getBillingInfo(
           billing.stable_api_credits_remaining_monetary_value,
         ratioSec
       )
-      isOrg = false
       hasSubscription = false
       break
     default: {

--- a/packages/ui-components/src/lib/billing.ts
+++ b/packages/ui-components/src/lib/billing.ts
@@ -193,6 +193,9 @@ export async function getBillingInfo(
     )
   }
 
+  // This slug check is not ideal: the API has no explicit free-tier flag.
+  const hasSubscription = tier !== 'free'
+
   return {
     balance: toMinutes(
       billing.monthly_api_credits_remaining_monetary_value +
@@ -202,7 +205,7 @@ export async function getBillingInfo(
     allowance: toMinutes(computedAllowance, ratioSec),
     userPaymentBalance: billing,
     payAsYouGoApiCreditPrice: ratioSec,
-    hasSubscription: tier !== 'free',
+    hasSubscription,
     isOrg,
   }
 }

--- a/packages/ui-components/src/lib/billing.ts
+++ b/packages/ui-components/src/lib/billing.ts
@@ -178,10 +178,6 @@ export async function getBillingInfo(
     }
   }
 
-  if (tier !== 'free' && tier !== 'plus') {
-    return createInvalidBillingDataError(`Unhandled subscription tier: ${tier}`)
-  }
-
   const toMinutes = (value: number, ratioSec: number) => value / ratioSec / 60
   const computedAllowance =
     subscriptions.modeling_app.monthly_pay_as_you_go_api_credits_monetary_value
@@ -201,7 +197,7 @@ export async function getBillingInfo(
     allowance: toMinutes(computedAllowance, ratioSec),
     userPaymentBalance: billing,
     payAsYouGoApiCreditPrice: ratioSec,
-    hasSubscription: tier === 'plus',
+    hasSubscription: tier !== 'free',
     isOrg,
   }
 }

--- a/packages/ui-components/src/lib/billing.ts
+++ b/packages/ui-components/src/lib/billing.ts
@@ -164,11 +164,16 @@ export async function getBillingInfo(
     return subscriptions
   }
 
-  const isOrg = subscriptions.modeling_app.type.type === 'organization'
-  const tier = subscriptions.modeling_app.name
-  const ratioSec = subscriptions.modeling_app.pay_as_you_go_api_credit_price
+  const plan = subscriptions.modeling_app
+  const isOrg = plan.type.type === 'organization'
+  const tier = plan.name
+  const ratioSec = plan.pay_as_you_go_api_credit_price
+  const hasUnlimitedCredits = Boolean(
+    plan.zoo_tools_included?.includes('modeling_app') &&
+      plan.endpoints_included?.includes('ml')
+  )
 
-  if (isOrg || tier === 'pro') {
+  if (hasUnlimitedCredits) {
     return {
       balance: Number.POSITIVE_INFINITY,
       userPaymentBalance: billing,
@@ -180,7 +185,7 @@ export async function getBillingInfo(
 
   const toMinutes = (value: number, ratioSec: number) => value / ratioSec / 60
   const computedAllowance =
-    subscriptions.modeling_app.monthly_pay_as_you_go_api_credits_monetary_value
+    plan.monthly_pay_as_you_go_api_credits_monetary_value
 
   if (ratioSec === undefined || computedAllowance === undefined) {
     return createInvalidBillingDataError(

--- a/packages/ui-components/src/lib/billing.ts
+++ b/packages/ui-components/src/lib/billing.ts
@@ -165,9 +165,10 @@ export async function getBillingInfo(
   }
 
   const isOrg = subscriptions.modeling_app.type.type === 'organization'
+  const tier = subscriptions.modeling_app.name
   const ratioSec = subscriptions.modeling_app.pay_as_you_go_api_credit_price
 
-  if (isOrg) {
+  if (isOrg || tier === 'pro') {
     return {
       balance: Number.POSITIVE_INFINITY,
       userPaymentBalance: billing,
@@ -177,60 +178,30 @@ export async function getBillingInfo(
     }
   }
 
-  const tier = subscriptions.modeling_app.name
+  if (tier !== 'free' && tier !== 'plus') {
+    return createInvalidBillingDataError(`Unhandled subscription tier: ${tier}`)
+  }
+
   const toMinutes = (value: number, ratioSec: number) => value / ratioSec / 60
   const computedAllowance =
     subscriptions.modeling_app.monthly_pay_as_you_go_api_credits_monetary_value
-  let balance = 0
-  let allowance: number | undefined
-  let hasSubscription = false
 
-  switch (tier) {
-    case 'pro':
-      balance = Number.POSITIVE_INFINITY
-      hasSubscription = true
-      break
-    case 'plus':
-      if (ratioSec === undefined || computedAllowance === undefined) {
-        return createInvalidBillingDataError(
-          'Missing ratioSec or computedAllowance for plus tier'
-        )
-      }
-      allowance = toMinutes(computedAllowance, ratioSec)
-      balance = toMinutes(
-        billing.monthly_api_credits_remaining_monetary_value +
-          billing.stable_api_credits_remaining_monetary_value,
-        ratioSec
-      )
-      hasSubscription = true
-      break
-    case 'free':
-      if (ratioSec === undefined || computedAllowance === undefined) {
-        return createInvalidBillingDataError(
-          'Missing ratioSec or computedAllowance for free tier'
-        )
-      }
-      allowance = toMinutes(computedAllowance, ratioSec)
-      balance = toMinutes(
-        billing.monthly_api_credits_remaining_monetary_value +
-          billing.stable_api_credits_remaining_monetary_value,
-        ratioSec
-      )
-      hasSubscription = false
-      break
-    default: {
-      return createInvalidBillingDataError(
-        `Unhandled subscription tier: ${tier}`
-      )
-    }
+  if (ratioSec === undefined || computedAllowance === undefined) {
+    return createInvalidBillingDataError(
+      `Missing ratioSec or computedAllowance for ${tier} tier`
+    )
   }
 
   return {
-    balance,
-    allowance,
+    balance: toMinutes(
+      billing.monthly_api_credits_remaining_monetary_value +
+        billing.stable_api_credits_remaining_monetary_value,
+      ratioSec
+    ),
+    allowance: toMinutes(computedAllowance, ratioSec),
     userPaymentBalance: billing,
     payAsYouGoApiCreditPrice: ratioSec,
-    hasSubscription,
+    hasSubscription: tier === 'plus',
     isOrg,
   }
 }

--- a/packages/ui-components/src/lib/billing.unit.test.ts
+++ b/packages/ui-components/src/lib/billing.unit.test.ts
@@ -1,7 +1,7 @@
 import {
   Client,
   type CustomerBalance,
-  type UserOrgInfo,
+  type SubscriptionTierType,
   type ZooProductSubscriptions,
 } from '@kittycad/lib'
 import {
@@ -39,26 +39,11 @@ function createUserPaymentBalanceResponse(opts: {
   }
 }
 
-function createUserOrgResponse(): UserOrgInfo {
-  return {
-    id: '78432284-8660-46bf-ac65-d00bf9b18c3e',
-    created_at: '2024-01-26T23:14:28.062Z',
-    updated_at: '2025-11-10T20:09:09.190Z',
-    name: 'Zoo',
-    billing_email: 'billing@zoo.dev',
-    image: 'https://avatars.githubusercontent.com/u/81783542?s=200&v=4',
-    domain: 'zoo.dev',
-    allow_users_in_domain_to_auto_join: true,
-    phone: '',
-    stripe_id: 'stripe_id',
-    role: 'member',
-  }
-}
-
 function createUserPaymentSubscriptionsResponse(opts: {
   monthlyPayAsYouGoApiBalanceTotalMonthlyValue?: number
   name: string
   payAsYouGoApiCreditPrice?: number
+  type?: SubscriptionTierType
 }): ZooProductSubscriptions {
   return {
     modeling_app: {
@@ -76,10 +61,7 @@ function createUserPaymentSubscriptionsResponse(opts: {
       },
       support_tier: 'community',
       training_data_behavior: 'default_on',
-      type: {
-        saml_sso: true,
-        type: 'organization',
-      },
+      type: opts.type ?? { type: 'individual' },
     },
   }
 }
@@ -123,9 +105,6 @@ test('Requests total due in user payment balance', async () => {
     http.get('*/user/payment/methods', () => {
       didRequestPaymentMethods = true
       return HttpResponse.json([])
-    }),
-    http.get('*/user/org', () => {
-      return new HttpResponse(null, { status: 403 })
     })
   )
 
@@ -153,9 +132,6 @@ test('Finds the credits of Free subscription', async () => {
           name: 'free',
         })
       )
-    }),
-    http.get('*/user/org', () => {
-      return new HttpResponse(null, { status: 403 })
     })
   )
 
@@ -185,9 +161,6 @@ test('Finds the credits of Plus subscription', async () => {
           name: 'plus',
         })
       )
-    }),
-    http.get('*/user/org', () => {
-      return new HttpResponse(null, { status: 403 })
     })
   )
 
@@ -217,9 +190,6 @@ test('Finds infinite credits for Pro subscription', async () => {
           name: 'pro',
         })
       )
-    }),
-    http.get('*/user/org', () => {
-      return new HttpResponse(null, { status: 403 })
     })
   )
 
@@ -231,36 +201,37 @@ test('Finds infinite credits for Pro subscription', async () => {
   expect(billing.isOrg).toBe(false)
 })
 
-test('Finds infinite credits for org user', async () => {
-  server.use(
-    http.get('*/user/payment/balance', () => {
-      return HttpResponse.json(
-        createUserPaymentBalanceResponse({
-          monthlyApiBalanceRemainingMonthlyValue: 10,
-          stableApiBalanceRemainingMonthlyValue: 0,
-        })
-      )
-    }),
-    http.get('*/user/payment/subscriptions', () => {
-      return HttpResponse.json(
-        createUserPaymentSubscriptionsResponse({
-          monthlyPayAsYouGoApiBalanceTotalMonthlyValue: 20,
-          name: 'enterprise',
-        })
-      )
-    }),
-    http.get('*/user/org', () => {
-      return HttpResponse.json(createUserOrgResponse())
-    })
-  )
+test.each(['enterprise', 'enterprise-free', 'team', 'custom-org-plan'])(
+  'Finds infinite credits for organization subscription %s',
+  async (name) => {
+    server.use(
+      http.get('*/user/payment/balance', () => {
+        return HttpResponse.json(
+          createUserPaymentBalanceResponse({
+            monthlyApiBalanceRemainingMonthlyValue: 10,
+            stableApiBalanceRemainingMonthlyValue: 0,
+          })
+        )
+      }),
+      http.get('*/user/payment/subscriptions', () => {
+        return HttpResponse.json(
+          createUserPaymentSubscriptionsResponse({
+            monthlyPayAsYouGoApiBalanceTotalMonthlyValue: 20,
+            name,
+            type: { type: 'organization', saml_sso: true },
+          })
+        )
+      })
+    )
 
-  const billing = await getBillingInfo(client)
-  if (BillingError.from(billing)) throw billing
-  expect(billing.balance).toBe(Number.POSITIVE_INFINITY)
-  expect(billing.allowance).toBeUndefined()
-  expect(billing.hasSubscription).toBe(true)
-  expect(billing.isOrg).toBe(true)
-})
+    const billing = await getBillingInfo(client)
+    if (BillingError.from(billing)) throw billing
+    expect(billing.balance).toBe(Number.POSITIVE_INFINITY)
+    expect(billing.allowance).toBeUndefined()
+    expect(billing.hasSubscription).toBe(true)
+    expect(billing.isOrg).toBe(true)
+  }
+)
 
 test('Returns billing error for missing subscription credit data', async () => {
   server.use(
@@ -278,9 +249,6 @@ test('Returns billing error for missing subscription credit data', async () => {
           name: 'plus',
         })
       )
-    }),
-    http.get('*/user/org', () => {
-      return new HttpResponse(null, { status: 403 })
     })
   )
 
@@ -309,9 +277,6 @@ test('Returns billing error for unsupported subscription tier', async () => {
           name: 'unsupported',
         })
       )
-    }),
-    http.get('*/user/org', () => {
-      return new HttpResponse(null, { status: 403 })
     })
   )
 

--- a/packages/ui-components/src/lib/billing.unit.test.ts
+++ b/packages/ui-components/src/lib/billing.unit.test.ts
@@ -260,7 +260,7 @@ test('Returns billing error for missing subscription credit data', async () => {
   })
 })
 
-test('Returns billing error for unsupported subscription tier', async () => {
+test('Finds the credits of a custom individual subscription', async () => {
   server.use(
     http.get('*/user/payment/balance', () => {
       return HttpResponse.json(
@@ -274,16 +274,17 @@ test('Returns billing error for unsupported subscription tier', async () => {
       return HttpResponse.json(
         createUserPaymentSubscriptionsResponse({
           monthlyPayAsYouGoApiBalanceTotalMonthlyValue: 10,
-          name: 'unsupported',
+          name: 'custom-individual-plan',
         })
       )
     })
   )
 
   const billing = await getBillingInfo(client)
-  expect(billing).toBeInstanceOf(BillingError)
-  expect(BillingError.from(billing) && billing.error).toEqual({
-    type: EBillingError.InvalidData,
-    message: 'Unhandled subscription tier: unsupported',
-  })
+  if (BillingError.from(billing)) throw billing
+  expect(Math.floor(billing.balance)).toEqual(20)
+  expect(Math.floor(billing.allowance!)).toEqual(20)
+  expect(billing.payAsYouGoApiCreditPrice).toEqual(0.0083)
+  expect(billing.hasSubscription).toBe(true)
+  expect(billing.isOrg).toBe(false)
 })

--- a/packages/ui-components/src/lib/billing.unit.test.ts
+++ b/packages/ui-components/src/lib/billing.unit.test.ts
@@ -1,8 +1,10 @@
 import {
   Client,
+  type ApiEndpoint,
   type CustomerBalance,
   type SubscriptionTierType,
   type ZooProductSubscriptions,
+  type ZooTool,
 } from '@kittycad/lib'
 import {
   BillingError,
@@ -39,12 +41,18 @@ function createUserPaymentBalanceResponse(opts: {
   }
 }
 
-function createUserPaymentSubscriptionsResponse(opts: {
+type SubscriptionOptions = {
   monthlyPayAsYouGoApiBalanceTotalMonthlyValue?: number
   name: string
   payAsYouGoApiCreditPrice?: number
   type?: SubscriptionTierType
-}): ZooProductSubscriptions {
+  zooToolsIncluded?: ZooTool[]
+  endpointsIncluded?: ApiEndpoint[]
+}
+
+function createUserPaymentSubscriptionsResponse(
+  opts: SubscriptionOptions
+): ZooProductSubscriptions {
   return {
     modeling_app: {
       annual_discount: 10,
@@ -62,6 +70,8 @@ function createUserPaymentSubscriptionsResponse(opts: {
       support_tier: 'community',
       training_data_behavior: 'default_on',
       type: opts.type ?? { type: 'individual' },
+      zoo_tools_included: opts.zooToolsIncluded,
+      endpoints_included: opts.endpointsIncluded,
     },
   }
 }
@@ -173,36 +183,41 @@ test('Finds the credits of Plus subscription', async () => {
   expect(billing.isOrg).toBe(false)
 })
 
-test('Finds infinite credits for Pro subscription', async () => {
-  server.use(
-    http.get('*/user/payment/balance', () => {
-      return HttpResponse.json(
-        createUserPaymentBalanceResponse({
-          monthlyApiBalanceRemainingMonthlyValue: 10,
-          stableApiBalanceRemainingMonthlyValue: 0,
-        })
-      )
-    }),
-    http.get('*/user/payment/subscriptions', () => {
-      return HttpResponse.json(
-        createUserPaymentSubscriptionsResponse({
-          monthlyPayAsYouGoApiBalanceTotalMonthlyValue: 20,
-          name: 'pro',
-        })
-      )
-    })
-  )
+test.each(['pro', 'custom-unlimited-individual-plan'])(
+  'Finds infinite credits for individual subscription %s with ML coverage',
+  async (name) => {
+    server.use(
+      http.get('*/user/payment/balance', () => {
+        return HttpResponse.json(
+          createUserPaymentBalanceResponse({
+            monthlyApiBalanceRemainingMonthlyValue: 10,
+            stableApiBalanceRemainingMonthlyValue: 0,
+          })
+        )
+      }),
+      http.get('*/user/payment/subscriptions', () => {
+        return HttpResponse.json(
+          createUserPaymentSubscriptionsResponse({
+            monthlyPayAsYouGoApiBalanceTotalMonthlyValue: 20,
+            name,
+            zooToolsIncluded: ['modeling_app'],
+            endpointsIncluded: ['modeling', 'ml', 'file'],
+          })
+        )
+      })
+    )
 
-  const billing = await getBillingInfo(client)
-  if (BillingError.from(billing)) throw billing
-  expect(billing.balance).toBe(Number.POSITIVE_INFINITY)
-  expect(billing.allowance).toBeUndefined()
-  expect(billing.hasSubscription).toBe(true)
-  expect(billing.isOrg).toBe(false)
-})
+    const billing = await getBillingInfo(client)
+    if (BillingError.from(billing)) throw billing
+    expect(billing.balance).toBe(Number.POSITIVE_INFINITY)
+    expect(billing.allowance).toBeUndefined()
+    expect(billing.hasSubscription).toBe(true)
+    expect(billing.isOrg).toBe(false)
+  }
+)
 
 test.each(['enterprise', 'enterprise-free', 'team', 'custom-org-plan'])(
-  'Finds infinite credits for organization subscription %s',
+  'Finds infinite credits for organization subscription %s with ML coverage',
   async (name) => {
     server.use(
       http.get('*/user/payment/balance', () => {
@@ -219,6 +234,8 @@ test.each(['enterprise', 'enterprise-free', 'team', 'custom-org-plan'])(
             monthlyPayAsYouGoApiBalanceTotalMonthlyValue: 20,
             name,
             type: { type: 'organization', saml_sso: true },
+            zooToolsIncluded: ['modeling_app'],
+            endpointsIncluded: ['modeling', 'ml', 'file'],
           })
         )
       })
@@ -260,7 +277,30 @@ test('Returns billing error for missing subscription credit data', async () => {
   })
 })
 
-test('Finds the credits of a custom individual subscription', async () => {
+test.each<SubscriptionOptions>([
+  { name: 'custom-individual-plan' },
+  {
+    name: 'pro',
+    zooToolsIncluded: ['modeling_app'],
+    endpointsIncluded: ['modeling'],
+  },
+  {
+    name: 'custom-text-to-cad-plan',
+    zooToolsIncluded: ['text_to_cad'],
+    endpointsIncluded: ['ml'],
+  },
+  {
+    name: 'team',
+    type: { type: 'organization', saml_sso: false },
+    zooToolsIncluded: ['modeling_app'],
+    endpointsIncluded: [],
+  },
+  {
+    name: 'custom-org-without-tools',
+    type: { type: 'organization', saml_sso: false },
+    endpointsIncluded: ['ml'],
+  },
+])('Finds metered credits for $name without app ML coverage', async (opts) => {
   server.use(
     http.get('*/user/payment/balance', () => {
       return HttpResponse.json(
@@ -274,7 +314,7 @@ test('Finds the credits of a custom individual subscription', async () => {
       return HttpResponse.json(
         createUserPaymentSubscriptionsResponse({
           monthlyPayAsYouGoApiBalanceTotalMonthlyValue: 10,
-          name: 'custom-individual-plan',
+          ...opts,
         })
       )
     })
@@ -286,5 +326,5 @@ test('Finds the credits of a custom individual subscription', async () => {
   expect(Math.floor(billing.allowance!)).toEqual(20)
   expect(billing.payAsYouGoApiCreditPrice).toEqual(0.0083)
   expect(billing.hasSubscription).toBe(true)
-  expect(billing.isOrg).toBe(false)
+  expect(billing.isOrg).toBe(opts.type?.type === 'organization')
 })


### PR DESCRIPTION
Big clean-up here of old billing code that was introduced at the very beginning when we didn't have all the things we have now.

Was surfaced in this [Slack thread](https://kittycadworkspace.slack.com/archives/C09TUQ6EVEV/p1788966833534219?thread_ts=1788966463.658969&cid=C09TUQ6EVEV).

1. We can forgo the org lookup since we have a nicely typed `plan.type.type === 'organization'` check we can do.
2. We can stop switching on the non-typed plan name string to determine if we should show the unlimited credits UI and instead rely directly on the capability `plan.endpoints_included?.includes('ml')`
