### PR TITLE
Fix Feature Tree source navigation route

### DIFF
--- a/src/components/layout/areas/FeatureTreePane.spec.ts
+++ b/src/components/layout/areas/FeatureTreePane.spec.ts
@@ -2,6 +2,7 @@ import type { Operation, OpKclValue } from '@rust/kcl-lib/bindings/Operation'
 import {
   buildOperationTree,
   getFeatureTreeSketchSelectionContext,
+  getFeatureTreeSourceNavigationTarget,
   getFeatureTreeValueDetail,
   namedViewTooltipText,
   supportsZ0006AutoFixBeforeFeatureTreeEdit,
@@ -11,6 +12,47 @@ import { defaultNodePath, type OperationsByModule } from '@src/lang/wasm'
 import { describe, expect, it } from 'vitest'
 
 describe('FeatureTreePane', () => {
+  describe('getFeatureTreeSourceNavigationTarget', () => {
+    it('stays in the current editor when the executor reports an empty local module path', () => {
+      expect(
+        getFeatureTreeSourceNavigationTarget({
+          currentProjectPath: '/project/main.kcl',
+          targetModulePath: {
+            type: 'Local',
+            value: '',
+            original_import_path: null,
+          },
+        })
+      ).toBeNull()
+    })
+
+    it('stays in the current editor when the local module path is already executing', () => {
+      expect(
+        getFeatureTreeSourceNavigationTarget({
+          currentProjectPath: '/project/main.kcl',
+          targetModulePath: {
+            type: 'Local',
+            value: '/project/main.kcl',
+            original_import_path: null,
+          },
+        })
+      ).toBeNull()
+    })
+
+    it('navigates to a different local module path', () => {
+      expect(
+        getFeatureTreeSourceNavigationTarget({
+          currentProjectPath: '/project/main.kcl',
+          targetModulePath: {
+            type: 'Local',
+            value: '/project/imported.kcl',
+            original_import_path: './imported.kcl',
+          },
+        })
+      ).toBe('/project/imported.kcl')
+    })
+  })
+
   describe('getFeatureTreeSketchSelectionContext', () => {
     function modelingActor({
       liveSketchNoFace,

--- a/src/components/layout/areas/FeatureTreePane.tsx
+++ b/src/components/layout/areas/FeatureTreePane.tsx
@@ -1,4 +1,5 @@
 import type { Diagnostic } from '@codemirror/lint'
+import type { ModulePath } from '@rust/kcl-lib/bindings/ModulePath'
 import type { Operation, OpKclValue } from '@rust/kcl-lib/bindings/Operation'
 import type { PlaneName } from '@rust/kcl-lib/bindings/PlaneName'
 import { type ContextMenu, ContextMenuItem } from '@src/components/ContextMenu'
@@ -192,6 +193,25 @@ function openCodePane(layout: Layout, setLayout: (l: Layout) => void) {
       shouldExpand: true,
     })
   )
+}
+
+export function getFeatureTreeSourceNavigationTarget({
+  currentProjectPath,
+  targetModulePath,
+}: {
+  currentProjectPath: string | null | undefined
+  targetModulePath: ModulePath | undefined
+}): string | null {
+  if (targetModulePath?.type !== 'Local' || !currentProjectPath) {
+    return null
+  }
+
+  const targetPath = targetModulePath.value
+  if (!targetPath || currentProjectPath === targetPath) {
+    return null
+  }
+
+  return targetPath
 }
 
 export const FeatureTreePaneContents = memo(() => {
@@ -1091,16 +1111,18 @@ const OperationItem = ({
         openCodePane(l, layout.set)
       }
 
-      if (targetModulePath?.type === 'Local' && app.project) {
-        const targetPath = targetModulePath.value
-        if (app.project.executingPath !== targetPath) {
-          kclManager.pendingFeatureTreeSourceSelection = {
-            path: targetPath,
-            range: providedSourceRange ?? item.sourceRange,
-          }
-          await navigate(`${PATHS.FILE}/${encodeURIComponent(targetPath)}`)
-          return
+      const targetPath = getFeatureTreeSourceNavigationTarget({
+        currentProjectPath: app.project?.executingPath,
+        targetModulePath,
+      })
+
+      if (targetPath !== null) {
+        kclManager.pendingFeatureTreeSourceSelection = {
+          path: targetPath,
+          range: providedSourceRange ?? item.sourceRange,
         }
+        await navigate(`${PATHS.FILE}/${encodeURIComponent(targetPath)}`)
+        return
       }
 
       const moduleStartRange: SourceRange = [0, 0, targetModuleId]


### PR DESCRIPTION
Treat an empty local module path from Feature Tree source navigation as the current editor instead of routing to `/file/`. Real nonempty imported-module paths retain the existing cross-file navigation.

Fixes #13797. All 40 focused integration tests and touched-file checks pass; the repo-wide check still reports unrelated existing Biome failures.