### PR TITLE
Fingerprint KCL WASM alongside its JavaScript

### DIFF
--- a/src/lang/wasmUtils.test.ts
+++ b/src/lang/wasmUtils.test.ts
@@ -35,11 +35,14 @@ describe('wasm utils', () => {
     })
   })
 
-  it('notifies listeners after browser wasm initialization', async () => {
+  it('loads the generated wasm package and notifies listeners', async () => {
     const { initialiseWasm } = await import('@src/lang/wasmUtils')
 
     await expect(initialiseWasm()).resolves.toBe(wasmModule)
 
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.stringMatching(/\/rust\/kcl-wasm-lib\/pkg\/kcl_wasm_lib_bg\.wasm$/)
+    )
     expect(mocks.reloadModule).toHaveBeenCalled()
     expect(mocks.init).toHaveBeenCalled()
     expect(mocks.notifyActiveWasmInstance).toHaveBeenCalledWith(wasmModule)

--- a/src/lang/wasmUtils.ts
+++ b/src/lang/wasmUtils.ts
@@ -1,4 +1,3 @@
-import { webSafeJoin, webSafePathSplit } from '@src/lib/paths'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { getModule, init, reloadModule } from '@src/lib/wasm_lib_wrapper'
 import { notifyActiveWasmInstance } from '@src/lib/wasmLifecycle'
@@ -10,17 +9,11 @@ export const wasmUrl = () => {
     return process.env.VITE_WASM_BASE_URL + wasmFile
   }
 
-  // For when we're in electron (file based) or web server (network based)
-  // For some reason relative paths don't work as expected. Otherwise we would
-  // just do /wasm_lib_bg.wasm. In particular, the issue arises when the path
-  // is used from within worker.ts.
-  const fullUrl = document.location.protocol.includes('http')
-    ? document.location.origin + '/kcl_wasm_lib_bg.wasm'
-    : document.location.protocol +
-      webSafeJoin(webSafePathSplit(document.location.pathname).slice(0, -1)) +
-      wasmFile
-
-  return fullUrl
+  // Workers need an absolute URL to the WASM emitted with this JavaScript build.
+  return new URL(
+    '../../rust/kcl-wasm-lib/pkg/kcl_wasm_lib_bg.wasm',
+    import.meta.url
+  ).href
 }
 
 // Renderer-side WASM start entry point. New startup paths should go through


### PR DESCRIPTION
Load renderer and LSP WASM through Vite’s fingerprinted asset URL so cached JavaScript stays paired with its matching binary.

Fixes #13245.

Deployments must retain older fingerprinted assets for tabs left open across releases.