### PR TITLE
Wait for Wasm in query-command tests

### DIFF
--- a/e2e/playwright/testing-samples-loading.spec.ts
+++ b/e2e/playwright/testing-samples-loading.spec.ts
@@ -187,6 +187,10 @@ test.describe('Query parameter command', { tag: '@web' }, () => {
     const queryString = `?cmd=add-kcl-file-to-project&groupId=application&projectName=browser&source=kcl-samples&sample=${sampleSlug}/main.kcl`
     await page.goto(page.url() + queryString)
 
+    await page.evaluate(async () => {
+      await window.app.wasmPromise
+    })
+
     await toolbar.openPane(DefaultLayoutPaneID.Code)
     await editor.expectEditor.toContain(sampleTitle, { timeout: 30_000 })
     await expect(page).toHaveURL(/socket-head-cap-screw%2Fmain\.kcl$/)

--- a/e2e/playwright/testing-samples-loading.spec.ts
+++ b/e2e/playwright/testing-samples-loading.spec.ts
@@ -155,6 +155,11 @@ test.describe('Query parameter command', { tag: '@web' }, () => {
   }) => {
     await page.goto('/?cmd=set-layout&groupId=application&layoutId=ttc')
 
+    // The root route awaits Wasm before mounting the query-command consumer.
+    await page.evaluate(async () => {
+      await window.app.wasmPromise
+    })
+
     await expect
       .poll(() =>
         page.evaluate(() => {


### PR DESCRIPTION
Wait for the application Wasm runtime after navigation in the TTC-layout and sample-query tests. Both routes await Wasm before mounting their UI, so the existing five-second assertions can otherwise expire on a blank page.

Closes #13827.

Local Chrome replays passed ungated controls and reproduced both failures with held Wasm bodies; the readiness wait passed after release. These used synthetic auth and blocked external traffic; the full authenticated E2E has not been rerun locally.
