### PR TITLE
Simplify video codec preflight

### DIFF
--- a/src/hooks/network/useTryConnect.test.ts
+++ b/src/hooks/network/useTryConnect.test.ts
@@ -65,7 +65,7 @@ describe('tryConnecting', () => {
     ).rejects.toEqual(connectionError)
 
     expect(manager.start).toHaveBeenCalledOnce()
-    expect(manager.tearDown).not.toHaveBeenCalled()
+    expect(manager.tearDown).toHaveBeenCalledOnce()
     expect(numberOfConnectionAttempts.current).toBe(0)
     expect(setShowManualConnect).toHaveBeenCalledWith(true)
   })

--- a/src/hooks/network/useTryConnect.test.ts
+++ b/src/hooks/network/useTryConnect.test.ts
@@ -65,7 +65,7 @@ describe('tryConnecting', () => {
     ).rejects.toEqual(connectionError)
 
     expect(manager.start).toHaveBeenCalledOnce()
-    expect(manager.tearDown).toHaveBeenCalledOnce()
+    expect(manager.tearDown).not.toHaveBeenCalled()
     expect(numberOfConnectionAttempts.current).toBe(0)
     expect(setShowManualConnect).toHaveBeenCalledWith(true)
   })

--- a/src/hooks/network/useTryConnect.tsx
+++ b/src/hooks/network/useTryConnect.tsx
@@ -305,12 +305,12 @@ export async function tryConnecting({
             message: `Attempt ${numberOfConnectionAttempts.current}/${NUMBER_OF_ENGINE_RETRIES} failed`,
             metadata: { terminalConnectionError },
           })
-          engineCommandManager.tearDown()
           if (terminalConnectionError) {
             numberOfConnectionAttempts.current = 0
             setShowManualConnect(true)
             return reject(terminalConnectionError)
           }
+          engineCommandManager.tearDown()
           if (numberOfConnectionAttempts.current >= NUMBER_OF_ENGINE_RETRIES) {
             numberOfConnectionAttempts.current = 0
             return reject(e)

--- a/src/hooks/network/useTryConnect.tsx
+++ b/src/hooks/network/useTryConnect.tsx
@@ -7,10 +7,7 @@ import { NUMBER_OF_ENGINE_RETRIES } from '@src/lib/constants'
 import { EngineDebugger } from '@src/lib/debugger'
 import type { ConnectionManager } from '@src/lib/engineConnection/connectionManager'
 import { getDimensions } from '@src/lib/engineConnection/utils'
-import {
-  isUnsupportedEngineVideoCodecError,
-  preflightEngineVideoCodecSupport,
-} from '@src/lib/engineConnection/videoCodecSupport'
+import { preflightEngineVideoCodecSupport } from '@src/lib/engineConnection/videoCodecSupport'
 import { reapplyActiveViewAfterReconnect } from '@src/lib/kclNamedViewActivation'
 import { resetCameraPosition } from '@src/lib/resetCameraPosition'
 import type RustContext from '@src/lib/rustContext'
@@ -44,19 +41,19 @@ const attemptToConnectToEngine = async ({
   engineCommandManager: ConnectionManager
   rustContext: RustContext
 }) => {
-  const codecSupport = await preflightEngineVideoCodecSupport()
-  if (isUnsupportedEngineVideoCodecError(codecSupport)) {
-    engineCommandManager.lastConnectionError = codecSupport
+  const codecError = await preflightEngineVideoCodecSupport()
+  if (codecError) {
+    engineCommandManager.lastConnectionError = codecError
     void reportClientError({
       code: ClientErrorCode.EngineUnsupportedVideoCodec,
-      error: codecSupport,
+      error: codecError,
       dedupeKey: ClientErrorCode.EngineUnsupportedVideoCodec,
       extra: {
-        browserVideoCodecs: codecSupport.browserCodecs,
-        engineVideoCodecs: codecSupport.engineCodecs,
+        browserVideoCodecs: codecError.browserCodecs,
+        engineVideoCodecs: codecError.engineCodecs,
       },
     })
-    return Promise.reject(codecSupport)
+    return Promise.reject(codecError)
   }
 
   const connection = new Promise<boolean>((resolve, reject) => {
@@ -308,12 +305,12 @@ export async function tryConnecting({
             message: `Attempt ${numberOfConnectionAttempts.current}/${NUMBER_OF_ENGINE_RETRIES} failed`,
             metadata: { terminalConnectionError },
           })
+          engineCommandManager.tearDown()
           if (terminalConnectionError) {
             numberOfConnectionAttempts.current = 0
             setShowManualConnect(true)
             return reject(terminalConnectionError)
           }
-          engineCommandManager.tearDown()
           if (numberOfConnectionAttempts.current >= NUMBER_OF_ENGINE_RETRIES) {
             numberOfConnectionAttempts.current = 0
             return reject(e)

--- a/src/lib/engineConnection/videoCodecSupport.test.ts
+++ b/src/lib/engineConnection/videoCodecSupport.test.ts
@@ -44,6 +44,8 @@ test('normalizes codec names before comparison', async () => {
 test('returns a typed terminal error when the offer lacks H.264', async () => {
   const close = stubLocalOffer(
     [
+      'm=audio 9 UDP/TLS/RTP/SAVPF 111',
+      'a=rtpmap:111 opus/48000/2',
       'm=video 9 UDP/TLS/RTP/SAVPF 96 97',
       'a=rtpmap:96 VP8/90000',
       'a=rtpmap:97 VP9/90000',

--- a/src/lib/engineConnection/videoCodecSupport.test.ts
+++ b/src/lib/engineConnection/videoCodecSupport.test.ts
@@ -1,14 +1,10 @@
 import {
   ENGINE_SUPPORTED_VIDEO_CODECS,
-  getEngineVideoCodecSupport,
-  getVideoCodecsFromSdp,
-  isUnsupportedEngineVideoCodecError,
   preflightEngineVideoCodecSupport,
-  UNSUPPORTED_ENGINE_VIDEO_CODEC_MESSAGE,
   UnsupportedEngineVideoCodecError,
 } from '@src/lib/engineConnection/videoCodecSupport'
 import { EngineConnectionErrorKind } from '@src/lib/engineConnection/utils'
-import { afterEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, expect, test, vi } from 'vitest'
 
 afterEach(() => {
   vi.unstubAllGlobals()
@@ -27,91 +23,47 @@ const stubLocalOffer = (sdp: string) => {
   return close
 }
 
-describe('Engine video codec support', () => {
-  test('accepts a browser that offers the Engine H.264 stream codec', () => {
-    expect(getEngineVideoCodecSupport(['video/VP8', 'video/H264'])).toEqual({
-      status: 'supported',
-      browserCodecs: ['video/vp8', 'video/h264'],
-      engineCodecs: ENGINE_SUPPORTED_VIDEO_CODECS,
-    })
-  })
+test('accepts and closes an offer containing H.264', async () => {
+  const close = stubLocalOffer(
+    ['m=video 9 UDP/TLS/RTP/SAVPF 96', 'a=rtpmap:96 H264/90000'].join('\r\n')
+  )
 
-  test('normalizes MIME type case', () => {
-    expect(getEngineVideoCodecSupport(['VIDEO/h264']).status).toBe('supported')
-  })
+  await expect(preflightEngineVideoCodecSupport()).resolves.toBeUndefined()
+  expect(close).toHaveBeenCalledOnce()
+})
 
-  test('rejects a browser with no codec the Engine can produce', () => {
-    expect(
-      getEngineVideoCodecSupport(['video/VP8', 'video/VP9', 'video/AV1'])
-    ).toEqual({
-      status: 'unsupported',
-      browserCodecs: ['video/vp8', 'video/vp9', 'video/av1'],
-      engineCodecs: ENGINE_SUPPORTED_VIDEO_CODECS,
-    })
-  })
+test('normalizes codec names before comparison', async () => {
+  const close = stubLocalOffer(
+    ['m=video 9 UDP/TLS/RTP/SAVPF 96', 'a=rtpmap:96 h264/90000'].join('\r\n')
+  )
 
-  test('allows normal negotiation when local SDP preflight is unavailable', () => {
-    expect(getEngineVideoCodecSupport(undefined)).toEqual({
-      status: 'unknown',
-      browserCodecs: [],
-      engineCodecs: ENGINE_SUPPORTED_VIDEO_CODECS,
-    })
-  })
+  await expect(preflightEngineVideoCodecSupport()).resolves.toBeUndefined()
+  expect(close).toHaveBeenCalledOnce()
+})
 
-  test('extracts only codecs from the SDP video section', () => {
-    const sdp = [
-      'm=audio 9 UDP/TLS/RTP/SAVPF 111',
-      'a=rtpmap:111 opus/48000/2',
-      'm=video 9 UDP/TLS/RTP/SAVPF 96 97 98',
+test('returns a typed terminal error when the offer lacks H.264', async () => {
+  const close = stubLocalOffer(
+    [
+      'm=video 9 UDP/TLS/RTP/SAVPF 96 97',
       'a=rtpmap:96 VP8/90000',
-      'a=rtpmap:97 H264/90000',
-      'a=rtpmap:98 rtx/90000',
+      'a=rtpmap:97 VP9/90000',
     ].join('\r\n')
+  )
 
-    expect(getVideoCodecsFromSdp(sdp)).toEqual([
-      'video/vp8',
-      'video/h264',
-      'video/rtx',
-    ])
+  const result = await preflightEngineVideoCodecSupport()
+
+  expect(result).toBeInstanceOf(UnsupportedEngineVideoCodecError)
+  expect(result).toMatchObject({
+    kind: EngineConnectionErrorKind.UnsupportedVideoCodec,
+    terminal: true,
+    browserCodecs: ['video/vp8', 'video/vp9'],
+    engineCodecs: ENGINE_SUPPORTED_VIDEO_CODECS,
   })
+  expect(close).toHaveBeenCalledOnce()
+})
 
-  test('returns a terminal error for a local offer without H.264', async () => {
-    const close = stubLocalOffer(
-      [
-        'm=video 9 UDP/TLS/RTP/SAVPF 96 97',
-        'a=rtpmap:96 VP8/90000',
-        'a=rtpmap:97 VP9/90000',
-      ].join('\r\n')
-    )
+test('falls back to normal negotiation when preflight is unavailable', async () => {
+  vi.stubGlobal('RTCPeerConnection', undefined)
 
-    await expect(preflightEngineVideoCodecSupport()).resolves.toBeInstanceOf(
-      UnsupportedEngineVideoCodecError
-    )
-    expect(close).toHaveBeenCalledOnce()
-  })
-
-  test('accepts and closes a local preflight offer with H.264', async () => {
-    const close = stubLocalOffer(
-      ['m=video 9 UDP/TLS/RTP/SAVPF 96', 'a=rtpmap:96 H264/90000'].join('\r\n')
-    )
-
-    await expect(preflightEngineVideoCodecSupport()).resolves.toMatchObject({
-      status: 'supported',
-    })
-    expect(close).toHaveBeenCalledOnce()
-  })
-
-  test('identifies unsupported codec errors as terminal', () => {
-    const error = new UnsupportedEngineVideoCodecError(['video/vp8'])
-
-    expect(error.message).toBe(UNSUPPORTED_ENGINE_VIDEO_CODEC_MESSAGE)
-    expect(error.message).toContain('Chrome, Edge, Firefox, or Safari')
-    expect(error.message).toContain('update it to the latest version')
-    expect(error.kind).toBe(EngineConnectionErrorKind.UnsupportedVideoCodec)
-    expect(error.terminal).toBe(true)
-    expect(isUnsupportedEngineVideoCodecError(error)).toBe(true)
-    expect(isUnsupportedEngineVideoCodecError(new Error('temporary'))).toBe(
-      false
-    )
-  })
+  await expect(preflightEngineVideoCodecSupport()).resolves.toBeUndefined()
 })

--- a/src/lib/engineConnection/videoCodecSupport.ts
+++ b/src/lib/engineConnection/videoCodecSupport.ts
@@ -3,21 +3,14 @@ import {
   EngineConnectionErrorKind,
 } from '@src/lib/engineConnection/utils'
 
-// Keep this list aligned with the video tracks Engine can produce. Once that
-// contract is available before Engine allocation, replace this constant with
-// API-provided metadata. See modeling-app#13673.
-export const ENGINE_SUPPORTED_VIDEO_CODECS = ['video/H264'] as const
+// Keep this aligned with the video tracks Engine can produce. Once this
+// contract is available before Engine allocation, use API-provided metadata.
+export const ENGINE_SUPPORTED_VIDEO_CODECS = ['video/h264'] as const
 
-export const UNSUPPORTED_ENGINE_VIDEO_CODEC_MESSAGE =
-  'Zoo Design Studio requires H.264 video, but this browser is not offering it. Use Chrome, Edge, Firefox, or Safari. If you are already using one of these browsers, update it to the latest version and reload this page. If Firefox is already up to date, enable OpenH264, restart Firefox, and try again.'
+const UNSUPPORTED_ENGINE_VIDEO_CODEC_MESSAGE =
+  'Browser does not offer the H.264 video codec required by Engine.'
 
 const normalizeCodec = (mimeType: string) => mimeType.trim().toLowerCase()
-
-export type EngineVideoCodecSupport = {
-  status: 'unknown' | 'supported' | 'unsupported'
-  browserCodecs: readonly string[]
-  engineCodecs: typeof ENGINE_SUPPORTED_VIDEO_CODECS
-}
 
 export class UnsupportedEngineVideoCodecError
   extends Error
@@ -35,7 +28,7 @@ export class UnsupportedEngineVideoCodecError
   }
 }
 
-export const getVideoCodecsFromSdp = (sdp: string) => {
+const getVideoCodecsFromSdp = (sdp: string) => {
   const codecs = new Set<string>()
   let isVideoSection = false
 
@@ -44,9 +37,7 @@ export const getVideoCodecsFromSdp = (sdp: string) => {
       isVideoSection = line.startsWith('m=video ')
       continue
     }
-    if (!isVideoSection) {
-      continue
-    }
+    if (!isVideoSection) continue
 
     const match = /^a=rtpmap:\d+\s+([^/\s]+)\//i.exec(line)
     if (match?.[1]) {
@@ -57,49 +48,16 @@ export const getVideoCodecsFromSdp = (sdp: string) => {
   return Array.from(codecs)
 }
 
-export const getEngineVideoCodecSupport = (
-  browserCodecs: readonly string[] | undefined
-): EngineVideoCodecSupport => {
-  if (!browserCodecs) {
-    return {
-      status: 'unknown',
-      browserCodecs: [],
-      engineCodecs: ENGINE_SUPPORTED_VIDEO_CODECS,
-    }
-  }
-
-  const normalizedBrowserCodecs = Array.from(
-    new Set(browserCodecs.map(normalizeCodec))
-  )
-  const engineCodecs = new Set(
-    ENGINE_SUPPORTED_VIDEO_CODECS.map(normalizeCodec)
-  )
-  const status = normalizedBrowserCodecs.some((codec) =>
-    engineCodecs.has(codec)
-  )
-    ? 'supported'
-    : 'unsupported'
-
-  return {
-    status,
-    browserCodecs: normalizedBrowserCodecs,
-    engineCodecs: ENGINE_SUPPORTED_VIDEO_CODECS,
-  }
-}
-
 const getBrowserOfferedVideoCodecs = async () => {
-  if (typeof RTCPeerConnection === 'undefined') {
-    return undefined
-  }
+  if (typeof RTCPeerConnection === 'undefined') return undefined
 
   const peerConnection = new RTCPeerConnection()
   try {
     peerConnection.addTransceiver('video', { direction: 'recvonly' })
     const offer = await peerConnection.createOffer()
-    return offer?.sdp ? getVideoCodecsFromSdp(offer.sdp) : undefined
+    return offer.sdp ? getVideoCodecsFromSdp(offer.sdp) : undefined
   } catch {
-    // Preserve the existing negotiation path when a browser cannot provide a
-    // local preflight offer. The real connection will report the full error.
+    // Preserve normal negotiation when local capability introspection fails.
     return undefined
   } finally {
     peerConnection.close()
@@ -107,18 +65,16 @@ const getBrowserOfferedVideoCodecs = async () => {
 }
 
 export const preflightEngineVideoCodecSupport = async (): Promise<
-  EngineVideoCodecSupport | UnsupportedEngineVideoCodecError
+  UnsupportedEngineVideoCodecError | undefined
 > => {
-  const support = getEngineVideoCodecSupport(
-    await getBrowserOfferedVideoCodecs()
-  )
-  if (support.status === 'unsupported') {
-    return new UnsupportedEngineVideoCodecError(support.browserCodecs)
-  }
-  return support
-}
+  const browserCodecs = await getBrowserOfferedVideoCodecs()
+  if (browserCodecs === undefined) return undefined
 
-export const isUnsupportedEngineVideoCodecError = (
-  error: unknown
-): error is UnsupportedEngineVideoCodecError =>
-  error instanceof UnsupportedEngineVideoCodecError
+  const supported = ENGINE_SUPPORTED_VIDEO_CODECS.some((codec) =>
+    browserCodecs.includes(codec)
+  )
+
+  return supported
+    ? undefined
+    : new UnsupportedEngineVideoCodecError(browserCodecs)
+}


### PR DESCRIPTION
Follow-up to #13674.

The codec preflight only needs to answer one question for its caller: did it find a terminal codec mismatch? This removes the unused `supported`/`unknown` result model and test-only helper exports, so the preflight now returns an `UnsupportedEngineVideoCodecError` or proceeds with normal negotiation.

The Engine codec constant and reported payload are normalized to lowercase. Browser-specific recovery instructions are replaced with a short diagnostic because the error text is no longer shown in the recovery UI. The tests are consolidated around the same behavior: accepting H.264 case-insensitively, rejecting unsupported video offers with a typed terminal error, ignoring non-video SDP codecs, closing the temporary peer connection, and falling back when preflight is unavailable.

This does not change when preflight runs, Engine allocation, retry or terminal-error behavior, teardown ordering, telemetry reporting, or the recovery UI.