### PR TITLE
Preserve worker errors in Playwright reporting

### DIFF
--- a/e2e/playwright/lib/api-reporter.ts
+++ b/e2e/playwright/lib/api-reporter.ts
@@ -6,9 +6,14 @@ import type {
 } from '@playwright/test/reporter'
 
 class APIReporter implements Reporter {
+  private hasGlobalError = false
   private pendingRequests: Promise<void>[] = []
   private allResults: Record<string, any>[] = []
   private blockingResults: Record<string, any>[] = []
+
+  onError(): void {
+    this.hasGlobalError = true
+  }
 
   async onEnd(result: FullResult): Promise<void> {
     await Promise.all(this.pendingRequests)
@@ -17,7 +22,7 @@ class APIReporter implements Reporter {
       return
     }
 
-    if (this.blockingResults.length === 0) {
+    if (!this.hasGlobalError && this.blockingResults.length === 0) {
       result.status = 'passed'
       if (!process.env.CI) {
         console.log('TAB API - Marked failures as non-blocking')


### PR DESCRIPTION
The TAB reporter could mark a Playwright run passed after worker teardown failed. Preserve global errors when applying TAB's nonblocking-test policy.

The browser-free reproduction in #13845 exits 0 with worker errors before this change and exits 1 afterward. Healthy runs and ordinary TAB blocking/nonblocking test outcomes are unchanged. The underlying Chrome launch/shutdown stall remains unresolved.

Fixes #13845.
