### PR TITLE
Wait for authentication before Engine-dependent E2E setup

### DIFF
--- a/e2e/playwright/editor-tests.spec.ts
+++ b/e2e/playwright/editor-tests.spec.ts
@@ -188,6 +188,7 @@ sketch001 = startSketchOn(XY)
     const u = await getUtils(page)
     await page.setBodyDimensions({ width: 1000, height: 500 })
 
+    await homePage.waitForAuthentication()
     await homePage.goToModelingScene()
     await scene.settled()
 

--- a/e2e/playwright/point-click.spec.ts
+++ b/e2e/playwright/point-click.spec.ts
@@ -2447,6 +2447,7 @@ extrude001 = extrude([sketch001.line1, sketch001.line2], length = 5, bodyType = 
         localStorage.setItem('persistCode', initialCode)
       }, initialCode)
       await page.setBodyDimensions({ width: 1500, height: 1000 })
+      await homePage.waitForAuthentication()
       await homePage.goToModelingScene()
       await scene.settled()
     })

--- a/e2e/playwright/test-network-and-connection-issues.spec.ts
+++ b/e2e/playwright/test-network-and-connection-issues.spec.ts
@@ -18,6 +18,7 @@ test.describe('Test network related behaviors', { tag: '@desktop' }, () => {
       const u = await getUtils(page)
       await page.setBodyDimensions({ width: 1200, height: 500 })
 
+      await homePage.waitForAuthentication()
       await homePage.goToModelingScene()
       await scene.settled()
 

--- a/e2e/playwright/testing-selections.spec.ts
+++ b/e2e/playwright/testing-selections.spec.ts
@@ -42,6 +42,7 @@ test.describe('Testing selections', { tag: '@desktop' }, () => {
     })
 
     await page.setBodyDimensions({ width: 1200, height: 500 })
+    await homePage.waitForAuthentication()
     await homePage.goToModelingScene()
     await u.waitForPageLoad()
 


### PR DESCRIPTION
Four Engine-dependent E2E setups could enter the modeling scene before authentication was ready. Wait for the existing Home-page authentication helper before each scene entry.

Validation: formatting and diff checks passed. Current CI passes the desktop E2E lanes; Vercel web E2E failed and Test Analysis Bot remains pending.