### PR TITLE
Cancel native KCL tasks with Python callers

### DIFF
--- a/rust/kcl-python-bindings/src/lib.rs
+++ b/rust/kcl-python-bindings/src/lib.rs
@@ -63,10 +63,18 @@ where
     T: Send + 'static,
     Fut: Future<Output = PyResult<T>> + Send + 'static,
 {
-    tokio()
-        .spawn(future)
-        .await
-        .map_err(|err| PyException::new_err(err.to_string()))?
+    struct AbortOnDrop(tokio::task::AbortHandle);
+
+    impl Drop for AbortOnDrop {
+        fn drop(&mut self) {
+            self.0.abort();
+        }
+    }
+
+    let task = tokio().spawn(future);
+    // Python cancellation drops this future; the native task must stop with it.
+    let _abort_on_drop = AbortOnDrop(task.abort_handle());
+    task.await.map_err(|err| PyException::new_err(err.to_string()))?
 }
 
 fn into_miette(error: kcl_lib::KclErrorWithOutputs, code: &str) -> PyErr {
@@ -1327,6 +1335,25 @@ define_stub_info_gatherer!(stub_info);
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn spawn_py_cancellation_drops_native_task() {
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (dropped_tx, dropped_rx) = tokio::sync::oneshot::channel::<()>();
+        let caller = tokio::spawn(spawn_py(async move {
+            let _drop_signal = dropped_tx;
+            started_tx.send(()).unwrap();
+            std::future::pending::<PyResult<()>>().await
+        }));
+
+        started_rx.await.unwrap();
+        caller.abort();
+        assert!(caller.await.unwrap_err().is_cancelled());
+        tokio::time::timeout(std::time::Duration::from_secs(1), dropped_rx)
+            .await
+            .expect("native task remained alive after caller cancellation")
+            .expect_err("native task should drop its sender");
+    }
 
     #[test]
     fn executor_settings_preserve_default_edge_visibility_without_override() {


### PR DESCRIPTION
Cancelling a Python KCL call dropped its waiter but left the spawned native task running. Abort that task when `spawn_py` is dropped so cancellation reaches native execution and releases its owned connection.

Addresses #13858. The regression fails on main and passes with this change. A separate check through the real Python binding and a local fake Engine reproduced a surviving socket and heartbeat before the fix; afterward the socket closed in approximately 1 ms with no further messages. Real Engine geometry interruption and GPU release remain unverified.