### PR TITLE
Handle sketch telemetry wait when sketch entry fails

### DIFF
--- a/e2e/playwright/regression-tests.spec.ts
+++ b/e2e/playwright/regression-tests.spec.ts
@@ -759,9 +759,14 @@ faceProfile001 = circle(faceSketch, center = [0, 0], radius = 0.01)`
         },
         { timeout: 15_000 }
       )
-      await toolbar.editSketch(1)
-      await toolbar.expectToolbarMode.toBe('sketching')
-      await legacySketchClientError
+      // Handle the request wait even if entering sketch mode fails.
+      await Promise.all([
+        legacySketchClientError,
+        (async () => {
+          await toolbar.editSketch(1)
+          await toolbar.expectToolbarMode.toBe('sketching')
+        })(),
+      ])
     })
 
     await test.step('Draw a circle and verify code', async () => {


### PR DESCRIPTION
Attach handlers to the sketch telemetry wait and sketch-entry assertions together with `Promise.all`. If sketch entry fails, page close can no longer turn the abandoned request wait into a second worker-level error.

The underlying sketch-entry failure remains separate. Focused browser lifecycle checks cover both failure orders and two success orders without retries; the complete authenticated washer scenario was not replayed.

Related to #13751.