### PR TITLE
Make KCL import export diagnostics actionable

### DIFF
--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -1310,11 +1310,11 @@ impl ExecutorContext {
                 for import_item in items {
                     // Extract the item from the module.
                     let mem = &exec_state.stack().memory;
-                    let mut value = mem.get_from_owned(&import_item.name.name, env_ref, import_item.into(), 0);
+                    let value = mem.get_from_owned(&import_item.name.name, env_ref, import_item.into(), 0);
                     let ty_name = format!("{}{}", memory::TYPE_PREFIX, import_item.name.name);
-                    let mut ty = mem.get_from_owned(&ty_name, env_ref, import_item.into(), 0);
+                    let ty = mem.get_from_owned(&ty_name, env_ref, import_item.into(), 0);
                     let mod_name = format!("{}{}", memory::MODULE_PREFIX, import_item.name.name);
-                    let mut mod_value = mem.get_from_owned(&mod_name, env_ref, import_item.into(), 0);
+                    let mod_value = mem.get_from_owned(&mod_name, env_ref, import_item.into(), 0);
 
                     if value.is_err() && ty.is_err() && mod_value.is_err() {
                         return Err(KclError::new_undefined_value(
@@ -1326,43 +1326,24 @@ impl ExecutorContext {
                         ));
                     }
 
-                    // Check that the item is allowed to be imported (in at least one namespace).
-                    if value.is_ok() && !module_exports.contains(&import_item.name.name) {
-                        value = Err(KclError::new_semantic(KclErrorDetails::new(
+                    // Import only exported namespaces. The name exists, so if none
+                    // are exported, report visibility rather than a failed value lookup.
+                    let value = value.ok().filter(|_| module_exports.contains(&import_item.name.name));
+                    let ty = ty.ok().filter(|_| module_exports.contains(&ty_name));
+                    let mod_value = mod_value.ok().filter(|_| module_exports.contains(&mod_name));
+                    if value.is_none() && ty.is_none() && mod_value.is_none() {
+                        let name = &import_item.name.name;
+                        let path = &import_stmt.path;
+                        return Err(KclError::new_semantic(KclErrorDetails::new(
                             format!(
-                                "Cannot import \"{}\" from module because it is not exported. Add \"export\" before the definition to export it.",
-                                import_item.name.name
+                                "Cannot import \"{name}\" from \"{path}\" because it is not exported. Add `export` before its declaration in \"{path}\" (for example, `export {name} = ...` for a variable)."
                             ),
                             vec![SourceRange::from(&import_item.name)],
                         )));
-                    }
-
-                    if ty.is_ok() && !module_exports.contains(&ty_name) {
-                        ty = Err(KclError::new_semantic(KclErrorDetails::new(
-                            format!(
-                                "Cannot import \"{}\" from module because it is not exported. Add \"export\" before the definition to export it.",
-                                import_item.name.name
-                            ),
-                            vec![SourceRange::from(&import_item.name)],
-                        )));
-                    }
-
-                    if mod_value.is_ok() && !module_exports.contains(&mod_name) {
-                        mod_value = Err(KclError::new_semantic(KclErrorDetails::new(
-                            format!(
-                                "Cannot import \"{}\" from module because it is not exported. Add \"export\" before the definition to export it.",
-                                import_item.name.name
-                            ),
-                            vec![SourceRange::from(&import_item.name)],
-                        )));
-                    }
-
-                    if value.is_err() && ty.is_err() && mod_value.is_err() {
-                        return value.map(|_| ());
                     }
 
                     // Add the item to the current module.
-                    if let Ok(value) = value {
+                    if let Some(value) = value {
                         exec_state.mut_stack().add(
                             import_item.identifier().to_owned(),
                             value,
@@ -1377,7 +1358,7 @@ impl ExecutorContext {
                         }
                     }
 
-                    if let Ok(ty) = ty {
+                    if let Some(ty) = ty {
                         let ty_name = format!("{}{}", memory::TYPE_PREFIX, import_item.identifier());
                         if matches!(
                             &ty,
@@ -1401,7 +1382,7 @@ impl ExecutorContext {
                         }
                     }
 
-                    if let Ok(mod_value) = mod_value {
+                    if let Some(mod_value) = mod_value {
                         let mod_name = format!("{}{}", memory::MODULE_PREFIX, import_item.identifier());
                         reject_module_clashing_with_enum(
                             exec_state,
@@ -1448,9 +1429,11 @@ impl ExecutorContext {
                     value: module_id,
                     meta: vec![source_range.into()],
                 };
-                exec_state
-                    .mut_stack()
-                    .add(format!("{}{}", memory::MODULE_PREFIX, name), item, source_range)?;
+                let mod_name = format!("{}{}", memory::MODULE_PREFIX, name);
+                exec_state.mut_stack().add(mod_name.clone(), item, source_range)?;
+                if let ItemVisibility::Export = import_stmt.visibility {
+                    exec_state.mod_local.module_exports.push(mod_name);
+                }
             }
         }
 

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -6821,6 +6821,72 @@ type Color { | Red | Green | Red }
         parse_execute_with_project_dir(main, Some(crate::TypedPath(tmpdir.path().into()))).await
     }
 
+    #[tokio::test(flavor = "multi_thread")]
+    async fn named_import_unexported_declaration() {
+        let name = "motorSideStationaryBearingOuter";
+        let settings = "@settings(experimentalFeatures = allow)\n";
+        for declaration in [
+            format!("{name} = 42\n"),
+            format!("fn {name}() {{ return 42 }}\n"),
+            format!("type {name} = number(mm)\n"),
+            format!("import \"inner.kcl\" as {name}\n"),
+        ] {
+            for alias in ["", " as bearing"] {
+                let main = format!("{settings}import {name}{alias} from \"bearing.kcl\"\n");
+                let module = format!("{settings}{declaration}");
+                let err = execute_with_modules(&main, &[("bearing.kcl", &module), ("inner.kcl", "")])
+                    .await
+                    .unwrap_err();
+                assert!(matches!(err, KclError::Semantic { .. }), "{declaration}: {err}");
+                assert_eq!(
+                    err.message(),
+                    format!(
+                        "Cannot import \"{name}\" from \"bearing.kcl\" because it is not exported. Add `export` before its declaration in \"bearing.kcl\" (for example, `export {name} = ...` for a variable)."
+                    ),
+                );
+                let start = main.find(name).unwrap();
+                assert_eq!(
+                    err.source_ranges(),
+                    vec![SourceRange::new(start, start + name.len(), ModuleId::default())]
+                );
+                // The serialized message is what the Wasm consumer displays.
+                assert_eq!(serde_json::to_value(&err).unwrap()["details"]["msg"], err.message());
+
+                // Apply the suggested fix in the source module. This also pins
+                // current export syntax for variables, functions, types and imports.
+                let exported = format!("{settings}export {declaration}");
+                execute_with_modules(&main, &[("bearing.kcl", &exported), ("inner.kcl", "")])
+                    .await
+                    .unwrap_or_else(|err| panic!("{exported}: {err}"));
+            }
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn named_import_undefined_declaration() {
+        let main = "import missing as bearing from \"bearing.kcl\"\n";
+        let err = execute_with_modules(main, &[("bearing.kcl", "other = 42\n")])
+            .await
+            .unwrap_err();
+        assert!(matches!(err, KclError::UndefinedValue { .. }));
+        assert_eq!(err.message(), "missing is not defined in module");
+        assert_eq!(err.source_ranges(), vec![SourceRange::new(7, 14, ModuleId::default())]);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn named_import_exported_in_one_namespace() {
+        let settings = "@settings(experimentalFeatures = allow)\n";
+        let main = format!("{settings}import bearing from \"bearing.kcl\"\n");
+        for declarations in [
+            "bearing = 42\nexport type bearing = number(mm)\n",
+            "export bearing = 42\ntype bearing = number(mm)\n",
+        ] {
+            execute_with_modules(&main, &[("bearing.kcl", &format!("{settings}{declarations}"))])
+                .await
+                .unwrap();
+        }
+    }
+
     /// Runs `main` with an empty imported module named `m.kcl` in mock
     /// execution and returns the recorded compilation issues; the run may
     /// end in an error (e.g. from operating on the module's missing return


### PR DESCRIPTION
Make private-import diagnostics name the source file and show where to add `export`, including the assignment form for variables. Preserve existing missing-name errors and record visibility on `export import` module declarations.

Fixes #13775. Regression cases cover variables, functions, types, modules, aliases, and split namespaces under both executors. Zookeeper requires a later binding release to receive the improved diagnostic.