### PR TITLE
docs: Fix doc comment link for square yards

### DIFF
--- a/rust/kcl-api/src/units.rs
+++ b/rust/kcl-api/src/units.rs
@@ -168,7 +168,7 @@ pub enum UnitArea {
     #[serde(rename = "mm2")]
     #[display("mm2")]
     SquareMillimeters,
-    /// Square yards <https://en.wikipedia.org/wiki/Square_mile>
+    /// Square yards <https://en.wikipedia.org/wiki/Square_yard>
     #[serde(rename = "yd2")]
     #[display("yd2")]
     SquareYards,

--- a/rust/kcl-python-bindings/kcl.pyi
+++ b/rust/kcl-python-bindings/kcl.pyi
@@ -1081,7 +1081,7 @@ class UnitArea(enum.Enum):
     """
     SquareYards = ...
     r"""
-    Square yards <https://en.wikipedia.org/wiki/Square_mile>
+    Square yards <https://en.wikipedia.org/wiki/Square_yard>
     """
 
 @typing.final


### PR DESCRIPTION
Found here:

- https://github.com/KittyCAD/modeling-app/pull/13801#discussion_r3990079504