### PR TITLE
Cancel stale idle teardown

### DIFF
--- a/src/hooks/network/useOnPageIdle.spec.tsx
+++ b/src/hooks/network/useOnPageIdle.spec.tsx
@@ -216,4 +216,83 @@ describe('useOnPageIdle', () => {
 
     unmount()
   })
+
+  test.each([
+    'mousemove',
+    'keydown',
+    'KCL execution',
+    'modeling interaction',
+    'idle disabled',
+    'idle duration changed',
+    'unmount',
+  ])('cancels a pending idle teardown after %s', async (change) => {
+    const save = Promise.withResolvers<undefined>()
+    const controls = hookMocks.state.kclManager.sceneInfra.camControls
+    controls.saveRemoteCameraState = vi.fn(() => save.promise)
+    const idleCallback = vi.fn()
+    const startCallback = vi.fn()
+    const { rerender, unmount } = renderHook(() =>
+      useOnPageIdle({ startCallback, idleCallback })
+    )
+
+    await advance(5_000)
+    expect(controls.saveRemoteCameraState).toHaveBeenCalledOnce()
+
+    act(() => {
+      if (change === 'mousemove' || change === 'keydown') {
+        document.dispatchEvent(new Event(change))
+      } else if (change === 'KCL execution') {
+        hookMocks.state.kclManager.isExecuting = true
+      } else if (change === 'modeling interaction') {
+        hookMocks.state.modelingValue = 'sketch'
+        rerender()
+      } else if (change === 'idle disabled') {
+        hookMocks.state.streamIdleMode = 0
+        rerender()
+      } else if (change === 'idle duration changed') {
+        hookMocks.state.streamIdleMode = 10_000
+        rerender()
+      } else {
+        unmount()
+      }
+    })
+    await act(async () => save.resolve(undefined))
+
+    expect(
+      hookMocks.state.kclManager.engineCommandManager.tearDown
+    ).not.toHaveBeenCalled()
+    expect(idleCallback).not.toHaveBeenCalled()
+
+    if (change === 'mousemove' || change === 'keydown') {
+      expect(startCallback).toHaveBeenCalledOnce()
+      controls.saveRemoteCameraState = vi.fn().mockResolvedValue(undefined)
+      await advance(4_000)
+      expect(idleCallback).not.toHaveBeenCalled()
+      await advance(1_000)
+      expect(idleCallback).toHaveBeenCalledOnce()
+    }
+    unmount()
+  })
+
+  test('cancels stale idle teardown when camera saving rejects after input', async () => {
+    const save = Promise.withResolvers<undefined>()
+    const controls = hookMocks.state.kclManager.sceneInfra.camControls
+    controls.saveRemoteCameraState = vi.fn(() => save.promise)
+    const idleCallback = vi.fn()
+    const { unmount } = renderHook(() =>
+      useOnPageIdle({ startCallback: vi.fn(), idleCallback })
+    )
+    await advance(5_000)
+    act(() => {
+      document.dispatchEvent(new Event('mousemove'))
+    })
+    await act(async () => save.reject(new Error('camera save timed out')))
+
+    expect(controls.clearOldCameraState).toHaveBeenCalledOnce()
+    expect(
+      hookMocks.state.kclManager.engineCommandManager.tearDown
+    ).not.toHaveBeenCalled()
+    expect(idleCallback).not.toHaveBeenCalled()
+    unmount()
+  })
 })

--- a/src/hooks/network/useOnPageIdle.spec.tsx
+++ b/src/hooks/network/useOnPageIdle.spec.tsx
@@ -180,7 +180,7 @@ describe('useOnPageIdle', () => {
     unmount()
   })
 
-  test('does not disconnect when a Zookeeper prompt starts during idle teardown', async () => {
+  test.each([false, true])('resumes idle after prompt (%s)', async (input) => {
     let finishSavingCameraState: () => void = () => undefined
     hookMocks.state.kclManager.sceneInfra.camControls.saveRemoteCameraState =
       vi.fn(
@@ -204,6 +204,11 @@ describe('useOnPageIdle', () => {
     ).toHaveBeenCalledTimes(1)
 
     zookeeperPromptRunningSignal.value = true
+    if (input) {
+      act(() => {
+        document.dispatchEvent(new Event('mousemove'))
+      })
+    }
     await act(async () => {
       finishSavingCameraState()
       await Promise.resolve()
@@ -213,6 +218,18 @@ describe('useOnPageIdle', () => {
       hookMocks.state.kclManager.engineCommandManager.tearDown
     ).not.toHaveBeenCalled()
     expect(idleCallback).not.toHaveBeenCalled()
+
+    zookeeperPromptRunningSignal.value = false
+    hookMocks.state.kclManager.sceneInfra.camControls.saveRemoteCameraState = vi
+      .fn()
+      .mockResolvedValue(undefined)
+    await advance(5_000)
+    expect(idleCallback).not.toHaveBeenCalled()
+    await advance(1_000)
+    expect(
+      hookMocks.state.kclManager.engineCommandManager.tearDown
+    ).toHaveBeenCalledOnce()
+    expect(idleCallback).toHaveBeenCalledOnce()
 
     unmount()
   })

--- a/src/hooks/network/useOnPageIdle.tsx
+++ b/src/hooks/network/useOnPageIdle.tsx
@@ -23,15 +23,7 @@ export const useOnPageIdle = ({
   const idleTimeMsRef = useRef(Number(streamIdleMode))
   const wasBusyRef = useRef(false)
   const timeoutStart = useRef<number | null>(null)
-
-  useEffect(() => {
-    return () => {
-      if (intervalId.current) {
-        clearInterval(intervalId.current)
-        intervalId.current = null
-      }
-    }
-  }, [])
+  const idleCheckVersion = useRef(0)
 
   useEffect(() => {
     startCallbackRef.current = startCallback
@@ -46,6 +38,7 @@ export const useOnPageIdle = ({
   }, [modelingMachineState])
 
   useEffect(() => {
+    idleCheckVersion.current++
     idleTimeMsRef.current = Number(streamIdleMode)
     timeoutStart.current = idleTimeMsRef.current ? Date.now() : null
   }, [streamIdleMode])
@@ -54,6 +47,7 @@ export const useOnPageIdle = ({
     if (intervalId.current) {
       return
     }
+    let disposed = false
 
     // Check every 1 second to see if you are idle.
     const interval = setInterval(() => {
@@ -73,6 +67,7 @@ export const useOnPageIdle = ({
         // Only start the idle timer once KCL execution and other modeling
         // interactions have fully finished.
         if (isBusy) {
+          idleCheckVersion.current++
           timeoutStart.current = null
           wasBusyRef.current = true
           return
@@ -87,6 +82,7 @@ export const useOnPageIdle = ({
         if (timeoutStart.current) {
           const elapsed = Date.now() - timeoutStart.current
           if (elapsed >= idleTimeMs) {
+            const version = idleCheckVersion.current
             timeoutStart.current = null
             try {
               await kclManager.sceneInfra.camControls.saveRemoteCameraState()
@@ -94,8 +90,14 @@ export const useOnPageIdle = ({
               console.warn('unable to save old camera state on idle', e)
               kclManager.sceneInfra.camControls.clearOldCameraState()
             }
-            // A prompt may have started while the camera state was being saved.
-            if (zookeeperPromptRunningSignal.value) {
+            // Input, settings, or lifecycle changes invalidate this idle check
+            // while camera saving is pending, including when the save rejects.
+            if (disposed || version !== idleCheckVersion.current) return
+            if (
+              kclManager.isExecuting ||
+              !modelingMachineStateRef.current.matches('idle') ||
+              zookeeperPromptRunningSignal.value
+            ) {
               wasBusyRef.current = true
               return
             }
@@ -113,12 +115,18 @@ export const useOnPageIdle = ({
       })()
     }, 1_000)
     intervalId.current = interval
+    return () => {
+      disposed = true
+      clearInterval(interval)
+      intervalId.current = null
+    }
   }, [kclManager])
 
   useEffect(() => {
     if (!idleTimeMsRef.current) return
 
     const onAnyInput = () => {
+      idleCheckVersion.current++
       // Just in case it happens in the middle of the user turning off
       // idle mode.
       if (!idleTimeMsRef.current) {

--- a/src/hooks/network/useOnPageIdle.tsx
+++ b/src/hooks/network/useOnPageIdle.tsx
@@ -16,7 +16,6 @@ export const useOnPageIdle = ({
   const settingsValues = settings.useSettings()
   const streamIdleMode = settingsValues.app.streamIdleMode.current
   const { state: modelingMachineState } = useModelingContext()
-  const intervalId = useRef<NodeJS.Timeout | null>(null)
   const startCallbackRef = useRef(startCallback)
   const idleCallbackRef = useRef(idleCallback)
   const modelingMachineStateRef = useRef(modelingMachineState)
@@ -38,17 +37,12 @@ export const useOnPageIdle = ({
   }, [modelingMachineState])
 
   useEffect(() => {
-    idleCheckVersion.current++
+    idleCheckVersion.current += 1
     idleTimeMsRef.current = Number(streamIdleMode)
     timeoutStart.current = idleTimeMsRef.current ? Date.now() : null
   }, [streamIdleMode])
 
   useEffect(() => {
-    if (intervalId.current) {
-      return
-    }
-    let disposed = false
-
     // Check every 1 second to see if you are idle.
     const interval = setInterval(() => {
       void (async () => {
@@ -67,7 +61,7 @@ export const useOnPageIdle = ({
         // Only start the idle timer once KCL execution and other modeling
         // interactions have fully finished.
         if (isBusy) {
-          idleCheckVersion.current++
+          idleCheckVersion.current += 1
           timeoutStart.current = null
           wasBusyRef.current = true
           return
@@ -90,9 +84,8 @@ export const useOnPageIdle = ({
               console.warn('unable to save old camera state on idle', e)
               kclManager.sceneInfra.camControls.clearOldCameraState()
             }
-            // Input, settings, or lifecycle changes invalidate this idle check
-            // while camera saving is pending, including when the save rejects.
-            if (disposed || version !== idleCheckVersion.current) return
+            // Input, settings changes, or cleanup can invalidate the pending save.
+            if (version !== idleCheckVersion.current) return
             if (
               kclManager.isExecuting ||
               !modelingMachineStateRef.current.matches('idle') ||
@@ -114,11 +107,9 @@ export const useOnPageIdle = ({
         }
       })()
     }, 1_000)
-    intervalId.current = interval
     return () => {
-      disposed = true
+      idleCheckVersion.current += 1
       clearInterval(interval)
-      intervalId.current = null
     }
   }, [kclManager])
 
@@ -126,7 +117,7 @@ export const useOnPageIdle = ({
     if (!idleTimeMsRef.current) return
 
     const onAnyInput = () => {
-      idleCheckVersion.current++
+      idleCheckVersion.current += 1
       // Just in case it happens in the middle of the user turning off
       // idle mode.
       if (!idleTimeMsRef.current) {

--- a/src/hooks/network/useOnPageIdle.tsx
+++ b/src/hooks/network/useOnPageIdle.tsx
@@ -125,12 +125,11 @@ export const useOnPageIdle = ({
         return
       }
       startCallbackRef.current()
-      timeoutStart.current =
+      wasBusyRef.current =
         kclManager.isExecuting ||
         !modelingMachineStateRef.current.matches('idle') ||
         zookeeperPromptRunningSignal.value
-          ? null
-          : Date.now()
+      timeoutStart.current = wasBusyRef.current ? null : Date.now()
     }
 
     // It's possible after a reconnect, the user doesn't move their mouse at


### PR DESCRIPTION
Cancel stale idle teardown after input, settings changes, or effect cleanup during camera saving. Recheck modeling activity before disconnecting, and remember activity observed during input so the idle countdown resumes afterward.

Closes #13812. Deferred-save and countdown regressions pass. Browser/Electron idle-and-wake smoke testing is still outstanding.
