### PR TITLE
Wait for blank-file navigation before checking Scene

### DIFF
--- a/e2e/playwright/onboarding-web.spec.ts
+++ b/e2e/playwright/onboarding-web.spec.ts
@@ -63,11 +63,11 @@ test(
       )}/onboarding/desktop/scene`
     )
 
-    await expect(page.getByRole('heading', { name: 'Scene' })).toBeVisible()
     await expect(page).toHaveURL(
       /tutorial-project%2Fblank\.kcl\/onboarding\/desktop\/scene/,
       { timeout: 15_000 }
     )
+    await expect(page.getByRole('heading', { name: 'Scene' })).toBeVisible()
     await expect
       .poll(() =>
         opfsPathExists(page, `${PROJECT_DIR}/tutorial-project/blank.kcl`)


### PR DESCRIPTION
The onboarding Scene test can inspect a blank document while its file route is still loading. Move the existing `blank.kcl` URL assertion before the heading check, keeping the current timeouts and assertions.

A local Wasm gate reproduced the failure; the reordered assertions passed gated and ungated controls with retries disabled, using mocked APIs without an Engine connection.

Fixes #13849.
