### PR TITLE
Hide the Zookeeper actor behind its session controller

### DIFF
--- a/src/lib/zookeeper/components/ZookeeperConversationPane.spec.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPane.spec.tsx
@@ -21,15 +21,13 @@ import type {
   ZookeeperConversationProps,
 } from '@src/lib/zookeeper/components/ZookeeperConversation'
 import { ZookeeperConversationPane } from '@src/lib/zookeeper/components/ZookeeperConversationPane'
-import type { ZookeeperSessionController } from '@src/lib/zookeeper/registry/controller'
+import type {
+  ZookeeperSessionController,
+  ZookeeperSessionView,
+} from '@src/lib/zookeeper/registry/controller'
 import type {
   Conversation,
   MlCopilotModeOption,
-  ZookeeperAttachmentFetchState,
-} from '@src/lib/zookeeper/zookeeperManagerMachine'
-import {
-  ZookeeperManagerStates,
-  ZookeeperManagerTransitions,
 } from '@src/lib/zookeeper/zookeeperManagerMachine'
 
 const completedConversation: Conversation = {
@@ -64,99 +62,37 @@ const interruptedConversation: Conversation = {
   ],
 }
 
-type FakeSnapshot = {
-  value: string
-  context: {
-    abruptlyClosed: boolean
-    attachmentFetches: Record<string, ZookeeperAttachmentFetchState>
-    attachmentsLoadedForCurrentPrompt: boolean
-    awaitingResponse: boolean
-    accessDeniedCode?: 'payment_method_failed'
-    closeReason?: string
-    conversation?: Conversation
-    conversationId?: string
-    defaultMode?: string
-    modeOptions?: MlCopilotModeOption[]
-    setupFailed: boolean
-  }
-  matches: (state: unknown) => boolean
-}
+const defaultView = (): ZookeeperSessionView => ({
+  attachmentFetches: {},
+  canClearChat: false,
+  connectionFailed: false,
+  disabled: false,
+  hasPromptCompleted: true,
+  interruptedTurnAwaitingResume: false,
+  isClearingChat: false,
+  isLoading: true,
+  isLoadingAttachments: false,
+  isProcessing: false,
+  isResumingInterruptedTurn: false,
+  needsReconnect: false,
+  queue: [],
+  showManualConnect: false,
+})
 
-const createFakeActor = (
-  context: Partial<FakeSnapshot['context']> = {},
-  value: string = ZookeeperManagerStates.Ready
+const createFakeController = (
+  viewOverrides: Partial<ZookeeperSessionView> = {}
 ) => {
-  let snapshot: FakeSnapshot
-  const listeners = new Set<(next: FakeSnapshot) => void>()
-
-  const makeSnapshot = (
-    nextContext: Partial<FakeSnapshot['context']>,
-    nextValue: string
-  ): FakeSnapshot => ({
-    value: nextValue,
-    context: {
-      abruptlyClosed: false,
-      attachmentFetches: {},
-      attachmentsLoadedForCurrentPrompt: true,
-      awaitingResponse: false,
-      setupFailed: false,
-      ...nextContext,
-    },
-    matches: (state) => state === nextValue,
+  const view = signal<ZookeeperSessionView>({
+    ...defaultView(),
+    ...viewOverrides,
   })
-
-  snapshot = makeSnapshot(context, value)
-
-  const setSnapshot = (
-    nextContext: Partial<FakeSnapshot['context']>,
-    nextValue = snapshot.value
-  ) => {
-    snapshot = makeSnapshot({ ...snapshot.context, ...nextContext }, nextValue)
-    for (const listener of listeners) {
-      listener(snapshot)
-    }
-  }
-
-  return {
-    actor: {
-      getSnapshot: () => snapshot,
-      subscribe: (listener: (next: FakeSnapshot) => void) => {
-        listeners.add(listener)
-        return {
-          unsubscribe: () => listeners.delete(listener),
-        }
-      },
-      send: vi.fn(),
-    },
-    setSnapshot,
-  }
-}
-
-const createFakeController = ({
-  actorContext,
-  actorValue,
-  isClearingChat = false,
-  isResumingInterruptedTurn = false,
-  queue = [],
-  showManualConnect = false,
-}: {
-  actorContext?: Partial<FakeSnapshot['context']>
-  actorValue?: string
-  isClearingChat?: boolean
-  isResumingInterruptedTurn?: boolean
-  queue?: QueuedMessage[]
-  showManualConnect?: boolean
-} = {}) => {
-  const actor = createFakeActor(actorContext, actorValue)
-  const queueSignal = signal<QueuedMessage[]>(queue)
-  const clearingSignal = signal(isClearingChat)
-  const resumingSignal = signal(isResumingInterruptedTurn)
-  const manualConnectSignal = signal(showManualConnect)
   const methods = {
     cancel: vi.fn(),
     checkBillingAccess: vi.fn(),
     clearConversation: vi.fn(async () => undefined),
-    dispose: vi.fn(),
+    dispose: vi.fn(async () => undefined),
+    fetchAttachment: vi.fn(),
+    getConversationExport: vi.fn(() => ({ fileName: '', markdown: '' })),
     reconnect: vi.fn(),
     removeQueued: vi.fn(),
     resumeInterruptedTurn: vi.fn(),
@@ -165,23 +101,15 @@ const createFakeController = ({
     updateAuthToken: vi.fn(),
   }
   const controller = {
-    actor: actor.actor,
-    isClearingChat: clearingSignal,
-    isResumingInterruptedTurn: resumingSignal,
     projectPath: '/projects/cube',
-    queue: queueSignal,
-    showManualConnect: manualConnectSignal,
+    view,
     ...methods,
-  } as unknown as ZookeeperSessionController
+  } satisfies ZookeeperSessionController
 
   return {
-    ...actor,
     ...methods,
-    clearingSignal,
     controller,
-    manualConnectSignal,
-    queueSignal,
-    resumingSignal,
+    view,
   }
 }
 
@@ -218,7 +146,7 @@ beforeEach(() => {
 })
 
 describe('ZookeeperConversationPane', () => {
-  test('maps actor state, controller signals, and visual context to the conversation', () => {
+  test('maps the controller view and visual context to the conversation', () => {
     const attachmentFetches = {
       'prompt:0:0': { status: 'loading' as const },
     }
@@ -238,20 +166,22 @@ describe('ZookeeperConversationPane', () => {
       } as MlCopilotModeOption,
     ]
     const fake = createFakeController({
-      actorContext: {
-        attachmentFetches,
-        attachmentsLoadedForCurrentPrompt: false,
-        accessDeniedCode: 'payment_method_failed',
-        awaitingResponse: true,
-        closeReason: 'Connection lost.',
-        conversation: completedConversation,
-        conversationId: 'conversation-id',
-        defaultMode: 'server-mode',
-        modeOptions,
-        setupFailed: true,
-      },
-      actorValue: ZookeeperManagerStates.Setup,
+      accessDeniedCode: 'payment_method_failed',
+      attachmentFetches,
+      canClearChat: true,
+      connectionError: 'No internet connection.',
+      connectionFailed: true,
+      conversation: completedConversation,
+      defaultMode: 'server-mode',
+      disabled: true,
+      hasPromptCompleted: false,
       isClearingChat: true,
+      isLoading: false,
+      isLoadingAttachments: true,
+      isProcessing: true,
+      loadingMessage: 'Connecting to Zookeeper...',
+      modeOptions,
+      needsReconnect: true,
       queue: [queuedMessage],
       showManualConnect: true,
     })
@@ -302,12 +232,10 @@ describe('ZookeeperConversationPane', () => {
     expect(props.userAvatarSrc).toBe('avatar.png')
   })
 
-  test('stays reactive to actor state and controller signals', () => {
+  test('stays reactive to controller view changes', () => {
     const fake = createFakeController({
-      actorContext: {
-        conversation: completedConversation,
-        conversationId: 'conversation-id',
-      },
+      conversation: completedConversation,
+      isLoading: false,
     })
 
     render(
@@ -319,18 +247,21 @@ describe('ZookeeperConversationPane', () => {
     expect(latestConversationProps().needsReconnect).toBe(false)
 
     act(() => {
-      fake.manualConnectSignal.value = true
-      fake.queueSignal.value = [
-        {
-          id: 'queued-message',
-          text: 'shell the part',
-          attachments: [],
-        },
-      ]
-      fake.setSnapshot({
-        awaitingResponse: true,
+      fake.view.value = {
+        ...fake.view.value,
         conversation: undefined,
-      })
+        isLoading: true,
+        isProcessing: true,
+        needsReconnect: true,
+        queue: [
+          {
+            id: 'queued-message',
+            text: 'shell the part',
+            attachments: [],
+          },
+        ],
+        showManualConnect: true,
+      }
     })
 
     const props = latestConversationProps()
@@ -348,7 +279,8 @@ describe('ZookeeperConversationPane', () => {
 
   test('delegates conversation actions to the session controller', () => {
     const fake = createFakeController({
-      actorContext: { conversation: completedConversation },
+      conversation: completedConversation,
+      isLoading: false,
     })
     const onMlCopilotModeChange = vi.fn()
     render(
@@ -382,10 +314,7 @@ describe('ZookeeperConversationPane', () => {
     expect(fake.sendOrQueue).toHaveBeenCalledWith('make a cylinder', 'edit', [
       attachment,
     ])
-    expect(fake.actor.send).toHaveBeenCalledWith({
-      type: ZookeeperManagerTransitions.AttachmentFetch,
-      attachmentRef,
-    })
+    expect(fake.fetchAttachment).toHaveBeenCalledWith(attachmentRef)
     expect(fake.clearConversation).toHaveBeenCalledOnce()
     expect(fake.reconnect).toHaveBeenCalledOnce()
     expect(fake.checkBillingAccess).toHaveBeenCalledOnce()
@@ -398,10 +327,8 @@ describe('ZookeeperConversationPane', () => {
 
   test('checks billing access after returning from the billing page', () => {
     const fake = createFakeController({
-      actorContext: {
-        accessDeniedCode: 'payment_method_failed',
-        setupFailed: true,
-      },
+      accessDeniedCode: 'payment_method_failed',
+      connectionFailed: true,
     })
     render(
       <MemoryRouter>
@@ -420,11 +347,11 @@ describe('ZookeeperConversationPane', () => {
 
   test('requires an explicit resume for an interrupted turn', () => {
     const fake = createFakeController({
-      actorContext: {
-        awaitingResponse: false,
-        conversation: interruptedConversation,
-      },
-      actorValue: ZookeeperManagerStates.WaitForContinueCheck,
+      conversation: interruptedConversation,
+      disabled: true,
+      hasPromptCompleted: false,
+      interruptedTurnAwaitingResume: true,
+      isLoading: false,
       isResumingInterruptedTurn: true,
     })
     render(
@@ -445,10 +372,9 @@ describe('ZookeeperConversationPane', () => {
 
   test('consumes the URL prompt and falls back through user and server modes', async () => {
     const fake = createFakeController({
-      actorContext: {
-        conversation: completedConversation,
-        defaultMode: 'server-mode',
-      },
+      conversation: completedConversation,
+      defaultMode: 'server-mode',
+      isLoading: false,
     })
     render(
       <MemoryRouter

--- a/src/lib/zookeeper/components/ZookeeperConversationPane.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPane.tsx
@@ -8,14 +8,7 @@ import { ZookeeperConversation } from '@src/lib/zookeeper/components/ZookeeperCo
 import { ZookeeperConversationWelcome } from '@src/lib/zookeeper/components/ZookeeperConversationWelcome'
 import type { ZookeeperSessionController } from '@src/lib/zookeeper/registry/controller'
 import type { MlCopilotModeId } from '@src/lib/zookeeper/zookeeperManagerMachine'
-import {
-  hasBeenInterruptedOnLast,
-  ZookeeperManagerStates,
-  ZookeeperManagerTransitions,
-} from '@src/lib/zookeeper/zookeeperManagerMachine'
 import type { ModelingMachineContext } from '@src/machines/modelingSharedTypes'
-import { S } from '@src/machines/utils'
-import { useSelector } from '@xstate/react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 
@@ -30,58 +23,7 @@ export const ZookeeperConversationPane = (props: {
   const [defaultPrompt, setDefaultPrompt] = useState('')
   const [searchParams, setSearchParams] = useSearchParams()
   const controller = props.controller
-  const actor = controller.actor
-
-  let conversation = useSelector(actor, (snapshot) => {
-    return snapshot.context.conversation
-  })
-  const abruptlyClosed = useSelector(actor, (snapshot) => {
-    return snapshot.context.abruptlyClosed
-  })
-  const setupFailed = useSelector(actor, (snapshot) => {
-    return snapshot.context.setupFailed
-  })
-  const closeReason = useSelector(actor, (snapshot) => {
-    return snapshot.context.closeReason
-  })
-  const accessDeniedCode = useSelector(actor, (snapshot) => {
-    return snapshot.context.accessDeniedCode
-  })
-  const conversationId = useSelector(actor, (snapshot) => {
-    return snapshot.context.conversationId
-  })
-  const isSettingUp = useSelector(actor, (snapshot) => {
-    return snapshot.matches(ZookeeperManagerStates.Setup)
-  })
-  const isAwaitingConnection = useSelector(actor, (snapshot) => {
-    return snapshot.matches(S.Await)
-  })
-  const isPromptRunning = useSelector(actor, (snapshot) => {
-    return snapshot.context.awaitingResponse
-  })
-  const interruptedTurnAwaitingResume = useSelector(
-    actor,
-    (snapshot) =>
-      snapshot.matches(ZookeeperManagerStates.WaitForContinueCheck) &&
-      hasBeenInterruptedOnLast(snapshot.context.conversation?.exchanges ?? [])
-  )
-  const modeOptions = useSelector(actor, (snapshot) => {
-    return snapshot.context.modeOptions
-  })
-  const attachmentsLoadedForCurrentPrompt = useSelector(
-    actor,
-    (snapshot) => snapshot.context.attachmentsLoadedForCurrentPrompt
-  )
-  const attachmentFetches = useSelector(actor, (snapshot) => {
-    return snapshot.context.attachmentFetches
-  })
-  const defaultMode = useSelector(actor, (snapshot) => {
-    return snapshot.context.defaultMode
-  })
-
-  if (isAwaitingConnection && !abruptlyClosed) {
-    conversation = undefined
-  }
+  const view = controller.view.value
 
   const checkBillingWhenFocused = useRef(false)
   const checkBillingAccess = useCallback(() => {
@@ -92,7 +34,7 @@ export const ZookeeperConversationPane = (props: {
   }, [])
 
   useEffect(() => {
-    if (!setupFailed || accessDeniedCode === undefined) {
+    if (!view.connectionFailed || view.accessDeniedCode === undefined) {
       checkBillingWhenFocused.current = false
       return
     }
@@ -116,7 +58,7 @@ export const ZookeeperConversationPane = (props: {
       window.removeEventListener('focus', checkAfterBilling)
       document.removeEventListener('visibilitychange', checkAfterBilling)
     }
-  }, [accessDeniedCode, checkBillingAccess, setupFailed])
+  }, [checkBillingAccess, view.accessDeniedCode, view.connectionFailed])
 
   useEffect(() => {
     const promptParam =
@@ -133,28 +75,19 @@ export const ZookeeperConversationPane = (props: {
     setSearchParams(nextSearchParams, { replace: true })
   }, [searchParams, setSearchParams])
 
-  const showManualConnect = controller.showManualConnect.value
-  const isClearingChat = controller.isClearingChat.value
-  const isResumingInterruptedTurn = controller.isResumingInterruptedTurn.value
-  const needsReconnect = abruptlyClosed || showManualConnect
-  const isLoadingAttachments =
-    !attachmentsLoadedForCurrentPrompt && conversation !== undefined
   const initialMlCopilotMode =
-    props.zookeeperMode.project ?? props.zookeeperMode.user ?? defaultMode
+    props.zookeeperMode.project ?? props.zookeeperMode.user ?? view.defaultMode
 
   return (
     <ZookeeperConversation
-      isLoading={conversation === undefined}
-      isLoadingAttachments={isLoadingAttachments}
+      isLoading={view.isLoading}
+      isLoadingAttachments={view.isLoadingAttachments}
       contexts={[{ type: 'selections', data: props.selectionRanges }]}
-      conversation={conversation}
-      attachmentFetches={attachmentFetches}
-      onFetchAttachment={(attachmentRef) => {
-        actor.send({
-          type: ZookeeperManagerTransitions.AttachmentFetch,
-          attachmentRef,
-        })
-      }}
+      conversation={view.conversation}
+      attachmentFetches={view.attachmentFetches}
+      onFetchAttachment={(attachmentRef) =>
+        controller.fetchAttachment(attachmentRef)
+      }
       welcomeMessage={<ZookeeperConversationWelcome />}
       onProcess={(prompt, mode, attachments) => {
         controller.sendOrQueue(prompt, mode, attachments)
@@ -165,42 +98,29 @@ export const ZookeeperConversationPane = (props: {
       onReconnect={() => controller.reconnect()}
       onCheckBilling={checkBillingAccess}
       onOpenBilling={onOpenBilling}
-      connectionError={
-        showManualConnect ? 'No internet connection.' : closeReason
-      }
-      connectionFailed={setupFailed}
-      accessDeniedCode={accessDeniedCode}
-      showManualConnect={showManualConnect}
-      canClearChat={setupFailed && conversationId !== undefined}
-      isClearingChat={isClearingChat}
-      loadingMessage={
-        isSettingUp
-          ? 'Connecting to Zookeeper...'
-          : needsReconnect
-            ? 'Reconnecting...'
-            : undefined
-      }
+      connectionError={view.connectionError}
+      connectionFailed={view.connectionFailed}
+      accessDeniedCode={view.accessDeniedCode}
+      showManualConnect={view.showManualConnect}
+      canClearChat={view.canClearChat}
+      isClearingChat={view.isClearingChat}
+      loadingMessage={view.loadingMessage}
       onCancel={() => controller.cancel()}
-      disabled={
-        needsReconnect ||
-        isClearingChat ||
-        interruptedTurnAwaitingResume ||
-        isResumingInterruptedTurn
-      }
-      needsReconnect={needsReconnect}
-      hasPromptCompleted={!isPromptRunning && !interruptedTurnAwaitingResume}
-      isProcessing={isPromptRunning}
-      interruptedTurnAwaitingResume={interruptedTurnAwaitingResume}
-      isResumingInterruptedTurn={isResumingInterruptedTurn}
+      disabled={view.disabled}
+      needsReconnect={view.needsReconnect}
+      hasPromptCompleted={view.hasPromptCompleted}
+      isProcessing={view.isProcessing}
+      interruptedTurnAwaitingResume={view.interruptedTurnAwaitingResume}
+      isResumingInterruptedTurn={view.isResumingInterruptedTurn}
       onResumeInterruptedTurn={() => controller.resumeInterruptedTurn()}
-      queue={[...controller.queue.value]}
+      queue={[...view.queue]}
       onRemoveFromQueue={(id) => controller.removeQueued(id)}
       onSteer={(id) => controller.steer(id)}
       userAvatarSrc={props.userAvatarSrc}
       defaultPrompt={defaultPrompt}
       initialMlCopilotMode={initialMlCopilotMode}
       onMlCopilotModeChange={props.onMlCopilotModeChange}
-      modeOptions={modeOptions}
+      modeOptions={view.modeOptions}
       modeScopeKey={controller.projectPath}
     />
   )

--- a/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.spec.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.spec.tsx
@@ -7,8 +7,10 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   browserSaveFile: vi.fn(async () => undefined),
   contextModeling: { selectionRanges: [] },
-  conversation: { exchanges: [] },
-  markdown: vi.fn(() => '# Conversation'),
+  getConversationExport: vi.fn(() => ({
+    fileName: 'conversation-123.md',
+    markdown: '# Conversation',
+  })),
   paneProps: undefined as Record<string, unknown> | undefined,
   settings: {
     app: { zookeeperMode: { project: undefined, user: undefined } },
@@ -100,19 +102,9 @@ vi.mock('@src/lib/browserSaveFile', () => ({
   browserSaveFile: mocks.browserSaveFile,
 }))
 
-vi.mock('@src/lib/zookeeper/zookeeperManagerMachine', () => ({
-  ZookeeperConversationToMarkdown: mocks.markdown,
-}))
-
-const actor = {
-  getSnapshot: () => ({
-    context: {
-      conversation: mocks.conversation,
-      conversationId: 'conversation-123',
-    },
-  }),
-}
-const controller = { actor } as unknown as ZookeeperSessionController
+const controller = {
+  getConversationExport: mocks.getConversationExport,
+} as unknown as ZookeeperSessionController
 
 function renderWrapper(onClose = vi.fn()) {
   return {
@@ -135,7 +127,7 @@ function renderWrapper(onClose = vi.fn()) {
 describe('ZookeeperConversationPaneWrapper', () => {
   beforeEach(() => {
     mocks.browserSaveFile.mockClear()
-    mocks.markdown.mockClear()
+    mocks.getConversationExport.mockClear()
     mocks.paneProps = undefined
     mocks.settingsSend.mockClear()
   })
@@ -179,7 +171,7 @@ describe('ZookeeperConversationPaneWrapper', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Export conversation' }))
 
-    expect(mocks.markdown).toHaveBeenCalledWith(mocks.conversation)
+    expect(mocks.getConversationExport).toHaveBeenCalledOnce()
     expect(mocks.browserSaveFile).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'text/markdown' }),
       'conversation-123.md',

--- a/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.tsx
+++ b/src/lib/zookeeper/components/ZookeeperConversationPaneWrapper.tsx
@@ -7,10 +7,6 @@ import { browserSaveFile } from '@src/lib/browserSaveFile'
 import type { AreaTypeComponentProps } from '@src/lib/layout'
 import { ZookeeperConversationPane } from '@src/lib/zookeeper/components/ZookeeperConversationPane'
 import type { ZookeeperSessionController } from '@src/lib/zookeeper/registry/controller'
-import {
-  ZookeeperConversationToMarkdown,
-  type ZookeeperManagerActor,
-} from '@src/lib/zookeeper/zookeeperManagerMachine'
 
 export function ZookeeperConversationPaneWrapper(
   props: Pick<AreaTypeComponentProps, 'layout' | 'onClose'> & {
@@ -34,7 +30,7 @@ export function ZookeeperConversationPaneWrapper(
         icon="sparkles"
         title="Zookeeper"
         onClose={props.onClose}
-        Menu={<ZookeeperConversationMenu actor={controller.actor} />}
+        Menu={<ZookeeperConversationMenu controller={controller} />}
       />
       <ZookeeperConversationPane
         controller={controller}
@@ -53,25 +49,23 @@ export function ZookeeperConversationPaneWrapper(
 }
 
 const ZookeeperConversationMenu = ({
-  actor,
+  controller,
 }: {
-  actor: ZookeeperManagerActor
+  controller: ZookeeperSessionController
 }) => (
   <HeaderMenu>
     <Menu.Item>
       <button
         type="button"
         onClick={() => {
-          const context = actor.getSnapshot().context
-          const markdown = ZookeeperConversationToMarkdown(context.conversation)
-          const blob = new Blob([new TextEncoder().encode(markdown)], {
-            type: 'text/markdown',
-          })
-          void browserSaveFile(
-            blob,
-            `${context.conversationId ?? new Date().toISOString()}.md`,
-            ''
+          const conversationExport = controller.getConversationExport()
+          const blob = new Blob(
+            [new TextEncoder().encode(conversationExport.markdown)],
+            {
+              type: 'text/markdown',
+            }
           )
+          void browserSaveFile(blob, conversationExport.fileName, '')
         }}
         className="menuButton"
       >

--- a/src/lib/zookeeper/registry/controller.test.ts
+++ b/src/lib/zookeeper/registry/controller.test.ts
@@ -1,4 +1,4 @@
-import { signal } from '@preact/signals-core'
+import { effect, signal } from '@preact/signals-core'
 import type { ZookeeperConversationStore } from '@src/lib/zookeeper/zookeeperConversationStore'
 import type * as ZookeeperManagerMachineModule from '@src/lib/zookeeper/zookeeperManagerMachine'
 import type { ZookeeperManagerActor } from '@src/lib/zookeeper/zookeeperManagerMachine'
@@ -78,6 +78,7 @@ import {
   createZookeeperSessionController,
   type ZookeeperSessionController,
   type ZookeeperSessionControllerDependencies,
+  type ZookeeperSessionView,
 } from '@src/lib/zookeeper/registry/controller'
 import {
   ZookeeperManagerStates,
@@ -90,6 +91,7 @@ type TestState =
   | 'await'
   | 'ready'
   | 'ready-await'
+  | 'setup'
   | 'wait-for-continue-check'
 
 type ActorSnapshot = ReturnType<ZookeeperManagerActor['getSnapshot']>
@@ -101,12 +103,18 @@ function createSnapshot(
 ): ActorSnapshot {
   return {
     context: {
+      accessDeniedCode: undefined,
       abruptlyClosed: false,
+      attachmentFetches: {},
+      attachmentsLoadedForCurrentPrompt: true,
       awaitingResponse: false,
+      closeReason: undefined,
       conversation: undefined,
       conversationId: undefined,
+      defaultMode: undefined,
       lastMessageId: undefined,
       lastMessageType: undefined,
+      modeOptions: undefined,
       setupFailed: false,
       ...context,
     },
@@ -119,6 +127,9 @@ function createSnapshot(
       }
       if (expected === ZookeeperManagerStates.Ready) {
         return state === 'ready' || state === 'ready-await'
+      }
+      if (expected === ZookeeperManagerStates.Setup) {
+        return state === 'setup'
       }
       if (expected === ZookeeperManagerStates.WaitForContinueCheck) {
         return state === 'wait-for-continue-check'
@@ -327,7 +338,6 @@ describe('Zookeeper session controller', () => {
         apiToken: 'rotated-token',
       },
     ])
-    expect(controller.actor).toBe(actor)
     expect(conversationStore.saveProjectConversationId).toHaveBeenCalledWith({
       projectId,
       conversationId: 'conversation-id',
@@ -337,6 +347,124 @@ describe('Zookeeper session controller', () => {
       { type: BillingTransition.UsageEnded },
       { type: BillingTransition.Update, apiToken: 'rotated-token' },
     ])
+  })
+
+  it('publishes actor and controller state through a reactive view', () => {
+    const conversation = { exchanges: [] }
+    const attachmentFetches = {
+      'prompt:0:0': { status: 'loading' as const },
+    }
+    const modeOptions = [
+      {
+        id: 'edit',
+        label: 'Edit',
+        description: 'Edit the model',
+        icon: 'sparkles' as const,
+        disabled: false,
+      },
+    ]
+    const { actor, controller } = createHarness({
+      actorState: 'setup',
+      actorContext: {
+        abruptlyClosed: true,
+        accessDeniedCode: 'payment_method_failed',
+        attachmentFetches,
+        attachmentsLoadedForCurrentPrompt: false,
+        awaitingResponse: true,
+        closeReason: 'Connection lost.',
+        conversation,
+        conversationId: 'conversation-id',
+        defaultMode: 'edit',
+        modeOptions,
+        setupFailed: true,
+      },
+    })
+
+    const publishedViews: ZookeeperSessionView[] = []
+    const stopViewEffect = effect(() => {
+      publishedViews.push(controller.view.value)
+    })
+    const initialView = controller.view.value
+    expect(initialView).toMatchObject({
+      accessDeniedCode: 'payment_method_failed',
+      attachmentFetches,
+      canClearChat: true,
+      connectionError: 'Connection lost.',
+      connectionFailed: true,
+      conversation,
+      defaultMode: 'edit',
+      disabled: true,
+      hasPromptCompleted: false,
+      interruptedTurnAwaitingResume: false,
+      isClearingChat: false,
+      isLoading: false,
+      isLoadingAttachments: true,
+      isProcessing: true,
+      isResumingInterruptedTurn: false,
+      loadingMessage: 'Connecting to Zookeeper...',
+      modeOptions,
+      needsReconnect: true,
+      queue: [],
+      showManualConnect: false,
+    })
+
+    actor.emit('await', { conversation })
+    expect(publishedViews).toHaveLength(2)
+    expect(controller.view.value).not.toBe(initialView)
+    expect(controller.view.value).toMatchObject({
+      conversation: undefined,
+      disabled: false,
+      hasPromptCompleted: true,
+      isLoading: true,
+      loadingMessage: undefined,
+      needsReconnect: false,
+    })
+
+    const awaitingView = controller.view.value
+    window.dispatchEvent(new Event('offline'))
+    expect(publishedViews).toHaveLength(3)
+    expect(controller.view.value).not.toBe(awaitingView)
+    expect(controller.view.value).toMatchObject({
+      connectionError: 'No internet connection.',
+      disabled: true,
+      loadingMessage: 'Reconnecting...',
+      needsReconnect: true,
+      showManualConnect: true,
+    })
+    stopViewEffect()
+  })
+
+  it('keeps actor commands behind the session controller', () => {
+    const { actor, controller } = createHarness({
+      actorState: 'await',
+      actorContext: {
+        conversation: interruptedConversation,
+        conversationId: 'conversation-id',
+      },
+    })
+    const attachmentRef = {
+      prompt_id: '00000000-0000-4000-8000-000000000001',
+      seq: 3,
+      index: 1,
+      content_hash:
+        'sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+    }
+
+    controller.fetchAttachment(attachmentRef)
+
+    expect(controller.view.value.conversation).toBeUndefined()
+    expect(
+      sentEvents(actor, ZookeeperManagerTransitions.AttachmentFetch)
+    ).toEqual([
+      {
+        type: ZookeeperManagerTransitions.AttachmentFetch,
+        attachmentRef,
+      },
+    ])
+    expect(controller.getConversationExport()).toEqual({
+      fileName: 'conversation-id.md',
+      markdown: expect.stringContaining('finish the bracket'),
+    })
   })
 
   it.each([
@@ -384,7 +512,7 @@ describe('Zookeeper session controller', () => {
     const attachment = new File(['notes'], 'notes.txt')
 
     controller.sendOrQueue('add two holes', undefined, [attachment])
-    expect(controller.queue.value).toHaveLength(1)
+    expect(controller.view.value.queue).toHaveLength(1)
 
     actor.emit('ready-await', { awaitingResponse: false })
 
@@ -393,7 +521,7 @@ describe('Zookeeper session controller', () => {
         sentEvents(actor, ZookeeperManagerTransitions.MessageSend)
       ).toHaveLength(1)
     })
-    expect(controller.queue.value).toHaveLength(0)
+    expect(controller.view.value.queue).toHaveLength(0)
     expect(projectFilesMocks.collect).toHaveBeenCalledWith({
       fileNames: kclManager.execState.filenames,
       projectContext: project,
@@ -418,7 +546,7 @@ describe('Zookeeper session controller', () => {
     executingEditor.value = undefined
     controller.sendOrQueue('add a mounting hole', undefined, [])
 
-    expect(controller.queue.value).toHaveLength(1)
+    expect(controller.view.value.queue).toHaveLength(1)
     expect(projectFilesMocks.collect).not.toHaveBeenCalled()
 
     executingEditor.value = kclManager
@@ -428,7 +556,7 @@ describe('Zookeeper session controller', () => {
         sentEvents(actor, ZookeeperManagerTransitions.MessageSend)
       ).toHaveLength(1)
     })
-    expect(controller.queue.value).toHaveLength(0)
+    expect(controller.view.value.queue).toHaveLength(0)
   })
 
   it('does not submit a queued prompt removed during project collection', async () => {
@@ -439,7 +567,7 @@ describe('Zookeeper session controller', () => {
     })
 
     controller.sendOrQueue('remove this prompt', undefined, [])
-    const queuedMessage = controller.queue.value[0]
+    const queuedMessage = controller.view.value.queue[0]
     if (!queuedMessage) {
       throw new Error('Expected the prompt to be queued')
     }
@@ -450,7 +578,7 @@ describe('Zookeeper session controller', () => {
     collectedFiles.resolve([])
     await flushPromises()
 
-    expect(controller.queue.value).toHaveLength(0)
+    expect(controller.view.value.queue).toHaveLength(0)
     expect(
       sentEvents(actor, ZookeeperManagerTransitions.MessageSend)
     ).toHaveLength(0)
@@ -461,7 +589,7 @@ describe('Zookeeper session controller', () => {
 
     controller.sendOrQueue('wait for request await', undefined, [])
 
-    expect(controller.queue.value).toHaveLength(1)
+    expect(controller.view.value.queue).toHaveLength(1)
     expect(projectFilesMocks.collect).not.toHaveBeenCalled()
 
     actor.emit('ready-await')
@@ -471,7 +599,7 @@ describe('Zookeeper session controller', () => {
         sentEvents(actor, ZookeeperManagerTransitions.MessageSend)
       ).toHaveLength(1)
     })
-    expect(controller.queue.value).toHaveLength(0)
+    expect(controller.view.value.queue).toHaveLength(0)
   })
 
   it('keeps rapid prompts in submission order', async () => {
@@ -488,7 +616,7 @@ describe('Zookeeper session controller', () => {
     controller.sendOrQueue('second prompt', undefined, [])
 
     expect(projectFilesMocks.collect).toHaveBeenCalledOnce()
-    expect(controller.queue.value.map(({ text }) => text)).toEqual([
+    expect(controller.view.value.queue.map(({ text }) => text)).toEqual([
       'first prompt',
       'second prompt',
     ])
@@ -658,11 +786,11 @@ describe('Zookeeper session controller', () => {
 
     online = false
     window.dispatchEvent(new Event('offline'))
-    expect(controller.showManualConnect.value).toBe(true)
+    expect(controller.view.value.showManualConnect).toBe(true)
 
     controller.reconnect()
 
-    expect(controller.showManualConnect.value).toBe(false)
+    expect(controller.view.value.showManualConnect).toBe(false)
     expect(
       sentEvents(actor, ZookeeperManagerTransitions.CacheSetupAndConnect)
     ).toHaveLength(2)
@@ -682,7 +810,7 @@ describe('Zookeeper session controller', () => {
 
     const clearPromise = controller.clearConversation()
 
-    expect(controller.isClearingChat.value).toBe(true)
+    expect(controller.view.value.isClearingChat).toBe(true)
     expect(
       sentEvents(actor, ZookeeperManagerTransitions.ConversationClose)
     ).toHaveLength(0)
@@ -701,8 +829,8 @@ describe('Zookeeper session controller', () => {
     actor.emit('await')
     await flushPromises()
 
-    expect(controller.queue.value).toHaveLength(0)
-    expect(controller.isClearingChat.value).toBe(false)
+    expect(controller.view.value.queue).toHaveLength(0)
+    expect(controller.view.value.isClearingChat).toBe(false)
     expect(workerMocks.processors[0].reset).toHaveBeenCalledOnce()
     expect(workerMocks.histories[0].reset).toHaveBeenCalledOnce()
     expect(
@@ -728,7 +856,7 @@ describe('Zookeeper session controller', () => {
       conversationId: 'old-conversation',
     })
 
-    expect(controller.isClearingChat.value).toBe(true)
+    expect(controller.view.value.isClearingChat).toBe(true)
     expect(conversationStore.saveProjectConversationId).not.toHaveBeenCalled()
 
     deletion.resolve(undefined)
@@ -764,7 +892,7 @@ describe('Zookeeper session controller', () => {
     actor.emit('await')
     await flushPromises()
 
-    expect(controller.queue.value).toHaveLength(0)
+    expect(controller.view.value.queue).toHaveLength(0)
     expect(
       sentEvents(actor, ZookeeperManagerTransitions.MessageSend)
     ).toHaveLength(0)
@@ -908,13 +1036,16 @@ describe('Zookeeper session controller', () => {
     })
 
     expect(projectFilesMocks.collect).not.toHaveBeenCalled()
-    expect(controller.isResumingInterruptedTurn.value).toBe(false)
+    expect(controller.view.value.interruptedTurnAwaitingResume).toBe(true)
+    expect(controller.view.value.disabled).toBe(true)
+    expect(controller.view.value.hasPromptCompleted).toBe(false)
+    expect(controller.view.value.isResumingInterruptedTurn).toBe(false)
 
     controller.resumeInterruptedTurn()
     controller.resumeInterruptedTurn()
 
     expect(projectFilesMocks.collect).toHaveBeenCalledOnce()
-    expect(controller.isResumingInterruptedTurn.value).toBe(true)
+    expect(controller.view.value.isResumingInterruptedTurn).toBe(true)
 
     collectedFiles.resolve([])
     await flushPromises()
@@ -926,7 +1057,7 @@ describe('Zookeeper session controller', () => {
         projectName: 'bracket',
       }),
     ])
-    expect(controller.isResumingInterruptedTurn.value).toBe(false)
+    expect(controller.view.value.isResumingInterruptedTurn).toBe(false)
   })
 
   it('invalidates a pending resume after leaving the continue state', async () => {
@@ -937,7 +1068,7 @@ describe('Zookeeper session controller', () => {
       conversation: interruptedConversation,
     })
     controller.resumeInterruptedTurn()
-    expect(controller.isResumingInterruptedTurn.value).toBe(true)
+    expect(controller.view.value.isResumingInterruptedTurn).toBe(true)
 
     actor.emit('ready', { conversation: interruptedConversation })
     actor.emit('wait-for-continue-check', {
@@ -946,7 +1077,7 @@ describe('Zookeeper session controller', () => {
     collectedFiles.resolve([])
     await flushPromises()
 
-    expect(controller.isResumingInterruptedTurn.value).toBe(false)
+    expect(controller.view.value.isResumingInterruptedTurn).toBe(false)
     expect(
       sentEvents(actor, ZookeeperManagerStates.ContinueCheck)
     ).toHaveLength(0)

--- a/src/lib/zookeeper/registry/controller.ts
+++ b/src/lib/zookeeper/registry/controller.ts
@@ -1,9 +1,13 @@
 import {
+  batch,
+  computed,
   effect,
   type ReadonlySignal,
   signal,
+  type Signal,
   untracked,
 } from '@preact/signals-core'
+import type { AttachmentRef, MlCopilotAccessDeniedCode } from '@kittycad/lib'
 import type { KclManager, ZDSProject } from '@src/lang/KclManager'
 import { BillingTransition } from '@src/lib/billing'
 import type { BillingRegistryService } from '@src/lib/billing/registry/contract'
@@ -17,10 +21,14 @@ import {
   zookeeperConversationStore,
 } from '@src/lib/zookeeper/zookeeperConversationStore'
 import {
+  type Conversation,
   createZookeeperManagerActor,
   hasBeenInterruptedOnLast,
   type MlCopilotModeId,
+  type MlCopilotModeOption,
   stopZookeeperManagerActor,
+  type ZookeeperAttachmentFetchState,
+  ZookeeperConversationToMarkdown,
   type ZookeeperManagerActor,
   ZookeeperManagerStates,
   ZookeeperManagerTransitions,
@@ -51,17 +59,43 @@ export interface QueuedMessage {
   attachments: File[]
 }
 
+export interface ZookeeperSessionView {
+  accessDeniedCode?: MlCopilotAccessDeniedCode
+  attachmentFetches: Record<string, ZookeeperAttachmentFetchState>
+  canClearChat: boolean
+  connectionError?: string
+  connectionFailed: boolean
+  conversation?: Conversation
+  defaultMode?: MlCopilotModeId
+  disabled: boolean
+  hasPromptCompleted: boolean
+  interruptedTurnAwaitingResume: boolean
+  isClearingChat: boolean
+  isLoading: boolean
+  isLoadingAttachments: boolean
+  isProcessing: boolean
+  isResumingInterruptedTurn: boolean
+  loadingMessage?: string
+  modeOptions?: MlCopilotModeOption[]
+  needsReconnect: boolean
+  queue: readonly QueuedMessage[]
+  showManualConnect: boolean
+}
+
+export interface ZookeeperConversationExport {
+  fileName: string
+  markdown: string
+}
+
 export interface ZookeeperSessionController {
-  readonly actor: ZookeeperManagerActor
-  readonly isClearingChat: ReadonlySignal<boolean>
-  readonly isResumingInterruptedTurn: ReadonlySignal<boolean>
   readonly projectPath: string
-  readonly queue: ReadonlySignal<readonly QueuedMessage[]>
-  readonly showManualConnect: ReadonlySignal<boolean>
+  readonly view: ReadonlySignal<ZookeeperSessionView>
   cancel(): void
   checkBillingAccess(): void
   clearConversation(): Promise<void>
   dispose(): Promise<void>
+  fetchAttachment(attachmentRef: AttachmentRef): void
+  getConversationExport(): ZookeeperConversationExport
   reconnect(): void
   removeQueued(id: string): void
   resumeInterruptedTurn(): void
@@ -77,24 +111,21 @@ export interface ZookeeperSessionController {
 type ZookeeperSnapshot = SnapshotFrom<ZookeeperManagerActor>
 
 class SessionController implements ZookeeperSessionController {
-  readonly actor: ZookeeperManagerActor
   readonly projectPath: string
+  readonly view: ReadonlySignal<ZookeeperSessionView>
+
+  private readonly actor: ZookeeperManagerActor
+  private readonly snapshotSignal: Signal<ZookeeperSnapshot>
 
   private readonly queueSignal = signal<QueuedMessage[]>([])
-  readonly queue: ReadonlySignal<readonly QueuedMessage[]> = this.queueSignal
 
   private readonly isClearingChatSignal = signal(false)
-  readonly isClearingChat: ReadonlySignal<boolean> = this.isClearingChatSignal
 
   private readonly isResumingInterruptedTurnSignal = signal(false)
-  readonly isResumingInterruptedTurn: ReadonlySignal<boolean> =
-    this.isResumingInterruptedTurnSignal
 
   private readonly showManualConnectSignal = signal(
     typeof navigator !== 'undefined' && navigator.onLine === false
   )
-  readonly showManualConnect: ReadonlySignal<boolean> =
-    this.showManualConnectSignal
 
   private apiToken: string
   private active = true
@@ -126,6 +157,8 @@ class SessionController implements ZookeeperSessionController {
     this.projectId = deps.projectId
     this.projectPath = deps.projectPath
     this.actor = createZookeeperManagerActor(deps.apiToken)
+    this.snapshotSignal = signal(this.actor.getSnapshot())
+    this.view = computed(() => this.createView(this.snapshotSignal.value))
     this.history = new ZookeeperEditPatchHistory(deps.kclManager)
     this.fileRequestProcessor = new ZookeeperFileRequestProcessor({
       getProject: () => this.getProject(),
@@ -143,7 +176,10 @@ class SessionController implements ZookeeperSessionController {
     })
 
     this.actorSubscription = this.actor.subscribe((snapshot) => {
-      this.handleSnapshot(snapshot)
+      batch(() => {
+        this.snapshotSignal.value = snapshot
+        this.handleSnapshot(snapshot)
+      })
     })
 
     if (typeof window !== 'undefined') {
@@ -244,6 +280,24 @@ class SessionController implements ZookeeperSessionController {
       apiToken: this.apiToken,
     })
     this.reconnect()
+  }
+
+  fetchAttachment(attachmentRef: AttachmentRef) {
+    if (!this.active) {
+      return
+    }
+    this.actor.send({
+      type: ZookeeperManagerTransitions.AttachmentFetch,
+      attachmentRef,
+    })
+  }
+
+  getConversationExport(): ZookeeperConversationExport {
+    const { conversation, conversationId } = this.actor.getSnapshot().context
+    return {
+      fileName: `${conversationId ?? new Date().toISOString()}.md`,
+      markdown: ZookeeperConversationToMarkdown(conversation),
+    }
   }
 
   reconnect = () => {
@@ -555,6 +609,57 @@ class SessionController implements ZookeeperSessionController {
     this.tryConnectWhenIdle(snapshot)
     this.reconcileReconnect(snapshot)
     this.flushQueue(snapshot)
+  }
+
+  private createView(snapshot: ZookeeperSnapshot): ZookeeperSessionView {
+    const { context } = snapshot
+    const showManualConnect = this.showManualConnectSignal.value
+    const isClearingChat = this.isClearingChatSignal.value
+    const isResumingInterruptedTurn = this.isResumingInterruptedTurnSignal.value
+    const needsReconnect = context.abruptlyClosed || showManualConnect
+    const interruptedTurnAwaitingResume =
+      snapshot.matches(ZookeeperManagerStates.WaitForContinueCheck) &&
+      hasBeenInterruptedOnLast(context.conversation?.exchanges ?? [])
+    const conversation =
+      snapshot.matches(S.Await) && !context.abruptlyClosed
+        ? undefined
+        : context.conversation
+
+    return {
+      accessDeniedCode: context.accessDeniedCode,
+      attachmentFetches: context.attachmentFetches,
+      canClearChat: context.setupFailed && context.conversationId !== undefined,
+      connectionError: showManualConnect
+        ? 'No internet connection.'
+        : context.closeReason,
+      connectionFailed: context.setupFailed,
+      conversation,
+      defaultMode: context.defaultMode,
+      disabled:
+        needsReconnect ||
+        isClearingChat ||
+        interruptedTurnAwaitingResume ||
+        isResumingInterruptedTurn,
+      hasPromptCompleted:
+        !context.awaitingResponse && !interruptedTurnAwaitingResume,
+      interruptedTurnAwaitingResume,
+      isClearingChat,
+      isLoading: conversation === undefined,
+      isLoadingAttachments:
+        !context.attachmentsLoadedForCurrentPrompt &&
+        conversation !== undefined,
+      isProcessing: context.awaitingResponse,
+      isResumingInterruptedTurn,
+      loadingMessage: snapshot.matches(ZookeeperManagerStates.Setup)
+        ? 'Connecting to Zookeeper...'
+        : needsReconnect
+          ? 'Reconnecting...'
+          : undefined,
+      modeOptions: context.modeOptions,
+      needsReconnect,
+      queue: this.queueSignal.value,
+      showManualConnect,
+    }
   }
 
   private updateBilling(isPromptRunning: boolean) {


### PR DESCRIPTION
Follow-up to #13741, addressing the review feedback about keeping session state and the XState actor out of React.

The session controller now exposes one reactive view plus named commands for attachment fetching and conversation export. The actor and raw snapshot stay private, while the pane becomes a renderer of controller state instead of interpreting machine states itself.

View publication is batched with actor reconciliation so consumers cannot observe an intermediate state. Conversation export still reads the latest underlying conversation, including while the display view intentionally hides it during connection setup.
