### PR TITLE
Keep recovery state in useTryConnect

### DIFF
--- a/src/components/ConnectionStream.tsx
+++ b/src/components/ConnectionStream.tsx
@@ -97,10 +97,12 @@ export const ConnectionStream = (props: ConnectionStreamProps) => {
   const isNetworkOkay =
     overallState === NetworkHealthState.Ok ||
     overallState === NetworkHealthState.Weak
-  const { tryConnecting, isConnecting, numberOfConnectionAttempts } =
-    useTryConnect(() => {
-      abnormalCloseRetries.current = 0
-    })
+  const {
+    tryConnecting,
+    isConnecting,
+    numberOfConnectionAttempts,
+    abnormalCloseRetries,
+  } = useTryConnect()
   const safariObjectFitClass = useMemo(() => {
     // on safari we want to apply object-fit: fill to fix video resize bug
     const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
@@ -450,6 +452,7 @@ export const ConnectionStream = (props: ConnectionStreamProps) => {
         setShowManualConnect(true)
       },
       engineCommandManager,
+      abnormalCloseRetries,
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
@@ -458,9 +461,10 @@ export const ConnectionStream = (props: ConnectionStreamProps) => {
       props.authToken,
       reportEngineDisconnect,
       settings,
+      abnormalCloseRetries,
     ]
   )
-  const abnormalCloseRetries = useOnWebsocketClose(onWebSocketCloseParams)
+  useOnWebsocketClose(onWebSocketCloseParams)
 
   const onVitestEngineOnline = useMemo(
     () => ({

--- a/src/hooks/network/useOnWebsocketClose.spec.tsx
+++ b/src/hooks/network/useOnWebsocketClose.spec.tsx
@@ -16,6 +16,7 @@ describe('useOnWebsocketClose', () => {
         await buildTheWorldAndNoEngineConnection(true)
       const { unmount } = renderHook(() =>
         useOnWebsocketClose({
+          abnormalCloseRetries: { current: 0 },
           callback,
           infiniteDetectionLoopCallback: infiniteLoopCallback,
           engineCommandManager,
@@ -34,6 +35,7 @@ describe('useOnWebsocketClose', () => {
       const spyRemove = vi.spyOn(engineCommandManager, 'removeEventListener')
       const { unmount } = renderHook(() =>
         useOnWebsocketClose({
+          abnormalCloseRetries: { current: 0 },
           callback,
           infiniteDetectionLoopCallback: infiniteLoopCallback,
           engineCommandManager,
@@ -50,6 +52,7 @@ describe('useOnWebsocketClose', () => {
         await buildTheWorldAndNoEngineConnection(true)
       const { unmount } = renderHook(() =>
         useOnWebsocketClose({
+          abnormalCloseRetries: { current: 0 },
           callback,
           infiniteDetectionLoopCallback: infiniteLoopCallback,
           engineCommandManager,
@@ -71,6 +74,7 @@ describe('useOnWebsocketClose', () => {
           await buildTheWorldAndNoEngineConnection(true)
         const { unmount } = renderHook(() =>
           useOnWebsocketClose({
+            abnormalCloseRetries: { current: 0 },
             callback,
             infiniteDetectionLoopCallback: infiniteLoopCallback,
             engineCommandManager,
@@ -94,6 +98,7 @@ describe('useOnWebsocketClose', () => {
         await buildTheWorldAndNoEngineConnection(true)
       const { unmount } = renderHook(() =>
         useOnWebsocketClose({
+          abnormalCloseRetries: { current: 0 },
           callback,
           infiniteDetectionLoopCallback: infiniteLoopCallback,
           engineCommandManager,
@@ -106,12 +111,14 @@ describe('useOnWebsocketClose', () => {
     })
 
     test('requires manual recovery after three abnormal closes', async () => {
+      const abnormalCloseRetries = { current: 0 }
       const callback = vi.fn(() => 1)
       const infiniteLoopCallback = vi.fn(() => 1)
       const { engineCommandManager } =
         await buildTheWorldAndNoEngineConnection(true)
-      const { result, rerender, unmount } = renderHook(() =>
+      const { rerender, unmount } = renderHook(() =>
         useOnWebsocketClose({
+          abnormalCloseRetries,
           callback,
           infiniteDetectionLoopCallback: infiniteLoopCallback,
           engineCommandManager,
@@ -135,7 +142,7 @@ describe('useOnWebsocketClose', () => {
       expect(callback).toHaveBeenCalledTimes(3)
       expect(infiniteLoopCallback).toHaveBeenCalledTimes(1)
       expect(infiniteLoopCallback).toHaveBeenCalledWith('1006')
-      result.current.current = 0
+      abnormalCloseRetries.current = 0
       engineCommandManager.dispatchEvent(infiniteEvent)
       expect(callback).toHaveBeenCalledTimes(4)
       expect(infiniteLoopCallback).toHaveBeenCalledTimes(1)
@@ -151,6 +158,7 @@ describe('useOnWebsocketClose', () => {
           await buildTheWorldAndNoEngineConnection(true)
         const { unmount } = renderHook(() =>
           useOnWebsocketClose({
+            abnormalCloseRetries: { current: 0 },
             callback,
             infiniteDetectionLoopCallback: infiniteLoopCallback,
             terminalErrorCallback,

--- a/src/hooks/network/useOnWebsocketClose.tsx
+++ b/src/hooks/network/useOnWebsocketClose.tsx
@@ -8,7 +8,7 @@ import {
   EngineConnectionManagerEvents,
   WebSocketCloseCode,
 } from '@src/lib/engineConnection/utils'
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
 
 export interface IUseOnWebsocketClose {
   callback: (code: string | undefined, reconnectRequested: boolean) => void
@@ -18,6 +18,7 @@ export interface IUseOnWebsocketClose {
     code: string | undefined
   ) => void
   engineCommandManager: ConnectionManager
+  abnormalCloseRetries: React.RefObject<number>
 }
 
 /**
@@ -30,9 +31,8 @@ export function useOnWebsocketClose({
   infiniteDetectionLoopCallback,
   terminalErrorCallback,
   engineCommandManager,
+  abnormalCloseRetries,
 }: IUseOnWebsocketClose) {
-  const abnormalCloseRetries = useRef(0)
-
   useEffect(() => {
     const onWebsocketClose = (
       event: CustomEvent<EngineDisconnectEventDetail>
@@ -86,6 +86,6 @@ export function useOnWebsocketClose({
     infiniteDetectionLoopCallback,
     terminalErrorCallback,
     engineCommandManager,
+    abnormalCloseRetries,
   ])
-  return abnormalCloseRetries
 }

--- a/src/hooks/network/useTryConnect.test.ts
+++ b/src/hooks/network/useTryConnect.test.ts
@@ -45,6 +45,7 @@ describe('tryConnecting', () => {
 
     await expect(
       tryConnecting({
+        abnormalCloseRetries: { current: 0 },
         isConnecting: { current: false },
         numberOfConnectionAttempts,
         authToken: 'token',

--- a/src/hooks/network/useTryConnect.tsx
+++ b/src/hooks/network/useTryConnect.tsx
@@ -204,7 +204,7 @@ const setupSceneAndExecuteCodeAfterOpenedEngineConnection = async ({
  * a single safe location to connect to the engine.
  */
 export async function tryConnecting({
-  onConnected,
+  abnormalCloseRetries,
   isConnecting,
   numberOfConnectionAttempts,
   authToken,
@@ -220,7 +220,7 @@ export async function tryConnecting({
   kclManager,
   rustContext,
 }: {
-  onConnected?: () => void
+  abnormalCloseRetries: React.RefObject<number>
   isConnecting: React.RefObject<boolean>
   numberOfConnectionAttempts: React.RefObject<number>
   authToken: string
@@ -286,7 +286,7 @@ export async function tryConnecting({
             )
           }
 
-          onConnected?.()
+          abnormalCloseRetries.current = 0
           isConnecting.current = false
           setAppState({ isStreamAcceptingInput: true })
           numberOfConnectionAttempts.current = 0
@@ -327,13 +327,17 @@ export async function tryConnecting({
   })
   return connection
 }
-export const useTryConnect = (onConnected: () => void) => {
+export const useTryConnect = () => {
   const { kclManager } = useSingletons()
   const isConnecting = useRef(false)
   const numberOfConnectionAttempts = useRef(0)
+  const abnormalCloseRetries = useRef(0)
   type TryConnectingArgs = Omit<
     Parameters<typeof tryConnecting>[0],
-    'engineCommandManager' | 'kclManager' | 'rustContext' | 'onConnected'
+    | 'engineCommandManager'
+    | 'kclManager'
+    | 'rustContext'
+    | 'abnormalCloseRetries'
   >
 
   return {
@@ -343,9 +347,10 @@ export const useTryConnect = (onConnected: () => void) => {
         engineCommandManager: kclManager.engineCommandManager,
         kclManager,
         rustContext: kclManager.rustContext,
-        onConnected,
+        abnormalCloseRetries,
       }),
     isConnecting,
     numberOfConnectionAttempts,
+    abnormalCloseRetries,
   }
 }


### PR DESCRIPTION
Keep the abnormal-close counter alongside the connection-attempt state in `useTryConnect`, and reset it directly after successful setup. This removes the reset callback through `ConnectionStream` while preserving the recovery behavior from #13816.

Closes #13838.

Validated with 10 focused tests without retries, TypeScript, formatting/lint, and circular-dependency checks. Full browser reconnect smoke testing was not run.

[Reference discussion](https://kittycadworkspace.slack.com/archives/C07A80B83FS/p1789248056904869?thread_ts=1789247472.672619&channel=C07A80B83FS&message_ts=1789248056.904869).
