### PR TITLE
Allow per-execution KCL auth and session callbacks

### DIFF
--- a/rust/kcl-lib/src/engine/engine_manager.rs
+++ b/rust/kcl-lib/src/engine/engine_manager.rs
@@ -106,6 +106,10 @@ impl std::fmt::Debug for EngineManager {
     }
 }
 
+/// Observes the server-issued session ID as soon as it arrives.
+#[cfg(not(target_arch = "wasm32"))]
+pub type SessionObserver = Arc<dyn Fn(String) + Send + Sync>;
+
 impl EngineManager {
     #[cfg(target_arch = "wasm32")]
     pub fn new_wasm_transport(
@@ -133,6 +137,15 @@ impl EngineManager {
 
     #[cfg(not(target_arch = "wasm32"))]
     pub async fn new_websocket_transport(ws: reqwest::Upgraded, heartbeats: Option<u64>) -> Self {
+        Self::new_websocket_transport_with_observer(ws, heartbeats, None).await
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub async fn new_websocket_transport_with_observer(
+        ws: reqwest::Upgraded,
+        heartbeats: Option<u64>,
+        session_observer: Option<SessionObserver>,
+    ) -> Self {
         use crate::engine::engine_manager::ws_transport::WebSocketTransport;
 
         let session_data: Arc<RwLock<Option<ModelingSessionData>>> = Arc::new(RwLock::new(None));
@@ -150,6 +163,7 @@ impl EngineManager {
             Arc::clone(&session_data),
             Arc::clone(&pending_errors),
             Arc::clone(&socket_health),
+            session_observer,
         )
         .await;
 

--- a/rust/kcl-lib/src/engine/engine_manager/ws_transport.rs
+++ b/rust/kcl-lib/src/engine/engine_manager/ws_transport.rs
@@ -121,6 +121,7 @@ impl WebSocketTransport {
         session_data: Arc<RwLock<Option<ModelingSessionData>>>,
         pending_errors: Arc<RwLock<Vec<String>>>,
         socket_health: Arc<RwLock<SocketHealth>>,
+        session_observer: Option<super::SessionObserver>,
     ) -> Self {
         let wsconfig = tokio_tungstenite::tungstenite::protocol::WebSocketConfig::default()
             // 4294967296 bytes, which is around 4.2 GB.
@@ -206,6 +207,10 @@ impl WebSocketTransport {
                             }) => {
                                 let mut sd = session_data_for_read.write().await;
                                 sd.replace(session.clone());
+                                drop(sd);
+                                if let Some(observer) = &session_observer {
+                                    observer(session.api_call_id.clone());
+                                }
                                 logln!("API Call ID: {}", session.api_call_id);
                             }
                             WebSocketResponse::Failure(FailureWebSocketResponse {

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -1122,6 +1122,16 @@ impl ExecutorContext {
     /// Create a new default executor context.
     #[cfg(not(target_arch = "wasm32"))]
     pub async fn new(client: &kittycad::Client, settings: ExecutorSettings) -> Result<Self> {
+        Self::new_with_session_observer(client, settings, None).await
+    }
+
+    /// Create an executor with a connection-local session observer.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub async fn new_with_session_observer(
+        client: &kittycad::Client,
+        settings: ExecutorSettings,
+        session_observer: Option<crate::engine::engine_manager::SessionObserver>,
+    ) -> Result<Self> {
         let pr = std::env::var("ZOO_ENGINE_PR").ok().and_then(|s| s.parse().ok());
         let (ws, _headers) = client
             .modeling()
@@ -1145,7 +1155,8 @@ impl ExecutorContext {
             })
             .await?;
 
-        let engine_conn = EngineManager::new_websocket_transport(ws, settings.heartbeats).await;
+        let engine_conn =
+            EngineManager::new_websocket_transport_with_observer(ws, settings.heartbeats, session_observer).await;
         let engine = Arc::new(engine_conn);
 
         Ok(Self::new_with_engine(engine, settings))
@@ -1230,11 +1241,18 @@ impl ExecutorContext {
         token: Option<String>,
         engine_addr: Option<String>,
     ) -> Result<Self> {
-        // Create the client.
-        let client = crate::engine::new_zoo_client(token, engine_addr)?;
+        Self::new_with_client_and_observer(settings, token, engine_addr, None).await
+    }
 
-        let ctx = Self::new(&client, settings).await?;
-        Ok(ctx)
+    #[cfg(not(target_arch = "wasm32"))]
+    pub async fn new_with_client_and_observer(
+        settings: ExecutorSettings,
+        token: Option<String>,
+        engine_addr: Option<String>,
+        session_observer: Option<crate::SessionObserver>,
+    ) -> Result<Self> {
+        let client = crate::engine::new_zoo_client(token, engine_addr)?;
+        Self::new_with_session_observer(&client, settings, session_observer).await
     }
 
     /// Create a new default executor context.

--- a/rust/kcl-lib/src/lib.rs
+++ b/rust/kcl-lib/src/lib.rs
@@ -164,6 +164,8 @@ pub mod lsp_support {
 pub use engine::AsyncTasks;
 pub use engine::EngineBatchContext;
 pub use engine::EngineStats;
+#[cfg(all(feature = "engine", not(target_arch = "wasm32")))]
+pub use engine::engine_manager::SessionObserver;
 pub use errors::BacktraceItem;
 pub use errors::BacktraceItemKind;
 pub use errors::CompilationIssue;

--- a/rust/kcl-python-bindings/kcl.pyi
+++ b/rust/kcl-python-bindings/kcl.pyi
@@ -21,6 +21,7 @@ __all__ = [
     "DxfExportOptions",
     "DxfStorage",
     "ExecOutcome",
+    "ExecutionOptions",
     "ExportFile",
     "FbxExportOptions",
     "FbxImportOptions",
@@ -205,6 +206,14 @@ class ExecOutcome:
         freedom.
         """
     def report_all(self) -> builtins.list[builtins.str]: ...
+
+@typing.final
+class ExecutionOptions:
+    r"""
+    Connection settings scoped to one execution, including its retries.
+    The callback runs synchronously on the native reader thread and must not block.
+    """
+    def __new__(cls, *, token: typing.Optional[builtins.str] = None, on_engine_session: typing.Optional[typing.Any] = None) -> ExecutionOptions: ...
 
 @typing.final
 class ExportFile:
@@ -1305,59 +1314,59 @@ async def default_units(path: builtins.str) -> zooDefaultUnits:
     Get the default length and angle units from a kcl file.
     """
 
-async def execute(path: builtins.str) -> zooExecOutcome:
+async def execute(path: builtins.str, *, options: typing.Optional[ExecutionOptions] = None) -> zooExecOutcome:
     r"""
     Execute the kcl code from a file path.
     """
 
-async def execute_and_bounding_box(path: builtins.str, entity_ids: typing.Optional[typing.Sequence[builtins.str]] = None, output_unit: typing.Optional[UnitLength] = None) -> zooBoundingBoxResponse:
+async def execute_and_bounding_box(path: builtins.str, entity_ids: typing.Optional[typing.Sequence[builtins.str]] = None, output_unit: typing.Optional[UnitLength] = None, *, options: typing.Optional[ExecutionOptions] = None) -> zooBoundingBoxResponse:
     r"""
     Execute a kcl file and return the model's bounding box.
     """
 
-async def execute_and_export(path: builtins.str, export_format: zooFileExportFormat) -> builtins.list[RawFile]:
+async def execute_and_export(path: builtins.str, export_format: zooFileExportFormat, *, options: typing.Optional[ExecutionOptions] = None) -> builtins.list[RawFile]:
     r"""
     Execute a kcl file and export it to a specific file format.
     """
 
-async def execute_and_measure(path: builtins.str, request: zooPhysicalPropertiesRequest) -> zooPhysicalPropertiesResponse:
+async def execute_and_measure(path: builtins.str, request: zooPhysicalPropertiesRequest, *, options: typing.Optional[ExecutionOptions] = None) -> zooPhysicalPropertiesResponse:
     r"""
     Execute a kcl file and measure physical properties of the resulting model.
     """
 
-async def execute_and_snapshot(path: builtins.str, image_format: zooImageFormat, *, zoom: typing.Optional[builtins.bool] = None, highlight_edges: typing.Optional[builtins.bool] = None) -> builtins.list[builtins.int]:
+async def execute_and_snapshot(path: builtins.str, image_format: zooImageFormat, *, zoom: typing.Optional[builtins.bool] = None, highlight_edges: typing.Optional[builtins.bool] = None, options: typing.Optional[ExecutionOptions] = None) -> builtins.list[builtins.int]:
     r"""
     Execute a kcl file and snapshot it in a specific format.
     """
 
-async def execute_and_snapshot_views(path: builtins.str, image_format: zooImageFormat, snapshot_options: typing.Sequence[SnapshotOptions], *, zoom: typing.Optional[builtins.bool] = None, highlight_edges: typing.Optional[builtins.bool] = None) -> builtins.list[builtins.list[builtins.int]]: ...
+async def execute_and_snapshot_views(path: builtins.str, image_format: zooImageFormat, snapshot_options: typing.Sequence[SnapshotOptions], *, zoom: typing.Optional[builtins.bool] = None, highlight_edges: typing.Optional[builtins.bool] = None, options: typing.Optional[ExecutionOptions] = None) -> builtins.list[builtins.list[builtins.int]]: ...
 
-async def execute_code(code: builtins.str) -> zooExecOutcome:
+async def execute_code(code: builtins.str, *, options: typing.Optional[ExecutionOptions] = None) -> zooExecOutcome:
     r"""
     Execute the kcl code.
     """
 
-async def execute_code_and_bounding_box(code: builtins.str, entity_ids: typing.Optional[typing.Sequence[builtins.str]] = None, output_unit: typing.Optional[UnitLength] = None) -> zooBoundingBoxResponse:
+async def execute_code_and_bounding_box(code: builtins.str, entity_ids: typing.Optional[typing.Sequence[builtins.str]] = None, output_unit: typing.Optional[UnitLength] = None, *, options: typing.Optional[ExecutionOptions] = None) -> zooBoundingBoxResponse:
     r"""
     Execute the kcl code and return the model's bounding box.
     """
 
-async def execute_code_and_export(code: builtins.str, export_format: zooFileExportFormat) -> builtins.list[RawFile]:
+async def execute_code_and_export(code: builtins.str, export_format: zooFileExportFormat, *, options: typing.Optional[ExecutionOptions] = None) -> builtins.list[RawFile]:
     r"""
     Execute the kcl code and export it to a specific file format.
     """
 
-async def execute_code_and_measure(code: builtins.str, request: zooPhysicalPropertiesRequest) -> zooPhysicalPropertiesResponse:
+async def execute_code_and_measure(code: builtins.str, request: zooPhysicalPropertiesRequest, *, options: typing.Optional[ExecutionOptions] = None) -> zooPhysicalPropertiesResponse:
     r"""
     Execute the kcl code and measure physical properties of the resulting model.
     """
 
-async def execute_code_and_snapshot(code: builtins.str, image_format: zooImageFormat, *, zoom: typing.Optional[builtins.bool] = None, highlight_edges: typing.Optional[builtins.bool] = None) -> builtins.list[builtins.int]:
+async def execute_code_and_snapshot(code: builtins.str, image_format: zooImageFormat, *, zoom: typing.Optional[builtins.bool] = None, highlight_edges: typing.Optional[builtins.bool] = None, options: typing.Optional[ExecutionOptions] = None) -> builtins.list[builtins.int]:
     r"""
     Execute the kcl code and snapshot it in a specific format.
     """
 
-async def execute_code_and_snapshot_views(code: builtins.str, image_format: zooImageFormat, snapshot_options: typing.Sequence[SnapshotOptions], *, zoom: typing.Optional[builtins.bool] = None, highlight_edges: typing.Optional[builtins.bool] = None) -> builtins.list[builtins.list[builtins.int]]:
+async def execute_code_and_snapshot_views(code: builtins.str, image_format: zooImageFormat, snapshot_options: typing.Sequence[SnapshotOptions], *, zoom: typing.Optional[builtins.bool] = None, highlight_edges: typing.Optional[builtins.bool] = None, options: typing.Optional[ExecutionOptions] = None) -> builtins.list[builtins.list[builtins.int]]:
     r"""
     Execute the kcl code and snapshot it in a specific format.
     Returns one image for each camera angle you provide.
@@ -1374,19 +1383,19 @@ async def format_dir(dir: builtins.str) -> None:
     Format a whole directory of kcl code.
     """
 
-async def get_sketch_constraint_status(path: builtins.str) -> zooSketchConstraintReport:
+async def get_sketch_constraint_status(path: builtins.str, *, options: typing.Optional[ExecutionOptions] = None) -> zooSketchConstraintReport:
     r"""
     Execute a kcl file and return a report of sketch constraint status.
     """
 
-async def get_sketch_constraint_status_code(code: builtins.str) -> zooSketchConstraintReport:
+async def get_sketch_constraint_status_code(code: builtins.str, *, options: typing.Optional[ExecutionOptions] = None) -> zooSketchConstraintReport:
     r"""
     Execute kcl code and return a report of sketch constraint status.
     """
 
-async def import_and_snapshot(filepaths: typing.Sequence[builtins.str], format: zooInputFormat3d, image_format: zooImageFormat, *, zoom: typing.Optional[builtins.bool] = None, highlight_edges: typing.Optional[builtins.bool] = None) -> builtins.list[builtins.int]: ...
+async def import_and_snapshot(filepaths: typing.Sequence[builtins.str], format: zooInputFormat3d, image_format: zooImageFormat, *, zoom: typing.Optional[builtins.bool] = None, highlight_edges: typing.Optional[builtins.bool] = None, options: typing.Optional[ExecutionOptions] = None) -> builtins.list[builtins.int]: ...
 
-async def import_and_snapshot_views(filepaths: typing.Sequence[builtins.str], format: zooInputFormat3d, image_format: zooImageFormat, snapshot_options: typing.Sequence[SnapshotOptions], *, zoom: typing.Optional[builtins.bool] = None, highlight_edges: typing.Optional[builtins.bool] = None) -> builtins.list[builtins.list[builtins.int]]: ...
+async def import_and_snapshot_views(filepaths: typing.Sequence[builtins.str], format: zooInputFormat3d, image_format: zooImageFormat, snapshot_options: typing.Sequence[SnapshotOptions], *, zoom: typing.Optional[builtins.bool] = None, highlight_edges: typing.Optional[builtins.bool] = None, options: typing.Optional[ExecutionOptions] = None) -> builtins.list[builtins.list[builtins.int]]: ...
 
 def lint(code: builtins.str) -> builtins.list[Discovered]:
     r"""

--- a/rust/kcl-python-bindings/src/lib.rs
+++ b/rust/kcl-python-bindings/src/lib.rs
@@ -2,6 +2,7 @@
 use std::future::Future;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use anyhow::Result;
 use kcl_api::UnitAngle;
@@ -250,16 +251,52 @@ fn executor_settings(current_file: Option<PathBuf>, highlight_edges: Option<bool
     settings
 }
 
+/// Connection settings scoped to one execution, including its retries.
+/// The callback runs synchronously on the native reader thread and must not block.
+#[derive(Clone, Default)]
+#[pyo3_stub_gen::derive::gen_stub_pyclass]
+#[pyclass(frozen, from_py_object)]
+struct ExecutionOptions {
+    token: Option<String>,
+    session_observer: Option<kcl_lib::SessionObserver>,
+}
+
+#[pyo3_stub_gen::derive::gen_stub_pymethods]
+#[pymethods]
+impl ExecutionOptions {
+    #[new]
+    #[pyo3(signature = (*, token=None, on_engine_session=None))]
+    fn new(token: Option<String>, on_engine_session: Option<Py<PyAny>>) -> PyResult<Self> {
+        if token.as_ref().is_some_and(|token| token.trim().is_empty()) {
+            return Err(pyo3::exceptions::PyValueError::new_err("token must not be empty"));
+        }
+        let session_observer = on_engine_session.map(|callback| {
+            Arc::new(move |id: String| {
+                Python::attach(|py| {
+                    // Telemetry must not change the execution result or expose callback errors.
+                    let _ = callback.call1(py, (id,));
+                });
+            }) as kcl_lib::SessionObserver
+        });
+        Ok(Self {
+            token,
+            session_observer,
+        })
+    }
+}
+
 async fn new_context_state(
     current_file: Option<PathBuf>,
     mock: bool,
     highlight_edges: Option<bool>,
+    options: Option<ExecutionOptions>,
 ) -> Result<(ExecutorContext, kcl_lib::ExecState)> {
     let settings = executor_settings(current_file, highlight_edges);
     let ctx = if mock {
         ExecutorContext::new_mock(Some(settings)).await
     } else {
-        ExecutorContext::new_with_client(settings, None, None).await?
+        let options = options.unwrap_or_default();
+        ExecutorContext::new_with_client_and_observer(settings, options.token, None, options.session_observer).await?
     };
     let state = kcl_lib::ExecState::new(&ctx);
     Ok((ctx, state))
@@ -330,7 +367,12 @@ struct ExecutedKcl {
     filename: String,
 }
 
-async fn run_kcl(input: KclInput, mock: bool, highlight_edges: Option<bool>) -> PyResult<ExecutedKcl> {
+async fn run_kcl(
+    input: KclInput,
+    mock: bool,
+    highlight_edges: Option<bool>,
+    options: Option<ExecutionOptions>,
+) -> PyResult<ExecutedKcl> {
     let KclProgram {
         code,
         program,
@@ -338,7 +380,7 @@ async fn run_kcl(input: KclInput, mock: bool, highlight_edges: Option<bool>) -> 
         filename,
     } = load_and_parse(input).await?;
 
-    let (ctx, mut state) = new_context_state(path, mock, highlight_edges)
+    let (ctx, mut state) = new_context_state(path, mock, highlight_edges, options)
         .await
         .map_err(to_py_exception)?;
     let (env_ref, _) = match ctx.run(&program, &mut state).await {
@@ -358,7 +400,7 @@ async fn run_kcl(input: KclInput, mock: bool, highlight_edges: Option<bool>) -> 
     })
 }
 
-async fn execute_impl(input: KclInput, mock: bool) -> PyResult<ExecOutcome> {
+async fn execute_impl(input: KclInput, mock: bool, options: Option<ExecutionOptions>) -> PyResult<ExecOutcome> {
     let ExecutedKcl {
         ctx,
         state,
@@ -366,7 +408,7 @@ async fn execute_impl(input: KclInput, mock: bool) -> PyResult<ExecOutcome> {
         code,
         filename,
         ..
-    } = run_kcl(input, mock, None).await?;
+    } = run_kcl(input, mock, None, options).await?;
     let outcome = match state.into_exec_outcome(env_ref, &ctx).await {
         Ok(outcome) => outcome,
         Err(err) => {
@@ -382,7 +424,10 @@ async fn execute_impl(input: KclInput, mock: bool) -> PyResult<ExecOutcome> {
     })
 }
 
-async fn sketch_constraint_report_impl(input: KclInput) -> PyResult<SketchConstraintReport> {
+async fn sketch_constraint_report_impl(
+    input: KclInput,
+    options: Option<ExecutionOptions>,
+) -> PyResult<SketchConstraintReport> {
     let (code, path, filename) = match input {
         KclInput::Path(input_path) => {
             let (code, path) = get_code_and_file_path(&input_path).await.map_err(to_py_exception)?;
@@ -400,7 +445,9 @@ async fn sketch_constraint_report_impl(input: KclInput) -> PyResult<SketchConstr
         }
     };
 
-    let (ctx, mut state) = new_context_state(path, false, None).await.map_err(to_py_exception)?;
+    let (ctx, mut state) = new_context_state(path, false, None, options)
+        .await
+        .map_err(to_py_exception)?;
     let result = match ctx.run(&program, &mut state).await {
         Ok((env_ref, _)) => {
             let outcome = state.into_exec_outcome(env_ref, &ctx).await.map_err(to_py_exception)?;
@@ -437,8 +484,9 @@ async fn execute_and_snapshot_views_impl(
     snapshot_options: Vec<SnapshotOptions>,
     zoom: bool,
     highlight_edges: Option<bool>,
+    options: Option<ExecutionOptions>,
 ) -> PyResult<Vec<Vec<u8>>> {
-    let ExecutedKcl { ctx, .. } = run_kcl(input, false, highlight_edges).await?;
+    let ExecutedKcl { ctx, .. } = run_kcl(input, false, highlight_edges, options).await?;
     let result = take_snaps(&ctx, image_format, snapshot_options, zoom).await;
     ctx.close().await;
     result
@@ -447,8 +495,9 @@ async fn execute_and_snapshot_views_impl(
 async fn execute_and_measure_impl(
     input: KclInput,
     request: PhysicalPropertiesRequest,
+    options: Option<ExecutionOptions>,
 ) -> PyResult<PhysicalPropertiesResponse> {
-    let ExecutedKcl { ctx, .. } = run_kcl(input, false, None).await?;
+    let ExecutedKcl { ctx, .. } = run_kcl(input, false, None, options).await?;
     let result = measure_model_properties(&ctx, request).await;
     ctx.close().await;
     result
@@ -466,22 +515,27 @@ async fn execute_and_bounding_box_impl(
     input: KclInput,
     entity_ids: Vec<String>,
     output_unit: Option<UnitLength>,
+    options: Option<ExecutionOptions>,
 ) -> PyResult<BoundingBoxResponse> {
     let entity_ids = parse_entity_ids(entity_ids)?;
-    let ExecutedKcl { ctx, .. } = run_kcl(input, false, None).await?;
+    let ExecutedKcl { ctx, .. } = run_kcl(input, false, None, options).await?;
     let result = get_bounding_box(&ctx, entity_ids, output_unit).await;
     ctx.close().await;
     result
 }
 
-async fn execute_and_export_impl(input: KclInput, export_format: FileExportFormat) -> PyResult<Vec<RawFile>> {
+async fn execute_and_export_impl(
+    input: KclInput,
+    export_format: FileExportFormat,
+    options: Option<ExecutionOptions>,
+) -> PyResult<Vec<RawFile>> {
     let ExecutedKcl {
         ctx,
         program,
         code,
         filename,
         ..
-    } = run_kcl(input, false, None).await?;
+    } = run_kcl(input, false, None, options).await?;
 
     let settings = match program.meta_settings() {
         Ok(x) => x.unwrap_or_default(),
@@ -577,59 +631,74 @@ fn parse_code(code: String) -> PyResult<bool> {
 
 /// Execute the kcl code from a file path.
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
-#[pyfunction]
-async fn execute(path: String) -> PyResult<ExecOutcome> {
-    spawn_py(async move { execute_impl(KclInput::Path(path), false).await }).await
+#[pyfunction(signature = (path, *, options=None))]
+async fn execute(path: String, options: Option<ExecutionOptions>) -> PyResult<ExecOutcome> {
+    spawn_py(async move { execute_impl(KclInput::Path(path), false, options).await }).await
 }
 
 /// Execute the kcl code.
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
-#[pyfunction]
-async fn execute_code(code: String) -> PyResult<ExecOutcome> {
-    spawn_py(async move { execute_impl(KclInput::Code(code), false).await }).await
+#[pyfunction(signature = (code, *, options=None))]
+async fn execute_code(code: String, options: Option<ExecutionOptions>) -> PyResult<ExecOutcome> {
+    spawn_py(async move { execute_impl(KclInput::Code(code), false, options).await }).await
 }
 
 /// Mock execute the kcl code.
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
 #[pyfunction]
 async fn mock_execute_code(code: String) -> PyResult<ExecOutcome> {
-    spawn_py(async move { execute_impl(KclInput::Code(code), true).await }).await
+    spawn_py(async move { execute_impl(KclInput::Code(code), true, None).await }).await
 }
 
 /// Mock execute the kcl code from a file path.
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
 #[pyfunction]
 async fn mock_execute(path: String) -> PyResult<ExecOutcome> {
-    spawn_py(async move { execute_impl(KclInput::Path(path), true).await }).await
+    spawn_py(async move { execute_impl(KclInput::Path(path), true, None).await }).await
 }
 
 /// Execute a kcl file and return a report of sketch constraint status.
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
-#[pyfunction]
-async fn get_sketch_constraint_status(path: String) -> PyResult<SketchConstraintReport> {
-    spawn_py(async move { sketch_constraint_report_impl(KclInput::Path(path)).await }).await
+#[pyfunction(signature = (path, *, options=None))]
+async fn get_sketch_constraint_status(
+    path: String,
+    options: Option<ExecutionOptions>,
+) -> PyResult<SketchConstraintReport> {
+    spawn_py(async move { sketch_constraint_report_impl(KclInput::Path(path), options).await }).await
 }
 
 /// Execute kcl code and return a report of sketch constraint status.
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
-#[pyfunction]
-async fn get_sketch_constraint_status_code(code: String) -> PyResult<SketchConstraintReport> {
-    spawn_py(async move { sketch_constraint_report_impl(KclInput::Code(code)).await }).await
+#[pyfunction(signature = (code, *, options=None))]
+async fn get_sketch_constraint_status_code(
+    code: String,
+    options: Option<ExecutionOptions>,
+) -> PyResult<SketchConstraintReport> {
+    spawn_py(async move { sketch_constraint_report_impl(KclInput::Code(code), options).await }).await
 }
 
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
-#[pyfunction(signature = (filepaths, format, image_format, *, zoom=None, highlight_edges=None))]
+#[pyfunction(signature = (filepaths, format, image_format, *, zoom=None, highlight_edges=None, options=None))]
 async fn import_and_snapshot(
     filepaths: Vec<String>,
     format: InputFormat3d,
     image_format: ImageFormat,
     zoom: Option<bool>,
     highlight_edges: Option<bool>,
+    options: Option<ExecutionOptions>,
 ) -> PyResult<Vec<u8>> {
     let zoom = zoom.unwrap_or(true);
-    let img = import_and_snapshot_views(filepaths, format, image_format, Vec::new(), Some(zoom), highlight_edges)
-        .await?
-        .pop();
+    let img = import_and_snapshot_views(
+        filepaths,
+        format,
+        image_format,
+        Vec::new(),
+        Some(zoom),
+        highlight_edges,
+        options,
+    )
+    .await?
+    .pop();
     Ok(img.unwrap())
 }
 
@@ -648,7 +717,7 @@ fn relevant_file_extensions() -> PyResult<Vec<String>> {
 }
 
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
-#[pyfunction(signature = (filepaths, format, image_format, snapshot_options, *, zoom=None, highlight_edges=None))]
+#[pyfunction(signature = (filepaths, format, image_format, snapshot_options, *, zoom=None, highlight_edges=None, options=None))]
 async fn import_and_snapshot_views(
     filepaths: Vec<String>,
     format: InputFormat3d,
@@ -656,10 +725,11 @@ async fn import_and_snapshot_views(
     snapshot_options: Vec<SnapshotOptions>,
     zoom: Option<bool>,
     highlight_edges: Option<bool>,
+    options: Option<ExecutionOptions>,
 ) -> PyResult<Vec<Vec<u8>>> {
     let zoom = zoom.unwrap_or(true);
     spawn_py(async move {
-        let (ctx, _state) = new_context_state(None, false, highlight_edges)
+        let (ctx, _state) = new_context_state(None, false, highlight_edges, options)
             .await
             .map_err(to_py_exception)?;
         if let Err(e) = import(&ctx, filepaths, format).await {
@@ -719,28 +789,30 @@ async fn import(ctx: &ExecutorContext, filepaths: Vec<String>, format: InputForm
 
 /// Execute a kcl file and snapshot it in a specific format.
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
-#[pyfunction(signature = (path, image_format, *, zoom=None, highlight_edges=None))]
+#[pyfunction(signature = (path, image_format, *, zoom=None, highlight_edges=None, options=None))]
 async fn execute_and_snapshot(
     path: String,
     image_format: ImageFormat,
     zoom: Option<bool>,
     highlight_edges: Option<bool>,
+    options: Option<ExecutionOptions>,
 ) -> PyResult<Vec<u8>> {
     let zoom = zoom.unwrap_or(true);
-    let img = execute_and_snapshot_views(path, image_format, Vec::new(), Some(zoom), highlight_edges)
+    let img = execute_and_snapshot_views(path, image_format, Vec::new(), Some(zoom), highlight_edges, options)
         .await?
         .pop();
     Ok(img.unwrap())
 }
 
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
-#[pyfunction(signature = (path, image_format, snapshot_options, *, zoom=None, highlight_edges=None))]
+#[pyfunction(signature = (path, image_format, snapshot_options, *, zoom=None, highlight_edges=None, options=None))]
 async fn execute_and_snapshot_views(
     path: String,
     image_format: ImageFormat,
     snapshot_options: Vec<SnapshotOptions>,
     zoom: Option<bool>,
     highlight_edges: Option<bool>,
+    options: Option<ExecutionOptions>,
 ) -> PyResult<Vec<Vec<u8>>> {
     let zoom = zoom.unwrap_or(true);
     spawn_py(async move {
@@ -750,6 +822,7 @@ async fn execute_and_snapshot_views(
             snapshot_options,
             zoom,
             highlight_edges,
+            options,
         )
         .await
     })
@@ -758,58 +831,68 @@ async fn execute_and_snapshot_views(
 
 /// Execute the kcl code and snapshot it in a specific format.
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
-#[pyfunction(signature = (code, image_format, *, zoom=None, highlight_edges=None))]
+#[pyfunction(signature = (code, image_format, *, zoom=None, highlight_edges=None, options=None))]
 async fn execute_code_and_snapshot(
     code: String,
     image_format: ImageFormat,
     zoom: Option<bool>,
     highlight_edges: Option<bool>,
+    options: Option<ExecutionOptions>,
 ) -> PyResult<Vec<u8>> {
     let zoom = zoom.unwrap_or(true);
     let mut snaps =
-        execute_code_and_snapshot_views(code, image_format, Vec::new(), Some(zoom), highlight_edges).await?;
+        execute_code_and_snapshot_views(code, image_format, Vec::new(), Some(zoom), highlight_edges, options).await?;
     Ok(snaps.pop().unwrap())
 }
 
 /// Execute a kcl file and measure physical properties of the resulting model.
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
-#[pyfunction]
-async fn execute_and_measure(path: String, request: PhysicalPropertiesRequest) -> PyResult<PhysicalPropertiesResponse> {
-    spawn_py(async move { execute_and_measure_impl(KclInput::Path(path), request).await }).await
+#[pyfunction(signature = (path, request, *, options=None))]
+async fn execute_and_measure(
+    path: String,
+    request: PhysicalPropertiesRequest,
+    options: Option<ExecutionOptions>,
+) -> PyResult<PhysicalPropertiesResponse> {
+    spawn_py(async move { execute_and_measure_impl(KclInput::Path(path), request, options).await }).await
 }
 
 /// Execute the kcl code and measure physical properties of the resulting model.
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
-#[pyfunction]
+#[pyfunction(signature = (code, request, *, options=None))]
 async fn execute_code_and_measure(
     code: String,
     request: PhysicalPropertiesRequest,
+    options: Option<ExecutionOptions>,
 ) -> PyResult<PhysicalPropertiesResponse> {
-    spawn_py(async move { execute_and_measure_impl(KclInput::Code(code), request).await }).await
+    spawn_py(async move { execute_and_measure_impl(KclInput::Code(code), request, options).await }).await
 }
 
 /// Execute a kcl file and return the model's bounding box.
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
-#[pyfunction(signature = (path, entity_ids=None, output_unit=None))]
+#[pyfunction(signature = (path, entity_ids=None, output_unit=None, *, options=None))]
 async fn execute_and_bounding_box(
     path: String,
     entity_ids: Option<Vec<String>>,
     output_unit: Option<UnitLength>,
+    options: Option<ExecutionOptions>,
 ) -> PyResult<BoundingBoxResponse> {
     let entity_ids = entity_ids.unwrap_or_default();
-    spawn_py(async move { execute_and_bounding_box_impl(KclInput::Path(path), entity_ids, output_unit).await }).await
+    spawn_py(async move { execute_and_bounding_box_impl(KclInput::Path(path), entity_ids, output_unit, options).await })
+        .await
 }
 
 /// Execute the kcl code and return the model's bounding box.
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
-#[pyfunction(signature = (code, entity_ids=None, output_unit=None))]
+#[pyfunction(signature = (code, entity_ids=None, output_unit=None, *, options=None))]
 async fn execute_code_and_bounding_box(
     code: String,
     entity_ids: Option<Vec<String>>,
     output_unit: Option<UnitLength>,
+    options: Option<ExecutionOptions>,
 ) -> PyResult<BoundingBoxResponse> {
     let entity_ids = entity_ids.unwrap_or_default();
-    spawn_py(async move { execute_and_bounding_box_impl(KclInput::Code(code), entity_ids, output_unit).await }).await
+    spawn_py(async move { execute_and_bounding_box_impl(KclInput::Code(code), entity_ids, output_unit, options).await })
+        .await
 }
 
 /// Customize a snapshot.
@@ -846,13 +929,14 @@ impl SnapshotOptions {
 /// Returns one image for each camera angle you provide.
 /// If you don't provide any camera angles, a default head-on camera angle will be used.
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
-#[pyfunction(signature = (code, image_format, snapshot_options, *, zoom=None, highlight_edges=None))]
+#[pyfunction(signature = (code, image_format, snapshot_options, *, zoom=None, highlight_edges=None, options=None))]
 async fn execute_code_and_snapshot_views(
     code: String,
     image_format: ImageFormat,
     snapshot_options: Vec<SnapshotOptions>,
     zoom: Option<bool>,
     highlight_edges: Option<bool>,
+    options: Option<ExecutionOptions>,
 ) -> PyResult<Vec<Vec<u8>>> {
     let zoom = zoom.unwrap_or(true);
     spawn_py(async move {
@@ -862,6 +946,7 @@ async fn execute_code_and_snapshot_views(
             snapshot_options,
             zoom,
             highlight_edges,
+            options,
         )
         .await
     })
@@ -1145,16 +1230,24 @@ async fn get_bounding_box(
 
 /// Execute a kcl file and export it to a specific file format.
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
-#[pyfunction]
-async fn execute_and_export(path: String, export_format: FileExportFormat) -> PyResult<Vec<RawFile>> {
-    spawn_py(async move { execute_and_export_impl(KclInput::Path(path), export_format).await }).await
+#[pyfunction(signature = (path, export_format, *, options=None))]
+async fn execute_and_export(
+    path: String,
+    export_format: FileExportFormat,
+    options: Option<ExecutionOptions>,
+) -> PyResult<Vec<RawFile>> {
+    spawn_py(async move { execute_and_export_impl(KclInput::Path(path), export_format, options).await }).await
 }
 
 /// Execute the kcl code and export it to a specific file format.
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
-#[pyfunction]
-async fn execute_code_and_export(code: String, export_format: FileExportFormat) -> PyResult<Vec<RawFile>> {
-    spawn_py(async move { execute_and_export_impl(KclInput::Code(code), export_format).await }).await
+#[pyfunction(signature = (code, export_format, *, options=None))]
+async fn execute_code_and_export(
+    code: String,
+    export_format: FileExportFormat,
+    options: Option<ExecutionOptions>,
+) -> PyResult<Vec<RawFile>> {
+    spawn_py(async move { execute_and_export_impl(KclInput::Code(code), export_format, options).await }).await
 }
 
 /// Format the kcl code. This will return the formatted code.
@@ -1291,6 +1384,7 @@ fn kcl(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(parse, m)?)?;
     m.add_function(wrap_pyfunction!(default_units, m)?)?;
     m.add_function(wrap_pyfunction!(parse_code, m)?)?;
+    m.add_class::<ExecutionOptions>()?;
     m.add_function(wrap_pyfunction!(execute, m)?)?;
     m.add_function(wrap_pyfunction!(execute_code, m)?)?;
     m.add_function(wrap_pyfunction!(mock_execute, m)?)?;
@@ -1371,7 +1465,7 @@ result = subtract(cube, tools = [cylinder])
 
     #[tokio::test(flavor = "multi_thread")]
     async fn exec_outcome_report_renders_csg_no_overlap_warning() {
-        let outcome = execute_impl(KclInput::Code(NO_OVERLAP_SUBTRACT_KCL.to_string()), false)
+        let outcome = execute_impl(KclInput::Code(NO_OVERLAP_SUBTRACT_KCL.to_string()), false, None)
             .await
             .expect("execute_impl should succeed for valid non-overlapping subtract");
 
@@ -1412,7 +1506,7 @@ result = subtract(cube, tools = [cylinder])
     #[tokio::test(flavor = "multi_thread")]
     async fn mock_exec_outcome_report_renders_imported_module_warning_against_imported_source() {
         let project_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/files/imported_warning");
-        let outcome = execute_impl(KclInput::Path(project_dir.to_owned()), true)
+        let outcome = execute_impl(KclInput::Path(project_dir.to_owned()), true, None)
             .await
             .expect("mock execute_impl should succeed for a project that only warns");
 

--- a/rust/kcl-python-bindings/tests/tests.py
+++ b/rust/kcl-python-bindings/tests/tests.py
@@ -942,3 +942,107 @@ async def test_sketch_constraint_status_execution_error_returns_partial_report()
     assert report.kcl_error is not None
     assert report.kcl_error.phase == "execution"
     assert "missing_sketch" in report.kcl_error.text
+
+
+@pytest.mark.parametrize("observer_raises", [False, True])
+@pytest.mark.asyncio
+async def test_execution_auth_and_session_observers_are_isolated(
+    monkeypatch, observer_raises
+):
+    import base64
+    import hashlib
+    import json
+
+    session_ids = {
+        "customer-a": "55555555-5555-4555-8555-555555555555",
+        "customer-b": "66666666-6666-4666-8666-666666666666",
+    }
+    observed = {}
+    all_observed = asyncio.Event()
+    release = asyncio.Event()
+    loop = asyncio.get_running_loop()
+
+    async def serve(reader, writer):
+        request = (await reader.readuntil(b"\r\n\r\n")).decode()
+        headers = dict(
+            line.split(": ", 1) for line in request.split("\r\n")[1:] if ": " in line
+        )
+        headers = {key.lower(): value for key, value in headers.items()}
+        token = headers["authorization"].removeprefix("Bearer ")
+        accept = base64.b64encode(
+            hashlib.sha1(
+                (
+                    headers["sec-websocket-key"]
+                    + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+                ).encode()
+            ).digest()
+        ).decode()
+        writer.write(
+            (
+                "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\n"
+                "Connection: Upgrade\r\nSec-WebSocket-Accept: " + accept + "\r\n\r\n"
+            ).encode()
+        )
+        payload = json.dumps(
+            {
+                "success": True,
+                "request_id": None,
+                "resp": {
+                    "type": "modeling_session_data",
+                    "data": {"session": {"api_call_id": session_ids[token]}},
+                },
+            }
+        ).encode()
+        writer.write(b"\x81\x7e" + len(payload).to_bytes(2, "big") + payload)
+        await writer.drain()
+        await release.wait()
+        writer.close()
+        await writer.wait_closed()
+
+    def record(token, api_call_id):
+        observed[token] = api_call_id
+        if len(observed) == 2:
+            all_observed.set()
+
+    def observer(token):
+        def acquired(api_call_id):
+            loop.call_soon_threadsafe(record, token, api_call_id)
+            if observer_raises:
+                raise ValueError("PRIVATE_CALLBACK_ERROR")
+
+        return acquired
+
+    server = await asyncio.start_server(serve, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    monkeypatch.setenv("ZOO_HOST", f"http://127.0.0.1:{port}")
+    monkeypatch.delenv("KITTYCAD_HOST", raising=False)
+    monkeypatch.setenv("ZOO_API_TOKEN", "wrong-shared-account")
+    tasks = [
+        asyncio.create_task(
+            kcl.execute_code(
+                "@settings(kclVersion = 2.0)\nx = 1",
+                options=kcl.ExecutionOptions(
+                    token=token, on_engine_session=observer(token)
+                ),
+            )
+        )
+        for token in session_ids
+    ]
+    async with server:
+        try:
+            await asyncio.wait_for(all_observed.wait(), 5)
+            assert observed == session_ids
+            assert not any(task.done() for task in tasks)
+        finally:
+            release.set()
+            outcomes = await asyncio.wait_for(
+                asyncio.gather(*tasks, return_exceptions=True), 5
+            )
+    assert all(isinstance(outcome, kcl.KclError) for outcome in outcomes)
+    assert "PRIVATE_CALLBACK_ERROR" not in repr(outcomes)
+
+
+def test_execution_options_reject_empty_auth():
+    with pytest.raises(ValueError, match="token must not be empty"):
+        kcl.ExecutionOptions(token=" ")
+    assert "private-token" not in repr(kcl.ExecutionOptions(token="private-token"))


### PR DESCRIPTION
Allow callers to supply a token and session callback for each native KCL execution. The callback receives the server-issued API-call ID as soon as the Engine session is acquired, preserving auth and callback isolation across concurrent executions.

Supports KittyCAD/text-to-cad#4263. Live Engine behavior remains unvalidated.