### PR TITLE
Fix consumed solids shared across imports

### DIFF
--- a/rust/kcl-lib/src/execution/state.rs
+++ b/rust/kcl-lib/src/execution/state.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeMap;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::MutexGuard;
 
 use ahash::AHashMap;
 use anyhow::Result;
@@ -78,6 +80,8 @@ pub type ModuleInfoMap = IndexMap<ModuleId, ModuleInfo>;
 
 #[derive(Debug, Clone)]
 pub(super) struct GlobalState {
+    /// Imported values and concurrent modules share the same engine bodies.
+    solid_consumption: Arc<Mutex<SolidConsumptionState>>,
     /// The deepest machine-executor call depth reached by executions sharing
     /// this state: the root module, its callbacks, and module bodies executed
     /// inline on it. Imported modules pre-executed in parallel run on cloned
@@ -338,21 +342,19 @@ pub(super) struct ModuleState {
     pub(super) allowed_warnings: Vec<&'static str>,
     pub(super) denied_warnings: Vec<&'static str>,
 
-    /// Map from consumed solid values to information about the operation that
-    /// consumed them. Populated by operations that destroy their inputs so that
-    /// subsequent attempts to use a consumed solid produce a clear KCL-level
-    /// error rather than a cryptic engine error.
-    pub(super) consumed_solids: AHashMap<ConsumedSolidKey, ConsumedSolidInfo>,
-    /// Defensive map from consumed engine UUID to consumption info.
-    /// Rust code may create a `Solid` with a consumed `engine_id` and a
-    /// different `instance_id` that was not recorded in `consumed_solids`. When
-    /// the exact key lookup misses, this map lets us reject that solid by
-    /// `engine_id`, unless the key is a recorded operation output.
-    pub(super) consumed_solid_ids: AHashMap<Uuid, ConsumedSolidInfo>,
     /// Region engine UUIDs consumed by successful modeling operations. Regions
     /// use the KCL `Sketch` representation, so this state keeps stale Region
     /// values from reaching an engine object that has become something else.
     pub(super) consumed_regions: AHashMap<Uuid, ConsumedRegionInfo>,
+}
+
+#[derive(Debug, Default)]
+struct SolidConsumptionState {
+    consumed_solids: AHashMap<ConsumedSolidKey, ConsumedSolidInfo>,
+    /// Catch stale engine IDs even when a Rust-created value has a new instance
+    /// ID; recorded operation outputs may legitimately reuse an engine ID.
+    consumed_solid_ids: AHashMap<Uuid, ConsumedSolidInfo>,
+    input_locks: AHashMap<Uuid, Arc<tokio::sync::Mutex<()>>>,
 }
 
 /// Information about the operation that consumed a Region.
@@ -415,7 +417,7 @@ impl ConsumedSolidKey {
 }
 
 /// Information about a solid value that was consumed by an operation.
-/// Stored in `ModuleState.consumed_solids` so subsequent attempts to use the
+/// Stored in `SolidConsumptionState` so subsequent attempts to use the
 /// solid produce a clear error pointing at the operation that consumed it.
 #[derive(Debug, Clone)]
 pub(crate) struct ConsumedSolidInfo {
@@ -870,27 +872,59 @@ impl ExecState {
         &mut self.mod_local.id_generator
     }
 
-    /// Record that a solid value has been consumed by a CSG boolean operation.
-    pub(crate) fn mark_solid_consumed(&mut self, consumed_key: ConsumedSolidKey, info: ConsumedSolidInfo) {
-        self.mod_local.consumed_solids.insert(consumed_key, info);
+    fn solid_consumption(&self) -> Result<MutexGuard<'_, SolidConsumptionState>, KclError> {
+        self.global.solid_consumption.lock().map_err(|_| {
+            KclError::new_internal(KclErrorDetails::new(
+                "Solid consumption state was poisoned by an earlier panic.".to_owned(),
+                vec![],
+            ))
+        })
     }
 
-    /// Record that an engine body UUID has been consumed by a CSG boolean
-    /// operation.
-    pub(crate) fn mark_solid_id_consumed(&mut self, consumed_id: Uuid, info: ConsumedSolidInfo) {
-        self.mod_local.consumed_solid_ids.insert(consumed_id, info);
+    /// Record a consumed value and its engine body together.
+    pub(crate) fn mark_solid_consumed(
+        &mut self,
+        consumed_key: ConsumedSolidKey,
+        info: ConsumedSolidInfo,
+    ) -> Result<(), KclError> {
+        let mut state = self.solid_consumption()?;
+        state.consumed_solid_ids.insert(consumed_key.engine_id(), info.clone());
+        state.consumed_solids.insert(consumed_key, info);
+        Ok(())
     }
 
     /// Look up whether a solid value was consumed by a previous CSG boolean
     /// operation.
-    pub(crate) fn check_solid_consumed(&self, key: &ConsumedSolidKey) -> Option<&ConsumedSolidInfo> {
-        self.mod_local.consumed_solids.get(key)
+    pub(crate) fn check_solid_consumed(&self, key: &ConsumedSolidKey) -> Result<Option<ConsumedSolidInfo>, KclError> {
+        Ok(self.solid_consumption()?.consumed_solids.get(key).cloned())
     }
 
     /// Look up whether an engine body UUID was consumed by a previous CSG
     /// boolean operation.
-    pub(crate) fn check_solid_id_consumed(&self, id: &Uuid) -> Option<&ConsumedSolidInfo> {
-        self.mod_local.consumed_solid_ids.get(id)
+    pub(crate) fn check_solid_id_consumed(&self, id: &Uuid) -> Result<Option<ConsumedSolidInfo>, KclError> {
+        Ok(self.solid_consumption()?.consumed_solid_ids.get(id).cloned())
+    }
+
+    /// Hold through validation, the consuming command, and recording its result.
+    /// Sort and deduplicate IDs to avoid deadlocks for overlapping input sets.
+    pub(crate) async fn lock_solid_inputs(
+        &self,
+        solids: &[crate::execution::Solid],
+    ) -> Result<Vec<tokio::sync::OwnedMutexGuard<()>>, KclError> {
+        let mut ids: Vec<_> = solids.iter().map(|solid| solid.id).collect();
+        ids.sort_unstable();
+        ids.dedup();
+        let locks = {
+            let mut state = self.solid_consumption()?;
+            ids.into_iter()
+                .map(|id| state.input_locks.entry(id).or_default().clone())
+                .collect::<Vec<_>>()
+        };
+        let mut guards = Vec::with_capacity(locks.len());
+        for lock in locks {
+            guards.push(lock.lock_owned().await);
+        }
+        Ok(guards)
     }
 
     pub(crate) fn mark_region_consumed(&mut self, id: Uuid, info: ConsumedRegionInfo) {
@@ -926,13 +960,15 @@ impl ExecState {
     pub(crate) fn latest_consumed_output(
         &self,
         suggested_replacement_key: Option<ConsumedSolidKey>,
-    ) -> Option<ConsumedSolidKey> {
-        let mut latest = suggested_replacement_key?;
+    ) -> Result<Option<ConsumedSolidKey>, KclError> {
+        let Some(mut latest) = suggested_replacement_key else {
+            return Ok(None);
+        };
         let mut seen = AhashIndexSet::default();
+        let state = self.solid_consumption()?;
 
         while seen.insert(latest) {
-            let Some(next) = self
-                .mod_local
+            let Some(next) = state
                 .consumed_solids
                 .get(&latest)
                 .and_then(|info| info.suggested_replacement_key())
@@ -942,7 +978,7 @@ impl ExecState {
             latest = next;
         }
 
-        Some(latest)
+        Ok(Some(latest))
     }
 
     /// Search the live environment for the name of a variable holding a Solid
@@ -1496,6 +1532,7 @@ pub(crate) fn declared_kcl_version(program: &Node<Program>) -> Result<Option<(Kc
 impl GlobalState {
     fn new(settings: &ExecutorSettings, segment_ids_edited: AhashIndexSet<ObjectId>) -> Self {
         let mut global = GlobalState {
+            solid_consumption: Default::default(),
             machine_depth_high_water: 0,
             path_to_source_id: Default::default(),
             module_infos: Default::default(),
@@ -1691,8 +1728,6 @@ impl ModuleState {
             constraint_state: Default::default(),
             allowed_warnings: Vec::new(),
             denied_warnings: Vec::new(),
-            consumed_solids: AHashMap::default(),
-            consumed_solid_ids: AHashMap::default(),
             consumed_regions: AHashMap::default(),
             inside_stdlib: false,
         }

--- a/rust/kcl-lib/src/std/csg.rs
+++ b/rust/kcl-lib/src/std/csg.rs
@@ -97,6 +97,7 @@ pub(crate) async fn inner_union(
     exec_state: &mut ExecState,
     args: Args,
 ) -> Result<Vec<Solid>, KclError> {
+    let _inputs = exec_state.lock_solid_inputs(&solids).await?;
     validate_solids_not_consumed(&solids, exec_state, args.source_range)?;
 
     let solid_out_id = exec_state.next_uuid();
@@ -107,7 +108,7 @@ pub(crate) async fn inner_union(
     let mut new_solids = vec![solid.clone()];
 
     if args.ctx.no_engine_commands().await {
-        record_consumed_solids(exec_state, &solids, ConsumedSolidOperation::Union, &new_solids);
+        record_consumed_solids(exec_state, &solids, ConsumedSolidOperation::Union, &new_solids)?;
         return Ok(new_solids);
     }
 
@@ -161,7 +162,7 @@ pub(crate) async fn inner_union(
         new_solids.push(new_solid);
     }
 
-    record_consumed_solids(exec_state, &solids, ConsumedSolidOperation::Union, &new_solids);
+    record_consumed_solids(exec_state, &solids, ConsumedSolidOperation::Union, &new_solids)?;
 
     Ok(new_solids)
 }
@@ -192,6 +193,7 @@ pub(crate) async fn inner_intersect(
     exec_state: &mut ExecState,
     args: Args,
 ) -> Result<Vec<Solid>, KclError> {
+    let _inputs = exec_state.lock_solid_inputs(&solids).await?;
     validate_solids_not_consumed(&solids, exec_state, args.source_range)?;
 
     let solid_out_id = exec_state.next_uuid();
@@ -202,7 +204,7 @@ pub(crate) async fn inner_intersect(
     let mut new_solids = vec![solid.clone()];
 
     if args.ctx.no_engine_commands().await {
-        record_consumed_solids(exec_state, &solids, ConsumedSolidOperation::Intersect, &new_solids);
+        record_consumed_solids(exec_state, &solids, ConsumedSolidOperation::Intersect, &new_solids)?;
         return Ok(new_solids);
     }
 
@@ -255,7 +257,7 @@ pub(crate) async fn inner_intersect(
         new_solids.push(new_solid);
     }
 
-    record_consumed_solids(exec_state, &solids, ConsumedSolidOperation::Intersect, &new_solids);
+    record_consumed_solids(exec_state, &solids, ConsumedSolidOperation::Intersect, &new_solids)?;
 
     Ok(new_solids)
 }
@@ -282,6 +284,7 @@ pub(crate) async fn inner_subtract(
     args: Args,
 ) -> Result<Vec<Solid>, KclError> {
     let combined_solids = solids.iter().chain(tools.iter()).cloned().collect::<Vec<Solid>>();
+    let _inputs = exec_state.lock_solid_inputs(&combined_solids).await?;
     validate_solids_not_consumed(&combined_solids, exec_state, args.source_range)?;
 
     let solid_out_id = exec_state.next_uuid();
@@ -307,8 +310,8 @@ pub(crate) async fn inner_subtract(
                 new_solid
             })
             .collect::<Vec<_>>();
-        record_consumed_solids(exec_state, &solids, ConsumedSolidOperation::Subtract, &new_solids);
-        record_consumed_solids(exec_state, &tools, ConsumedSolidOperation::Subtract, &[]);
+        record_consumed_solids(exec_state, &solids, ConsumedSolidOperation::Subtract, &new_solids)?;
+        record_consumed_solids(exec_state, &tools, ConsumedSolidOperation::Subtract, &[])?;
         return Ok(new_solids);
     }
 
@@ -363,8 +366,8 @@ pub(crate) async fn inner_subtract(
         })
         .collect::<Vec<_>>();
 
-    record_consumed_solids(exec_state, &solids, ConsumedSolidOperation::Subtract, &new_solids);
-    record_consumed_solids(exec_state, &tools, ConsumedSolidOperation::Subtract, &[]);
+    record_consumed_solids(exec_state, &solids, ConsumedSolidOperation::Subtract, &new_solids)?;
+    record_consumed_solids(exec_state, &tools, ConsumedSolidOperation::Subtract, &[])?;
 
     Ok(new_solids)
 }
@@ -415,6 +418,12 @@ pub(crate) async fn inner_imprint(
     exec_state: &mut ExecState,
     args: Args,
 ) -> Result<Vec<Solid>, KclError> {
+    let inputs = targets
+        .iter()
+        .chain(tools.iter().flatten())
+        .cloned()
+        .collect::<Vec<_>>();
+    let _inputs = exec_state.lock_solid_inputs(&inputs).await?;
     validate_solids_not_consumed(&targets, exec_state, args.source_range)?;
     if let Some(tools) = tools.as_ref() {
         validate_solids_not_consumed(tools, exec_state, args.source_range)?;
@@ -437,9 +446,9 @@ pub(crate) async fn inner_imprint(
             new_solid.become_new_body(extra_solid_id, extra_solid_id.into());
             new_solids.push(new_solid);
         }
-        record_consumed_solids(exec_state, &targets, ConsumedSolidOperation::Split, &new_solids);
+        record_consumed_solids(exec_state, &targets, ConsumedSolidOperation::Split, &new_solids)?;
         if !keep_tools && let Some(tools) = tools.as_ref() {
-            record_consumed_solids(exec_state, tools, ConsumedSolidOperation::Split, &[]);
+            record_consumed_solids(exec_state, tools, ConsumedSolidOperation::Split, &[])?;
         }
         return Ok(new_solids);
     }
@@ -502,9 +511,9 @@ pub(crate) async fn inner_imprint(
         new_solids.push(new_solid);
     }
 
-    record_consumed_solids(exec_state, &targets, ConsumedSolidOperation::Split, &new_solids);
+    record_consumed_solids(exec_state, &targets, ConsumedSolidOperation::Split, &new_solids)?;
     if !keep_tools && let Some(tools) = tools.as_ref() {
-        record_consumed_solids(exec_state, tools, ConsumedSolidOperation::Split, &[]);
+        record_consumed_solids(exec_state, tools, ConsumedSolidOperation::Split, &[])?;
     }
 
     Ok(new_solids)

--- a/rust/kcl-lib/src/std/solid_consumption.rs
+++ b/rust/kcl-lib/src/std/solid_consumption.rs
@@ -100,14 +100,14 @@ fn validate_solid_not_consumed(
 
 fn consumed_solid_error_message(solid: &Solid, exec_state: &ExecState) -> Result<Option<String>, KclError> {
     let key = consumed_solid_key(solid);
-    let Some(info) = exec_state.check_solid_consumed(&key) else {
-        if let Some(info) = exec_state.check_solid_id_consumed(&solid.id)
+    let Some(info) = exec_state.check_solid_consumed(&key)? else {
+        if let Some(info) = exec_state.check_solid_id_consumed(&solid.id)?
             && info.should_report_reused_engine_id_as_consumed(key)
         {
             let operation = info.operation();
             let current_var = exec_state.find_var_name_for_solid_key(key)?;
             let output_var = exec_state
-                .latest_consumed_output(info.suggested_replacement_key())
+                .latest_consumed_output(info.suggested_replacement_key())?
                 .map(|key| exec_state.find_var_name_for_solid_key(key))
                 .transpose()?
                 .flatten();
@@ -122,7 +122,7 @@ fn consumed_solid_error_message(solid: &Solid, exec_state: &ExecState) -> Result
     let suggested_replacement_key = info.suggested_replacement_key();
     let consumed_var = exec_state.find_var_name_for_solid_key(key)?;
     let output_var = exec_state
-        .latest_consumed_output(suggested_replacement_key)
+        .latest_consumed_output(suggested_replacement_key)?
         .map(|key| exec_state.find_var_name_for_solid_key(key))
         .transpose()?
         .flatten();
@@ -136,13 +136,13 @@ pub(super) fn record_consumed_solids(
     solids: &[Solid],
     operation: ConsumedSolidOperation,
     output_solids: &[Solid],
-) {
+) -> Result<(), KclError> {
     let returned_solid_keys = output_solids.iter().map(consumed_solid_key).collect::<Vec<_>>();
     for solid in solids {
         let info = ConsumedSolidInfo::new(operation, returned_solid_keys.clone());
-        exec_state.mark_solid_consumed(consumed_solid_key(solid), info.clone());
-        exec_state.mark_solid_id_consumed(solid.id, info);
+        exec_state.mark_solid_consumed(consumed_solid_key(solid), info)?;
     }
+    Ok(())
 }
 
 fn consumed_solid_key(solid: &Solid) -> ConsumedSolidKey {
@@ -238,6 +238,134 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn imported_solid_consumption() {
+        let seed = r#"
+@settings(defaultLengthUnit = mm, kclVersion = 2.0)
+export fn make(rad) {
+  profile = sketch(on = XY) {
+    rim = circle(center = [var 0mm, var 0mm], start = [var 5mm, var 0mm])
+    coincident([rim.center, ORIGIN])
+    horizontal([rim.center, rim.start])
+    radius(rim) == rad
+  }
+  return extrude(region(segments = [profile.rim]), length = 10mm)
+}
+export solid = make(rad = 10mm)
+"#;
+        for concurrent in [false, true] {
+            for import in ["import \"seed.kcl\" as seed", "import solid as seed from \"seed.kcl\""] {
+                for initial in ["seed", "make(rad = 10mm)", "clone([seed])[0]"] {
+                    let consumer = format!(
+                        r#"
+@settings(defaultLengthUnit = mm, kclVersion = 2.0)
+{import}
+import make from "seed.kcl"
+result = reduce([2mm, 3mm], initial = {initial}, f = fn(@r, accum) {{
+  tool = make(rad = r)
+  cut = subtract([accum], tools = [tool])
+  return cut[0]
+}})
+"#
+                    );
+                    let project = crate::TypedPath::new("/imported-solid-consumption");
+                    let files = [("seed.kcl", seed), ("a.kcl", &consumer), ("b.kcl", &consumer)]
+                        .into_iter()
+                        .map(|(name, code)| (project.join(name).to_string(), code.as_bytes().to_vec()))
+                        .collect();
+                    let mut ctx = crate::ExecutorContext::new_mock(Some(crate::ExecutorSettings {
+                        project_directory: Some(project.clone()),
+                        current_file: Some(project.join("main.kcl")),
+                        ..Default::default()
+                    }))
+                    .await;
+                    ctx.fs = crate::fs::new_file_system_handle(crate::InMemoryFiles::new(files));
+                    let program = crate::Program::parse_no_errs(
+                        "@settings(kclVersion = 2.0)\nimport \"a.kcl\" as a\nimport \"b.kcl\" as b\nparts = [a,b]\n",
+                    )
+                    .unwrap();
+                    let result = if concurrent {
+                        let mut state = ExecState::new(&ctx);
+                        ctx.run(&program, &mut state).await.map(|_| ())
+                    } else {
+                        ctx.run_mock(
+                            &program,
+                            &MockConfig {
+                                use_prev_memory: false,
+                                ..Default::default()
+                            },
+                        )
+                        .await
+                        .map(|_| ())
+                    };
+                    ctx.close().await;
+                    if initial == "seed" {
+                        let error = result.expect_err("shared imported target must be consumed only once");
+                        assert!(matches!(error.error, KclError::Semantic { .. }), "{error:?}");
+                        assert!(
+                            error
+                                .error
+                                .message()
+                                .contains("already consumed by a `subtract` operation")
+                        );
+                    } else {
+                        result
+                            .unwrap_or_else(|error| panic!("{initial}, {import}, concurrent={concurrent}: {error:?}"));
+                    }
+                }
+            }
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn subtract_rechecks_shared_inputs_after_waiting() {
+        use futures::FutureExt;
+
+        use crate::std::Args;
+        use crate::std::csg::CsgAlgorithm;
+
+        let ctx = crate::ExecutorContext::new_mock(None).await;
+        let mut first = ExecState::new(&ctx);
+        let mut second = first.clone();
+        let target = procedural_solid(Uuid::from_u128(1), Uuid::from_u128(1));
+        let tool = procedural_solid(Uuid::from_u128(2), Uuid::from_u128(2));
+        let other_tool = procedural_solid(Uuid::from_u128(3), Uuid::from_u128(3));
+        let inputs = first.lock_solid_inputs(std::slice::from_ref(&target)).await.unwrap();
+        let args = || Args::new_no_args(SourceRange::synthetic(), None, ctx.clone(), None);
+        let competing = super::super::csg::inner_subtract(
+            vec![target.clone()],
+            vec![tool],
+            None,
+            CsgAlgorithm::legacy(false),
+            &mut second,
+            args(),
+        );
+        tokio::pin!(competing);
+        assert!(futures::poll!(&mut competing).is_pending());
+
+        // A blocked consumer must not serialize operations on other bodies.
+        let mut independent = first.clone();
+        let other = procedural_solid(Uuid::from_u128(4), Uuid::from_u128(4));
+        super::super::csg::inner_subtract(
+            vec![other],
+            vec![other_tool],
+            None,
+            CsgAlgorithm::legacy(false),
+            &mut independent,
+            args(),
+        )
+        .now_or_never()
+        .expect("independent bodies must not wait")
+        .unwrap();
+
+        record_consumed_solids(&mut first, &[target], ConsumedSolidOperation::Subtract, &[]).unwrap();
+        drop(inputs);
+        let error = competing.await.unwrap_err();
+        assert!(matches!(error, KclError::Semantic { .. }));
+        assert!(error.message().contains("already consumed by a `subtract` operation"));
+        ctx.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn consumed_solid_diagnostic_names_match_between_memory_backends() {
         for &backend in MemoryBackendKind::all() {
             let ctx = crate::ExecutorContext::new_mock(None).await;
@@ -263,7 +391,8 @@ mod tests {
                 std::slice::from_ref(&target),
                 ConsumedSolidOperation::Subtract,
                 &[],
-            );
+            )
+            .unwrap();
 
             let err = validate_solids_not_consumed(std::slice::from_ref(&target), &exec_state, SourceRange::default())
                 .expect_err("consumed target should be rejected");
@@ -292,7 +421,8 @@ mod tests {
             std::slice::from_ref(&consumed),
             ConsumedSolidOperation::Subtract,
             std::slice::from_ref(&output),
-        );
+        )
+        .unwrap();
 
         validate_solids_not_consumed(std::slice::from_ref(&output), &exec_state, SourceRange::default())
             .expect("replacement output should remain usable");
@@ -316,7 +446,8 @@ mod tests {
             std::slice::from_ref(&consumed),
             ConsumedSolidOperation::Subtract,
             std::slice::from_ref(&output),
-        );
+        )
+        .unwrap();
 
         let err = validate_solids_not_consumed(std::slice::from_ref(&stale_alias), &exec_state, SourceRange::default())
             .expect_err("stale engine body id should be rejected before the engine sees it");
@@ -342,7 +473,8 @@ mod tests {
             std::slice::from_ref(&consumed),
             ConsumedSolidOperation::Subtract,
             &[primary_output, extra_output.clone()],
-        );
+        )
+        .unwrap();
 
         validate_solids_not_consumed(std::slice::from_ref(&extra_output), &exec_state, SourceRange::default())
             .expect("any replacement output should remain usable");

--- a/rust/kcl-lib/src/std/surfaces.rs
+++ b/rust/kcl-lib/src/std/surfaces.rs
@@ -404,6 +404,8 @@ async fn inner_join(
     exec_state: &mut ExecState,
     args: Args,
 ) -> Result<Solid, KclError> {
+    let _inputs = exec_state.lock_solid_inputs(&selection).await?;
+    super::solid_consumption::validate_solids_not_consumed(&selection, exec_state, args.source_range)?;
     if selection.len() == 1 {
         let cmd = mcmd::Solid3dJoin::builder().object_id(selection[0].id).build();
 
@@ -456,7 +458,7 @@ async fn inner_join(
             &selection,
             ConsumedSolidOperation::JoinSurfaces,
             std::slice::from_ref(&solid),
-        );
+        )?;
         Ok(solid)
     }
 }


### PR DESCRIPTION
Move consumed-solid bookkeeping from module-local state to execution-shared state. Per-body locks serialize only overlapping Boolean and join inputs across concurrent module evaluation, and validation runs again after a waiter acquires the locks. Independent bodies remain parallel.\n\nThe focused tests cover shared imports in serial and concurrent execution, valid constructor/clone controls, and deterministic contention. All current CI checks pass, including the Rust shards and generated bindings. Real Engine replay has not run, so this remains a draft.\n\nFixes #13848.