### PR TITLE
Non-matching kclVersion in imported modules is an error in KCL 3

### DIFF
--- a/docs/kcl-lang/settings.md
+++ b/docs/kcl-lang/settings.md
@@ -61,9 +61,11 @@ Valid properties are:
       replaces a cut edge with a new face, so look up an edge (for example with
       `getOppositeEdge` or `getNextAdjacentEdge`) before the `fillet` or `chamfer` that
       consumes it, and store the result in a variable.
-    - Every imported file that declares its own `kclVersion` must declare the same version as
-      the file being executed. Mixing versions in one program is an error that names both
-      files. Imported files that declare no `kclVersion` are fine and run under the executed
-      file's version. The standard library is exempt.
+    - Every imported file that declares its own `kclVersion` must declare the
+      same version as the file being executed. Mixing versions in one program is
+      an error. Imported files that declare no `kclVersion` use the executed
+      file's version. But it's recommended to specify it in every file so that
+      viewing an imported file doesn't unintentionally change `kclVersion` to
+      the default of `1.0`.
 
 These settings override any project-wide settings (configured in project.toml or via the UI).

--- a/docs/kcl-lang/settings.md
+++ b/docs/kcl-lang/settings.md
@@ -61,5 +61,9 @@ Valid properties are:
       replaces a cut edge with a new face, so look up an edge (for example with
       `getOppositeEdge` or `getNextAdjacentEdge`) before the `fillet` or `chamfer` that
       consumes it, and store the result in a variable.
+    - Every imported file that declares its own `kclVersion` must declare the same version as
+      the file being executed. Mixing versions in one program is an error that names both
+      files. Imported files that declare no `kclVersion` are fine and run under the executed
+      file's version. The standard library is exempt.
 
 These settings override any project-wide settings (configured in project.toml or via the UI).

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -1030,6 +1030,12 @@ impl ExecutorContext {
     ) -> Result<ModuleExecutionOutcome, (KclError, Option<EnvironmentRef>, Option<ModuleArtifactState>)> {
         crate::log::log(format!("enter module {path} {}", exec_state.stack()));
 
+        // KCL 3.0: reject an imported file whose declared kclVersion differs
+        // from the entry point's before any of it executes.
+        exec_state
+            .check_imported_module_kcl_version(path, program, None)
+            .map_err(|err| (err, None, None))?;
+
         // When executing only the new statements in incremental execution or
         // mock executing for sketch mode, we need the scene objects that were
         // created during the last execution, which are in the execution cache.
@@ -1290,6 +1296,19 @@ impl ExecutorContext {
         let module_id = self
             .open_module(&import_stmt.path, attrs, &module_path, exec_state, source_range)
             .await?;
+
+        // KCL 3.0: check the imported file's declared kclVersion at the import
+        // site as well. Mock execution runs a whole-module import's body only
+        // when the module is referenced, so for an unreferenced one this is
+        // the only place the check can run. In engine execution, every
+        // imported module's body (and so this check) ran before the root body
+        // got here.
+        if let ImportPath::Kcl { .. } = &import_stmt.path
+            && let Some(ModuleRepr::Kcl(program, _)) =
+                exec_state.global.module_infos.get(&module_id).map(|info| &info.repr)
+        {
+            exec_state.check_imported_module_kcl_version(&module_path, program, Some(source_range))?;
+        }
 
         if let ModulePath::Local { value, .. } = &module_path {
             let name = import_stmt

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -4995,9 +4995,14 @@ startSketchOn(XY)
         }
     }
 
+    /// The `defaultAngleUnit` gate in an imported module follows the effective
+    /// kclVersion: the entry point's when it declares KCL 3.0, otherwise the
+    /// module's own (undeclared here, so 1.0). The module declares no
+    /// kclVersion because a KCL 3.0 entry point rejects an import declaring a
+    /// different one before this gate is reached.
     #[tokio::test(flavor = "multi_thread")]
     async fn default_angle_unit_in_import_uses_effective_kcl_version() {
-        let dep = "@settings(kclVersion = 2.0, defaultAngleUnit = deg)\nexport x = 1\n";
+        let dep = "@settings(defaultAngleUnit = deg)\nexport x = 1\n";
         for version in ["1.0", "2.0", "\"3.0-preview\""] {
             let main = format!("@settings(kclVersion = {version})\nimport x from \"dep.kcl\"\n");
             let result = execute_with_modules(&main, &[("dep.kcl", dep)]).await;
@@ -5210,25 +5215,28 @@ export fn filletedBox() {
 "#;
 
     /// A KCL 3.0 entry point pins the kclVersion for the whole execution: an
-    /// imported 2.0 module observes KCL 3.0 both in its module-level code and
-    /// in its functions, wherever they are called from.
+    /// imported module that declares no kclVersion (1.0 under the legacy
+    /// lookup) observes KCL 3.0 both in its module-level code and in its
+    /// functions, wherever they are called from. An import declaring a
+    /// different version is rejected instead; see
+    /// [`imported_module_kcl_version_must_match_v3_entry_point`].
     #[tokio::test(flavor = "multi_thread")]
     async fn entry_point_v3_pins_kcl_version_for_imported_modules() {
         use kittycad_modeling_cmds::shared::EdgeCutVersion;
 
-        let dep = format!("@settings(kclVersion = 2.0)\n{FILLET_AT_MODULE_TOP_LEVEL}");
+        let dep = FILLET_AT_MODULE_TOP_LEVEL;
         let main = r#"@settings(kclVersion = "3.0-preview")
 import "dep.kcl" as dep
 "#;
-        let result = execute_with_modules(main, &[("dep.kcl", &dep)]).await.unwrap();
+        let result = execute_with_modules(main, &[("dep.kcl", dep)]).await.unwrap();
         assert_eq!(emitted_fillet_versions_everywhere(&result), vec![EdgeCutVersion::V2]);
 
-        let dep = format!("@settings(kclVersion = 2.0)\n{FILLET_IN_EXPORTED_FN}");
+        let dep = FILLET_IN_EXPORTED_FN;
         let main = r#"@settings(kclVersion = "3.0-preview")
 import filletedBox from "dep.kcl"
 box = filletedBox()
 "#;
-        let result = execute_with_modules(main, &[("dep.kcl", &dep)]).await.unwrap();
+        let result = execute_with_modules(main, &[("dep.kcl", dep)]).await.unwrap();
         assert_eq!(emitted_fillet_versions_everywhere(&result), vec![EdgeCutVersion::V2]);
     }
 
@@ -5254,6 +5262,249 @@ box = filletedBox()
 "#;
         let result = execute_with_modules(main, &[("dep.kcl", &dep)]).await.unwrap();
         assert_eq!(emitted_fillet_versions_everywhere(&result), vec![EdgeCutVersion::V1]);
+    }
+
+    /// Builds a mock-engine context whose project directory holds `modules`
+    /// in an in-memory file system, with `main.kcl` as the current file so
+    /// that errors can name the entry point's path. Nothing touches disk, so
+    /// parallel tests share no state.
+    fn versioned_modules_context(modules: &[(&str, &str)]) -> ExecutorContext {
+        let project_dir = crate::TypedPath::new("/zma-kcl-version-mismatch");
+        // Key each module by the same join that import resolution performs,
+        // so the lookup matches on every platform.
+        let files = modules
+            .iter()
+            .map(|(name, source)| (project_dir.join(name).to_string(), source.as_bytes().to_vec()))
+            .collect();
+        ExecutorContext {
+            engine: Arc::new(EngineManager::new_mock()),
+            engine_batch: EngineBatchContext::default(),
+            fs: crate::fs::new_file_system_handle(crate::InMemoryFiles::new(files)),
+            settings: ExecutorSettings {
+                current_file: Some(project_dir.join("main.kcl")),
+                project_directory: Some(project_dir),
+                ..Default::default()
+            },
+            context_type: ContextType::Mock,
+            execution_callbacks: Default::default(),
+            executor_kind: machine::ExecutorKind::resolve(),
+            machine_call_depth_limit: crate::execution::machine::DEFAULT_MACHINE_CALL_DEPTH_LIMIT,
+        }
+    }
+
+    /// Runs `main` with `modules` (see [`versioned_modules_context`]) the way
+    /// engine execution does, which runs every imported module eagerly.
+    async fn run_versioned_modules(main: &str, modules: &[(&str, &str)]) -> Result<(), KclError> {
+        let ctx = versioned_modules_context(modules);
+        let program = crate::Program::parse_no_errs(main).unwrap();
+        let mut exec_state = ExecState::new(&ctx);
+        let result = ctx.run(&program, &mut exec_state).await;
+        ctx.close().await;
+        result.map(|_| ()).map_err(|err| err.error)
+    }
+
+    /// Runs `main` with `modules` (see [`versioned_modules_context`]) through
+    /// mock execution, which runs imported modules lazily.
+    async fn run_versioned_modules_mock(main: &str, modules: &[(&str, &str)]) -> Result<(), KclError> {
+        let ctx = versioned_modules_context(modules);
+        let program = crate::Program::parse_no_errs(main).unwrap();
+        let mock_config = MockConfig {
+            use_prev_memory: false,
+            ..Default::default()
+        };
+        let result = ctx.run_mock_returning_state(&program, &mock_config).await;
+        ctx.close().await;
+        result.map(|_| ()).map_err(|err| err.error)
+    }
+
+    const V3_MAIN_IMPORTING_DEP: &str =
+        "@settings(kclVersion = \"3.0-preview\")\nimport width from \"dep.kcl\"\nx = width\n";
+
+    fn dep_declaring(version: &str) -> String {
+        format!("@settings(kclVersion = {version})\nexport width = 10\n")
+    }
+
+    /// The error a mismatch between `main.kcl` and `dep.kcl` must produce,
+    /// with `expected_dep_version` as the imported file's version.
+    #[track_caller]
+    fn assert_kcl_version_mismatch(error: &KclError, expected_dep_version: &str) {
+        assert!(matches!(error, KclError::Semantic { .. }), "{error:#?}");
+        assert_eq!(
+            error.message(),
+            format!(
+                "Mixing KCL versions in a single program is not allowed. The entry point `/zma-kcl-version-mismatch/main.kcl` declares kclVersion 3.0-preview, but the imported file `/zma-kcl-version-mismatch/dep.kcl` declares kclVersion {expected_dep_version}. Update the kclVersion setting in one of these files to match the other."
+            )
+        );
+    }
+
+    /// A KCL 3.0 entry point rejects an imported file that declares a
+    /// different kclVersion. The error names both files and both versions,
+    /// points at the declaration in the imported file, and carries the import
+    /// site in the entry point as its outer frame.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn imported_module_kcl_version_must_match_v3_entry_point() {
+        for dep_version in ["2.0", "1.0"] {
+            let dep = dep_declaring(dep_version);
+            let error = run_versioned_modules(V3_MAIN_IMPORTING_DEP, &[("dep.kcl", &dep)])
+                .await
+                .expect_err("mismatched kclVersion should be rejected");
+            assert_kcl_version_mismatch(&error, dep_version);
+
+            let ranges = error.source_ranges();
+            assert_eq!(ranges.len(), 2, "{ranges:#?}");
+            // The `kclVersion = ...` setting in dep.kcl.
+            assert!(!ranges[0].module_id().is_top_level());
+            let declaration = format!("kclVersion = {dep_version}");
+            let start = dep.find(&declaration).unwrap();
+            assert_eq!((ranges[0].start(), ranges[0].end()), (start, start + declaration.len()));
+            // The import statement in main.kcl.
+            assert!(ranges[1].module_id().is_top_level());
+            let import_stmt = "import width from \"dep.kcl\"";
+            let start = V3_MAIN_IMPORTING_DEP.find(import_stmt).unwrap();
+            assert_eq!((ranges[1].start(), ranges[1].end()), (start, start + import_stmt.len()));
+            assert_eq!(
+                error
+                    .backtrace()
+                    .iter()
+                    .map(|frame| frame.fn_name.as_deref())
+                    .collect::<Vec<_>>(),
+                [Some("import dep.kcl"), None]
+            );
+        }
+    }
+
+    /// Imported files that declare no kclVersion are unaffected: they run
+    /// under the entry point's version, as before.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn imported_module_without_kcl_version_is_allowed_under_v3_entry_point() {
+        for dep in [
+            "export width = 10\n",
+            "@settings(defaultLengthUnit = in)\nexport width = 10\n",
+        ] {
+            run_versioned_modules(V3_MAIN_IMPORTING_DEP, &[("dep.kcl", dep)])
+                .await
+                .unwrap_or_else(|err| panic!("dep={dep:?}: {err:#?}"));
+        }
+    }
+
+    /// Declaring the entry point's own version, in any accepted spelling, is
+    /// a match.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn imported_module_matching_v3_kcl_version_is_allowed() {
+        for dep_version in ["\"3.0-preview\"", "\"3-preview\"", "\"3.0.0-preview\""] {
+            let dep = dep_declaring(dep_version);
+            run_versioned_modules(V3_MAIN_IMPORTING_DEP, &[("dep.kcl", &dep)])
+                .await
+                .unwrap_or_else(|err| panic!("dep={dep_version}: {err:#?}"));
+        }
+    }
+
+    /// Without a KCL 3.0 entry point, versions may still be mixed, as before.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn kcl_version_mismatch_is_not_checked_without_v3_entry_point() {
+        for main_header in ["", "@settings(kclVersion = 1.0)\n", "@settings(kclVersion = 2.0)\n"] {
+            for dep_version in ["1.0", "2.0", "\"3.0-preview\""] {
+                let main = format!("{main_header}import width from \"dep.kcl\"\nx = width\n");
+                let dep = dep_declaring(dep_version);
+                run_versioned_modules(&main, &[("dep.kcl", &dep)])
+                    .await
+                    .unwrap_or_else(|err| panic!("main={main_header:?} dep={dep_version}: {err:#?}"));
+            }
+        }
+    }
+
+    /// The check covers transitive imports. The message names the entry point
+    /// and the mismatched file; the file in between appears in the import
+    /// backtrace.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn transitive_import_kcl_version_mismatch_names_entry_point_and_mismatched_file() {
+        let main = "@settings(kclVersion = \"3.0-preview\")\nimport doubled from \"a.kcl\"\nx = doubled\n";
+        let a = "import width from \"b.kcl\"\nexport doubled = width * 2\n";
+        let b = dep_declaring("2.0");
+        let error = run_versioned_modules(main, &[("a.kcl", a), ("b.kcl", &b)])
+            .await
+            .expect_err("mismatched kclVersion in a transitive import should be rejected");
+        assert_eq!(
+            error.message(),
+            "Mixing KCL versions in a single program is not allowed. The entry point `/zma-kcl-version-mismatch/main.kcl` declares kclVersion 3.0-preview, but the imported file `/zma-kcl-version-mismatch/b.kcl` declares kclVersion 2.0. Update the kclVersion setting in one of these files to match the other."
+        );
+        assert_eq!(
+            error
+                .backtrace()
+                .iter()
+                .map(|frame| frame.fn_name.as_deref())
+                .collect::<Vec<_>>(),
+            [Some("import b.kcl"), Some("import a.kcl"), None]
+        );
+        let ranges = error.source_ranges();
+        assert_eq!(ranges.len(), 3, "{ranges:#?}");
+        assert!(!ranges[0].module_id().is_top_level());
+        assert!(!ranges[1].module_id().is_top_level());
+        assert!(ranges[2].module_id().is_top_level());
+    }
+
+    /// Mock execution runs a whole-module import's body only when the module
+    /// is referenced, so the check also runs at the import site.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unreferenced_whole_module_import_kcl_version_is_checked_in_mock_execution() {
+        let main = "@settings(kclVersion = \"3.0-preview\")\nimport \"dep.kcl\" as dep\nx = 1\n";
+        let dep = dep_declaring("2.0");
+        let error = run_versioned_modules_mock(main, &[("dep.kcl", &dep)])
+            .await
+            .expect_err("mismatched kclVersion should be rejected in mock execution");
+        assert_kcl_version_mismatch(&error, "2.0");
+        let ranges = error.source_ranges();
+        assert_eq!(ranges.len(), 2, "{ranges:#?}");
+        assert!(!ranges[0].module_id().is_top_level());
+        assert!(ranges[1].module_id().is_top_level());
+        let import_stmt = "import \"dep.kcl\" as dep";
+        let start = main.find(import_stmt).unwrap();
+        assert_eq!((ranges[1].start(), ranges[1].end()), (start, start + import_stmt.len()));
+
+        // Engine execution runs the module eagerly and rejects it too.
+        let error = run_versioned_modules(main, &[("dep.kcl", &dep)])
+            .await
+            .expect_err("mismatched kclVersion should be rejected in engine execution");
+        assert_kcl_version_mismatch(&error, "2.0");
+
+        // An undeclared version is fine in mock execution as well.
+        run_versioned_modules_mock(main, &[("dep.kcl", "export width = 10\n")])
+            .await
+            .unwrap();
+    }
+
+    /// Standard library modules declare kclVersion 1.0 but are exempt: they
+    /// always run under the entry point's version, and the user cannot edit
+    /// them. The prelude is imported implicitly; `std::turns` is imported
+    /// explicitly here.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn std_modules_are_exempt_from_kcl_version_matching() {
+        let main = "@settings(kclVersion = \"3.0-preview\", experimentalFeatures = allow)\nimport QUARTER_TURN from \"std::turns\"\nx = QUARTER_TURN\n";
+        run_versioned_modules(main, &[]).await.unwrap();
+        run_versioned_modules_mock(main, &[]).await.unwrap();
+    }
+
+    /// When execution was started without a file path, the message still
+    /// describes the entry point, just without a path.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn kcl_version_mismatch_without_entry_point_path() {
+        let dep = dep_declaring("2.0");
+        let error = execute_with_modules(V3_MAIN_IMPORTING_DEP, &[("dep.kcl", &dep)])
+            .await
+            .expect_err("mismatched kclVersion should be rejected");
+        let message = error.message();
+        assert!(
+            message.starts_with(
+                "Mixing KCL versions in a single program is not allowed. The entry point declares kclVersion 3.0-preview, but the imported file `"
+            ),
+            "{message}"
+        );
+        assert!(
+            message.ends_with(
+                "dep.kcl` declares kclVersion 2.0. Update the kclVersion setting in one of these files to match the other."
+            ),
+            "{message}"
+        );
     }
 
     #[track_caller]
@@ -5554,9 +5805,10 @@ x = f()
         );
 
         // A KCL 3.0 entry point applies early return everywhere, including
-        // inside an imported 2.0 module.
-        let dep = r#"@settings(kclVersion = 2.0)
-export fn f() {
+        // inside an imported module that declares no kclVersion (1.0 under the
+        // legacy lookup). Declaring 2.0 there is rejected as a version mismatch
+        // instead.
+        let dep = r#"export fn f() {
   return 1
   assert(1, isEqualTo = 2, error = "ran past return")
 }
@@ -5622,13 +5874,14 @@ assert(total, isEqualTo = 100, error = "each call returns 1")
 
     /// A return escaping to the top level of an imported module is rejected
     /// under a KCL 3.0 entry point. The entry module's version governs, so
-    /// the imported module declaring 2.0 doesn't opt back out. (Without a
-    /// KCL 3.0 entry point the return is silently ignored; see
+    /// the imported module, which declares no kclVersion (1.0 under the
+    /// legacy lookup), doesn't opt back out. Declaring 2.0 there would be
+    /// rejected as a version mismatch instead. (Without a KCL 3.0 entry point
+    /// the return is silently ignored; see
     /// top_level_if_arm_return_ignored_without_v3.)
     #[tokio::test(flavor = "multi_thread")]
     async fn top_level_if_arm_return_in_imported_module_errors_in_v3() {
-        let dep = r#"@settings(kclVersion = 2.0)
-x = if true {
+        let dep = r#"x = if true {
   return 1
   0
 } else {
@@ -6061,10 +6314,11 @@ x = leakCheck
         let result = execute_with_modules(main, &[("dep.kcl", dep)]).await.unwrap();
         assert_eq!(variable_f64(&result, "x"), 1.0);
 
-        // A KCL 3.0 entry point applies arm scoping everywhere,
-        // including inside an imported 2.0 module.
-        let dep = r#"@settings(kclVersion = 2.0)
-ignored = if true {
+        // A KCL 3.0 entry point applies arm scoping everywhere, including
+        // inside an imported module that declares no kclVersion (1.0 under the
+        // legacy lookup). Declaring 2.0 there is rejected as a version mismatch
+        // instead.
+        let dep = r#"ignored = if true {
   arm = 1
   arm
 } else {

--- a/rust/kcl-lib/src/execution/state.rs
+++ b/rust/kcl-lib/src/execution/state.rs
@@ -61,7 +61,9 @@ use crate::modules::ModulePath;
 use crate::modules::ModuleRepr;
 use crate::modules::ModuleSource;
 use crate::parsing::ast::types::Annotation;
+use crate::parsing::ast::types::Node;
 use crate::parsing::ast::types::NodeRef;
+use crate::parsing::ast::types::Program;
 use crate::parsing::ast::types::TagNode;
 
 /// State for executing a program.
@@ -1402,6 +1404,89 @@ impl ExecState {
             _ => None,
         };
     }
+
+    /// KCL 3.0: an imported file may not declare a kclVersion that differs
+    /// from the entry point's.
+    ///
+    /// Only applies when the entry point declares 3.0-preview or later; see
+    /// [`Self::set_entry_point_kcl_version`]. A file that declares no
+    /// kclVersion is fine: it runs under the entry point's version, as it
+    /// always has. Only user files (local imports) are checked. Standard
+    /// library modules are exempt: they ship with the interpreter, always run
+    /// under the entry point's pinned version, and the user cannot edit them
+    /// to resolve a mismatch. Foreign imports carry no KCL settings.
+    ///
+    /// `import_range` is the import statement when the check runs at the
+    /// import site; it is appended to the error so that the importing file is
+    /// labeled too. When the check runs as the module body starts executing,
+    /// the import backtrace added by the caller supplies that location.
+    pub(crate) fn check_imported_module_kcl_version(
+        &self,
+        path: &ModulePath,
+        program: &Node<Program>,
+        import_range: Option<SourceRange>,
+    ) -> Result<(), KclError> {
+        let Some(entry_point_version) = self.global.entry_point_kcl_version else {
+            return Ok(());
+        };
+        if !matches!(path, ModulePath::Local { .. }) {
+            return Ok(());
+        }
+        let Some((declared, declared_range)) = declared_kcl_version(program)? else {
+            return Ok(());
+        };
+        if declared == entry_point_version {
+            return Ok(());
+        }
+
+        // The root module's path is the executor's current file, which is
+        // empty when execution was started without one.
+        let entry_point = match self
+            .global
+            .module_infos
+            .get(&ModuleId::default())
+            .map(|info| &info.path)
+        {
+            Some(root @ ModulePath::Local { .. }) if !root.to_string().is_empty() => {
+                format!("The entry point `{root}`")
+            }
+            _ => "The entry point".to_owned(),
+        };
+        let mut source_ranges = vec![declared_range];
+        source_ranges.extend(import_range);
+        Err(KclError::new_semantic(KclErrorDetails::new(
+            format!(
+                "Mixing KCL versions in a single program is not allowed. {entry_point} declares kclVersion {}, but the imported file `{path}` declares kclVersion {}. Update the kclVersion setting in one of these files to match the other.",
+                entry_point_version.as_str(),
+                declared.as_str(),
+            ),
+            source_ranges,
+        )))
+    }
+}
+
+/// The kclVersion that a program's `@settings` annotations declare, with the
+/// source range of the declaring property, or `None` when the program does not
+/// declare one. The last declaration wins, as in
+/// [`MetaSettings::update_from_annotation`].
+pub(crate) fn declared_kcl_version(program: &Node<Program>) -> Result<Option<(KclVersion, SourceRange)>, KclError> {
+    let mut declared = None;
+    for annotation in &program.inner_attrs {
+        if annotation.name() != Some(annotations::SETTINGS) {
+            continue;
+        }
+        for property in annotation.properties.iter().flatten() {
+            if &*property.inner.key.name != annotations::SETTINGS_VERSION {
+                continue;
+            }
+            let value = annotations::expect_kcl_version(&property.inner.value)?;
+            let version = value.parse::<KclVersion>().map_err(|err| {
+                KclError::new_semantic(KclErrorDetails::new(err.to_string(), vec![property.as_source_range()]))
+            })?;
+            declared = Some((version, property.as_source_range()));
+        }
+    }
+    Ok(declared)
 }
 
 impl GlobalState {
@@ -1759,6 +1844,37 @@ mod tests {
     use crate::front::ObjectKind;
     use crate::front::Plane;
     use crate::front::SourceRef;
+
+    #[test]
+    fn declared_kcl_version_finds_the_setting_and_its_range() {
+        let parse = |code: &str| crate::parsing::top_level_parse(code).unwrap();
+
+        assert_eq!(super::declared_kcl_version(&parse("x = 1\n")).unwrap(), None);
+        assert_eq!(
+            super::declared_kcl_version(&parse("@settings(defaultLengthUnit = in)\nx = 1\n")).unwrap(),
+            None
+        );
+
+        let code = "@settings(defaultLengthUnit = in, kclVersion = 2.0)\nx = 1\n";
+        let (version, range) = super::declared_kcl_version(&parse(code)).unwrap().unwrap();
+        assert_eq!(version, KclVersion::V2);
+        let start = code.find("kclVersion").unwrap();
+        assert_eq!((range.start(), range.end()), (start, start + "kclVersion = 2.0".len()));
+
+        let (version, _) = super::declared_kcl_version(&parse("@settings(kclVersion = \"3.0-preview\")\n"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(version, KclVersion::V3Preview);
+
+        // An unknown version is an error located at the setting.
+        let code = "@settings(kclVersion = 9.0)\n";
+        let error = super::declared_kcl_version(&parse(code)).unwrap_err();
+        let start = code.find("kclVersion").unwrap();
+        assert_eq!(
+            error.source_ranges().first().map(|range| (range.start(), range.end())),
+            Some((start, start + "kclVersion = 9.0".len()))
+        );
+    }
 
     #[test]
     fn kcl_version_serializes_as_canonical_setting_value() {

--- a/rust/kcl-lib/src/execution/state.rs
+++ b/rust/kcl-lib/src/execution/state.rs
@@ -1417,9 +1417,7 @@ impl ExecState {
     /// to resolve a mismatch. Foreign imports carry no KCL settings.
     ///
     /// `import_range` is the import statement when the check runs at the
-    /// import site; it is appended to the error so that the importing file is
-    /// labeled too. When the check runs as the module body starts executing,
-    /// the import backtrace added by the caller supplies that location.
+    /// import site, which is included in the error.
     pub(crate) fn check_imported_module_kcl_version(
         &self,
         path: &ModulePath,

--- a/rust/kcl-lib/src/execution/state.rs
+++ b/rust/kcl-lib/src/execution/state.rs
@@ -1466,25 +1466,31 @@ impl ExecState {
 /// The kclVersion that a program's `@settings` annotations declare, with the
 /// source range of the declaring property, or `None` when the program does not
 /// declare one. The last declaration wins, as in
-/// [`MetaSettings::update_from_annotation`].
+/// [`MetaSettings::update_from_annotation`], so this searches from the end and
+/// stops at the first match.
 pub(crate) fn declared_kcl_version(program: &Node<Program>) -> Result<Option<(KclVersion, SourceRange)>, KclError> {
-    let mut declared = None;
-    for annotation in &program.inner_attrs {
-        if annotation.name() != Some(annotations::SETTINGS) {
-            continue;
-        }
-        for property in annotation.properties.iter().flatten() {
-            if &*property.inner.key.name != annotations::SETTINGS_VERSION {
-                continue;
-            }
-            let value = annotations::expect_kcl_version(&property.inner.value)?;
-            let version = value.parse::<KclVersion>().map_err(|err| {
-                KclError::new_semantic(KclErrorDetails::new(err.to_string(), vec![property.as_source_range()]))
-            })?;
-            declared = Some((version, property.as_source_range()));
-        }
-    }
-    Ok(declared)
+    let Some(property) = program
+        .inner_attrs
+        .iter()
+        .rev()
+        .filter(|annotation| annotation.name() == Some(annotations::SETTINGS))
+        .find_map(|annotation| {
+            annotation
+                .properties
+                .as_deref()
+                .unwrap_or_default()
+                .iter()
+                .rev()
+                .find(|property| &*property.inner.key.name == annotations::SETTINGS_VERSION)
+        })
+    else {
+        return Ok(None);
+    };
+    let value = annotations::expect_kcl_version(&property.inner.value)?;
+    let version = value.parse::<KclVersion>().map_err(|err| {
+        KclError::new_semantic(KclErrorDetails::new(err.to_string(), vec![property.as_source_range()]))
+    })?;
+    Ok(Some((version, property.as_source_range())))
 }
 
 impl GlobalState {
@@ -1863,6 +1869,17 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(version, KclVersion::V3Preview);
+
+        // The last declaration wins, whether it is in a later annotation or
+        // later within the same annotation.
+        let code = "@settings(kclVersion = 1.0)\n@settings(defaultLengthUnit = in)\n@settings(kclVersion = 2.0, kclVersion = \"3.0-preview\")\n";
+        let (version, range) = super::declared_kcl_version(&parse(code)).unwrap().unwrap();
+        assert_eq!(version, KclVersion::V3Preview);
+        let start = code.rfind("kclVersion").unwrap();
+        assert_eq!(
+            (range.start(), range.end()),
+            (start, start + "kclVersion = \"3.0-preview\"".len())
+        );
 
         // An unknown version is an error located at the setting.
         let code = "@settings(kclVersion = 9.0)\n";

--- a/rust/kcl-lib/src/simulation_tests.rs
+++ b/rust/kcl-lib/src/simulation_tests.rs
@@ -8309,3 +8309,24 @@ mod member_expression_order_v3 {
         super::execute(TEST_NAME, true).await
     }
 }
+mod import_kcl_version_mismatch_v3 {
+    const TEST_NAME: &str = "import_kcl_version_mismatch_v3";
+
+    /// Test parsing KCL.
+    #[test]
+    fn parse() {
+        super::parse(TEST_NAME)
+    }
+
+    /// Test that parsing and unparsing KCL produces the original KCL input.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unparse() {
+        super::unparse(TEST_NAME).await
+    }
+
+    /// Test that KCL is executed correctly.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn kcl_test_execute() {
+        super::execute(TEST_NAME, false).await
+    }
+}

--- a/rust/kcl-lib/tests/early_return_cross_module/ast.snap
+++ b/rust/kcl-lib/tests/early_return_cross_module/ast.snap
@@ -176,7 +176,7 @@ description: Result of parsing early_return_cross_module.kcl
         "preComments": [
           "// The entry point's kclVersion governs the whole execution: this",
           "// KCL 3.0 entry point gives early-return semantics to functions from",
-          "// an imported 2.0 module too."
+          "// an imported module that declares no kclVersion too."
         ],
         "properties": [
           {

--- a/rust/kcl-lib/tests/early_return_cross_module/dep.kcl
+++ b/rust/kcl-lib/tests/early_return_cross_module/dep.kcl
@@ -1,5 +1,5 @@
-@settings(kclVersion = 2.0)
-
+// Declares no kclVersion, so it runs under the entry point's version.
+// Declaring a different one would be rejected as a version mismatch.
 export fn addOne(@x) {
   return x + 1
   assert(1, isEqualTo = 2, error = "code after return ran in the imported module")

--- a/rust/kcl-lib/tests/early_return_cross_module/input.kcl
+++ b/rust/kcl-lib/tests/early_return_cross_module/input.kcl
@@ -1,6 +1,6 @@
 // The entry point's kclVersion governs the whole execution: this
 // KCL 3.0 entry point gives early-return semantics to functions from
-// an imported 2.0 module too.
+// an imported module that declares no kclVersion too.
 @settings(kclVersion = "3.0-preview")
 
 import addOne from "dep.kcl"

--- a/rust/kcl-lib/tests/early_return_cross_module/unparsed.snap
+++ b/rust/kcl-lib/tests/early_return_cross_module/unparsed.snap
@@ -4,7 +4,7 @@ description: Result of unparsing early_return_cross_module.kcl
 ---
 // The entry point's kclVersion governs the whole execution: this
 // KCL 3.0 entry point gives early-return semantics to functions from
-// an imported 2.0 module too.
+// an imported module that declares no kclVersion too.
 @settings(kclVersion = "3.0-preview")
 
 import addOne from "dep.kcl"

--- a/rust/kcl-lib/tests/early_return_cross_module/unparsed@dep.kcl.snap
+++ b/rust/kcl-lib/tests/early_return_cross_module/unparsed@dep.kcl.snap
@@ -2,8 +2,8 @@
 source: kcl-lib/src/simulation_tests.rs
 description: Result of unparsing tests/early_return_cross_module/dep.kcl
 ---
-@settings(kclVersion = 2.0)
-
+// Declares no kclVersion, so it runs under the entry point's version.
+// Declaring a different one would be rejected as a version mismatch.
 export fn addOne(@x) {
   return x + 1
   assert(1, isEqualTo = 2, error = "code after return ran in the imported module")

--- a/rust/kcl-lib/tests/import_kcl_version_mismatch_v3/artifact_commands.snap
+++ b/rust/kcl-lib/tests/import_kcl_version_mismatch_v3/artifact_commands.snap
@@ -1,0 +1,5 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Artifact commands import_kcl_version_mismatch_v3.kcl
+---
+{}

--- a/rust/kcl-lib/tests/import_kcl_version_mismatch_v3/artifact_graph_flowchart.snap
+++ b/rust/kcl-lib/tests/import_kcl_version_mismatch_v3/artifact_graph_flowchart.snap
@@ -1,0 +1,6 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Artifact graph flowchart import_kcl_version_mismatch_v3.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/rust/kcl-lib/tests/import_kcl_version_mismatch_v3/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/import_kcl_version_mismatch_v3/artifact_graph_flowchart.snap.md
@@ -1,0 +1,3 @@
+```mermaid
+flowchart LR
+```

--- a/rust/kcl-lib/tests/import_kcl_version_mismatch_v3/ast.snap
+++ b/rust/kcl-lib/tests/import_kcl_version_mismatch_v3/ast.snap
@@ -1,0 +1,155 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Result of parsing import_kcl_version_mismatch_v3.kcl
+---
+{
+  "Ok": {
+    "body": [
+      {
+        "commentStart": 0,
+        "end": 0,
+        "moduleId": 0,
+        "path": {
+          "type": "Kcl",
+          "filename": "dep.kcl"
+        },
+        "selector": {
+          "type": "List",
+          "items": [
+            {
+              "alias": null,
+              "commentStart": 0,
+              "end": 0,
+              "moduleId": 0,
+              "name": {
+                "commentStart": 0,
+                "end": 0,
+                "moduleId": 0,
+                "name": "width",
+                "start": 0,
+                "type": "Identifier"
+              },
+              "start": 0,
+              "type": "ImportItem"
+            }
+          ]
+        },
+        "start": 0,
+        "type": "ImportStatement",
+        "type": "ImportStatement"
+      },
+      {
+        "commentStart": 0,
+        "declaration": {
+          "commentStart": 0,
+          "end": 0,
+          "id": {
+            "commentStart": 0,
+            "end": 0,
+            "moduleId": 0,
+            "name": "x",
+            "start": 0,
+            "type": "Identifier"
+          },
+          "init": {
+            "abs_path": false,
+            "commentStart": 0,
+            "end": 0,
+            "moduleId": 0,
+            "name": {
+              "commentStart": 0,
+              "end": 0,
+              "moduleId": 0,
+              "name": "width",
+              "start": 0,
+              "type": "Identifier"
+            },
+            "path": [],
+            "start": 0,
+            "type": "Name",
+            "type": "Name"
+          },
+          "moduleId": 0,
+          "start": 0,
+          "type": "VariableDeclarator"
+        },
+        "end": 0,
+        "kind": "const",
+        "moduleId": 0,
+        "start": 0,
+        "type": "VariableDeclaration",
+        "type": "VariableDeclaration"
+      }
+    ],
+    "commentStart": 0,
+    "end": 0,
+    "innerAttrs": [
+      {
+        "commentStart": 0,
+        "end": 0,
+        "moduleId": 0,
+        "name": {
+          "commentStart": 0,
+          "end": 0,
+          "moduleId": 0,
+          "name": "settings",
+          "start": 0,
+          "type": "Identifier"
+        },
+        "preComments": [
+          "// KCL 3.0: an imported file may not declare a kclVersion that differs from",
+          "// the entry point's."
+        ],
+        "properties": [
+          {
+            "commentStart": 0,
+            "end": 0,
+            "key": {
+              "commentStart": 0,
+              "end": 0,
+              "moduleId": 0,
+              "name": "kclVersion",
+              "start": 0,
+              "type": "Identifier"
+            },
+            "moduleId": 0,
+            "start": 0,
+            "type": "ObjectProperty",
+            "value": {
+              "commentStart": 0,
+              "end": 0,
+              "moduleId": 0,
+              "raw": "\"3.0-preview\"",
+              "start": 0,
+              "type": "Literal",
+              "type": "Literal",
+              "value": "3.0-preview"
+            }
+          }
+        ],
+        "start": 0,
+        "type": "Annotation"
+      }
+    ],
+    "moduleId": 0,
+    "nonCodeMeta": {
+      "nonCodeNodes": {
+        "0": [
+          {
+            "commentStart": 0,
+            "end": 0,
+            "moduleId": 0,
+            "start": 0,
+            "type": "NonCodeNode",
+            "value": {
+              "type": "newLine"
+            }
+          }
+        ]
+      },
+      "startNodes": []
+    },
+    "start": 0,
+    "type": "Program"
+  }
+}

--- a/rust/kcl-lib/tests/import_kcl_version_mismatch_v3/dep.kcl
+++ b/rust/kcl-lib/tests/import_kcl_version_mismatch_v3/dep.kcl
@@ -1,0 +1,3 @@
+@settings(kclVersion = 2.0)
+
+export width = 10

--- a/rust/kcl-lib/tests/import_kcl_version_mismatch_v3/execution_error.snap
+++ b/rust/kcl-lib/tests/import_kcl_version_mismatch_v3/execution_error.snap
@@ -1,0 +1,32 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Error from executing import_kcl_version_mismatch_v3.kcl
+---
+KCL Semantic error
+
+  × semantic: Mixing KCL versions in a single program is not allowed. The
+  │ entry point `tests/import_kcl_version_mismatch_v3/input.kcl` declares
+  │ kclVersion 3.0-preview, but the imported file `tests/
+  │ import_kcl_version_mismatch_v3/dep.kcl` declares kclVersion 2.0. Update
+  │ the kclVersion setting in one of these files to match the other.
+   ╭─[1:11]
+ 1 │ @settings(kclVersion = 2.0)
+   ·           ────────┬───────
+   ·                   ╰── tests/import_kcl_version_mismatch_v3/dep.kcl
+ 2 │ 
+   ╰────
+  ╰─▶ KCL Semantic error
+      
+        × semantic: Mixing KCL versions in a single program is not allowed.
+        │ The entry point `tests/import_kcl_version_mismatch_v3/input.kcl`
+        │ declares kclVersion 3.0-preview, but the imported file `tests/
+        │ import_kcl_version_mismatch_v3/dep.kcl` declares kclVersion 2.0.
+        │ Update the kclVersion setting in one of these files to match the
+        │ other.
+         ╭─[5:1]
+       4 │
+       5 │ import width from "dep.kcl"
+         · ─────────────┬─────────────
+         ·              ╰── tests/import_kcl_version_mismatch_v3/input.kcl
+       6 │
+         ╰────

--- a/rust/kcl-lib/tests/import_kcl_version_mismatch_v3/input.kcl
+++ b/rust/kcl-lib/tests/import_kcl_version_mismatch_v3/input.kcl
@@ -1,0 +1,7 @@
+// KCL 3.0: an imported file may not declare a kclVersion that differs from
+// the entry point's.
+@settings(kclVersion = "3.0-preview")
+
+import width from "dep.kcl"
+
+x = width

--- a/rust/kcl-lib/tests/import_kcl_version_mismatch_v3/ops.snap
+++ b/rust/kcl-lib/tests/import_kcl_version_mismatch_v3/ops.snap
@@ -1,0 +1,164 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Operations executed import_kcl_version_mismatch_v3.kcl
+---
+{
+  "std::math": [
+    {
+      "type": "VariableDeclaration",
+      "name": "PI",
+      "value": {
+        "type": "Number",
+        "value": 3.141592653589793,
+        "ty": {
+          "type": "Unknown"
+        }
+      },
+      "visibility": "export",
+      "nodePath": {
+        "steps": []
+      },
+      "sourceRange": []
+    },
+    {
+      "type": "VariableDeclaration",
+      "name": "E",
+      "value": {
+        "type": "Number",
+        "value": 2.718281828459045,
+        "ty": {
+          "type": "Known",
+          "type": "Count"
+        }
+      },
+      "visibility": "export",
+      "nodePath": {
+        "steps": []
+      },
+      "sourceRange": []
+    },
+    {
+      "type": "VariableDeclaration",
+      "name": "TAU",
+      "value": {
+        "type": "Number",
+        "value": 6.283185307179586,
+        "ty": {
+          "type": "Known",
+          "type": "Count"
+        }
+      },
+      "visibility": "export",
+      "nodePath": {
+        "steps": []
+      },
+      "sourceRange": []
+    }
+  ],
+  "std::prelude": [
+    {
+      "type": "VariableDeclaration",
+      "name": "START",
+      "value": {
+        "type": "String",
+        "value": "start"
+      },
+      "visibility": "export",
+      "nodePath": {
+        "steps": []
+      },
+      "sourceRange": []
+    },
+    {
+      "type": "VariableDeclaration",
+      "name": "END",
+      "value": {
+        "type": "String",
+        "value": "end"
+      },
+      "visibility": "export",
+      "nodePath": {
+        "steps": []
+      },
+      "sourceRange": []
+    },
+    {
+      "type": "VariableDeclaration",
+      "name": "NEW",
+      "value": {
+        "type": "String",
+        "value": "new"
+      },
+      "visibility": "export",
+      "nodePath": {
+        "steps": []
+      },
+      "sourceRange": []
+    },
+    {
+      "type": "VariableDeclaration",
+      "name": "MERGE",
+      "value": {
+        "type": "String",
+        "value": "merge"
+      },
+      "visibility": "export",
+      "nodePath": {
+        "steps": []
+      },
+      "sourceRange": []
+    },
+    {
+      "type": "VariableDeclaration",
+      "name": "SOLID",
+      "value": {
+        "type": "String",
+        "value": "solid"
+      },
+      "visibility": "export",
+      "nodePath": {
+        "steps": []
+      },
+      "sourceRange": []
+    },
+    {
+      "type": "VariableDeclaration",
+      "name": "SURFACE",
+      "value": {
+        "type": "String",
+        "value": "surface"
+      },
+      "visibility": "export",
+      "nodePath": {
+        "steps": []
+      },
+      "sourceRange": []
+    },
+    {
+      "type": "VariableDeclaration",
+      "name": "CCW",
+      "value": {
+        "type": "String",
+        "value": "ccw"
+      },
+      "visibility": "export",
+      "nodePath": {
+        "steps": []
+      },
+      "sourceRange": []
+    },
+    {
+      "type": "VariableDeclaration",
+      "name": "CW",
+      "value": {
+        "type": "String",
+        "value": "cw"
+      },
+      "visibility": "export",
+      "nodePath": {
+        "steps": []
+      },
+      "sourceRange": []
+    }
+  ]
+}

--- a/rust/kcl-lib/tests/import_kcl_version_mismatch_v3/program_memory.snap
+++ b/rust/kcl-lib/tests/import_kcl_version_mismatch_v3/program_memory.snap
@@ -1,0 +1,5 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Variables in memory after executing import_kcl_version_mismatch_v3.kcl
+---
+{}

--- a/rust/kcl-lib/tests/import_kcl_version_mismatch_v3/unparsed.snap
+++ b/rust/kcl-lib/tests/import_kcl_version_mismatch_v3/unparsed.snap
@@ -1,0 +1,11 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Result of unparsing import_kcl_version_mismatch_v3.kcl
+---
+// KCL 3.0: an imported file may not declare a kclVersion that differs from
+// the entry point's.
+@settings(kclVersion = "3.0-preview")
+
+import width from "dep.kcl"
+
+x = width

--- a/rust/kcl-lib/tests/import_kcl_version_mismatch_v3/unparsed@dep.kcl.snap
+++ b/rust/kcl-lib/tests/import_kcl_version_mismatch_v3/unparsed@dep.kcl.snap
@@ -1,0 +1,7 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Result of unparsing tests/import_kcl_version_mismatch_v3/dep.kcl
+---
+@settings(kclVersion = 2.0)
+
+export width = 10


### PR DESCRIPTION
Resolves #13569

When you execute a KCL file, this file is call the entry-point of the program. It may declare a KCL version using `@settings(kclVersion = "3.0-preview")` and it may import other KCL files. The imported KCL files may also declare a KCL version. If the entry-point's declared KCL version is 3.0 or later (including 3.0-preview), it's an error for imported files to declare a KCL version that doesn't match.

```
// assembly.kcl
@settings(kclVersion = "3.0-preview")
import "part.kcl"
```

```
// part.kcl
@settings(kclVersion = 2.0) // error
```

Although it's possible to omit kclVersion from imported files, e.g. `part.kcl` -- in this case, they inherit the version from the entry-point file -- it is recommended to specify the version in every file so that when you view or otherwise execute the `part.kcl`, it correctly uses the kclVersion. When not specified in the entry-point file, the default kclVersion is 1.0, which is probably not what you want. We cannot change this because it would be a breaking change for old files that were created before KCL 2.0 existed.

### Why

This is required because going forward, the KCL version will be sent as part of the engine session setup, and engine will behave differently depending on that version. Not only would it be confusing to users reading KCL source for a version to change throughout a single execution, but certain semantics will be tied to the engine, and its version won't be able to change over the course of a KCL program execution.