### PR TITLE
Clarify deprecated sketch function guidance

### DIFF
--- a/docs/kcl-lang/pipelines.md
+++ b/docs/kcl-lang/pipelines.md
@@ -40,29 +40,25 @@ This helps keep your code neat and avoid unnecessary declarations.
 
 ## Pipelines and keyword arguments
 
-Say you have a long pipeline of sketch functions, like this:
+Say you have a long pipeline of functions that modify a solid, like this:
 
 ```kcl
-startSketchOn(XZ)
-  |> startProfile(at = [0, 0])
-  |> line(%, end = [3, 4])
-  |> line(%, end = [10, 10])
-  |> line(%, end = [-13, -14])
-  |> close(%)
+solid
+  |> appearance(%, color = "#ff0000")
+  |> appearance(%, metalness = 50)
+  |> appearance(%, roughness = 50)
 ```
 
-In this example, each function call outputs a sketch, and it gets put into the next function call via
+In this example, each function call outputs a solid, and it gets put into the next function call via
 the `%`, into the first (unlabeled) argument.
 
 If a function call uses an unlabeled first parameter, it will default to `%` if it's not given. This
-means that `|> line(%, end = [3, 4])` and `|> line(end = [3, 4])` are equivalent! So the above
+means that `|> appearance(%, color = "#ff0000")` and `|> appearance(color = "#ff0000")` are equivalent! So the above
 could be rewritten as 
 
 ```kcl
-startSketchOn(XZ)
-  |> startProfile(at = [0, 0])
-  |> line(end = [3, 4])
-  |> line(end = [10, 10])
-  |> line(end = [-13, -14])
-  |> close()
+solid
+  |> appearance(color = "#ff0000")
+  |> appearance(metalness = 50)
+  |> appearance(roughness = 50)
 ```

--- a/docs/kcl-std/functions/std-sketch-angledLine.md
+++ b/docs/kcl-std/functions/std-sketch-angledLine.md
@@ -24,6 +24,8 @@ angledLine(
 
 This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
+Legacy sketch functions cannot be used with constraints; strongly prefer
+constraint-based sketch functions inside a `sketch` block.
 
 ### Arguments
 

--- a/docs/kcl-std/functions/std-sketch-angledLine.md
+++ b/docs/kcl-std/functions/std-sketch-angledLine.md
@@ -25,7 +25,8 @@ angledLine(
 This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
 Legacy sketch functions cannot be used with constraints; strongly prefer
-constraint-based sketch functions inside a `sketch` block.
+[`solver::line`](/docs/kcl-std/functions/std-solver-line) with an angle
+constraint inside a `sketch` block instead.
 
 ### Arguments
 

--- a/docs/kcl-std/functions/std-sketch-angledLineThatIntersects.md
+++ b/docs/kcl-std/functions/std-sketch-angledLineThatIntersects.md
@@ -22,7 +22,8 @@ angledLineThatIntersects(
 This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
 Legacy sketch functions cannot be used with constraints; strongly prefer
-constraint-based sketch functions inside a `sketch` block.
+[`solver::line`](/docs/kcl-std/functions/std-solver-line) with angle and
+coincident constraints inside a `sketch` block instead.
 
 ### Arguments
 

--- a/docs/kcl-std/functions/std-sketch-angledLineThatIntersects.md
+++ b/docs/kcl-std/functions/std-sketch-angledLineThatIntersects.md
@@ -21,6 +21,8 @@ angledLineThatIntersects(
 
 This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
+Legacy sketch functions cannot be used with constraints; strongly prefer
+constraint-based sketch functions inside a `sketch` block.
 
 ### Arguments
 

--- a/docs/kcl-std/functions/std-sketch-arc.md
+++ b/docs/kcl-std/functions/std-sketch-arc.md
@@ -25,7 +25,8 @@ arc(
 This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
 Legacy sketch functions cannot be used with constraints; strongly prefer
-constraint-based sketch functions inside a `sketch` block.
+[`solver::arc`](/docs/kcl-std/functions/std-solver-arc) inside a `sketch`
+block instead.
 
 The arc is constructed such that the current position of the sketch is
 placed along an imaginary circle of the specified radius, at angleStart

--- a/docs/kcl-std/functions/std-sketch-arc.md
+++ b/docs/kcl-std/functions/std-sketch-arc.md
@@ -24,6 +24,8 @@ arc(
 
 This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
+Legacy sketch functions cannot be used with constraints; strongly prefer
+constraint-based sketch functions inside a `sketch` block.
 
 The arc is constructed such that the current position of the sketch is
 placed along an imaginary circle of the specified radius, at angleStart

--- a/docs/kcl-std/functions/std-sketch-bezierCurve.md
+++ b/docs/kcl-std/functions/std-sketch-bezierCurve.md
@@ -23,8 +23,10 @@ bezierCurve(
 ```
 
 This is part of sketch v1 and is deprecated in favor of
-[sketch-solve](/docs/kcl-std/modules/std-solver). The sketch-solve version
-of bezier curve is still under development.
+[sketch-solve](/docs/kcl-std/modules/std-solver). Legacy sketch functions
+cannot be used with constraints; strongly prefer constraint-based sketch
+functions when possible. No constraint-based Bezier curve is available yet;
+first try approximating the shape with one or more constrained arcs.
 
 ### Arguments
 

--- a/docs/kcl-std/functions/std-sketch-circle.md
+++ b/docs/kcl-std/functions/std-sketch-circle.md
@@ -19,7 +19,9 @@ circle(
 ): Sketch
 ```
 
-This is part of sketch v1 and is deprecated. In KCL 2, create a
+This is part of sketch v1 and is deprecated. Legacy sketch functions cannot
+be used with constraints. Strongly prefer constraint-based sketch functions:
+in KCL 2, create a
 [`solver::circle`](/docs/kcl-std/functions/std-solver-circle) inside a
 [`sketch` block](/docs/kcl-lang/sketches), then select the
 closed profile with [`region`](/docs/kcl-std/functions/std-sketch-region).

--- a/docs/kcl-std/functions/std-sketch-circleThreePoint.md
+++ b/docs/kcl-std/functions/std-sketch-circleThreePoint.md
@@ -21,6 +21,8 @@ circleThreePoint(
 
 This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
+Legacy sketch functions cannot be used with constraints; strongly prefer
+constraint-based sketch functions inside a `sketch` block.
 
 ### Arguments
 

--- a/docs/kcl-std/functions/std-sketch-circleThreePoint.md
+++ b/docs/kcl-std/functions/std-sketch-circleThreePoint.md
@@ -22,7 +22,8 @@ circleThreePoint(
 This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
 Legacy sketch functions cannot be used with constraints; strongly prefer
-constraint-based sketch functions inside a `sketch` block.
+[`solver::circle`](/docs/kcl-std/functions/std-solver-circle) inside a
+`sketch` block instead.
 
 ### Arguments
 

--- a/docs/kcl-std/functions/std-sketch-close.md
+++ b/docs/kcl-std/functions/std-sketch-close.md
@@ -18,6 +18,8 @@ close(
 
 This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
+Legacy sketch functions cannot be used with constraints; strongly prefer
+constraint-based sketch functions inside a `sketch` block.
 
 If you want to perform some 3-dimensional operation on a sketch, like
 extrude or sweep, you must `close` it first. `close` must be called even

--- a/docs/kcl-std/functions/std-sketch-close.md
+++ b/docs/kcl-std/functions/std-sketch-close.md
@@ -19,7 +19,8 @@ close(
 This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
 Legacy sketch functions cannot be used with constraints; strongly prefer
-constraint-based sketch functions inside a `sketch` block.
+[`solver::coincident`](/docs/kcl-std/functions/std-solver-coincident)
+constraints inside a `sketch` block instead.
 
 If you want to perform some 3-dimensional operation on a sketch, like
 extrude or sweep, you must `close` it first. `close` must be called even

--- a/docs/kcl-std/functions/std-sketch-conic.md
+++ b/docs/kcl-std/functions/std-sketch-conic.md
@@ -24,8 +24,10 @@ conic(
 ```
 
 This is part of sketch v1 and is soft deprecated in favor of
-[sketch-solve](/docs/kcl-std/modules/std-solver). The sketch-solve version
-of conic is still under development.
+[sketch-solve](/docs/kcl-std/modules/std-solver). Legacy sketch functions
+cannot be used with constraints; strongly prefer constraint-based sketch
+functions when possible. No constraint-based conic is available yet; first
+try approximating the shape with one or more constrained arcs.
 
 ### Arguments
 

--- a/docs/kcl-std/functions/std-sketch-ellipse.md
+++ b/docs/kcl-std/functions/std-sketch-ellipse.md
@@ -21,8 +21,10 @@ ellipse(
 ```
 
 This is part of sketch v1 and is soft deprecated in favor of
-[sketch-solve](/docs/kcl-std/modules/std-solver). The sketch-solve version
-of ellipse is still under development.
+[sketch-solve](/docs/kcl-std/modules/std-solver). Legacy sketch functions
+cannot be used with constraints; strongly prefer constraint-based sketch
+functions when possible. No constraint-based ellipse is available yet; first
+try approximating the shape with one or more constrained arcs.
 
 ### Arguments
 

--- a/docs/kcl-std/functions/std-sketch-elliptic.md
+++ b/docs/kcl-std/functions/std-sketch-elliptic.md
@@ -23,8 +23,10 @@ elliptic(
 ```
 
 This is part of sketch v1 and is soft deprecated in favor of
-[sketch-solve](/docs/kcl-std/modules/std-solver). The sketch-solve version
-of elliptic is still under development.
+[sketch-solve](/docs/kcl-std/modules/std-solver). Legacy sketch functions
+cannot be used with constraints; strongly prefer constraint-based sketch
+functions when possible. No constraint-based elliptic curve is available
+yet; first try approximating the shape with one or more constrained arcs.
 
 ### Arguments
 

--- a/docs/kcl-std/functions/std-sketch-hyperbolic.md
+++ b/docs/kcl-std/functions/std-sketch-hyperbolic.md
@@ -23,8 +23,10 @@ hyperbolic(
 ```
 
 This is part of sketch v1 and is soft deprecated in favor of
-[sketch-solve](/docs/kcl-std/modules/std-solver). The sketch-solve version
-of hyperbolic is still under development.
+[sketch-solve](/docs/kcl-std/modules/std-solver). Legacy sketch functions
+cannot be used with constraints; strongly prefer constraint-based sketch
+functions when possible. No constraint-based hyperbola is available yet;
+first try approximating the shape with one or more constrained arcs.
 
 ### Arguments
 

--- a/docs/kcl-std/functions/std-sketch-involuteCircular.md
+++ b/docs/kcl-std/functions/std-sketch-involuteCircular.md
@@ -25,6 +25,8 @@ involuteCircular(
 This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver) and the
 [gear module](/docs/kcl-std/modules/std-gear).
+Legacy sketch functions cannot be used with constraints; strongly prefer
+constraint-based sketch functions inside a `sketch` block.
 
 ### Arguments
 

--- a/docs/kcl-std/functions/std-sketch-involuteCircular.md
+++ b/docs/kcl-std/functions/std-sketch-involuteCircular.md
@@ -26,7 +26,8 @@ This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver) and the
 [gear module](/docs/kcl-std/modules/std-gear).
 Legacy sketch functions cannot be used with constraints; strongly prefer
-constraint-based sketch functions inside a `sketch` block.
+the gear module when it applies. No constraint-based involute is available
+yet; first try approximating the shape with one or more constrained arcs.
 
 ### Arguments
 

--- a/docs/kcl-std/functions/std-sketch-line.md
+++ b/docs/kcl-std/functions/std-sketch-line.md
@@ -20,6 +20,8 @@ line(
 
 This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
+Legacy sketch functions cannot be used with constraints; strongly prefer
+constraint-based sketch functions inside a `sketch` block.
 
 ### Arguments
 

--- a/docs/kcl-std/functions/std-sketch-line.md
+++ b/docs/kcl-std/functions/std-sketch-line.md
@@ -21,7 +21,8 @@ line(
 This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
 Legacy sketch functions cannot be used with constraints; strongly prefer
-constraint-based sketch functions inside a `sketch` block.
+[`solver::line`](/docs/kcl-std/functions/std-solver-line) inside a `sketch`
+block instead.
 
 ### Arguments
 

--- a/docs/kcl-std/functions/std-sketch-parabolic.md
+++ b/docs/kcl-std/functions/std-sketch-parabolic.md
@@ -22,8 +22,10 @@ parabolic(
 ```
 
 This is part of sketch v1 and is soft deprecated in favor of
-[sketch-solve](/docs/kcl-std/modules/std-solver). The sketch-solve version
-of parabolic is still under development.
+[sketch-solve](/docs/kcl-std/modules/std-solver). Legacy sketch functions
+cannot be used with constraints; strongly prefer constraint-based sketch
+functions when possible. No constraint-based parabola is available yet;
+first try approximating the shape with one or more constrained arcs.
 
 ### Arguments
 

--- a/docs/kcl-std/functions/std-sketch-polygon.md
+++ b/docs/kcl-std/functions/std-sketch-polygon.md
@@ -21,6 +21,8 @@ polygon(
 
 This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
+Legacy sketch functions cannot be used with constraints; strongly prefer
+constraint-based sketch functions inside a `sketch` block.
 
 ### Arguments
 

--- a/docs/kcl-std/functions/std-sketch-polygon.md
+++ b/docs/kcl-std/functions/std-sketch-polygon.md
@@ -22,7 +22,8 @@ polygon(
 This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
 Legacy sketch functions cannot be used with constraints; strongly prefer
-constraint-based sketch functions inside a `sketch` block.
+[`solver::line`](/docs/kcl-std/functions/std-solver-line) segments inside a
+`sketch` block instead.
 
 ### Arguments
 

--- a/docs/kcl-std/functions/std-sketch-rectangle.md
+++ b/docs/kcl-std/functions/std-sketch-rectangle.md
@@ -21,6 +21,8 @@ rectangle(
 
 This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
+Legacy sketch functions cannot be used with constraints; strongly prefer
+constraint-based sketch functions inside a `sketch` block.
 
 A rectangle can be defined by its width, height, and location. Either the center or corner must be provided, but not both, to specify its location.
 

--- a/docs/kcl-std/functions/std-sketch-rectangle.md
+++ b/docs/kcl-std/functions/std-sketch-rectangle.md
@@ -22,7 +22,8 @@ rectangle(
 This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
 Legacy sketch functions cannot be used with constraints; strongly prefer
-constraint-based sketch functions inside a `sketch` block.
+[`solver::line`](/docs/kcl-std/functions/std-solver-line) segments inside a
+`sketch` block instead.
 
 A rectangle can be defined by its width, height, and location. Either the center or corner must be provided, but not both, to specify its location.
 

--- a/docs/kcl-std/functions/std-sketch-startProfile.md
+++ b/docs/kcl-std/functions/std-sketch-startProfile.md
@@ -20,7 +20,7 @@ startProfile(
 This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
 Legacy sketch functions cannot be used with constraints; strongly prefer
-constraint-based sketch functions inside a `sketch` block.
+a [`sketch` block](/docs/kcl-lang/sketches) instead.
 
 ### Arguments
 

--- a/docs/kcl-std/functions/std-sketch-startProfile.md
+++ b/docs/kcl-std/functions/std-sketch-startProfile.md
@@ -19,6 +19,8 @@ startProfile(
 
 This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
+Legacy sketch functions cannot be used with constraints; strongly prefer
+constraint-based sketch functions inside a `sketch` block.
 
 ### Arguments
 

--- a/docs/kcl-std/functions/std-sketch-startSketchOn.md
+++ b/docs/kcl-std/functions/std-sketch-startSketchOn.md
@@ -22,7 +22,7 @@ startSketchOn(
 This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
 Legacy sketch functions cannot be used with constraints; strongly prefer
-constraint-based sketch functions inside a `sketch` block.
+a [`sketch` block](/docs/kcl-lang/sketches) instead.
 
 ### Sketch on Face Behavior
 

--- a/docs/kcl-std/functions/std-sketch-startSketchOn.md
+++ b/docs/kcl-std/functions/std-sketch-startSketchOn.md
@@ -21,6 +21,8 @@ startSketchOn(
 
 This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
+Legacy sketch functions cannot be used with constraints; strongly prefer
+constraint-based sketch functions inside a `sketch` block.
 
 ### Sketch on Face Behavior
 

--- a/docs/kcl-std/functions/std-sketch-subtract2d.md
+++ b/docs/kcl-std/functions/std-sketch-subtract2d.md
@@ -16,7 +16,9 @@ subtract2d(
 ): Sketch
 ```
 
-This is part of sketch v1 and is deprecated. In KCL 2, construct the outer
+This is part of sketch v1 and is deprecated. Legacy sketch functions cannot
+be used with constraints. Strongly prefer constraint-based sketch functions:
+in KCL 2, construct the outer
 boundary and hole as segments inside a
 [`sketch` block](/docs/kcl-lang/sketches), then select the
 required bounded face with

--- a/docs/kcl-std/functions/std-sketch-tangentialArc.md
+++ b/docs/kcl-std/functions/std-sketch-tangentialArc.md
@@ -24,7 +24,8 @@ tangentialArc(
 This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
 Legacy sketch functions cannot be used with constraints; strongly prefer
-constraint-based sketch functions inside a `sketch` block.
+[`solver::arc`](/docs/kcl-std/functions/std-solver-arc) with tangent
+constraints inside a `sketch` block instead.
 
 When using radius and angle, draw a curved line segment along part of an
 imaginary circle. The arc is constructed such that the last line segment is

--- a/docs/kcl-std/functions/std-sketch-tangentialArc.md
+++ b/docs/kcl-std/functions/std-sketch-tangentialArc.md
@@ -23,6 +23,8 @@ tangentialArc(
 
 This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
+Legacy sketch functions cannot be used with constraints; strongly prefer
+constraint-based sketch functions inside a `sketch` block.
 
 When using radius and angle, draw a curved line segment along part of an
 imaginary circle. The arc is constructed such that the last line segment is

--- a/docs/kcl-std/functions/std-sketch-xLine.md
+++ b/docs/kcl-std/functions/std-sketch-xLine.md
@@ -20,6 +20,8 @@ xLine(
 
 This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
+Legacy sketch functions cannot be used with constraints; strongly prefer
+constraint-based sketch functions inside a `sketch` block.
 
 ### Arguments
 

--- a/docs/kcl-std/functions/std-sketch-xLine.md
+++ b/docs/kcl-std/functions/std-sketch-xLine.md
@@ -21,7 +21,8 @@ xLine(
 This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
 Legacy sketch functions cannot be used with constraints; strongly prefer
-constraint-based sketch functions inside a `sketch` block.
+[`solver::line`](/docs/kcl-std/functions/std-solver-line) with horizontal
+or vertical constraints inside a `sketch` block instead.
 
 ### Arguments
 

--- a/docs/kcl-std/functions/std-sketch-yLine.md
+++ b/docs/kcl-std/functions/std-sketch-yLine.md
@@ -20,6 +20,8 @@ yLine(
 
 This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
+Legacy sketch functions cannot be used with constraints; strongly prefer
+constraint-based sketch functions inside a `sketch` block.
 
 ### Arguments
 

--- a/docs/kcl-std/functions/std-sketch-yLine.md
+++ b/docs/kcl-std/functions/std-sketch-yLine.md
@@ -21,7 +21,8 @@ yLine(
 This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
 Legacy sketch functions cannot be used with constraints; strongly prefer
-constraint-based sketch functions inside a `sketch` block.
+[`solver::line`](/docs/kcl-std/functions/std-solver-line) with horizontal
+or vertical constraints inside a `sketch` block instead.
 
 ### Arguments
 

--- a/rust/kcl-lib/std/sketch.kcl
+++ b/rust/kcl-lib/std/sketch.kcl
@@ -14,7 +14,7 @@ import Axis2d, Axis3d, BoundedEdge, Edge, Face, Helix, Plane, Point2d, Point3d, 
 /// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
 /// Legacy sketch functions cannot be used with constraints; strongly prefer
-/// constraint-based sketch functions inside a `sketch` block.
+/// a [`sketch` block](/docs/kcl-lang/sketches) instead.
 ///
 /// ### Sketch on Face Behavior
 ///
@@ -295,7 +295,7 @@ export fn startSketchOn(
 /// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
 /// Legacy sketch functions cannot be used with constraints; strongly prefer
-/// constraint-based sketch functions inside a `sketch` block.
+/// a [`sketch` block](/docs/kcl-lang/sketches) instead.
 ///
 /// ```kcl,legacySketch
 /// exampleSketch = startSketchOn(XZ)
@@ -364,7 +364,8 @@ export fn startProfile(
 /// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
 /// Legacy sketch functions cannot be used with constraints; strongly prefer
-/// constraint-based sketch functions inside a `sketch` block.
+/// [`solver::line`](/docs/kcl-std/functions/std-solver-line) segments inside a
+/// `sketch` block instead.
 ///
 /// A rectangle can be defined by its width, height, and location. Either the center or corner must be provided, but not both, to specify its location.
 ///
@@ -1474,7 +1475,8 @@ export fn getBoundedEdge(
 /// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
 /// Legacy sketch functions cannot be used with constraints; strongly prefer
-/// constraint-based sketch functions inside a `sketch` block.
+/// [`solver::circle`](/docs/kcl-std/functions/std-solver-circle) inside a
+/// `sketch` block instead.
 ///
 /// ```kcl,legacySketch
 /// exampleSketch = startSketchOn(XY)
@@ -1500,7 +1502,8 @@ export fn circleThreePoint(
 /// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
 /// Legacy sketch functions cannot be used with constraints; strongly prefer
-/// constraint-based sketch functions inside a `sketch` block.
+/// [`solver::line`](/docs/kcl-std/functions/std-solver-line) segments inside a
+/// `sketch` block instead.
 ///
 /// ```kcl,legacySketch
 /// // Create a regular hexagon inscribed in a circle of radius 10
@@ -2549,7 +2552,8 @@ export fn profileStartY(
 /// [sketch-solve](/docs/kcl-std/modules/std-solver) and the
 /// [gear module](/docs/kcl-std/modules/std-gear).
 /// Legacy sketch functions cannot be used with constraints; strongly prefer
-/// constraint-based sketch functions inside a `sketch` block.
+/// the gear module when it applies. No constraint-based involute is available
+/// yet; first try approximating the shape with one or more constrained arcs.
 ///
 /// ```kcl,no3d,legacySketch
 /// a = 10
@@ -2632,7 +2636,8 @@ export fn involuteCircular(
 /// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
 /// Legacy sketch functions cannot be used with constraints; strongly prefer
-/// constraint-based sketch functions inside a `sketch` block.
+/// [`solver::line`](/docs/kcl-std/functions/std-solver-line) inside a `sketch`
+/// block instead.
 ///
 /// ```kcl,legacySketch
 /// triangle = startSketchOn(XZ)
@@ -2675,7 +2680,8 @@ export fn line(
 /// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
 /// Legacy sketch functions cannot be used with constraints; strongly prefer
-/// constraint-based sketch functions inside a `sketch` block.
+/// [`solver::line`](/docs/kcl-std/functions/std-solver-line) with horizontal
+/// or vertical constraints inside a `sketch` block instead.
 ///
 /// ```kcl,legacySketch
 /// exampleSketch = startSketchOn(XZ)
@@ -2715,7 +2721,8 @@ export fn xLine(
 /// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
 /// Legacy sketch functions cannot be used with constraints; strongly prefer
-/// constraint-based sketch functions inside a `sketch` block.
+/// [`solver::line`](/docs/kcl-std/functions/std-solver-line) with horizontal
+/// or vertical constraints inside a `sketch` block instead.
 ///
 /// ```kcl,legacySketch
 /// exampleSketch = startSketchOn(XZ)
@@ -2750,7 +2757,8 @@ export fn yLine(
 /// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
 /// Legacy sketch functions cannot be used with constraints; strongly prefer
-/// constraint-based sketch functions inside a `sketch` block.
+/// [`solver::line`](/docs/kcl-std/functions/std-solver-line) with an angle
+/// constraint inside a `sketch` block instead.
 ///
 /// ```kcl,legacySketch
 /// exampleSketch = startSketchOn(XZ)
@@ -2793,7 +2801,8 @@ export fn angledLine(
 /// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
 /// Legacy sketch functions cannot be used with constraints; strongly prefer
-/// constraint-based sketch functions inside a `sketch` block.
+/// [`solver::line`](/docs/kcl-std/functions/std-solver-line) with angle and
+/// coincident constraints inside a `sketch` block instead.
 ///
 /// ```kcl,legacySketch
 /// exampleSketch = startSketchOn(XZ)
@@ -2830,7 +2839,8 @@ export fn angledLineThatIntersects(
 /// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
 /// Legacy sketch functions cannot be used with constraints; strongly prefer
-/// constraint-based sketch functions inside a `sketch` block.
+/// [`solver::coincident`](/docs/kcl-std/functions/std-solver-coincident)
+/// constraints inside a `sketch` block instead.
 ///
 /// If you want to perform some 3-dimensional operation on a sketch, like
 /// extrude or sweep, you must `close` it first. `close` must be called even
@@ -2868,7 +2878,8 @@ export fn close(
 /// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
 /// Legacy sketch functions cannot be used with constraints; strongly prefer
-/// constraint-based sketch functions inside a `sketch` block.
+/// [`solver::arc`](/docs/kcl-std/functions/std-solver-arc) inside a `sketch`
+/// block instead.
 ///
 /// The arc is constructed such that the current position of the sketch is
 /// placed along an imaginary circle of the specified radius, at angleStart
@@ -2932,7 +2943,8 @@ export fn arc(
 /// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
 /// Legacy sketch functions cannot be used with constraints; strongly prefer
-/// constraint-based sketch functions inside a `sketch` block.
+/// [`solver::arc`](/docs/kcl-std/functions/std-solver-arc) with tangent
+/// constraints inside a `sketch` block instead.
 ///
 /// When using radius and angle, draw a curved line segment along part of an
 /// imaginary circle. The arc is constructed such that the last line segment is

--- a/rust/kcl-lib/std/sketch.kcl
+++ b/rust/kcl-lib/std/sketch.kcl
@@ -13,6 +13,8 @@ import Axis2d, Axis3d, BoundedEdge, Edge, Face, Helix, Plane, Point2d, Point3d, 
 ///
 /// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
+/// Legacy sketch functions cannot be used with constraints; strongly prefer
+/// constraint-based sketch functions inside a `sketch` block.
 ///
 /// ### Sketch on Face Behavior
 ///
@@ -292,6 +294,8 @@ export fn startSketchOn(
 ///
 /// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
+/// Legacy sketch functions cannot be used with constraints; strongly prefer
+/// constraint-based sketch functions inside a `sketch` block.
 ///
 /// ```kcl,legacySketch
 /// exampleSketch = startSketchOn(XZ)
@@ -359,6 +363,8 @@ export fn startProfile(
 ///
 /// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
+/// Legacy sketch functions cannot be used with constraints; strongly prefer
+/// constraint-based sketch functions inside a `sketch` block.
 ///
 /// A rectangle can be defined by its width, height, and location. Either the center or corner must be provided, but not both, to specify its location.
 ///
@@ -395,7 +401,9 @@ export fn rectangle(
 /// Construct a 2-dimensional circle, of the specified radius, centered at
 /// the provided (x, y) origin point.
 ///
-/// This is part of sketch v1 and is deprecated. In KCL 2, create a
+/// This is part of sketch v1 and is deprecated. Legacy sketch functions cannot
+/// be used with constraints. Strongly prefer constraint-based sketch functions:
+/// in KCL 2, create a
 /// [`solver::circle`](/docs/kcl-std/functions/std-solver-circle) inside a
 /// [`sketch` block](/docs/kcl-lang/sketches), then select the
 /// closed profile with [`region`](/docs/kcl-std/functions/std-sketch-region).
@@ -442,8 +450,10 @@ export fn circle(
 /// Construct a 2-dimensional ellipse, of the specified major/minor radius, centered at the provided (x, y) point.
 ///
 /// This is part of sketch v1 and is soft deprecated in favor of
-/// [sketch-solve](/docs/kcl-std/modules/std-solver). The sketch-solve version
-/// of ellipse is still under development.
+/// [sketch-solve](/docs/kcl-std/modules/std-solver). Legacy sketch functions
+/// cannot be used with constraints; strongly prefer constraint-based sketch
+/// functions when possible. No constraint-based ellipse is available yet; first
+/// try approximating the shape with one or more constrained arcs.
 ///
 /// ```kcl,no3d,legacySketch
 /// @settings(experimentalFeatures = allow)
@@ -1463,6 +1473,8 @@ export fn getBoundedEdge(
 ///
 /// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
+/// Legacy sketch functions cannot be used with constraints; strongly prefer
+/// constraint-based sketch functions inside a `sketch` block.
 ///
 /// ```kcl,legacySketch
 /// exampleSketch = startSketchOn(XY)
@@ -1487,6 +1499,8 @@ export fn circleThreePoint(
 ///
 /// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
+/// Legacy sketch functions cannot be used with constraints; strongly prefer
+/// constraint-based sketch functions inside a `sketch` block.
 ///
 /// ```kcl,legacySketch
 /// // Create a regular hexagon inscribed in a circle of radius 10
@@ -2534,6 +2548,8 @@ export fn profileStartY(
 /// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver) and the
 /// [gear module](/docs/kcl-std/modules/std-gear).
+/// Legacy sketch functions cannot be used with constraints; strongly prefer
+/// constraint-based sketch functions inside a `sketch` block.
 ///
 /// ```kcl,no3d,legacySketch
 /// a = 10
@@ -2615,6 +2631,8 @@ export fn involuteCircular(
 ///
 /// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
+/// Legacy sketch functions cannot be used with constraints; strongly prefer
+/// constraint-based sketch functions inside a `sketch` block.
 ///
 /// ```kcl,legacySketch
 /// triangle = startSketchOn(XZ)
@@ -2656,6 +2674,8 @@ export fn line(
 ///
 /// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
+/// Legacy sketch functions cannot be used with constraints; strongly prefer
+/// constraint-based sketch functions inside a `sketch` block.
 ///
 /// ```kcl,legacySketch
 /// exampleSketch = startSketchOn(XZ)
@@ -2694,6 +2714,8 @@ export fn xLine(
 ///
 /// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
+/// Legacy sketch functions cannot be used with constraints; strongly prefer
+/// constraint-based sketch functions inside a `sketch` block.
 ///
 /// ```kcl,legacySketch
 /// exampleSketch = startSketchOn(XZ)
@@ -2727,6 +2749,8 @@ export fn yLine(
 ///
 /// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
+/// Legacy sketch functions cannot be used with constraints; strongly prefer
+/// constraint-based sketch functions inside a `sketch` block.
 ///
 /// ```kcl,legacySketch
 /// exampleSketch = startSketchOn(XZ)
@@ -2768,6 +2792,8 @@ export fn angledLine(
 ///
 /// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
+/// Legacy sketch functions cannot be used with constraints; strongly prefer
+/// constraint-based sketch functions inside a `sketch` block.
 ///
 /// ```kcl,legacySketch
 /// exampleSketch = startSketchOn(XZ)
@@ -2803,6 +2829,8 @@ export fn angledLineThatIntersects(
 ///
 /// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
+/// Legacy sketch functions cannot be used with constraints; strongly prefer
+/// constraint-based sketch functions inside a `sketch` block.
 ///
 /// If you want to perform some 3-dimensional operation on a sketch, like
 /// extrude or sweep, you must `close` it first. `close` must be called even
@@ -2839,6 +2867,8 @@ export fn close(
 ///
 /// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
+/// Legacy sketch functions cannot be used with constraints; strongly prefer
+/// constraint-based sketch functions inside a `sketch` block.
 ///
 /// The arc is constructed such that the current position of the sketch is
 /// placed along an imaginary circle of the specified radius, at angleStart
@@ -2901,6 +2931,8 @@ export fn arc(
 ///
 /// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
+/// Legacy sketch functions cannot be used with constraints; strongly prefer
+/// constraint-based sketch functions inside a `sketch` block.
 ///
 /// When using radius and angle, draw a curved line segment along part of an
 /// imaginary circle. The arc is constructed such that the last line segment is
@@ -2976,8 +3008,10 @@ export fn tangentialArc(
 /// shape.
 ///
 /// This is part of sketch v1 and is deprecated in favor of
-/// [sketch-solve](/docs/kcl-std/modules/std-solver). The sketch-solve version
-/// of bezier curve is still under development.
+/// [sketch-solve](/docs/kcl-std/modules/std-solver). Legacy sketch functions
+/// cannot be used with constraints; strongly prefer constraint-based sketch
+/// functions when possible. No constraint-based Bezier curve is available yet;
+/// first try approximating the shape with one or more constrained arcs.
 ///
 /// ```kcl,legacySketch
 /// // Example using relative control points.
@@ -3025,7 +3059,9 @@ export fn bezierCurve(
 
 /// Use a 2-dimensional sketch to cut a hole in another 2-dimensional sketch.
 ///
-/// This is part of sketch v1 and is deprecated. In KCL 2, construct the outer
+/// This is part of sketch v1 and is deprecated. Legacy sketch functions cannot
+/// be used with constraints. Strongly prefer constraint-based sketch functions:
+/// in KCL 2, construct the outer
 /// boundary and hole as segments inside a
 /// [`sketch` block](/docs/kcl-lang/sketches), then select the
 /// required bounded face with
@@ -3075,8 +3111,10 @@ export fn subtract2d(
 /// Add a conic section to an existing sketch.
 ///
 /// This is part of sketch v1 and is soft deprecated in favor of
-/// [sketch-solve](/docs/kcl-std/modules/std-solver). The sketch-solve version
-/// of conic is still under development.
+/// [sketch-solve](/docs/kcl-std/modules/std-solver). Legacy sketch functions
+/// cannot be used with constraints; strongly prefer constraint-based sketch
+/// functions when possible. No constraint-based conic is available yet; first
+/// try approximating the shape with one or more constrained arcs.
 ///
 /// ```kcl,legacySketch
 /// @settings(experimentalFeatures = allow)
@@ -3117,8 +3155,10 @@ export fn conic(
 /// Add a parabolic segment to an existing sketch.
 ///
 /// This is part of sketch v1 and is soft deprecated in favor of
-/// [sketch-solve](/docs/kcl-std/modules/std-solver). The sketch-solve version
-/// of parabolic is still under development.
+/// [sketch-solve](/docs/kcl-std/modules/std-solver). Legacy sketch functions
+/// cannot be used with constraints; strongly prefer constraint-based sketch
+/// functions when possible. No constraint-based parabola is available yet;
+/// first try approximating the shape with one or more constrained arcs.
 ///
 /// ```kcl,no3d,legacySketch
 /// @settings(experimentalFeatures = allow)
@@ -3170,8 +3210,10 @@ export fn parabolicPoint(
 /// Add a hyperbolic section to an existing sketch.
 ///
 /// This is part of sketch v1 and is soft deprecated in favor of
-/// [sketch-solve](/docs/kcl-std/modules/std-solver). The sketch-solve version
-/// of hyperbolic is still under development.
+/// [sketch-solve](/docs/kcl-std/modules/std-solver). Legacy sketch functions
+/// cannot be used with constraints; strongly prefer constraint-based sketch
+/// functions when possible. No constraint-based hyperbola is available yet;
+/// first try approximating the shape with one or more constrained arcs.
 ///
 /// ```kcl,no3d,legacySketch
 /// @settings(experimentalFeatures = allow)
@@ -3226,8 +3268,10 @@ export fn hyperbolicPoint(
 /// Add an elliptic section to an existing sketch.
 ///
 /// This is part of sketch v1 and is soft deprecated in favor of
-/// [sketch-solve](/docs/kcl-std/modules/std-solver). The sketch-solve version
-/// of elliptic is still under development.
+/// [sketch-solve](/docs/kcl-std/modules/std-solver). Legacy sketch functions
+/// cannot be used with constraints; strongly prefer constraint-based sketch
+/// functions when possible. No constraint-based elliptic curve is available
+/// yet; first try approximating the shape with one or more constrained arcs.
 ///
 /// ```kcl,legacySketch
 /// @settings(experimentalFeatures = allow)


### PR DESCRIPTION
Adds some nuance to why old sketch functions are deprecated, and when they're ok to use. Also removes some mentions of it in the pipelines docs