### PR TITLE
Wait for sample file navigation in the loading test

### DIFF
--- a/e2e/playwright/testing-samples-loading.spec.ts
+++ b/e2e/playwright/testing-samples-loading.spec.ts
@@ -133,6 +133,8 @@ test.describe('Testing loading external models', { tag: '@desktop' }, () => {
       await expect(
         page.getByTestId('file-tree-item').getByText(sampleOne.folderName)
       ).toBeVisible()
+      // The folder can appear before navigation closes the command bar.
+      await expect(page).toHaveURL(/ball-bearing(?:%2F|%5C)main\.kcl$/)
     })
 
     await test.step('Load a KCL sample with the command palette', async () => {
@@ -144,6 +146,7 @@ test.describe('Testing loading external models', { tag: '@desktop' }, () => {
       await expect(
         page.getByTestId('file-tree-item').getByText(sampleOne.folderName1)
       ).toBeVisible()
+      await expect(page).toHaveURL(/ball-bearing-1(?:%2F|%5C)main\.kcl$/)
     })
   })
 })


### PR DESCRIPTION
The sample-loading test can reopen the command bar before the first sample's navigation finishes, which closes the new palette and detaches its option. Wait for each imported sample's file route before continuing.

Fixes https://github.com/KittyCAD/modeling-app/issues/13832.

A controlled React Router/CommandBar replay reproduced the pending-navigation failure and passed the navigation-first control. Native desktop replay remains unverified locally because this checkout has no test API token; the original failed trace was overwritten by the successful rerun.
