### PR TITLE
KCL: Disable physical measurement snapshots

### DIFF
--- a/rust/kcl-lib/src/simulation_tests.rs
+++ b/rust/kcl-lib/src/simulation_tests.rs
@@ -846,9 +846,9 @@ async fn execute_test(test: &Test, render_to_png: bool, export_step: bool) {
             ctx.close().await;
 
             let mut snapshot_results = common_snapshots(test, program_memory, responses);
-            if let Some(physical_properties) = physical_properties {
+            if let Some(_physical_properties) = physical_properties {
                 snapshot_results.push(catch_unwind(AssertUnwindSafe(|| {
-                    assert_physical_properties_snapshot(test, physical_properties)
+                    // assert_physical_properties_snapshot(test, physical_properties)
                 })));
             } else {
                 let physical_properties_snap_path = test.output_dir.join("physical_properties.snap");


### PR DESCRIPTION
Simplifies @mlfarrell 's life for a few hours so he can merge his big bounding box change.

Order of operations:

 - Mike gets his engine PR approved
 - We merge this
 - Mike runs his engine CI, which pulls this, his engine CI passes
 - Mike merges his engine PR
 - Mike's engine PR gets deployed
 - We revert this and redo all the bounding box snapshot artifacts.