### PR TITLE
chore: documentation on how to run these python tests

### DIFF
--- a/rust/kcl-python-bindings/README.md
+++ b/rust/kcl-python-bindings/README.md
@@ -29,6 +29,20 @@ There are four main commands:
 `pyo3` bindings are automatically detected. 
 `maturin` doesn't need extra configuration files and doesn't clash with an existing setuptools-rust or milksnake configuration.
 
+### How to run tests
+
+Starting from scratch to run a single test
+
+```shell
+export ZOO_API_TOKEN=<Token from zoo.dev aka production token>
+cd modeling-app/rust/kcl-python-bindings
+uv venv
+just dev-install
+uv run pytest tests/tests.py -k "tests and test_import_and_snapshots_single"
+```
+
+If you do not use a `ZOO_API_TOKEN` from the production environment of `zoo.dev` it will not work.
+
 ### Releasing a new version
 
 1. Make sure the `Cargo.toml` has the new version you want to release.


### PR DESCRIPTION
# Issue

A python binding broken in main and I wanted to run it locally. I was not able to easily find documentation on how to run the tests

# Problem

I kept getting an error saying
```
KclError: ('engine: KclErrorDetails { source_ranges: [SourceRange([0, 0, 0])], backtrace: [BacktraceItem { source_range: SourceRange([0, 0, 0]), fn_name: None, kind: Call }], message: "Please send `{ headers: { Authorization: \\"Bearer <token>\\" } }` over this websocket." }', False)
```

Which makes no sense because I was passing a `ZOO_API_TOKEN` but it didn't say it needed to be the production token
Also I don't know if there is any way to configure the ZOO_HOST?

I wrote documentation on what to do. 