### PR TITLE
Release Shift after boolean test selection

### DIFF
--- a/e2e/playwright/boolean-sketch-v1.spec.ts
+++ b/e2e/playwright/boolean-sketch-v1.spec.ts
@@ -101,6 +101,10 @@ test.describe(
           // Select second object
           await clickSecondObject({ pixelDiff: 50 })
 
+          if (operationName !== 'subtract') {
+            await page.keyboard.up('Shift')
+          }
+
           await page.waitForTimeout(1000)
 
           // Confirm the operation in the command bar

--- a/e2e/playwright/boolean-sketch-v1.spec.ts
+++ b/e2e/playwright/boolean-sketch-v1.spec.ts
@@ -100,10 +100,7 @@ test.describe(
 
           // Select second object
           await clickSecondObject({ pixelDiff: 50 })
-
-          if (operationName !== 'subtract') {
-            await page.keyboard.up('Shift')
-          }
+          await page.keyboard.up('Shift')
 
           await page.waitForTimeout(1000)
 

--- a/e2e/playwright/boolean.spec.ts
+++ b/e2e/playwright/boolean.spec.ts
@@ -101,6 +101,10 @@ test.describe(
           // Select second object
           await clickSecondObject({ pixelDiff: 50 })
 
+          if (operationName !== 'subtract') {
+            await page.keyboard.up('Shift')
+          }
+
           await page.waitForTimeout(1000)
 
           // Confirm the operation in the command bar

--- a/e2e/playwright/boolean.spec.ts
+++ b/e2e/playwright/boolean.spec.ts
@@ -100,10 +100,7 @@ test.describe(
 
           // Select second object
           await clickSecondObject({ pixelDiff: 50 })
-
-          if (operationName !== 'subtract') {
-            await page.keyboard.up('Shift')
-          }
+          await page.keyboard.up('Shift')
 
           await page.waitForTimeout(1000)
 


### PR DESCRIPTION
Release Shift immediately after selecting the second solid in both boolean E2E suites. Electron workers reuse the page, so leaving Shift held turns a later Ctrl+K into Ctrl+Shift+K and prevents the command palette from opening. Fixes #13837.

All eight boolean cases, including both subtract cases, and the unchanged sketch shortcut test passed in one Ubuntu Electron worker without retries. This replay used the instrumented diagnostic revision `9cc81f6d1f`; CI will validate the PR against current main.
