### PR TITLE
Generalize workspace modes and add DFM Review plugin

### DIFF
--- a/e2e/playwright/fixtures/fixtureSetup.ts
+++ b/e2e/playwright/fixtures/fixtureSetup.ts
@@ -1,4 +1,4 @@
-import type { Feature } from '@kittycad/lib'
+import type { UserFeature } from '@src/lib/userFeatures'
 /* eslint-disable react-hooks/rules-of-hooks */
 import type {
   BrowserContext,
@@ -98,7 +98,7 @@ export class AuthenticatedApp {
     this.testInfo = testInfo
   }
 
-  async initialise(code = '', userFeatures: readonly Feature[] = []) {
+  async initialise(code = '', userFeatures: readonly UserFeature[] = []) {
     await setup(this.context, this.page, this.testInfo, userFeatures)
     const u = await getUtils(this.page)
 
@@ -198,7 +198,7 @@ export class ElectronZoo {
 
   async createInstanceIfMissing(
     testInfo: TestInfo,
-    userFeatures: readonly Feature[] = []
+    userFeatures: readonly UserFeature[] = []
   ) {
     // Create or otherwise clear the folder.
     this.projectDirName = testInfo.outputPath('electron-test-projects-dir')
@@ -443,7 +443,7 @@ const fixturesForWeb = {
     }: {
       page: Page
       context: BrowserContext
-      userFeatures: readonly Feature[]
+      userFeatures: readonly UserFeature[]
     },
     use: FnUse,
     testInfo: TestInfo

--- a/e2e/playwright/modes.spec.ts
+++ b/e2e/playwright/modes.spec.ts
@@ -1,0 +1,186 @@
+import { expect, test } from '@e2e/playwright/zoo-test'
+import { DFM_REVIEW_FEATURE_FLAG } from '@src/lib/constants'
+
+const GDT_COMMANDS = [
+  'angularity',
+  'annotation',
+  'circularity',
+  'concentricity',
+  'cylindricity',
+  'datum',
+  'distance',
+  'flatness',
+  'note',
+  'parallelism',
+  'perpendicularity',
+  'position',
+  'profile',
+  'runout',
+  'straightness',
+  'symmetry',
+]
+
+test.describe('Registry modes', { tag: ['@web', '@desktop'] }, () => {
+  test.beforeEach(async ({ homePage, scene }) => {
+    await homePage.goToModelingScene()
+    await scene.settled()
+  })
+
+  test.describe('without the DFM Review feature', () => {
+    test.use({ userFeatures: [] })
+
+    test('does not expose the mode or plugin toggle', async ({ page }) => {
+      await expect(page.getByTestId('toolbar')).toHaveAttribute(
+        'data-current-mode',
+        'modeling'
+      )
+      await expect(page.locator('option[value="dfm-review"]')).toHaveCount(0)
+
+      await page.getByRole('link', { name: 'Settings' }).last().click()
+      await page.getByRole('radio', { name: 'Plugins' }).click()
+      await expect(
+        page.getByRole('heading', { name: 'DFM Review' })
+      ).toHaveCount(0)
+      await expect(page.locator('#plugin-toggle-dfm-review')).toHaveCount(0)
+    })
+  })
+
+  test.describe('with the DFM Review feature', () => {
+    test.use({ userFeatures: [DFM_REVIEW_FEATURE_FLAG] })
+
+    test('switches toolbars without replacing the engine stream and safely enters and exits sketch', async ({
+      page,
+      scene,
+      toolbar,
+    }) => {
+      const mode = page.getByRole('combobox', { name: 'Mode', exact: true })
+      const toolbarElement = page.getByTestId('toolbar')
+      const video = page.locator('#video-stream')
+
+      await scene.connectionEstablished()
+      await expect
+        .poll(() => video.evaluate((el: HTMLVideoElement) => !!el.srcObject))
+        .toBe(true)
+      const engineStream = await video.evaluateHandle(
+        (el: HTMLVideoElement) => ({
+          video: el,
+          media: el.srcObject,
+        })
+      )
+      const expectSameEngineStream = async () => {
+        expect(
+          await engineStream.evaluate(
+            ({ video: originalVideo, media }) =>
+              originalVideo === document.getElementById('video-stream') &&
+              originalVideo.srcObject === media
+          )
+        ).toBe(true)
+      }
+
+      await test.step('DFM Review exposes every GD&T command on the existing engine scene', async () => {
+        await expect(mode).toHaveValue('modeling')
+        await mode.selectOption({ label: 'DFM Review' })
+        await expect(toolbarElement).toHaveAttribute(
+          'data-current-mode',
+          'dfm-review'
+        )
+        await expect(toolbar.startSketchBtn).toHaveCount(0)
+        for (const command of GDT_COMMANDS) {
+          await expect(
+            toolbarElement.getByTestId(`gdt-${command}`)
+          ).toBeVisible()
+          await expect(
+            toolbarElement.getByTestId(`gdt-${command}`)
+          ).toBeEnabled()
+        }
+        await expectSameEngineStream()
+
+        await toolbarElement.getByTestId('gdt-note').click()
+        await expect(page.getByTestId('command-name')).toHaveText('GDT Note')
+        await page.keyboard.press('Escape')
+        await expect(page.getByTestId('command-bar-wrapper')).not.toBeVisible()
+      })
+
+      await test.step('Modeling restores the standard tools and keeps the engine stream', async () => {
+        await mode.selectOption({ label: 'Modeling' })
+        await expect(toolbarElement).toHaveAttribute(
+          'data-current-mode',
+          'modeling'
+        )
+        await expect(toolbar.startSketchBtn).toBeEnabled()
+        await expectSameEngineStream()
+      })
+
+      await test.step('Sketch owns its mode until the sketch is exited', async () => {
+        await toolbar.startSketchOnDefaultPlane('Top plane')
+        await expect(toolbar.exitSketchBtn).toBeEnabled()
+        await expect(mode).toBeDisabled()
+        await expect(mode.locator('option:checked')).toHaveText('Sketch')
+        await toolbar.exitSketch()
+        await expect(mode).toBeEnabled()
+        await expect(mode).toHaveValue('modeling')
+        await mode.selectOption({ label: 'DFM Review' })
+        await expect(toolbarElement).toHaveAttribute(
+          'data-current-mode',
+          'dfm-review'
+        )
+      })
+
+      await engineStream.dispose()
+    })
+
+    test('plugin settings preserve the active mode until its plugin is disabled', async ({
+      page,
+      toolbar,
+    }) => {
+      const mode = page.getByRole('combobox', { name: 'Mode', exact: true })
+      await mode.selectOption({ label: 'DFM Review' })
+
+      await test.step('Changing an unrelated plugin preserves DFM Review', async () => {
+        await page.getByRole('link', { name: 'Settings' }).last().click()
+        await page.getByRole('radio', { name: 'Plugins' }).click()
+        const slicerToggle = page.locator('#plugin-toggle-slicer')
+        const wasSlicerEnabled = await slicerToggle.isChecked()
+        await page.locator('label', { has: slicerToggle }).click()
+        await expect(slicerToggle).toBeChecked({ checked: !wasSlicerEnabled })
+        await page.getByTestId('settings-close-button').click()
+
+        await expect(mode).toHaveValue('dfm-review')
+        await expect(page.getByTestId('toolbar')).toHaveAttribute(
+          'data-current-mode',
+          'dfm-review'
+        )
+      })
+
+      await page.getByRole('link', { name: 'Settings' }).last().click()
+      await page.getByRole('radio', { name: 'Plugins' }).click()
+      const pluginToggle = page.locator('#plugin-toggle-dfm-review')
+      const pluginToggleLabel = page.locator('label', { has: pluginToggle })
+      await expect(pluginToggle).toBeChecked()
+      await pluginToggleLabel.click()
+      await expect(pluginToggle).not.toBeChecked()
+      await page.getByTestId('settings-close-button').click()
+
+      await expect(page.getByTestId('toolbar')).toHaveAttribute(
+        'data-current-mode',
+        'modeling'
+      )
+      await expect(toolbar.startSketchBtn).toBeEnabled()
+      await expect(page.locator('option[value="dfm-review"]')).toHaveCount(0)
+
+      await page.getByRole('link', { name: 'Settings' }).last().click()
+      await page.getByRole('radio', { name: 'Plugins' }).click()
+      await pluginToggleLabel.click()
+      await expect(pluginToggle).toBeChecked()
+      await page.getByTestId('settings-close-button').click()
+
+      await expect(mode).toHaveValue('modeling')
+      await mode.selectOption({ label: 'DFM Review' })
+      await expect(page.getByTestId('toolbar')).toHaveAttribute(
+        'data-current-mode',
+        'dfm-review'
+      )
+      await expect(page.getByTestId('gdt-flatness')).toBeEnabled()
+    })
+  })
+})

--- a/e2e/playwright/test-utils.ts
+++ b/e2e/playwright/test-utils.ts
@@ -1,6 +1,7 @@
+import type { UserFeature } from '@src/lib/userFeatures'
 import path from 'path'
 import * as TOML from '@iarna/toml'
-import type { Feature, OutputFormat3d } from '@kittycad/lib'
+import type { OutputFormat3d } from '@kittycad/lib'
 import type {
   BrowserContext,
   Locator,
@@ -1021,7 +1022,7 @@ export async function setup(
   context: BrowserContext,
   page: Page,
   testInfo?: TestInfo,
-  userFeatures: readonly Feature[] = [],
+  userFeatures: readonly UserFeature[] = [],
   { cloudSyncEnabled = false }: { cloudSyncEnabled?: boolean } = {}
 ) {
   const testProjectSettings =

--- a/e2e/playwright/zoo-test.ts
+++ b/e2e/playwright/zoo-test.ts
@@ -1,10 +1,10 @@
+import type { UserFeature } from '@src/lib/userFeatures'
 import { expect, test as playwrightTestFn } from '@e2e/playwright/base-test'
 import type { Fixtures } from '@e2e/playwright/fixtures/fixtureSetup'
 import {
   ElectronZoo,
   fixturesBasedOnProcessEnvPlatform,
 } from '@e2e/playwright/fixtures/fixtureSetup'
-import type { Feature } from '@kittycad/lib'
 
 export { expect }
 
@@ -32,7 +32,7 @@ let isFirstRun = true
 // switch between web and electron if needed.
 const playwrightTestFnWithFixtures_ = playwrightTestFn.extend<{
   tronApp?: ElectronZoo
-  userFeatures: Feature[]
+  userFeatures: UserFeature[]
 }>({
   userFeatures: [[], { option: true }],
   tronApp: [

--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -5,6 +5,7 @@ import { ActionButtonDropdown } from '@src/components/ActionButtonDropdown'
 import { ActionButtonRecentDropdown } from '@src/components/ActionButtonRecentDropdown'
 import { LegacySketchModeBanner } from '@src/components/Announcements'
 import { CustomIcon } from '@src/components/CustomIcon'
+import { ModePicker } from '@src/components/ModePicker'
 import Tooltip, {
   RICH_TOOLTIP_SURFACE_CLASS_NAME,
 } from '@src/components/Tooltip'
@@ -21,6 +22,7 @@ import {
 } from '@src/lib/automaticRendering'
 import { useApp, useSingletons } from '@src/lib/boot'
 import { EngineConnectionStateType } from '@src/lib/engineConnection/utils'
+import { EXPERIMENTAL_POINT_AND_CLICK_FLAG } from '@src/lib/constants'
 import { type HotkeySequence, hotkeyDisplay } from '@src/lib/hotkeys'
 import { isDesktop } from '@src/lib/isDesktop'
 import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
@@ -32,6 +34,7 @@ import type {
   ToolbarItemResolvedDropdown,
 } from '@src/lib/toolbar'
 import {
+  filterExperimentalToolbarItems,
   getDefaultRecentToolbarItemIds,
   getToolbarDropdownDisplay,
   isSketchToolbarTransitioning,
@@ -50,6 +53,10 @@ import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { getSymmetricToolSelectionStep } from '@src/machines/sketchSolve/constraints/constraintUtils'
 import type { sketchSolveMachine } from '@src/machines/sketchSolve/sketchSolveDiagram'
 import { executingEditorService } from '@src/registry/contracts/executingEditor'
+import {
+  modesService,
+  resolveModeKeymapScopes,
+} from '@src/registry/contracts/modes'
 import {
   findKeymapItemForCommand,
   keymapKeystrokesDisplay,
@@ -87,6 +94,10 @@ const Toolbar_ = memo(
     const executionService = app.registry.signal(executingEditorService).value
     const keymapScopes = app.registry.signal(keymapScopesValueSpec).value
     const toolbarConfig = useToolbarConfig()
+    const showExperimentalFeatures = app.userFeatures.useHas(
+      EXPERIMENTAL_POINT_AND_CLICK_FLAG,
+      false
+    )
     const wasmInstance = use(kclManager.wasmInstancePromise)
     const iconClassName =
       'group-disabled:text-chalkboard-50 !text-inherit dark:group-enabled:group-hover:!text-inherit'
@@ -125,14 +136,25 @@ const Toolbar_ = memo(
       !props.isStreamReady ||
       !props.isStreamAcceptingInput
 
-    // Load bearing logic for determining the items in the toolbar
-    // Based on the state of the modeling machine determine what toolbar should be rendered
-    const toolbarConfigurationName = modelingMachineStateToToolbarModeName(
-      props.state
+    const activeMode = app.registry.get(modesService).activeMode.value
+    const toolbarConfigurationName = activeMode?.id ?? 'modeling'
+    const modeToolbar = activeMode?.toolbar ?? 'modeling'
+    const toolbarItems = useMemo(
+      () =>
+        typeof modeToolbar === 'string'
+          ? toolbarConfig[modeToolbar].items
+          : filterExperimentalToolbarItems(
+              modeToolbar,
+              showExperimentalFeatures
+            ),
+      [modeToolbar, toolbarConfig, showExperimentalFeatures]
     )
-    const currentToolbarKeymapScopes = [
-      toolbarModeNameToKeymapScope[toolbarConfigurationName],
-    ]
+    const currentToolbarKeymapScopes = resolveModeKeymapScopes(
+      activeMode,
+      toolbarModeNameToKeymapScope[
+        modelingMachineStateToToolbarModeName(props.state)
+      ]
+    )
     const unrenderedExecuteHotkeyLabel = keymapKeystrokesDisplay(
       findKeymapItemForCommand(
         keymapTree,
@@ -233,25 +255,23 @@ const Toolbar_ = memo(
       | ToolbarItemResolvedDropdown
       | 'break'
     )[] = useMemo(() => {
-      return toolbarConfig[toolbarConfigurationName].items.map(
-        (maybeIconConfig) => {
-          if (maybeIconConfig === 'break') {
-            return 'break'
-          } else if (isToolbarDropdown(maybeIconConfig)) {
-            return {
-              id: maybeIconConfig.id,
-              display: maybeIconConfig.display,
-              visibleItemCount: maybeIconConfig.visibleItemCount,
-              defaultVisibleItemIds: maybeIconConfig.defaultVisibleItemIds,
-              array: maybeIconConfig.array.map((item) =>
-                resolveItemConfig(item, wasmInstance)
-              ),
-            }
-          } else {
-            return resolveItemConfig(maybeIconConfig, wasmInstance)
+      return toolbarItems.map((maybeIconConfig) => {
+        if (maybeIconConfig === 'break') {
+          return 'break'
+        } else if (isToolbarDropdown(maybeIconConfig)) {
+          return {
+            id: maybeIconConfig.id,
+            display: maybeIconConfig.display,
+            visibleItemCount: maybeIconConfig.visibleItemCount,
+            defaultVisibleItemIds: maybeIconConfig.defaultVisibleItemIds,
+            array: maybeIconConfig.array.map((item) =>
+              resolveItemConfig(item, wasmInstance)
+            ),
           }
+        } else {
+          return resolveItemConfig(maybeIconConfig, wasmInstance)
         }
-      )
+      })
 
       function resolveItemConfig(
         maybeIconConfig: ToolbarItem,
@@ -331,6 +351,8 @@ const Toolbar_ = memo(
       // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
     }, [
       toolbarConfigurationName,
+      toolbarItems,
+      activeMode?.keymapScope,
       disableAllButtons,
       disableSketchToolbar,
       configCallbackProps,
@@ -342,12 +364,7 @@ const Toolbar_ = memo(
 
     // To remember the last selected item in a standard ActionButtonDropdown
     const [lastSelectedMultiActionItem, setLastSelectedMultiActionItem] =
-      useState(
-        new Map<
-          number /* index in currentModeItems */,
-          number /* index in maybeIconConfig */
-        >()
-      )
+      useState(new Map<string, string>())
     const [, setRecentDropdownItemIds] = useState(new Map<string, string[]>())
     const [visibleRecentDropdownItemIds, setVisibleRecentDropdownItemIds] =
       useState(new Map<string, string[]>())
@@ -364,23 +381,24 @@ const Toolbar_ = memo(
         itemId: string,
         shouldPromoteIntoVisibleItems: boolean
       ) => {
+        const dropdownKey = `${toolbarConfigurationName}/${dropdown.id}`
         setRecentDropdownItemIds((previous) => {
           const next = new Map(previous)
           const nextRecentItemIds = recordRecentToolbarItemId(
             itemId,
-            next.get(dropdown.id) ?? [],
+            next.get(dropdownKey) ?? [],
             dropdown
           )
-          next.set(dropdown.id, nextRecentItemIds)
+          next.set(dropdownKey, nextRecentItemIds)
 
           if (shouldPromoteIntoVisibleItems) {
             setVisibleRecentDropdownItemIds((previousVisible) => {
               const nextVisible = new Map(previousVisible)
               nextVisible.set(
-                dropdown.id,
+                dropdownKey,
                 promoteRecentToolbarItemId(
                   itemId,
-                  nextVisible.get(dropdown.id) ??
+                  nextVisible.get(dropdownKey) ??
                     getDefaultRecentToolbarItemIds(dropdown),
                   nextRecentItemIds,
                   dropdown
@@ -393,7 +411,7 @@ const Toolbar_ = memo(
           return next
         })
       },
-      []
+      [toolbarConfigurationName]
     )
 
     return (
@@ -412,6 +430,7 @@ const Toolbar_ = memo(
             disableSketchToolbar ? 'pointer-events-none' : ''
           }`}
         >
+          <ModePicker disabled={props.isExecuting} />
           {/* A menu item will either be a vertical line break, a button with a dropdown, or a single button */}
           {currentModeItems.map((maybeIconConfig, i) => {
             // Vertical Line Break
@@ -423,9 +442,11 @@ const Toolbar_ = memo(
                 />
               )
             } else if (isToolbarItemResolvedDropdown(maybeIconConfig)) {
+              if (maybeIconConfig.array.length === 0) return null
+              const dropdownKey = `${toolbarConfigurationName}/${maybeIconConfig.id}`
               if (getToolbarDropdownDisplay(maybeIconConfig) === 'recent') {
                 const visibleItemIds =
-                  visibleRecentDropdownItemIds.get(maybeIconConfig.id) ??
+                  visibleRecentDropdownItemIds.get(dropdownKey) ??
                   getDefaultRecentToolbarItemIds(maybeIconConfig)
                 const { visibleItems } = resolveRecentToolbarItems(
                   maybeIconConfig,
@@ -560,7 +581,11 @@ const Toolbar_ = memo(
 
               const selectedIcon =
                 maybeIconConfig.array.find((c) => c.isActive) ||
-                maybeIconConfig.array[lastSelectedMultiActionItem.get(i) ?? 0]
+                maybeIconConfig.array.find(
+                  (item) =>
+                    item.id === lastSelectedMultiActionItem.get(dropdownKey)
+                ) ||
+                maybeIconConfig.array[0]
 
               return (
                 <ActionButtonDropdown
@@ -588,7 +613,7 @@ const Toolbar_ = memo(
                     onClick: (event) => {
                       setLastSelectedMultiActionItem((previous) => {
                         const next = new Map(previous)
-                        next.set(i, maybeIconConfig.array.indexOf(itemConfig))
+                        next.set(dropdownKey, itemConfig.id)
                         return next
                       })
                       itemConfig.onClick({

--- a/src/components/ConnectionStream.tsx
+++ b/src/components/ConnectionStream.tsx
@@ -1,5 +1,5 @@
 import { useAppState } from '@src/AppState'
-import { ClientSideScene } from '@src/clientSideScene/ClientSideSceneComp'
+import { ModeScene } from '@src/components/ModeScene'
 import Loading from '@src/components/Loading'
 import { ViewControlContextMenu } from '@src/components/ViewControlMenu'
 import { useOnOfflineToExitSketchMode } from '@src/hooks/network/useOnOfflineToExitSketchMode'
@@ -655,13 +655,7 @@ export const ConnectionStream = (props: ConnectionStreamProps) => {
       >
         No canvas support
       </canvas>
-      <ClientSideScene
-        cameraControls={settingsValues.modeling.mouseControls.current}
-        enableTouchControls={
-          settingsValues.modeling.enableTouchControls.current
-        }
-        sketchSolveStreamDimming={props.sketchSolveStreamDimming}
-      />
+      <ModeScene {...props.streamLayerProps} />
       {props.streamLayers.map((layer) => {
         return (
           <div

--- a/src/components/ModePicker.test.tsx
+++ b/src/components/ModePicker.test.tsx
@@ -1,0 +1,145 @@
+import {
+  Registry,
+  Slot,
+  createPlugin,
+  defineRegistryItem,
+  pluginsValueSpec,
+} from '@kittycad/registry'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({ useApp: vi.fn() }))
+vi.mock('@src/lib/boot', () => ({ useApp: mocks.useApp }))
+
+import { ModePicker } from '@src/components/ModePicker'
+import { modesService, provideMode } from '@src/registry/contracts/modes'
+import modesRegistryItem from '@src/registry/extensions/modes'
+
+describe('ModePicker', () => {
+  let registry: Registry
+  let pluginSlot: Slot
+
+  beforeEach(() => {
+    registry = new Registry()
+    pluginSlot = new Slot()
+    registry.configure([modesRegistryItem, pluginSlot.of()])
+    mocks.useApp.mockReturnValue({ registry })
+  })
+
+  afterEach(() => {
+    cleanup()
+    registry[Symbol.dispose]()
+    vi.clearAllMocks()
+  })
+
+  async function installReviewMode() {
+    await act(async () => {
+      await registry.reconfigureAsync(pluginSlot, [
+        createPlugin({
+          id: 'review-plugin',
+          title: 'DFM Review',
+          description: 'Review the current model.',
+          items: [
+            defineRegistryItem({
+              provides: [
+                provideMode({
+                  id: 'dfm-review',
+                  label: 'DFM Review',
+                  toolbar: [],
+                }),
+              ],
+            }),
+          ],
+        }),
+      ])
+    })
+  }
+
+  function renderPicker(disabled = false) {
+    render(
+      <ul>
+        <ModePicker disabled={disabled} />
+      </ul>
+    )
+  }
+
+  it('stays hidden until another selectable mode is registered', async () => {
+    renderPicker()
+    expect(screen.queryByRole('combobox', { name: 'Mode' })).toBeNull()
+
+    await installReviewMode()
+
+    expect(screen.getByRole('combobox', { name: 'Mode' })).toHaveValue(
+      'modeling'
+    )
+    expect(
+      screen.getAllByRole('option').map((option) => option.textContent)
+    ).toEqual(['Modeling', 'DFM Review'])
+  })
+
+  it('switches the selected mode through the registry service', async () => {
+    await installReviewMode()
+    renderPicker()
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Mode' }), {
+      target: { value: 'dfm-review' },
+    })
+
+    expect(registry.get(modesService).activeMode.value?.id).toBe('dfm-review')
+    expect(screen.getByRole('combobox', { name: 'Mode' })).toHaveValue(
+      'dfm-review'
+    )
+  })
+
+  it('shows the forced sketch mode and disables switching until sketch exit', async () => {
+    await installReviewMode()
+    renderPicker()
+    const modes = registry.get(modesService)
+    act(() => {
+      modes.setMode('dfm-review')
+      modes.syncModelingMode('sketchSolve')
+    })
+
+    expect(screen.getByRole('combobox', { name: 'Mode' })).toBeDisabled()
+    expect(screen.getByRole('combobox', { name: 'Mode' })).toHaveValue(
+      'sketchSolve'
+    )
+    expect(screen.getByRole('option', { name: 'Sketch' })).toBeInTheDocument()
+
+    act(() => modes.syncModelingMode('modeling'))
+
+    expect(screen.getByRole('combobox', { name: 'Mode' })).toBeEnabled()
+    expect(screen.getByRole('combobox', { name: 'Mode' })).toHaveValue(
+      'dfm-review'
+    )
+    expect(screen.queryByRole('option', { name: 'Sketch' })).toBeNull()
+  })
+
+  it('respects toolbar-level interaction locks', async () => {
+    await installReviewMode()
+    renderPicker(true)
+
+    expect(screen.getByRole('combobox', { name: 'Mode' })).toBeDisabled()
+  })
+
+  it('removes a disabled plugin mode and falls back without reselecting it on enable', async () => {
+    await installReviewMode()
+    renderPicker()
+    fireEvent.change(screen.getByRole('combobox', { name: 'Mode' }), {
+      target: { value: 'dfm-review' },
+    })
+    const [plugin] = registry.get(pluginsValueSpec)
+    const toggle = registry.get(plugin.service)
+
+    await act(async () => toggle.disable())
+
+    expect(screen.queryByRole('combobox', { name: 'Mode' })).toBeNull()
+    expect(registry.get(modesService).activeMode.value?.id).toBe('modeling')
+
+    await act(async () => toggle.enable())
+
+    expect(screen.getByRole('combobox', { name: 'Mode' })).toHaveValue(
+      'modeling'
+    )
+  })
+})

--- a/src/components/ModePicker.tsx
+++ b/src/components/ModePicker.tsx
@@ -1,0 +1,36 @@
+import { useSignals } from '@preact/signals-react/runtime'
+import { useApp } from '@src/lib/boot'
+import { modesService } from '@src/registry/contracts/modes'
+
+export function ModePicker({ disabled = false }: { disabled?: boolean }) {
+  useSignals()
+  const { registry } = useApp()
+  const modes = registry.get(modesService)
+  const activeMode = modes.activeMode.value
+  const selectableModes = modes.modes.value.filter(
+    (mode) => mode.selectable !== false
+  )
+
+  if (selectableModes.length < 2 || !activeMode) return null
+
+  return (
+    <li className="flex items-center border-r border-chalkboard-30 dark:border-chalkboard-80 pr-2 mr-1">
+      <select
+        aria-label="Mode"
+        className="text-xs bg-transparent rounded-sm border-0 py-1 pr-5 cursor-pointer disabled:cursor-default disabled:opacity-50"
+        value={activeMode.id}
+        disabled={disabled || !modes.canSelectMode.value}
+        onChange={(event) => modes.setMode(event.target.value)}
+      >
+        {activeMode.selectable === false && (
+          <option value={activeMode.id}>{activeMode.label}</option>
+        )}
+        {selectableModes.map((mode) => (
+          <option key={mode.id} value={mode.id}>
+            {mode.label}
+          </option>
+        ))}
+      </select>
+    </li>
+  )
+}

--- a/src/components/ModeScene.test.tsx
+++ b/src/components/ModeScene.test.tsx
@@ -1,0 +1,193 @@
+import {
+  Registry,
+  Slot,
+  createPlugin,
+  defineRegistryItem,
+  pluginsValueSpec,
+} from '@kittycad/registry'
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { useEffect } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  useApp: vi.fn(),
+  mountClientScene: vi.fn(),
+  unmountClientScene: vi.fn(),
+  mountCustomScene: vi.fn(),
+  unmountCustomScene: vi.fn(),
+}))
+
+vi.mock('@src/lib/boot', () => ({ useApp: mocks.useApp }))
+vi.mock('@src/clientSideScene/ClientSideSceneComp', () => ({
+  ClientSideScene: ({
+    sketchSolveStreamDimming,
+  }: {
+    sketchSolveStreamDimming: number
+  }) => {
+    useEffect(() => {
+      mocks.mountClientScene()
+      return mocks.unmountClientScene
+    }, [])
+    return <div>Engine interaction scene: {sketchSolveStreamDimming}</div>
+  },
+}))
+
+import { ModeScene } from '@src/components/ModeScene'
+import type { EngineSceneExtensionContext } from '@src/registry/contracts/engineScene'
+import { modesService, provideMode } from '@src/registry/contracts/modes'
+import modesRegistryItem from '@src/registry/extensions/modes'
+
+// Scene routing only forwards machine state; these scenes never read it.
+const context: EngineSceneExtensionContext = {
+  modelingState: null!,
+  modelingSend: vi.fn(),
+  sketchSolveStreamDimming: 0.3,
+  setSketchSolveStreamDimming: vi.fn(),
+}
+
+function CustomScene({
+  sketchSolveStreamDimming,
+}: EngineSceneExtensionContext) {
+  useEffect(() => {
+    mocks.mountCustomScene()
+    return mocks.unmountCustomScene
+  }, [])
+  return <div>Custom review scene: {sketchSolveStreamDimming}</div>
+}
+
+describe('ModeScene', () => {
+  let registry: Registry
+  let pluginSlot: Slot
+
+  beforeEach(() => {
+    registry = new Registry()
+    pluginSlot = new Slot()
+    registry.configure([modesRegistryItem, pluginSlot.of()])
+    mocks.useApp.mockReturnValue({
+      registry,
+      settings: {
+        useSettings: () => ({
+          modeling: {
+            mouseControls: { current: 'Zoo' },
+            enableTouchControls: { current: true },
+          },
+        }),
+      },
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    registry[Symbol.dispose]()
+    vi.clearAllMocks()
+  })
+
+  async function installReviewMode(Scene?: typeof CustomScene) {
+    await act(async () => {
+      await registry.reconfigureAsync(pluginSlot, [
+        createPlugin({
+          id: 'review-plugin',
+          title: 'Review',
+          description: 'Review the current model.',
+          items: [
+            defineRegistryItem({
+              provides: [
+                provideMode({
+                  id: 'review',
+                  label: 'Review',
+                  toolbar: [],
+                  Scene,
+                }),
+              ],
+            }),
+          ],
+        }),
+      ])
+    })
+  }
+
+  async function renderScene() {
+    const result = render(<ModeScene {...context} />)
+    await screen.findByText('Engine interaction scene: 0.3')
+    return result
+  }
+
+  it('keeps the same client scene mounted across toolbar-only and built-in sketch modes', async () => {
+    await installReviewMode()
+    await renderScene()
+    const modes = registry.get(modesService)
+
+    act(() => {
+      modes.setMode('review')
+    })
+    act(() => modes.syncModelingMode('onlyCancel'))
+    act(() => modes.syncModelingMode('sketching'))
+    act(() => modes.syncModelingMode('sketchSolve'))
+    act(() => modes.syncModelingMode('modeling'))
+    act(() => {
+      modes.setMode('modeling')
+    })
+
+    expect(
+      screen.getByText('Engine interaction scene: 0.3')
+    ).toBeInTheDocument()
+    expect(mocks.mountClientScene).toHaveBeenCalledTimes(1)
+    expect(mocks.unmountClientScene).not.toHaveBeenCalled()
+  })
+
+  it('mounts a plugin scene with viewport context and returns to the engine client scene on exit', async () => {
+    await installReviewMode(CustomScene)
+    await renderScene()
+    const modes = registry.get(modesService)
+
+    act(() => {
+      modes.setMode('review')
+    })
+
+    expect(screen.getByText('Custom review scene: 0.3')).toBeInTheDocument()
+    expect(screen.queryByText('Engine interaction scene: 0.3')).toBeNull()
+    expect(mocks.mountCustomScene).toHaveBeenCalledTimes(1)
+    expect(mocks.unmountClientScene).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      modes.setMode('modeling')
+    })
+
+    expect(
+      screen.getByText('Engine interaction scene: 0.3')
+    ).toBeInTheDocument()
+    expect(mocks.unmountCustomScene).toHaveBeenCalledTimes(1)
+    expect(mocks.mountClientScene).toHaveBeenCalledTimes(2)
+  })
+
+  it('unmounts an active plugin scene when the plugin is disabled', async () => {
+    await installReviewMode(CustomScene)
+    await renderScene()
+    act(() => {
+      registry.get(modesService).setMode('review')
+    })
+    const [plugin] = registry.get(pluginsValueSpec)
+
+    await act(async () => registry.get(plugin.service).disable())
+
+    expect(
+      screen.getByText('Engine interaction scene: 0.3')
+    ).toBeInTheDocument()
+    expect(mocks.unmountCustomScene).toHaveBeenCalledTimes(1)
+    expect(registry.get(modesService).selectedModeId.value).toBe('modeling')
+  })
+
+  it('does not remount the inherited client scene when a toolbar-only plugin is disabled', async () => {
+    await installReviewMode()
+    await renderScene()
+    act(() => {
+      registry.get(modesService).setMode('review')
+    })
+    const [plugin] = registry.get(pluginsValueSpec)
+
+    await act(async () => registry.get(plugin.service).disable())
+
+    expect(mocks.mountClientScene).toHaveBeenCalledTimes(1)
+    expect(mocks.unmountClientScene).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/ModeScene.tsx
+++ b/src/components/ModeScene.tsx
@@ -1,0 +1,20 @@
+import { useSignals } from '@preact/signals-react/runtime'
+import { useApp } from '@src/lib/boot'
+import type { EngineSceneExtensionContext } from '@src/registry/contracts/engineScene'
+import { modesService } from '@src/registry/contracts/modes'
+import { BuiltInModeScene } from '@src/registry/extensions/modes/builtinModes'
+import { Suspense } from 'react'
+
+/** The engine stream stays mounted while modes supply their client scene. */
+export function ModeScene(props: EngineSceneExtensionContext) {
+  useSignals()
+  const { registry } = useApp()
+  const Scene =
+    registry.get(modesService).activeMode.value?.Scene ?? BuiltInModeScene
+
+  return (
+    <Suspense fallback={null}>
+      <Scene {...props} />
+    </Suspense>
+  )
+}

--- a/src/components/ModelingMachineProvider.tsx
+++ b/src/components/ModelingMachineProvider.tsx
@@ -32,6 +32,10 @@ import {
 } from '@src/lib/engineConnection/utils'
 import { MODE_MODELING_COMMAND_SCOPE } from '@src/registry/contracts/commands'
 import { keymapService } from '@src/registry/contracts/keymap'
+import {
+  modesService,
+  resolveModeKeymapScopes,
+} from '@src/registry/contracts/modes'
 
 const MODELING_COMMAND_SCOPES = [MODE_MODELING_COMMAND_SCOPE] as const
 
@@ -175,16 +179,43 @@ export const ModelingMachineProvider = ({
 
   const toolbarConfigurationName =
     modelingMachineStateToToolbarModeName(modelingState)
-  const toolbarModeKeymapScope =
-    toolbarModeNameToKeymapScope[toolbarConfigurationName]
+  const modes = registry.get(modesService)
+
+  useEffect(() => {
+    // Service wrappers change identity when plugins reconfigure the registry.
+    // The machine subscription and its cleanup belong to this workspace.
+    const modes = registry.get(modesService)
+    const syncMode = (snapshot: StateFrom<typeof modelingMachine>) => {
+      modes.syncModelingMode(
+        modelingMachineStateToToolbarModeName(snapshot),
+        snapshot.matches('idle')
+      )
+    }
+    syncMode(modelingActor.getSnapshot())
+    const subscription = modelingActor.subscribe(syncMode)
+    return () => {
+      subscription.unsubscribe()
+      modes.reset()
+    }
+  }, [modelingActor, registry])
+
+  const activeMode = modes.activeMode.value
+  const modeKeymapScopes = useMemo(
+    () =>
+      resolveModeKeymapScopes(
+        activeMode,
+        toolbarModeNameToKeymapScope[toolbarConfigurationName]
+      ),
+    [activeMode, toolbarConfigurationName]
+  )
   const keymap = registry.get(keymapService)
 
   useEffect(() => {
-    keymap.applyScope(toolbarModeKeymapScope)
+    for (const scope of modeKeymapScopes) keymap.applyScope(scope)
     return () => {
-      keymap.removeScope(toolbarModeKeymapScope)
+      for (const scope of modeKeymapScopes) keymap.removeScope(scope)
     }
-  }, [keymap, toolbarModeKeymapScope])
+  }, [keymap, modeKeymapScopes])
 
   // Assumes all commands are network commands
   useSketchModeMenuEnableDisable(

--- a/src/components/PluginList.tsx
+++ b/src/components/PluginList.tsx
@@ -1,4 +1,4 @@
-import type { Feature } from '@kittycad/lib'
+import type { UserFeature } from '@src/lib/userFeatures'
 import type {
   PluginRecord,
   Registry,
@@ -27,7 +27,7 @@ export const PluginsList = forwardRef(
     const app = useApp()
     const settingsContext = app.settings.useSettings()
     const userFeaturesContext = app.userFeatures.useContext()
-    const hasFeature = (feature: Feature) =>
+    const hasFeature = (feature: UserFeature) =>
       userFeaturesContextHas(userFeaturesContext, feature, false)
     const activationSettings = props.registry.get(
       zdsPluginActivationSettingsValueSpec

--- a/src/components/Settings/AllSettingsFields.tsx
+++ b/src/components/Settings/AllSettingsFields.tsx
@@ -1,5 +1,5 @@
+import type { UserFeature } from '@src/lib/userFeatures'
 import { ActionButton } from '@src/components/ActionButton'
-import type { Feature } from '@kittycad/lib'
 import { SettingsFieldInput } from '@src/components/Settings/SettingsFieldInput'
 import { SettingsSection } from '@src/components/Settings/SettingsSection'
 import { useApp } from '@src/lib/boot'
@@ -54,7 +54,7 @@ export const AllSettingsFields = forwardRef(
     const context = settings.useSettings()
     const userFeaturesContext = userFeatures.useContext()
     const isOnboardingStartPending = useOnboardingStartPending()
-    const hasFeature = (feature: Feature) =>
+    const hasFeature = (feature: UserFeature) =>
       userFeaturesContextHas(userFeaturesContext, feature, false)
     const projectPath = useMemo(() => {
       const filteredPathname = location.pathname

--- a/src/components/Settings/SettingsSearchBar.tsx
+++ b/src/components/Settings/SettingsSearchBar.tsx
@@ -1,5 +1,5 @@
+import type { UserFeature } from '@src/lib/userFeatures'
 import { Combobox } from '@headlessui/react'
-import type { Feature } from '@kittycad/lib'
 import { useSignalEffect } from '@preact/signals-react'
 import { useSignals } from '@preact/signals-react/runtime'
 import { getKeybindingRows } from '@src/components/Settings/keybindingRows'
@@ -75,7 +75,7 @@ export function SettingsSearchBar({
   const settingsValues = settings.useSettings()
   const userFeaturesContext = userFeatures.useContext()
   const hasFeature = useCallback(
-    (feature: Feature) =>
+    (feature: UserFeature) =>
       userFeaturesContextHas(userFeaturesContext, feature, false),
     [userFeaturesContext]
   )

--- a/src/components/Settings/SettingsSectionsList.tsx
+++ b/src/components/Settings/SettingsSectionsList.tsx
@@ -1,4 +1,4 @@
-import type { Feature } from '@kittycad/lib'
+import type { UserFeature } from '@src/lib/userFeatures'
 import { useApp } from '@src/lib/boot'
 import type { SettingsLevel } from '@src/lib/settings/settingsTypes'
 import {
@@ -19,7 +19,7 @@ export function SettingsSectionsList({
   const { settings, userFeatures } = useApp()
   const context = settings.useSettings()
   const userFeaturesContext = userFeatures.useContext()
-  const hasFeature = (feature: Feature) =>
+  const hasFeature = (feature: UserFeature) =>
     userFeaturesContextHas(userFeaturesContext, feature, false)
 
   const visibleCategories = Object.entries(context).filter(

--- a/src/lang/lsp/service.test.ts
+++ b/src/lang/lsp/service.test.ts
@@ -1,4 +1,4 @@
-import type { Feature } from '@kittycad/lib'
+import type { UserFeature } from '@src/lib/userFeatures'
 import { createLspService } from '@src/lang/lsp/service'
 import type { KclLspEditor } from '@src/lang/lsp/types'
 import {
@@ -107,7 +107,7 @@ function createAuth(initialToken = 'token-a') {
 
 function createUserFeatures(
   initialState: UserFeaturesState,
-  initialFeatureIds: Set<Feature> = new Set()
+  initialFeatureIds: Set<UserFeature> = new Set()
 ) {
   let state = initialState
   let featureIds = initialFeatureIds
@@ -130,10 +130,13 @@ function createUserFeatures(
     listenerCount: () => listeners.size,
     service: {
       actor,
-      has: (featureFlagId: Feature, defaultValue: boolean) =>
+      has: (featureFlagId: UserFeature, defaultValue: boolean) =>
         featureIds.has(featureFlagId) ? true : defaultValue,
     } as unknown as UserFeaturesRegistryService,
-    update: (nextState: UserFeaturesState, nextFeatureIds: Set<Feature>) => {
+    update: (
+      nextState: UserFeaturesState,
+      nextFeatureIds: Set<UserFeature>
+    ) => {
       state = nextState
       featureIds = nextFeatureIds
       fetchedAt = nextState === UserFeaturesState.Ready ? new Date() : undefined

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -1,9 +1,10 @@
-import type { Feature } from '@kittycad/lib'
+import type { UserFeature } from '@src/lib/userFeatures'
 import { pluginsValueSpec } from '@kittycad/registry'
 import { signal } from '@preact/signals-core'
 import { File, type KclManager } from '@src/lang/KclManager'
 import { App } from '@src/lib/app'
 import {
+  DFM_REVIEW_FEATURE_FLAG,
   KCL_CEK_EXECUTOR_FEATURE_FLAG,
   KCL_NEW_LEXER_PARSER_FEATURE_FLAG,
   OPFS_CLOUD_FEATURE_FLAG,
@@ -29,6 +30,7 @@ import { commandsValueSpec } from '@src/registry/contracts/commands'
 import { engineConnectionService } from '@src/registry/contracts/engineConnection'
 import { executingEditorService } from '@src/registry/contracts/executingEditor'
 import { machineManagerService } from '@src/registry/contracts/machineManager'
+import { modesService } from '@src/registry/contracts/modes'
 import { projectSession } from '@src/registry/contracts/projectSession'
 import { userFeaturesService } from '@src/registry/contracts/userFeatures'
 import { wasmPromiseValueSpec } from '@src/registry/contracts/wasm'
@@ -135,10 +137,10 @@ function createUserFeaturesForTest(
     context: contextSignal,
     contextSignal,
     ready: readySignal,
-    has: (featureFlagId: Feature, defaultValue: boolean) =>
+    has: (featureFlagId: UserFeature, defaultValue: boolean) =>
       contextSignal.value.featureIds.has(featureFlagId) ? true : defaultValue,
     useContext: () => contextSignal.value,
-    useHas: (featureFlagId: Feature, defaultValue: boolean) =>
+    useHas: (featureFlagId: UserFeature, defaultValue: boolean) =>
       userFeatures.has(featureFlagId, defaultValue),
     setFeatureIds: (nextFeatureIds: UserFeaturesContext['featureIds']) => {
       contextSignal.value = {
@@ -536,6 +538,86 @@ describe('project system', () => {
           }),
         ])
       )
+    } finally {
+      app.dispose()
+    }
+  })
+
+  it('keeps DFM Review hidden and inactive without its feature, even when enabled in settings', async () => {
+    const userFeatures = createUserFeaturesForTest(new Set())
+    const app = createAppForTest({ userFeatures })
+
+    try {
+      await waitForSettingsIdle(app)
+      const setting = app.settings.get().plugins['dfm-review']
+
+      expect(setting.current).toBe(false)
+      expect(setting.hideWithoutFeature).toBe(DFM_REVIEW_FEATURE_FLAG)
+      expect(getPluginToggle(app, 'dfm-review').active.value).toBe(false)
+
+      app.settings.actor.send({
+        type: 'set.plugins.dfm-review',
+        data: { level: 'user', value: true },
+        doNotPersist: true,
+      })
+      await waitForSettingsIdle(app)
+
+      expect(app.settings.get().plugins['dfm-review'].current).toBe(true)
+      expect(getPluginToggle(app, 'dfm-review').active.value).toBe(false)
+      expect(app.registry.get(modesService).setMode('dfm-review')).toBe(false)
+    } finally {
+      app.dispose()
+    }
+  })
+
+  it('enables DFM Review when its feature arrives and disables it when the feature is removed', async () => {
+    const userFeatures = createUserFeaturesForTest(new Set())
+    const app = createAppForTest({ userFeatures })
+
+    try {
+      await waitForSettingsIdle(app)
+      userFeatures.setFeatureIds(new Set([DFM_REVIEW_FEATURE_FLAG]))
+
+      await expect
+        .poll(() => getPluginToggle(app, 'dfm-review').active.value)
+        .toBe(true)
+      expect(app.settings.get().plugins['dfm-review'].current).toBe(true)
+      const modes = app.registry.get(modesService)
+      expect(modes.setMode('dfm-review')).toBe(true)
+      expect(modes.activeMode.value?.id).toBe('dfm-review')
+
+      userFeatures.setFeatureIds(new Set())
+
+      await expect
+        .poll(() => getPluginToggle(app, 'dfm-review').active.value)
+        .toBe(false)
+      expect(modes.activeMode.value?.id).toBe('modeling')
+    } finally {
+      app.dispose()
+    }
+  })
+
+  it('preserves an explicit DFM Review opt-out for feature-flagged users', async () => {
+    const userFeatures = createUserFeaturesForTest(
+      new Set([DFM_REVIEW_FEATURE_FLAG])
+    )
+    const app = createAppForTest({ userFeatures })
+
+    try {
+      await expect
+        .poll(() => getPluginToggle(app, 'dfm-review').active.value)
+        .toBe(true)
+
+      app.settings.actor.send({
+        type: 'set.plugins.dfm-review',
+        data: { level: 'user', value: false },
+        doNotPersist: true,
+      })
+      await waitForSettingsIdle(app)
+      userFeatures.setFeatureIds(new Set([DFM_REVIEW_FEATURE_FLAG]))
+
+      expect(app.settings.get().plugins['dfm-review'].current).toBe(false)
+      expect(getPluginToggle(app, 'dfm-review').active.value).toBe(false)
     } finally {
       app.dispose()
     }

--- a/src/lib/cloudSync/registry/extension.test.ts
+++ b/src/lib/cloudSync/registry/extension.test.ts
@@ -1,4 +1,4 @@
-import type { Feature } from '@kittycad/lib'
+import type { UserFeature } from '@src/lib/userFeatures'
 import {
   defineRegistryItem,
   provideService,
@@ -243,7 +243,7 @@ describe('cloud sync extension', () => {
       id: 'test.user-features',
       providesServices: [
         provideService(userFeaturesService, {
-          has: (featureFlagId: Feature, defaultValue: boolean) =>
+          has: (featureFlagId: UserFeature, defaultValue: boolean) =>
             featureFlagId === OPFS_CLOUD_FEATURE_FLAG
               ? featureEnabled.value
               : defaultValue,

--- a/src/lib/cloudSync/registry/plugin.spec.tsx
+++ b/src/lib/cloudSync/registry/plugin.spec.tsx
@@ -1,4 +1,4 @@
-import type { Feature } from '@kittycad/lib'
+import type { UserFeature } from '@src/lib/userFeatures'
 import {
   defineRegistryItem,
   pluginsValueSpec,
@@ -356,7 +356,7 @@ function createSettingsService({
 }
 
 function createUserFeaturesService(
-  featureIds: Set<Feature> = new Set([OPFS_CLOUD_FEATURE_FLAG])
+  featureIds: Set<UserFeature> = new Set([OPFS_CLOUD_FEATURE_FLAG])
 ): UserFeaturesRegistryService {
   const context = signal({
     featureIds,
@@ -366,10 +366,10 @@ function createUserFeaturesService(
     context,
     contextSignal: context,
     ready: signal(true),
-    has: (featureFlagId: Feature, defaultValue: boolean) =>
+    has: (featureFlagId: UserFeature, defaultValue: boolean) =>
       context.value.featureIds.has(featureFlagId) ? true : defaultValue,
     useContext: () => context.value,
-    useHas: (featureFlagId: Feature, defaultValue: boolean) =>
+    useHas: (featureFlagId: UserFeature, defaultValue: boolean) =>
       context.value.featureIds.has(featureFlagId) ? true : defaultValue,
   } as unknown as UserFeaturesRegistryService
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,5 @@
 import type { Feature, WebSocketResponse } from '@kittycad/lib'
+import type { UserFeature } from '@src/lib/userFeatures'
 
 import type { UnitLength } from '@rust/kcl-lib/bindings/ModelingCmd'
 import type { WarningLevel } from '@rust/kcl-lib/bindings/WarningLevel'
@@ -33,6 +34,7 @@ export const DEFAULT_KCL_VERSION = '2.0'
 export const EXPERIMENTAL_POINT_AND_CLICK_FLAG: Feature =
   'sketch_experimental_features'
 export const OPFS_CLOUD_FEATURE_FLAG: Feature = 'web_app_file_browser'
+export const DFM_REVIEW_FEATURE_FLAG: UserFeature = 'dfm_review'
 export const SEGMENTS_BASED_REGIONS_FEATURE_FLAG: Feature =
   'segments_based_regions'
 export const KCL_CEK_EXECUTOR_FEATURE_FLAG: Feature = 'kcl_cek_executor'

--- a/src/lib/gdtToolbar.test.ts
+++ b/src/lib/gdtToolbar.test.ts
@@ -1,0 +1,37 @@
+import { createGdtToolbarItems } from '@src/lib/gdtToolbar'
+import { describe, expect, it, vi } from 'vitest'
+
+describe('GD&T toolbar', () => {
+  it('opens every GD&T command using its existing modeling command identity', () => {
+    const send = vi.fn()
+    const items = createGdtToolbarItems({ send })
+
+    expect(items.map(({ title }) => title)).toEqual([
+      'Angularity',
+      'Annotation',
+      'Circularity',
+      'Concentricity',
+      'Cylindricity',
+      'Datum',
+      'Distance',
+      'Flatness',
+      'Note',
+      'Parallelism',
+      'Perpendicularity',
+      'Position',
+      'Profile',
+      'Runout',
+      'Straightness',
+      'Symmetry',
+    ])
+
+    for (const item of items) {
+      item.onClick()
+
+      expect(send).toHaveBeenLastCalledWith({
+        type: 'Find and select command',
+        data: { name: `GDT ${item.title}`, groupId: 'modeling' },
+      })
+    }
+  })
+})

--- a/src/lib/gdtToolbar.ts
+++ b/src/lib/gdtToolbar.ts
@@ -1,0 +1,341 @@
+import type { ToolbarItem } from '@src/lib/toolbar'
+import { withSiteBaseURL } from '@src/lib/withBaseURL'
+import type { CommandSystemService } from '@src/registry/contracts/commands'
+
+type GdtToolbarItem = ToolbarItem & {
+  title: string
+  onClick: () => void
+}
+
+/** GD&T actions shared by the modeling dropdown and DFM Review toolbar. */
+export function createGdtToolbarItems(
+  commands: Pick<CommandSystemService, 'send'>
+): GdtToolbarItem[] {
+  const items: GdtToolbarItem[] = [
+    {
+      id: 'gdt-flatness',
+      onClick: () =>
+        commands.send({
+          type: 'Find and select command',
+          data: { name: 'GDT Flatness', groupId: 'modeling' },
+        }),
+      status: 'available',
+      title: 'Flatness',
+      icon: 'gdtFlatness',
+      description:
+        'Specifies flatness tolerance - how much a surface can deviate from perfectly flat.',
+      links: [
+        {
+          label: 'KCL docs',
+          url: withSiteBaseURL('/docs/kcl-std/functions/std-gdt-flatness'),
+        },
+      ],
+    },
+    {
+      id: 'gdt-straightness',
+      onClick: () =>
+        commands.send({
+          type: 'Find and select command',
+          data: { name: 'GDT Straightness', groupId: 'modeling' },
+        }),
+      status: 'available',
+      title: 'Straightness',
+      icon: 'gdtStraightness',
+      description:
+        'Specifies straightness tolerance - how much a face or edge can deviate from perfectly straight.',
+      links: [
+        {
+          label: 'KCL docs',
+          url: withSiteBaseURL('/docs/kcl-std/functions/std-gdt-straightness'),
+        },
+      ],
+    },
+    {
+      id: 'gdt-circularity',
+      onClick: () =>
+        commands.send({
+          type: 'Find and select command',
+          data: { name: 'GDT Circularity', groupId: 'modeling' },
+        }),
+      status: 'available',
+      title: 'Circularity',
+      icon: 'gdtCircularity',
+      description:
+        'Specifies circularity tolerance - how much a round face or edge can deviate from a perfect circle.',
+      links: [
+        {
+          label: 'KCL docs',
+          url: withSiteBaseURL('/docs/kcl-std/functions/std-gdt-circularity'),
+        },
+      ],
+    },
+    {
+      id: 'gdt-cylindricity',
+      onClick: () =>
+        commands.send({
+          type: 'Find and select command',
+          data: { name: 'GDT Cylindricity', groupId: 'modeling' },
+        }),
+      status: 'available',
+      title: 'Cylindricity',
+      icon: 'gdtCylindricity',
+      description:
+        'Specifies cylindricity tolerance - how much a round face or edge can deviate from a perfect cylinder.',
+      links: [
+        {
+          label: 'KCL docs',
+          url: withSiteBaseURL('/docs/kcl-std/functions/std-gdt-cylindricity'),
+        },
+      ],
+    },
+    {
+      id: 'gdt-datum',
+      onClick: () =>
+        commands.send({
+          type: 'Find and select command',
+          data: { name: 'GDT Datum', groupId: 'modeling' },
+        }),
+      status: 'available',
+      title: 'Datum',
+      icon: 'gdtDatum',
+      description:
+        'Establishes a reference surface for other GD&T measurements.',
+      links: [
+        {
+          label: 'KCL docs',
+          url: withSiteBaseURL('/docs/kcl-std/functions/std-gdt-datum'),
+        },
+      ],
+    },
+    {
+      id: 'gdt-profile',
+      onClick: () =>
+        commands.send({
+          type: 'Find and select command',
+          data: { name: 'GDT Profile', groupId: 'modeling' },
+        }),
+      status: 'available',
+      title: 'Profile',
+      icon: 'gdtProfile',
+      description:
+        'Specifies how much a surface or edge can deviate from its ideal shape.',
+      links: [
+        {
+          label: 'KCL docs',
+          url: withSiteBaseURL('/docs/kcl-std/functions/std-gdt-profile'),
+        },
+      ],
+    },
+    {
+      id: 'gdt-position',
+      onClick: () =>
+        commands.send({
+          type: 'Find and select command',
+          data: { name: 'GDT Position', groupId: 'modeling' },
+        }),
+      status: 'available',
+      title: 'Position',
+      icon: 'gdtPosition',
+      description:
+        'Controls location tolerance of holes, pins, and other features.',
+      links: [
+        {
+          label: 'KCL docs',
+          url: withSiteBaseURL('/docs/kcl-std/functions/std-gdt-position'),
+        },
+      ],
+    },
+    {
+      id: 'gdt-concentricity',
+      onClick: () =>
+        commands.send({
+          type: 'Find and select command',
+          data: {
+            name: 'GDT Concentricity',
+            groupId: 'modeling',
+          },
+        }),
+      status: 'available',
+      title: 'Concentricity',
+      icon: 'gdtConcentricity',
+      description:
+        'Controls how closely a feature axis aligns with a datum axis.',
+      links: [
+        {
+          label: 'KCL docs',
+          url: withSiteBaseURL('/docs/kcl-std/functions/std-gdt-concentricity'),
+        },
+      ],
+    },
+    {
+      id: 'gdt-symmetry',
+      onClick: () =>
+        commands.send({
+          type: 'Find and select command',
+          data: {
+            name: 'GDT Symmetry',
+            groupId: 'modeling',
+          },
+        }),
+      status: 'available',
+      title: 'Symmetry',
+      icon: 'gdtSymmetry',
+      description:
+        'Controls how closely median points align with a datum center plane.',
+      links: [
+        {
+          label: 'KCL docs',
+          url: withSiteBaseURL('/docs/kcl-std/functions/std-gdt-symmetry'),
+        },
+      ],
+    },
+    {
+      id: 'gdt-runout',
+      onClick: () =>
+        commands.send({
+          type: 'Find and select command',
+          data: {
+            name: 'GDT Runout',
+            groupId: 'modeling',
+          },
+        }),
+      status: 'available',
+      title: 'Runout',
+      icon: 'gdtRunout',
+      description:
+        'Controls how much a round feature may vary as it rotates around a datum axis.',
+      links: [
+        {
+          label: 'KCL docs',
+          url: withSiteBaseURL('/docs/kcl-std/functions/std-gdt-runout'),
+        },
+      ],
+    },
+    {
+      id: 'gdt-angularity',
+      onClick: () =>
+        commands.send({
+          type: 'Find and select command',
+          data: {
+            name: 'GDT Angularity',
+            groupId: 'modeling',
+          },
+        }),
+      status: 'available',
+      title: 'Angularity',
+      icon: 'angle',
+      description:
+        'Specifies how much a feature may deviate from an orientation at a basic angle.',
+      links: [
+        {
+          label: 'KCL docs',
+          url: withSiteBaseURL('/docs/kcl-std/functions/std-gdt-angularity'),
+        },
+      ],
+    },
+    {
+      id: 'gdt-perpendicularity',
+      onClick: () =>
+        commands.send({
+          type: 'Find and select command',
+          data: {
+            name: 'GDT Perpendicularity',
+            groupId: 'modeling',
+          },
+        }),
+      status: 'available',
+      title: 'Perpendicularity',
+      icon: 'perpendicular',
+      description:
+        'Specifies how perpendicular one feature must be to another.',
+      links: [
+        {
+          label: 'KCL docs',
+          url: withSiteBaseURL(
+            '/docs/kcl-std/functions/std-gdt-perpendicularity'
+          ),
+        },
+      ],
+    },
+    {
+      id: 'gdt-parallelism',
+      onClick: () =>
+        commands.send({
+          type: 'Find and select command',
+          data: {
+            name: 'GDT Parallelism',
+            groupId: 'modeling',
+          },
+        }),
+      status: 'available',
+      title: 'Parallelism',
+      icon: 'parallel',
+      description: 'Specifies how parallel one feature must be to another.',
+      links: [
+        {
+          label: 'KCL docs',
+          url: withSiteBaseURL('/docs/kcl-std/functions/std-gdt-parallelism'),
+        },
+      ],
+    },
+    {
+      id: 'gdt-distance',
+      onClick: () =>
+        commands.send({
+          type: 'Find and select command',
+          data: { name: 'GDT Distance', groupId: 'modeling' },
+        }),
+      status: 'available',
+      title: 'Distance',
+      icon: 'dimension',
+      description:
+        'Adds distance annotations to edge lengths or between two entities.',
+      links: [
+        {
+          label: 'KCL docs',
+          url: withSiteBaseURL('/docs/kcl-std/functions/std-gdt-distance'),
+        },
+      ],
+    },
+    {
+      id: 'gdt-annotation',
+      onClick: () =>
+        commands.send({
+          type: 'Find and select command',
+          data: { name: 'GDT Annotation', groupId: 'modeling' },
+        }),
+      status: 'available',
+      title: 'Annotation',
+      icon: 'text',
+      description:
+        'Adds text annotations for manufacturing instructions or inspection requirements.',
+      links: [
+        {
+          label: 'KCL docs',
+          url: withSiteBaseURL('/docs/kcl-std/functions/std-gdt-annotation'),
+        },
+      ],
+    },
+    {
+      id: 'gdt-note',
+      onClick: () =>
+        commands.send({
+          type: 'Find and select command',
+          data: { name: 'GDT Note', groupId: 'modeling' },
+        }),
+      status: 'available',
+      title: 'Note',
+      icon: 'note',
+      description:
+        'Adds a free-floating note on a plane, not attached to any geometry.',
+      links: [
+        {
+          label: 'KCL docs',
+          url: withSiteBaseURL('/docs/kcl-std/functions/std-gdt-note'),
+        },
+      ],
+    },
+  ]
+
+  return items.sort((a, b) => a.title.localeCompare(b.title))
+}

--- a/src/lib/kclRuntimeFlags.test.ts
+++ b/src/lib/kclRuntimeFlags.test.ts
@@ -1,4 +1,4 @@
-import type { Feature } from '@kittycad/lib'
+import type { UserFeature } from '@src/lib/userFeatures'
 import type { KclRuntimeFlags } from '@rust/kcl-lib/bindings/KclRuntimeFlags'
 import {
   KCL_CEK_EXECUTOR_FEATURE_FLAG,
@@ -16,9 +16,9 @@ import {
 } from '@src/machines/userFeaturesMachine'
 import { describe, expect, it, vi } from 'vitest'
 
-function userFeaturesWith(features: Set<Feature>) {
+function userFeaturesWith(features: Set<UserFeature>) {
   return {
-    has: (featureFlagId: Feature, defaultValue: boolean) =>
+    has: (featureFlagId: UserFeature, defaultValue: boolean) =>
       features.has(featureFlagId) ? true : defaultValue,
   }
 }
@@ -116,7 +116,7 @@ describe('kclRuntimeFlagsEqual', () => {
 describe('waitForSettledKclRuntimeFlags', () => {
   function gatedUserFeatures() {
     let settled = false
-    let featureIds = new Set<Feature>()
+    let featureIds = new Set<UserFeature>()
     const listeners = new Set<(snapshot: UserFeaturesSettleSnapshot) => void>()
     const snapshot = (): UserFeaturesSettleSnapshot => ({
       matches: (state) => settled && state === UserFeaturesState.Ready,
@@ -124,7 +124,7 @@ describe('waitForSettledKclRuntimeFlags', () => {
     })
     return {
       userFeatures: {
-        has: (featureFlagId: Feature, defaultValue: boolean) =>
+        has: (featureFlagId: UserFeature, defaultValue: boolean) =>
           featureIds.has(featureFlagId) ? true : defaultValue,
         actor: {
           getSnapshot: snapshot,
@@ -136,7 +136,7 @@ describe('waitForSettledKclRuntimeFlags', () => {
           },
         },
       },
-      settleWith: (nextFeatureIds: Set<Feature>) => {
+      settleWith: (nextFeatureIds: Set<UserFeature>) => {
         settled = true
         featureIds = nextFeatureIds
         for (const listener of listeners) {

--- a/src/lib/layout/registry/contract.ts
+++ b/src/lib/layout/registry/contract.ts
@@ -1,4 +1,4 @@
-import type { Feature } from '@kittycad/lib'
+import type { UserFeature } from '@src/lib/userFeatures'
 import {
   defineContract,
   defineService,
@@ -21,7 +21,7 @@ import type {
  */
 export type UserFeatureLayoutTransformation = {
   id: string
-  feature: Feature
+  feature: UserFeature
   defaultValue?: boolean
   transform: (layout: Layout, enabled: boolean) => Layout
 }

--- a/src/lib/layout/registry/extension.test.ts
+++ b/src/lib/layout/registry/extension.test.ts
@@ -1,4 +1,4 @@
-import type { Feature } from '@kittycad/lib'
+import type { UserFeature } from '@src/lib/userFeatures'
 import {
   Registry,
   defineRegistryItem,
@@ -106,9 +106,9 @@ function createRuntimeService(runtimeInfo = playwrightRuntime) {
 }
 
 function createUserFeaturesService(
-  featureIds: readonly Feature[] = []
+  featureIds: readonly UserFeature[] = []
 ): UserFeaturesRegistryService & {
-  setFeatureIds: (featureIds: readonly Feature[]) => void
+  setFeatureIds: (featureIds: readonly UserFeature[]) => void
 } {
   const context = signal({ featureIds: new Set(featureIds) })
   const snapshot = {
@@ -130,14 +130,15 @@ function createUserFeaturesService(
     context,
     contextSignal: context,
     ready,
-    has: (_featureFlagId: Feature, defaultValue: boolean) => defaultValue,
+    has: (_featureFlagId: UserFeature, defaultValue: boolean) => defaultValue,
     useContext: () => context.value,
-    useHas: (_featureFlagId: Feature, defaultValue: boolean) => defaultValue,
-    setFeatureIds: (nextFeatureIds: readonly Feature[]) => {
+    useHas: (_featureFlagId: UserFeature, defaultValue: boolean) =>
+      defaultValue,
+    setFeatureIds: (nextFeatureIds: readonly UserFeature[]) => {
       context.value = { featureIds: new Set(nextFeatureIds) }
     },
   } as unknown as UserFeaturesRegistryService & {
-    setFeatureIds: (featureIds: readonly Feature[]) => void
+    setFeatureIds: (featureIds: readonly UserFeature[]) => void
   }
 }
 

--- a/src/lib/settings/settingsTypes.ts
+++ b/src/lib/settings/settingsTypes.ts
@@ -1,4 +1,5 @@
-import type { Feature, UnitAngle, UnitLength } from '@kittycad/lib'
+import type { UserFeature } from '@src/lib/userFeatures'
+import type { UnitAngle, UnitLength } from '@kittycad/lib'
 import type { Registry } from '@kittycad/registry'
 
 import type { CameraOrbitType } from '@rust/kcl-lib/bindings/CameraOrbitType'
@@ -145,14 +146,14 @@ export interface SettingProps<T = unknown> {
    * Whether to hide the setting unless a user feature flag is enabled.
    * This will be applied in the settings panel, settings search, and command bar.
    */
-  hideWithoutFeature?: Feature
+  hideWithoutFeature?: UserFeature
   /**
    * Whether to hide the setting on a specific platform unless a user feature
    * flag is enabled. This is useful when a feature flag gates web-only access
    * to a desktop-default capability.
    */
   hideWithoutFeatureOnPlatform?: Partial<
-    Record<Exclude<HideOnPlatformValue, 'both'>, Feature>
+    Record<Exclude<HideOnPlatformValue, 'both'>, UserFeature>
   >
   /**
    * A React component to use for the setting in the settings panel.

--- a/src/lib/settings/settingsUtils.ts
+++ b/src/lib/settings/settingsUtils.ts
@@ -1,8 +1,8 @@
+import type { UserFeature } from '@src/lib/userFeatures'
 import type { Configuration } from '@rust/kcl-lib/bindings/Configuration'
 import type { NamedView } from '@rust/kcl-lib/bindings/NamedView'
 import type { ProjectConfiguration } from '@rust/kcl-lib/bindings/ProjectConfiguration'
 import type { JsonValue } from '@rust/kcl-lib/bindings/serde_json/JsonValue'
-import type { Feature } from '@kittycad/lib'
 import {
   serializeConfiguration,
   serializeProjectConfiguration,
@@ -1287,7 +1287,7 @@ export function setSettingsAtLevel(
 export function shouldHideSetting(
   setting: Setting<unknown>,
   settingsLevel: SettingsLevel,
-  hasFeature?: (feature: Feature) => boolean
+  hasFeature?: (feature: UserFeature) => boolean
 ): boolean {
   // Async functions should have been resolved in loadAndValidateSettings,
   // but if we encounter one (shouldn't happen), default to hidden
@@ -1317,7 +1317,7 @@ export function shouldHideSetting(
 export function shouldShowSettingInput(
   setting: Setting<unknown>,
   settingsLevel: SettingsLevel,
-  hasFeature?: (feature: Feature) => boolean
+  hasFeature?: (feature: UserFeature) => boolean
 ): boolean {
   const isHidden = shouldHideSetting(setting, settingsLevel, hasFeature)
   if (isHidden) {
@@ -1381,7 +1381,7 @@ export function jsAppSettings(s: SettingsType | SettingsActorType) {
 export function hiddenOnPlatform(
   setting: Setting,
   desktop: boolean,
-  hasFeature?: (feature: Feature) => boolean
+  hasFeature?: (feature: UserFeature) => boolean
 ): boolean {
   const hideOnPlatform = setting.hideOnPlatform
 
@@ -1409,7 +1409,7 @@ export function hiddenOnPlatform(
 function hiddenWithoutFeature(
   setting: Setting<unknown>,
   desktop: boolean,
-  hasFeature?: (feature: Feature) => boolean
+  hasFeature?: (feature: UserFeature) => boolean
 ): boolean {
   if (setting.hideWithoutFeature && !hasFeature?.(setting.hideWithoutFeature)) {
     return true

--- a/src/lib/toolbar.spec.ts
+++ b/src/lib/toolbar.spec.ts
@@ -7,6 +7,7 @@ vi.mock('@src/lib/boot', () => ({
 
 import {
   buildToolbarConfig,
+  filterExperimentalToolbarItems,
   getConstraintToolbarToggleEvent,
   getDefaultRecentToolbarItemIds,
   getSketchSolveToolIconMap,
@@ -91,6 +92,63 @@ function getToolbarItems(
     })
   )
 }
+
+describe('plugin toolbar visibility', () => {
+  const available: ToolbarItem = {
+    id: 'plugin.available',
+    title: 'Available action',
+    status: 'available',
+    description: 'A plugin action.',
+    links: [],
+    onClick: vi.fn(),
+  }
+  const experimental: ToolbarItem = {
+    ...available,
+    id: 'plugin.experimental',
+    title: 'Experimental action',
+    status: 'experimental',
+  }
+
+  test('hides experimental plugin actions without changing their registration', () => {
+    const items = Object.freeze([available, experimental])
+
+    expect(filterExperimentalToolbarItems(items, false)).toEqual([available])
+    expect(items).toEqual([available, experimental])
+    expect(filterExperimentalToolbarItems(items, true)).toEqual(items)
+  })
+
+  test('removes experimental dropdown actions and their recent-button defaults', () => {
+    const dropdown: ToolbarDropdown = {
+      id: 'plugin.dropdown',
+      array: [experimental, available],
+      display: 'recent',
+      defaultVisibleItemIds: [experimental.id, available.id],
+    }
+
+    expect(filterExperimentalToolbarItems([dropdown], false)).toEqual([
+      {
+        ...dropdown,
+        array: [available],
+        defaultVisibleItemIds: [available.id],
+      },
+    ])
+    expect(dropdown.array).toEqual([experimental, available])
+    expect(dropdown.defaultVisibleItemIds).toEqual([
+      experimental.id,
+      available.id,
+    ])
+  })
+
+  test('removes dropdowns left empty by filtering and restores them when enabled', () => {
+    const dropdown: ToolbarDropdown = {
+      id: 'plugin.experimental-dropdown',
+      array: [experimental],
+    }
+
+    expect(filterExperimentalToolbarItems([dropdown], false)).toEqual([])
+    expect(filterExperimentalToolbarItems([dropdown], true)).toEqual([dropdown])
+  })
+})
 
 describe('toolbar state helpers', () => {
   test('keeps the sketch solve toolbar visible while animating into sketch solve', () => {

--- a/src/lib/toolbar.ts
+++ b/src/lib/toolbar.ts
@@ -14,6 +14,7 @@ import {
   SKETCH_DEFAULT_PLANE_YZ,
   SKETCH_SELECTION_RGB_STR,
 } from '@src/lib/constants'
+import { createGdtToolbarItems } from '@src/lib/gdtToolbar'
 import type { HotkeySequence } from '@src/lib/hotkeys'
 import { isDesktop } from '@src/lib/isDesktop'
 import { getSelectedDefaultPlane, selectSketchPlane } from '@src/lib/selections'
@@ -152,8 +153,18 @@ function filterExperimentalToolbarConfig(
 function filterExperimentalToolbarMode(toolbarMode: ToolbarMode): ToolbarMode {
   return {
     ...toolbarMode,
-    items: toolbarMode.items.flatMap(filterExperimentalToolbarItem),
+    items: filterExperimentalToolbarItems(toolbarMode.items, false),
   }
+}
+
+/** Apply the same experimental-action visibility to built-in and plugin modes. */
+export function filterExperimentalToolbarItems(
+  items: readonly (ToolbarItem | ToolbarDropdown | 'break')[],
+  showExperimentalFeatures: boolean
+): ToolbarMode['items'] {
+  return showExperimentalFeatures
+    ? [...items]
+    : items.flatMap(filterExperimentalToolbarItem)
 }
 
 function filterExperimentalToolbarItem(
@@ -230,12 +241,6 @@ export function getToolbarDropdownDisplay(
   dropdown: Pick<ToolbarDropdown, 'display'>
 ): 'default' | 'recent' {
   return dropdown.display ?? 'default'
-}
-
-function sortToolbarItemsByTitle<T extends ToolbarItem & { title: string }>(
-  items: T[]
-): T[] {
-  return [...items].sort((a, b) => a.title.localeCompare(b.title))
 }
 
 export function getDefaultRecentToolbarItemIds(
@@ -1365,358 +1370,7 @@ export function buildToolbarConfig(
         'break',
         {
           id: 'gdt',
-          array: sortToolbarItemsByTitle([
-            {
-              id: 'gdt-flatness',
-              onClick: () =>
-                commands.send({
-                  type: 'Find and select command',
-                  data: { name: 'GDT Flatness', groupId: 'modeling' },
-                }),
-              status: 'available',
-              title: 'Flatness',
-              icon: 'gdtFlatness',
-              description:
-                'Specifies flatness tolerance - how much a surface can deviate from perfectly flat.',
-              links: [
-                {
-                  label: 'KCL docs',
-                  url: withSiteBaseURL(
-                    '/docs/kcl-std/functions/std-gdt-flatness'
-                  ),
-                },
-              ],
-            },
-            {
-              id: 'gdt-straightness',
-              onClick: () =>
-                commands.send({
-                  type: 'Find and select command',
-                  data: { name: 'GDT Straightness', groupId: 'modeling' },
-                }),
-              status: 'available',
-              title: 'Straightness',
-              icon: 'gdtStraightness',
-              description:
-                'Specifies straightness tolerance - how much a face or edge can deviate from perfectly straight.',
-              links: [
-                {
-                  label: 'KCL docs',
-                  url: withSiteBaseURL(
-                    '/docs/kcl-std/functions/std-gdt-straightness'
-                  ),
-                },
-              ],
-            },
-            {
-              id: 'gdt-circularity',
-              onClick: () =>
-                commands.send({
-                  type: 'Find and select command',
-                  data: { name: 'GDT Circularity', groupId: 'modeling' },
-                }),
-              status: 'available',
-              title: 'Circularity',
-              icon: 'gdtCircularity',
-              description:
-                'Specifies circularity tolerance - how much a round face or edge can deviate from a perfect circle.',
-              links: [
-                {
-                  label: 'KCL docs',
-                  url: withSiteBaseURL(
-                    '/docs/kcl-std/functions/std-gdt-circularity'
-                  ),
-                },
-              ],
-            },
-            {
-              id: 'gdt-cylindricity',
-              onClick: () =>
-                commands.send({
-                  type: 'Find and select command',
-                  data: { name: 'GDT Cylindricity', groupId: 'modeling' },
-                }),
-              status: 'available',
-              title: 'Cylindricity',
-              icon: 'gdtCylindricity',
-              description:
-                'Specifies cylindricity tolerance - how much a round face or edge can deviate from a perfect cylinder.',
-              links: [
-                {
-                  label: 'KCL docs',
-                  url: withSiteBaseURL(
-                    '/docs/kcl-std/functions/std-gdt-cylindricity'
-                  ),
-                },
-              ],
-            },
-            {
-              id: 'gdt-datum',
-              onClick: () =>
-                commands.send({
-                  type: 'Find and select command',
-                  data: { name: 'GDT Datum', groupId: 'modeling' },
-                }),
-              status: 'available',
-              title: 'Datum',
-              icon: 'gdtDatum',
-              description:
-                'Establishes a reference surface for other GD&T measurements.',
-              links: [
-                {
-                  label: 'KCL docs',
-                  url: withSiteBaseURL('/docs/kcl-std/functions/std-gdt-datum'),
-                },
-              ],
-            },
-            {
-              id: 'gdt-profile',
-              onClick: () =>
-                commands.send({
-                  type: 'Find and select command',
-                  data: { name: 'GDT Profile', groupId: 'modeling' },
-                }),
-              status: 'available',
-              title: 'Profile',
-              icon: 'gdtProfile',
-              description:
-                'Specifies how much a surface or edge can deviate from its ideal shape.',
-              links: [
-                {
-                  label: 'KCL docs',
-                  url: withSiteBaseURL(
-                    '/docs/kcl-std/functions/std-gdt-profile'
-                  ),
-                },
-              ],
-            },
-            {
-              id: 'gdt-position',
-              onClick: () =>
-                commands.send({
-                  type: 'Find and select command',
-                  data: { name: 'GDT Position', groupId: 'modeling' },
-                }),
-              status: 'available',
-              title: 'Position',
-              icon: 'gdtPosition',
-              description:
-                'Controls location tolerance of holes, pins, and other features.',
-              links: [
-                {
-                  label: 'KCL docs',
-                  url: withSiteBaseURL(
-                    '/docs/kcl-std/functions/std-gdt-position'
-                  ),
-                },
-              ],
-            },
-            {
-              id: 'gdt-concentricity',
-              onClick: () =>
-                commands.send({
-                  type: 'Find and select command',
-                  data: {
-                    name: 'GDT Concentricity',
-                    groupId: 'modeling',
-                  },
-                }),
-              status: 'available',
-              title: 'Concentricity',
-              icon: 'gdtConcentricity',
-              description:
-                'Controls how closely a feature axis aligns with a datum axis.',
-              links: [
-                {
-                  label: 'KCL docs',
-                  url: withSiteBaseURL(
-                    '/docs/kcl-std/functions/std-gdt-concentricity'
-                  ),
-                },
-              ],
-            },
-            {
-              id: 'gdt-symmetry',
-              onClick: () =>
-                commands.send({
-                  type: 'Find and select command',
-                  data: {
-                    name: 'GDT Symmetry',
-                    groupId: 'modeling',
-                  },
-                }),
-              status: 'available',
-              title: 'Symmetry',
-              icon: 'gdtSymmetry',
-              description:
-                'Controls how closely median points align with a datum center plane.',
-              links: [
-                {
-                  label: 'KCL docs',
-                  url: withSiteBaseURL(
-                    '/docs/kcl-std/functions/std-gdt-symmetry'
-                  ),
-                },
-              ],
-            },
-            {
-              id: 'gdt-runout',
-              onClick: () =>
-                commands.send({
-                  type: 'Find and select command',
-                  data: {
-                    name: 'GDT Runout',
-                    groupId: 'modeling',
-                  },
-                }),
-              status: 'available',
-              title: 'Runout',
-              icon: 'gdtRunout',
-              description:
-                'Controls how much a round feature may vary as it rotates around a datum axis.',
-              links: [
-                {
-                  label: 'KCL docs',
-                  url: withSiteBaseURL(
-                    '/docs/kcl-std/functions/std-gdt-runout'
-                  ),
-                },
-              ],
-            },
-            {
-              id: 'gdt-angularity',
-              onClick: () =>
-                commands.send({
-                  type: 'Find and select command',
-                  data: {
-                    name: 'GDT Angularity',
-                    groupId: 'modeling',
-                  },
-                }),
-              status: 'available',
-              title: 'Angularity',
-              icon: 'angle',
-              description:
-                'Specifies how much a feature may deviate from an orientation at a basic angle.',
-              links: [
-                {
-                  label: 'KCL docs',
-                  url: withSiteBaseURL(
-                    '/docs/kcl-std/functions/std-gdt-angularity'
-                  ),
-                },
-              ],
-            },
-            {
-              id: 'gdt-perpendicularity',
-              onClick: () =>
-                commands.send({
-                  type: 'Find and select command',
-                  data: {
-                    name: 'GDT Perpendicularity',
-                    groupId: 'modeling',
-                  },
-                }),
-              status: 'available',
-              title: 'Perpendicularity',
-              icon: 'perpendicular',
-              description:
-                'Specifies how perpendicular one feature must be to another.',
-              links: [
-                {
-                  label: 'KCL docs',
-                  url: withSiteBaseURL(
-                    '/docs/kcl-std/functions/std-gdt-perpendicularity'
-                  ),
-                },
-              ],
-            },
-            {
-              id: 'gdt-parallelism',
-              onClick: () =>
-                commands.send({
-                  type: 'Find and select command',
-                  data: {
-                    name: 'GDT Parallelism',
-                    groupId: 'modeling',
-                  },
-                }),
-              status: 'available',
-              title: 'Parallelism',
-              icon: 'parallel',
-              description:
-                'Specifies how parallel one feature must be to another.',
-              links: [
-                {
-                  label: 'KCL docs',
-                  url: withSiteBaseURL(
-                    '/docs/kcl-std/functions/std-gdt-parallelism'
-                  ),
-                },
-              ],
-            },
-            {
-              id: 'gdt-distance',
-              onClick: () =>
-                commands.send({
-                  type: 'Find and select command',
-                  data: { name: 'GDT Distance', groupId: 'modeling' },
-                }),
-              status: 'available',
-              title: 'Distance',
-              icon: 'dimension',
-              description:
-                'Adds distance annotations to edge lengths or between two entities.',
-              links: [
-                {
-                  label: 'KCL docs',
-                  url: withSiteBaseURL(
-                    '/docs/kcl-std/functions/std-gdt-distance'
-                  ),
-                },
-              ],
-            },
-            {
-              id: 'gdt-annotation',
-              onClick: () =>
-                commands.send({
-                  type: 'Find and select command',
-                  data: { name: 'GDT Annotation', groupId: 'modeling' },
-                }),
-              status: 'available',
-              title: 'Annotation',
-              icon: 'text',
-              description:
-                'Adds text annotations for manufacturing instructions or inspection requirements.',
-              links: [
-                {
-                  label: 'KCL docs',
-                  url: withSiteBaseURL(
-                    '/docs/kcl-std/functions/std-gdt-annotation'
-                  ),
-                },
-              ],
-            },
-            {
-              id: 'gdt-note',
-              onClick: () =>
-                commands.send({
-                  type: 'Find and select command',
-                  data: { name: 'GDT Note', groupId: 'modeling' },
-                }),
-              status: 'available',
-              title: 'Note',
-              icon: 'note',
-              description:
-                'Adds a free-floating note on a plane, not attached to any geometry.',
-              links: [
-                {
-                  label: 'KCL docs',
-                  url: withSiteBaseURL('/docs/kcl-std/functions/std-gdt-note'),
-                },
-              ],
-            },
-          ]),
+          array: createGdtToolbarItems(commands),
         },
       ],
     },

--- a/src/lib/userFeatures.ts
+++ b/src/lib/userFeatures.ts
@@ -1,0 +1,4 @@
+import type { Feature } from '@kittycad/lib'
+
+/** Feature flags supported by the app, including additions pending an SDK release. */
+export type UserFeature = Feature | 'dfm_review'

--- a/src/machines/userFeaturesMachine.test.ts
+++ b/src/machines/userFeaturesMachine.test.ts
@@ -1,4 +1,4 @@
-import type { Feature } from '@kittycad/lib'
+import type { UserFeature } from '@src/lib/userFeatures'
 import type * as ClientErrorsModule from '@src/lib/clientErrors'
 import {
   USER_FEATURES_POLL_INTERVAL_MS,
@@ -33,45 +33,46 @@ type TestFetchUserFeaturesInput = {
   token: string
 }
 
-type TestFetchUserFeaturesResult = { featureIds: Set<Feature> } | Error
+type TestFetchUserFeaturesResult = { featureIds: Set<UserFeature> } | Error
 
 describe('userFeaturesMachine', () => {
   beforeEach(() => {
     mockState.reportClientError.mockClear()
   })
 
-  it('loads feature ids once for a token and answers membership from context', async () => {
-    const fetchFeatures = vi.fn(async () => ({
-      featureIds: new Set<Feature>(['sketch_experimental_features']),
-    }))
-    const actor = createActor(
-      userFeaturesMachine.provide({
-        actors: {
-          [UserFeaturesActor.Fetch]: fromPromise<
-            TestFetchUserFeaturesResult,
-            TestFetchUserFeaturesInput
-          >(fetchFeatures),
-        },
-      })
-    ).start()
+  it.each<UserFeature>(['sketch_experimental_features', 'dfm_review'])(
+    'loads the %s feature once for a token and answers membership from context',
+    async (feature) => {
+      const fetchFeatures = vi.fn(async () => ({
+        featureIds: new Set<UserFeature>([feature]),
+      }))
+      const actor = createActor(
+        userFeaturesMachine.provide({
+          actors: {
+            [UserFeaturesActor.Fetch]: fromPromise<
+              TestFetchUserFeaturesResult,
+              TestFetchUserFeaturesInput
+            >(fetchFeatures),
+          },
+        })
+      ).start()
 
-    try {
-      actor.send({ type: UserFeaturesTransition.Load, token: 'token-a' })
+      try {
+        actor.send({ type: UserFeaturesTransition.Load, token: 'token-a' })
 
-      await waitFor(actor, (state) => state.matches(UserFeaturesState.Ready))
+        await waitFor(actor, (state) => state.matches(UserFeaturesState.Ready))
 
-      actor.send({ type: UserFeaturesTransition.Load, token: 'token-a' })
+        actor.send({ type: UserFeaturesTransition.Load, token: 'token-a' })
 
-      const context = actor.getSnapshot().context
-      expect(fetchFeatures).toHaveBeenCalledTimes(1)
-      expect(context.token).toBe('token-a')
-      expect(
-        userFeaturesContextHas(context, 'sketch_experimental_features', false)
-      ).toBe(true)
-    } finally {
-      actor.stop()
+        const context = actor.getSnapshot().context
+        expect(fetchFeatures).toHaveBeenCalledTimes(1)
+        expect(context.token).toBe('token-a')
+        expect(userFeaturesContextHas(context, feature, false)).toBe(true)
+      } finally {
+        actor.stop()
+      }
     }
-  })
+  )
 
   it('clears feature ids on clear', async () => {
     const actor = createActor(
@@ -81,7 +82,7 @@ describe('userFeaturesMachine', () => {
             TestFetchUserFeaturesResult,
             TestFetchUserFeaturesInput
           >(async () => ({
-            featureIds: new Set<Feature>(['sketch_experimental_features']),
+            featureIds: new Set<UserFeature>(['sketch_experimental_features']),
           })),
         },
       })
@@ -115,7 +116,9 @@ describe('userFeaturesMachine', () => {
             }
 
             return {
-              featureIds: new Set<Feature>(['sketch_experimental_features']),
+              featureIds: new Set<UserFeature>([
+                'sketch_experimental_features',
+              ]),
             }
           }),
         },
@@ -164,9 +167,9 @@ describe('userFeaturesMachine', () => {
     vi.useFakeTimers()
     const fetchFeatures = vi
       .fn()
-      .mockResolvedValueOnce({ featureIds: new Set<Feature>() })
+      .mockResolvedValueOnce({ featureIds: new Set<UserFeature>() })
       .mockResolvedValueOnce({
-        featureIds: new Set<Feature>(['sketch_experimental_features']),
+        featureIds: new Set<UserFeature>(['sketch_experimental_features']),
       })
     const actor = createActor(
       userFeaturesMachine.provide({
@@ -225,7 +228,7 @@ describe('userFeaturesMachine', () => {
       .fn()
       .mockResolvedValueOnce(new Error('feature service unavailable'))
       .mockResolvedValueOnce({
-        featureIds: new Set<Feature>(['sketch_experimental_features']),
+        featureIds: new Set<UserFeature>(['sketch_experimental_features']),
       })
     const actor = createActor(
       userFeaturesMachine.provide({

--- a/src/machines/userFeaturesMachine.ts
+++ b/src/machines/userFeaturesMachine.ts
@@ -1,4 +1,5 @@
-import { type Feature, type UserFeatureList, users } from '@kittycad/lib'
+import type { UserFeature } from '@src/lib/userFeatures'
+import { type UserFeatureList, users } from '@kittycad/lib'
 import { ClientErrorCode, reportClientError } from '@src/lib/clientErrors'
 import { createKCClient, kcCall } from '@src/lib/kcClient'
 import { isErr } from '@src/lib/trap'
@@ -31,14 +32,14 @@ type FetchUserFeaturesInput = {
 }
 
 type FetchUserFeaturesOutput = {
-  featureIds: Set<Feature>
+  featureIds: Set<UserFeature>
 }
 type FetchUserFeaturesResult = FetchUserFeaturesOutput | Error
 type FetchUserFeaturesDoneEvent = DoneActorEvent<FetchUserFeaturesResult>
 type FetchUserFeaturesErrorEvent = ErrorActorEvent<Error>
 
 export interface UserFeaturesContext {
-  featureIds: Set<Feature>
+  featureIds: Set<UserFeature>
   token?: string
   fetchedAt?: Date
   error?: Error
@@ -52,7 +53,7 @@ export type UserFeaturesEvent =
   | FetchUserFeaturesErrorEvent
 
 export type UserFeaturesService = {
-  has: (featureFlagId: Feature, defaultValue: boolean) => boolean
+  has: (featureFlagId: UserFeature, defaultValue: boolean) => boolean
 }
 
 /**
@@ -157,7 +158,7 @@ export function waitForUserFeaturesSettled(
 
 function createDefaultContext(): UserFeaturesContext {
   return {
-    featureIds: new Set<Feature>(),
+    featureIds: new Set<UserFeature>(),
     token: undefined,
     fetchedAt: undefined,
     error: undefined,
@@ -187,7 +188,7 @@ function hasEventToken(
   return typeof token === 'string' && token.length > 0
 }
 
-function featureIdsFromResponse(data: UserFeatureList): Set<Feature> {
+function featureIdsFromResponse(data: UserFeatureList): Set<UserFeature> {
   return new Set(data.features.map(({ id }) => id))
 }
 
@@ -201,7 +202,7 @@ function userFeaturesErrorContext(context: UserFeaturesContext) {
 
 export function userFeaturesContextHas(
   context: UserFeaturesContext,
-  featureFlagId: Feature,
+  featureFlagId: UserFeature,
   defaultValue: boolean
 ): boolean {
   return context.featureIds.has(featureFlagId) ? true : defaultValue
@@ -269,7 +270,7 @@ export const userFeaturesMachine = setup({
         ...(context.token === token
           ? {}
           : {
-              featureIds: new Set<Feature>(),
+              featureIds: new Set<UserFeature>(),
               fetchedAt: undefined,
             }),
       }

--- a/src/registry/contracts/modes.test.ts
+++ b/src/registry/contracts/modes.test.ts
@@ -1,0 +1,67 @@
+import {
+  DEFAULT_COMMAND_SCOPES,
+  FILE_AND_CODE_EDITOR_COMMAND_SCOPES,
+  FILE_COMMAND_SCOPES,
+  MODE_MODELING_COMMAND_SCOPE,
+  MODE_SKETCH_SOLVE_COMMAND_SCOPE,
+  getEffectiveCommandScopeSet,
+  isCommandAvailable,
+} from '@src/registry/contracts/commands'
+import {
+  type ModeDefinition,
+  resolveModeKeymapScopes,
+} from '@src/registry/contracts/modes'
+import { describe, expect, it } from 'vitest'
+
+const review: ModeDefinition = {
+  id: 'review',
+  label: 'Review',
+  toolbar: [],
+}
+
+describe('mode command and keymap scopes', () => {
+  it('keeps the machine scope for modes without custom bindings', () => {
+    expect(
+      resolveModeKeymapScopes(review, MODE_MODELING_COMMAND_SCOPE)
+    ).toEqual([MODE_MODELING_COMMAND_SCOPE])
+    expect(
+      resolveModeKeymapScopes(undefined, MODE_SKETCH_SOLVE_COMMAND_SCOPE)
+    ).toEqual([MODE_SKETCH_SOLVE_COMMAND_SCOPE])
+  })
+
+  it('does not apply the same scope twice for built-in modes', () => {
+    expect(
+      resolveModeKeymapScopes(
+        { ...review, keymapScope: MODE_SKETCH_SOLVE_COMMAND_SCOPE },
+        MODE_SKETCH_SOLVE_COMMAND_SCOPE
+      )
+    ).toEqual([MODE_SKETCH_SOLVE_COMMAND_SCOPE])
+  })
+
+  it('keeps file and editor commands available beside a plugin command scope', () => {
+    const pluginScope = 'review.commands'
+    const scopes = resolveModeKeymapScopes(
+      { ...review, keymapScope: pluginScope },
+      MODE_MODELING_COMMAND_SCOPE
+    )
+    const effectiveScopes = getEffectiveCommandScopeSet(scopes, [
+      ...DEFAULT_COMMAND_SCOPES,
+      { id: pluginScope, displayName: 'Review', priority: 150 },
+    ])
+
+    // Viewport focus must retain file commands (camera/delete) and editor
+    // commands (undo/redo/render) without requiring editor focus as a fallback.
+    expect(
+      isCommandAvailable({ scopes: FILE_COMMAND_SCOPES }, effectiveScopes)
+    ).toBe(true)
+    expect(
+      isCommandAvailable(
+        { scopes: FILE_AND_CODE_EDITOR_COMMAND_SCOPES },
+        effectiveScopes
+      )
+    ).toBe(true)
+    expect(isCommandAvailable({ scopes: [pluginScope] }, effectiveScopes)).toBe(
+      true
+    )
+  })
+})

--- a/src/registry/contracts/modes.ts
+++ b/src/registry/contracts/modes.ts
@@ -1,0 +1,83 @@
+import {
+  defineContract,
+  defineService,
+  defineValueSpec,
+  provide,
+  type Precedence,
+} from '@kittycad/registry'
+import type { ReadonlySignal } from '@preact/signals-core'
+import type { CustomIconName } from '@src/components/CustomIcon'
+import type {
+  ToolbarDropdown,
+  ToolbarItem,
+  ToolbarModeName,
+} from '@src/lib/toolbar'
+import type { EngineSceneExtensionContext } from '@src/registry/contracts/engineScene'
+import type { ComponentType } from 'react'
+
+export type ModeToolbarItem = ToolbarItem | ToolbarDropdown | 'break'
+
+/**
+ * A workspace mode contributed by a built-in registry item or a plugin.
+ *
+ * Omit Scene to retain the modeling mode's client scene. An optional Scene
+ * replaces that layer above the engine stream, which stays mounted. A custom
+ * renderer can overlay the engine or cover it with an opaque viewport.
+ */
+export type ModeDefinition = {
+  id: string
+  label: string
+  icon?: CustomIconName
+  toolbar: ToolbarModeName | readonly ModeToolbarItem[]
+  Scene?: ComponentType<EngineSceneExtensionContext>
+  /** Additional command/keymap scope; the machine's scope stays active. */
+  keymapScope?: string
+  /** Machine-driven modes such as sketching cannot be selected directly. */
+  selectable?: boolean
+}
+
+export type ModesRegistryService = {
+  modes: ReadonlySignal<readonly ModeDefinition[]>
+  selectedModeId: ReadonlySignal<string>
+  activeMode: ReadonlySignal<ModeDefinition | undefined>
+  canSelectMode: ReadonlySignal<boolean>
+  /** Returns false for unavailable modes or while a machine mode is active. */
+  setMode: (id: string) => boolean
+  /** The modeling machine owns sketch entry, exit, and transition locks. */
+  syncModelingMode: (mode: ToolbarModeName, canSelect?: boolean) => void
+  reset: () => void
+}
+
+export const modesContract = defineContract({
+  modesValueSpec: defineValueSpec<ModeDefinition, readonly ModeDefinition[]>({
+    name: 'modes',
+    defaultValue: [],
+    combine: (inputs) => {
+      const ids = new Set<string>()
+      return inputs.filter((mode) => {
+        if (ids.has(mode.id)) return false
+        ids.add(mode.id)
+        return true
+      })
+    },
+  }),
+  modesService: defineService<ModesRegistryService>('modes.service'),
+})
+
+export const { modesValueSpec, modesService } = modesContract
+
+/** Register a mode with a stable identity, preserving registry precedence. */
+export function provideMode(mode: ModeDefinition, precedence?: Precedence) {
+  return provide(modesValueSpec, mode, { key: mode.id, precedence })
+}
+
+/** Keep workspace commands available when a plugin adds its own bindings. */
+export function resolveModeKeymapScopes(
+  mode: ModeDefinition | undefined,
+  modelingScope: string
+): readonly string[] {
+  if (!mode?.keymapScope || mode.keymapScope === modelingScope) {
+    return [modelingScope]
+  }
+  return [modelingScope, mode.keymapScope]
+}

--- a/src/registry/contracts/userFeatures.ts
+++ b/src/registry/contracts/userFeatures.ts
@@ -1,4 +1,4 @@
-import type { Feature } from '@kittycad/lib'
+import type { UserFeature } from '@src/lib/userFeatures'
 import { defineContract, defineService } from '@kittycad/registry'
 import type { ReadonlySignal } from '@preact/signals-core'
 import type {
@@ -17,7 +17,7 @@ export type UserFeaturesRegistryService = UserFeaturesService & {
   contextSignal: ReadonlySignal<UserFeaturesContext>
   ready: ReadonlySignal<boolean>
   useContext: () => UserFeaturesContext
-  useHas: (featureFlagId: Feature, defaultValue: boolean) => boolean
+  useHas: (featureFlagId: UserFeature, defaultValue: boolean) => boolean
 }
 
 export const userFeaturesContract = defineContract({

--- a/src/registry/createZdsPlugin.ts
+++ b/src/registry/createZdsPlugin.ts
@@ -1,4 +1,4 @@
-import type { Feature } from '@kittycad/lib'
+import type { UserFeature } from '@src/lib/userFeatures'
 import {
   appendValueSpec,
   createPlugin,
@@ -21,7 +21,7 @@ export type ZdsPluginFeatureActivationPolicy = {
   /**
    * Feature flag that controls whether this plugin may become active.
    */
-  feature: Feature
+  feature: UserFeature
   /**
    * When true, feature-flagged users get the plugin enabled by default. Existing
    * user preferences are preserved unless `forceEnabledOnPlatform` matches.
@@ -69,7 +69,7 @@ type ZdsPluginActivationSettingSpec = {
    * command bar, and plugins list through the same settings config rather than
    * a bespoke check per surface.
    */
-  hideWithoutFeature?: Feature
+  hideWithoutFeature?: UserFeature
   featurePolicy?: ZdsPluginFeatureActivationPolicy
   userToml?: { sectionKey: string; tomlKey: string }
   projectToml?: { sectionKey: string; tomlKey: string }

--- a/src/registry/extensions/modes/BuiltInModeScene.tsx
+++ b/src/registry/extensions/modes/BuiltInModeScene.tsx
@@ -1,0 +1,18 @@
+import { ClientSideScene } from '@src/clientSideScene/ClientSideSceneComp'
+import { useApp } from '@src/lib/boot'
+import type { EngineSceneExtensionContext } from '@src/registry/contracts/engineScene'
+
+export function BuiltInModeScene({
+  sketchSolveStreamDimming,
+}: EngineSceneExtensionContext) {
+  const { settings } = useApp()
+  const settingsValues = settings.useSettings()
+
+  return (
+    <ClientSideScene
+      cameraControls={settingsValues.modeling.mouseControls.current}
+      enableTouchControls={settingsValues.modeling.enableTouchControls.current}
+      sketchSolveStreamDimming={sketchSolveStreamDimming}
+    />
+  )
+}

--- a/src/registry/extensions/modes/README.md
+++ b/src/registry/extensions/modes/README.md
@@ -1,0 +1,89 @@
+# Workspace modes
+
+Modes are app registry contributions. A plugin registers a stable ID, a label,
+and a toolbar through `provideMode`; the mode picker discovers active
+contributions automatically. Include the plugin in the app's registry tree, as
+with other plugins.
+
+This example adds a toolbar using the existing GD&T actions:
+
+```ts
+import {
+  defineRegistryItemFactory,
+  defineRuntimeRegistryItem,
+} from '@kittycad/registry'
+import { createGdtToolbarItems } from '@src/lib/gdtToolbar'
+import { commandSystemService } from '@src/registry/contracts/commands'
+import { provideMode } from '@src/registry/contracts/modes'
+import { createZdsPlugin } from '@src/registry/createZdsPlugin'
+
+const reviewMode = defineRegistryItemFactory(({ services }) => ({
+  item: defineRuntimeRegistryItem({
+    id: 'review-example.mode',
+    provides: [
+      provideMode({
+        id: 'review-example',
+        label: 'Review',
+        icon: 'gdtDatum',
+        toolbar: createGdtToolbarItems({
+          send: (...args) => services.get(commandSystemService).send(...args),
+        }),
+      }),
+    ],
+  }),
+}), 'review-example.mode')
+
+export default createZdsPlugin({
+  id: 'review-example',
+  title: 'Review',
+  description: 'Review geometric dimensions and tolerances.',
+  items: [reviewMode],
+  defaultSetting: 'off',
+})
+```
+
+Resolve services inside callbacks, as above, rather than while constructing the
+registry graph. Toolbar entries use the existing `ToolbarItem` callbacks,
+disabled predicates, dropdowns, and `'break'` separators. Experimental entries
+follow the same feature flag as built-in toolbars. A toolbar may also name a
+built-in toolbar configuration.
+
+The modeling machine's command/keymap scope stays active, preserving core file
+commands such as undo, render, and camera controls. `keymapScope` adds a plugin
+scope alongside it. Register matching commands, keybindings, and optional scope
+metadata with `provideCommandScope`. Keep plugin scopes outside the `context`
+group: the app owns that exclusive group for modeling, sketch, home, and settings
+states. Set scope priority when bindings need to take precedence over existing
+bindings.
+
+## Scenes
+
+Omitting `Scene` keeps the built-in client interaction scene. Supplying a React
+component replaces that client layer above the engine stream; the engine stream
+and connection stay mounted. The component receives `EngineSceneExtensionContext`
+and can draw over the stream or cover it with its own renderer. Keep the component
+identity stable and clean up resources on unmount. Prefer a lazy import when a
+scene reaches app boot or other eagerly initialized registry modules.
+
+All built-in modes share `BuiltInModeScene`. Switching between modeling, sketch,
+and a plugin without a custom scene therefore preserves the same client canvas
+and camera controls.
+
+## Selection and lifecycle
+
+`modesService.setMode(id)` selects an available mode and returns whether the
+switch succeeded. The modeling machine owns sketch modes (`selectable: false`)
+and blocks manual switching during sketches and transitions. It temporarily
+overrides the selected plugin mode; leaving the sketch restores that selection.
+Leaving the workspace resets selection to modeling.
+
+Disabling or removing a plugin removes its modes. If its mode was selected, the
+selection resets to modeling, including while a sketch is active. Enabling the
+plugin again makes its mode available without reselecting it.
+
+For feature-gated modes, configure the plugin's activation policy. The
+[DFM Review plugin](../../plugins/dfmReview/index.ts) starts disabled until
+`dfm_review` is available, enables by default for eligible users while respecting
+their preference, and uses `disableWithoutFeature` to deactivate on flag loss.
+That removal follows the same mode and scene cleanup path as disabling the
+plugin in settings.

--- a/src/registry/extensions/modes/builtinModes.ts
+++ b/src/registry/extensions/modes/builtinModes.ts
@@ -1,0 +1,55 @@
+import { defineRegistryItem } from '@kittycad/registry'
+import {
+  MODE_MODELING_KEYMAP_SCOPE,
+  MODE_SKETCH_NO_FACE_KEYMAP_SCOPE,
+  MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
+  MODE_SKETCHING_KEYMAP_SCOPE,
+} from '@src/registry/contracts/keymap'
+import { provideMode } from '@src/registry/contracts/modes'
+import { lazy } from 'react'
+
+// All built-in modes share the same component identity so the interaction canvas
+// stays mounted while the modeling machine enters and exits a sketch.
+export const BuiltInModeScene = lazy(async () => {
+  const { BuiltInModeScene } = await import('./BuiltInModeScene')
+  return { default: BuiltInModeScene }
+})
+
+export default defineRegistryItem({
+  id: 'builtin-modes',
+  provides: [
+    provideMode({
+      id: 'modeling',
+      label: 'Modeling',
+      toolbar: 'modeling',
+      Scene: BuiltInModeScene,
+      keymapScope: MODE_MODELING_KEYMAP_SCOPE,
+    }),
+    provideMode({
+      id: 'onlyCancel',
+      label: 'Sketch',
+      toolbar: 'onlyCancel',
+      Scene: BuiltInModeScene,
+      keymapScope: MODE_SKETCH_NO_FACE_KEYMAP_SCOPE,
+      selectable: false,
+    }),
+    provideMode({
+      id: 'sketching',
+      label: 'Sketch',
+      icon: 'sketch',
+      toolbar: 'sketching',
+      Scene: BuiltInModeScene,
+      keymapScope: MODE_SKETCHING_KEYMAP_SCOPE,
+      selectable: false,
+    }),
+    provideMode({
+      id: 'sketchSolve',
+      label: 'Sketch',
+      icon: 'sketch',
+      toolbar: 'sketchSolve',
+      Scene: BuiltInModeScene,
+      keymapScope: MODE_SKETCH_SOLVE_KEYMAP_SCOPE,
+      selectable: false,
+    }),
+  ],
+})

--- a/src/registry/extensions/modes/index.test.ts
+++ b/src/registry/extensions/modes/index.test.ts
@@ -1,0 +1,232 @@
+import {
+  Registry,
+  Slot,
+  createPlugin,
+  defineRegistryItem,
+  pluginsValueSpec,
+  provide,
+} from '@kittycad/registry'
+import { signal } from '@preact/signals-core'
+import {
+  type ModeDefinition,
+  modesService,
+  modesValueSpec,
+  provideMode,
+} from '@src/registry/contracts/modes'
+import { modesExtension } from '@src/registry/extensions/modes'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const modeling: ModeDefinition = {
+  id: 'modeling',
+  label: 'Modeling',
+  toolbar: 'modeling',
+}
+const review: ModeDefinition = {
+  id: 'review',
+  label: 'Review',
+  toolbar: [],
+}
+const sketchModes: ModeDefinition[] = [
+  {
+    id: 'sketching',
+    label: 'Sketch',
+    toolbar: 'sketching',
+    selectable: false,
+  },
+  {
+    id: 'sketchSolve',
+    label: 'Sketch',
+    toolbar: 'sketchSolve',
+    selectable: false,
+  },
+  {
+    id: 'onlyCancel',
+    label: 'Sketch',
+    toolbar: 'onlyCancel',
+    selectable: false,
+  },
+]
+const builtinModes = defineRegistryItem({
+  provides: [modeling, ...sketchModes].map((mode) => provideMode(mode)),
+})
+
+describe('registry modes', () => {
+  let registry: Registry | undefined
+
+  afterEach(() => {
+    registry?.[Symbol.dispose]()
+    registry = undefined
+  })
+
+  function setup() {
+    const modeSlot = new Slot()
+    const plugin = createPlugin({
+      id: 'review-plugin',
+      title: 'Review',
+      description: 'Review the current model.',
+      items: [defineRegistryItem({ provides: [provideMode(review)] })],
+    })
+    const container = new Registry()
+    registry = container
+    container.configure([builtinModes, modesExtension, modeSlot.of(plugin)])
+    return {
+      container,
+      service: container.get(modesService),
+      modeSlot,
+      plugin,
+    }
+  }
+
+  it('selects a plugin toolbar without requiring a custom scene', () => {
+    const { service } = setup()
+
+    expect(service.activeMode.value).toBe(modeling)
+    expect(service.setMode(review.id)).toBe(true)
+    expect(service.selectedModeId.value).toBe(review.id)
+    expect(service.activeMode.value?.toolbar).toBe(review.toolbar)
+    expect(service.activeMode.value?.Scene).toBeUndefined()
+  })
+
+  it('rejects unknown and machine-driven modes without changing selection', () => {
+    const { service } = setup()
+    service.setMode(review.id)
+
+    expect(service.setMode('not-installed')).toBe(false)
+    for (const sketch of sketchModes) {
+      expect(service.setMode(sketch.id)).toBe(false)
+    }
+    expect(service.activeMode.value).toBe(review)
+  })
+
+  it('lets sketch workflows own the mode and restores the selected plugin on exit', () => {
+    const { service } = setup()
+    service.setMode(review.id)
+
+    for (const mode of ['onlyCancel', 'sketching', 'sketchSolve'] as const) {
+      service.syncModelingMode(mode)
+      expect(service.activeMode.value?.id).toBe(mode)
+      expect(service.canSelectMode.value).toBe(false)
+      expect(service.setMode(modeling.id)).toBe(false)
+      expect(service.selectedModeId.value).toBe(review.id)
+    }
+
+    service.syncModelingMode('modeling')
+    expect(service.canSelectMode.value).toBe(true)
+    expect(service.activeMode.value).toBe(review)
+  })
+
+  it('blocks mode switches during transitions that retain the modeling toolbar', () => {
+    const { service } = setup()
+    service.syncModelingMode('modeling', false)
+
+    expect(service.canSelectMode.value).toBe(false)
+    expect(service.setMode(review.id)).toBe(false)
+    expect(service.activeMode.value).toBe(modeling)
+
+    service.syncModelingMode('modeling', true)
+    expect(service.setMode(review.id)).toBe(true)
+  })
+
+  it('falls back immediately when a plugin is disabled and does not reselect it when enabled', async () => {
+    const { container, service } = setup()
+    const [plugin] = container.get(pluginsValueSpec)
+    const toggle = container.get(plugin.service)
+    service.setMode(review.id)
+
+    await toggle.disable()
+    // No active-mode reads between removal and reinstallation: cleanup must
+    // follow the registry lifecycle independently of whether a view is mounted.
+    await toggle.enable()
+
+    expect(service.selectedModeId.value).toBe(modeling.id)
+    expect(service.activeMode.value).toBe(modeling)
+    expect(service.modes.value).toContain(review)
+  })
+
+  it('forgets a removed plugin while sketching without interrupting the sketch', async () => {
+    const { container, service, modeSlot, plugin } = setup()
+    service.setMode(review.id)
+    service.syncModelingMode('sketchSolve')
+
+    await container.reconfigureAsync(modeSlot, [])
+    expect(service.activeMode.value?.id).toBe('sketchSolve')
+    expect(service.selectedModeId.value).toBe(modeling.id)
+
+    await container.reconfigureAsync(modeSlot, [plugin])
+    service.syncModelingMode('modeling')
+    expect(service.activeMode.value).toBe(modeling)
+  })
+
+  it('drops a selection if its reactive registration stops being selectable', () => {
+    const reactiveMode = signal(review)
+    const container = new Registry()
+    registry = container
+    container.configure([
+      builtinModes,
+      modesExtension,
+      defineRegistryItem({
+        provides: [provide(modesValueSpec, reactiveMode)],
+      }),
+    ])
+    const service = container.get(modesService)
+    service.setMode(review.id)
+
+    reactiveMode.value = { ...review, selectable: false }
+    expect(service.activeMode.value).toBe(modeling)
+    expect(service.selectedModeId.value).toBe(modeling.id)
+  })
+
+  it('preserves selection when unrelated registry content changes', async () => {
+    const { container, service, modeSlot, plugin } = setup()
+    service.setMode(review.id)
+
+    await container.reconfigureAsync(modeSlot, [
+      plugin,
+      defineRegistryItem({ id: 'unrelated-feature' }),
+    ])
+
+    expect(container.get(modesService).selectedModeId.value).toBe(review.id)
+    expect(service.activeMode.value).toBe(review)
+  })
+
+  it('resets both the selected mode and machine override when leaving the workspace', () => {
+    const { service } = setup()
+    service.setMode(review.id)
+    service.syncModelingMode('sketchSolve', false)
+
+    service.reset()
+
+    expect(service.selectedModeId.value).toBe(modeling.id)
+    expect(service.activeMode.value).toBe(modeling)
+    expect(service.canSelectMode.value).toBe(true)
+  })
+
+  it('prevents a disposed mode service from changing a later workspace', async () => {
+    const { container, service } = setup()
+    service.setMode(review.id)
+
+    await container.configureAsync([builtinModes])
+    expect(service.setMode(review.id)).toBe(false)
+    service.syncModelingMode('sketchSolve')
+    expect(service.selectedModeId.value).toBe(modeling.id)
+    expect(service.activeMode.value).toBe(modeling)
+  })
+
+  it('resolves duplicate mode IDs using registry precedence', () => {
+    const container = new Registry()
+    registry = container
+    const replacement = { ...review, label: 'Priority Review' }
+    container.configure([
+      defineRegistryItem({ provides: [provideMode(review)] }),
+      defineRegistryItem({
+        provides: [provideMode(replacement, 'high')],
+      }),
+      defineRegistryItem({
+        // Direct contributions still cannot create duplicate selector entries.
+        provides: [provide(modesValueSpec, { ...review })],
+      }),
+    ])
+
+    expect(container.get(modesValueSpec)).toEqual([replacement])
+  })
+})

--- a/src/registry/extensions/modes/index.ts
+++ b/src/registry/extensions/modes/index.ts
@@ -1,0 +1,100 @@
+import {
+  defineRegistryItem,
+  defineRegistryItemFactory,
+  defineRuntimeRegistryItem,
+  provideService,
+} from '@kittycad/registry'
+import { batch, computed, effect, signal } from '@preact/signals-core'
+import type { ToolbarModeName } from '@src/lib/toolbar'
+import {
+  type ModesRegistryService,
+  modesService,
+  modesValueSpec,
+} from '@src/registry/contracts/modes'
+import builtinModes from './builtinModes'
+
+export const modesExtension = defineRegistryItemFactory(({ valueSpecs }) => {
+  const modes = valueSpecs.signal(modesValueSpec)
+  const selectedModeId = signal('modeling')
+  const modelingMode = signal<ToolbarModeName>('modeling')
+  const selectionAllowed = signal(true)
+  const canSelectMode = computed(
+    () => modelingMode.value === 'modeling' && selectionAllowed.value
+  )
+  const activeMode = computed(() => {
+    const id =
+      modelingMode.value === 'modeling'
+        ? selectedModeId.value
+        : modelingMode.value
+    return (
+      modes.value.find((mode) => mode.id === id) ??
+      modes.value.find((mode) => mode.id === 'modeling')
+    )
+  })
+  let stopWatchingSelection: (() => void) | undefined
+  let disposed = false
+
+  const serviceImpl: ModesRegistryService = {
+    modes,
+    selectedModeId,
+    activeMode,
+    canSelectMode,
+    setMode: (id) => {
+      if (
+        disposed ||
+        !canSelectMode.value ||
+        !modes.value.some((mode) => mode.id === id && mode.selectable !== false)
+      ) {
+        return false
+      }
+
+      // Subscribe only when first used, after registry graph construction.
+      // Removing a plugin clears its selection even if no view is reading the
+      // active mode, so re-enabling it cannot unexpectedly reactivate its mode.
+      stopWatchingSelection ??= effect(() => {
+        if (
+          selectedModeId.value !== 'modeling' &&
+          !modes.value.some(
+            (mode) =>
+              mode.id === selectedModeId.value && mode.selectable !== false
+          )
+        ) {
+          selectedModeId.value = 'modeling'
+        }
+      })
+      selectedModeId.value = id
+      return true
+    },
+    syncModelingMode: (mode, canSelect = true) => {
+      if (disposed) return
+      batch(() => {
+        modelingMode.value = mode
+        selectionAllowed.value = canSelect
+      })
+    },
+    reset: () => {
+      batch(() => {
+        selectedModeId.value = 'modeling'
+        modelingMode.value = 'modeling'
+        selectionAllowed.value = true
+      })
+    },
+  }
+
+  return {
+    item: defineRuntimeRegistryItem({
+      id: 'modes-extension',
+      providesServices: [provideService(modesService, serviceImpl)],
+      dispose: () => {
+        disposed = true
+        stopWatchingSelection?.()
+        serviceImpl.reset()
+      },
+    }),
+  }
+}, 'modes-extension')
+
+export default defineRegistryItem({
+  id: 'modes',
+  uses: [builtinModes, modesExtension],
+})

--- a/src/registry/plugins/dfmReview/index.test.ts
+++ b/src/registry/plugins/dfmReview/index.test.ts
@@ -1,0 +1,65 @@
+import { Registry, pluginsValueSpec } from '@kittycad/registry'
+import { DFM_REVIEW_FEATURE_FLAG } from '@src/lib/constants'
+import { modesValueSpec } from '@src/registry/contracts/modes'
+import { settingsValueSpec } from '@src/registry/contracts/settings'
+import { zdsPluginActivationSettingsValueSpec } from '@src/registry/createZdsPlugin'
+import dfmReview, {
+  DFM_REVIEW_MODE_ID,
+  DFM_REVIEW_PLUGIN_ID,
+} from '@src/registry/plugins/dfmReview'
+import { afterEach, describe, expect, it } from 'vitest'
+
+describe('DFM Review plugin', () => {
+  let registry: Registry | undefined
+
+  afterEach(() => {
+    registry?.[Symbol.dispose]()
+  })
+
+  it('registers its engine-backed mode only while the plugin is enabled', async () => {
+    registry = new Registry()
+    registry.configure([dfmReview])
+
+    const [plugin] = registry.get(pluginsValueSpec)
+    const toggle = registry.get(plugin.service)
+    expect(plugin).toMatchObject({
+      id: DFM_REVIEW_PLUGIN_ID,
+      title: 'DFM Review',
+    })
+    expect(toggle.active.value).toBe(false)
+    expect(registry.get(modesValueSpec)).toEqual([])
+    expect(
+      registry
+        .get(settingsValueSpec)
+        .plugins[DFM_REVIEW_PLUGIN_ID].createSetting()
+    ).toMatchObject({
+      default: false,
+      hideWithoutFeature: DFM_REVIEW_FEATURE_FLAG,
+    })
+    expect(registry.get(zdsPluginActivationSettingsValueSpec)).toEqual([
+      expect.objectContaining({
+        pluginId: DFM_REVIEW_PLUGIN_ID,
+        featurePolicy: {
+          feature: DFM_REVIEW_FEATURE_FLAG,
+          defaultEnabled: true,
+          disableWithoutFeature: true,
+        },
+      }),
+    ])
+
+    await toggle.enable()
+
+    const [mode] = registry.get(modesValueSpec)
+    expect(mode).toMatchObject({
+      id: DFM_REVIEW_MODE_ID,
+      label: 'DFM Review',
+    })
+    expect(mode.Scene).toBeUndefined()
+    expect(mode.keymapScope).toBeUndefined()
+    expect(mode.toolbar).toHaveLength(16)
+
+    await toggle.disable()
+
+    expect(registry.get(modesValueSpec)).toEqual([])
+  })
+})

--- a/src/registry/plugins/dfmReview/index.ts
+++ b/src/registry/plugins/dfmReview/index.ts
@@ -1,0 +1,60 @@
+import {
+  defineRegistryItemFactory,
+  defineRuntimeRegistryItem,
+} from '@kittycad/registry'
+import { DFM_REVIEW_FEATURE_FLAG } from '@src/lib/constants'
+import { createGdtToolbarItems } from '@src/lib/gdtToolbar'
+import {
+  type CommandSystemService,
+  commandSystemService,
+} from '@src/registry/contracts/commands'
+import { provideMode } from '@src/registry/contracts/modes'
+import { createZdsPlugin } from '@src/registry/createZdsPlugin'
+
+export const DFM_REVIEW_PLUGIN_ID = 'dfm-review'
+export const DFM_REVIEW_MODE_ID = 'dfm-review'
+
+const dfmReviewMode = defineRegistryItemFactory((ctx) => {
+  const commands: Pick<CommandSystemService, 'send'> = {
+    send: (...args) => ctx.services.get(commandSystemService).send(...args),
+  }
+
+  return {
+    item: defineRuntimeRegistryItem({
+      id: 'dfm-review.mode',
+      provides: [
+        provideMode({
+          id: DFM_REVIEW_MODE_ID,
+          label: 'DFM Review',
+          icon: 'gdtDatum',
+          toolbar: createGdtToolbarItems(commands),
+        }),
+      ],
+    }),
+  }
+}, 'dfm-review.mode')
+
+export default createZdsPlugin({
+  id: DFM_REVIEW_PLUGIN_ID,
+  title: 'DFM Review',
+  description: 'Review designs with geometric dimensions and tolerances.',
+  items: [dfmReviewMode],
+  defaultSetting: 'off',
+  activationSetting: {
+    category: 'plugins',
+    settingName: DFM_REVIEW_PLUGIN_ID,
+    title: 'DFM Review',
+    description: 'Whether the DFM Review plugin is enabled.',
+    hideOnLevel: 'project',
+    hideWithoutFeature: DFM_REVIEW_FEATURE_FLAG,
+    featurePolicy: {
+      feature: DFM_REVIEW_FEATURE_FLAG,
+      defaultEnabled: true,
+      disableWithoutFeature: true,
+    },
+    userToml: {
+      sectionKey: 'plugins',
+      tomlKey: DFM_REVIEW_PLUGIN_ID,
+    },
+  },
+})


### PR DESCRIPTION
Plugins can now register workspace modes with their own toolbar and an optional client scene. Modeling and sketch use the same registry contract; the modeling machine still owns sketch entry, exit, and transition locks. The mode picker follows active plugin contributions, and removing the selected plugin falls back to Modeling. The engine stream stays mounted across mode switches, including when a plugin supplies a different client renderer.

Adds a DFM Review plugin gated by `dfm_review` from https://github.com/KittyCAD/api/pull/4651. Eligible users get it enabled by default, with their plugin preference preserved. It keeps the existing engine scene and exposes all 16 existing GD&T commands in its toolbar. The modeling dropdown shares the same actions. An app-local feature type supports the new flag ahead of the SDK release.

Mode-specific shortcuts add to the normal workspace shortcuts, and plugin toolbars use the existing experimental-feature filtering. Tests cover plugin/flag removal, unrelated plugin toggles, sketch transitions, custom-scene cleanup, GD&T command dispatch, and preservation of the live engine stream. The full integration suite hit engine authentication/network failures locally; the focused app, toolbar, registry, and browser tests passed. The main manual smoke check is a GD&T edit on a populated model in DFM Review.

Mode authoring is documented in `src/registry/extensions/modes/README.md`.
