### PR TITLE
Regenerate facing argument metadata after removedIn rename

### DIFF
--- a/rust/kcl-lib/expected-bindings/ts-rs/StdLibCommands.ts
+++ b/rust/kcl-lib/expected-bindings/ts-rs/StdLibCommands.ts
@@ -6651,7 +6651,7 @@ export default {
         "addedIn": null,
         "deprecated": false,
         "deprecatedSince": null,
-        "removedSince": null
+        "removedIn": null
       },
       {
         "name": "toolDiameter",
@@ -6663,7 +6663,7 @@ export default {
         "addedIn": null,
         "deprecated": false,
         "deprecatedSince": null,
-        "removedSince": null
+        "removedIn": null
       },
       {
         "name": "stepOver",
@@ -6675,7 +6675,7 @@ export default {
         "addedIn": null,
         "deprecated": false,
         "deprecatedSince": null,
-        "removedSince": null
+        "removedIn": null
       }
     ]
   },


### PR DESCRIPTION
The merge of #13733 retained three `removedSince` keys in `operation::facing` argument metadata after #13747 renamed that field to `removedIn`. This breaks main's TypeScript check and Rust binding preflight; downstream PR merge builds inherit the same failure before Rust tests can run.

Regenerate the three keys in the expected stdlib command bindings. The generated diff contains only those replacements. The app's exact command-metadata type check reproduces TS1360 with the old binding and passes with the regenerated binding under the pinned TypeScript 7.0.2. Command signatures, behavior, and geometry snapshots are unchanged.
