### PR TITLE
Issue-2683: add graceful reconnection support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@csstools/postcss-oklab-function": "^4.0.12",
         "@headlessui/react": "^1.7.19",
         "@headlessui/tailwindcss": "^0.2.2",
-        "@kittycad/lib": "^4.4.7",
+        "@kittycad/lib": "^4.4.13",
         "@lezer/highlight": "^1.2.1",
         "@lezer/lr": "^1.4.10",
         "@microlink/react-json-view": "^1.31.28",
@@ -9301,18 +9301,18 @@
       "link": true
     },
     "node_modules/@kittycad/kcl-wasm-lib": {
-      "version": "0.1.181",
-      "resolved": "https://registry.npmjs.org/@kittycad/kcl-wasm-lib/-/kcl-wasm-lib-0.1.181.tgz",
-      "integrity": "sha512-9AtdDbjVHW1uryaJlEKI9/jnQNYHk9NoTEPLGuErkmHxzR+bRTxhsrliQA8ITwkNSYkCtqCzq0LfcCY8a0JrkA==",
+      "version": "0.1.182",
+      "resolved": "https://registry.npmjs.org/@kittycad/kcl-wasm-lib/-/kcl-wasm-lib-0.1.182.tgz",
+      "integrity": "sha512-Xo2stZMNYDtw2kOViqLJmUt8bxQGzrEhelYSUPiTYVxUwZYpknHWHgYB0E8xBQQ50OHq6I3uKuxWyuENySYnqA==",
       "license": "MIT"
     },
     "node_modules/@kittycad/lib": {
-      "version": "4.4.7",
-      "resolved": "https://registry.npmjs.org/@kittycad/lib/-/lib-4.4.7.tgz",
-      "integrity": "sha512-geAhfMJpwY0ToyzBHtyUVQ0Bh6c9GLgYCogGylEvZ8Ejecp2iW3Dt63ob7TZssF5KAMjlcd75wpoK3yicNFarA==",
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/@kittycad/lib/-/lib-4.4.13.tgz",
+      "integrity": "sha512-PJbOp9NPKx84Y5qhASH62oHEclSt8uY+KJGDHj9dQgqxDNuMJMkaSTA19fhkP1NcX/65Nn/cSl9i4ZWkiujAcA==",
       "license": "MIT",
       "dependencies": {
-        "@kittycad/kcl-wasm-lib": "0.1.181",
+        "@kittycad/kcl-wasm-lib": "0.1.182",
         "@kittycad/oauth2-auth-code-pkce": "^4.0.0",
         "@msgpack/msgpack": "^3.1.3",
         "bson": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@csstools/postcss-oklab-function": "^4.0.12",
     "@headlessui/react": "^1.7.19",
     "@headlessui/tailwindcss": "^0.2.2",
-    "@kittycad/lib": "^4.4.7",
+    "@kittycad/lib": "^4.4.13",
     "@lezer/highlight": "^1.2.1",
     "@lezer/lr": "^1.4.10",
     "@microlink/react-json-view": "^1.31.28",

--- a/src/components/ConnectionStream.tsx
+++ b/src/components/ConnectionStream.tsx
@@ -407,10 +407,15 @@ export const ConnectionStream = (props: ConnectionStreamProps) => {
 
   const onWebSocketCloseParams = useMemo(
     () => ({
-      callback: (code: string | undefined) => {
-        reportEngineDisconnect(EngineConnectionManagerEvents.WebsocketClosed, {
-          websocketCloseCode: code,
-        })
+      callback: (code: string | undefined, reconnectRequested: boolean) => {
+        if (!reconnectRequested) {
+          reportEngineDisconnect(
+            EngineConnectionManagerEvents.WebsocketClosed,
+            {
+              websocketCloseCode: code,
+            }
+          )
+        }
         setShowManualConnect(false)
         tryConnecting({
           authToken: props.authToken || '',

--- a/src/hooks/network/useOnWebsocketClose.spec.tsx
+++ b/src/hooks/network/useOnWebsocketClose.spec.tsx
@@ -60,8 +60,51 @@ describe('useOnWebsocketClose', () => {
       )
       unmount()
       expect(callback).toHaveBeenCalledTimes(1)
-      expect(callback).toHaveBeenCalledWith(undefined)
+      expect(callback).toHaveBeenCalledWith(undefined, false)
     })
+    test.each(['1000', '1006'])(
+      'recovers from a requested reconnect ending with %s',
+      async (code) => {
+        const callback = vi.fn()
+        const infiniteLoopCallback = vi.fn()
+        const { engineCommandManager } =
+          await buildTheWorldAndNoEngineConnection(true)
+        const { unmount } = renderHook(() =>
+          useOnWebsocketClose({
+            callback,
+            infiniteDetectionLoopCallback: infiniteLoopCallback,
+            engineCommandManager,
+          })
+        )
+        engineCommandManager.tearDown({
+          websocketClosed: true,
+          code,
+          reconnectRequested: true,
+        })
+        expect(callback).toHaveBeenCalledExactlyOnceWith(code, true)
+        expect(infiniteLoopCallback).not.toHaveBeenCalled()
+        unmount()
+      }
+    )
+
+    test('preserves normal closure recovery when no reconnect was requested', async () => {
+      const callback = vi.fn()
+      const infiniteLoopCallback = vi.fn()
+      const { engineCommandManager } =
+        await buildTheWorldAndNoEngineConnection(true)
+      const { unmount } = renderHook(() =>
+        useOnWebsocketClose({
+          callback,
+          infiniteDetectionLoopCallback: infiniteLoopCallback,
+          engineCommandManager,
+        })
+      )
+      engineCommandManager.tearDown({ websocketClosed: true, code: '1000' })
+      expect(callback).toHaveBeenCalledExactlyOnceWith('1000', false)
+      expect(infiniteLoopCallback).not.toHaveBeenCalled()
+      unmount()
+    })
+
     test('should call infinite detection loop callback on close event', async () => {
       const callback = vi.fn(() => 1)
       const infiniteLoopCallback = vi.fn(() => 1)
@@ -88,41 +131,47 @@ describe('useOnWebsocketClose', () => {
       expect(infiniteLoopCallback).toHaveBeenCalledTimes(1)
       expect(infiniteLoopCallback).toHaveBeenCalledWith('1006')
     })
-    test('routes terminal errors without invoking automatic reconnect callbacks', async () => {
-      const callback = vi.fn(() => 1)
-      const infiniteLoopCallback = vi.fn(() => 1)
-      const terminalErrorCallback = vi.fn(() => 1)
-      const { engineCommandManager } =
-        await buildTheWorldAndNoEngineConnection(true)
-      const { unmount } = renderHook(() =>
-        useOnWebsocketClose({
-          callback,
-          infiniteDetectionLoopCallback: infiniteLoopCallback,
-          terminalErrorCallback,
-          engineCommandManager,
+    test.each([false, true])(
+      'routes terminal errors without reconnecting (reconnectRequested=%s)',
+      async (reconnectRequested) => {
+        const callback = vi.fn(() => 1)
+        const infiniteLoopCallback = vi.fn(() => 1)
+        const terminalErrorCallback = vi.fn(() => 1)
+        const { engineCommandManager } =
+          await buildTheWorldAndNoEngineConnection(true)
+        const { unmount } = renderHook(() =>
+          useOnWebsocketClose({
+            callback,
+            infiniteDetectionLoopCallback: infiniteLoopCallback,
+            terminalErrorCallback,
+            engineCommandManager,
+          })
+        )
+        const connectionError = {
+          kind: EngineConnectionErrorKind.BackendDisconnect,
+          message: 'backend disconnected',
+          terminal: true,
+        }
+
+        engineCommandManager.tearDown({
+          websocketClosed: true,
+          code: '1011',
+          connectionError,
+          reconnectRequested,
         })
-      )
-      const connectionError = {
-        kind: EngineConnectionErrorKind.BackendDisconnect,
-        message: 'backend disconnected',
-        terminal: true,
+        unmount()
+
+        expect(engineCommandManager.lastConnectionError).toEqual(
+          connectionError
+        )
+        expect(terminalErrorCallback).toHaveBeenCalledOnce()
+        expect(terminalErrorCallback).toHaveBeenCalledWith(
+          connectionError,
+          '1011'
+        )
+        expect(callback).not.toHaveBeenCalled()
+        expect(infiniteLoopCallback).not.toHaveBeenCalled()
       }
-
-      engineCommandManager.tearDown({
-        websocketClosed: true,
-        code: '1011',
-        connectionError,
-      })
-      unmount()
-
-      expect(engineCommandManager.lastConnectionError).toEqual(connectionError)
-      expect(terminalErrorCallback).toHaveBeenCalledOnce()
-      expect(terminalErrorCallback).toHaveBeenCalledWith(
-        connectionError,
-        '1011'
-      )
-      expect(callback).not.toHaveBeenCalled()
-      expect(infiniteLoopCallback).not.toHaveBeenCalled()
-    })
+    )
   })
 })

--- a/src/hooks/network/useOnWebsocketClose.tsx
+++ b/src/hooks/network/useOnWebsocketClose.tsx
@@ -4,11 +4,14 @@ import type {
   EngineConnectionError,
   EngineDisconnectEventDetail,
 } from '@src/lib/engineConnection/utils'
-import { EngineConnectionManagerEvents } from '@src/lib/engineConnection/utils'
+import {
+  EngineConnectionManagerEvents,
+  WebSocketCloseCode,
+} from '@src/lib/engineConnection/utils'
 import { useEffect } from 'react'
 
 export interface IUseOnWebsocketClose {
-  callback: (code: string | undefined) => void
+  callback: (code: string | undefined, reconnectRequested: boolean) => void
   infiniteDetectionLoopCallback: (code: string | undefined) => void
   terminalErrorCallback?: (
     error: EngineConnectionError,
@@ -45,22 +48,23 @@ export function useOnWebsocketClose({
         return
       }
 
-      if (event?.detail?.code === '1006') {
-        // Most likely your internet is out. Do not try to auto reconnect
-        // This will result in an infinite loop
+      const code = event.detail?.code
+      const reconnectRequested = event.detail?.reconnectRequested ?? false
+      if (
+        code === WebSocketCloseCode.AbnormalClosure.toString() &&
+        !reconnectRequested
+      ) {
         EngineDebugger.addLog({
           label: 'useOnWebsocketClose',
           message: 'detected infinite loop',
-          metadata: {
-            code: event?.detail?.code,
-          },
+          metadata: { code },
         })
 
-        infiniteDetectionLoopCallback(event.detail.code)
+        infiniteDetectionLoopCallback(code)
         return
       }
 
-      callback(event?.detail?.code)
+      callback(code, reconnectRequested)
     }
 
     engineCommandManager.addEventListener(

--- a/src/lib/engineConnection/connection.ts
+++ b/src/lib/engineConnection/connection.ts
@@ -25,6 +25,7 @@ import {
   EngineConnectionEvents,
   EngineConnectionStateType,
   PING_INTERVAL_MS,
+  WebSocketCloseCode,
   WebSocketStatusCodes,
 } from '@src/lib/engineConnection/utils'
 import {
@@ -102,6 +103,7 @@ export class Connection extends EventTarget {
   rejectPendingCommand: ({ cmdId }: { cmdId: string }) => void
   handleMessage: ((event: MessageEvent<any>) => void) | null
   private readonly getCloudProjectId: () => string | undefined
+  private reconnectRequested = false
 
   constructor({
     url,
@@ -647,6 +649,20 @@ export class Connection extends EventTarget {
       },
       getCloudProjectId: this.getCloudProjectId,
       tearDownManager: this.tearDownManager.bind(this),
+      requestReconnect: () => {
+        if (
+          this.reconnectRequested ||
+          this.websocket?.readyState !== WebSocket.OPEN
+        ) {
+          return
+        }
+
+        this.reconnectRequested = true
+        this.websocket.close(
+          WebSocketCloseCode.NormalClosure,
+          'reconnect requested'
+        )
+      },
     })
     const onWebSocketClose = createOnWebSocketClose({
       websocket: this.websocket,
@@ -655,6 +671,7 @@ export class Connection extends EventTarget {
       onWebSocketMessage: onWebSocketMessage,
       tearDownManager: this.tearDownManager.bind(this),
       dispatchEvent: this.dispatchEvent.bind(this),
+      getReconnectRequested: () => this.reconnectRequested,
     })
 
     // Meta close will remove all the internal events itself but then the this.websocket.close

--- a/src/lib/engineConnection/connectionManager.test.ts
+++ b/src/lib/engineConnection/connectionManager.test.ts
@@ -1,6 +1,33 @@
 import { ConnectionManager } from '@src/lib/engineConnection/connectionManager'
 import type { SettingsActorType } from '@src/machines/settingsMachine'
-import { describe, expect, it, vi } from 'vitest'
+import { Connection } from '@src/lib/engineConnection/connection'
+import {
+  EngineConnectionManagerEvents,
+  type EngineDisconnectEventDetail,
+} from '@src/lib/engineConnection/utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+class ReconnectTestWebSocket extends EventTarget {
+  static OPEN = 1
+  static CLOSED = 3
+  static instances: ReconnectTestWebSocket[] = []
+  readyState = ReconnectTestWebSocket.OPEN
+  binaryType: BinaryType = 'blob'
+  send = vi.fn()
+  close = vi.fn(() => {
+    this.readyState = 2
+  })
+
+  constructor() {
+    super()
+    ReconnectTestWebSocket.instances.push(this)
+  }
+
+  finishClose(code: number) {
+    this.readyState = ReconnectTestWebSocket.CLOSED
+    this.dispatchEvent(new CloseEvent('close', { code }))
+  }
+}
 
 function createConnectionManager() {
   return new ConnectionManager({
@@ -23,6 +50,71 @@ function startConnectionManager(
 }
 
 describe('ConnectionManager', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    ReconnectTestWebSocket.instances = []
+  })
+
+  it.each([1000, 1006])(
+    'carries a reconnect request through socket closure %s and manager cleanup',
+    (code) => {
+      vi.stubGlobal('WebSocket', ReconnectTestWebSocket)
+      const manager = createConnectionManager()
+      const closeDetails: EngineDisconnectEventDetail[] = []
+      manager.addEventListener(
+        EngineConnectionManagerEvents.WebsocketClosed,
+        (event) => {
+          if (event instanceof CustomEvent) closeDetails.push(event.detail)
+        }
+      )
+      const connection = new Connection({
+        url: 'ws://localhost/modeling-test',
+        token: 'test-token',
+        handleOnDataChannelMessage: vi.fn(),
+        tearDownManager: manager.tearDown.bind(manager),
+        rejectPendingCommand: vi.fn(),
+        handleMessage: vi.fn(),
+        getCloudProjectId: () => undefined,
+      })
+      connection.deferredSdpAnswer = {
+        promise: Promise.resolve(),
+        resolve: vi.fn(),
+        reject: vi.fn(),
+      }
+      manager.connection = connection
+      manager.started = true
+      const rejectPending = vi.spyOn(manager, 'rejectAllPendingCommands')
+      connection.createWebSocketConnection()
+      const socket = ReconnectTestWebSocket.instances[0]
+      const notice = JSON.stringify({
+        success: true,
+        request_id: null,
+        resp: { type: 'reconnect', data: {} },
+      })
+      socket.dispatchEvent(new MessageEvent('message', { data: notice }))
+      socket.dispatchEvent(new MessageEvent('message', { data: notice }))
+      expect(socket.close).toHaveBeenCalledExactlyOnceWith(
+        1000,
+        'reconnect requested'
+      )
+      expect(closeDetails).toEqual([])
+
+      socket.finishClose(code)
+      expect(closeDetails).toEqual([
+        { code: String(code), reconnectRequested: true },
+      ])
+      expect(rejectPending).toHaveBeenCalledOnce()
+      expect(manager.connection).toBeUndefined()
+      expect(manager.started).toBe(false)
+
+      // Stale events on the retired socket must not start another recovery.
+      socket.finishClose(code)
+      socket.dispatchEvent(new MessageEvent('message', { data: notice }))
+      expect(closeDetails).toHaveLength(1)
+      expect(socket.close).toHaveBeenCalledOnce()
+    }
+  )
+
   it.each([
     [{ width: 240, height: 256 }, 'width must be between 256 and 2160, 240'],
     [{ width: 256, height: 240 }, 'height must be between 256 and 2160, 240'],

--- a/src/lib/engineConnection/connectionManager.ts
+++ b/src/lib/engineConnection/connectionManager.ts
@@ -46,6 +46,7 @@ import {
   EngineConnectionStateType,
   REJECTED_TOO_EARLY_WEBSOCKET_MESSAGE,
   validateStreamDimensions,
+  type EngineDisconnectEventDetail,
 } from '@src/lib/engineConnection/utils'
 import {
   isExportResponse,
@@ -1080,12 +1081,16 @@ export class ConnectionManager extends EventTarget {
     // It was torn down from a websocket close.
     if (options?.websocketClosed) {
       this.dispatchEvent(
-        new CustomEvent(EngineConnectionManagerEvents.WebsocketClosed, {
-          detail: {
-            code: options.code,
-            connectionError: options.connectionError,
-          },
-        })
+        new CustomEvent<EngineDisconnectEventDetail>(
+          EngineConnectionManagerEvents.WebsocketClosed,
+          {
+            detail: {
+              code: options.code,
+              connectionError: options.connectionError,
+              reconnectRequested: options.reconnectRequested ?? false,
+            },
+          }
+        )
       )
     } else if (options?.peerConnectionClosed) {
       this.dispatchEvent(

--- a/src/lib/engineConnection/utils.ts
+++ b/src/lib/engineConnection/utils.ts
@@ -349,6 +349,7 @@ export type EngineConnectionError = {
 }
 
 export type EngineDisconnectEventDetail = {
+  reconnectRequested?: boolean
   code?: string
   connectionError?: EngineConnectionError
 }
@@ -467,6 +468,11 @@ function validateStreamDimension(dimension: number, label: string) {
   return undefined
 }
 
+export const WebSocketCloseCode = {
+  NormalClosure: 1000,
+  AbnormalClosure: 1006,
+} as const
+
 export interface ManagerTearDown {
   websocketClosed?: boolean
   peerConnectionFailed?: boolean
@@ -475,6 +481,7 @@ export interface ManagerTearDown {
   dataChannelClosed?: boolean
   code?: string
   connectionError?: EngineConnectionError
+  reconnectRequested?: boolean
 }
 
 // 7.4.1 Defined Status Codes from RFC 6455 The WebSocket Protocol
@@ -484,7 +491,7 @@ export const WebSocketStatusCodes: Readonly<Record<string, string>> =
      * indicates a normal closure, meaning that the purpose for
      * which the connection was established has been fulfilled.
      */
-    '1000': 'normal closure',
+    [WebSocketCloseCode.NormalClosure]: 'normal closure',
     /**
      * indicates that an endpoint is "going away", such as a server
      * going down or a browser having navigated away from a page.
@@ -520,7 +527,7 @@ export const WebSocketStatusCodes: Readonly<Record<string, string>> =
      * connection was closed abnormally, e.g., without sending or
      * receiving a Close control frame.
      */
-    '1006': 'abnormally closed',
+    [WebSocketCloseCode.AbnormalClosure]: 'abnormally closed',
     /**
      * indicates that an endpoint is terminating the connection
      * because it has received data within a message that was not

--- a/src/lib/engineConnection/websocketConnection.test.ts
+++ b/src/lib/engineConnection/websocketConnection.test.ts
@@ -15,7 +15,10 @@ import { createOnWebSocketMessage } from '@src/lib/engineConnection/websocketCon
 const disconnectAll = vi.fn()
 const tearDownManager = vi.fn()
 
-const createMessageHandler = (cloudProjectId?: string) =>
+const createMessageHandler = (
+  cloudProjectId?: string,
+  requestReconnect = vi.fn()
+) =>
   createOnWebSocketMessage({
     disconnectAll,
     setPong: vi.fn(),
@@ -33,6 +36,7 @@ const createMessageHandler = (cloudProjectId?: string) =>
     setApiCallId: vi.fn(),
     getCloudProjectId: () => cloudProjectId,
     tearDownManager,
+    requestReconnect,
   })
 
 const dispatchFailureMessage = (message: string, cloudProjectId?: string) => {
@@ -51,6 +55,39 @@ describe('createOnWebSocketMessage', () => {
     vi.clearAllMocks()
     vi.spyOn(console, 'error').mockImplementation(() => {})
     vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  it('requests reconnection for a reconnect response without reporting a failure', () => {
+    const requestReconnect = vi.fn()
+    const handler = createMessageHandler(undefined, requestReconnect)
+    handler(
+      new MessageEvent('message', {
+        data: JSON.stringify({
+          success: true,
+          request_id: null,
+          resp: { type: 'reconnect', data: {} },
+        }),
+      })
+    )
+    expect(requestReconnect).toHaveBeenCalledOnce()
+    expect(reportClientError).not.toHaveBeenCalled()
+  })
+
+  it('does not request reconnection for a pong response', () => {
+    const requestReconnect = vi.fn()
+    createMessageHandler(
+      undefined,
+      requestReconnect
+    )(
+      new MessageEvent('message', {
+        data: JSON.stringify({
+          success: true,
+          request_id: null,
+          resp: { type: 'pong', data: {} },
+        }),
+      })
+    )
+    expect(requestReconnect).not.toHaveBeenCalled()
   })
 
   it('reports backend Engine disconnect failures with the cloud project ID', () => {

--- a/src/lib/engineConnection/websocketConnection.ts
+++ b/src/lib/engineConnection/websocketConnection.ts
@@ -106,6 +106,7 @@ export const createOnWebSocketMessage = ({
   setApiCallId,
   getCloudProjectId,
   tearDownManager,
+  requestReconnect,
 }: {
   disconnectAll: () => void
   setPong: (pong: number) => void
@@ -123,6 +124,7 @@ export const createOnWebSocketMessage = ({
   setApiCallId: (apiCallId: string) => void
   getCloudProjectId: () => string | undefined
   tearDownManager: (options?: ManagerTearDown) => void
+  requestReconnect: () => void
 }) => {
   const onWebSocketMessage = (event: MessageEvent<any>) => {
     // In the EngineConnection, we're looking for messages to/from
@@ -430,6 +432,9 @@ export const createOnWebSocketMessage = ({
           })
 
         break
+      case 'reconnect':
+        requestReconnect()
+        return
     }
   }
 
@@ -443,6 +448,7 @@ export const createOnWebSocketClose = ({
   onWebSocketMessage,
   tearDownManager,
   dispatchEvent,
+  getReconnectRequested,
 }: {
   websocket: WebSocket
   onWebSocketOpen: (event: Event) => void
@@ -450,6 +456,7 @@ export const createOnWebSocketClose = ({
   onWebSocketMessage: (event: MessageEvent<any>) => void
   tearDownManager: (options?: ManagerTearDown) => void
   dispatchEvent: (event: Event) => boolean
+  getReconnectRequested: () => boolean
 }) => {
   const onDataChannelClose = (event: CloseEvent) => {
     websocket.removeEventListener('open', onWebSocketOpen)
@@ -460,7 +467,11 @@ export const createOnWebSocketClose = ({
         detail: { name: event.code },
       })
     )
-    tearDownManager({ websocketClosed: true, code: event.code.toString() })
+    tearDownManager({
+      websocketClosed: true,
+      code: event.code.toString(),
+      reconnectRequested: getReconnectRequested(),
+    })
   }
   return onDataChannelClose
 }


### PR DESCRIPTION
Reference: [Issue-2683](https://github.com/KittyCAD/api/issues/2683)

This PR adds support for graceful reconnection. When modeling-api receives a `reconnect` message, it should close the current connection, automatically establish a new one, and restore the model so editing can continue. The backend work will be done in a separate PR to actually send the message.

Testing:

Added automated tests for:

1. Handling `reconnect` response
2. Closing WebSocket when duplicate reconnect messages arrive
3. Passing the reconnect flag through socket closure and manager teardown
4. Automatically recovering from reconnects with close codes 1000 and 1006, while preserving the existing handling of unexpected closures.

Manual testing:

Used DevTools to mock a WebSocket message through the app's actual message handler:

```

{
  "success": true,
  "request_id": null,
  "resp": {
    "type": "reconnect",
    "data": {}
  }
}

```

Tested these cases:

1. With an open project, injected the notification after rendering was done and confirmed automatic reconnection. Changed geometry and verified that it updated.
2. During active rendering, injected a notification when `isExecuting` was true and there were pending engine commands. Confirmed that the notification was triggered, the project recovered, and the following dimension edits continued to update the geometry. After recovery, verified that the connection instance changed, the new connection was connected, execution finished, and no engine commands remained pending.