### PR TITLE
Bound automatic Engine recovery

### DIFF
--- a/src/components/ConnectionStream.tsx
+++ b/src/components/ConnectionStream.tsx
@@ -455,7 +455,9 @@ export const ConnectionStream = (props: ConnectionStreamProps) => {
       settings,
     ]
   )
-  useOnWebsocketClose(onWebSocketCloseParams)
+  const { resetAbnormalCloseRetries } = useOnWebsocketClose(
+    onWebSocketCloseParams
+  )
 
   const onVitestEngineOnline = useMemo(
     () => ({
@@ -686,6 +688,7 @@ export const ConnectionStream = (props: ConnectionStreamProps) => {
           className="absolute inset-0 h-screen"
           showManualConnect={showManualConnect}
           callback={() => {
+            resetAbnormalCloseRetries()
             setShowManualConnect(false)
             tryConnecting({
               authToken: props.authToken || '',

--- a/src/components/ConnectionStream.tsx
+++ b/src/components/ConnectionStream.tsx
@@ -31,6 +31,7 @@ import { ClientErrorCode, reportClientError } from '@src/lib/clientErrors'
 import {
   LEGACY_SKETCH_MODE_FEATURE_FLAG,
   LEGACY_SKETCH_MODE_REMOVED_MESSAGE,
+  NUMBER_OF_ENGINE_RETRIES,
 } from '@src/lib/constants'
 import { EngineDebugger } from '@src/lib/debugger'
 import { EngineConnectionManagerEvents } from '@src/lib/engineConnection/utils'
@@ -436,6 +437,8 @@ export const ConnectionStream = (props: ConnectionStreamProps) => {
         })
       },
       infiniteDetectionLoopCallback: (code: string | undefined) => {
+        // Also exhaust any retry already running when the close budget is spent.
+        numberOfConnectionAttempts.current = NUMBER_OF_ENGINE_RETRIES
         reportEngineDisconnect(EngineConnectionManagerEvents.WebsocketClosed, {
           websocketCloseCode: code,
         })
@@ -455,9 +458,7 @@ export const ConnectionStream = (props: ConnectionStreamProps) => {
       settings,
     ]
   )
-  const { resetAbnormalCloseRetries } = useOnWebsocketClose(
-    onWebSocketCloseParams
-  )
+  const abnormalCloseRetries = useOnWebsocketClose(onWebSocketCloseParams)
 
   const onVitestEngineOnline = useMemo(
     () => ({
@@ -688,7 +689,8 @@ export const ConnectionStream = (props: ConnectionStreamProps) => {
           className="absolute inset-0 h-screen"
           showManualConnect={showManualConnect}
           callback={() => {
-            resetAbnormalCloseRetries()
+            abnormalCloseRetries.current = 0
+            numberOfConnectionAttempts.current = 0
             setShowManualConnect(false)
             tryConnecting({
               authToken: props.authToken || '',

--- a/src/components/ConnectionStream.tsx
+++ b/src/components/ConnectionStream.tsx
@@ -98,7 +98,9 @@ export const ConnectionStream = (props: ConnectionStreamProps) => {
     overallState === NetworkHealthState.Ok ||
     overallState === NetworkHealthState.Weak
   const { tryConnecting, isConnecting, numberOfConnectionAttempts } =
-    useTryConnect()
+    useTryConnect(() => {
+      abnormalCloseRetries.current = 0
+    })
   const safariObjectFitClass = useMemo(() => {
     // on safari we want to apply object-fit: fill to fix video resize bug
     const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent)

--- a/src/hooks/network/useOnWebsocketClose.spec.tsx
+++ b/src/hooks/network/useOnWebsocketClose.spec.tsx
@@ -105,12 +105,12 @@ describe('useOnWebsocketClose', () => {
       unmount()
     })
 
-    test('recovers from three abnormal closes, then requires manual recovery', async () => {
+    test('requires manual recovery after three abnormal closes', async () => {
       const callback = vi.fn(() => 1)
       const infiniteLoopCallback = vi.fn(() => 1)
       const { engineCommandManager } =
         await buildTheWorldAndNoEngineConnection(true)
-      const { unmount } = renderHook(() =>
+      const { result, rerender, unmount } = renderHook(() =>
         useOnWebsocketClose({
           callback,
           infiniteDetectionLoopCallback: infiniteLoopCallback,
@@ -128,100 +128,17 @@ describe('useOnWebsocketClose', () => {
       for (let attempt = 1; attempt <= 3; attempt++) {
         engineCommandManager.dispatchEvent(infiniteEvent)
         expect(callback).toHaveBeenCalledTimes(attempt)
-        expect(callback).toHaveBeenLastCalledWith('1006', false)
         expect(infiniteLoopCallback).not.toHaveBeenCalled()
+        rerender()
       }
       engineCommandManager.dispatchEvent(infiniteEvent)
-      unmount()
       expect(callback).toHaveBeenCalledTimes(3)
       expect(infiniteLoopCallback).toHaveBeenCalledTimes(1)
       expect(infiniteLoopCallback).toHaveBeenCalledWith('1006')
-    })
-
-    test('keeps the abnormal-close budget across rerenders and successful handshakes', async () => {
-      const { engineCommandManager } =
-        await buildTheWorldAndNoEngineConnection(true)
-      const callback = vi.fn()
-      const infiniteDetectionLoopCallback = vi.fn()
-      const { rerender, unmount } = renderHook(() =>
-        useOnWebsocketClose({
-          callback: (...args) => callback(...args),
-          infiniteDetectionLoopCallback,
-          engineCommandManager,
-        })
-      )
-      for (let attempt = 0; attempt < 4; attempt++) {
-        engineCommandManager.tearDown({ websocketClosed: true, code: '1006' })
-        // A successful reconnect must not make a crash/reconnect cycle unbounded.
-        engineCommandManager.dispatchEvent(
-          new Event(EngineConnectionManagerEvents.EngineAvailable)
-        )
-        rerender()
-      }
-      expect(callback).toHaveBeenCalledTimes(3)
-      expect(infiniteDetectionLoopCallback).toHaveBeenCalledExactlyOnceWith(
-        '1006'
-      )
-      unmount()
-    })
-
-    test('manual recovery explicitly grants another bounded abnormal-close budget', async () => {
-      const { engineCommandManager } =
-        await buildTheWorldAndNoEngineConnection(true)
-      const callback = vi.fn()
-      const infiniteDetectionLoopCallback = vi.fn()
-      const { result, unmount } = renderHook(() =>
-        useOnWebsocketClose({
-          callback,
-          infiniteDetectionLoopCallback,
-          engineCommandManager,
-        })
-      )
-      for (let budget = 0; budget < 2; budget++) {
-        for (let attempt = 0; attempt < 4; attempt++) {
-          engineCommandManager.tearDown({ websocketClosed: true, code: '1006' })
-        }
-        expect(callback).toHaveBeenCalledTimes((budget + 1) * 3)
-        expect(infiniteDetectionLoopCallback).toHaveBeenCalledTimes(budget + 1)
-        result.current.resetAbnormalCloseRetries()
-      }
-      unmount()
-    })
-
-    test('normal and requested closes neither consume nor reset the abnormal budget', async () => {
-      const { engineCommandManager } =
-        await buildTheWorldAndNoEngineConnection(true)
-      const callback = vi.fn()
-      const infiniteDetectionLoopCallback = vi.fn()
-      const { unmount } = renderHook(() =>
-        useOnWebsocketClose({
-          callback,
-          infiniteDetectionLoopCallback,
-          engineCommandManager,
-        })
-      )
-      for (let attempt = 0; attempt < 3; attempt++) {
-        engineCommandManager.tearDown({ websocketClosed: true, code: '1000' })
-        engineCommandManager.tearDown({
-          websocketClosed: true,
-          code: '1006',
-          reconnectRequested: true,
-        })
-        engineCommandManager.tearDown({ websocketClosed: true, code: '1006' })
-        expect(callback).toHaveBeenCalledTimes((attempt + 1) * 3)
-        expect(infiniteDetectionLoopCallback).not.toHaveBeenCalled()
-      }
-      engineCommandManager.tearDown({ websocketClosed: true, code: '1006' })
-      expect(callback).toHaveBeenCalledTimes(9)
-      expect(infiniteDetectionLoopCallback).toHaveBeenCalledOnce()
-      // Requested recovery still passes through after the abnormal budget is spent.
-      engineCommandManager.tearDown({
-        websocketClosed: true,
-        code: '1006',
-        reconnectRequested: true,
-      })
-      expect(callback).toHaveBeenCalledTimes(10)
-      expect(callback).toHaveBeenLastCalledWith('1006', true)
+      result.current.current = 0
+      engineCommandManager.dispatchEvent(infiniteEvent)
+      expect(callback).toHaveBeenCalledTimes(4)
+      expect(infiniteLoopCallback).toHaveBeenCalledTimes(1)
       unmount()
     })
     test.each([false, true])(

--- a/src/hooks/network/useOnWebsocketClose.spec.tsx
+++ b/src/hooks/network/useOnWebsocketClose.spec.tsx
@@ -105,7 +105,7 @@ describe('useOnWebsocketClose', () => {
       unmount()
     })
 
-    test('should call infinite detection loop callback on close event', async () => {
+    test('recovers from three abnormal closes, then requires manual recovery', async () => {
       const callback = vi.fn(() => 1)
       const infiniteLoopCallback = vi.fn(() => 1)
       const { engineCommandManager } =
@@ -125,11 +125,104 @@ describe('useOnWebsocketClose', () => {
           },
         }
       )
+      for (let attempt = 1; attempt <= 3; attempt++) {
+        engineCommandManager.dispatchEvent(infiniteEvent)
+        expect(callback).toHaveBeenCalledTimes(attempt)
+        expect(callback).toHaveBeenLastCalledWith('1006', false)
+        expect(infiniteLoopCallback).not.toHaveBeenCalled()
+      }
       engineCommandManager.dispatchEvent(infiniteEvent)
       unmount()
-      expect(callback).toHaveBeenCalledTimes(0)
+      expect(callback).toHaveBeenCalledTimes(3)
       expect(infiniteLoopCallback).toHaveBeenCalledTimes(1)
       expect(infiniteLoopCallback).toHaveBeenCalledWith('1006')
+    })
+
+    test('keeps the abnormal-close budget across rerenders and successful handshakes', async () => {
+      const { engineCommandManager } =
+        await buildTheWorldAndNoEngineConnection(true)
+      const callback = vi.fn()
+      const infiniteDetectionLoopCallback = vi.fn()
+      const { rerender, unmount } = renderHook(() =>
+        useOnWebsocketClose({
+          callback: (...args) => callback(...args),
+          infiniteDetectionLoopCallback,
+          engineCommandManager,
+        })
+      )
+      for (let attempt = 0; attempt < 4; attempt++) {
+        engineCommandManager.tearDown({ websocketClosed: true, code: '1006' })
+        // A successful reconnect must not make a crash/reconnect cycle unbounded.
+        engineCommandManager.dispatchEvent(
+          new Event(EngineConnectionManagerEvents.EngineAvailable)
+        )
+        rerender()
+      }
+      expect(callback).toHaveBeenCalledTimes(3)
+      expect(infiniteDetectionLoopCallback).toHaveBeenCalledExactlyOnceWith(
+        '1006'
+      )
+      unmount()
+    })
+
+    test('manual recovery explicitly grants another bounded abnormal-close budget', async () => {
+      const { engineCommandManager } =
+        await buildTheWorldAndNoEngineConnection(true)
+      const callback = vi.fn()
+      const infiniteDetectionLoopCallback = vi.fn()
+      const { result, unmount } = renderHook(() =>
+        useOnWebsocketClose({
+          callback,
+          infiniteDetectionLoopCallback,
+          engineCommandManager,
+        })
+      )
+      for (let budget = 0; budget < 2; budget++) {
+        for (let attempt = 0; attempt < 4; attempt++) {
+          engineCommandManager.tearDown({ websocketClosed: true, code: '1006' })
+        }
+        expect(callback).toHaveBeenCalledTimes((budget + 1) * 3)
+        expect(infiniteDetectionLoopCallback).toHaveBeenCalledTimes(budget + 1)
+        result.current.resetAbnormalCloseRetries()
+      }
+      unmount()
+    })
+
+    test('normal and requested closes neither consume nor reset the abnormal budget', async () => {
+      const { engineCommandManager } =
+        await buildTheWorldAndNoEngineConnection(true)
+      const callback = vi.fn()
+      const infiniteDetectionLoopCallback = vi.fn()
+      const { unmount } = renderHook(() =>
+        useOnWebsocketClose({
+          callback,
+          infiniteDetectionLoopCallback,
+          engineCommandManager,
+        })
+      )
+      for (let attempt = 0; attempt < 3; attempt++) {
+        engineCommandManager.tearDown({ websocketClosed: true, code: '1000' })
+        engineCommandManager.tearDown({
+          websocketClosed: true,
+          code: '1006',
+          reconnectRequested: true,
+        })
+        engineCommandManager.tearDown({ websocketClosed: true, code: '1006' })
+        expect(callback).toHaveBeenCalledTimes((attempt + 1) * 3)
+        expect(infiniteDetectionLoopCallback).not.toHaveBeenCalled()
+      }
+      engineCommandManager.tearDown({ websocketClosed: true, code: '1006' })
+      expect(callback).toHaveBeenCalledTimes(9)
+      expect(infiniteDetectionLoopCallback).toHaveBeenCalledOnce()
+      // Requested recovery still passes through after the abnormal budget is spent.
+      engineCommandManager.tearDown({
+        websocketClosed: true,
+        code: '1006',
+        reconnectRequested: true,
+      })
+      expect(callback).toHaveBeenCalledTimes(10)
+      expect(callback).toHaveBeenLastCalledWith('1006', true)
+      unmount()
     })
     test.each([false, true])(
       'routes terminal errors without reconnecting (reconnectRequested=%s)',

--- a/src/hooks/network/useOnWebsocketClose.tsx
+++ b/src/hooks/network/useOnWebsocketClose.tsx
@@ -31,7 +31,6 @@ export function useOnWebsocketClose({
   terminalErrorCallback,
   engineCommandManager,
 }: IUseOnWebsocketClose) {
-  // A successful handshake can still crash on replay; only manual recovery resets this.
   const abnormalCloseRetries = useRef(0)
 
   useEffect(() => {

--- a/src/hooks/network/useOnWebsocketClose.tsx
+++ b/src/hooks/network/useOnWebsocketClose.tsx
@@ -8,9 +8,7 @@ import {
   EngineConnectionManagerEvents,
   WebSocketCloseCode,
 } from '@src/lib/engineConnection/utils'
-import { useCallback, useEffect, useRef } from 'react'
-
-const MAX_AUTOMATIC_ABNORMAL_RECOVERIES = 3
+import { useEffect, useRef } from 'react'
 
 export interface IUseOnWebsocketClose {
   callback: (code: string | undefined, reconnectRequested: boolean) => void
@@ -33,12 +31,8 @@ export function useOnWebsocketClose({
   terminalErrorCallback,
   engineCommandManager,
 }: IUseOnWebsocketClose) {
-  const abnormalRecoveries = useRef(0)
-  // Only explicit manual recovery resets the budget. A successful handshake
-  // alone does not prove that replaying the model will keep the Engine alive.
-  const resetAbnormalCloseRetries = useCallback(() => {
-    abnormalRecoveries.current = 0
-  }, [])
+  // A successful handshake can still crash on replay; only manual recovery resets this.
+  const abnormalCloseRetries = useRef(0)
 
   useEffect(() => {
     const onWebsocketClose = (
@@ -61,19 +55,17 @@ export function useOnWebsocketClose({
       const reconnectRequested = event.detail?.reconnectRequested ?? false
       if (
         code === WebSocketCloseCode.AbnormalClosure.toString() &&
-        !reconnectRequested
+        !reconnectRequested &&
+        ++abnormalCloseRetries.current > 3
       ) {
-        if (abnormalRecoveries.current >= MAX_AUTOMATIC_ABNORMAL_RECOVERIES) {
-          EngineDebugger.addLog({
-            label: 'useOnWebsocketClose',
-            message: 'abnormal close recovery budget exhausted',
-            metadata: { code, automaticRecoveries: abnormalRecoveries.current },
-          })
+        EngineDebugger.addLog({
+          label: 'useOnWebsocketClose',
+          message: 'abnormal close recovery budget exhausted',
+          metadata: { code },
+        })
 
-          infiniteDetectionLoopCallback(code)
-          return
-        }
-        abnormalRecoveries.current++
+        infiniteDetectionLoopCallback(code)
+        return
       }
 
       callback(code, reconnectRequested)
@@ -96,5 +88,5 @@ export function useOnWebsocketClose({
     terminalErrorCallback,
     engineCommandManager,
   ])
-  return { resetAbnormalCloseRetries }
+  return abnormalCloseRetries
 }

--- a/src/hooks/network/useOnWebsocketClose.tsx
+++ b/src/hooks/network/useOnWebsocketClose.tsx
@@ -8,7 +8,9 @@ import {
   EngineConnectionManagerEvents,
   WebSocketCloseCode,
 } from '@src/lib/engineConnection/utils'
-import { useEffect } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
+
+const MAX_AUTOMATIC_ABNORMAL_RECOVERIES = 3
 
 export interface IUseOnWebsocketClose {
   callback: (code: string | undefined, reconnectRequested: boolean) => void
@@ -31,6 +33,13 @@ export function useOnWebsocketClose({
   terminalErrorCallback,
   engineCommandManager,
 }: IUseOnWebsocketClose) {
+  const abnormalRecoveries = useRef(0)
+  // Only explicit manual recovery resets the budget. A successful handshake
+  // alone does not prove that replaying the model will keep the Engine alive.
+  const resetAbnormalCloseRetries = useCallback(() => {
+    abnormalRecoveries.current = 0
+  }, [])
+
   useEffect(() => {
     const onWebsocketClose = (
       event: CustomEvent<EngineDisconnectEventDetail>
@@ -54,14 +63,17 @@ export function useOnWebsocketClose({
         code === WebSocketCloseCode.AbnormalClosure.toString() &&
         !reconnectRequested
       ) {
-        EngineDebugger.addLog({
-          label: 'useOnWebsocketClose',
-          message: 'detected infinite loop',
-          metadata: { code },
-        })
+        if (abnormalRecoveries.current >= MAX_AUTOMATIC_ABNORMAL_RECOVERIES) {
+          EngineDebugger.addLog({
+            label: 'useOnWebsocketClose',
+            message: 'abnormal close recovery budget exhausted',
+            metadata: { code, automaticRecoveries: abnormalRecoveries.current },
+          })
 
-        infiniteDetectionLoopCallback(code)
-        return
+          infiniteDetectionLoopCallback(code)
+          return
+        }
+        abnormalRecoveries.current++
       }
 
       callback(code, reconnectRequested)
@@ -84,4 +96,5 @@ export function useOnWebsocketClose({
     terminalErrorCallback,
     engineCommandManager,
   ])
+  return { resetAbnormalCloseRetries }
 }

--- a/src/hooks/network/useTryConnect.test.ts
+++ b/src/hooks/network/useTryConnect.test.ts
@@ -1,9 +1,6 @@
 import type { SceneInfra } from '@src/clientSideScene/sceneInfra'
 import { tryConnecting } from '@src/hooks/network/useTryConnect'
 import type { KclManager } from '@src/lang/KclManager'
-import { emptyExecState } from '@src/lang/wasm'
-import { NUMBER_OF_ENGINE_RETRIES } from '@src/lib/constants'
-import { Connection } from '@src/lib/engineConnection/connection'
 import type { ConnectionManager } from '@src/lib/engineConnection/connectionManager'
 import {
   type EngineConnectionError,
@@ -11,7 +8,7 @@ import {
 } from '@src/lib/engineConnection/utils'
 import type RustContext from '@src/lib/rustContext'
 import type { SettingsActorType } from '@src/machines/settingsMachine'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 vi.mock('@src/lib/boot', () => ({ useSingletons: vi.fn() }))
 vi.mock('@src/lib/kclNamedViewActivation', () => ({
@@ -26,157 +23,50 @@ vi.mock('@src/lib/settings/settingsUtils', () => ({
 }))
 vi.mock('@src/lib/trap', () => ({ reportRejection: vi.fn() }))
 
-function connectionFixture() {
-  const connection = new Connection({
-    url: 'wss://example.test/modeling',
-    token: '',
-    handleOnDataChannelMessage: vi.fn(),
-    tearDownManager: vi.fn(),
-    rejectPendingCommand: vi.fn(),
-    handleMessage: vi.fn(),
-    getCloudProjectId: () => undefined,
-  })
-  connection.mediaStream = new MediaStream()
-  const manager = {
-    started: false,
-    connection: undefined as Connection | undefined,
-    lastConnectionError: undefined as EngineConnectionError | undefined,
-    start: vi.fn(async () => {
-      manager.started = true
-      manager.connection = connection
-    }),
-    tearDown: vi.fn(() => {
-      manager.started = false
-      manager.connection = undefined
-    }),
-  }
-  const args = {
-    isConnecting: { current: false },
-    numberOfConnectionAttempts: { current: 0 },
-    authToken: 'token',
-    videoWrapperRef: { current: document.createElement('div') },
-    setAppState: vi.fn(),
-    videoRef: { current: document.createElement('video') },
-    setIsSceneReady: vi.fn(),
-    timeToConnect: 1_000,
-    settingsActor: {} as SettingsActorType,
-    setShowManualConnect: vi.fn(),
-    sceneInfra: {
-      camControls: { clearOldCameraState: vi.fn() },
-    } as unknown as SceneInfra,
-    engineCommandManager: manager as unknown as ConnectionManager,
-    kclManager: {
-      executeCode: vi.fn().mockResolvedValue(undefined),
-    } as unknown as KclManager,
-    rustContext: {
-      clearSceneAndBustCache: vi.fn().mockResolvedValue(undefined),
-    } as unknown as RustContext,
-  }
-  return { args, manager, connection }
-}
-
 describe('tryConnecting', () => {
-  beforeEach(() => vi.useFakeTimers())
-  afterEach(() => {
-    vi.clearAllTimers()
-    vi.useRealTimers()
-  })
-
   it('stops the initial retry loop after a terminal connection error', async () => {
-    const { args, manager } = connectionFixture()
     const connectionError: EngineConnectionError = {
       kind: EngineConnectionErrorKind.BackendDisconnect,
       message: 'backend disconnected',
       terminal: true,
     }
-    manager.start.mockImplementation(async () => {
-      manager.lastConnectionError = connectionError
-      throw new Error('connection failed')
-    })
+    const manager = {
+      started: false,
+      connection: undefined,
+      lastConnectionError: undefined as EngineConnectionError | undefined,
+      start: vi.fn(async () => {
+        manager.lastConnectionError = connectionError
+        throw new Error('connection failed')
+      }),
+      tearDown: vi.fn(),
+    }
+    const setShowManualConnect = vi.fn()
+    const numberOfConnectionAttempts = { current: 0 }
 
-    await expect(tryConnecting(args)).rejects.toEqual(connectionError)
+    await expect(
+      tryConnecting({
+        isConnecting: { current: false },
+        numberOfConnectionAttempts,
+        authToken: 'token',
+        videoWrapperRef: {
+          current: { clientWidth: 256, clientHeight: 256 } as HTMLDivElement,
+        },
+        setAppState: vi.fn(),
+        videoRef: { current: null },
+        setIsSceneReady: vi.fn(),
+        timeToConnect: 1_000,
+        settingsActor: {} as SettingsActorType,
+        setShowManualConnect,
+        sceneInfra: {} as SceneInfra,
+        engineCommandManager: manager as unknown as ConnectionManager,
+        kclManager: {} as KclManager,
+        rustContext: {} as RustContext,
+      })
+    ).rejects.toEqual(connectionError)
+
     expect(manager.start).toHaveBeenCalledOnce()
     expect(manager.tearDown).not.toHaveBeenCalled()
-    expect(args.numberOfConnectionAttempts.current).toBe(0)
-    expect(args.isConnecting.current).toBe(false)
-    expect(args.setShowManualConnect).toHaveBeenCalledWith(true)
-  })
-
-  it.each([false, true])(
-    'keeps competing callers out of a pending attempt (automatic retry=%s)',
-    async (retry) => {
-      const { args, manager, connection } = connectionFixture()
-      const started = Promise.withResolvers<undefined>()
-      const finish = Promise.withResolvers<undefined>()
-      if (retry)
-        manager.start.mockRejectedValueOnce(new Error('transient failure'))
-      manager.start.mockImplementation(async () => {
-        manager.started = true
-        manager.connection = connection
-        started.resolve(undefined)
-        await finish.promise
-      })
-      const owner = tryConnecting(args)
-      await started.promise
-      try {
-        expect(args.isConnecting.current).toBe(true)
-        await expect(tryConnecting(args)).resolves.toBe('connecting')
-        expect(manager.start).toHaveBeenCalledTimes(retry ? 2 : 1)
-        expect(manager.tearDown).toHaveBeenCalledTimes(retry ? 1 : 0)
-        expect(manager.connection).toBe(connection)
-        expect(args.numberOfConnectionAttempts.current).toBe(retry ? 2 : 1)
-      } finally {
-        finish.resolve(undefined)
-        await owner
-      }
-      expect(args.isConnecting.current).toBe(false)
-      expect(args.numberOfConnectionAttempts.current).toBe(0)
-      expect(args.setShowManualConnect).toHaveBeenLastCalledWith(false)
-      expect(args.setAppState).toHaveBeenLastCalledWith({
-        isStreamAcceptingInput: true,
-      })
-    }
-  )
-
-  it('releases the lock after retry exhaustion so manual recovery can connect', async () => {
-    const { args, manager } = connectionFixture()
-    const startNormally = manager.start.getMockImplementation()
-    const error = new Error('connection failed')
-    manager.start.mockRejectedValue(error)
-    await expect(tryConnecting(args)).rejects.toBe(error)
-    expect(manager.start).toHaveBeenCalledTimes(NUMBER_OF_ENGINE_RETRIES)
-    expect(manager.tearDown).toHaveBeenCalledTimes(NUMBER_OF_ENGINE_RETRIES)
-    expect(args.isConnecting.current).toBe(false)
-    expect(args.numberOfConnectionAttempts.current).toBe(0)
-    if (!startNormally) throw new Error('Missing fixture start implementation')
-    manager.start.mockImplementation(startNormally)
-    await expect(tryConnecting(args)).resolves.toBe('connected')
-    expect(args.isConnecting.current).toBe(false)
-    expect(args.setShowManualConnect).toHaveBeenLastCalledWith(false)
-  })
-
-  it('keeps ownership until scene setup finishes', async () => {
-    const { args, manager } = connectionFixture()
-    const setupStarted = Promise.withResolvers<undefined>()
-    const finishSetup = Promise.withResolvers<undefined>()
-    vi.spyOn(args.rustContext, 'clearSceneAndBustCache').mockImplementation(
-      async () => {
-        setupStarted.resolve(undefined)
-        await finishSetup.promise
-        return emptyExecState()
-      }
-    )
-    const owner = tryConnecting(args)
-    await setupStarted.promise
-    try {
-      await expect(tryConnecting(args)).resolves.toBe('connecting')
-      expect(manager.start).toHaveBeenCalledOnce()
-      expect(manager.tearDown).not.toHaveBeenCalled()
-      expect(args.isConnecting.current).toBe(true)
-    } finally {
-      finishSetup.resolve(undefined)
-      await owner
-    }
-    expect(args.isConnecting.current).toBe(false)
+    expect(numberOfConnectionAttempts.current).toBe(0)
+    expect(setShowManualConnect).toHaveBeenCalledWith(true)
   })
 })

--- a/src/hooks/network/useTryConnect.test.ts
+++ b/src/hooks/network/useTryConnect.test.ts
@@ -1,6 +1,9 @@
 import type { SceneInfra } from '@src/clientSideScene/sceneInfra'
 import { tryConnecting } from '@src/hooks/network/useTryConnect'
 import type { KclManager } from '@src/lang/KclManager'
+import { emptyExecState } from '@src/lang/wasm'
+import { NUMBER_OF_ENGINE_RETRIES } from '@src/lib/constants'
+import { Connection } from '@src/lib/engineConnection/connection'
 import type { ConnectionManager } from '@src/lib/engineConnection/connectionManager'
 import {
   type EngineConnectionError,
@@ -8,7 +11,7 @@ import {
 } from '@src/lib/engineConnection/utils'
 import type RustContext from '@src/lib/rustContext'
 import type { SettingsActorType } from '@src/machines/settingsMachine'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@src/lib/boot', () => ({ useSingletons: vi.fn() }))
 vi.mock('@src/lib/kclNamedViewActivation', () => ({
@@ -23,50 +26,157 @@ vi.mock('@src/lib/settings/settingsUtils', () => ({
 }))
 vi.mock('@src/lib/trap', () => ({ reportRejection: vi.fn() }))
 
+function connectionFixture() {
+  const connection = new Connection({
+    url: 'wss://example.test/modeling',
+    token: '',
+    handleOnDataChannelMessage: vi.fn(),
+    tearDownManager: vi.fn(),
+    rejectPendingCommand: vi.fn(),
+    handleMessage: vi.fn(),
+    getCloudProjectId: () => undefined,
+  })
+  connection.mediaStream = new MediaStream()
+  const manager = {
+    started: false,
+    connection: undefined as Connection | undefined,
+    lastConnectionError: undefined as EngineConnectionError | undefined,
+    start: vi.fn(async () => {
+      manager.started = true
+      manager.connection = connection
+    }),
+    tearDown: vi.fn(() => {
+      manager.started = false
+      manager.connection = undefined
+    }),
+  }
+  const args = {
+    isConnecting: { current: false },
+    numberOfConnectionAttempts: { current: 0 },
+    authToken: 'token',
+    videoWrapperRef: { current: document.createElement('div') },
+    setAppState: vi.fn(),
+    videoRef: { current: document.createElement('video') },
+    setIsSceneReady: vi.fn(),
+    timeToConnect: 1_000,
+    settingsActor: {} as SettingsActorType,
+    setShowManualConnect: vi.fn(),
+    sceneInfra: {
+      camControls: { clearOldCameraState: vi.fn() },
+    } as unknown as SceneInfra,
+    engineCommandManager: manager as unknown as ConnectionManager,
+    kclManager: {
+      executeCode: vi.fn().mockResolvedValue(undefined),
+    } as unknown as KclManager,
+    rustContext: {
+      clearSceneAndBustCache: vi.fn().mockResolvedValue(undefined),
+    } as unknown as RustContext,
+  }
+  return { args, manager, connection }
+}
+
 describe('tryConnecting', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
   it('stops the initial retry loop after a terminal connection error', async () => {
+    const { args, manager } = connectionFixture()
     const connectionError: EngineConnectionError = {
       kind: EngineConnectionErrorKind.BackendDisconnect,
       message: 'backend disconnected',
       terminal: true,
     }
-    const manager = {
-      started: false,
-      connection: undefined,
-      lastConnectionError: undefined as EngineConnectionError | undefined,
-      start: vi.fn(async () => {
-        manager.lastConnectionError = connectionError
-        throw new Error('connection failed')
-      }),
-      tearDown: vi.fn(),
-    }
-    const setShowManualConnect = vi.fn()
-    const numberOfConnectionAttempts = { current: 0 }
+    manager.start.mockImplementation(async () => {
+      manager.lastConnectionError = connectionError
+      throw new Error('connection failed')
+    })
 
-    await expect(
-      tryConnecting({
-        isConnecting: { current: false },
-        numberOfConnectionAttempts,
-        authToken: 'token',
-        videoWrapperRef: {
-          current: { clientWidth: 256, clientHeight: 256 } as HTMLDivElement,
-        },
-        setAppState: vi.fn(),
-        videoRef: { current: null },
-        setIsSceneReady: vi.fn(),
-        timeToConnect: 1_000,
-        settingsActor: {} as SettingsActorType,
-        setShowManualConnect,
-        sceneInfra: {} as SceneInfra,
-        engineCommandManager: manager as unknown as ConnectionManager,
-        kclManager: {} as KclManager,
-        rustContext: {} as RustContext,
-      })
-    ).rejects.toEqual(connectionError)
-
+    await expect(tryConnecting(args)).rejects.toEqual(connectionError)
     expect(manager.start).toHaveBeenCalledOnce()
     expect(manager.tearDown).not.toHaveBeenCalled()
-    expect(numberOfConnectionAttempts.current).toBe(0)
-    expect(setShowManualConnect).toHaveBeenCalledWith(true)
+    expect(args.numberOfConnectionAttempts.current).toBe(0)
+    expect(args.isConnecting.current).toBe(false)
+    expect(args.setShowManualConnect).toHaveBeenCalledWith(true)
+  })
+
+  it.each([false, true])(
+    'keeps competing callers out of a pending attempt (automatic retry=%s)',
+    async (retry) => {
+      const { args, manager, connection } = connectionFixture()
+      const started = Promise.withResolvers<undefined>()
+      const finish = Promise.withResolvers<undefined>()
+      if (retry)
+        manager.start.mockRejectedValueOnce(new Error('transient failure'))
+      manager.start.mockImplementation(async () => {
+        manager.started = true
+        manager.connection = connection
+        started.resolve(undefined)
+        await finish.promise
+      })
+      const owner = tryConnecting(args)
+      await started.promise
+      try {
+        expect(args.isConnecting.current).toBe(true)
+        await expect(tryConnecting(args)).resolves.toBe('connecting')
+        expect(manager.start).toHaveBeenCalledTimes(retry ? 2 : 1)
+        expect(manager.tearDown).toHaveBeenCalledTimes(retry ? 1 : 0)
+        expect(manager.connection).toBe(connection)
+        expect(args.numberOfConnectionAttempts.current).toBe(retry ? 2 : 1)
+      } finally {
+        finish.resolve(undefined)
+        await owner
+      }
+      expect(args.isConnecting.current).toBe(false)
+      expect(args.numberOfConnectionAttempts.current).toBe(0)
+      expect(args.setShowManualConnect).toHaveBeenLastCalledWith(false)
+      expect(args.setAppState).toHaveBeenLastCalledWith({
+        isStreamAcceptingInput: true,
+      })
+    }
+  )
+
+  it('releases the lock after retry exhaustion so manual recovery can connect', async () => {
+    const { args, manager } = connectionFixture()
+    const startNormally = manager.start.getMockImplementation()
+    const error = new Error('connection failed')
+    manager.start.mockRejectedValue(error)
+    await expect(tryConnecting(args)).rejects.toBe(error)
+    expect(manager.start).toHaveBeenCalledTimes(NUMBER_OF_ENGINE_RETRIES)
+    expect(manager.tearDown).toHaveBeenCalledTimes(NUMBER_OF_ENGINE_RETRIES)
+    expect(args.isConnecting.current).toBe(false)
+    expect(args.numberOfConnectionAttempts.current).toBe(0)
+    if (!startNormally) throw new Error('Missing fixture start implementation')
+    manager.start.mockImplementation(startNormally)
+    await expect(tryConnecting(args)).resolves.toBe('connected')
+    expect(args.isConnecting.current).toBe(false)
+    expect(args.setShowManualConnect).toHaveBeenLastCalledWith(false)
+  })
+
+  it('keeps ownership until scene setup finishes', async () => {
+    const { args, manager } = connectionFixture()
+    const setupStarted = Promise.withResolvers<undefined>()
+    const finishSetup = Promise.withResolvers<undefined>()
+    vi.spyOn(args.rustContext, 'clearSceneAndBustCache').mockImplementation(
+      async () => {
+        setupStarted.resolve(undefined)
+        await finishSetup.promise
+        return emptyExecState()
+      }
+    )
+    const owner = tryConnecting(args)
+    await setupStarted.promise
+    try {
+      await expect(tryConnecting(args)).resolves.toBe('connecting')
+      expect(manager.start).toHaveBeenCalledOnce()
+      expect(manager.tearDown).not.toHaveBeenCalled()
+      expect(args.isConnecting.current).toBe(true)
+    } finally {
+      finishSetup.resolve(undefined)
+      await owner
+    }
+    expect(args.isConnecting.current).toBe(false)
   })
 })

--- a/src/hooks/network/useTryConnect.tsx
+++ b/src/hooks/network/useTryConnect.tsx
@@ -204,6 +204,7 @@ const setupSceneAndExecuteCodeAfterOpenedEngineConnection = async ({
  * a single safe location to connect to the engine.
  */
 export async function tryConnecting({
+  onConnected,
   isConnecting,
   numberOfConnectionAttempts,
   authToken,
@@ -219,6 +220,7 @@ export async function tryConnecting({
   kclManager,
   rustContext,
 }: {
+  onConnected?: () => void
   isConnecting: React.RefObject<boolean>
   numberOfConnectionAttempts: React.RefObject<number>
   authToken: string
@@ -284,6 +286,7 @@ export async function tryConnecting({
             )
           }
 
+          onConnected?.()
           isConnecting.current = false
           setAppState({ isStreamAcceptingInput: true })
           numberOfConnectionAttempts.current = 0
@@ -324,13 +327,13 @@ export async function tryConnecting({
   })
   return connection
 }
-export const useTryConnect = () => {
+export const useTryConnect = (onConnected: () => void) => {
   const { kclManager } = useSingletons()
   const isConnecting = useRef(false)
   const numberOfConnectionAttempts = useRef(0)
   type TryConnectingArgs = Omit<
     Parameters<typeof tryConnecting>[0],
-    'engineCommandManager' | 'kclManager' | 'rustContext'
+    'engineCommandManager' | 'kclManager' | 'rustContext' | 'onConnected'
   >
 
   return {
@@ -340,6 +343,7 @@ export const useTryConnect = () => {
         engineCommandManager: kclManager.engineCommandManager,
         kclManager,
         rustContext: kclManager.rustContext,
+        onConnected,
       }),
     isConnecting,
     numberOfConnectionAttempts,

--- a/src/hooks/network/useTryConnect.tsx
+++ b/src/hooks/network/useTryConnect.tsx
@@ -294,7 +294,8 @@ export async function tryConnecting({
           })
           resolve('connected')
         } catch (e) {
-          isConnecting.current = false
+          // Keep ownership through teardown and automatic retries so another
+          // caller cannot start a competing connection sequence.
           setAppState({ isStreamAcceptingInput: false })
           const terminalConnectionError =
             engineCommandManager.lastConnectionError?.terminal === true
@@ -306,12 +307,14 @@ export async function tryConnecting({
             metadata: { terminalConnectionError },
           })
           if (terminalConnectionError) {
+            isConnecting.current = false
             numberOfConnectionAttempts.current = 0
             setShowManualConnect(true)
             return reject(terminalConnectionError)
           }
           engineCommandManager.tearDown()
           if (numberOfConnectionAttempts.current >= NUMBER_OF_ENGINE_RETRIES) {
+            isConnecting.current = false
             numberOfConnectionAttempts.current = 0
             return reject(e)
           }

--- a/src/hooks/network/useTryConnect.tsx
+++ b/src/hooks/network/useTryConnect.tsx
@@ -294,8 +294,6 @@ export async function tryConnecting({
           })
           resolve('connected')
         } catch (e) {
-          // Keep ownership through teardown and automatic retries so another
-          // caller cannot start a competing connection sequence.
           setAppState({ isStreamAcceptingInput: false })
           const terminalConnectionError =
             engineCommandManager.lastConnectionError?.terminal === true


### PR DESCRIPTION
Allow three automatic recoveries after unrequested WebSocket 1006 closes. A successful connection and scene setup reset the budget; failures share it. Keep the connection lock across retries and stop any active retry on exhaustion. Manual Reconnect resets both counters.

Closes #9869 and #13813; supersedes #13815.

Full-app transient-loss and repeated-failure smoke testing remains before release.
