### PR TITLE
Keep Zookeeper attachment URLs stable across rerenders

### DIFF
--- a/src/components/Thinking.spec.tsx
+++ b/src/components/Thinking.spec.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import { StrictMode } from 'react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
 import type { MlCopilotFile, MlCopilotServerMessage } from '@kittycad/lib'
@@ -222,78 +221,6 @@ describe('FilesSnapshot', () => {
     expect(revokeObjectURLMock).not.toHaveBeenCalled()
     unmount()
     expect(revokeObjectURLMock).toHaveBeenCalledTimes(2)
-  })
-
-  test('detaches an old image source before revoking it on replacement', () => {
-    const revokedWhileDisplayed: string[] = []
-    revokeObjectURLMock.mockImplementation((url: string) => {
-      if (
-        screen
-          .queryAllByRole('img')
-          .some((image) => image.getAttribute('src') === url)
-      ) {
-        revokedWhileDisplayed.push(url)
-      }
-    })
-    const file: MlCopilotFile = {
-      name: 'snapshot.png',
-      mimetype: 'image/png',
-      data: MOCK_PNG_DATA,
-    }
-    const { rerender, unmount } = render(<FilesSnapshot files={[file]} />)
-    const oldUrl = screen.getByAltText(file.name).getAttribute('src')
-
-    rerender(
-      <FilesSnapshot files={[{ ...file, data: [...MOCK_PNG_DATA, 0] }]} />
-    )
-    expect(screen.getByAltText(file.name)).not.toHaveAttribute('src', oldUrl)
-    expect(revokeObjectURLMock).toHaveBeenCalledExactlyOnceWith(oldUrl)
-    unmount()
-    expect(revokedWhileDisplayed).toEqual([])
-    expect(revokeObjectURLMock).toHaveBeenCalledTimes(2)
-  })
-
-  test('retries image rendering when a failed source is replaced', () => {
-    const file: MlCopilotFile = {
-      name: 'snapshot.png',
-      mimetype: 'image/png',
-      data: MOCK_PNG_DATA,
-    }
-    const { rerender } = render(<FilesSnapshot files={[file]} />)
-    fireEvent.error(screen.getByAltText(file.name))
-    expect(screen.queryByAltText(file.name)).not.toBeInTheDocument()
-
-    rerender(
-      <FilesSnapshot files={[{ ...file, data: [...MOCK_PNG_DATA, 0] }]} />
-    )
-    expect(screen.getByAltText(file.name)).toBeInTheDocument()
-  })
-
-  test('releases each URL once through StrictMode setup and final unmount', () => {
-    const file: MlCopilotFile = {
-      name: 'snapshot.png',
-      mimetype: 'image/png',
-      data: MOCK_PNG_DATA,
-    }
-    const view = () => (
-      <StrictMode>
-        <FilesSnapshot files={[file]} />
-      </StrictMode>
-    )
-    const { rerender, unmount } = render(view())
-    const url = screen.getByAltText(file.name).getAttribute('src')
-    const created = createObjectURLMock.mock.calls.length
-    rerender(view())
-    expect(screen.getByAltText(file.name)).toHaveAttribute('src', url)
-    expect(createObjectURLMock).toHaveBeenCalledTimes(created)
-    expect(revokeObjectURLMock).not.toHaveBeenCalledWith(url)
-    unmount()
-    const createdUrls = createObjectURLMock.mock.results.map(
-      ({ value }) => value
-    )
-    expect(revokeObjectURLMock.mock.calls.map(([url]) => url).sort()).toEqual(
-      createdUrls.sort()
-    )
   })
 
   test('renders a single image file with correct filename', () => {

--- a/src/components/Thinking.spec.tsx
+++ b/src/components/Thinking.spec.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react'
+import { StrictMode } from 'react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
 import type { MlCopilotFile, MlCopilotServerMessage } from '@kittycad/lib'
@@ -31,7 +32,10 @@ describe('FilesSnapshot', () => {
   let revokeObjectURLMock: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
-    createObjectURLMock = vi.fn((blob: Blob) => `blob:mock-url-${blob.type}`)
+    let nextUrl = 0
+    createObjectURLMock = vi.fn(
+      (blob: Blob) => `blob:mock-url-${blob.type}-${++nextUrl}`
+    )
     revokeObjectURLMock = vi.fn()
 
     global.URL.createObjectURL =
@@ -134,6 +138,162 @@ describe('FilesSnapshot', () => {
 
     expect(screen.getByAltText('reference.png')).toBeInTheDocument()
     expect(createObjectURLMock).toHaveBeenCalledOnce()
+  })
+
+  test('preserves image URLs when the reasoning parent rerenders', () => {
+    const file: MlCopilotFile = {
+      name: 'snapshot.png',
+      mimetype: 'image/png',
+      data: MOCK_PNG_DATA,
+    }
+    const view = () => (
+      <Thinking
+        thoughts={[{ files: { files: [{ ...file }] } }]}
+        isDone={true}
+        onlyShowImmediateThought={false}
+      />
+    )
+    const { rerender } = render(view())
+    const image = screen.getByAltText(file.name)
+    const url = image.getAttribute('src')
+
+    rerender(view())
+    rerender(view())
+
+    expect(screen.getByAltText(file.name)).toBe(image)
+    expect(image).toHaveAttribute('src', url)
+    expect(createObjectURLMock).toHaveBeenCalledOnce()
+    expect(revokeObjectURLMock).not.toHaveBeenCalled()
+  })
+
+  test('keeps a loaded image while another attachment loads', () => {
+    const firstRef = { prompt_id: 'prompt', seq: 1, index: 0 }
+    const secondRef = { ...firstRef, index: 1 }
+    const first: MlCopilotFile = {
+      name: 'first.png',
+      mimetype: 'image/png',
+      data: [],
+      attachment_ref: firstRef,
+    }
+    const second = { ...first, name: 'second.png', attachment_ref: secondRef }
+    const loadedFirst = { ...first, data: MOCK_PNG_DATA }
+    const loadedSecond = { ...second, data: MOCK_PNG_DATA }
+    const onFetchAttachment = vi.fn()
+    const { rerender, unmount } = render(
+      <FilesSnapshot
+        files={[first, second]}
+        attachmentFetches={{
+          'prompt:1:0': { status: 'loaded', file: loadedFirst },
+        }}
+        onFetchAttachment={onFetchAttachment}
+      />
+    )
+    const firstUrl = screen.getByAltText(first.name).getAttribute('src')
+
+    fireEvent.click(screen.getByRole('button', { name: /second.png: Load/ }))
+    expect(onFetchAttachment).toHaveBeenCalledExactlyOnceWith(secondRef)
+    rerender(
+      <FilesSnapshot
+        files={[first, second]}
+        attachmentFetches={{
+          'prompt:1:0': { status: 'loaded', file: loadedFirst },
+          'prompt:1:1': { status: 'loading' },
+        }}
+        onFetchAttachment={onFetchAttachment}
+      />
+    )
+    expect(screen.getByAltText(first.name)).toHaveAttribute('src', firstUrl)
+    expect(createObjectURLMock).toHaveBeenCalledOnce()
+    expect(revokeObjectURLMock).not.toHaveBeenCalled()
+
+    rerender(
+      <FilesSnapshot
+        files={[first, second]}
+        attachmentFetches={{
+          'prompt:1:0': { status: 'loaded', file: loadedFirst },
+          'prompt:1:1': { status: 'loaded', file: loadedSecond },
+        }}
+        onFetchAttachment={onFetchAttachment}
+      />
+    )
+    expect(screen.getByAltText(first.name)).toHaveAttribute('src', firstUrl)
+    expect(screen.getByAltText(second.name)).toBeInTheDocument()
+    expect(createObjectURLMock).toHaveBeenCalledTimes(2)
+    expect(revokeObjectURLMock).not.toHaveBeenCalled()
+    unmount()
+    expect(revokeObjectURLMock).toHaveBeenCalledTimes(2)
+  })
+
+  test('detaches an old image source before revoking it on replacement', () => {
+    const revokedWhileDisplayed: string[] = []
+    revokeObjectURLMock.mockImplementation((url: string) => {
+      if (
+        screen
+          .queryAllByRole('img')
+          .some((image) => image.getAttribute('src') === url)
+      ) {
+        revokedWhileDisplayed.push(url)
+      }
+    })
+    const file: MlCopilotFile = {
+      name: 'snapshot.png',
+      mimetype: 'image/png',
+      data: MOCK_PNG_DATA,
+    }
+    const { rerender, unmount } = render(<FilesSnapshot files={[file]} />)
+    const oldUrl = screen.getByAltText(file.name).getAttribute('src')
+
+    rerender(
+      <FilesSnapshot files={[{ ...file, data: [...MOCK_PNG_DATA, 0] }]} />
+    )
+    expect(screen.getByAltText(file.name)).not.toHaveAttribute('src', oldUrl)
+    expect(revokeObjectURLMock).toHaveBeenCalledExactlyOnceWith(oldUrl)
+    unmount()
+    expect(revokedWhileDisplayed).toEqual([])
+    expect(revokeObjectURLMock).toHaveBeenCalledTimes(2)
+  })
+
+  test('retries image rendering when a failed source is replaced', () => {
+    const file: MlCopilotFile = {
+      name: 'snapshot.png',
+      mimetype: 'image/png',
+      data: MOCK_PNG_DATA,
+    }
+    const { rerender } = render(<FilesSnapshot files={[file]} />)
+    fireEvent.error(screen.getByAltText(file.name))
+    expect(screen.queryByAltText(file.name)).not.toBeInTheDocument()
+
+    rerender(
+      <FilesSnapshot files={[{ ...file, data: [...MOCK_PNG_DATA, 0] }]} />
+    )
+    expect(screen.getByAltText(file.name)).toBeInTheDocument()
+  })
+
+  test('releases each URL once through StrictMode setup and final unmount', () => {
+    const file: MlCopilotFile = {
+      name: 'snapshot.png',
+      mimetype: 'image/png',
+      data: MOCK_PNG_DATA,
+    }
+    const view = () => (
+      <StrictMode>
+        <FilesSnapshot files={[file]} />
+      </StrictMode>
+    )
+    const { rerender, unmount } = render(view())
+    const url = screen.getByAltText(file.name).getAttribute('src')
+    const created = createObjectURLMock.mock.calls.length
+    rerender(view())
+    expect(screen.getByAltText(file.name)).toHaveAttribute('src', url)
+    expect(createObjectURLMock).toHaveBeenCalledTimes(created)
+    expect(revokeObjectURLMock).not.toHaveBeenCalledWith(url)
+    unmount()
+    const createdUrls = createObjectURLMock.mock.results.map(
+      ({ value }) => value
+    )
+    expect(revokeObjectURLMock.mock.calls.map(([url]) => url).sort()).toEqual(
+      createdUrls.sort()
+    )
   })
 
   test('renders a single image file with correct filename', () => {

--- a/src/components/Thinking.spec.tsx
+++ b/src/components/Thinking.spec.tsx
@@ -147,7 +147,7 @@ describe('FilesSnapshot', () => {
     }
     const view = () => (
       <Thinking
-        thoughts={[{ files: { files: [{ ...file }] } }]}
+        thoughts={[{ files: { files: [{ ...file, data: [...file.data] }] } }]}
         isDone={true}
         onlyShowImmediateThought={false}
       />
@@ -165,8 +165,13 @@ describe('FilesSnapshot', () => {
     expect(revokeObjectURLMock).not.toHaveBeenCalled()
   })
 
-  test('keeps a loaded image while another attachment loads', () => {
-    const firstRef = { prompt_id: 'prompt', seq: 1, index: 0 }
+  test('only recreates URLs when an attachment finishes loading', () => {
+    const firstRef = {
+      prompt_id: 'prompt',
+      seq: 1,
+      index: 0,
+      content_hash: 'sha256:' + '0'.repeat(64),
+    }
     const secondRef = { ...firstRef, index: 1 }
     const first: MlCopilotFile = {
       name: 'first.png',
@@ -215,12 +220,31 @@ describe('FilesSnapshot', () => {
         onFetchAttachment={onFetchAttachment}
       />
     )
-    expect(screen.getByAltText(first.name)).toHaveAttribute('src', firstUrl)
+    expect(screen.getByAltText(first.name)).not.toHaveAttribute('src', firstUrl)
     expect(screen.getByAltText(second.name)).toBeInTheDocument()
-    expect(createObjectURLMock).toHaveBeenCalledTimes(2)
-    expect(revokeObjectURLMock).not.toHaveBeenCalled()
+    expect(createObjectURLMock).toHaveBeenCalledTimes(3)
+    expect(revokeObjectURLMock).toHaveBeenCalledExactlyOnceWith(firstUrl)
     unmount()
-    expect(revokeObjectURLMock).toHaveBeenCalledTimes(2)
+    expect(revokeObjectURLMock).toHaveBeenCalledTimes(3)
+  })
+
+  test.each([
+    { label: 'inline bytes', data: [3, 2, 1], mimetype: 'image/png' },
+    { label: 'MIME type', data: [1, 2, 3], mimetype: 'image/jpeg' },
+  ])('updates the URL when $label changes', ({ data, mimetype }) => {
+    const file: MlCopilotFile = {
+      name: 'snapshot.png',
+      mimetype: 'image/png',
+      data: [1, 2, 3],
+    }
+    const { rerender } = render(<FilesSnapshot files={[file]} />)
+    const oldUrl = screen.getByAltText(file.name).getAttribute('src')
+
+    rerender(<FilesSnapshot files={[{ ...file, data, mimetype }]} />)
+
+    expect(screen.getByAltText(file.name)).not.toHaveAttribute('src', oldUrl)
+    expect(createObjectURLMock).toHaveBeenCalledTimes(2)
+    expect(revokeObjectURLMock).toHaveBeenCalledExactlyOnceWith(oldUrl)
   })
 
   test('renders a single image file with correct filename', () => {

--- a/src/components/Thinking.tsx
+++ b/src/components/Thinking.tsx
@@ -476,9 +476,9 @@ const ImageFileItem = (props: {
   url: string | undefined
   onDownload: (url: string, filename: string) => void
 }) => {
-  const [failedUrl, setFailedUrl] = useState<string>()
+  const [imageError, setImageError] = useState(false)
 
-  if (!props.url || props.url === failedUrl) {
+  if (!props.url || imageError) {
     // Fallback to file icon if image fails to load
     return (
       <button
@@ -509,7 +509,7 @@ const ImageFileItem = (props: {
           src={props.url}
           alt={props.file.name}
           className="block h-auto max-w-full"
-          onError={() => setFailedUrl(props.url)}
+          onError={() => setImageError(true)}
         />
       </button>
     </div>
@@ -519,24 +519,15 @@ const ImageFileItem = (props: {
 // Each rendered file owns its URL independently of the surrounding file list.
 const LoadedFileItem = (props: { file: MlCopilotFile }) => {
   const { data, mimetype } = props.file
-  const [objectUrl, setObjectUrl] = useState<{
-    data: number[]
-    mimetype: string
-    url: string
-  }>()
+  const [url, setUrl] = useState<string>()
 
   useEffect(() => {
-    if (data.length === 0) return
-    const url = bytesToDataUrl(data, mimetype)
-    setObjectUrl({ data, mimetype, url })
-    return () => URL.revokeObjectURL(url)
+    const url = data.length > 0 ? bytesToDataUrl(data, mimetype) : undefined
+    setUrl(url)
+    return () => {
+      if (url) URL.revokeObjectURL(url)
+    }
   }, [data, mimetype])
-
-  // Detach a replaced source in the commit before its effect cleanup revokes it.
-  const url =
-    objectUrl?.data === data && objectUrl.mimetype === mimetype
-      ? objectUrl.url
-      : undefined
 
   const handleDownload = (url: string, filename: string) => {
     const link = document.createElement('a')

--- a/src/components/Thinking.tsx
+++ b/src/components/Thinking.tsx
@@ -516,48 +516,9 @@ const ImageFileItem = (props: {
   )
 }
 
-// Each rendered file owns its URL independently of the surrounding file list.
-const LoadedFileItem = (props: { file: MlCopilotFile }) => {
-  const { data, mimetype } = props.file
-  const [url, setUrl] = useState<string>()
-
-  useEffect(() => {
-    const url = data.length > 0 ? bytesToDataUrl(data, mimetype) : undefined
-    setUrl(url)
-    return () => {
-      if (url) URL.revokeObjectURL(url)
-    }
-  }, [data, mimetype])
-
-  const handleDownload = (url: string, filename: string) => {
-    const link = document.createElement('a')
-    link.href = url
-    link.download = filename
-    document.body.appendChild(link)
-    link.click()
-    document.body.removeChild(link)
-  }
-
-  if (isImageMimetype(mimetype)) {
-    return (
-      <ImageFileItem file={props.file} url={url} onDownload={handleDownload} />
-    )
-  }
-
-  return (
-    <button
-      onClick={() => url && handleDownload(url, props.file.name)}
-      className="flex flex-row gap-2 items-center cursor-pointer hover:bg-chalkboard-20 dark:hover:bg-chalkboard-90 p-2 rounded transition-colors text-left w-full"
-      title={`Click to download ${props.file.name}`}
-    >
-      <CustomIcon name="file" className="w-5 h-5 flex-shrink-0" />
-      <span className="text-sm truncate">{props.file.name}</span>
-      <CustomIcon name="download" className="w-4 h-4 ml-auto flex-shrink-0" />
-    </button>
-  )
-}
-
 const FileList = (props: { files: MlCopilotFile[] } & AttachmentFetchProps) => {
+  const [objectUrls, setObjectUrls] = useState<Array<string | undefined>>([])
+
   const resolvedFiles = useMemo(
     () =>
       props.files.map((file) => {
@@ -570,6 +531,46 @@ const FileList = (props: { files: MlCopilotFile[] } & AttachmentFetchProps) => {
       }),
     [props.attachmentFetches, props.files]
   )
+
+  // Hashes identify loaded bytes; inline files fall back to their contents.
+  const contentKey = JSON.stringify(
+    resolvedFiles.map((file) => [
+      file.attachment_ref?.content_hash ?? file.data,
+      file.mimetype,
+      file.data.length > 0,
+      isReplayAttachmentUnavailable(file),
+    ])
+  )
+
+  useEffect(() => {
+    // Create object URLs for all files
+    const urls = resolvedFiles.map((file) =>
+      isReplayAttachmentUnavailable(file) || file.data.length === 0
+        ? undefined
+        : bytesToDataUrl(file.data, file.mimetype)
+    )
+    setObjectUrls(urls)
+
+    // Cleanup object URLs when component unmounts
+    return () => {
+      urls.forEach((url) => {
+        if (url) {
+          URL.revokeObjectURL(url)
+        }
+      })
+    }
+    // The key covers every file value used to create or skip an object URL.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [contentKey])
+
+  const handleDownload = (url: string, filename: string) => {
+    const link = document.createElement('a')
+    link.href = url
+    link.download = filename
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+  }
 
   const fileItems = resolvedFiles.map((file, index) => ({ file, index }))
   const imageFiles = fileItems.filter(({ file }) =>
@@ -610,7 +611,15 @@ const FileList = (props: { files: MlCopilotFile[] } & AttachmentFetchProps) => {
         const fetchItem = attachmentFetchItem(index)
         if (fetchItem) return fetchItem
 
-        return <LoadedFileItem key={`${file.name}-${index}`} file={file} />
+        const url = objectUrls[index]
+        return (
+          <ImageFileItem
+            key={`${file.name}-${index}`}
+            file={file}
+            url={url}
+            onDownload={handleDownload}
+          />
+        )
       })}
       {otherFiles.map(({ file, index }) => {
         if (isReplayAttachmentUnavailable(file)) {
@@ -621,7 +630,22 @@ const FileList = (props: { files: MlCopilotFile[] } & AttachmentFetchProps) => {
         const fetchItem = attachmentFetchItem(index)
         if (fetchItem) return fetchItem
 
-        return <LoadedFileItem key={`${file.name}-${index}`} file={file} />
+        const url = objectUrls[index]
+        return (
+          <button
+            key={`${file.name}-${index}`}
+            onClick={() => url && handleDownload(url, file.name)}
+            className="flex flex-row gap-2 items-center cursor-pointer hover:bg-chalkboard-20 dark:hover:bg-chalkboard-90 p-2 rounded transition-colors text-left w-full"
+            title={`Click to download ${file.name}`}
+          >
+            <CustomIcon name="file" className="w-5 h-5 flex-shrink-0" />
+            <span className="text-sm truncate">{file.name}</span>
+            <CustomIcon
+              name="download"
+              className="w-4 h-4 ml-auto flex-shrink-0"
+            />
+          </button>
+        )
       })}
     </div>
   )

--- a/src/components/Thinking.tsx
+++ b/src/components/Thinking.tsx
@@ -476,9 +476,9 @@ const ImageFileItem = (props: {
   url: string | undefined
   onDownload: (url: string, filename: string) => void
 }) => {
-  const [imageError, setImageError] = useState(false)
+  const [failedUrl, setFailedUrl] = useState<string>()
 
-  if (!props.url || imageError) {
+  if (!props.url || props.url === failedUrl) {
     // Fallback to file icon if image fails to load
     return (
       <button
@@ -509,16 +509,64 @@ const ImageFileItem = (props: {
           src={props.url}
           alt={props.file.name}
           className="block h-auto max-w-full"
-          onError={() => setImageError(true)}
+          onError={() => setFailedUrl(props.url)}
         />
       </button>
     </div>
   )
 }
 
-const FileList = (props: { files: MlCopilotFile[] } & AttachmentFetchProps) => {
-  const [objectUrls, setObjectUrls] = useState<Array<string | undefined>>([])
+// Each rendered file owns its URL independently of the surrounding file list.
+const LoadedFileItem = (props: { file: MlCopilotFile }) => {
+  const { data, mimetype } = props.file
+  const [objectUrl, setObjectUrl] = useState<{
+    data: number[]
+    mimetype: string
+    url: string
+  }>()
 
+  useEffect(() => {
+    if (data.length === 0) return
+    const url = bytesToDataUrl(data, mimetype)
+    setObjectUrl({ data, mimetype, url })
+    return () => URL.revokeObjectURL(url)
+  }, [data, mimetype])
+
+  // Detach a replaced source in the commit before its effect cleanup revokes it.
+  const url =
+    objectUrl?.data === data && objectUrl.mimetype === mimetype
+      ? objectUrl.url
+      : undefined
+
+  const handleDownload = (url: string, filename: string) => {
+    const link = document.createElement('a')
+    link.href = url
+    link.download = filename
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+  }
+
+  if (isImageMimetype(mimetype)) {
+    return (
+      <ImageFileItem file={props.file} url={url} onDownload={handleDownload} />
+    )
+  }
+
+  return (
+    <button
+      onClick={() => url && handleDownload(url, props.file.name)}
+      className="flex flex-row gap-2 items-center cursor-pointer hover:bg-chalkboard-20 dark:hover:bg-chalkboard-90 p-2 rounded transition-colors text-left w-full"
+      title={`Click to download ${props.file.name}`}
+    >
+      <CustomIcon name="file" className="w-5 h-5 flex-shrink-0" />
+      <span className="text-sm truncate">{props.file.name}</span>
+      <CustomIcon name="download" className="w-4 h-4 ml-auto flex-shrink-0" />
+    </button>
+  )
+}
+
+const FileList = (props: { files: MlCopilotFile[] } & AttachmentFetchProps) => {
   const resolvedFiles = useMemo(
     () =>
       props.files.map((file) => {
@@ -531,34 +579,6 @@ const FileList = (props: { files: MlCopilotFile[] } & AttachmentFetchProps) => {
       }),
     [props.attachmentFetches, props.files]
   )
-
-  useEffect(() => {
-    // Create object URLs for all files
-    const urls = resolvedFiles.map((file) =>
-      isReplayAttachmentUnavailable(file) || file.data.length === 0
-        ? undefined
-        : bytesToDataUrl(file.data, file.mimetype)
-    )
-    setObjectUrls(urls)
-
-    // Cleanup object URLs when component unmounts
-    return () => {
-      urls.forEach((url) => {
-        if (url) {
-          URL.revokeObjectURL(url)
-        }
-      })
-    }
-  }, [resolvedFiles])
-
-  const handleDownload = (url: string, filename: string) => {
-    const link = document.createElement('a')
-    link.href = url
-    link.download = filename
-    document.body.appendChild(link)
-    link.click()
-    document.body.removeChild(link)
-  }
 
   const fileItems = resolvedFiles.map((file, index) => ({ file, index }))
   const imageFiles = fileItems.filter(({ file }) =>
@@ -599,15 +619,7 @@ const FileList = (props: { files: MlCopilotFile[] } & AttachmentFetchProps) => {
         const fetchItem = attachmentFetchItem(index)
         if (fetchItem) return fetchItem
 
-        const url = objectUrls[index]
-        return (
-          <ImageFileItem
-            key={`${file.name}-${index}`}
-            file={file}
-            url={url}
-            onDownload={handleDownload}
-          />
-        )
+        return <LoadedFileItem key={`${file.name}-${index}`} file={file} />
       })}
       {otherFiles.map(({ file, index }) => {
         if (isReplayAttachmentUnavailable(file)) {
@@ -618,22 +630,7 @@ const FileList = (props: { files: MlCopilotFile[] } & AttachmentFetchProps) => {
         const fetchItem = attachmentFetchItem(index)
         if (fetchItem) return fetchItem
 
-        const url = objectUrls[index]
-        return (
-          <button
-            key={`${file.name}-${index}`}
-            onClick={() => url && handleDownload(url, file.name)}
-            className="flex flex-row gap-2 items-center cursor-pointer hover:bg-chalkboard-20 dark:hover:bg-chalkboard-90 p-2 rounded transition-colors text-left w-full"
-            title={`Click to download ${file.name}`}
-          >
-            <CustomIcon name="file" className="w-5 h-5 flex-shrink-0" />
-            <span className="text-sm truncate">{file.name}</span>
-            <CustomIcon
-              name="download"
-              className="w-4 h-4 ml-auto flex-shrink-0"
-            />
-          </button>
-        )
+        return <LoadedFileItem key={`${file.name}-${index}`} file={file} />
       })}
     </div>
   )


### PR DESCRIPTION
Closes #13793.

Loaded Zookeeper screenshots recreated and revoked their blob URLs on every reasoning rerender because the effect depended on a freshly allocated file list. Keep the existing component structure and make that effect depend on a stable content key instead. The key includes the attachment content hash (or byte contents for files without a hash), MIME type, loaded state, and unavailable state. No UI or download code is moved.

The unchanged-file rerender and loading-state regressions fail on the base. A hash-only key fails four checks: lazy loading, loading a second attachment, changed inline bytes, and MIME changes. The corrected key passes those checks and 56 focused tests. In an isolated Chromium comparison, 120 unchanged rerenders create zero new URLs instead of 120; resizing/scrolling also creates zero. Finishing an attachment load changes the whole list key, so the existing list-level effect rebuilds the URLs once. All ten URLs created across the candidate scenarios are released.

Hash-backed files avoid serializing their bytes. For legacy inline files without hashes, key generation serializes the bytes on each render; a synthetic Chromium stress check with four 1 MiB inline files measured 13.2 ms median per key (20 samples). The four hashed equivalents produced a 397-character key below the timer resolution. This small patch trades that fallback cost and one list rebuild on real content changes for avoiding the per-file component extraction.

Existing content-replacement/image-error behavior is preserved: old URLs can be revoked before images update, and a failed image needs a remount to recover. Packaged desktop replay and active-turn idle/reconnect smoke testing remain outstanding.
