### PR TITLE
Fix Windows VS Code test profile cleanup

### DIFF
--- a/rust/kcl-language-server/client/src/test/runTest.ts
+++ b/rust/kcl-language-server/client/src/test/runTest.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
 import { runTests } from '@vscode/test-electron'
+import { removeVSCodeProfile } from './vscodeProfile'
 
 function createShortVSCodeProfileDir() {
   const tempRoot = process.platform === 'win32' ? os.tmpdir() : '/tmp'
@@ -34,7 +35,7 @@ async function main() {
     console.error('Failed to run tests')
     process.exitCode = 1
   } finally {
-    fs.rmSync(vscodeProfileDir, { force: true, recursive: true })
+    await removeVSCodeProfile(vscodeProfileDir)
   }
 }
 

--- a/rust/kcl-language-server/client/src/test/suite/vscodeProfile.test.ts
+++ b/rust/kcl-language-server/client/src/test/suite/vscodeProfile.test.ts
@@ -1,0 +1,26 @@
+import * as assert from 'assert'
+import { chmod, mkdtemp, stat, writeFile } from 'fs/promises'
+import * as os from 'os'
+import * as path from 'path'
+import { suite, test } from 'mocha'
+import { removeVSCodeProfile } from '../vscodeProfile'
+
+suite('VS Code profile cleanup', () => {
+  test('removes a profile containing a read-only file', async () => {
+    const profileDir = await mkdtemp(path.join(os.tmpdir(), 'kcl-ls-cleanup-'))
+    const profileFile = path.join(profileDir, 'settings.json')
+    await writeFile(profileFile, '{}')
+
+    try {
+      await chmod(profileFile, 0o444)
+      await removeVSCodeProfile(profileDir)
+      await assert.rejects(stat(profileDir), { code: 'ENOENT' })
+    } finally {
+      // Allow cleanup even if the regression leaves the read-only file behind.
+      await chmod(profileFile, 0o666).catch((error: NodeJS.ErrnoException) => {
+        assert.strictEqual(error.code, 'ENOENT')
+      })
+      await removeVSCodeProfile(profileDir)
+    }
+  }).timeout(15_000)
+})

--- a/rust/kcl-language-server/client/src/test/vscodeProfile.ts
+++ b/rust/kcl-language-server/client/src/test/vscodeProfile.ts
@@ -1,0 +1,12 @@
+import { rm } from 'fs/promises'
+
+export async function removeVSCodeProfile(profileDir: string): Promise<void> {
+  // Node 24's rmSync skips retries for Windows permission-denied errors.
+  // Async removal handles read-only files and retries lingering file locks.
+  await rm(profileDir, {
+    force: true,
+    recursive: true,
+    maxRetries: 10,
+    retryDelay: 200,
+  })
+}

--- a/rust/kcl-language-server/package.json
+++ b/rust/kcl-language-server/package.json
@@ -108,7 +108,7 @@
     "compile": "cross-env NODE_ENV=production tsc -b",
     "build": "npm run build-base -- --sourcemap",
     "watch": "npm run build-base -- --sourcemap --watch",
-    "pretest": "npm run build && npm run test-compile",
+    "pretest": "npm run build && npm run test-compile && mocha --ui tdd ./dist/client/src/test/suite/vscodeProfile.test.js",
     "test": "node ./dist/client/src/test/runTest.js",
     "package": "vsce package -o kcl-language-server.vsix"
   },


### PR DESCRIPTION
Windows VS Code integration tests can pass and then fail with `EPERM` while deleting their temporary profile, as in [this job](https://github.com/KittyCAD/modeling-app/actions/runs/34392241677/job/102606466272). Node 24.11.0's [synchronous removal code](https://github.com/nodejs/node/blob/v24.11.0/src/node_file.cc#L1647-L1709) excludes Windows `permission_denied` from its retry path. Await asynchronous profile removal with bounded retries, which handles read-only files and transient locks while still surfacing persistent cleanup failures.

Add a regression that removes a profile containing a read-only file. Run it under the host Node runtime before launching VS Code, since the runner and VS Code's embedded Node can have different versions.

Extracted from #13762 so this fix can land independently on `main`. The cleanup change also overlaps with #13769, which targets the facing feature branch and includes documentation changes.
